### PR TITLE
Fix the unsound Leaf annotations and extend fast-call coverage

### DIFF
--- a/Jint.SourceGenerators/Attributes.cs
+++ b/Jint.SourceGenerators/Attributes.cs
@@ -73,8 +73,9 @@ internal static class Attributes
             /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
             /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
             /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-            /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-            /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+            /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+            /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+            /// and a body that does would run user code frameless.
             /// </para>
             /// <para>
             /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.SourceGenerators/Models.cs
+++ b/Jint.SourceGenerators/Models.cs
@@ -958,7 +958,9 @@ internal sealed record class FunctionDefinition(
                         var argGuard = GuardForCoercion(p.Kind);
                         if (argGuard is null)
                         {
-                            leafBlocked ??= $"parameter {position} uses a coercion no FastCallGuard can make a no-op";
+                            leafBlocked ??= p.Kind == ParameterKind.ValueAt
+                                ? $"parameter {position} is a plain JsValue, so nothing stops the body coercing it through a user valueOf/toString inside the frameless window — declare the conversion ([ToNumber], [ToInteger], …) so the lane can guard it"
+                                : $"parameter {position} uses a coercion no FastCallGuard can make a no-op";
                         }
                         else
                         {
@@ -1043,13 +1045,19 @@ internal sealed record class FunctionDefinition(
     /// <summary>
     /// The guard under which a parameter coercion provably runs no user code. Every numeric
     /// conversion funnels through <c>ToNumber</c>, whose object path calls <c>valueOf</c>; the string
-    /// ones call <c>toString</c>. A plain <c>JsValue</c> parameter is forwarded untouched, so it
-    /// needs no guard. <c>[ToObject]</c> gets none: it throws for null/undefined, and no guard
-    /// expresses "not nullish".
+    /// ones call <c>toString</c>. <c>[ToObject]</c> gets none: it throws for null/undefined, and no
+    /// guard expresses "not nullish".
+    /// <para>
+    /// A plain <c>JsValue</c> parameter gets none either, which blocks <c>Leaf</c> outright. It used
+    /// to map to <c>Any</c> on the premise that an undeclared parameter is "forwarded untouched" —
+    /// but the generator cannot see the body, and four <c>String.prototype</c> methods took the
+    /// value and coerced it themselves, running user <c>valueOf</c> in a window with no frame. The
+    /// declaration is the only thing the generator can trust, so an undeclared coercion now costs
+    /// the leaf lane rather than silently forfeiting the guard that would have prevented it.
+    /// </para>
     /// </summary>
     private static FastCallGuardKind? GuardForCoercion(ParameterKind kind) => kind switch
     {
-        ParameterKind.ValueAt => FastCallGuardKind.Any,
         ParameterKind.ToNumber => FastCallGuardKind.Number,
         ParameterKind.ToInteger => FastCallGuardKind.Number,
         ParameterKind.ToInt32 => FastCallGuardKind.Number,

--- a/Jint.Tests.SourceGenerators/ObjectGeneratorTests.cs
+++ b/Jint.Tests.SourceGenerators/ObjectGeneratorTests.cs
@@ -1010,8 +1010,8 @@ public class ObjectGeneratorTests
         // Plain (FastCall) reports Supported with no guards — the frame is still pushed, so passing
         // arguments in registers is safe for any value. Leaf additionally reports the guards under
         // which frame elision is legal: [ToNumber] is a no-op for an actual number, [ToJsString] for
-        // an actual string. Absent guards on the second Leaf arg say the body is leaf-safe for any
-        // value there.
+        // an actual string, [ToInteger] for a number again. Every Leaf value parameter must declare
+        // its conversion; an undeclared one is rejected (see LeafOnUnguardableHazards).
         return VerifyGenerator("""
             using Jint;
             using Jint.Native;
@@ -1031,7 +1031,7 @@ public class ObjectGeneratorTests
                 private static JsValue Abs(JsValue thisObject, [ToNumber] double x) => JsNumber.Create(x);
 
                 [JsFunction(Length = 2, Leaf = true)]
-                private static JsValue CharAt(JsValue thisObject, [ToJsString] JsString s, JsValue index) => s;
+                private static JsValue CharAt(JsValue thisObject, [ToJsString] JsString s, [ToInteger] double index) => s;
 
                 [JsFunction(Length = 0)]
                 private static JsValue Untouched(JsValue thisObject) => JsValue.Undefined;
@@ -1213,10 +1213,12 @@ public class ObjectGeneratorTests
     public Task LeafOnUnguardableHazards_ProducesDiagnostic()
     {
         // Frame elision needs every route to user code or a JS error closed off by a guard the
-        // runtime can check. None of these three can be: ObjectInstance has no matching
+        // runtime can check. None of these four can be: ObjectInstance has no matching
         // FastCallGuard, [ToObject] throws for null/undefined and "not nullish" is not expressible,
-        // and [RequireObjectCoercible] on an unguarded 'this' is the same problem. Each is an error
-        // at the declaration rather than a silent downgrade to the non-leaf lane.
+        // [RequireObjectCoercible] on an unguarded 'this' is the same problem, and an undeclared
+        // JsValue parameter hides whatever the body does with it — the shape that let four
+        // String.prototype methods run a user valueOf frameless. Each is an error at the
+        // declaration rather than a silent downgrade to the non-leaf lane.
         return VerifyGenerator("""
             using Jint;
             using Jint.Native;
@@ -1240,6 +1242,9 @@ public class ObjectGeneratorTests
                 [RequireObjectCoercible]
                 [JsFunction(Length = 0, Leaf = true)]
                 private static JsValue NeedsCoercible(JsValue thisObject) => JsValue.Undefined;
+
+                [JsFunction(Length = 1, Leaf = true)]
+                private static JsValue Undeclared(JsValue thisObject, JsValue pos) => pos;
 
                 protected override void Initialize() => CreateProperties_Generated();
             }

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterAndSetter#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterAndSetter#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterOnly#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterOnly#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorWrongArity_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorWrongArity_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ArgCountParameter#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ArgCountParameter#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.CoercedRestSpan#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.CoercedRestSpan#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.CoercedRestSpanTypeMismatch_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.CoercedRestSpanTypeMismatch_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConflictingAccessorFlags_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConflictingAccessorFlags_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConflictingConversionAttrs_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConflictingConversionAttrs_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConversionTypeMismatch_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConversionTypeMismatch_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.DuplicateIntrinsicReference_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.DuplicateIntrinsicReference_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.DuplicateThrower_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.DuplicateThrower_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallLanes#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallLanes#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallLanes#Sample.Foo.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallLanes#Sample.Foo.g.verified.cs
@@ -50,7 +50,7 @@ internal sealed partial class Foo
             switch (_slot)
             {
                 case Slot.Abs: return Foo.Abs(thisObject, global::Jint.Runtime.TypeConverter.ToNumber(global::Jint.Runtime.Arguments.At(arguments, 0)));
-                case Slot.CharAt: return Foo.CharAt(thisObject, global::Jint.Runtime.TypeConverter.ToJsString(global::Jint.Runtime.Arguments.At(arguments, 0)), global::Jint.Runtime.Arguments.At(arguments, 1));
+                case Slot.CharAt: return Foo.CharAt(thisObject, global::Jint.Runtime.TypeConverter.ToJsString(global::Jint.Runtime.Arguments.At(arguments, 0)), global::Jint.Runtime.TypeConverter.ToInteger(global::Jint.Runtime.Arguments.At(arguments, 1)));
                 case Slot.Passthrough: return Foo.Passthrough(thisObject, global::Jint.Runtime.Arguments.At(arguments, 0));
                 case Slot.Untouched: return Foo.Untouched(thisObject);
                 default: throw UnknownSlot(_slot);
@@ -89,7 +89,7 @@ internal sealed partial class Foo
             switch (_slot)
             {
                 case Slot.Abs: return new global::Jint.Native.Function.FastCallShape(true, true, global::Jint.Native.Function.FastCallGuard.Any, global::Jint.Native.Function.FastCallGuard.Number, global::Jint.Native.Function.FastCallGuard.Any);
-                case Slot.CharAt: return new global::Jint.Native.Function.FastCallShape(true, true, global::Jint.Native.Function.FastCallGuard.Any, global::Jint.Native.Function.FastCallGuard.String, global::Jint.Native.Function.FastCallGuard.Any);
+                case Slot.CharAt: return new global::Jint.Native.Function.FastCallShape(true, true, global::Jint.Native.Function.FastCallGuard.Any, global::Jint.Native.Function.FastCallGuard.String, global::Jint.Native.Function.FastCallGuard.Number);
                 case Slot.Passthrough: return new global::Jint.Native.Function.FastCallShape(true, false, global::Jint.Native.Function.FastCallGuard.Any, global::Jint.Native.Function.FastCallGuard.Any, global::Jint.Native.Function.FastCallGuard.Any);
                 default: return default;
             }
@@ -100,7 +100,7 @@ internal sealed partial class Foo
             switch (_slot)
             {
                 case Slot.Abs: return Foo.Abs(thisObject, global::Jint.Runtime.TypeConverter.ToNumber(arg0));
-                case Slot.CharAt: return Foo.CharAt(thisObject, global::Jint.Runtime.TypeConverter.ToJsString(arg0), arg1);
+                case Slot.CharAt: return Foo.CharAt(thisObject, global::Jint.Runtime.TypeConverter.ToJsString(arg0), global::Jint.Runtime.TypeConverter.ToInteger(arg1));
                 case Slot.Passthrough: return Foo.Passthrough(thisObject, arg0);
                 default: return base.CallFast(thisObject, arg0, arg1);
             }

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallOnArgCount_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallOnArgCount_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallOnRawArguments_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallOnRawArguments_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallOnRestAndOverlongArity_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallOnRestAndOverlongArity_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallSingleSlot#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallSingleSlot#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallTypedReceiver#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallTypedReceiver#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FunctionCaptureField#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FunctionCaptureField#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.InstanceMethod#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.InstanceMethod#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntegerConversions#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntegerConversions#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntrinsicReference#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntrinsicReference#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntrinsicReferenceWithoutRealmField_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntrinsicReferenceWithoutRealmField_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.LeafOnUnguardableHazards_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.LeafOnUnguardableHazards_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.LeafOnUnguardableHazards_ProducesDiagnostic.verified.txt
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.LeafOnUnguardableHazards_ProducesDiagnostic.verified.txt
@@ -38,6 +38,19 @@
         DefaultSeverity: Error,
         IsEnabledByDefault: true
       }
+    },
+    {
+      Location: : (24,27)-(24,37),
+      Message: Method 'Undeclared' requests Leaf = true but the generator cannot honor it: parameter 0 is a plain JsValue, so nothing stops the body coercing it through a user valueOf/toString inside the frameless window — declare the conversion ([ToNumber], [ToInteger], …) so the lane can guard it,
+      Severity: Error,
+      Descriptor: {
+        Id: JINT023,
+        Title: [JsFunction] cannot be invoked through the requested fast-call lane,
+        MessageFormat: Method '{0}' requests {1} = true but the generator cannot honor it: {2},
+        Category: Jint.SourceGenerators,
+        DefaultSeverity: Error,
+        IsEnabledByDefault: true
+      }
     }
   ]
 }

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.MinimalClass#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.MinimalClass#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.MissingRealmField_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.MissingRealmField_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.NotPartial_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.NotPartial_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.OverloadCollision_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.OverloadCollision_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.PassthroughArguments#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.PassthroughArguments#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.PropertyConstants#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.PropertyConstants#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RestParameter#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RestParameter#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RichConversions#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RichConversions#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ShapeAliasAndInstanceSlot#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ShapeAliasAndInstanceSlot#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ShapeFunctionCaptureField#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ShapeFunctionCaptureField#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ShapeIntrinsicReference#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ShapeIntrinsicReference#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ShapeSymbolAlias#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ShapeSymbolAlias#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ShapeThrowerAccessor#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ShapeThrowerAccessor#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.StringAliasSharesDescriptor#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.StringAliasSharesDescriptor#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolAccessorGetterOnly#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolAccessorGetterOnly#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolAlias#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolAlias#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolFunctionCaptureField#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolFunctionCaptureField#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolFunctionMethod#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolFunctionMethod#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolMember#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolMember#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToCallable#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToCallable#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToObjectInstance#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToObjectInstance#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThrowerAccessor#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThrowerAccessor#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ToNumberConversion#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ToNumberConversion#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.UnsupportedReturnType_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.UnsupportedReturnType_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -69,8 +69,9 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// (<c>[ToNumber]</c>, <c>[ToInteger]</c>, <c>[ToInt32]</c>, <c>[ToUint32]</c>,
     /// <c>[ToLength]</c>) contributes a Number guard, <c>[ToString]</c>/<c>[ToJsString]</c>
     /// contribute a String guard, and a cast <c>thisObject</c> contributes the guard matching
-    /// its type. A plain <c>JsValue</c> parameter carries no guard, so declaring
-    /// <c>Leaf</c> asserts the body is leaf-safe for <em>any</em> value in that position.
+    /// its type. A plain <c>JsValue</c> value parameter carries no guard and is therefore
+    /// rejected outright (JINT023): the generator cannot see whether the body coerces it,
+    /// and a body that does would run user code frameless.
     /// </para>
     /// <para>
     /// This is never inferred from the signature, because a body with perfectly numeric

--- a/Jint.Tests/Runtime/FastCallLaneTests.cs
+++ b/Jint.Tests/Runtime/FastCallLaneTests.cs
@@ -1,4 +1,5 @@
 using Jint.Native;
+using Jint.Runtime;
 
 namespace Jint.Tests.Runtime;
 
@@ -136,6 +137,212 @@ public class FastCallLaneTests
 
         result.AsString().Should().Be("98,1");
     }
