### PR TITLE
Stop a closing iterator from swallowing the error that closed it

### DIFF
--- a/Jint.Tests/Runtime/IteratorHelpersTests.cs
+++ b/Jint.Tests/Runtime/IteratorHelpersTests.cs
@@ -132,4 +132,182 @@ public class IteratorHelpersTests
 
         result.Should().BeTrue();
     }
+
+    // IteratorClose step 4 - "If completion is a throw completion, return ? completion" - is reached
+    // before innerResult is inspected, so the error that triggered the close outranks anything the
+    // close itself raises. That covers the GetMethod of step 2, not just the call of step 3.c.
+    private const string ClosingReceivers = """
+        // "return" is a throwing accessor: GetMethod itself completes abruptly
+        function throwingGetter() {
+            return {
+                __proto__: proto,
+                get next() { throw new Error('next must not be read'); },
+                get return() { throw new Error('SWALLOWED'); }
+            };
+        }
+
+        // "return" is present but not callable: GetMethod throws a TypeError of its own
+        function badReturnValue() {
+            return {
+                __proto__: proto,
+                get next() { throw new Error('next must not be read'); },
+                return: 42
+            };
+        }
+
+        // the already-correct control: the close CALL throws
+        function throwingCall() {
+            return {
+                __proto__: proto,
+                get next() { throw new Error('next must not be read'); },
+                return() { throw new Error('SWALLOWED'); }
+            };
+        }
+
+        function raised(fn) {
+            try {
+                fn();
+                return '<no throw>';
+            } catch (e) {
+                return e.constructor.name + ': ' + e.message;
+            }
+        }
+        """;
+
+    [Theory]
+    // every helper that validates an argument before building the iterator record closes the
+    // receiver, and every one of them used to surrender its error to a throwing "return" getter
+    [InlineData("map")]
+    [InlineData("filter")]
+    [InlineData("flatMap")]
+    [InlineData("forEach")]
+    [InlineData("some")]
+    [InlineData("every")]
+    [InlineData("find")]
+    [InlineData("reduce")]
+    public void ClosingTheReceiverNeverReplacesTheValidationError(string method)
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate($$"""
+            const proto = Iterator.prototype;
+            {{ClosingReceivers}}
+            JSON.stringify([
+                raised(() => proto.{{method}}.call(throwingGetter())),
+                raised(() => proto.{{method}}.call(badReturnValue())),
+                raised(() => proto.{{method}}.call(throwingCall()))
+            ]);
+            """).AsString();
+
+        result.Should().Be("""["TypeError: Argument must be callable","TypeError: Argument must be callable","TypeError: Argument must be callable"]""");
+    }
+
+    [Theory]
+    // take/drop raise a RangeError, so a close that leaks its own error changes the observable
+    // error TYPE, not just its message
+    [InlineData("take", "NaN")]
+    [InlineData("take", "-1")]
+    [InlineData("drop", "NaN")]
+    [InlineData("drop", "-1")]
+    public void ClosingTheReceiverNeverReplacesTheLimitRangeError(string method, string limit)
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate($$"""
+            const proto = Iterator.prototype;
+            {{ClosingReceivers}}
+            JSON.stringify([
+                raised(() => proto.{{method}}.call(throwingGetter(), {{limit}})),
+                raised(() => proto.{{method}}.call(badReturnValue(), {{limit}})),
+                raised(() => proto.{{method}}.call(throwingCall(), {{limit}}))
+            ]);
+            """).AsString();
+
+        var expected = $"RangeError: {(limit == "NaN" ? "NaN" : "-1")} must be positive";
+        result.Should().Be($"""["{expected}","{expected}","{expected}"]""");
+    }
+
+    [Fact]
+    public void ClosingTheReceiverNeverReplacesACoercionError()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate($$"""
+            const proto = Iterator.prototype;
+            {{ClosingReceivers}}
+            const uncoercible = { valueOf() { throw new Error('FROM-VALUEOF'); } };
+            const unstringifiable = { toString() { throw new Error('FROM-TOSTRING'); } };
+            JSON.stringify([
+                raised(() => proto.take.call(throwingGetter(), uncoercible)),
+                raised(() => proto.drop.call(badReturnValue(), uncoercible)),
+                // join closes on a separator whose ToString throws, before "next" is ever read
+                raised(() => proto.join.call(throwingGetter(), unstringifiable)),
+                raised(() => proto.join.call(badReturnValue(), unstringifiable))
+            ]);
+            """).AsString();
+
+        result.Should().Be("""["Error: FROM-VALUEOF","Error: FROM-VALUEOF","Error: FROM-TOSTRING","Error: FROM-TOSTRING"]""");
+    }
+
+    [Theory]
+    [InlineData("map")]
+    [InlineData("filter")]
+    [InlineData("flatMap")]
+    [InlineData("forEach")]
+    [InlineData("some")]
+    [InlineData("every")]
+    [InlineData("find")]
+    [InlineData("reduce")]
+    public void AsyncClosingTheReceiverNeverReplacesTheValidationError(string method)
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate($$"""
+            const proto = AsyncIterator.prototype;
+            {{ClosingReceivers}}
+            JSON.stringify([
+                raised(() => proto.{{method}}.call(throwingGetter())),
+                raised(() => proto.{{method}}.call(badReturnValue())),
+                raised(() => proto.{{method}}.call(throwingCall()))
+            ]);
+            """).AsString();
+
+        result.Should().Be("""["TypeError: Argument must be callable","TypeError: Argument must be callable","TypeError: Argument must be callable"]""");
+    }
+
+    [Theory]
+    [InlineData("take")]
+    [InlineData("drop")]
+    public void AsyncClosingTheReceiverNeverReplacesTheLimitRangeError(string method)
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate($$"""
+            const proto = AsyncIterator.prototype;
+            {{ClosingReceivers}}
+            JSON.stringify([
+                raised(() => proto.{{method}}.call(throwingGetter(), NaN)),
+                raised(() => proto.{{method}}.call(badReturnValue(), NaN)),
+                raised(() => proto.{{method}}.call(throwingCall(), NaN))
+            ]);
+            """).AsString();
+
+        result.Should().Be("""["RangeError: NaN must be positive","RangeError: NaN must be positive","RangeError: NaN must be positive"]""");
+    }
+
+    [Fact]
+    public void ClosingTheReceiverStillHappens()
+    {
+        // the fix suppresses the close's own error, it must not suppress the close
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            let closed = 0;
+            const closable = {
+                __proto__: Iterator.prototype,
+                get next() { throw new Error('next must not be read'); },
+                return() { closed++; return {}; }
+            };
+
+            try { closable.map(); } catch { }
+            try { closable.take(NaN); } catch { }
+            closed;
+            """).AsNumber();
+
+        result.Should().Be(2);
+    }
 }

--- a/Jint/Native/Iterator/AsyncIteratorPrototype.cs
+++ b/Jint/Native/Iterator/AsyncIteratorPrototype.cs
@@ -92,11 +92,24 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
     private static IteratorInstance.ObjectIterator GetIteratorDirect(ObjectInstance objectInstance) => new(objectInstance);
 
     /// <summary>
+    /// https://tc39.es/ecma262/#sec-iteratorclose
     /// Close an iterator by calling its return() method directly.
     /// </summary>
     private static void IteratorClose(ObjectInstance obj, CompletionType completionType)
     {
-        var returnMethod = obj.GetMethod(CommonProperties.Return);
+        // See the identical helper on IteratorPrototype: step 4 runs before innerResult is
+        // inspected, so neither the GetMethod of step 2 nor the call of step 3.c may replace the
+        // error that triggered the close.
+        ICallable? returnMethod;
+        try
+        {
+            returnMethod = obj.GetMethod(CommonProperties.Return);
+        }
+        catch when (completionType == CompletionType.Throw)
+        {
+            return;
+        }
+
         if (returnMethod is null)
         {
             return;

--- a/Jint/Native/Iterator/IteratorPrototype.cs
+++ b/Jint/Native/Iterator/IteratorPrototype.cs
@@ -125,12 +125,27 @@ internal partial class IteratorPrototype : Prototype
     private static IteratorInstance.ObjectIterator GetIteratorDirect(ObjectInstance objectInstance) => new(objectInstance);
 
     /// <summary>
+    /// https://tc39.es/ecma262/#sec-iteratorclose
     /// Close an iterator by calling its return() method directly (without reading next).
     /// Used when validation fails before GetIteratorDirect is called.
     /// </summary>
     private static void IteratorClose(ObjectInstance obj, CompletionType completionType)
     {
-        var returnMethod = obj.GetMethod(CommonProperties.Return);
+        // Step 4 - "If completion is a throw completion, return ? completion" - is reached before
+        // innerResult is inspected, so nothing raised while closing may replace the error that
+        // triggered the close. That covers the GetMethod in step 2 as much as the call in step 3.c:
+        // a throwing "return" accessor, or a "return" that is present but not callable, must leave
+        // the original TypeError/RangeError/coercion error standing.
+        ICallable? returnMethod;
+        try
+        {
+            returnMethod = obj.GetMethod(CommonProperties.Return);
+        }
+        catch when (completionType == CompletionType.Throw)
+        {
+            return;
+        }
+
         if (returnMethod is null)
         {
             return;


### PR DESCRIPTION
Every `%Iterator.prototype%` and `%AsyncIterator.prototype%` helper that validates an argument does so *before* building the iterator record, and closes the receiver when validation fails — `map`/`filter`/`flatMap`/`forEach`/`some`/`every`/`find`/`reduce` on a non-callable, `take`/`drop` on a NaN or negative limit or an argument whose `ToNumber` throws, and (since #2867) `join` on a separator whose `ToString` throws.

[IteratorClose](https://tc39.es/ecma262/#sec-iteratorclose) reaches step 4 — *"If completion is a throw completion, return ? completion"* — before it ever inspects `innerResult`, so nothing raised while closing may replace the error that triggered the close:

```
2. Let innerResult be Completion(GetMethod(iterator, "return")).
3. If innerResult is a normal completion, then
   a. Let return be innerResult.[[Value]].
   b. If return is undefined, return ? completion.
   c. Set innerResult to Completion(Call(return, iterator)).
4. If completion is a throw completion, return ? completion.   <-- before step 5
5. If innerResult is a throw completion, return ? innerResult.
```

The private `IteratorClose` helper on each of those two prototypes honoured that for the **call** in step 3.c and not for the **GetMethod** in step 2 — the lookup sat outside the `try`/`catch when`, so it escaped.

### Reproduction

```js
const closable = {
  __proto__: Iterator.prototype,
  get return() { throw new Error('mine'); },
};

closable.map();        // Error: mine        — must be TypeError
closable.take(NaN);    // Error: mine        — must be RangeError

const weird = { __proto__: Iterator.prototype, return: 42 };
weird.take(NaN);       // TypeError          — must be RangeError
```

The second shape is the sharper one: `GetMethod` throws a `TypeError` of its own for a `return` that is present and not callable, so the error a caller catches changes **type**, not just message. Both shapes reproduce identically on `AsyncIterator.prototype`.

test262 does not cover either — its `get-return-method-throws.js` tests exercise the helper's *own* `return()`, a different path — which is why this went unnoticed. All 23 affected entry points (12 sync + 11 async) are wrong; the receiver's error wins every time.

### Fix

Both helpers now wrap the lookup in the same `catch when (completionType == CompletionType.Throw)` the call already had, which is exactly what `IteratorInstance.ObjectIterator.Close` — the record-based close used once iteration is under way — has always done. The close still happens; only its own error is suppressed, and only when the completion being carried is already a throw.

`JintYieldExpression.AsyncIteratorClose` has a similar shape and is deliberately left alone: both of its call sites pass `CompletionType.Normal`, so the branch that would carry the same bug is unreachable.

### Verification

The new test cases in `IteratorHelpersTests` were run against the unfixed engine first, on this exact rebased base — **23 of the file's 32 cases fail without the change, all 32 pass with it**. The 9 that pass either way are the pre-existing `toArray`/`join` tests plus `ClosingTheReceiverStillHappens`, which pins that the close is still *performed* — the fix suppresses the close's own error, not the close. Each theory also folds in an already-correct throwing-`return()` control, so a fix that over-suppressed would be caught too.

Full Release run on this branch:

| suite | result |
| --- | --- |
| `Jint.Tests.Test262` | 99484 passed, 0 failed, 157 skipped |
| `Jint.Tests` (net10.0 / net472) | 4660 / 4579 passed, 0 failed |
| `Jint.Tests.PublicInterface` (net10.0 / net472) | 1240 / 1239 passed, 0 failed |

Rebased onto `main` after #2867 merged; `join` closes through the same helper, so it joined the coercion-error coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
