### PR TITLE
Unwrap a JintStatement suspension node so for-await resumes into the right branch

### DIFF
--- a/Jint.Tests/Runtime/AsyncTests.cs
+++ b/Jint.Tests/Runtime/AsyncTests.cs
@@ -47,6 +47,48 @@ public class AsyncTests
     }
 
     [Fact]
+    public void ShouldResumeForAwaitInsideElseWithoutReevaluatingIfTest()
+    {
+        // A `for await...of` records its suspension against the LOOP STATEMENT - its implicit
+        // await lives in JintForInForOfStatement itself, not in a JintExpression.
+        // GetSuspensionNode only unwrapped Node and JintExpression, so it returned null for every
+        // for-await suspension and JintIfStatement forgot which branch it was in, re-running its
+        // test on resume. Here the else-branch sets `built` before suspending, so a re-evaluated
+        // test takes the `if` branch and returns the half-filled array (0 items).
+        var engine = new Engine();
+
+        var result = engine.Evaluate("""
+            (async () => {
+                async function* gen() {
+                    for await (const x of [1, 2, 3]) {
+                        yield x;
+                    }
+                }
+
+                const state = { built: false, items: [] };
+
+                async function build() {
+                    if (state.built) {
+                        return state.items;       // must NOT be reached on resume
+                    } else {
+                        state.built = true;       // the test above reads this
+                        for (const _ of ['a']) {
+                            for await (const v of gen()) {
+                                state.items.push(v);
+                            }
+                        }
+                        return state.items;
+                    }
+                }
+
+                return (await build()).length;
+            })()
+            """).UnwrapIfPromise(TimeSpan.FromSeconds(5));
+
+        result.AsNumber().Should().Be(3);
+    }
+
+    [Fact]
     public void ShouldNotLeakCatchBindingAfterAwaitInsideCatch()
     {
         var result = EvaluateAsyncJson("""

--- a/Jint/Runtime/Interpreter/Statements/JintStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintStatement.cs
@@ -129,8 +129,16 @@ internal abstract class JintStatement
             return null;
         }
 
+        // LastSuspensionNode may be an AST Node, a JintExpression (an await/yield expression),
+        // or a JintStatement. The last case is what `for await...of` records: its implicit await
+        // lives in the loop statement itself, not in a JintExpression. Without that case this
+        // returned null for EVERY for-await suspension, so resume-aware statements
+        // (JintIfStatement, JintSwitchStatement, ...) lost track of which branch they were in and
+        // re-evaluated their test on resume - silently taking the other branch when that test
+        // reads state the suspended code had already mutated.
         return suspendable.LastSuspensionNode as Node
-            ?? (suspendable.LastSuspensionNode as JintExpression)?._expression as Node;
+            ?? (suspendable.LastSuspensionNode as JintExpression)?._expression as Node
+            ?? (suspendable.LastSuspensionNode as JintStatement)?._statement;
     }
 
     internal static bool IsNodeInsideRange(Node node, in Range range)


### PR DESCRIPTION
## Summary

`GetSuspensionNode` never unwrapped a `JintStatement`, so it returned null for
every `for await...of` suspension — and an enclosing `if`/`else` re-evaluated its
test on resume, silently taking the other branch.

## Details

`for await...of` records its suspension against the loop STATEMENT: the implicit
await lives in `JintForInForOfStatement` itself, not in a `JintExpression`.
`JintStatement.GetSuspensionNode` unwrapped only `Node` and `JintExpression`, so
both casts failed and it returned null.

Resume-aware statements use that node to work out which branch they were in when
the frame suspended. With it null, `JintIfStatement` falls through to
re-evaluating its test — and when that test reads state the suspended code has
already mutated, it takes the opposite branch. Nothing throws; the caller just
gets a half-built result.

```js
async function* gen() {
    for await (const x of [1, 2, 3]) { yield x; }
}

const state = { built: false, items: [] };

async function build() {
    if (state.built) {
        return state.items;       // must NOT be reached on resume
    } else {
        state.built = true;       // the test above reads this
        for (const _ of ['a']) {
            for await (const v of gen()) { state.items.push(v); }
        }
        return state.items;
    }
}

(await build()).length; // 0 under Jint (Node: 3)
```

We hit this in a real workload (a large async-heavy codebase running under
Jint). An accounting config cache had exactly this guard-then-build shape: it
suspended inside the build loop, resumed into its own "already cached" test —
which its own partial execution had just made true — and returned an empty
environment. Every later config lookup then missed, so the run silently did less
work while still reporting success. That silence is the dangerous part: no
error, no rejection, just wrong results.

Reproduces on 4.12.0, 4.13.0, 4.14.0 and current `main`, so it is long-standing
rather than a regression.

### The fix

Add the missing `JintStatement` case to the unwrap chain, mirroring the existing
`JintExpression` one:

```csharp
return suspendable.LastSuspensionNode as Node
    ?? (suspendable.LastSuspensionNode as JintExpression)?._expression as Node
    ?? (suspendable.LastSuspensionNode as JintStatement)?._statement;
```

`JintStatement._statement` is a `Statement`, which derives from `Node`, so no
cast is needed. Behavior is unchanged wherever the node was already non-null —
this only replaces a null return with the correct node.

## Linked issue

No existing issue covers this; happy to file one if preferred.

## Test plan

- [x] Added a unit test in `Jint.Tests` —
  `Runtime/AsyncTests.cs::ShouldResumeForAwaitInsideElseWithoutReevaluatingIfTest`,
  the reduced form of the workload failure above. It fails on pristine
  `origin/main` (0 items) and passes with the one-line change.
- [x] Ran the full `Jint.Tests` suite locally — 4545 passed, no new failures
  (identical failure set to unpatched `main`: 5 timezone-dependent
  `DateTests.CanParseDate` cases from this machine's tzdata).
- [x] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no
  regressions (identical results to unpatched `main`: 99,439 passed; the 2
  failures are pre-existing `intl402` timezone-canonicalization cases that fail
  identically on unpatched `main` on this machine).
- [ ] For interop changes: n/a
- [ ] For perf changes: n/a — one extra type test, and only on a path that
  already established the frame is resuming.

## Breaking change?

No.