### PR TITLE
Make the cyclic-module error state machine match the spec

### DIFF
--- a/Jint.Tests/Runtime/ModuleTests.cs
+++ b/Jint.Tests/Runtime/ModuleTests.cs
@@ -1096,4 +1096,101 @@ export const count = globals.counter;
         // Must not be SyntaxError per test262 expectations for SourceTextModule source phase.
         ex.Error.Get("name").AsString().Should().NotBe("SyntaxError");
     }
+
+    [Fact]
+    public void ShouldRethrowWhenImportingAModuleThatAlreadyFailed()
+    {
+        // https://tc39.es/ecma262/#sec-moduleevaluation - a module whose evaluation threw stays
+        // EVALUATED with a recorded [[EvaluationError]], and Evaluate() replays it forever after.
+        // The host-facing Import must not hand back a namespace whose bindings were never
+        // initialized. Mirrors test262 language/expressions/dynamic-import/import-errored-module.js.
+        _engine.Modules.Add("my-module", "throw new Error('boom');");
+
+        Invoking(() => _engine.Modules.Import("my-module")).Should().ThrowExactly<JavaScriptException>()
+            .Which.Message.Should().Be("boom");
+
+        Invoking(() => _engine.Modules.Import("my-module")).Should().ThrowExactly<JavaScriptException>()
+            .Which.Message.Should().Be("boom");
+    }
+
+    [Fact]
+    public void ShouldRethrowWhenAnotherEntryPointImportsAModuleThatAlreadyThrew()
+    {
+        // https://tc39.es/ecma262/#sec-innermoduleevaluation step 13.a is `Perform ?
+        // module.ExecuteModule()`: an abrupt execution returns at once, so the throwing module
+        // stays on the stack and Evaluate() step 9.a.iii records the error on it. If it were
+        // popped and marked EVALUATED with an empty [[EvaluationError]] instead, a second entry
+        // point importing it would evaluate happily against uninitialized bindings.
+        _engine.Modules.Add("throws", "export const value = 1; throw new Error('boom');");
+        _engine.Modules.Add("first", "import 'throws';");
+        _engine.Modules.Add("second", "import { value } from 'throws'; globalThis.seen = value;");
+
+        Invoking(() => _engine.Modules.Import("first")).Should().ThrowExactly<JavaScriptException>()
+            .Which.Message.Should().Be("boom");
+
+        Invoking(() => _engine.Modules.Import("second")).Should().ThrowExactly<JavaScriptException>()
+            .Which.Message.Should().Be("boom");
+    }
+
+    [Fact]
+    public void ShouldReplayTheEvaluationErrorWhenReevaluatingAModuleWithoutACycleRoot()
+    {
+        // https://tc39.es/ecma262/#sec-moduleevaluation step 3: the redirect to [[CycleRoot]] is
+        // guarded by "If module.[[CycleRoot]] is not empty". A module marked EVALUATED by step
+        // 9.a - because a dependency threw - never reached the InnerModuleEvaluation pop loop that
+        // assigns [[CycleRoot]], so it keeps an empty one and stays the subject of the evaluation.
+        _engine.Modules.Add("throws", "throw new Error('boom');");
+        _engine.Modules.Add("main", "import 'throws';");
+
+        Invoking(() => _engine.Modules.Import("main")).Should().ThrowExactly<JavaScriptException>()
+            .Which.Message.Should().Be("boom");
+
+        _engine.Evaluate("globalThis.outcome = null; import('main').then(() => { globalThis.outcome = 'resolved'; }, e => { globalThis.outcome = e.message; });");
+        _engine.Advanced.ProcessTasks();
+
+        _engine.Evaluate("globalThis.outcome").AsString().Should().Be("boom");
+    }
+
+    [Fact]
+    public void ShouldRecordTheEvaluationErrorOnEveryMemberOfAFailedCycle()
+    {
+        // https://tc39.es/ecma262/#sec-innermoduleevaluation ends with "Return index"; Jint used to
+        // return the execution completion instead, so the DFS counter collapsed to 0 (ToInt32 of
+        // undefined) after the first synchronous dependency. Every later sibling then saw
+        // moduleIndex == [[DFSAncestorIndex]] and popped itself out of the strongly connected
+        // component, becoming its own [[CycleRoot]] and going EVALUATED before the real root ran.
+        // 'member' is genuinely part of the cycle {root, member} and must therefore be marked
+        // EVALUATED *with* root's [[EvaluationError]] by Evaluate() step 9.a.
+        _engine.Modules.Add("leaf", "export const v = 1;");
+        _engine.Modules.Add("member", "import 'root'; export const w = 2;");
+        _engine.Modules.Add("root", "import 'leaf'; import 'member'; throw new Error('root-boom');");
+        _engine.Modules.Add("other", "import { w } from 'member'; globalThis.seen = w;");
+
+        Invoking(() => _engine.Modules.Import("root")).Should().ThrowExactly<JavaScriptException>()
+            .Which.Message.Should().Be("root-boom");
+
+        Invoking(() => _engine.Modules.Import("other")).Should().ThrowExactly<JavaScriptException>()
+            .Which.Message.Should().Be("root-boom");
+    }
+
+    [Fact]
+    public void ShouldNotExecuteAnAsyncParentThatAlreadyFailed()
+    {
+        // https://tc39.es/ecma262/#sec-async-module-execution-fulfilled step 12.a: a module of
+        // sortedExecList whose [[Status]] is already EVALUATED must be skipped (its
+        // [[EvaluationError]] is not empty). Here 'mid' throws when the exec list is drained, and
+        // AsyncModuleExecutionRejected propagates that to its async parent 'top' - which appears
+        // later in the very same list. Executing 'top' anyway would run a module body the spec
+        // never runs.
+        var log = new List<string>();
+        _engine.SetValue("log", log.Add);
+        _engine.Modules.Add("async-dep", "await 0; export const x = 1;");
+        _engine.Modules.Add("mid", "import 'async-dep'; log('mid'); throw new Error('mid-boom');");
+        _engine.Modules.Add("top", "import 'mid'; log('top');");
+
+        Invoking(() => _engine.Modules.Import("top")).Should().ThrowExactly<JavaScriptException>()
+            .Which.Message.Should().Be("mid-boom");
+
+        log.Should().Equal("mid");
+    }
 }

