### PR TITLE
Let a layout declare lazy slots so a shaped object can defer expensive members

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@ Jint is not only an engine to work on, it is an engine that gets **embedded**. I
 | `Constraint` + `IsAmortizable` | `Jint/IConstraint.cs` |
 | `ProxyHandler` — public abstract class, 13 virtual traps (the ECMAScript trap set), `null` meaning "forward to target" | `Jint/Runtime/Interop/ProxyHandler.cs` |
 | `ObjectWrapper.GetPropertyDescriptor(Engine, object, MemberInfo)` — public **static** | `Jint/Runtime/Interop/ObjectWrapper.cs` |
-| `JsObjectLayout`, `JsObject.Create`, `JsObject.CreateFromEntries` | `Jint/Native/` |
+| `JsObjectLayout` + `JsObjectLayout.CreateBuilder`/`Builder.Add`/`Builder.AddLazy` + `LazySlotFactory`, `JsObject.Create`, `JsObject.CreateFromEntries` | `Jint/Native/` |
 | `JsObjectShape` + `JsObjectShape.Builder` + `JsObjectShape.Set/GetHostState` | `Jint/Native/JsObjectShape.cs` |
 | `Options.AddLazyGlobal` — extension method on `OptionsExtensions` | `Jint/Options.Extensions.cs` |
 | `ReferencedGlobals` + `Prepared<T>.ReferencedGlobals` + `{Script,Module}PreparationOptions.CollectReferencedGlobals` | `Jint/ReferencedGlobals.cs`, `Jint/Prepared.cs`, `Jint/PreparationOptions.cs` |

--- a/Jint.Benchmark/HostLayoutLazySlotBenchmark.cs
+++ b/Jint.Benchmark/HostLayoutLazySlotBenchmark.cs
@@ -1,0 +1,312 @@
+#nullable enable
+
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// The embedding shape lazy layout slots exist for: a <b>batch</b> of host records with a fixed member set,
+/// most of it cheap fields and a few members each decoding a part of that item's raw payload, over which a
+/// script touches only some of the expensive ones. Modelled on a real adoption's envelope — 15 members, 4 of
+/// them decoded on demand — with the script reading one decoded member per item, so 3 of every 4 decodes are
+/// avoidable and the question is only whether the representation lets a host avoid them without losing the
+/// shared hidden class.
+///
+/// <para><b>What each lane proves</b></para>
+/// <list type="bullet">
+/// <item><description>
+/// <see cref="EnvelopeKind.LayoutEager"/> is today's shaped answer: one
+/// <see cref="JsObjectLayout"/>, every value supplied at <c>JsObject.Create</c> time. The batch keeps one
+/// interned hidden class and the projection loop stays monomorphic — but every item pays all four decodes,
+/// including the three nothing reads. This is the row the lazy lane must beat, and the gap between them is
+/// (avoided decodes × decode cost), nothing else.
+/// </description></item>
+/// <item><description>
+/// <see cref="EnvelopeKind.LayoutLazy"/> is the same layout with those four members declared through
+/// <c>JsObjectLayout.Builder.AddLazy</c> and the raw payload handed over as the per-object state. Same
+/// hidden class as the eager lane — a lazy layout interns the very shape its eager twin does — so the read
+/// lanes are identical and only the decode count differs. Read <c>Allocated</c> next to <c>Mean</c>: one
+/// sentinel per item is the storage this lane adds, against three decoded objects per item it removes.
+/// </description></item>
+/// <item><description>
+/// <see cref="EnvelopeKind.DictionaryCustomValue"/> is what a host had to write before: the same 11 cheap
+/// members through <c>FastSetDataProperty</c> and the same 4 lazy ones as
+/// <see cref="PropertyFlag.CustomJsValue"/> descriptors through <c>FastSetProperty</c>. It decodes exactly
+/// as little as the lazy layout does, so its distance from <see cref="EnvelopeKind.LayoutLazy"/> is purely
+/// the price of the dictionary representation: a per-item property dictionary and 15 descriptors on the
+/// build side, and a batch that never shares a hidden class — so the projection loop's member sites see a
+/// new object with a new descriptor set per item — on the read side.
+/// </description></item>
+/// </list>
+///
+/// <para>
+/// Both benchmarks rebuild the batch, because that is the point: a lazy slot memoizes, so a second pass over
+/// the same items would decode nothing and measure the wrong thing. <see cref="Build"/> isolates creation;
+/// <see cref="BuildAndProject"/> adds the script that decides which members are ever observed.
+/// </para>
+///
+/// <para>
+/// The host types here are deliberately restricted to what a third-party embedder can reach, even though
+/// this project has <c>InternalsVisibleTo</c>: <see cref="RawEnvelope"/> is a plain CLR record,
+/// <see cref="LazyMemberDescriptor"/> overrides only <c>PropertyDescriptor.CustomValue</c>, and the batch is
+/// assembled from script through a host delegate. No internal member participates, so the numbers are the
+/// ones an embedder would see. Two places the restriction bites, both recorded here rather than quietly
+/// worked around: the batch array is built by script calling <c>makeItem(i)</c> instead of through an
+/// internal array intrinsic, which adds one host-delegate call per item — identical in every lane, so a
+/// constant offset and never a lane difference; and the descriptor override has to be spelled
+/// <c>protected internal</c> because this project is a friend assembly, where an embedder writes
+/// <c>protected</c> for the same member.
+/// </para>
+/// </summary>
+[MemoryDiagnoser]
+public class HostLayoutLazySlotBenchmark
+{
+    private const int ItemCount = 500;
+
+    /// <summary>Cheap members, supplied as values in every lane.</summary>
+    private static readonly string[] EagerNames =
+    [
+        "id", "type", "stream", "sequence", "created", "correlationId",
+        "causationId", "contentType", "isJson", "position", "commitPosition"
+    ];
+
+    /// <summary>The members that decode a part of the payload on demand.</summary>
+    private static readonly string[] LazyNames = ["body", "metadata", "headers", "annotations"];
+
+    /// <summary>
+    /// One item's undecoded payload: four encoded member bodies, plus the cheap fields. Decoding is a
+    /// deliberate stand-in for the real thing (a JSON parse) — it walks the encoded text once and builds one
+    /// object per member, which is the cost profile that matters here and keeps the benchmark free of any
+    /// dependency on the JSON built-in's own performance.
+    /// </summary>
+    private sealed class RawEnvelope
+    {
+        internal RawEnvelope(int index)
+        {
+            Index = index;
+            Encoded = new string[LazyNames.Length];
+            for (var i = 0; i < Encoded.Length; i++)
+            {
+                Encoded[i] = $"f0={i}-{index};f1=value-{index};f2=other-{index};f3={index * 7};f4=tail-{index}";
+            }
+        }
+
+        internal int Index { get; }
+        internal string[] Encoded { get; }
+
+        internal JsValue Decode(JsObject owner, int member)
+        {
+            var text = Encoded[member];
+            var entries = new List<KeyValuePair<string, JsValue>>(5);
+            var start = 0;
+            while (start < text.Length)
+            {
+                var end = text.IndexOf(';', start);
+                if (end < 0)
+                {
+                    end = text.Length;
+                }
+
+                var pair = text.Substring(start, end - start);
+                var eq = pair.IndexOf('=');
+                entries.Add(new KeyValuePair<string, JsValue>(pair.Substring(0, eq), JsString.Create(pair.Substring(eq + 1))));
+                start = end + 1;
+            }
+
+            return JsObject.CreateFromEntries(owner.Engine, entries);
+        }
+    }
+
+    /// <summary>
+    /// The pre-existing workaround: a lazy member installed as a raw descriptor. Memoizes into the inherited
+    /// value field on first read, exactly as a host would write it.
+    /// </summary>
+    private sealed class LazyMemberDescriptor : PropertyDescriptor
+    {
+        private readonly JsObject _owner;
+        private readonly RawEnvelope _raw;
+        private readonly int _member;
+        private JsValue? _resolved;
+
+        internal LazyMemberDescriptor(JsObject owner, RawEnvelope raw, int member)
+            : base(null, PropertyFlag.ConfigurableEnumerableWritable | PropertyFlag.CustomJsValue)
+        {
+            _owner = owner;
+            _raw = raw;
+            _member = member;
+        }
+
+        // Spelled `protected internal` only because this project is a friend assembly of Jint; a real
+        // embedder writes `protected override` for the same member (a protected internal member is seen as
+        // protected from outside the assembly). Nothing else about the type differs.
+        protected internal override JsValue? CustomValue
+        {
+            get => _resolved ??= _raw.Decode(_owner, _member);
+            set => _resolved = value;
+        }
+    }
+
+    // Declared once for the process, as a host would. The eager and the lazy layout carry the same names in
+    // the same order, so they resolve to the very same interned hidden class in a given engine.
+    private static readonly JsObjectLayout EagerLayout = new([.. EagerNames, .. LazyNames]);
+
+    private static readonly JsObjectLayout LazyLayout = BuildLazyLayout();
+
+    private static JsObjectLayout BuildLazyLayout()
+    {
+        var builder = JsObjectLayout.CreateBuilder();
+        foreach (var name in EagerNames)
+        {
+            builder.Add(name);
+        }
+
+        // One static factory per member index, so nothing engine-affine is captured: everything item-specific
+        // arrives through the state argument.
+        builder.AddLazy(LazyNames[0], static (o, state) => ((RawEnvelope) state!).Decode(o, 0));
+        builder.AddLazy(LazyNames[1], static (o, state) => ((RawEnvelope) state!).Decode(o, 1));
+        builder.AddLazy(LazyNames[2], static (o, state) => ((RawEnvelope) state!).Decode(o, 2));
+        builder.AddLazy(LazyNames[3], static (o, state) => ((RawEnvelope) state!).Decode(o, 3));
+        return builder.Build();
+    }
+
+    private const string BuildSource = """
+        function build(n) {
+          var items = new Array(n);
+          for (var i = 0; i < n; i++) { items[i] = makeItem(i); }
+          return items;
+        }
+        function project(n) {
+          var items = build(n);
+          var total = 0;
+          for (var i = 0; i < items.length; i++) {
+            var e = items[i];
+            if (e.type === 'a') { total += e.sequence + e.body.f0.length; }
+          }
+          return total;
+        }
+        """;
+
+    private Engine _engine = null!;
+    private Prepared<Script> _build;
+    private Prepared<Script> _project;
+
+    [Params(EnvelopeKind.LayoutEager, EnvelopeKind.LayoutLazy, EnvelopeKind.DictionaryCustomValue)]
+    public EnvelopeKind Kind { get; set; }
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _engine = new Engine();
+        _engine.Execute(BuildSource);
+
+        var kind = Kind;
+        var engine = _engine;
+        _engine.SetValue("makeItem", new Func<int, JsValue>(index => MakeItem(engine, kind, index)));
+
+        _build = Engine.PrepareScript($"build({ItemCount}).length;");
+        _project = Engine.PrepareScript($"project({ItemCount});");
+
+        // Warm the handler-tree caches so the measured runs are the steady state, and prove both lanes work.
+        _engine.Evaluate(_build);
+        _engine.Evaluate(_project);
+    }
+
+    /// <summary>Creation only: no member is ever observed, so the eager lane's decodes are pure waste.</summary>
+    [Benchmark]
+    public JsValue Build() => _engine.Evaluate(_build);
+
+    /// <summary>Creation plus the projection loop, which observes one decoded member of every item.</summary>
+    [Benchmark]
+    public JsValue BuildAndProject() => _engine.Evaluate(_project);
+
+    private static JsValue MakeItem(Engine engine, EnvelopeKind kind, int index)
+    {
+        var raw = new RawEnvelope(index);
+        return kind switch
+        {
+            EnvelopeKind.LayoutEager => CreateEager(engine, raw),
+            EnvelopeKind.LayoutLazy => CreateLazy(engine, raw),
+            EnvelopeKind.DictionaryCustomValue => CreateDictionary(engine, raw),
+            _ => throw new NotSupportedException(kind.ToString())
+        };
+    }
+
+    private static JsObject CreateEager(Engine engine, RawEnvelope raw)
+    {
+        var values = new JsValue[EagerNames.Length + LazyNames.Length];
+        FillEager(values, raw);
+
+        // Decoding needs the object the members belong to, and Create has not produced it yet, so the eager
+        // lane builds the shell first and fills the decoded members straight into their slots. That is the
+        // ordinary write path, so the object stays shaped — this lane is not handicapped by the ordering.
+        var obj = JsObject.Create(engine, EagerLayout, values);
+        for (var i = 0; i < LazyNames.Length; i++)
+        {
+            obj.Set(LazyNames[i], raw.Decode(obj, i));
+        }
+
+        return obj;
+    }
+
+    private static JsObject CreateLazy(Engine engine, RawEnvelope raw)
+    {
+        var values = new JsValue[EagerNames.Length + LazyNames.Length];
+        FillEager(values, raw);
+        return JsObject.Create(engine, LazyLayout, values, raw);
+    }
+
+    private static JsObject CreateDictionary(Engine engine, RawEnvelope raw)
+    {
+        var obj = new JsObject(engine);
+        var values = new JsValue[EagerNames.Length + LazyNames.Length];
+        FillEager(values, raw);
+        for (var i = 0; i < EagerNames.Length; i++)
+        {
+            obj.FastSetDataProperty(EagerNames[i], values[i]);
+        }
+
+        for (var i = 0; i < LazyNames.Length; i++)
+        {
+            obj.FastSetProperty(LazyNames[i], new LazyMemberDescriptor(obj, raw, i));
+        }
+
+        return obj;
+    }
+
+    private static void FillEager(JsValue[] values, RawEnvelope raw)
+    {
+        var index = raw.Index;
+        values[0] = JsString.Create("id-" + index);
+        values[1] = JsString.Create(index % 2 == 0 ? "a" : "b");
+        values[2] = JsString.Create("stream-" + (index % 8));
+        values[3] = JsNumber.Create(index);
+        values[4] = JsNumber.Create(1_700_000_000 + index);
+        values[5] = JsString.Create("corr-" + index);
+        values[6] = JsString.Create("cause-" + index);
+        values[7] = JsString.Create("application/json");
+        values[8] = JsBoolean.True;
+        values[9] = JsNumber.Create(index * 64);
+        values[10] = JsNumber.Create(index * 64 + 32);
+        // The lazy members are supplied by the layout; the eager lane overwrites these after creation.
+        for (var i = EagerNames.Length; i < values.Length; i++)
+        {
+            values[i] = null!;
+        }
+    }
+}
+
+/// <summary>The three ways a host can present a batch of records with a few expensive members.</summary>
+public enum EnvelopeKind
+{
+    /// <summary>One shared hidden class, every member decoded at creation.</summary>
+    LayoutEager,
+
+    /// <summary>One shared hidden class, the expensive members decoded on the first read that observes them.</summary>
+    LayoutLazy,
+
+    /// <summary>The pre-existing workaround: raw <c>CustomJsValue</c> descriptors, dictionary representation.</summary>
+    DictionaryCustomValue
+}

