### PR TITLE
Answer an authoritative miss from the builtin-shape probe lane

### DIFF
--- a/Jint.Benchmark/HostPrototypeShapeBenchmark.cs
+++ b/Jint.Benchmark/HostPrototypeShapeBenchmark.cs
@@ -24,7 +24,7 @@ namespace Jint.Benchmark;
 /// as absolute per-document figures.
 /// </para>
 ///
-/// <para><b>The three lanes</b></para>
+/// <para><b>The lanes</b></para>
 /// <list type="bullet">
 /// <item><description>
 /// <see cref="BuildPrototypes"/> — per-engine setup, the headline. <see cref="HostPrototypeKind.Dictionary"/>
@@ -48,6 +48,18 @@ namespace Jint.Benchmark;
 /// instances claim inherited members as their own can never reach this lane whatever its prototypes look
 /// like, so measuring against such a receiver would credit this feature for a fix that is not its own.
 /// </description></item>
+/// <item><description>
+/// <see cref="AbsentNameMissOverChain"/> — the absent-name walk, over a depth-<see cref="ChainDepth"/>
+/// prototype chain built the way a DOM binding stacks its interfaces. A Web IDL named-property check
+/// (<c>el.attributes['nope']</c>) asks for a name nothing declares, and the question is refused once per
+/// level before the chain as a whole can answer it, so this is where a per-level cost multiplies. The
+/// <c>in</c> operator drives exactly that walk.
+/// </description></item>
+/// <item><description>
+/// <see cref="DeepHitOverChain"/> — the same loop aimed at a member declared only on the ROOT of the chain,
+/// so it pays every level's refusal and then one hit. The hit-path control: whatever the miss lane costs,
+/// this row must not move.
+/// </description></item>
 /// </list>
 ///
 /// <para>
@@ -67,6 +79,9 @@ public class HostPrototypeShapeBenchmark
     private const int WidePrototypeMembers = 292;
     private const int TouchedPrototypes = 5;
     private const int SteadyStateInstances = 50;
+    private const int ChainDepth = 4;
+    private const int ChainMembersPerLevel = 24;
+    private const int ChainLoopIterations = 20000;
 
     private static readonly JsObjectShape[] _shapes = BuildShapes(PrototypeCount, MembersPerPrototype);
     private static readonly JsObjectShape _wideShape = BuildShape("Wide", WidePrototypeMembers);
@@ -74,9 +89,14 @@ public class HostPrototypeShapeBenchmark
     private static readonly MemberTable[] _tables = BuildTables(PrototypeCount, MembersPerPrototype);
     private static readonly MemberTable _wideTable = new("Wide", WidePrototypeMembers);
 
+    private static readonly MemberTable[] _chainTables = BuildChainTables();
+    private static readonly JsObjectShape[] _chainShapes = BuildChainShapes();
+
     private Engine _readEngine = null!;
     private Prepared<Script> _readLoop;
     private Prepared<Script> _touchScript;
+    private Prepared<Script> _absentMissLoop;
+    private Prepared<Script> _deepHitLoop;
 
     /// <summary>How the per-engine prototype objects are built.</summary>
     [Params(HostPrototypeKind.Dictionary, HostPrototypeKind.Shape)]
@@ -136,6 +156,34 @@ public class HostPrototypeShapeBenchmark
 
         _readEngine.SetValue("items", new JsArray(_readEngine, items));
         _readEngine.Evaluate(_readLoop);
+
+        // The chain lanes: a depth-ChainDepth prototype chain in the same engine, with an ordinary script
+        // object in front of it as the receiver. BuildChain asserts every level's representation.
+        var deepestMember = _chainTables[0].Members[0].Name;
+        _absentMissLoop = Engine.PrepareScript($$"""
+            (function (obj) {
+              var hits = 0;
+              for (var i = 0; i < {{ChainLoopIterations}}; i++) {
+                hits += ('__absent__' in obj) ? 1 : 0;
+              }
+              return hits;
+            })(chainObj)
+            """);
+
+        _deepHitLoop = Engine.PrepareScript($$"""
+            (function (obj) {
+              var hits = 0;
+              for (var i = 0; i < {{ChainLoopIterations}}; i++) {
+                hits += ('{{deepestMember}}' in obj) ? 1 : 0;
+              }
+              return hits;
+            })(chainObj)
+            """);
+
+        _readEngine.SetValue("chainLeaf", BuildChain(_readEngine, PrototypeKind));
+        _readEngine.Execute("var chainObj = Object.create(chainLeaf);");
+        _readEngine.Evaluate(_absentMissLoop);
+        _readEngine.Evaluate(_deepHitLoop);
     }
 
     /// <summary>Lane A: everything a fresh document pays before a single line of script runs.</summary>
@@ -171,6 +219,84 @@ public class HostPrototypeShapeBenchmark
     /// <summary>Lane C: warmed inherited reads and calls through a correct host instance.</summary>
     [Benchmark]
     public JsValue SteadyStateReads() => _readEngine.Evaluate(_readLoop);
