### PR TITLE
Let hosts build shared prototype shapes

### DIFF
--- a/Jint.Benchmark/HostPrototypeShapeBenchmark.cs
+++ b/Jint.Benchmark/HostPrototypeShapeBenchmark.cs
@@ -1,0 +1,404 @@
+#nullable enable
+
+using System.Globalization;
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Interop;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// The embedding shape a DOM-style binding has: a large, fixed family of prototype objects rebuilt for every
+/// engine, where each prototype carries dozens of Web IDL members (enumerable accessors, operations,
+/// constants, a <c>constructor</c> back-reference and a <c>Symbol.toStringTag</c>) and a page touches only a
+/// fraction of them. Modelled on a real report of ~170 prototypes costing ~33 MB and ~110 ms per document
+/// before any script runs.
+///
+/// <para>
+/// Scaled down to stay runnable: <see cref="PrototypeCount"/> prototypes × <see cref="MembersPerPrototype"/>
+/// members, roughly a quarter of the reported width, plus one full-width prototype
+/// (<see cref="WidePrototypeMembers"/> members) for the widest real interface. Read the deltas as ratios, not
+/// as absolute per-document figures.
+/// </para>
+///
+/// <para><b>The three lanes</b></para>
+/// <list type="bullet">
+/// <item><description>
+/// <see cref="BuildPrototypes"/> — per-engine setup, the headline. <see cref="HostPrototypeKind.Dictionary"/>
+/// is today's pattern: a plain <see cref="ObjectInstance"/> populated through
+/// <see cref="ObjectInstance.FastSetProperty(string, PropertyDescriptor)"/> with one eagerly-created
+/// <see cref="ClrFunction"/> per operation and a getter/setter pair per attribute.
+/// <see cref="HostPrototypeKind.Shape"/> is the same members declared once per process as a
+/// <see cref="JsObjectShape"/> and instantiated per engine. The <c>Allocated</c> column is the point: the
+/// shaped lane allocates one small object per prototype and defers every descriptor and function.
+/// </description></item>
+/// <item><description>
+/// <see cref="BuildAndTouchPrototypes"/> — the honest one. Setup, then three member reads on
+/// <see cref="TouchedPrototypes"/> of the prototypes, modelling a page that touches ten to twenty DOM types.
+/// Laziness only pays where nothing is touched, so this lane bounds the win rather than flattering it.
+/// </description></item>
+/// <item><description>
+/// <see cref="SteadyStateReads"/> — a warmed read/call loop over instances whose <c>[[Prototype]]</c> is the
+/// prototype under test. The receiver is a <em>correct</em> host object: it answers only its own properties
+/// and overrides nothing but <see cref="ObjectInstance.GetOwnProperty"/>, so inherited members genuinely
+/// resolve on the prototype and the prototype-method inline cache is reachable. That matters — a host whose
+/// instances claim inherited members as their own can never reach this lane whatever its prototypes look
+/// like, so measuring against such a receiver would credit this feature for a fix that is not its own.
+/// </description></item>
+/// </list>
+///
+/// <para>
+/// <b>Public surface only.</b> Jint grants this project <c>InternalsVisibleTo</c>, but every host type below
+/// restricts itself to members an embedder in an unrelated assembly could also reach — otherwise the lanes
+/// would measure a host nobody can actually write. The one place the restriction bites is
+/// <see cref="ReflectiveHostInstance"/>: it cannot answer a read without allocating a
+/// <see cref="PropertyDescriptor"/>, because the public surface offers no reusable data-descriptor form. That
+/// cost sits in both prototype lanes equally, so it does not distort the comparison.
+/// </para>
+/// </summary>
+[MemoryDiagnoser]
+public class HostPrototypeShapeBenchmark
+{
+    private const int PrototypeCount = 32;
+    private const int MembersPerPrototype = 48;
+    private const int WidePrototypeMembers = 292;
+    private const int TouchedPrototypes = 5;
+    private const int SteadyStateInstances = 50;
+
+    private static readonly JsObjectShape[] _shapes = BuildShapes(PrototypeCount, MembersPerPrototype);
+    private static readonly JsObjectShape _wideShape = BuildShape("Wide", WidePrototypeMembers);
+
+    private static readonly MemberTable[] _tables = BuildTables(PrototypeCount, MembersPerPrototype);
+    private static readonly MemberTable _wideTable = new("Wide", WidePrototypeMembers);
+
+    private Engine _readEngine = null!;
+    private Prepared<Script> _readLoop;
+    private Prepared<Script> _touchScript;
+
+    /// <summary>How the per-engine prototype objects are built.</summary>
+    [Params(HostPrototypeKind.Dictionary, HostPrototypeKind.Shape)]
+    public HostPrototypeKind PrototypeKind { get; set; }
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _touchScript = Engine.PrepareScript($$"""
+            (function (protos) {
+              var sum = 0;
+              for (var i = 0; i < {{TouchedPrototypes}}; i++) {
+                var p = protos[i];
+                sum += p.CONST_0;
+                sum += p.op_0 !== undefined ? 1 : 0;
+                sum += p.attr_0 === undefined ? 0 : 1;
+              }
+              return sum;
+            })(protos)
+            """);
+
+        _readLoop = Engine.PrepareScript("""
+            (function (items) {
+              var total = 0;
+              for (var i = 0; i < items.length; i++) {
+                var it = items[i];
+                total += it.attr_0.length + it.op_0().length + it.CONST_0;
+              }
+              return total;
+            })(items)
+            """);
+
+        // The read lane's engine is built once: it measures steady-state reads, not setup.
+        _readEngine = new Engine();
+        var prototype = BuildPrototype(_readEngine, PrototypeKind, 0);
+
+        // Engagement is asserted, never inferred from timing: if the shaped lane silently stopped being
+        // shaped, the row would still run and quietly measure the dictionary path. The representation
+        // settles on first touch, so force one before asking.
+        prototype.Get("CONST_0");
+
+        var expected = PrototypeKind == HostPrototypeKind.Shape
+            ? ObjectRepresentation.SharedBuiltinLayout
+            : ObjectRepresentation.Dictionary;
+        var representation = _readEngine.Advanced.GetObjectRepresentation(prototype);
+        if (representation != expected)
+        {
+            throw new InvalidOperationException(
+                $"{PrototypeKind} prototypes landed in the {representation} representation, expected {expected}.");
+        }
+
+        var items = new JsValue[SteadyStateInstances];
+        for (var i = 0; i < items.Length; i++)
+        {
+            items[i] = new ReflectiveHostInstance(_readEngine, prototype, i);
+        }
+
+        _readEngine.SetValue("items", new JsArray(_readEngine, items));
+        _readEngine.Evaluate(_readLoop);
+    }
+
+    /// <summary>Lane A: everything a fresh document pays before a single line of script runs.</summary>
+    [Benchmark]
+    public Engine BuildPrototypes()
+    {
+        var engine = new Engine();
+        for (var i = 0; i < PrototypeCount; i++)
+        {
+            BuildPrototype(engine, PrototypeKind, i);
+        }
+
+        BuildWidePrototype(engine, PrototypeKind);
+        return engine;
+    }
+
+    /// <summary>Lane B: the same setup, plus the members a page that touches a handful of types actually reads.</summary>
+    [Benchmark]
+    public JsValue BuildAndTouchPrototypes()
+    {
+        var engine = new Engine();
+        var protos = new JsValue[PrototypeCount];
+        for (var i = 0; i < PrototypeCount; i++)
+        {
+            protos[i] = BuildPrototype(engine, PrototypeKind, i);
+        }
+
+        BuildWidePrototype(engine, PrototypeKind);
+        engine.SetValue("protos", new JsArray(engine, protos));
+        return engine.Evaluate(_touchScript);
+    }
+
+    /// <summary>Lane C: warmed inherited reads and calls through a correct host instance.</summary>
+    [Benchmark]
+    public JsValue SteadyStateReads() => _readEngine.Evaluate(_readLoop);
+
+    private static ObjectInstance BuildPrototype(Engine engine, HostPrototypeKind kind, int index)
+        => kind == HostPrototypeKind.Shape
+            ? _shapes[index].Instantiate(engine)
+            : BuildDictionaryPrototype(engine, _tables[index]);
+
+    private static ObjectInstance BuildWidePrototype(Engine engine, HostPrototypeKind kind)
+        => kind == HostPrototypeKind.Shape
+            ? _wideShape.Instantiate(engine)
+            : BuildDictionaryPrototype(engine, _wideTable);
+
+    /// <summary>
+    /// Today's pattern, verbatim: a plain object filled with raw descriptors, one eagerly-created function per
+    /// operation and a getter/setter pair per attribute. Nothing here is lazy and nothing is shared between
+    /// engines, which is the cost the shaped lane is measured against.
+    /// </summary>
+    private static ObjectInstance BuildDictionaryPrototype(Engine engine, MemberTable table)
+    {
+        var prototype = new JsObject(engine);
+
+        foreach (var member in table.Members)
+        {
+            switch (member.Kind)
+            {
+                case MemberKind.Operation:
+                    prototype.FastSetProperty(
+                        member.Name,
+                        new PropertyDescriptor(
+                            new ClrFunction(engine, member.Name, member.Implementation!, 0),
+                            PropertyFlag.ConfigurableEnumerableWritable));
+                    break;
+
+                case MemberKind.Attribute:
+                    prototype.FastSetProperty(
+                        member.Name,
+                        new GetSetPropertyDescriptor(
+                            new ClrFunction(engine, "get " + member.Name, member.Implementation!, 0),
+                            new ClrFunction(engine, "set " + member.Name, member.Setter!, 1),
+                            enumerable: true,
+                            configurable: true));
+                    break;
+
+                default:
+                    prototype.FastSetProperty(
+                        member.Name,
+                        new PropertyDescriptor(member.Constant!, PropertyFlag.OnlyEnumerable));
+                    break;
+            }
+        }
+
+        prototype.FastSetProperty("constructor", new PropertyDescriptor(JsValue.Undefined, PropertyFlag.NonEnumerable));
+        prototype.FastSetProperty(
+            ToStringTagKey,
+            new PropertyDescriptor(new JsString(table.Name), PropertyFlag.Configurable));
+
+        return prototype;
+    }
+
+    private static JsObjectShape[] BuildShapes(int count, int members)
+    {
+        var shapes = new JsObjectShape[count];
+        for (var i = 0; i < count; i++)
+        {
+            shapes[i] = BuildShape("Type" + i.ToString(CultureInfo.InvariantCulture), members);
+        }
+
+        return shapes;
+    }
+
+    /// <summary>
+    /// The shape a Web IDL binding generator would emit once per interface: declared from the same member
+    /// table the dictionary lane walks, so the two lanes present identical members in identical order.
+    /// </summary>
+    private static JsObjectShape BuildShape(string name, int memberCount)
+    {
+        var table = new MemberTable(name, memberCount);
+        var builder = new JsObjectShape.Builder();
+        foreach (var member in table.Members)
+        {
+            switch (member.Kind)
+            {
+                case MemberKind.Operation:
+                    builder.Method(member.Name, member.Implementation!);
+                    break;
+                case MemberKind.Attribute:
+                    builder.Accessor(member.Name, member.Implementation, member.Setter);
+                    break;
+                default:
+                    builder.Constant(member.Name, member.Constant!);
+                    break;
+            }
+        }
+
+        return builder
+            .PerRealmSlot("constructor", enumerable: false)
+            .ToStringTag(name)
+            .Build();
+    }
+
+    private static MemberTable[] BuildTables(int count, int members)
+    {
+        var tables = new MemberTable[count];
+        for (var i = 0; i < count; i++)
+        {
+            tables[i] = new MemberTable("Type" + i.ToString(CultureInfo.InvariantCulture), members);
+        }
+
+        return tables;
+    }
+
+    /// <summary>
+    /// Reached the way an embedder would — through script, since the well-known symbol table is internal.
+    /// A well-known symbol is process-shared, so one lookup serves every engine the benchmark builds.
+    /// </summary>
+    private static JsValue ToStringTagKey { get; } = new Engine().Evaluate("Symbol.toStringTag");
+}
+
+/// <summary>How the per-engine prototype objects under test are built.</summary>
+public enum HostPrototypeKind
+{
+    /// <summary>
+    /// A plain object filled with raw descriptors and eagerly-created functions — the shape a binding written
+    /// against today's public API ends up with, and the one the report measured.
+    /// </summary>
+    Dictionary,
+
+    /// <summary>
+    /// One process-shared <see cref="JsObjectShape"/> per interface, instantiated per engine.
+    /// </summary>
+    Shape,
+}
+
+internal enum MemberKind
+{
+    Operation,
+    Attribute,
+    Constant,
+}
+
+/// <summary>
+/// One interface's member list, generated deterministically so the two prototype lanes are built from exactly
+/// the same declarations. The mix — one constant in six, two attributes in six, the rest operations — is
+/// modelled on a Web IDL interface with its inherited members flattened onto it.
+/// </summary>
+internal sealed class MemberTable
+{
+    internal MemberTable(string name, int memberCount)
+    {
+        Name = name;
+        var members = new Member[memberCount];
+        for (var i = 0; i < memberCount; i++)
+        {
+            var suffix = i.ToString(CultureInfo.InvariantCulture);
+            members[i] = (i % 6) switch
+            {
+                0 => new Member("CONST_" + suffix, MemberKind.Constant, null, null, JsNumber.Create(i)),
+                1 or 2 => new Member("attr_" + suffix, MemberKind.Attribute, ReadAttribute, WriteAttribute, null),
+                _ => new Member("op_" + suffix, MemberKind.Operation, RunOperation, null, null),
+            };
+        }
+
+        // Name the first member of each kind predictably so the benchmark scripts can address them.
+        members[0] = new Member("CONST_0", MemberKind.Constant, null, null, JsNumber.Create(1));
+        members[1] = new Member("attr_0", MemberKind.Attribute, ReadAttribute, WriteAttribute, null);
+        members[3] = new Member("op_0", MemberKind.Operation, RunOperation, null, null);
+
+        Members = members;
+    }
+
+    internal string Name { get; }
+
+    internal Member[] Members { get; }
+
+    // Engine-independent by construction: the receiver carries both the host state and the engine, which is
+    // exactly the contract a shape's delegates must satisfy.
+    private static JsValue ReadAttribute(JsValue thisObject, JsValue[] arguments)
+        => thisObject is ObjectInstance o ? o.Get("_state") : JsValue.Undefined;
+
+    private static JsValue WriteAttribute(JsValue thisObject, JsValue[] arguments)
+    {
+        if (thisObject is ObjectInstance o && arguments.Length > 0)
+        {
+            o.Set("_state", arguments[0]);
+        }
+
+        return JsValue.Undefined;
+    }
+
+    private static JsValue RunOperation(JsValue thisObject, JsValue[] arguments)
+        => thisObject is ObjectInstance o ? o.Get("_state") : JsValue.Undefined;
+}
+
+internal sealed record Member(
+    string Name,
+    MemberKind Kind,
+    Func<JsValue, JsValue[], JsValue>? Implementation,
+    Func<JsValue, JsValue[], JsValue>? Setter,
+    JsValue? Constant);
+
+/// <summary>
+/// The receiver Lane C reads through: a host instance that answers <b>only</b> its own state and lets every
+/// declared member resolve on its prototype. That honesty is what makes the prototype-method inline cache
+/// reachable, and it is the precondition a host must meet before any prototype representation can help its
+/// steady-state reads.
+/// <para>
+/// It overrides <see cref="ObjectInstance.GetOwnProperty"/> and nothing else, so the engine derives ordinary
+/// access semantics for it without the host declaring anything.
+/// </para>
+/// </summary>
+internal sealed class ReflectiveHostInstance : ObjectInstance
+{
+    private readonly JsValue _state;
+
+    public ReflectiveHostInstance(Engine engine, ObjectInstance prototype, int index) : base(engine)
+    {
+        Prototype = prototype;
+        _state = new JsString("state-" + index.ToString(CultureInfo.InvariantCulture));
+    }
+
+    public override PropertyDescriptor GetOwnProperty(JsValue property)
+    {
+        if (property.IsString() && string.Equals(property.ToString(), "_state", StringComparison.Ordinal))
+        {
+            // A fresh descriptor per call: the public surface has no reusable data-descriptor form. Identical
+            // in both prototype lanes, so it cancels out of the comparison.
+            return new PropertyDescriptor(_state, writable: true, enumerable: false, configurable: true);
+        }
+
+        return PropertyDescriptor.Undefined;
+    }
+}