--- a/Jint.Tests.PublicInterface/HostLayoutLazySlotTests.cs
+++ b/Jint.Tests.PublicInterface/HostLayoutLazySlotTests.cs
@@ -1,0 +1,712 @@
+using System.Collections.Generic;
+using System.Linq;
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// Lazily-produced layout properties: <c>JsObjectLayout.CreateBuilder().AddLazy(...)</c> plus the
+/// <c>JsObject.Create</c> overload that carries the per-object state those factories read.
+/// <para>
+/// The shape this exists for is a batch of host records — many items, a fixed set of members, a few of which
+/// are expensive to produce (each parses or decodes a part of the item's raw payload) and most of which are
+/// never touched by the script. What must hold: every item is still a hidden-class object sharing one shape
+/// with the rest of the batch, no factory runs until something observes that member's value, and asking
+/// merely whether a member exists never runs one.
+/// </para>
+/// <para>
+/// Everything here goes through the public API only, so it also proves the surface is reachable by a third
+/// party.
+/// </para>
+/// </summary>
+public class HostLayoutLazySlotTests
+{
+    /// <summary>
+    /// One item's raw payload: the "not yet parsed" state a lazy factory decodes, plus a counter per member
+    /// so a test can assert exactly which factories ran. Deliberately a plain CLR object with no Jint
+    /// dependency — this is what a host would already have.
+    /// </summary>
+    private sealed class Payload
+    {
+        public Payload(int id, string body, string metadata)
+        {
+            Id = id;
+            RawBody = body;
+            RawMetadata = metadata;
+        }
+
+        public int Id { get; }
+        public string RawBody { get; }
+        public string RawMetadata { get; }
+
+        public int BodyParses { get; private set; }
+        public int MetadataParses { get; private set; }
+
+        public JsValue ParseBody(JsObject owner)
+        {
+            BodyParses++;
+            return owner.Engine.Evaluate("JSON.parse").Call(new JsString(RawBody));
+        }
+
+        public JsValue ParseMetadata(JsObject owner)
+        {
+            MetadataParses++;
+            return owner.Engine.Evaluate("JSON.parse").Call(new JsString(RawMetadata));
+        }
+    }
+
+    // Declared once for the process, as a host would: the factories are static lambdas, so nothing
+    // engine-affine is captured and the same layout serves every engine.
+    private static readonly JsObjectLayout EnvelopeLayout = JsObjectLayout.CreateBuilder()
+        .Add("id")
+        .Add("type")
+        .Add("stream")
+        .Add("created")
+        .AddLazy("body", static (o, state) => ((Payload) state!).ParseBody(o))
+        .AddLazy("metadata", static (o, state) => ((Payload) state!).ParseMetadata(o))
+        .Build();
+
+    private static JsObject CreateEnvelope(Engine engine, Payload payload) => JsObject.Create(
+        engine,
+        EnvelopeLayout,
+        [
+            JsNumber.Create(payload.Id),
+            new JsString("ItemCreated"),
+            new JsString("stream-1"),
+            JsNumber.Create(1234),
+            null,
+            null
+        ],
+        payload);
+
+    private static Payload SamplePayload(int id = 1) =>
+        new(id, $$"""{"amount":{{id}},"note":"n{{id}}"}""", """{"origin":"test"}""");
+
+    private static Engine EngineWithEnvelope(out Payload payload, out JsObject envelope)
+    {
+        var engine = new Engine();
+        payload = SamplePayload();
+        envelope = CreateEnvelope(engine, payload);
+        engine.SetValue("e", envelope);
+        return engine;
+    }
+
+    // ---- creation ----
+
+    [Fact]
+    public void CreateRunsNoFactoryAndStillProducesAHiddenClassObject()
+    {
+        var engine = EngineWithEnvelope(out var payload, out var envelope);
+
+        payload.BodyParses.Should().Be(0);
+        payload.MetadataParses.Should().Be(0);
+        engine.Advanced.GetObjectRepresentation(envelope).Should().Be(ObjectRepresentation.HiddenClass);
+    }
+
+    [Fact]
+    public void EagerMembersReadNormallyAndRunNoFactory()
+    {
+        var engine = EngineWithEnvelope(out var payload, out _);
+
+        engine.Evaluate("e.id").AsNumber().Should().Be(1);
+        engine.Evaluate("e.type").AsString().Should().Be("ItemCreated");
+        engine.Evaluate("e.stream + e.created").AsString().Should().Be("stream-11234");
+
+        payload.BodyParses.Should().Be(0);
+        payload.MetadataParses.Should().Be(0);
+    }
+
+    [Fact]
+    public void ALazyMemberMaterializesOnceOnFirstReadAndLeavesItsSiblingsAlone()
+    {
+        var engine = EngineWithEnvelope(out var payload, out _);
+
+        engine.Evaluate("e.body.amount").AsNumber().Should().Be(1);
+        payload.BodyParses.Should().Be(1);
+        payload.MetadataParses.Should().Be(0);
+
+        // Repeated reads are served from the memo, and identity is stable — the factory produced one object.
+        engine.Evaluate("e.body === e.body").AsBoolean().Should().BeTrue();
+        engine.Evaluate("e.body.note").AsString().Should().Be("n1");
+        payload.BodyParses.Should().Be(1);
+        payload.MetadataParses.Should().Be(0);
+    }
+
+    [Fact]
+    public void ObjectStaysAHiddenClassObjectAcrossMaterialization()
+    {
+        var engine = EngineWithEnvelope(out _, out var envelope);
+
+        engine.Advanced.GetObjectRepresentation(envelope).Should().Be(ObjectRepresentation.HiddenClass);
+        engine.Evaluate("e.body");
+        engine.Advanced.GetObjectRepresentation(envelope).Should().Be(ObjectRepresentation.HiddenClass);
+        engine.Evaluate("e.metadata");
+        engine.Advanced.GetObjectRepresentation(envelope).Should().Be(ObjectRepresentation.HiddenClass);
+    }
+
+    // ---- the batch: one hidden class, one factory run per item ----
+
+    [Fact]
+    public void ABatchSharesOneHiddenClassAndRunsOneFactoryPerItem()
+    {
+        const int count = 64;
+        var engine = new Engine();
+        var payloads = Enumerable.Range(1, count).Select(SamplePayload).ToArray();
+
+        var push = engine.Evaluate("var items = []; (function (o) { items.push(o); })");
+        for (var i = 0; i < count; i++)
+        {
+            var envelope = CreateEnvelope(engine, payloads[i]);
+            engine.Advanced.GetObjectRepresentation(envelope).Should().Be(ObjectRepresentation.HiddenClass);
+            push.Call(envelope);
+        }
+
+        // One eager and one lazy member per item, the loop a script over such a batch actually writes.
+        var total = engine.Evaluate("""
+            let total = 0;
+            for (let i = 0; i < items.length; i++) { total += items[i].id + items[i].body.amount; }
+            total;
+            """).AsNumber();
+
+        total.Should().Be(2 * Enumerable.Range(1, count).Sum());
+        payloads.Should().AllSatisfy(static p => p.BodyParses.Should().Be(1));
+        // The untouched lazy member of every item never ran.
+        payloads.Should().AllSatisfy(static p => p.MetadataParses.Should().Be(0));
+    }
+
+    // ---- existence questions never materialize ----
+
+    [Theory]
+    [InlineData("'body' in e")]
+    [InlineData("e.hasOwnProperty('body')")]
+    [InlineData("Object.prototype.propertyIsEnumerable.call(e, 'body')")]
+    [InlineData("Object.keys(e).indexOf('body') >= 0")]
+    [InlineData("Object.getOwnPropertyNames(e).indexOf('body') >= 0")]
+    [InlineData("Reflect.ownKeys(e).indexOf('body') >= 0")]
+    [InlineData("(function () { for (const k in e) { if (k === 'body') return true; } return false; })()")]
+    public void ExistenceQuestionsAnswerTrueWithoutRunningAnyFactory(string expression)
+    {
+        var engine = EngineWithEnvelope(out var payload, out _);
+
+        engine.Evaluate(expression).AsBoolean().Should().BeTrue();
+
+        payload.BodyParses.Should().Be(0);
+        payload.MetadataParses.Should().Be(0);
+    }
+
+    [Fact]
+    public void KeyOrderIsLayoutOrderWithoutRunningAnyFactory()
+    {
+        var engine = EngineWithEnvelope(out var payload, out _);
+
+        engine.Evaluate("Object.keys(e).join(',')").AsString()
+            .Should().Be("id,type,stream,created,body,metadata");
+        payload.BodyParses.Should().Be(0);
+    }
+
+    [Fact]
+    public void StringifyingAnObjectThatDropsTheEnvelopeRunsNoFactory()
+    {
+        var engine = EngineWithEnvelope(out var payload, out _);
+
+        engine.Evaluate("JSON.stringify({ e: e, n: 1 }, function (k, v) { return k === 'e' ? undefined : v; })")
+            .AsString().Should().Be("""{"n":1}""");
+
+        payload.BodyParses.Should().Be(0);
+        payload.MetadataParses.Should().Be(0);
+    }
+
+    // ---- value observations do materialize ----
+
+    [Theory]
+    [InlineData("Object.values(e).length")]
+    [InlineData("Object.entries(e).length")]
+    [InlineData("JSON.stringify(e).length")]
+    [InlineData("Object.keys({ ...e }).length")]
+    [InlineData("Object.keys(Object.assign({}, e)).length")]
+    [InlineData("Object.getOwnPropertyDescriptor(e, 'body').value.amount")]
+    [InlineData("e['bo' + 'dy'].amount")]
+    [InlineData("Reflect.get(e, 'body').amount")]
+    [InlineData("e.body.hasOwnProperty('amount') ? 1 : 0")]
+    public void ValueObservationsRunTheFactory(string expression)
+    {
+        var engine = EngineWithEnvelope(out var payload, out _);
+
+        engine.Evaluate(expression);
+
+        payload.BodyParses.Should().Be(1);
+    }
+
+    [Fact]
+    public void StringifyIncludesTheLazyMembersAndMaterializesEachOnce()
+    {
+        var engine = EngineWithEnvelope(out var payload, out _);
+
+        engine.Evaluate("JSON.stringify(e)").AsString().Should().Be(
+            """{"id":1,"type":"ItemCreated","stream":"stream-1","created":1234,"body":{"amount":1,"note":"n1"},"metadata":{"origin":"test"}}""");
+
+        payload.BodyParses.Should().Be(1);
+        payload.MetadataParses.Should().Be(1);
+    }
+
+    [Fact]
+    public void SpreadCopiesMaterializedValuesAndReadsTheSourceOnce()
+    {
+        var engine = EngineWithEnvelope(out var payload, out _);
+
+        engine.Evaluate("const c = { ...e }; c.body === e.body").AsBoolean().Should().BeTrue();
+        payload.BodyParses.Should().Be(1);
+        payload.MetadataParses.Should().Be(1);
+
+        // The copy is a plain object: reading it again cannot re-run anything.
+        engine.Evaluate("c.body.amount").AsNumber().Should().Be(1);
+        payload.BodyParses.Should().Be(1);
+    }
+
+    [Fact]
+    public void ASpreadCopyIsItselfAHiddenClassObject()
+    {
+        var engine = EngineWithEnvelope(out _, out _);
+
+        var copy = engine.Evaluate("({ ...e })").Should().BeOfType<JsObject>().Which;
+        engine.Advanced.GetObjectRepresentation(copy).Should().Be(ObjectRepresentation.HiddenClass);
+        engine.Evaluate("Object.keys({ ...e }).join(',')").AsString()
+            .Should().Be("id,type,stream,created,body,metadata");
+    }
+
+    // ---- write / delete before read discards the factory ----
+
+    [Fact]
+    public void WritingALazyMemberBeforeAnyReadDiscardsItsFactory()
+    {
+        var engine = EngineWithEnvelope(out var payload, out var envelope);
+
+        engine.Evaluate("e.body = 'replaced'");
+        engine.Evaluate("e.body").AsString().Should().Be("replaced");
+        engine.Evaluate("JSON.stringify(e.body)").AsString().Should().Be("\"replaced\"");
+
+        payload.BodyParses.Should().Be(0);
+        // A write keeps the object shaped; the untouched sibling is still lazy.
+        engine.Advanced.GetObjectRepresentation(envelope).Should().Be(ObjectRepresentation.HiddenClass);
+        payload.MetadataParses.Should().Be(0);
+        engine.Evaluate("e.metadata.origin").AsString().Should().Be("test");
+        payload.MetadataParses.Should().Be(1);
+    }
+
+    [Fact]
+    public void DeletingALazyMemberBeforeAnyReadDiscardsItsFactory()
+    {
+        var engine = EngineWithEnvelope(out var payload, out _);
+
+        engine.Evaluate("delete e.body").AsBoolean().Should().BeTrue();
+        engine.Evaluate("'body' in e").AsBoolean().Should().BeFalse();
+        engine.Evaluate("e.body").Should().Be(JsValue.Undefined);
+
+        payload.BodyParses.Should().Be(0);
+        payload.MetadataParses.Should().Be(0);
+    }
+
+    // ---- deopt keeps laziness ----
+
+    [Fact]
+    public void DeletingAnUnrelatedKeyLeavesTheOtherLazyMembersLazy()
+    {
+        var engine = EngineWithEnvelope(out var payload, out var envelope);
+
+        engine.Evaluate("delete e.stream");
+        engine.Advanced.GetObjectRepresentation(envelope).Should().Be(ObjectRepresentation.Dictionary);
+        payload.BodyParses.Should().Be(0);
+        payload.MetadataParses.Should().Be(0);
+
+        // Still lazy, and still answers existence questions without running.
+        engine.Evaluate("'body' in e").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.keys(e).join(',')").AsString().Should().Be("id,type,created,body,metadata");
+        payload.BodyParses.Should().Be(0);
+
+        engine.Evaluate("e.body.amount").AsNumber().Should().Be(1);
+        payload.BodyParses.Should().Be(1);
+        payload.MetadataParses.Should().Be(0);
+    }
+
+    [Fact]
+    public void DefiningAnUnrelatedKeyLeavesTheLazyMembersLazy()
+    {
+        var engine = EngineWithEnvelope(out var payload, out var envelope);
+
+        engine.Evaluate("Object.defineProperty(e, 'extra', { value: 7, enumerable: true })");
+        engine.Advanced.GetObjectRepresentation(envelope).Should().Be(ObjectRepresentation.Dictionary);
+        payload.BodyParses.Should().Be(0);
+
+        engine.Evaluate("e.extra").AsNumber().Should().Be(7);
+        payload.BodyParses.Should().Be(0);
+
+        engine.Evaluate("e.body.amount").AsNumber().Should().Be(1);
+        payload.BodyParses.Should().Be(1);
+    }
+
+    [Fact]
+    public void RedefiningTheLazyKeyWithAValueDiscardsItsFactory()
+    {
+        var engine = EngineWithEnvelope(out var payload, out _);
+
+        // Supplying a value is a write, so — exactly like `e.body = ...` — the factory is discarded rather
+        // than run and then overwritten.
+        engine.Evaluate("Object.defineProperty(e, 'body', { value: 'x' })");
+        engine.Evaluate("e.body").AsString().Should().Be("x");
+        engine.Evaluate("JSON.stringify(e.body)").AsString().Should().Be("\"x\"");
+
+        payload.BodyParses.Should().Be(0);
+        payload.MetadataParses.Should().Be(0);
+    }
+
+    [Fact]
+    public void RedefiningTheLazyKeyWithAttributesOnlyKeepsItLazy()
+    {
+        var engine = EngineWithEnvelope(out var payload, out _);
+
+        engine.Evaluate("Object.defineProperty(e, 'body', { enumerable: false })");
+        engine.Evaluate("Object.keys(e).indexOf('body')").AsNumber().Should().Be(-1);
+        engine.Evaluate("'body' in e").AsBoolean().Should().BeTrue();
+        payload.BodyParses.Should().Be(0);
+
+        engine.Evaluate("e.body.amount").AsNumber().Should().Be(1);
+        payload.BodyParses.Should().Be(1);
+    }
+
+    [Fact]
+    public void RedefiningANonConfigurableLazyKeyValidatesAgainstItsRealValue()
+    {
+        var engine = EngineWithEnvelope(out var payload, out _);
+
+        // Freezing leaves the member lazy and non-writable; a redefinition that supplies a DIFFERENT value
+        // must be rejected, which is the one redefinition that genuinely has to know the current value.
+        engine.Evaluate("Object.freeze(e)");
+        payload.BodyParses.Should().Be(0);
+
+        Invoking(() => engine.Evaluate("Object.defineProperty(e, 'body', { value: 'other' })"))
+            .Should().Throw<JavaScriptException>();
+        payload.BodyParses.Should().Be(1);
+
+        // Redefining it to the value it already has is allowed, and does not run the factory a second time.
+        engine.Evaluate("Object.defineProperty(e, 'body', { value: e.body })");
+        payload.BodyParses.Should().Be(1);
+    }
+
+    [Fact]
+    public void FreezingKeepsTheMembersLazyRejectsWritesAndStillServesReads()
+    {
+        var engine = EngineWithEnvelope(out var payload, out var envelope);
+
+        engine.Evaluate("Object.freeze(e)");
+        engine.Advanced.GetObjectRepresentation(envelope).Should().Be(ObjectRepresentation.Dictionary);
+        engine.Evaluate("Object.isFrozen(e)").AsBoolean().Should().BeTrue();
+        payload.BodyParses.Should().Be(0);
+        payload.MetadataParses.Should().Be(0);
+
+        engine.Evaluate("e.body.amount").AsNumber().Should().Be(1);
+        payload.BodyParses.Should().Be(1);
+        payload.MetadataParses.Should().Be(0);
+
+        // Writes are rejected, in both modes.
+        engine.Evaluate("e.metadata = 1; e.metadata.origin").AsString().Should().Be("test");
+        Invoking(() => engine.Evaluate("'use strict'; e.body = 1;")).Should().Throw<JavaScriptException>();
+    }
+
+    [Fact]
+    public void SealingKeepsTheMembersLazyAndWritable()
+    {
+        var engine = EngineWithEnvelope(out var payload, out _);
+
+        engine.Evaluate("Object.seal(e)");
+        payload.BodyParses.Should().Be(0);
+
+        engine.Evaluate("e.body = 5; e.body").AsNumber().Should().Be(5);
+        // A write into a sealed lazy member still discards the factory rather than running it.
+        payload.BodyParses.Should().Be(0);
+    }
+
+    // ---- factory contract ----
+
+    [Fact]
+    public void AFactoryReturningNullStoresUndefined()
+    {
+        var layout = JsObjectLayout.CreateBuilder()
+            .Add("a")
+            .AddLazy("b", static (_, _) => null!)
+            .Build();
+
+        var engine = new Engine();
+        engine.SetValue("o", JsObject.Create(engine, layout, [JsNumber.Create(1), null], null));
+
+        engine.Evaluate("o.b").Should().Be(JsValue.Undefined);
+        engine.Evaluate("'b' in o").AsBoolean().Should().BeTrue();
+        engine.Evaluate("JSON.stringify(o)").AsString().Should().Be("""{"a":1}""");
+    }
+
+    [Fact]
+    public void AThrowingFactorySurfacesAndLeavesTheSlotUnmaterialized()
+    {
+        var runs = new int[1];
+        var layout = JsObjectLayout.CreateBuilder()
+            .Add("a")
+            .AddLazy("b", static (o, state) =>
+            {
+                var counter = (int[]) state!;
+                counter[0]++;
+                if (counter[0] < 3)
+                {
+                    throw new InvalidOperationException("payload is corrupt");
+                }
+
+                return JsNumber.Create(counter[0]);
+            })
+            .Build();
+
+        var engine = new Engine();
+        engine.SetValue("o", JsObject.Create(engine, layout, [JsNumber.Create(1), null], runs));
+
+        Invoking(() => engine.Evaluate("o.b")).Should().Throw<InvalidOperationException>();
+        runs[0].Should().Be(1);
+
+        // No half-memo: the next read retries.
+        Invoking(() => engine.Evaluate("o.b")).Should().Throw<InvalidOperationException>();
+        runs[0].Should().Be(2);
+
+        engine.Evaluate("o.b").AsNumber().Should().Be(3);
+        engine.Evaluate("o.b").AsNumber().Should().Be(3);
+        runs[0].Should().Be(3);
+    }
+
+    [Fact]
+    public void EachObjectGetsItsOwnStateAndItsOwnMaterialization()
+    {
+        var engine = new Engine();
+        var first = SamplePayload(1);
+        var second = SamplePayload(2);
+        engine.SetValue("a", CreateEnvelope(engine, first));
+        engine.SetValue("b", CreateEnvelope(engine, second));
+
+        engine.Evaluate("a.body.amount").AsNumber().Should().Be(1);
+        first.BodyParses.Should().Be(1);
+        second.BodyParses.Should().Be(0);
+
+        engine.Evaluate("b.body.amount").AsNumber().Should().Be(2);
+        first.BodyParses.Should().Be(1);
+        second.BodyParses.Should().Be(1);
+
+        engine.Evaluate("a.body === b.body").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void OneLayoutServesSeveralEnginesIndependently()
+    {
+        var firstEngine = new Engine();
+        var secondEngine = new Engine();
+        var first = SamplePayload(1);
+        var second = SamplePayload(2);
+
+        firstEngine.SetValue("e", CreateEnvelope(firstEngine, first));
+        secondEngine.SetValue("e", CreateEnvelope(secondEngine, second));
+
+        firstEngine.Evaluate("e.body.amount").AsNumber().Should().Be(1);
+        first.BodyParses.Should().Be(1);
+        second.BodyParses.Should().Be(0);
+
+        secondEngine.Evaluate("e.body.amount").AsNumber().Should().Be(2);
+        second.BodyParses.Should().Be(1);
+
+        // Each engine interns its own hidden class from the shared, engine-agnostic layout.
+        var firstObject = firstEngine.Evaluate("e").Should().BeOfType<JsObject>().Which;
+        var secondObject = secondEngine.Evaluate("e").Should().BeOfType<JsObject>().Which;
+        firstEngine.Advanced.GetObjectRepresentation(firstObject).Should().Be(ObjectRepresentation.HiddenClass);
+        secondEngine.Advanced.GetObjectRepresentation(secondObject).Should().Be(ObjectRepresentation.HiddenClass);
+    }
+
+    [Fact]
+    public void AMemberCallOnALazyMemberMaterializesIt()
+    {
+        var layout = JsObjectLayout.CreateBuilder()
+            .Add("id")
+            .AddLazy("decode", static (o, _) => o.Engine.Evaluate("(function () { return 'decoded'; })"))
+            .Build();
+
+        var engine = new Engine();
+        engine.SetValue("o", JsObject.Create(engine, layout, [JsNumber.Create(1), null], null));
+
+        // The callee lane, not the read lane: `o.decode` is resolved as a call target.
+        engine.Evaluate("o.decode()").AsString().Should().Be("decoded");
+    }
+
+    // ---- API validation ----
+
+    [Fact]
+    public void AValueMustNotBeGivenForALazyProperty()
+    {
+        var engine = new Engine();
+
+        Invoking(() => JsObject.Create(engine, EnvelopeLayout,
+            [
+                JsNumber.Create(1), new JsString("t"), new JsString("s"), JsNumber.Create(0),
+                new JsString("supplied"), null
+            ], SamplePayload()))
+            .Should().Throw<ArgumentException>()
+            .WithMessage("*index 4 ('body') must be null*");
+    }
+
+    [Fact]
+    public void TheThreeArgumentCreateWorksWithALazyLayoutAndPassesNullState()
+    {
+        var layout = JsObjectLayout.CreateBuilder()
+            .Add("a")
+            .AddLazy("b", static (_, state) => state is null ? new JsString("no state") : new JsString("state"))
+            .Build();
+
+        var engine = new Engine();
+        engine.SetValue("o", JsObject.Create(engine, layout, [JsNumber.Create(1), null]));
+
+        engine.Evaluate("o.b").AsString().Should().Be("no state");
+    }
+
+    [Fact]
+    public void BuilderRejectsANullFactory()
+    {
+        Invoking(() => JsObjectLayout.CreateBuilder().AddLazy("a", null))
+            .Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void BuilderAppliesTheSameNameRulesAsTheConstructors()
+    {
+        Invoking(() => JsObjectLayout.CreateBuilder().Add("a").Add("a"))
+            .Should().Throw<ArgumentException>().WithMessage("*Duplicate property name 'a'*");
+        Invoking(() => JsObjectLayout.CreateBuilder().Add("a").AddLazy("a", static (_, _) => JsValue.Undefined))
+            .Should().Throw<ArgumentException>().WithMessage("*Duplicate property name 'a'*");
+        Invoking(() => JsObjectLayout.CreateBuilder().Add(null))
+            .Should().Throw<ArgumentException>().WithMessage("*null or empty*");
+        Invoking(() => JsObjectLayout.CreateBuilder().Add(""))
+            .Should().Throw<ArgumentException>().WithMessage("*null or empty*");
+        Invoking(() => JsObjectLayout.CreateBuilder().AddLazy("0x", static (_, _) => JsValue.Undefined))
+            .Should().Throw<ArgumentException>().WithMessage("*starts with a digit*");
+    }
+
+    [Fact]
+    public void BuilderRejectsMorePropertiesThanAHiddenClassCanDescribe()
+    {
+        var builder = JsObjectLayout.CreateBuilder();
+        for (var i = 0; i < 64; i++)
+        {
+            builder.Add("p" + i);
+        }
+
+        builder.Build().Count.Should().Be(64);
+
+        var another = JsObjectLayout.CreateBuilder();
+        for (var i = 0; i < 64; i++)
+        {
+            another.Add("p" + i);
+        }
+
+        Invoking(() => another.Add("overflow")).Should().Throw<ArgumentException>().WithMessage("*at most 64*");
+    }
+
+    [Fact]
+    public void ABuilderIsSingleUse()
+    {
+        var builder = JsObjectLayout.CreateBuilder().Add("a");
+        builder.Build().Count.Should().Be(1);
+
+        Invoking(() => builder.Build()).Should().Throw<InvalidOperationException>();
+        Invoking(() => builder.Add("b")).Should().Throw<InvalidOperationException>();
+        Invoking(() => builder.AddLazy("b", static (_, _) => JsValue.Undefined)).Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void AnAllEagerBuilderProducesAnOrdinaryLayout()
+    {
+        var layout = JsObjectLayout.CreateBuilder().Add("x").Add("y").Build();
+        layout.Count.Should().Be(2);
+        layout.IndexOf("y").Should().Be(1);
+        layout.IndexOf("nope").Should().Be(-1);
+
+        var engine = new Engine();
+        var obj = JsObject.Create(engine, layout, [JsNumber.Create(1), JsNumber.Create(2)]);
+        engine.Advanced.GetObjectRepresentation(obj).Should().Be(ObjectRepresentation.HiddenClass);
+
+        // The same hidden class an equivalent literal reaches — a builder-built layout is nothing special.
+        var literal = engine.Evaluate("({ x: 1, y: 2 })").Should().BeOfType<JsObject>().Which;
+        engine.Advanced.GetObjectRepresentation(literal).Should().Be(ObjectRepresentation.HiddenClass);
+        engine.SetValue("o", obj);
+        engine.Evaluate("Object.keys(o).join(',')").AsString().Should().Be("x,y");
+    }
+
+    [Fact]
+    public void ALayoutMayBeEntirelyLazy()
+    {
+        var layout = JsObjectLayout.CreateBuilder()
+            .AddLazy("a", static (_, state) => JsNumber.Create(((int[]) state!)[0]++))
+            .AddLazy("b", static (_, state) => JsNumber.Create(((int[]) state!)[0]++))
+            .Build();
+
+        var counter = new[] { 10 };
+        var engine = new Engine();
+        engine.SetValue("o", JsObject.Create(engine, layout, [null, null], counter));
+
+        engine.Evaluate("Object.keys(o).join(',')").AsString().Should().Be("a,b");
+        counter[0].Should().Be(10);
+
+        engine.Evaluate("o.b").AsNumber().Should().Be(10);
+        engine.Evaluate("o.a").AsNumber().Should().Be(11);
+        engine.Evaluate("o.a + o.b").AsNumber().Should().Be(21);
+        counter[0].Should().Be(12);
+    }
+
+    [Fact]
+    public void ALazyMemberIsAnOrdinaryDataProperty()
+    {
+        var engine = EngineWithEnvelope(out _, out _);
+
+        var descriptor = engine.Evaluate("Object.getOwnPropertyDescriptor(e, 'body')");
+        engine.SetValue("d", descriptor);
+        engine.Evaluate("d.writable && d.enumerable && d.configurable").AsBoolean().Should().BeTrue();
+        engine.Evaluate("'get' in d").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void ProxyingAnEnvelopeSeesOrdinaryProperties()
+    {
+        var engine = EngineWithEnvelope(out var payload, out _);
+
+        engine.Evaluate("const p = new Proxy(e, {});");
+        engine.Evaluate("'body' in p").AsBoolean().Should().BeTrue();
+        payload.BodyParses.Should().Be(0);
+
+        engine.Evaluate("p.body.amount").AsNumber().Should().Be(1);
+        payload.BodyParses.Should().Be(1);
+        engine.Evaluate("p.body === e.body").AsBoolean().Should().BeTrue();
+        payload.BodyParses.Should().Be(1);
+    }
+
+    [Fact]
+    public void AWithScopeResolvesLazyMembers()
+    {
+        var engine = EngineWithEnvelope(out var payload, out _);
+
+        engine.Evaluate("var found; with (e) { found = 'body' in e; } found").AsBoolean().Should().BeTrue();
+        payload.BodyParses.Should().Be(0);
+
+        engine.Evaluate("var amount; with (e) { amount = body.amount; } amount").AsNumber().Should().Be(1);
+        payload.BodyParses.Should().Be(1);
+    }
+
+    [Fact]
+    public void ToObjectMaterializesEveryMember()
+    {
+        var engine = EngineWithEnvelope(out var payload, out var envelope);
+
+        var dictionary = envelope.ToObject().Should().BeAssignableTo<IDictionary<string, object>>().Which;
+        dictionary.Keys.Should().Contain("body");
+        payload.BodyParses.Should().Be(1);
+        payload.MetadataParses.Should().Be(1);
+    }
+}

--- a/Jint.Tests/Runtime/GarbageCollectionTests.cs
+++ b/Jint.Tests/Runtime/GarbageCollectionTests.cs
@@ -194,6 +194,53 @@ public class GarbageCollectionTests
         }
     }
 
+    [Fact]
+    public void ALayoutWithLazySlotsDoesNotRetainEnginesOrPerObjectState()
+    {
+        // A JsObjectLayout is meant to live in a static readonly field for the whole process, and one with
+        // lazy slots carries delegates and is referenced from every unmaterialized slot of every object built
+        // from it. If a factory, the engine's per-prototype layout memo or the sentinel reached back to the
+        // engine or to the per-object state, every item of every batch ever created would be immortal.
+
+        var layout = Jint.Native.JsObjectLayout.CreateBuilder()
+            .Add("id")
+            .AddLazy("value", static (_, state) => Jint.Native.JsString.Create((string) state))
+            .Build();
+
+        var references = new List<WeakReference>();
+        for (var i = 0; i < 10; i++)
+        {
+            references.AddRange(RunOnceAndForget(layout, i));
+        }
+
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+
+        var aliveCount = references.Count(static r => r.IsAlive);
+        GC.KeepAlive(layout);
+
+        aliveCount.Should().Be(0, $"{aliveCount} of {references.Count} engines/objects/states were not collected — the shared layout still pins them.");
+
+        // NoInlining so nothing stays stack-rooted in this frame across the GC.Collect calls.
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static WeakReference[] RunOnceAndForget(Jint.Native.JsObjectLayout layout, int i)
+        {
+            var engine = new Engine();
+            // A distinct state object per item, and only half of the items materialized, so both the resolved
+            // and the still-unmaterialized shapes are covered.
+            var state = new string('x', 16 + i);
+            var obj = Jint.Native.JsObject.Create(engine, layout, [Jint.Native.JsNumber.Create(i), null], state);
+            engine.SetValue("o", obj);
+            if (i % 2 == 0)
+            {
+                engine.Evaluate("o.value");
+            }
+
+            return [new WeakReference(engine), new WeakReference(state), new WeakReference(obj)];
+        }
+    }
+
     /// <summary>
     /// Only ever used by <see cref="NestedTypeAccessDoesNotRetainEngines"/>: the accessor cache is
     /// process-wide, so a type another test also resolves would let that test's engine take the blame.

--- a/Jint.Tests/Runtime/LazyLayoutSlotInternalsTests.cs
+++ b/Jint.Tests/Runtime/LazyLayoutSlotInternalsTests.cs
@@ -1,0 +1,316 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Jint.Native;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Descriptors.Specialized;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// The parts of lazy layout slots (<c>JsObjectLayout.Builder.AddLazy</c>) that are invisible from the public
+/// surface: that an unmaterialized slot really is a sentinel in the slot array rather than a descriptor, that
+/// the <see cref="InternalTypes.HasLazySlots"/> flag arrives and leaves when it should, that the deopt emits
+/// a field-backed lazy descriptor, and that spread declines to adopt a shape whose slots are not all real
+/// values yet. The publicly observable behavior lives in
+/// Jint.Tests.PublicInterface/HostLayoutLazySlotTests.cs.
+/// </summary>
+public class LazyLayoutSlotInternalsTests
+{
+    private sealed class Counter
+    {
+        public int A;
+        public int B;
+    }
+
+    private static readonly JsObjectLayout MixedLayout = JsObjectLayout.CreateBuilder()
+        .Add("eager")
+        .AddLazy("a", static (_, state) => JsNumber.Create(++((Counter) state!).A))
+        .AddLazy("b", static (_, state) => JsNumber.Create(100 + ++((Counter) state!).B))
+        .Build();
+
+    private static JsObject Create(Engine engine, Counter counter) =>
+        JsObject.Create(engine, MixedLayout, [JsNumber.Create(0), null!, null!], counter);
+
+    private static bool HasLazyFlag(JsObject obj) =>
+        (obj._type & InternalTypes.HasLazySlots) != InternalTypes.Empty;
+
+    // ---- storage ----
+
+    [Fact]
+    public void AnUnmaterializedSlotHoldsOneSentinelSharedByEveryLazySlot()
+    {
+        var engine = new Engine();
+        var obj = Create(engine, new Counter());
+
+        (obj._type & InternalTypes.ShapeMode).Should().NotBe(InternalTypes.Empty);
+        HasLazyFlag(obj).Should().BeTrue();
+
+        obj.GetSlot(0).Should().BeOfType<JsNumber>();
+        var first = obj.GetSlot(1);
+        var second = obj.GetSlot(2);
+        first.Should().BeOfType<JsObject.UnmaterializedSlots>();
+        // One allocation for the whole object, not one per lazy member.
+        second.Should().BeSameAs(first);
+    }
+
+    [Fact]
+    public void ALazyLayoutInternsTheSameShapeAsAnEquivalentEagerOneAndAsALiteral()
+    {
+        var engine = new Engine();
+        var lazy = Create(engine, new Counter());
+        var eager = JsObject.Create(engine, new JsObjectLayout("eager", "a", "b"),
+            [JsNumber.Create(0), JsNumber.Create(1), JsNumber.Create(2)]);
+        var literal = engine.Evaluate("({ eager: 0, a: 1, b: 2 })").Should().BeOfType<JsObject>().Which;
+
+        // The hidden class describes names and slots only, so laziness never segregates the transition tree —
+        // which is what keeps a call site reading `o.a` monomorphic across all three.
+        lazy.ShapeOf.Should().BeSameAs(eager.ShapeOf);
+        lazy.ShapeOf.Should().BeSameAs(literal.ShapeOf);
+    }
+
+    [Fact]
+    public void EveryObjectOfALazyLayoutSharesOneShape()
+    {
+        var engine = new Engine();
+        var first = Create(engine, new Counter());
+        for (var i = 0; i < 50; i++)
+        {
+            var next = Create(engine, new Counter());
+            next.Should().NotBeSameAs(first);
+            next.ShapeOf.Should().BeSameAs(first.ShapeOf);
+        }
+    }
+
+    // ---- flag lifecycle ----
+
+    [Fact]
+    public void TheFlagClearsWhenTheLastSentinelIsMaterialized()
+    {
+        var engine = new Engine();
+        var counter = new Counter();
+        var obj = Create(engine, counter);
+        engine.SetValue("o", obj);
+
+        HasLazyFlag(obj).Should().BeTrue();
+
+        engine.Evaluate("o.a").AsNumber().Should().Be(1);
+        // One of two resolved: still flagged, so the checked read lane stays engaged.
+        HasLazyFlag(obj).Should().BeTrue();
+        obj.GetSlot(1).Should().BeOfType<JsNumber>();
+
+        engine.Evaluate("o.b").AsNumber().Should().Be(101);
+        // Fully materialized: the object rejoins the plain shape lanes, indistinguishable from a literal.
+        HasLazyFlag(obj).Should().BeFalse();
+        (obj._type & InternalTypes.ShapeMode).Should().NotBe(InternalTypes.Empty);
+
+        engine.Evaluate("o.a + o.b").AsNumber().Should().Be(102);
+        counter.A.Should().Be(1);
+        counter.B.Should().Be(1);
+    }
+
+    [Fact]
+    public void AWriteOverASentinelDiscardsTheFactoryAndTheFlagClearsOnTheNextMaterialization()
+    {
+        var engine = new Engine();
+        var counter = new Counter();
+        var obj = Create(engine, counter);
+        engine.SetValue("o", obj);
+
+        engine.Evaluate("o.a = 7");
+        obj.GetSlot(1).Should().BeOfType<JsNumber>();
+        counter.A.Should().Be(0);
+
+        // The write path is deliberately raw, so it does not pay for a rescan: the flag is conservative and
+        // stays set until something materializes and finds nothing left.
+        HasLazyFlag(obj).Should().BeTrue();
+
+        engine.Evaluate("o.b").AsNumber().Should().Be(101);
+        HasLazyFlag(obj).Should().BeFalse();
+    }
+
+    [Fact]
+    public void DeoptClearsTheFlagAndTheSlots()
+    {
+        var engine = new Engine();
+        var obj = Create(engine, new Counter());
+        engine.SetValue("o", obj);
+
+        engine.Evaluate("delete o.eager");
+
+        HasLazyFlag(obj).Should().BeFalse();
+        (obj._type & InternalTypes.ShapeMode).Should().Be(InternalTypes.Empty);
+        engine.Advanced.GetObjectRepresentation(obj).Should().Be(ObjectRepresentation.Dictionary);
+    }
+
+    // ---- deopt ----
+
+    [Fact]
+    public void DeoptEmitsAFieldBackedLazyDescriptorForAnUnmaterializedSlotOnly()
+    {
+        var engine = new Engine();
+        var counter = new Counter();
+        var obj = Create(engine, counter);
+        engine.SetValue("o", obj);
+
+        // Materialize exactly one, then force the deopt.
+        engine.Evaluate("o.a");
+        engine.Evaluate("delete o.eager");
+
+        counter.A.Should().Be(1);
+        counter.B.Should().Be(0);
+
+        var properties = obj._properties!;
+        properties["a"].Should().BeOfType<PropertyDescriptor>("a materialized before the deopt");
+        var lazy = properties["b"].Should().BeOfType<LazySlotPropertyDescriptor>().Which;
+        // The marker is what lets a global-snapshot restore revert this descriptor by writing its fields —
+        // including back to unmaterialized, which is exactly "the captured state".
+        lazy.Should().BeAssignableTo<IFieldBackedLazyDescriptor>();
+        lazy._value.Should().BeNull();
+        (lazy.Flags & PropertyFlag.CustomJsValue).Should().NotBe(PropertyFlag.None);
+
+        engine.Evaluate("o.b").AsNumber().Should().Be(101);
+        counter.B.Should().Be(1);
+        lazy._value.Should().NotBeNull();
+        // Once resolved it is an ordinary data descriptor again, so the caches stop paying for the hook.
+        (lazy.Flags & PropertyFlag.CustomJsValue).Should().Be(PropertyFlag.None);
+    }
+
+    [Fact]
+    public void FreezingLeavesTheDescriptorLazyAndOnlyFlipsItsFlags()
+    {
+        var engine = new Engine();
+        var counter = new Counter();
+        var obj = Create(engine, counter);
+        engine.SetValue("o", obj);
+
+        engine.Evaluate("Object.freeze(o)");
+
+        var lazy = obj._properties!["b"].Should().BeOfType<LazySlotPropertyDescriptor>().Which;
+        lazy._value.Should().BeNull();
+        lazy.Writable.Should().BeFalse();
+        lazy.Configurable.Should().BeFalse();
+        lazy.Enumerable.Should().BeTrue();
+        counter.A.Should().Be(0);
+        counter.B.Should().Be(0);
+    }
+
+    // ---- the dictionary fallback arm ----
+
+    [Fact]
+    public void TheBudgetExhaustedFallbackBuildsTheSameObjectWithTheSameLaziness()
+    {
+        var engine = new Engine();
+        // Burn the engine's host transition budget so Create cannot intern this layout's shape.
+        var field = typeof(Engine).GetField("_hostShapeTransitions",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        field.SetValue(engine, Engine.HostShapeTransitionBudget);
+
+        var counter = new Counter();
+        var obj = Create(engine, counter);
+        engine.SetValue("o", obj);
+
+        engine.Advanced.GetObjectRepresentation(obj).Should().Be(ObjectRepresentation.Dictionary);
+        obj._properties!["b"].Should().BeOfType<LazySlotPropertyDescriptor>();
+
+        // Behaviour-identical to the shaped arm, down to the factory not having run.
+        counter.A.Should().Be(0);
+        engine.Evaluate("Object.keys(o).join(',')").AsString().Should().Be("eager,a,b");
+        engine.Evaluate("'a' in o").AsBoolean().Should().BeTrue();
+        counter.A.Should().Be(0);
+
+        engine.Evaluate("o.a").AsNumber().Should().Be(1);
+        engine.Evaluate("o.a").AsNumber().Should().Be(1);
+        counter.A.Should().Be(1);
+        counter.B.Should().Be(0);
+    }
+
+    // ---- spread ----
+
+    [Fact]
+    public void SpreadDeclinesShapeAdoptionWhileASentinelIsLiveAndReadsTheSourceOnce()
+    {
+        var engine = new Engine();
+        var counter = new Counter();
+        var obj = Create(engine, counter);
+        engine.SetValue("o", obj);
+
+        var copy = engine.Evaluate("({ ...o })").Should().BeOfType<JsObject>().Which;
+
+        // Streamed, not adopted — but the result is still shaped and holds real values, never the sentinel.
+        counter.A.Should().Be(1);
+        counter.B.Should().Be(1);
+        (copy._type & InternalTypes.ShapeMode).Should().NotBe(InternalTypes.Empty);
+        HasLazyFlag(copy).Should().BeFalse();
+        copy.ShapeOf.Should().BeSameAs(obj.ShapeOf);
+        copy.GetSlot(1).Should().BeOfType<JsNumber>();
+
+        // The source materialized exactly once, so a second spread copies the memo.
+        engine.Evaluate("({ ...o })");
+        counter.A.Should().Be(1);
+        counter.B.Should().Be(1);
+    }
+
+    [Fact]
+    public void SpreadAdoptsTheShapeAgainOnceEveryLazySlotIsMaterialized()
+    {
+        var engine = new Engine();
+        var obj = Create(engine, new Counter());
+        engine.SetValue("o", obj);
+
+        engine.Evaluate("o.a; o.b;");
+        HasLazyFlag(obj).Should().BeFalse();
+
+        var target = new JsObject(engine);
+        target.StartShapeBuilding(engine.GetEmptyShape(engine.Realm.Intrinsics.Object.PrototypeObject));
+        target.TryAdoptShapeFrom(obj).Should().BeTrue();
+        target.ShapeOf.Should().BeSameAs(obj.ShapeOf);
+    }
+
+    [Fact]
+    public void ShapeAdoptionIsRefusedWhileTheFlagIsSet()
+    {
+        var engine = new Engine();
+        var obj = Create(engine, new Counter());
+
+        var target = new JsObject(engine);
+        target.StartShapeBuilding(engine.GetEmptyShape(engine.Realm.Intrinsics.Object.PrototypeObject));
+        target.TryAdoptShapeFrom(obj).Should().BeFalse();
+    }
+
+    // ---- global snapshot corner ----
+
+    [Fact]
+    public void ASubstitutedLazyGlobalIsCapturedAndRestoredWithoutMaterializing()
+    {
+        // The only way a lazy layout slot reaches snapshot capture: a host substitutes a hidden-class JsObject
+        // as the global. Capture normalizes it with ConvertToDictionaryMode, which emits the lazy descriptors;
+        // because they are field-backed, capture records the (flags, null) pair and restore writes it back —
+        // returning the property to unmaterialized, which is exactly the captured state.
+        var engine = new Engine();
+        var counter = new Counter();
+        var host = Create(engine, counter);
+        engine.SetValue("host", host);
+
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+        counter.A.Should().Be(0);
+        counter.B.Should().Be(0);
+
+        engine.Evaluate("host.a").AsNumber().Should().Be(1);
+        counter.A.Should().Be(1);
+
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        // The object itself is a global's VALUE, captured by reference, so its own state is untouched by the
+        // restore — the memo stands and the untouched sibling is still lazy.
+        engine.Evaluate("host.a").AsNumber().Should().Be(1);
+        counter.A.Should().Be(1);
+        counter.B.Should().Be(0);
+        engine.Evaluate("host.b").AsNumber().Should().Be(101);
+        counter.B.Should().Be(1);
+    }
+
+}

--- a/Jint/Engine.Advanced.cs
+++ b/Jint/Engine.Advanced.cs
@@ -152,7 +152,7 @@ public partial class Engine
         /// something Jint is free to change underneath it.
         /// </para>
         /// <para>
-        /// The motivating case: <see cref="JsObject.Create"/> and <see cref="JsObject.CreateFromEntries(Engine, IEnumerable{KeyValuePair{string, JsValue}})"/>
+        /// The motivating case: <see cref="JsObject.Create(Engine, JsObjectLayout, ReadOnlySpan{JsValue})"/> and <see cref="JsObject.CreateFromEntries(Engine, IEnumerable{KeyValuePair{string, JsValue}})"/>
         /// fall back to the dictionary representation silently and correctly when they cannot shape an
         /// object, and two of the triggers are not knowable at the call site (they depend on what the engine
         /// has already built). Without this method a host cannot write a test proving its objects are still
@@ -341,7 +341,7 @@ public enum ObjectRepresentation
     /// <summary>
     /// A plain object whose own string-keyed properties are described by a hidden class shared with every
     /// other object of the same layout, leaving only the values stored per object. This is what
-    /// <see cref="Jint.Native.JsObject.Create"/> and <c>JsObject.CreateFromEntries</c> aim for, and what an
+    /// <c>JsObject.Create</c> and <c>JsObject.CreateFromEntries</c> aim for, and what an
     /// ordinary object literal reaches.
     /// </summary>
     HiddenClass = 1,

--- a/Jint/Native/JsObject.Create.cs
+++ b/Jint/Native/JsObject.Create.cs
@@ -1,5 +1,6 @@
 using Jint.Native.Object;
 using Jint.Runtime;
+using Jint.Runtime.Descriptors.Specialized;
 
 namespace Jint.Native;
 
@@ -31,11 +32,47 @@ public sealed partial class JsObject
     /// <param name="layout">The property layout; see <see cref="JsObjectLayout"/>.</param>
     /// <param name="values">
     /// One value per layout property, in layout order. A <c>null</c> entry is stored as
-    /// <see cref="JsValue.Undefined"/>.
+    /// <see cref="JsValue.Undefined"/> — except at a property the layout declared through
+    /// <see cref="JsObjectLayout.Builder.AddLazy"/>, where <c>null</c> is required and the layout supplies
+    /// the value. Use the
+    /// <see cref="Create(Engine, JsObjectLayout, ReadOnlySpan{JsValue}, object)"/> overload to give those
+    /// factories per-object state; this one passes <c>null</c>.
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="engine"/> or <paramref name="layout"/> is <c>null</c>.</exception>
     /// <exception cref="ArgumentException"><paramref name="values"/> does not have exactly <see cref="JsObjectLayout.Count"/> entries.</exception>
     public static JsObject Create(Engine engine, JsObjectLayout layout, ReadOnlySpan<JsValue> values)
+        => Create(engine, layout, values, lazySlotState: null);
+
+    /// <summary>
+    /// Creates an object with <paramref name="layout"/>'s properties exactly as
+    /// <see cref="Create(Engine, JsObjectLayout, ReadOnlySpan{JsValue})"/> does, additionally handing
+    /// <paramref name="lazySlotState"/> to the factories of any properties the layout declared through
+    /// <see cref="JsObjectLayout.Builder.AddLazy"/>.
+    /// <para>
+    /// The result is indistinguishable from the equivalent object literal — same own-key order, same
+    /// configurable/enumerable/writable data properties, same hidden class as every other object built from
+    /// this layout — <em>except</em> for when a lazy property's value comes into existence: on the first read
+    /// that observes it, not here. Nothing in this call runs a factory.
+    /// </para>
+    /// </summary>
+    /// <param name="engine">The engine the object belongs to.</param>
+    /// <param name="layout">The property layout; see <see cref="JsObjectLayout"/>.</param>
+    /// <param name="values">
+    /// One value per layout property, in layout order. A <c>null</c> entry for an ordinary property is stored
+    /// as <see cref="JsValue.Undefined"/>; the entry for a lazy property MUST be <c>null</c>, since the
+    /// layout supplies that value.
+    /// </param>
+    /// <param name="lazySlotState">
+    /// The per-object state passed to every lazy factory of this object — typically the host record the
+    /// object projects, so several lazy properties can read different parts of one payload. Unlike the
+    /// layout, it is per object and may be engine-affine. Ignored by an all-eager layout.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="engine"/> or <paramref name="layout"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="values"/> does not have exactly <see cref="JsObjectLayout.Count"/> entries, or a
+    /// non-<c>null</c> value was given for a lazy property.
+    /// </exception>
+    public static JsObject Create(Engine engine, JsObjectLayout layout, ReadOnlySpan<JsValue> values, object? lazySlotState)
     {
         if (engine is null)
         {
@@ -55,6 +92,22 @@ public sealed partial class JsObject
                 nameof(values));
         }
 
+        var hasLazySlots = layout.HasLazySlots;
+        if (hasLazySlots)
+        {
+            // Catch the mistake — "I passed the parsed body as well" — at creation rather than letting the
+            // value be silently shadowed by the factory's result, or vice versa.
+            for (var i = 0; i < keys.Length; i++)
+            {
+                if (values[i] is not null && layout.GetFactory(i) is not null)
+                {
+                    Throw.ArgumentException(
+                        $"The value at index {i} ('{keys[i].Name}') must be null: that property is produced by the layout's lazy factory.",
+                        nameof(values));
+                }
+            }
+        }
+
         var obj = new JsObject(engine);
 
         // The JsObject constructor already anchored the object to the active realm's Object.prototype;
@@ -64,9 +117,19 @@ public sealed partial class JsObject
         {
             // No prototype (only reachable while the realm is still being built) or the engine's host
             // transition budget is spent: build the same object in the ordinary dictionary representation.
+            // A lazy property becomes the same descriptor the shaped object's deopt would have produced, so
+            // the fallback is behaviorally identical — including that its factory has still not run.
+            var fallbackSentinel = hasLazySlots ? new UnmaterializedSlots(layout, lazySlotState) : null;
             for (var i = 0; i < keys.Length; i++)
             {
-                obj.FastSetDataProperty(keys[i].Name, values[i] ?? Undefined);
+                if (fallbackSentinel is not null && layout.GetFactory(i) is not null)
+                {
+                    obj.FastSetProperty(keys[i].Name, new LazySlotPropertyDescriptor(obj, fallbackSentinel, i));
+                }
+                else
+                {
+                    obj.FastSetDataProperty(keys[i].Name, values[i] ?? Undefined);
+                }
             }
 
             return obj;
@@ -78,6 +141,13 @@ public sealed partial class JsObject
         for (var i = 0; i < values.Length; i++)
         {
             obj.SetSlot(i, values[i] ?? Undefined);
+        }
+
+        if (hasLazySlots)
+        {
+            // One sentinel shared by every lazy slot, so an object with four of them costs one extra
+            // allocation, not four closures.
+            obj.InstallLazySlots(layout, lazySlotState);
         }
 
         return obj;
@@ -103,6 +173,12 @@ public sealed partial class JsObject
     /// (the object-used-as-a-hash-map pattern). Each engine also bounds how many new layouts host code may
     /// intern over its lifetime; past that, this method keeps working and simply returns dictionary-mode
     /// objects.
+    /// <para>
+    /// Entries are always eager. Lazily-produced properties are declared on a layout
+    /// (<see cref="JsObjectLayout.Builder.AddLazy"/>), and a key set only known at runtime has nowhere to
+    /// declare them; build such an object with <see cref="Create(Engine, JsObjectLayout, ReadOnlySpan{JsValue}, object)"/>
+    /// instead, or install a <see cref="Jint.Runtime.Descriptors.PropertyFlag.CustomJsValue"/> descriptor.
+    /// </para>
     /// </remarks>
     /// <param name="engine">The engine the object belongs to.</param>
     /// <param name="entries">The property names and values, in the order they should appear.</param>

--- a/Jint/Native/JsObject.LazySlots.cs
+++ b/Jint/Native/JsObject.LazySlots.cs
@@ -5,7 +5,7 @@ using Jint.Runtime;
 namespace Jint.Native;
 
 /// <summary>
-/// Lazy layout slots: the storage side of <c>JsObjectLayout.Builder.AddLazy</c>.
+/// Lazy layout slots: the storage side of <see cref="JsObjectLayout.Builder.AddLazy"/>.
 /// </summary>
 public sealed partial class JsObject
 {

--- a/Jint/Native/JsObject.LazySlots.cs
+++ b/Jint/Native/JsObject.LazySlots.cs
@@ -1,0 +1,128 @@
+using System.Runtime.CompilerServices;
+using Jint.Native.Object;
+using Jint.Runtime;
+
+namespace Jint.Native;
+
+/// <summary>
+/// Lazy layout slots: the storage side of <c>JsObjectLayout.Builder.AddLazy</c>.
+/// </summary>
+public sealed partial class JsObject
+{
+    /// <summary>
+    /// Reads a slot the way every path that observes a slot's <em>value</em> must: materializing it first if
+    /// it is still a lazy layout slot whose factory has not run. Callers that only need keys, flags or slot
+    /// counts must keep using the raw accessors — an existence question never runs a factory.
+    /// <para>
+    /// The check is a single type test against a value the caller has already loaded, and the branch is
+    /// perfectly predicted (a given slot is a sentinel at most once in its life). The hot interpreter lanes
+    /// avoid even that by gating on <see cref="InternalTypes.HasLazySlots"/> and routing here only for the
+    /// objects that can actually have one.
+    /// </para>
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal JsValue GetSlotForRead(int slot)
+    {
+        var value = GetSlot(slot);
+        if (value is UnmaterializedSlots sentinel)
+        {
+            return MaterializeSlot(sentinel, slot);
+        }
+
+        return value;
+    }
+
+    /// <summary>
+    /// Runs one lazy slot's factory and memoizes the result into the slot, so the slot itself is the memo and
+    /// every read lane sees the value immediately (nothing anywhere caches a slot's value — the inline caches
+    /// cache the slot <em>index</em> and re-read the slot on every hit).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private JsValue MaterializeSlot(UnmaterializedSlots sentinel, int slot)
+    {
+        var factory = sentinel.Layout.GetFactory(slot);
+        System.Diagnostics.Debug.Assert(factory is not null, "a slot holding the sentinel must have a factory");
+        var value = factory!(this, sentinel.State) ?? Undefined;
+
+        // A factory is morally a getter body, so it may have mutated this very object while it ran: written
+        // the property being read, deleted an unrelated one (deopting to a dictionary), or frozen the object.
+        // Memoize only while the slot is still the one this read started from; otherwise the mutation stands
+        // and this read merely returns the factory's value, which is exactly how a JavaScript getter that
+        // mutates its own object behaves.
+        if ((_type & InternalTypes.ShapeMode) != InternalTypes.Empty
+            && slot < _shape!.SlotCount
+            && ReferenceEquals(GetSlot(slot), sentinel))
+        {
+            SetSlot(slot, value);
+            ClearLazyFlagIfFullyMaterialized();
+        }
+
+        return value;
+    }
+
+    /// <summary>
+    /// Drops <see cref="InternalTypes.HasLazySlots"/> once no slot holds a sentinel any more, returning the
+    /// object to the plain shape read lanes — from then on it is indistinguishable from an object literal of
+    /// the same layout. O(slot count), bounded by the maximum a hidden class can describe, and paid only
+    /// on the materializations themselves.
+    /// </summary>
+    /// <seealso cref="Shape.MaxShapeProperties"/>
+    private void ClearLazyFlagIfFullyMaterialized()
+    {
+        var slotCount = _shape!.SlotCount;
+        for (var i = 0; i < slotCount; i++)
+        {
+            if (GetSlot(i) is UnmaterializedSlots)
+            {
+                return;
+            }
+        }
+
+        _type &= ~InternalTypes.HasLazySlots;
+    }
+
+    /// <summary>
+    /// Installs one shared sentinel in every lazy slot of <paramref name="layout"/> and flags the object, so
+    /// the read lanes know to check. One allocation per object regardless of how many lazy slots it has.
+    /// </summary>
+    internal void InstallLazySlots(JsObjectLayout layout, object? lazySlotState)
+    {
+        var sentinel = new UnmaterializedSlots(layout, lazySlotState);
+        var count = layout.Count;
+        for (var i = 0; i < count; i++)
+        {
+            if (layout.GetFactory(i) is not null)
+            {
+                SetSlot(i, sentinel);
+            }
+        }
+
+        _type |= InternalTypes.HasLazySlots;
+    }
+
+    /// <summary>
+    /// The placeholder a lazy layout slot holds until its factory runs, carrying everything that run needs:
+    /// the layout (which owns the per-slot factories) and the per-object state. One instance is shared by all
+    /// of an object's lazy slots, so an object with four lazy members still costs one extra allocation.
+    /// <para>
+    /// Never observable: it is <see cref="Types.Empty"/>, like <see cref="JsEmpty"/>, and every path that
+    /// observes a slot's value goes through <see cref="GetSlotForRead"/>, the descriptor view
+    /// (<c>SlotPropertyDescriptor</c>) or the dictionary deopt, each of which resolves it first.
+    /// </para>
+    /// </summary>
+    internal sealed class UnmaterializedSlots : JsValue
+    {
+        internal readonly JsObjectLayout Layout;
+        internal readonly object? State;
+
+        internal UnmaterializedSlots(JsObjectLayout layout, object? state) : base(Types.Empty)
+        {
+            Layout = layout;
+            State = state;
+        }
+
+        public override object? ToObject() => null;
+
+        public override string ToString() => "[unmaterialized lazy slot]";
+    }
+}

--- a/Jint/Native/JsObject.cs
+++ b/Jint/Native/JsObject.cs
@@ -108,13 +108,16 @@ public sealed partial class JsObject : ObjectInstance
     }
 
     /// <summary>Drops shape mode back to dictionary mode's starting state (clears the shape and slot
-    /// storage and the <see cref="InternalTypes.ShapeMode"/> flag). Callers must populate <c>_properties</c>.</summary>
+    /// storage and the <see cref="InternalTypes.ShapeMode"/> flag). Callers must populate <c>_properties</c>.
+    /// <see cref="InternalTypes.HasLazySlots"/> goes with it: nothing can hold a sentinel once the slots are
+    /// gone, and any still-unmaterialized slot is carried into the dictionary by the caller as a lazy
+    /// descriptor instead.</summary>
     internal void ClearShape()
     {
         _shape = null;
         _overflow = null;
         _inline = default; // release in-object slot references so they don't outlive shape mode
-        _type &= ~(InternalTypes.ShapeMode | InternalTypes.ShapeBuilding);
+        _type &= ~(InternalTypes.ShapeMode | InternalTypes.ShapeBuilding | InternalTypes.HasLazySlots);
     }
 
     /// <summary>
@@ -223,7 +226,14 @@ public sealed partial class JsObject : ObjectInstance
         // enumerable ones, so decline and let the caller stream them), and share this object's prototype.
         // The interned shape is rooted per prototype (Engine.GetEmptyShape), so a shape whose root belongs
         // to a different prototype must never be installed here.
-        if ((source._type & InternalTypes.ShapeMode) == InternalTypes.Empty
+        //
+        // A source with lazy layout slots is also refused: the raw slot copy below would clone the
+        // unmaterialized sentinel into the target, so the factory would run once per derived object (or,
+        // after the source materialized, not at all) — CopyDataProperties reads each source value exactly
+        // once, which is what the streaming fallback does. Conservative in the harmless direction: an object
+        // whose sentinels were all overwritten by writes still carries the flag until something materializes,
+        // and merely streams instead of adopting.
+        if ((source._type & (InternalTypes.ShapeMode | InternalTypes.HasLazySlots)) != InternalTypes.ShapeMode
             || source._symbols is not null
             || !ReferenceEquals(source._prototype, _prototype))
         {

--- a/Jint/Native/JsObjectLayout.cs
+++ b/Jint/Native/JsObjectLayout.cs
@@ -5,6 +5,39 @@ using Jint.Runtime;
 namespace Jint.Native;
 
 /// <summary>
+/// Produces the value of one lazy layout slot for one object, on the first read that observes that value.
+/// Declared through <c>JsObjectLayout.Builder.AddLazy</c>.
+/// </summary>
+/// <param name="instance">
+/// The object being read. Reach the engine it belongs to through <see cref="ObjectInstance.Engine"/>.
+/// </param>
+/// <param name="state">
+/// The per-object state handed to <c>JsObject.Create</c> — typically the host record the object projects, so
+/// several lazy slots of one object can read different parts of one payload.
+/// </param>
+/// <returns>
+/// The property's value. <c>null</c> is stored as <see cref="JsValue.Undefined"/>.
+/// </returns>
+/// <remarks>
+/// <para>
+/// A factory MUST be engine-independent — a static lambda, or one capturing only engine-independent CLR
+/// state. The <see cref="JsObjectLayout"/> carrying it is process-shared by design (a <c>static readonly</c>
+/// field used by every engine in the process), exactly like a <see cref="JsObjectShape"/> member
+/// implementation, so a captured <see cref="Engine"/>, <see cref="Realm"/> or <see cref="JsValue"/> would
+/// leak one engine's state into another's objects. Everything engine- or item-specific belongs in
+/// <paramref name="state"/>, which is per object.
+/// </para>
+/// <para>
+/// A factory is morally a getter body: it runs on the engine's thread, during property resolution, and may
+/// build values against <c>instance.Engine</c>. It must not read the very property it computes — that
+/// recurses, exactly as a JavaScript getter reading its own property does. If it throws, the exception
+/// propagates out of the operation performing the read and the slot stays unmaterialized, so the next read
+/// runs the factory again.
+/// </para>
+/// </remarks>
+public delegate JsValue LazySlotFactory(JsObject instance, object? state);
+
+/// <summary>
 /// An immutable description of a fixed own-property layout — a set of property names in a fixed order —
 /// that host code can hand to <see cref="JsObject.Create(Engine, JsObjectLayout, ReadOnlySpan{JsValue})"/>
 /// to build objects directly in Jint's hidden-class representation.
@@ -49,6 +82,12 @@ public sealed class JsObjectLayout
     // straight walk of interned transitions with no re-hashing.
     private readonly Key[] _keys;
 
+    // Parallel to _keys, and null for the overwhelmingly common all-eager layout: a null array means "no
+    // lazy slots", and inside a non-null array a null entry means "that slot is eager". Kept as a plain
+    // parallel array rather than folded into _keys so the eager layout carries no extra field-per-slot and
+    // resolving the layout to a Shape stays a walk of _keys alone.
+    private readonly LazySlotFactory?[]? _factories;
+
     // Lazily built for wide layouts only.
     private Dictionary<Key, int>? _index;
 
@@ -84,32 +123,15 @@ public sealed class JsObjectLayout
         }
 
         var count = propertyNames.Count;
-        if (count > Shape.MaxShapeProperties)
-        {
-            Throw.ArgumentException(
-                $"A layout can describe at most {Shape.MaxShapeProperties} properties, but {count} property names were given.",
-                nameof(propertyNames));
-        }
+        CheckCount(count, nameof(propertyNames));
 
         var keys = count > 0 ? new Key[count] : System.Array.Empty<Key>();
         for (var i = 0; i < count; i++)
         {
             var name = propertyNames[i];
-            if (string.IsNullOrEmpty(name))
-            {
-                Throw.ArgumentException(
-                    $"Property name at index {i} is null or empty; layout property names must be non-empty strings.",
-                    nameof(propertyNames));
-            }
+            CheckName(name, i, nameof(propertyNames));
 
-            if (Shape.IsIntegerIndexLikeKey(name))
-            {
-                Throw.ArgumentException(
-                    $"Property name '{name}' at index {i} starts with a digit. Integer-index-like keys must be enumerated in ascending numeric order before the string keys, which a fixed layout cannot express; build such objects with JsObject.CreateFromEntries instead.",
-                    nameof(propertyNames));
-            }
-
-            Key key = name;
+            Key key = name!;
             for (var j = 0; j < i; j++)
             {
                 if (keys[j] == key)
@@ -126,8 +148,58 @@ public sealed class JsObjectLayout
         _keys = keys;
     }
 
+    /// <summary>
+    /// Builder-only constructor: the names were validated one at a time as they were added, so nothing is
+    /// re-checked here. <paramref name="factories"/> is <c>null</c> for an all-eager layout.
+    /// </summary>
+    private JsObjectLayout(Key[] keys, LazySlotFactory?[]? factories)
+    {
+        _keys = keys;
+        _factories = factories;
+    }
+
+    private static void CheckCount(int count, string paramName)
+    {
+        if (count > Shape.MaxShapeProperties)
+        {
+            Throw.ArgumentException(
+                $"A layout can describe at most {Shape.MaxShapeProperties} properties, but {count} property names were given.",
+                paramName);
+        }
+    }
+
+    private static void CheckName(string? name, int index, string paramName)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            Throw.ArgumentException(
+                $"Property name at index {index} is null or empty; layout property names must be non-empty strings.",
+                paramName);
+        }
+
+        if (Shape.IsIntegerIndexLikeKey(name!))
+        {
+            Throw.ArgumentException(
+                $"Property name '{name}' at index {index} starts with a digit. Integer-index-like keys must be enumerated in ascending numeric order before the string keys, which a fixed layout cannot express; build such objects with JsObject.CreateFromEntries instead.",
+                paramName);
+        }
+    }
+
     /// <summary>The number of properties this layout describes.</summary>
     public int Count => _keys.Length;
+
+    /// <summary>Whether any slot of this layout is produced by a <see cref="LazySlotFactory"/>.</summary>
+    internal bool HasLazySlots
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _factories is not null;
+    }
+
+    /// <summary>
+    /// The factory for <paramref name="slot"/>, or <c>null</c> when that slot is eager. The slot is always in
+    /// range: it comes from the <see cref="Shape"/> this layout was resolved to.
+    /// </summary>
+    internal LazySlotFactory? GetFactory(int slot) => _factories?[slot];
 
     /// <summary>
     /// The slot of <paramref name="name"/> in this layout — the index its value occupies in the

--- a/Jint/Native/JsObjectLayout.cs
+++ b/Jint/Native/JsObjectLayout.cs
@@ -6,14 +6,15 @@ namespace Jint.Native;
 
 /// <summary>
 /// Produces the value of one lazy layout slot for one object, on the first read that observes that value.
-/// Declared through <c>JsObjectLayout.Builder.AddLazy</c>.
+/// Declared through <see cref="JsObjectLayout.Builder.AddLazy"/>.
 /// </summary>
 /// <param name="instance">
 /// The object being read. Reach the engine it belongs to through <see cref="ObjectInstance.Engine"/>.
 /// </param>
 /// <param name="state">
-/// The per-object state handed to <c>JsObject.Create</c> — typically the host record the object projects, so
-/// several lazy slots of one object can read different parts of one payload.
+/// The per-object state handed to
+/// <see cref="JsObject.Create(Engine, JsObjectLayout, ReadOnlySpan{JsValue}, object)"/> — typically the host
+/// record the object projects, so several lazy slots of one object can read different parts of one payload.
 /// </param>
 /// <returns>
 /// The property's value. <c>null</c> is stored as <see cref="JsValue.Undefined"/>.
@@ -185,6 +186,33 @@ public sealed class JsObjectLayout
         }
     }
 
+    /// <summary>
+    /// Creates a builder for a layout that mixes eager properties with lazily-produced ones.
+    /// </summary>
+    /// <remarks>
+    /// The constructors build an all-eager layout, every value of which is supplied at
+    /// <see cref="JsObject.Create(Engine, JsObjectLayout, ReadOnlySpan{JsValue})"/> time. Use a builder when
+    /// some members are expensive to produce and most items never have them read — the canonical case being a
+    /// record whose few costly members each parse or decode a part of that item's raw payload. See
+    /// <see cref="Builder.AddLazy"/>.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// private static readonly JsObjectLayout EnvelopeLayout = JsObjectLayout.CreateBuilder()
+    ///     .Add("id")
+    ///     .Add("type")
+    ///     .AddLazy("body", static (_, state) =&gt; ((Payload) state!).ParseBody())
+    ///     .Build();
+    ///
+    /// JsObject ToJs(Engine engine, Payload p) =&gt; JsObject.Create(
+    ///     engine,
+    ///     EnvelopeLayout,
+    ///     [new JsString(p.Id), new JsString(p.Type), null],
+    ///     p);
+    /// </code>
+    /// </example>
+    public static Builder CreateBuilder() => new Builder();
+
     /// <summary>The number of properties this layout describes.</summary>
     public int Count => _keys.Length;
 
@@ -249,5 +277,149 @@ public sealed class JsObjectLayout
         }
 
         return index;