--- a/Jint/Engine.Modules.cs
+++ b/Jint/Engine.Modules.cs
@@ -176,6 +176,16 @@ public partial class Engine
                     Throw.NotSupportedException($"Error while evaluating module: Module is in an invalid state: '{cyclicModule.Status}'");
                 }
             }
+            else if (cyclicModule.Status == ModuleStatus.Evaluated)
+            {
+                // The module has already been evaluated - either as its own entry point or as a
+                // dependency of some other graph. https://tc39.es/ecma262/#sec-ContinueDynamicImport
+                // evaluates it again regardless, and https://tc39.es/ecma262/#sec-moduleevaluation
+                // makes that a no-op that hands back the already settled promise, with one exception:
+                // a module whose evaluation threw replays its recorded [[EvaluationError]]. Skipping
+                // the call returned a namespace over bindings the failed evaluation never initialized.
+                _engine.ExecuteWithConstraints(true, () => EvaluateModule(request.Specifier, cyclicModule));
+            }
 
             _engine.RunAvailableContinuations();
 

--- a/Jint/Runtime/Modules/CyclicModule.cs
+++ b/Jint/Runtime/Modules/CyclicModule.cs
@@ -100,8 +100,16 @@ public abstract class CyclicModule : Module
         var module = this;
 
         // https://tc39.es/ecma262/#sec-moduleevaluation
-        // Step 4: If module.[[Status]] is either evaluating-async or evaluated, set module to module.[[CycleRoot]].
-        if (module.Status is ModuleStatus.EvaluatingAsync or ModuleStatus.Evaluated)
+        // Step 3: If module.[[Status]] is either evaluating-async or evaluated, then
+        //   a. If module.[[CycleRoot]] is not empty, then
+        //      i. Set module to module.[[CycleRoot]].
+        //   b. Else,
+        //      i. Assert: module.[[Status]] is evaluated and module.[[EvaluationError]] is a throw completion.
+        // The guard is load-bearing: only the InnerModuleEvaluation pop loop assigns [[CycleRoot]],
+        // and a module marked evaluated by step 9.a below - because a dependency threw before the
+        // loop could reach it - never got one. Such a module stays the subject of the evaluation and
+        // replays its own recorded [[EvaluationError]] through InnerModuleEvaluation.
+        if ((module.Status is ModuleStatus.EvaluatingAsync or ModuleStatus.Evaluated) && module._cycleRoot is not null)
         {
             module = module._cycleRoot;
         }
@@ -391,7 +399,6 @@ public abstract class CyclicModule : Module
             }
         }
 
