### PR TITLE
Only bind a module's own lexical declarations at module level

### DIFF
--- a/Jint.Tests/Runtime/ModuleTests.cs
+++ b/Jint.Tests/Runtime/ModuleTests.cs
@@ -1193,4 +1193,56 @@ export const count = globals.counter;
 
         log.Should().Equal("mid");
     }
+
+    [Fact]
+    public void ShouldNotBindALexicalDeclarationFromANestedBlockAtModuleLevel()
+    {
+        // A block's `let` is not a module item, so binding it at module level would leave the `var` of the same name uninitialized.
+        _engine.Modules.Add("my-module", "{ let a = 1; } var a = 2; export const value = a;");
+        var ns = _engine.Modules.Import("my-module");
+
+        ns.Get("value").AsInteger().Should().Be(2);
+    }
+
+    [Fact]
+    public void ShouldNotBindAForHeadDeclarationAtModuleLevel()
+    {
+        // The `let` of a for head is scoped to the loop, so nothing named `key` reaches module scope.
+        _engine.Modules.Add("my-module", "for (let key in { x: 1 }) {} export const value = typeof key;");
+        var ns = _engine.Modules.Import("my-module");
+
+        ns.Get("value").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void ShouldNotBindAClassDeclaredInABlockAtModuleLevel()
+    {
+        _engine.Modules.Add("my-module", "{ class C {} } export const value = typeof C;");
+        var ns = _engine.Modules.Import("my-module");
+
+        ns.Get("value").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void ShouldBindExportedLexicalDeclarationsAtModuleLevel()
+    {
+        // The counterpart: an exported declaration sits inside the export declaration and is a module item.
+        _engine.Modules.Add("my-module", "export const c = 1; export let l = 2; export class K {} export default class D {}");
+        var ns = _engine.Modules.Import("my-module");
+
+        ns.Get("c").AsInteger().Should().Be(1);
+        ns.Get("l").AsInteger().Should().Be(2);
+        ns.Get("K").IsCallable.Should().BeTrue();
+        ns.Get("default").IsCallable.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldStillApplyTheTemporalDeadZoneToModuleLevelDeclarations()
+    {
+        // A module-level `const` is bound uninitialized until its declaration runs, so reading it early throws even through typeof.
+        _engine.Modules.Add("my-module", "globalThis.probe = typeof x; const x = 1;");
+
+        Invoking(() => _engine.Modules.Import("my-module")).Should().ThrowExactly<JavaScriptException>()
+            .Which.Message.Should().Be("Cannot access 'x' before initialization");
+    }
 }

--- a/Jint.Tests/Runtime/ModuleTests.cs
+++ b/Jint.Tests/Runtime/ModuleTests.cs
@@ -1198,29 +1198,40 @@ export const count = globals.counter;
     public void ShouldNotBindALexicalDeclarationFromANestedBlockAtModuleLevel()
     {
         // A block's `let` is not a module item, so binding it at module level would leave the `var` of the same name uninitialized.
-        _engine.Modules.Add("my-module", "{ let a = 1; } var a = 2; export const value = a;");
+        // The value is read from inside the block as well, because the post-block value alone cannot tell the fixed behaviour
+        // apart from the equally wrong one where the block's initializer lands on the module-level `var`.
+        _engine.Modules.Add("my-module", "let inner; { let a = 1; inner = a; } var a = 2; export const value = a; export { inner };");
         var ns = _engine.Modules.Import("my-module");
 
+        ns.Get("inner").AsInteger().Should().Be(1);
         ns.Get("value").AsInteger().Should().Be(2);
     }
 
     [Fact]
     public void ShouldNotBindAForHeadDeclarationAtModuleLevel()
     {
-        // The `let` of a for head is scoped to the loop, so nothing named `key` reaches module scope.
-        _engine.Modules.Add("my-module", "for (let key in { x: 1 }) {} export const value = typeof key;");
-        var ns = _engine.Modules.Import("my-module");
+        // The `let` of a for head is scoped to the loop, so nothing it binds reaches module scope, and a module-level
+        // `var` of the same name stays writable. Each head shape is a separate branch of the walk, and the two a
+        // bundler actually emits are `for` and `for-of`.
+        _engine.Modules.Add("for-in", "for (let key in { x: 1 }) {} export const value = typeof key;");
+        _engine.Modules.Add("for", "for (let i = 0; i < 1; i++) {} var i = 5; export const value = i;");
+        _engine.Modules.Add("for-of", "for (const o of [1]) {} var o = 6; export const value = o;");
 
-        ns.Get("value").AsString().Should().Be("undefined");
+        _engine.Modules.Import("for-in").Get("value").AsString().Should().Be("undefined");
+        _engine.Modules.Import("for").Get("value").AsInteger().Should().Be(5);
+        _engine.Modules.Import("for-of").Get("value").AsInteger().Should().Be(6);
     }
 
     [Fact]
     public void ShouldNotBindAClassDeclaredInABlockAtModuleLevel()
     {
-        _engine.Modules.Add("my-module", "{ class C {} } export const value = typeof C;");
-        var ns = _engine.Modules.Import("my-module");
+        // A class declaration is a separate branch of the walk from a variable declaration, so it needs both facts: the
+        // name is invisible outside its block, and it does not leave a module-level `var` of the same name uninitialized.
+        _engine.Modules.Add("invisible", "{ class C {} } export const value = typeof C;");
+        _engine.Modules.Add("clobbered", "{ class C {} } var C = 1; export const value = C;");
 
-        ns.Get("value").AsString().Should().Be("undefined");
+        _engine.Modules.Import("invisible").Get("value").AsString().Should().Be("undefined");
+        _engine.Modules.Import("clobbered").Get("value").AsInteger().Should().Be(1);
     }
 
     [Fact]
@@ -1237,10 +1248,22 @@ export const count = globals.counter;
     }
 
     [Fact]
+    public void ShouldBindADefaultExportedClassAtModuleLevel()
+    {
+        // `export default class D {}` binds `D` at module level like any other module item, so `D` is in scope - and in
+        // its temporal dead zone - for the module items above it. The namespace's `default` is supplied by the export
+        // machinery either way, so only an early read of the name itself pins this arm of the whitelist.
+        _engine.Modules.Add("my-module", "export const value = typeof D; export default class D {}");
+
+        Invoking(() => _engine.Modules.Import("my-module")).Should().ThrowExactly<JavaScriptException>()
+            .Which.Message.Should().Be("Cannot access 'D' before initialization");
+    }
+
+    [Fact]
     public void ShouldStillApplyTheTemporalDeadZoneToModuleLevelDeclarations()
     {
         // A module-level `const` is bound uninitialized until its declaration runs, so reading it early throws even through typeof.
-        _engine.Modules.Add("my-module", "globalThis.probe = typeof x; const x = 1;");
+        _engine.Modules.Add("my-module", "typeof x; const x = 1;");
 
         Invoking(() => _engine.Modules.Import("my-module")).Should().ThrowExactly<JavaScriptException>()
             .Which.Message.Should().Be("Cannot access 'x' before initialization");

--- a/Jint/HoistingScope.cs
+++ b/Jint/HoistingScope.cs
@@ -267,6 +267,10 @@ internal sealed class HoistingScope
 
             var effectiveLexicalNames = currentScopeLexicalNames ?? enclosingLexicalNames;
 
+            // Only a direct child of the module, or an export wrapping one, is a module item; a top-level block or `for` head is not.
+            var atTopLevel = parent is null
+                || (parent is AstModule && node.Type is NodeType.ExportNamedDeclaration or NodeType.ExportDefaultDeclaration);
+
             foreach (var childNode in node.ChildNodes)
             {
                 var childType = childNode.Type;
@@ -288,7 +292,7 @@ internal sealed class HoistingScope
                         }
                     }
 
-                    if (parent is null or AstModule && variableDeclaration.Kind != VariableDeclarationKind.Var)
+                    if (atTopLevel && variableDeclaration.Kind != VariableDeclarationKind.Var)
                     {
                         _lexicalDeclarations ??= [];
                         _lexicalDeclarations.Add(variableDeclaration);
@@ -349,7 +353,7 @@ internal sealed class HoistingScope
                         }
                     }
                 }
