### PR TITLE
Count CLR array conversions so a host can audit its crossing semantics

### DIFF
--- a/Jint.Tests.PublicInterface/HostArrayConversionDiagnosticsTests.cs
+++ b/Jint.Tests.PublicInterface/HostArrayConversionDiagnosticsTests.cs
@@ -1,0 +1,262 @@
+#nullable enable
+
+using System.Collections.Generic;
+using Jint.Runtime.Interop;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// Covers <see cref="Engine.AdvancedOperations.GetInteropConversionDiagnostics"/>, the answer to a question a
+/// host cannot otherwise ask: did any CLR array cross into script during this run, and under which semantics?
+/// <para>
+/// <see cref="ArrayConversionMode.LiveView"/> has been the default since 4.14, and the two modes differ in
+/// behavior a script can observe — a live view writes through to the CLR array, a copy does not. A host that
+/// does not own all of its Jint consumers therefore has a real audit to perform and, before these counters, no
+/// way to perform it except by reading every transitive caller. These tests live outside the Jint assembly on
+/// purpose: the project has no internals access, so the audit written here is one a third party can write.
+/// </para>
+/// </summary>
+public class HostArrayConversionDiagnosticsTests
+{
+    private static Engine CreateEngine(ArrayConversionMode? mode = null) => new(options =>
+    {
+        options.AllowClr(typeof(HostWithArrays).Assembly);
+        if (mode is not null)
+        {
+            options.Interop.ArrayConversion = mode.Value;
+        }
+    });
+
+    // ---- reachability ----
+
+    [Fact]
+    public void TheCountersAreReadableFromOutsideTheJintAssemblyAndStartAtZero()
+    {
+        // This project has no InternalsVisibleTo, so the call below compiling at all is the guarantee.
+        var diagnostics = new Engine().Advanced.GetInteropConversionDiagnostics();
+
+        diagnostics.ArrayLiveViewConversions.Should().Be(0);
+        diagnostics.ArrayCopyConversions.Should().Be(0);
+    }
+
+    // ---- the audit ----
+
+    [Fact]
+    public void AnAuditOfARunThatCrossesNoArrayAnswersZero()
+    {
+        // The negative result is the one the audit usually wants, and the one that has to be trustworthy: a
+        // busy run over host objects, strings, numbers, a delegate, a dictionary and a list — everything an
+        // embedder normally projects except an array — must leave both counters untouched. Anything that
+        // counted an ordinary wrapper would make the audit useless by always answering "yes".
+        var engine = CreateEngine();
+        engine.SetValue("host", new HostWithArrays());
+        engine.SetValue("callback", new Func<int, int>(x => x * 2));
+
+        engine.Execute(
+            """
+            var total = 0;
+            for (var i = 0; i < 5; i++) {
+                total += host.Number + host.Text.length + callback(i);
+                total += host.Names.length;
+                total += host.Lookup.Count;
+                total += host.Nested.Number;
+            }
+            """);
+
+        var diagnostics = engine.Advanced.GetInteropConversionDiagnostics();
+        diagnostics.ArrayLiveViewConversions.Should().Be(0);
+        diagnostics.ArrayCopyConversions.Should().Be(0);
+    }
+
+    [Fact]
+    public void AnAuditOfARunThatCrossesAnArrayAnswersHowItCrossed()
+    {
+        // ...and the positive result names the semantics, which is the half that decides whether the host
+        // cares. The same script under the two modes gives the host two different facts about its own data.
+        var liveViewEngine = CreateEngine(ArrayConversionMode.LiveView);
+        liveViewEngine.SetValue("host", new HostWithArrays());
+        liveViewEngine.Evaluate("host.Values[0]").Should().Be(1);
+
+        var live = liveViewEngine.Advanced.GetInteropConversionDiagnostics();
+        live.ArrayLiveViewConversions.Should().Be(1);
+        live.ArrayCopyConversions.Should().Be(0);
+
+        var copyEngine = CreateEngine(ArrayConversionMode.Copy);
+        copyEngine.SetValue("host", new HostWithArrays());
+        copyEngine.Evaluate("host.Values[0]").Should().Be(1);
+
+        var copy = copyEngine.Advanced.GetInteropConversionDiagnostics();
+        copy.ArrayLiveViewConversions.Should().Be(0);
+        copy.ArrayCopyConversions.Should().Be(1);
+    }
+
+    [Fact]
+    public void TheCountedSemanticsAreTheOnesTheScriptObserves()
+    {
+        // The counter is only worth reading if it names what actually happened, so pin it against the
+        // behavioural difference itself: a live view writes through to the CLR array, a copy does not.
+        var host = new HostWithArrays();
+        var liveViewEngine = CreateEngine(ArrayConversionMode.LiveView);
+        liveViewEngine.SetValue("host", host);
+        liveViewEngine.Execute("host.Values[0] = 99;");
+
+        host.Values[0].Should().Be(99);
+        liveViewEngine.Advanced.GetInteropConversionDiagnostics().ArrayLiveViewConversions.Should().Be(1);
+
+        var copied = new HostWithArrays();
+        var copyEngine = CreateEngine(ArrayConversionMode.Copy);
+        copyEngine.SetValue("host", copied);
+        copyEngine.Execute("host.Values[0] = 99;");
+
+        copied.Values[0].Should().Be(1);
+        copyEngine.Advanced.GetInteropConversionDiagnostics().ArrayCopyConversions.Should().Be(1);
+    }
+
+    // ---- what is and is not counted ----
+
+    [Fact]
+    public void ARecrossingServedFromTheIdentityCacheIsNotCountedAgain()
+    {
+        // A cache hit performs no conversion, so counting it would be counting nothing. It also cannot hide a
+        // crossing: a hit implies an earlier miss that was counted, which is exactly what "did arrays cross"
+        // needs. Documented as part of the counted set, so pinned here.
+        var engine = CreateEngine();
+        engine.SetValue("host", new HostWithArrays());
+
+        engine.Execute("for (var i = 0; i < 10; i++) { host.Values[0]; }");
+
+        engine.Advanced.GetInteropConversionDiagnostics().ArrayLiveViewConversions.Should().Be(1);
+    }
+
+    [Fact]
+    public void DistinctArraysAreCountedSeparately()
+    {
+        var engine = CreateEngine();
+        engine.SetValue("host", new HostWithArrays());
+
+        engine.Execute("host.Values[0]; host.Others[0];");
+
+        engine.Advanced.GetInteropConversionDiagnostics().ArrayLiveViewConversions.Should().Be(2);
+    }
+
+    [Fact]
+    public void AnArrayNoViewCanBeBuiltOverIsCountedAsTheCopyItBecomes()
+    {
+        // LiveView is a preference, not a guarantee: a wrap handler declining the value drops the conversion
+        // to the copy lane. The counter follows what happened rather than what was configured, which is the
+        // whole reason a host reads it instead of reading its own options.
+        var engine = new Engine(options =>
+        {
+            options.AllowClr(typeof(HostWithArrays).Assembly);
+            options.Interop.ArrayConversion = ArrayConversionMode.LiveView;
+            options.Interop.WrapObjectHandler = static (e, target, type) =>
+                target is Array ? null : ObjectWrapper.Create(e, target, type);
+        });
+        engine.SetValue("host", new HostWithArrays());
+
+        engine.Evaluate("host.Values[0]").Should().Be(1);
+
+        var diagnostics = engine.Advanced.GetInteropConversionDiagnostics();
+        diagnostics.ArrayLiveViewConversions.Should().Be(0);
+        diagnostics.ArrayCopyConversions.Should().Be(1);
+    }
+
+    [Fact]
+    public void ADeclaredCollectionTypeDecidesWhetherTheArrayLaneIsTakenAtAll()
+    {
+        // The documented scope boundary. Under LiveView an array reaching script under a non-array declared
+        // type honors that declared contract through the ordinary wrapper lane — no array conversion happens,
+        // so none is counted. Under Copy the same value still takes the copy lane, and is counted there.
+        var liveViewEngine = CreateEngine(ArrayConversionMode.LiveView);
+        liveViewEngine.SetValue("host", new HostWithArrays());
+        liveViewEngine.Evaluate("host.Declared[0]").Should().Be(1);
+
+        var live = liveViewEngine.Advanced.GetInteropConversionDiagnostics();
+        live.ArrayLiveViewConversions.Should().Be(0);
+        live.ArrayCopyConversions.Should().Be(0);
+
+        var copyEngine = CreateEngine(ArrayConversionMode.Copy);
+        copyEngine.SetValue("host", new HostWithArrays());
+        copyEngine.Evaluate("host.Declared[0]").Should().Be(1);
+
+        var copy = copyEngine.Advanced.GetInteropConversionDiagnostics();
+        copy.ArrayLiveViewConversions.Should().Be(0);
+        copy.ArrayCopyConversions.Should().Be(1);
+    }
+
+    [Fact]
+    public void EachEngineCountsItsOwnConversions()
+    {
+        // A host pooling engines audits per engine, so the counters must not be static.
+        var first = CreateEngine();
+        var second = CreateEngine();
+        first.SetValue("host", new HostWithArrays());
+        second.SetValue("host", new HostWithArrays());
+
+        first.Execute("host.Values[0]; host.Others[0];");
+        second.Execute("host.Values[0];");
+
+        first.Advanced.GetInteropConversionDiagnostics().ArrayLiveViewConversions.Should().Be(2);
+        second.Advanced.GetInteropConversionDiagnostics().ArrayLiveViewConversions.Should().Be(1);
+    }
+
+    [Fact]
+    public void TheCountersAreCumulativeAcrossEvaluations()
+    {
+        var engine = CreateEngine();
+        engine.SetValue("host", new HostWithArrays());
+
+        engine.Execute("host.Values[0];");
+        var afterFirst = engine.Advanced.GetInteropConversionDiagnostics();
+
+        // A fresh array each time, so the identity caches cannot answer.
+        engine.SetValue("host", new HostWithArrays());
+        engine.Execute("host.Values[0];");
+        var afterSecond = engine.Advanced.GetInteropConversionDiagnostics();
+
+        afterFirst.ArrayLiveViewConversions.Should().Be(1);
+        afterSecond.ArrayLiveViewConversions.Should().Be(2);
+    }
+
+    [Fact]
+    public void TheResultIsAValueSnapshotNotALiveHandle()
+    {
+        // Reading the counters must not hand back something that keeps changing underneath the host, or an
+        // audit could not compare a before against an after.
+        var engine = CreateEngine();
+        engine.SetValue("host", new HostWithArrays());
+
+        var before = engine.Advanced.GetInteropConversionDiagnostics();
+        engine.Execute("host.Values[0];");
+        var after = engine.Advanced.GetInteropConversionDiagnostics();
+
+        before.ArrayLiveViewConversions.Should().Be(0);
+        after.ArrayLiveViewConversions.Should().Be(1);
+        before.Should().NotBe(after);
+        engine.Advanced.GetInteropConversionDiagnostics().Should().Be(after);
+    }
+
+    /// <summary>
+    /// A plain CLR host with the members an embedder normally projects, plus the array shapes the counters
+    /// discriminate between.
+    /// </summary>
+    public sealed class HostWithArrays
+    {
+        public int Number => 7;
+        public string Text => "text";
+        public List<string> Names { get; } = ["a", "b"];
+        public Dictionary<string, int> Lookup { get; } = new() { ["a"] = 1 };
+        public HostLeaf Nested { get; } = new();
+
+        public int[] Values { get; } = [1, 2, 3];
+        public int[] Others { get; } = [4, 5];
+
+        /// <summary>An array reaching script under a declared type that is not an array type.</summary>
+        public IReadOnlyList<int> Declared { get; } = new[] { 1, 2, 3 };
+    }
+
+    public sealed class HostLeaf
+    {
+        public int Number => 3;
+    }
+}

