### PR TITLE
Fix calling and instanceof on bound functions whose target is itself bound

### DIFF
--- a/Jint.Tests/Runtime/FunctionTests.cs
+++ b/Jint.Tests/Runtime/FunctionTests.cs
@@ -86,6 +86,77 @@ public class FunctionTests
     }
 
     [Fact]
+    public void CanCallBoundFunctionWhoseTargetIsItselfBound()
+    {
+        // Per the spec a bound function's [[BoundTargetFunction]] only needs to be callable —
+        // binding an already-bound function must produce a function that still calls through
+        // (the first bind wins the this-binding).
+        var result = _engine.Evaluate("""
+            (function () {
+                function f(a) { return this.x + ':' + a; }
+                const once = f.bind({ x: 1 });
+                const twice = once.bind({ x: 2 }, 'arg');
+                return twice();
+            })()
+            """);
+        result.AsString().Should().Be("1:arg");
+    }
+
+    [Fact]
+    public void RepeatedBindAccumulatesArgumentsInOrder()
+    {
+        var result = _engine.Evaluate("""
+            (function () {
+                function f() { return Array.prototype.join.call(arguments, ','); }
+                return f.bind(null, 'a').bind(null, 'b').bind(null, 'c')('d');
+            })()
+            """);
+        result.AsString().Should().Be("a,b,c,d");
+    }
+
+    [Fact]
+    public void CanCallDeeplyReboundObjectMethod()
+    {
+        // The double-bind-into-a-dispatch-map pattern: obj.method.bind(obj) stored,
+        // then bound again when registered into a command map.
+        var result = _engine.Evaluate("""
+            (function () {
+                const obj = { x: 42, method(suffix) { return this.x + suffix; } };
+                const bound = obj.method.bind(obj);
+                const map = { cmd: bound.bind(null, '!') };
+                return map.cmd();
+            })()
+            """);
+        result.AsString().Should().Be("42!");
+    }
+
+    [Fact]
+    public void CanConstructThroughBoundFunctionWhoseTargetIsItselfBound()
+    {
+        var result = _engine.Evaluate("""
+            (function () {
+                function C(a, b) { this.value = a + b; }
+                const Bound = C.bind(null, 1).bind(null, 2);
+                return new Bound().value;
+            })()
+            """);
+        result.AsNumber().Should().Be(3);
+    }
+
+    [Fact]
+    public void InstanceofWorksAgainstBoundFunctionWhoseTargetIsItselfBound()
+    {
+        var result = _engine.Evaluate("""
+            (function () {
+                function C() {}
+                const Bound = C.bind(null).bind(null);
+                return (new C()) instanceof Bound;
+            })()
+            """);
+        result.AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
     public void ArrowFunctionShouldBeExtensible()
     {
         new Engine()

--- a/Jint/Native/Function/BindFunction.cs
+++ b/Jint/Native/Function/BindFunction.cs
@@ -43,7 +43,13 @@ public sealed class BindFunction : ObjectInstance, IConstructor, ICallable
 
     JsValue ICallable.Call(JsValue thisObject, params JsCallArguments arguments)
     {
-        var f = BoundTargetFunction as Function;
+        // Per https://tc39.es/ecma262/#sec-bound-function-exotic-objects-call-thisargument-argumentslist
+        // the [[BoundTargetFunction]] only needs to be callable — it is not necessarily a
+        // Function instance. Binding an already-bound function produces a BindFunction whose
+        // target is another BindFunction (an ObjectInstance, not a Function), which a
+        // Function-only cast rejected — making `f.bind(a).bind(b)()` throw where the spec
+        // (and every other engine) calls through.
+        var f = BoundTargetFunction as ICallable;
         if (f is null)
         {
             Throw.TypeError(_realm, "Bind must be called on a function");
@@ -79,7 +85,16 @@ public sealed class BindFunction : ObjectInstance, IConstructor, ICallable
 
     internal override bool OrdinaryHasInstance(JsValue v)
     {
-        var f = BoundTargetFunction as Function;
+        // Per https://tc39.es/ecma262/#sec-instanceofoperator a bound function delegates
+        // instanceof to its [[BoundTargetFunction]], which may itself be a bound function —
+        // follow the chain to the underlying function.
+        var target = BoundTargetFunction;
+        while (target is BindFunction nested)
+        {
+            target = nested.BoundTargetFunction;
+        }
+
+        var f = target as Function;
         if (f is null)
         {
             Throw.TypeError(_realm, "Right-hand side of 'instanceof' is not callable");


### PR DESCRIPTION
## Summary

Calling (or `instanceof` against) a bound function whose target is itself
bound threw `TypeError: Bind must be called on a function`.

## Details

`Function.prototype.bind` accepts any callable as its target, so binding an
already-bound function succeeds — but calling the result throws:

​```js
function f(a) { return this.x + ':' + a; }
const twice = f.bind({ x: 1 }).bind(null, 'arg');
twice(); // TypeError: Bind must be called on a function (Node: "1:arg")
​```

`x instanceof f.bind().bind()` fails the same way. Reproduces on every release
tested (4.9.3 → 4.14.0) and current `main`. We hit it in a real workload via a
common dispatch-map
pattern: `this.method = handlers.method.bind(this)` stored once, then
`this.method.bind(this)` registered into a command map — every dispatch threw.

### Root cause

`BindFunction` is an `ObjectInstance` (not a `Function` subclass). Its
`ICallable.Call` casts `BoundTargetFunction as Function` — for a bound-of-bound
function the target is another `BindFunction`, the cast yields null, and the
guard throws. Per
https://tc39.es/ecma262/#sec-bound-function-exotic-objects-call-thisargument-argumentslist
the target only needs to be callable. `OrdinaryHasInstance` had the same
Function-only cast; per InstanceofOperator it must follow the bound-target
chain. (`[[Construct]]` already cast to `IConstructor`, which `BindFunction`
implements, so bound-of-bound construction worked.)

### The fix

- `ICallable.Call`: cast the target to `ICallable` instead of `Function`.
- `OrdinaryHasInstance`: walk nested `BindFunction` targets to the underlying
  function before delegating.

## Linked issue

No existing issue covers this; happy to file one if preferred.

## Test plan

- [x] Added or updated unit tests in `Jint.Tests` — five tests in
  `Runtime/FunctionTests.cs`: call through a rebound function (first bind wins
  the this-binding), argument accumulation order across three binds, the
  dispatch-map double-bind pattern, construction through a rebound constructor
  (pins the already-working path), and `instanceof` against a rebound
  constructor. Four fail before the fix; all five pass after.
- [x] Ran `dotnet test --configuration Release` locally — no new failures
  (identical failure set to unpatched `main`).
- [x] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no
  regressions (identical results to unpatched `main`).
- [ ] For interop changes: n/a
- [ ] For perf changes: n/a — same cast shape (`as ICallable` for `as
  Function`) on the same path.

## Breaking change?

No.