### PR TITLE
Preserve loop iteration state across suspensions in async generators and for-await-of

### DIFF
--- a/Jint.Tests/Runtime/AsyncGeneratorForOfTests.cs
+++ b/Jint.Tests/Runtime/AsyncGeneratorForOfTests.cs
@@ -279,6 +279,103 @@ public class AsyncGeneratorForOfTests
     }
 
     [Fact]
+    public void ForAwaitOfWithAwaitInBodyInAsyncGeneratorReEntersCurrentIteration()
+    {
+        // A plain await inside the for-await-of body suspends mid-iteration; the resume
+        // must re-enter the CURRENT iteration rather than awaiting the iterator's next
+        // result — otherwise every in-flight item is dropped and the loop silently
+        // completes empty once the stream ends.
+        var result = EvaluateWithGuard("""
+            (async function () {
+                async function* source() { yield 'a'; yield 'b'; yield 'c'; yield 'd'; }
+                async function* gen(iterable) {
+                    for await (const x of iterable) {
+                        await Promise.resolve();
+                        yield x;
+                    }
+                }
+                const seen = [];
+                let guard = 0;
+                for await (const x of gen(source())) {
+                    seen.push(x);
+                    if (++guard > 12) { seen.push('RUNAWAY'); break; }
+                }
+                return seen.join(',') || '(EMPTY)';
+            })()
+            """);
+        result.Should().Be("a,b,c,d");
+    }
+
+    [Fact]
+    public void ForAwaitOfWithAwaitInBodyInAsyncFunctionReEntersCurrentIteration()
+    {
+        // The same in-body-await drop in a plain async function (no generator involved).
+        var result = EvaluateWithGuard("""
+            (async function () {
+                async function* source() { yield 'a'; yield 'b'; yield 'c'; yield 'd'; }
+                const seen = [];
+                let guard = 0;
+                for await (const x of source()) {
+                    await Promise.resolve();
+                    seen.push(x);
+                    if (++guard > 12) { seen.push('RUNAWAY'); break; }
+                }
+                return seen.join(',') || '(EMPTY)';
+            })()
+            """);
+        result.Should().Be("a,b,c,d");
+    }
+
+    [Fact]
+    public void ForAwaitOfWithMultipleAwaitsPerIterationReEntersCurrentIteration()
+    {
+        var result = EvaluateWithGuard("""
+            (async function () {
+                async function* source() { yield 'a'; yield 'b'; }
+                async function* gen(iterable) {
+                    for await (const x of iterable) {
+                        const one = await Promise.resolve(1);
+                        const two = await Promise.resolve(2);
+                        yield x + one + two;
+                    }
+                }
+                const seen = [];
+                let guard = 0;
+                for await (const x of gen(source())) {
+                    seen.push(x);
+                    if (++guard > 12) { seen.push('RUNAWAY'); break; }
+                }
+                return seen.join(',') || '(EMPTY)';
+            })()
+            """);
+        result.Should().Be("a12,b12");
+    }
+
+    [Fact]
+    public void ForAwaitOfWithAwaitInBodyAccumulatesAcrossIterations()
+    {
+        // Values computed before the await must survive the mid-iteration suspension,
+        // and the loop must visit every item exactly once.
+        var result = EvaluateWithGuard("""
+            (async function () {
+                async function* source() { yield 1; yield 2; yield 3; }
+                const seen = [];
+                let total = 0;
+                let guard = 0;
+                for await (const n of source()) {
+                    const doubled = n * 2;
+                    await Promise.resolve();
+                    total += doubled;
+                    seen.push(n);
+                    if (++guard > 12) { seen.push('RUNAWAY'); break; }
+                }
+                return seen.join(',') + '|' + total;
+            })()
+            """);
+        result.Should().Be("1,2,3|12");
+    }
+
+    [Fact]
     public void SyncGeneratorForOfWithYieldStaysCorrect()
     {
         // The sync-generator route (ExecutionContext.Generator) already saved suspend

--- a/Jint.Tests/Runtime/AsyncGeneratorForOfTests.cs
+++ b/Jint.Tests/Runtime/AsyncGeneratorForOfTests.cs
@@ -1,0 +1,344 @@
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Regression coverage for a defect where a synchronous <c>for...of</c> loop inside an
+/// async generator lost its iterator position across a <c>yield</c>/<c>await</c> suspension:
+/// suspend state was saved for sync generators (ExecutionContext.Generator) and async
+/// functions (ExecutionContext.AsyncFunction) but never for async generators
+/// (ExecutionContext.AsyncGenerator), so every resume re-entered the statement with no
+/// saved state, re-evaluated the head into a fresh iterator, replayed the first step into
+/// the consumed resume value, and re-yielded the second element forever (a,b,b,b,...).
+/// </summary>
+public class AsyncGeneratorForOfTests
+{
+    // Every generator drain is bounded by a guard so a regression fails loudly with the
+    // RUNAWAY marker in the produced sequence instead of hanging the test run forever.
+    private static string EvaluateWithGuard(string script)
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate(script);
+        return result.UnwrapIfPromise().AsString();
+    }
+
+    private static string DrainAsyncGenerator(string generatorBody, string arrayLiteral = "['a', 'b', 'c', 'd']")
+    {
+        return EvaluateWithGuard($$"""
+            (async function () {
+                async function* gen(arr) { {{generatorBody}} }
+                const arr = {{arrayLiteral}};
+                const seen = [];
+                let guard = 0;
+                for await (const x of gen(arr)) {
+                    seen.push(x);
+                    if (++guard > 12) { seen.push('RUNAWAY'); break; }
+                }
+                return seen.join(',');
+            })()
+            """);
+    }
+
+    [Fact]
+    public void ForOfWithYieldPreservesIteratorPositionAcrossSuspension()
+    {
+        // The core defect: for...of over an array, yielding each element.
+        var result = DrainAsyncGenerator("for (const x of arr) { yield x; }");
+        result.Should().Be("a,b,c,d");
+    }
+
+    [Fact]
+    public void IndexBasedForWithYieldStaysCorrect()
+    {
+        // Control: index-based iteration never depended on iterator suspend state.
+        var result = DrainAsyncGenerator("for (let i = 0; i < arr.length; i++) { yield arr[i]; }");
+        result.Should().Be("a,b,c,d");
+    }
+
+    [Fact]
+    public void ForOfWithoutYieldInBodyStaysCorrect()
+    {
+        // Control: no suspension inside the loop; yields happen after it completes.
+        var result = DrainAsyncGenerator("""
+            const collected = [];
+            for (const x of arr) { collected.push(x); }
+            for (let i = 0; i < collected.length; i++) { yield collected[i]; }
+            """);
+        result.Should().Be("a,b,c,d");
+    }
+
+    [Fact]
+    public void ForOfWithAwaitInBodyPreservesIteratorPosition()
+    {
+        // Await (not just yield) suspends the async generator inside the loop body too.
+        var result = DrainAsyncGenerator("for (const x of arr) { await Promise.resolve(); yield x; }");
+        result.Should().Be("a,b,c,d");
+    }
+
+    [Fact]
+    public void ForOfWithYieldOverMapPreservesIteratorPosition()
+    {
+        var result = EvaluateWithGuard("""
+            (async function () {
+                async function* gen(map) { for (const [k, v] of map) { yield k + '=' + v; } }
+                const map = new Map([['a', 1], ['b', 2], ['c', 3]]);
+                const seen = [];
+                let guard = 0;
+                for await (const x of gen(map)) {
+                    seen.push(x);
+                    if (++guard > 12) { seen.push('RUNAWAY'); break; }
+                }
+                return seen.join(',');
+            })()
+            """);
+        result.Should().Be("a=1,b=2,c=3");
+    }
+
+    [Fact]
+    public void ForOfWithYieldOverSetPreservesIteratorPosition()
+    {
+        var result = EvaluateWithGuard("""
+            (async function () {
+                async function* gen(set) { for (const x of set) { yield x; } }
+                const set = new Set(['a', 'b', 'c', 'd']);
+                const seen = [];
+                let guard = 0;
+                for await (const x of gen(set)) {
+                    seen.push(x);
+                    if (++guard > 12) { seen.push('RUNAWAY'); break; }
+                }
+                return seen.join(',');
+            })()
+            """);
+        result.Should().Be("a,b,c,d");
+    }
+
+    [Fact]
+    public void ForOfWithYieldOverStringPreservesIteratorPosition()
+    {
+        var result = EvaluateWithGuard("""
+            (async function () {
+                async function* gen(s) { for (const ch of s) { yield ch; } }
+                const seen = [];
+                let guard = 0;
+                for await (const x of gen('abcd')) {
+                    seen.push(x);
+                    if (++guard > 12) { seen.push('RUNAWAY'); break; }
+                }
+                return seen.join(',');
+            })()
+            """);
+        result.Should().Be("a,b,c,d");
+    }
+
+    [Fact]
+    public void ForOfWithYieldOverSyncGeneratorIterablePreservesIteratorPosition()
+    {
+        // A one-shot iterator makes any hidden head re-evaluation fatal rather than silent:
+        // a fresh iterator could not even replay earlier elements.
+        var result = EvaluateWithGuard("""
+            (async function () {
+                function* source() { yield 'a'; yield 'b'; yield 'c'; yield 'd'; }
+                async function* gen(iterable) { for (const x of iterable) { yield x; } }
+                const seen = [];
+                let guard = 0;
+                for await (const x of gen(source())) {
+                    seen.push(x);
+                    if (++guard > 12) { seen.push('RUNAWAY'); break; }
+                }
+                return seen.join(',');
+            })()
+            """);
+        result.Should().Be("a,b,c,d");
+    }
+
+    [Fact]
+    public void ForOfWithYieldSupportsBreakAcrossSuspension()
+    {
+        var result = DrainAsyncGenerator("""
+            for (const x of arr) {
+                if (x === 'c') { break; }
+                yield x;
+            }
+            yield 'end';
+            """);
+        result.Should().Be("a,b,end");
+    }
+
+    [Fact]
+    public void ForOfWithYieldSupportsContinueAcrossSuspension()
+    {
+        var result = DrainAsyncGenerator("""
+            for (const x of arr) {
+                if (x === 'b') { continue; }
+                yield x;
+            }
+            """);
+        result.Should().Be("a,c,d");
+    }
+
+    [Fact]
+    public void ForOfWithYieldSupportsEarlyReturnAcrossSuspension()
+    {
+        var result = DrainAsyncGenerator("""
+            for (const x of arr) {
+                yield x;
+                if (x === 'b') { return; }
+            }
+            yield 'unreachable';
+            """);
+        result.Should().Be("a,b");
+    }
+
+    [Fact]
+    public void NestedForOfWithYieldPreservesBothIteratorPositions()
+    {
+        var result = EvaluateWithGuard("""
+            (async function () {
+                async function* gen(outer, inner) {
+                    for (const o of outer) {
+                        for (const i of inner) {
+                            yield o + i;
+                        }
+                    }
+                }
+                const seen = [];
+                let guard = 0;
+                for await (const x of gen(['a', 'b'], ['1', '2'])) {
+                    seen.push(x);
+                    if (++guard > 12) { seen.push('RUNAWAY'); break; }
+                }
+                return seen.join(',');
+            })()
+            """);
+        result.Should().Be("a1,a2,b1,b2");
+    }
+
+    [Fact]
+    public void SequentialForOfLoopsWithYieldEachPreserveTheirIterator()
+    {
+        var result = DrainAsyncGenerator("""
+            for (const x of arr) { yield '1' + x; }
+            for (const x of arr) { yield '2' + x; }
+            """, "['a', 'b']");
+        result.Should().Be("1a,1b,2a,2b");
+    }
+
+    [Fact]
+    public void ForOfWithYieldOverEmptyIterableCompletesImmediately()
+    {
+        var result = DrainAsyncGenerator("""
+            for (const x of arr) { yield x; }
+            yield 'end';
+            """, "[]");
+        result.Should().Be("end");
+    }
+
+    [Fact]
+    public void ForOfWithYieldOverSingleElementIterableYieldsOnce()
+    {
+        var result = DrainAsyncGenerator("""
+            for (const x of arr) { yield x; }
+            yield 'end';
+            """, "['a']");
+        result.Should().Be("a,end");
+    }
+
+    [Fact]
+    public void ForOfWithMultipleYieldsPerIterationPreservesIteratorPosition()
+    {
+        var result = DrainAsyncGenerator("""
+            for (const x of arr) {
+                yield x + '1';
+                yield x + '2';
+            }
+            """, "['a', 'b']");
+        result.Should().Be("a1,a2,b1,b2");
+    }
+
+    [Fact]
+    public void ForAwaitOfWithYieldOverAsyncIterablePreservesIteratorPosition()
+    {
+        // for-await-of over an async iterable takes the ForAwaitSuspendData path;
+        // pinned here so both suspend-state routes stay covered.
+        var result = EvaluateWithGuard("""
+            (async function () {
+                async function* source() { yield 'a'; yield 'b'; yield 'c'; yield 'd'; }
+                async function* gen(iterable) { for await (const x of iterable) { yield x; } }
+                const seen = [];
+                let guard = 0;
+                for await (const x of gen(source())) {
+                    seen.push(x);
+                    if (++guard > 12) { seen.push('RUNAWAY'); break; }
+                }
+                return seen.join(',');
+            })()
+            """);
+        result.Should().Be("a,b,c,d");
+    }
+
+    [Fact]
+    public void SyncGeneratorForOfWithYieldStaysCorrect()
+    {
+        // The sync-generator route (ExecutionContext.Generator) already saved suspend
+        // state before the fix; pinned so the async-generator change cannot regress it.
+        var result = EvaluateWithGuard("""
+            (function () {
+                function* gen(arr) { for (const x of arr) { yield x; } }
+                const seen = [];
+                let guard = 0;
+                for (const x of gen(['a', 'b', 'c', 'd'])) {
+                    seen.push(x);
+                    if (++guard > 12) { seen.push('RUNAWAY'); break; }
+                }
+                return seen.join(',');
+            })()
+            """);
+        result.Should().Be("a,b,c,d");
+    }
+
+    [Fact]
+    public void AsyncFunctionForOfWithAwaitStaysCorrect()
+    {
+        // The async-function route (ExecutionContext.AsyncFunction) already saved suspend
+        // state before the fix; pinned so the async-generator change cannot regress it.
+        var result = EvaluateWithGuard("""
+            (async function () {
+                const seen = [];
+                let guard = 0;
+                for (const x of ['a', 'b', 'c', 'd']) {
+                    await Promise.resolve();
+                    seen.push(x);
+                    if (++guard > 12) { seen.push('RUNAWAY'); break; }
+                }
+                return seen.join(',');
+            })()
+            """);
+        result.Should().Be("a,b,c,d");
+    }
+
+    [Fact]
+    public void ForOfWithYieldAccumulatesBodyCompletionValue()
+    {
+        // The generator's overall completion value flows through the loop's accumulated
+        // value bookkeeping, which the fix also extends to async generators.
+        var result = EvaluateWithGuard("""
+            (async function () {
+                async function* gen(arr) { for (const x of arr) { yield x; } return 'done'; }
+                const g = gen(['a', 'b']);
+                const parts = [];
+                let step = await g.next();
+                let guard = 0;
+                while (!step.done) {
+                    parts.push(step.value);
+                    if (++guard > 12) { parts.push('RUNAWAY'); break; }
+                    step = await g.next();
+                }
+                parts.push('final=' + step.value);
+                return parts.join(',');
+            })()
+            """);
+        result.Should().Be("a,b,final=done");
+    }
+}