--- a/Jint/Engine.Advanced.cs
+++ b/Jint/Engine.Advanced.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Jint.Native;
 using Jint.Native.Object;
 using Jint.Native.Promise;
@@ -258,6 +259,43 @@ public partial class Engine
         }
 
         /// <summary>
+        /// Reports how many CLR arrays this engine has converted for script, and under which semantics.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>This is a diagnostic, and it is not part of Jint's compatibility contract.</b> Exactly which
+        /// internal events are counted may be refined in any release, and
+        /// <see cref="InteropConversionDiagnostics"/> may gain members; neither is a breaking change. Use it
+        /// for audits, assertions and regression tests, never for production branching.
+        /// </para>
+        /// <para>
+        /// The motivating case: <see cref="ArrayConversionMode.LiveView"/> has been the default since 4.14, and
+        /// the two modes differ in behavior a script can observe — a live view writes through to the CLR array
+        /// and tracks its contents, a copy does neither. A host that does not own all of its Jint consumers has
+        /// no way to find out whether any CLR array crosses into script at all, let alone under which
+        /// semantics, short of auditing every transitive caller by hand. Reading the counters around a run
+        /// answers it directly.
+        /// </para>
+        /// <para>
+        /// Scope, stated honestly. What is counted is a conversion that actually went through the
+        /// array-conversion lane, which is not quite the same as "a CLR array reached script". Under
+        /// <see cref="ArrayConversionMode.LiveView"/> an array crossing under a non-array <i>declared</i>
+        /// type — <c>IReadOnlyList&lt;T&gt;</c>, <c>IEnumerable&lt;T&gt;</c> — honors that declared contract
+        /// through the ordinary wrapper lane instead, converts no array, and is not counted; under
+        /// <see cref="ArrayConversionMode.Copy"/> the same value does take the copy lane and is counted. A
+        /// re-crossing served from an identity cache is never counted, since a cache hit performs no
+        /// conversion and implies an earlier one that was — which is what "did arrays cross, and how" needs
+        /// to know.
+        /// </para>
+        /// <para>
+        /// The counters are cumulative for the life of the engine and never reset. Two engines count
+        /// independently, so a host pooling engines should read them per engine.
+        /// </para>
+        /// </remarks>
+        public InteropConversionDiagnostics GetInteropConversionDiagnostics()
+            => new(_engine._arrayLiveViewConversions, _engine._arrayCopyConversions);
+
+        /// <summary>
         /// Event raised when a promise is rejected without a handler (operation = Reject),
         /// or when a handler is added to a previously unhandled rejected promise (operation = Handle).
         /// This implements the HostPromiseRejectionTracker abstract operation from the TC39 spec.
