### PR TITLE
Fix eval var destructuring in direct eval

### DIFF
--- a/Jint.Tests/Runtime/EvalTests.cs
+++ b/Jint.Tests/Runtime/EvalTests.cs
@@ -119,6 +119,46 @@ public class EvalTests
     }
 
     [Fact]
+    public void SloppyDirectEvalSupportsVarDestructuring()
+    {
+        var engine = new Engine();
+
+        var result = engine.Evaluate("""
+            try {
+                eval('var { first: f, last: l } = { first: "Jane", last: "Doe" }');
+                f + " " + l;
+            } catch (error) {
+                "caught";
+            }
+            """);
+
+        result.AsString().Should().Be("Jane Doe");
+    }
+
+    [Fact]
+    public void SloppyDirectEvalSupportsVarDestructuringInNestedScopes()
+    {
+        var engine = new Engine();
+
+        var result = engine.Evaluate("""
+            function blockScope() {
+                {
+                    let outer = 0;
+                    eval('var { blockResult } = { blockResult: "block" }');
+                }
+                return blockResult;
+            }
+            function parameterScope(parameter = 0) {
+                eval('var { parameterResult } = { parameterResult: "parameter" }');
+                return parameterResult;
+            }
+            [blockScope(), parameterScope()].join(",");
+            """);
+
+        result.AsString().Should().Be("block,parameter");
+    }
+
+    [Fact]
     public void IndirectEvalWithUseStrictKeepsVarsLocal()
     {
         var engine = new Engine();

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1966,7 +1966,7 @@ public sealed partial class Engine : IDisposable
                     var varName = varNames[i];
                     if (globalEnvironmentRecord.HasLexicalDeclaration(varName))
                     {
-                        Throw.SyntaxError(realm, "Identifier '" + varName + "' has already been declared");
+                        Throw.SyntaxError(realm, $"Identifier '{varName}' has already been declared");
                     }
                 }
             }

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1958,16 +1958,15 @@ public sealed partial class Engine : IDisposable
 
         if (!strict && hoistingScope._variablesDeclarations != null)
         {
+            var varNames = script.GetVarNames(hoistingScope);
             if (varEnvRec is GlobalEnvironment globalEnvironmentRecord)
             {
-                ref readonly var nodes = ref hoistingScope._variablesDeclarations;
-                for (var i = 0; i < nodes.Count; i++)
+                for (var i = 0; i < varNames.Count; i++)
                 {
-                    var variablesDeclaration = nodes[i];
-                    var identifier = (Identifier) variablesDeclaration.Declarations[0].Id;
-                    if (globalEnvironmentRecord.HasLexicalDeclaration(identifier.Name))
+                    var varName = varNames[i];
+                    if (globalEnvironmentRecord.HasLexicalDeclaration(varName))
                     {
-                        Throw.SyntaxError(realm, "Identifier '" + identifier.Name + "' has already been declared");
+                        Throw.SyntaxError(realm, "Identifier '" + varName + "' has already been declared");
                     }
                 }
             }
@@ -1980,14 +1979,12 @@ public sealed partial class Engine : IDisposable
                 // are allowed to shadow catch parameters in non-strict mode
                 if (thisEnvRec is not ObjectEnvironment && thisEnvRec is not DeclarativeEnvironment { _catchEnvironment: true })
                 {
-                    ref readonly var nodes = ref hoistingScope._variablesDeclarations;
-                    for (var i = 0; i < nodes.Count; i++)
+                    for (var i = 0; i < varNames.Count; i++)
                     {
-                        var variablesDeclaration = nodes[i];
-                        var identifier = (Identifier) variablesDeclaration.Declarations[0].Id;
-                        if (thisEnvRec.HasBinding(identifier.Name))
+                        var varName = varNames[i];
+                        if (thisEnvRec.HasBinding(varName))
                         {
-                            Throw.SyntaxError(realm, $"Identifier '{identifier.Name}' has already been declared");
+                            Throw.SyntaxError(realm, $"Identifier '{varName}' has already been declared");
                         }
                     }
                 }
@@ -2004,24 +2001,22 @@ public sealed partial class Engine : IDisposable
             // this is a simple function without hasParameterExpressions and we don't need this check.
             if (varEnv is DeclarativeEnvironment and not FunctionEnvironment && varEnv._outerEnv is FunctionEnvironment funcEnv)
             {
-                ref readonly var nodes = ref hoistingScope._variablesDeclarations;
-                for (var i = 0; i < nodes.Count; i++)
+                for (var i = 0; i < varNames.Count; i++)
                 {
-                    var variablesDeclaration = nodes[i];
-                    var identifier = (Identifier) variablesDeclaration.Declarations[0].Id;
-                    if (funcEnv.HasBinding(identifier.Name))
+                    var varName = varNames[i];
+                    if (funcEnv.HasBinding(varName))
                     {
-                        Throw.SyntaxError(realm, $"Identifier '{identifier.Name}' has already been declared");
+                        Throw.SyntaxError(realm, $"Identifier '{varName}' has already been declared");
                     }
 
                     // Non-arrow functions always have an implicit "arguments" binding per spec
                     // (10.2.11 FunctionDeclarationInstantiation steps 17-21), even when the
                     // arguments object creation was optimized away because the function body
                     // doesn't reference "arguments". Detect this implicit binding conflict.
-                    if (string.Equals(identifier.Name, "arguments", StringComparison.Ordinal)
+                    if (string.Equals(varName.Name, "arguments", StringComparison.Ordinal)
                         && funcEnv._functionObject._thisMode != FunctionThisMode.Lexical)
                     {
-                        Throw.SyntaxError(realm, $"Identifier '{identifier.Name}' has already been declared");
+                        Throw.SyntaxError(realm, $"Identifier '{varName}' has already been declared");
                     }
                 }
             }

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1958,6 +1958,8 @@ public sealed partial class Engine : IDisposable
 
         if (!strict && hoistingScope._variablesDeclarations != null)
         {
+            void ThrowDuplicateBindingError(Key name) => Throw.SyntaxError(realm, $"Identifier '{name}' has already been declared");
+
             var varNames = script.GetVarNames(hoistingScope);
             if (varEnvRec is GlobalEnvironment globalEnvironmentRecord)
             {
@@ -1966,7 +1968,7 @@ public sealed partial class Engine : IDisposable
                     var varName = varNames[i];
                     if (globalEnvironmentRecord.HasLexicalDeclaration(varName))
                     {
-                        Throw.SyntaxError(realm, $"Identifier '{varName}' has already been declared");
+                        ThrowDuplicateBindingError(varName);
                     }
                 }
             }
@@ -1984,7 +1986,7 @@ public sealed partial class Engine : IDisposable
                         var varName = varNames[i];
                         if (thisEnvRec.HasBinding(varName))
                         {
-                            Throw.SyntaxError(realm, $"Identifier '{varName}' has already been declared");
+                            ThrowDuplicateBindingError(varName);
                         }
                     }
                 }
@@ -2006,7 +2008,7 @@ public sealed partial class Engine : IDisposable
                     var varName = varNames[i];
                     if (funcEnv.HasBinding(varName))
                     {
-                        Throw.SyntaxError(realm, $"Identifier '{varName}' has already been declared");
+                        ThrowDuplicateBindingError(varName);
                     }
 
                     // Non-arrow functions always have an implicit "arguments" binding per spec
@@ -2016,7 +2018,7 @@ public sealed partial class Engine : IDisposable
                     if (string.Equals(varName.Name, "arguments", StringComparison.Ordinal)
                         && funcEnv._functionObject._thisMode != FunctionThisMode.Lexical)
                     {
-                        Throw.SyntaxError(realm, $"Identifier '{varName}' has already been declared");
+                        ThrowDuplicateBindingError(varName);
                     }
                 }
             }


### PR DESCRIPTION
Fixes #2825

Use the complete bound-name list for sloppy direct-eval declaration checks, so destructuring patterns and multi-declarator var statements do not assume an Identifier AST node. Adds regressions for global, block-lexical, and parameter environments.