### PR TITLE
Pass the original receiver to inherited accessors in ObjectInstance.TryGetValue

### DIFF
--- a/Jint.Tests/Runtime/PrototypeAccessorReceiverTests.cs
+++ b/Jint.Tests/Runtime/PrototypeAccessorReceiverTests.cs
@@ -1,0 +1,99 @@
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// https://tc39.es/ecma262/#sec-ordinaryget - an inherited accessor's getter runs with the
+/// ORIGINAL receiver as its <c>this</c>, not with the prototype object that happens to hold it.
+/// </summary>
+public class PrototypeAccessorReceiverTests
+{
+    private readonly Engine _engine = new();
+
+    [Fact]
+    public void ArrayDestructuringPassesTheReceiverToAnInheritedLengthGetter()
+    {
+        // Array destructuring probes 'length' via IsArrayLike before choosing between the
+        // array-like fast path and the iterator protocol. That probe walks the prototype
+        // chain; running the class's `get length()` with the prototype as `this` made it
+        // read an undefined backing field and throw instead of falling through to the
+        // iterator.
+        var result = _engine.Evaluate("""
+            class List {
+                constructor(items) { this._items = items; }
+                get length() { return this._items.length; }
+                [Symbol.iterator]() { return this._items[Symbol.iterator](); }
+            }
+            const [first, second] = new List(['a', 'b']);
+            first + ',' + second;
+            """);
+
+        result.AsString().Should().Be("a,b");
+    }
+
+    [Fact]
+    public void ArrayDestructuringWorksWhenTheGetterIsInheritedFromAGrandparent()
+    {
+        var result = _engine.Evaluate("""
+            class Base {
+                get length() { return this._items.length; }
+                [Symbol.iterator]() { return this._items[Symbol.iterator](); }
+            }
+            class Middle extends Base { }
+            class Leaf extends Middle {
+                constructor(items) { super(); this._items = items; }
+            }
+            const [a, b, c] = new Leaf([1, 2, 3]);
+            [a, b, c].join(',');
+            """);
+
+        result.AsString().Should().Be("1,2,3");
+    }
+
+    [Fact]
+    public void ArrayPrototypeKeysPassesTheReceiverToAnInheritedLengthGetter()
+    {
+        // Array.prototype.keys/values gate on the same IsArrayLike probe.
+        var result = _engine.Evaluate("""
+            class List {
+                constructor(items) { this._items = items; }
+                get length() { return this._items.length; }
+            }
+            Array.from(Array.prototype.keys.call(new List(['x', 'y', 'z']))).join(',');
+            """);
+
+        result.AsString().Should().Be("0,1,2");
+    }
+
+    [Fact]
+    public void InheritedGetterOnAnObjectLiteralPrototypeSeesTheReceiver()
+    {
+        var result = _engine.Evaluate("""
+            const proto = {
+                get length() { return this._items.length; },
+                [Symbol.iterator]() { return this._items[Symbol.iterator](); }
+            };
+            const instance = Object.create(proto);
+            instance._items = ['p', 'q'];
+            const [first, second] = instance;
+            first + ',' + second;
+            """);
+
+        result.AsString().Should().Be("p,q");
+    }
+
+    [Fact]
+    public void OwnAccessorStillReceivesTheObjectItself()
+    {
+        // The receiver threading must not disturb the ordinary own-accessor case.
+        var result = _engine.Evaluate("""
+            const o = {
+                _items: ['m', 'n'],
+                get length() { return this._items.length; },
+                [Symbol.iterator]() { return this._items[Symbol.iterator](); }
+            };
+            const [first, second] = o;
+            first + ',' + second + ',' + o.length;
+            """);
+
+        result.AsString().Should().Be("m,n,2");
+    }
+}

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -1525,6 +1525,22 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
     }
 
     public bool TryGetValue(JsValue property, out JsValue value)