-                else if (childType == NodeType.ClassDeclaration && parent is null or AstModule)
+                else if (childType == NodeType.ClassDeclaration && atTopLevel)
                 {
                     _lexicalDeclarations ??= [];
                     _lexicalDeclarations.Add((Declaration) childNode);

--- a/Jint/HoistingScope.cs
+++ b/Jint/HoistingScope.cs
@@ -70,7 +70,7 @@ internal sealed class HoistingScope
         bool collectLexicalNames = false)
     {
         // modules area always strict
-        var treeWalker = new ScriptWalker(collectVarNames, collectLexicalNames);
+        var treeWalker = new ScriptWalker(collectVarNames, collectLexicalNames, module: true);
         treeWalker.Visit(module, null);
         return new HoistingScope(
             treeWalker._functions,
@@ -186,6 +186,12 @@ internal sealed class HoistingScope
         internal List<Key>? _lexicalNames;
 
         /// <summary>
+        /// Whether the walk started at an <see cref="AstModule"/>. Only there can an export declaration wrap a
+        /// module-level lexical declaration, so a script or function body walk stops at the root test.
+        /// </summary>
+        private readonly bool _module;
+
+        /// <summary>
         /// B.3.2/B.3.3: Function declarations inside blocks/switch cases in sloppy mode.
         /// </summary>
         internal List<FunctionDeclaration>? _annexBFunctions;
@@ -193,10 +199,11 @@ internal sealed class HoistingScope
         private int _depth;
         private const int MaxDepth = 256;
 
-        public ScriptWalker(bool collectVarNames, bool collectLexicalNames)
+        public ScriptWalker(bool collectVarNames, bool collectLexicalNames, bool module = false)
         {
             _collectVarNames = collectVarNames;
             _collectLexicalNames = collectLexicalNames;
+            _module = module;
         }
 
         public void Visit(Node node, Node? parent, HashSet<string>? enclosingLexicalNames = null)
@@ -267,9 +274,11 @@ internal sealed class HoistingScope
 
             var effectiveLexicalNames = currentScopeLexicalNames ?? enclosingLexicalNames;
 
+            // https://tc39.es/ecma262/#sec-module-semantics-static-semantics-lexicallyscopeddeclarations
             // Only a direct child of the module, or an export wrapping one, is a module item; a top-level block or `for` head is not.
+            // Outside a module the module-item question cannot arise, so the root test is the whole answer.
             var atTopLevel = parent is null
-                || (parent is AstModule && node.Type is NodeType.ExportNamedDeclaration or NodeType.ExportDefaultDeclaration);
+                || (_module && node.Type is NodeType.ExportNamedDeclaration or NodeType.ExportDefaultDeclaration && parent is AstModule);
 
             foreach (var childNode in node.ChildNodes)
             {


### PR DESCRIPTION
`InitializeEnvironment` walks the `LexicallyScopedDeclarations` of the module body, which for `Module : ModuleItemList` are its top-level declarations only — a `let`, `const` or `class` inside a Block or a `for` head belongs to that statement's own scope. Binding one at module level as well creates a second binding that nothing ever initializes, so it stays in its temporal dead zone for the whole evaluation:

```js
{ let a = 1; }
var a = 2;
a;                       // ReferenceError, must be 2

for (let key in obj) {}
typeof key;              // ReferenceError, must be "undefined"

{ class C {} }
typeof C;                // ReferenceError, must be "undefined"
```

The first is the damaging one. `InitializeEnvironment` binds *and initializes* the module's var names before it creates the lexical bindings, and the lexical pass calls `CreateMutableBinding` unconditionally — so the extra binding replaces an initialized `var` of the same name with an uninitialized one, and every read of that name throws from then on.

The name need not appear twice in the same source file. A bundler concatenating one file's top-level `for (let key in ...)` with another's `for (var key in ...)` produces exactly this, which is where it turned up: running an ESM dev bundle, `css-vendor`'s `for (var key in jsCssMap)` threw because `immer` contributed a top-level `for (let key in objectTraps)` to the same module.

## Cause

`HoistingScope` collected module-level lexical declarations with `parent is null or AstModule`. `parent is AstModule` holds for any direct child of the module, which is what lets an exported declaration through — it sits one level down, inside the export declaration. But it equally matches any other top-level statement that owns a declaration one level down, and a Block and a `for` head both do.

Declarations in an `if` branch, a `switch` case or a function body escaped only because theirs sit two levels down, where the parent is the `IfStatement`, `SwitchCase` or function — which is why the failure looked so selective:

| At module top level | before | after | spec |
|---|---|---|---|
| `{ let a = 1; }` | ReferenceError | `undefined` | `undefined` |
| `{ class C {} }` | ReferenceError | `undefined` | `undefined` |
| `for (let a in x) {}` | ReferenceError | `undefined` | `undefined` |
| `if (1) { let a = 1; }` | `undefined` | `undefined` | `undefined` |
| `switch (1) { case 1: let a = 1; }` | `undefined` | `undefined` | `undefined` |
| `function f() { let a = 1; }` | `undefined` | `undefined` | `undefined` |

The check now also requires that intermediate node to be an export declaration. `ExportAllDeclaration` is deliberately left out: `export * from` binds no name locally, so it has no declaration to collect.

Scripts were never affected — there the parent of a top-level statement is a `Program`, so `parent is null` alone already selected the right set. This only makes modules agree with them.

## Tests

Five in `ModuleTests`. The three `ShouldNotBind…` ones fail without the change; `ShouldBindExportedLexicalDeclarationsAtModuleLevel` (covering `export const` / `export let` / `export class` / `export default class`, the case `parent is AstModule` exists to serve) and `ShouldStillApplyTheTemporalDeadZoneToModuleLevelDeclarations` pass either way and are there as guards.

test262 is green either way — 99484 passed, 0 failed, unchanged before and after — so nothing in it covers a lexical declaration inside a module's top-level block.

`Jint.Tests`: 4663 passed. The two failures on my machine are `ToStringUsesDaylightNameWhenInDst` and `DateToStringMethodsShouldUseCurrentTimeZoneAndCulture`, which assert OS-localised time zone display names and fail here regardless of this change.