--- a/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
@@ -390,6 +390,22 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
             oldEnv = suspendData.OuterEnv;
             engine.UpdateLexicalEnvironment(oldEnv);
         }
+        else if (resuming && iteratorKind == IteratorKind.Async
+                 && suspendable?.Data.TryGet<ForAwaitSuspendData>(this, out var forAwaitEntryData) == true
+                 && forAwaitEntryData is { CurrentValue: not null, OuterEnv: not null })
+        {
+            // Same restoration for a for-await-of resuming from a suspension INSIDE the
+            // loop body (CurrentValue set): the saved execution context's lexical env is
+            // the env at the await itself (e.g. the body block's env). Leaving oldEnv
+            // pointing there would parent the NEXT iteration's environment under the
+            // previous iteration's body block — and the block's env-reuse cache then
+            // re-attaches that block env under the new iteration env, creating a CYCLIC
+            // environment chain that turns the next identifier lookup into an infinite
+            // walk. (A resume from the awaited next() suspends at loop level, where the
+            // context env already is the outer env — nothing to restore.)
+            oldEnv = forAwaitEntryData.OuterEnv;
+            engine.UpdateLexicalEnvironment(oldEnv);
+        }
 
         // Reusable fixed-slot iteration environment: gated on a non-suspendable context so a
         // pooled env never round-trips through suspend/resume save-and-restore. ResetSlots at