+
+    /// <summary>
+    /// The frame invariant again, but at a <em>warmed</em> site — the state the lane's leaf branch is
+    /// only ever reached from. <see cref="NonNumericArgumentsStillCoerceExactlyOnce"/> calls each
+    /// built-in once, so the site never warms and the leaf branch is never taken; these four
+    /// String.prototype methods take their arguments as plain <c>JsValue</c> and coerce them in the
+    /// body, which no <c>FastCallGuard</c> can see, so a Leaf claim on them elides the frame around
+    /// user <c>valueOf</c>.
+    /// </summary>
+    [Theory]
+    [InlineData("\"abc\".charCodeAt(p)", "charCodeAt")]
+    [InlineData("\"abc\".charAt(p)", "charAt")]
+    [InlineData("\"abc\".substring(p)", "substring")]
+    [InlineData("\"abc\".substring(0, p)", "substring")]
+    [InlineData("\"abc\".slice(p)", "slice")]
+    [InlineData("\"abc\".slice(0, p)", "slice")]
+    public void AWarmedSiteKeepsTheBuiltinFrameWhenAnArgumentCoercesThroughUserCode(string call, string builtin)
+    {
+        var engine = new Engine();
+        var stack = engine.Evaluate($$"""
+            function f(p) { return {{call}}; }
+            f(1); f(1);
+            let captured = "";
+            try { f({ valueOf: function () { throw new Error("x"); } }); } catch (e) { captured = e.stack; }
+            captured;
+            """).AsString();
+
+        stack.Should().Contain("at " + builtin, "the built-in frame must survive at a warmed site too");
+    }
+
+    /// <summary>
+    /// The other half of the elided frame: the frame push is also where <c>LimitRecursion</c> is
+    /// charged. The recursion cycle here contains no interpreted frame at all — a user
+    /// <c>valueOf</c> reached through a coercion is invoked directly, without one — so the built-in's
+    /// own frame is the only thing bounding it. The two priming calls matter: a call site caches its
+    /// callee only after a dispatch <em>returns</em>, so a site that first recurses into itself is
+    /// still cold all the way down and never reaches the leaf branch.
+    /// </summary>
+    [Fact]
+    public void ARecursionThatOnlyPassesThroughABuiltinIsStillChargedTheRecursionLimit()
+    {
+        var engine = new Engine(options => options.LimitRecursion(24));
+        engine.Execute("""
+            var depth = 0;
+            var arg = 0;
+            var o = { valueOf: function () { depth++; if (depth > 200) return 0; return "abc".charCodeAt(arg); } };
+            o.valueOf(); o.valueOf();
+            depth = 0; arg = o;
+            """);
+
+        try
+        {
+            engine.Execute("\"abc\".charCodeAt(o);");
+        }
+        catch (RecursionDepthOverflowException)
+        {
+            // expected: the recursion limit is what must stop this, not the 200-deep escape hatch
+        }
+
+        engine.Evaluate("depth").AsNumber().Should().BeLessThan(100,
+            "the frame the leaf lane elides is also what charges LimitRecursion");
+    }
+
+    /// <summary>
+    /// Absent-argument semantics for the four String.prototype methods whose numeric parameters the
+    /// fast-call lane touches. An absent <c>end</c> means "to the end of the string", which is
+    /// deliberately NOT the same as an explicit NaN — a difference that survives only while the
+    /// undefined-ness of the argument is still observable in the body.
+    /// </summary>
+    [Theory]
+    [InlineData("\"abcdef\".substring(2)", "cdef")]
+    [InlineData("\"abcdef\".substring(2, undefined)", "cdef")]
+    [InlineData("\"abcdef\".substring(2, NaN)", "ab")]
+    [InlineData("\"abcdef\".substring(undefined, 2)", "ab")]
+    [InlineData("\"abcdef\".slice(2)", "cdef")]
+    [InlineData("\"abcdef\".slice(2, undefined)", "cdef")]
+    [InlineData("\"abcdef\".slice(2, NaN)", "")]
+    [InlineData("\"abcdef\".slice(undefined, 2)", "ab")]
+    [InlineData("String(\"abc\".charCodeAt())", "97")]
+    [InlineData("String(\"abc\".charCodeAt(undefined))", "97")]
+    [InlineData("String(\"abc\".charCodeAt(NaN))", "97")]
+    [InlineData("\"abc\".charAt()", "a")]
+    [InlineData("\"abc\".charAt(undefined)", "a")]
+    [InlineData("\"abc\".charAt(NaN)", "a")]
+    public void AbsentNumericArgumentsKeepTheirSpecDefinedMeaning(string expression, string expected)
+    {
+        var engine = new Engine();
+
+        // Once cold, once warm — the lane must not change the answer.
+        engine.Evaluate($"function f() {{ return {expression}; }} f();").AsString().Should().Be(expected);
+        engine.Evaluate($"function g() {{ return {expression}; }} g(); g();").AsString().Should().Be(expected);
+    }
+
+    /// <summary>
+    /// Coercion order: the receiver's ToString runs before an argument's valueOf, per steps 2→3 of
+    /// each of these methods. Only observable when both are objects.
+    /// </summary>
+    [Theory]
+    [InlineData("charCodeAt")]
+    [InlineData("charAt")]
+    [InlineData("substring")]
+    public void TheReceiverIsCoercedBeforeTheArguments(string method)
+    {
+        var engine = new Engine();
+        var order = engine.Evaluate($$"""
+            const log = [];
+            const receiver = { toString: function () { log.push("this"); return "abc"; } };
+            const pos = { valueOf: function () { log.push("arg"); return 1; } };
+            function f(r, p) { return String.prototype.{{method}}.call(r, p); }
+            f("abc", 1); f("abc", 1);
+            f(receiver, pos);
+            log.join(",");
+            """).AsString();
+
+        order.Should().Be("this,arg");
+    }
+
+    /// <summary>
+    /// The receiver-only String.prototype methods claim Leaf under a String receiver guard. A
+    /// receiver that is anything else — a boxed String, an object with a user <c>toString</c> —
+    /// must fail the guard and keep both its frame and its exact semantics, at a warmed site.
+    /// </summary>
+    [Theory]
+    [InlineData("trim")]
+    [InlineData("trimStart")]
+    [InlineData("trimEnd")]
+    [InlineData("toUpperCase")]
+    [InlineData("toLowerCase")]
+    public void AReceiverGuardedLeafBuiltinStillFramesEveryOtherReceiver(string method)
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate($$"""
+            function f(r) { return r.{{method}}(); }
+            const primitive = f("  aB  ");
+            f("  aB  ");
+            const boxed = f(new String("  aB  "));
+            let stack = "";
+            const host = { toString: function () { stack = new Error().stack; return "  aB  "; } };
+            host.{{method}} = String.prototype.{{method}};
+            const hosted = f(host);
+            [primitive === boxed, primitive === hosted, stack.indexOf("at {{method}}") >= 0].join(",");
+            """).AsString();
+
+        result.Should().Be("true,true,true");
+    }
+
+    /// <summary>
+    /// Sanity for the annotation sweep: each newly lane-eligible built-in must give the same answer
+    /// warm as cold, including the receiver TypeError its brand check raises.
+    /// </summary>
+    [Fact]
+    public void NewlyLaneEligibleBuiltinsAgreeWarmAndCold()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            const out = [];
+            function run(f, a, b) {
+                const cold = f(a, b);
+                f(a, b);
+                return f(a, b) === cold ? cold : "DRIFT";
+            }
+            const m = new Map();
+            out.push(run(function (k, v) { m.set(k, v); return m.get(k); }, "k", 7));
+            const s = new Set([1, 2]);
+            out.push(run(function (v) { return s.has(v); }, 1));
+            out.push(run(function (v) { return new Set([1, 2]).delete(v); }, 2));
+            out.push(run(function (v) { return [1, 2, 3].reverse().join(""); }));
+            out.push(run(function (v) { return [1, 2, 3].toReversed().join(""); }));
+            out.push(run(function (v) { return [1, 2, 3].shift(); }));
+            out.push(run(function (v) { return (1.23456).toFixed(v); }, 2));
+            out.push(run(function (v) { return Math.trunc(v); }, -4.7));
+            out.push(run(function (v) { return /a(b)/.test(v); }, "cab"));
+            out.push(run(function (v) { return ({ x: 1 }).hasOwnProperty(v); }, "x"));
+            out.push(run(function (v) { return isNaN(v); }, "nope"));
+            out.push(run(function (v) { return isFinite(v); }, "12"));
+            out.push(run(function (v) { return typeof Date.now(); }));
+            let brand = "";
+            try { const g = Map.prototype.get; g({}, 1); g({}, 1); } catch (e) { brand = e.constructor.name; }
+            out.push(brand);
+            out.join("|");
+            """).AsString();
+
+        result.Should().Be("7|true|true|321|321|1|1.23|-4|true|true|true|true|number|TypeError");
+    }
+
+#if !NETFRAMEWORK // Math.f16round needs System.Half, which .NET Framework does not have
+    /// <summary>
+    /// <c>Math.f16round</c> must return a Number for every input. It used to hand back the argument
+    /// itself on the infinity / signed-zero branches, which is only the same value when the argument
+    /// was already a number.
+    /// </summary>
+    [Fact]
+    public void F16RoundAlwaysReturnsANumber()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            const inf = Math.f16round({ valueOf: function () { return Infinity; } });
+            const negZero = Math.f16round({ valueOf: function () { return -0; } });
+            const zero = Math.f16round({ valueOf: function () { return 0; } });
+            const warm = Math.f16round(1.337) === Math.f16round(1.337);
+            [typeof inf, inf, typeof negZero, 1 / negZero, typeof zero, 1 / zero, warm].join(",");
+            """).AsString();
+
+        result.Should().Be("number,Infinity,number,-Infinity,number,Infinity,true");
+    }
+#endif
 
     /// <summary>
     /// A Prepared&lt;Script&gt; shares its handler tree across engines, so a call-site cache populated

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -1697,7 +1697,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
         return a;
     }
 
