### PR TITLE
Parse JSON from char spans and UTF-8 bytes

### DIFF
--- a/Jint.Tests.PublicInterface/JsonSpanParsingTests.cs
+++ b/Jint.Tests.PublicInterface/JsonSpanParsingTests.cs
@@ -1,0 +1,512 @@
+using System.Buffers;
+using System.Globalization;
+using System.Text;
+using Jint.Native;
+using Jint.Native.Json;
+using Jint.Runtime;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// The span overloads of <see cref="JsonParser.Parse(ReadOnlySpan{char})"/> and
+/// <see cref="JsonParser.Parse(ReadOnlySpan{byte})"/> exist so a host holding a document in a buffer — a
+/// UTF-8 event payload, most typically — does not have to materialize it as a string first. Their contract
+/// is that they produce exactly what <see cref="JsonParser.Parse(string)"/> produces for the same
+/// characters, so almost every test here is a comparison against that overload rather than against a
+/// hand-written expectation.
+/// </summary>
+public class JsonSpanParsingTests
+{
+    public static TheoryData<string> Documents => new()
+    {
+        // primitives, including the number shapes the scanner special-cases
+        "null",
+        "true",
+        "false",
+        "0",
+        "-0",
+        "1",
+        "-1",
+        "1.5",
+        "-1.5",
+        "1e3",
+        "1E+3",
+        "1e-3",
+        "-1.5e-7",
+        "0.1",
+        "9007199254740991",
+        "12345678901234567890",
+        "1.7976931348623157e308",
+        "\"\"",
+        "\"plain\"",
+
+        // whitespace in every position the JSON grammar allows it
+        " \t\r\n{\"a\" : 1 , \"b\" : [ 1 , 2 ] }\t\r\n ",
+        "[]",
+        "{}",
+        "[ ]",
+        "{ }",
+
+        // every escape the scanner decodes
+        "\"\\\"\\\\\\/\\b\\f\\n\\r\\t\"",
+        "\"\\u0000\\u001f\\u0061\\u003C\\u003e\\u003c\"",
+        "\"a\\u0000b\\u001Fc\"",
+        "\"\\ud83d\\ude00\"",
+        "{\"\\u0041\\tb\":\"v\"}",
+
+        // raw non-ASCII, which is exactly what the UTF-8 lane has to carry
+        "\"h\u00e9llo\"",
+        "\"\u4e2d\u6587\"",
+        "\"\ud83d\ude00\"",
+        "\"\u2028\u2029\"",
+        "{\"\ud83d\ude00\":\"\u4e2d\"}",
+
+        // structure, duplicate and integer-like keys, __proto__
+        "{\"a\":1,\"b\":[1,2,3],\"c\":{\"d\":null},\"e\":true}",
+        "[[[[[1]]]]]",
+        "[{\"id\":1,\"name\":\"a\"},{\"id\":2,\"name\":\"b\"},{\"id\":3,\"name\":\"a\"}]",
+        "{\"a\":1,\"a\":2}",
+        "{\"__proto__\":{\"x\":1}}",
+        "{\"2\":\"b\",\"1\":\"a\",\"x\":\"c\"}",
+        "[1,\"1\",true,null,{},[]]",
+    };
+
+    public static TheoryData<string> MalformedDocuments => new()
+    {
+        "",
+        " ",
+        "{",
+        "[",
+        "{\"a\":1",
+        "{\"a\":1},",
+        "{1}",
+        "{\"a\" \"a\"}",
+        "{true}",
+        "{:}",
+        "\"\\uah\"",
+        "0123",
+        "1e+A",
+        "1.",
+        "truE",
+        "nul",
+        "\"ab\t\"",
+        "\"ab",
+        "alpha",
+        "{\"a\":}",
+        "{}\ufeff",
+    };
+
+    [Theory]
+    [MemberData(nameof(Documents))]
+    public void ParsingACharSpanMatchesParsingTheString(string json)
+    {
+        var engine = new Engine();
+
+        var fromString = Describe(engine, new JsonParser(engine).Parse(json));
+        var fromSpan = Describe(engine, new JsonParser(engine).Parse(json.AsSpan()));
+
+        fromSpan.Should().Be(fromString);
+    }
+
+    [Theory]
+    [MemberData(nameof(Documents))]
+    public void ParsingUtf8MatchesParsingTheString(string json)
+    {
+        var engine = new Engine();
+
+        var fromString = Describe(engine, new JsonParser(engine).Parse(json));
+        var fromUtf8 = Describe(engine, new JsonParser(engine).Parse(Encoding.UTF8.GetBytes(json)));
+
+        fromUtf8.Should().Be(fromString);
+    }
+
+    [Theory]
+    [MemberData(nameof(MalformedDocuments))]
+    public void ACharSpanIsRejectedExactlyLikeTheString(string json)
+    {
+        var engine = new Engine();
+
+        var fromString = Invoking(() => new JsonParser(engine).Parse(json)).Should().Throw<JavaScriptException>().Which;
+        var fromSpan = Invoking(() => new JsonParser(engine).Parse(json.AsSpan())).Should().Throw<JavaScriptException>().Which;
+
+        // the message carries the failing position, so this pins the error offsets too
+        fromSpan.Message.Should().Be(fromString.Message);
+    }
+
+    [Theory]
+    [MemberData(nameof(MalformedDocuments))]
+    public void Utf8IsRejectedExactlyLikeTheString(string json)
+    {
+        var engine = new Engine();
+
+        var fromString = Invoking(() => new JsonParser(engine).Parse(json)).Should().Throw<JavaScriptException>().Which;
+        var fromUtf8 = Invoking(() => new JsonParser(engine).Parse(Encoding.UTF8.GetBytes(json))).Should().Throw<JavaScriptException>().Which;
+
+        fromUtf8.Message.Should().Be(fromString.Message);
+    }
+
+    /// <summary>
+    /// U+FEFF is not JSON whitespace, so a leading one is a syntax error for the character overloads just
+    /// as it is for the string overload. Only the UTF-8 overload strips a mark, and it strips the byte
+    /// sequence rather than the decoded character.
+    /// </summary>
+    [Fact]
+    public void ALeadingByteOrderMarkIsASyntaxErrorForTheCharacterOverloads()
+    {
+        var engine = new Engine();
+        var json = (char) 0xFEFF + "{}";
+
+        var fromString = Invoking(() => new JsonParser(engine).Parse(json)).Should().Throw<JavaScriptException>().Which;
+        Invoking(() => new JsonParser(engine).Parse(json.AsSpan()))
+            .Should().Throw<JavaScriptException>().WithMessage(fromString.Message);
+
+        // the same document handed over as UTF-8 bytes parses, because the mark is stripped there
+        new JsonSerializer(engine).Serialize(new JsonParser(engine).Parse(Encoding.UTF8.GetBytes(json)))
+            .AsString().Should().Be("{}");
+    }
+
+    /// <summary>
+    /// The scanner reads straight out of the caller's span instead of copying the document. An allocation
+    /// count would be a brittle way to pin that, so this pins the half of it a caller actually depends on:
+    /// nothing the parse produces keeps a view on the buffer, which is what makes it safe to hand over a
+    /// pooled or stack buffer and reuse it immediately afterwards.
+    /// </summary>
+    [Fact]
+    public void TheDocumentBufferIsNotRetainedAfterTheParse()
+    {
+        var engine = new Engine();
+        var buffer = new char[64];
+        "{\"a\":\"value\"}".AsSpan().CopyTo(buffer);
+
+        var parsed = new JsonParser(engine).Parse(buffer.AsSpan(0, 13));
+
+        // scribble over the caller's buffer: a parser that had kept a view on it would be visible here
+        buffer.AsSpan().Fill('\0');
+
+        new JsonSerializer(engine).Serialize(parsed).AsString().Should().Be("{\"a\":\"value\"}");
+    }
+
+    [Fact]
+    public void ANullStringIsRejected()
+    {
+        var parser = new JsonParser(new Engine());
+
+        Invoking(() => parser.Parse((string) null)).Should().Throw<ArgumentNullException>();
+    }
+
+    #region UTF-8 specifics
+
+    [Fact]
+    public void SkipsALeadingByteOrderMark()
+    {
+        var engine = new Engine();
+        const string Json = "{\"a\":[1,2,\"h\u00e9llo \ud83d\ude00\"]}";
+
+        var withBom = WithBom(Encoding.UTF8.GetBytes(Json));
+
+        Describe(engine, new JsonParser(engine).Parse(withBom))
+            .Should().Be(Describe(engine, new JsonParser(engine).Parse(Json)));
+    }
+
+    [Fact]
+    public void SkipsOnlyOneByteOrderMark()
+    {
+        var engine = new Engine();
+        var twoMarks = WithBom(WithBom(Encoding.UTF8.GetBytes("{}")));
+
+        // the second mark decodes to U+FEFF, which is not JSON whitespace
+        Invoking(() => new JsonParser(engine).Parse(twoMarks))
+            .Should().Throw<JavaScriptException>()
+            .WithMessage("*at position 0");
+    }
+
+    [Fact]
+    public void AByteOrderMarkInsideTheDocumentIsASyntaxError()
+    {
+        var engine = new Engine();
+        var bytes = Encoding.UTF8.GetBytes("[1,\ufeff2]");
+
+        Invoking(() => new JsonParser(engine).Parse(bytes)).Should().Throw<JavaScriptException>();
+    }
+
+    [Fact]
+    public void EmptyInputIsRejectedTheSameWayByEveryOverload()
+    {
+        var engine = new Engine();
+        var expected = Invoking(() => new JsonParser(engine).Parse("")).Should().Throw<JavaScriptException>().Which.Message;
+
+        expected.Should().Be("Unexpected end of JSON input at position 0");
+
+        Invoking(() => new JsonParser(engine).Parse(ReadOnlySpan<char>.Empty))
+            .Should().Throw<JavaScriptException>().WithMessage(expected);
+
+        Invoking(() => new JsonParser(engine).Parse(ReadOnlySpan<byte>.Empty))
+            .Should().Throw<JavaScriptException>().WithMessage(expected);
+
+        // a document that is nothing but a byte order mark is an empty document
+        Invoking(() => new JsonParser(engine).Parse(WithBom([])))
+            .Should().Throw<JavaScriptException>().WithMessage(expected);
+    }
+
+    public static TheoryData<byte[], string> InvalidUtf8 => new()
+    {
+        { [0xFF], "a byte that never starts a sequence" },
+        { [0x22, 0x80, 0x22], "a lone continuation byte" },
+        { [0x22, 0xC3, 0x22], "a truncated two-byte sequence" },
+        { [0x22, 0xE2, 0x82, 0x22], "a truncated three-byte sequence" },
+        { [0x22, 0xF0, 0x9F, 0x98, 0x22], "a truncated four-byte sequence" },
+        { [0x22, 0xC0, 0xAF, 0x22], "an overlong encoding" },
+        { [0x22, 0xED, 0xA0, 0x80, 0x22], "a surrogate encoded as UTF-8" },
+        { [0x22, 0xF5, 0x80, 0x80, 0x80, 0x22], "a code point beyond U+10FFFF" },
+        { [0x5B, 0x31, 0x2C, 0xC3, 0x5D], "a bad sequence in the middle of a document" },
+        { [0x22, 0x61, 0x62, 0x63, 0xE2], "a sequence truncated by the end of the input" },
+    };
+
+    [Theory]
+    [MemberData(nameof(InvalidUtf8))]
+    public void InvalidUtf8IsReportedAsASyntaxError(byte[] bytes, string because)
+    {
+        var engine = new Engine();
+
+        var exception = Invoking(() => new JsonParser(engine).Parse(bytes))
+            .Should().Throw<JavaScriptException>(because).Which;
+
+        exception.Message.Should().StartWith("Invalid UTF-8 sequence in JSON at position ");
+        exception.Error.Should().BeOfType<JsError>()
+            .Which.Get("name").ToString().Should().Be("SyntaxError");
+    }
+
+    /// <summary>
+    /// The decoder's own <see cref="DecoderFallbackException"/> is an <see cref="ArgumentException"/>,
+    /// which script cannot catch; the overload contracts to raise the parser's own SyntaxError instead, so
+    /// a host wrapping the call in a script-visible function behaves like <c>JSON.parse</c> does.
+    /// </summary>
+    [Fact]
+    public void InvalidUtf8IsCatchableFromScript()
+    {
+        var engine = new Engine();
+        var parser = new JsonParser(engine);
+        byte[] bytes = [0x5B, 0x22, 0xC3, 0x22, 0x5D];
+
+        engine.SetValue("hostParse", new Func<JsValue>(() => parser.Parse(bytes)));
+
+        var result = engine.Evaluate(
+            """
+            try {
+                hostParse();
+                'no throw';
+            } catch (e) {
+                (e instanceof SyntaxError) + '|' + e.message;
+            }
+            """).AsString();
+
+        result.Should().StartWith("true|Invalid UTF-8 sequence in JSON at position ");
+    }
+
+    [Fact]
+    public void InvalidUtf8ReportsTheByteOffsetOfTheOffendingSequence()
+    {
+        var engine = new Engine();
+
+        // '[' '1' ',' '1' ',' then a lone continuation byte at index 5
+        Invoking(() => new JsonParser(engine).Parse((byte[]) [0x5B, 0x31, 0x2C, 0x31, 0x2C, 0x80, 0x5D]))
+            .Should().Throw<JavaScriptException>()
+            .WithMessage("Invalid UTF-8 sequence in JSON at position 5");
+
+        // the offset is counted after the byte order mark, so the same document reports the same position
+        Invoking(() => new JsonParser(engine).Parse(WithBom([0x5B, 0x31, 0x2C, 0x31, 0x2C, 0x80, 0x5D])))
+            .Should().Throw<JavaScriptException>()
+            .WithMessage("Invalid UTF-8 sequence in JSON at position 5");
+    }
+
+    #endregion
+
+    #region Buffer sizing
+
+    /// <summary>
+    /// Short documents transcode into a stack buffer and longer ones into a pooled array. The threshold is
+    /// an implementation detail, so these sizes bracket it generously from both sides rather than probing
+    /// for it.
+    /// </summary>
+    [Theory]
+    [InlineData(4)]
+    [InlineData(5)]
+    [InlineData(64)]
+    [InlineData(254)]
+    [InlineData(255)]
+    [InlineData(256)]
+    [InlineData(257)]
+    [InlineData(258)]
+    [InlineData(512)]
+    [InlineData(4096)]
+    [InlineData(70_000)]
+    public void TranscodesAsciiDocumentsOfAnySize(int byteLength)
+    {
+        var json = "[\"" + new string('x', byteLength - 4) + "\"]";
+        var bytes = Encoding.UTF8.GetBytes(json);
+        bytes.Length.Should().Be(byteLength);
+
+        var engine = new Engine();
+        Describe(engine, new JsonParser(engine).Parse(bytes))
+            .Should().Be(Describe(engine, new JsonParser(engine).Parse(json)));
+    }
+
+    /// <summary>
+    /// Multi-byte content makes the decoded char count strictly smaller than the byte count, which is the
+    /// direction the buffer sizing relies on (a UTF-8 sequence never yields more chars than it has bytes).
+    /// </summary>
+    [Theory]
+    [InlineData(1)]
+    [InlineData(20)]
+    [InlineData(28)]
+    [InlineData(29)]
+    [InlineData(30)]
+    [InlineData(31)]
+    [InlineData(200)]
+    [InlineData(5000)]
+    public void TranscodesMultiByteDocumentsOfAnySize(int repeats)
+    {
+        var padding = string.Concat(Enumerable.Repeat("\u00e9\u4e2d\ud83d\ude00", repeats));
+        var json = "[\"" + padding + "\"]";
+        var bytes = Encoding.UTF8.GetBytes(json);
+
+        // 2 + 3 + 4 bytes per repeat, but only 1 + 1 + 2 chars
+        bytes.Length.Should().Be(4 + (9 * repeats));
+
+        var engine = new Engine();
+        Describe(engine, new JsonParser(engine).Parse(bytes))
+            .Should().Be(Describe(engine, new JsonParser(engine).Parse(json)));
+    }
+
+    /// <summary>
+    /// The pooled buffer is rented before transcoding and must come back on the throwing paths too — both
+    /// the one that fails inside the decoder and the one that fails later in the parser. A buffer lost to
+    /// the pool would not fail here directly, but a buffer returned twice or handed out while still in use
+    /// would corrupt the parse that follows, which is what this checks.
+    /// </summary>
+    [Fact]
+    public void AFailedLargeParseLeavesThePoolUsable()
+    {
+        var engine = new Engine();
+        var parser = new JsonParser(engine);
+        var padding = new string('x', 5000);
+
+        var badEncoding = Encoding.UTF8.GetBytes("[\"" + padding + "\"").Concat((byte[]) [0xC3, 0x5D]).ToArray();
+        var badSyntax = Encoding.UTF8.GetBytes("[\"" + padding + "\" \"y\"]");
+        var good = Encoding.UTF8.GetBytes("[\"" + padding + "\"]");
+
+        for (var i = 0; i < 3; i++)
+        {
+            Invoking(() => parser.Parse(badEncoding)).Should().Throw<JavaScriptException>();
+            Invoking(() => parser.Parse(badSyntax)).Should().Throw<JavaScriptException>();
+
+            var parsed = parser.Parse(good);
+            new JsonSerializer(engine).Serialize(parsed).AsString().Should().Be("[\"" + padding + "\"]");
+        }
+    }
+
+    #endregion
+
+    [Fact]
+    public void OneParserInstanceServesEveryOverload()
+    {
+        var engine = new Engine();
+        var parser = new JsonParser(engine);
+        var serializer = new JsonSerializer(engine);
+
+        // the per-parse intern tables are reset by every entry point, so repeated keys and values across
+        // consecutive parses through different overloads must not leak into one another
+        const string First = "{\"key\":\"value\",\"other\":\"value\"}";
+        const string Second = "{\"key\":\"different\",\"other\":\"value\"}";
+
+        serializer.Serialize(parser.Parse(First)).AsString().Should().Be(First);
+        serializer.Serialize(parser.Parse(Second.AsSpan())).AsString().Should().Be(Second);
+        serializer.Serialize(parser.Parse(Encoding.UTF8.GetBytes(First))).AsString().Should().Be(First);
+        serializer.Serialize(parser.Parse(Second)).AsString().Should().Be(Second);
+    }
+
+    [Fact]
+    public void RoundTripsAValueThroughTheUtf8Serializer()
+    {
+        var engine = new Engine();
+        var value = engine.Evaluate(
+            "({ id: 7, name: 'h\\u00e9llo \\uD83D\\uDE00 \\u4E2D', items: [1, 2.5, null, true, ''], nested: { a: [{ b: 'x' }] } })");
+
+        var writer = new TestBufferWriter();
+        new JsonSerializer(engine).Serialize(value, writer).Should().BeTrue();
+
+        var reparsed = new JsonParser(engine).Parse(writer.WrittenSpan);
+
+        Describe(engine, reparsed).Should().Be(Describe(engine, value));
+    }
+
+    [Fact]
+    public void RoundTripsALargeValueThroughTheUtf8Serializer()
+    {
+        var engine = new Engine();
+        var value = engine.Evaluate(
+            "(function () { var a = []; for (var i = 0; i < 2000; i++) { a.push({ id: i, name: 'v\\uD83D\\uDE00' + i }); } return a; })()");
+
+        var writer = new TestBufferWriter();
+        new JsonSerializer(engine).Serialize(value, writer).Should().BeTrue();
+        writer.WrittenSpan.Length.Should().BeGreaterThan(256);
+
+        var reparsed = new JsonParser(engine).Parse(writer.WrittenSpan);
+
+        Describe(engine, reparsed).Should().Be(Describe(engine, value));
+    }
+
+    /// <summary>
+    /// A structural fingerprint of a parsed value: the JSON the serializer produces for it, plus the exact
+    /// bits of a number so that <c>-0</c> is distinguishable from <c>0</c> (which JSON cannot express).
+    /// </summary>
+    private static string Describe(Engine engine, JsValue value)
+    {
+        var serialized = new JsonSerializer(engine).Serialize(value);
+        var text = serialized.IsUndefined() ? "<undefined>" : serialized.AsString();
+
+        if (value.IsNumber())
+        {
+            text += "|" + BitConverter.DoubleToInt64Bits(value.AsNumber()).ToString(CultureInfo.InvariantCulture);
+        }
+
+        return value.Type + "|" + text;
+    }
+
+    private static byte[] WithBom(byte[] bytes) => [0xEF, 0xBB, 0xBF, .. bytes];
+
+    private sealed class TestBufferWriter : IBufferWriter<byte>
+    {
+        private byte[] _buffer = new byte[16];
+
+        public ReadOnlySpan<byte> WrittenSpan => _buffer.AsSpan(0, WrittenCount);
+
+        private int WrittenCount { get; set; }
+
+        public void Advance(int count) => WrittenCount += count;
+
+        public Memory<byte> GetMemory(int sizeHint = 0)
+        {
+            // Prepare can replace _buffer, so it has to run before the receiver is read
+            var length = Prepare(sizeHint);
+            return _buffer.AsMemory(WrittenCount, length);
+        }
+
+        public Span<byte> GetSpan(int sizeHint = 0)
+        {
+            var length = Prepare(sizeHint);
+            return _buffer.AsSpan(WrittenCount, length);
+        }
+
+        private int Prepare(int sizeHint)
+        {
+            var wanted = System.Math.Max(sizeHint, 1);
+            if (_buffer.Length - WrittenCount < wanted)
+            {
+                Array.Resize(ref _buffer, System.Math.Max(_buffer.Length * 2, WrittenCount + wanted));
+            }
+
+            return _buffer.Length - WrittenCount;
+        }
+    }
+}

