### PR TITLE
Run the repository's own host tests under Release-mode contract verification

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,3 +53,34 @@ jobs:
     - name: Test
       run: dotnet test --configuration Release --logger "console;verbosity=quiet" --logger "GitHubActions;summary-include-passed=false;summary-include-skipped=false"
 
+  # The matrix above is the shipped configuration: Release with host-contract verification off, which is what
+  # the probe-count and no-descriptor pins in Jint.Tests.PublicInterface document as costing nothing. This leg
+  # is the other one an embedder is told to use — the shipped Release package with
+  # Jint.EnableHostContractVerification set — so that a verifier which misbehaves under the Release JIT, or a
+  # gating bug, fails here rather than in someone's integration suite. One OS is enough: the verifiers are
+  # platform-independent, and the switch is set the same way everywhere.
+  test-release-verification:
+
+    name: 'linux - host-contract verification'
+
+    runs-on: ubuntu-latest
+
+    env:
+      JINT_HOST_CONTRACT_VERIFICATION: 1
+
+    steps:
+
+    - name: Setup NET
+      uses: actions/setup-dotnet@v6
+      with:
+        dotnet-version: 10.0
+
+    - name: Checkout source code
+      uses: actions/checkout@v7
+
+    - name: Test Jint.Tests
+      run: dotnet test Jint.Tests/Jint.Tests.csproj --configuration Release --logger "console;verbosity=quiet" --logger "GitHubActions;summary-include-passed=false;summary-include-skipped=false"
+
+    - name: Test Jint.Tests.PublicInterface
+      run: dotnet test Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj --configuration Release --logger "console;verbosity=quiet" --logger "GitHubActions;summary-include-passed=false;summary-include-skipped=false"
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,8 @@ dotnet test -c Release Jint.Tests.Test262/Jint.Tests.Test262.csproj
 
 Always build and test in **Release** — it is the faster feedback loop and the configuration performance claims are about. Never pass `--no-build`; always work against freshly compiled code. `TreatWarningsAsErrors` is on, so every warning must be fixed. Packages are managed centrally through `Directory.Packages.props`.
 
+Setting `JINT_HOST_CONTRACT_VERIFICATION=1` runs `Jint.Tests` and `Jint.Tests.PublicInterface` with the host-contract verifiers on in Release, which is the configuration an embedder is told to use; see [Host-contract verification](#host-contract-verification). It is a separate leg, not the default.
+
 ### Quick manual testing with Jint.Repl
 
 ```bash
@@ -156,6 +158,17 @@ Several extension points oblige a host to keep two answers consistent, and the e
 - **Release builds — including the shipped NuGet package**: on when the host sets the AppContext switch `Jint.EnableHostContractVerification` **before its first use of any Jint type**. The flag is read once at type initialization, so setting it later does nothing for the rest of the process.
 
 The point of the switch is reach: the verifiers used to be `[Conditional("DEBUG")]`, and Jint ships Release only, so reaching them meant cloning and building the repository. When adding a verifier, gate it with an explicit `if (HostContractVerification.Enabled)` **at the call site** — `[Conditional]` removes the call and a runtime flag cannot — and report through `HostContractVerification.Fail`, which throws. `Debug.Fail`/`Debug.Assert` are themselves `[Conditional("DEBUG")]` and would report a Release violation into nothing. Reserve them for in-box invariants an embedder can neither violate nor act on (`JintExpression.AssertEvaluationResult`, `FastCallShape`'s leaf-call guard, the pools' validation), which stay compile-time.
+
+**This repository dogfoods that recipe.** `Jint.Tests` and `Jint.Tests.PublicInterface` turn the switch on when the environment variable `JINT_HOST_CONTRACT_VERIFICATION` is `1` or `true`, so the whole host-test surface can be run in the exact configuration an embedder is told to use:
+
+```bash
+JINT_HOST_CONTRACT_VERIFICATION=1 dotnet test -c Release Jint.Tests/Jint.Tests.csproj
+JINT_HOST_CONTRACT_VERIFICATION=1 dotnet test -c Release Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj
+```
+
+The switch is set from a `[ModuleInitializer]` in `Jint.Tests/HostContractVerificationSwitch.cs` (compiled into both projects, and polyfilled on `net472` by the repository's global `PolySharp` reference), because that is the only hook early enough — a fixture, a collection or a class constructor all run after some Jint type has already been touched, and the gate is read once. `HostContractVerificationSwitch.Enabled` is what every verification-aware expectation selects on; `Jint.Tests.Runtime.HostContractVerificationSwitchTests` pins it against Jint's own gate, and `HostContractVerificationTests.TheHarnessSetsTheSwitchEarlyEnoughForJintToObserveIt` proves the same ordering from behaviour alone. The PR workflow runs it as the `linux - host-contract verification` job.
+
+The **default** Release run stays switch-off, deliberately. The probe-count and no-descriptor pins are the regression net for the claim that the gate folds to zero cost when nobody asked for it, and they can only mean that in a run where nobody did. So a test whose expectation differs between the two configurations selects it at runtime from `HostContractVerificationSwitch.Enabled` rather than on `#if DEBUG`, and a test that only makes sense in one of them says so with `[Fact(Skip = "…", SkipUnless = nameof(Verifying))]` (or `nameof(NotVerifying)`) rather than being compiled out. Every verified figure measured so far equals the Debug one — the extra probes are the verifier's own, and nothing else about the two builds differs on these paths.
 
 What is verified: `TryGetOwnPropertyValue` and `ProbeOwnProperty` against `GetOwnProperty`, a declared `PropertyAccessSemantics.Ordinary` against the type's own `Get`, `ArrayLikeObject.HasIndex` against `TryGetIndex`, the builtin-shape probe lane against `GetOwnProperty`, and a typed `AddObjectConverter` registration against what its `TryConvert` actually converts. Each verifier redoes exactly the work the lane it checks exists to avoid, so any figure about descriptors-not-materialized or probes-per-read is a figure from a process with verification **off** — never quote a Debug number as a cost. `Options.Debugger.Enabled` (`Engine._isDebugMode`), which disarms the interpreter's tight-loop lane, is a separate runtime option and has nothing to do with this switch or with the `DEBUG` symbol.
 

--- a/Jint.Tests.PublicInterface/HostArrayLikeHasIndexTests.cs
+++ b/Jint.Tests.PublicInterface/HostArrayLikeHasIndexTests.cs
@@ -171,17 +171,31 @@ public class HostArrayLikeHasIndexTests
     }
 
     /// <summary>
