### PR TITLE
Document that an unresolvable reference's base is a sentinel, not undefined

### DIFF
--- a/Jint.Tests/Runtime/NullPropagation.cs
+++ b/Jint.Tests/Runtime/NullPropagation.cs
@@ -10,7 +10,10 @@ public class NullPropagation
     {
         public bool TryUnresolvableReference(Engine engine, Reference reference, out JsValue value)
         {
-            value = reference.Base;
+            // Deliberately not `value = reference.Base`: for an unresolvable reference the base is the
+            // engine's internal sentinel (a JsString reading "[[Unresolvable]]"), not undefined, so passing
+            // it through would leak it into script. See the remarks on IReferenceResolver.TryUnresolvableReference.
+            value = JsValue.Undefined;
             return true;
         }
 

--- a/Jint/Runtime/Interop/IReferenceResolver.cs
+++ b/Jint/Runtime/Interop/IReferenceResolver.cs
@@ -14,7 +14,22 @@ public interface IReferenceResolver
     /// When unresolvable reference occurs, check if another value can be provided instead of it.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// A reference error will be thrown if this method return false.
+    /// </para>
+    /// <para>
+    /// While this method runs, <see cref="Reference.Base"/> holds the engine's internal sentinel for the
+    /// unresolvable state — a real <see cref="JsString"/> reading <c>[[Unresolvable]]</c> — and not
+    /// <see cref="JsValue.Undefined"/>. A resolver that passes that base straight through
+    /// (<c>value = reference.Base; return true;</c>) therefore hands the sentinel to script, where the
+    /// unknown name reads as the literal string <c>"[[Unresolvable]]"</c>. A resolver that wants
+    /// unresolvable names to read as <c>undefined</c> has to assign <see cref="JsValue.Undefined"/> to
+    /// <paramref name="value" /> explicitly.
+    /// </para>
+    /// <para>
+    /// <see cref="Reference.IsUnresolvableReference"/> is the supported way to recognize the state; never
+    /// test for it by inspecting or comparing <see cref="Reference.Base"/>.
+    /// </para>
     /// </remarks>
     /// <param name="engine">The current engine instance.</param>
     /// <param name="reference">The reference that is being processed.</param>

--- a/Jint/Runtime/Reference.cs
+++ b/Jint/Runtime/Reference.cs
@@ -28,6 +28,12 @@ public sealed class Reference
     /// <summary>
     /// The value or Environment Record which holds the binding. A [[Base]] of unresolvable indicates that the binding could not be resolved.
     /// </summary>
+    /// <remarks>
+    /// When the binding could not be resolved this property holds an internal sentinel standing for that state — a
+    /// <see cref="JsString"/> reading <c>[[Unresolvable]]</c> — and not <see cref="JsValue.Undefined"/>, so a host
+    /// handing this value to script (from <see cref="Interop.IReferenceResolver.TryUnresolvableReference"/>, for
+    /// instance) leaks it there. Use <see cref="IsUnresolvableReference"/> to test for the state.
+    /// </remarks>
     public JsValue Base
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Adds an XML doc remark to `IReferenceResolver.TryUnresolvableReference` and to the `Reference.Base` property recording that, for an unresolvable reference, `Base` holds an internal sentinel — a real `JsString` reading `[[Unresolvable]]` — rather than `undefined`, so a resolver that wants unknown names to read as `undefined` must assign `JsValue.Undefined` explicitly instead of passing the base through, and `Reference.IsUnresolvableReference` is the supported way to recognize the state. No behavior change in the engine.

The friction came from the Squidex adoption of 4.15.2 (squidex/squidex#1326): their production resolver is written the obvious way — `value = reference.Base; return true;` — so `String(unknownName)` yields the literal string `"[[Unresolvable]]"`. It is pre-existing behavior that nothing in the docs warned about.

A second commit fixes the propagation vector: `Jint.Tests/Runtime/NullPropagation.cs`, the null-propagation sample an integrator copies, contained that exact idiom, so the sample now assigns `JsValue.Undefined` and carries a comment pointing at the new doc note — it should demonstrate the documented idiom rather than the leaking one. Nothing pinned the old behaviour (no test asserts on the sentinel string, and the only test reaching that hook asserts only that execution does not throw), and the repository's two other resolvers already used the correct idiom.

Gate: `dotnet build -c Release Jint/Jint.csproj` zero warnings; `Jint.Tests` green on both TFMs (4588 net10.0 / 4508 net472, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uV6H9cTntzsoKiaJRBn4f