--- a/Jint/Jint.csproj
+++ b/Jint/Jint.csproj
@@ -34,7 +34,10 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
-    <DefineConstants>$(DefineConstants);SUPPORTS_HALF</DefineConstants>
+    <!-- SUPPORTS_UTF8_TRANSCODE: System.Text.Unicode.Utf8 (OperationStatus-based, allocation-free
+         transcoding). It is a .NET Core 3.0+ type and is NOT part of netstandard2.1, so it cannot ride
+         along on SUPPORTS_SPAN_PARSE. -->
+    <DefineConstants>$(DefineConstants);SUPPORTS_HALF;SUPPORTS_UTF8_TRANSCODE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -44,6 +44,20 @@ public sealed class JsonParser
 {
     private const int ConstraintCheckInterval = Engine.ConstraintCheckInterval;
 
+    /// <summary>
+    /// Documents up to this many UTF-8 bytes transcode into a stack buffer of the same char count (the
+    /// char count can never exceed the byte count); longer ones rent from <see cref="ArrayPool{T}"/>.
+    /// </summary>
+    private const int Utf8TranscodeStackallocLimit = 256;
+
+#if !SUPPORTS_UTF8_TRANSCODE
+    /// <summary>
+    /// Throws on malformed input instead of substituting U+FFFD, matching the strictness of
+    /// <c>Utf8.ToUtf16(..., replaceInvalidSequences: false)</c> used on the newer runtimes.
+    /// </summary>
+    private static readonly UTF8Encoding StrictUtf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+#endif
+
     private readonly Engine _engine;
     private readonly int _maxDepth;
 
@@ -79,7 +93,6 @@ public sealed class JsonParser
     private int _index; // position in the stream
     private int _length; // length of the stream
     private Token _lookahead = null!;
-    private string _source = null!;
     private readonly Token[] _tokenBuffer;
     private int _tokenBufferIndex;
 
@@ -164,15 +177,15 @@ public sealed class JsonParser
                (ch == '\r');
     }
 
