### PR TITLE
Stop the prototype-method cache trusting a version that cannot witness the name

### DIFF
--- a/Jint.Tests.PublicInterface/HostObjectPropertySetChangeTests.cs
+++ b/Jint.Tests.PublicInterface/HostObjectPropertySetChangeTests.cs
@@ -1,0 +1,205 @@
+using System;
+using Jint.Native;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// Covers what happens when the own-property set of a host <see cref="Jint.Native.Object.ObjectInstance"/>
+/// subclass changes <em>behind the engine's back</em> — the native state a projecting host reflects gains or
+/// loses a member without any JavaScript-visible write.
+///
+/// <para>
+/// This is the shape the member-read inline caches cannot version. The engine bumps an internal counter from
+/// its own property-bag mutators and the caches validate against it, but a host that stores its properties
+/// itself never touches that bag, so the counter is frozen for the object's whole lifetime and cannot stand
+/// in for "the own-property set is unchanged". Every read of such a receiver — and of such a prototype — must
+/// therefore ask the host again rather than trust a cached answer.
+/// </para>
+///
+/// <para>
+/// Each test drives the reads through <b>one</b> member expression evaluated repeatedly, because the caches
+/// are per-AST-node: a fresh <c>Evaluate</c> per read would compile a fresh node and never warm anything.
+/// </para>
+/// </summary>
+public class HostObjectPropertySetChangeTests
+{
+    [Fact]
+    public void AProjectedPropertyAppearingOnAReceiverShadowsThePrototypeOnTheNextRead()
+    {
+        var engine = new Engine();
+        var host = new ProjectedHostObject(engine);
+        engine.SetValue("host", host);
+        engine.SetValue("projectShared", new Action(() => host.Project("shared", "from-host")));
+
+        var seen = engine.Evaluate(
+            """
+            Object.prototype.shared = 'from-prototype';
+
+            var seen = [];
+            for (var i = 0; i < 3; i++) {
+                seen.push(host.shared);
+                if (i === 0) {
+                    projectShared();
+                }
+            }
+            seen.join(',');
+            """);
+
+        seen.Should().Be("from-prototype,from-host,from-host");
+    }
+
+    [Fact]
+    public void AProjectedMethodAppearingOnAReceiverShadowsThePrototypeOnTheNextCall()
+    {
+        // The member-call callee lane shares the same non-plain-receiver completion, so it needs the same guard.
+        var engine = new Engine();
+        var host = new ProjectedHostObject(engine);
+        engine.SetValue("host", host);
+        engine.SetValue(
+            "projectGreet",
+            new Action(() => host.Project("greet", engine.Evaluate("(function () { return 'from-host'; })"))));
+
+        var seen = engine.Evaluate(
+            """
+            Object.prototype.greet = function () { return 'from-prototype'; };
+
+            var seen = [];
+            for (var i = 0; i < 3; i++) {
+                seen.push(host.greet());
+                if (i === 0) {
+                    projectGreet();
+                }
+            }
+            seen.join(',');
+            """);
+
+        seen.Should().Be("from-prototype,from-host,from-host");
+    }
+
+    [Fact]
+    public void AProjectedPropertyDisappearingFromAReceiverFallsBackToThePrototype()
+    {
+        var engine = new Engine();
+        var host = new ProjectedHostObject(engine).Project("shared", "from-host");
+        engine.SetValue("host", host);
+        engine.SetValue("unprojectShared", new Action(() => host.Unproject("shared")));
+
+        var seen = engine.Evaluate(
+            """
+            Object.prototype.shared = 'from-prototype';
+
+            var seen = [];
+            for (var i = 0; i < 3; i++) {
+                seen.push(host.shared);
+                if (i === 0) {
+                    unprojectShared();
+                }
+            }
+            seen.join(',');
+            """);
+
+        seen.Should().Be("from-host,from-prototype,from-prototype");
+    }
+
+    /// <summary>
+    /// The other per-node caches, from the outside. The own-property and shape lanes are gated on internal
+    /// storage flags a host subclass cannot carry, and the wrapper lane on the receiver's exact type, so none
+    /// of them ever holds a descriptor produced by a host — which is observable here, because this host builds
+    /// a fresh descriptor per probe and a cached one would freeze the value.
+    /// </summary>
+    [Fact]
+    public void AProjectedPropertyChangingValueOnAReceiverIsSeenByTheNextRead()
+    {
+        var engine = new Engine();
+        var host = new ProjectedHostObject(engine).Project("value", "v1");
+        engine.SetValue("host", host);
+        engine.SetValue("reproject", new Action(() => host.Project("value", "v2")));
+
+        var seen = engine.Evaluate(
+            """
+            var seen = [];
+            for (var i = 0; i < 3; i++) {
+                seen.push(host.value);
+                if (i === 0) {
+                    reproject();
+                }
+            }
+            seen.join(',');
+            """);
+
+        seen.Should().Be("v1,v2,v2");
+    }
+
+    [Fact]
+    public void AHostUsedAsAPrototypeIsRereadWhenItsProjectionChanges()
+    {
+        // The holder side of the same cache. Here the receiver is an ordinary script object whose version the
+        // engine does own; it is the prototype that projects its members, and its version is the frozen one.
+        var engine = new Engine();
+        var hostPrototype = new ProjectedHostObject(engine).Project("shared", "v1");
+        engine.SetValue("hostPrototype", hostPrototype);
+        engine.SetValue("reproject", new Action(() => hostPrototype.Project("shared", "v2")));
+
+        var seen = engine.Evaluate(
+            """
+            var obj = Object.create(hostPrototype);
+
+            var seen = [];
+            for (var i = 0; i < 3; i++) {
+                seen.push(obj.shared);
+                if (i === 0) {
+                    reproject();
+                }
+            }
+            seen.join(',');
+            """);
+
+        seen.Should().Be("v1,v2,v2");
+    }
+
+    [Fact]
+    public void AHostUsedAsAPrototypeIsRereadWhenAProjectedMemberDisappears()
+    {
+        var engine = new Engine();
+        var hostPrototype = new ProjectedHostObject(engine).Project("shared", "from-host-prototype");
+        engine.SetValue("hostPrototype", hostPrototype);
+        engine.SetValue("unprojectShared", new Action(() => hostPrototype.Unproject("shared")));
+
+        var seen = engine.Evaluate(
+            """
+            var obj = Object.create(hostPrototype);
+
+            var seen = [];
+            for (var i = 0; i < 3; i++) {
+                seen.push(obj.shared === undefined ? 'absent' : obj.shared);
+                if (i === 0) {
+                    unprojectShared();
+                }
+            }
+            seen.join(',');
+            """);
+
+        seen.Should().Be("from-host-prototype,absent,absent");
+    }
+
+    [Fact]
+    public void AReceiverThatGainsAProjectedPropertyStillReportsItThroughTheObjectProtocol()
+    {
+        // The same change seen from outside the member-read lane, so a failure of the lane is distinguishable
+        // from a host fixture that simply does not work.
+        var engine = new Engine();
+        var host = new ProjectedHostObject(engine);
+        engine.SetValue("host", host);
+
+        engine.Execute("Object.prototype.shared = 'from-prototype';");
+        engine.Evaluate("host.shared").Should().Be("from-prototype");
+
+        host.Project("shared", "from-host");
+
+        engine.Evaluate("host.shared").Should().Be("from-host");
+        engine.Evaluate("host['share' + 'd']").Should().Be("from-host");
+        host.Get("shared").Should().Be("from-host");
+        engine.Evaluate("Object.getOwnPropertyDescriptor(host, 'shared').value").Should().Be("from-host");
+        engine.Evaluate("Object.prototype.hasOwnProperty.call(host, 'shared')").Should().Be(JsBoolean.True);
+    }
+}