@@ -450,10 +466,42 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                          && suspendable?.Data.TryGet<ForAwaitSuspendData>(this, out var asyncResumeData) == true
                          && asyncResumeData?.CurrentValue is not null)
                 {
-                    // Resuming from yield inside destructuring in for-await-of
+                    // Resuming from a yield/await inside the loop body (LhsBindingComplete,
+                    // saved before the body ran) or from a yield inside destructuring
+                    // (LhsBindingComplete false) in for-await-of — re-enter the CURRENT
+                    // iteration instead of awaiting the iterator's next result.
                     nextValue = asyncResumeData.CurrentValue;
-                    asyncResumeData.CurrentValue = null;
+                    iterationEnv = asyncResumeData.IterationEnv;
+                    skipLhsSetup = asyncResumeData.LhsBindingComplete;
+                    asyncResumeData.CurrentValue = null; // Clear after use
+                    asyncResumeData.LhsBindingComplete = false; // Save block re-sets if body re-suspends
                     resuming = false;
+
+                    // Restore the iteration environment if it was saved — but never rewind a
+                    // FINER-grained environment the resume machinery already restored: an async
+                    // function's saved execution context holds the env at the await itself
+                    // (e.g. the body block's environment, a descendant of the iteration env when
+                    // the body declares let/const). Clobbering it would detach the body block's
+                    // fast-forward from its own bindings. Only update when the current env is
+                    // not already the iteration env or nested inside it.
+                    if (iterationEnv is not null)
+                    {
+                        var currentEnv = engine.ExecutionContext.LexicalEnvironment;
+                        var withinIterationEnv = false;
+                        for (var env = currentEnv; env is not null; env = env._outerEnv)
+                        {
+                            if (ReferenceEquals(env, iterationEnv))
+                            {
+                                withinIterationEnv = true;
+                                break;
+                            }
+                        }
+
+                        if (!withinIterationEnv)
+                        {
+                            engine.UpdateLexicalEnvironment(iterationEnv);
+                        }
+                    }
                 }
                 else if (iteratorKind == IteratorKind.Async)
                 {
@@ -754,6 +802,23 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                     asyncGenData.LhsBindingComplete = true;
                 }
 