+    }
+
+    /// <summary>
+    /// Declares a layout one property at a time, so that individual properties can be marked as produced on
+    /// demand rather than supplied up front. Obtained from <see cref="CreateBuilder"/>; a builder is
+    /// single-use and not thread-safe, while the <see cref="JsObjectLayout"/> it produces is immutable and
+    /// safe to share.
+    /// </summary>
+    public sealed class Builder
+    {
+        private readonly List<Key> _keys = [];
+
+        // Allocated on the first AddLazy and back-filled with nulls for the eager properties already added,
+        // so the overwhelmingly common all-eager builder never allocates it.
+        private List<LazySlotFactory?>? _factories;
+        private bool _built;
+
+        /// <summary>Creates an empty builder.</summary>
+        public Builder()
+        {
+        }
+
+        /// <summary>
+        /// Declares an ordinary property, whose value is supplied at this slot's index in the <c>values</c>
+        /// span passed to <c>JsObject.Create</c>.
+        /// </summary>
+        /// <param name="propertyName">The property name.</param>
+        /// <returns>This builder, for chaining.</returns>
+        /// <exception cref="ArgumentException">
+        /// The name is <c>null</c> or empty, already declared, or starts with a digit; or the layout is
+        /// already at the maximum a hidden class can describe.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">The layout has already been built.</exception>
+        public Builder Add(string propertyName) => Add(propertyName, factory: null);
+
+        /// <summary>
+        /// Declares a property whose value is produced by <paramref name="factory"/> on the first read that
+        /// observes it, and memoized on the object from then on. The corresponding entry in the
+        /// <c>values</c> span passed to <c>JsObject.Create</c> must be <c>null</c>; the per-object state the
+        /// factory reads is the single <c>lazySlotState</c> argument of that same call.
+        /// <para>
+        /// A lazy property is an ordinary configurable/enumerable/writable data property in every observable
+        /// respect: it appears in <c>Object.keys</c>, answers <c>in</c> and <c>hasOwnProperty</c>, and does
+        /// so <em>without</em> running the factory — only observing the value runs it. Writing the property
+        /// before anything reads it discards the factory entirely, and so does deleting it.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The factory is part of the layout, so it is shared by every object built from it and by every
+        /// engine using it, and must be engine-independent — see <see cref="LazySlotFactory"/>. Reads that
+        /// observe the value (<c>Object.values</c>/<c>entries</c>, <c>Object.assign</c>, spread,
+        /// <c>JSON.stringify</c>, <c>getOwnPropertyDescriptor</c>, and of course an ordinary property read)
+        /// run it; <c>Object.keys</c>, <c>for-in</c>, <c>Reflect.ownKeys</c>, <c>in</c>,
+        /// <c>hasOwnProperty</c> and <c>propertyIsEnumerable</c> do not.
+        /// </para>
+        /// <para>
+        /// Laziness survives everything that drops the object to the ordinary dictionary representation — a
+        /// <c>delete</c>, a <c>defineProperty</c> on another key, <c>Object.freeze</c> — so a script touching
+        /// one member never forces the rest to materialize. Defining, freezing or reading the lazy property
+        /// itself does materialize it, since each of those observes its value.
+        /// </para>
+        /// </remarks>
+        /// <param name="propertyName">The property name.</param>
+        /// <param name="factory">Produces the value on first observation.</param>
+        /// <returns>This builder, for chaining.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="factory"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">
+        /// The name is <c>null</c> or empty, already declared, or starts with a digit; or the layout is
+        /// already at the maximum a hidden class can describe.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">The layout has already been built.</exception>
+        public Builder AddLazy(string propertyName, LazySlotFactory factory)
+        {
+            if (factory is null)
+            {
+                Throw.ArgumentNullException(nameof(factory));
+            }
+
+            return Add(propertyName, factory);
+        }
+
+        /// <summary>
+        /// Produces the immutable layout. The builder cannot be used afterwards.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">The layout has already been built.</exception>
+        public JsObjectLayout Build()
+        {
+            CheckNotBuilt();
+            _built = true;
+
+            var keys = _keys.Count > 0 ? _keys.ToArray() : System.Array.Empty<Key>();
+            LazySlotFactory?[]? factories = null;
+            if (_factories is not null)
+            {
+                factories = new LazySlotFactory?[keys.Length];
+                _factories.CopyTo(factories);
+            }
+
+            return new JsObjectLayout(keys, factories);
+        }
+
+        private Builder Add(string propertyName, LazySlotFactory? factory)
+        {
+            CheckNotBuilt();
+
+            var index = _keys.Count;
+            CheckCount(index + 1, nameof(propertyName));
+            CheckName(propertyName, index, nameof(propertyName));
+
+            Key key = propertyName;
+            for (var i = 0; i < _keys.Count; i++)
+            {
+                if (_keys[i] == key)
+                {
+                    Throw.ArgumentException(
+                        $"Duplicate property name '{propertyName}'; layout property names must be distinct.",
+                        nameof(propertyName));
+                }
+            }
+
+            _keys.Add(key);
+
+            if (factory is not null && _factories is null)
+            {
+                // First lazy property: back-fill nulls for the eager ones already declared.
+                _factories = new List<LazySlotFactory?>(index + 1);
+                for (var i = 0; i < index; i++)
+                {
+                    _factories.Add(null);
+                }
+            }
+
+            _factories?.Add(factory);
+            return this;
+        }
+
+        private void CheckNotBuilt()
+        {
+            if (_built)
+            {
+                Throw.InvalidOperationException("The layout has already been built; a builder must not be reused or modified after Build().");
+            }
+        }
     }
 }

