### PR TITLE
Measured micro-optimizations from the pre-release review

### DIFF
--- a/Jint.Benchmark/ArrayCopyingMethodsBenchmark.cs
+++ b/Jint.Benchmark/ArrayCopyingMethodsBenchmark.cs
@@ -1,0 +1,84 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// <c>Array.prototype.toReversed</c> and <c>with</c> build a brand-new array by reading the source once per
+/// index. A hole-free dense source admits a bulk copy instead, which is what these rows size.
+/// <para>
+/// Each method has a <c>Dense</c> row and a <c>Holey</c> control on an otherwise identical source: a single
+/// hole makes the read a full <c>[[Get]]</c> that can reach the prototype chain, so the bulk copy declines
+/// and the control row should not move at all. <c>ToSorted_Dense</c> is a second control - a sibling that
+/// builds a new array the same way and is untouched here.
+/// </para>
+/// <para>
+/// <c>Size</c> separates the two things the lane changes: at 8 elements the per-call overhead dominates and
+/// a win means the dispatch shrank, at 1024 the per-element cost does and a win means the copy did. The
+/// allocation is the same either way - both paths allocate exactly one backing array - so <c>Allocated</c>
+/// is a control column here, not a result.
+/// </para>
+/// </summary>
+[MemoryDiagnoser]
+public class ArrayCopyingMethodsBenchmark
+{
+    private const int OperationsPerInvoke = 100;
+
+    [Params(8, 1024)]
+    public int Size { get; set; }
+
+    private Engine _engine = null!;
+
+    private Prepared<Script> _toReversedDense;
+    private Prepared<Script> _toReversedHoley;
+    private Prepared<Script> _withDense;
+    private Prepared<Script> _withHoley;
+    private Prepared<Script> _toSortedDense;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _engine = new Engine();
+        _engine.Execute($$"""
+            var size = {{Size}};
+            var dense = new Array(size);
+            for (var i = 0; i < size; i++) dense[i] = i;
+            var holey = new Array(size);
+            for (var i = 0; i < size; i++) holey[i] = i;
+            delete holey[size >> 1];
+            """);
+
+        _toReversedDense = Prepare("dense.toReversed()");
+        _toReversedHoley = Prepare("holey.toReversed()");
+        _withDense = Prepare("dense.with(0, 'X')");
+        _withHoley = Prepare("holey.with(0, 'X')");
+        _toSortedDense = Prepare("dense.toSorted()");
+
+        _engine.Evaluate(_toReversedDense);
+        _engine.Evaluate(_toReversedHoley);
+        _engine.Evaluate(_withDense);
+        _engine.Evaluate(_withHoley);
+        _engine.Evaluate(_toSortedDense);
+    }
+
+    private static Prepared<Script> Prepare(string call)
+        => Engine.PrepareScript("var r; for (var n = 0; n < " + OperationsPerInvoke + "; n++) { r = " + call + "; } r.length");
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public JsValue ToReversed_Dense() => _engine.Evaluate(_toReversedDense);
+
+    /// <summary>Control: one hole sends the whole call down the per-element path.</summary>
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public JsValue ToReversed_Holey() => _engine.Evaluate(_toReversedHoley);
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public JsValue With_Dense() => _engine.Evaluate(_withDense);
+
+    /// <summary>Control: one hole sends the whole call down the per-element path.</summary>
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public JsValue With_Holey() => _engine.Evaluate(_withHoley);
+
+    /// <summary>Control: an untouched sibling that also builds a new array from the source.</summary>
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public JsValue ToSorted_Dense() => _engine.Evaluate(_toSortedDense);
+}

--- a/Jint.Benchmark/EncodeUriBenchmark.cs
+++ b/Jint.Benchmark/EncodeUriBenchmark.cs
@@ -1,0 +1,89 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// The encode twin of <see cref="DecodeUriBenchmark"/>. <c>encodeURI</c>/<c>encodeURIComponent</c> walk the
+/// input deciding per character whether it needs escaping, so the rows separate the three inputs that walk
+/// differs on: one that needs no escaping at all (the common case for an already-safe URI, and the one an
+/// early-out answers without touching a buffer), one that is mostly clean with a few escapes spread through
+/// it (where copying whole clean runs pays), and one where nearly every character escapes (the floor - all
+/// work, no runs to copy).
+/// <para>
+/// Every row runs a tight loop over one prepared script on one long-lived engine, so the measurement is the
+/// encode, not the parse. <c>[MemoryDiagnoser]</c> matters for the clean row: with an early-out it should
+/// allocate the result string only, without one it builds a whole second buffer to produce a copy of its
+/// input.
+/// </para>
+/// </summary>
+[MemoryDiagnoser]
+public class EncodeUriBenchmark
+{
+    private const int OperationsPerInvoke = 1_000;
+
+    private const string Setup = """
+        var clean = 'https://example.com/path/to/resource-name_v2.html';
+        var mixed = 'https://example.com/search?q=hello world&lang=en#some fragment';
+        var dirty = '中文 éèê / 中文 éèê';
+        var longClean = clean + clean + clean + clean + clean + clean + clean + clean;
+        """;
+
+    private Engine _engine = null!;
+
+    private Prepared<Script> _cleanUri;
+    private Prepared<Script> _cleanComponent;
+    private Prepared<Script> _longClean;
+    private Prepared<Script> _mixedUri;
+    private Prepared<Script> _mixedComponent;
+    private Prepared<Script> _dirtyUri;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _engine = new Engine();
+        _engine.Execute(Setup);
+
+        _cleanUri = Prepare("encodeURI(clean)");
+        _cleanComponent = Prepare("encodeURIComponent(clean)");
+        _longClean = Prepare("encodeURI(longClean)");
+        _mixedUri = Prepare("encodeURI(mixed)");
+        _mixedComponent = Prepare("encodeURIComponent(mixed)");
+        _dirtyUri = Prepare("encodeURI(dirty)");
+
+        _engine.Evaluate(_cleanUri);
+        _engine.Evaluate(_cleanComponent);
+        _engine.Evaluate(_longClean);
+        _engine.Evaluate(_mixedUri);
+        _engine.Evaluate(_mixedComponent);
+        _engine.Evaluate(_dirtyUri);
+    }
+
+    private static Prepared<Script> Prepare(string call)
+        => Engine.PrepareScript("var r; for (var n = 0; n < " + OperationsPerInvoke + "; n++) { r = " + call + "; } r");
+
+    /// <summary>Nothing to escape: no buffer needs building at all.</summary>
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public JsValue EncodeUri_Clean() => _engine.Evaluate(_cleanUri);
+
+    /// <summary>
+    /// The same input through <c>encodeURIComponent</c>, whose allowed set excludes the URI reserved
+    /// characters, so this one does escape - the control that the clean row is about the input, not the call.
+    /// </summary>
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public JsValue EncodeUriComponent_Clean() => _engine.Evaluate(_cleanComponent);
+
+    /// <summary>Eight times the clean input: the early-out's win should scale with the length it skips.</summary>
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public JsValue EncodeUri_LongClean() => _engine.Evaluate(_longClean);
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public JsValue EncodeUri_Mixed() => _engine.Evaluate(_mixedUri);
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public JsValue EncodeUriComponent_Mixed() => _engine.Evaluate(_mixedComponent);
+
+    /// <summary>Almost every character escapes: no clean runs to copy, so this row is the floor.</summary>
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public JsValue EncodeUri_Dirty() => _engine.Evaluate(_dirtyUri);
+}

--- a/Jint.Benchmark/FastCallMigrationBenchmark.cs
+++ b/Jint.Benchmark/FastCallMigrationBenchmark.cs
@@ -1,0 +1,111 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Per-call cost of the built-ins whose bodies were migrated off the raw <c>JsCallArguments</c> array onto
+/// positional parameters so they could reach the fast-call lane. On the lane a warm call site hands its
+/// arguments over in registers instead of filling a pooled array, so these rows are where the migration
+/// shows up.
+/// <para>
+/// Every row runs its call in a tight loop inside one prepared script on one long-lived engine, so the
+/// site is warm and the measurement is the call, not the parse or the first-touch dispatch. The loop body
+/// is deliberately trivial where the method allows it (a short scan, an immediate hit) so the dispatch is
+/// not buried under the built-in's own work.
+/// </para>
+/// <para>
+/// <c>Control_ArrayLastIndexOf</c> and <c>Control_ArrayFindLast</c> are the untouched siblings of the
+/// migrated pair either side of them: still on <c>JsCallArguments</c>, so they should not move at all and
+/// are the cross-run floor for reading the others.
+/// </para>
+/// </summary>
+[MemoryDiagnoser]
+public class FastCallMigrationBenchmark
+{
+    private const int OperationsPerInvoke = 1_000;
+
+    private const string Setup = """
+        var data = new Array(64);
+        for (var i = 0; i < 64; i++) data[i] = i;
+        var text = 'hello world foo bar baz';
+        var isThree = function (x) { return x === 3; };
+        """;
+
+    private Engine _engine = null!;
+
+    private Prepared<Script> _stringIncludes;
+    private Prepared<Script> _stringEndsWith;
+    private Prepared<Script> _arrayIndexOf;
+    private Prepared<Script> _arraySome;
+    private Prepared<Script> _arrayFind;
+    private Prepared<Script> _arrayFindIndex;
+    private Prepared<Script> _numberToString;
+    private Prepared<Script> _numberToStringRadix;
+    private Prepared<Script> _arrayLastIndexOf;
+    private Prepared<Script> _arrayFindLast;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _engine = new Engine();
+        _engine.Execute(Setup);
+
+        _stringIncludes = Prepare("text.includes('bar')");
+        _stringEndsWith = Prepare("text.endsWith('baz')");
+        _arrayIndexOf = Prepare("data.indexOf(3)");
+        _arraySome = Prepare("data.some(isThree)");
+        _arrayFind = Prepare("data.find(isThree)");
+        _arrayFindIndex = Prepare("data.findIndex(isThree)");
+        _numberToString = Prepare("(255).toString()");
+        _numberToStringRadix = Prepare("(255).toString(16)");
+        _arrayLastIndexOf = Prepare("data.lastIndexOf(3)");
+        _arrayFindLast = Prepare("data.findLast(isThree)");
+
+        _engine.Evaluate(_stringIncludes);
+        _engine.Evaluate(_stringEndsWith);
+        _engine.Evaluate(_arrayIndexOf);
+        _engine.Evaluate(_arraySome);
+        _engine.Evaluate(_arrayFind);
+        _engine.Evaluate(_arrayFindIndex);
+        _engine.Evaluate(_numberToString);
+        _engine.Evaluate(_numberToStringRadix);
+        _engine.Evaluate(_arrayLastIndexOf);
+        _engine.Evaluate(_arrayFindLast);
+    }
+
+    private static Prepared<Script> Prepare(string call)
+        => Engine.PrepareScript("var r; for (var n = 0; n < " + OperationsPerInvoke + "; n++) { r = " + call + "; } r");
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public JsValue StringIncludes() => _engine.Evaluate(_stringIncludes);
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public JsValue StringEndsWith() => _engine.Evaluate(_stringEndsWith);
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public JsValue ArrayIndexOf() => _engine.Evaluate(_arrayIndexOf);
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public JsValue ArraySome() => _engine.Evaluate(_arraySome);
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public JsValue ArrayFind() => _engine.Evaluate(_arrayFind);
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public JsValue ArrayFindIndex() => _engine.Evaluate(_arrayFindIndex);
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public JsValue NumberToString() => _engine.Evaluate(_numberToString);
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public JsValue NumberToStringRadix() => _engine.Evaluate(_numberToStringRadix);
+
+    /// <summary>Untouched sibling of <see cref="ArrayIndexOf"/>: still takes the raw argument array.</summary>
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public JsValue Control_ArrayLastIndexOf() => _engine.Evaluate(_arrayLastIndexOf);
+
+    /// <summary>Untouched sibling of <see cref="ArrayFind"/>: still takes the raw argument array.</summary>
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public JsValue Control_ArrayFindLast() => _engine.Evaluate(_arrayFindLast);
+}