@@ -323,6 +361,47 @@ public enum ObjectRepresentation
     /// so none of the other members would describe it honestly.
     /// </summary>
     Specialized = 3,
+}
+
+/// <summary>
+/// Counts of the CLR-array interop conversions an engine has performed, as reported by
+/// <see cref="Engine.AdvancedOperations.GetInteropConversionDiagnostics"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>These counts describe internal events and are not part of Jint's compatibility contract.</b> Which
+/// events are counted may be refined in any release, and this type may gain members. Neither is a breaking
+/// change, and neither will be treated as one — which is why the constructor is internal: a host reads the
+/// properties it knows about and is unaffected when another appears.
+/// </para>
+/// <para>
+/// See <see cref="Engine.AdvancedOperations.GetInteropConversionDiagnostics"/> for what falls inside and
+/// outside the counted set.
+/// </para>
+/// </remarks>
+[StructLayout(LayoutKind.Auto)]
+public readonly record struct InteropConversionDiagnostics
+{
+    internal InteropConversionDiagnostics(long arrayLiveViewConversions, long arrayCopyConversions)
+    {
+        ArrayLiveViewConversions = arrayLiveViewConversions;
+        ArrayCopyConversions = arrayCopyConversions;
+    }
+
+    /// <summary>
+    /// Live wrapper views created over a CLR array under <see cref="ArrayConversionMode.LiveView"/>. Such a
+    /// view reads and writes the CLR array itself, so script sees later changes to it and the host sees
+    /// script's writes.
+    /// </summary>
+    public long ArrayLiveViewConversions { get; }
+
+    /// <summary>
+    /// Snapshot copies of a CLR array created under <see cref="ArrayConversionMode.Copy"/>, or under
+    /// <see cref="ArrayConversionMode.LiveView"/> where no view could be built — a custom
+    /// <c>WrapObjectHandler</c> declining the value. The resulting JavaScript array is disconnected from the
+    /// CLR array in both directions.
+    /// </summary>
+    public long ArrayCopyConversions { get; }
 }
 
 /// <summary>

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -270,6 +270,15 @@ public sealed partial class Engine : IDisposable
     // bounded cache of most recently wrapped CLR objects, see Options.Interop.CacheRecentObjectWrappers
     internal RecentObjectWrapperCache? _recentObjectWrapperCache;
 
