### PR TITLE
Let a test observe the access semantics the engine derived for a host type

### DIFF
--- a/Jint.Tests.PublicInterface/HostObjectSemanticsTests.cs
+++ b/Jint.Tests.PublicInterface/HostObjectSemanticsTests.cs
@@ -338,6 +338,149 @@ public class HostObjectSemanticsTests
         engine.Evaluate("host.value").Should().Be(1);
         host.GetOwnPropertyCalls.Should().Be(OrdinaryOwnReadProbes);
     }
+
+    // ---- Engine.Advanced.GetPropertyAccessSemantics ----
+
+    [Fact]
+    public void TheResolvedSemanticsAreReadableFromOutsideTheJintAssembly()
+    {
+        // This project has no InternalsVisibleTo, so the call below compiling at all is the guarantee: before
+        // it existed, everything that decides the answer — the flag, the probe, the probe counter — was
+        // internal, and a host could only infer the derivation from probe counts against its own overrides.
+        var engine = new Engine();
+
+        engine.Advanced.GetPropertyAccessSemantics(new ProjectedHostObject(engine))
+            .Should().Be(PropertyAccessSemantics.Ordinary);
+    }
+
+    [Fact]
+    public void AHostThatOverridesGetIsReportedExotic()
+    {
+        var engine = new Engine();
+
+        engine.Advanced.GetPropertyAccessSemantics(new ComputingHostObject(engine))
+            .Should().Be(PropertyAccessSemantics.Exotic);
+    }
+
+    [Fact]
+    public void TwoHostsThatAnswerEveryReadIdenticallyStillReportTheDerivationThatSeparatesThem()
+    {
+        // The motivating pin, and the reason the diagnostic is worth a public method. These two types project
+        // the same fields and answer every read the same way — one overrides Get with a pure pass-through to
+        // base, the other does not override it at all — so no assertion about *values* can tell them apart.
+        // The derivation still separates them, and it decides how every read against them is routed. Delete
+        // PassThroughGetHostObject's one-line override, or move it to a base class where the probe stops
+        // seeing it as an override, and the type silently changes from Exotic to Ordinary with every
+        // behavioural test still green. This is the assertion that goes red.
+        var engine = new Engine();
+
+        var withoutOverride = new ProjectedHostObject(engine).Project("value", 42);
+        var withOverride = new PassThroughGetHostObject(engine).Project("value", 42);
+
+        engine.SetValue("a", withoutOverride);
+        engine.SetValue("b", withOverride);
+        engine.Evaluate("a.value").Should().Be(42);
+        engine.Evaluate("b.value").Should().Be(42);
+        engine.Evaluate("a.absent").Should().Be(JsValue.Undefined);
+        engine.Evaluate("b.absent").Should().Be(JsValue.Undefined);
+
+        engine.Advanced.GetPropertyAccessSemantics(withoutOverride).Should().Be(PropertyAccessSemantics.Ordinary);
+        engine.Advanced.GetPropertyAccessSemantics(withOverride).Should().Be(PropertyAccessSemantics.Exotic);
+    }
+
+    [Fact]
+    public void ADeclarationIsWhatTheDiagnosticReports()
+    {
+        // For the two shapes the rule cannot see, the declaration is the answer — so the diagnostic reports
+        // the resolved semantics, not the derived ones. Both directions, plus the last-call-wins rule.
+        var engine = new Engine();
+
+        // overrides Get, declares Ordinary
+        engine.Advanced.GetPropertyAccessSemantics(new TracingHostObject(engine))
+            .Should().Be(PropertyAccessSemantics.Ordinary);
+
+        // does not override Get, declares Exotic
+        engine.Advanced.GetPropertyAccessSemantics(new MutatingHostObject(engine))
+            .Should().Be(PropertyAccessSemantics.Exotic);
+
+        engine.Advanced.GetPropertyAccessSemantics(
+                new RedeclaringHostObject(engine, PropertyAccessSemantics.Exotic, PropertyAccessSemantics.Ordinary))
+            .Should().Be(PropertyAccessSemantics.Ordinary);
+
+        engine.Advanced.GetPropertyAccessSemantics(
+                new RedeclaringHostObject(engine, PropertyAccessSemantics.Ordinary, PropertyAccessSemantics.Exotic))
+            .Should().Be(PropertyAccessSemantics.Exotic);
+    }
+
+    [Fact]
+    public void TheDeclarationIsPerInstanceNotPerType()
+    {
+        // SetPropertyAccessSemantics is called from a constructor and writes the instance, so two instances of
+        // one type can resolve differently. A Type-keyed diagnostic could not report this.
+        var engine = new Engine();
+
+        engine.Advanced.GetPropertyAccessSemantics(
+                new RedeclaringHostObject(engine, PropertyAccessSemantics.Ordinary, PropertyAccessSemantics.Ordinary))
+            .Should().Be(PropertyAccessSemantics.Ordinary);
+
+        engine.Advanced.GetPropertyAccessSemantics(
+                new RedeclaringHostObject(engine, PropertyAccessSemantics.Ordinary, PropertyAccessSemantics.Exotic))
+            .Should().Be(PropertyAccessSemantics.Exotic);
+    }
+
+    [Fact]
+    public void TheEnginesOwnObjectsAreClassifiedToo()
+    {
+        // Non-contractual by documentation — an in-box object's classification may be refined in any release —
+        // but pinned here so a host reading these answers in a test sees what they are today, and so a change
+        // to any of them is a deliberate edit rather than a silent one.
+        var engine = new Engine(options => options.AllowClr(typeof(HostPoint).Assembly));
+
+        // Ordinary is the absence of the exotic claim: a plain object, an array and an ordinary function all
+        // have exactly ordinary [[Get]].
+        engine.Advanced.GetPropertyAccessSemantics(engine.Evaluate("({ a: 1 })").AsObject())
+            .Should().Be(PropertyAccessSemantics.Ordinary);
+        engine.Advanced.GetPropertyAccessSemantics(engine.Evaluate("[1, 2, 3]").AsObject())
+            .Should().Be(PropertyAccessSemantics.Ordinary);
+        engine.Advanced.GetPropertyAccessSemantics(engine.Evaluate("(function f() {})").AsObject())
+            .Should().Be(PropertyAccessSemantics.Ordinary);
+
+        // The built-ins that genuinely deviate say so.
+        engine.Advanced.GetPropertyAccessSemantics(engine.Evaluate("new Proxy({}, {})").AsObject())
+            .Should().Be(PropertyAccessSemantics.Exotic);
+        engine.Advanced.GetPropertyAccessSemantics(engine.Evaluate("new Uint8Array(4)").AsObject())
+            .Should().Be(PropertyAccessSemantics.Exotic);
+        engine.Advanced.GetPropertyAccessSemantics(engine.Evaluate("(function () { return arguments; })(1)").AsObject())
+            .Should().Be(PropertyAccessSemantics.Exotic);
+
+        // ...and so does a CLR object wrapper, whose members resolve against the wrapped type rather than a
+        // descriptor store.
+        engine.SetValue("point", new HostPoint());
+        engine.Advanced.GetPropertyAccessSemantics(engine.Evaluate("point").AsObject())
+            .Should().Be(PropertyAccessSemantics.Exotic);
+    }
+
+    [Fact]
+    public void AMissingOrForeignObjectIsRejected()
+    {
+        var engine = new Engine();
+        var other = new Engine();
+
+        Invoking(() => engine.Advanced.GetPropertyAccessSemantics(null!))
+            .Should().Throw<ArgumentNullException>();
+
+        // The resolved semantics do not actually depend on the engine, but the guard matches
+        // GetObjectRepresentation's so that the mixed-up-engine mistake fails loudly in the multi-engine tests
+        // these diagnostics are written for.
+        Invoking(() => engine.Advanced.GetPropertyAccessSemantics(new ProjectedHostObject(other)))
+            .Should().Throw<ArgumentException>();
+    }
+
+    /// <summary>A plain CLR object, so a test can ask about the wrapper the engine builds for it.</summary>
+    public sealed class HostPoint
+    {
+        public int X { get; set; }
+    }
 }
 
 /// <summary>