--- a/Jint.Tests.PublicInterface/HostObjectSemanticsTests.cs
+++ b/Jint.Tests.PublicInterface/HostObjectSemanticsTests.cs
@@ -28,8 +28,10 @@ public class HostObjectSemanticsTests
     // Release strips the verification, and its count is the one the probes-per-read guard is about.
 #if DEBUG
     private const int OrdinaryOwnReadProbes = 3;
+    private const int OrdinaryWarmPrototypeReadProbes = 3;
 #else
     private const int OrdinaryOwnReadProbes = 1;
+    private const int OrdinaryWarmPrototypeReadProbes = 1;
 #endif
 
     [Fact]
@@ -125,7 +127,7 @@ public class HostObjectSemanticsTests
     }
 
     [Fact]
-    public void AWarmPrototypeReadDoesNotReprobeTheHost()
+    public void AWarmPrototypeReadProbesTheHostOncePerRead()
     {
         var engine = new Engine();
         var host = new ProjectedHostObject(engine);
@@ -134,11 +136,13 @@ public class HostObjectSemanticsTests
 
         engine.Evaluate("var total = 0; for (var i = 0; i < 10; i++) { total += host.protoMethod(); } total;").Should().Be(10);
 
-        // The ordinary lane must not cost the prototype-method cache: ten reads of a prototype method through a
-        // single node probe the receiver once, not ten times. That is why the lane consults that cache before it
-        // probes for an own property — doing it the other way round turns the nine cached iterations back into
-        // nine virtual probes.
-        host.GetOwnPropertyCalls.Should().Be(OrdinaryOwnReadProbes);
+        // Ten reads of a prototype method through a single node, and each one asks the host whether it now owns
+        // that name. That probe cannot be skipped: the host stores its own-property set itself, so nothing the
+        // engine watches moves when a projected member appears, and a cached prototype hit reused on trust would
+        // keep shadowing it. Its result is what makes the next line honest — the prototype-method cache still
+        // answers the read, so the cost is one probe per read rather than the two an uncached read pays (one to
+        // establish the miss, one inside the Get that follows it).
+        host.GetOwnPropertyCalls.Should().Be(10 * OrdinaryWarmPrototypeReadProbes);
     }
 
     [Fact]