-    /// The claim the hook exists for. In Release no element is produced at all for an existence question; under
-    /// Debug the only <c>TryGetIndex</c> calls are the verifier's, one per probe.
+    /// Whether Jint's host-contract verifiers are running: always in a Debug build, and in Release when
+    /// <c>Jint.EnableHostContractVerification</c> was set before the first use of any Jint type — which is what
+    /// this repository's Release verification leg does (<c>JINT_HOST_CONTRACT_VERIFICATION=1</c>). Public and
+    /// static so xUnit can read it for <c>SkipUnless</c>.
+    /// </summary>
+    public static bool Verifying => HostContractVerificationSwitch.Enabled;
+
+    /// <inheritdoc cref="Verifying" />
+    public static bool NotVerifying => !Verifying;
+
+    /// <summary>
+    /// The claim the hook exists for. Unverified, no element is produced at all for an existence question; while
+    /// verifying, the only <c>TryGetIndex</c> calls are the verifier's, one per probe.
     /// </summary>
     private static void AssertNoValueWasMaterialized(SparseHostList list)
     {
         list.HasIndexCalls.Should().BeGreaterThan(0, "the existence question must reach the containment hook");
-#if DEBUG
-        list.TryGetIndexCalls.Should().Be(list.HasIndexCalls, "under Debug the agreement verifier re-runs TryGetIndex once per probe");
-#else
-        list.TryGetIndexCalls.Should().Be(0, "an existence question must not project an element");
-#endif
+        if (Verifying)
+        {
+            list.TryGetIndexCalls.Should().Be(list.HasIndexCalls, "the agreement verifier re-runs TryGetIndex once per probe");
+        }
+        else
+        {
+            list.TryGetIndexCalls.Should().Be(0, "an existence question must not project an element");
+        }
     }
 
     [Theory]
@@ -293,14 +307,13 @@ public class HostArrayLikeHasIndexTests
         engine.Evaluate("list[1]").Should().Be("B");
     }
 
-#if DEBUG
     /// <summary>
     /// The other side of the same coin: with verification on — a Debug build, or the shipped Release package
     /// with the <c>Jint.EnableHostContractVerification</c> switch set before first use — the damage pinned below
     /// never gets the chance to happen, because the first probe that disagrees with <c>TryGetIndex</c> throws
     /// and names the host, the index and both answers.
     /// </summary>
-    [Theory]
+    [Theory(Skip = "host-contract verification is off in this run", SkipUnless = nameof(Verifying))]
     [InlineData(true)]
     [InlineData(false)]
     public void VerificationTurnsASilentIndexDisagreementIntoAThrow(bool overclaiming)
@@ -314,9 +327,7 @@ public class HostArrayLikeHasIndexTests
         act.Should().Throw<InvalidOperationException>()
             .WithMessage("*HasIndex*");
     }
-#endif
 
-#if !DEBUG
     /// <summary>
     /// What a host that breaks the agreement observes when nothing is verifying. These are <b>not</b> a
     /// specification of desired behaviour — they pin the damage so it is on the record and reviewable, exactly
@@ -324,10 +335,10 @@ public class HostArrayLikeHasIndexTests
     /// does not re-verify it on the hot path, so a violation is silent unless verification is turned on.
     /// <para>
     /// Guarded to the unverified configuration on purpose: with the verifier running, the first disagreeing
-    /// probe throws, which is what the Debug-side theory above asserts instead.
+    /// probe throws, which is what the theory above asserts instead.
     /// </para>
     /// </summary>
-    [Fact]
+    [Fact(Skip = "host-contract verification is on in this run", SkipUnless = nameof(NotVerifying))]
     public void AHostClaimingAnIndexItCannotServeAdvertisesAKeyThatReadsAsUndefined()
     {
         var engine = new Engine();
@@ -348,7 +359,7 @@ public class HostArrayLikeHasIndexTests
             .Should().Be(true);
     }
 
-    [Fact]
+    [Fact(Skip = "host-contract verification is on in this run", SkipUnless = nameof(NotVerifying))]
     public void AHostDenyingAnIndexItDoesServeHidesTheElementFromEveryEnumeration()
     {
         var engine = new Engine();
@@ -364,5 +375,4 @@ public class HostArrayLikeHasIndexTests
         engine.Evaluate("list[1]").Should().Be("item1");
         engine.Evaluate("JSON.stringify(list)").Should().Be("""["item0","item1","item2"]""");
     }
-#endif
 }

--- a/Jint.Tests.PublicInterface/HostContractVerificationTests.cs
+++ b/Jint.Tests.PublicInterface/HostContractVerificationTests.cs
@@ -1,9 +1,14 @@
 #nullable enable
 
+using System.Collections.Generic;
 using System.Reflection;
 #if NET8_0_OR_GREATER
 using System.Runtime.Loader;
 #endif
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
 
 namespace Jint.Tests.PublicInterface;
 
@@ -50,23 +55,87 @@ public class HostContractVerificationTests
     [Fact]
     public void TheDefaultIsOnForADebugBuildAndOffForTheShippedRelease()
     {
-        // Reading it here also forces this process's copy to initialize while the switch is still unset, so the
-        // test below cannot accidentally turn verification on for the rest of a parallel suite run.
+        // Reading it here also forces this process's copy to initialize while the switch is still whatever the
+        // harness left it, so the test below cannot accidentally change it for the rest of a parallel suite run.
         var enabled = ReadGate(typeof(Engine).Assembly);
 
 #if DEBUG
         enabled.Should().BeTrue("a Debug build of Jint verifies host contracts without being asked");
 #else
-        enabled.Should().BeFalse("the shipped Release package must cost nothing until an embedder opts in");
+        if (HostContractVerificationSwitch.RequestedByTheEnvironment())
+        {
+            enabled.Should().BeTrue(
+                "this run asked for verification through " + HostContractVerificationSwitch.EnvironmentVariableName +
+                ", and the harness set the switch from a module initializer — before the first use of any Jint type");
+        }
+        else
+        {
+            enabled.Should().BeFalse("the shipped Release package must cost nothing until an embedder opts in");
+        }
 #endif
+    }
+
+    /// <summary>
+    /// The ordering claim, proven through <b>behaviour</b> rather than through the gate's field: a host whose
+    /// <c>ProbeOwnProperty</c> contradicts its own <c>GetOwnProperty</c> throws exactly when the verifiers are
+    /// running. A `true` here means Jint read the switch this harness set, and read it in time — the whole
+    /// contract of a <c>static readonly</c> gate.
+    /// </summary>
+    [Fact]
+    public void TheHarnessSetsTheSwitchEarlyEnoughForJintToObserveIt()
+    {
+        var engine = new Engine();
+        engine.SetValue("host", new SelfContradictingHost(engine));
+
+        var act = () => engine.Evaluate("Object.keys(host).join(',')");
+
+        if (HostContractVerificationSwitch.Enabled)
+        {
+            act.Should().Throw<InvalidOperationException>(
+                "the verifiers are on in this run, so the contradiction must be reported").WithMessage("*lied*");
+        }
+        else
+        {
+            act.Should().NotThrow("nothing is verifying in this run, so the contradiction is believed");
+            engine.Evaluate("Object.keys(host).join(',')").AsString().Should().Be("honest");
+        }
+    }
+
+    /// <summary>
+    /// Denies through its probe one name its own <c>GetOwnProperty</c> plainly serves. The engine trusts the
+    /// probe and never re-asks, so the key simply vanishes from every enumeration — silently, unless something
+    /// is verifying.
+    /// </summary>
+    private sealed class SelfContradictingHost : ObjectInstance
+    {
+        public SelfContradictingHost(Engine engine) : base(engine)
+        {
+        }
+
+        public override PropertyDescriptor GetOwnProperty(JsValue property)
+        {
+            var name = property.ToString();
+            return name is "honest" or "lied"
+                ? new PropertyDescriptor(name, writable: true, enumerable: true, configurable: true)
+                : PropertyDescriptor.Undefined;
+        }
+
+        // outside the Jint assembly a `protected internal` member is visible as `protected`
+        protected override OwnPropertyProbe ProbeOwnProperty(JsValue property)
+            => property.ToString() == "lied" ? OwnPropertyProbe.Missing : base.ProbeOwnProperty(property);
+
+        public override List<JsValue> GetOwnPropertyKeys(Types types = Types.String | Types.Symbol)
+            => [new JsString("honest"), new JsString("lied")];
     }
 
 #if NET8_0_OR_GREATER && !DEBUG
     [Fact]
     public void TheSwitchTurnsVerificationOnInAReleaseBuild()
     {
-        // force this process's copy to initialize first, with the switch unset
-        ReadGate(typeof(Engine).Assembly).Should().BeFalse();
+        var requested = HostContractVerificationSwitch.RequestedByTheEnvironment();
+
+        // force this process's copy to initialize first, with the switch at whatever the harness left it
+        ReadGate(typeof(Engine).Assembly).Should().Be(requested);
 
         AppContext.SetSwitch(SwitchName, true);
         try
@@ -79,7 +148,8 @@ public class HostContractVerificationTests
         }
         finally
         {
-            AppContext.SetSwitch(SwitchName, false);
+            // back to what the harness asked for, so nothing later in the process sees a switch it did not set
+            AppContext.SetSwitch(SwitchName, requested);
         }
     }
 #endif