-    [JsFunction]
+    [JsFunction(FastCall = true)]
     private JsValue Shift(JsValue thisObject)
     {
         var o = ArrayOperations.For(_realm, thisObject, forWrite: true);
@@ -1747,7 +1747,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-array.prototype.reverse
     /// </summary>
-    [JsFunction]
+    [JsFunction(FastCall = true)]
     private JsValue Reverse(JsValue thisObject)
     {
         var o = ArrayOperations.For(_realm, thisObject, forWrite: true);
@@ -2240,7 +2240,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
         return func(array, Arguments.Empty);
     }
 
-    [JsFunction]
+    [JsFunction(FastCall = true)]
     private JsValue ToReversed(JsValue thisObject)
     {
         var o = ArrayOperations.For(_realm, thisObject, forWrite: false);

--- a/Jint/Native/Date/DateConstructor.cs
+++ b/Jint/Native/Date/DateConstructor.cs
@@ -96,7 +96,10 @@ internal sealed partial class DateConstructor : Constructor
         return finalDate.TimeClip().ToJsValue();
     }
 
-    [JsFunction]
+    // Leaf: no arguments, no JS-error path, no interpreted code. A host ITimeSystem does run inside
+    // the frameless window, which is the same exposure the 19 Leaf getters on DatePrototype already
+    // ship with — a host clock is not script and cannot observe error.stack.
+    [JsFunction(FastCall = true, Leaf = true)]
     private JsValue Now(JsValue thisObject)
     {
         return (long) (_timeSystem.GetUtcNow().DateTime - Epoch).TotalMilliseconds;

--- a/Jint/Native/Global/GlobalObject.cs
+++ b/Jint/Native/Global/GlobalObject.cs
@@ -243,7 +243,7 @@ public sealed partial class GlobalObject : ObjectInstance
     /// <summary>
     /// http://www.ecma-international.org/ecma-262/5.1/#sec-15.1.2.4
     /// </summary>
-    [JsFunction]
+    [JsFunction(FastCall = true)]
     private static JsValue IsNaN(JsValue thisObject, JsValue value)
     {
         if (ReferenceEquals(value, JsNumber.DoubleNaN))
@@ -258,7 +258,7 @@ public sealed partial class GlobalObject : ObjectInstance
     /// <summary>
     /// http://www.ecma-international.org/ecma-262/5.1/#sec-15.1.2.5
     /// </summary>
-    [JsFunction]
+    [JsFunction(FastCall = true)]
     private static JsValue IsFinite(JsValue thisObject, JsValue value)
     {
         var n = TypeConverter.ToNumber(value);

--- a/Jint/Native/Map/MapPrototype.cs
+++ b/Jint/Native/Map/MapPrototype.cs
@@ -44,7 +44,7 @@ internal sealed partial class MapPrototype : Prototype
         return JsNumber.Create(0);
     }
 
-    [JsFunction(Name = "get")]
+    [JsFunction(Name = "get", FastCall = true)]
     private JsValue MapGet(JsValue thisObject, JsValue key)
     {
         var map = AssertMapInstance(thisObject);
@@ -85,7 +85,7 @@ internal sealed partial class MapPrototype : Prototype
             : JsBoolean.False;
     }
 
-    [JsFunction(Name = "set")]
+    [JsFunction(Name = "set", FastCall = true)]
     private JsValue MapSet(JsValue thisObject, JsValue key, JsValue value)
     {
         var map = AssertMapInstance(thisObject);

--- a/Jint/Native/Math/MathInstance.cs
+++ b/Jint/Native/Math/MathInstance.cs
@@ -801,13 +801,14 @@ internal sealed partial class MathInstance : BuiltinShapeObject
     /// <summary>
     /// https://tc39.es/proposal-float16array/#sec-math.f16round
     /// </summary>
-    [JsFunction(Length = 1, Name = "f16round")]
-    private static JsValue F16Round(JsValue thisObject, JsValue arg0)
+    // FastCall only, like Fround: on the TFMs without Half this throws, and the frame belongs on a
+    // throwing built-in. The declared [ToNumber] is what keeps the coercion out of the body — where
+    // it used to make the infinity / signed-zero branches hand back the *argument*, so an object
+    // coercing to Infinity was returned as itself instead of as a Number.
+    [JsFunction(Length = 1, Name = "f16round", FastCall = true)]
+    private static JsValue F16Round(JsValue thisObject, [ToNumber] double n)
     {
 #if SUPPORTS_HALF
-        var x = arg0;
-        var n = TypeConverter.ToNumber(x);
-
         if (double.IsNaN(n))
         {
             return JsNumber.DoubleNaN;
@@ -815,7 +816,7 @@ internal sealed partial class MathInstance : BuiltinShapeObject
 
         if (double.IsInfinity(n) || NumberInstance.IsPositiveZero(n) || NumberInstance.IsNegativeZero(n))
         {
-            return x;
+            return n;
         }
 
         return (double) (Half) n;
@@ -902,7 +903,7 @@ internal sealed partial class MathInstance : BuiltinShapeObject
         return System.Math.Tanh(x);
     }
 
-    [JsFunction(Name = "trunc")]
+    [JsFunction(Name = "trunc", FastCall = true, Leaf = true)]
     private static JsValue Truncate(JsValue thisObject, [ToNumber] double x)
     {
         if (double.IsNaN(x))

--- a/Jint/Native/Number/NumberPrototype.cs
+++ b/Jint/Native/Number/NumberPrototype.cs
@@ -79,7 +79,9 @@ internal sealed partial class NumberPrototype : NumberInstance
 
     private const double Ten21 = 1e21;
 
-    [JsFunction]
+    // FastCall only: the body raises a RangeError for out-of-range digits and coerces the receiver
+    // through ToNumber, so the frame has to stay — matching toExponential/toPrecision.
+    [JsFunction(FastCall = true)]
     private JsValue ToFixed(JsValue thisObject, [ToInteger] double fAsDouble)
     {
         var f = (int) fAsDouble;

--- a/Jint/Native/Object/ObjectPrototype.cs
+++ b/Jint/Native/Object/ObjectPrototype.cs
@@ -277,7 +277,7 @@ public sealed partial class ObjectPrototype : Prototype
     /// <summary>
     /// http://www.ecma-international.org/ecma-262/5.1/#sec-15.2.4.5
     /// </summary>
-    [JsFunction]
+    [JsFunction(FastCall = true)]
     private JsValue HasOwnProperty(JsValue thisObject, JsValue v)
     {
         var p = TypeConverter.ToPropertyKey(v);

--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -808,7 +808,7 @@ internal sealed partial class RegExpPrototype : Prototype
         return "/" + pattern + "/" + flags;
     }
 
-    [JsFunction]
+    [JsFunction(FastCall = true)]
     private JsValue Test(JsValue thisObject, JsValue stringArg)
     {
         var r = AssertThisIsObjectInstance(thisObject, "RegExp.prototype.test");

--- a/Jint/Native/Set/SetPrototype.cs
+++ b/Jint/Native/Set/SetPrototype.cs
@@ -65,7 +65,7 @@ internal sealed partial class SetPrototype : Prototype
         return Undefined;
     }
 
-    [JsFunction]
+    [JsFunction(FastCall = true)]
     private JsBoolean Delete(JsValue thisObject, JsValue value)
     {
         var set = AssertSetInstance(thisObject);
@@ -386,7 +386,7 @@ internal sealed partial class SetPrototype : Prototype
     }
 
 
-    [JsFunction]
+    [JsFunction(FastCall = true)]
     private JsBoolean Has(JsValue thisObject, JsValue value)
     {
         var set = AssertSetInstance(thisObject);

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -157,7 +157,7 @@ internal sealed partial class StringPrototype : StringInstance
     /// https://tc39.es/ecma262/#sec-string.prototype.trim
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [JsFunction]
+    [JsFunction(FastCall = true, Leaf = true, LeafReceiver = FastCallGuard.String)]
     [RequireObjectCoercible]
     private static JsValue Trim(JsValue thisObject)
     {
@@ -172,7 +172,7 @@ internal sealed partial class StringPrototype : StringInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-string.prototype.trimstart
     /// </summary>
-    [JsFunction]
+    [JsFunction(FastCall = true, Leaf = true, LeafReceiver = FastCallGuard.String)]
     [RequireObjectCoercible]
     private static JsValue TrimStart(JsValue thisObject)
     {
@@ -187,7 +187,7 @@ internal sealed partial class StringPrototype : StringInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-string.prototype.trimend
     /// </summary>
-    [JsFunction]
+    [JsFunction(FastCall = true, Leaf = true, LeafReceiver = FastCallGuard.String)]
     [RequireObjectCoercible]
     private static JsValue TrimEnd(JsValue thisObject)
     {
@@ -229,7 +229,7 @@ internal sealed partial class StringPrototype : StringInstance
         return new JsString(ToUpperCaseWithSpecialCasing(s, culture));
     }
 
-    [JsFunction]
+    [JsFunction(FastCall = true, Leaf = true, LeafReceiver = FastCallGuard.String)]
     [RequireObjectCoercible]
     private JsValue ToUpperCase(JsValue thisObject)
     {
@@ -444,7 +444,7 @@ internal sealed partial class StringPrototype : StringInstance
         return ToLowerCaseWithSpecialCasing(s, culture);
     }
 
-    [JsFunction]
+    [JsFunction(FastCall = true, Leaf = true, LeafReceiver = FastCallGuard.String)]
     [RequireObjectCoercible]
     private JsValue ToLowerCase(JsValue thisObject)
     {
@@ -920,7 +920,14 @@ internal sealed partial class StringPrototype : StringInstance
         return intVal;
     }
 
-    [JsFunction(Length = 2, FastCall = true, Leaf = true, LeafReceiver = FastCallGuard.String)]
+    // FastCall only, deliberately not Leaf: the two arguments arrive as plain JsValue and are
+    // coerced in the body, so no declared guard can keep an object argument — whose valueOf is
+    // user code that can read error.stack — off the frameless lane. Migrating them to
+    // [ToNumber] double would move the coercion into the dispatcher, ahead of ToJsString(this),
+    // inverting the spec's step 2 → step 4/5 order; and step 5 needs `end === undefined` told
+    // apart from an explicit NaN, which survives no numeric coercion. Math.fround is the same
+    // shape and the same verdict.
+    [JsFunction(Length = 2, FastCall = true)]
     [RequireObjectCoercible]
     private static JsValue Substring(JsValue thisObject, JsValue startArg, JsValue endArg)
     {
@@ -1255,7 +1262,11 @@ internal sealed partial class StringPrototype : StringInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-string.prototype.slice
     /// </summary>
-    [JsFunction(Length = 2, FastCall = true, Leaf = true, LeafReceiver = FastCallGuard.String)]
+    // FastCall only, not Leaf — see the note on Substring: raw JsValue arguments coerced in the
+    // body cannot be guarded, and declaring the coercions would move them into the dispatcher,
+    // ahead of the step-2 ToJsString the body now performs first. The undefined-vs-NaN distinction
+    // `end` needs would not survive the migration either.
+    [JsFunction(Length = 2, FastCall = true)]
     [RequireObjectCoercible]
     private static JsValue Slice(JsValue thisObject, JsValue startArg, JsValue endArg)
     {
@@ -1631,7 +1642,11 @@ internal sealed partial class StringPrototype : StringInstance
         return jsString;
     }
 
-    [JsFunction(Length = 1, FastCall = true, Leaf = true, LeafReceiver = FastCallGuard.String)]
+    // FastCall only, not Leaf: `pos` is a raw JsValue coerced in the body, so an object argument
+    // would run user valueOf inside a frameless window. A [ToInteger] double migration would earn
+    // the Number guard but move the coercion ahead of ToJsString(this), inverting the spec's
+    // step 2 → step 3 order.
+    [JsFunction(Length = 1, FastCall = true)]
     [RequireObjectCoercible]
     private static JsValue CharCodeAt(JsValue thisObject, JsValue pos)
     {
@@ -1692,7 +1707,8 @@ internal sealed partial class StringPrototype : StringInstance
         return new CodePointResult(char.ConvertToUtf32(first, second), 2, false);
     }
 
-    [JsFunction(Length = 1, FastCall = true, Leaf = true, LeafReceiver = FastCallGuard.String)]
+    // FastCall only, not Leaf — same reasoning as CharCodeAt.
+    [JsFunction(Length = 1, FastCall = true)]
     [RequireObjectCoercible]
     private static JsValue CharAt(JsValue thisObject, JsValue pos)
     {

--- a/Jint/Native/WeakMap/WeakMapPrototype.cs
+++ b/Jint/Native/WeakMap/WeakMapPrototype.cs
@@ -75,7 +75,7 @@ internal sealed partial class WeakMapPrototype : Prototype
         return map.WeakMapDelete(key) ? JsBoolean.True : JsBoolean.False;
     }
 
-    [JsFunction(Name = "set")]
+    [JsFunction(Name = "set", FastCall = true)]
     private JsValue MapSet(JsValue thisObject, JsValue key, JsValue value)
     {
         var map = AssertWeakMapInstance(thisObject);

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -349,10 +349,23 @@ internal sealed class JintCallExpression : JintExpression
     {
         if (_fastShape.IsLeafFor(thisObject, arg0, arg1))
         {
+#if DEBUG
+            // try/finally so a throw out of a mis-annotated built-in cannot strand the debug
+            // counter above zero and poison every later assertion on this thread. Compiled out
+            // rather than left to [Conditional] emptying the finally, so Release codegen on the
+            // engine's fastest lane carries no exception-handling region at all.
             LeafCallGuard.Enter();
-            var leafResult = target.CallFast(thisObject, arg0, arg1);
-            LeafCallGuard.Exit();
-            return leafResult;
+            try
+            {
+                return target.CallFast(thisObject, arg0, arg1);
+            }
+            finally
+            {
+                LeafCallGuard.Exit();
+            }
+#else
+            return target.CallFast(thisObject, arg0, arg1);
+#endif
         }
 
         var callStack = engine.CallStack;

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -49,6 +49,14 @@ public static class TypeConverter
 
     private static JsValue ToPrimitiveObjectInstance(ObjectInstance oi, Types preferredType)
     {
+        // The third leaf-lane assertion point, and the only one a *well-behaved* user conversion
+        // reaches: JintCallStack.Push and the JavaScriptException constructor both need the
+        // valueOf/toString to nest a call or throw, so a trivial one slipped past the audit
+        // entirely. Converting an object to a primitive always means asking script-supplied code,
+        // which is precisely what a frameless built-in must not do — every shipped Leaf shape
+        // guards its receiver and arguments to Number/String/Date, none of which land here.
+        Native.Function.LeafCallGuard.AssertNotInLeafCall("an object-to-primitive conversion (TypeConverter.ToPrimitive)");
+
         var exoticToPrim = oi.GetMethod(GlobalSymbolRegistry.ToPrimitive);
         if (exoticToPrim is not null)
         {


### PR DESCRIPTION
The v4.15.0 pre-release review audited every `Leaf = true` annotation the fast-call lane (#2783) carries. Of 43 sites, exactly four were unsound — `String.prototype.substring` / `slice` / `charCodeAt` / `charAt` coerce raw `JsValue` arguments in-body under `Any` guards, so a user `valueOf` ran frameless: no built-in frame in `error.stack`, recursion not charged against `LimitRecursion`, and a throwing coercion could poison the Debug-mode depth verifier. This PR fixes the audit findings and then extends the lane's coverage to the methods a safe-list audit cleared.

**Soundness fixes**

* The four unsound sites drop `Leaf` and keep `FastCall` (the `Math.fround` precedent). Migrating them to declared `[ToNumber]` parameters was evaluated and rejected with tests pinning why: the emitter coerces declared arguments before the body's `ToString(this)`, inverting the spec's receiver-first order, and `ToNumber` cannot preserve the `undefined`-vs-`NaN` distinction `substring`/`slice` step 5 needs.
* The generator now rejects `Leaf` on any raw `JsValue` value parameter (JINT023 is an error), so the unsound state is unrepresentable rather than merely fixed.
* The Debug-mode leaf guard gains a try/finally (compiled out in Release) and a third audit point in `ToPrimitive`'s object path — proven live against the exact blind spot the four sites exploited: a trivial `valueOf` that neither throws nor recurses now trips the verifier.
* `Math.f16round` had the same shape and a latent bug — `return x` handed back the original argument *object* when it coerced to ±∞/±0. It gets the `[ToNumber] double` migration (sound for Math, which has no receiver coercion), fixing both.

**Coverage extension** (all verified attribute-compatible; the Debug audit machinery and frame/recursion tests are the lane-engagement proof — no timing claims)

* `FastCall`: `Map.get`/`set`, `WeakMap.set`, `Set.has`/`delete`, `Array.shift`/`reverse`/`toReversed`, `Number.toFixed`, `RegExp.test`, `Object.prototype.hasOwnProperty`, `isNaN`, `isFinite`
* `FastCall` + `Leaf`: `String.prototype.trim`/`trimStart`/`trimEnd`/`toUpperCase`/`toLowerCase` (`LeafReceiver = String`), `Math.trunc`, `Date.now`

Red-run evidence: six stack-frame tests and a recursion-accounting test failed on unmodified main and pass now; `Math.f16round({valueOf:()=>Infinity})` returned an object before, a number now.

Gate: full suite on net10.0/net472 in Release and Debug (the Debug leaf audit is silent), and a complete Test262 run with zero new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