+                // for-await-of (async iterators) needs the same save: an await/yield in the
+                // body suspends and re-enters this statement from the top, and without the
+                // saved current value the resume path would await the iterator's NEXT result
+                // instead of re-entering the current iteration — dropping the in-flight item
+                // and, once the stream ends, silently completing the loop.
+                if (iteratorKind == IteratorKind.Async && suspendable is not null
+                    && (asyncFnBody is not null || asyncGenBody is not null))
+                {
+                    var forAwaitData = suspendable.Data.GetOrCreate<ForAwaitSuspendData>(this);
+                    forAwaitData.Iterator = iteratorRecord;
+                    forAwaitData.AccumulatedValue = v;
+                    forAwaitData.CurrentValue = valueForResume;
+                    forAwaitData.IterationEnv = iterationEnv;
+                    forAwaitData.OuterEnv = oldEnv;
+                    forAwaitData.LhsBindingComplete = true;
+                }
+
                 var result = stmt.Execute(context);
 
                 // Clear current value after successful body execution (not suspended)
@@ -770,6 +835,16 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                     {
                         currentData!.CurrentValue = null;
                     }
+                }
+
+                // The for-await-of current value must clear too once the body has run
+                // without suspending — a stale value would shadow the awaited-next()
+                // resume on a LATER suspension and replay this iteration's item.
+                if (iteratorKind == IteratorKind.Async && !context.IsSuspended()
+                    && suspendable?.Data.TryGet<ForAwaitSuspendData>(this, out var completedAwaitData) == true)
+                {
+                    completedAwaitData!.CurrentValue = null;
+                    completedAwaitData.LhsBindingComplete = false;
                 }
 
                 // Dispose iteration env's resources. If the env has async-dispose