+    // Diagnostic counters for the two mode-governed CLR-array conversions, surfaced through
+    // Engine.Advanced.GetInteropConversionDiagnostics. Bumped only inside DefaultObjectConverter, at the two
+    // points that have just decided to build a live wrapper view or an N-element snapshot copy — so the cost
+    // is one increment on a path that is already allocating, and exactly nothing on every path that converts
+    // no array. Plain longs, not Interlocked: an engine is single-threaded by contract, like every other
+    // per-engine counter here.
+    internal long _arrayLiveViewConversions;
+    internal long _arrayCopyConversions;
+
     internal readonly JintCallStack CallStack;
     internal readonly StackGuard _stackGuard;
 

--- a/Jint/Runtime/Interop/DefaultObjectConverter.cs
+++ b/Jint/Runtime/Interop/DefaultObjectConverter.cs
@@ -289,6 +289,7 @@ internal static class DefaultObjectConverter
         }
 
         var result = new JsArray(e, values);
+        e._arrayCopyConversions++;
 
         if (e.Options.Interop.TrackObjectWrapperIdentity)
         {
@@ -330,6 +331,8 @@ internal static class DefaultObjectConverter
             result = null;
             return false;
         }
+
+        e._arrayLiveViewConversions++;
 
         if (e.Options.Interop.TrackObjectWrapperIdentity)
         {


### PR DESCRIPTION
From the KurrentDB 4.15.0 adoption friction report: a host that does not own all of its Jint consumers (theirs carries a transitive dependency that builds its own engines) cannot audit whether 4.14's `ArrayConversion` default change affects it — there was no way to ask an engine whether a CLR array ever crossed. Two per-engine counters behind `Engine.Advanced.GetInteropConversionDiagnostics()` answer it, with `GetObjectRepresentation`'s fenced-diagnostics framing.

Cost when unused is two `++` statements on paths that already allocate (the copy lane's array construction, the wrapper lane's view creation); neither site changes a value, branch or exception, so nothing is script-observable and Test262 is unaffected by construction.

Two design-stage claims failed under test and are corrected in code and docs: an array under a non-array declared type IS counted under `Copy` (it routes to the copy lane regardless of declared type — pinned in both directions), and multi-dimensional arrays do not fall back from LiveView to Copy — the copy lane throws on them, pre-existing. 11 new public-surface tests including the motivating audit shape: a busy non-array interop run leaves both counters at zero; an array crossing names its semantics, matching the write-through behavior the script observes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)