@@ -243,6 +247,16 @@ internal class ProjectedHostObject : ObjectInstance
     public ProjectedHostObject Project(string name, JsValue value)
     {
         _fields[name] = value;
+        return this;
+    }
+
+    /// <summary>
+    /// Drops a projected field, the way the native state behind a host object changes on its own. Like
+    /// <see cref="Project"/> this is not a JavaScript-visible write, so nothing in the engine observes it.
+    /// </summary>
+    public ProjectedHostObject Unproject(string name)
+    {
+        _fields.Remove(name);
         return this;
     }
 

--- a/Jint.Tests/Runtime/PrototypeMethodCacheTests.cs
+++ b/Jint.Tests/Runtime/PrototypeMethodCacheTests.cs
@@ -26,7 +26,12 @@ public class PrototypeMethodCacheTests
     /// <item>non-ordinary only for keys it also reports from <c>GetOwnProperty</c> (array integer indices and
     /// <c>length</c>) — safe <em>without</em> the flag, because the populate path defers to the full
     /// <c>Get</c> whenever <c>GetOwnProperty</c> is non-undefined. <see cref="ArrayInstance"/> is the one
-    /// such case, and must stay unflagged so <c>arr.push</c> / <c>arr.pop</c> stay cacheable.</item>
+    /// such case, and must stay unflagged so <c>arr.push</c> / <c>arr.pop</c> stay cacheable. That covers
+    /// only the own properties it has <em>at populate time</em>: an array's elements live in its own
+    /// dense/sparse storage, which the hot element paths write without moving <c>_propertiesVersion</c>, so
+    /// an entry for an <em>index-like</em> name could not be invalidated when an element appeared later. The
+    /// cache therefore declines to create one — see <c>VersionWitnessesOwnProperty</c>, and
+    /// <see cref="AnArrayElementAddedAfterCachingShadowsThePrototypeIndex"/>.</item>
     /// </list>
     /// When a new override appears this test fails, forcing the author to classify it rather than silently
     /// regressing (or mis-caching) prototype-method reads.