--- a/Jint/Engine.Advanced.cs
+++ b/Jint/Engine.Advanced.cs
@@ -200,6 +200,64 @@ public partial class Engine
         }
 
         /// <summary>
+        /// Reports the <see cref="PropertyAccessSemantics"/> the engine resolved for <paramref name="value"/> —
+        /// derived from its runtime type, or declared through
+        /// <see cref="ObjectInstance.SetPropertyAccessSemantics"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>This is a diagnostic, and it is not part of Jint's compatibility contract.</b> Use it in
+        /// diagnostics, assertions and regression tests; do not branch on it in production code. For an object
+        /// of a <i>host-defined</i> type the answer is exactly the semantics the engine's read lanes honor for
+        /// that instance, and it is stable as long as the type is. For the engine's own types the answer names
+        /// an internal classification which may be refined in any release without notice, and the enum may gain
+        /// members; neither is a breaking change.
+        /// </para>
+        /// <para>
+        /// The motivating case: the derivation is deliberately silent. A host type is
+        /// <see cref="PropertyAccessSemantics.Exotic"/> because it overrides
+        /// <see cref="ObjectInstance.Get(JsValue, JsValue)"/> and
+        /// <see cref="PropertyAccessSemantics.Ordinary"/> because it does not, so an edit that removes the last
+        /// <c>Get</c> override — or a refactor that moves it to a base class the probe cannot see as an
+        /// override — flips the semantics of every read against that type with nothing to fail. Without this
+        /// method a host can only pin the derivation indirectly, by instrumenting its own overrides and
+        /// asserting probe counts.
+        /// </para>
+        /// <para>
+        /// It reports the resolved <see cref="PropertyAccessSemantics"/> and nothing else. In particular it
+        /// does not report whether the type overrides <c>TryGetOwnPropertyValue</c>, which is an orthogonal
+        /// routing decision a host observes directly by instrumenting that override.
+        /// </para>
+        /// </remarks>
+        /// <param name="value">The object to inspect. It must belong to this engine.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="value"/> belongs to a different engine.</exception>
+        public PropertyAccessSemantics GetPropertyAccessSemantics(ObjectInstance value)
+        {
+            if (value is null)
+            {
+                Throw.ArgumentNullException(nameof(value));
+            }
+
+            if (!ReferenceEquals(value.Engine, _engine))
+            {
+                // The resolved semantics happen not to depend on the engine, but rejecting a foreign object
+                // keeps this diagnostic consistent with GetObjectRepresentation and turns the mixed-up-engine
+                // mistake — easy to make in exactly the multi-engine tests these APIs are written for — into a
+                // failure instead of a misleading pass.
+                Throw.ArgumentException("The object belongs to a different engine.", nameof(value));
+            }
+
+            // Ordinary is the absence of the exotic claim, not a flag of its own: an in-box object built through
+            // the internal constructor carries neither OrdinaryGet nor ExoticGet, and ordinary is what such an
+            // object has. Only ExoticGet — set by the built-ins that deviate, derived for a host type that
+            // overrides Get, and settable either way through SetPropertyAccessSemantics — can move the answer.
+            return (value._type & InternalTypes.ExoticGet) != InternalTypes.Empty
+                ? PropertyAccessSemantics.Exotic
+                : PropertyAccessSemantics.Ordinary;
+        }
+
+        /// <summary>
         /// Event raised when a promise is rejected without a handler (operation = Reject),
         /// or when a handler is added to a previously unhandled rejected promise (operation = Handle).
         /// This implements the HostPromiseRejectionTracker abstract operation from the TC39 spec.


### PR DESCRIPTION
From the KurrentDB 4.15.0 adoption friction report: removing a `Get` override reclassifies a host type Exotic→Ordinary silently, and nothing but a Debug build can catch it. `Engine.Advanced.GetPropertyAccessSemantics(ObjectInstance)` mirrors `GetObjectRepresentation`'s fenced, non-contractual observability so a host test can pin the derivation.

One subtlety the implementation records: in-box objects built through the internal constructor carry neither semantics flag, so ordinary is read as the absence of the exotic claim — testing `OrdinaryGet` positively would misreport every built-in. The XML docs split the fencing accordingly: host-type answers are exactly what the read lanes honor; in-box answers name an internal classification free to change.

The motivating pin: two hosts projecting identical fields and answering every read identically — no value assertion separates them — while the derivation assertion goes red the moment the one-line `Get` override is deleted. 7 new public-surface tests; full suite green both TFMs, Release and Debug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)