### PR TITLE
Add a UTF-8 `IBufferWriter<byte>` overload to `JsonSerializer.Serialize`

### DIFF
--- a/Jint.Tests.PublicInterface/JsonUtf8SerializationTests.cs
+++ b/Jint.Tests.PublicInterface/JsonUtf8SerializationTests.cs
@@ -1,0 +1,261 @@
+using System.Buffers;
+using System.Text;
+using Jint.Native;
+using Jint.Native.Json;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// The UTF-8 overloads of <see cref="JsonSerializer.Serialize(JsValue, IBufferWriter{byte})"/> exist so a
+/// host that emits UTF-8 does not have to materialize the document as a string first. Their contract is
+/// that the bytes are exactly the UTF-8 encoding of what the string-returning overloads produce, so every
+/// test here is a round-trip against that overload rather than against a hand-written expectation.
+/// </summary>
+public class JsonUtf8SerializationTests
+{
+    public static TheoryData<string> Documents => new()
+    {
+        // primitives and empties
+        "undefined",
+        "null",
+        "true",
+        "({})",
+        "([])",
+        "''",
+        "0",
+        "-0",
+        "1.5",
+        "1e300",
+        "NaN",
+        "Infinity",
+        "'plain text'",
+
+        // no JSON representation at all
+        "(function () {})",
+        "(() => 1)",
+        "({ a: undefined, b: function () {} })",
+
+        // every escape class the serializer emits
+        "'\\n\\t\\\"\\\\\\b\\f\\r'",
+        "'\\u0000\\u0001\\u001F'",
+        "'\\u007F\\u2028\\u2029\\u00FF\\u0100\\u07FF\\u0800\\uFFFD'",
+        "'a\\u0000b\\u001Fc'",
+
+        // surrogates and non-BMP
+        "'\\uD83D\\uDE00'",
+        "'\\u{1F600}\\u{10FFFF}'",
+        "'\\uD800'",
+        "'\\uDC00'",
+        "'a\\uD800b\\uDC00c'",
+        "({ '\\uD800': '\\uDC00' })",
+        "({ '\\uD83D\\uDE00': '\\u{10FFFF}' })",
+
+        // structure
+        "({ a: 1, b: [1, 2, { c: null }], d: 'x' })",
+        "[[[[[[[[[[1]]]]]]]]]]",
+        "(function () { var o = {}; var c = o; for (var i = 0; i < 100; i++) { c.next = {}; c = c.next; } return o; })()",
+
+        // documents large enough to need many transcode rounds
+        "(function () { var a = []; for (var i = 0; i < 5000; i++) { a.push({ id: i, name: 'value \\uD83D\\uDE00 ' + i }); } return a; })()",
+        "(function () { var s = ''; for (var i = 0; i < 4000; i++) { s += '\\uD83D\\uDE00'; } return s; })()",
+    };
+
+    [Theory]
+    [MemberData(nameof(Documents))]
+    public void WritesTheSameDocumentAsTheStringOverload(string script)
+    {
+        AssertRoundTrip(script);
+    }
+
+    [Theory]
+    [InlineData("2")]
+    [InlineData("10")]
+    [InlineData("100")]
+    [InlineData("0")]
+    [InlineData("'\\t'")]
+    [InlineData("'--'")]
+    [InlineData("'0123456789abcdef'")]
+    public void HonoursTheSpaceArgument(string space)
+    {
+        AssertRoundTrip("({ a: 1, b: [1, { c: 'x\\uD83D\\uDE00' }], d: {}, e: [] })", space: space);
+    }
+
+    [Fact]
+    public void HonoursAReplacerFunction()
+    {
+        AssertRoundTrip(
+            "({ a: 1, b: 'keep', c: { d: 2 } })",
+            replacer: "(function (key, value) { return key === 'a' ? undefined : value; })");
+    }
+
+    [Fact]
+    public void HonoursAReplacerArray()
+    {
+        AssertRoundTrip("({ a: 1, b: 2, c: 3 })", replacer: "['c', 'a']");
+    }
+
+    [Fact]
+    public void HonoursAReplacerAndSpaceTogether()
+    {
+        AssertRoundTrip(
+            "({ a: 1, b: { c: 2, d: 3 } })",
+            replacer: "(function (key, value) { return value; })",
+            space: "'\\t'");
+    }
+
+    [Fact]
+    public void ACallableWithAReplacerStillProducesOutput()
+    {
+        AssertRoundTrip("(function () {})", replacer: "(function (key, value) { return 42; })");
+    }
+
+    [Fact]
+    public void ReportsNoOutputWithoutTouchingTheWriter()
+    {
+        var engine = new Engine();
+        var writer = new TestBufferWriter();
+
+        var written = new JsonSerializer(engine).Serialize(JsValue.Undefined, writer);
+
+        written.Should().BeFalse();
+        writer.WrittenCount.Should().Be(0);
+        writer.GetSpanCallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void ALargeDocumentIsWrittenInSeveralRounds()
+    {
+        var engine = new Engine();
+        var value = engine.Evaluate("(function () { var a = []; for (var i = 0; i < 5000; i++) { a.push(i); } return a; })()");
+
+        var writer = new TestBufferWriter(exactSpans: true);
+        new JsonSerializer(engine).Serialize(value, writer).Should().BeTrue();
+
+        writer.GetSpanCallCount.Should().BeGreaterThan(1);
+    }
+
+    [Fact]
+    public void ARequestedSpanIsNeverProportionalToTheDocument()
+    {
+        var engine = new Engine();
+        var script = "(function () { var a = []; for (var i = 0; i < 20000; i++) { a.push('abcdefghij'); } return a; })()";
+        var value = engine.Evaluate(script);
+
+        var writer = new TestBufferWriter(exactSpans: true);
+        new JsonSerializer(engine).Serialize(value, writer).Should().BeTrue();
+
+        writer.WrittenCount.Should().BeGreaterThan(200_000);
+        writer.LargestSpanRequest.Should().BeLessThan(8 * 1024);
+    }
+
+    [Fact]
+    public void ANullWriterIsRejected()
+    {
+        var engine = new Engine();
+        var serializer = new JsonSerializer(engine);
+
+        Invoking(() => serializer.Serialize(JsValue.Undefined, null!)).Should().Throw<ArgumentNullException>();
+    }
+
+    /// <summary>
+    /// Strings and property names are always escaped, so an unpaired surrogate cannot reach the output
+    /// through them. The <c>space</c> argument is copied verbatim, which is the one route by which the
+    /// string overload can produce text that UTF-8 cannot represent; both overloads then agree only after
+    /// the encoder's U+FFFD substitution, which is what the documented contract promises.
+    /// </summary>
+    [Fact]
+    public void AnUnpairedSurrogateInTheIndentBecomesTheReplacementCharacter()
+    {
+        var engine = new Engine();
+        var value = engine.Evaluate("({ a: 1 })");
+        var space = engine.Evaluate("'\\uD800'");
+
+        var asString = new JsonSerializer(engine).Serialize(value, JsValue.Undefined, space).AsString();
+        asString.Should().Contain("\uD800");
+
+        var writer = new TestBufferWriter();
+        new JsonSerializer(engine).Serialize(value, JsValue.Undefined, space, writer).Should().BeTrue();
+
+        writer.ToArray().Should().Equal(Encoding.UTF8.GetBytes(asString));
+        writer.AsUtf8String().Should().Contain("\uFFFD").And.NotContain("\uD800");
+    }
+
+    private static void AssertRoundTrip(string script, string replacer = null, string space = null)
+    {
+        var engine = new Engine();
+        var value = engine.Evaluate(script);
+        var replacerValue = replacer is null ? JsValue.Undefined : engine.Evaluate(replacer);
+        var spaceValue = space is null ? JsValue.Undefined : engine.Evaluate(space);
+
+        var expected = new JsonSerializer(engine).Serialize(value, replacerValue, spaceValue);
+
+        foreach (var exactSpans in new[] { false, true })
+        {
+            var writer = new TestBufferWriter(exactSpans);
+            var written = new JsonSerializer(engine).Serialize(value, replacerValue, spaceValue, writer);
+
+            if (expected.IsUndefined())
+            {
+                written.Should().BeFalse($"'{script}' has no JSON representation");
+                writer.WrittenCount.Should().Be(0);
+                continue;
+            }
+
+            written.Should().BeTrue();
+            writer.ToArray().Should().Equal(Encoding.UTF8.GetBytes(expected.AsString()));
+        }
+    }
+
+    /// <summary>
+    /// A writer that hands back exactly the requested amount when <paramref name="exactSpans"/> is set,
+    /// which is the smallest span the <see cref="IBufferWriter{T}"/> contract allows and therefore forces
+    /// the serializer through its chunking loop instead of letting one oversized span absorb everything.
+    /// </summary>
+    private sealed class TestBufferWriter(bool exactSpans = false) : IBufferWriter<byte>
+    {
+        private byte[] _buffer = new byte[16];
+
+        public int WrittenCount { get; private set; }
+
+        public int GetSpanCallCount { get; private set; }
+
+        public int LargestSpanRequest { get; private set; }
+
+        public byte[] ToArray() => _buffer.AsSpan(0, WrittenCount).ToArray();
+
+        public string AsUtf8String() => Encoding.UTF8.GetString(_buffer, 0, WrittenCount);
+
+        public void Advance(int count)
+        {
+            count.Should().BeGreaterThanOrEqualTo(0);
+            (WrittenCount + count).Should().BeLessThanOrEqualTo(_buffer.Length);
+            WrittenCount += count;
+        }
+
+        public Memory<byte> GetMemory(int sizeHint = 0)
+        {
+            var length = Prepare(sizeHint);
+            return _buffer.AsMemory(WrittenCount, length);
+        }
+
+        public Span<byte> GetSpan(int sizeHint = 0)
+        {
+            var length = Prepare(sizeHint);
+            return _buffer.AsSpan(WrittenCount, length);
+        }
+
+        private int Prepare(int sizeHint)
+        {
+            GetSpanCallCount++;
+            LargestSpanRequest = System.Math.Max(LargestSpanRequest, sizeHint);
+
+            var wanted = System.Math.Max(sizeHint, 1);
+            if (_buffer.Length - WrittenCount < wanted)
+            {
+                Array.Resize(ref _buffer, System.Math.Max(_buffer.Length * 2, WrittenCount + wanted));
+            }
+
+            return exactSpans ? wanted : _buffer.Length - WrittenCount;
+        }
+    }
+}

--- a/Jint/Native/Json/JsonSerializer.cs
+++ b/Jint/Native/Json/JsonSerializer.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -38,20 +39,10 @@ public sealed class JsonSerializer
 
     public JsValue Serialize(JsValue value, JsValue replacer, JsValue space)
     {
-        _stack = new ObjectTraverseStack(_engine);
-
-        // for JSON.stringify(), any function passed as the first argument will return undefined
-        // if the replacer is not defined. The function is not called either.
-        if (value.IsCallable && ReferenceEquals(replacer, JsValue.Undefined))
+        if (!TryCreateHolder(value, replacer, space, out var wrapper))
         {
             return JsValue.Undefined;
         }
-
-        SetupReplacer(replacer);
-        _gap = BuildSpacingGap(space);
-
-        var wrapper = _engine.Realm.Intrinsics.Object.Construct(Arguments.Empty);
-        wrapper.DefineOwnProperty(JsString.Empty, new PropertyDescriptor(value, PropertyFlag.ConfigurableEnumerableWritable));
 
         string result;
         var json = new ValueStringBuilder();
@@ -67,6 +58,130 @@ public sealed class JsonSerializer
             result = json.ToString();
         }
         return new JsString(result);
+    }
+
+    /// <summary>
+    /// Serializes <paramref name="value"/> and writes the document to <paramref name="writer"/> as UTF-8,
+    /// for callers that hold or emit UTF-8 and would otherwise transcode the result of
+    /// <see cref="Serialize(JsValue)"/> themselves.
+    /// </summary>
+    /// <returns>
+    /// <see langword="false"/> when the value has no JSON representation, matching the cases where
+    /// <see cref="Serialize(JsValue)"/> returns <see cref="JsValue.Undefined"/>; nothing is written then.
+    /// Otherwise <see langword="true"/>.
+    /// </returns>
+    public bool Serialize(JsValue value, IBufferWriter<byte> writer)
+    {
+        return Serialize(value, JsValue.Undefined, JsValue.Undefined, writer);
+    }
+
+    /// <summary>
+    /// Serializes <paramref name="value"/> and writes the document to <paramref name="writer"/> as UTF-8,
+    /// for callers that hold or emit UTF-8 and would otherwise transcode the result of
+    /// <see cref="Serialize(JsValue, JsValue, JsValue)"/> themselves.
+    /// </summary>
+    /// <returns>
+    /// <see langword="false"/> when the value has no JSON representation, matching the cases where
+    /// <see cref="Serialize(JsValue, JsValue, JsValue)"/> returns <see cref="JsValue.Undefined"/>; nothing
+    /// is written then. Otherwise <see langword="true"/>.
+    /// </returns>
+    /// <remarks>
+    /// The bytes are exactly <c>Encoding.UTF8.GetBytes</c> of what the string-returning overload produces
+    /// for the same arguments. That is byte-for-byte round-trippable except where the document itself is
+    /// not well-formed UTF-16: string contents and property names are always escaped as <c>\uXXXX</c>, but
+    /// the <c>space</c> indentation, raw JSON text and host-supplied interop JSON are copied through
+    /// verbatim, so an unpaired surrogate reaching the output through one of those becomes U+FFFD here.
+    /// A caller transcoding the string overload's result with <c>Encoding.UTF8</c> gets the same
+    /// substitution, so this is a property of UTF-8 rather than a divergence between the two overloads.
+    /// </remarks>
+    public bool Serialize(JsValue value, JsValue replacer, JsValue space, IBufferWriter<byte> writer)
+    {
+        if (writer is null)
+        {
+            Throw.ArgumentNullException(nameof(writer));
+        }
+
+        if (!TryCreateHolder(value, replacer, space, out var wrapper))
+        {
+            return false;
+        }
+
+        var json = new ValueStringBuilder();
+        try
+        {
+            if (SerializeJSONProperty(JsString.Empty, wrapper, ref json) == SerializeResult.Undefined)
+            {
+                return false;
+            }
+
+            WriteUtf8(json.AsSpan(), writer);
+            return true;
+        }
+        finally
+        {
+            json.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// The shared prologue of https://tc39.es/ecma262/#sec-json.stringify: configures the replacer and the
+    /// gap, and builds the wrapper object the value is serialized out of. Returns <see langword="false"/>
+    /// for the inputs that produce no output at all.
+    /// </summary>
+    private bool TryCreateHolder(JsValue value, JsValue replacer, JsValue space, out ObjectInstance wrapper)
+    {
+        _stack = new ObjectTraverseStack(_engine);
+
+        // for JSON.stringify(), any function passed as the first argument will return undefined
+        // if the replacer is not defined. The function is not called either.
+        if (value.IsCallable && ReferenceEquals(replacer, JsValue.Undefined))
+        {
+            wrapper = null!;
+            return false;
+        }
+
+        SetupReplacer(replacer);
+        _gap = BuildSpacingGap(space);
+
+        wrapper = _engine.Realm.Intrinsics.Object.Construct(Arguments.Empty);
+        wrapper.DefineOwnProperty(JsString.Empty, new PropertyDescriptor(value, PropertyFlag.ConfigurableEnumerableWritable));
+        return true;
+    }
+
+    /// <summary>
+    /// Transcodes the finished document in bounded rounds so the writer is never asked for more than one
+    /// chunk's worth of destination space, however large the document is. The stateful encoder carries a
+    /// surrogate pair split across a chunk boundary into the next round.
+    /// </summary>
+    private static unsafe void WriteUtf8(ReadOnlySpan<char> chars, IBufferWriter<byte> writer)
+    {
+        const int ChunkLength = 1024;
+
+        var encoder = Encoding.UTF8.GetEncoder();
+        while (!chars.IsEmpty)
+        {
+            var chunk = chars.Length <= ChunkLength ? chars : chars.Slice(0, ChunkLength);
+            var flush = chunk.Length == chars.Length;
+
+            // GetMaxByteCount leaves room for a surrogate held over from the previous round, so a
+            // conforming writer always hands back enough space to drain the whole chunk in one go.
+            var destination = writer.GetSpan(Encoding.UTF8.GetMaxByteCount(chunk.Length));
+
+            int charsUsed;
+            int bytesUsed;
+#if SUPPORTS_SPAN_PARSE
+            encoder.Convert(chunk, destination, flush, out charsUsed, out bytesUsed, out _);
+#else
+            fixed (char* chunkPtr = chunk)
+            fixed (byte* destinationPtr = destination)
+            {
+                encoder.Convert(chunkPtr, chunk.Length, destinationPtr, destination.Length, flush, out charsUsed, out bytesUsed, out _);
+            }
+#endif
+
+            writer.Advance(bytesUsed);
+            chars = chars.Slice(charsUsed);
+        }
     }
 
     private void SetupReplacer(JsValue replacer)


### PR DESCRIPTION
## This is new permanent public API surface — easy to decline

Two new public overloads on `Jint.Native.Json.JsonSerializer`. Under an
internal-first rule this needs a real consumer, and the consumer here is
generic-embedder-shaped rather than a caller inside the repo: nothing in Jint
itself calls it. If you would rather not commit to the surface, closing this
costs nothing and the change is self-contained in one file.

```csharp
public bool Serialize(JsValue value, IBufferWriter<byte> writer);
public bool Serialize(JsValue value, JsValue replacer, JsValue space, IBufferWriter<byte> writer);
```

## Motivation

`JSON.stringify`-equivalent output is only reachable as a `JsString` today. A
host that ultimately writes UTF-8 — to a socket, a file, a log, an on-disk
document store — has to take that `string` and transcode it, so a large
document is copied in full: a `string` (LOH-sized for big payloads), a
`JsString` wrapping it, and then the host's own `byte[]`. One embedder audited
for this work had hand-written a few hundred lines of duplicate JSON
serialization purely to avoid that round trip.

The overloads remove one full O(n) copy and the string/`JsString` pair for
byte-oriented embedders. No benchmark is attached and none was run — the win
is the removal of a copy that is evident from the shape of the code rather
than a directional claim that needs measuring.

## Scope — deliberately narrow

`JsonSerializer` builds into a char-based `ValueStringBuilder` threaded by
`ref` through about ten mutually recursive methods. **This PR does not thread
`IBufferWriter<byte>` through those methods, on purpose.** Doing so would fork
the serializer's correctness surface — which Test262 exercises heavily on the
char path and would not exercise at all on a byte path — for the second-order
win of removing an already-`ArrayPool`-amortized char buffer.

Instead the transcode happens at the single point where the char pipeline
already became a string. The recursion is byte-for-byte the same code on both
paths; the only refactor to the existing path is lifting the shared
`JSON.stringify` prologue (replacer setup, gap, holder wrapper) into a private
`TryCreateHolder` so both entry points share it.

**The char buffer is retained deliberately.** Please don't treat this as a
half-finished byte path to be "completed" later by pushing
`IBufferWriter<byte>` down into the recursion — that is the part this PR is
arguing against, not the part it ran out of time for.

## Chunking

`Encoding.UTF8.GetMaxByteCount(n)` is `3n + 3`, and demanding that much from
the host in a single `GetSpan` request is rude for a large document. The
transcode runs in 1024-char rounds through a stateful `Encoder`, so the writer
never sees a request larger than ~3 KB regardless of document size, and a
surrogate pair straddling a chunk boundary is carried into the next round by
the encoder rather than mis-encoded. Small documents ask for only what they
need — `{}` requests 9 bytes.

## Surrogates — the one real correctness item

Determined empirically rather than from the spec, because the two differ here.

`QuoteJSONString` already escapes unpaired surrogates as `\uXXXX`, so **string
contents and property names can never carry a lone surrogate into the
output** — this is a well-formed-stringify implementation. Verified for direct
strings, keys, and values produced by a replacer function.

Three routes copy text through verbatim and *can* put an unpaired surrogate in
the output of the existing string overload:

- the `space` indentation (`JSON.stringify({a: 1}, null, "\uD800")` really
  does emit a raw U+D800),
- `JSON.rawJSON` text,
- host-supplied interop JSON (`Options.Interop.SerializeToJson`).

UTF-8 cannot represent an unpaired surrogate, so exact equality with the
string overload is not available in those three cases. **The decision taken is
that the bytes are exactly `Encoding.UTF8.GetBytes(<what the string overload
returns>)`** — i.e. the default replacement fallback applies and the surrogate
becomes U+FFFD. That is precisely what a host transcoding the string
overload's result itself would get, so the overloads never disagree about
anything the caller could otherwise have obtained; it is a property of UTF-8,
not a divergence introduced here. Throwing was the alternative and was
rejected as a worse failure mode for output the caller did not choose.

This is documented in the XML doc on the overload, not left implicit, and is
pinned by a dedicated test.

## Availability

No new package dependency. `System.Buffers.IBufferWriter<T>` comes from
`System.Memory` 4.5.5, which is already a direct dependency of `Acornima` on
`net462`/`netstandard2.0` and therefore already in Jint's package closure;
`netstandard2.1+` has it in the framework.

`Encoder.Convert(ReadOnlySpan<char>, Span<byte>, ...)` does not exist
down-level, so the `net462`/`netstandard2.0` builds use the pointer overload
under `fixed`, split on the existing `SUPPORTS_SPAN_PARSE` constant (whose TFM
split is exactly the right one) rather than a newly invented one.
`AllowUnsafeBlocks` was already on.

## Testing

Tests are in `Jint.Tests.PublicInterface` — that project has no
`InternalsVisibleTo`, so they also prove the API is reachable from outside the
assembly, and its `net472` leg exercises the down-level `fixed` transcode.

The gate is round-trip equivalence against the existing string overload over a
corpus rather than hand-written expected bytes: deep nesting, every escape
class (`\n \t \" \\ \b \f \r`), control characters, `\uXXXX`, surrogate pairs,
lone surrogates, non-BMP characters, both `space` forms, a replacer function
and a replacer array, `undefined`/callable inputs producing no output at all,
empty object and empty array, and documents large enough to force many
`GetSpan` rounds. Every case runs twice: once against a generous writer and
once against a writer that hands back exactly the requested number of bytes,
which is the smallest span the `IBufferWriter<T>` contract allows and forces
the chunking loop.

- `dotnet build --configuration Release` — clean, all five TFMs, 0 warnings.
- `Jint.Tests` — 4280 passed (net10.0) / 4212 passed (net472), unchanged.
- `Jint.Tests.PublicInterface` — 383 passed on both TFMs, from a 335 baseline
  (48 new).
- `Jint.Tests.Test262` — unchanged from baseline, which is the signal that the
  change did not leak into the shared char path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