+
+    /// <summary>Lane D: a name nothing on the chain declares, refused once per prototype level, in a loop.</summary>
+    [Benchmark]
+    public JsValue AbsentNameMissOverChain() => _readEngine.Evaluate(_absentMissLoop);
+
+    /// <summary>Lane E: the same loop resolving on the chain's deepest level — the hit-path control.</summary>
+    [Benchmark]
+    public JsValue DeepHitOverChain() => _readEngine.Evaluate(_deepHitLoop);
+
+    /// <summary>
+    /// Builds the depth-<see cref="ChainDepth"/> prototype chain both chain lanes walk and returns its leaf.
+    /// The root chains to <c>Object.prototype</c>, exactly as the flat prototypes do, so the walk ends where a
+    /// real one does. Each level's representation is asserted after a forcing touch — engagement is asserted,
+    /// never inferred from timing: a shaped level that silently stopped being shaped would still run the row
+    /// and quietly measure the dictionary path.
+    /// </summary>
+    private static ObjectInstance BuildChain(Engine engine, HostPrototypeKind kind)
+    {
+        var expected = kind == HostPrototypeKind.Shape
+            ? ObjectRepresentation.SharedBuiltinLayout
+            : ObjectRepresentation.Dictionary;
+
+        ObjectInstance? previous = null;
+        for (var i = 0; i < ChainDepth; i++)
+        {
+            ObjectInstance level;
+            if (kind == HostPrototypeKind.Shape)
+            {
+                level = previous is null
+                    ? _chainShapes[i].Instantiate(engine)
+                    : _chainShapes[i].Instantiate(engine, previous);
+            }
+            else
+            {
+                level = BuildDictionaryPrototype(engine, _chainTables[i]);
+                if (previous is not null)
+                {
+                    level.Prototype = previous;
+                }
+            }
+
+            // The representation settles on first touch, so force one before asking.
+            level.Get(_chainTables[i].Members[0].Name);
+            var representation = engine.Advanced.GetObjectRepresentation(level);
+            if (representation != expected)
+            {
+                throw new InvalidOperationException(
+                    $"{kind} chain level {i} landed in the {representation} representation, expected {expected}.");
+            }
+
+            previous = level;
+        }
+
+        return previous!;
+    }
+
+    private static MemberTable[] BuildChainTables()
+    {
+        var tables = new MemberTable[ChainDepth];
+        for (var i = 0; i < ChainDepth; i++)
+        {
+            var level = i.ToString(CultureInfo.InvariantCulture);
+            tables[i] = new MemberTable("ChainLevel" + level, ChainMembersPerLevel, "l" + level + "_");
+        }
+
+        return tables;
+    }
+
+    private static JsObjectShape[] BuildChainShapes()
+    {
+        var shapes = new JsObjectShape[ChainDepth];
+        for (var i = 0; i < ChainDepth; i++)
+        {
+            shapes[i] = BuildShapeFrom(_chainTables[i]);
+        }
+
+        return shapes;
+    }
 
     private static ObjectInstance BuildPrototype(Engine engine, HostPrototypeKind kind, int index)
         => kind == HostPrototypeKind.Shape
@@ -244,9 +370,11 @@ public class HostPrototypeShapeBenchmark
     /// The shape a Web IDL binding generator would emit once per interface: declared from the same member
     /// table the dictionary lane walks, so the two lanes present identical members in identical order.
     /// </summary>
