### PR TITLE
Create ModuleOperations before configuration callbacks run

### DIFF
--- a/Jint.Tests.PublicInterface/ModuleLoaderTests.cs
+++ b/Jint.Tests.PublicInterface/ModuleLoaderTests.cs
@@ -267,4 +267,14 @@ public class ModuleLoaderTests
             }
         }
     }
+
+    [Fact]
+    public void ModulesCanBeRegisteredFromAConfigurationCallback()
+    {
+        var engine = new Engine(options => options.Configure(e => e.Modules.Add("lib", "export const answer = 42;")));
+
+        var ns = engine.Modules.Import("lib");
+
+        ns.Get("answer").AsNumber().Should().Be(42);
+    }
 }

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -193,6 +193,11 @@ public class Options
     /// </summary>
     internal void Apply(Engine engine)
     {
+        // Modules must exist before the configuration callbacks run: a host's
+        // options.Configure(e => e.Modules.Add(...)) is the documented way to
+        // register programmatic modules at construction time.
+        engine.Modules = new Engine.ModuleOperations(engine, Modules.ModuleLoader);
+
         foreach (var configuration in _configurations)
         {
             configuration(engine);
@@ -234,8 +239,6 @@ public class Options
                     }),
                 PropertyFlag.AllForbidden));
         }
-
-        engine.Modules = new Engine.ModuleOperations(engine, Modules.ModuleLoader);
     }
 
     private static void AttachExtensionMethodsToPrototypes(Engine engine)


### PR DESCRIPTION
`options.Configure(e => e.Modules.Add(...))` is the documented way to register programmatic modules at construction time, but `Options.Apply` assigned `engine.Modules` only after running the configuration callbacks, so any callback touching `Modules` dereferenced null.

One-line move, with a public-surface regression test that NREs on main. Extracted from #2424 — the fix is @desty2k's, carried there inside the larger `ResetState` feature; credited with `Co-authored-by`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)