--- a/Jint/Native/JsObjectLayout.cs
+++ b/Jint/Native/JsObjectLayout.cs
@@ -335,9 +335,12 @@ public sealed class JsObjectLayout
         /// </para>
         /// <para>
         /// Laziness survives everything that drops the object to the ordinary dictionary representation — a
-        /// <c>delete</c>, a <c>defineProperty</c> on another key, <c>Object.freeze</c> — so a script touching
-        /// one member never forces the rest to materialize. Defining, freezing or reading the lazy property
-        /// itself does materialize it, since each of those observes its value.
+        /// <c>delete</c>, a <c>defineProperty</c> on another key, <c>Object.freeze</c>, <c>Object.seal</c> —
+        /// so a script touching one member never forces the rest to materialize, and a host that wants
+        /// read-only members can freeze the object right after creating it. What materializes is only what
+        /// observes the value: a redefinition of the lazy property that supplies a value discards the factory
+        /// (it is a write), and one that must validate against the current value — redefining a
+        /// non-writable, non-configurable property — runs it.
         /// </para>
         /// </remarks>
         /// <param name="propertyName">The property name.</param>

--- a/Jint/Native/JsObjectLayout.cs
+++ b/Jint/Native/JsObjectLayout.cs
@@ -57,6 +57,14 @@ public delegate JsValue LazySlotFactory(JsObject instance, object? state);
 /// The property names are validated once, here, so object creation itself has nothing left to check.
 /// </para>
 /// <para>
