### PR TITLE
Close the four doc gaps the API-necessity audit found

### DIFF
--- a/Jint/Native/JsObjectLayout.cs
+++ b/Jint/Native/JsObjectLayout.cs
@@ -22,7 +22,13 @@ namespace Jint.Native;
 /// <para>
 /// The property names are validated once, here, so object creation itself has nothing left to check.
 /// </para>
+/// <para>
+/// A layout builds per-item <em>data records</em>: many short-lived objects sharing one set of plain
+/// value properties. For the other shape of sharing — a singleton prototype whose methods, accessors
+/// and constants materialize lazily per realm — use <see cref="JsObjectShape"/> instead.
+/// </para>
 /// </summary>
+/// <seealso cref="JsObjectShape"/>
 /// <example>
 /// <code>
 /// private static readonly JsObjectLayout PointLayout = new("x", "y", "label");

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -22,6 +22,16 @@ using TypeConverter = Jint.Runtime.TypeConverter;
 
 namespace Jint.Native.Object;
 
+/// <summary>
+/// Base class for every JavaScript object.
+/// </summary>
+/// <remarks>
+/// An <see cref="ObjectInstance"/> is bound to the <see cref="Engine"/> (and realm) that created it and
+/// holds a hard reference to it. Handing an instance to another engine — as an argument, a global, a
+/// prototype or a return value — is unsupported: nothing validates it, and the object will resolve its
+/// prototype chain, intrinsics and interop services against the wrong engine. Convert through a
+/// serialization boundary instead, or create the value on the engine that will consume it.
+/// </remarks>
 [DebuggerTypeProxy(typeof(ObjectInstanceDebugView))]
 public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
 {

--- a/README.md
+++ b/README.md
@@ -235,6 +235,13 @@ engine per operation never reaches them by design. Note the mirror image if you 
 warmed call site holds a reference to the last receiver it served until it caches a different one, so pooled
 engines can keep host objects alive between runs.
 
+**Registering only what a script uses.** When the ambient API is large and scripts touch little of it,
+prepare with `ScriptPreparationOptions.CollectReferencedGlobals` and read `Prepared<T>.ReferencedGlobals`:
+the free identifiers the program actually references, resolved per binding site, as an immutable set you can
+intersect with your registry — including the CLR-side context you would otherwise build speculatively, which
+lazy globals cannot defer. Honor `HasDirectEvalCall`: a program with direct `eval` can reference anything,
+so install everything for those.
+
 **Reusing a configured engine.** If you build a fresh engine per evaluation only because you need a clean
 global, `engine.Advanced.CaptureGlobalSnapshot()` and `RestoreGlobalSnapshot(snapshot)` are the cheaper route:
 capture once after your `SetValue` calls and module setup, then restore between evaluations. Restore reverts
@@ -242,6 +249,11 @@ the global object's own properties, its prototype and extensibility, and the top
 declarations (which nothing else can clear, so a script with a top-level `let` can otherwise only be run once
 per engine); it also clears the `RegExp.$1`-style legacy statics and resets the interop wrapper caches. The
 per-node caches above are deliberately kept, so the next run starts warm.
+
+Choosing between this and `AddLazyGlobal` is a question of engine lifetime: a fresh-engine-per-evaluation
+host wants lazy globals (nothing to restore — the win is never building what the script does not read); a
+pooled host wants the snapshot. They compose: restore returns a global that was still lazy at capture to its
+unmaterialized state, so a pooled engine keeps both benefits.
 
 Restore also ends the previous cycle on the event loop. Queued jobs are discarded, and — because discarding
 cannot reach work that has not been enqueued yet — any promise registered before the restore is dropped when


### PR DESCRIPTION
A pre-tag necessity audit of every public addition since v4.14.0 concluded nothing should be trimmed — each surface traces to a named integrator pattern or a live adopter — but found four missing sentences. This adds them: the `JsObjectLayout` → `JsObjectShape` cross-pointer (the reverse existed), a README paragraph for `ReferencedGlobals`, the stated choosing rule between `AddLazyGlobal` and the global snapshot (fresh engine → lazy; pooled → snapshot; they compose), and a class-level remark on `ObjectInstance` stating engine affinity — the one place no public XML doc said it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)