@@ -152,6 +157,180 @@ public class PrototypeMethodCacheTests
             out.join(',');
             """;
         new Engine().Evaluate(script).AsString().Should().Be("A,A,B,B");
+    }
+
+    /// <summary>
+    /// The cached entry stays valid only while the receiver's <c>_propertiesVersion</c> can still prove the
+    /// name is not an own property of it. An array's elements are not in the property bag that version
+    /// describes, so an index-named entry would never be invalidated by one appearing.
+    /// <para>
+    /// Note the <em>string</em>-literal index: <c>a['0']</c> is a string-keyed member read and takes this
+    /// cache, whereas <c>a[0]</c> and <c>a[k]</c> resolve through the dense-array lanes, which never consult
+    /// it. <see cref="ANumericIndexReadIsUnaffectedBecauseItTakesTheDenseLane"/> pins that difference so the
+    /// exclusion is not mistaken for something broader than it is.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void AnArrayElementAddedAfterCachingShadowsThePrototypeIndex()
+    {
+        const string script = """
+            Array.prototype[0] = 'proto';
+            var a = [], out = [];
+            for (var i = 0; i < 4; i++) {
+                if (i === 2) { a.push('own'); }
+                out.push(a['0']);
+            }
+            out.join(',');
+            """;
+        new Engine().Evaluate(script).AsString().Should().Be("proto,proto,own,own");
+    }
+
+    [Fact]
+    public void AnArrayElementAssignedAfterCachingShadowsThePrototypeIndex()
+    {
+        const string script = """
+            Array.prototype[1] = 'proto';
+            var a = [], out = [];
+            for (var i = 0; i < 4; i++) {
+                if (i === 2) { a[1] = 'own'; }
+                out.push(a['1']);
+            }
+            out.join(',');
+            """;
+        new Engine().Evaluate(script).AsString().Should().Be("proto,proto,own,own");
+    }
+
+    [Theory]
+    [InlineData("a[0]")]
+    [InlineData("a[k]")]
+    public void ANumericIndexReadIsUnaffectedBecauseItTakesTheDenseLane(string read)
+    {
+        // The two spellings that never reach the prototype-method cache: a numeric literal and a computed
+        // index both resolve through the dense-array lanes, which re-read the element every time. They were
+        // already correct before the exclusion and must stay that way — the scope of the bug is exactly the
+        // string-keyed spelling.
+        var script = $$"""
+            Array.prototype[0] = 'proto';
+            var a = [], k = 0, out = [];
+            for (var i = 0; i < 4; i++) {
+                if (i === 2) { a.push('own'); }
+                out.push({{read}});
+            }
+            out.join(',');
+            """;
+        new Engine().Evaluate(script).AsString().Should().Be("proto,proto,own,own");
+    }
+
+    [Fact]
+    public void AnArrayPrototypeMethodUnderANonIndexNameStaysCorrectWhileElementsChange()
+    {
+        // The counterpart of the two above: the exclusion is by name, so only index-like names give it up.
+        // A method name keeps resolving through the same node while elements come and go — the shape the
+        // exclusion had to be written narrowly enough not to disturb (arr.push / arr.pop / arr.slice).
+        const string script = """
+            Array.prototype.tag = function () { return 'v1:' + this.length; };
+            var a = [], out = [];
+            for (var i = 0; i < 4; i++) {
+                a[a.length] = i;
+                if (i === 2) { Array.prototype.tag = function () { return 'v2:' + this.length; }; }
+                out[out.length] = a.tag();
+            }
+            out.join(',');
+            """;
+        new Engine().Evaluate(script).AsString().Should().Be("v1:1,v1:2,v2:3,v2:4");
+    }
+
+    /// <summary>
+    /// A function's <c>name</c> and <c>length</c> are configurable own properties held in fields rather than in
+    /// the property bag, so defining one had to start moving the version itself — otherwise a define following a
+    /// delete re-created the own property invisibly. (<c>prototype</c> shares the storage but not the hazard: it
+    /// is non-configurable, so it can never leave the own set and come back.)
+    /// <para>
+    /// The <c>delete</c> is load-bearing and must come first: it is what makes the opening read miss the own
+    /// property and cache <c>Function.prototype</c>'s. Defining over a <c>name</c> that is still own is an
+    /// own-property hit throughout, caches nothing, and was always correct.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void AFunctionOwnPropertyDefinedAfterCachingShadowsThePrototype()
+    {
+        const string script = """
+            function f() {}
+            delete f.name;
+            var out = [];
+            for (var i = 0; i < 4; i++) {
+                if (i === 2) { Object.defineProperty(f, 'name', { value: 'own', configurable: true }); }
+                out.push(f.name === '' ? 'inherited' : f.name);
+            }
+            out.join(',');
+            """;
+        new Engine().Evaluate(script).AsString().Should().Be("inherited,inherited,own,own");
+    }
+
+    [Fact]
+    public void AFunctionOwnLengthDefinedAfterCachingShadowsThePrototype()
+    {
+        const string script = """
+            function f() {}
+            delete f.length;
+            var out = [];
+            for (var i = 0; i < 4; i++) {
+                if (i === 2) { Object.defineProperty(f, 'length', { value: 7, configurable: true }); }
+                out.push(f.length);
+            }
+            out.join(',');
+            """;
+        new Engine().Evaluate(script).AsString().Should().Be("0,0,7,7");
+    }
+
+    /// <summary>
+    /// A constructor's lazily created <c>prototype</c> object holds <c>constructor</c> in a field too, and it
+    /// is the holder here rather than the receiver — the same version, read from the other side of the cache.
+    /// This one needs no unusual spelling at all: an ordinary constructor, an ordinary instance, an ordinary
+    /// <c>delete</c>.
+    /// </summary>
+    [Fact]
+    public void ConstructorDeletedFromThePrototypeAfterCachingFallsBack()
+    {
+        const string script = """
+            function C() {}
+            function name(ctor) {
+                if (ctor === C) { return 'C'; }
+                if (ctor === Object) { return 'Object'; }
+                return 'other';
+            }
+            var c = new C(), out = [];
+            for (var i = 0; i < 4; i++) {
+                if (i === 2) { delete C.prototype.constructor; }
+                out.push(name(c.constructor));
+            }
+            out.join(',');
+            """;
+        new Engine().Evaluate(script).AsString().Should().Be("C,C,Object,Object");
+    }
+
+    /// <summary>
+    /// The control that scopes all of the above. A receiver whose own-property set the engine <em>does</em>
+    /// store, and therefore versions, has always shadowed correctly — so the defect was never the
+    /// prototype-method cache's design, only the set of receivers whose version was taken to describe them.
+    /// <see cref="OwnPropertyAddedAfterCachingShadowsPrototype"/> is the same statement for a constructed
+    /// object; this covers the two prototype sources a plain object can have.
+    /// </summary>
+    [Theory]
+    [InlineData("var proto = { shared: 'from-proto' }; var o = Object.create(proto);")]
+    [InlineData("Object.prototype.shared = 'from-proto'; var o = {};")]
+    public void APlainObjectShadowsItsPrototypeOnTheReadAfterTheOwnPropertyAppears(string setup)
+    {
+        var script = $$"""
+            {{setup}}
+            var out = [];
+            for (var i = 0; i < 4; i++) {
+                if (i === 2) { o.shared = 'own'; }
+                out.push(o.shared);
+            }
+            out.join(',');
+            """;
+        new Engine().Evaluate(script).AsString().Should().Be("from-proto,from-proto,own,own");
     }
 
     [Fact]

--- a/Jint/Native/Function/Function.cs
+++ b/Jint/Native/Function/Function.cs
@@ -330,7 +330,16 @@ public abstract partial class Function : ObjectInstance, ICallable
         else
         {
             base.SetOwnProperty(property, desc);
+            return;
         }
+
+        // These own properties live in fields rather than in the property bag, so the base store's version
+        // bump does not run for them. It has to run anyway: every one of them is configurable, so a define
+        // can make the name own again after a delete removed it, and the member-read inline caches read
+        // _propertiesVersion as proof that no own property has appeared to shadow a cached prototype hit.
+        // Materializing a pending descriptor deliberately does not bump — that changes the descriptor, not
+        // which names are own.
+        unchecked { _propertiesVersion++; }
     }
 
     public override void RemoveOwnProperty(JsValue property)
@@ -620,11 +629,20 @@ public abstract partial class Function : ObjectInstance, ICallable
         return $"function {name}() {{ [native code] }}";
     }
 
+    /// <summary>
+    /// A constructor's lazily created <c>prototype</c> object, which serves <c>constructor</c> from a field
+    /// instead of the property bag. It goes through the internal constructor rather than the protected one so
+    /// its type flags are stated rather than derived per type: it does not override
+    /// <see cref="ObjectInstance.Get(JsValue, JsValue)"/>, so the derivation would answer
+    /// <see cref="Native.Object.PropertyAccessSemantics.Ordinary"/> — correct, but it would also put an in-box
+    /// type on the lane meant for objects whose own-property set the engine cannot version, and this one keeps
+    /// its version accurate itself (below).
+    /// </summary>
     private sealed class ObjectInstanceWithConstructor : ObjectInstance
     {
         private PropertyDescriptor? _constructor;
 
-        public ObjectInstanceWithConstructor(Engine engine, ObjectInstance thisObj) : base(engine)
+        public ObjectInstanceWithConstructor(Engine engine, ObjectInstance thisObj) : base(engine, ObjectClass.Object)
         {
             _constructor = new PropertyDescriptor(thisObj, PropertyFlag.NonEnumerable);
         }
@@ -656,7 +674,11 @@ public abstract partial class Function : ObjectInstance, ICallable
         {
             if (CommonProperties.Constructor.Equals(property))
             {
+                // Same reason as Function.SetOwnProperty: the field is own-property storage the base store's
+                // version bump never sees, and `constructor` is configurable, so it can be deleted and defined
+                // again while a member-read inline cache holds a prototype hit for that name.
                 _constructor = desc;
+                unchecked { _propertiesVersion++; }
             }
             else
             {
@@ -669,6 +691,7 @@ public abstract partial class Function : ObjectInstance, ICallable
             if (CommonProperties.Constructor.Equals(property))
             {
                 _constructor = null;
+                unchecked { _propertiesVersion++; }
             }
             else
             {

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -39,7 +39,8 @@ internal sealed class JintMemberExpression : JintExpression
     // prototype's dictionary. Validity: same receiver (so a per-site monomorphic hit), receiver own-shape
     // unchanged (no own property added that would shadow), direct prototype unchanged (not re-pointed),
     // and the holder's own-property shape unchanged (method not redefined/removed). Exotic receivers and
-    // prototypes (Proxy/TypedArray/IteratorResult) are excluded via InternalTypes.ExoticGet.
+    // prototypes (Proxy/TypedArray/IteratorResult) are excluded via InternalTypes.ExoticGet, and objects
+    // whose _propertiesVersion cannot witness this property name are excluded by CanCacheAgainstVersions.
     private ObjectInstance? _cachedProtoReceiver;
     private uint _cachedProtoReceiverVersion;
     private ObjectInstance? _cachedProtoHolder;
@@ -697,8 +698,9 @@ internal sealed class JintMemberExpression : JintExpression
     }
 
     /// <summary>
-    /// Read completion for receivers outside the shape / plain-object lanes. A host object that declared
-    /// <see cref="PropertyAccessSemantics.Ordinary"/> resolves from a single own-property probe. Otherwise an
+    /// Read completion for receivers outside the shape / plain-object lanes. A host object resolved to
+    /// <see cref="PropertyAccessSemantics.Ordinary"/> resolves from a single own-property probe, which also
+    /// re-establishes the own miss the prototype-method cache needs. Otherwise an
     /// <see cref="ObjectWrapper"/> receiver consults the wrapper member cache: on a hit (same wrapper instance,
     /// unchanged <c>_propertiesVersion</c>) the stored descriptor is still exactly what <c>ObjectWrapper.Get</c>'s
     /// own-property probe would return, so it unwraps directly — for a CLR property that re-invokes the CLR
@@ -710,30 +712,27 @@ internal sealed class JintMemberExpression : JintExpression
     {
         if ((baseObject._type & InternalTypes.OrdinaryGet) != InternalTypes.Empty)
         {
-            // A host-defined object that promised ordinary [[Get]]. The prototype-method cache goes first: a
-            // warm hit already proved this name resolves on the prototype for this receiver, so probing the
-            // host again would undo the whole point of the cache (a member node reads one name, so a site that
-            // hits here is never an own-property site). It is one null test when it does not apply.
-            var protoHolder = _cachedProtoHolder;
-            if (protoHolder is not null && TryReadFromPrototypeCache(baseObject, protoHolder, out var cachedValue))
-            {
-                return cachedValue;
-            }
-
-            // Otherwise the probe that proves the own property exists *is* the read: the descriptor no longer
-            // has to be materialized a second time inside Get (ObjectInstance.Get's fast path needs
-            // PlainObject, which such an object cannot claim because it stores nothing in _properties). On a
-            // miss the probe also discharges ReadAfterOwnMissUncached's shadow re-check, and — unlike the
-            // ExoticGet receivers that share this method — the prototype-method cache may then be populated.
+            // A host-defined object with ordinary [[Get]]. Its own properties live in the host, not in the
+            // engine's property bag, so nothing moves _propertiesVersion when that set changes and the version
+            // cannot stand in for "this receiver still has no own property of this name" — a projected member
+            // that appears after a prototype read was cached must shadow it from the very next read.
+            //
+            // The question is answered by the same probe that reads the value, so the probe goes first, and
+            // the prototype-method cache is consulted only once it has missed. That order is also the whole
+            // reason such a receiver may be cached at all: it is the only lane that reaches the cache with one,
+            // and it re-proves the own miss before every consult (see CanCacheAgainstVersions).
             var ownDescriptor = baseObject.GetOwnProperty(property);
             if (!ReferenceEquals(ownDescriptor, PropertyDescriptor.Undefined))
             {
+                // The probe that proves the own property exists *is* the read: the descriptor no longer has to
+                // be materialized a second time inside Get (ObjectInstance.Get's fast path needs PlainObject,
+                // which such an object cannot claim because it stores nothing in _properties).
                 var ownValue = ObjectInstance.UnwrapJsValue(ownDescriptor, baseObject);
                 AssertOrdinaryGetAgrees(baseObject, property, ownValue);
                 return ownValue;
             }
 
-            var inheritedValue = ReadAfterOwnMissUncached(baseObject, property, ownMissConfirmed: true);
+            var inheritedValue = ReadAfterOwnMiss(baseObject, property, ownMissConfirmed: true);
             AssertOrdinaryGetAgrees(baseObject, property, inheritedValue);
             return inheritedValue;
         }
@@ -819,8 +818,9 @@ internal sealed class JintMemberExpression : JintExpression
 
     /// <summary>
     /// The prototype-method inline cache's validity check, split out so the ordinary-semantics lane can consult
-    /// it before probing the receiver. <paramref name="holder"/> is the already-loaded <c>_cachedProtoHolder</c>,
-    /// non-null.
+    /// it after probing the receiver. <paramref name="holder"/> is the already-loaded <c>_cachedProtoHolder</c>,
+    /// non-null. Both version comparisons are only meaningful because
+    /// <see cref="CanCacheAgainstVersions"/> refused to create an entry whose versions cannot witness the name.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool TryReadFromPrototypeCache(ObjectInstance baseObject, ObjectInstance holder, out JsValue value)
@@ -859,7 +859,8 @@ internal sealed class JintMemberExpression : JintExpression
             {
                 // ...and an own property on the *direct* prototype (deeper chains fall to the slow Get).
                 var descriptor = proto.GetOwnProperty(property);
-                if (!ReferenceEquals(descriptor, PropertyDescriptor.Undefined))
+                if (!ReferenceEquals(descriptor, PropertyDescriptor.Undefined)
+                    && CanCacheAgainstVersions(baseObject, proto, property))
                 {
                     _cachedProtoReceiver = baseObject;
                     _cachedProtoReceiverVersion = baseObject._propertiesVersion;
@@ -872,6 +873,49 @@ internal sealed class JintMemberExpression : JintExpression
         }
 
         return baseObject.Get(property, baseObject);
+    }
+
+    /// <summary>
+    /// Whether an entry may be created for this (receiver, holder, name) triple — that is, whether the two
+    /// <c>_propertiesVersion</c> comparisons <see cref="TryReadFromPrototypeCache"/> makes can still prove, on a
+    /// later read, that the name is absent from the receiver and owned by the holder.
+    /// <para>
+    /// A version only witnesses the own properties the engine stores itself. Two kinds of object keep some of
+    /// theirs elsewhere and move no version when that part of the set changes: an <b>array</b>, whose elements
+    /// live in its own dense/sparse storage and are written straight there by the hot element paths, and a
+    /// <b>host-defined subclass</b> with ordinary reads, whose whole own-property set lives outside the engine.
+    /// So an array must not be validated by its version for an index-like name, and a host object must not be
+    /// validated by its version for any name.
+    /// </para>
+    /// <para>
+    /// The receiver side has one exemption: <see cref="ReadFromNonPlainReceiver"/> is the only lane that reaches
+    /// this cache with a host receiver, and it establishes the own miss with a real probe before every consult,
+    /// so that receiver's frozen version is never load-bearing. A holder has no such lane and must be witnessed
+    /// outright.
+    /// </para>
+    /// </summary>
+    private static bool CanCacheAgainstVersions(ObjectInstance receiver, ObjectInstance holder, JsString property)
+    {
+        var receiverIsProvable = (receiver._type & InternalTypes.OrdinaryGet) != InternalTypes.Empty
+                                 || VersionWitnessesOwnProperty(receiver, property);
+
+        return receiverIsProvable && VersionWitnessesOwnProperty(holder, property);
+    }
+
+    /// <summary>
+    /// Whether <paramref name="o"/>'s <c>_propertiesVersion</c> moves when a property named
+    /// <paramref name="property"/> joins or leaves its own-property set. See <see cref="CanCacheAgainstVersions"/>
+    /// for the two storage kinds it does not cover.
+    /// </summary>
+    private static bool VersionWitnessesOwnProperty(ObjectInstance o, JsString property)
+    {
+        if ((o._type & InternalTypes.OrdinaryGet) != InternalTypes.Empty)
+        {
+            return false;
+        }
+
+        return (o._type & InternalTypes.Array) == InternalTypes.Empty
+               || !ArrayInstance.IsArrayIndex(property, out _);
     }
 
     /// <summary>


### PR DESCRIPTION
```js
function C() {}
var c = new C(), out = [];
for (var i = 0; i < 4; i++) {
    if (i === 2) { delete C.prototype.constructor; }
    out.push(c.constructor === C);
}
out.join(',');   // "true,true,true,true" — should be "true,true,false,false"
```

An ordinary constructor, an ordinary instance, an ordinary `delete`, and the read keeps answering the deleted property. No host object, no interop, no configuration.

**Test262 does not catch it**, and cannot as written: the member-read caches are per-AST-node and only warm on repeated reads through the *same* node. A conformance test reads each expression once, so every read there compiles its own node and starts cold. The bug only shows up in a loop, or in any function called more than once.

## What is going on

The prototype-method inline cache in `JintMemberExpression` decides an entry is still good from receiver identity plus `ObjectInstance._propertiesVersion`: same receiver, same version, same direct prototype, same holder version. The receiver version stands in for *"no own property of this name has appeared since we cached the prototype's"*, and the holder version for *"the prototype still owns it"*.

A version only witnesses the own properties **the engine stores itself**. Three kinds of object keep some of theirs elsewhere and move no version when that part of the set changes.

### 1. Own properties held in fields

A constructor prototype's `constructor` (above), and a function's `name` and `length`: all configurable, all stored in fields rather than in the property bag. `RemoveOwnProperty` bumped the version, `SetOwnProperty` did not.

```js
function f() {}
delete f.name;                 // ← load-bearing, and must come first
var out = [];
for (var i = 0; i < 4; i++) {
    if (i === 2) { Object.defineProperty(f, 'name', { value: 'own', configurable: true }); }
    out.push(f.name);
}
out.join(',');   // ",,," — should be ",,own,own"
```

The `delete` is what makes the opening read miss the own property and cache `Function.prototype.name`. Defining over a `name` that is **still own** is an own-property hit throughout, caches nothing, and was always correct — so that variant is not affected and is not claimed here.

### 2. An array, for a *string-keyed* index read

Elements live in dense/sparse storage the hot element paths write directly, so a `push` makes an index own without a bump:

```js
Array.prototype[0] = 'proto';
var a = [], out = [];
for (var i = 0; i < 4; i++) {
    if (i === 2) { a.push('own'); }
    out.push(a['0']);            // ← string literal
}
out.join(',');   // "proto,proto,proto,proto" — should be "proto,proto,own,own"
```

**Only that spelling.** `a[0]` and `a[k]` resolve through the dense-array lanes, which never consult this cache and were already correct. A test pins that difference so the exclusion is not read as broader than it is.

### 3. A host `ObjectInstance` subclass that manages its own storage

The documented way to project native data: override `GetOwnProperty`, keep the members in your own dictionary. Nothing ever touches `_properties`, so the version is frozen for the object's whole lifetime and a projected member appearing after a prototype read was cached never shadows it. The same object used **as a prototype** is worse — reprojecting or dropping a member is invisible too, and the descriptor is rebuilt per probe, so even a value change is lost.

## What was already correct — and why that matters

Receivers whose own-property set the engine *does* store, and therefore versions, all answered correctly before this change: a plain object shadowing an inherited property (from `Object.create` or from `Object.prototype`), `a.length`, `for (var p in a)` over an array that gains an element, and both computed index spellings.

That places the defect precisely. **It is not a general flaw in the prototype-method cache** — it is the set of receivers whose `_propertiesVersion` was taken to describe them. Those controls are now tests.

## Not new

All of it reproduces identically on the commit **before** host access semantics became derived, where a host subclass carried no flag at all and reached the same cache consult with no own probe. Deriving *narrowed* the exposed set rather than widening it — a host that overrides `Get` is now exotic and excluded outright — but it did not touch this.

## The fix, and the regression it costs

`CanCacheAgainstVersions` refuses to create an entry whose versions cannot witness the name, and the field-backed cases start moving their version so that they can. The array exclusion is **by name**, so only index-like names give up the cache and `arr.push` / `arr.slice` keep it; the check runs once, when an entry is created.

The receiver side has one exemption, and it is where the cost lands. `ReadFromNonPlainReceiver` is the only lane that reaches this cache with a host receiver, so it now probes `GetOwnProperty` **before** consulting the cache instead of after, re-establishing the own miss on every read.

> **This is a regression, and it is the order #2804 deliberately avoided.** A warm prototype read off a host receiver goes from **0 probes to 1**, so ten iterations of `host.protoMethod()` cost ten probes rather than one — partially undoing a case that PR was measured on.

The reasoning for accepting it: correctness is not optional, and the alternative is answering from a prototype the receiver now shadows. The cache still earns the read — **1 probe rather than the 2 an uncached read pays**, and no prototype walk. `AWarmPrototypeReadProbesTheHostOncePerRead` records the new number and why it cannot be lower. No other receiver family changes cost; the new check is two flag tests on the populate path.

Two alternatives were rejected, both for reasons a reviewer should not have to reconstruct:

- **A `protected InvalidatePropertyCaches()`.** Leaves every host that does not know the API exists still wrong — the same failure mode that made *declaring* the semantics the wrong shape in the first place.
- **Deriving `Exotic` for every `GetOwnProperty` override.** Safe, but forfeits the single-probe lane for exactly the lazily projecting host it was built for.

## The other per-node caches

Unaffected for host receivers, structurally: the own-property and shape lanes are gated on `InternalTypes.PlainObject` / `ShapeMode`, which only the internal constructor and the sealed `JsObject` can supply, and the wrapper lane requires the receiver's exact type to be `ObjectWrapper` (whose constructor is internal, so it cannot be subclassed from outside either). A host subclass reaches none of them — which is why a projected *value* change is already seen on every read. Covered by a test so a future change cannot quietly extend one of them to host receivers.

## Also here

- A constructor's lazily created `prototype` object takes the internal constructor rather than the protected one, so an in-box type states its flags instead of having them derived per type, and stays off the lane meant for objects whose own-property set the engine cannot version.
- `PrototypeMethodCacheTests`' classification comment claimed `ArrayInstance` was "safe without the flag"; that reasoning only covered the own properties an array has at populate time, and is corrected.

Code and tests only — no documentation changes, to stay out of the way of the `AGENTS.md`/`CLAUDE.md` consolidation in flight. The integration notes there still quote pre-derivation probe counts; the numbers this change moves live in `HostObjectSemanticsTests` and `HostObjectProbeCountTests`, which carry both a Release and a Debug column.

## Verification

Baseline measured on clean `main` first; every number is identical to it except the added tests (10 in `Jint.Tests`, 7 in `PublicInterface`).

| | baseline | this branch |
| --- | --- | --- |
| `Jint.Tests` net10.0 / net472 | 4280 / 4212 | 4290 / 4222 |
| `Jint.Tests.PublicInterface` net10.0 / net472 | 335 / 335 | 342 / 342 |
| `Jint.Tests.PublicInterface` **Debug** net10.0 | — | 342 |
| `Jint.Tests.Test262` | 99441 / 0 failed / 157 skipped | **99441 / 0 / 157** |
| `Jint.Tests.CommonScripts` net10.0 / net472 | — | 28 / 28 |

Release build clean; the only warning is the pre-existing `MSB3277` in `Jint.Tests.CommonScripts` net472, present on clean `main` too. Suites re-run after the rebase onto `4948603`. No benchmarks or profilers were run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