+/// A record with members that are expensive to produce and rarely read — a body that must be parsed, a
+/// field that must be decoded — declares those through <see cref="CreateBuilder"/> and
+/// <see cref="Builder.AddLazy"/> and hands the raw payload to
+/// <see cref="JsObject.Create(Engine, JsObjectLayout, ReadOnlySpan{JsValue}, object)"/>: such a member
+/// comes into existence on the first read that observes its value, and the object is a hidden-class
+/// object throughout, before and after.
+/// </para>
+/// <para>
 /// A layout builds per-item <em>data records</em>: many short-lived objects sharing one set of plain
 /// value properties. For the other shape of sharing — a singleton prototype whose methods, accessors
 /// and constants materialize lazily per realm — use <see cref="JsObjectShape"/> instead.

--- a/Jint/Native/Json/JsonSerializer.cs
+++ b/Jint/Native/Json/JsonSerializer.cs
@@ -892,7 +892,8 @@ public sealed class JsonSerializer
             JsValue member;
             if (ReferenceEquals(value.ShapeOf, shape))
             {
-                member = value.GetSlot(i);
+                // Serializing a member is a value observation, so a lazy layout slot materializes here.
+                member = value.GetSlotForRead(i);
                 if (member._type > InternalTypes.Integer || !_replacerFunction.IsUndefined())
                 {
                     // the key is observable (toJSON/replacer argument); materialize it only now

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -1899,15 +1899,28 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
         // Step 3
         var currentGet = current.Get;
         var currentSet = current.Set;
-        var currentValue = current.Value;
+
+        // current.[[Value]] is fetched where it is first needed rather than here. Reading it runs a
+        // PropertyFlag.CustomJsValue override, and for the engine's lazy descriptors — a lazy global, a lazy
+        // layout slot — that RESOLVES the value, which is a side effect an attribute-only redefinition must
+        // not have: Object.freeze and Object.seal redefine every own key with attributes and nothing else,
+        // and would otherwise force every lazy property on the object into existence. Each fetch site below
+        // sits behind a test such a redefinition never passes. Still fetched at most once, so a host
+        // CustomValue override projecting live state is observed exactly as often as it was before.
+        JsValue? currentValue = null;
+        var currentValueFetched = false;
 
         // 4. If every field in Desc is absent, return true.
         if ((current._flags & (PropertyFlag.ConfigurableSet | PropertyFlag.EnumerableSet | PropertyFlag.WritableSet)) == PropertyFlag.None &&
             currentGet is null &&
-            currentSet is null &&
-            currentValue is null)
+            currentSet is null)
         {
-            return true;
+            currentValue = current.Value;
+            currentValueFetched = true;
+            if (currentValue is null)
+            {
+                return true;
+            }
         }
 
         // Step 6
@@ -1918,11 +1931,19 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
             current.Writable == desc.Writable && current.WritableSet == desc.WritableSet &&
             current.Enumerable == desc.Enumerable && current.EnumerableSet == desc.EnumerableSet &&
             ((currentGet is null && descGet is null) || (currentGet is not null && descGet is not null && SameValue(currentGet, descGet))) &&
-            ((currentSet is null && descSet is null) || (currentSet is not null && descSet is not null && SameValue(currentSet, descSet))) &&
-            ((currentValue is null && descValue is null) || (currentValue is not null && descValue is not null && currentValue == descValue))
+            ((currentSet is null && descSet is null) || (currentSet is not null && descSet is not null && SameValue(currentSet, descSet)))
         )
         {
-            return true;
+            if (!currentValueFetched)
+            {
+                currentValue = current.Value;
+                currentValueFetched = true;
+            }
+
+            if ((currentValue is null && descValue is null) || (currentValue is not null && descValue is not null && currentValue == descValue))
+            {
+                return true;
+            }
         }
 
         if (!current.Configurable)