--- a/Jint.Tests.PublicInterface/HostObjectProbeCountTests.cs
+++ b/Jint.Tests.PublicInterface/HostObjectProbeCountTests.cs
@@ -67,49 +67,48 @@ namespace Jint.Tests.PublicInterface;
 /// </summary>
 public class HostObjectProbeCountTests
 {
-    // A Debug build of Jint verifies the ordinary semantics on every read, by recomputing the read through Get
-    // and through GetOwnProperty and comparing, and verifies a value-hook answer against the descriptor it
-    // claims to agree with. Both cost probes of their own. Release strips them entirely, and Release is the
-    // configuration these numbers are about.
-#if DEBUG
-    private const int OrdinaryOwnHit = 3;
-    private const int OrdinaryOwnMiss = 4;
-    private const int OrdinaryPrototypeHit = 3;
-    private const int HookOwnHit = 3;
-    private const int HookOwnMiss = 4;
-    private const int HookPrototypeHit = 3;
-    private const int HookMemberCallBase = 1;
-#else
-    private const int OrdinaryOwnHit = 1;
-    private const int OrdinaryOwnMiss = 2;
-    private const int OrdinaryPrototypeHit = 1;
-    private const int HookOwnHit = 0;
-    private const int HookOwnMiss = 0;
-    private const int HookPrototypeHit = 0;
-    private const int HookMemberCallBase = 0;
-#endif
+    /// <summary>
+    /// What one read costs a host of a given shape, in <c>GetOwnProperty</c> calls.
+    /// </summary>
+    private readonly record struct ProbeCosts(int OwnHit, int OwnMiss, int PrototypeHit, int MemberCallBase);
 
-    // The exotic host's Get delegates to base.Get, which probes once whatever the outcome: on a hit the probe
-    // produces the value, on a miss it establishes the miss before the prototype walk. Nothing in the
-    // interpreter probes on its own behalf for an exotic receiver, so these are entirely the host's own doing —
-    // which is also why no Debug verifier runs for them and the counts do not depend on the configuration.
-    private const int ExoticOwnHit = 1;
-    private const int ExoticOwnMiss = 1;
-    private const int ExoticPrototypeHit = 1;
+    // Jint's host-contract verifiers recompute an ordinary read through both Get and GetOwnProperty and compare
+    // them, and check a value-hook answer against the descriptor it claims to agree with. Both cost probes of
+    // their own. They run in a Debug build, and in Release when Jint.EnableHostContractVerification was set
+    // before the first use of any Jint type — which is what this repository's Release verification leg does
+    // (JINT_HOST_CONTRACT_VERIFICATION=1). The unverified numbers are the ones an embedder pays, and the ones
+    // every cost claim about this lane is about.
+    private static ProbeCosts CostsFor(ProbeCountingHostKind kind) => kind switch
+    {
+        ProbeCountingHostKind.Ordinary => HostContractVerificationSwitch.Enabled
+            ? new ProbeCosts(OwnHit: 3, OwnMiss: 4, PrototypeHit: 3, MemberCallBase: 1)
+            : new ProbeCosts(OwnHit: 1, OwnMiss: 2, PrototypeHit: 1, MemberCallBase: 1),
 
-    // The base of a member call resolves straight through ObjectInstance.Get rather than through the
-    // member-read lane, so it costs one probe in the two descriptor columns — and the member lane's Debug
-    // verifier never runs for it. This was already true before the derivation; it is what showed that the extra
-    // probe on the value lane was removable rather than intrinsic. The value hook does reach this lane, because
-    // Get consults it, which is what shows the hook is not member-read-only.
-    private const int MemberCallBase = 1;
+        ProbeCountingHostKind.OrdinaryWithValueHook => HostContractVerificationSwitch.Enabled
+            ? new ProbeCosts(OwnHit: 3, OwnMiss: 4, PrototypeHit: 3, MemberCallBase: 1)
+            : new ProbeCosts(OwnHit: 0, OwnMiss: 0, PrototypeHit: 0, MemberCallBase: 0),
+
+        // The exotic host's Get delegates to base.Get, which probes once whatever the outcome: on a hit the
+        // probe produces the value, on a miss it establishes the miss before the prototype walk. Nothing in the
+        // interpreter probes on its own behalf for an exotic receiver, so these are entirely the host's own
+        // doing — which is also why no verifier runs for them and the counts do not depend on the configuration.
+        //
+        // The base of a member call resolves straight through ObjectInstance.Get rather than through the
+        // member-read lane, so it costs one probe in the two descriptor columns — and the member lane's verifier
+        // never runs for it. This was already true before the derivation; it is what showed that the extra probe
+        // on the value lane was removable rather than intrinsic. The value hook does reach this lane, because
+        // Get consults it, which is what shows the hook is not member-read-only.
+        _ => new ProbeCosts(OwnHit: 1, OwnMiss: 1, PrototypeHit: 1, MemberCallBase: 1),
+    };
 
     [Theory]
-    [InlineData(ProbeCountingHostKind.Ordinary, OrdinaryOwnHit)]
-    [InlineData(ProbeCountingHostKind.OrdinaryWithValueHook, HookOwnHit)]
-    [InlineData(ProbeCountingHostKind.Exotic, ExoticOwnHit)]
-    public void AnOwnPropertyReadProbesTheHostObject(ProbeCountingHostKind kind, int expectedProbes)
+    [InlineData(ProbeCountingHostKind.Ordinary)]
+    [InlineData(ProbeCountingHostKind.OrdinaryWithValueHook)]
+    [InlineData(ProbeCountingHostKind.Exotic)]
+    public void AnOwnPropertyReadProbesTheHostObject(ProbeCountingHostKind kind)
     {
+        var expectedProbes = CostsFor(kind).OwnHit;
+
         var engine = new Engine();
         var host = ProbeCountingHostObject.Create(engine, kind);
         engine.SetValue("host", host);
@@ -126,11 +125,13 @@ public class HostObjectProbeCountTests
     }
 
     [Theory]
-    [InlineData(ProbeCountingHostKind.Ordinary, 3 * OrdinaryOwnHit)]
-    [InlineData(ProbeCountingHostKind.OrdinaryWithValueHook, 3 * HookOwnHit)]
-    [InlineData(ProbeCountingHostKind.Exotic, 3 * ExoticOwnHit)]
-    public void EachOwnPropertyReadCostsItsOwnProbes(ProbeCountingHostKind kind, int expectedProbes)
+    [InlineData(ProbeCountingHostKind.Ordinary)]
+    [InlineData(ProbeCountingHostKind.OrdinaryWithValueHook)]
+    [InlineData(ProbeCountingHostKind.Exotic)]
+    public void EachOwnPropertyReadCostsItsOwnProbes(ProbeCountingHostKind kind)
     {
+        var expectedProbes = 3 * CostsFor(kind).OwnHit;
+
         var engine = new Engine();
         var host = ProbeCountingHostObject.Create(engine, kind);
         engine.SetValue("host", host);
@@ -144,11 +145,13 @@ public class HostObjectProbeCountTests
     }
 
     [Theory]
-    [InlineData(ProbeCountingHostKind.Ordinary, OrdinaryOwnMiss)]
-    [InlineData(ProbeCountingHostKind.OrdinaryWithValueHook, HookOwnMiss)]
-    [InlineData(ProbeCountingHostKind.Exotic, ExoticOwnMiss)]
-    public void AMissingOwnPropertyReadIsNoCheaperThanAHit(ProbeCountingHostKind kind, int expectedProbes)
+    [InlineData(ProbeCountingHostKind.Ordinary)]
+    [InlineData(ProbeCountingHostKind.OrdinaryWithValueHook)]
+    [InlineData(ProbeCountingHostKind.Exotic)]
+    public void AMissingOwnPropertyReadIsNoCheaperThanAHit(ProbeCountingHostKind kind)
     {
+        var expectedProbes = CostsFor(kind).OwnMiss;
+
         var engine = new Engine();
         var host = ProbeCountingHostObject.Create(engine, kind);
         engine.SetValue("host", host);
@@ -165,11 +168,13 @@ public class HostObjectProbeCountTests
     }
 
     [Theory]
-    [InlineData(ProbeCountingHostKind.Ordinary, OrdinaryPrototypeHit)]
-    [InlineData(ProbeCountingHostKind.OrdinaryWithValueHook, HookPrototypeHit)]
-    [InlineData(ProbeCountingHostKind.Exotic, ExoticPrototypeHit)]
-    public void APrototypeReadReEstablishesTheOwnMissOnTheHost(ProbeCountingHostKind kind, int expectedProbes)
+    [InlineData(ProbeCountingHostKind.Ordinary)]
+    [InlineData(ProbeCountingHostKind.OrdinaryWithValueHook)]
+    [InlineData(ProbeCountingHostKind.Exotic)]
+    public void APrototypeReadReEstablishesTheOwnMissOnTheHost(ProbeCountingHostKind kind)
     {
+        var expectedProbes = CostsFor(kind).PrototypeHit;
+
         var engine = new Engine();
         var host = ProbeCountingHostObject.Create(engine, kind);
         engine.SetValue("host", host);
@@ -186,11 +191,13 @@ public class HostObjectProbeCountTests
     }
 
     [Theory]
-    [InlineData(ProbeCountingHostKind.Ordinary, MemberCallBase)]
-    [InlineData(ProbeCountingHostKind.OrdinaryWithValueHook, HookMemberCallBase)]
-    [InlineData(ProbeCountingHostKind.Exotic, MemberCallBase)]
-    public void AMemberCallBaseProbesOnceUnlessTheHostAnswersItself(ProbeCountingHostKind kind, int expectedProbes)
+    [InlineData(ProbeCountingHostKind.Ordinary)]
+    [InlineData(ProbeCountingHostKind.OrdinaryWithValueHook)]
+    [InlineData(ProbeCountingHostKind.Exotic)]
+    public void AMemberCallBaseProbesOnceUnlessTheHostAnswersItself(ProbeCountingHostKind kind)
     {
+        var expectedProbes = CostsFor(kind).MemberCallBase;
+
         var engine = new Engine();
         var host = ProbeCountingHostObject.Create(engine, kind);
         engine.SetValue("host", host);

--- a/Jint.Tests.PublicInterface/HostObjectProbeOverrideTests.cs
+++ b/Jint.Tests.PublicInterface/HostObjectProbeOverrideTests.cs
@@ -108,13 +108,27 @@ public class HostObjectProbeOverrideTests
     {
         foreach (var key in keys)
         {
-#if DEBUG
-            host.DescriptorsBuiltFor.Should().Contain(key, "the verifier re-asks GetOwnProperty once per probe");
-#else
-            host.DescriptorsBuiltFor.Should().NotContain(key, "an existence question must not build a descriptor");
-#endif
+            if (Verifying)
+            {
+                host.DescriptorsBuiltFor.Should().Contain(key, "the verifier re-asks GetOwnProperty once per probe");
+            }
+            else
+            {
+                host.DescriptorsBuiltFor.Should().NotContain(key, "an existence question must not build a descriptor");
+            }
         }
     }
+
+    /// <summary>
+    /// Whether Jint's host-contract verifiers are running: always in a Debug build, and in Release when
+    /// <c>Jint.EnableHostContractVerification</c> was set before the first use of any Jint type — which is what
+    /// this repository's Release verification leg does (<c>JINT_HOST_CONTRACT_VERIFICATION=1</c>). Public and
+    /// static so xUnit can read it for <c>SkipUnless</c>/<c>SkipWhen</c>.
+    /// </summary>
+    public static bool Verifying => HostContractVerificationSwitch.Enabled;
+
+    /// <inheritdoc cref="Verifying" />
+    public static bool NotVerifying => !Verifying;
 
     private static (Engine Engine, HostRecord Host) CreateEngine()
     {
@@ -139,11 +153,14 @@ public class HostObjectProbeOverrideTests
         engine.Evaluate("'absent' in host").AsBoolean().Should().BeFalse();
 
         host.ProbeCalls.Should().Be(3);
-#if DEBUG
-        host.DescriptorsBuiltFor.Should().Equal("visible", "secret", "absent");
-#else
-        host.DescriptorsBuiltFor.Should().BeEmpty();
-#endif
+        if (Verifying)
+        {
+            host.DescriptorsBuiltFor.Should().Equal("visible", "secret", "absent");
+        }
+        else
+        {
+            host.DescriptorsBuiltFor.Should().BeEmpty();
+        }
     }
 
     [Fact]
@@ -293,14 +310,13 @@ public class HostObjectProbeOverrideTests
             => new() { new JsString("honest"), new JsString(_key) };
     }
 
-#if DEBUG
     /// <summary>
     /// With verification on — a Debug build, or the shipped Release package with the
     /// <c>Jint.EnableHostContractVerification</c> switch set before first use — a probe that disagrees with
     /// <c>GetOwnProperty</c> for the same key throws on the spot, naming the host, the key and both answers,
     /// instead of quietly dropping the key. This is the hook that had no verifier at all.
     /// </summary>
-    [Theory]
+    [Theory(Skip = "host-contract verification is off in this run", SkipUnless = nameof(Verifying))]
     [InlineData(OwnPropertyProbe.Missing)]
     [InlineData(OwnPropertyProbe.NonEnumerable)]
     public void VerificationTurnsASilentProbeDisagreementIntoAThrow(OwnPropertyProbe lie)
@@ -313,7 +329,7 @@ public class HostObjectProbeOverrideTests
         act.Should().Throw<InvalidOperationException>().WithMessage("*ProbeOwnProperty*lied*");
     }
 