-    private static JsObjectShape BuildShape(string name, int memberCount)
+    private static JsObjectShape BuildShape(string name, int memberCount) => BuildShapeFrom(new MemberTable(name, memberCount));
+
+    private static JsObjectShape BuildShapeFrom(MemberTable table)
     {
-        var table = new MemberTable(name, memberCount);
+        var name = table.Name;
         var builder = new JsObjectShape.Builder();
         foreach (var member in table.Members)
         {
@@ -317,7 +445,11 @@ internal enum MemberKind
 /// </summary>
 internal sealed class MemberTable
 {
-    internal MemberTable(string name, int memberCount)
+    /// <param name="memberPrefix">
+    /// Prepended to every member name. Empty for the flat lanes; the chain lanes give each level its own
+    /// prefix so no level shadows another and a lookup can be aimed at a chosen depth.
+    /// </param>
+    internal MemberTable(string name, int memberCount, string memberPrefix = "")
     {
         Name = name;
         var members = new Member[memberCount];
@@ -326,16 +458,16 @@ internal sealed class MemberTable
             var suffix = i.ToString(CultureInfo.InvariantCulture);
             members[i] = (i % 6) switch
             {
-                0 => new Member("CONST_" + suffix, MemberKind.Constant, null, null, JsNumber.Create(i)),
-                1 or 2 => new Member("attr_" + suffix, MemberKind.Attribute, ReadAttribute, WriteAttribute, null),
-                _ => new Member("op_" + suffix, MemberKind.Operation, RunOperation, null, null),
+                0 => new Member(memberPrefix + "CONST_" + suffix, MemberKind.Constant, null, null, JsNumber.Create(i)),
+                1 or 2 => new Member(memberPrefix + "attr_" + suffix, MemberKind.Attribute, ReadAttribute, WriteAttribute, null),
+                _ => new Member(memberPrefix + "op_" + suffix, MemberKind.Operation, RunOperation, null, null),
             };
         }
 
         // Name the first member of each kind predictably so the benchmark scripts can address them.
-        members[0] = new Member("CONST_0", MemberKind.Constant, null, null, JsNumber.Create(1));
-        members[1] = new Member("attr_0", MemberKind.Attribute, ReadAttribute, WriteAttribute, null);
-        members[3] = new Member("op_0", MemberKind.Operation, RunOperation, null, null);
+        members[0] = new Member(memberPrefix + "CONST_0", MemberKind.Constant, null, null, JsNumber.Create(1));
+        members[1] = new Member(memberPrefix + "attr_0", MemberKind.Attribute, ReadAttribute, WriteAttribute, null);
+        members[3] = new Member(memberPrefix + "op_0", MemberKind.Operation, RunOperation, null, null);
 
         Members = members;
     }

--- a/Jint.Tests.PublicInterface/HostPrototypeShapeTests.cs
+++ b/Jint.Tests.PublicInterface/HostPrototypeShapeTests.cs
@@ -38,6 +38,22 @@ public class HostPrototypeShapeTests
         .ToStringTag("Element")
         .Build();
 
+    // Three shapes stacked into a prototype chain, the way a DOM binding stacks Node -> Element -> HTMLElement.
+    // Each level declares a member of its own, so a lookup can be aimed at any depth — and an absent name has
+    // to be refused by every level in turn before the chain as a whole can answer it.
+    private static readonly JsObjectShape ChainRootShape = new JsObjectShape.Builder()
+        .Method("rootMember", static (thisObject, args) => new JsString("root"))
+        .Constant("ROOT_CONST", JsNumber.Create(10))
+        .Build();
+
+    private static readonly JsObjectShape ChainMiddleShape = new JsObjectShape.Builder()
+        .Method("middleMember", static (thisObject, args) => new JsString("middle"))
+        .Build();
+
+    private static readonly JsObjectShape ChainLeafShape = new JsObjectShape.Builder()
+        .Method("leafMember", static (thisObject, args) => new JsString("leaf"))
+        .Build();
+
     // Engine-independent by construction: state comes from the receiver, never from a captured engine.
     private static JsValue GetTag(JsValue thisObject, JsValue[] arguments)
         => thisObject is ObjectInstance o ? o.Get("_tag") : JsValue.Undefined;
@@ -598,6 +614,126 @@ public class HostPrototypeShapeTests
         engine.Evaluate("'neverDeclared' in proto").Should().Be(false);
         engine.Evaluate("proto.hasOwnProperty('toString')").Should().Be(false, "toString is inherited, not own");
         engine.Evaluate("'toString' in proto").Should().Be(true);
+    }
+
+    [Fact]
+    public void AbsentNamesAnswerAcrossAChainOfShapedPrototypes()
+    {
+        // A name nothing declares is the expensive question: it is refused once per prototype level before the
+        // chain as a whole can answer it, so a chain of shaped prototypes is where an absent name has to stay
+        // as cheap and as correct as one dictionary prototype.
+        var engine = new Engine();
+        var root = ChainRootShape.Instantiate(engine);
+        var middle = ChainMiddleShape.Instantiate(engine, root);
+        var leaf = ChainLeafShape.Instantiate(engine, middle);
+
+        engine.SetValue("root", root);
+        engine.SetValue("middle", middle);
+        engine.SetValue("leaf", leaf);
+        engine.Execute("var instance = Object.create(leaf);");
+
+        // Touch every level so the representation has settled, then witness it.
+        engine.Evaluate("[root.ROOT_CONST, typeof middle.middleMember, typeof leaf.leafMember].length").Should().Be(3);
+        engine.Advanced.GetObjectRepresentation(root).Should().Be(ObjectRepresentation.SharedBuiltinLayout);
+        engine.Advanced.GetObjectRepresentation(middle).Should().Be(ObjectRepresentation.SharedBuiltinLayout);
+        engine.Advanced.GetObjectRepresentation(leaf).Should().Be(ObjectRepresentation.SharedBuiltinLayout);
+
+        engine.Evaluate("Object.getPrototypeOf(leaf) === middle").Should().Be(true);
+        engine.Evaluate("Object.getPrototypeOf(middle) === root").Should().Be(true);
+        engine.Evaluate("Object.getPrototypeOf(root) === Object.prototype").Should().Be(true);
+
+        // The absent name: refused by the instance, then by all three shaped levels, then by Object.prototype.
+        engine.Evaluate("'nope' in instance").Should().Be(false);
+        engine.Evaluate("instance.nope").Should().Be(JsValue.Undefined);
+        engine.Evaluate("instance.hasOwnProperty('nope')").Should().Be(false);
+        engine.Evaluate("leaf.hasOwnProperty('nope')").Should().Be(false);
+        engine.Evaluate("middle.hasOwnProperty('nope')").Should().Be(false);
+        engine.Evaluate("root.hasOwnProperty('nope')").Should().Be(false);
+        engine.Evaluate("Object.getOwnPropertyDescriptor(middle, 'nope')").Should().Be(JsValue.Undefined);
+
+        // ...while a member declared only on the deepest level still resolves the whole way down.
+        engine.Evaluate("'rootMember' in instance").Should().Be(true);
+        engine.Evaluate("instance.rootMember()").Should().Be("root");
+        engine.Evaluate("instance.ROOT_CONST").Should().Be(10);
+        engine.Evaluate("instance.leafMember()").Should().Be("leaf");
+        engine.Evaluate("instance.middleMember()").Should().Be("middle");
+        engine.Evaluate("instance.hasOwnProperty('rootMember')").Should().Be(false, "it is inherited, not own");
+        engine.Evaluate("root.hasOwnProperty('rootMember')").Should().Be(true);
+        engine.Evaluate("middle.hasOwnProperty('rootMember')").Should().Be(false);
+    }
+
+    [Fact]
+    public void AnUntouchedFactorySlotAnswersExistenceBeforeItsFactoryRuns()
+    {
+        // A per-realm factory slot has no declared attributes until its factory has run, so the shared layout
+        // cannot answer its enumerability on its own. That is a "cannot answer yet", never a "not there" — an
+        // existence question about a declared-but-unmaterialized member must still answer true.
+        var calls = 0;
+        var shape = new JsObjectShape.Builder()
+            .Method("m", static (t, a) => JsValue.Undefined)
+            .PerRealmSlot("lazyCtor", o => { calls++; return new JsString("made"); })
+            .Build();
+
+        var engine = new Engine();
+        var proto = shape.Instantiate(engine);
+        engine.SetValue("proto", proto);
+
+        // Initialize the object through a different member, leaving the factory slot untouched.
+        engine.Evaluate("typeof proto.m").Should().Be("function");
+        calls.Should().Be(0, "nothing has asked for the slot's value yet");
+
+        engine.Evaluate("proto.hasOwnProperty('lazyCtor')").Should().Be(true);
+        engine.Evaluate("'lazyCtor' in proto").Should().Be(true);
+        engine.Evaluate("Object.getOwnPropertyNames(proto).join(',')").Should().Be("m,lazyCtor");
+
+        engine.Evaluate("proto.lazyCtor").Should().Be("made");
+        engine.Evaluate("proto.hasOwnProperty('lazyCtor')").Should().Be(true);
+        engine.Evaluate("proto.hasOwnProperty('neverDeclared')").Should().Be(false);
+    }
+
+    [Fact]
+    public void AbsentNamesStayCorrectAfterAHybridAddition()
+    {
+        // A brand-new string key joins a side dictionary beside the shared layout, so the layout index alone
+        // is no longer the whole own-property set — an absent-name answer must account for the addition.
+        var engine = EngineWithPrototype(out var prototype);
+
+        engine.Execute("proto.extra = 1;");
+        engine.Advanced.GetObjectRepresentation(prototype).Should().Be(ObjectRepresentation.SharedBuiltinLayout);
+
+        engine.Evaluate("proto.hasOwnProperty('extra')").Should().Be(true);
+        engine.Evaluate("'extra' in proto").Should().Be(true);
+        engine.Evaluate("proto.extra").Should().Be(1);
+
+        engine.Evaluate("proto.hasOwnProperty('stillAbsent')").Should().Be(false);
+        engine.Evaluate("'stillAbsent' in proto").Should().Be(false);
+        engine.Evaluate("Object.getOwnPropertyDescriptor(proto, 'stillAbsent')").Should().Be(JsValue.Undefined);
+
+        // and the declared members are untouched by either answer
+        engine.Evaluate("proto.greet('x')").Should().Be("hello x");
+        engine.Evaluate("proto.hasOwnProperty('ELEMENT_NODE')").Should().Be(true);
+    }
+
+    [Fact]
+    public void AbsentNamesStayCorrectAfterADigitLeadingDefineDeopts()
+    {
+        // An integer-like key cannot be expressed in the shape-then-additions own-key order, so defining one
+        // drops the object back to the ordinary dictionary. Every answer has to survive the transition.
+        var engine = EngineWithPrototype(out var prototype);
+
+        engine.Execute("Object.defineProperty(proto, '0', { value: 1, configurable: true });");
+        engine.Advanced.GetObjectRepresentation(prototype).Should().Be(ObjectRepresentation.Specialized);
+
+        engine.Evaluate("proto.hasOwnProperty('0')").Should().Be(true);
+        engine.Evaluate("'0' in proto").Should().Be(true);
+        engine.Evaluate("proto[0]").Should().Be(1);
+
+        engine.Evaluate("proto.hasOwnProperty('nope')").Should().Be(false);
+        engine.Evaluate("'nope' in proto").Should().Be(false);
+        engine.Evaluate("Object.getOwnPropertyDescriptor(proto, 'nope')").Should().Be(JsValue.Undefined);
+
+        engine.Evaluate("proto.greet('x')").Should().Be("hello x");
+        engine.Evaluate("proto.ELEMENT_NODE").Should().Be(1);
     }
 
     [Fact]

--- a/Jint.Tests/Runtime/GlobalSnapshotInternalsTests.cs
+++ b/Jint.Tests/Runtime/GlobalSnapshotInternalsTests.cs
@@ -96,10 +96,12 @@ public class GlobalSnapshotInternalsTests
 
         var snapshot = engine.Advanced.CaptureGlobalSnapshot();
         var slotsBefore = shaped.BuiltinDescriptors!.Length;
+        (global._type & InternalTypes.BuiltinShapeIndexAuthoritative).Should().NotBe(InternalTypes.Empty);
 
         engine.Evaluate("globalThis[0] = 'deopt';");
         shaped.BuiltinDescriptors.Should().BeNull();
         (global._type & InternalTypes.BuiltinShapeMode).Should().Be(InternalTypes.Empty);
+        (global._type & InternalTypes.BuiltinShapeIndexAuthoritative).Should().Be(InternalTypes.Empty);
 
         engine.Advanced.RestoreGlobalSnapshot(snapshot);
 
@@ -107,6 +109,13 @@ public class GlobalSnapshotInternalsTests
         shaped.BuiltinDescriptors.Should().NotBeNull();
         shaped.BuiltinDescriptors!.Length.Should().Be(slotsBefore);
         global._properties.Should().BeNull("the deopt's dictionary must not survive as hybrid overflow");
+
+        // The mode's companion bit must be RE-DERIVED on the way back in, not merely left behind by the
+        // deopt: a bare `|= BuiltinShapeMode` would cost a restored global the absent-name fast lane forever,
+        // in precisely the capture/restore reuse pattern that lane exists for.
+        (global._type & InternalTypes.BuiltinShapeIndexAuthoritative).Should().NotBe(InternalTypes.Empty);
+        engine.Evaluate("'notDeclaredAnywhere' in globalThis").Should().Be(false);
+        engine.Evaluate("'AggregateError' in globalThis").Should().Be(true, "a lazily materialized intrinsic is declared by the layout even before its factory runs");
     }
 
     [Fact]