--- a/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
@@ -736,12 +736,37 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                     asyncData.LhsBindingComplete = true;
                 }
 
+                // Async generators iterating a SYNC iterable (a plain for...of in an async
+                // generator body) need the same treatment: a yield/await in the body suspends
+                // and later re-enters this statement from the top, and without saved state
+                // the resume path restarts the loop with a fresh iterator — replaying the
+                // first step into the consumed resume value and re-yielding the second
+                // element forever. for-await-of (async iterables) is handled separately via
+                // ForAwaitSuspendData in SuspendForAsyncIteration.
+                var asyncGenBody = engine.ExecutionContext.AsyncGenerator;
+                if (iteratorKind == IteratorKind.Sync && asyncGenBody is not null)
+                {
+                    var asyncGenData = asyncGenBody.Data.GetOrCreate<ForOfSuspendData>(this, iteratorRecord);
+                    asyncGenData.AccumulatedValue = v;
+                    asyncGenData.CurrentValue = valueForResume;
+                    asyncGenData.IterationEnv = iterationEnv;
+                    asyncGenData.OuterEnv = oldEnv;
+                    asyncGenData.LhsBindingComplete = true;
+                }
+
                 var result = stmt.Execute(context);
 
                 // Clear current value after successful body execution (not suspended)
                 if (generator is not null && !context.IsSuspended())
                 {
                     if (generator.Data.TryGet<ForOfSuspendData>(this, out var currentData))
+                    {
+                        currentData!.CurrentValue = null;
+                    }
+                }
+                else if (asyncGenBody is not null && !context.IsSuspended())
+                {
+                    if (asyncGenBody.Data.TryGet<ForOfSuspendData>(this, out var currentData))
                     {
                         currentData!.CurrentValue = null;
                     }
@@ -791,6 +816,10 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                     if (generator is not null && generator.Data.TryGet<ForOfSuspendData>(this, out var data))
                     {
                         data!.AccumulatedValue = v;
+                    }
+                    else if (asyncGenBody is not null && asyncGenBody.Data.TryGet<ForOfSuspendData>(this, out var asyncGenAccData))
+                    {
+                        asyncGenAccData!.AccumulatedValue = v;
                     }
                 }
 

