### PR TITLE
Make JsString.Create(string) public

### DIFF
--- a/Jint.Tests.PublicInterface/HostValueBridgingTests.cs
+++ b/Jint.Tests.PublicInterface/HostValueBridgingTests.cs
@@ -126,4 +126,34 @@ public class HostValueBridgingTests
 
         bridged.Should().Equal("a", null, null, "d");
     }
+
+    [Fact]
+    public void JsStringCreateReturnsTheInternedEmptyInstance()
+    {
+        JsString.Create("").Should().BeSameAs(JsString.Empty);
+    }
+
+    [Fact]
+    public void JsStringCreateReturnsAnInternedInstanceForASingleCharacter()
+    {
+        JsString.Create("a").Should().BeSameAs(JsString.Create("a"));
+    }
+
+    [Fact]
+    public void JsStringCreateRoundTripsALongerString()
+    {
+        var value = JsString.Create("ab");
+
+        value.ToString().Should().Be("ab");
+
+        var engine = new Engine();
+        engine.SetValue("bridged", value);
+        engine.Evaluate("bridged + '!'").AsString().Should().Be("ab!");
+    }
+
+    [Fact]
+    public void JsStringCreateRejectsNull()
+    {
+        Invoking(() => JsString.Create(null!)).Should().Throw<ArgumentNullException>();
+    }
 }

--- a/Jint/Native/JsString.cs
+++ b/Jint/Native/JsString.cs
@@ -195,8 +195,21 @@ public class JsString : JsValue, IEquatable<JsString>, IEquatable<string>
         return !(a == b);
     }
 
-    internal static JsString Create(string value)
+    /// <summary>
+    /// Creates a <see cref="JsString"/> for a .NET string. The counterpart of <see cref="JsNumber.Create(double)"/>,
+    /// and the preferred way for a host to produce a string value: it returns a shared interned instance for the
+    /// empty string and for single-ASCII-character strings instead of allocating a new one.
+    /// </summary>
+    /// <param name="value">The string value.</param>
+    /// <returns>A <see cref="JsString"/> for <paramref name="value" />.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="value" /> is <see langword="null" />.</exception>
+    public static JsString Create(string value)
     {
+        if (value is null)
+        {
+            Throw.ArgumentNullException(nameof(value));
+        }
+
         if (value.Length > 1)
         {
             return new JsString(value);


### PR DESCRIPTION
`JsNumber.Create(double)` is public while `JsString.Create(string)` was internal — an asymmetry a host hits inside a single method: mapping a JSON document into script needs both, and only the number side was reachable. The fallback, `new JsString(s)`, allocates even for the empty string and for single-ASCII-character strings that `Create` answers from the interned tables. Surfaced by the Squidex 4.15.2 adoption (squidex/squidex#1326), whose `JsonMapper` had to keep `new JsString(s)`.

This promotes the `string` overload, adds a `Throw.ArgumentNullException` guard (one predicted branch — the method dereferences `value.Length` immediately anyway, so the guard only converts an NRE into the correct `ArgumentNullException`) and documents the interning behaviour. The `char`/`int`/`uint` overloads stay internal: a minimal symmetric surface, and widening later is free. The repo tracks no `PublicAPI.*.txt`, so there is nothing else to update.

Tests in `Jint.Tests.PublicInterface/HostValueBridgingTests.cs` — the project without `InternalsVisibleTo`, so they would not compile if the member were still internal — cover the interned empty and single-character instances, a longer string round-tripping through the engine, and the null guard.

Gate: `dotnet build -c Release Jint/Jint.csproj` zero warnings; `Jint.Tests` green (4588 net10.0 / 4508 net472), `Jint.Tests.PublicInterface` green (1176 per TFM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uV6H9cTntzsoKiaJRBn4f