--- a/Jint.Tests/Runtime/SharedObjectShapeTests.cs
+++ b/Jint.Tests/Runtime/SharedObjectShapeTests.cs
@@ -292,41 +292,72 @@ public class SharedObjectShapeTests
             }
         }
 
-        // A fresh engine reaches 122 shared-layout objects carrying 1154 own string keys between them, each
-        // compared once untouched and once materialized. The floors are deliberately loose — they exist to
-        // fail if the sweep ever stops reaching the built-ins, not to track the exact intrinsic count.
+        // A fresh engine reaches 122 shared-layout objects carrying 1154 own string keys between them, plus
+        // the nine tricky names probed on each of those objects — 2252 comparisons — each compared once
+        // untouched and once materialized. The floors are deliberately loose: they exist to fail if the sweep
+        // ever stops reaching the built-ins, not to track the exact intrinsic count.
         shapedChecked.Should().BeGreaterThan(100, "the sweep must keep reaching the engine's shared-layout built-ins");
-        keysChecked.Should().BeGreaterThan(1000);
+        keysChecked.Should().BeGreaterThan(2000);
 
         static int AssertProbesAgree(ObjectInstance target)
         {
             var checkedKeys = 0;
             foreach (var key in target.GetOwnPropertyKeys(Jint.Runtime.Types.String))
             {
-                var probe = target.ProbeOwnProperty(key);
-                var descriptor = target.GetOwnProperty(key);
+                AssertOneAgrees(target, key);
+                checkedKeys++;
+            }
 
-                OwnPropertyProbe expected;
-                if (ReferenceEquals(descriptor, Jint.Runtime.Descriptors.PropertyDescriptor.Undefined))
-                {
-                    expected = OwnPropertyProbe.Missing;
-                }
-                else if (descriptor.Enumerable)
-                {
-                    expected = OwnPropertyProbe.Enumerable;
-                }
-                else
-                {
-                    expected = OwnPropertyProbe.NonEnumerable;
-                }
-
-                probe.Should().Be(expected, $"{target.GetType().Name}.{key} must probe as its descriptor reports");
+            // ...and the other half of the contract: a name the object does NOT declare. The probe answers
+            // an absent name from the shared layout index alone, so every shaped type has to be swept for
+            // one that would disagree — a subclass resolving string names ahead of the layout, or a slot
+            // the layout cannot answer without materializing it. Several of these names ARE declared on
+            // some of the objects the sweep reaches (Function.prototype declares length/name, every
+            // prototype declares constructor and toString); the assertion is the agreement, not the answer.
+            foreach (var name in TrickyProbeNames)
+            {
+                AssertOneAgrees(target, JsString.Create(name));
                 checkedKeys++;
             }
 
             return checkedKeys;
         }