--- a/Jint/Runtime/SuspendData.cs
+++ b/Jint/Runtime/SuspendData.cs
@@ -293,7 +293,8 @@ internal sealed class ForAwaitSuspendData : SuspendData
     public JsValue AccumulatedValue { get; set; } = JsValue.Undefined;
 
     /// <summary>
-    /// The current value being processed when yield fired inside destructuring.
+    /// The current value being processed when a yield/await suspended mid-iteration
+    /// (inside destructuring or inside the loop body).
     /// When set, the resume should skip the iterator step and use this value.
     /// </summary>
     public JsValue? CurrentValue { get; set; }
@@ -303,6 +304,15 @@ internal sealed class ForAwaitSuspendData : SuspendData
     /// async-dispose suspension so the dispose state machine can advance on resume.
     /// </summary>
     public DeclarativeEnvironment? IterationEnv { get; set; }
+
+    /// <summary>
+    /// True when the iteration's lhs setup (iteration env creation, BindingInstantiation,
+    /// destructuring/simple-binding initialization) had already completed for the current
+    /// value before suspension occurred (i.e. suspension happened inside the loop body, not
+    /// inside destructuring). On resume, the lhs setup must be skipped to avoid re-running
+    /// destructuring against a one-shot iterator that has already been consumed.
+    /// </summary>
+    public bool LhsBindingComplete { get; set; }
 
     /// <summary>
     /// The outer environment of the for-of loop body evaluation, restored on


### PR DESCRIPTION
## Summary

Fix `for...of`/`for await...of` losing per-iteration state when the loop body
suspends in async generators and async functions.

## Details

Two related defects in how `JintForInForOfStatement` preserves per-iteration
state across a suspension, both reproducing on every release tested (4.9.3 →
4.14.0) and current `main`.