--- a/Jint.Benchmark/HostDelegateCallBenchmark.cs
+++ b/Jint.Benchmark/HostDelegateCallBenchmark.cs
@@ -1,0 +1,93 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Per-call cost of invoking a host delegate registered through <c>Engine.SetValue(string, Delegate)</c>.
+/// Each row runs one call site in a tight loop inside a single prepared script, so the site warms on its
+/// first dispatch and every later call takes the wrapper's arity-specialized lane — the lane that binds
+/// its arguments from two registers instead of a <c>JsCallArguments</c> array.
+/// <para>
+/// The rows are chosen so the argument-binding shapes are separable. <c>Arity1_Int</c> and
+/// <c>Arity2_IntString</c> box a value-typed argument, <c>Arity1_String</c> and <c>Arity1_JsValue</c> do
+/// not (a <see cref="JsValue"/> parameter is handed its argument straight through), and
+/// <c>Arity1_Nullable</c> exercises the boxed-<see cref="Nullable{T}"/> representation. <c>Arity0</c> and
+/// <c>Arity3_Ints</c> are controls: the former binds nothing, the latter exceeds the two argument
+/// registers and therefore stays on the generic <c>Call</c> path for the whole run.
+/// </para>
+/// <para>
+/// <c>[MemoryDiagnoser]</c> is the point of the lane rows — the per-call argument array is directly
+/// visible in <c>Allocated</c>, while the boxes of the value-typed rows are not removable (the invocation
+/// contract is <c>object?</c>) and should stay put.
+/// </para>
+/// </summary>
+[MemoryDiagnoser]
+public class HostDelegateCallBenchmark
+{
+    private const int OperationsPerInvoke = 1_000;
+
+    private const string Loop = "var s = 0; for (var i = 0; i < 1000; i++) { s = ";
+
+    private Engine _engine = null!;
+
+    private Prepared<Script> _arity0;
+    private Prepared<Script> _arity1Int;
+    private Prepared<Script> _arity1String;
+    private Prepared<Script> _arity1JsValue;
+    private Prepared<Script> _arity1Nullable;
+    private Prepared<Script> _arity2IntString;
+    private Prepared<Script> _arity3Ints;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _engine = new Engine();
+        _engine.SetValue("zero", new Func<int>(() => 1));
+        _engine.SetValue("oneInt", new Func<int, int>(x => x + 1));
+        _engine.SetValue("oneString", new Func<string, int>(x => x.Length));
+        _engine.SetValue("oneJsValue", new Func<JsValue, int>(_ => 1));
+        _engine.SetValue("oneNullable", new Func<int?, int>(x => x ?? 0));
+        _engine.SetValue("twoIntString", new Func<int, string, int>((x, y) => x + y.Length));
+        _engine.SetValue("threeInts", new Func<int, int, int, int>((x, y, z) => x + y + z));
+
+        _arity0 = Engine.PrepareScript(Loop + "zero(); } s");
+        _arity1Int = Engine.PrepareScript(Loop + "oneInt(i); } s");
+        _arity1String = Engine.PrepareScript(Loop + "oneString('abc'); } s");
+        _arity1JsValue = Engine.PrepareScript(Loop + "oneJsValue(i); } s");
+        _arity1Nullable = Engine.PrepareScript(Loop + "oneNullable(i); } s");
+        _arity2IntString = Engine.PrepareScript(Loop + "twoIntString(i, 'abc'); } s");
+        _arity3Ints = Engine.PrepareScript(Loop + "threeInts(i, 1, 2); } s");
+
+        // populate the handler-tree caches so the measured runs are steady-state
+        _engine.Evaluate(_arity0);
+        _engine.Evaluate(_arity1Int);
+        _engine.Evaluate(_arity1String);
+        _engine.Evaluate(_arity1JsValue);
+        _engine.Evaluate(_arity1Nullable);
+        _engine.Evaluate(_arity2IntString);
+        _engine.Evaluate(_arity3Ints);
+    }
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public JsValue Arity0() => _engine.Evaluate(_arity0);
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public JsValue Arity1_Int() => _engine.Evaluate(_arity1Int);
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public JsValue Arity1_String() => _engine.Evaluate(_arity1String);
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public JsValue Arity1_JsValue() => _engine.Evaluate(_arity1JsValue);
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public JsValue Arity1_Nullable() => _engine.Evaluate(_arity1Nullable);
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public JsValue Arity2_IntString() => _engine.Evaluate(_arity2IntString);
+
+    /// <summary>Control: three parameters exceed the two argument registers, so this row never leaves the generic path.</summary>
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public JsValue Arity3_Ints() => _engine.Evaluate(_arity3Ints);
+}

--- a/Jint.Benchmark/InteropObjectConverterBenchmark.cs
+++ b/Jint.Benchmark/InteropObjectConverterBenchmark.cs
@@ -7,31 +7,51 @@ using Jint.Runtime.Interop;
 namespace Jint.Benchmark;
 
 /// <summary>
-/// Sizes an engine-wide de-optimization that has no other coverage: registering a single
-/// <see cref="IObjectConverter"/> makes <c>Engine._objectConverters</c> non-null, and the compiled
-/// member-accessor lane bails out whenever that field is set
-/// (<c>Runtime/Interop/Reflection/CompilableMemberAccessor.cs</c>). It has to — a registered
-/// converter is entitled to see every CLR value before it becomes a <see cref="JsValue"/>, and the
-/// compiled lane produces the <see cref="JsValue"/> itself — but the consequence is that
-/// <b>one</b> converter, however narrow, sends <b>every</b> CLR property read on <b>every</b>
-/// wrapped object in the engine back through reflection.
+/// Sizes what registering an <see cref="IObjectConverter"/> costs the compiled member-accessor lane
+/// (<c>Runtime/Interop/Reflection/CompilableMemberAccessor.cs</c>). A registered converter is entitled to
+/// see every CLR value before it becomes a <see cref="JsValue"/> and the compiled lane produces the
+/// <see cref="JsValue"/> itself, so the lane has to decline for any member the converter could be handed.
 ///
 /// <para>
-/// The converter installed here deliberately converts nothing: it returns <c>false</c> for every
-/// value, so both rows produce identical results and the delta is purely the cost of the
-/// converter's <i>presence</i>. Embedders routinely register exactly one narrow converter (for a
-/// single host type) without knowing it prices in every other read.
+/// The three rows separate the two things that used to be one. <see cref="ConverterKind.None"/> is the
+/// unconverted baseline. <see cref="ConverterKind.Untyped"/> is a converter registered without declaring
+/// its CLR types: it can be handed anything, so <b>every</b> CLR property read on <b>every</b> wrapped
+/// object in the engine goes back through reflection — the behaviour every registration used to have.
+/// <see cref="ConverterKind.Typed"/> declares a type this benchmark's host record never exposes, so every
+/// read here keeps the lane; what it still pays is the per-read question "could this converter be handed a
+/// value of this member's declared type?", and this row is what sizes that.
 /// </para>
 ///
 /// <para>