-    private char ScanHexEscape()
+    private char ScanHexEscape(ReadOnlySpan<char> source)
     {
         int code = char.MinValue;
 
         for (int i = 0; i < 4; ++i)
         {
-            if (_index < _length && IsHexDigit(_source[_index]))
+            if (_index < _length && IsHexDigit(source[_index]))
             {
-                char ch = char.ToLower(_source[_index++], CultureInfo.InvariantCulture);
+                char ch = char.ToLower(source[_index++], CultureInfo.InvariantCulture);
                 code = code * 16 + "0123456789abcdef".IndexOf(ch);
             }
             else
@@ -183,16 +196,16 @@ public sealed class JsonParser
         return (char) code;
     }
 
-    private char ReadToNextSignificantCharacter()
+    private char ReadToNextSignificantCharacter(ReadOnlySpan<char> source)
     {
-        char result = _index < _length ? _source[_index] : char.MinValue;
+        char result = _index < _length ? source[_index] : char.MinValue;
         while (IsWhiteSpace(result))
         {
             if ((++_index) >= _length)
             {
                 return char.MinValue;
             }
-            result = _source[_index];
+            result = source[_index];
         }
         return result;
     }
@@ -212,10 +225,10 @@ public sealed class JsonParser
         return result;
     }
 
-    private Token ScanPunctuator()
+    private Token ScanPunctuator(ReadOnlySpan<char> source)
     {
         int start = _index;
-        char code = start < _source.Length ? _source[_index] : char.MinValue;
+        char code = start < source.Length ? source[_index] : char.MinValue;
 
         string value = ScanPunctuatorValue(start, code);
         ++_index;
@@ -239,25 +252,25 @@ public sealed class JsonParser
         }
     }
 