@@ -1976,9 +1997,15 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
                         return false;
                     }
 
-                    if (!current.Writable)
+                    if (!current.Writable && descValue is not null)
                     {
-                        if (descValue is not null && !SameValue(descValue, currentValue!))
+                        if (!currentValueFetched)
+                        {
+                            currentValue = current.Value;
+                            currentValueFetched = true;
+                        }
+
+                        if (!SameValue(descValue, currentValue!))
                         {
                             return false;
                         }

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -212,6 +212,11 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
     /// freshly-built <see cref="PropertyDictionary"/> as an ordinary CEW data descriptor (in slot =
     /// insertion order). After this the object is byte-for-byte the pre-shapes representation, so every
     /// consumer runs the unchanged dictionary code. No-op when not a shape-mode <see cref="JsObject"/>.
+    /// <para>
+    /// A slot still holding a lazy layout sentinel becomes a <see cref="LazySlotPropertyDescriptor"/> rather
+    /// than being materialized, so deleting one key — or freezing the object — does not force every lazy
+    /// member's factory to run.
+    /// </para>
     /// </summary>
     internal void ConvertToDictionaryMode()
     {
@@ -229,9 +234,22 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
         {
             var keys = new Key[slotCount];
             shape.CollectKeys(keys);
-            for (var i = 0; i < slotCount; i++)
+            if ((_type & InternalTypes.HasLazySlots) == InternalTypes.Empty)
             {
-                properties[keys[i]] = new PropertyDescriptor(jo.GetSlot(i), PropertyFlag.ConfigurableEnumerableWritable);
+                for (var i = 0; i < slotCount; i++)
+                {
+                    properties[keys[i]] = new PropertyDescriptor(jo.GetSlot(i), PropertyFlag.ConfigurableEnumerableWritable);
+                }
+            }
+            else
+            {
+                for (var i = 0; i < slotCount; i++)
+                {
+                    var value = jo.GetSlot(i);
+                    properties[keys[i]] = value is JsObject.UnmaterializedSlots sentinel
+                        ? new LazySlotPropertyDescriptor(jo, sentinel, i)
+                        : new PropertyDescriptor(value, PropertyFlag.ConfigurableEnumerableWritable);
+                }
             }
         }
         // The object is now a live mutable dictionary; re-setting an existing key (e.g. defineProperty
@@ -881,7 +899,10 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
                 var jo = Unsafe.As<JsObject>(this);
                 if (jo.ShapeOf.TryGetSlot(property.ToString(), out var slot))
                 {
-                    return jo.GetSlot(slot);
+                    // Checked read rather than the raw slot: this is the semi-hot generic lane (computed
+                    // keys, Reflect.get, with, proxy-forwarded reads) and it serves every shaped object, so
+                    // it carries the lazy-slot check unconditionally instead of being duplicated per flag.
+                    return jo.GetSlotForRead(slot);
                 }
 
                 return Prototype?.Get(property, receiver) ?? Undefined;

--- a/Jint/Runtime/Descriptors/Specialized/LazySlotPropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/LazySlotPropertyDescriptor.cs
@@ -1,0 +1,51 @@
+using System.Runtime.CompilerServices;
+using Jint.Native;
+
+namespace Jint.Runtime.Descriptors.Specialized;
+
+/// <summary>
+/// Data descriptor that carries a still-unmaterialized lazy layout slot through a shaped object's deopt to
+/// dictionary mode, so laziness survives the deopt: deleting one key, redefining an unrelated one or freezing
+/// the object must not force every lazy member's factory to run. The factory runs on the first read of
+/// <em>this</em> property, exactly as it would have through the slot.
+/// <para>
+/// Follows the <see cref="LazyBuiltinSlotDescriptor"/> memo pattern exactly — resolve into the inherited
+/// <c>_value</c>, then clear <see cref="PropertyFlag.CustomJsValue"/> — which is what
+/// <see cref="IFieldBackedLazyDescriptor"/> claims and what lets a global snapshot capture and restore this
+/// descriptor (including back to unmaterialized) by writing those two fields.
+/// </para>
+/// </summary>
+internal sealed class LazySlotPropertyDescriptor : PropertyDescriptor, IFieldBackedLazyDescriptor
+{
+    private readonly JsObject _owner;
+    private readonly JsObject.UnmaterializedSlots _sentinel;
+    private readonly int _slot;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal LazySlotPropertyDescriptor(JsObject owner, JsObject.UnmaterializedSlots sentinel, int slot)
+        : base(null, PropertyFlag.ConfigurableEnumerableWritable | PropertyFlag.CustomJsValue)
+    {
+        _flags &= ~PropertyFlag.NonData;
+        _owner = owner;
+        _sentinel = sentinel;
+        _slot = slot;
+    }
+
+    protected internal override JsValue? CustomValue
+    {
+        get
+        {
+            var value = _value;
+            if (value is null)
+            {
+                _value = value = _sentinel.Layout.GetFactory(_slot)!(_owner, _sentinel.State) ?? JsValue.Undefined;
+                // Once materialized this is semantically a plain data descriptor; clearing the
+                // flag lets value reads/writes skip the CustomValue indirection and admits the
+                // descriptor to the global-binding and member-write inline caches.
+                _flags &= ~PropertyFlag.CustomJsValue;
+            }
+            return value;
+        }
+        set => _value = value;
+    }
+}

--- a/Jint/Runtime/Descriptors/Specialized/LazySlotPropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/LazySlotPropertyDescriptor.cs
@@ -1,4 +1,4 @@
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using Jint.Native;
 
 namespace Jint.Runtime.Descriptors.Specialized;
@@ -21,9 +21,22 @@ internal sealed class LazySlotPropertyDescriptor : PropertyDescriptor, IFieldBac
     private readonly JsObject.UnmaterializedSlots _sentinel;
     private readonly int _slot;
 
+    // Configurable + enumerable + writable, with the three "attribute present" bits spelled out. Semantically
+    // identical to PropertyFlag.ConfigurableEnumerableWritable — every ConfigurableSet/EnumerableSet/
+    // WritableSet getter already reports true when the corresponding attribute bit is on — but it matters to
+    // one raw-bit test: ValidateAndApplyPropertyDescriptor's "every field absent" fast-out inspects those
+    // three bits directly and, when they are all clear, goes on to read the descriptor's VALUE, which for a
+    // lazy descriptor is the one thing that must not happen. Object.freeze and Object.seal redefine every own
+    // key attribute-only, so without this a freeze would run every lazy factory on the object.
+    private const PropertyFlag LazySlotFlags = PropertyFlag.ConfigurableEnumerableWritable
+                                               | PropertyFlag.ConfigurableSet
+                                               | PropertyFlag.EnumerableSet
+                                               | PropertyFlag.WritableSet
+                                               | PropertyFlag.CustomJsValue;
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal LazySlotPropertyDescriptor(JsObject owner, JsObject.UnmaterializedSlots sentinel, int slot)
-        : base(null, PropertyFlag.ConfigurableEnumerableWritable | PropertyFlag.CustomJsValue)
+        : base(null, LazySlotFlags)
     {
         _flags &= ~PropertyFlag.NonData;
         _owner = owner;

--- a/Jint/Runtime/Descriptors/Specialized/SlotPropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/SlotPropertyDescriptor.cs
@@ -29,8 +29,12 @@ internal sealed class SlotPropertyDescriptor : PropertyDescriptor
 
     protected internal override JsValue? CustomValue
     {
+        // The descriptor VIEW of a slot, so it is a value observation: a lazy layout slot materializes here.
+        // This is the single point through which every descriptor-shaped consumer — GetOwnProperty,
+        // TryGetProperty, GetOwnProperties, getOwnPropertyDescriptor, enumeration of values, spread,
+        // Object.assign — observes a slot's value.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => _owner.GetSlot(_slot);
+        get => _owner.GetSlotForRead(_slot);
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         set => _owner.SetSlot(_slot, value!);
     }

--- a/Jint/Runtime/InternalTypes.cs
+++ b/Jint/Runtime/InternalTypes.cs
@@ -85,7 +85,17 @@ internal enum InternalTypes
     // same answer — one probe and one discarded descriptor later. Orthogonal to the Ordinary/Exotic pair,
     // because what the hook answers (own property or not) does not depend on what Get does with the answer.
     OwnValueHook = 8388608,
+    // a shape-mode JsObject at least one of whose slots may still hold the UnmaterializedSlots sentinel —
+    // a lazy layout slot whose factory has not run yet (JsObjectLayout.Builder.AddLazy). Conservative in
+    // one direction only: set means "check the slot before handing its value out", clear means "no slot
+    // can hold a sentinel". Cleared when a materialization finds no sentinel left, and on deopt to
+    // dictionary mode; a raw write over a sentinel (which discards the factory, by design) does not
+    // bother clearing it, since the lazy read lane is correct for a fully-materialized object too.
+    // Implies ShapeMode. Exists so the hot shape read lanes can keep their single AND+CMP gate — they
+    // test the pair against ShapeMode, so an object with no lazy slots runs byte-identical code — and a
+    // sibling arm serves lazy objects through the checked JsObject.GetSlotForRead.
+    HasLazySlots = 16777216,
 
     Primitive = Boolean | String | Number | Integer | BigInt | Symbol,
-    InternalFlags = ObjectEnvironmentRecord | RequiresCloning | PlainObject | Array | Module | IsHTMLDDA | ShapeMode | ShapeBuilding | ExoticGet | BuiltinShapeMode | Callable | Function | OrdinaryGet | OwnValueHook
+    InternalFlags = ObjectEnvironmentRecord | RequiresCloning | PlainObject | Array | Module | IsHTMLDDA | ShapeMode | ShapeBuilding | ExoticGet | BuiltinShapeMode | Callable | Function | OrdinaryGet | OwnValueHook | HasLazySlots
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -410,7 +410,12 @@ internal sealed class JintMemberExpression : JintExpression
             if (baseValue.IsObject())
             {
                 var baseObject = baseValue.AsObjectNoTypeCheck();
-                if ((baseObject._type & InternalTypes.ShapeMode) != InternalTypes.Empty)
+                // One AND against the pair, then two compares against it. Testing the pair rather than
+                // ShapeMode alone is what keeps the plain arm below identical to what it was before lazy
+                // layout slots existed: an object with no lazy slots takes the same single AND+CMP it always
+                // did, and only an object that can actually hold an unmaterialized slot pays the checked read.
+                var shapeFlags = baseObject._type & (InternalTypes.ShapeMode | InternalTypes.HasLazySlots);
+                if (shapeFlags == InternalTypes.ShapeMode)
                 {
                     // Shape-keyed read: a matching shape proves the slot index; read it straight out of
                     // the slot array (no descriptor, no dictionary). Misses re-resolve the slot for the
@@ -430,6 +435,33 @@ internal sealed class JintMemberExpression : JintExpression
                     }
 
                     // Slot miss ⇒ no own string property (any non-shapeable property would have deopted).
+                    return ReadAfterOwnMiss(baseObject, determinedProperty, ownMissConfirmed: true);
+                }
+
+                if (shapeFlags == (InternalTypes.ShapeMode | InternalTypes.HasLazySlots))
+                {
+                    // Same cache, same slot indices, one checked read: a slot still holding an
+                    // unmaterialized lazy layout slot runs its factory here and memoizes into the slot.
+                    // _cachedShape/_cachedShapeSlot are deliberately SHARED with the plain arm: a shape maps
+                    // names to slots identically whatever the object's slots currently hold — a lazy layout's
+                    // shape is the very shape an object literal of the same keys interns — and an object
+                    // carrying the flag can never enter the plain arm, so a hit resolved by either arm is
+                    // valid for the other. Once every lazy slot is materialized the flag clears and the
+                    // object is served by the plain arm, indistinguishable from a literal.
+                    var lazyObj = Unsafe.As<JsObject>(baseObject);
+                    var lazyShape = lazyObj.ShapeOf;
+                    if (ReferenceEquals(lazyShape, _cachedShape))
+                    {
+                        return lazyObj.GetSlotForRead(_cachedShapeSlot);
+                    }
+
+                    if (lazyShape.TryGetSlot(determinedProperty.ToString(), out var lazySlot))
+                    {
+                        _cachedShape = lazyShape;
+                        _cachedShapeSlot = lazySlot;
+                        return lazyObj.GetSlotForRead(lazySlot);
+                    }
+
                     return ReadAfterOwnMiss(baseObject, determinedProperty, ownMissConfirmed: true);
                 }
 
@@ -651,7 +683,10 @@ internal sealed class JintMemberExpression : JintExpression
             var baseObject = baseValue.AsObjectNoTypeCheck();
             thisObject = baseObject;
 
-            if ((baseObject._type & InternalTypes.ShapeMode) != InternalTypes.Empty)
+            // See the read lane: testing the pair keeps the plain arm byte-equivalent, and the sibling arm
+            // below serves the objects that can hold an unmaterialized lazy layout slot.
+            var shapeFlags = baseObject._type & (InternalTypes.ShapeMode | InternalTypes.HasLazySlots);
+            if (shapeFlags == InternalTypes.ShapeMode)
             {
                 var shapeObj = Unsafe.As<JsObject>(baseObject);
                 var shape = shapeObj.ShapeOf;
@@ -668,6 +703,28 @@ internal sealed class JintMemberExpression : JintExpression
                 }
 
                 // Slot miss ⇒ no own string property (any non-shapeable property would have deopted).
+                return ReadAfterOwnMiss(baseObject, determinedProperty, ownMissConfirmed: true);
+            }
+
+            if (shapeFlags == (InternalTypes.ShapeMode | InternalTypes.HasLazySlots))
+            {
+                // A member call whose callee is a lazy member (`e.body.toString()` resolves the base through
+                // the read lane; `e.decode()` resolves the callee here) materializes it like any other value
+                // observation. Cache fields shared with the plain arm — see the read lane's note.
+                var lazyObj = Unsafe.As<JsObject>(baseObject);
+                var lazyShape = lazyObj.ShapeOf;
+                if (ReferenceEquals(lazyShape, _cachedShape))
+                {
+                    return lazyObj.GetSlotForRead(_cachedShapeSlot);
+                }
+
+                if (lazyShape.TryGetSlot(determinedProperty.ToString(), out var lazySlot))
+                {
+                    _cachedShape = lazyShape;
+                    _cachedShapeSlot = lazySlot;
+                    return lazyObj.GetSlotForRead(lazySlot);
+                }
+
                 return ReadAfterOwnMiss(baseObject, determinedProperty, ownMissConfirmed: true);
             }
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,11 @@ receiver gets no own-property inline caching — every own read reaches your `Ge
 - For fixed-shape records, do not subclass at all: `JsObject.Create(engine, layout, values)` and
   `JsObject.CreateFromEntries` build straight into the hidden-class representation, so every object sharing a
   `JsObjectLayout` shares one hidden class and a script reading a batch of them keeps a monomorphic inline
-  cache.
+  cache. A record with expensive members most items never have read — a body that must be parsed, a field that
+  must be decoded — declares them with `JsObjectLayout.CreateBuilder().AddLazy(name, factory)` and passes the
+  raw payload as the `lazySlotState` argument of `JsObject.Create`: the factory runs on the first read that
+  observes that member's value and the result is memoized on the object, while enumerating keys, `in` and
+  `hasOwnProperty` never run it. The object stays a hidden-class object throughout.
 - For CLR objects, `engine.SetValue(name, obj)` wraps them in `ObjectWrapper`, whose member resolution and
   compiled accessors are cached process-wide on the `TypeResolver`.
 - For the *prototypes* those objects sit behind, declare the members once per process with `JsObjectShape` and


### PR DESCRIPTION
The second-most-requested capability from the 4.15.0 adoption round, wanted independently by two hosts: a fresh per-item object built from a `JsObjectLayout` shares one hidden class across items — but a member whose value is expensive (an event envelope where four of fifteen members each parse a JSON document; a database host's lazily-projected fields) could only be installed as a raw descriptor, which deopts to dictionary representation and forfeits the shared shape. "Fresh shaped object per item *with* lazy members" was unexpressible.

`JsObjectLayout.CreateBuilder()` gains `AddLazy(name, factory)` with a `LazySlotFactory(JsObject instance, object? state)` delegate, and `JsObject.Create` an overload carrying one per-instance state object. Factories are layout-shared and engine-independent (documented like `JsObjectShape`'s); the state is per-instance and may be engine-affine. Storage is a sentinel in the slot gated by a per-object type bit: the shape hot lanes' gate widens from `& ShapeMode != 0` to `& (ShapeMode|HasLazySlots) == ShapeMode`, byte-equivalent for every existing object, with a checked sibling arm for lazy carriers. The slot itself is the memo; a write before first read discards the factory (write paths unchanged); `defineProperty`/`delete` deopt through a descriptor that keeps the laziness (and satisfies the snapshot-repair marker contract by construction).

Two things reviewers should look at deliberately:

* **A spec-path change in `ValidateAndApplyPropertyDescriptor`**: it read the current value unconditionally at step 3, so `Object.freeze` materialized every lazy member — including, today, every lazy global on `Object.freeze(globalThis)`. The value is now fetched where first needed, still at most once (a host `CustomValue` projecting live state is observed exactly as often as before), behind short-circuits an attribute-only redefinition never passes. The full Test262 suite is the evidence: 99,441 passed, 0 failed, twice (before and after rebase, byte-identical).
* **One deliberate departure from the design doc**: `defineProperty(o, k, {value})` on an unmaterialized member discards the factory rather than running it — supplying a value is a write, consistent with `o.k = v`. Redefining a non-writable lazy member still materializes (it must validate against the real value). Both pinned.

Measured (idle machine, default job; the batch benchmark models the envelope: 500 items × 15 members, 4 expensive, script reads one): **LayoutLazy 302.6 µs / 731 KB vs LayoutEager 1,089.2 µs / 2,882 KB vs the dictionary-mode `CustomJsValue` workaround 495.4 µs / 1,485 KB.** Neutrality gate on untouched paths: Dromaeo two-pair cross-verdict zero confirmed regressions (two confirmed wins), JSON worst row +0.4%.

66 new tests (52 public-surface including the motivating envelope acceptance test with hidden-class witness and factory-count assertions; internals bit-lifecycle, GC non-retention of engines/objects/state from a process-held layout). Full suite green in Release and Debug on both TFMs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)