-    [Fact]
+    [Fact(Skip = "host-contract verification is off in this run", SkipUnless = nameof(Verifying))]
     public void VerificationAlsoCoversTheExistenceQuestions()
     {
         var engine = new Engine();
@@ -326,23 +342,23 @@ public class HostObjectProbeOverrideTests
         ((Action) (() => engine.Evaluate("JSON.stringify({ ...host })"))).Should().Throw<InvalidOperationException>();
     }
 
-    [Fact]
+    [Fact(Skip = "host-contract verification is off in this run", SkipUnless = nameof(Verifying))]
     public void AnHonestOverrideIsUnaffectedByVerification()
     {
-        // the whole Debug run of this file is the real assertion; this one states it directly
+        // the whole verifying run of this file is the real assertion; this one states it directly
         var (engine, host) = CreateEngine();
 
         engine.Evaluate("Object.keys(host).join(',')").AsString().Should().Be("visible,also");
         engine.Evaluate("'secret' in host").AsBoolean().Should().BeTrue();
         host.ProbeCalls.Should().Be(4);
     }
-#else
+
     /// <summary>
     /// What the same host does when nothing is verifying: the lie is believed. Pinned so the damage is on the
     /// record — a wrong <c>Missing</c> costs the key everywhere existence is asked, while a read still produces
     /// it, and nothing anywhere reports a problem.
     /// </summary>