-        Completion completion;
         if (_pendingAsyncDependencies > 0 || _hasTLA)
         {
             if (_asyncEvaluation)
@@ -403,20 +410,28 @@ public abstract class CyclicModule : Module
             _asyncEvalOrder = asyncEvalOrder++;
             if (_pendingAsyncDependencies == 0)
             {
-                // No pending dependencies, execute immediately
-                completion = ExecuteAsyncModule();
+                // Step 12.c: If module.[[PendingAsyncDependencies]] = 0, perform ExecuteAsyncModule(module).
+                // ExecuteAsyncModule returns unused - it routes both outcomes through the module's own
+                // promise capability - so there is no completion to propagate from here.
+                ExecuteAsyncModule();
             }
-            else
-            {
-                // Has pending async dependencies - don't execute yet.
-                // The module will be executed by AsyncModuleExecutionFulfilled
-                // when all dependencies complete.
-                completion = new Completion(CompletionType.Normal, index, default);
-            }
+
+            // Otherwise the module has pending async dependencies and must not execute yet:
+            // AsyncModuleExecutionFulfilled runs it once they all complete.
         }
         else
         {
-            completion = ExecuteModule();
+            // Step 13.a: Perform ? module.ExecuteModule().
+            // The "?" is load-bearing. On an abrupt execution InnerModuleEvaluation returns at once,
+            // leaving this module and every unfinished ancestor on the stack so that Evaluate() step
+            // 9.a can mark them all evaluated *with* the evaluation error. Falling through to the pop
+            // loop below instead stranded them as evaluated with an empty [[EvaluationError]], and a
+            // later import then resolved against bindings the failed evaluation never initialized.
+            var completion = ExecuteModule();
+            if (completion.Type != CompletionType.Normal)
+            {
+                return completion;
+            }
         }
 
         if (StackReferenceCount(stack) != 1)
@@ -449,7 +464,14 @@ public abstract class CyclicModule : Module
             }
         }
 
-        return completion;
+        // Step 17: Return index.
+        // This is the DFS counter, not the module's execution completion. Returning the latter made
+        // the caller's step 11.b (`index = TypeConverter.ToInt32(result.Value)`) read ToInt32 of the
+        // completion value - undefined, so 0 - which collapsed the counter: every sibling visited
+        // after the first synchronous dependency then started at index 0, saw
+        // moduleIndex == [[DFSAncestorIndex]], and popped itself out of its strongly connected
+        // component as its own [[CycleRoot]] before the real root had executed.
+        return new Completion(CompletionType.Normal, index, default);
     }
 
     private int StackReferenceCount(Stack<CyclicModule> stack)
@@ -540,9 +562,18 @@ public abstract class CyclicModule : Module
         for (var i = 0; i < execList.Count; i++)
         {
             var m = execList[i];
-            if (m.Status == ModuleStatus.Evaluated && m._evalError is null)
+
+            // Step 12.a: If m.[[Status]] is evaluated, then i. Assert: m.[[EvaluationError]] is not empty.
+            // Nothing else happens for such a module. An earlier element of sortedExecList can reject
+            // and, through AsyncModuleExecutionRejected, record the error on its async parents - which
+            // may sit later in this very list. Those are finished; executing them anyway would run a
+            // module body the spec never runs and resolve a capability that was already rejected.
+            if (m.Status == ModuleStatus.Evaluated)
             {
-                Throw.InvalidOperationException("Error while evaluating module: Module is in an invalid state");
+                if (m._evalError is null)
+                {
+                    Throw.InvalidOperationException("Error while evaluating module: Module is in an invalid state");
+                }
             }
             else if (m._hasTLA)
             {


### PR DESCRIPTION
This makes the cyclic-module error state machine match the spec on five points found during the v4.15.0 pre-release review. They are pre-existing defects (v4.14.0 ships identical behaviour), one state machine, and three of them are interdependent — shipping the first without the second would turn a silent wrong answer into a `NullReferenceException`.

Each fix was proven load-bearing individually: the five regression tests were red on unmodified main, and reverting each fix in isolation re-reddens exactly the tests it carries.

* An abrupt `ExecuteModule` completion no longer runs the DFS pop loop, so the module records its evaluation error instead of leaving later importers to evaluate against uninitialized bindings (`sec-innermoduleevaluation` step 13.a). Before, a second entry point importing an already-thrown dependency evaluated happily.
* `Evaluate()` guards `[[CycleRoot]]` per `sec-moduleevaluation` step 3 — re-evaluating a module that failed without a cycle root replays the recorded error instead of throwing a `NullReferenceException` out of the engine.
* `AsyncModuleExecutionFulfilled` skips parents that are already EVALUATED-with-error (`sec-async-module-execution-fulfilled` step 12.a); before, a failed async parent's body ran anyway.
* `InnerModuleEvaluation` returns its DFS `index` instead of the execution completion value; `ToInt32(undefined)` collapsed the counter to 0 and popped every later sibling out of its strongly-connected component as its own `[[CycleRoot]]`, so only the first member of a failed cycle recorded the error.
* `Modules.Import` of an already-evaluated module routes through `Evaluate()` (`sec-ContinueDynamicImport`), so re-importing a module that failed rethrows its recorded error. **Behaviour change for embedders:** this previously returned the namespace as if the import had succeeded.

Spec steps are cited inline at each site. Cross-checked against test262 `dynamic-import/import-errored-module.js`, `import-fulfilled-member-of-errored-cycle.js` and `top-level-await/fulfillment-order.js`.

Gate: full test suite on net10.0 and net472, and a complete Test262 run — 99,441 passed, 0 failed, identical to the baseline run on unmodified main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