+
+        static void AssertOneAgrees(ObjectInstance target, JsValue key)
+        {
+            // Probe FIRST: GetOwnProperty may materialize the slot, which would hide a lane that only
+            // answers correctly once a live descriptor exists.
+            var probe = target.ProbeOwnProperty(key);
+            var descriptor = target.GetOwnProperty(key);
+
+            OwnPropertyProbe expected;
+            if (ReferenceEquals(descriptor, Jint.Runtime.Descriptors.PropertyDescriptor.Undefined))
+            {
+                expected = OwnPropertyProbe.Missing;
+            }
+            else if (descriptor.Enumerable)
+            {
+                expected = OwnPropertyProbe.Enumerable;
+            }
+            else
+            {
+                expected = OwnPropertyProbe.NonEnumerable;
+            }
+
+            probe.Should().Be(expected, $"{target.GetType().Name}.{key} must probe as its descriptor reports");
+        }
     }
+
+    /// <summary>
+    /// Names the shaped-object sweep probes on every object besides its own keys: one that nothing can
+    /// possibly declare, the five that a <c>Function</c>-derived or otherwise field-backed host answers
+    /// ahead of its shared layout, and two integer-like ones an array-backed host answers from element
+    /// storage.
+    /// </summary>
+    private static readonly string[] TrickyProbeNames =
+    [
+        "__definitelyAbsentSweepName__", "length", "name", "prototype", "toString", "constructor", "hasOwnProperty", "0", "42",
+    ];
 
     private sealed class ReferenceComparer : IEqualityComparer<ObjectInstance>
     {

--- a/Jint/Engine.GlobalSnapshot.cs
+++ b/Jint/Engine.GlobalSnapshot.cs
@@ -505,9 +505,13 @@ public sealed class GlobalSnapshot
             }
 
             ((IBuiltinShaped) global).BuiltinDescriptors = descriptors;