+        => TryGetValue(property, this, out value);
+
+    // Same as the public overload, but threads the ORIGINAL receiver through the
+    // prototype-chain walk. Spec: OrdinaryGet(O, P, Receiver) calls an inherited
+    // accessor's getter with `Receiver` - the object the lookup STARTED on - not
+    // with the prototype the accessor happened to be found on. The previous
+    // implementation recursed as `Prototype?.TryGetValue(property, out value)`,
+    // which re-entered with `this` rebound to the prototype and therefore invoked
+    // the getter with the holder as its `this`. Any class whose prototype accessor
+    // reads instance state then saw an "empty" prototype object - e.g.
+    // `get length() { return this._arr.length; }` threw "Cannot read properties of
+    // undefined (reading 'length')" because the prototype has no `_arr`. Reached
+    // most visibly through IsArrayLike, which probes 'length' before every array
+    // destructuring, so `const [a, b] = someInstanceOfSuchAClass;` threw instead of
+    // falling through to the iterator protocol.
+    private bool TryGetValue(JsValue property, JsValue receiver, out JsValue value)
     {
         value = Undefined;
         var desc = GetOwnProperty(property);
@@ -1546,11 +1562,11 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
 
             // if getter is not undefined it must be ICallable
             var callable = (ICallable) getter;
-            value = callable.Call(this, Arguments.Empty);
+            value = callable.Call(receiver, Arguments.Empty);
             return true;
         }
 
-        return Prototype?.TryGetValue(property, out value) == true;
+        return Prototype?.TryGetValue(property, receiver, out value) == true;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
## Summary

An inherited accessor's getter ran with the prototype as `this` instead of the
original receiver, breaking array destructuring of class instances.

## Details

OrdinaryGet(O, P, Receiver) calls an inherited accessor's [[Get]] with
Receiver — the object the lookup started on
(https://tc39.es/ecma262/#sec-ordinaryget). `ObjectInstance.TryGetValue`
instead recursed as `Prototype?.TryGetValue(property, out value)`, rebinding
`this` to the prototype at every hop, and then invoked the getter with that
prototype as its this value.

Any class whose prototype accessor reads instance state therefore saw an
"empty" object:

​```js
class List {
    constructor(items) { this._items = items; }
    get length() { return this._items.length; }
    [Symbol.iterator]() { return this._items[Symbol.iterator](); }
}
const [a, b] = new List(['a', 'b']);
// TypeError: Cannot read properties of undefined (reading 'length')
// (Node destructures fine)
​```

Array destructuring reaches this through `IsArrayLike`, which probes `length`
before choosing between the array-like fast path and the iterator protocol —
so the getter threw where the probe should simply have answered, and the
destructuring never fell through to the perfectly good `Symbol.iterator`.
`Array.prototype.keys`/`values` gate on the same probe. Reproduces on 4.12.0
and current `main`; we hit it in a real workload the moment any
domain-collection instance (`get length() { return this._arr.length; }`) was
destructured.

### The fix

Thread the receiver through the prototype walk via a private
`TryGetValue(property, receiver, out value)` overload; the public signature is
unchanged, own accessors still receive the object itself, and data-property
lookups are untouched.

Reviewers may want to double-check: `TryGetValue`'s other callers (e.g.
`IsArrayLike`, iteration helpers) all start the walk on the receiver they care
about, so the new overload only changes which `this` an inherited getter sees —
exactly the spec's Receiver.

## Linked issue

No existing issue covers this; happy to file one if preferred.

## Test plan

- [x] Added or updated unit tests in `Jint.Tests` —
  `Runtime/PrototypeAccessorReceiverTests.cs` (new, 5 tests): destructuring
  with an inherited `length` getter, a grandparent-inherited getter, the
  `Array.prototype.keys` route, an `Object.create` prototype chain, and an
  own-accessor control that must keep passing. Four fail before the fix; all
  five pass after.
- [x] Ran `dotnet test --configuration Release` locally — no new failures
  (identical failure set to unpatched `main`).
- [x] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no
  regressions (identical results to unpatched `main`).
- [ ] For interop changes: n/a
- [ ] For perf changes: n/a — one extra argument on an already-recursive
  private path; the own-property fast path is unchanged.

## Breaking change?

No — `TryGetValue`'s public signature is unchanged. Behavior changes only for
inherited accessors, which now see the spec-mandated `this`.