### PR TITLE
Answer existence questions on in-box exotics without materializing descriptors

### DIFF
--- a/Jint.Tests/Runtime/OwnPropertyProbeTests.cs
+++ b/Jint.Tests/Runtime/OwnPropertyProbeTests.cs
@@ -1,0 +1,281 @@
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Native.Symbol;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// <see cref="ObjectInstance.ProbeOwnProperty"/> answers existence and enumerability without building a
+/// <see cref="PropertyDescriptor"/>, and the engine trusts the answer without re-verifying it: a wrong
+/// <see cref="OwnPropertyProbe.Missing"/> silently drops the key from <c>in</c>, <c>hasOwnProperty</c>,
+/// <c>propertyIsEnumerable</c>, <c>Object.keys</c>/<c>values</c>/<c>entries</c>, <c>Object.assign</c>,
+/// object spread and <c>JSON.stringify</c>.
+/// <para>
+/// These tests are the checker for the in-box exotics that override it. Each one probes a spread of keys
+/// <em>first</em>, then reads the descriptor for the same keys, and requires the two to agree — which is
+/// the whole contract. Probing before reading matters for the types whose <c>GetOwnProperty</c> mutates
+/// state (an arguments object materializes; an array materializes a per-index descriptor), because the
+/// claim under test is that the probe answered what <c>GetOwnProperty</c> <em>would have</em> answered.
+/// </para>
+/// </summary>
+public class OwnPropertyProbeTests
+{
+    private static void AssertProbesAgreeWithDescriptors(ObjectInstance target, params JsValue[] keys)
+    {
+        var probes = new OwnPropertyProbe[keys.Length];
+        for (var i = 0; i < keys.Length; i++)
+        {
+            probes[i] = target.ProbeOwnProperty(keys[i]);
+        }
+
+        for (var i = 0; i < keys.Length; i++)
+        {
+            var descriptor = target.GetOwnProperty(keys[i]);
+            var expected = ReferenceEquals(descriptor, PropertyDescriptor.Undefined)
+                ? OwnPropertyProbe.Missing
+                : descriptor.Enumerable
+                    ? OwnPropertyProbe.Enumerable
+                    : OwnPropertyProbe.NonEnumerable;
+
+            probes[i].Should().Be(expected, "the probe of '{0}' must agree with GetOwnProperty on {1}", keys[i], target.GetType().Name);
+        }
+    }
+
+    /// <summary>
+    /// Virtual read mode is private state with no public surface (every internal accessor for it
+    /// materializes on the way out), so the one assertion that needs to see it reads the field.
+    /// </summary>
+    private static bool IsVirtual(JsArguments target) =>
+        (bool) typeof(JsArguments)
+            .GetField("_virtualMode", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .GetValue(target)!;
+
+    private static JsValue[] IndexLikeKeys() =>
+    [
+        JsString.Create("0"),
+        JsString.Create("1"),
+        JsString.Create("2"),
+        JsString.Create("3"),
+        JsString.Create("42"),
+        JsString.Create("-1"),
+        JsString.Create("-0"),
+        JsString.Create("1.5"),
+        JsString.Create("0.0"),
+        JsString.Create("00"),
+        JsString.Create("1e21"),
+        JsString.Create("4294967295"),
+        JsString.Create("NaN"),
+        JsString.Create("Infinity"),
+        JsString.Create("length"),
+        JsString.Create("nope"),
+        JsString.Create("toString"),
+        JsNumber.Create(0),
+        JsNumber.Create(2),
+        JsNumber.Create(7),
+        GlobalSymbolRegistry.Iterator,
+        GlobalSymbolRegistry.ToStringTag,
+    ];
+
+    [Fact]
+    public void StringInstanceProbeAgreesWithDescriptor()
+    {
+        var engine = new Engine();
+        var target = (ObjectInstance) engine.Evaluate("new String('abc')");
+
+        AssertProbesAgreeWithDescriptors(target, IndexLikeKeys());
+    }
+
+    [Fact]
+    public void StringInstanceProbeAgreesForEmptyAndRedefinedShapes()
+    {
+        var engine = new Engine();
+
+        AssertProbesAgreeWithDescriptors((ObjectInstance) engine.Evaluate("new String('')"), IndexLikeKeys());
+
+        // an own property shadowing an index, and a non-enumerable own property, must both keep their
+        // own flags rather than the index lane's Enumerable
+        var shadowed = (ObjectInstance) engine.Evaluate(
+            "var s = new String('abc'); Object.defineProperty(s, 'hidden', { value: 1, enumerable: false }); s");
+        AssertProbesAgreeWithDescriptors(shadowed, [.. IndexLikeKeys(), JsString.Create("hidden")]);
+
+        // String.prototype is itself a StringInstance, and a shaped built-in
+        AssertProbesAgreeWithDescriptors(
+            engine.Realm.Intrinsics.String.PrototypeObject,
+            [.. IndexLikeKeys(), JsString.Create("charAt"), JsString.Create("constructor")]);
+    }
+
+    [Fact]
+    public void StringInstanceEnumerationIsUnchanged()
+    {
+        var engine = new Engine();
+
+        engine.Evaluate("JSON.stringify(Object.keys(new String('abc')))").AsString().Should().Be("[\"0\",\"1\",\"2\"]");
+        engine.Evaluate("JSON.stringify(Object.assign({}, new String('ab')))").AsString().Should().Be("{\"0\":\"a\",\"1\":\"b\"}");
+        engine.Evaluate("JSON.stringify({ ...new String('ab') })").AsString().Should().Be("{\"0\":\"a\",\"1\":\"b\"}");
+        engine.Evaluate("new String('abc').hasOwnProperty('2')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("new String('abc').hasOwnProperty('3')").AsBoolean().Should().BeFalse();
+        engine.Evaluate("new String('abc').hasOwnProperty('length')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("new String('abc').propertyIsEnumerable('length')").AsBoolean().Should().BeFalse();
+        engine.Evaluate("new String('abc').propertyIsEnumerable('0')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("'0' in new String('abc')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("'Infinity' in new String('abc')").AsBoolean().Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("new Uint8Array([1,2,3])")]
+    [InlineData("new Float64Array([1.5,2.5])")]
+    [InlineData("new BigInt64Array(2)")]
+    [InlineData("new Uint8Array(0)")]
+    [InlineData("new Uint8Array(new ArrayBuffer(8, { maxByteLength: 16 }))")]
+    public void TypedArrayProbeAgreesWithDescriptor(string source)
+    {
+        var engine = new Engine();
+        var target = (ObjectInstance) engine.Evaluate(source);
+
+        AssertProbesAgreeWithDescriptors(target, IndexLikeKeys());
+    }
+
+    [Fact]
+    public void DetachedTypedArrayProbeReportsEveryIndexMissing()
+    {
+        var engine = new Engine();
+        var target = (ObjectInstance) engine.Evaluate(
+            "var b = new ArrayBuffer(8); var ta = new Uint8Array(b); ta.buffer.transfer(); ta");
+
+        AssertProbesAgreeWithDescriptors(target, IndexLikeKeys());
+
+        target.ProbeOwnProperty(JsString.Create("0")).Should().Be(OwnPropertyProbe.Missing);
+        engine.Evaluate("0 in ta").AsBoolean().Should().BeFalse();
+        engine.Evaluate("Object.keys(ta).length").AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void TypedArrayEnumerationIsUnchanged()
+    {
+        var engine = new Engine();
+
+        engine.Evaluate("JSON.stringify(Object.keys(new Uint8Array([1,2,3])))").AsString().Should().Be("[\"0\",\"1\",\"2\"]");
+        engine.Evaluate("JSON.stringify(Object.assign({}, new Uint8Array([1,2])))").AsString().Should().Be("{\"0\":1,\"1\":2}");
+        engine.Evaluate("JSON.stringify(new Uint8Array([1,2]))").AsString().Should().Be("{\"0\":1,\"1\":2}");
+        engine.Evaluate("new Uint8Array([1,2]).hasOwnProperty(1)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("new Uint8Array([1,2]).hasOwnProperty(2)").AsBoolean().Should().BeFalse();
+        engine.Evaluate("new Uint8Array([1,2]).propertyIsEnumerable(0)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("'1.5' in new Uint8Array([1,2])").AsBoolean().Should().BeFalse();
+        engine.Evaluate("'-0' in new Uint8Array([1,2])").AsBoolean().Should().BeFalse();
+    }
+
+    [Theory]
+    // mapped (sloppy, simple parameter list), unmapped (strict), rest/pattern parameter lists,
+    // and both the still-virtual and the already-materialized states
+    [InlineData("(function (a, b) { return arguments; })(1, 2)")]
+    [InlineData("(function (a, b) { 'use strict'; return arguments; })(1, 2)")]
+    [InlineData("(function (...r) { return arguments; })(1, 2)")]
+    [InlineData("(function ([a], b) { return arguments; })([1], 2)")]
+    [InlineData("(function (a, a) { return arguments; })(1, 2)")]
+    [InlineData("(function (a) { return arguments; })()")]
+    [InlineData("(function (a, b) { var x = Object.keys(arguments); return arguments; })(1, 2)")]
+    [InlineData("(function (a, b) { delete arguments[0]; return arguments; })(1, 2)")]
+    [InlineData("(function (a, b) { Object.defineProperty(arguments, '0', { enumerable: false }); return arguments; })(1, 2)")]
+    [InlineData("(function (a, b) { arguments[5] = 9; return arguments; })(1, 2)")]
+    public void ArgumentsProbeAgreesWithDescriptor(string source)
+    {
+        var engine = new Engine();
+        var target = (ObjectInstance) engine.Evaluate(source);
+
+        AssertProbesAgreeWithDescriptors(target, [.. IndexLikeKeys(), JsString.Create("callee")]);
+    }
+
+    [Fact]
+    public void ArgumentsProbeDoesNotMaterialize()
+    {
+        var engine = new Engine();
+        var target = (JsArguments) engine.Evaluate("(function (a, b) { return arguments; })(1, 2)");
+
+        // the object is still virtual here, so the probe must answer without running Initialize
+        IsVirtual(target).Should().BeTrue("the returned arguments object has not been materialized yet");
+        target.ProbeOwnProperty(JsString.Create("0")).Should().Be(OwnPropertyProbe.Enumerable);
+        target.ProbeOwnProperty(JsString.Create("5")).Should().Be(OwnPropertyProbe.Missing);
+        target.ProbeOwnProperty(JsString.Create("length")).Should().Be(OwnPropertyProbe.NonEnumerable);
+        target.ProbeOwnProperty(JsString.Create("callee")).Should().Be(OwnPropertyProbe.NonEnumerable);
+        target.ProbeOwnProperty(GlobalSymbolRegistry.Iterator).Should().Be(OwnPropertyProbe.NonEnumerable);
+        target.ProbeOwnProperty(JsString.Create("nope")).Should().Be(OwnPropertyProbe.Missing);
+        IsVirtual(target).Should().BeTrue("no probe may run Initialize");
+
+        // ...and the materialized answer is the same one
+        AssertProbesAgreeWithDescriptors(target, [.. IndexLikeKeys(), JsString.Create("callee")]);
+    }
+
+    [Fact]
+    public void ArgumentsEnumerationIsUnchanged()
+    {
+        var engine = new Engine();
+
+        engine.Evaluate("(function (a, b) { return JSON.stringify(Object.keys(arguments)); })(1, 2)").AsString().Should().Be("[\"0\",\"1\"]");
+        engine.Evaluate("(function (a, b) { return 0 in arguments; })(1, 2)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("(function (a, b) { return 2 in arguments; })(1, 2)").AsBoolean().Should().BeFalse();
+        engine.Evaluate("(function (a, b) { return arguments.hasOwnProperty('length'); })(1, 2)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("(function (a, b) { return arguments.hasOwnProperty('callee'); })(1, 2)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("(function (a, b) { 'use strict'; return arguments.hasOwnProperty('callee'); })(1, 2)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("(function (a, b) { return arguments.propertyIsEnumerable('length'); })(1, 2)").AsBoolean().Should().BeFalse();
+        engine.Evaluate("(function (a, b) { return arguments.propertyIsEnumerable(0); })(1, 2)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("(function (a, b) { return JSON.stringify(Object.assign({}, arguments)); })(1, 2)").AsString().Should().Be("{\"0\":1,\"1\":2}");
+        engine.Evaluate("(function (a, b) { var s = ''; for (var k in arguments) s += k; return s; })(1, 2)").AsString().Should().Be("01");
+
+        // `n in arguments` must not disturb the mapped-binding overlay
+        engine.Evaluate("(function (a) { var seen = 0 in arguments; a = 7; return arguments[0]; })(1)").AsNumber().Should().Be(7);
+        engine.Evaluate("(function (a) { var seen = 0 in arguments; arguments[0] = 7; return a; })(1)").AsNumber().Should().Be(7);
+    }
+
+    [Fact]
+    public void ModuleNamespaceProbeAgreesWithDescriptor()
+    {
+        var engine = new Engine();
+        engine.Modules.Add("lib", "export const a = 1; export function b() {} export default 3;");
+        var target = (ObjectInstance) engine.Modules.Import("lib");
+
+        AssertProbesAgreeWithDescriptors(
+            target,
+            [
+                JsString.Create("a"),
+                JsString.Create("b"),
+                JsString.Create("default"),
+                JsString.Create("missing"),
+                JsString.Create("then"),
+                JsString.Create("toString"),
+                GlobalSymbolRegistry.ToStringTag,
+                GlobalSymbolRegistry.Iterator,
+            ]);
+    }
+
+    [Fact]
+    public void ModuleNamespaceProbeStillThrowsForAnUninitializedBinding()
+    {
+        // https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-getownproperty-p step 4 performs
+        // [[Get]], which throws for a TDZ binding; every probe consumer has to propagate that, so the
+        // probe cannot answer from the export-name set alone.
+        var engine = new Engine();
+        engine.Modules.Add("self", """
+            import * as ns from 'self';
+            export const observed = (function () {
+                var results = [];
+                results.push(typeof ns);
+                try { Object.prototype.hasOwnProperty.call(ns, 'later'); results.push('no-throw'); }
+                catch (e) { results.push(e.constructor.name); }
+                try { Object.keys(ns); results.push('no-throw'); }
+                catch (e) { results.push(e.constructor.name); }
+                try { Object.prototype.propertyIsEnumerable.call(ns, 'later'); results.push('no-throw'); }
+                catch (e) { results.push(e.constructor.name); }
+                // [[HasProperty]] does not resolve the binding, so `in` must NOT throw
+                results.push('later' in ns);
+                results.push('absent' in ns);
+                return results.join('|');
+            })();
+            export const later = 1;
+            """);
+
+        var ns = engine.Modules.Import("self");
+        ns.Get("observed").AsString().Should().Be("object|ReferenceError|ReferenceError|ReferenceError|true|false");
+    }
+}

--- a/Jint/Native/JsArguments.cs
+++ b/Jint/Native/JsArguments.cs
@@ -269,6 +269,73 @@ public sealed class JsArguments : ObjectInstance
         return base.GetOwnProperty(property);
     }
 
+    /// <summary>
+    /// Existence and enumerability without materializing. While virtual, the own-property set the object
+    /// <em>would</em> materialize is fully determined by <c>_args</c> and <c>_func</c>, so
+    /// <c>n in arguments</c> / <c>arguments.hasOwnProperty(n)</c> / <c>Reflect.has</c> answer from those
+    /// instead of running <see cref="Initialize"/> — which builds the parameter map, a descriptor per
+    /// argument and three more slots, and permanently unpools the object, all to answer a yes/no.
+    /// Once materialized the probe still skips the parameter-map consultation, which only ever overrides
+    /// a descriptor's <em>value</em> (see <see cref="GetOwnProperty"/>) and never its existence or flags —
+    /// so a read-only probe no longer writes to a cached descriptor.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The virtual lane's claim is that <see cref="InitializeCore"/> would define exactly
+    /// <c>[0, _args.Length)</c> (ConfigurableEnumerableWritable, in both the mapped and the unmapped
+    /// shape), <c>length</c> (NonEnumerable), <c>callee</c> (the function or the %ThrowTypeError% accessor
+    /// pair, non-enumerable either way) and <c>@@iterator</c> (Writable | Configurable), and nothing else.
+    /// Both premises of "and nothing else" are checked rather than assumed:
+    /// </para>
+    /// <list type="bullet">
+    /// <item>the property bag must still be empty — every property-adding path routes through
+    /// <c>EnsureInitialized</c> first, but <c>FastSetProperty</c> is public and does not, and this object
+    /// is reachable from a host as a plain <c>ObjectInstance</c>;</item>
+    /// <item><c>_hasRestParameter</c> must be false — <see cref="DefineOwnProperty"/> short-circuits to
+    /// <c>true</c> without defining anything when it is set, which would make the
+    /// <c>DefinePropertyOrThrow</c>/<c>CreateDataProperty</c> calls in <c>InitializeCore</c> no-ops and the
+    /// materialized set something other than the set described above. It cannot currently be set — the flag
+    /// is only ever passed by <c>CreateMappedArgumentsObject</c>, reached only for a <em>simple</em>
+    /// parameter list, which by definition has no rest parameter — but the lane does not depend on that
+    /// staying true.</item>
+    /// </list>
+    /// <para>Either premise failing falls through to the materializing path, i.e. to the previous behaviour.</para>
+    /// </remarks>
+    protected internal override OwnPropertyProbe ProbeOwnProperty(JsValue property)
+    {
+        if (_virtualMode
+            && !_hasRestParameter
+            && _properties is null or { Count: 0 }
+            && _symbols is null or { Count: 0 })
+        {
+            if (Array.ArrayInstance.IsArrayIndex(property, out var index))
+            {
+                return index < (uint) _args.Length ? OwnPropertyProbe.Enumerable : OwnPropertyProbe.Missing;
+            }
+
+            if (CommonProperties.Length.Equals(property)
+                || CommonProperties.Callee.Equals(property)
+                || ReferenceEquals(property, GlobalSymbolRegistry.Iterator))
+            {
+                return OwnPropertyProbe.NonEnumerable;
+            }
+
+            return OwnPropertyProbe.Missing;
+        }
+
+        EnsureInitialized();
+
+        // ObjectInstance.GetOwnProperty, called non-virtually: the ordinary bag lookup, without the
+        // parameter-map value patch this type's GetOwnProperty applies on top of it.
+        var desc = base.GetOwnProperty(property);
+        if (ReferenceEquals(desc, PropertyDescriptor.Undefined))
+        {
+            return OwnPropertyProbe.Missing;
+        }
+
+        return desc.Enumerable ? OwnPropertyProbe.Enumerable : OwnPropertyProbe.NonEnumerable;
+    }
+
     /// Implementation from ObjectInstance official specs as the one
     /// in ObjectInstance is optimized for the general case and wouldn't work
     /// for arrays

--- a/Jint/Native/JsTypedArray.cs
+++ b/Jint/Native/JsTypedArray.cs
@@ -151,6 +151,35 @@ public sealed class JsTypedArray : ObjectInstance
     }
 
     /// <summary>
+    /// Integer-index existence and enumerability straight from the buffer witness, without the element
+    /// read and the <see cref="PropertyDescriptor"/> that
+    /// <see cref="GetOwnProperty(JsValue)"/> allocates per key. Enumerating a typed array
+    /// (for-in, Object.keys/values/entries, Object.assign, spread, JSON.stringify) previously built one
+    /// CEW descriptor and decoded one element per index purely to test it.
+    /// </summary>
+    /// <remarks>
+    /// Agreement with <see cref="GetOwnProperty(JsValue)"/> is exact: for a canonical numeric index that
+    /// method reports the property absent exactly when <c>IntegerIndexedElementGet</c> yields
+    /// <c>undefined</c>, which it does exactly when <see cref="IsValidIntegerIndex(double)"/> is false (a
+    /// valid index always decodes to a number or a BigInt, never <c>undefined</c>), and otherwise builds
+    /// a <see cref="PropertyFlag.ConfigurableEnumerableWritable"/> descriptor. Detached, out-of-bounds and
+    /// length-tracking buffers are all covered because <c>IsValidIntegerIndex</c> is the same witness the
+    /// element read consults. Non-index keys keep the ordinary lookup.
+    /// </remarks>
+    protected internal override OwnPropertyProbe ProbeOwnProperty(JsValue property)
+    {
+        var numericIndex = TypeConverter.CanonicalNumericIndexString(property);
+        if (numericIndex is not null)
+        {
+            return IsValidIntegerIndex(numericIndex.Value)
+                ? OwnPropertyProbe.Enumerable
+                : OwnPropertyProbe.Missing;
+        }
+
+        return base.ProbeOwnProperty(property);
+    }
+
+    /// <summary>
     /// https://tc39.es/ecma262/#sec-integer-indexed-exotic-objects-get-p-receiver
     /// </summary>
     public override JsValue Get(JsValue property, JsValue receiver)

--- a/Jint/Native/String/StringInstance.cs
+++ b/Jint/Native/String/StringInstance.cs
@@ -66,6 +66,61 @@ internal class StringInstance : ObjectInstance, IJsPrimitive
         return new PropertyDescriptor(str[index], PropertyFlag.OnlyEnumerable);
     }
 
+    /// <summary>
+    /// Index and <c>length</c> existence answered from the string itself, without the
+    /// <see cref="PropertyDescriptor"/> (and the boxed character) that
+    /// <see cref="GetOwnProperty(JsValue)"/> allocates per index. Enumerating a String object
+    /// (for-in, Object.keys/values/entries, Object.assign, spread, JSON.stringify) previously built one
+    /// descriptor per character purely to test it; the probe also skips the
+    /// <see cref="JsString.ToString"/> flattening a rope-backed value would otherwise pay.
+    /// </summary>
+    /// <remarks>
+    /// Mirrors <see cref="GetOwnProperty(JsValue)"/> step for step, so the two agree at every instant:
+    /// the <c>Infinity</c> guard, then <c>length</c> off the same <see cref="_length"/> field (whose
+    /// flags a redefinition can change, so enumerability is read off the descriptor rather than assumed),
+    /// then the ordinary property bag — which shadows an index, exactly as there — and only then the
+    /// index lane, which yields <see cref="PropertyFlag.OnlyEnumerable"/> for an in-range index.
+    /// </remarks>
+    protected internal sealed override OwnPropertyProbe ProbeOwnProperty(JsValue property)
+    {
+        if (CommonProperties.Infinity.Equals(property))
+        {
+            return OwnPropertyProbe.Missing;
+        }
+
+        if (CommonProperties.Length.Equals(property))
+        {
+            var length = _length;
+            if (length is null)
+            {
+                return OwnPropertyProbe.Missing;
+            }
+
+            return length.Enumerable ? OwnPropertyProbe.Enumerable : OwnPropertyProbe.NonEnumerable;
+        }
+
+        // ObjectInstance.GetOwnProperty, called non-virtually: the ordinary bag lookup this type's
+        // GetOwnProperty performs at this point, which allocates nothing for a String object.
+        var desc = base.GetOwnProperty(property);
+        if (!ReferenceEquals(desc, PropertyDescriptor.Undefined))
+        {
+            return desc.Enumerable ? OwnPropertyProbe.Enumerable : OwnPropertyProbe.NonEnumerable;
+        }
+
+        if ((property._type & (InternalTypes.Number | InternalTypes.Integer | InternalTypes.String)) == InternalTypes.Empty)
+        {
+            return OwnPropertyProbe.Missing;
+        }
+
+        var number = TypeConverter.ToNumber(property);
+        if (!IsInt32(number, out var index) || index < 0 || index >= StringData.Length)
+        {
+            return OwnPropertyProbe.Missing;
+        }
+
+        return OwnPropertyProbe.Enumerable;
+    }
+
     public sealed override IEnumerable<KeyValuePair<JsValue, PropertyDescriptor>> GetOwnProperties()
     {
         foreach (var entry in base.GetOwnProperties())

--- a/Jint/Runtime/Modules/ModuleNamespace.cs
+++ b/Jint/Runtime/Modules/ModuleNamespace.cs
@@ -129,6 +129,40 @@ internal sealed class ModuleNamespace : ObjectInstance
     }
 
     /// <summary>
+    /// Existence and enumerability of an export without the <see cref="PropertyDescriptor"/>
+    /// <see cref="GetOwnProperty"/> allocates per key — a namespace descriptor is invariably
+    /// <c>(value, writable, enumerable, non-configurable)</c>, so the flags never need one.
+    /// </summary>
+    /// <remarks>
+    /// The binding resolution is <b>not</b> skippable, which is why this probe still calls
+    /// <see cref="Get(JsValue, JsValue)"/> and discards the value: step 4 of
+    /// https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-getownproperty-p performs
+    /// <c>[[Get]]</c>, and <c>[[Get]]</c> of an uninitialized (TDZ) binding throws a ReferenceError.
+    /// Every probe consumer — <c>hasOwnProperty</c>, <c>propertyIsEnumerable</c>, <c>Object.keys</c>,
+    /// for-in — is spec-required to propagate that throw, so answering from <c>_exports</c> alone would
+    /// silently make those operations succeed. (<c>in</c> never reaches here: this type overrides
+    /// <see cref="HasProperty"/>, whose spec algorithm correctly does not resolve the binding.)
+    /// </remarks>
+    protected internal override OwnPropertyProbe ProbeOwnProperty(JsValue property)
+    {
+        if (IsSymbolLikeNamespaceKey(property))
+        {
+            return base.ProbeOwnProperty(property);
+        }
+
+        var exports = GetModuleExportsList();
+        var p = TypeConverter.ToString(property);
+
+        if (!exports.Contains(p))
+        {
+            return OwnPropertyProbe.Missing;
+        }
+
+        Get(property);
+        return OwnPropertyProbe.Enumerable;
+    }
+
+    /// <summary>
     /// https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-defineownproperty-p-desc
     /// </summary>
     public override bool DefineOwnProperty(JsValue property, PropertyDescriptor desc)


### PR DESCRIPTION
The pre-release review found in-box exotic objects still materializing a `PropertyDescriptor` to answer questions that only need existence or enumerability — `in`, `hasOwnProperty`, `propertyIsEnumerable`, `Object.keys`, `JSON.stringify`. This overrides `ProbeOwnProperty` on the four types where the cheaper answer is provably exact, following `ArrayInstance`'s precedent and #2836's shared-layout lane.

* **`JsTypedArray`** — integer indices answer from `IsValidIntegerIndex`, the same witness the element read consults, so detached, out-of-bounds and length-tracking buffers agree by construction.
* **`StringInstance`** — mirrors `GetOwnProperty` step for step and stops flattening a rope-backed value just to answer existence. Covers `String.prototype` (which is not builtin-shaped — verified, not assumed).
* **`JsArguments`** — while in virtual mode, `n in arguments` no longer forces full materialization (parameter map, one descriptor per argument, permanent unpooling). The "nothing else can exist yet" premise is checked, not assumed; either check failing falls through to the old path. Post-materialization the probe also stops writing to a cached descriptor for a read-only question.
* **`ModuleNamespace`** — the review's premise here was wrong, and the implementation honors the spec instead: step 4 of the exotic `[[GetOwnProperty]]` performs `[[Get]]`, which must throw for an uninitialized binding — four test262 tests pin it. The override keeps the binding resolution and drops only the descriptor allocation.

**`ObjectWrapper` is deliberately not converted**: its `GetOwnProperty` memoizes (the descriptor path *is* the fast path from the second touch), the one re-resolving shape (dictionary wrappers) currently has a compiled read but a reflective `ContainsKey` — a probe would be slower than what it replaces — and the resolution order carries host-observable steps (member-accessor hook, amortized constraint checks) a probe would have to reproduce exactly. Revisit when the dictionary `ContainsKey` sibling is compiled.

There is intentionally no general Debug agreement verifier for probes: `GetOwnProperty` is not side-effect free (proxy traps fire, `ArrayInstance` materializes), so double-invocation would be observable and break proxy trap-count conformance. The new test file is the checker instead — 24 tests probing first and reading descriptors after, across mapped/unmapped/rest/pattern arguments shapes, five typed-array element kinds including resizable and detached, String objects, and module namespaces including the TDZ throw.

One incidental finding documented in the code: `JsArguments._hasRestParameter` is unreachable dead state (only passed from the simple-parameter-list path, only set on the non-simple path); its `DefineOwnProperty` short-circuit would silently no-op materialization if it ever fired. Documented rather than fixed here.

Full suite green on both TFMs in Release and Debug; Test262 99,441 passed, 0 failed, in both configurations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