-            // DeoptBuiltinShape is the only thing that leaves this mode and it touches no other _type bit
-            // and no state beyond BuiltinDescriptors and _properties, both of which are rebuilt here.
-            global._type |= InternalTypes.BuiltinShapeMode;
+            // DeoptBuiltinShape is the only thing that leaves this mode, and it touches no state beyond
+            // BuiltinDescriptors and _properties — both rebuilt here — plus the _type bits that describe the
+            // mode itself. Those must be RE-DERIVED rather than merely re-set: BuiltinShapeIndexAuthoritative
+            // rides along with the mode, so entering it with a bare |= BuiltinShapeMode would leave a global
+            // that had once deopted permanently without the fast-miss lane, in exactly the capture/restore
+            // reuse pattern that lane exists for.
+            global._type |= global.BuiltinShapeModeBits();
         }
         else if ((global._type & InternalTypes.BuiltinShapeMode) != InternalTypes.Empty)
         {
@@ -515,7 +519,7 @@ public sealed class GlobalSnapshot
             // global captured unshaped cannot have become shaped. If it ever could, the captured dictionary
             // is the whole truth and the shape has to go.
             ((IBuiltinShaped) global).BuiltinDescriptors = null;
-            global._type &= ~InternalTypes.BuiltinShapeMode;
+            global._type &= ~(InternalTypes.BuiltinShapeMode | InternalTypes.BuiltinShapeIndexAuthoritative);
         }
 
         // A host-substituted global may have entered hidden-class shape mode since the capture.

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -1178,12 +1178,27 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
                 : OwnPropertyProbe.Missing;
         }
 
-        if ((_type & InternalTypes.BuiltinShapeMode) != InternalTypes.Empty
-            && property is JsString declaredName
-            && TryProbeBuiltinShapeSlot(declaredName.ToString(), out var slotProbe))
+        if ((_type & InternalTypes.BuiltinShapeMode) != InternalTypes.Empty && property is JsString declaredName)
         {
-            AssertBuiltinShapeProbeAgrees(this, property, slotProbe);
-            return slotProbe;
+            if (TryProbeBuiltinShapeSlot(declaredName.ToString(), out var slotProbe, out var nameDeclared))
+            {
+                AssertBuiltinShapeProbeAgrees(this, property, slotProbe);
+                return slotProbe;
+            }
+
+            // Fast miss. The name is not in the shared layout index, no hybrid addition can own it (the side
+            // dictionary is still empty) and this type declares nothing ahead of the layout, so nothing on
+            // this object can own it either — the answer is already final and the confirming virtual
+            // GetOwnProperty below would only redo the key conversion and the same index lookup. A DECLARED
+            // name that merely could not be answered here (an unmaterialized Factory slot) reports
+            // nameDeclared and keeps falling through, where GetOwnProperty materializes it and answers.
+            if (!nameDeclared
+                && _properties is null
+                && (_type & InternalTypes.BuiltinShapeIndexAuthoritative) != InternalTypes.Empty)
+            {
+                AssertBuiltinShapeProbeAgrees(this, property, OwnPropertyProbe.Missing);
+                return OwnPropertyProbe.Missing;
+            }
         }
 
         var desc = GetOwnProperty(property);
@@ -1209,23 +1224,31 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
     /// <see cref="BuiltinShape.FixedSlotsAllNonEnumerable"/> gives up on one.
     /// </para>
     /// <para>
-    /// It also declines for any name the shape does not declare, rather than reporting it missing. The name
-    /// may be a post-initialization addition in the side dictionary, and — since this runs on the base class
-    /// — it may equally be one a subclass resolves ahead of the shared layout: a <c>Function</c>-derived
-    /// shaped host answers <c>length</c>/<c>name</c>/<c>prototype</c> from its own fields, and an
-    /// array-backed one answers indices from its element storage. Declining routes those to the virtual
-    /// <see cref="GetOwnProperty"/>, which is what every shaped host did before this lane existed.
+    /// It declines for a name the shape does not declare too, but distinguishes that case through
+    /// <paramref name="nameDeclared"/>: <c>false</c> means the shared layout index genuinely has no such
+    /// slot, <c>true</c> means the name IS declared and merely could not be answered from the layout alone
+    /// (the Factory case above). Only the first lets the caller answer an authoritative miss, and only for
+    /// an object that qualifies — the two other ways a shaped host can own a string key the index does not
+    /// list are excluded by the caller's gate, not here: a post-initialization addition lives in the side
+    /// dictionary, and — since this runs on the base class — a subclass may resolve names ahead of the
+    /// shared layout, as a <c>Function</c>-derived shaped host does for
+    /// <c>length</c>/<c>name</c>/<c>prototype</c> and an array-backed one does for indices. Declining
+    /// otherwise routes the name to the virtual <see cref="GetOwnProperty"/>, which is what every shaped
+    /// host did before this lane existed.
     /// </para>
     /// </summary>
