### PR TITLE
Annotate the layout values span so a lazy entry's null needs no suppression

### DIFF
--- a/Jint.Benchmark/HostLayoutLazySlotBenchmark.cs
+++ b/Jint.Benchmark/HostLayoutLazySlotBenchmark.cs
@@ -236,7 +236,7 @@ public class HostLayoutLazySlotBenchmark
 
     private static JsObject CreateEager(Engine engine, RawEnvelope raw)
     {
-        var values = new JsValue[EagerNames.Length + LazyNames.Length];
+        var values = new JsValue?[EagerNames.Length + LazyNames.Length];
         FillEager(values, raw);
 
         // Decoding needs the object the members belong to, and Create has not produced it yet, so the eager
@@ -253,7 +253,7 @@ public class HostLayoutLazySlotBenchmark
 
     private static JsObject CreateLazy(Engine engine, RawEnvelope raw)
     {
-        var values = new JsValue[EagerNames.Length + LazyNames.Length];
+        var values = new JsValue?[EagerNames.Length + LazyNames.Length];
         FillEager(values, raw);
         return JsObject.Create(engine, LazyLayout, values, raw);
     }
@@ -261,11 +261,11 @@ public class HostLayoutLazySlotBenchmark
     private static JsObject CreateDictionary(Engine engine, RawEnvelope raw)
     {
         var obj = new JsObject(engine);
-        var values = new JsValue[EagerNames.Length + LazyNames.Length];
+        var values = new JsValue?[EagerNames.Length + LazyNames.Length];
         FillEager(values, raw);
         for (var i = 0; i < EagerNames.Length; i++)
         {
-            obj.FastSetDataProperty(EagerNames[i], values[i]);
+            obj.FastSetDataProperty(EagerNames[i], values[i]!);
         }
 
         for (var i = 0; i < LazyNames.Length; i++)
@@ -276,7 +276,7 @@ public class HostLayoutLazySlotBenchmark
         return obj;
     }
 
-    private static void FillEager(JsValue[] values, RawEnvelope raw)
+    private static void FillEager(JsValue?[] values, RawEnvelope raw)
     {
         var index = raw.Index;
         values[0] = JsString.Create("id-" + index);
@@ -293,7 +293,7 @@ public class HostLayoutLazySlotBenchmark
         // The lazy members are supplied by the layout; the eager lane overwrites these after creation.
         for (var i = EagerNames.Length; i < values.Length; i++)
         {
-            values[i] = null!;
+            values[i] = null;
         }
     }
 }

--- a/Jint.Tests/Runtime/LazyLayoutSlotInternalsTests.cs
+++ b/Jint.Tests/Runtime/LazyLayoutSlotInternalsTests.cs
@@ -33,7 +33,7 @@ public class LazyLayoutSlotInternalsTests
         .Build();
 
     private static JsObject Create(Engine engine, Counter counter) =>
-        JsObject.Create(engine, MixedLayout, [JsNumber.Create(0), null!, null!], counter);
+        JsObject.Create(engine, MixedLayout, [JsNumber.Create(0), null, null], counter);
 
     private static bool HasLazyFlag(JsObject obj) =>
         (obj._type & InternalTypes.HasLazySlots) != InternalTypes.Empty;

--- a/Jint/Native/JsObject.Create.cs
+++ b/Jint/Native/JsObject.Create.cs
@@ -35,17 +35,17 @@ public sealed partial class JsObject
     /// <see cref="JsValue.Undefined"/> — except at a property the layout declared through
     /// <see cref="JsObjectLayout.Builder.AddLazy"/>, where <c>null</c> is required and the layout supplies
     /// the value. Use the
-    /// <see cref="Create(Engine, JsObjectLayout, ReadOnlySpan{JsValue}, object)"/> overload to give those
+    /// <see cref="Create(Engine, JsObjectLayout, ReadOnlySpan{JsValue?}, object)"/> overload to give those
     /// factories per-object state; this one passes <c>null</c>.
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="engine"/> or <paramref name="layout"/> is <c>null</c>.</exception>
     /// <exception cref="ArgumentException"><paramref name="values"/> does not have exactly <see cref="JsObjectLayout.Count"/> entries.</exception>
-    public static JsObject Create(Engine engine, JsObjectLayout layout, ReadOnlySpan<JsValue> values)
+    public static JsObject Create(Engine engine, JsObjectLayout layout, ReadOnlySpan<JsValue?> values)
         => Create(engine, layout, values, lazySlotState: null);
 
     /// <summary>
     /// Creates an object with <paramref name="layout"/>'s properties exactly as
-    /// <see cref="Create(Engine, JsObjectLayout, ReadOnlySpan{JsValue})"/> does, additionally handing
+    /// <see cref="Create(Engine, JsObjectLayout, ReadOnlySpan{JsValue?})"/> does, additionally handing
     /// <paramref name="lazySlotState"/> to the factories of any properties the layout declared through
     /// <see cref="JsObjectLayout.Builder.AddLazy"/>.
     /// <para>
@@ -72,7 +72,7 @@ public sealed partial class JsObject
     /// <paramref name="values"/> does not have exactly <see cref="JsObjectLayout.Count"/> entries, or a
     /// non-<c>null</c> value was given for a lazy property.
     /// </exception>
-    public static JsObject Create(Engine engine, JsObjectLayout layout, ReadOnlySpan<JsValue> values, object? lazySlotState)
+    public static JsObject Create(Engine engine, JsObjectLayout layout, ReadOnlySpan<JsValue?> values, object? lazySlotState)
     {
         if (engine is null)
         {


### PR DESCRIPTION
Same-day adoption feedback on #2850: `JsObject.Create`'s contract requires `null` at every lazy index — the layout supplies those values — but the parameter said `ReadOnlySpan<JsValue>`, so a nullable-enabled host writes `null!` once per lazy member (the first adopter's envelope has four). Both overloads become `ReadOnlySpan<JsValue?>`.

Annotation-only: the element type is erased at runtime so nothing is binary-breaking, the implementation already null-handles every entry (`?? Undefined`, the lazy-index validation), and eager callers passing `JsValue[]` convert exactly as before. Jint's own call sites drop their suppressions; full suite green on both TFMs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)