-/// Expected shape: <c>ObjectConverterRegistered=true</c> slower than <c>false</c> on both time and
-/// <c>Allocated</c>, with the gap proportional to the number of CLR member reads in the loop.
+/// The converter installed here deliberately converts nothing: it returns <c>false</c> for every value, so
+/// all three rows produce identical results and the deltas are purely the cost of the converter's
+/// <i>presence</i>. Embedders routinely register exactly one narrow converter (for a single host type)
+/// without knowing what it prices in.
+/// </para>
+///
+/// <para>
+/// Expected shape: <c>Untyped</c> well behind <c>None</c> on both time and <c>Allocated</c>, with the gap
+/// proportional to the number of CLR member reads in the loop; <c>Typed</c> alongside <c>None</c> on
+/// <c>Allocated</c> and within a small constant of it on time.
 /// </para>
 /// </summary>
 [MemoryDiagnoser]
 public class InteropObjectConverterBenchmark
 {
     private const int Iterations = 1_000;
+
+    /// <summary>How (and whether) an object converter is registered on the engine under test.</summary>
+    public enum ConverterKind
+    {
+        /// <summary>No converter at all — the lane is unconditionally available.</summary>
+        None,
+
+        /// <summary>A converter registered without declared types: claims every member, so the lane never runs.</summary>
+        Untyped,
+
+        /// <summary>A converter declaring a type no member here has: the lane runs, after answering the type question.</summary>
+        Typed,
+    }
 
     private const string Source = """
         function readAll(o, n) {
@@ -47,18 +67,24 @@ public class InteropObjectConverterBenchmark
     private Engine _engine = null!;
     private Prepared<Script> _script;
 
-    [Params(false, true)]
-    public bool ObjectConverterRegistered { get; set; }
+    [Params(ConverterKind.None, ConverterKind.Untyped, ConverterKind.Typed)]
+    public ConverterKind Converter { get; set; }
 
     [GlobalSetup]
     public void GlobalSetup()
     {
-        var converterRegistered = ObjectConverterRegistered;
+        var kind = Converter;
         _engine = new Engine(options =>
         {
-            if (converterRegistered)
+            if (kind == ConverterKind.Untyped)
             {
                 options.AddObjectConverter(new NeverConvertingObjectConverter());
+            }
+            else if (kind == ConverterKind.Typed)
+            {
+                // Uri is unrelated to every member HostRecord exposes (string, double, int), so the
+                // filter answers "not claimed" for all of them and the lane stays available.
+                options.AddObjectConverter(new NeverConvertingObjectConverter(), typeof(Uri));
             }
         });
 

--- a/Jint.Tests.PublicInterface/HostDelegateTests.cs
+++ b/Jint.Tests.PublicInterface/HostDelegateTests.cs
@@ -119,6 +119,33 @@ public class HostDelegateTests
         engine.Evaluate("join('-', 'a', 'b', 'c')").AsString().Should().Be("a-b-c");
     }
 
+    private static string Describe(params JsValue[] values)
+    {
+        var parts = new List<string>();
+        foreach (var value in values)
+        {
+            parts.Add(value.Type.ToString());
+        }
+        return string.Join(",", parts);
+    }
+
+    [Fact]
+    public void ParamsJsValueArrayDelegatePassesEveryArgumentThrough()
+    {
+        // A `params JsValue[]` tail is the one params shape whose elements need no conversion at all, so
+        // it is built as the typed array it already is. Every value kind has to survive that unchanged.
+        var engine = new Engine();
+        engine.SetValue("describe", new Func<JsValue[], string>(Describe));
+
+        engine.Evaluate("describe()").AsString().Should().Be("");
+        engine.Evaluate("describe(1)").AsString().Should().Be("Number");
+        engine.Evaluate("describe('a', 1, true, null, undefined, {}, [])").AsString()
+            .Should().Be("String,Number,Boolean,Null,Undefined,Object,Object");
+        // repeated evaluation of one call site, so a warmed site is covered too
+        engine.Evaluate("function f() { return describe('a', 1); } f(); f(); f()").AsString()
+            .Should().Be("String,Number");
+    }
+
     [Fact]
     public void ValueReferenceAndVoidReturnTypes()
     {

--- a/Jint.Tests.PublicInterface/HostDelegateTests.cs
+++ b/Jint.Tests.PublicInterface/HostDelegateTests.cs
@@ -332,4 +332,82 @@ public class HostDelegateTests
         engine.Evaluate("callOne()").Should().Be(engine.Invoke("one", 5));
         engine.Evaluate("callTwo()").Should().Be(engine.Invoke("two", 5, "x"));
     }
+
+    // The tests below warm one call site before asserting, so the arity-specialized lane — only selected
+    // once a site has dispatched at least once — is the one under test. Each has an unwarmed twin above;
+    // together they pin that the specialized lane answers identically.
+
+    [Fact]
+    public void AWarmedSiteConvertsAndReturnsExactlyAsAColdOne()
+    {
+        var engine = new Engine();
+        engine.SetValue("one", new Func<int, string>(a => $"{a}"));
+        engine.SetValue("two", new Func<int, string, string>((a, b) => $"{a}|{b}"));
+        engine.SetValue("nullable", new Func<int?, string>(a => a?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "none"));
+
+        engine.Execute("""
+            function callOne(v) { return one(v); }
+            function callTwo(a, b) { return two(a, b); }
+            function callNullable(v) { return nullable(v); }
+            for (var i = 0; i < 5; i++) { callOne(1); callTwo(1, 'a'); callNullable(1); }
+            """);
+
+        engine.Evaluate("callOne(7)").AsString().Should().Be("7");
+        engine.Evaluate("callTwo(7, 'z')").AsString().Should().Be("7|z");
+        engine.Evaluate("callNullable(7)").AsString().Should().Be("7");
+        engine.Evaluate("callNullable(null)").AsString().Should().Be("none");
+    }
+
+    [Fact]
+    public void AWarmedVarianceRelaxedSiteKeepsTheBinderError()
+    {
+        // The unwarmed twin is AVarianceRelaxedDelegateKeepsTheBinderError. The specialized lane declines
+        // on exactly the same exact-type check, so a wrong-typed argument must still reach the reflection
+        // binder rather than a cast failure surfaced as a host error.
+        var recorder = new Recorder();
+        Action<string> narrowed = recorder.Record;
+
+        var engine = new Engine();
+        engine.SetValue("f", narrowed);
+        engine.Execute("function call(v) { f(v); } for (var i = 0; i < 5; i++) { call('warm'); }");
+
+        recorder.Values.Should().HaveCount(5);
+        Invoking(() => engine.Execute("call(1);")).Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void AWarmedJsValueParameterNarrowerThanItsArgumentKeepsTheBinderError()
+    {
+        var engine = new Engine();
+        engine.SetValue("f", new Func<JsString, string>(v => v.ToString()));
+        engine.Execute("function call(v) { return f(v); } for (var i = 0; i < 5; i++) { call('warm'); }");
+
+        engine.Evaluate("call('ok')").AsString().Should().Be("ok");
+        Invoking(() => engine.Execute("call(1);")).Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void AWarmedSiteKeepsTheHostExceptionAndItsThrowSite()
+    {
+        var engine = new Engine();
+        engine.SetValue("boom", new Func<int, int>(x => x < 0 ? throw new InvalidOperationException("host failure") : x));
+        engine.Execute("function call(v) { return boom(v); } for (var i = 0; i < 5; i++) { call(1); }");
+
+        var exception = Invoking(() => engine.Execute("call(-1);"))
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("host failure")
+            .Which;
+
+        exception.StackTrace.Should().Contain(nameof(AWarmedSiteKeepsTheHostExceptionAndItsThrowSite));
+    }
+
+    [Fact]
+    public void AWarmedSiteStillConvertsAnAwaitableResult()
+    {
+        var engine = new Engine();
+        engine.SetValue("later", new Func<int, Task<int>>(x => Task.FromResult(x + 1)));
+        engine.Execute("function call(v) { return later(v); } for (var i = 0; i < 5; i++) { call(1); }");
+
+        engine.Evaluate("call(41)").UnwrapIfPromise().AsNumber().Should().Be(42);
+    }
 }

--- a/Jint.Tests.PublicInterface/ObjectConverterRegistrationTests.cs
+++ b/Jint.Tests.PublicInterface/ObjectConverterRegistrationTests.cs
@@ -323,6 +323,37 @@ public class ObjectConverterRegistrationTests
     }
 
     [Fact]
+    public void ASharedMethodDescriptorAnswersTheConverterQuestionPerFilterNotOnce()
+    {
+        // The method-invoker twin of the accessor memo test above: descriptors are shared through
+        // the resolver, so the engine whose converter claims the return type must never be served
+        // the other's "not claimed" verdict. Interleaved in both orders, and repeated.
+        var resolver = new TypeResolver();
+
+        Engine Create(Type declared)
+        {
+            var engine = new Engine(options =>
+            {
+                options.Interop.TypeResolver = resolver;
+                options.AddObjectConverter(new MeddlingConverter(), declared);
+            });
+            engine.SetValue("host", new Host());
+            return engine;
+        }
+
+        var claiming = Create(typeof(bool));
+        var unrelated = Create(typeof(Guid));
+
+        for (var i = 0; i < 3; i++)
+        {
+            ShouldRead(unrelated, "host.GetFlag()", whenBypassed: true, whenConverted: false);
+            claiming.Evaluate("host.GetFlag()").Should().Be(false);
+            claiming.Evaluate("host.GetFlag()").Should().Be(false);
+            ShouldRead(unrelated, "host.GetFlag()", whenBypassed: true, whenConverted: false);
+        }
+    }
+
+    [Fact]
     public void DeclaredConverterDoesNotAffectWrites()
     {
         var host = new Host();

--- a/Jint.Tests.PublicInterface/ObjectConverterRegistrationTests.cs
+++ b/Jint.Tests.PublicInterface/ObjectConverterRegistrationTests.cs
@@ -290,6 +290,39 @@ public class ObjectConverterRegistrationTests
     #region 4. writes
 
     [Fact]
+    public void ASharedAccessorAnswersTheConverterQuestionPerFilterNotOnce()
+    {
+        // Same shape as above, but both engines have a converter - only one of them declares bool. The
+        // accessor remembers which filter last told it "this member type is not claimed" so it need not
+        // re-derive a constant answer per read; that memo is keyed on the filter, so the engine whose
+        // converter does claim bool must never be served the other's verdict. Interleaved in both orders,
+        // and repeated, so a memo that ignored the filter would show up whichever engine warmed it.
+        var resolver = new TypeResolver();
+
+        Engine Create(Type declared)
+        {
+            var engine = new Engine(options =>
+            {
+                options.Interop.TypeResolver = resolver;
+                options.AddObjectConverter(new MeddlingConverter(), declared);
+            });
+            engine.SetValue("host", new Host());
+            return engine;
+        }
+
+        var claiming = Create(typeof(bool));
+        var unrelated = Create(typeof(Guid));
+
+        for (var i = 0; i < 3; i++)
+        {
+            ShouldRead(unrelated, "host.Flag", whenBypassed: true, whenConverted: false);
+            claiming.Evaluate("host.Flag").Should().Be(false);
+            claiming.Evaluate("host.Flag").Should().Be(false);
+            ShouldRead(unrelated, "host.Flag", whenBypassed: true, whenConverted: false);
+        }
+    }
+
+    [Fact]
     public void DeclaredConverterDoesNotAffectWrites()
     {
         var host = new Host();

--- a/Jint.Tests/Runtime/ArrayTests.cs
+++ b/Jint.Tests/Runtime/ArrayTests.cs
@@ -826,6 +826,92 @@ return get + '' === ""length,0,1,2,3"";";
     }
 
     /// <summary>
+    /// <c>toReversed</c> and <c>with</c> both build a brand-new array by reading the source per index, so a
+    /// dense source admits a bulk copy. Every case here is one the bulk copy cannot express and must
+    /// therefore decline: holes (step 5.c / 9.c is a full <c>[[Get]]</c>, which for a missing index reaches
+    /// the prototype chain, and the result array has the index <em>present</em> either way), an index
+    /// property inherited from <c>Array.prototype</c>, a sparse array whose length exceeds its backing
+    /// store, and a non-array array-like. Expected values match V8.
+    /// </summary>
+    [Theory]
+    [InlineData("[1,2,3].toReversed()", "[3,2,1]len=3")]
+    [InlineData("[].toReversed()", "[]len=0")]
+    [InlineData("[1].toReversed()", "[1]len=1")]
+    [InlineData("[1,,3].toReversed()", "[3,undefined,1]len=3")]
+    [InlineData("(function(){var a=[1,2];a[5]=6;return a.toReversed();})()", "[6,undefined,undefined,undefined,2,1]len=6")]
+    [InlineData("Array.prototype.toReversed.call({length:3, 0:'a', 2:'c'})", "[c,undefined,a]len=3")]
+    [InlineData("(function(){Array.prototype[1]='p';try{return [0,,2].toReversed();}finally{delete Array.prototype[1];}})()", "[2,p,0]len=3")]
+    [InlineData("[1,2,3,4].with(1,'X')", "[1,X,3,4]len=4")]
+    [InlineData("[1,2,3,4].with(-1,'X')", "[1,2,3,X]len=4")]
+    [InlineData("[1,,3].with(0,'X')", "[X,undefined,3]len=3")]
+    [InlineData("[1,,3].with(1,'X')", "[1,X,3]len=3")]
+    [InlineData("(function(){var a=[1,2];a[4]=5;return a.with(0,'X');})()", "[X,2,undefined,undefined,5]len=5")]
+    [InlineData("Array.prototype.with.call({length:3, 0:'a', 2:'c'}, 1, 'X')", "[a,X,c]len=3")]
+    [InlineData("(function(){Array.prototype[1]='p';try{return [0,,2].with(0,'X');}finally{delete Array.prototype[1];}})()", "[X,p,2]len=3")]
+    public void ToReversedAndWithProduceADenseResultWhateverTheSource(string expression, string expected)
+    {
+        var engine = new Engine();
+        engine.Execute("""
+            function d(a) {
+                var parts = [];
+                for (var i = 0; i < a.length; i++) parts.push(i in a ? String(a[i]) : "<hole>");
+                return "[" + parts.join(",") + "]len=" + a.length;
+            }
+            """);
+        engine.Evaluate($"d({expression})").AsString().Should().Be(expected);
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-array.prototype.with captures <c>len</c> at step 2, before step 3's
+    /// <c>ToIntegerOrInfinity(index)</c> gets to run arbitrary user code, and then reads every element with
+    /// a live <c>? Get(O, Pk)</c> at step 9.c. A <c>valueOf</c> that shrinks the source therefore produces a
+    /// result of the <em>original</em> length whose tail is <c>undefined</c> — a bulk copy out of the
+    /// backing store, whose capacity still covers those indices, would hand back the stale elements
+    /// instead. Expected values match V8.
+    /// </summary>
+    [Fact]
+    public void WithReadsTheLiveSourceWhenArgumentCoercionShrinksTheArray()
+    {
+        var engine = new Engine();
+
+        var result = engine.Evaluate("""
+            var a = [0,1,2,3,4,5,6,7];
+            var r = a.with({ valueOf: function () { a.length = 4; return 1; } }, 'X');
+            r.length + '|' + r.join(',') + '|' + (5 in r) + '|' + String(r[5]) + '|' + a.length
+            """).AsString();
+
+        result.Should().Be("8|0,X,2,3,,,,|true|undefined|4");
+
+        // a source that grows during the coercion is read live too, but only up to the captured length
+        var grown = engine.Evaluate("""
+            var b = [0,1];
+            var s = b.with({ valueOf: function () { b.push(9, 9, 9); return 0; } }, 'Y');
+            s.length + '|' + s.join(',')
+            """).AsString();
+
+        grown.Should().Be("2|Y,1");
+    }
+
+    /// <summary>
+    /// The same window seen from the other side: a coercion that replaces the source's backing store (by
+    /// making it sparse, or by moving an index property onto the prototype) must not be read through a
+    /// reference the lane captured beforehand.
+    /// </summary>
+    [Fact]
+    public void WithReadsTheLiveSourceWhenArgumentCoercionDeoptimizesTheArray()
+    {
+        var engine = new Engine();
+
+        var result = engine.Evaluate("""
+            var a = [0,1,2,3];
+            var r = a.with({ valueOf: function () { Object.defineProperty(a, '2', { get: function () { return 'G'; }, configurable: true }); return 0; } }, 'X');
+            r.join(',')
+            """).AsString();
+
+        result.Should().Be("X,1,G,3");
+    }
+
+    /// <summary>
     /// https://tc39.es/ecma262/#sec-array.prototype.copywithin captures <c>len</c> at step 3, before the
     /// target/start/end coercions at steps 5, 7 and 9 get to run arbitrary user code. Keeping that stale
     /// bound is correct for the copy loop, but the loop writes through <c>Set(O, toKey, fromVal, true)</c>,

--- a/Jint.Tests/Runtime/FastCallLaneTests.cs
+++ b/Jint.Tests/Runtime/FastCallLaneTests.cs
@@ -322,6 +322,98 @@ public class FastCallLaneTests
         result.Should().Be("7|true|true|321|321|1|1.23|-4|true|true|true|true|number|TypeError");
     }
 
+    /// <summary>
+    /// The audit every migration from a raw <c>JsCallArguments</c> body to positional parameters has to
+    /// pass: the lane pads its argument registers with <c>Undefined</c>, so an absent argument and an
+    /// explicit <c>undefined</c> become indistinguishable inside the body. Each pair below must therefore
+    /// already agree — and each is checked cold as well as warm, since only the warm call takes the lane.
+    /// </summary>
+    [Theory]
+    [InlineData("\"abcdef\".includes(\"cd\")", "true")]
+    [InlineData("\"abcdef\".includes(\"cd\", undefined)", "true")]
+    [InlineData("\"abcdef\".includes(\"cd\", 3)", "false")]
+    [InlineData("\"abcdef\".endsWith(\"ef\")", "true")]
+    [InlineData("\"abcdef\".endsWith(\"ef\", undefined)", "true")]
+    [InlineData("\"abcdef\".endsWith(\"cd\", 4)", "true")]
+    [InlineData("String([1,2,3].indexOf(2))", "1")]
+    [InlineData("String([1,2,3].indexOf(2, undefined))", "1")]
+    [InlineData("String([1,2,3].indexOf(2, 2))", "-1")]
+    [InlineData("String([1,2,3].some(function (v) { return v === 2; }))", "true")]
+    [InlineData("String([1,2,3].some(function (v) { return v === 2; }, undefined))", "true")]
+    [InlineData("String([1,2,3].find(function (v) { return v === 2; }))", "2")]
+    [InlineData("String([1,2,3].find(function (v) { return v === 2; }, undefined))", "2")]
+    [InlineData("String([1,2,3].findIndex(function (v) { return v === 2; }))", "1")]
+    [InlineData("String([1,2,3].findIndex(function (v) { return v === 2; }, undefined))", "1")]
+    [InlineData("(255).toString()", "255")]
+    [InlineData("(255).toString(undefined)", "255")]
+    [InlineData("(255).toString(16)", "ff")]
+    public void AnAbsentOptionalArgumentMatchesAnExplicitUndefined(string expression, string expected)
+    {
+        var engine = new Engine();
+
+        engine.Evaluate($"function f() {{ return String({expression}); }} f();").AsString().Should().Be(expected);
+        engine.Evaluate($"function g() {{ return String({expression}); }} g(); g();").AsString().Should().Be(expected);
+    }
+
+    /// <summary>
+    /// The sibling of <see cref="NewlyLaneEligibleBuiltinsAgreeWarmAndCold"/> for the built-ins whose
+    /// bodies had to be migrated off <c>JsCallArguments</c> to become lane-expressible. Callback-taking
+    /// methods are included with a <c>thisArg</c>, since that is the second argument register.
+    /// </summary>
+    [Fact]
+    public void MigratedLaneEligibleBuiltinsAgreeWarmAndCold()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            const out = [];
+            function run(f, a, b) {
+                const cold = f(a, b);
+                f(a, b);
+                return f(a, b) === cold ? cold : "DRIFT";
+            }
+            out.push(run(function (v, p) { return "abcdef".includes(v, p); }, "cd", 1));
+            out.push(run(function (v, p) { return "abcdef".endsWith(v, p); }, "cd", 4));
+            out.push(run(function (v, p) { return [1, 2, 3].indexOf(v, p); }, 3, 1));
+            const box = { limit: 2 };
+            out.push(run(function (f, t) { return [1, 2, 3].some(f, t); }, function (v) { return v > this.limit; }, box));
+            out.push(run(function (f, t) { return [1, 2, 3].find(f, t); }, function (v) { return v > this.limit; }, box));
+            out.push(run(function (f, t) { return [1, 2, 3].findIndex(f, t); }, function (v) { return v > this.limit; }, box));
+            out.push(run(function (v) { return (255).toString(v); }, 16));
+            let brand = "";
+            try { const t = Number.prototype.toString; t.call({}); t.call({}); } catch (e) { brand = e.constructor.name; }
+            out.push(brand);
+            let uncallable = "";
+            try { [1].find(1); [1].find(1); } catch (e) { uncallable = e.constructor.name; }
+            out.push(uncallable);
+            out.join("|");
+            """).AsString();
+
+        result.Should().Be("true|true|2|true|3|2|ff|TypeError|TypeError");
+    }
+
+    /// <summary>
+    /// Step 7 of <c>String.prototype.endsWith</c> keys on <c>endPosition</c> being the value
+    /// <c>undefined</c>, not on the argument being absent. Jint read the argument with a non-undefined
+    /// default that only applied when it was missing, so an explicit <c>undefined</c> was coerced to 0 and
+    /// searched an empty prefix. test262 does not discriminate the two (its only <c>undefined</c> case
+    /// uses an empty search string, which matches at any position).
+    /// </summary>
+    [Fact]
+    public void EndsWithTreatsAnExplicitUndefinedEndPositionAsTheStringLength()
+    {
+        var engine = new Engine();
+
+        engine.Evaluate("'abc'.endsWith('c', undefined)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("'abc'.endsWith('c')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("'abc'.endsWith('b', undefined)").AsBoolean().Should().BeFalse();
+        // an explicit numeric position is unaffected
+        engine.Evaluate("'abc'.endsWith('b', 2)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("'abc'.endsWith('c', 0)").AsBoolean().Should().BeFalse();
+        // null still coerces to 0, per step 7's else branch
+        engine.Evaluate("'abc'.endsWith('c', null)").AsBoolean().Should().BeFalse();
+        engine.Evaluate("'abc'.endsWith('', null)").AsBoolean().Should().BeTrue();
+    }
+
 #if !NETFRAMEWORK // Math.f16round needs System.Half, which .NET Framework does not have
     /// <summary>
     /// <c>Math.f16round</c> must return a Number for every input. It used to hand back the argument

--- a/Jint.Tests/Runtime/UriEncodingTests.cs
+++ b/Jint.Tests/Runtime/UriEncodingTests.cs
@@ -1,0 +1,89 @@
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// <c>encodeURI</c>/<c>encodeURIComponent</c> answer an input that needs no escaping without building a
+/// buffer, and copy whole clean runs between escapes rather than one character per turn. Both are pure
+/// short-cuts through https://tc39.es/ecma262/#sec-encode, so these pin the boundaries the short-cuts
+/// have to get right: an empty input, an input that is entirely clean, one that starts or ends with an
+/// escape, adjacent escapes, and the surrogate handling — where the walk consumes two characters at once
+/// and a malformed pair must still raise a URIError rather than being copied over as part of a clean run.
+/// <para>
+/// Inputs that contain characters with no UTF-8 encoding (lone surrogates) or no visible spelling (NUL) are
+/// built with <c>String.fromCharCode</c> rather than written as C# literals: a source file cannot carry a
+/// lone surrogate at all — it stores U+FFFD instead, and the test silently stops testing anything.
+/// </para>
+/// </summary>
+public class UriEncodingTests
+{
+    private readonly Engine _engine = new();
+
+    [Theory]
+    // nothing to escape - the whole input is in the allowed set for both functions
+    [InlineData("''", "", "")]
+    [InlineData("'abc'", "abc", "abc")]
+    [InlineData("\"abcABC123-_.!~*'()\"", "abcABC123-_.!~*'()", "abcABC123-_.!~*'()")]
+    // escape at the very start, at the very end, and both
+    [InlineData("' abc'", "%20abc", "%20abc")]
+    [InlineData("'abc '", "abc%20", "abc%20")]
+    [InlineData("' abc '", "%20abc%20", "%20abc%20")]
+    [InlineData("' '", "%20", "%20")]
+    // adjacent escapes, and a clean run between two of them
+    [InlineData("'a  b'", "a%20%20b", "a%20%20b")]
+    [InlineData("'a b c'", "a%20b%20c", "a%20b%20c")]
+    [InlineData("'  '", "%20%20", "%20%20")]
+    // the two functions disagree: reserved characters are clean for encodeURI only
+    [InlineData("';/?:@&=+$,'", ";/?:@&=+$,", "%3B%2F%3F%3A%40%26%3D%2B%24%2C")]
+    [InlineData("'#'", "#", "%23")]
+    [InlineData("'https://example.com/a?b=c&d=e#f'", "https://example.com/a?b=c&d=e#f", "https%3A%2F%2Fexample.com%2Fa%3Fb%3Dc%26d%3De%23f")]
+    // multi-byte UTF-8, and a surrogate pair, each surrounded by clean runs
+    [InlineData("'café'", "caf%C3%A9", "caf%C3%A9")]
+    [InlineData("'中文'", "%E4%B8%AD%E6%96%87", "%E4%B8%AD%E6%96%87")]
+    [InlineData("'a😀b'", "a%F0%9F%98%80b", "a%F0%9F%98%80b")]
+    [InlineData("String.fromCharCode(0)", "%00", "%00")]
+    [InlineData("'ok' + String.fromCharCode(0) + 'ok'", "ok%00ok", "ok%00ok")]
+    public void EncodesTheSameWhateverTheShapeOfTheInput(string expression, string expectedUri, string expectedComponent)
+    {
+        _engine.Evaluate($"encodeURI({expression})").AsString().Should().Be(expectedUri);
+        _engine.Evaluate($"encodeURIComponent({expression})").AsString().Should().Be(expectedComponent);
+    }
+
+    /// <summary>
+    /// An unpaired surrogate is a URIError (step 2.c / 2.e.iii of the encode algorithm). A clean-run copy
+    /// must never swallow one: no surrogate is in either allowed set, so a run always stops before it.
+    /// </summary>
+    [Theory]
+    [InlineData("String.fromCharCode(0xD800)")]
+    [InlineData("'a' + String.fromCharCode(0xD800)")]
+    [InlineData("String.fromCharCode(0xDFFF)")]
+    [InlineData("'a' + String.fromCharCode(0xDFFF) + 'b'")]
+    [InlineData("'clean text ' + String.fromCharCode(0xD800) + ' more'")]
+    [InlineData("'clean text ' + String.fromCharCode(0xD800, 0xD800)")]
+    [InlineData("'clean text ' + String.fromCharCode(0xDC00, 0xD800)")]
+    public void AnUnpairedSurrogateIsAUriErrorHoweverMuchCleanTextSurroundsIt(string expression)
+    {
+        Invoking(() => _engine.Evaluate($"encodeURI({expression})")).Should().Throw<JavaScriptException>();
+        Invoking(() => _engine.Evaluate($"encodeURIComponent({expression})")).Should().Throw<JavaScriptException>();
+    }
+
+    /// <summary>
+    /// Round-tripping is the strongest single statement about the walk: whatever the escapes, decoding the
+    /// result has to give the input back.
+    /// </summary>
+    [Fact]
+    public void EveryEncodableCharacterRoundTrips()
+    {
+        var result = _engine.Evaluate("""
+            var bad = 0;
+            for (var i = 0; i <= 0xFFFF; i++) {
+                if (i >= 0xD800 && i <= 0xDFFF) continue;
+                var s = String.fromCharCode(i);
+                if (decodeURIComponent(encodeURIComponent(s)) !== s) bad++;
+            }
+            bad;
+            """).AsNumber();
+
+        result.Should().Be(0);
+    }
+}

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -1738,14 +1738,13 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
 
     /// <inheritdoc />
     internal sealed override bool FindWithCallback(
-        JsCallArguments arguments,
+        JsValue callbackfn,
+        JsValue thisArg,
         out ulong index,
         out JsValue value,
         bool visitUnassigned,
         bool fromEnd = false)
     {
-        var thisArg = arguments.At(1);
-        var callbackfn = arguments.At(0);
         var callable = GetCallable(callbackfn);
 
         var len = GetLength();

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -981,11 +981,11 @@ public sealed partial class ArrayPrototype : ArrayInstance
         return false;
     }
 
-    [JsFunction(Length = 1)]
-    private JsValue Some(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1, FastCall = true)]
+    private JsValue Some(JsValue thisObject, JsValue arg0, JsValue arg1)
     {
         var target = TypeConverter.ToObject(_realm, thisObject);
-        return target.FindWithCallback(arguments, out _, out _, false);
+        return target.FindWithCallback(arg0, arg1, out _, out _, false);
     }
 
     /// <summary>
@@ -1040,8 +1040,8 @@ public sealed partial class ArrayPrototype : ArrayInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-array.prototype.indexof
     /// </summary>
-    [JsFunction(Length = 1)]
-    private JsValue IndexOf(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1, FastCall = true)]
+    private JsValue IndexOf(JsValue thisObject, JsValue arg0, JsValue arg1)
     {
         var o = ArrayOperations.For(_realm, thisObject, forWrite: false);
         var len = o.GetLongLength();
@@ -1050,9 +1050,10 @@ public sealed partial class ArrayPrototype : ArrayInstance
             return -1;
         }
 