-    private bool TryProbeBuiltinShapeSlot(string name, out OwnPropertyProbe probe)
+    private bool TryProbeBuiltinShapeSlot(string name, out OwnPropertyProbe probe, out bool nameDeclared)
     {
         var shaped = Unsafe.As<IBuiltinShaped>(this);
         var shape = shaped.BuiltinShape;
         if (!shape.Index.TryGetValue(name, out var slot))
         {
             probe = OwnPropertyProbe.Missing;
+            nameDeclared = false;
             return false;
         }
+
+        nameDeclared = true;
 
         // An alias carries no flags of its own: materializing it hands back the descriptor of the slot it
         // shares, so that slot's state is the one to read.
@@ -1408,7 +1431,7 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
             }
         }
 
-        _type &= ~InternalTypes.BuiltinShapeMode;
+        _type &= ~(InternalTypes.BuiltinShapeMode | InternalTypes.BuiltinShapeIndexAuthoritative);
         shaped.BuiltinDescriptors = null;
         SetProperties(properties); // sets _properties, bumps version (symbols stay in _symbols)
     }
@@ -1457,8 +1480,26 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
     {
         var shaped = Unsafe.As<IBuiltinShaped>(this);
         shaped.BuiltinDescriptors = (PropertyDescriptor?[]) shaped.BuiltinShape.ConstTemplate.Clone();
-        _type |= InternalTypes.BuiltinShapeMode;
+        _type |= BuiltinShapeModeBits();
     }
+
+    /// <summary>
+    /// The <c>_type</c> bits an object takes on when it enters built-in-shape storage. Besides
+    /// <see cref="InternalTypes.BuiltinShapeMode"/> this derives
+    /// <see cref="InternalTypes.BuiltinShapeIndexAuthoritative"/>, which gates the fast-miss lane in
+    /// <see cref="ProbeOwnProperty"/>: a type overriding <see cref="GetInitialOwnStringPropertyKeys"/>
+    /// resolves string names from its own fields ahead of the shared layout — <c>Function</c>'s
+    /// <c>length</c>/<c>name</c>/<c>prototype</c>, <c>StringInstance</c>'s indices — so a layout-index miss
+    /// there says nothing about whether the name is an own property, and such a type must not answer one.
+    /// Everything else leaves the layout index and the hybrid side dictionary as the only declarers of a
+    /// string key on the object. Asking is free: both overrides are sealed iterator methods, and an iterator
+    /// that is never enumerated runs none of its body.
+    /// </summary>
+    internal InternalTypes BuiltinShapeModeBits()
+        => InternalTypes.BuiltinShapeMode
+           | (ReferenceEquals(GetInitialOwnStringPropertyKeys(), System.Linq.Enumerable.Empty<JsValue>())
+               ? InternalTypes.BuiltinShapeIndexAuthoritative
+               : InternalTypes.Empty);
 
     // Fill a per-realm instance-property slot (reserved via BuiltinShape.Builder.Instance) with its value
     // for this realm. Called from generated CreateProperties_Generated after InitializeBuiltinShape.

--- a/Jint/Runtime/InternalTypes.cs
+++ b/Jint/Runtime/InternalTypes.cs
@@ -95,7 +95,17 @@ internal enum InternalTypes
     // test the pair against ShapeMode, so an object with no lazy slots runs byte-identical code — and a
     // sibling arm serves lazy objects through the checked JsObject.GetSlotForRead.
     HasLazySlots = 16777216,
+    // a built-in-shape host on which the shared layout index is the only declarer of a string-keyed own
+    // property besides _properties: a string probe that reaches the base builtin-shape lane and misses
+    // shape.Index can then only be answered by _properties (the hybrid side dictionary), so with that
+    // dictionary still empty the miss is authoritative and ProbeOwnProperty may report it without the
+    // confirming virtual GetOwnProperty call. Subclasses whose own storage resolves string names ahead of the
+    // shared layout must either intercept those names in their own ProbeOwnProperty before calling base
+    // (ArrayInstance does, for length and every canonical index) or override GetInitialOwnStringPropertyKeys
+    // (Function and StringInstance do), which suppresses this flag at derivation. Derived in
+    // InitializeBuiltinShape, cleared on deopt, and only meaningful while BuiltinShapeMode is set.
+    BuiltinShapeIndexAuthoritative = 33554432,
 
     Primitive = Boolean | String | Number | Integer | BigInt | Symbol,