**1. `for...of` + `yield`/`await` inside an async generator — infinite loop:**

​```js
async function* gen(arr) {
    for (const x of arr) { yield x; }
}
for await (const x of gen(['a', 'b', 'c', 'd'])) {
    console.log(x); // a, b, b, b, b, ... forever (Node prints a, b, c, d)
}
​```

**2. `for await...of` + a plain `await` in the body — every item dropped:**

​```js
async function* source() { yield 'a'; yield 'b'; }
const seen = [];
for await (const x of source()) {
    await Promise.resolve();
    seen.push(x);
}
// seen is [] under Jint ([a, b] under Node); same in async generators
​```

We hit both in a real workload (a large async-heavy codebase running under
Jint): the first presents as a silent 100%-CPU hang, the second as data that
was verifiably written being reported as "not found" (a lookup's result stream
came back empty).

### Root cause

`BodyEvaluation` saves per-loop suspend state (the live iterator, current
value, iteration env) before executing the body — but only for **sync
generators** (`ExecutionContext.Generator`) and **async functions**
(`ExecutionContext.AsyncFunction`), and only for **sync** iterators. The resume
path in `ExecuteInternal` reads through `ExecutionContext.Suspendable`, which
covers async generators too — so:

- In an **async generator**, `ExecutionContext.Generator` is null and nothing
  is saved. Every resume finds no state, re-runs `HeadEvaluation` into a fresh
  iterator from position 0, the body's fast-forward consumes step 1 as the
  pending resume value, and the next real step re-yields element 2 — forever.
- For **for-await-of**, `ForAwaitSuspendData.CurrentValue` was only saved for a
  yield inside destructuring. When the body suspends at a plain `await`, the
  resume finds `CurrentValue == null`, clears `IsResuming`, and proceeds to
  await the iterator's **next** result — dropping the in-flight item; when the
  stream ends the loop completes as if it had processed everything.

### The fix

- Mirror the existing async-function save block for **async generators** (sync
  iteration kind), and extend the current-value clear and accumulated-value
  bookkeeping the same way.
- For **for-await-of** in an async function or async generator, save
  `CurrentValue`/`IterationEnv`/`LhsBindingComplete` before the body runs, so a
  mid-body suspension re-enters the CURRENT iteration on resume (the existing
  `CurrentValue is not null` resume branch, extended to restore the iteration
  environment and skip lhs re-binding); clear it once the body completes
  without suspending so a later awaited-`next()` resume is not shadowed.
  `LhsBindingComplete` is added to `ForAwaitSuspendData` (same contract as the
  existing field on `ForOfSuspendData`).

No behavior change for sync generators, async functions over sync iterables,
destructuring-yield resumes, or non-suspendable contexts.

## Linked issue

No existing issue covers this; happy to file one if preferred.

## Test plan

- [x] Added or updated unit tests in `Jint.Tests` —
  `Runtime/AsyncGeneratorForOfTests.cs` (new, 24 tests). Each drains its
  generator with an iteration guard so a regression fails loudly with a bounded
  wrong sequence (`…,RUNAWAY` / `(EMPTY)`) instead of hanging the run.
  Coverage: the two defects plus controls that must stay correct (index-based
  loop, no-suspension loop, sync-generator route, async-function route,
  for-await-of + yield route); `await` and `yield` suspension variants;
  `Map`/`Set`/string/one-shot-generator iterables; `break`/`continue`/
  early-`return`/nested loops/multiple yields and awaits per iteration across
  suspensions; empty and single-element iterables; accumulated values surviving
  suspension. Before the fix, 17 of the 24 fail; after, all 24 pass.
- [x] Ran `dotnet test --configuration Release` locally — no new failures
  (identical failure set to unpatched `main`: 5 timezone-dependent
  `DateTests.CanParseDate` cases caused by this machine's tzdata).
- [x] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no
  regressions (identical results to unpatched `main`: 99,439 passed; the 2
  failures are pre-existing `intl402` timezone-canonicalization cases that fail
  identically on unpatched `main` on this machine).
- [ ] For interop changes: n/a
- [ ] For perf changes: n/a — suspend-state bookkeeping only runs in
  suspendable contexts; the non-suspendable fast path is untouched.

## Breaking change?

No.