-        var startIndex = arguments.Length > 1
-            ? TypeConverter.ToIntegerOrInfinity(arguments.At(1))
-            : 0;
+        // An absent fromIndex and an explicit `undefined` both coerce to 0 (step 4 is
+        // ToIntegerOrInfinity, and ToNumber(undefined) is NaN, which it maps to +0), so reading the
+        // argument positionally keeps the answer the branch on arguments.Length gave.
+        var startIndex = TypeConverter.ToIntegerOrInfinity(arg1);
 
         if (startIndex > ArrayOperations.MaxArrayLikeLength)
         {
@@ -1087,7 +1088,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
             k = smallestIndex;
         }
 
-        var searchElement = arguments.At(0);
+        var searchElement = arg0;
 
         // Fast path: dense JsArray scan avoids the per-element HasProperty + Get virtual call pair.
         if (thisObject is JsArray { CanUseFastAccess: true } fast && fast._dense is { } dense)
@@ -1128,22 +1129,22 @@ public sealed partial class ArrayPrototype : ArrayInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-array.prototype.find
     /// </summary>
-    [JsFunction(Length = 1)]
-    private JsValue Find(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1, FastCall = true)]
+    private JsValue Find(JsValue thisObject, JsValue arg0, JsValue arg1)
     {
         var target = TypeConverter.ToObject(_realm, thisObject);
-        target.FindWithCallback(arguments, out _, out var value, visitUnassigned: true);
+        target.FindWithCallback(arg0, arg1, out _, out var value, visitUnassigned: true);
         return value;
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-array.prototype.findindex
     /// </summary>
-    [JsFunction(Length = 1)]
-    private JsValue FindIndex(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1, FastCall = true)]
+    private JsValue FindIndex(JsValue thisObject, JsValue arg0, JsValue arg1)
     {
         var target = TypeConverter.ToObject(_realm, thisObject);
-        if (target.FindWithCallback(arguments, out var index, out _, visitUnassigned: true))
+        if (target.FindWithCallback(arg0, arg1, out var index, out _, visitUnassigned: true))
         {
             return index;
         }
@@ -1154,7 +1155,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
     private JsValue FindLast(JsValue thisObject, JsCallArguments arguments)
     {
         var target = TypeConverter.ToObject(_realm, thisObject);
-        target.FindWithCallback(arguments, out _, out var value, visitUnassigned: true, fromEnd: true);
+        target.FindWithCallback(arguments.At(0), arguments.At(1), out _, out var value, visitUnassigned: true, fromEnd: true);
         return value;
     }
 
@@ -1162,7 +1163,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
     private JsValue FindLastIndex(JsValue thisObject, JsCallArguments arguments)
     {
         var target = TypeConverter.ToObject(_realm, thisObject);
-        if (target.FindWithCallback(arguments, out var index, out _, visitUnassigned: true, fromEnd: true))
+        if (target.FindWithCallback(arguments.At(0), arguments.At(1), out var index, out _, visitUnassigned: true, fromEnd: true))
         {
             return index;
         }

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -132,6 +132,34 @@ public sealed partial class ArrayPrototype : ArrayInstance
         }
 
         var a = CreateBackingArray(len);
+
+        // Fast path: step 9 reads every index the source still has and copies it into a brand-new array,
+        // so a hole-free dense source is one Array.Copy plus the single replaced element instead of `len`
+        // trips through the property protocol.
+        //
+        // Every condition is re-derived HERE, after step 3's ToIntegerOrInfinity has run arbitrary user
+        // code, and none of it may be hoisted above that: a valueOf can switch the receiver's prototype,
+        // define an accessor over an index, make the array sparse, or replace the backing store outright,
+        // and step 9.c is a live `? Get(O, Pk)` that has to observe all of it. CanUseFastAccess is what
+        // proves no index property lives on the prototype chain and no own index carries exotic
+        // attributes; the hole scan is what proves every index in range answers from the backing store,
+        // since a hole is a full [[Get]] that would walk that chain. `len` is the length captured at step
+        // 2 and can exceed the live one, so the store must cover it and still report it - matching the
+        // fill/copyWithin lanes, which bound by the live length as well as by capacity.
+        if (o.Target is JsArray { CanUseFastAccess: true } fast
+            && fast._dense is { } dense
+            && len <= (ulong) dense.Length
+            && len <= fast.GetLongLength())
+        {
+            var count = (int) len;
+            if (System.Array.IndexOf(dense, null, 0, count) < 0)
+            {
+                System.Array.Copy(dense, a, count);
+                a[actualIndex] = value;
+                return new JsArray(_engine, a);
+            }
+        }
+
         ulong k = 0;
         while (k < len)
         {
@@ -2254,6 +2282,28 @@ public sealed partial class ArrayPrototype : ArrayInstance
         }
 
         var a = CreateBackingArray(len);
+
+        // Fast path: a hole-free dense source is copied wholesale and reversed in place, instead of
+        // paying a virtual Get per element. Same lane conditions as `with` — CanUseFastAccess proves no
+        // index property is inherited and none of the own ones is exotic, and the hole scan proves every
+        // index answers from the backing store rather than from a [[Get]] up the prototype chain. Unlike
+        // `with` there is no coercion window to guard against: toReversed takes no arguments, so nothing
+        // between the length read and here can run user code. Span.Reverse is vectorized where the
+        // runtime supports it.
+        if (o.Target is JsArray { CanUseFastAccess: true } fast
+            && fast._dense is { } dense
+            && len <= (ulong) dense.Length
+            && len <= fast.GetLongLength())
+        {
+            var count = (int) len;
+            if (System.Array.IndexOf(dense, null, 0, count) < 0)
+            {
+                System.Array.Copy(dense, a, count);
+                a.AsSpan(0, count).Reverse();
+                return new JsArray(_engine, a);
+            }
+        }
+
         ulong k = 0;
         while (k < len)
         {

--- a/Jint/Native/Global/GlobalObject.cs
+++ b/Jint/Native/Global/GlobalObject.cs
@@ -296,15 +296,32 @@ public sealed partial class GlobalObject : ObjectInstance
     private JsValue Encode(string uri, SearchValues<char> allowedCharacters)
     {
         var strLen = uri.Length;
+
+        // Nothing needs escaping: hand the input straight back rather than rebuilding it character by
+        // character into a fresh buffer. This is the shape Decode already has for a '%'-free input, and
+        // the overwhelmingly common one — most strings handed to encodeURI are already URI-safe.
+        var k = IndexOfFirstDisallowed(uri.AsSpan(), allowedCharacters);
+        if (k < 0)
+        {
+            return uri;
+        }
+
         var builder = new ValueStringBuilder(uri.Length);
+        builder.Append(uri.AsSpan(0, k));
         Span<byte> buffer = stackalloc byte[4];
 
-        for (var k = 0; k < strLen; k++)
+        for (; k < strLen; k++)
         {
             var c = uri[k];
             if (allowedCharacters.Contains(c))
             {
-                builder.Append(c);
+                // Copy the whole clean run at once instead of one character per loop turn. The run
+                // cannot be empty (c is allowed), so k always advances.
+                var remaining = uri.AsSpan(k);
+                var next = IndexOfFirstDisallowed(remaining, allowedCharacters);
+                var runLength = next < 0 ? remaining.Length : next;
+                builder.Append(remaining.Slice(0, runLength));
+                k += runLength - 1;
             }
             else
             {
@@ -386,6 +403,29 @@ uriError:
         builder.Dispose();
         _engine.SignalError(UriError);
         return JsEmpty.Instance;
+    }
+
+    /// <summary>
+    /// Index of the first character <paramref name="allowed"/> does not cover, or -1 when it covers every
+    /// one of them. Vectorized where the runtime provides it; the fallback is the character-at-a-time scan
+    /// this replaced.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int IndexOfFirstDisallowed(ReadOnlySpan<char> value, SearchValues<char> allowed)
+    {
+#if NET8_0_OR_GREATER
+        return value.IndexOfAnyExcept(allowed);
+#else
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (!allowed.Contains(value[i]))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+#endif
     }
 
     [JsFunction(Name = "decodeURI")]

--- a/Jint/Native/Number/NumberPrototype.cs
+++ b/Jint/Native/Number/NumberPrototype.cs
@@ -405,17 +405,17 @@ internal sealed partial class NumberPrototype : NumberInstance
         return sb.ToString();
     }
 
-    [JsFunction(Length = 1, Name = "toString")]
-    private JsValue ToNumberString(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1, Name = "toString", FastCall = true)]
+    private JsValue ToNumberString(JsValue thisObject, JsValue arg0)
     {
         if (!thisObject.IsNumber() && (ReferenceEquals(thisObject.TryCast<NumberInstance>(), null)))
         {
             Throw.TypeError(_realm, "Number.prototype.toString requires that 'this' be a Number");
         }
 
-        var radix = arguments.At(0).IsUndefined()
+        var radix = arg0.IsUndefined()
             ? 10
-            : (int) TypeConverter.ToInteger(arguments.At(0));
+            : (int) TypeConverter.ToInteger(arg0);
 
         if (radix < 2 || radix > 36)
         {
@@ -441,7 +441,7 @@ internal sealed partial class NumberPrototype : NumberInstance
 
         if (x < 0)
         {
-            return "-" + ToNumberString(-x, arguments);
+            return "-" + ToNumberString(-x, arg0);
         }
 
         if (radix == 10)

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -2182,10 +2182,13 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
     }
 
     /// <summary>
-    /// Handles the generic find of (callback[, thisArg])
+    /// Handles the generic find of (callback[, thisArg]). The two arguments are taken positionally rather
+    /// than as a <c>JsCallArguments</c> array so the callers can be reached through the fast-call lane,
+    /// which carries its arguments in registers; an absent argument is <c>Undefined</c> either way.
     /// </summary>
     internal virtual bool FindWithCallback(
-        JsCallArguments arguments,
+        JsValue callbackfn,
+        JsValue thisArg,
         out ulong index,
         out JsValue value,
         bool visitUnassigned,
@@ -2217,8 +2220,6 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
             return false;
         }
 
-        var callbackfn = arguments.At(0);
-        var thisArg = arguments.At(1);
         var callable = GetCallable(callbackfn);
 
         // args is rented from the pool whose factory allocates new JsValue[3], so it is an exact

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -1864,13 +1864,13 @@ internal sealed partial class StringPrototype : StringInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-string.prototype.endswith
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction(Length = 1, FastCall = true)]
     [RequireObjectCoercible]
-    private JsValue EndsWith(JsValue thisObject, JsCallArguments arguments)
+    private JsValue EndsWith(JsValue thisObject, JsValue arg0, JsValue arg1)
     {
         var s = TypeConverter.ToJsString(thisObject);
 
-        var searchString = arguments.At(0);
+        var searchString = arg0;
         if (ReferenceEquals(searchString, Null))
         {
             searchString = "null";
@@ -1886,7 +1886,11 @@ internal sealed partial class StringPrototype : StringInstance
         var searchStr = TypeConverter.ToString(searchString);
 
         var len = s.Length;
-        var pos = TypeConverter.ToInt32(arguments.At(1, len));
+        // Step 7 keys on the *value* undefined, not on the argument being absent: both spell "search the
+        // whole string". Reading the argument positionally is what makes that spelling the only one
+        // available, and it is the spec's - an explicit `undefined` used to be coerced to 0 here, which
+        // made `'abc'.endsWith('c', undefined)` false.
+        var pos = arg1.IsUndefined() ? len : TypeConverter.ToInt32(arg1);
         var end = System.Math.Min(System.Math.Max(pos, 0), len);
 
         return s.EndsWith(searchStr, end);
@@ -1895,12 +1899,12 @@ internal sealed partial class StringPrototype : StringInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-string.prototype.includes
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction(Length = 1, FastCall = true)]
     [RequireObjectCoercible]
-    private JsValue Includes(JsValue thisObject, JsCallArguments arguments)
+    private JsValue Includes(JsValue thisObject, JsValue arg0, JsValue arg1)
     {
         var s = TypeConverter.ToJsString(thisObject);
-        var searchString = arguments.At(0);
+        var searchString = arg0;
 
         if (searchString.IsRegExp())
         {
@@ -1909,9 +1913,9 @@ internal sealed partial class StringPrototype : StringInstance
 
         var searchStr = TypeConverter.ToString(searchString);
         double pos = 0;
-        if (arguments.Length > 1 && !arguments[1].IsUndefined())
+        if (!arg1.IsUndefined())
         {
-            pos = TypeConverter.ToInteger(arguments[1]);
+            pos = TypeConverter.ToInteger(arg1);
         }
 
         if (searchStr.Length == 0)

--- a/Jint/Runtime/Interop/CompiledDelegateInvoker.cs
+++ b/Jint/Runtime/Interop/CompiledDelegateInvoker.cs
@@ -1,6 +1,5 @@
 #if NET8_0_OR_GREATER
 using System.Collections.Concurrent;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -42,13 +41,32 @@ internal static class CompiledDelegateInvoker
     internal delegate object? Invoker(Delegate target, object?[] arguments);
 
     /// <summary>
+    /// The one- and two-parameter twins of <see cref="Invoker"/>: same thunk, same casts, but the
+    /// arguments arrive in registers instead of an array the caller has to allocate and fill first.
+    /// A delegate type's arity is fixed at build time, so exactly one of them is ever built (and only
+    /// for arity 1 or 2 — the arities the arity-specialized call lane offers).
+    /// </summary>
+    internal delegate object? Invoker1(Delegate target, object? argument0);
+
+    /// <inheritdoc cref="Invoker1"/>
+    internal delegate object? Invoker2(Delegate target, object? argument0, object? argument1);
+
+    /// <summary>
     /// A built thunk together with the signature it binds — the delegate type's own <c>Invoke</c> signature,
     /// which the caller has to check against the target method before using the thunk.
-    /// <see cref="Invoke"/> is <see langword="null"/> for a declined delegate type, in which case the other
-    /// two members are <see langword="null"/> as well.
+    /// <see cref="Invoke"/> is <see langword="null"/> for a declined delegate type, in which case every other
+    /// member is <see langword="null"/> as well. <see cref="Invoke1"/>/<see cref="Invoke2"/> are the
+    /// register-passing twins, non-null only for a delegate type of exactly that arity; a caller that has one
+    /// may skip building the argument array entirely, and a caller that does not falls back to
+    /// <see cref="Invoke"/>.
     /// </summary>
     [StructLayout(LayoutKind.Auto)]
-    internal readonly record struct CompiledInvoker(Invoker? Invoke, Type[]? ParameterTypes, Type? ReturnType);
+    internal readonly record struct CompiledInvoker(
+        Invoker? Invoke,
+        Invoker1? Invoke1,
+        Invoker2? Invoke2,
+        Type[]? ParameterTypes,
+        Type? ReturnType);
 
     // Process-wide L2 cache; a null thunk is the "known ineligible" sentinel so a declined delegate
     // type is never re-probed. Keyed on a Type, which pins nothing the delegate instance did not
@@ -72,24 +90,18 @@ internal static class CompiledDelegateInvoker
             // Build ONLY when the runtime will JIT the thunk. Under AOT and under an interpreted-only
             // Expression.Compile (e.g. the Mono interpreter) an interpreted lambda is no faster than
             // DynamicInvoke, so decline and keep the reflection path.
-            if (!RuntimeFeature.IsDynamicCodeCompiled || !TryBuild(t, out var built, out var parameterTypes, out var returnType))
+            if (!RuntimeFeature.IsDynamicCodeCompiled || !TryBuild(t, out var built))
             {
                 return default;
             }
 
-            return new CompiledInvoker(built, parameterTypes, returnType);
+            return built;
         });
     }
 
-    private static bool TryBuild(
-        Type delegateType,
-        [NotNullWhen(true)] out Invoker? invoker,
-        [NotNullWhen(true)] out Type[]? parameterTypes,
-        [NotNullWhen(true)] out Type? returnType)
+    private static bool TryBuild(Type delegateType, out CompiledInvoker result)
     {
-        invoker = null;
-        parameterTypes = null;
-        returnType = null;
+        result = default;
 
         if (!delegateType.IsVisible || delegateType.GetMethod("Invoke") is not { } invokeMethod)
         {
@@ -124,32 +136,73 @@ internal static class CompiledDelegateInvoker
         for (var i = 0; i < parameters.Length; i++)
         {
             var element = Expression.ArrayIndex(argumentsParameter, Expression.Constant(i));
-            arguments[i] = Expression.Convert(element, parameters[i].ParameterType);
+            arguments[i] = Expression.Convert(element, invokeParameterTypes[i]);
         }
 
-        Expression body = Expression.Invoke(Expression.Convert(delegateParameter, delegateType), arguments);
+        var invoker = Compile<Invoker>(delegateType, invokeReturnType, arguments, delegateParameter, argumentsParameter);
+        if (invoker is null)
+        {
+            return false;
+        }
+
+        // The register-passing twin for the arities the arity-specialized call lane serves. It is a
+        // pure convenience for the caller — same delegate type, same casts, same exceptions — so
+        // failing to build one is not a reason to decline the array-shaped thunk.
+        Invoker1? invoker1 = null;
+        Invoker2? invoker2 = null;
+        if (parameters.Length == 1)
+        {
+            var argument0 = Expression.Parameter(typeof(object), "a0");
+            invoker1 = Compile<Invoker1>(
+                delegateType,
+                invokeReturnType,
+                [Expression.Convert(argument0, invokeParameterTypes[0])],
+                delegateParameter,
+                argument0);
+        }
+        else if (parameters.Length == 2)
+        {
+            var argument0 = Expression.Parameter(typeof(object), "a0");
+            var argument1 = Expression.Parameter(typeof(object), "a1");
+            invoker2 = Compile<Invoker2>(
+                delegateType,
+                invokeReturnType,
+                [Expression.Convert(argument0, invokeParameterTypes[0]), Expression.Convert(argument1, invokeParameterTypes[1])],
+                delegateParameter,
+                argument0,
+                argument1);
+        }
+
+        result = new CompiledInvoker(invoker, invoker1, invoker2, invokeParameterTypes, invokeReturnType);
+        return true;
+    }
+
+    /// <summary>
+    /// Compiles one thunk shape: <c>(Delegate d, ...) =&gt; (object) ((TDelegate) d).Invoke(&lt;arguments&gt;)</c>,
+    /// with a <see langword="null"/> stand-in for a <c>void</c> return. The first lambda parameter is always
+    /// the <see cref="Delegate"/> to cast; the rest supply the arguments and differ per shape.
+    /// </summary>
+    private static TInvoker? Compile<TInvoker>(
+        Type delegateType,
+        Type invokeReturnType,
+        Expression[] arguments,
+        params ParameterExpression[] lambdaParameters)
+        where TInvoker : Delegate
+    {
+        Expression body = Expression.Invoke(Expression.Convert(lambdaParameters[0], delegateType), arguments);
         body = invokeReturnType == typeof(void)
             ? Expression.Block(body, Expression.Constant(null, typeof(object)))
             : Expression.Convert(body, typeof(object));
 
         try
         {
-            invoker = Expression.Lambda<Invoker>(body, delegateParameter, argumentsParameter).Compile();
+            return Expression.Lambda<TInvoker>(body, lambdaParameters).Compile();
         }
         catch (Exception)
         {
             // any shape the expression compiler refuses keeps the reflection path
-            return false;
+            return null;
         }
-
-        if (invoker is null)
-        {
-            return false;
-        }
-
-        parameterTypes = invokeParameterTypes;
-        returnType = invokeReturnType;
-        return true;
     }
 
     private static bool IsBindable(Type type) => !type.IsByRef && !type.IsPointer && type.IsVisible;

--- a/Jint/Runtime/Interop/DelegateWrapper.cs
+++ b/Jint/Runtime/Interop/DelegateWrapper.cs
@@ -233,19 +233,35 @@ internal sealed class DelegateWrapper : Function
             var paramsCount = Math.Max(0, jsArgumentsCount - delegateNonParamsArgumentsCount);
 
             var paramsParameterType = metadata.ParamsElementType!;
+
+            // A `params JsValue[]` tail takes its arguments straight through, so it can be built and
+            // filled as the typed array it is. Array.CreateInstance goes through the runtime's general
+            // array factory to produce the very same JsValue[], and Array.SetValue then re-derives the
+            // element type and re-checks assignability once per element - both to store a value the
+            // C# type system already proved fits. Every other element type keeps the general path,
+            // where SetValue's widening conversions are part of the behaviour.
+            if (metadata.ParamsElementIsJsValue)
+            {
+                var typedParams = new JsValue[paramsCount];
+                for (var i = paramsArgumentIndex; i < jsArgumentsCount; i++)
+                {
+                    // typedParams is exactly JsValue[] by construction, so the covariant store check
+                    // the CLR would otherwise emit is provably redundant
+                    Arguments.WriteNoTypeCheck(typedParams, i - paramsArgumentIndex, arguments[i]);
+                }
+
+                parameters[paramsArgumentIndex] = typedParams;
+                return parameters;
+            }
+
             var paramsParameter = Array.CreateInstance(paramsParameterType, paramsCount);
 
             for (var i = paramsArgumentIndex; i < jsArgumentsCount; i++)
             {
                 var paramsIndex = i - paramsArgumentIndex;
                 var value = arguments[i];
-                object? converted;
 
-                if (metadata.ParamsElementIsJsValue)
-                {
-                    converted = value;
-                }
-                else if (!ReflectionExtensions.TryConvertViaTypeCoercion(paramsParameterType, valueCoercionType, value, out converted))
+                if (!ReflectionExtensions.TryConvertViaTypeCoercion(paramsParameterType, valueCoercionType, value, out var converted))
                 {
                     converted = converter.Convert(
                         value.ToObject(),

--- a/Jint/Runtime/Interop/DelegateWrapper.cs
+++ b/Jint/Runtime/Interop/DelegateWrapper.cs
@@ -1,6 +1,8 @@
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Jint.Extensions;
 using Jint.Native;
@@ -31,6 +33,12 @@ internal sealed class DelegateWrapper : Function
     // Strongly-typed invocation lane; null when the runtime cannot compile one, in which case the
     // reflection-based DynamicInvoke path is kept.
     private readonly CompiledDelegateInvoker.Invoker? _invoker;
+
+    // The same lane for a delegate of exactly one or two parameters, taking its arguments in registers
+    // so the arity-specialized call lane needs no argument array at all. At most one is ever non-null,
+    // and only when _invoker is too.
+    private readonly CompiledDelegateInvoker.Invoker1? _invoker1;
+    private readonly CompiledDelegateInvoker.Invoker2? _invoker2;
 #endif
 
     public DelegateWrapper(
@@ -43,7 +51,12 @@ internal sealed class DelegateWrapper : Function
 
 #if NET8_0_OR_GREATER
         var compiled = CompiledDelegateInvoker.For(d.GetType());
-        _invoker = ThunkBindsTheTargetSignature(in compiled, d.Method) ? compiled.Invoke : null;
+        if (ThunkBindsTheTargetSignature(in compiled, d.Method))
+        {
+            _invoker = compiled.Invoke;
+            _invoker1 = compiled.Invoke1;
+            _invoker2 = compiled.Invoke2;
+        }
 #endif
     }
 
@@ -129,6 +142,14 @@ internal sealed class DelegateWrapper : Function
         return new FastCallShape(Supported: true, Leaf: false, FastCallGuard.Any, FastCallGuard.Any, FastCallGuard.Any);
     }
 
+    /// <remarks>
+    /// The arity is fixed per delegate type, so on this lane the argument array exists only to satisfy the
+    /// thunk's own signature. Where a register-passing thunk was built for that arity, the converted values
+    /// go straight into it and no array is allocated. Everything else — the conversions, the exact-type
+    /// check that decides between the compiled and the reflection lane, and the exceptions either produces —
+    /// is unchanged; only the shapes that stay on <see cref="Delegate.DynamicInvoke"/>, which takes the
+    /// array, still build one.
+    /// </remarks>
     internal override JsValue CallFast(JsValue thisObject, JsValue arg0, JsValue arg1)
     {
         var parameterMetadata = _metadata.Parameters;
@@ -141,13 +162,35 @@ internal sealed class DelegateWrapper : Function
         var converter = Engine.TypeConverter;
         var valueCoercionType = Engine.Options.Interop.ValueCoercion;
 
-        var parameters = new object?[count];
-        for (var i = 0; i < count; i++)
+        // GetFastCallShape only offers this lane for one or two parameters, so element 0 always exists:
+        // take a bounds-check-free reference to it (MA0212) and reach element 1 through Unsafe.Add.
+        ref var parameter0 = ref MemoryMarshal.GetReference(parameterMetadata.AsSpan());
+
+        var converted0 = Convert(in parameter0, arg0, converter, valueCoercionType);
+        if (count == 1)
         {
-            parameters[i] = Convert(in parameterMetadata[i], i == 0 ? arg0 : arg1, converter, valueCoercionType);
+#if NET8_0_OR_GREATER
+            var invoker1 = _invoker1;
+            if (invoker1 is not null && DelegateMetadata.CanBind(in parameter0, converted0))
+            {
+                return InvokeInRegisters(invoker1, converted0);
+            }
+#endif
+            return Invoke([converted0]);
         }
 
-        return Invoke(parameters);
+        ref var parameter1 = ref Unsafe.Add(ref parameter0, 1);
+        var converted1 = Convert(in parameter1, arg1, converter, valueCoercionType);
+#if NET8_0_OR_GREATER
+        var invoker2 = _invoker2;
+        if (invoker2 is not null
+            && DelegateMetadata.CanBind(in parameter0, converted0)
+            && DelegateMetadata.CanBind(in parameter1, converted1))
+        {
+            return InvokeInRegisters(invoker2, converted0, converted1);
+        }
+#endif
+        return Invoke([converted0, converted1]);
     }
 
     private object?[] BindArguments(JsCallArguments arguments)
@@ -265,13 +308,60 @@ internal sealed class DelegateWrapper : Function
         catch (TargetInvocationException exception)
 #endif
         {
-            // a throwing host call never reaches the post-invoke check below; re-check here so a
-            // loop of throwing host calls cannot stretch the detection window either
-            Engine.CheckAmortizedConstraintsAtHostBoundary();
-            Throw.MeaningfulException(Engine, exception as TargetInvocationException ?? new TargetInvocationException(exception));
+            ThrowHostCallFailure(exception);
             throw;
         }
 
+        return CompleteHostCall(result);
+    }
+
+#if NET8_0_OR_GREATER
+    private JsValue InvokeInRegisters(CompiledDelegateInvoker.Invoker1 invoker, object? argument0)
+    {
+        object? result;
+        try
+        {
+            result = invoker(_d, argument0);
+        }
+        catch (Exception exception)
+        {
+            ThrowHostCallFailure(exception);
+            throw;
+        }
+
+        return CompleteHostCall(result);
+    }
+
+    private JsValue InvokeInRegisters(CompiledDelegateInvoker.Invoker2 invoker, object? argument0, object? argument1)
+    {
+        object? result;
+        try
+        {
+            result = invoker(_d, argument0, argument1);
+        }
+        catch (Exception exception)
+        {
+            ThrowHostCallFailure(exception);
+            throw;
+        }
+
+        return CompleteHostCall(result);
+    }
+#endif
+
+    /// <summary>
+    /// A throwing host call never reaches the post-invoke boundary check, so it is re-checked here: a loop
+    /// of throwing host calls must not stretch the constraint-detection window either.
+    /// </summary>
+    [DoesNotReturn]
+    private void ThrowHostCallFailure(Exception exception)
+    {
+        Engine.CheckAmortizedConstraintsAtHostBoundary();
+        Throw.MeaningfulException(Engine, exception as TargetInvocationException ?? new TargetInvocationException(exception));
+    }
+
+    private JsValue CompleteHostCall(object? result)
+    {
         // an awaitable result must reach promise conversion before a constraint can throw,
         // so that the in-flight Task gets a continuation attached and is never left unobserved
         var returnValue = IsAwaitable(result)
@@ -413,32 +503,34 @@ internal sealed class DelegateMetadata
         var parameterMetadata = Parameters;
         for (var i = 0; i < parameterMetadata.Length; i++)
         {
-            var parameter = parameterMetadata[i];
-            var value = parameters[i];
-
-            if (value is null)
-            {
-                // a castclass accepts null and so does a Nullable<T> conversion; a plain unbox does not
-                if (parameter.IsValueType && ReferenceEquals(parameter.BoxedType, parameter.ParameterType))
-                {
-                    return false;
-                }
-
-                continue;
-            }
-
-            if (ReferenceEquals(value.GetType(), parameter.BoxedType))
-            {
-                continue;
-            }
-
-            if (parameter.IsValueType || !parameter.ParameterType.IsInstanceOfType(value))
+            if (!CanBind(in parameterMetadata[i], parameters[i]))
             {
                 return false;
             }
         }
 
         return true;
+    }
+
+    /// <inheritdoc cref="CanBind(object?[])"/>
+    /// <remarks>
+    /// The single-parameter form, so a caller holding its converted arguments in locals can ask the same
+    /// question without materializing an array to ask it through.
+    /// </remarks>
+    internal static bool CanBind(in ParameterMetadata parameter, object? value)
+    {
+        if (value is null)
+        {
+            // a castclass accepts null and so does a Nullable<T> conversion; a plain unbox does not
+            return !parameter.IsValueType || !ReferenceEquals(parameter.BoxedType, parameter.ParameterType);
+        }
+
+        if (ReferenceEquals(value.GetType(), parameter.BoxedType))
+        {
+            return true;
+        }
+
+        return !parameter.IsValueType && parameter.ParameterType.IsInstanceOfType(value);
     }
 #endif
 }

--- a/Jint/Runtime/Interop/MethodDescriptor.cs
+++ b/Jint/Runtime/Interop/MethodDescriptor.cs
@@ -228,6 +228,35 @@ internal sealed class MethodDescriptor
     private bool _returnValueVisibilityResolved;
     private bool _returnValueIsInvisibleToObjectConverters;
 
+    // The last converter-type filter that answered "does not claim ReturnType", or null if none
+    // has. The method-invoker twin of CompilableMemberAccessor's memo, with the same safety
+    // argument: descriptors are shared across engines whose filters differ, so the filter
+    // reference is the memo key; only the negative verdict is stored, written after that filter
+    // answered and compared only by reference, so an unsynchronized stale read can at worst
+    // recompute — never wrongly bypass a converter. The affirmative verdict takes the call off
+    // the compiled lane entirely, a path far more expensive than the probe this memo saves.
+    private ObjectConverterTypeFilter? _returnTypeUnclaimedBy;
+
+    /// <summary>
+    /// Whether <paramref name="filter"/> claims this method's return type, with the negative
+    /// answer — the one every call on the compiled lane has to have — memoized per filter.
+    /// </summary>
+    internal bool ReturnTypeClaimedBy(ObjectConverterTypeFilter filter)
+    {
+        if (ReferenceEquals(_returnTypeUnclaimedBy, filter))
+        {
+            return false;
+        }
+
+        if (filter.Claims(ReturnType))
+        {
+            return true;
+        }
+
+        _returnTypeUnclaimedBy = filter;
+        return false;
+    }
+
     /// <summary>
     /// Whether this method's return value is one that registered <see cref="IObjectConverter"/>s
     /// could never observe, so the compiled invoker may produce the <see cref="JsValue"/> itself

--- a/Jint/Runtime/Interop/MethodInfoFunction.cs
+++ b/Jint/Runtime/Interop/MethodInfoFunction.cs
@@ -184,7 +184,7 @@ internal sealed class MethodInfoFunction : Function
                 var converterTypeFilter = _engine._objectConverterTypeFilter;
                 if ((converterTypeFilter is null
                         || method.ReturnValueIsInvisibleToObjectConverters
-                        || !converterTypeFilter.Claims(method.ReturnType))
+                        || !method.ReturnTypeClaimedBy(converterTypeFilter))
                     && _engine._typeConverterIsDefault
                     && method.GetCompiledInvoker() is { } compiledInvoker
                     && (method.IsStatic || method.DeclaringType?.IsInstanceOfType(thisObj) == true))

--- a/Jint/Runtime/Interop/Reflection/CompilableMemberAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/CompilableMemberAccessor.cs
@@ -37,6 +37,12 @@ internal abstract class CompilableMemberAccessor : ReflectionAccessor
     private Action<object, object?>? _rawSetter;
     private bool _rawSetterResolved;
 
+    /// <summary>
+    /// The last converter-type filter that answered "does not claim <see cref="ReflectionAccessor.MemberType"/>",
+    /// or <see langword="null"/> if none has. See <see cref="Claims"/>.
+    /// </summary>
+    private ObjectConverterTypeFilter? _unclaimedBy;
+
     protected CompilableMemberAccessor(MemberInfo member, Type memberType, PropertyInfo? indexer)
         : base(memberType, indexer)
     {
@@ -66,7 +72,7 @@ internal abstract class CompilableMemberAccessor : ReflectionAccessor
         // OptionsExtensions.AddObjectConverter) leaves every other member on the fast lane. A converter
         // registered without declaring them claims everything, which is the pre-existing behaviour.
         var converterTypeFilter = engine._objectConverterTypeFilter;
-        if (converterTypeFilter is not null && converterTypeFilter.Claims(MemberType))
+        if (converterTypeFilter is not null && Claims(converterTypeFilter))
         {
             return false;
         }
@@ -184,6 +190,43 @@ internal abstract class CompilableMemberAccessor : ReflectionAccessor
         {
             throw new TargetInvocationException(exception);
         }
+    }
+
+    /// <summary>
+    /// Whether <paramref name="filter"/> claims this accessor's member type, with the affirmative answer —
+    /// the one every read on the lane has to have — memoized.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The answer is constant for a given <c>(accessor, filter)</c> pair: <see cref="ReflectionAccessor.MemberType"/>
+    /// is fixed at construction and a filter's declared type set is immutable. It cannot be stored on the
+    /// accessor outright, because <c>TypeResolver</c>'s accessor cache key deliberately excludes the converter
+    /// set, so one accessor is shared by engines whose filters differ — hence the filter reference is part of
+    /// the memo and a mismatch simply recomputes.
+    /// </para>
+    /// <para>
+    /// Only the <see langword="false"/> verdict is remembered, which is what makes a single reference field
+    /// enough and keeps the memo safe to read and write without synchronization: the field is written only
+    /// after that filter answered "does not claim", and it is only ever compared for reference equality, so a
+    /// stale or half-published read can at worst repeat the computation — never produce a wrong
+    /// <see langword="false"/>, which would silently bypass a converter. The affirmative verdict needs no memo:
+    /// it takes the read off this lane entirely, onto a path far more expensive than the probe saved.
+    /// </para>
+    /// </remarks>
+    private bool Claims(ObjectConverterTypeFilter filter)
+    {
+        if (ReferenceEquals(_unclaimedBy, filter))
+        {
+            return false;
+        }
+
+        if (filter.Claims(MemberType))
+        {
+            return true;
+        }
+
+        _unclaimedBy = filter;
+        return false;
     }
 
     [DoesNotReturn]


### PR DESCRIPTION
The measurement-gated tail of the v4.15.0 pre-release review: seven bisectable commits, each A/B-measured against main on an idle machine (default BenchmarkDotNet job, paired runs, per-class control rows). One further candidate — answering global existence probes off the builtin shape layout — was implemented, measured, and **dropped**: it cost uncached misses +17% for a within-noise gain on hits. The gate exists to kill those.

Measured results (branch vs main, means; allocations where they moved):

* **Host-delegate register lane** — arity-specific compiled invokers replace the per-call `object?[]` for arities the fast lane serves: `Func<int,_>` −12.5% and −40% alloc, `Func<string,_>` −18.8% and −57% alloc, two-arg −15.4% and −45% alloc; the arity-3 off-lane control row is flat.
* **Converter-verdict memos** — the typed-converter member-read memo plus its method-invoker twin (the same constant question the compiled lane re-asked per call): typed-converter property sweep −7.3%, with the no-converter and untyped-converter controls flat.
* **Fast-call migrations** (`String.includes`/`endsWith`, `Array.indexOf`/`some`/`find`/`findIndex`, `Number.toString`) — −2…−14% per row, non-migrated siblings pinned as flat controls. Each method passed a per-method absent-argument audit; `parseInt`/`parseFloat` were skipped with the reason recorded (deliberately shared `ClrFunction` identity). Includes one spec fix the audit surfaced: `'abc'.endsWith('c', undefined)` returned `false` — the default applied on argument *absence* where the spec keys on the *value* — verified against V8.
* **encodeURI/encodeURIComponent clean-input early-out** (the Decode twins' pattern): clean inputs −44% / −85% with −79% / −96% allocations; mixed inputs −6…−29%; the fully-escaping worst case pays the pre-scan at +6%, recorded as the accepted trade.
* **`toReversed`/`with` dense lanes** (the `join` precedent, with the shrink-during-coercion discipline the review's `copyWithin` fix established): dense 1024-element `with` −86%, `toReversed` −43%; holey sources decline and pay the hole scan at +3…+8%, recorded.
* **Typed `params JsValue[]` tail** — `new JsValue[n]` instead of `Array.CreateInstance` + per-element `SetValue`.

Full suite green on both TFMs in Release and Debug; SourceGenerators snapshots reviewed; Test262 0 failed across four runs, byte-identical to the base tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