-    InternalFlags = ObjectEnvironmentRecord | RequiresCloning | PlainObject | Array | Module | IsHTMLDDA | ShapeMode | ShapeBuilding | ExoticGet | BuiltinShapeMode | Callable | Function | OrdinaryGet | OwnValueHook | HasLazySlots
+    InternalFlags = ObjectEnvironmentRecord | RequiresCloning | PlainObject | Array | Module | IsHTMLDDA | ShapeMode | ShapeBuilding | ExoticGet | BuiltinShapeMode | Callable | Function | OrdinaryGet | OwnValueHook | HasLazySlots | BuiltinShapeIndexAuthoritative
 }


### PR DESCRIPTION
Fixes #2857.

`ProbeOwnProperty`'s builtin-shape lane could only answer a hit; a miss declined into the virtual `GetOwnProperty`, which redid the key conversion and repeated the same shape-index lookup — at every level of a `HasProperty` chain walk. A chain of `JsObjectShape` prototypes therefore answered an absent name measurably slower than the dictionary prototypes it replaced, which WebIDL named-indexer checks (`el.attributes['nope']`) hit constantly.

### The fix

A `JsString` probe that is a **true shape-index miss** is answered `Missing` directly when the side dictionary is empty and the type qualifies, gated by a new derived `InternalTypes.BuiltinShapeIndexAuthoritative` bit:

- Derived in `InitializeBuiltinShape` from the existing sentinel check `ReferenceEquals(GetInitialOwnStringPropertyKeys(), Enumerable.Empty<JsValue>())` — the same predicate `GetForInStringKeys` already trusts. `Function`-derived hosts (`length`/`name`/`prototype` from fields) and `StringInstance` override that provider and are excluded automatically; future overriders self-exclude. `ArrayInstance` keeps the flag soundly because its own `ProbeOwnProperty` intercepts `length` and every canonical index before calling base, and digit-leading names can never be hybrid additions (the write deopts).
- Cleared on `DeoptBuiltinShape`, **re-derived on global snapshot restore** — a bare `|= BuiltinShapeMode` there would have permanently lost the lane after one deopt+restore cycle, exactly the capture/restore reuse pattern the lane serves.

### The trap that ruled out the issue's original diff

`TryProbeBuiltinShapeSlot` returns `false` for two different reasons: a true index miss, and a *declared* name whose slot is an unmaterialized `Factory` slot. The issue's narrow `SharedShapeObject` diff fired on both — and `JsObjectShape.Builder.PerRealmSlot(name, factory)` produces exactly such slots, so `proto.hasOwnProperty('lazyCtor')` on an untouched factory slot would have answered `false` while `proto.lazyCtor` materializes fine. The signature now distinguishes the cases (`out bool nameDeclared`), and only a true index miss may fast-miss; factory declines keep falling through to `GetOwnProperty`. (The `GlobalObject.AggregateError` failure that killed the issue's wide-guard attempt was a factory decline, not an index miss — the 56 lazy intrinsics are generated `Factory` slots.) A mutation check confirms the new tests pin this: reverting the gate to fire on any decline fails both `SharedObjectShapeTests` and the new `HostPrototypeShapeTests` factory-slot fact in Release.

### Measurements

New `HostPrototypeShapeBenchmark` chain lanes (depth-4 shaped chain, ordinary receiver, `in`-operator loops; every level's representation asserted in `GlobalSetup`), default job, idle machine, paired runs:

| Row | old engine | fixed | Δ |
|---|---|---|---|
| AbsentNameMissOverChain, Shape | 2,430.6 µs | 1,831.5 µs | **−24.6%** |
| AbsentNameMissOverChain, Dictionary | 1,905.6 µs | 1,821.3 µs | −4.4% |
| DeepHitOverChain, Shape | 2,058.3 µs | 1,644.1 µs | −20.1% |
| DeepHitOverChain, Dictionary | 1,549.5 µs | 1,551.9 µs | flat |
| SteadyStateReads (hit control) | ~14 µs | ~14 µs | flat |

The shaped miss walk goes from **+27.6% over dictionary prototypes to parity (+0.6%, CIs touching)**. The Dictionary row improving too is the derived-flag design's bonus: every miss walk ends at `Object.prototype`, which is builtin-shaped and now fast-misses as well.

AngleSharp.Js (all DOM prototypes on `JsObjectShape`, two independent baseline/fix pairs, `LoopOnly`-subtracted): `NamedIndex` (`attrs['title']`, the WebIDL named-indexer walk) **−11.1% / −16.8%** across the pairs; every other row within its cross-run noise with sign-flips, and `Allocated` byte-identical on all rows.

### Validation

- `Jint.Tests` 4588/0 (Release **and Debug** — the Debug run re-verifies every fast miss against the virtual `GetOwnProperty` via `AssertBuiltinShapeProbeAgrees`, which is wired onto the new return), `Jint.Tests.PublicInterface` 1172/0, Test262 **99441/0**.
- AngleSharp.Js 240-test DOM suite green on net8.0/net472/net462 against a Debug build of this branch.
- New pins: probe-vs-descriptor sweep extended with absent/tricky names over every reachable shaped object; snapshot-restore flag round-trip; public-surface facts for chain misses, untouched factory slots, hybrid additions, and digit-leading deopt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