-    private Token ScanNumericLiteral()
+    private Token ScanNumericLiteral(ReadOnlySpan<char> source)
     {
         using var sb = new ValueStringBuilder(stackalloc char[64]);
         var start = _index;
-        var ch = _source.CharCodeAt(_index);
+        var ch = source.CharCodeAt(_index);
         var canBeInteger = true;
 
         // Number start with a -
         if (ch == '-')
         {
             sb.Append(ch);
-            ch = _source.CharCodeAt(++_index);
+            ch = source.CharCodeAt(++_index);
         }
 
         if (ch != '.')
         {
             var firstCharacter = ch;
             sb.Append(ch);
-            ch = _source.CharCodeAt(++_index);
+            ch = source.CharCodeAt(++_index);
 
             // Hex number starts with '0x'.
             // Octal number starts with '0'.
@@ -273,7 +286,7 @@ public sealed class JsonParser
                 }
             }
 
-            while (IsDecimalDigit((ch = _source.CharCodeAt(_index))))
+            while (IsDecimalDigit((ch = source.CharCodeAt(_index))))
             {
                 sb.Append(ch);
                 _index++;
@@ -287,12 +300,12 @@ public sealed class JsonParser
             _index++;
 
             // the JSON grammar requires at least one digit after the decimal point ('1.' is illegal)
-            if (!IsDecimalDigit(_source.CharCodeAt(_index)))
+            if (!IsDecimalDigit(source.CharCodeAt(_index)))
             {
-                ThrowError(_index, Messages.UnexpectedToken, _source.CharCodeAt(_index));
+                ThrowError(_index, Messages.UnexpectedToken, source.CharCodeAt(_index));
             }
 
-            while (IsDecimalDigit((ch = _source.CharCodeAt(_index))))
+            while (IsDecimalDigit((ch = source.CharCodeAt(_index))))
             {
                 sb.Append(ch);
                 _index++;
@@ -303,15 +316,15 @@ public sealed class JsonParser
         {
             canBeInteger = false;
             sb.Append(ch);
-            ch = _source.CharCodeAt(++_index);
+            ch = source.CharCodeAt(++_index);
             if (ch is '+' or '-')
             {
                 sb.Append(ch);
-                ch = _source.CharCodeAt(++_index);
+                ch = source.CharCodeAt(++_index);
             }
             if (IsDecimalDigit(ch))
             {
-                while (IsDecimalDigit(ch = _source.CharCodeAt(_index)))
+                while (IsDecimalDigit(ch = source.CharCodeAt(_index)))
                 {
                     sb.Append(ch);
                     _index++;
@@ -319,7 +332,7 @@ public sealed class JsonParser
             }
             else
             {
-                ThrowError(_index, Messages.UnexpectedToken, _source.CharCodeAt(_index));
+                ThrowError(_index, Messages.UnexpectedToken, source.CharCodeAt(_index));
             }
         }
 
@@ -466,15 +479,15 @@ public sealed class JsonParser
     }
 #endif
 
-    private Token ScanBooleanLiteral()
+    private Token ScanBooleanLiteral(ReadOnlySpan<char> source)
     {
         var start = _index;
-        if (ConsumeMatch("true"))
+        if (ConsumeMatch(source, "true"))
         {
             return CreateToken(Tokens.BooleanLiteral, "true", '\t', JsBoolean.True, new TextRange(start, _index));
         }
 
-        if (ConsumeMatch("false"))
+        if (ConsumeMatch(source, "false"))
         {
             return CreateToken(Tokens.BooleanLiteral, "false", '\f', JsBoolean.False, new TextRange(start, _index));
         }
@@ -483,11 +496,11 @@ public sealed class JsonParser
         return null!;
     }
 
-    private bool ConsumeMatch(string text)
+    private bool ConsumeMatch(ReadOnlySpan<char> source, string text)
     {
         var start = _index;
         var length = text.Length;
-        if (start + length - 1 < _source.Length && _source.AsSpan(start, length).SequenceEqual(text.AsSpan()))
+        if (start + length - 1 < source.Length && source.Slice(start, length).SequenceEqual(text.AsSpan()))
         {
             _index += length;
             return true;
@@ -496,10 +509,10 @@ public sealed class JsonParser
         return false;
     }
 
-    private Token ScanNullLiteral()
+    private Token ScanNullLiteral(ReadOnlySpan<char> source)
     {
         int start = _index;
-        if (ConsumeMatch("null"))
+        if (ConsumeMatch(source, "null"))
         {
             return CreateToken(Tokens.NullLiteral, "null", 'n', JsValue.Null, new TextRange(start, _index));
         }
@@ -549,11 +562,11 @@ public sealed class JsonParser
 
     private Token ScanStringLiteral(ref State state, bool isPropertyKey)
     {
-        char quote = _source[_index];
+        var source = state.Source;
+        char quote = source[_index];
         int start = _index;
         ++_index;
 
-        var source = _source;
         var length = _length;
 
         using var sb = new ValueStringBuilder(stackalloc char[64]);
@@ -564,7 +577,7 @@ public sealed class JsonParser
             // control character (< 0x20) in one shot. The search lands on exactly the character a
             // per-char loop would have stopped at, so escapes and every error position are preserved
             // byte-for-byte.
-            var remaining = source.AsSpan(_index, length - _index);
+            var remaining = source.Slice(_index, length - _index);
 #if NET8_0_OR_GREATER
             var stop = remaining.IndexOfAny(JsonStringStopChars);
 #else
@@ -630,7 +643,7 @@ public sealed class JsonParser
                         sb.Append('\t');
                         break;
                     case 'u':
-                        sb.Append(ScanHexEscape());
+                        sb.Append(ScanHexEscape(source));
                         break;
                     case 'b':
                         sb.Append('\b');
@@ -731,7 +744,8 @@ public sealed class JsonParser
         var isPropertyKey = _expectKey;
         _expectKey = false;
 
-        char ch = ReadToNextSignificantCharacter();
+        var source = state.Source;
+        char ch = ReadToNextSignificantCharacter(source);
 
         if (ch == char.MinValue)
         {
@@ -747,29 +761,29 @@ public sealed class JsonParser
 
         if (ch == '-') // Negative Number
         {
-            if (IsDecimalDigit(_source.CharCodeAt(_index + 1)))
+            if (IsDecimalDigit(source.CharCodeAt(_index + 1)))
             {
-                return ScanNumericLiteral();
+                return ScanNumericLiteral(source);
             }
-            return ScanPunctuator();
+            return ScanPunctuator(source);
         }
 
         if (IsDecimalDigit(ch))
         {
-            return ScanNumericLiteral();
+            return ScanNumericLiteral(source);
         }
 
         if (ch == 't' || ch == 'f')
         {
-            return ScanBooleanLiteral();
+            return ScanBooleanLiteral(source);
         }
 
         if (ch == 'n')
         {
-            return ScanNullLiteral();
+            return ScanNullLiteral(source);
         }
 
-        return ScanPunctuator();
+        return ScanPunctuator(source);
     }
 
     private Token Lex(ref State state)
@@ -812,12 +826,12 @@ public sealed class JsonParser
     /// (to avoid the per-number string allocation), so their raw source text is reconstructed from the
     /// token range here — byte-identical to the scanned text since numbers contain no escapes.
     /// </summary>
-    private string TokenText(Token token)
-        => token.Text ?? _source.Substring(token.Range.Start, token.Range.End - token.Range.Start);
+    private static string TokenText(ReadOnlySpan<char> source, Token token)
+        => token.Text ?? source.Slice(token.Range.Start, token.Range.End - token.Range.Start).ToString();
 
     // Throw an exception because of the token.
 
-    private void ThrowUnexpected(Token token)
+    private void ThrowUnexpected(ReadOnlySpan<char> source, Token token)
     {
         if (token.Type == Tokens.EOF)
         {
@@ -835,7 +849,7 @@ public sealed class JsonParser
         }
 
         // BooleanLiteral, NullLiteral, or Punctuator.
-        ThrowError(token, Messages.UnexpectedToken, TokenText(token));
+        ThrowError(token, Messages.UnexpectedToken, TokenText(source, token));
     }
 
     // Expect the next token to match the specified punctuator.
@@ -845,7 +859,7 @@ public sealed class JsonParser
         Token token = Lex(ref state);
         if (token.Type != Tokens.Punctuator || value != token.FirstCharacter)
         {
-            ThrowUnexpected(token);
+            ThrowUnexpected(state.Source, token);
         }
     }
 
@@ -923,7 +937,7 @@ public sealed class JsonParser
             Tokens type = _lookahead.Type;
             if (type != Tokens.String)
             {
-                ThrowUnexpected(Lex(ref state));
+                ThrowUnexpected(state.Source, Lex(ref state));
             }
 
             var nameToken = Lex(ref state);
@@ -1043,33 +1057,45 @@ public sealed class JsonParser
                 {
                     return ParseJsonObject(ref state);
                 }
-                ThrowUnexpected(Lex(ref state));
+                ThrowUnexpected(state.Source, Lex(ref state));
                 break;
         }
 
-        ThrowUnexpected(Lex(ref state));
+        ThrowUnexpected(state.Source, Lex(ref state));
         // can't be reached
         return JsValue.Null;
     }
 
+    /// <summary>
+    /// Parses a JSON document, throwing a <see cref="JavaScriptException"/> carrying a
+    /// <c>SyntaxError</c> if it is malformed.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="code"/> is <see langword="null"/>.</exception>
     public JsValue Parse(string code)
     {
-        _source = code;
-        _index = 0;
-        _length = _source.Length;
-        _lookahead = null!;
-        _shapeBudget = ShapeTransitionBudget;
-        if (_internedKeys is not null)
+        if (code is null)
         {
-            System.Array.Clear(_internedKeys, 0, _internedKeys.Length);
+            Throw.ArgumentNullException(nameof(code));
         }
-        if (_internedValues is not null)
-        {
-            System.Array.Clear(_internedValues, 0, _internedValues.Length);
-        }
-        _expectKey = false;
 
-        State state = new State();
+        return Parse(code.AsSpan());
+    }
+
+    /// <summary>
+    /// Parses a JSON document held as UTF-16 characters, for callers that already have the document in a
+    /// buffer and would otherwise materialize a <see cref="string"/> only to hand it to
+    /// <see cref="Parse(string)"/>. The document itself is never copied: the scanner reads straight out of
+    /// <paramref name="code"/>, so only the values the document actually produces are allocated.
+    /// </summary>
+    /// <remarks>
+    /// Byte-for-byte equivalent to <see cref="Parse(string)"/> over the same characters, error positions
+    /// included. In particular a leading U+FEFF is <em>not</em> skipped — it is not JSON whitespace, so it
+    /// is a syntax error exactly as it is for the string overload. Only the UTF-8 overload strips a byte
+    /// order mark.
+    /// </remarks>
+    public JsValue Parse(ReadOnlySpan<char> code)
+    {
+        State state = Reset(code);
 
         Peek(ref state);
         JsValue jsv = ParseJsonValue(ref state);
@@ -1078,20 +1104,118 @@ public sealed class JsonParser
 
         if (_lookahead.Type != Tokens.EOF)
         {
-            ThrowError(_lookahead, Messages.UnexpectedToken, TokenText(_lookahead));
+            ThrowError(_lookahead, Messages.UnexpectedToken, TokenText(state.Source, _lookahead));
         }
         return jsv;
     }
 
     /// <summary>
-    /// Parses JSON and returns both the value and source tracking information.
-    /// Used for the JSON.parse source text access proposal.
+    /// Parses a JSON document held as UTF-8 bytes, for callers such as network and storage layers that
+    /// hold the document as bytes and would otherwise transcode it to a <see cref="string"/> only to hand
+    /// it to <see cref="Parse(string)"/>.
     /// </summary>
-    internal JsonParseResult ParseWithSourceInfo(string code)
+    /// <remarks>
+    /// <para>
+    /// The engine's scanner is UTF-16, so the bytes are transcoded before parsing; what is avoided is the
+    /// intermediate <see cref="string"/>, not the transcode. Short documents are converted on the stack
+    /// and longer ones into a buffer rented from <see cref="ArrayPool{T}"/> and returned on every path,
+    /// so no per-parse allocation is made for the document text itself. This is not a byte-level parser.
+    /// </para>
+    /// <para>
+    /// A leading UTF-8 byte order mark (<c>EF BB BF</c>) is skipped, matching what callers of
+    /// <c>JsonDocument.Parse</c> over UTF-8 expect. Only one leading mark is skipped; a U+FEFF anywhere
+    /// else is a syntax error, as it is for the other overloads.
+    /// </para>
+    /// <para>
+    /// <paramref name="utf8Json"/> must be well-formed UTF-8. An invalid sequence is reported the same way
+    /// malformed JSON is — a <see cref="JavaScriptException"/> carrying a <c>SyntaxError</c>, catchable by
+    /// script — rather than as an <see cref="ArgumentException"/> from the decoder. The position in the
+    /// message is the byte offset of the offending sequence, counted after any byte order mark.
+    /// </para>
+    /// </remarks>
+    public JsValue Parse(ReadOnlySpan<byte> utf8Json)
     {
-        _source = code;
+        // Matches JsonDocument.Parse: a byte order mark is a legitimate part of a UTF-8 stream but not of
+        // the JSON grammar, so exactly one leading mark is consumed here.
+        if (utf8Json.Length >= 3 && utf8Json[0] == 0xEF && utf8Json[1] == 0xBB && utf8Json[2] == 0xBF)
+        {
+            utf8Json = utf8Json.Slice(3);
+        }
+
+        // A UTF-8 sequence never decodes to more UTF-16 code units than it has bytes (a 4-byte sequence
+        // becomes a 2-char surrogate pair), so the byte count is always a sufficient char capacity.
+        char[]? rented = null;
+        Span<char> buffer = utf8Json.Length <= Utf8TranscodeStackallocLimit
+            ? stackalloc char[Utf8TranscodeStackallocLimit]
+            : (rented = ArrayPool<char>.Shared.Rent(utf8Json.Length));
+
+        try
+        {
+            var length = TranscodeUtf8(utf8Json, buffer);
+            return Parse(buffer.Slice(0, length));
+        }
+        finally
+        {
+            if (rented is not null)
+            {
+                ArrayPool<char>.Shared.Return(rented);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Decodes <paramref name="utf8Json"/> into <paramref name="destination"/>, which the caller has sized
+    /// to at least the byte count. Decoding is strict: an invalid sequence raises the parser's own
+    /// <c>SyntaxError</c> at its byte offset rather than being replaced with U+FFFD, so a corrupt document
+    /// is reported as such instead of being parsed as if it contained replacement characters.
+    /// </summary>
+    private unsafe int TranscodeUtf8(ReadOnlySpan<byte> utf8Json, Span<char> destination)
+    {
+        if (utf8Json.IsEmpty)
+        {
+            return 0;
+        }
+
+#if SUPPORTS_UTF8_TRANSCODE
+        // The destination cannot be too small (see the caller) and the whole document is present, so Done
+        // is the only non-error outcome; everything else means the bytes are not well-formed UTF-8.
+        var status = System.Text.Unicode.Utf8.ToUtf16(utf8Json, destination, out var bytesRead, out var charsWritten, replaceInvalidSequences: false);
+        if (status != OperationStatus.Done)
+        {
+            ThrowError(bytesRead, Messages.InvalidUtf8);
+        }
+
+        return charsWritten;
+#else
+        // No span-based decoding on the legacy runtimes: a UTF8Encoding configured to throw gives the same
+        // strictness through the pointer overloads, and reports the offending offset on the exception.
+        try
+        {
+            fixed (byte* bytes = utf8Json)
+            fixed (char* chars = destination)
+            {
+                return StrictUtf8.GetChars(bytes, utf8Json.Length, chars, destination.Length);
+            }
+        }
+        catch (DecoderFallbackException ex)
+        {
+            ThrowError(ex.Index, Messages.InvalidUtf8);
+            return 0;
+        }
+#endif
+    }
+
+    /// <summary>
+    /// Resets the per-parse scanner state and returns the <see cref="State"/> carrying the document being
+    /// parsed. The document lives in the state rather than in a field because a
+    /// <see cref="ReadOnlySpan{T}"/> cannot be a field of a class, and <see cref="State"/> is a
+    /// <c>ref struct</c> already threaded through the whole descent — which is what lets the scanner read
+    /// the caller's buffer directly, whatever kind of buffer it is.
+    /// </summary>
+    private State Reset(ReadOnlySpan<char> code)
+    {
         _index = 0;
-        _length = _source.Length;
+        _length = code.Length;
         _lookahead = null!;
         _shapeBudget = ShapeTransitionBudget;
         if (_internedKeys is not null)
@@ -1104,7 +1228,16 @@ public sealed class JsonParser
         }
         _expectKey = false;
 
-        State state = new State();
+        return new State(code);
+    }
+
+    /// <summary>
+    /// Parses JSON and returns both the value and source tracking information.
+    /// Used for the JSON.parse source text access proposal.
+    /// </summary>
+    internal JsonParseResult ParseWithSourceInfo(string code)
+    {
+        State state = Reset(code.AsSpan());
 
         Peek(ref state);
         var result = ParseJsonValueWithSourceInfo(ref state);
@@ -1113,7 +1246,7 @@ public sealed class JsonParser
 
         if (_lookahead.Type != Tokens.EOF)
         {
-            ThrowError(_lookahead, Messages.UnexpectedToken, TokenText(_lookahead));
+            ThrowError(_lookahead, Messages.UnexpectedToken, TokenText(state.Source, _lookahead));
         }
         return result;
     }
@@ -1145,11 +1278,11 @@ public sealed class JsonParser
                 {
                     return ParseJsonObjectWithSourceInfo(ref state);
                 }
-                ThrowUnexpected(Lex(ref state));
+                ThrowUnexpected(state.Source, Lex(ref state));
                 break;
         }
 
-        ThrowUnexpected(Lex(ref state));
+        ThrowUnexpected(state.Source, Lex(ref state));
         return new JsonParseResult(JsValue.Null, null);
     }
 
@@ -1239,7 +1372,7 @@ public sealed class JsonParser
             Tokens type = _lookahead.Type;
             if (type != Tokens.String)
             {
-                ThrowUnexpected(Lex(ref state));
+                ThrowUnexpected(state.Source, Lex(ref state));
             }
 
             var nameToken = Lex(ref state);
@@ -1280,6 +1413,18 @@ public sealed class JsonParser
     [StructLayout(LayoutKind.Auto)]
     private ref struct State
     {
+        public State(ReadOnlySpan<char> source)
+        {
+            Source = source;
+        }
+
+        /// <summary>
+        /// The document being parsed. It is carried here rather than in a field of the parser because a
+        /// <see cref="ReadOnlySpan{T}"/> cannot be a field of a class, and this struct is already threaded
+        /// by <c>ref</c> through the whole descent.
+        /// </summary>
+        public readonly ReadOnlySpan<char> Source;
+
         /// <summary>
         /// The current recursion depth
         /// </summary>
@@ -1347,6 +1492,7 @@ public sealed class JsonParser
         public const string UnexpectedString = "Unexpected string in JSON";
         public const string UnexpectedEOS = "Unexpected end of JSON input";
         public const string MaxDepthLevelReached = "Max. depth level of JSON reached";
+        public const string InvalidUtf8 = "Invalid UTF-8 sequence in JSON";
     };
 }
 
@@ -1355,6 +1501,18 @@ internal static class StringExtensions
     internal static char CharCodeAt(this string source, int index)
     {
         if (index > source.Length - 1)
+        {
+            // char.MinValue is used as the null value
+            return char.MinValue;
+        }
+
+        return source[index];
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static char CharCodeAt(this ReadOnlySpan<char> source, int index)
+    {
+        if ((uint) index >= (uint) source.Length)
         {
             // char.MinValue is used as the null value
             return char.MinValue;


### PR DESCRIPTION
One audited integrator holds raw UTF-8 event payloads and transcodes a full `string` per event solely because `JsonParser.Parse` is string-shaped. This adds `Parse(ReadOnlySpan<char>)` and a UTF-8 `Parse(ReadOnlySpan<byte>)`, the parsing twin of the UTF-8 `JsonSerializer.Serialize` overload (#2822).

The char-span overload is a true span lane, not a pooled copy: the parser's document moved from a `string` field into the `ref struct State` it already threads through the descent, so `Parse(string)` now delegates to the span overload and there is one lane, not two. The UTF-8 overload transcodes into a stackalloc or pooled buffer (returned on all paths), strictly: invalid UTF-8 raises the parser's own `SyntaxError` at the byte offset — script-catchable, never a CLR exception — and a leading BOM is skipped, matching `JsonDocument.Parse`.

One deliberate behavior change: `Parse(null)` now throws `ArgumentNullException` instead of `NullReferenceException` — without the guard, a null argument would have silently degraded into a script-level `SyntaxError`.

166 new tests in `Jint.Tests.PublicInterface`: grammar-corpus equivalence between all three overloads including identical error messages on a malformed corpus, ten invalid-UTF-8 classes, BOM placements, pool/stackalloc threshold crossings in both directions, throw-path buffer hygiene, and round-trips with the #2822 serializer. net472 exercises the legacy-encoder transcode path end to end. Full suite green; Test262 zero new failures (shared parse internals changed, so the full run was done and cross-checked against a pristine-main control).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