-    [Fact]
+    [Fact(Skip = "host-contract verification is on in this run", SkipUnless = nameof(NotVerifying))]
     public void WithoutVerificationAWrongMissingSilentlyDropsTheKey()
     {
         var engine = new Engine();
@@ -358,7 +374,7 @@ public class HostObjectProbeOverrideTests
         engine.Evaluate("Object.getOwnPropertyDescriptor(host, 'lied') !== undefined").AsBoolean().Should().BeTrue();
     }
 
-    [Fact]
+    [Fact(Skip = "host-contract verification is on in this run", SkipUnless = nameof(NotVerifying))]
     public void WithoutVerificationAWrongEnumerabilitySilentlyHidesTheKeyFromCopies()
     {
         var engine = new Engine();
@@ -371,5 +387,4 @@ public class HostObjectProbeOverrideTests
         engine.Evaluate("'lied' in host").AsBoolean().Should().BeTrue();
         engine.Evaluate("Object.getOwnPropertyDescriptor(host, 'lied').enumerable").AsBoolean().Should().BeTrue();
     }
-#endif
 }

--- a/Jint.Tests.PublicInterface/HostObjectSemanticsTests.cs
+++ b/Jint.Tests.PublicInterface/HostObjectSemanticsTests.cs
@@ -31,31 +31,25 @@ namespace Jint.Tests.PublicInterface;
 /// </summary>
 public class HostObjectSemanticsTests
 {
-    // A Debug build of Jint verifies the Ordinary contract on every read by recomputing it (one probe to walk
-    // the chain looking for side-effect-free descriptors, one more inside the Get it compares against), and
-    // verifies a value-hook answer against the descriptor it claims to match (one more, on the hook lanes
-    // only). Release strips both, and its count is the one the probes-per-read guard is about.
-#if DEBUG
-    private const int OrdinaryOwnReadProbes = 3;
-    private const int OrdinaryWarmPrototypeReadProbes = 3;
-    private const int HookMemberReadProbes = 3;
-    private const int HookMemberReadHookCalls = 2;
-    private const int HookComputedReadProbes = 1;
-    private const int HookPrototypeReadProbes = 3;
-    private const int HookAbsentReadProbes = 4;
+    // Jint's host-contract verifiers check the Ordinary contract on every read by recomputing it (one probe to
+    // walk the chain looking for side-effect-free descriptors, one more inside the Get it compares against), and
+    // check a value-hook answer against the descriptor it claims to match (one more, on the hook lanes only).
+    // They run in a Debug build, and in Release when Jint.EnableHostContractVerification was set before the
+    // first use of any Jint type — which is what this repository's Release verification leg does
+    // (JINT_HOST_CONTRACT_VERIFICATION=1). The unverified count is the one the probes-per-read guard is about.
+    private static bool Verifying => HostContractVerificationSwitch.Enabled;
+
+    private static readonly int OrdinaryOwnReadProbes = Verifying ? 3 : 1;
+    private static readonly int OrdinaryWarmPrototypeReadProbes = Verifying ? 3 : 1;
+    private static readonly int HookMemberReadProbes = Verifying ? 3 : 0;
+    private static readonly int HookMemberReadHookCalls = Verifying ? 2 : 1;
+    private static readonly int HookComputedReadProbes = Verifying ? 1 : 0;
+    private static readonly int HookPrototypeReadProbes = Verifying ? 3 : 0;
+    private static readonly int HookAbsentReadProbes = Verifying ? 4 : 0;
+
     // Deferring to the base implementation is the descriptor lane again, plus the verifier that asks
-    // GetOwnProperty a second time on each of the two hook consults a Debug read makes.
-    private const int HookDeferredReadProbes = 5;
-#else
-    private const int OrdinaryOwnReadProbes = 1;
-    private const int OrdinaryWarmPrototypeReadProbes = 1;
-    private const int HookMemberReadProbes = 0;
-    private const int HookMemberReadHookCalls = 1;
-    private const int HookComputedReadProbes = 0;
-    private const int HookPrototypeReadProbes = 0;
-    private const int HookAbsentReadProbes = 0;
-    private const int HookDeferredReadProbes = 1;
-#endif
+    // GetOwnProperty a second time on each of the two hook consults a verifying read makes.
+    private static readonly int HookDeferredReadProbes = Verifying ? 5 : 1;
 
     [Fact]
     public void OrdinarySemanticsAgreeWithGetOwnPropertyForEveryReadOutcome()

--- a/Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj
+++ b/Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj
@@ -32,6 +32,12 @@
   <ItemGroup>
     <!-- Shared so that a JsValue can be compared against a CLR value in both test projects. -->
     <Compile Include="..\Jint.Tests\JsValueAssertions.cs" Link="JsValueAssertions.cs" />
+    <!--
+      Shared so that both suites turn Jint's host-contract verifiers on the same way, and early enough: the
+      module initializer inside runs before any Jint type is touched, which is the only point at which the
+      AppContext switch can still be observed.
+    -->
+    <Compile Include="..\Jint.Tests\HostContractVerificationSwitch.cs" Link="HostContractVerificationSwitch.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jint.Tests.PublicInterface/ObjectConverterRegistrationTests.cs
+++ b/Jint.Tests.PublicInterface/ObjectConverterRegistrationTests.cs
@@ -74,6 +74,17 @@ public class ObjectConverterRegistrationTests
     /// and converting an undeclared type is exactly the drift the claim verifier reports: with host-contract
     /// verification on, the read therefore throws rather than quietly returning the converted value.
     /// </summary>
+    /// <summary>
+    /// Whether Jint's host-contract verifiers are running: always in a Debug build, and in Release when
+    /// <c>Jint.EnableHostContractVerification</c> was set before the first use of any Jint type — which is what
+    /// this repository's Release verification leg does (<c>JINT_HOST_CONTRACT_VERIFICATION=1</c>). Public and
+    /// static so xUnit can read it for <c>SkipUnless</c>.
+    /// </summary>
+    public static bool Verifying => HostContractVerificationSwitch.Enabled;
+
+    /// <inheritdoc cref="Verifying" />
+    public static bool NotVerifying => !Verifying;
+
     private static void ShouldRead(Engine engine, string expression, JsValue whenBypassed, JsValue whenConverted)
     {
         if (_compiledReadLaneAvailable)
@@ -82,12 +93,14 @@ public class ObjectConverterRegistrationTests
             return;
         }
 
-#if DEBUG
-        ((Action) (() => engine.Evaluate(expression))).Should().Throw<InvalidOperationException>(
-            "the converter is reached here, and it converts a type its registration did not declare");
-#else
+        if (Verifying)
+        {
+            ((Action) (() => engine.Evaluate(expression))).Should().Throw<InvalidOperationException>(
+                "the converter is reached here, and it converts a type its registration did not declare");
+            return;
+        }
+
         engine.Evaluate(expression).Should().Be(whenConverted);
-#endif
     }
 
     /// <summary>Turns every bool it sees into its negation, and every enum into its name.</summary>