--- a/Jint.Tests.PublicInterface/HostPrototypeShapeTests.cs
+++ b/Jint.Tests.PublicInterface/HostPrototypeShapeTests.cs
@@ -1,0 +1,778 @@
+#nullable enable
+
+using System.Collections.Generic;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// <see cref="JsObjectShape"/> — the host-facing way to declare a prototype-like object's members once per
+/// process and create one such object per engine. These tests live in the public-interface suite on purpose:
+/// the project has no <c>InternalsVisibleTo</c> grant, so every green assertion here is proof that a
+/// third-party embedder can reach the same capability.
+///
+/// <para>
+/// The three things the API promises, and which the tests below pin: a built shape is immutable and shared
+/// (two engines instantiate from one <c>static readonly</c> field and cannot observe each other), members
+/// materialize lazily and then keep a stable identity, and nothing about the representation is
+/// script-visible — every mutation an ordinary object would accept behaves identically here, including the
+/// ones that force the object back to the ordinary property dictionary.
+/// </para>
+/// </summary>
+public class HostPrototypeShapeTests
+{
+    // The shared prototype description, declared once exactly as a host would: process-wide, engine-free,
+    // capturing nothing but static delegates. Declaration order is own-key order, which several tests assert
+    // verbatim, so members are grouped by kind rather than by enumerability.
+    private static readonly JsObjectShape ElementShape = new JsObjectShape.Builder()
+        .Method("greet", static (thisObject, args) => new JsString("hello " + (args.Length > 0 ? args[0].ToString() : "world")), length: 1)
+        .Method("secretMethod", static (thisObject, args) => new JsString("secret"), enumerable: false)
+        .Accessor("tagName", getter: GetTag, setter: SetTag)
+        .Accessor("readOnlyTag", getter: GetTag)
+        .Constant("ELEMENT_NODE", JsNumber.Create(1))
+        .Constant("SECRET", new JsString("s"), enumerable: false)
+        .PerRealmSlot("constructor", enumerable: false)
+        .ToStringTag("Element")
+        .Build();
+
+    // Engine-independent by construction: state comes from the receiver, never from a captured engine.
+    private static JsValue GetTag(JsValue thisObject, JsValue[] arguments)
+        => thisObject is ObjectInstance o ? o.Get("_tag") : JsValue.Undefined;
+
+    private static JsValue SetTag(JsValue thisObject, JsValue[] arguments)
+    {
+        if (thisObject is ObjectInstance o)
+        {
+            o.Set("_tag", arguments.Length > 0 ? arguments[0] : JsValue.Undefined);
+        }
+
+        return JsValue.Undefined;
+    }
+
+    private static Engine EngineWithPrototype(out ObjectInstance prototype)
+    {
+        var engine = new Engine();
+        prototype = ElementShape.Instantiate(engine);
+        engine.SetValue("proto", prototype);
+        engine.Execute("var el = Object.create(proto);");
+        return engine;
+    }
+
+    // ---- reachability and representation witness ----
+
+    [Fact]
+    public void ShapeCountReportsDeclaredMemberCount()
+    {
+        // Eight string-keyed members; Symbol.toStringTag is not one of them (symbols live outside the
+        // shared string-keyed layout).
+        ElementShape.Count.Should().Be(7);
+    }
+
+    [Fact]
+    public void AnInstantiatedObjectUsesTheSharedBuiltinLayout()
+    {
+        var engine = EngineWithPrototype(out var prototype);
+
+        // GetObjectRepresentation observes without perturbing, so it reports the settled representation only
+        // after something has touched the object.
+        engine.Evaluate("proto.ELEMENT_NODE").Should().Be(1);
+
+        engine.Advanced.GetObjectRepresentation(prototype).Should().Be(ObjectRepresentation.SharedBuiltinLayout);
+    }
+
+    [Fact]
+    public void InstantiateUsesObjectPrototypeByDefaultAndTheGivenPrototypeOtherwise()
+    {
+        var engine = new Engine();
+
+        var defaulted = ElementShape.Instantiate(engine);
+        engine.SetValue("defaulted", defaulted);
+        engine.Evaluate("Object.getPrototypeOf(defaulted) === Object.prototype").Should().Be(true);
+
+        var bare = ElementShape.Instantiate(engine, prototype: null);
+        engine.SetValue("bare", bare);
+        engine.Evaluate("Object.getPrototypeOf(bare) === null").Should().Be(true);
+        // still fully functional without Object.prototype behind it
+        engine.Evaluate("bare.ELEMENT_NODE").Should().Be(1);
+
+        var chained = ElementShape.Instantiate(engine, defaulted);
+        engine.SetValue("chained", chained);
+        engine.Evaluate("Object.getPrototypeOf(chained) === defaulted").Should().Be(true);
+    }
+
+    [Fact]
+    public void InstantiateRejectsANullEngineAndAForeignPrototype()
+    {
+        Invoking(() => ElementShape.Instantiate(null!)).Should().Throw<ArgumentNullException>();
+        Invoking(() => ElementShape.Instantiate(null!, null)).Should().Throw<ArgumentNullException>();
+
+        var engine = new Engine();
+        var other = new Engine();
+        Invoking(() => ElementShape.Instantiate(engine, ElementShape.Instantiate(other)))
+            .Should().Throw<ArgumentException>()
+            .WithMessage("*different engine*");
+    }
+
+    // ---- members work through the prototype ----
+
+    [Fact]
+    public void MethodsAccessorsAndConstantsResolveThroughAnInstance()
+    {
+        var engine = EngineWithPrototype(out _);
+
+        engine.Evaluate("el.greet('world')").Should().Be("hello world");
+        engine.Evaluate("el.greet.length").Should().Be(1);
+        engine.Evaluate("el.greet.name").Should().Be("greet");
+        engine.Evaluate("el.secretMethod()").Should().Be("secret");
+        engine.Evaluate("el.ELEMENT_NODE").Should().Be(1);
+        engine.Evaluate("el.SECRET").Should().Be("s");
+
+        // The accessor's `this` is the receiver, not the prototype that owns the member.
+        engine.Execute("el._tag = 'DIV';");
+        engine.Evaluate("el.tagName").Should().Be("DIV");
+        engine.Evaluate("proto.tagName").Should().Be(JsValue.Undefined);
+
+        engine.Execute("var other = Object.create(proto); other._tag = 'SPAN';");
+        engine.Evaluate("other.tagName").Should().Be("SPAN");
+        engine.Evaluate("el.tagName").Should().Be("DIV");
+
+        // ...and the setter reaches the receiver too.
+        engine.Execute("el.tagName = 'P';");
+        engine.Evaluate("el._tag").Should().Be("P");
+        engine.Evaluate("other._tag").Should().Be("SPAN");
+    }
+
+    [Fact]
+    public void AnAccessorWithoutASetterIsReadOnly()
+    {
+        var engine = EngineWithPrototype(out _);
+        engine.Execute("el._tag = 'DIV';");
+
+        engine.Evaluate("el.readOnlyTag").Should().Be("DIV");
+        engine.Evaluate("Object.getOwnPropertyDescriptor(proto, 'readOnlyTag').set").Should().Be(JsValue.Undefined);
+        engine.Evaluate("typeof Object.getOwnPropertyDescriptor(proto, 'readOnlyTag').get").Should().Be("function");
+
+        Invoking(() => engine.Execute("'use strict'; el.readOnlyTag = 'X';"))
+            .Should().Throw<JavaScriptException>();
+    }
+
+    [Fact]
+    public void AccessorHalvesAreNamedPerSpecConvention()
+    {
+        var engine = EngineWithPrototype(out _);
+
+        engine.Evaluate("Object.getOwnPropertyDescriptor(proto, 'tagName').get.name").Should().Be("get tagName");
+        engine.Evaluate("Object.getOwnPropertyDescriptor(proto, 'tagName').set.name").Should().Be("set tagName");
+        engine.Evaluate("Object.getOwnPropertyDescriptor(proto, 'tagName').get.length").Should().Be(0);
+        engine.Evaluate("Object.getOwnPropertyDescriptor(proto, 'tagName').set.length").Should().Be(1);
+    }
+
+    [Fact]
+    public void MaterializedMembersKeepAStableIdentityWithinAnEngine()
+    {
+        var engine = EngineWithPrototype(out _);
+
+        engine.Evaluate("proto.greet === proto.greet").Should().Be(true);
+        engine.Evaluate("el.greet === proto.greet").Should().Be(true);
+
+        var descriptorIdentity = engine.Evaluate(
+            "Object.getOwnPropertyDescriptor(proto, 'tagName').get === Object.getOwnPropertyDescriptor(proto, 'tagName').get");
+        descriptorIdentity.Should().Be(true);
+    }
+
+    [Fact]
+    public void MaterializedFunctionsBelongToTheInstantiatingRealm()
+    {
+        // Materialization is lazy, so it can be triggered while a different realm is the active one — a
+        // ShadowRealm callback, say. The function must still be anchored to the realm of the object it came
+        // from, which is what its [[Prototype]] shows.
+        var engine = EngineWithPrototype(out _);
+
+        engine.Evaluate("Object.getPrototypeOf(proto.greet) === Function.prototype").Should().Be(true);
+        engine.Evaluate("Object.getPrototypeOf(Object.getOwnPropertyDescriptor(proto, 'tagName').get) === Function.prototype")
+            .Should().Be(true);
+
+        // Running a ShadowRealm in between changes nothing about members materialized afterwards.
+        engine.Execute("var sr = new ShadowRealm(); sr.evaluate('1 + 1');");
+        engine.Evaluate("Object.getPrototypeOf(proto.secretMethod) === Function.prototype").Should().Be(true);
+        engine.Evaluate("proto.secretMethod()").Should().Be("secret");
+    }
+
+    [Fact]
+    public void ToStringTagIsApplied()
+    {
+        var engine = EngineWithPrototype(out _);
+
+        engine.Evaluate("Object.prototype.toString.call(proto)").Should().Be("[object Element]");
+        engine.Evaluate("Object.prototype.toString.call(el)").Should().Be("[object Element]");
+        engine.Evaluate("proto[Symbol.toStringTag]").Should().Be("Element");
+
+        // the intrinsic convention: non-enumerable, non-writable, configurable
+        engine.Evaluate("Object.getOwnPropertyDescriptor(proto, Symbol.toStringTag).enumerable").Should().Be(false);
+        engine.Evaluate("Object.getOwnPropertyDescriptor(proto, Symbol.toStringTag).writable").Should().Be(false);
+        engine.Evaluate("Object.getOwnPropertyDescriptor(proto, Symbol.toStringTag).configurable").Should().Be(true);
+    }
+
+    // ---- constants ----
+
+    [Fact]
+    public void ConstantsAreNonWritableAndNonConfigurable()
+    {
+        var engine = EngineWithPrototype(out _);
+
+        engine.Evaluate("Object.getOwnPropertyDescriptor(proto, 'ELEMENT_NODE').writable").Should().Be(false);
+        engine.Evaluate("Object.getOwnPropertyDescriptor(proto, 'ELEMENT_NODE').configurable").Should().Be(false);
+        engine.Evaluate("Object.getOwnPropertyDescriptor(proto, 'ELEMENT_NODE').enumerable").Should().Be(true);
+        engine.Evaluate("Object.getOwnPropertyDescriptor(proto, 'SECRET').enumerable").Should().Be(false);
+
+        // sloppy write is silently ignored, strict write throws, the value never changes
+        engine.Execute("proto.ELEMENT_NODE = 9;");
+        engine.Evaluate("proto.ELEMENT_NODE").Should().Be(1);
+        Invoking(() => engine.Execute("'use strict'; proto.ELEMENT_NODE = 9;")).Should().Throw<JavaScriptException>();
+
+        Invoking(() => engine.Execute("Object.defineProperty(proto, 'ELEMENT_NODE', { value: 9 });"))
+            .Should().Throw<JavaScriptException>();
+        engine.Evaluate("proto.ELEMENT_NODE").Should().Be(1);
+
+        // a same-value redefine is allowed by the spec and must leave the shared descriptor intact
+        engine.Execute("Object.defineProperty(proto, 'ELEMENT_NODE', { value: 1, writable: false, configurable: false });");
+        engine.Evaluate("proto.ELEMENT_NODE").Should().Be(1);
+    }
+
+    [Fact]
+    public void DeletingANonConfigurableConstantFailsPerSpec()
+    {
+        var engine = EngineWithPrototype(out var prototype);
+
+        engine.Evaluate("delete proto.ELEMENT_NODE").Should().Be(false);
+        Invoking(() => engine.Execute("'use strict'; delete proto.ELEMENT_NODE;")).Should().Throw<JavaScriptException>();
+
+        engine.Evaluate("proto.ELEMENT_NODE").Should().Be(1);
+        engine.Advanced.GetObjectRepresentation(prototype).Should().Be(ObjectRepresentation.SharedBuiltinLayout);
+    }
+
+    // ---- per-realm slots ----
+
+    [Fact]
+    public void APerRealmValueSlotStartsUndefinedAndIsFilledPerEngine()
+    {
+        var engineA = new Engine();
+        var protoA = ElementShape.Instantiate(engineA);
+        engineA.SetValue("proto", protoA);
+
+        var engineB = new Engine();
+        var protoB = ElementShape.Instantiate(engineB);
+        engineB.SetValue("proto", protoB);
+
+        engineA.Evaluate("proto.constructor").Should().Be(JsValue.Undefined);
+
+        // The setup-time fill: a raw descriptor store into a declared slot, which replaces it in place.
+        protoA.FastSetProperty("constructor", new PropertyDescriptor(new JsString("ctor-A"), PropertyFlag.NonEnumerable));
+        protoB.FastSetProperty("constructor", new PropertyDescriptor(new JsString("ctor-B"), PropertyFlag.NonEnumerable));
+
+        engineA.Evaluate("proto.constructor").Should().Be("ctor-A");
+        engineB.Evaluate("proto.constructor").Should().Be("ctor-B");
+
+        // ...and the object is still shaped afterwards (a declared name never forces the dictionary)
+        engineA.Advanced.GetObjectRepresentation(protoA).Should().Be(ObjectRepresentation.SharedBuiltinLayout);
+        engineB.Advanced.GetObjectRepresentation(protoB).Should().Be(ObjectRepresentation.SharedBuiltinLayout);
+
+        // the declared attributes permit the ordinary spec-validated route too
+        engineA.Execute("Object.defineProperty(proto, 'constructor', { value: 'redefined' });");
+        engineA.Evaluate("proto.constructor").Should().Be("redefined");
+        engineB.Evaluate("proto.constructor").Should().Be("ctor-B");
+    }
+
+    [Fact]
+    public void APerRealmFactorySlotRunsOnceOnFirstAccessAndNotBefore()
+    {
+        var calls = 0;
+        var shape = new JsObjectShape.Builder()
+            .Method("m", static (t, a) => JsValue.Undefined)
+            .PerRealmSlot("lazy", o => { calls++; return new JsString("value-" + calls.ToString(System.Globalization.CultureInfo.InvariantCulture)); })
+            .Build();
+
+        var engine = new Engine();
+        var proto = shape.Instantiate(engine);
+        engine.SetValue("proto", proto);
+        calls.Should().Be(0, "instantiation must not run any member factory");
+
+        // Touching a different member initializes the object but must not run this factory.
+        engine.Evaluate("typeof proto.m").Should().Be("function");
+        calls.Should().Be(0);
+
+        engine.Evaluate("proto.lazy").Should().Be("value-1");
+        engine.Evaluate("proto.lazy").Should().Be("value-1");
+        calls.Should().Be(1, "the factory result is cached per instantiated object");
+
+        // A second object from the same shape gets its own value.
+        var second = shape.Instantiate(engine);
+        engine.SetValue("second", second);
+        engine.Evaluate("second.lazy").Should().Be("value-2");
+        calls.Should().Be(2);
+    }
+
+    [Fact]
+    public void APerRealmFactorySlotReceivesTheInstantiatedObject()
+    {
+        var shape = new JsObjectShape.Builder()
+            .PerRealmSlot("self", static o => o)
+            .Build();
+
+        var engine = new Engine();
+        var proto = shape.Instantiate(engine);
+        engine.SetValue("proto", proto);
+
+        engine.Evaluate("proto.self === proto").Should().Be(true);
+    }
+
+    // ---- sharing across engines ----
+
+    [Fact]
+    public void TwoEnginesShareOneShapeWithoutSharingAnythingElse()
+    {
+        var engineA = new Engine();
+        var protoA = ElementShape.Instantiate(engineA);
+        engineA.SetValue("proto", protoA);
+        engineA.Execute("var el = Object.create(proto); el._tag = 'A';");
+
+        var engineB = new Engine();
+        var protoB = ElementShape.Instantiate(engineB);
+        engineB.SetValue("proto", protoB);
+        engineB.Execute("var el = Object.create(proto); el._tag = 'B';");
+
+        engineA.Evaluate("el.greet('a')").Should().Be("hello a");
+        engineB.Evaluate("el.greet('b')").Should().Be("hello b");
+        engineA.Evaluate("el.tagName").Should().Be("A");
+        engineB.Evaluate("el.tagName").Should().Be("B");
+
+        // A polyfill overwrite in A is invisible in B...
+        engineA.Execute("proto.greet = function () { return 'patched'; };");
+        engineA.Evaluate("el.greet()").Should().Be("patched");
+        engineB.Evaluate("el.greet('b')").Should().Be("hello b");
+
+        // ...as is a redefine, a delete and a freeze. (Delete before freeze: freezing makes every member
+        // non-configurable, which is exactly what a later delete is supposed to be refused by.)
+        engineA.Execute("Object.defineProperty(proto, 'ELEMENT_NODE_2', { value: 2, enumerable: true });");
+        engineB.Evaluate("'ELEMENT_NODE_2' in proto").Should().Be(false);
+
+        engineA.Execute("delete proto.secretMethod;");
+        engineA.Evaluate("proto.secretMethod").Should().Be(JsValue.Undefined);
+        engineB.Evaluate("proto.secretMethod()").Should().Be("secret");
+
+        engineA.Execute("Object.freeze(proto);");
+        engineA.Evaluate("Object.isFrozen(proto)").Should().Be(true);
+        engineB.Evaluate("Object.isFrozen(proto)").Should().Be(false);
+
+        // B is untouched down to its representation and its constant attributes.
+        engineB.Advanced.GetObjectRepresentation(protoB).Should().Be(ObjectRepresentation.SharedBuiltinLayout);
+        engineB.Evaluate("Object.getOwnPropertyDescriptor(proto, 'ELEMENT_NODE').writable").Should().Be(false);
+        engineB.Evaluate("Object.getOwnPropertyDescriptor(proto, 'ELEMENT_NODE').configurable").Should().Be(false);
+        engineB.Evaluate("Object.getOwnPropertyDescriptor(proto, 'ELEMENT_NODE').enumerable").Should().Be(true);
+        engineB.Evaluate("proto.ELEMENT_NODE").Should().Be(1);
+    }
+
+    [Fact]
+    public void FunctionIdentityIsPerEngine()
+    {
+        var engineA = new Engine();
+        var protoA = ElementShape.Instantiate(engineA);
+        var engineB = new Engine();
+        var protoB = ElementShape.Instantiate(engineB);
+
+        var greetA = protoA.Get("greet");
+        var greetB = protoB.Get("greet");
+
+        greetA.Should().NotBeNull();
+        ReferenceEquals(greetA, greetB).Should().BeFalse("each engine materializes its own function objects");
+        ReferenceEquals(greetA, protoA.Get("greet")).Should().BeTrue("identity is stable within one engine");
+    }
+
+    // ---- mutation and deopt semantics ----
+
+    [Fact]
+    public void AWritableMethodCanBeOverwrittenInPlace()
+    {
+        var engine = EngineWithPrototype(out var prototype);
+
+        engine.Evaluate("el.greet('x')").Should().Be("hello x");
+        engine.Execute("proto.greet = function () { return 'patched'; };");
+        engine.Evaluate("el.greet('x')").Should().Be("patched");
+        engine.Advanced.GetObjectRepresentation(prototype).Should().Be(ObjectRepresentation.SharedBuiltinLayout);
+    }
+
+    [Fact]
+    public void RedefiningADeclaredMemberIncludingDataToAccessorKeepsTheSharedLayout()
+    {
+        var engine = EngineWithPrototype(out var prototype);
+
+        engine.Execute("Object.defineProperty(proto, 'greet', { value: 42, writable: true, enumerable: true, configurable: true });");
+        engine.Evaluate("proto.greet").Should().Be(42);
+
+        engine.Execute("Object.defineProperty(proto, 'greet', { get: function () { return 'from getter'; }, configurable: true });");
+        engine.Evaluate("proto.greet").Should().Be("from getter");
+        engine.Evaluate("typeof Object.getOwnPropertyDescriptor(proto, 'greet').get").Should().Be("function");
+
+        engine.Advanced.GetObjectRepresentation(prototype).Should().Be(ObjectRepresentation.SharedBuiltinLayout);
+    }
+
+    [Fact]
+    public void AddingANewStringKeyKeepsTheSharedLayoutAndAppendsToOwnKeyOrder()
+    {
+        var engine = EngineWithPrototype(out var prototype);
+
+        engine.Execute("proto.added = 1; Object.defineProperty(proto, 'defined', { value: 2, enumerable: true, configurable: true });");
+
+        engine.Evaluate("Object.getOwnPropertyNames(proto).join(',')")
+            .Should().Be("greet,secretMethod,tagName,readOnlyTag,ELEMENT_NODE,SECRET,constructor,added,defined");
+        engine.Advanced.GetObjectRepresentation(prototype).Should().Be(ObjectRepresentation.SharedBuiltinLayout);
+        engine.Evaluate("proto.added").Should().Be(1);
+        engine.Evaluate("proto.defined").Should().Be(2);
+    }
+
+    [Fact]
+    public void AddingAnIntegerLikeKeyFallsBackToTheDictionary()
+    {
+        var engine = EngineWithPrototype(out var prototype);
+
+        engine.Execute("proto[0] = 'zero';");
+
+        engine.Advanced.GetObjectRepresentation(prototype).Should().Be(ObjectRepresentation.Specialized);
+        engine.Evaluate("proto[0]").Should().Be("zero");
+        engine.Evaluate("proto.greet('x')").Should().Be("hello x");
+        engine.Evaluate("Object.getOwnPropertyNames(proto)[0]").Should().Be("0");
+    }
+
+    [Fact]
+    public void DeletingAConfigurableMemberFallsBackToTheDictionaryAndKeepsEveryOtherMemberCorrect()
+    {
+        var engine = EngineWithPrototype(out var prototype);
+
+        // Touch exactly one member first, so the delete has to carry both a materialized and a whole set of
+        // never-touched members across the fallback.
+        engine.Evaluate("proto.greet('x')").Should().Be("hello x");
+
+        engine.Evaluate("delete proto.greet").Should().Be(true);
+
+        engine.Advanced.GetObjectRepresentation(prototype).Should().Be(ObjectRepresentation.Specialized);
+        engine.Evaluate("proto.greet").Should().Be(JsValue.Undefined);
+
+        // Every member that was never touched before the fallback still works, including the ones that need
+        // a function or a factory created after it.
+        engine.Evaluate("proto.secretMethod()").Should().Be("secret");
+        engine.Evaluate("proto.ELEMENT_NODE").Should().Be(1);
+        engine.Evaluate("proto.SECRET").Should().Be("s");
+        engine.Execute("el._tag = 'DIV';");
+        engine.Evaluate("el.tagName").Should().Be("DIV");
+        engine.Evaluate("Object.prototype.toString.call(proto)").Should().Be("[object Element]");
+        engine.Evaluate("Object.getOwnPropertyNames(proto).join(',')")
+            .Should().Be("secretMethod,tagName,readOnlyTag,ELEMENT_NODE,SECRET,constructor");
+    }
+
+    [Fact]
+    public void PreventExtensionsAndFreezeBehaveAsOnAnyOtherObject()
+    {
+        var engine = EngineWithPrototype(out var prototype);
+
+        engine.Execute("Object.preventExtensions(proto);");
+        engine.Evaluate("Object.isExtensible(proto)").Should().Be(false);
+        engine.Execute("proto.brandNew = 1;");
+        engine.Evaluate("'brandNew' in proto").Should().Be(false);
+        engine.Evaluate("proto.greet('x')").Should().Be("hello x");
+        engine.Advanced.GetObjectRepresentation(prototype).Should().Be(ObjectRepresentation.SharedBuiltinLayout);
+
+        engine.Execute("Object.freeze(proto);");
+        engine.Evaluate("Object.isFrozen(proto)").Should().Be(true);
+        engine.Execute("proto.greet = 1;");
+        engine.Evaluate("typeof proto.greet").Should().Be("function");
+        // reads keep working, and the object stays in the shared layout after the freeze materialized it
+        engine.Evaluate("proto.ELEMENT_NODE").Should().Be(1);
+        engine.Advanced.GetObjectRepresentation(prototype).Should().Be(ObjectRepresentation.SharedBuiltinLayout);
+    }
+
+    [Fact]
+    public void SettingThePrototypeOfAShapedObjectDoesNotDisturbItsMembers()
+    {
+        var engine = EngineWithPrototype(out var prototype);
+        engine.Execute("var base = { inherited: 'yes' }; Object.setPrototypeOf(proto, base);");
+
+        engine.Evaluate("proto.inherited").Should().Be("yes");
+        engine.Evaluate("proto.greet('x')").Should().Be("hello x");
+        engine.Advanced.GetObjectRepresentation(prototype).Should().Be(ObjectRepresentation.SharedBuiltinLayout);
+    }
+
+    [Fact]
+    public void SymbolKeyedMembersNeverDisturbTheSharedLayout()
+    {
+        var engine = EngineWithPrototype(out var prototype);
+
+        engine.Execute("var s = Symbol('extra'); Object.defineProperty(proto, s, { value: 7, configurable: true }); proto.symbolValue = s;");
+        engine.Evaluate("proto[proto.symbolValue]").Should().Be(7);
+        engine.Evaluate("Object.prototype.toString.call(proto)").Should().Be("[object Element]");
+
+        engine.Execute("delete proto[proto.symbolValue];");
+        engine.Evaluate("proto[proto.symbolValue]").Should().Be(JsValue.Undefined);
+        engine.Advanced.GetObjectRepresentation(prototype).Should().Be(ObjectRepresentation.SharedBuiltinLayout);
+    }
+
+    // ---- enumeration ----
+
+    [Fact]
+    public void EnumerationSeesExactlyTheEnumerableMembers()
+    {
+        var engine = EngineWithPrototype(out _);
+
+        // enumerable: greet, tagName, readOnlyTag, ELEMENT_NODE — non-enumerable: secretMethod, SECRET,
+        // constructor. Own-key order is declaration order in both cases.
+        engine.Evaluate("Object.keys(proto).join(',')").Should().Be("greet,tagName,readOnlyTag,ELEMENT_NODE");
+        engine.Evaluate("Object.getOwnPropertyNames(proto).join(',')")
+            .Should().Be("greet,secretMethod,tagName,readOnlyTag,ELEMENT_NODE,SECRET,constructor");
+
+        engine.Evaluate("Object.values(proto).length").Should().Be(4);
+        engine.Evaluate("Object.entries(proto).map(function (e) { return e[0]; }).join(',')")
+            .Should().Be("greet,tagName,readOnlyTag,ELEMENT_NODE");
+
+        engine.Evaluate("proto.hasOwnProperty('SECRET')").Should().Be(true);
+        engine.Evaluate("proto.hasOwnProperty('nope')").Should().Be(false);
+        engine.Evaluate("proto.propertyIsEnumerable('ELEMENT_NODE')").Should().Be(true);
+        engine.Evaluate("proto.propertyIsEnumerable('SECRET')").Should().Be(false);
+        engine.Evaluate("'SECRET' in el").Should().Be(true);
+    }
+
+    [Fact]
+    public void ForInWalksTheEnumerablePrototypeMembers()
+    {
+        var engine = EngineWithPrototype(out _);
+        engine.Execute("el.own = 1;");
+
+        engine.Evaluate("(function () { var k = []; for (var n in el) { k.push(n); } return k.join(','); })()")
+            .Should().Be("own,greet,tagName,readOnlyTag,ELEMENT_NODE");
+    }
+
+    [Fact]
+    public void JsonStringifyAndSpreadSeeTheEnumerableMembers()
+    {
+        var engine = EngineWithPrototype(out _);
+
+        // greet is a function (omitted) and tagName's getter yields undefined for the prototype (omitted).
+        engine.Evaluate("JSON.stringify(proto)").Should().Be("{\"ELEMENT_NODE\":1}");
+
+        engine.Execute("proto._tag = 'ROOT';");
+        engine.Evaluate("JSON.stringify({ tag: proto.tagName, node: proto.ELEMENT_NODE })")
+            .Should().Be("{\"tag\":\"ROOT\",\"node\":1}");
+
+        engine.Evaluate("Object.keys(Object.assign({}, proto)).join(',')").Should().Be("greet,tagName,readOnlyTag,ELEMENT_NODE,_tag");
+        engine.Evaluate("Object.keys({ ...proto }).join(',')").Should().Be("greet,tagName,readOnlyTag,ELEMENT_NODE,_tag");
+    }
+
+    // ---- inline-cache interaction ----
+
+    [Fact]
+    public void WarmedReadsStayCorrectAcrossAMidLoopOverwriteWithTheShapedObjectAsReceiver()
+    {
+        var engine = EngineWithPrototype(out _);
+
+        engine.Evaluate("""
+            (function () {
+              var seen = '';
+              for (var i = 0; i < 40; i++) {
+                if (i === 20) { proto.greet = function () { return 'patched'; }; }
+                if (i === 30) { Object.defineProperty(proto, 'greet', { value: function () { return 'redefined'; } }); }
+                seen = proto.greet('x');
+              }
+              return seen;
+            })()
+            """).Should().Be("redefined");
+    }
+
+    [Fact]
+    public void WarmedReadsThroughAScriptReceiverStayCorrectAcrossAMidLoopOverwrite()
+    {
+        var engine = EngineWithPrototype(out _);
+
+        engine.Evaluate("""
+            (function () {
+              var results = [];
+              for (var i = 0; i < 40; i++) {
+                if (i === 20) { proto.greet = function () { return 'patched'; }; }
+                results.push(el.greet('x'));
+              }
+              return results[0] + '|' + results[39];
+            })()
+            """).Should().Be("hello x|patched");
+    }
+
+    [Fact]
+    public void WarmedReadsThroughAHostInstanceStayCorrectAcrossAMidLoopOverwrite()
+    {
+        var engine = new Engine();
+        var prototype = ElementShape.Instantiate(engine);
+        var host = new MinimalHostObject(engine, prototype).Project("_tag", new JsString("HOST"));
+
+        engine.SetValue("proto", prototype);
+        engine.SetValue("host", host);
+
+        // Cold, then warm, then invalidated mid-loop: the prototype-method cache must not keep serving the
+        // pre-overwrite descriptor.
+        engine.Evaluate("""
+            (function () {
+              var results = [];
+              for (var i = 0; i < 40; i++) {
+                if (i === 20) { proto.greet = function () { return 'patched'; }; }
+                results.push(host.greet('x') + ':' + host.tagName);
+              }
+              return results[0] + '|' + results[39];
+            })()
+            """).Should().Be("hello x:HOST|patched:HOST");
+
+        // and an own property projected by the host after the fact still shadows the prototype
+        host.Project("greet", new JsString("shadowed"));
+        engine.Evaluate("host.greet").Should().Be("shadowed");
+    }
+
+    // ---- builder validation ----
+
+    [Fact]
+    public void BuilderRejectsInvalidNames()
+    {
+        Invoking(() => new JsObjectShape.Builder().Method(null!, static (t, a) => JsValue.Undefined))
+            .Should().Throw<ArgumentException>().WithMessage("*non-empty*");
+        Invoking(() => new JsObjectShape.Builder().Method("", static (t, a) => JsValue.Undefined))
+            .Should().Throw<ArgumentException>().WithMessage("*non-empty*");
+        Invoking(() => new JsObjectShape.Builder().Constant("0", JsNumber.Create(1)))
+            .Should().Throw<ArgumentException>().WithMessage("*starts with a digit*");
+        Invoking(() => new JsObjectShape.Builder().Accessor("42x", getter: static (t, a) => JsValue.Undefined))
+            .Should().Throw<ArgumentException>().WithMessage("*starts with a digit*");
+    }
+
+    [Fact]
+    public void BuilderRejectsDuplicateNamesAcrossKinds()
+    {
+        Invoking(() => new JsObjectShape.Builder()
+                .Method("x", static (t, a) => JsValue.Undefined)
+                .Constant("x", JsNumber.Create(1)))
+            .Should().Throw<ArgumentException>().WithMessage("*already been declared*");
+
+        Invoking(() => new JsObjectShape.Builder()
+                .Accessor("x", getter: static (t, a) => JsValue.Undefined)
+                .PerRealmSlot("x"))
+            .Should().Throw<ArgumentException>().WithMessage("*already been declared*");
+    }
+
+    [Fact]
+    public void BuilderRejectsMissingDelegatesAndObjectConstants()
+    {
+        Invoking(() => new JsObjectShape.Builder().Method("x", null!))
+            .Should().Throw<ArgumentNullException>();
+        Invoking(() => new JsObjectShape.Builder().Method("x", static (t, a) => JsValue.Undefined, length: -1))
+            .Should().Throw<ArgumentOutOfRangeException>();
+        Invoking(() => new JsObjectShape.Builder().Accessor("x", getter: null, setter: null))
+            .Should().Throw<ArgumentException>().WithMessage("*neither a getter nor a setter*");
+        Invoking(() => new JsObjectShape.Builder().PerRealmSlot("x", (Func<ObjectInstance, JsValue>) null!))
+            .Should().Throw<ArgumentNullException>();
+        Invoking(() => new JsObjectShape.Builder().Constant("x", null!))
+            .Should().Throw<ArgumentNullException>();
+
+        var engine = new Engine();
+        var objectValue = engine.Evaluate("({})").AsObject();
+        Invoking(() => new JsObjectShape.Builder().Constant("x", objectValue))
+            .Should().Throw<ArgumentException>().WithMessage("*object value*");
+    }
+
+    [Fact]
+    public void BuilderRejectsAnUnfillablePerRealmSlot()
+    {
+        Invoking(() => new JsObjectShape.Builder().PerRealmSlot("x", writable: false, configurable: false))
+            .Should().Throw<ArgumentException>().WithMessage("*neither writable nor configurable*");
+    }
+
+    [Fact]
+    public void BuilderRejectsASecondToStringTag()
+    {
+        Invoking(() => new JsObjectShape.Builder().ToStringTag("A").ToStringTag("B"))
+            .Should().Throw<InvalidOperationException>().WithMessage("*already been declared*");
+        Invoking(() => new JsObjectShape.Builder().ToStringTag(null!))
+            .Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void BuilderRejectsUseAfterBuild()
+    {
+        var builder = new JsObjectShape.Builder().Method("x", static (t, a) => JsValue.Undefined);
+        builder.Build();
+
+        Invoking(() => builder.Method("y", static (t, a) => JsValue.Undefined))
+            .Should().Throw<InvalidOperationException>().WithMessage("*already been built*");
+        Invoking(() => builder.Constant("y", JsNumber.Create(1)))
+            .Should().Throw<InvalidOperationException>();
+        Invoking(() => builder.Accessor("y", getter: static (t, a) => JsValue.Undefined))
+            .Should().Throw<InvalidOperationException>();
+        Invoking(() => builder.PerRealmSlot("y"))
+            .Should().Throw<InvalidOperationException>();
+        Invoking(() => builder.ToStringTag("y"))
+            .Should().Throw<InvalidOperationException>();
+        Invoking(() => builder.Build())
+            .Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void BuilderRejectsMoreMembersThanAShapeCanDescribe()
+    {
+        var builder = new JsObjectShape.Builder();
+        for (var i = 0; i <= 4096; i++)
+        {
+            builder.Constant("c" + i.ToString(System.Globalization.CultureInfo.InvariantCulture), JsNumber.Create(i));
+        }
+
+        Invoking(() => builder.Build()).Should().Throw<ArgumentException>().WithMessage("*at most 4096 members*");
+    }
+
+    [Fact]
+    public void AnEmptyShapeIsUsable()
+    {
+        var shape = new JsObjectShape.Builder().Build();
+        shape.Count.Should().Be(0);
+
+        var engine = new Engine();
+        var obj = shape.Instantiate(engine);
+        engine.SetValue("o", obj);
+        engine.Evaluate("Object.keys(o).length").Should().Be(0);
+        engine.Execute("o.x = 1;");
+        engine.Evaluate("o.x").Should().Be(1);
+    }
+
+    /// <summary>
+    /// The smallest host receiver that reaches the prototype-method inline cache: an
+    /// <see cref="ObjectInstance"/> subclass overriding <see cref="ObjectInstance.GetOwnProperty"/> and
+    /// nothing else, so the engine derives ordinary access semantics for it. Deliberately built only from
+    /// members an embedder in an unrelated assembly can reach.
+    /// </summary>
+    private sealed class MinimalHostObject : ObjectInstance
+    {
+        private readonly Dictionary<string, JsValue> _own = new(StringComparer.Ordinal);
+
+        public MinimalHostObject(Engine engine, ObjectInstance prototype) : base(engine)
+        {
+            Prototype = prototype;
+        }
+
+        public MinimalHostObject Project(string name, JsValue value)
+        {
+            _own[name] = value;
+            return this;
+        }
+
+        public override PropertyDescriptor GetOwnProperty(JsValue property)
+        {
+            if (property.IsString() && _own.TryGetValue(property.ToString(), out var value))
+            {
+                return new PropertyDescriptor(value, writable: true, enumerable: true, configurable: true);
+            }
+
+            return PropertyDescriptor.Undefined;
+        }
+    }
+}

--- a/Jint.Tests/Runtime/SharedObjectShapeTests.cs
+++ b/Jint.Tests/Runtime/SharedObjectShapeTests.cs
@@ -1,0 +1,171 @@
+#nullable enable
+
+using Jint.Native;
+using Jint.Native.Object;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// The half of <see cref="JsObjectShape"/>'s contract that only the engine's own assembly can witness: that an
+/// instantiated object really does carry the shared <c>BuiltinShape</c> storage, that it fills that storage one
+/// member at a time, and — the critical one — that a process-held shape retains no engine.
+/// <para>
+/// The script-visible behaviour is pinned from outside the assembly instead, in
+/// <c>Jint.Tests.PublicInterface.HostPrototypeShapeTests</c>, where a green test also proves reachability.
+/// </para>
+/// </summary>
+// The GC test measures collectability, which nothing else running concurrently may perturb.
+[CollectionDefinition(nameof(SharedObjectShapeTests), DisableParallelization = true)]
+[Collection(nameof(SharedObjectShapeTests))]
+public class SharedObjectShapeTests
+{
+    private static readonly JsObjectShape MethodsOnlyShape = new JsObjectShape.Builder()
+        .Method("a", static (t, args) => new JsString("a"))
+        .Method("b", static (t, args) => new JsString("b"))
+        .Method("c", static (t, args) => new JsString("c"))
+        .Build();
+
+    private static readonly JsObjectShape MixedShape = new JsObjectShape.Builder()
+        .Method("m", static (t, args) => new JsString("m"))
+        .Accessor("acc", getter: static (t, args) => new JsString("acc"))
+        .Constant("K", JsNumber.Create(7))
+        .PerRealmSlot("constructor", enumerable: false)
+        .ToStringTag("Mixed")
+        .Build();
+
+    [Fact]
+    public void InstantiateAllocatesNoPerRealmStorageUntilTheObjectIsTouched()
+    {
+        var engine = new Engine();
+        var proto = (IBuiltinShaped) MethodsOnlyShape.Instantiate(engine);
+
+        proto.BuiltinDescriptors.Should().BeNull("instantiation must allocate nothing but the object itself");
+
+        // Any property access initializes the object; the descriptor array appears, still entirely empty
+        // because every slot of this shape is a lazily-materialized function.
+        ((ObjectInstance) proto).Get("a");
+
+        var descriptors = proto.BuiltinDescriptors;
+        descriptors.Should().NotBeNull();
+        descriptors!.Length.Should().Be(3);
+        descriptors[0].Should().NotBeNull("the touched member is the one that materialized");
+        descriptors[1].Should().BeNull();
+        descriptors[2].Should().BeNull();
+
+        ((ObjectInstance) proto).Get("c");
+        proto.BuiltinDescriptors![1].Should().BeNull("an untouched member stays unmaterialized");
+        proto.BuiltinDescriptors![2].Should().NotBeNull();
+    }
+
+    [Fact]
+    public void InitializationPreWiresOnlyConstantsAndPerRealmValueSlots()
+    {
+        var engine = new Engine();
+        var proto = MixedShape.Instantiate(engine);
+
+        // Touch a symbol so initialization runs without materializing any string-keyed member.
+        proto.Get(GlobalSymbolRegistryToStringTag(engine));
+
+        var descriptors = ((IBuiltinShaped) proto).BuiltinDescriptors;
+        descriptors.Should().NotBeNull();
+        descriptors![0].Should().BeNull("the method materializes on first access");
+        descriptors[1].Should().BeNull("the accessor materializes on first access");
+        descriptors[2].Should().NotBeNull("a constant points at the shape's shared descriptor from the start");
+        descriptors[3].Should().NotBeNull("a value-form per-realm slot needs a live descriptor to be fillable");
+
+        descriptors[3]!.Value.Should().Be(JsValue.Undefined);
+    }
+
+    [Fact]
+    public void EveryEngineGetsItsOwnDescriptorsWhileTheShapeStaysUntouched()
+    {
+        var engineA = new Engine();
+        var protoA = MixedShape.Instantiate(engineA);
+        var engineB = new Engine();
+        var protoB = MixedShape.Instantiate(engineB);
+
+        var constantBefore = protoA.GetOwnProperty("K");
+
+        protoA.Get("m").Should().NotBeNull();
+        protoB.Get("m").Should().NotBeNull();
+
+        var descriptorsA = ((IBuiltinShaped) protoA).BuiltinDescriptors!;
+        var descriptorsB = ((IBuiltinShaped) protoB).BuiltinDescriptors!;
+
+        ReferenceEquals(descriptorsA, descriptorsB).Should().BeFalse();
+        ReferenceEquals(descriptorsA[0], descriptorsB[0]).Should().BeFalse("materialized members are engine-affine");
+        ReferenceEquals(descriptorsA[2], descriptorsB[2]).Should().BeTrue("a constant's descriptor is the shared one");
+
+        // Mutating a materialized member and falling back to the dictionary in A leaves B — and the shared
+        // shape both were built from — exactly as they were.
+        engineA.SetValue("proto", protoA);
+        engineA.Execute("proto.m = 1; delete proto.acc;");
+
+        protoB.Get("m").Should().NotBe(JsValue.Undefined);
+        engineB.SetValue("proto", protoB);
+        engineB.Evaluate("typeof proto.m").Should().Be("function");
+        engineB.Evaluate("proto.acc").Should().Be("acc");
+        engineB.Advanced.GetObjectRepresentation(protoB).Should().Be(ObjectRepresentation.SharedBuiltinLayout);
+
+        // A third engine, instantiated after all that, is indistinguishable from the first.
+        var engineC = new Engine();
+        var protoC = MixedShape.Instantiate(engineC);
+        engineC.SetValue("proto", protoC);
+        engineC.Evaluate("typeof proto.m").Should().Be("function");
+        engineC.Evaluate("proto.K").Should().Be(7);
+        ReferenceEquals(protoC.GetOwnProperty("K"), constantBefore).Should().BeTrue("the shared constant descriptor is never replaced");
+        constantBefore.Value.Should().Be(7);
+        constantBefore.Writable.Should().BeFalse();
+        constantBefore.Configurable.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ASharedShapeDoesNotRetainEngines()
+    {
+        // The critical invariant of the whole feature: a host declares one shape per process and instantiates
+        // it into every short-lived engine, so anything the shape held on to — an engine, a realm, a
+        // materialized function, an instantiated prototype — would leak one of those per engine, forever.
+        // Modelled on SharedPreparedScriptDoesNotRetainEngines in GarbageCollectionTests.
+        var shape = new JsObjectShape.Builder()
+            .Method("greet", static (t, args) => new JsString("hello"))
+            .Accessor("tag", getter: static (t, args) => new JsString("tag"), setter: static (t, args) => JsValue.Undefined)
+            .Constant("K", JsNumber.Create(1))
+            .PerRealmSlot("constructor", enumerable: false)
+            .PerRealmSlot("lazy", static o => new JsString("lazy"), enumerable: false)
+            .ToStringTag("Retention")
+            .Build();
+
+        const int count = 20;
+        var references = new List<WeakReference>(count);
+        for (var i = 0; i < count; i++)
+        {
+            references.Add(RunOnceAndForget(shape));
+        }
+
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+
+        var aliveCount = references.Count(static r => r.IsAlive);
+        GC.KeepAlive(shape);
+
+        aliveCount.Should().Be(0, $"{aliveCount} of {count} engines were not collected — the shared shape still pins engines.");
+
+        // NoInlining so the engine reference cannot be stack-rooted in this frame across the GC.Collect calls.
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static WeakReference RunOnceAndForget(JsObjectShape shape)
+        {
+            var engine = new Engine();
+            var proto = shape.Instantiate(engine);
+            proto.FastSetProperty("constructor", new Jint.Runtime.Descriptors.PropertyDescriptor(new JsString("ctor"), Jint.Runtime.Descriptors.PropertyFlag.NonEnumerable));
+            engine.SetValue("proto", proto);
+            // Materialize every kind of member, so anything a materialization could have parked on the shape
+            // would be parked by the time the engine is dropped.
+            engine.Execute("var el = Object.create(proto); el.greet(); el.tag; el.K; el.constructor; el.lazy; Object.keys(proto); String(proto);");
+            return new WeakReference(engine);
+        }
+    }
+
+    private static JsValue GlobalSymbolRegistryToStringTag(Engine engine)
+        => engine.Evaluate("Symbol.toStringTag");
+}

--- a/Jint/Native/JsObjectShape.cs
+++ b/Jint/Native/JsObjectShape.cs
@@ -1,0 +1,610 @@
+using System.Runtime.InteropServices;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Interop;
+
+namespace Jint.Native;
+
+/// <summary>
+/// An immutable, process-shared description of the members of a host-built prototype-like object:
+/// methods, get/set accessors, immutable constants and per-realm value slots. Build one with
+/// <see cref="Builder"/> (typically into a <c>static readonly</c> field), then create one object
+/// per engine with <see cref="Instantiate(Engine, ObjectInstance)"/>.
+/// <para>
+/// This is the member-layout sibling of <see cref="JsObjectLayout"/>: a layout describes per-item
+/// <em>data</em> objects built in the hidden-class representation, while a shape describes
+/// <em>singleton</em> prototype/namespace objects built in the shared-layout representation the
+/// engine uses for its own intrinsics (<c>Math</c>, <c>Generator.prototype</c>, …). An instantiated
+/// object allocates no per-member state up front: each member's descriptor — and for methods and
+/// accessors the function object itself — is created on first access in that engine and cached
+/// there, so a shape with hundreds of members costs an engine only the members its scripts touch.
+/// </para>
+/// <para>
+/// <b>Thread safety and sharing.</b> A built shape is immutable and safe to publish to and use from
+/// any number of engines on any threads; so are the delegates and constant values placed into it,
+/// which is why everything placed <em>into</em> a shape must be engine-independent — see the member
+/// factory methods on <see cref="Builder"/> for the per-kind rules. Everything the shape
+/// <em>materializes</em> is by contrast an ordinary engine-affine value: the object
+/// <see cref="Instantiate(Engine, ObjectInstance)"/> returns, its per-engine descriptor array and
+/// every function created for a method or accessor belong to the engine that instantiated it. The
+/// shape itself holds no reference to any engine, realm or instantiated object, so a
+/// <c>static readonly</c> shape never keeps an engine alive.
+/// </para>
+/// <para>
+/// The representation is an implementation detail with no script-visible consequence: an
+/// instantiated object behaves exactly like an ordinary object carrying the same properties, and
+/// anything the shared layout cannot express (deleting a member, adding an integer-like key) falls
+/// back to the ordinary property dictionary automatically and correctly.
+/// </para>
+/// </summary>
+/// <example>
+/// <code>
+/// private static readonly JsObjectShape NodeShape = new JsObjectShape.Builder()
+///     .Method("appendChild", static (t, args) =&gt; Dom.AppendChild(t, args), length: 1)
+///     .Accessor("firstChild", getter: static (t, _) =&gt; Dom.GetFirstChild(t))
+///     .Constant("ELEMENT_NODE", 1)
+///     .PerRealmSlot("constructor", static o =&gt; HostRealmState.For(o.Engine).NodeConstructor, enumerable: false)
+///     .ToStringTag("Node")
+///     .Build();
+///
+/// // once per engine, cached by the host:
+/// var nodeProto = NodeShape.Instantiate(engine, eventTargetProto);
+/// </code>
+/// </example>
+public sealed class JsObjectShape
+{
+    /// <summary>
+    /// The largest number of members a shape can describe. Function dispatch ids are 16-bit, and the
+    /// widest real-world prototype (a Web IDL interface with every inherited member flattened onto it)
+    /// runs to a few hundred, so this bound exists only to turn a runaway generator into a clear error.
+    /// </summary>
+    internal const int MaxMembers = 4096;
+
+    private readonly BuiltinShape _layout;
+    private readonly FunctionEntry[] _functions;
+    private readonly PerRealmValueSlot[] _perRealmValueSlots;
+    private readonly JsString? _toStringTag;
+
+    private JsObjectShape(
+        BuiltinShape layout,
+        FunctionEntry[] functions,
+        PerRealmValueSlot[] perRealmValueSlots,
+        JsString? toStringTag)
+    {
+        _layout = layout;
+        _functions = functions;
+        _perRealmValueSlots = perRealmValueSlots;
+        _toStringTag = toStringTag;
+    }
+
+    /// <summary>The number of string-keyed members this shape declares.</summary>
+    public int Count => _layout.Count;
+
+    /// <summary>
+    /// Creates one object with this shape in <paramref name="engine"/>, using the engine's
+    /// <c>Object.prototype</c> as its prototype. Equivalent to
+    /// <c>Instantiate(engine, engine.Realm.Intrinsics.Object.PrototypeObject)</c>.
+    /// </summary>
+    /// <param name="engine">The engine the object belongs to.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="engine"/> is <c>null</c>.</exception>
+    public ObjectInstance Instantiate(Engine engine)
+    {
+        if (engine is null)
+        {
+            Throw.ArgumentNullException(nameof(engine));
+        }
+
+        return new SharedShapeObject(engine, this, engine.Realm.Intrinsics.Object.PrototypeObject);
+    }
+
+    /// <summary>
+    /// Creates one object with this shape in <paramref name="engine"/> whose <c>[[Prototype]]</c> is
+    /// <paramref name="prototype"/> (<c>null</c> for a prototype-less object, as in
+    /// <c>Object.create(null)</c>). The call itself allocates only the object; members materialize
+    /// lazily on first access. Each call creates a new, independent object — keeping one prototype
+    /// per engine is the caller's job, typically through the host's existing per-engine prototype
+    /// cache.
+    /// </summary>
+    /// <param name="engine">The engine the object belongs to.</param>
+    /// <param name="prototype">The prototype of the created object, or <c>null</c> for none.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="engine"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="prototype"/> belongs to a different engine.</exception>
+    public ObjectInstance Instantiate(Engine engine, ObjectInstance? prototype)
+    {
+        if (engine is null)
+        {
+            Throw.ArgumentNullException(nameof(engine));
+        }
+
+        if (prototype is not null && !ReferenceEquals(prototype.Engine, engine))
+        {
+            // An object's prototype must belong to its own engine; accepting a foreign one would build a
+            // cross-engine object graph, which nothing in Jint supports. Easy to get wrong in exactly the
+            // multi-engine host code this API is written for, so it fails instead of misbehaving later.
+            Throw.ArgumentException("The prototype belongs to a different engine.", nameof(prototype));
+        }
+
+        return new SharedShapeObject(engine, this, prototype);
+    }
+
+    /// <summary>The shared member layout, handed to the engine's <c>IBuiltinShaped</c> storage protocol.</summary>
+    internal BuiltinShape Layout => _layout;
+
+    /// <summary>
+    /// The slots declared through the value form of <c>PerRealmSlot</c>, which the engine's shared-layout
+    /// storage requires to carry a live descriptor from initialization on (unlike function and factory
+    /// slots, it has no way to produce one on demand).
+    /// </summary>
+    internal PerRealmValueSlot[] PerRealmValueSlots => _perRealmValueSlots;
+
+    /// <summary>The declared <c>Symbol.toStringTag</c> value, or <c>null</c> when none was declared.</summary>
+    internal JsString? ToStringTagValue => _toStringTag;
+
+    /// <summary>
+    /// Creates the function object for a method slot or an accessor half, in <paramref name="realm"/>.
+    /// Called once per (instantiated object, member) by the engine's lazy slot materialization.
+    /// </summary>
+    internal Jint.Native.Function.Function MakeFunction(Engine engine, Realm realm, ushort slot)
+    {
+        var entry = _functions[slot];
+        return new ClrFunction(engine, realm, entry.Name, entry.Implementation, entry.Length);
+    }
+
+    /// <summary>One entry of the shape's process-shared function table: everything a per-realm function needs.</summary>
+    [StructLayout(LayoutKind.Auto)]
+    private readonly record struct FunctionEntry(string Name, JsCallDelegate Implementation, int Length);
+
+    /// <summary>A value-form per-realm slot: which slot to pre-fill, and with which attributes.</summary>
+    [StructLayout(LayoutKind.Auto)]
+    internal readonly record struct PerRealmValueSlot(int Slot, PropertyFlag Flags);
+
+    /// <summary>
+    /// Accumulates member declarations, in own-key (declaration) order, and produces the shared shape.
+    /// The builder is <b>not</b> thread-safe and must not be used after <see cref="Build"/>; the shape it
+    /// builds is thread-safe and process-shareable.
+    /// <para>
+    /// Member names must be non-empty, distinct, and must not start with a digit — an integer-index-like
+    /// key has to enumerate in ascending numeric order ahead of the string keys, which a fixed member list
+    /// cannot express.
+    /// </para>
+    /// </summary>
+    public sealed class Builder
+    {
+        private readonly List<MemberDeclaration> _members = [];
+        private readonly List<FunctionEntry> _functions = [];
+        private readonly HashSet<string> _declaredNames = new(StringComparer.Ordinal);
+        private JsString? _toStringTag;
+        private bool _built;
+
+        /// <summary>Creates an empty builder.</summary>
+        public Builder()
+        {
+        }
+
+        /// <summary>
+        /// Declares a method: a data property whose value is a function created per engine on first access,
+        /// exactly like an intrinsic prototype method. Attribute defaults follow Web IDL operations
+        /// (<c>{ writable: true, enumerable: true, configurable: true }</c>); pass
+        /// <paramref name="enumerable"/><c>: false</c> for ECMAScript-built-in style.
+        /// <para>
+        /// <paramref name="implementation"/> is invoked as <c>(thisObject, arguments)</c> — the same
+        /// signature <see cref="ClrFunction"/> takes — and MUST be engine-independent: a static lambda, or
+        /// one capturing only engine-independent CLR state (a <c>MemberInfo</c>, a compiled open delegate,
+        /// attribute metadata). It may run on behalf of any engine that instantiated the shape, concurrently
+        /// with other engines; reach the current engine through the receiver
+        /// (<c>((ObjectInstance) thisObject).Engine</c>) when it is needed.
+        /// </para>
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="implementation">The method body.</param>
+        /// <param name="length">The function's <c>length</c> — its declared parameter count.</param>
+        /// <param name="enumerable">Whether the property is enumerable.</param>
+        /// <param name="writable">Whether the property is writable.</param>
+        /// <param name="configurable">Whether the property is configurable.</param>
+        /// <returns>This builder, for chaining.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="implementation"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="name"/> is invalid or already declared.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="length"/> is negative.</exception>
+        /// <exception cref="InvalidOperationException">The shape has already been built.</exception>
+        public Builder Method(
+            string name,
+            Func<JsValue, JsValue[], JsValue> implementation,
+            int length = 0,
+            bool enumerable = true,
+            bool writable = true,
+            bool configurable = true)
+        {
+            DeclareName(name);
+
+            if (implementation is null)
+            {
+                Throw.ArgumentNullException(nameof(implementation));
+            }
+
+            if (length < 0)
+            {
+                Throw.ArgumentOutOfRangeException(nameof(length), "A function's length must not be negative.");
+            }
+
+            var slot = AddFunction(name, implementation, length);
+            _members.Add(new MemberDeclaration(
+                name,
+                MemberKind.Method,
+                DataFlags(enumerable, writable, configurable),
+                slot,
+                BuiltinShape.NotAFunction,
+                Constant: null,
+                Factory: null));
+            return this;
+        }
+
+        /// <summary>
+        /// Declares an accessor property. The getter and setter functions are created per engine on first
+        /// access of the property, both halves together so that
+        /// <c>Object.getOwnPropertyDescriptor</c> observes a settled pair; an absent half surfaces as
+        /// <c>undefined</c>, per spec. The materialized functions are named <c>"get name"</c> /
+        /// <c>"set name"</c> per spec convention. Defaults follow Web IDL attributes
+        /// (<c>{ enumerable: true, configurable: true }</c>).
+        /// <para>
+        /// The delegates carry the same engine-independence contract as <see cref="Method"/>.
+        /// </para>
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="getter">The getter body, or <c>null</c> for a set-only property.</param>
+        /// <param name="setter">The setter body, or <c>null</c> for a get-only property.</param>
+        /// <param name="enumerable">Whether the property is enumerable.</param>
+        /// <param name="configurable">Whether the property is configurable.</param>
+        /// <returns>This builder, for chaining.</returns>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="name"/> is invalid or already declared, or both <paramref name="getter"/> and
+        /// <paramref name="setter"/> are <c>null</c>.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">The shape has already been built.</exception>
+        public Builder Accessor(
+            string name,
+            Func<JsValue, JsValue[], JsValue>? getter,
+            Func<JsValue, JsValue[], JsValue>? setter = null,
+            bool enumerable = true,
+            bool configurable = true)
+        {
+            DeclareName(name);
+
+            if (getter is null && setter is null)
+            {
+                Throw.ArgumentException(
+                    $"Accessor '{name}' declares neither a getter nor a setter; at least one half is required.",
+                    nameof(getter));
+            }
+
+            var getterSlot = getter is null ? BuiltinShape.NotAFunction : AddFunction("get " + name, getter, 0);
+            var setterSlot = setter is null ? BuiltinShape.NotAFunction : AddFunction("set " + name, setter, 1);
+
+            // GetSetPropertyDescriptor owns the writable bits (an accessor has none), so only the
+            // enumerable/configurable claims travel with the slot.
+            var flags = (enumerable ? PropertyFlag.Enumerable : PropertyFlag.EnumerableSet)
+                        | (configurable ? PropertyFlag.Configurable : PropertyFlag.ConfigurableSet);
+
+            _members.Add(new MemberDeclaration(
+                name,
+                MemberKind.Accessor,
+                flags,
+                getterSlot,
+                setterSlot,
+                Constant: null,
+                Factory: null));
+            return this;
+        }
+
+        /// <summary>
+        /// Declares an immutable constant: <c>{ value, writable: false, enumerable, configurable: false }</c>
+        /// — the Web IDL constant shape.
+        /// <para>
+        /// The attributes are forced rather than offered because the descriptor is created once and shared
+        /// by every engine that instantiates the shape: a writable or configurable shared descriptor could
+        /// be mutated through one engine and observed through another.
+        /// </para>
+        /// <para>
+        /// <paramref name="value"/> must be a primitive — number, string, boolean, bigint, <c>null</c>,
+        /// <c>undefined</c>, or a symbol. Object values are engine-affine and are rejected; declare an
+        /// object-valued member with
+        /// <see cref="PerRealmSlot(string, Func{ObjectInstance, JsValue}, bool, bool, bool)"/> instead.
+        /// </para>
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="value">The constant value; must be a primitive.</param>
+        /// <param name="enumerable">Whether the property is enumerable.</param>
+        /// <returns>This builder, for chaining.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="name"/> is invalid or already declared, or <paramref name="value"/> is an object.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">The shape has already been built.</exception>
+        public Builder Constant(string name, JsValue value, bool enumerable = true)
+        {
+            DeclareName(name);
+
+            if (value is null)
+            {
+                Throw.ArgumentNullException(nameof(value));
+            }
+
+            if (value is ObjectInstance)
+            {
+                Throw.ArgumentException(
+                    $"Constant '{name}' has an object value. A constant's descriptor is shared by every engine that instantiates the shape, and an object belongs to exactly one engine; declare an object-valued member with PerRealmSlot instead.",
+                    nameof(value));
+            }
+
+            // writable:false + configurable:false is what makes sharing one descriptor across engines sound.
+            // ValidateAndApplyPropertyDescriptor mutates the *current* descriptor in place, and for a constant
+            // slot "current" is the process-shared instance — so a writable or configurable constant would let
+            // one engine's `p.X = 1` or `Object.defineProperty(p, 'X', …)` rewrite what every other engine
+            // reads. With both attributes off, every mutation that reaches the descriptor is provably a
+            // same-value store: a value write requires SameValue to have passed first, and an attribute write
+            // re-stores the flag it already carries; anything that would actually change is rejected by the
+            // non-configurable checks before the descriptor is touched.
+            var flags = enumerable ? PropertyFlag.OnlyEnumerable : PropertyFlag.AllForbidden;
+            _members.Add(new MemberDeclaration(
+                name,
+                MemberKind.Constant,
+                flags,
+                BuiltinShape.NotAFunction,
+                BuiltinShape.NotAFunction,
+                new PropertyDescriptor(value, flags),
+                Factory: null));
+            return this;
+        }
+
+        /// <summary>
+        /// Declares a data property whose value differs per engine — the canonical case being
+        /// <c>constructor</c>. The slot starts as <c>undefined</c> with the declared attributes on every
+        /// instantiated object; the host fills it after creating the object, either with
+        /// <see cref="ObjectInstance.FastSetProperty(string, PropertyDescriptor)"/> (a setup-time in-place
+        /// slot replacement — on a shaped object a declared name never falls back to a dictionary) or with
+        /// <c>DefineOwnProperty</c> / <c>Set</c>, which are spec-validated and therefore need the declared
+        /// attributes to permit the write. That is why the slot must be declared writable or configurable.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="enumerable">Whether the property is enumerable.</param>
+        /// <param name="writable">Whether the property is writable.</param>
+        /// <param name="configurable">Whether the property is configurable.</param>
+        /// <returns>This builder, for chaining.</returns>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="name"/> is invalid or already declared, or the slot is declared neither writable
+        /// nor configurable, which would make it impossible to fill.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">The shape has already been built.</exception>
+        public Builder PerRealmSlot(
+            string name,
+            bool enumerable = false,
+            bool writable = true,
+            bool configurable = true)
+        {
+            DeclareName(name);
+
+            if (!writable && !configurable)
+            {
+                Throw.ArgumentException(
+                    $"Per-realm slot '{name}' is declared neither writable nor configurable, so nothing could ever fill it; declare it writable or configurable, or use Constant for an immutable member.",
+                    nameof(writable));
+            }
+
+            _members.Add(new MemberDeclaration(
+                name,
+                MemberKind.PerRealmValue,
+                DataFlags(enumerable, writable, configurable),
+                BuiltinShape.NotAFunction,
+                BuiltinShape.NotAFunction,
+                Constant: null,
+                Factory: null));
+            return this;
+        }
+
+        /// <summary>
+        /// Per-realm slot variant that stays fully lazy: <paramref name="factory"/> runs at most once per
+        /// instantiated object, on the first access of that member in that engine, and the result is cached
+        /// there. This is how a prototype's <c>constructor</c> reference is declared without forcing the
+        /// constructor — or the prototype's member table — into existence at setup time.
+        /// <para>
+        /// The factory receives the instantiated object (reach the engine through
+        /// <see cref="ObjectInstance.Engine"/>) and must itself be engine-independent — a static lambda, with
+        /// all per-engine state coming from the argument. Note that the factory also runs if the object ever
+        /// falls back to the ordinary property dictionary (for instance because a member was deleted) while
+        /// this member is still untouched, so it should be cheap and free of side effects beyond producing
+        /// the value.
+        /// </para>
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="factory">Produces the value for one instantiated object.</param>
+        /// <param name="enumerable">Whether the property is enumerable.</param>
+        /// <param name="writable">Whether the property is writable.</param>
+        /// <param name="configurable">Whether the property is configurable.</param>
+        /// <returns>This builder, for chaining.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="factory"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="name"/> is invalid or already declared.</exception>
+        /// <exception cref="InvalidOperationException">The shape has already been built.</exception>
+        public Builder PerRealmSlot(
+            string name,
+            Func<ObjectInstance, JsValue> factory,
+            bool enumerable = false,
+            bool writable = true,
+            bool configurable = true)
+        {
+            DeclareName(name);
+
+            if (factory is null)
+            {
+                Throw.ArgumentNullException(nameof(factory));
+            }
+
+            var flags = DataFlags(enumerable, writable, configurable);
+
+            // Captures only the host's factory and the declared attributes — both process-shared — so the
+            // closure keeps the engine-independence the shared layout requires of a slot factory.
+            _members.Add(new MemberDeclaration(
+                name,
+                MemberKind.PerRealmFactory,
+                flags,
+                BuiltinShape.NotAFunction,
+                BuiltinShape.NotAFunction,
+                Constant: null,
+                o => new PropertyDescriptor(factory(o) ?? JsValue.Undefined, flags)));
+            return this;
+        }
+
+        /// <summary>
+        /// Declares the <c>Symbol.toStringTag</c> value (non-writable, non-enumerable, configurable — the
+        /// intrinsic convention), which is what <c>Object.prototype.toString.call(obj)</c> reports.
+        /// <para>
+        /// Symbols are stored per object — the shared string-keyed layout is orthogonal to them — so this
+        /// costs one descriptor per instantiated object, applied on first touch along with the rest of the
+        /// object's initialization. Other symbol-keyed members are added per object after instantiation with
+        /// <c>DefineOwnProperty</c>; symbol keys never disturb the shared layout.
+        /// </para>
+        /// </summary>
+        /// <param name="value">The tag, e.g. the Web IDL interface name.</param>
+        /// <returns>This builder, for chaining.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c>.</exception>
+        /// <exception cref="InvalidOperationException">
+        /// The tag has already been declared, or the shape has already been built.
+        /// </exception>
+        public Builder ToStringTag(string value)
+        {
+            ThrowIfBuilt();
+
+            if (value is null)
+            {
+                Throw.ArgumentNullException(nameof(value));
+            }
+
+            if (_toStringTag is not null)
+            {
+                Throw.InvalidOperationException("Symbol.toStringTag has already been declared on this shape.");
+            }
+
+            _toStringTag = JsString.Create(value);
+            return this;
+        }
+
+        /// <summary>
+        /// Builds the immutable shape. The builder must not be used again afterwards.
+        /// </summary>
+        /// <returns>The shared, thread-safe shape.</returns>
+        /// <exception cref="ArgumentException">More than <c>4096</c> members were declared.</exception>
+        /// <exception cref="InvalidOperationException">The shape has already been built.</exception>
+        public JsObjectShape Build()
+        {
+            ThrowIfBuilt();
+
+            var count = _members.Count;
+            if (count > MaxMembers)
+            {
+                Throw.ArgumentException(
+                    $"A shape can describe at most {MaxMembers} members, but {count} were declared.");
+            }
+
+            _built = true;
+
+            var layoutBuilder = new BuiltinShape.Builder(count);
+            var perRealmValueSlots = new List<PerRealmValueSlot>();
+            for (var i = 0; i < count; i++)
+            {
+                var member = _members[i];
+                Key key = member.Name;
+                switch (member.Kind)
+                {
+                    case MemberKind.Constant:
+                        layoutBuilder.Constant(in key, member.Constant!);
+                        break;
+                    case MemberKind.Method:
+                        layoutBuilder.Function(in key, member.GetterSlot, member.Flags);
+                        break;
+                    case MemberKind.Accessor:
+                        layoutBuilder.Accessor(in key, member.GetterSlot, member.SetterSlot, member.Flags);
+                        break;
+                    case MemberKind.PerRealmValue:
+                        layoutBuilder.Instance(in key);
+                        perRealmValueSlots.Add(new PerRealmValueSlot(i, member.Flags));
+                        break;
+                    default:
+                        layoutBuilder.Factory(in key, member.Factory!);
+                        break;
+                }
+            }
+
+            return new JsObjectShape(
+                layoutBuilder.Build(),
+                _functions.ToArray(),
+                perRealmValueSlots.Count > 0 ? perRealmValueSlots.ToArray() : [],
+                _toStringTag);
+        }
+
+        private ushort AddFunction(string name, JsCallDelegate implementation, int length)
+        {
+            if (_functions.Count >= BuiltinShape.NotAFunction)
+            {
+                Throw.ArgumentException(
+                    $"A shape can describe at most {MaxMembers} members, and this one has already exhausted the function-slot space.");
+            }
+
+            var slot = (ushort) _functions.Count;
+            _functions.Add(new FunctionEntry(name, implementation, length));
+            return slot;
+        }
+
+        private void DeclareName(string name)
+        {
+            ThrowIfBuilt();
+
+            if (string.IsNullOrEmpty(name))
+            {
+                Throw.ArgumentException("Member names must be non-empty strings.", nameof(name));
+            }
+
+            if (Shape.IsIntegerIndexLikeKey(name))
+            {
+                Throw.ArgumentException(
+                    $"Member name '{name}' starts with a digit. Integer-index-like keys must be enumerated in ascending numeric order before the string keys, which a fixed member list cannot express.",
+                    nameof(name));
+            }
+
+            if (!_declaredNames.Add(name))
+            {
+                Throw.ArgumentException($"Member '{name}' has already been declared; member names must be distinct.", nameof(name));
+            }
+        }
+
+        private void ThrowIfBuilt()
+        {
+            if (_built)
+            {
+                Throw.InvalidOperationException("The shape has already been built; a builder must not be reused or modified after Build().");
+            }
+        }
+
+        private static PropertyFlag DataFlags(bool enumerable, bool writable, bool configurable)
+            => (enumerable ? PropertyFlag.Enumerable : PropertyFlag.EnumerableSet)
+               | (writable ? PropertyFlag.Writable : PropertyFlag.WritableSet)
+               | (configurable ? PropertyFlag.Configurable : PropertyFlag.ConfigurableSet);
+
+        private enum MemberKind : byte
+        {
+            Constant,
+            Method,
+            Accessor,
+            PerRealmValue,
+            PerRealmFactory,
+        }
+
+        [StructLayout(LayoutKind.Auto)]
+        private readonly record struct MemberDeclaration(
+            string Name,
+            MemberKind Kind,
+            PropertyFlag Flags,
+            ushort GetterSlot,
+            ushort SetterSlot,
+            PropertyDescriptor? Constant,
+            Func<ObjectInstance, PropertyDescriptor>? Factory);
+    }
+}

--- a/Jint/Native/Object/SharedShapeObject.cs
+++ b/Jint/Native/Object/SharedShapeObject.cs
@@ -1,0 +1,88 @@
+using Jint.Native.Symbol;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.Native.Object;
+
+/// <summary>
+/// The object <see cref="JsObjectShape.Instantiate(Engine, ObjectInstance)"/> hands a host: an ordinary
+/// object whose string-keyed own properties are the shape's process-shared <see cref="BuiltinShape"/> plus
+/// a per-engine, lazily-filled descriptor array — the exact storage Jint's own shaped intrinsics use,
+/// reached through <see cref="IBuiltinShaped"/> and dispatched from <see cref="ObjectInstance"/>'s property
+/// virtuals under <see cref="InternalTypes.BuiltinShapeMode"/>.
+/// <para>
+/// The type is deliberately <b>internal and sealed</b>, and a host reaches it only through the factory. Two
+/// reasons. First, those <c>BuiltinShapeMode</c> branches reach this object's storage through
+/// <c>Unsafe.As&lt;IBuiltinShaped&gt;</c> and trust the shape's invariants — names never leave the layout
+/// without a deopt, materialization never bumps <c>_propertiesVersion</c>, post-initialization additions live
+/// in the side dictionary — which a host override of <c>GetOwnProperty</c> / <c>Get</c> / <c>Delete</c> could
+/// silently break. Sealing makes them invariants by construction. Second, it lets the object be built
+/// through the internal <see cref="ObjectInstance"/> constructor, so it carries neither
+/// <see cref="InternalTypes.OrdinaryGet"/> nor <see cref="InternalTypes.ExoticGet"/> — exactly like an in-box
+/// intrinsic. That is what makes it eligible as a prototype-method inline-cache holder: its version does
+/// witness its own name set, so a host instance reading an inherited member through it caches like a script
+/// object reading through <c>Object.prototype</c>.
+/// </para>
+/// <para>
+/// Nothing is materialized at construction. <see cref="Initialize"/> — which the base class runs on the first
+/// property access of any kind — installs the shared layout, pre-fills the value-form per-realm slots and
+/// applies <c>Symbol.toStringTag</c>; each method, accessor and factory slot then produces its descriptor on
+/// the first access of that member and caches it, so identity is stable from then on.
+/// </para>
+/// </summary>
+internal sealed class SharedShapeObject : ObjectInstance, IBuiltinShaped
+{
+    private readonly JsObjectShape _shape;
+
+    // The realm captured at instantiation. Materialization can be triggered while a *different* realm is
+    // active (a ShadowRealm callback reading a member of a host prototype, say), and the functions this
+    // object hands out must belong to the realm the object itself belongs to.
+    private readonly Realm _realm;
+
+    // Parallel to the shape's member list: constants point at the shared descriptors, everything else is
+    // null until first materialized. Null once the object has deopted to the ordinary dictionary.
+    private PropertyDescriptor?[]? _builtinDescriptors;
+
+    internal SharedShapeObject(Engine engine, JsObjectShape shape, ObjectInstance? prototype)
+        : base(engine, ObjectClass.Object, InternalTypes.Object)
+    {
+        _shape = shape;
+        _realm = engine.Realm;
+        // Assigned unconditionally: the base constructor defaults to the realm's Object.prototype, and a
+        // caller asking for a prototype-less object must get one.
+        _prototype = prototype;
+    }
+
+    protected override void Initialize()
+    {
+        InitializeBuiltinShape();
+
+        // Value-form per-realm slots are the one kind the shared storage cannot produce on demand — it has
+        // no function to call and no factory to run — so they start life as `undefined` with their declared
+        // attributes, ready for the host to fill.
+        var valueSlots = _shape.PerRealmValueSlots;
+        for (var i = 0; i < valueSlots.Length; i++)
+        {
+            SetBuiltinInstanceDescriptor(valueSlots[i].Slot, Undefined, valueSlots[i].Flags);
+        }
+
+        var toStringTag = _shape.ToStringTagValue;
+        if (toStringTag is not null)
+        {
+            // Symbols live outside the shared string-keyed layout, so this is one descriptor per object.
+            var symbols = new SymbolDictionary(1);
+            symbols[GlobalSymbolRegistry.ToStringTag] = new PropertyDescriptor(toStringTag, PropertyFlag.Configurable);
+            SetSymbols(symbols);
+        }
+    }
+
+    BuiltinShape IBuiltinShaped.BuiltinShape => _shape.Layout;
+
+    PropertyDescriptor?[]? IBuiltinShaped.BuiltinDescriptors
+    {
+        get => _builtinDescriptors;
+        set => _builtinDescriptors = value;
+    }
+
+    Function.Function IBuiltinShaped.MakeBuiltinFunction(ushort slot) => _shape.MakeFunction(_engine, _realm, slot);
+}

--- a/Jint/Runtime/Interop/ClrFunction.cs
+++ b/Jint/Runtime/Interop/ClrFunction.cs
@@ -33,6 +33,34 @@ public sealed class ClrFunction : Function, IEquatable<ClrFunction>
         _bubbleExceptions = _engine.Options.Interop.ExceptionHandler == Options.InteropOptions._defaultExceptionHandler;
     }
 
+    /// <summary>
+    /// Creates a function pinned to <paramref name="realm"/> rather than to whichever realm happens to be
+    /// active. The public constructor above reads <c>engine.Realm</c> at call time and anchors the function
+    /// to the engine's original intrinsics, which is right for a host wiring a function up front but wrong
+    /// for one created lazily: a shared-shape prototype can materialize a member while another realm is
+    /// running (from a ShadowRealm callback, say), and the function must still belong to the realm that owns
+    /// the object it came from.
+    /// </summary>
+    internal ClrFunction(
+        Engine engine,
+        Realm realm,
+        string name,
+        JsCallDelegate func,
+        int length,
+        PropertyFlag lengthFlags = PropertyFlag.AllForbidden)
+        : base(engine, realm, JsString.CachedCreate(name))
+    {
+        _func = func;
+
+        _prototype = realm.Intrinsics.Function.PrototypeObject;
+
+        _length = lengthFlags == PropertyFlag.AllForbidden
+            ? PropertyDescriptor.AllForbiddenDescriptor.ForNumber(length)
+            : new PropertyDescriptor(JsNumber.Create(length), lengthFlags);
+
+        _bubbleExceptions = _engine.Options.Interop.ExceptionHandler == Options.InteropOptions._defaultExceptionHandler;
+    }
+
     protected internal override JsValue Call(JsValue thisObject, JsCallArguments arguments) => _bubbleExceptions ? _func(thisObject, arguments) : CallSlow(thisObject, arguments);
 
     [MethodImpl(MethodImplOptions.NoInlining)]


### PR DESCRIPTION
Host binding layers that project large native APIs build the same prototype objects again and again — one audited shape builds ~170 prototypes with ~23,000 functions per engine, tens of MB and ~100 ms per document before a script runs. Jint's own intrinsics never pay that: they share immutable shapes per realm and materialize member functions lazily. This PR opens that machinery to hosts.

`JsObjectShape.Builder` declares methods, accessors, primitive constants, per-realm slots and a `@@toStringTag`; `Build()` produces an immutable, process-shareable `JsObjectShape`; `Instantiate(engine)` creates a per-engine prototype object backed by the existing builtin-shape storage engine — the descriptor array appears on first touch, each member's function on first access of that member, and objects instantiated from one shape share it across engines and threads.

The shareability contract is explicit and pinned: the shape, the host delegates and the constant descriptors are process-shared; everything materialized is engine-affine. Constants are therefore forced non-writable/non-configurable and primitive-valued (a shared descriptor must never be mutated in place on behalf of one engine); per-realm slots carry the engine-affine values, in eager or lazy form. `defineProperty`/`delete`/`freeze` against an instantiated object deopt exactly as the existing machinery does for intrinsics — spec-correct, just no longer lazy.

Footprint: one new public type, one internal sealed instance type, and +28 lines to existing code (an internal realm-pinning `ClrFunction` constructor). Nothing in the dispatch, inline caches or source generator changed.

Points explicitly flagged for review, since they are one-way API doors: member flags are expressed as named booleans (not `PropertyFlag`), the enumerability default is Web IDL-shaped (`enumerable: true` for methods/accessors), and `Instantiate` returns plain `ObjectInstance`.

Tests: 39 in `Jint.Tests.PublicInterface` (reachability without `InternalsVisibleTo`: build/instantiate on two engines, accessor semantics, constants, per-realm isolation, the full enumeration matrix over enumerable and non-enumerable slots, deopt paths) and 4 internals tests including the critical GC invariant — a process-held `JsObjectShape` retains no engine that instantiated it (modeled on `SharedPreparedScriptDoesNotRetainEngines`). A `[MemoryDiagnoser]` benchmark modeling the many-prototypes case is included but intentionally not run for this PR. Full suite and Test262 green (zero new failures, verified against a pristine-main control run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
