### PR TITLE
Do not store the suspension sentinel when an await suspends a right-hand side

### DIFF
--- a/Jint.Tests/Runtime/AsyncTests.cs
+++ b/Jint.Tests/Runtime/AsyncTests.cs
@@ -89,6 +89,79 @@ public class AsyncTests
     }
 
     [Fact]
+    public void RejectedAwaitInARightHandSideMustNotClobberALocalTarget()
+    {
+        // `x = await p` suspends in the middle of the assignment: the right-hand side value on
+        // the suspend pass is the suspension sentinel, and storing it overwrites x. When p
+        // RESOLVES the resumed re-entry re-assigns and hides the damage, but when p REJECTS the
+        // resumption throws before reaching the store — so x stays clobbered forever.
+        var result = EvaluateAsyncJson("""
+            let value = 'initial';
+            try {
+                value = await Promise.reject(new Error('boom'));
+            } catch (e) {
+                return { value: value, caught: e.message };
+            }
+            return { value: value, caught: null };
+            """);
+
+        result.Should().Be("""{"value":"initial","caught":"boom"}""");
+    }
+
+    [Fact]
+    public void RejectedAwaitInARightHandSideMustNotClobberAMemberTarget()
+    {
+        var result = EvaluateAsyncJson("""
+            const holder = { value: 'initial' };
+            try {
+                holder.value = await Promise.reject(new Error('boom'));
+            } catch (e) {
+                return holder;
+            }
+            return holder;
+            """);
+
+        result.Should().Be("""{"value":"initial"}""");
+    }
+
+    [Fact]
+    public void RejectedAwaitInARightHandSideMustNotClobberAGlobalTarget()
+    {
+        // Repeated so the write goes through the warmed cached-global-binding lane too, not
+        // just the environment-record slow path it takes on the first pass.
+        var engine = new Engine();
+
+        var result = engine.Evaluate("""
+            var value = 'initial';
+            (async () => {
+                for (let i = 0; i < 3; i++) {
+                    try {
+                        value = await Promise.reject(new Error('boom'));
+                    } catch (e) {
+                    }
+                }
+                return value;
+            })()
+            """).UnwrapIfPromise(TimeSpan.FromSeconds(1));
+
+        result.AsString().Should().Be("initial");
+    }
+
+    [Fact]
+    public void ResolvedAwaitInARightHandSideStillAssigns()
+    {
+        var result = EvaluateAsyncJson("""
+            let local = 'initial';
+            const holder = { value: 'initial' };
+            local = await Promise.resolve('local-ok');
+            holder.value = await Promise.resolve('member-ok');
+            return { local: local, member: holder.value };
+            """);
+
+        result.Should().Be("""{"local":"local-ok","member":"member-ok"}""");
+    }
+
+    [Fact]
     public void ShouldNotLeakCatchBindingAfterAwaitInsideCatch()
     {
         var result = EvaluateAsyncJson("""

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -984,8 +984,12 @@ internal sealed class JintAssignmentExpression : JintExpression
                 ? JsNumber.Create(unboxedProductSum)
                 : _right.GetValue(context);
 
-            // If generator suspended or return requested during right-hand side evaluation, don't assign
-            if (context.IsGeneratorAborted())
+            // If generator suspended or return requested during right-hand side evaluation, don't assign.
+            // IsSuspended also covers an async function suspending at an `await` in the right-hand side:
+            // the RHS value at that point is the suspension sentinel (undefined), and storing it would
+            // clobber the target's previous value - visible forever if the awaited promise then REJECTS,
+            // because the resumed re-entry throws before it can re-assign.
+            if (context.IsGeneratorAborted() || context.IsSuspended())
             {
                 engine._referencePool.Return(lref);
                 return rval;
@@ -1065,8 +1069,11 @@ internal sealed class JintAssignmentExpression : JintExpression
                     return completion;
                 }
 
-                // If generator suspended or return requested during right-hand side evaluation, don't assign
-                if (context.IsGeneratorAborted())
+                // If generator suspended or return requested during right-hand side evaluation, don't assign.
+                // IsSuspended also covers an async function suspending at an `await` in the right-hand side
+                // (see the note in SetValue): storing the suspension sentinel here permanently clobbers the
+                // target when the awaited promise rejects.
+                if (context.IsGeneratorAborted() || context.IsSuspended())
                 {
                     return completion;
                 }
@@ -1133,8 +1140,12 @@ internal sealed class JintAssignmentExpression : JintExpression
                 return completion;
             }
 
-            // If generator suspended or return requested during right-hand side evaluation, don't assign
-            if (context.IsGeneratorAborted())
+            // If generator suspended or return requested during right-hand side evaluation, don't assign.
+            // IsSuspended also covers an async function suspending at an `await` in the right-hand side:
+            // the RHS value at that point is the suspension sentinel (undefined), and storing it would
+            // clobber the target's previous value - visible forever if the awaited promise then REJECTS,
+            // because the resumed re-entry throws before it can re-assign.
+            if (context.IsGeneratorAborted() || context.IsSuspended())
             {
                 return completion;
             }


### PR DESCRIPTION
## Summary

`x = await p` wrote the suspension sentinel into `x` on the suspend pass; a
rejecting `p` left `x` clobbered to `undefined` forever.

## Details

`x = await p` evaluates its right-hand side, suspends the async function at
the await, and returns a sentinel value standing in for "no value yet". The
assignment lanes guarded that store with `IsGeneratorAborted()` only, so on
the suspend pass the sentinel was written straight into the target.

When `p` RESOLVES the resumed re-entry re-evaluates and stores the real value,
which hid the damage. When `p` REJECTS the resumption throws before it reaches
the store, and the target is left clobbered for good:

​```js
let value = 'initial';
try {
    value = await Promise.reject(new Error('boom'));
} catch (e) {
    value; // undefined under Jint; 'initial' per spec and other engines
}
​```

Same for member targets (`obj.prop = await p`) and global bindings.
Reproduces on 4.12.0 and current `main`. We hit it in a real workload as
state that "reset itself" after a failed fetch: every `cache = await
refresh()` in a try/catch wiped the previous cache on failure.

### The fix

Per the assignment-operator evaluation semantics
(https://tc39.es/ecma262/#sec-assignment-operators-runtime-semantics-evaluation)
PutValue runs only after GetValue(rref) has actually produced a value — an
await that suspends never reaches the store. Guard the three store sites in
`JintAssignmentExpression` (`SetValue`, `AssignToIdentifier`,
`AssignToCachedGlobalBinding`) on `context.IsSuspended()` in addition to
`IsGeneratorAborted()`.

`JintMemberExpression.TryAssignFast` needs no equivalent guard — it already
declines whenever the execution context is suspendable.

## Linked issue

No existing issue covers this; happy to file one if preferred.

## Test plan

- [x] Added or updated unit tests in `Jint.Tests` — four tests in
  `Runtime/AsyncTests.cs`: rejected-await clobber of a local, of a member
  target, of a global through the warmed cached-global-binding lane (looped so
  the cache is hit), and a resolved-await control that must keep assigning.
  Three fail before the fix; all four pass after.
- [x] Ran `dotnet test --configuration Release` locally — no new failures
  (identical failure set to unpatched `main`).
- [x] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no
  regressions (identical results to unpatched `main`).
- [ ] For interop changes: n/a
- [ ] For perf changes: n/a — the added check is two flag tests on a path that
  only executes when the context is already suspending.

## Breaking change?

No.