@@ -411,14 +424,13 @@ public class ObjectConverterRegistrationTests
 
     #region 5. the declaration and the converter's switch drifting apart
 
-#if DEBUG
     /// <summary>
     /// Declaring types is a promise, and nothing links it to the <c>switch</c> inside the converter: add a case
     /// to <c>TryConvert</c> and forget the registration, and the engine keeps the fast lanes for every member
     /// that cannot produce the declared types — so the new case is silently skipped on exactly those members,
     /// and works everywhere else. With host-contract verification on, converting an undeclared type says so.
     /// </summary>
-    [Fact]
+    [Fact(Skip = "host-contract verification is off in this run", SkipUnless = nameof(Verifying))]
     public void VerificationCatchesAConverterConvertingAnUndeclaredType()
     {
         // Boxed is declared `object`, so no declaration can exclude it and the converter is always offered its
@@ -433,7 +445,7 @@ public class ObjectConverterRegistrationTests
             .WithMessage("*MeddlingConverter*Boolean*Guid*");
     }
 
-    [Fact]
+    [Fact(Skip = "host-contract verification is off in this run", SkipUnless = nameof(Verifying))]
     public void VerificationIsSilentForAConverterThatStaysInsideItsDeclaration()
     {
         var engine = CreateEngine(
@@ -445,7 +457,7 @@ public class ObjectConverterRegistrationTests
         engine.Evaluate("host.EnumValue").Should().Be("One");
     }
 
-    [Fact]
+    [Fact(Skip = "host-contract verification is off in this run", SkipUnless = nameof(Verifying))]
     public void VerificationLeavesAnUndeclaredRegistrationAlone()
     {
         // registering without declared types claims everything, so nothing can be out of scope
@@ -453,13 +465,13 @@ public class ObjectConverterRegistrationTests
 
         engine.Evaluate("host.Boxed").Should().Be(false);
     }
-#else
+
     /// <summary>
     /// The same drift with nothing verifying: the converter runs on the members whose declared type happens to
     /// be wide enough to reach it, and is skipped on the rest. Pinned so the damage is on the record — the
     /// inconsistency is invisible from script and from the host.
     /// </summary>
-    [Fact]
+    [Fact(Skip = "host-contract verification is on in this run", SkipUnless = nameof(NotVerifying))]
     public void WithoutVerificationADriftedDeclarationIsSilentlyInconsistent()
     {
         var engine = CreateEngine(
@@ -471,7 +483,6 @@ public class ObjectConverterRegistrationTests
         // ...while the same value read through a `bool`-typed member skips it, where the lane exists
         ShouldRead(engine, "host.Flag", whenBypassed: true, whenConverted: false);
     }
-#endif
 
     #endregion
 }

--- a/Jint.Tests/HostContractVerificationSwitch.cs
+++ b/Jint.Tests/HostContractVerificationSwitch.cs
@@ -1,0 +1,80 @@
+#nullable enable
+
+using System.Runtime.CompilerServices;
+
+namespace Jint.Tests;
+
+/// <summary>
+/// Turns Jint's <b>host-contract verifiers</b> on for a Release run of this repository's own test suites, so the
+/// exact configuration an embedder is told to use is one the harness itself exercises.
+///
+/// <para>
+/// The verifiers are gated on <c>HostContractVerification.Enabled</c>, which is <see langword="true"/> in a Debug
+/// build and, in Release, whatever the AppContext switch <c>Jint.EnableHostContractVerification</c> said at
+/// <em>type initialization</em>. That last word is the whole difficulty: the flag is a <c>static readonly bool</c>
+/// read once, so the switch has to be set before the first use of any Jint type — a test fixture, a class
+/// constructor or an assembly-level <c>IAsyncLifetime</c> all run far too late.
+/// </para>
+///
+/// <para>
+/// A <see cref="ModuleInitializerAttribute">module initializer</see> is early enough by construction: the runtime
+/// runs it before any code in this assembly executes, and Jint is only ever reached <em>from</em> this assembly's
+/// code. It also needs nothing per target framework — <c>net472</c> has no
+/// <c>ModuleInitializerAttribute</c> in its BCL, but the repository's global <c>PolySharp</c> reference emits one,
+/// and the compiler recognizes the attribute by name rather than by identity.
+/// </para>
+///
+/// <para>
+/// The opt-in is the environment variable <c>JINT_HOST_CONTRACT_VERIFICATION</c> (<c>1</c> or <c>true</c>):
+/// </para>
+///
+/// <code>
+/// JINT_HOST_CONTRACT_VERIFICATION=1 dotnet test -c Release
+/// </code>
+///
+/// <para>
+/// It is deliberately <b>not</b> the default. The Release probe-count and no-descriptor pins in
+/// <c>Jint.Tests.PublicInterface</c> are the regression net for the claim that the gate folds to zero cost when
+/// nobody asked for it, and they can only mean that in a run where nobody did.
+/// </para>
+/// </summary>
+public static class HostContractVerificationSwitch
+{
+    /// <summary>The AppContext switch Jint's gate reads.</summary>
+    public const string SwitchName = "Jint.EnableHostContractVerification";
+
+    /// <summary>The environment variable this harness turns into that switch.</summary>
+    public const string EnvironmentVariableName = "JINT_HOST_CONTRACT_VERIFICATION";
+
+    /// <summary>
+    /// Whether the verifiers actually run in this process. Computed exactly the way Jint's own gate computes it,
+    /// and from the environment rather than from the switch, so it cannot be disturbed by a test that flips the
+    /// switch after Jint has already read it.
+    /// </summary>
+    public static readonly bool Enabled =
+#if DEBUG
+        true;
+#else
+        RequestedByTheEnvironment();
+#endif
+
+    /// <summary>
+    /// Whether the run was asked to verify. Distinct from <see cref="Enabled"/> only in a Debug build, where the
+    /// verifiers are on whether or not anyone asked.
+    /// </summary>
+    public static bool RequestedByTheEnvironment()
+    {
+        var requested = Environment.GetEnvironmentVariable(EnvironmentVariableName);
+        return string.Equals(requested, "1", StringComparison.Ordinal)
+            || string.Equals(requested, "true", StringComparison.OrdinalIgnoreCase);
+    }
+
+    [ModuleInitializer]
+    internal static void SetSwitchBeforeAnyJintTypeIsTouched()
+    {
+        if (RequestedByTheEnvironment())
+        {
+            AppContext.SetSwitch(SwitchName, true);
+        }
+    }
+}

--- a/Jint.Tests/Runtime/ArrayLikeObjectLaneTests.cs
+++ b/Jint.Tests/Runtime/ArrayLikeObjectLaneTests.cs
@@ -165,12 +165,15 @@ public class ArrayLikeObjectLaneTests
 
         operations.HasProperty(1).Should().Be(true);
         host.HasIndexCalls.Should().Be(1);
-#if DEBUG
-        // the agreement verifier re-runs TryGetIndex once per probe
-        host.TryGetIndexCalls.Should().Be(1);
-#else
-        host.TryGetIndexCalls.Should().Be(0);
-#endif
+        if (HostContractVerificationSwitch.Enabled)
+        {
+            // the agreement verifier re-runs TryGetIndex once per probe
+            host.TryGetIndexCalls.Should().Be(1);
+        }
+        else
+        {
+            host.TryGetIndexCalls.Should().Be(0);
+        }
 
         var before = host.TryGetIndexCalls;
         var hasIndexBefore = host.HasIndexCalls;

--- a/Jint.Tests/Runtime/HostContractVerificationSwitchTests.cs
+++ b/Jint.Tests/Runtime/HostContractVerificationSwitchTests.cs
@@ -1,0 +1,44 @@
+#nullable enable
+
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Pins the harness half of the host-contract verification story: that
+/// <see cref="HostContractVerificationSwitch"/> — which every verification-aware expectation in both test suites
+/// selects on — reports the same thing Jint's own gate does.
+///
+/// <para>
+/// The two are computed independently and from different inputs. Jint reads the AppContext switch
+/// <c>Jint.EnableHostContractVerification</c> once, at the type initialization of
+/// <c>HostContractVerification</c>; the harness reads the environment variable
+/// <c>JINT_HOST_CONTRACT_VERIFICATION</c> and sets that switch from a module initializer. They can only agree if
+/// the module initializer really did run before the first use of any Jint type — which is the entire ordering
+/// contract of a <c>static readonly</c> gate, and the thing a fixture or a class constructor would be too late
+/// for. This project has <c>InternalsVisibleTo</c>, so it can read the gate directly; the same claim is made
+/// from behaviour alone in <c>Jint.Tests.PublicInterface.HostContractVerificationTests</c>.
+/// </para>
+/// </summary>
+public class HostContractVerificationSwitchTests
+{
+    [Fact]
+    public void TheHarnessSwitchAgreesWithJintsOwnGate()
+    {
+        HostContractVerificationSwitch.Enabled.Should().Be(
+            HostContractVerification.Enabled,
+            "the module initializer must set the AppContext switch before Jint's gate reads it");
+    }
+
+    [Fact]
+    public void AskingForVerificationIsWhatTurnsItOnOutsideDebug()
+    {
+#if DEBUG
+        HostContractVerification.Enabled.Should().BeTrue("a Debug build verifies host contracts without being asked");
+#else
+        HostContractVerification.Enabled.Should().Be(
+            HostContractVerificationSwitch.RequestedByTheEnvironment(),
+            "a Release run verifies exactly when " + HostContractVerificationSwitch.EnvironmentVariableName + " asked it to");
+#endif
+    }
+}

--- a/Jint.Tests/Runtime/SharedObjectShapeTests.cs
+++ b/Jint.Tests/Runtime/SharedObjectShapeTests.cs
@@ -153,17 +153,20 @@ public class SharedObjectShapeTests
         descriptors[0].Should().NotBeNull("the member whose value was read had to materialize");
         descriptors[4].Should().NotBeNull("a constant points at the shape's shared descriptor from the start");
 
-#if DEBUG
-        // A Debug build cross-checks every probe against GetOwnProperty, which materializes the slot — the
-        // checker doing its job, and the reason the no-materialization figure is a Release figure.
-        descriptors[1].Should().NotBeNull();
-        descriptors[2].Should().NotBeNull();
-        descriptors[3].Should().NotBeNull();
-#else
-        descriptors[1].Should().BeNull("an enumerable member's name and flag come from the shared layout");
-        descriptors[2].Should().BeNull("so do a non-enumerable member's");
-        descriptors[3].Should().BeNull("an accessor is not created to answer whether it is enumerable");
-#endif
+        if (HostContractVerificationSwitch.Enabled)
+        {
+            // Host-contract verification cross-checks every probe against GetOwnProperty, which materializes the
+            // slot — the checker doing its job, and the reason the no-materialization figure is an unverified one.
+            descriptors[1].Should().NotBeNull();
+            descriptors[2].Should().NotBeNull();
+            descriptors[3].Should().NotBeNull();
+        }
+        else
+        {
+            descriptors[1].Should().BeNull("an enumerable member's name and flag come from the shared layout");
+            descriptors[2].Should().BeNull("so do a non-enumerable member's");
+            descriptors[3].Should().BeNull("an accessor is not created to answer whether it is enumerable");
+        }
 
         // Reading the values is what creates them, and the answers are unchanged.
         engine.Evaluate("Object.values(proto).length").Should().Be(4);
@@ -191,11 +194,14 @@ public class SharedObjectShapeTests
         engine.Evaluate("'cbrt' in Math").Should().Be(true);
         engine.Evaluate("(function () { var n = 0; for (var k in Math) { n++; } return n; })()").Should().Be(0);
 
-#if DEBUG
-        CountMaterialized(math).Should().BeGreaterThan(materializedAfterOneCall, "the Debug probe checker materializes what it re-reads");
-#else
-        CountMaterialized(math).Should().Be(materializedAfterOneCall, "no enumerability question created a function");
-#endif
+        if (HostContractVerificationSwitch.Enabled)
+        {
+            CountMaterialized(math).Should().BeGreaterThan(materializedAfterOneCall, "the probe checker materializes what it re-reads");
+        }
+        else
+        {
+            CountMaterialized(math).Should().Be(materializedAfterOneCall, "no enumerability question created a function");
+        }
 
         static int CountMaterialized(IBuiltinShaped shaped)
         {


### PR DESCRIPTION
#2864 made the host-contract verifiers reachable from the shipped Release package, and its `AssemblyLoadContext` test proves the `Jint.EnableHostContractVerification` switch turns them on. But nothing exercised the **full host-test surface** that way — the exact configuration an embedder is told to use. CI gates in Release, where the verifiers are dormant; broadly they ran only in Debug, on a developer's machine. A verifier that misbehaves under the Release JIT (tiering, inlining, dead-branch folding), or a gating bug, would have shipped unseen. This dogfoods the documented recipe in-repo.

**This PR touches only test projects, the PR workflow and AGENTS.md.** No shipped code changes.

## The opt-in

`JINT_HOST_CONTRACT_VERIFICATION=1` (or `true`), turned into the AppContext switch by a `[ModuleInitializer]` in `Jint.Tests/HostContractVerificationSwitch.cs`, compiled into both `Jint.Tests` and `Jint.Tests.PublicInterface`:

```bash
JINT_HOST_CONTRACT_VERIFICATION=1 dotnet test -c Release Jint.Tests/Jint.Tests.csproj
JINT_HOST_CONTRACT_VERIFICATION=1 dotnet test -c Release Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj
```

A module initializer is the only hook early enough. The gate is a `static readonly bool` read once at type initialization, so a fixture, a collection or a class constructor all run *after* some Jint type has already been touched. It also needs nothing per target framework: `net472` has no `ModuleInitializerAttribute` in its BCL, but the repository's global `PolySharp` reference emits one and the compiler matches the attribute by name rather than by identity. Verified on `net472` specifically — it is the TFM most likely to break this, and it does not.

## A dedicated leg, not a blanket flip

The Release probe-count and no-descriptor pins are the regression net for the claim that the disabled gate folds to zero cost, and they can only mean that in a run where nobody asked for verification. So the default Release run stays switch-off.

Every expectation that differs between the two configurations now selects at runtime from `HostContractVerificationSwitch.Enabled` instead of on `#if DEBUG`:

| File | What moved |
| --- | --- |
| `HostObjectProbeCountTests` | the `#if DEBUG` constants became a per-kind `ProbeCosts` table — `[InlineData]` arguments must be compile-time constants, so the counts moved out of the attributes into the method body |
| `HostObjectSemanticsTests` | eight `const int` → `static readonly int` |
| `HostObjectProbeOverrideTests` | the descriptor-materialization assertions, plus 3 + 2 configuration-specific tests |
| `HostArrayLikeHasIndexTests` | the `TryGetIndex`-not-called assertion, plus 2 + 2 configuration-specific tests |
| `ObjectConverterRegistrationTests` | the `ShouldRead` helper, plus 3 + 1 configuration-specific tests |
| `Jint.Tests/Runtime/ArrayLikeObjectLaneTests` | the `HasIndex`/`TryGetIndex` agreement count |
| `Jint.Tests/Runtime/SharedObjectShapeTests` | the two builtin-shape no-materialization assertions |

The nine tests that only make sense with the verifiers on, and the five that only make sense with them off, are now compiled in **both** configurations and skipped with `SkipUnless`, so a run states which configuration it is rather than silently containing fewer tests.

**Measured, not assumed:** every Release+switch count equals the Debug one. The extra probes really are only the verifier's own, and nothing else about the two builds differs on these paths.

## Ordering, pinned from both sides

- `Jint.Tests.Runtime.HostContractVerificationSwitchTests` checks the harness flag against Jint's own gate — `Jint.Tests` has `InternalsVisibleTo`, so it can read `HostContractVerification.Enabled` directly. The two are computed from different inputs (the switch vs. the environment variable) and can only agree if the module initializer really did run before the first use of any Jint type.
- `HostContractVerificationTests.TheHarnessSetsTheSwitchEarlyEnoughForJintToObserveIt` proves the same thing from **behaviour** alone, which is all `Jint.Tests.PublicInterface` may use: a host whose `ProbeOwnProperty` contradicts its own `GetOwnProperty` throws exactly when the verifiers are running.
- `TheDefaultIsOnForADebugBuildAndOffForTheShippedRelease` now asserts *off* unless the harness asked, so the zero-cost default stays pinned in the default run and the opt-in is pinned in the verification leg.

## CI

One new job in `pr.yml`, `linux - host-contract verification`, running both suites in Release with the variable set. One OS is enough — the verifiers are platform-independent and the switch is set the same way everywhere — and it deliberately does not multiply the four-OS matrix.

## Gate

All four legs green locally, `net10.0` **and** `net472` in each:

| Leg | `Jint.Tests` (net10.0 / net472) | `Jint.Tests.PublicInterface` (net10.0 / net472) |
| --- | --- | --- |
| Release, switch **off** (default) | 4622 / 4541 passed, 0 failed | 1240 / 1239 passed, 9 skipped, 0 failed |
| Release, switch **on** (new leg) | 4622 / 4541 passed, 0 failed | 1244 / 1243 passed, 5 skipped, 0 failed |
| Debug | 4622 / 4541 passed, 0 failed | 1243 / 1243 passed, 5 skipped, 0 failed |

`dotnet build -c Release` (whole solution): 0 errors, 0 compiler warnings. The one remaining warning is a pre-existing MSBuild `MSB3277` (`System.Memory` 4.0.1.2 vs 4.0.2.0) in `Jint.Tests.CommonScripts` on `net472`, a project this PR does not touch. Test262 was not run — no shipped code changed.

Red-first: with the mechanism in and the tests untouched, the switch-on Release run failed 41 tests on `net10.0` and 45 on `net472`, which is both the proof that the switch reached Jint on both TFMs and the list of expectations that needed adapting.
