### PR TITLE
Give every benchmark row its own engine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,16 @@ The cross-engine comparison (`EngineComparisonBenchmark`) has its own notes and 
 3. For standalone benchmarks, add `[Benchmark]` methods directly, using `Engine.PrepareScript()` to separate parsing from execution.
 4. Put required JS files in `Jint.Benchmark/Scripts/`; they are copied to the output directory automatically.
 
+### Never warm one engine with more than one row's workload
+
+**`[GlobalSetup]` may only touch the engine a row is measured on with that row's own work.** A class that builds one `Engine` and warms it by evaluating *every* `[Benchmark]` row's script hands each row an engine carrying its siblings' state: their globals on the shared global object (nearly every micro-script here declares `var i`, `var s` or `function f`, so they collide outright), their entries in the engine-owned handler-tree caches (`Engine._functionDefinitions`, `_scriptStatementLists`), their per-call-site monomorphic caches, and the environment-reuse and constructor-shape state behind them. A row's number then depends on which sibling rows exist and on what a change did to *them*. This is not theoretical: a call-path change that a single-workload reproduction showed to be 2.5–3.0% **faster** was reported by `MethodCallBenchmark` as +5.6…+9.2% **slower** on three rows, reproducibly and in both A/B orderings.
+
+The default fix is **one engine per row**, built in `[GlobalSetup]` and warmed with that row's script and nothing else — `IsolatedScript` (`Jint.Benchmark/IsolatedScript.cs`) is the helper, `MethodCallBenchmark` and `ClosureCallBenchmarks` the worked examples, and `InteropMethodDispatchBenchmark` the pre-existing precedent for doing it with plain `Engine` fields when a row's workload is not a `Prepared<Script>`. It keeps each row's *warm* dispatch character — several of these classes exist specifically to measure warm dispatch, and making them cold would silently change what the suite is for — and keeps engine construction and warm-up out of the measurement.
+
+Two things this rule does **not** forbid. A shared *fixture* every row needs (`engine.Execute("var testArray = [...]")`) is fine, as long as each row still gets its own engine. And re-evaluating one row's own script many times on one engine is fine where that is the point. Where a benchmark genuinely wants cold-start behaviour, build the engine **inside the benchmark method** so BenchmarkDotNet can auto-scale `InvocationCount` — see `DromaeoBenchmark`, `SunSpiderBenchmark` and `SingleScriptBenchmark`. **Never reach for `[IterationSetup]`**: it forces `InvocationCount=1`, which leaks tiered-JIT warmup into the measured iterations and made identical code report 2.489 ms and 9.811 ms in different runs (the full account is in `DromaeoBenchmark`'s comment).
+
+Document the choice in the class's XML doc comment, including whether engine construction now enters the measurement and roughly what it costs relative to the op.
+
 ## Architecture
 
 ```

--- a/Jint.Benchmark/ArrayCallbackBenchmark.cs
+++ b/Jint.Benchmark/ArrayCallbackBenchmark.cs
@@ -8,18 +8,26 @@ namespace Jint.Benchmark;
 /// over 100,000 LCG-mixed small integers (values vary enough that the branch predictor cannot
 /// memorize outcomes, yet stay inside the small-int cache so rows measure callback dispatch,
 /// not number boxing). One built-in call per op — the element count is the loop.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine — built by <c>CreateEngine</c>, which
+/// re-runs <see cref="SetupSource"/> so each engine owns its own <c>data</c>/<c>data10k</c> — and warmed
+/// with its own script and nothing else (see <see cref="IsolatedScript"/>). It used to be one engine
+/// warmed with all six row scripts, so each row was measured on an engine carrying the other five rows'
+/// handler-tree and call-site caches and their callback shapes, which makes a row's number depend on
+/// which siblings exist and on what a change did to <em>them</em>. The rows still measure warm callback
+/// dispatch, and engine construction and warm-up stay in <c>[GlobalSetup]</c>, outside the measurement.
+/// <b>Numbers from this class are not comparable to any published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]
 public class ArrayCallbackBenchmark
 {
-    private Engine _engine = null!;
-    private Prepared<Script> _reduceSum;
-    private Prepared<Script> _reduceToObject;
-    private Prepared<Script> _forEachSum;
-    private Prepared<Script> _someMiss;
-    private Prepared<Script> _everyHit;
-    private Prepared<Script> _mapFilterReduceChain;
+    private IsolatedScript _reduceSum;
+    private IsolatedScript _reduceToObject;
+    private IsolatedScript _forEachSum;
+    private IsolatedScript _someMiss;
+    private IsolatedScript _everyHit;
+    private IsolatedScript _mapFilterReduceChain;
 
     internal const string SetupSource = """
         var data = [];
@@ -42,52 +50,50 @@ public class ArrayCallbackBenchmark
             .reduce(function (a, x) { return a + x; }, 0);
         """;
 
+    /// <summary>Builds a fresh engine carrying the fixture every row needs, and nothing else.</summary>
+    private static Engine CreateEngine()
+    {
+        var engine = new Engine();
+        engine.Execute(SetupSource);
+        return engine;
+    }
+
     [GlobalSetup]
     public void Setup()
     {
-        _engine = new Engine();
-        _engine.Execute(SetupSource);
-
-        _reduceSum = Engine.PrepareScript(ReduceSumSource);
+        _reduceSum = IsolatedScript.Warm(Engine.PrepareScript(ReduceSumSource), CreateEngine);
 
         // the dictionary-growth reduce shape: accumulator object gains keys as it goes
-        _reduceToObject = Engine.PrepareScript("""
+        _reduceToObject = IsolatedScript.Warm(Engine.PrepareScript("""
             data10k.reduce(function (a, x) { a['k' + (x & 63)] = x; return a; }, {});
-            """);
+            """), CreateEngine);
 
-        _forEachSum = Engine.PrepareScript(ForEachSumSource);
+        _forEachSum = IsolatedScript.Warm(Engine.PrepareScript(ForEachSumSource), CreateEngine);
 
         // full-scan miss: predicate never satisfied
-        _someMiss = Engine.PrepareScript("data.some(function (x) { return x < 0; });");
+        _someMiss = IsolatedScript.Warm(Engine.PrepareScript("data.some(function (x) { return x < 0; });"), CreateEngine);
 
         // full-scan hit: predicate always satisfied
-        _everyHit = Engine.PrepareScript("data.every(function (x) { return x >= 0; });");
+        _everyHit = IsolatedScript.Warm(Engine.PrepareScript("data.every(function (x) { return x >= 0; });"), CreateEngine);
 
-        _mapFilterReduceChain = Engine.PrepareScript(MapFilterReduceChainSource);
-
-        _engine.Evaluate(_reduceSum);
-        _engine.Evaluate(_reduceToObject);
-        _engine.Evaluate(_forEachSum);
-        _engine.Evaluate(_someMiss);
-        _engine.Evaluate(_everyHit);
-        _engine.Evaluate(_mapFilterReduceChain);
+        _mapFilterReduceChain = IsolatedScript.Warm(Engine.PrepareScript(MapFilterReduceChainSource), CreateEngine);
     }
 
     [Benchmark]
-    public JsValue ReduceSum() => _engine.Evaluate(_reduceSum);
+    public JsValue ReduceSum() => _reduceSum.Run();
 
     [Benchmark]
-    public JsValue ReduceToObject() => _engine.Evaluate(_reduceToObject);
+    public JsValue ReduceToObject() => _reduceToObject.Run();
 
     [Benchmark]
-    public JsValue ForEachSum() => _engine.Evaluate(_forEachSum);
+    public JsValue ForEachSum() => _forEachSum.Run();
 
     [Benchmark]
-    public JsValue SomeMiss() => _engine.Evaluate(_someMiss);
+    public JsValue SomeMiss() => _someMiss.Run();
 
     [Benchmark]
-    public JsValue EveryHit() => _engine.Evaluate(_everyHit);
+    public JsValue EveryHit() => _everyHit.Run();
 
     [Benchmark]
-    public JsValue MapFilterReduceChain() => _engine.Evaluate(_mapFilterReduceChain);
+    public JsValue MapFilterReduceChain() => _mapFilterReduceChain.Run();
 }

--- a/Jint.Benchmark/ArrayCopyingMethodsBenchmark.cs
+++ b/Jint.Benchmark/ArrayCopyingMethodsBenchmark.cs
@@ -18,6 +18,15 @@ namespace Jint.Benchmark;
 /// allocation is the same either way - both paths allocate exactly one backing array - so <c>Allocated</c>
 /// is a control column here, not a result.
 /// </para>
+/// <para><b>Engine isolation.</b> Every row gets its own engine — built by <c>CreateEngine</c>, which
+/// rebuilds this instance's <see cref="Size"/>-dependent <c>dense</c>/<c>holey</c> fixture — and warmed
+/// with its own script and nothing else (see <see cref="IsolatedScript"/>). It used to be one shared
+/// engine per <see cref="Size"/>, warmed with all five row scripts, so each dense row and its holey
+/// control were measured on an engine already carrying the others' handler-tree and call-site state —
+/// which is how a control row that must not move at all can move because a sibling changed. The rows
+/// still measure warm dispatch, and engine construction, the fixture and the warm-up all stay in
+/// <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from this class are not comparable to any
+/// published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 public class ArrayCopyingMethodsBenchmark
@@ -27,19 +36,17 @@ public class ArrayCopyingMethodsBenchmark
     [Params(8, 1024)]
     public int Size { get; set; }
 
-    private Engine _engine = null!;
+    private IsolatedScript _toReversedDense;
+    private IsolatedScript _toReversedHoley;
+    private IsolatedScript _withDense;
+    private IsolatedScript _withHoley;
+    private IsolatedScript _toSortedDense;
 
-    private Prepared<Script> _toReversedDense;
-    private Prepared<Script> _toReversedHoley;
-    private Prepared<Script> _withDense;
-    private Prepared<Script> _withHoley;
-    private Prepared<Script> _toSortedDense;
-
-    [GlobalSetup]
-    public void GlobalSetup()
+    /// <summary>Builds a fresh engine carrying the fixture every row needs, and nothing else.</summary>
+    private Engine CreateEngine()
     {
-        _engine = new Engine();
-        _engine.Execute($$"""
+        var engine = new Engine();
+        engine.Execute($$"""
             var size = {{Size}};
             var dense = new Array(size);
             for (var i = 0; i < size; i++) dense[i] = i;
@@ -47,38 +54,37 @@ public class ArrayCopyingMethodsBenchmark
             for (var i = 0; i < size; i++) holey[i] = i;
             delete holey[size >> 1];
             """);
+        return engine;
+    }
 
-        _toReversedDense = Prepare("dense.toReversed()");
-        _toReversedHoley = Prepare("holey.toReversed()");
-        _withDense = Prepare("dense.with(0, 'X')");
-        _withHoley = Prepare("holey.with(0, 'X')");
-        _toSortedDense = Prepare("dense.toSorted()");
-
-        _engine.Evaluate(_toReversedDense);
-        _engine.Evaluate(_toReversedHoley);
-        _engine.Evaluate(_withDense);
-        _engine.Evaluate(_withHoley);
-        _engine.Evaluate(_toSortedDense);
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _toReversedDense = IsolatedScript.Warm(Prepare("dense.toReversed()"), CreateEngine);
+        _toReversedHoley = IsolatedScript.Warm(Prepare("holey.toReversed()"), CreateEngine);
+        _withDense = IsolatedScript.Warm(Prepare("dense.with(0, 'X')"), CreateEngine);
+        _withHoley = IsolatedScript.Warm(Prepare("holey.with(0, 'X')"), CreateEngine);
+        _toSortedDense = IsolatedScript.Warm(Prepare("dense.toSorted()"), CreateEngine);
     }
 
     private static Prepared<Script> Prepare(string call)
         => Engine.PrepareScript("var r; for (var n = 0; n < " + OperationsPerInvoke + "; n++) { r = " + call + "; } r.length");
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue ToReversed_Dense() => _engine.Evaluate(_toReversedDense);
+    public JsValue ToReversed_Dense() => _toReversedDense.Run();
 
     /// <summary>Control: one hole sends the whole call down the per-element path.</summary>
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue ToReversed_Holey() => _engine.Evaluate(_toReversedHoley);
+    public JsValue ToReversed_Holey() => _toReversedHoley.Run();
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue With_Dense() => _engine.Evaluate(_withDense);
+    public JsValue With_Dense() => _withDense.Run();
 
     /// <summary>Control: one hole sends the whole call down the per-element path.</summary>
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue With_Holey() => _engine.Evaluate(_withHoley);
+    public JsValue With_Holey() => _withHoley.Run();
 
     /// <summary>Control: an untouched sibling that also builds a new array from the source.</summary>
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue ToSorted_Dense() => _engine.Evaluate(_toSortedDense);
+    public JsValue ToSorted_Dense() => _toSortedDense.Run();
 }

--- a/Jint.Benchmark/ArrayHoleTraversalBenchmark.cs
+++ b/Jint.Benchmark/ArrayHoleTraversalBenchmark.cs
@@ -9,19 +9,28 @@ namespace Jint.Benchmark;
 /// HasProperty/Get walk), so index loops, join and indexOf pay a per-hole penalty that a packed
 /// array never sees. The dense/holey lane pairs measure that gap; `in` exercises the raw
 /// HasProperty probe.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine — built by <c>CreateEngine</c>, which
+/// re-runs the <c>dense</c>/<c>holey</c> fixture — and warmed with its own script and nothing else (see
+/// <see cref="IsolatedScript"/>). It used to be one engine warmed with all seven row scripts, so each
+/// row was measured on an engine carrying the other six rows' handler-tree and call-site caches, and
+/// every row's <c>function f</c> declaration collided on the shared global object. That matters most
+/// for a paired benchmark like this one: the point of a dense/holey pair is that only one half should
+/// move, which cross-row state can quietly break. The rows still measure warm traversal, and engine
+/// construction and warm-up stay in <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from this
+/// class are not comparable to any published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]
 public class ArrayHoleTraversalBenchmark
 {
-    private Engine _engine = null!;
-    private Prepared<Script> _sumDense;
-    private Prepared<Script> _sumHoley;
-    private Prepared<Script> _joinDense;
-    private Prepared<Script> _joinHoley;
-    private Prepared<Script> _indexOfMissDense;
-    private Prepared<Script> _indexOfMissHoley;
-    private Prepared<Script> _inOperatorHoley;
+    private IsolatedScript _sumDense;
+    private IsolatedScript _sumHoley;
+    private IsolatedScript _joinDense;
+    private IsolatedScript _joinHoley;
+    private IsolatedScript _indexOfMissDense;
+    private IsolatedScript _indexOfMissHoley;
+    private IsolatedScript _inOperatorHoley;
 
     private const string SetupSource = """
         var dense = [];
@@ -34,13 +43,18 @@ public class ArrayHoleTraversalBenchmark
         })();
         """;
 
+    /// <summary>Builds a fresh engine carrying the fixture every row needs, and nothing else.</summary>
+    private static Engine CreateEngine()
+    {
+        var engine = new Engine();
+        engine.Execute(SetupSource);
+        return engine;
+    }
+
     [GlobalSetup]
     public void Setup()
     {
-        _engine = new Engine();
-        _engine.Execute(SetupSource);
-
-        _sumDense = Engine.PrepareScript("""
+        _sumDense = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var s = 0;
                 for (var n = 0; n < 20; n++) {
@@ -49,9 +63,9 @@ public class ArrayHoleTraversalBenchmark
                 return s;
             }
             f();
-            """);
+            """), CreateEngine);
 
-        _sumHoley = Engine.PrepareScript("""
+        _sumHoley = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var s = 0;
                 for (var n = 0; n < 20; n++) {
@@ -60,45 +74,45 @@ public class ArrayHoleTraversalBenchmark
                 return s;
             }
             f();
-            """);
+            """), CreateEngine);
 
-        _joinDense = Engine.PrepareScript("""
+        _joinDense = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var len = 0;
                 for (var n = 0; n < 10; n++) { len += dense.join(',').length; }
                 return len;
             }
             f();
-            """);
+            """), CreateEngine);
 
-        _joinHoley = Engine.PrepareScript("""
+        _joinHoley = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var len = 0;
                 for (var n = 0; n < 10; n++) { len += holey.join(',').length; }
                 return len;
             }
             f();
-            """);
+            """), CreateEngine);
 
-        _indexOfMissDense = Engine.PrepareScript("""
+        _indexOfMissDense = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var s = 0;
                 for (var n = 0; n < 50; n++) { s += dense.indexOf(-1); }
                 return s;
             }
             f();
-            """);
+            """), CreateEngine);
 
-        _indexOfMissHoley = Engine.PrepareScript("""
+        _indexOfMissHoley = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var s = 0;
                 for (var n = 0; n < 50; n++) { s += holey.indexOf(-1); }
                 return s;
             }
             f();
-            """);
+            """), CreateEngine);
 
-        _inOperatorHoley = Engine.PrepareScript("""
+        _inOperatorHoley = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var s = 0;
                 for (var n = 0; n < 20; n++) {
@@ -107,35 +121,27 @@ public class ArrayHoleTraversalBenchmark
                 return s;
             }
             f();
-            """);
-
-        _engine.Evaluate(_sumDense);
-        _engine.Evaluate(_sumHoley);
-        _engine.Evaluate(_joinDense);
-        _engine.Evaluate(_joinHoley);
-        _engine.Evaluate(_indexOfMissDense);
-        _engine.Evaluate(_indexOfMissHoley);
-        _engine.Evaluate(_inOperatorHoley);
+            """), CreateEngine);
     }
 
     [Benchmark]
-    public JsValue SumDense() => _engine.Evaluate(_sumDense);
+    public JsValue SumDense() => _sumDense.Run();
 
     [Benchmark]
-    public JsValue SumHoley() => _engine.Evaluate(_sumHoley);
+    public JsValue SumHoley() => _sumHoley.Run();
 
     [Benchmark]
-    public JsValue JoinDense() => _engine.Evaluate(_joinDense);
+    public JsValue JoinDense() => _joinDense.Run();
 
     [Benchmark]
-    public JsValue JoinHoley() => _engine.Evaluate(_joinHoley);
+    public JsValue JoinHoley() => _joinHoley.Run();
 
     [Benchmark]
-    public JsValue IndexOfMissDense() => _engine.Evaluate(_indexOfMissDense);
+    public JsValue IndexOfMissDense() => _indexOfMissDense.Run();
 
     [Benchmark]
-    public JsValue IndexOfMissHoley() => _engine.Evaluate(_indexOfMissHoley);
+    public JsValue IndexOfMissHoley() => _indexOfMissHoley.Run();
 
     [Benchmark]
-    public JsValue InOperatorHoley() => _engine.Evaluate(_inOperatorHoley);
+    public JsValue InOperatorHoley() => _inOperatorHoley.Run();
 }

--- a/Jint.Benchmark/AsyncAwaitBenchmark.cs
+++ b/Jint.Benchmark/AsyncAwaitBenchmark.cs
@@ -10,18 +10,26 @@ namespace Jint.Benchmark;
 /// one Evaluate; <see cref="AsyncFunctionExitBenchmark"/> keeps owning bare exit cost.
 /// <see cref="SyncCallLoop"/> is the baseline: the same call count without suspension, so
 /// per-await overhead = (AwaitResolvedLoop − SyncCallLoop) / 1000.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own default engine, warmed with its own script and
+/// nothing else (see <see cref="IsolatedScript"/>). It used to be one engine warmed with all six row
+/// scripts, which is worse here than almost anywhere else: the rows share global names (<c>f</c>, <c>i</c>,
+/// <c>last</c>, <c>p</c>) and each one additionally leaves promise, microtask and event-loop state behind
+/// for the next, on top of the usual handler-tree and call-site caches — so the baseline <em>and</em> the
+/// row measured against it both depended on which siblings existed. The rows still measure warm async
+/// dispatch, and engine construction and warm-up stay in <c>[GlobalSetup]</c>, outside the measurement.
+/// <b>Numbers from this class are not comparable to any published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]
 public class AsyncAwaitBenchmark
 {
-    private Engine _engine = null!;
-    private Prepared<Script> _syncCallLoop;
-    private Prepared<Script> _awaitResolvedLoop;
-    private Prepared<Script> _awaitChainDepth50;
-    private Prepared<Script> _promiseAll100;
-    private Prepared<Script> _thenChain1000;
-    private Prepared<Script> _microtaskFanout;
+    private IsolatedScript _syncCallLoop;
+    private IsolatedScript _awaitResolvedLoop;
+    private IsolatedScript _awaitChainDepth50;
+    private IsolatedScript _promiseAll100;
+    private IsolatedScript _thenChain1000;
+    private IsolatedScript _microtaskFanout;
 
     internal const string AwaitResolvedLoopSource = """
         async function f() {
@@ -56,10 +64,8 @@ public class AsyncAwaitBenchmark
     [GlobalSetup]
     public void Setup()
     {
-        _engine = new Engine();
-
         // the sync floor for the same call count
-        _syncCallLoop = Engine.PrepareScript("""
+        _syncCallLoop = IsolatedScript.Warm(Engine.PrepareScript("""
             function g(i) { return i + 1; }
             function f() {
                 var s = 0;
@@ -67,12 +73,12 @@ public class AsyncAwaitBenchmark
                 return s;
             }
             f();
-            """);
+            """));
 
-        _awaitResolvedLoop = Engine.PrepareScript(AwaitResolvedLoopSource);
+        _awaitResolvedLoop = IsolatedScript.Warm(Engine.PrepareScript(AwaitResolvedLoopSource));
 
         // 20 × a 50-deep await-recursion chain
-        _awaitChainDepth50 = Engine.PrepareScript("""
+        _awaitChainDepth50 = IsolatedScript.Warm(Engine.PrepareScript("""
             async function step(n) {
                 if (n === 0) { return 0; }
                 return (await step(n - 1)) + 1;
@@ -82,43 +88,36 @@ public class AsyncAwaitBenchmark
                 for (var i = 0; i < 20; i++) { last = step(50); }
                 return last;
             })();
-            """);
+            """));
 
-        _promiseAll100 = Engine.PrepareScript(PromiseAll100Source);
-        _thenChain1000 = Engine.PrepareScript(ThenChain1000Source);
+        _promiseAll100 = IsolatedScript.Warm(Engine.PrepareScript(PromiseAll100Source));
+        _thenChain1000 = IsolatedScript.Warm(Engine.PrepareScript(ThenChain1000Source));
 
         // 1,000 independent resolved promises, one .then each
-        _microtaskFanout = Engine.PrepareScript("""
+        _microtaskFanout = IsolatedScript.Warm(Engine.PrepareScript("""
             (function () {
                 var last;
                 for (var i = 0; i < 1000; i++) { last = Promise.resolve(i).then(function (x) { return x + 1; }); }
                 return last;
             })();
-            """);
-
-        _engine.Evaluate(_syncCallLoop);
-        _engine.Evaluate(_awaitResolvedLoop);
-        _engine.Evaluate(_awaitChainDepth50);
-        _engine.Evaluate(_promiseAll100);
-        _engine.Evaluate(_thenChain1000);
-        _engine.Evaluate(_microtaskFanout);
+            """));
     }
 
     [Benchmark(Baseline = true)]
-    public JsValue SyncCallLoop() => _engine.Evaluate(_syncCallLoop);
+    public JsValue SyncCallLoop() => _syncCallLoop.Run();
 
     [Benchmark]
-    public JsValue AwaitResolvedLoop() => _engine.Evaluate(_awaitResolvedLoop);
+    public JsValue AwaitResolvedLoop() => _awaitResolvedLoop.Run();
 
     [Benchmark]
-    public JsValue AwaitChainDepth50() => _engine.Evaluate(_awaitChainDepth50);
+    public JsValue AwaitChainDepth50() => _awaitChainDepth50.Run();
 
     [Benchmark]
-    public JsValue PromiseAll100() => _engine.Evaluate(_promiseAll100);
+    public JsValue PromiseAll100() => _promiseAll100.Run();
 
     [Benchmark]
-    public JsValue ThenChain1000() => _engine.Evaluate(_thenChain1000);
+    public JsValue ThenChain1000() => _thenChain1000.Run();
 
     [Benchmark]
-    public JsValue MicrotaskFanout() => _engine.Evaluate(_microtaskFanout);
+    public JsValue MicrotaskFanout() => _microtaskFanout.Run();
 }

--- a/Jint.Benchmark/ClosureCallBenchmarks.cs
+++ b/Jint.Benchmark/ClosureCallBenchmarks.cs
@@ -13,24 +13,35 @@ namespace Jint.Benchmark;
 /// path the fixed-slot cap routes that binding count to.
 /// The Sloppy rows run the method-call shapes non-strict, where OrdinaryCallBindThis additionally
 /// pays TypeConverter.ToObject on the receiver every call — a cost the strict rows never see.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine, warmed with its own script and nothing
+/// else (see <see cref="IsolatedScript"/>). It used to be two shared engines — one strict, one sloppy —
+/// each warmed with every one of its rows' scripts, so a row was measured on an engine carrying its
+/// siblings' globals (all six scripts declare <c>i</c>, four declare <c>b</c>) and their handler-tree,
+/// call-site and environment-reuse state; a change affecting one row could then move another. The
+/// strict/sloppy split is preserved per row, the rows still measure warm dispatch, and engine
+/// construction and warm-up stay in <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from this
+/// class are not comparable to any published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]
 public class ClosureCallBenchmarks
 {
-    private Engine _engine = null!;
-    private Engine _sloppyEngine = null!;
-    private Prepared<Script> _emptyClosureCall;
-    private Prepared<Script> _capturedVarReadWrite;
-    private Prepared<Script> _paramLocalCall;
-    private Prepared<Script> _manyLocalCall;
-    private Prepared<Script> _sloppyEmptyClosureCall;
-    private Prepared<Script> _sloppyCapturedVarReadWrite;
+    private IsolatedScript _emptyClosureCall;
+    private IsolatedScript _capturedVarReadWrite;
+    private IsolatedScript _paramLocalCall;
+    private IsolatedScript _manyLocalCall;
+    private IsolatedScript _sloppyEmptyClosureCall;
+    private IsolatedScript _sloppyCapturedVarReadWrite;
+
+    private static Engine CreateStrictEngine() => new(static options => options.Strict());
+
+    private static Engine CreateSloppyEngine() => new();
 
     [GlobalSetup]
     public void Setup()
     {
-        _emptyClosureCall = Engine.PrepareScript("""
+        _emptyClosureCall = IsolatedScript.Warm(Engine.PrepareScript("""
             (function() {
                 function Box() {
                     this.nop = function () { };
@@ -43,9 +54,9 @@ public class ClosureCallBenchmarks
                 }
                 return b;
             })();
-            """, strict: true);
+            """, strict: true), CreateStrictEngine);
 
-        _capturedVarReadWrite = Engine.PrepareScript("""
+        _capturedVarReadWrite = IsolatedScript.Warm(Engine.PrepareScript("""
             (function() {
                 function Box() {
                     var on = false;
@@ -62,9 +73,9 @@ public class ClosureCallBenchmarks
                 }
                 return b;
             })();
-            """, strict: true);
+            """, strict: true), CreateStrictEngine);
 
-        _paramLocalCall = Engine.PrepareScript("""
+        _paramLocalCall = IsolatedScript.Warm(Engine.PrepareScript("""
             (function() {
                 function add(a, b) {
                     var sum = a + b;
@@ -78,12 +89,12 @@ public class ClosureCallBenchmarks
                 }
                 return acc;
             })();
-            """, strict: true);
+            """, strict: true), CreateStrictEngine);
 
         // 2 params + 18 var locals = 20 bindings. The body has no inner closures, so the environment is
         // pooled and reused across calls (mirrors 3d-cube's DrawLine). Whether per-call setup uses the
         // array-backed fixed-slot path or the dictionary path depends on the fixed-slot cap.
-        _manyLocalCall = Engine.PrepareScript("""
+        _manyLocalCall = IsolatedScript.Warm(Engine.PrepareScript("""
             (function() {
                 function compute(a, b) {
                     var v0 = a + b;
@@ -112,9 +123,9 @@ public class ClosureCallBenchmarks
                 }
                 return acc;
             })();
-            """, strict: true);
+            """, strict: true), CreateStrictEngine);
 
-        _sloppyEmptyClosureCall = Engine.PrepareScript("""
+        _sloppyEmptyClosureCall = IsolatedScript.Warm(Engine.PrepareScript("""
             (function() {
                 function Box() {
                     this.nop = function () { };
@@ -127,9 +138,9 @@ public class ClosureCallBenchmarks
                 }
                 return b;
             })();
-            """);
+            """), CreateSloppyEngine);
 
-        _sloppyCapturedVarReadWrite = Engine.PrepareScript("""
+        _sloppyCapturedVarReadWrite = IsolatedScript.Warm(Engine.PrepareScript("""
             (function() {
                 function Box() {
                     var on = false;
@@ -146,34 +157,24 @@ public class ClosureCallBenchmarks
                 }
                 return b;
             })();
-            """);
-
-        _engine = new Engine(static options => options.Strict());
-        _engine.Evaluate(_emptyClosureCall);
-        _engine.Evaluate(_capturedVarReadWrite);
-        _engine.Evaluate(_paramLocalCall);
-        _engine.Evaluate(_manyLocalCall);
-
-        _sloppyEngine = new Engine();
-        _sloppyEngine.Evaluate(_sloppyEmptyClosureCall);
-        _sloppyEngine.Evaluate(_sloppyCapturedVarReadWrite);
+            """), CreateSloppyEngine);
     }
 
     [Benchmark]
-    public JsValue EmptyClosureCall() => _engine.Evaluate(_emptyClosureCall);
+    public JsValue EmptyClosureCall() => _emptyClosureCall.Run();
 
     [Benchmark]
-    public JsValue CapturedVarReadWrite() => _engine.Evaluate(_capturedVarReadWrite);
+    public JsValue CapturedVarReadWrite() => _capturedVarReadWrite.Run();
 
     [Benchmark]
-    public JsValue ParamLocalCall() => _engine.Evaluate(_paramLocalCall);
+    public JsValue ParamLocalCall() => _paramLocalCall.Run();
 
     [Benchmark]
-    public JsValue ManyLocalCall() => _engine.Evaluate(_manyLocalCall);
+    public JsValue ManyLocalCall() => _manyLocalCall.Run();
 
     [Benchmark]
-    public JsValue SloppyEmptyClosureCall() => _sloppyEngine.Evaluate(_sloppyEmptyClosureCall);
+    public JsValue SloppyEmptyClosureCall() => _sloppyEmptyClosureCall.Run();
 
     [Benchmark]
-    public JsValue SloppyCapturedVarReadWrite() => _sloppyEngine.Evaluate(_sloppyCapturedVarReadWrite);
+    public JsValue SloppyCapturedVarReadWrite() => _sloppyCapturedVarReadWrite.Run();
 }

--- a/Jint.Benchmark/DateConstructionBenchmarks.cs
+++ b/Jint.Benchmark/DateConstructionBenchmarks.cs
@@ -6,19 +6,29 @@ namespace Jint.Benchmark;
 /// <summary>
 /// Isolates `new Date()` current-time construction (the stopwatch.js hot allocation) and
 /// guards the explicit-milliseconds constructor which must keep full TimeClip semantics.
+///
+/// <para><b>Engine isolation.</b> Each row gets its own engine, warmed with its own script and nothing
+/// else (see <see cref="IsolatedScript"/>). It used to be one engine warmed with both scripts, so each
+/// row was measured on an engine already carrying the other row's handler-tree entries, call-site caches
+/// and Date construction state — which makes a row's number depend on what a change did to its sibling.
+/// Both scripts wrap their work in an IIFE, so no globals collided here, but the engine-level caches did.
+/// The rows still measure warm construction, and engine construction and warm-up stay in
+/// <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from this class are not comparable to any
+/// published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]
 public class DateConstructionBenchmarks
 {
-    private Engine _engine = null!;
-    private Prepared<Script> _newDateNow;
-    private Prepared<Script> _newDateMillis;
+    private IsolatedScript _newDateNow;
+    private IsolatedScript _newDateMillis;
+
+    private static Engine CreateEngine() => new(static options => options.Strict());
 
     [GlobalSetup]
     public void Setup()
     {
-        _newDateNow = Engine.PrepareScript("""
+        _newDateNow = IsolatedScript.Warm(Engine.PrepareScript("""
             (function() {
                 var last = null;
                 for (var i = 0; i < 100000; i++) {
@@ -26,9 +36,9 @@ public class DateConstructionBenchmarks
                 }
                 return last;
             })();
-            """, strict: true);
+            """, strict: true), CreateEngine);
 
-        _newDateMillis = Engine.PrepareScript("""
+        _newDateMillis = IsolatedScript.Warm(Engine.PrepareScript("""
             (function() {
                 var last = null;
                 for (var i = 0; i < 100000; i++) {
@@ -36,16 +46,12 @@ public class DateConstructionBenchmarks
                 }
                 return last;
             })();
-            """, strict: true);
-
-        _engine = new Engine(static options => options.Strict());
-        _engine.Evaluate(_newDateNow);
-        _engine.Evaluate(_newDateMillis);
+            """, strict: true), CreateEngine);
     }
 
     [Benchmark]
-    public JsValue NewDateNow() => _engine.Evaluate(_newDateNow);
+    public JsValue NewDateNow() => _newDateNow.Run();
 
     [Benchmark]
-    public JsValue NewDateMillis() => _engine.Evaluate(_newDateMillis);
+    public JsValue NewDateMillis() => _newDateMillis.Run();
 }

--- a/Jint.Benchmark/DatePrototypeBenchmarks.cs
+++ b/Jint.Benchmark/DatePrototypeBenchmarks.cs
@@ -7,37 +7,37 @@ namespace Jint.Benchmark;
 /// Source-gen sentinel for Date.prototype getter/setter methods. Post-source-gen the prototype
 /// uses [JsFunction] for all 49 methods + [JsSymbolFunction] for [Symbol.toPrimitive]. The
 /// toGMTString === toUTCString aliasing is preserved via post-init SetOwnProperty.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine, warmed with its own script and nothing
+/// else (see <see cref="IsolatedScript"/>). It used to be one engine warmed with all five scripts, so a
+/// row was measured on an engine that had already lazily initialized and cached the other four rows'
+/// Date.prototype members and their call sites, plus <c>Warm_SetMonth</c>'s global <c>d</c> — which makes
+/// a row's number depend on what a change did to its siblings. The rows still measure warm dispatch, and
+/// engine construction and warm-up stay in <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from
+/// this class are not comparable to any published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 public class DatePrototypeBenchmarks
 {
-    private Engine _warm = null!;
-    private Prepared<Script> _now;
-    private Prepared<Script> _getTime;
-    private Prepared<Script> _toIso;
-    private Prepared<Script> _setMonth;
-    private Prepared<Script> _toString;
+    private IsolatedScript _now;
+    private IsolatedScript _getTime;
+    private IsolatedScript _toIso;
+    private IsolatedScript _setMonth;
+    private IsolatedScript _toString;
 
     [GlobalSetup]
     public void GlobalSetup()
     {
-        _now      = Engine.PrepareScript("Date.now()");
-        _getTime  = Engine.PrepareScript("new Date(2026, 0, 1).getTime()");
-        _toIso    = Engine.PrepareScript("new Date(2026, 0, 1).toISOString()");
-        _setMonth = Engine.PrepareScript("var d = new Date(2026, 0, 1); d.setMonth(5); d.getMonth()");
-        _toString = Engine.PrepareScript("new Date(2026, 0, 1).toString()");
-
-        _warm = new Engine();
-        _warm.Evaluate(_now);
-        _warm.Evaluate(_getTime);
-        _warm.Evaluate(_toIso);
-        _warm.Evaluate(_setMonth);
-        _warm.Evaluate(_toString);
+        _now      = IsolatedScript.Warm("Date.now()");
+        _getTime  = IsolatedScript.Warm("new Date(2026, 0, 1).getTime()");
+        _toIso    = IsolatedScript.Warm("new Date(2026, 0, 1).toISOString()");
+        _setMonth = IsolatedScript.Warm("var d = new Date(2026, 0, 1); d.setMonth(5); d.getMonth()");
+        _toString = IsolatedScript.Warm("new Date(2026, 0, 1).toString()");
     }
 
-    [Benchmark] public JsValue Warm_DateNow() => _warm.Evaluate(_now);
-    [Benchmark] public JsValue Warm_GetTime() => _warm.Evaluate(_getTime);
-    [Benchmark] public JsValue Warm_ToISOString() => _warm.Evaluate(_toIso);
-    [Benchmark] public JsValue Warm_SetMonth() => _warm.Evaluate(_setMonth);
-    [Benchmark] public JsValue Warm_ToString() => _warm.Evaluate(_toString);
+    [Benchmark] public JsValue Warm_DateNow() => _now.Run();
+    [Benchmark] public JsValue Warm_GetTime() => _getTime.Run();
+    [Benchmark] public JsValue Warm_ToISOString() => _toIso.Run();
+    [Benchmark] public JsValue Warm_SetMonth() => _setMonth.Run();
+    [Benchmark] public JsValue Warm_ToString() => _toString.Run();
 }

--- a/Jint.Benchmark/ElementAccessBenchmark.cs
+++ b/Jint.Benchmark/ElementAccessBenchmark.cs
@@ -10,51 +10,61 @@ namespace Jint.Benchmark;
 /// small-integer cache so the signal is the access cost, not JsNumber boxing. Arrays are pre-filled
 /// so reads/writes hit existing dense slots (the fast path); the chained case mirrors MMulti's
 /// <c>m[i][j]</c> double-indexing.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine, warmed with its own script and nothing
+/// else (see <see cref="IsolatedScript"/>). It used to be one engine warmed with all five scripts, so a
+/// row was measured on an engine carrying its siblings' globals — all five declare <c>i</c>, three declare
+/// <c>a</c> and <c>k</c>, and two declare <c>m</c>, so a row inherited whichever sibling wrote the array
+/// last and with it whatever backing storage that left behind — as well as their handler-tree and
+/// per-call-site state. The rows still measure warm indexed access, and engine construction and warm-up
+/// stay in <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from this class are not comparable to
+/// any published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]
 public class ElementAccessBenchmark
 {
-    private Engine _engine = null!;
-    private Prepared<Script> _read;
-    private Prepared<Script> _write;
-    private Prepared<Script> _readModifyWrite;
-    private Prepared<Script> _chainedRead;
-    private Prepared<Script> _appendWrite;
+    private IsolatedScript _read;
+    private IsolatedScript _write;
+    private IsolatedScript _readModifyWrite;
+    private IsolatedScript _chainedRead;
+    private IsolatedScript _appendWrite;
+
+    private static Engine CreateEngine() => new(static options => options.Strict());
 
     [GlobalSetup]
     public void Setup()
     {
-        _read = Engine.PrepareScript("""
+        _read = IsolatedScript.Warm(Engine.PrepareScript("""
             var a = []; for (var k = 0; k < 1024; k++) a[k] = k;
             var s = 0;
             for (var i = 0; i < 1000000; i++) s = (s + a[i & 1023]) & 1023;
             s;
-            """, strict: true);
+            """, strict: true), CreateEngine);
 
-        _write = Engine.PrepareScript("""
+        _write = IsolatedScript.Warm(Engine.PrepareScript("""
             var a = []; for (var k = 0; k < 1024; k++) a[k] = 0;
             for (var i = 0; i < 1000000; i++) a[i & 1023] = i & 1023;
             a[0];
-            """, strict: true);
+            """, strict: true), CreateEngine);
 
-        _readModifyWrite = Engine.PrepareScript("""
+        _readModifyWrite = IsolatedScript.Warm(Engine.PrepareScript("""
             var a = []; for (var k = 0; k < 1024; k++) a[k] = 0;
             for (var i = 0; i < 1000000; i++) { var j = i & 1023; a[j] = (a[j] + 1) & 1023; }
             a[0];
-            """, strict: true);
+            """, strict: true), CreateEngine);
 
-        _chainedRead = Engine.PrepareScript("""
+        _chainedRead = IsolatedScript.Warm(Engine.PrepareScript("""
             var m = []; for (var r = 0; r < 4; r++) { m[r] = []; for (var c = 0; c < 4; c++) m[r][c] = r * 4 + c; }
             var s = 0;
             for (var i = 0; i < 1000000; i++) s = (s + m[i & 3][(i >> 2) & 3]) & 1023;
             s;
-            """, strict: true);
+            """, strict: true), CreateEngine);
 
         // the MMulti/VMulti build pattern: every write is an append at the current length
         // into a fresh array (index masking would turn appends into overwrites, so the signal
         // includes the JsNumber boxing of the stored values like the cube itself does)
-        _appendWrite = Engine.PrepareScript("""
+        _appendWrite = IsolatedScript.Warm(Engine.PrepareScript("""
             var sink = 0;
             for (var i = 0; i < 100000; i++) {
                 var m = [];
@@ -62,28 +72,21 @@ public class ElementAccessBenchmark
                 sink = (sink + m[3]) & 1023;
             }
             sink;
-            """, strict: true);
-
-        _engine = new Engine(static options => options.Strict());
-        _engine.Evaluate(_read);
-        _engine.Evaluate(_write);
-        _engine.Evaluate(_readModifyWrite);
-        _engine.Evaluate(_chainedRead);
-        _engine.Evaluate(_appendWrite);
+            """, strict: true), CreateEngine);
     }
 
     [Benchmark]
-    public JsValue Read() => _engine.Evaluate(_read);
+    public JsValue Read() => _read.Run();
 
     [Benchmark]
-    public JsValue Write() => _engine.Evaluate(_write);
+    public JsValue Write() => _write.Run();
 
     [Benchmark]
-    public JsValue ReadModifyWrite() => _engine.Evaluate(_readModifyWrite);
+    public JsValue ReadModifyWrite() => _readModifyWrite.Run();
 
     [Benchmark]
-    public JsValue ChainedRead() => _engine.Evaluate(_chainedRead);
+    public JsValue ChainedRead() => _chainedRead.Run();
 
     [Benchmark]
-    public JsValue AppendWrite() => _engine.Evaluate(_appendWrite);
+    public JsValue AppendWrite() => _appendWrite.Run();
 }

--- a/Jint.Benchmark/EncodeUriBenchmark.cs
+++ b/Jint.Benchmark/EncodeUriBenchmark.cs
@@ -11,11 +11,19 @@ namespace Jint.Benchmark;
 /// it (where copying whole clean runs pays), and one where nearly every character escapes (the floor - all
 /// work, no runs to copy).
 /// <para>
-/// Every row runs a tight loop over one prepared script on one long-lived engine, so the measurement is the
-/// encode, not the parse. <c>[MemoryDiagnoser]</c> matters for the clean row: with an early-out it should
+/// Every row runs a tight loop over one prepared script on its own long-lived engine, so the measurement is
+/// the encode, not the parse. <c>[MemoryDiagnoser]</c> matters for the clean row: with an early-out it should
 /// allocate the result string only, without one it builds a whole second buffer to produce a copy of its
 /// input.
 /// </para>
+/// <para><b>Engine isolation.</b> Every row gets its own engine, warmed with its own script and nothing else
+/// (see <see cref="IsolatedScript"/>). It used to be one engine warmed with all six scripts, so a row was
+/// measured on an engine carrying the other five rows' globals (every script declares <c>r</c> and <c>n</c>)
+/// and their handler-tree and per-call-site state — which makes a row's number depend on what a change did to
+/// its siblings. The input fixture the rows share is still shared, but now by being re-run per engine rather
+/// than by the engine being re-used. The rows still measure warm encoding, and engine construction and
+/// warm-up stay in <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from this class are not
+/// comparable to any published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 public class EncodeUriBenchmark
@@ -29,34 +37,30 @@ public class EncodeUriBenchmark
         var longClean = clean + clean + clean + clean + clean + clean + clean + clean;
         """;
 
-    private Engine _engine = null!;
+    private IsolatedScript _cleanUri;
+    private IsolatedScript _cleanComponent;
+    private IsolatedScript _longClean;
+    private IsolatedScript _mixedUri;
+    private IsolatedScript _mixedComponent;
+    private IsolatedScript _dirtyUri;
 
-    private Prepared<Script> _cleanUri;
-    private Prepared<Script> _cleanComponent;
-    private Prepared<Script> _longClean;
-    private Prepared<Script> _mixedUri;
-    private Prepared<Script> _mixedComponent;
-    private Prepared<Script> _dirtyUri;
+    /// <summary>Builds a fresh engine carrying the input fixture every row reads from.</summary>
+    private static Engine CreateEngine()
+    {
+        var engine = new Engine();
+        engine.Execute(Setup);
+        return engine;
+    }
 
     [GlobalSetup]
     public void GlobalSetup()
     {
-        _engine = new Engine();
-        _engine.Execute(Setup);
-
-        _cleanUri = Prepare("encodeURI(clean)");
-        _cleanComponent = Prepare("encodeURIComponent(clean)");
-        _longClean = Prepare("encodeURI(longClean)");
-        _mixedUri = Prepare("encodeURI(mixed)");
-        _mixedComponent = Prepare("encodeURIComponent(mixed)");
-        _dirtyUri = Prepare("encodeURI(dirty)");
-
-        _engine.Evaluate(_cleanUri);
-        _engine.Evaluate(_cleanComponent);
-        _engine.Evaluate(_longClean);
-        _engine.Evaluate(_mixedUri);
-        _engine.Evaluate(_mixedComponent);
-        _engine.Evaluate(_dirtyUri);
+        _cleanUri = IsolatedScript.Warm(Prepare("encodeURI(clean)"), CreateEngine);
+        _cleanComponent = IsolatedScript.Warm(Prepare("encodeURIComponent(clean)"), CreateEngine);
+        _longClean = IsolatedScript.Warm(Prepare("encodeURI(longClean)"), CreateEngine);
+        _mixedUri = IsolatedScript.Warm(Prepare("encodeURI(mixed)"), CreateEngine);
+        _mixedComponent = IsolatedScript.Warm(Prepare("encodeURIComponent(mixed)"), CreateEngine);
+        _dirtyUri = IsolatedScript.Warm(Prepare("encodeURI(dirty)"), CreateEngine);
     }
 
     private static Prepared<Script> Prepare(string call)
@@ -64,26 +68,26 @@ public class EncodeUriBenchmark
 
     /// <summary>Nothing to escape: no buffer needs building at all.</summary>
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue EncodeUri_Clean() => _engine.Evaluate(_cleanUri);
+    public JsValue EncodeUri_Clean() => _cleanUri.Run();
 
     /// <summary>
     /// The same input through <c>encodeURIComponent</c>, whose allowed set excludes the URI reserved
     /// characters, so this one does escape - the control that the clean row is about the input, not the call.
     /// </summary>
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue EncodeUriComponent_Clean() => _engine.Evaluate(_cleanComponent);
+    public JsValue EncodeUriComponent_Clean() => _cleanComponent.Run();
 
     /// <summary>Eight times the clean input: the early-out's win should scale with the length it skips.</summary>
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue EncodeUri_LongClean() => _engine.Evaluate(_longClean);
+    public JsValue EncodeUri_LongClean() => _longClean.Run();
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue EncodeUri_Mixed() => _engine.Evaluate(_mixedUri);
+    public JsValue EncodeUri_Mixed() => _mixedUri.Run();
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue EncodeUriComponent_Mixed() => _engine.Evaluate(_mixedComponent);
+    public JsValue EncodeUriComponent_Mixed() => _mixedComponent.Run();
 
     /// <summary>Almost every character escapes: no clean runs to copy, so this row is the floor.</summary>
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue EncodeUri_Dirty() => _engine.Evaluate(_dirtyUri);
+    public JsValue EncodeUri_Dirty() => _dirtyUri.Run();
 }

--- a/Jint.Benchmark/ErrorHandlingBenchmark.cs
+++ b/Jint.Benchmark/ErrorHandlingBenchmark.cs
@@ -7,18 +7,27 @@ namespace Jint.Benchmark;
 /// Exception-path costs that validation/parse-style code pays constantly: try scaffolding without
 /// a throw (read against the LoopDispatch CounterAdd floor), throw+catch round-trips, Error
 /// construction with and without touching <c>.stack</c>, and unwinding through a deep call chain.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine, warmed with its own script and nothing
+/// else (see <see cref="IsolatedScript"/>). It used to be one engine warmed with all six scripts, so a row
+/// was measured on an engine carrying the other five rows' globals (every script declares
+/// <c>function f</c>, so they overwrite one another outright) and their handler-tree, call-site and
+/// Error-intrinsic state — which makes a row's number depend on what a change did to its siblings. The
+/// <c>reusedError</c> fixture is still shared, but now by being re-created per engine rather than by the
+/// engine being re-used. The rows still measure warm exception handling, and engine construction and
+/// warm-up stay in <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from this class are not
+/// comparable to any published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]
 public class ErrorHandlingBenchmark
 {
-    private Engine _engine = null!;
-    private Prepared<Script> _tryNoThrow;
-    private Prepared<Script> _throwCatchLoop;
-    private Prepared<Script> _throwCatchReuseError;
-    private Prepared<Script> _errorConstructOnly;
-    private Prepared<Script> _errorStackAccess;
-    private Prepared<Script> _deepStackThrow;
+    private IsolatedScript _tryNoThrow;
+    private IsolatedScript _throwCatchLoop;
+    private IsolatedScript _throwCatchReuseError;
+    private IsolatedScript _errorConstructOnly;
+    private IsolatedScript _errorStackAccess;
+    private IsolatedScript _deepStackThrow;
 
     internal const string TryNoThrowSource = """
         function f() {
@@ -54,17 +63,22 @@ public class ErrorHandlingBenchmark
         f();
         """;
 
+    /// <summary>Builds a fresh engine carrying the <c>reusedError</c> fixture the unwind-only row throws.</summary>
+    private static Engine CreateEngine()
+    {
+        var engine = new Engine();
+        engine.Execute("var reusedError = new Error('r');");
+        return engine;
+    }
+
     [GlobalSetup]
     public void Setup()
     {
-        _engine = new Engine();
-        _engine.Execute("var reusedError = new Error('r');");
-
-        _tryNoThrow = Engine.PrepareScript(TryNoThrowSource);
-        _throwCatchLoop = Engine.PrepareScript(ThrowCatchLoopSource);
+        _tryNoThrow = IsolatedScript.Warm(Engine.PrepareScript(TryNoThrowSource), CreateEngine);
+        _throwCatchLoop = IsolatedScript.Warm(Engine.PrepareScript(ThrowCatchLoopSource), CreateEngine);
 
         // unwind cost isolated from Error construction
-        _throwCatchReuseError = Engine.PrepareScript("""
+        _throwCatchReuseError = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 10000; i++) {
@@ -73,10 +87,10 @@ public class ErrorHandlingBenchmark
                 return s;
             }
             f();
-            """);
+            """), CreateEngine);
 
         // construction only: no throw, no stack read
-        _errorConstructOnly = Engine.PrepareScript("""
+        _errorConstructOnly = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 10000; i++) {
@@ -86,12 +100,12 @@ public class ErrorHandlingBenchmark
                 return s;
             }
             f();
-            """);
+            """), CreateEngine);
 
-        _errorStackAccess = Engine.PrepareScript(ErrorStackAccessSource);
+        _errorStackAccess = IsolatedScript.Warm(Engine.PrepareScript(ErrorStackAccessSource), CreateEngine);
 
         // throw from 50 frames down, catch at the top
-        _deepStackThrow = Engine.PrepareScript("""
+        _deepStackThrow = IsolatedScript.Warm(Engine.PrepareScript("""
             function d(n) {
                 if (n === 0) { throw new Error('deep'); }
                 return d(n - 1);
@@ -104,31 +118,24 @@ public class ErrorHandlingBenchmark
                 return s;
             }
             f();
-            """);
-
-        _engine.Evaluate(_tryNoThrow);
-        _engine.Evaluate(_throwCatchLoop);
-        _engine.Evaluate(_throwCatchReuseError);
-        _engine.Evaluate(_errorConstructOnly);
-        _engine.Evaluate(_errorStackAccess);
-        _engine.Evaluate(_deepStackThrow);
+            """), CreateEngine);
     }
 
     [Benchmark]
-    public JsValue TryNoThrow() => _engine.Evaluate(_tryNoThrow);
+    public JsValue TryNoThrow() => _tryNoThrow.Run();
 
     [Benchmark]
-    public JsValue ThrowCatchLoop() => _engine.Evaluate(_throwCatchLoop);
+    public JsValue ThrowCatchLoop() => _throwCatchLoop.Run();
 
     [Benchmark]
-    public JsValue ThrowCatchReuseError() => _engine.Evaluate(_throwCatchReuseError);
+    public JsValue ThrowCatchReuseError() => _throwCatchReuseError.Run();
 
     [Benchmark]
-    public JsValue ErrorConstructOnly() => _engine.Evaluate(_errorConstructOnly);
+    public JsValue ErrorConstructOnly() => _errorConstructOnly.Run();
 
     [Benchmark]
-    public JsValue ErrorStackAccess() => _engine.Evaluate(_errorStackAccess);
+    public JsValue ErrorStackAccess() => _errorStackAccess.Run();
 
     [Benchmark]
-    public JsValue DeepStackThrow() => _engine.Evaluate(_deepStackThrow);
+    public JsValue DeepStackThrow() => _deepStackThrow.Run();
 }

--- a/Jint.Benchmark/EvalCacheBenchmarks.cs
+++ b/Jint.Benchmark/EvalCacheBenchmarks.cs
@@ -7,15 +7,25 @@ namespace Jint.Benchmark;
 /// Isolates the eval / new Function compile pipeline (dromaeo-core-eval shape).
 /// SameSource variants hit a repeated identical source (cacheable); DistinctSources
 /// variants generate a unique source per call and guard the cache-miss path.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine, warmed with its own script and nothing
+/// else (see <see cref="IsolatedScript"/>). The compile caches this class is about are engine-owned, and
+/// the two SameSource rows eval <em>byte-identical</em> source, so on the single engine this used to
+/// share, whichever was warmed first populated the cache the other was then measured against — on top of
+/// the globals the scripts collide on (all three declare <c>res</c> and <c>n</c>; the SameSource pair also
+/// share <c>cmd</c>). The rows still measure the warm pipeline, and engine construction and warm-up stay
+/// in <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from this class are not comparable to any
+/// published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]
 public class EvalCacheBenchmarks
 {
-    private Engine _engine = null!;
-    private Prepared<Script> _evalSameSource;
-    private Prepared<Script> _newFunctionSameSource;
-    private Prepared<Script> _evalDistinctSources;
+    private IsolatedScript _evalSameSource;
+    private IsolatedScript _newFunctionSameSource;
+    private IsolatedScript _evalDistinctSources;
+
+    private static Engine CreateEngine() => new(static options => options.Strict());
 
     [GlobalSetup]
     public void Setup()
@@ -25,25 +35,25 @@ public class EvalCacheBenchmarks
             var cmd = "var s='';for(var i=0;i<50;i++){s+='a';}res=s;";
             """;
 
-        _evalSameSource = Engine.PrepareScript(Source + """
+        _evalSameSource = IsolatedScript.Warm(Engine.PrepareScript(Source + """
             var res = null;
             for (var n = 0; n < 50; n++) {
                 eval(cmd);
             }
             res;
-            """, strict: true);
+            """, strict: true), CreateEngine);
 
-        _newFunctionSameSource = Engine.PrepareScript(Source + """
+        _newFunctionSameSource = IsolatedScript.Warm(Engine.PrepareScript(Source + """
             var res = null;
             for (var n = 0; n < 50; n++) {
                 (new Function(cmd))();
             }
             res;
-            """, strict: true);
+            """, strict: true), CreateEngine);
 
         // globalThis counter keeps every eval'd source unique across benchmark ops so this
         // permanently measures the cache-miss path (including any eviction policy).
-        _evalDistinctSources = Engine.PrepareScript("""
+        _evalDistinctSources = IsolatedScript.Warm(Engine.PrepareScript("""
             globalThis.__evalCounter = globalThis.__evalCounter || 0;
             var res = null;
             for (var n = 0; n < 50; n++) {
@@ -51,20 +61,15 @@ public class EvalCacheBenchmarks
                 res = eval("var v" + u + " = " + u + "; v" + u + " + 1;");
             }
             res;
-            """, strict: true);
-
-        _engine = new Engine(static options => options.Strict());
-        _engine.Evaluate(_evalSameSource);
-        _engine.Evaluate(_newFunctionSameSource);
-        _engine.Evaluate(_evalDistinctSources);
+            """, strict: true), CreateEngine);
     }
 
     [Benchmark]
-    public JsValue EvalSameSource() => _engine.Evaluate(_evalSameSource);
+    public JsValue EvalSameSource() => _evalSameSource.Run();
 
     [Benchmark]
-    public JsValue NewFunctionSameSource() => _engine.Evaluate(_newFunctionSameSource);
+    public JsValue NewFunctionSameSource() => _newFunctionSameSource.Run();
 
     [Benchmark]
-    public JsValue EvalDistinctSources() => _engine.Evaluate(_evalDistinctSources);
+    public JsValue EvalDistinctSources() => _evalDistinctSources.Run();
 }

--- a/Jint.Benchmark/FastCallLaneBenchmarks.cs
+++ b/Jint.Benchmark/FastCallLaneBenchmarks.cs
@@ -42,33 +42,42 @@ namespace Jint.Benchmark;
 /// Every row runs its call 1000 times inside one prepared script on an engine that has already
 /// evaluated it, so what is measured is dispatch plus body rather than parse or first-call warmup —
 /// and the lane is only reachable from a warm site in the first place.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine, warmed with its own script and nothing
+/// else (see <see cref="IsolatedScript"/>). All 18 rows used to be warmed on one engine by a single
+/// <c>foreach</c> loop, so each was measured on an engine carrying the other 17 rows' globals — they
+/// collide outright on <c>s</c> and <c>i</c>, and the three <c>push</c> rows all declare <c>a</c> and the
+/// two object-argument rows both declare <c>o</c>, so a row inherited whichever sibling wrote last — plus
+/// 17 other rows' handler-tree entries and call-site caches. Since the whole point of the class is which
+/// call sites reach the fast-call lane, sibling state on those very sites is exactly the wrong thing to
+/// carry. The rows still measure warm dispatch, and engine construction and warm-up stay in
+/// <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from this class are not comparable to any
+/// published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 public class FastCallLaneBenchmarks
 {
     private const int OperationsPerInvoke = 1_000;
 
-    private Engine _engine = null!;
+    private IsolatedScript _charCodeAtGuarded;
+    private IsolatedScript _charCodeAtObject;
+    private IsolatedScript _charAtGuarded;
+    private IsolatedScript _substringGuarded;
+    private IsolatedScript _substringAbsentEnd;
+    private IsolatedScript _substringObject;
+    private IsolatedScript _sliceGuarded;
 
-    private Prepared<Script> _charCodeAtGuarded;
-    private Prepared<Script> _charCodeAtObject;
-    private Prepared<Script> _charAtGuarded;
-    private Prepared<Script> _substringGuarded;
-    private Prepared<Script> _substringAbsentEnd;
-    private Prepared<Script> _substringObject;
-    private Prepared<Script> _sliceGuarded;
-
-    private Prepared<Script> _max2;
-    private Prepared<Script> _max1;
-    private Prepared<Script> _maxArity3;
-    private Prepared<Script> _min2;
-    private Prepared<Script> _hypot2;
-    private Prepared<Script> _push1;
-    private Prepared<Script> _push2;
-    private Prepared<Script> _pushArity3;
-    private Prepared<Script> _concat1;
-    private Prepared<Script> _concat2;
-    private Prepared<Script> _concatArity3;
+    private IsolatedScript _max2;
+    private IsolatedScript _max1;
+    private IsolatedScript _maxArity3;
+    private IsolatedScript _min2;
+    private IsolatedScript _hypot2;
+    private IsolatedScript _push1;
+    private IsolatedScript _push2;
+    private IsolatedScript _pushArity3;
+    private IsolatedScript _concat1;
+    private IsolatedScript _concat2;
+    private IsolatedScript _concatArity3;
 
     [GlobalSetup]
     public void GlobalSetup()
@@ -97,70 +106,43 @@ public class FastCallLaneBenchmarks
         _concat1 = Loop("s += \"ab\".concat(\"cd\").length");
         _concat2 = Loop("s += \"ab\".concat(\"cd\", \"ef\").length");
         _concatArity3 = Loop("s += \"ab\".concat(\"cd\", \"ef\", \"gh\").length");
-
-        _engine = new Engine();
-        foreach (var script in AllScripts())
-        {
-            _engine.Evaluate(script);
-        }
     }
 
     /// <summary>
-    /// One call per iteration inside a warm loop. <c>s</c> accumulates so the call cannot be dropped,
-    /// and the loop variable feeds the argument so the values are not constant-folded into the site.
+    /// One call per iteration inside a warm loop, on the row's own engine. <c>s</c> accumulates so the
+    /// call cannot be dropped, and the loop variable feeds the argument so the values are not
+    /// constant-folded into the site.
     /// <para>
     /// Everything is declared with <c>var</c> on purpose: each row is evaluated many times on one
     /// engine, and a <c>const</c> would survive in the global lexical environment and make the second
     /// evaluation a redeclaration SyntaxError.
     /// </para>
     /// </summary>
-    private static Prepared<Script> Loop(string body, string prelude = "")
-        => Engine.PrepareScript($$"""
+    private static IsolatedScript Loop(string body, string prelude = "")
+        => IsolatedScript.Warm(Engine.PrepareScript($$"""
             {{prelude}}
             var s = 0;
             for (var i = 0; i < {{OperationsPerInvoke}}; i++) { {{body}}; }
             s;
-            """);
+            """));
 
-    private IEnumerable<Prepared<Script>> AllScripts()
-    {
-        yield return _charCodeAtGuarded;
-        yield return _charCodeAtObject;
-        yield return _charAtGuarded;
-        yield return _substringGuarded;
-        yield return _substringAbsentEnd;
-        yield return _substringObject;
-        yield return _sliceGuarded;
-        yield return _max2;
-        yield return _max1;
-        yield return _maxArity3;
-        yield return _min2;
-        yield return _hypot2;
-        yield return _push1;
-        yield return _push2;
-        yield return _pushArity3;
-        yield return _concat1;
-        yield return _concat2;
-        yield return _concatArity3;
-    }
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue CharCodeAt_Guarded() => _charCodeAtGuarded.Run();
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue CharCodeAt_Object() => _charCodeAtObject.Run();
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue CharAt_Guarded() => _charAtGuarded.Run();
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue Substring_Guarded() => _substringGuarded.Run();
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue Substring_AbsentEnd() => _substringAbsentEnd.Run();
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue Substring_Object() => _substringObject.Run();
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue Slice_Guarded() => _sliceGuarded.Run();
 
-    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue CharCodeAt_Guarded() => _engine.Evaluate(_charCodeAtGuarded);
-    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue CharCodeAt_Object() => _engine.Evaluate(_charCodeAtObject);
-    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue CharAt_Guarded() => _engine.Evaluate(_charAtGuarded);
-    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue Substring_Guarded() => _engine.Evaluate(_substringGuarded);
-    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue Substring_AbsentEnd() => _engine.Evaluate(_substringAbsentEnd);
-    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue Substring_Object() => _engine.Evaluate(_substringObject);
-    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue Slice_Guarded() => _engine.Evaluate(_sliceGuarded);
-
-    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue MathMax_Arity1() => _engine.Evaluate(_max1);
-    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue MathMax_Arity2() => _engine.Evaluate(_max2);
-    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue MathMax_Arity3() => _engine.Evaluate(_maxArity3);
-    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue MathMin_Arity2() => _engine.Evaluate(_min2);
-    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue MathHypot_Arity2() => _engine.Evaluate(_hypot2);
-    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue ArrayPush_Arity1() => _engine.Evaluate(_push1);
-    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue ArrayPush_Arity2() => _engine.Evaluate(_push2);
-    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue ArrayPush_Arity3() => _engine.Evaluate(_pushArity3);
-    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue StringConcat_Arity1() => _engine.Evaluate(_concat1);
-    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue StringConcat_Arity2() => _engine.Evaluate(_concat2);
-    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue StringConcat_Arity3() => _engine.Evaluate(_concatArity3);
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue MathMax_Arity1() => _max1.Run();
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue MathMax_Arity2() => _max2.Run();
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue MathMax_Arity3() => _maxArity3.Run();
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue MathMin_Arity2() => _min2.Run();
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue MathHypot_Arity2() => _hypot2.Run();
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue ArrayPush_Arity1() => _push1.Run();
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue ArrayPush_Arity2() => _push2.Run();
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue ArrayPush_Arity3() => _pushArity3.Run();
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue StringConcat_Arity1() => _concat1.Run();
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue StringConcat_Arity2() => _concat2.Run();
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue StringConcat_Arity3() => _concatArity3.Run();
 }

--- a/Jint.Benchmark/FastCallMigrationBenchmark.cs
+++ b/Jint.Benchmark/FastCallMigrationBenchmark.cs
@@ -9,7 +9,7 @@ namespace Jint.Benchmark;
 /// arguments over in registers instead of filling a pooled array, so these rows are where the migration
 /// shows up.
 /// <para>
-/// Every row runs its call in a tight loop inside one prepared script on one long-lived engine, so the
+/// Every row runs its call in a tight loop inside one prepared script on its own long-lived engine, so the
 /// site is warm and the measurement is the call, not the parse or the first-touch dispatch. The loop body
 /// is deliberately trivial where the method allows it (a short scan, an immediate hit) so the dispatch is
 /// not buried under the built-in's own work.
@@ -19,6 +19,15 @@ namespace Jint.Benchmark;
 /// migrated pair either side of them: still on <c>JsCallArguments</c>, so they should not move at all and
 /// are the cross-run floor for reading the others.
 /// </para>
+/// <para><b>Engine isolation.</b> Every row gets its own engine, warmed with its own script and nothing
+/// else (see <see cref="IsolatedScript"/>). It used to be one engine warmed with all ten scripts, so a row
+/// was measured on an engine carrying the other nine rows' globals (every script declares <c>r</c> and
+/// <c>n</c>) and their handler-tree entries and per-call-site caches — which is what the two control rows
+/// exist to be free of, so leaving them exposed to it defeated their purpose. The <c>data</c>/<c>text</c>
+/// fixture is still shared, but now by being re-run per engine rather than by the engine being re-used.
+/// The rows still measure warm dispatch, and engine construction and warm-up stay in <c>[GlobalSetup]</c>,
+/// outside the measurement. <b>Numbers from this class are not comparable to any published before the
+/// harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 public class FastCallMigrationBenchmark
@@ -32,25 +41,28 @@ public class FastCallMigrationBenchmark
         var isThree = function (x) { return x === 3; };
         """;
 
-    private Engine _engine = null!;
+    private IsolatedScript _stringIncludes;
+    private IsolatedScript _stringEndsWith;
+    private IsolatedScript _arrayIndexOf;
+    private IsolatedScript _arraySome;
+    private IsolatedScript _arrayFind;
+    private IsolatedScript _arrayFindIndex;
+    private IsolatedScript _numberToString;
+    private IsolatedScript _numberToStringRadix;
+    private IsolatedScript _arrayLastIndexOf;
+    private IsolatedScript _arrayFindLast;
 
-    private Prepared<Script> _stringIncludes;
-    private Prepared<Script> _stringEndsWith;
-    private Prepared<Script> _arrayIndexOf;
-    private Prepared<Script> _arraySome;
-    private Prepared<Script> _arrayFind;
-    private Prepared<Script> _arrayFindIndex;
-    private Prepared<Script> _numberToString;
-    private Prepared<Script> _numberToStringRadix;
-    private Prepared<Script> _arrayLastIndexOf;
-    private Prepared<Script> _arrayFindLast;
+    /// <summary>Builds a fresh engine carrying the <c>data</c>/<c>text</c>/<c>isThree</c> fixture every row uses.</summary>
+    private static Engine CreateEngine()
+    {
+        var engine = new Engine();
+        engine.Execute(Setup);
+        return engine;
+    }
 
     [GlobalSetup]
     public void GlobalSetup()
     {
-        _engine = new Engine();
-        _engine.Execute(Setup);
-
         _stringIncludes = Prepare("text.includes('bar')");
         _stringEndsWith = Prepare("text.endsWith('baz')");
         _arrayIndexOf = Prepare("data.indexOf(3)");
@@ -61,51 +73,42 @@ public class FastCallMigrationBenchmark
         _numberToStringRadix = Prepare("(255).toString(16)");
         _arrayLastIndexOf = Prepare("data.lastIndexOf(3)");
         _arrayFindLast = Prepare("data.findLast(isThree)");
-
-        _engine.Evaluate(_stringIncludes);
-        _engine.Evaluate(_stringEndsWith);
-        _engine.Evaluate(_arrayIndexOf);
-        _engine.Evaluate(_arraySome);
-        _engine.Evaluate(_arrayFind);
-        _engine.Evaluate(_arrayFindIndex);
-        _engine.Evaluate(_numberToString);
-        _engine.Evaluate(_numberToStringRadix);
-        _engine.Evaluate(_arrayLastIndexOf);
-        _engine.Evaluate(_arrayFindLast);
     }
 
-    private static Prepared<Script> Prepare(string call)
-        => Engine.PrepareScript("var r; for (var n = 0; n < " + OperationsPerInvoke + "; n++) { r = " + call + "; } r");
+    private static IsolatedScript Prepare(string call)
+        => IsolatedScript.Warm(
+            Engine.PrepareScript("var r; for (var n = 0; n < " + OperationsPerInvoke + "; n++) { r = " + call + "; } r"),
+            CreateEngine);
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue StringIncludes() => _engine.Evaluate(_stringIncludes);
+    public JsValue StringIncludes() => _stringIncludes.Run();
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue StringEndsWith() => _engine.Evaluate(_stringEndsWith);
+    public JsValue StringEndsWith() => _stringEndsWith.Run();
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue ArrayIndexOf() => _engine.Evaluate(_arrayIndexOf);
+    public JsValue ArrayIndexOf() => _arrayIndexOf.Run();
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue ArraySome() => _engine.Evaluate(_arraySome);
+    public JsValue ArraySome() => _arraySome.Run();
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue ArrayFind() => _engine.Evaluate(_arrayFind);
+    public JsValue ArrayFind() => _arrayFind.Run();
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue ArrayFindIndex() => _engine.Evaluate(_arrayFindIndex);
+    public JsValue ArrayFindIndex() => _arrayFindIndex.Run();
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue NumberToString() => _engine.Evaluate(_numberToString);
+    public JsValue NumberToString() => _numberToString.Run();
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue NumberToStringRadix() => _engine.Evaluate(_numberToStringRadix);
+    public JsValue NumberToStringRadix() => _numberToStringRadix.Run();
 
     /// <summary>Untouched sibling of <see cref="ArrayIndexOf"/>: still takes the raw argument array.</summary>
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue Control_ArrayLastIndexOf() => _engine.Evaluate(_arrayLastIndexOf);
+    public JsValue Control_ArrayLastIndexOf() => _arrayLastIndexOf.Run();
 
     /// <summary>Untouched sibling of <see cref="ArrayFind"/>: still takes the raw argument array.</summary>
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue Control_ArrayFindLast() => _engine.Evaluate(_arrayFindLast);
+    public JsValue Control_ArrayFindLast() => _arrayFindLast.Run();
 }

--- a/Jint.Benchmark/FastCoercionBenchmarks.cs
+++ b/Jint.Benchmark/FastCoercionBenchmarks.cs
@@ -14,34 +14,36 @@ namespace Jint.Benchmark;
 ///   - String.prototype.charCodeAt with a number (already JsNumber → ToInteger fast-path)
 /// All three currently pay a TypeConverter call inside the dispatcher; [FastJsValue] would emit a
 /// type-flag check + direct cast so the JsString-already case bypasses ToJsString entirely.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine, warmed with its own script and nothing
+/// else (see <see cref="IsolatedScript"/>). It used to be one engine warmed with all four scripts, so a
+/// row was measured on an engine carrying the other three rows' handler-tree entries and call-site caches
+/// (plus <c>Warm_MapGet</c>'s global <c>m</c>) — and since the class is precisely about what a call site
+/// has learned about its argument types, sibling state on those sites is the wrong thing to carry. The
+/// rows still measure warm dispatch, and engine construction and warm-up stay in <c>[GlobalSetup]</c>,
+/// outside the measurement. <b>Numbers from this class are not comparable to any published before the
+/// harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 public class FastCoercionBenchmarks
 {
-    private Engine _warm = null!;
-    private Prepared<Script> _stringIndexOf;
-    private Prepared<Script> _mapGet;
-    private Prepared<Script> _charCodeAt;
-    private Prepared<Script> _stringIncludes;
+    private IsolatedScript _stringIndexOf;
+    private IsolatedScript _mapGet;
+    private IsolatedScript _charCodeAt;
+    private IsolatedScript _stringIncludes;
 
     [GlobalSetup]
     public void GlobalSetup()
     {
         // Each script keeps the call site monomorphic on a JsString needle / key.
-        _stringIndexOf  = Engine.PrepareScript("'hello world foo bar baz'.indexOf('foo')");
-        _mapGet         = Engine.PrepareScript("var m = new Map(); m.set('a', 1); m.set('b', 2); m.get('b')");
-        _charCodeAt     = Engine.PrepareScript("'abcdefg'.charCodeAt(3)");
-        _stringIncludes = Engine.PrepareScript("'hello world foo bar baz'.includes('bar')");
-
-        _warm = new Engine();
-        _warm.Evaluate(_stringIndexOf);
-        _warm.Evaluate(_mapGet);
-        _warm.Evaluate(_charCodeAt);
-        _warm.Evaluate(_stringIncludes);
+        _stringIndexOf  = IsolatedScript.Warm("'hello world foo bar baz'.indexOf('foo')");
+        _mapGet         = IsolatedScript.Warm("var m = new Map(); m.set('a', 1); m.set('b', 2); m.get('b')");
+        _charCodeAt     = IsolatedScript.Warm("'abcdefg'.charCodeAt(3)");
+        _stringIncludes = IsolatedScript.Warm("'hello world foo bar baz'.includes('bar')");
     }
 
-    [Benchmark] public JsValue Warm_StringIndexOf() => _warm.Evaluate(_stringIndexOf);
-    [Benchmark] public JsValue Warm_MapGet() => _warm.Evaluate(_mapGet);
-    [Benchmark] public JsValue Warm_CharCodeAt() => _warm.Evaluate(_charCodeAt);
-    [Benchmark] public JsValue Warm_StringIncludes() => _warm.Evaluate(_stringIncludes);
+    [Benchmark] public JsValue Warm_StringIndexOf() => _stringIndexOf.Run();
+    [Benchmark] public JsValue Warm_MapGet() => _mapGet.Run();
+    [Benchmark] public JsValue Warm_CharCodeAt() => _charCodeAt.Run();
+    [Benchmark] public JsValue Warm_StringIncludes() => _stringIncludes.Run();
 }

--- a/Jint.Benchmark/ForInGuardBenchmark.cs
+++ b/Jint.Benchmark/ForInGuardBenchmark.cs
@@ -8,23 +8,32 @@ namespace Jint.Benchmark;
 /// hasOwnProperty guard, prototype-chain filtering, for-in over arrays (dense, holey, and with
 /// extra named own props), for-of over a string, and typeof / instanceof / in dispatch over
 /// LCG-mixed inputs the branch predictor cannot memorize.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine — built by <c>CreateEngine</c>, which
+/// re-runs <see cref="SetupSource"/> so each engine owns its own fixture objects — and warmed with its
+/// own script and nothing else (see <see cref="IsolatedScript"/>). It used to be one engine warmed with
+/// all eleven row scripts, so each row was measured on an engine carrying the other ten rows' globals
+/// (every one of them declares <c>function f</c>, so they collided outright) plus their handler-tree,
+/// call-site and enumeration-cache state — which makes a row's number depend on which siblings exist and
+/// on what a change did to <em>them</em>. The rows still measure warm iteration, and engine construction
+/// and warm-up stay in <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from this class are not
+/// comparable to any published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]
 public class ForInGuardBenchmark
 {
-    private Engine _engine = null!;
-    private Prepared<Script> _forInSmall;
-    private Prepared<Script> _forInWide;
-    private Prepared<Script> _forInHasOwnGuard;
-    private Prepared<Script> _forInProtoChain;
-    private Prepared<Script> _forInDenseArray;
-    private Prepared<Script> _forInHoleyArray;
-    private Prepared<Script> _forInArrayExtraProps;
-    private Prepared<Script> _forOfString;
-    private Prepared<Script> _typeofSwitchMixed;
-    private Prepared<Script> _instanceofMixed;
-    private Prepared<Script> _inOperatorMixed;
+    private IsolatedScript _forInSmall;
+    private IsolatedScript _forInWide;
+    private IsolatedScript _forInHasOwnGuard;
+    private IsolatedScript _forInProtoChain;
+    private IsolatedScript _forInDenseArray;
+    private IsolatedScript _forInHoleyArray;
+    private IsolatedScript _forInArrayExtraProps;
+    private IsolatedScript _forOfString;
+    private IsolatedScript _typeofSwitchMixed;
+    private IsolatedScript _instanceofMixed;
+    private IsolatedScript _inOperatorMixed;
 
     internal const string SetupSource = """
         var six = { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6 };
@@ -99,13 +108,18 @@ public class ForInGuardBenchmark
         f();
         """;
 
+    /// <summary>Builds a fresh engine carrying the fixture every row needs, and nothing else.</summary>
+    private static Engine CreateEngine()
+    {
+        var engine = new Engine();
+        engine.Execute(SetupSource);
+        return engine;
+    }
+
     [GlobalSetup]
     public void Setup()
     {
-        _engine = new Engine();
-        _engine.Execute(SetupSource);
-
-        _forInSmall = Engine.PrepareScript("""
+        _forInSmall = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 20000; i++) {
@@ -114,9 +128,9 @@ public class ForInGuardBenchmark
                 return s;
             }
             f();
-            """);
+            """), CreateEngine);
 
-        _forInWide = Engine.PrepareScript("""
+        _forInWide = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 2000; i++) {
@@ -125,12 +139,12 @@ public class ForInGuardBenchmark
                 return s;
             }
             f();
-            """);
+            """), CreateEngine);
 
-        _forInHasOwnGuard = Engine.PrepareScript(ForInHasOwnGuardSource);
+        _forInHasOwnGuard = IsolatedScript.Warm(Engine.PrepareScript(ForInHasOwnGuardSource), CreateEngine);
 
         // 1,000 dense int-indexed keys, no holes, no named own props
-        _forInDenseArray = Engine.PrepareScript("""
+        _forInDenseArray = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 200; i++) {
@@ -139,10 +153,10 @@ public class ForInGuardBenchmark
                 return s;
             }
             f();
-            """);
+            """), CreateEngine);
 
         // every 4th index present; enumeration must skip the holes
-        _forInHoleyArray = Engine.PrepareScript("""
+        _forInHoleyArray = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 200; i++) {
@@ -151,10 +165,10 @@ public class ForInGuardBenchmark
                 return s;
             }
             f();
-            """);
+            """), CreateEngine);
 
         // 100 indices plus two named own props; order must stay indices-then-named
-        _forInArrayExtraProps = Engine.PrepareScript("""
+        _forInArrayExtraProps = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 2000; i++) {
@@ -163,10 +177,10 @@ public class ForInGuardBenchmark
                 return s;
             }
             f();
-            """);
+            """), CreateEngine);
 
         // 6 own + 6 enumerable inherited keys; the guard filters the inherited half
-        _forInProtoChain = Engine.PrepareScript("""
+        _forInProtoChain = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 10000; i++) {
@@ -177,9 +191,9 @@ public class ForInGuardBenchmark
                 return s;
             }
             f();
-            """);
+            """), CreateEngine);
 
-        _forOfString = Engine.PrepareScript("""
+        _forOfString = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var n = 0;
                 for (var i = 0; i < 5; i++) {
@@ -188,11 +202,11 @@ public class ForInGuardBenchmark
                 return n;
             }
             f();
-            """);
+            """), CreateEngine);
 
-        _typeofSwitchMixed = Engine.PrepareScript(TypeofSwitchMixedSource);
+        _typeofSwitchMixed = IsolatedScript.Warm(Engine.PrepareScript(TypeofSwitchMixedSource), CreateEngine);
 
-        _instanceofMixed = Engine.PrepareScript("""
+        _instanceofMixed = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
@@ -201,9 +215,9 @@ public class ForInGuardBenchmark
                 return s;
             }
             f();
-            """);
+            """), CreateEngine);
 
-        _inOperatorMixed = Engine.PrepareScript("""
+        _inOperatorMixed = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
@@ -212,51 +226,39 @@ public class ForInGuardBenchmark
                 return s;
             }
             f();
-            """);
-
-        _engine.Evaluate(_forInSmall);
-        _engine.Evaluate(_forInWide);
-        _engine.Evaluate(_forInHasOwnGuard);
-        _engine.Evaluate(_forInProtoChain);
-        _engine.Evaluate(_forInDenseArray);
-        _engine.Evaluate(_forInHoleyArray);
-        _engine.Evaluate(_forInArrayExtraProps);
-        _engine.Evaluate(_forOfString);
-        _engine.Evaluate(_typeofSwitchMixed);
-        _engine.Evaluate(_instanceofMixed);
-        _engine.Evaluate(_inOperatorMixed);
+            """), CreateEngine);
     }
 
     [Benchmark]
-    public JsValue ForInSmall() => _engine.Evaluate(_forInSmall);
+    public JsValue ForInSmall() => _forInSmall.Run();
 
     [Benchmark]
-    public JsValue ForInWide() => _engine.Evaluate(_forInWide);
+    public JsValue ForInWide() => _forInWide.Run();
 
     [Benchmark]
-    public JsValue ForInHasOwnGuard() => _engine.Evaluate(_forInHasOwnGuard);
+    public JsValue ForInHasOwnGuard() => _forInHasOwnGuard.Run();
 
     [Benchmark]
-    public JsValue ForInProtoChain() => _engine.Evaluate(_forInProtoChain);
+    public JsValue ForInProtoChain() => _forInProtoChain.Run();
 
     [Benchmark]
-    public JsValue ForInDenseArray() => _engine.Evaluate(_forInDenseArray);
+    public JsValue ForInDenseArray() => _forInDenseArray.Run();
 
     [Benchmark]
-    public JsValue ForInHoleyArray() => _engine.Evaluate(_forInHoleyArray);
+    public JsValue ForInHoleyArray() => _forInHoleyArray.Run();
 
     [Benchmark]
-    public JsValue ForInArrayExtraProps() => _engine.Evaluate(_forInArrayExtraProps);
+    public JsValue ForInArrayExtraProps() => _forInArrayExtraProps.Run();
 
     [Benchmark]
-    public JsValue ForOfString() => _engine.Evaluate(_forOfString);
+    public JsValue ForOfString() => _forOfString.Run();
 
     [Benchmark]
-    public JsValue TypeofSwitchMixed() => _engine.Evaluate(_typeofSwitchMixed);
+    public JsValue TypeofSwitchMixed() => _typeofSwitchMixed.Run();
 
     [Benchmark]
-    public JsValue InstanceofMixed() => _engine.Evaluate(_instanceofMixed);
+    public JsValue InstanceofMixed() => _instanceofMixed.Run();
 
     [Benchmark]
-    public JsValue InOperatorMixed() => _engine.Evaluate(_inOperatorMixed);
+    public JsValue InOperatorMixed() => _inOperatorMixed.Run();
 }

--- a/Jint.Benchmark/ForOfArrayBenchmark.cs
+++ b/Jint.Benchmark/ForOfArrayBenchmark.cs
@@ -9,6 +9,16 @@ namespace Jint.Benchmark;
 /// per-element step rather than array construction. Gates the ArrayIterator/ArrayLikeIterator
 /// TryStepValue override that hands the element straight to the loop instead of allocating an
 /// IteratorResult object per element — watch the Allocated column.
+///
+/// <para><b>Engine isolation.</b> Each row gets its own engine — built by <c>CreateEngine</c>, which
+/// re-runs the array fixture so each engine owns its own <c>denseArr</c>/<c>holeyArr</c> — and warmed
+/// with its own script and nothing else (see <see cref="IsolatedScript"/>). It used to be one engine
+/// warmed with both scripts, so each row was measured on an engine already carrying the other row's
+/// <c>function f</c> global (both scripts declare it, so they collided outright) and its handler-tree
+/// and call-site caches, which makes a row's number depend on what a change did to its sibling. The
+/// rows still measure the warm per-element step, and engine construction and warm-up stay in
+/// <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from this class are not comparable to any
+/// published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 public class ForOfArrayBenchmark
@@ -16,22 +26,26 @@ public class ForOfArrayBenchmark
     private const int ArraySize = 1000;
     private const int Repeat = 1000;
 
-    private Engine _engine = null!;
-    private Prepared<Script> _forOfDense;
-    private Prepared<Script> _forOfHoley;
+    private IsolatedScript _forOfDense;
+    private IsolatedScript _forOfHoley;
 
-    [GlobalSetup]
-    public void Setup()
+    /// <summary>Builds a fresh engine carrying the fixture every row needs, and nothing else.</summary>
+    private static Engine CreateEngine()
     {
-        _engine = new Engine();
-        _engine.Execute($$"""
+        var engine = new Engine();
+        engine.Execute($$"""
             var denseArr = [];
             for (var i = 0; i < {{ArraySize}}; i++) { denseArr[i] = i; }
             var holeyArr = [];
             for (var i = 0; i < {{ArraySize}}; i += 2) { holeyArr[i] = i; }
             """);
+        return engine;
+    }
 
-        _forOfDense = Engine.PrepareScript($$"""
+    [GlobalSetup]
+    public void Setup()
+    {
+        _forOfDense = IsolatedScript.Warm(Engine.PrepareScript($$"""
             function f() {
                 var s = 0;
                 for (var k = 0; k < {{Repeat}}; k++) {
@@ -40,9 +54,9 @@ public class ForOfArrayBenchmark
                 return s;
             }
             f();
-            """);
+            """), CreateEngine);
 
-        _forOfHoley = Engine.PrepareScript($$"""
+        _forOfHoley = IsolatedScript.Warm(Engine.PrepareScript($$"""
             function f() {
                 var s = 0;
                 for (var k = 0; k < {{Repeat}}; k++) {
@@ -51,15 +65,12 @@ public class ForOfArrayBenchmark
                 return s;
             }
             f();
-            """);
-
-        _engine.Evaluate(_forOfDense);
-        _engine.Evaluate(_forOfHoley);
+            """), CreateEngine);
     }
 
     [Benchmark]
-    public JsValue ForOfDenseArray() => _engine.Evaluate(_forOfDense);
+    public JsValue ForOfDenseArray() => _forOfDense.Run();
 
     [Benchmark]
-    public JsValue ForOfHoleyArray() => _engine.Evaluate(_forOfHoley);
+    public JsValue ForOfHoleyArray() => _forOfHoley.Run();
 }

--- a/Jint.Benchmark/FunctionDeclarationAllocBenchmark.cs
+++ b/Jint.Benchmark/FunctionDeclarationAllocBenchmark.cs
@@ -10,38 +10,43 @@ namespace Jint.Benchmark;
 /// skips its prototype object + two descriptor allocations. <see cref="ConstructEach"/> is the guard:
 /// when the functions ARE used as constructors the prototype must still materialize (no allocation win,
 /// no regression).
+///
+/// <para><b>Engine isolation.</b> Each row gets its own engine, warmed with its own script and nothing
+/// else (see <see cref="IsolatedScript"/>). It used to be one engine warmed with both scripts, so each
+/// row was measured on an engine already carrying the other row's <c>arr</c> global (both declare it, so
+/// they collided outright) plus its handler-tree, call-site and function-prototype state — the very
+/// state this class exists to size. The rows still measure the warm declaration path, and engine
+/// construction and warm-up stay in <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from this
+/// class are not comparable to any published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]
 public class FunctionDeclarationAllocBenchmark
 {
-    private Engine _engine = null!;
-    private Prepared<Script> _declareMany;
-    private Prepared<Script> _constructEach;
+    private IsolatedScript _declareMany;
+    private IsolatedScript _constructEach;
+
+    private static Engine CreateEngine() => new(static options => options.Strict());
 
     [GlobalSetup]
     public void Setup()
     {
-        _declareMany = Engine.PrepareScript("""
+        _declareMany = IsolatedScript.Warm(Engine.PrepareScript("""
             var arr = [];
             for (var i = 0; i < 500; i++) { arr.push(function (a, b) { return a + b; }); }
             arr.length;
-            """, strict: true);
+            """, strict: true), CreateEngine);
 
-        _constructEach = Engine.PrepareScript("""
+        _constructEach = IsolatedScript.Warm(Engine.PrepareScript("""
             var arr = [];
             for (var i = 0; i < 500; i++) { var F = function () { this.x = 1; }; arr.push(new F()); }
             arr.length;
-            """, strict: true);
-
-        _engine = new Engine(static options => options.Strict());
-        _engine.Evaluate(_declareMany);
-        _engine.Evaluate(_constructEach);
+            """, strict: true), CreateEngine);
     }
 
     [Benchmark]
-    public JsValue DeclareMany() => _engine.Evaluate(_declareMany);
+    public JsValue DeclareMany() => _declareMany.Run();
 
     [Benchmark]
-    public JsValue ConstructEach() => _engine.Evaluate(_constructEach);
+    public JsValue ConstructEach() => _constructEach.Run();
 }

--- a/Jint.Benchmark/FunctionInvocationBenchmarks.cs
+++ b/Jint.Benchmark/FunctionInvocationBenchmarks.cs
@@ -7,41 +7,42 @@ namespace Jint.Benchmark;
 /// Source-gen sentinel for Function.prototype.{call,apply,bind}. Post-source-gen these methods take
 /// `ICallable thisObject` directly with the generator emitting the cast + TypeError. Warm-path numbers
 /// should match the pre-source-gen baseline; the cast emit replaces a manual `as ICallable` + null check.
+///
+/// <para><b>Engine isolation.</b> Each row gets its own engine, warmed with its own script and nothing
+/// else (see <see cref="IsolatedScript"/>). It used to be one engine warmed with all four scripts, so
+/// each row was measured on an engine carrying the other three rows' handler-tree and call-site state
+/// (plus <c>Warm_BindThenCall</c>'s <c>f</c> global), which makes a row's number depend on which siblings
+/// exist and on what a change did to <em>them</em>. The rows still measure the warm path, and engine
+/// construction and warm-up stay in <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from this
+/// class are not comparable to any published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 public class FunctionInvocationBenchmarks
 {
-    private Engine _warm = null!;
-    private Prepared<Script> _call;
-    private Prepared<Script> _apply;
-    private Prepared<Script> _bind;
-    private Prepared<Script> _bindThenCall;
+    private IsolatedScript _call;
+    private IsolatedScript _apply;
+    private IsolatedScript _bind;
+    private IsolatedScript _bindThenCall;
 
     [GlobalSetup]
     public void GlobalSetup()
     {
         // Each benchmark builds its own function on the engine to keep the call sites monomorphic.
-        _call  = Engine.PrepareScript("(function(a, b) { return a + b; }).call(null, 1, 2)");
-        _apply = Engine.PrepareScript("(function(a, b) { return a + b; }).apply(null, [1, 2])");
-        _bind  = Engine.PrepareScript("(function(a, b) { return a + b; }).bind(null, 1)");
-        _bindThenCall = Engine.PrepareScript("var f = (function(a, b) { return a + b; }).bind(null, 1); f(2)");
-
-        _warm = new Engine();
-        _warm.Evaluate(_call);
-        _warm.Evaluate(_apply);
-        _warm.Evaluate(_bind);
-        _warm.Evaluate(_bindThenCall);
+        _call  = IsolatedScript.Warm("(function(a, b) { return a + b; }).call(null, 1, 2)");
+        _apply = IsolatedScript.Warm("(function(a, b) { return a + b; }).apply(null, [1, 2])");
+        _bind  = IsolatedScript.Warm("(function(a, b) { return a + b; }).bind(null, 1)");
+        _bindThenCall = IsolatedScript.Warm("var f = (function(a, b) { return a + b; }).bind(null, 1); f(2)");
     }
 
     [Benchmark]
-    public JsValue Warm_Call() => _warm.Evaluate(_call);
+    public JsValue Warm_Call() => _call.Run();
 
     [Benchmark]
-    public JsValue Warm_Apply() => _warm.Evaluate(_apply);
+    public JsValue Warm_Apply() => _apply.Run();
 
     [Benchmark]
-    public JsValue Warm_Bind() => _warm.Evaluate(_bind);
+    public JsValue Warm_Bind() => _bind.Run();
 
     [Benchmark]
-    public JsValue Warm_BindThenCall() => _warm.Evaluate(_bindThenCall);
+    public JsValue Warm_BindThenCall() => _bindThenCall.Run();
 }

--- a/Jint.Benchmark/FunctionLocalNumberLoopBenchmark.cs
+++ b/Jint.Benchmark/FunctionLocalNumberLoopBenchmark.cs
@@ -8,23 +8,31 @@ namespace Jint.Benchmark;
 /// environment slots. These are the workloads where transient JsNumber allocations dominate
 /// (values outside the int cache allocate per write), which the rest of the suite under-covers
 /// because its loops live at script top level where bindings are global-object properties.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine, warmed with its own script and nothing
+/// else (see <see cref="IsolatedScript"/>). It used to be one engine warmed with all six scripts, so each
+/// row was measured on an engine carrying the other five rows' globals (every one of them declares
+/// <c>function f</c>, so they collided outright) plus their handler-tree, call-site and
+/// environment-reuse state — which makes a row's number depend on which siblings exist and on what a
+/// change did to <em>them</em>. The rows still measure the warm loop, and engine construction and
+/// warm-up stay in <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from this class are not
+/// comparable to any published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 public class FunctionLocalNumberLoopBenchmark
 {
-    private Engine _engine = null!;
-    private Prepared<Script> _doubleAccumulator;
-    private Prepared<Script> _largeIntCounter;
-    private Prepared<Script> _accumulatorWithCallArg;
-    private Prepared<Script> _mixedArithmetic;
-    private Prepared<Script> _whileAccumulator;
-    private Prepared<Script> _doWhileCounter;
+    private IsolatedScript _doubleAccumulator;
+    private IsolatedScript _largeIntCounter;
+    private IsolatedScript _accumulatorWithCallArg;
+    private IsolatedScript _mixedArithmetic;
+    private IsolatedScript _whileAccumulator;
+    private IsolatedScript _doWhileCounter;
 
     [GlobalSetup]
     public void GlobalSetup()
     {
         // pure accumulator: every += result is an uncached double
-        _doubleAccumulator = Engine.PrepareScript("""
+        _doubleAccumulator = IsolatedScript.Warm("""
             function f() {
                 var s = 0.5;
                 for (var i = 0; i < 100000; i++) {
@@ -36,7 +44,7 @@ public class FunctionLocalNumberLoopBenchmark
             """);
 
         // counter beyond the interned-int range with a materializing loop test
-        _largeIntCounter = Engine.PrepareScript("""
+        _largeIntCounter = IsolatedScript.Warm("""
             function f() {
                 var n = 0;
                 for (var i = 0; i < 100000; i++) {
@@ -48,7 +56,7 @@ public class FunctionLocalNumberLoopBenchmark
             """);
 
         // unboxed write followed by a materializing read every iteration
-        _accumulatorWithCallArg = Engine.PrepareScript("""
+        _accumulatorWithCallArg = IsolatedScript.Warm("""
             function g(v) { return v > 0; }
             function f() {
                 var s = 0.5;
@@ -63,7 +71,7 @@ public class FunctionLocalNumberLoopBenchmark
             """);
 
         // several locals updated per iteration (numeric kernel shape)
-        _mixedArithmetic = Engine.PrepareScript("""
+        _mixedArithmetic = IsolatedScript.Warm("""
             function f() {
                 var x = 0.1;
                 var y = 0.2;
@@ -81,7 +89,7 @@ public class FunctionLocalNumberLoopBenchmark
 
         // the while/do-while twins of the for-loop accumulator: same tight-lane body shapes,
         // different loop statements
-        _whileAccumulator = Engine.PrepareScript("""
+        _whileAccumulator = IsolatedScript.Warm("""
             function f() {
                 var s = 0.5;
                 var i = 0;
@@ -94,7 +102,7 @@ public class FunctionLocalNumberLoopBenchmark
             f();
             """);
 
-        _doWhileCounter = Engine.PrepareScript("""
+        _doWhileCounter = IsolatedScript.Warm("""
             function f() {
                 var n = 0;
                 var i = 0;
@@ -106,31 +114,23 @@ public class FunctionLocalNumberLoopBenchmark
             }
             f();
             """);
-
-        _engine = new Engine();
-        _engine.Evaluate(_doubleAccumulator);
-        _engine.Evaluate(_largeIntCounter);
-        _engine.Evaluate(_accumulatorWithCallArg);
-        _engine.Evaluate(_mixedArithmetic);
-        _engine.Evaluate(_whileAccumulator);
-        _engine.Evaluate(_doWhileCounter);
     }
 
     [Benchmark]
-    public JsValue DoubleAccumulator() => _engine.Evaluate(_doubleAccumulator);
+    public JsValue DoubleAccumulator() => _doubleAccumulator.Run();
 
     [Benchmark]
-    public JsValue LargeIntCounter() => _engine.Evaluate(_largeIntCounter);
+    public JsValue LargeIntCounter() => _largeIntCounter.Run();
 
     [Benchmark]
-    public JsValue AccumulatorWithCallArg() => _engine.Evaluate(_accumulatorWithCallArg);
+    public JsValue AccumulatorWithCallArg() => _accumulatorWithCallArg.Run();
 
     [Benchmark]
-    public JsValue MixedArithmetic() => _engine.Evaluate(_mixedArithmetic);
+    public JsValue MixedArithmetic() => _mixedArithmetic.Run();
 
     [Benchmark]
-    public JsValue WhileAccumulator() => _engine.Evaluate(_whileAccumulator);
+    public JsValue WhileAccumulator() => _whileAccumulator.Run();
 
     [Benchmark]
-    public JsValue DoWhileCounter() => _engine.Evaluate(_doWhileCounter);
+    public JsValue DoWhileCounter() => _doWhileCounter.Run();
 }

--- a/Jint.Benchmark/GlobalAccessBenchmarks.cs
+++ b/Jint.Benchmark/GlobalAccessBenchmarks.cs
@@ -7,22 +7,39 @@ namespace Jint.Benchmark;
 /// Isolates top-level (global binding) variable access — the stopwatch.js shape where loop
 /// counters and state live as global-object properties and every read/write pays a property
 /// dictionary lookup. LocalVarLoop is the fixed-slot ceiling/guard for the same operations.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine — built by <c>CreateEngine</c>, which
+/// re-runs the global-declaration fixture so each engine owns its own <c>gx</c>/<c>gy</c>/… — and warmed
+/// with its own script and nothing else (see <see cref="IsolatedScript"/>). It used to be one engine
+/// warmed with all five scripts, which is the worst possible arrangement for a class about global
+/// bindings: every row wrote the other rows' globals on the one global object they all shared, and each
+/// row was additionally measured on the others' handler-tree, call-site and identifier-cache state. The
+/// rows still measure warm access, and engine construction and warm-up stay in <c>[GlobalSetup]</c>,
+/// outside the measurement. <b>Numbers from this class are not comparable to any published before the
+/// harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]
 public class GlobalAccessBenchmarks
 {
-    private Engine _engine = null!;
-    private Prepared<Script> _globalVarLoop;
-    private Prepared<Script> _localVarLoop;
-    private Prepared<Script> _globalUpdateLoop;
-    private Prepared<Script> _nestedGlobalReadLoop;
-    private Prepared<Script> _nestedGlobalWriteLoop;
+    private IsolatedScript _globalVarLoop;
+    private IsolatedScript _localVarLoop;
+    private IsolatedScript _globalUpdateLoop;
+    private IsolatedScript _nestedGlobalReadLoop;
+    private IsolatedScript _nestedGlobalWriteLoop;
+
+    /// <summary>Builds a fresh engine carrying the fixture every row needs, and nothing else.</summary>
+    private static Engine CreateEngine()
+    {
+        var engine = new Engine(static options => options.Strict());
+        engine.Execute("var gx = 0; var gy = 0; var gz = 0; var gobj = null; var gsum = 0; var gval = 0;");
+        return engine;
+    }
 
     [GlobalSetup]
     public void Setup()
     {
-        _globalVarLoop = Engine.PrepareScript("""
+        _globalVarLoop = IsolatedScript.Warm(Engine.PrepareScript("""
             gx = 0; gy = 0; gz = 0;
             for (var gi = 0; gi < 200000; gi++) {
                 gz = gx ^ gy;
@@ -30,9 +47,9 @@ public class GlobalAccessBenchmarks
                 gy = (gy + (gz & 3)) & 2047;
             }
             gz;
-            """, strict: true);
+            """, strict: true), CreateEngine);
 
-        _localVarLoop = Engine.PrepareScript("""
+        _localVarLoop = IsolatedScript.Warm(Engine.PrepareScript("""
             (function() {
                 var x = 0, y = 0, z = 0;
                 for (var i = 0; i < 200000; i++) {
@@ -42,26 +59,26 @@ public class GlobalAccessBenchmarks
                 }
                 return z;
             })();
-            """, strict: true);
+            """, strict: true), CreateEngine);
 
         // Update-expression heavy: gx++, gy++, and the gi++/go++ loop counters are all global
         // UpdateExpressions, which #2507 did not cache (it cached reads and simple assignments). The
         // counters stay in the small-integer cache (reset each outer iteration) so the measurement is
         // the binding-resolution cost, not JsNumber boxing — the stopwatch.js shape (x<1021, y<383).
-        _globalUpdateLoop = Engine.PrepareScript("""
+        _globalUpdateLoop = IsolatedScript.Warm(Engine.PrepareScript("""
             gx = 0; gy = 0;
             for (var go = 0; go < 1000; go++) {
                 for (var gi = 0; gi < 1000; gi++) { gx++; gy++; }
                 gx = 0; gy = 0;
             }
             gx + gy;
-            """, strict: true);
+            """, strict: true), CreateEngine);
 
         // Global reads from a NESTED lexical scope (let-header loop + const body): the validator
         // cannot take the hop-0 identity arm and re-walks the chain with shadow probes per read —
         // the stopwatch-modern shape where the most-referenced binding (`sw`) is a global reached
         // from two levels of loop scope.
-        _nestedGlobalReadLoop = Engine.PrepareScript("""
+        _nestedGlobalReadLoop = IsolatedScript.Warm(Engine.PrepareScript("""
             gobj = { n: 0 };
             gsum = 0;
             (function () {
@@ -75,9 +92,9 @@ public class GlobalAccessBenchmarks
                 }
                 return t;
             })();
-            """, strict: true);
+            """, strict: true), CreateEngine);
 
-        _nestedGlobalWriteLoop = Engine.PrepareScript("""
+        _nestedGlobalWriteLoop = IsolatedScript.Warm(Engine.PrepareScript("""
             gval = 0;
             (function () {
                 for (let r = 0; r < 20; r++) {
@@ -87,29 +104,21 @@ public class GlobalAccessBenchmarks
                 }
                 return gval;
             })();
-            """, strict: true);
-
-        _engine = new Engine(static options => options.Strict());
-        _engine.Execute("var gx = 0; var gy = 0; var gz = 0; var gobj = null; var gsum = 0; var gval = 0;");
-        _engine.Evaluate(_globalVarLoop);
-        _engine.Evaluate(_localVarLoop);
-        _engine.Evaluate(_globalUpdateLoop);
-        _engine.Evaluate(_nestedGlobalReadLoop);
-        _engine.Evaluate(_nestedGlobalWriteLoop);
+            """, strict: true), CreateEngine);
     }
 
     [Benchmark]
-    public JsValue GlobalVarLoop() => _engine.Evaluate(_globalVarLoop);
+    public JsValue GlobalVarLoop() => _globalVarLoop.Run();
 
     [Benchmark]
-    public JsValue LocalVarLoop() => _engine.Evaluate(_localVarLoop);
+    public JsValue LocalVarLoop() => _localVarLoop.Run();
 
     [Benchmark]
-    public JsValue GlobalUpdateLoop() => _engine.Evaluate(_globalUpdateLoop);
+    public JsValue GlobalUpdateLoop() => _globalUpdateLoop.Run();
 
     [Benchmark]
-    public JsValue NestedGlobalReadLoop() => _engine.Evaluate(_nestedGlobalReadLoop);
+    public JsValue NestedGlobalReadLoop() => _nestedGlobalReadLoop.Run();
 
     [Benchmark]
-    public JsValue NestedGlobalWriteLoop() => _engine.Evaluate(_nestedGlobalWriteLoop);
+    public JsValue NestedGlobalWriteLoop() => _nestedGlobalWriteLoop.Run();
 }

--- a/Jint.Benchmark/GuardComparisonBenchmark.cs
+++ b/Jint.Benchmark/GuardComparisonBenchmark.cs
@@ -7,18 +7,27 @@ namespace Jint.Benchmark;
 /// Guard-style strict comparisons over LCG-mixed inputs the branch predictor cannot memorize:
 /// `v === undefined`, `v === null`, `v == null` and `typeof v === '...'` — the idioms defensive
 /// library code (linq.js, lodash, handlebars) runs on nearly every call.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine — built by <c>CreateEngine</c>, which
+/// re-runs <see cref="SetupSource"/> so each engine owns its own <c>mixedVals</c>/<c>order</c> — and
+/// warmed with its own script and nothing else (see <see cref="IsolatedScript"/>). It used to be one
+/// engine warmed with all six scripts, so each row was measured on an engine carrying the other five
+/// rows' globals (every one of them declares <c>function f</c>, so they collided outright) plus their
+/// handler-tree and call-site state, which makes a row's number depend on which siblings exist and on
+/// what a change did to <em>them</em>. The rows still measure warm comparison dispatch, and engine
+/// construction and warm-up stay in <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from this
+/// class are not comparable to any published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]
 public class GuardComparisonBenchmark
 {
-    private Engine _engine = null!;
-    private Prepared<Script> _isUndefinedGuard;
-    private Prepared<Script> _isNullGuard;
-    private Prepared<Script> _looseNullGuard;
-    private Prepared<Script> _typeofStringGuard;
-    private Prepared<Script> _typeofUndefinedGuard;
-    private Prepared<Script> _logicalGuard;
+    private IsolatedScript _isUndefinedGuard;
+    private IsolatedScript _isNullGuard;
+    private IsolatedScript _looseNullGuard;
+    private IsolatedScript _typeofStringGuard;
+    private IsolatedScript _typeofUndefinedGuard;
+    private IsolatedScript _logicalGuard;
 
     private const string SetupSource = """
         var mixedVals = [];
@@ -40,13 +49,18 @@ public class GuardComparisonBenchmark
         })();
         """;
 
+    /// <summary>Builds a fresh engine carrying the fixture every row needs, and nothing else.</summary>
+    private static Engine CreateEngine()
+    {
+        var engine = new Engine();
+        engine.Execute(SetupSource);
+        return engine;
+    }
+
     [GlobalSetup]
     public void Setup()
     {
-        _engine = new Engine();
-        _engine.Execute(SetupSource);
-
-        _isUndefinedGuard = Engine.PrepareScript("""
+        _isUndefinedGuard = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
@@ -57,9 +71,9 @@ public class GuardComparisonBenchmark
                 return s;
             }
             f();
-            """);
+            """), CreateEngine);
 
-        _isNullGuard = Engine.PrepareScript("""
+        _isNullGuard = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
@@ -70,9 +84,9 @@ public class GuardComparisonBenchmark
                 return s;
             }
             f();
-            """);
+            """), CreateEngine);
 
-        _looseNullGuard = Engine.PrepareScript("""
+        _looseNullGuard = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
@@ -82,9 +96,9 @@ public class GuardComparisonBenchmark
                 return s;
             }
             f();
-            """);
+            """), CreateEngine);
 
-        _typeofStringGuard = Engine.PrepareScript("""
+        _typeofStringGuard = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
@@ -95,9 +109,9 @@ public class GuardComparisonBenchmark
                 return s;
             }
             f();
-            """);
+            """), CreateEngine);
 
-        _typeofUndefinedGuard = Engine.PrepareScript("""
+        _typeofUndefinedGuard = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
@@ -107,12 +121,12 @@ public class GuardComparisonBenchmark
                 return s;
             }
             f();
-            """);
+            """), CreateEngine);
 
         // Composed guards: `&&`/`||`/`!` over comparisons in a boolean `if` context. Each
         // comparison feeds the enclosing logical operator's unboxed GetBooleanValue, so the whole
         // condition stays off the JsBoolean-materialization path.
-        _logicalGuard = Engine.PrepareScript("""
+        _logicalGuard = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
@@ -125,31 +139,24 @@ public class GuardComparisonBenchmark
                 return s;
             }
             f();
-            """);
-
-        _engine.Evaluate(_isUndefinedGuard);
-        _engine.Evaluate(_isNullGuard);
-        _engine.Evaluate(_looseNullGuard);
-        _engine.Evaluate(_typeofStringGuard);
-        _engine.Evaluate(_typeofUndefinedGuard);
-        _engine.Evaluate(_logicalGuard);
+            """), CreateEngine);
     }
 
     [Benchmark]
-    public JsValue IsUndefinedGuard() => _engine.Evaluate(_isUndefinedGuard);
+    public JsValue IsUndefinedGuard() => _isUndefinedGuard.Run();
 
     [Benchmark]
-    public JsValue IsNullGuard() => _engine.Evaluate(_isNullGuard);
+    public JsValue IsNullGuard() => _isNullGuard.Run();
 
     [Benchmark]
-    public JsValue LooseNullGuard() => _engine.Evaluate(_looseNullGuard);
+    public JsValue LooseNullGuard() => _looseNullGuard.Run();
 
     [Benchmark]
-    public JsValue TypeofStringGuard() => _engine.Evaluate(_typeofStringGuard);
+    public JsValue TypeofStringGuard() => _typeofStringGuard.Run();
 
     [Benchmark]
-    public JsValue TypeofUndefinedGuard() => _engine.Evaluate(_typeofUndefinedGuard);
+    public JsValue TypeofUndefinedGuard() => _typeofUndefinedGuard.Run();
 
     [Benchmark]
-    public JsValue LogicalGuard() => _engine.Evaluate(_logicalGuard);
+    public JsValue LogicalGuard() => _logicalGuard.Run();
 }

--- a/Jint.Benchmark/HostArrayLikeBenchmark.cs
+++ b/Jint.Benchmark/HostArrayLikeBenchmark.cs
@@ -49,6 +49,19 @@ namespace Jint.Benchmark;
 /// flag, so it advertises a <c>length</c> property and lets the engine's dynamic probe find it, which is exactly
 /// what a real host has to do.
 /// </para>
+///
+/// <para>
+/// <b>Engine isolation.</b> Each of the three rows gets its own engine — built by <c>CreateEngine</c>, which
+/// re-creates the receiver and re-registers the one <c>list</c> global every row reads — and warmed with its
+/// own script and nothing else (see <see cref="IsolatedScript"/>). It used to be one engine per parameter
+/// combination warmed with all three scripts, so each row was measured on an engine carrying the other two
+/// rows' globals (<see cref="IndexedLoop"/> and <see cref="ForOf"/> both declare <c>n</c>) and their
+/// handler-tree and call-site state — and for a class whose whole subject is the per-element lanes an
+/// <see cref="ArrayLikeObject"/> receiver reaches, a row's number must not depend on which siblings warmed
+/// those lanes first. The rows still measure warm reads, and engine construction and warm-up stay in
+/// <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from this class are not comparable to any
+/// published before the harness changed.</b>
+/// </para>
 /// </summary>
 [MemoryDiagnoser]
 public class HostArrayLikeBenchmark
@@ -66,10 +79,9 @@ public class HostArrayLikeBenchmark
     [Params(10_000)]
     public int Count { get; set; }
 
-    private Engine _engine = null!;
-    private Prepared<Script> _indexedLoop;
-    private Prepared<Script> _join;
-    private Prepared<Script> _forOf;
+    private IsolatedScript _indexedLoop;
+    private IsolatedScript _join;
+    private IsolatedScript _forOf;
 
     private static List<string> BuildItems(int count)
     {
@@ -151,37 +163,47 @@ public class HostArrayLikeBenchmark
         }
     }
 
-    [GlobalSetup]
-    public void Setup()
+    /// <summary>
+    /// Builds a fresh engine carrying the one <c>list</c> global every row reads, and nothing else. The
+    /// backing <see cref="List{T}"/> is shared by the three engines — it is plain CLR state with no engine
+    /// affinity, so sharing it keeps the rows projecting byte-identical items — while the receiver in front
+    /// of it is per engine, as an <see cref="ObjectInstance"/> must be.
+    /// </summary>
+    private Engine CreateEngine(List<string> items)
     {
-        _engine = new Engine();
-        var items = BuildItems(Count);
+        var engine = new Engine();
 
         JsValue list = Kind switch
         {
-            HostArrayLikeKind.PlainHost => new PlainHostList(_engine, items),
-            HostArrayLikeKind.ArrayLike => new ArrayLikeHostList(_engine, items),
-            _ => CopyToJsArray(_engine, items),
+            HostArrayLikeKind.PlainHost => new PlainHostList(engine, items),
+            HostArrayLikeKind.ArrayLike => new ArrayLikeHostList(engine, items),
+            _ => CopyToJsArray(engine, items),
         };
 
-        _engine.SetValue("list", list);
+        engine.SetValue("list", list);
+        return engine;
+    }
 
-        _indexedLoop = Engine.PrepareScript("var n = 0; for (var i = 0; i < list.length; i++) { if (list[i].length > 4) { n++; } } n;");
-        _join = Engine.PrepareScript("list.join(',').length;");
-        _forOf = Engine.PrepareScript("var n = 0; for (var x of list) { n += x.length; } n;");
+    [GlobalSetup]
+    public void Setup()
+    {
+        var items = BuildItems(Count);
+        Engine Factory() => CreateEngine(items);
 
-        // Warm the per-node caches — a host that runs the same script repeatedly is the case this measures.
-        _engine.Evaluate(_indexedLoop);
-        _engine.Evaluate(_join);
-        _engine.Evaluate(_forOf);
+        // Warming stays: a host that runs the same script repeatedly is the case this measures. Only the
+        // sibling rows' warm-up is gone, and with it their state on the engine each row is measured on.
+        _indexedLoop = IsolatedScript.Warm(
+            Engine.PrepareScript("var n = 0; for (var i = 0; i < list.length; i++) { if (list[i].length > 4) { n++; } } n;"), Factory);
+        _join = IsolatedScript.Warm(Engine.PrepareScript("list.join(',').length;"), Factory);
+        _forOf = IsolatedScript.Warm(Engine.PrepareScript("var n = 0; for (var x of list) { n += x.length; } n;"), Factory);
     }
 
     [Benchmark]
-    public JsValue IndexedLoop() => _engine.Evaluate(_indexedLoop);
+    public JsValue IndexedLoop() => _indexedLoop.Run();
 
     [Benchmark]
-    public JsValue Join() => _engine.Evaluate(_join);
+    public JsValue Join() => _join.Run();
 
     [Benchmark]
-    public JsValue ForOf() => _engine.Evaluate(_forOf);
+    public JsValue ForOf() => _forOf.Run();
 }

--- a/Jint.Benchmark/HostDelegateCallBenchmark.cs
+++ b/Jint.Benchmark/HostDelegateCallBenchmark.cs
@@ -21,6 +21,17 @@ namespace Jint.Benchmark;
 /// visible in <c>Allocated</c>, while the boxes of the value-typed rows are not removable (the invocation
 /// contract is <c>object?</c>) and should stay put.
 /// </para>
+/// <para>
+/// <b>Engine isolation.</b> Every row gets its own engine — built by <c>CreateEngine</c>, which registers
+/// the identical seven-delegate host surface every row saw before — and warmed with its own script and
+/// nothing else (see <see cref="IsolatedScript"/>). It used to be one engine warmed with all seven
+/// scripts, so each row was measured on an engine carrying the other six rows' globals (every script
+/// declares <c>s</c> and <c>i</c>, so they collided outright) plus their handler-tree, call-site and
+/// delegate-wrapper state — which for a class about per-call-site argument-binding lanes is exactly the
+/// state a row must own. The rows still measure the warm lane, and engine construction and warm-up stay
+/// in <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from this class are not comparable to any
+/// published before the harness changed.</b>
+/// </para>
 /// </summary>
 [MemoryDiagnoser]
 public class HostDelegateCallBenchmark
@@ -29,65 +40,65 @@ public class HostDelegateCallBenchmark
 
     private const string Loop = "var s = 0; for (var i = 0; i < 1000; i++) { s = ";
 
-    private Engine _engine = null!;
+    private IsolatedScript _arity0;
+    private IsolatedScript _arity1Int;
+    private IsolatedScript _arity1String;
+    private IsolatedScript _arity1JsValue;
+    private IsolatedScript _arity1Nullable;
+    private IsolatedScript _arity2IntString;
+    private IsolatedScript _arity3Ints;
 
-    private Prepared<Script> _arity0;
-    private Prepared<Script> _arity1Int;
-    private Prepared<Script> _arity1String;
-    private Prepared<Script> _arity1JsValue;
-    private Prepared<Script> _arity1Nullable;
-    private Prepared<Script> _arity2IntString;
-    private Prepared<Script> _arity3Ints;
+    /// <summary>
+    /// Builds a fresh engine carrying the host surface every row needs, and nothing else. All seven
+    /// delegates are registered on every engine, exactly as the one shared engine carried them, so a row
+    /// still resolves its callee out of a global object of the same size and shape.
+    /// </summary>
+    private static Engine CreateEngine()
+    {
+        var engine = new Engine();
+        engine.SetValue("zero", new Func<int>(() => 1));
+        engine.SetValue("oneInt", new Func<int, int>(x => x + 1));
+        engine.SetValue("oneString", new Func<string, int>(x => x.Length));
+        engine.SetValue("oneJsValue", new Func<JsValue, int>(_ => 1));
+        engine.SetValue("oneNullable", new Func<int?, int>(x => x ?? 0));
+        engine.SetValue("twoIntString", new Func<int, string, int>((x, y) => x + y.Length));
+        engine.SetValue("threeInts", new Func<int, int, int, int>((x, y, z) => x + y + z));
+        return engine;
+    }
 
     [GlobalSetup]
     public void GlobalSetup()
     {
-        _engine = new Engine();
-        _engine.SetValue("zero", new Func<int>(() => 1));
-        _engine.SetValue("oneInt", new Func<int, int>(x => x + 1));
-        _engine.SetValue("oneString", new Func<string, int>(x => x.Length));
-        _engine.SetValue("oneJsValue", new Func<JsValue, int>(_ => 1));
-        _engine.SetValue("oneNullable", new Func<int?, int>(x => x ?? 0));
-        _engine.SetValue("twoIntString", new Func<int, string, int>((x, y) => x + y.Length));
-        _engine.SetValue("threeInts", new Func<int, int, int, int>((x, y, z) => x + y + z));
-
-        _arity0 = Engine.PrepareScript(Loop + "zero(); } s");
-        _arity1Int = Engine.PrepareScript(Loop + "oneInt(i); } s");
-        _arity1String = Engine.PrepareScript(Loop + "oneString('abc'); } s");
-        _arity1JsValue = Engine.PrepareScript(Loop + "oneJsValue(i); } s");
-        _arity1Nullable = Engine.PrepareScript(Loop + "oneNullable(i); } s");
-        _arity2IntString = Engine.PrepareScript(Loop + "twoIntString(i, 'abc'); } s");
-        _arity3Ints = Engine.PrepareScript(Loop + "threeInts(i, 1, 2); } s");
-
-        // populate the handler-tree caches so the measured runs are steady-state
-        _engine.Evaluate(_arity0);
-        _engine.Evaluate(_arity1Int);
-        _engine.Evaluate(_arity1String);
-        _engine.Evaluate(_arity1JsValue);
-        _engine.Evaluate(_arity1Nullable);
-        _engine.Evaluate(_arity2IntString);
-        _engine.Evaluate(_arity3Ints);
+        // each row's engine is warmed with that row's script only, so the handler-tree caches the
+        // measured runs read are its own and the runs are still steady-state
+        _arity0 = IsolatedScript.Warm(Engine.PrepareScript(Loop + "zero(); } s"), CreateEngine);
+        _arity1Int = IsolatedScript.Warm(Engine.PrepareScript(Loop + "oneInt(i); } s"), CreateEngine);
+        _arity1String = IsolatedScript.Warm(Engine.PrepareScript(Loop + "oneString('abc'); } s"), CreateEngine);
+        _arity1JsValue = IsolatedScript.Warm(Engine.PrepareScript(Loop + "oneJsValue(i); } s"), CreateEngine);
+        _arity1Nullable = IsolatedScript.Warm(Engine.PrepareScript(Loop + "oneNullable(i); } s"), CreateEngine);
+        _arity2IntString = IsolatedScript.Warm(Engine.PrepareScript(Loop + "twoIntString(i, 'abc'); } s"), CreateEngine);
+        _arity3Ints = IsolatedScript.Warm(Engine.PrepareScript(Loop + "threeInts(i, 1, 2); } s"), CreateEngine);
     }
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue Arity0() => _engine.Evaluate(_arity0);
+    public JsValue Arity0() => _arity0.Run();
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue Arity1_Int() => _engine.Evaluate(_arity1Int);
+    public JsValue Arity1_Int() => _arity1Int.Run();
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue Arity1_String() => _engine.Evaluate(_arity1String);
+    public JsValue Arity1_String() => _arity1String.Run();
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue Arity1_JsValue() => _engine.Evaluate(_arity1JsValue);
+    public JsValue Arity1_JsValue() => _arity1JsValue.Run();
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue Arity1_Nullable() => _engine.Evaluate(_arity1Nullable);
+    public JsValue Arity1_Nullable() => _arity1Nullable.Run();
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue Arity2_IntString() => _engine.Evaluate(_arity2IntString);
+    public JsValue Arity2_IntString() => _arity2IntString.Run();
 
     /// <summary>Control: three parameters exceed the two argument registers, so this row never leaves the generic path.</summary>
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue Arity3_Ints() => _engine.Evaluate(_arity3Ints);
+    public JsValue Arity3_Ints() => _arity3Ints.Run();
 }

--- a/Jint.Benchmark/HostLayoutLazySlotBenchmark.cs
+++ b/Jint.Benchmark/HostLayoutLazySlotBenchmark.cs
@@ -60,6 +60,18 @@ namespace Jint.Benchmark;
 /// <c>protected internal</c> because this project is a friend assembly, where an embedder writes
 /// <c>protected</c> for the same member.
 /// </para>
+///
+/// <para>
+/// <b>Engine isolation.</b> Each of the two rows gets its own engine — built by <c>CreateEngine</c>, which
+/// re-runs <c>BuildSource</c> and re-registers the <c>makeItem</c> host delegate — and warmed with its own
+/// script and nothing else (see <see cref="IsolatedScript"/>). It used to be one engine per parameter
+/// combination warmed with both scripts, so <see cref="Build"/> was measured on an engine on which
+/// <see cref="BuildAndProject"/> had already warmed the projection loop's member sites, and vice versa —
+/// and for a class whose subject is which hidden class a batch lands in and how a member site sees it,
+/// that is precisely the state a row must own. The rows still measure warm creation, and engine
+/// construction and warm-up stay in <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from this
+/// class are not comparable to any published before the harness changed.</b>
+/// </para>
 /// </summary>
 [MemoryDiagnoser]
 public class HostLayoutLazySlotBenchmark
@@ -189,38 +201,39 @@ public class HostLayoutLazySlotBenchmark
         }
         """;
 
-    private Engine _engine = null!;
-    private Prepared<Script> _build;
-    private Prepared<Script> _project;
+    private IsolatedScript _build;
+    private IsolatedScript _project;
 
     [Params(EnvelopeKind.LayoutEager, EnvelopeKind.LayoutLazy, EnvelopeKind.DictionaryCustomValue)]
     public EnvelopeKind Kind { get; set; }
 
+    /// <summary>Builds a fresh engine carrying the fixture every row needs, and nothing else.</summary>
+    private Engine CreateEngine()
+    {
+        var engine = new Engine();
+        engine.Execute(BuildSource);
+
+        var kind = Kind;
+        engine.SetValue("makeItem", new Func<int, JsValue>(index => MakeItem(engine, kind, index)));
+        return engine;
+    }
+
     [GlobalSetup]
     public void GlobalSetup()
     {
-        _engine = new Engine();
-        _engine.Execute(BuildSource);
-
-        var kind = Kind;
-        var engine = _engine;
-        _engine.SetValue("makeItem", new Func<int, JsValue>(index => MakeItem(engine, kind, index)));
-
-        _build = Engine.PrepareScript($"build({ItemCount}).length;");
-        _project = Engine.PrepareScript($"project({ItemCount});");
-
-        // Warm the handler-tree caches so the measured runs are the steady state, and prove both lanes work.
-        _engine.Evaluate(_build);
-        _engine.Evaluate(_project);
+        // Warm each row's own engine with that row's script, so the measured runs are the steady state and
+        // both lanes are proven to work, without either row warming the other's.
+        _build = IsolatedScript.Warm(Engine.PrepareScript($"build({ItemCount}).length;"), CreateEngine);
+        _project = IsolatedScript.Warm(Engine.PrepareScript($"project({ItemCount});"), CreateEngine);
     }
 
     /// <summary>Creation only: no member is ever observed, so the eager lane's decodes are pure waste.</summary>
     [Benchmark]
-    public JsValue Build() => _engine.Evaluate(_build);
+    public JsValue Build() => _build.Run();
 
     /// <summary>Creation plus the projection loop, which observes one decoded member of every item.</summary>
     [Benchmark]
-    public JsValue BuildAndProject() => _engine.Evaluate(_project);
+    public JsValue BuildAndProject() => _project.Run();
 
     private static JsValue MakeItem(Engine engine, EnvelopeKind kind, int index)
     {

--- a/Jint.Benchmark/HostPrototypeShapeBenchmark.cs
+++ b/Jint.Benchmark/HostPrototypeShapeBenchmark.cs
@@ -70,6 +70,20 @@ namespace Jint.Benchmark;
 /// <see cref="PropertyDescriptor"/>, because the public surface offers no reusable data-descriptor form. That
 /// cost sits in both prototype lanes equally, so it does not distort the comparison.
 /// </para>
+///
+/// <para>
+/// <b>Engine isolation.</b> <see cref="BuildPrototypes"/> and <see cref="BuildAndTouchPrototypes"/> build
+/// their engine inside the benchmark method, which is what they measure. The other three rows used to
+/// share one <c>_readEngine</c> warmed with all three of their scripts, so each was measured on an engine
+/// carrying the others' globals (<c>items</c>, <c>chainLeaf</c>, <c>chainObj</c>) and their handler-tree
+/// and prototype-method-cache state — and a class whose whole subject is what a prototype lookup costs
+/// must not let one row warm another's caches. Each now gets its own engine, built by
+/// <c>CreateReadEngine</c> or <c>CreateChainEngine</c> and warmed with its own script and nothing else
+/// (see <see cref="IsolatedScript"/>); both factories keep the representation assertions, so engagement is
+/// still asserted per engine rather than inferred. The rows still measure warm reads, and engine
+/// construction and warm-up stay in <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from the
+/// three warm rows are not comparable to any published before the harness changed.</b>
+/// </para>
 /// </summary>
 [MemoryDiagnoser]
 public class HostPrototypeShapeBenchmark
@@ -92,11 +106,10 @@ public class HostPrototypeShapeBenchmark
     private static readonly MemberTable[] _chainTables = BuildChainTables();
     private static readonly JsObjectShape[] _chainShapes = BuildChainShapes();
 
-    private Engine _readEngine = null!;
-    private Prepared<Script> _readLoop;
+    private IsolatedScript _readLoop;
     private Prepared<Script> _touchScript;
-    private Prepared<Script> _absentMissLoop;
-    private Prepared<Script> _deepHitLoop;
+    private IsolatedScript _absentMissLoop;
+    private IsolatedScript _deepHitLoop;
 
     /// <summary>How the per-engine prototype objects are built.</summary>
     [Params(HostPrototypeKind.Dictionary, HostPrototypeKind.Shape)]
@@ -118,7 +131,7 @@ public class HostPrototypeShapeBenchmark
             })(protos)
             """);
 
-        _readLoop = Engine.PrepareScript("""
+        _readLoop = IsolatedScript.Warm(Engine.PrepareScript("""
             (function (items) {
               var total = 0;
               for (var i = 0; i < items.length; i++) {
@@ -127,11 +140,40 @@ public class HostPrototypeShapeBenchmark
               }
               return total;
             })(items)
-            """);
+            """), CreateReadEngine);
 
-        // The read lane's engine is built once: it measures steady-state reads, not setup.
-        _readEngine = new Engine();
-        var prototype = BuildPrototype(_readEngine, PrototypeKind, 0);
+        // The chain lanes: a depth-ChainDepth prototype chain, with an ordinary script object in front of
+        // it as the receiver. BuildChain asserts every level's representation.
+        var deepestMember = _chainTables[0].Members[0].Name;
+        _absentMissLoop = IsolatedScript.Warm(Engine.PrepareScript($$"""
+            (function (obj) {
+              var hits = 0;
+              for (var i = 0; i < {{ChainLoopIterations}}; i++) {
+                hits += ('__absent__' in obj) ? 1 : 0;
+              }
+              return hits;
+            })(chainObj)
+            """), CreateChainEngine);
+
+        _deepHitLoop = IsolatedScript.Warm(Engine.PrepareScript($$"""
+            (function (obj) {
+              var hits = 0;
+              for (var i = 0; i < {{ChainLoopIterations}}; i++) {
+                hits += ('{{deepestMember}}' in obj) ? 1 : 0;
+              }
+              return hits;
+            })(chainObj)
+            """), CreateChainEngine);
+    }
+
+    /// <summary>
+    /// The read row's engine: the prototype under test plus the instances in front of it, and nothing else.
+    /// It is built in <c>[GlobalSetup]</c> because the row measures steady-state reads, not setup.
+    /// </summary>
+    private Engine CreateReadEngine()
+    {
+        var engine = new Engine();
+        var prototype = BuildPrototype(engine, PrototypeKind, 0);
 
         // Engagement is asserted, never inferred from timing: if the shaped lane silently stopped being
         // shaped, the row would still run and quietly measure the dictionary path. The representation
@@ -141,7 +183,7 @@ public class HostPrototypeShapeBenchmark
         var expected = PrototypeKind == HostPrototypeKind.Shape
             ? ObjectRepresentation.SharedBuiltinLayout
             : ObjectRepresentation.Dictionary;
-        var representation = _readEngine.Advanced.GetObjectRepresentation(prototype);
+        var representation = engine.Advanced.GetObjectRepresentation(prototype);
         if (representation != expected)
         {
             throw new InvalidOperationException(
@@ -151,39 +193,24 @@ public class HostPrototypeShapeBenchmark
         var items = new JsValue[SteadyStateInstances];
         for (var i = 0; i < items.Length; i++)
         {
-            items[i] = new ReflectiveHostInstance(_readEngine, prototype, i);
+            items[i] = new ReflectiveHostInstance(engine, prototype, i);
         }
 
-        _readEngine.SetValue("items", new JsArray(_readEngine, items));
-        _readEngine.Evaluate(_readLoop);
+        engine.SetValue("items", new JsArray(engine, items));
+        return engine;
+    }
 
-        // The chain lanes: a depth-ChainDepth prototype chain in the same engine, with an ordinary script
-        // object in front of it as the receiver. BuildChain asserts every level's representation.
-        var deepestMember = _chainTables[0].Members[0].Name;
-        _absentMissLoop = Engine.PrepareScript($$"""
-            (function (obj) {
-              var hits = 0;
-              for (var i = 0; i < {{ChainLoopIterations}}; i++) {
-                hits += ('__absent__' in obj) ? 1 : 0;
-              }
-              return hits;
-            })(chainObj)
-            """);
-
-        _deepHitLoop = Engine.PrepareScript($$"""
-            (function (obj) {
-              var hits = 0;
-              for (var i = 0; i < {{ChainLoopIterations}}; i++) {
-                hits += ('{{deepestMember}}' in obj) ? 1 : 0;
-              }
-              return hits;
-            })(chainObj)
-            """);
-
-        _readEngine.SetValue("chainLeaf", BuildChain(_readEngine, PrototypeKind));
-        _readEngine.Execute("var chainObj = Object.create(chainLeaf);");
-        _readEngine.Evaluate(_absentMissLoop);
-        _readEngine.Evaluate(_deepHitLoop);
+    /// <summary>
+    /// A chain row's engine: the depth-<see cref="ChainDepth"/> prototype chain, an ordinary script object
+    /// in front of it as the receiver, and nothing else. Each chain row gets one of its own, so neither
+    /// walks a chain the other has already warmed.
+    /// </summary>
+    private Engine CreateChainEngine()
+    {
+        var engine = new Engine();
+        engine.SetValue("chainLeaf", BuildChain(engine, PrototypeKind));
+        engine.Execute("var chainObj = Object.create(chainLeaf);");
+        return engine;
     }
 
     /// <summary>Lane A: everything a fresh document pays before a single line of script runs.</summary>
@@ -218,15 +245,15 @@ public class HostPrototypeShapeBenchmark
 
     /// <summary>Lane C: warmed inherited reads and calls through a correct host instance.</summary>
     [Benchmark]
-    public JsValue SteadyStateReads() => _readEngine.Evaluate(_readLoop);
+    public JsValue SteadyStateReads() => _readLoop.Run();
 
     /// <summary>Lane D: a name nothing on the chain declares, refused once per prototype level, in a loop.</summary>
     [Benchmark]
-    public JsValue AbsentNameMissOverChain() => _readEngine.Evaluate(_absentMissLoop);
+    public JsValue AbsentNameMissOverChain() => _absentMissLoop.Run();
 
     /// <summary>Lane E: the same loop resolving on the chain's deepest level — the hit-path control.</summary>
     [Benchmark]
-    public JsValue DeepHitOverChain() => _readEngine.Evaluate(_deepHitLoop);
+    public JsValue DeepHitOverChain() => _deepHitLoop.Run();
 
     /// <summary>
     /// Builds the depth-<see cref="ChainDepth"/> prototype chain both chain lanes walk and returns its leaf.

--- a/Jint.Benchmark/InternalCallBenchmarks.cs
+++ b/Jint.Benchmark/InternalCallBenchmarks.cs
@@ -12,45 +12,46 @@ namespace Jint.Benchmark;
 ///
 /// for-of over a JsArray invokes ArrayIteratorPrototype.next() on every iteration; that's a tight
 /// loop where the precondition cost is measurable. Map/Set iteration uses the same pattern.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine, warmed with its own script and nothing
+/// else (see <see cref="IsolatedScript"/>). It used to be one engine warmed with all five scripts, so
+/// each row was measured on an engine carrying the other four rows' globals (<c>a</c> is declared by two
+/// of them with different values, and <c>s</c>/<c>i</c> by three) plus their handler-tree and iterator
+/// call-site state — which, for a class about the receiver type an internal <c>next()</c> call site
+/// sees, is exactly the state a row must own. The rows still measure the warm path, and engine
+/// construction and warm-up stay in <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from this
+/// class are not comparable to any published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 public class InternalCallBenchmarks
 {
     private const int OperationsPerInvoke = 100;
 
-    private Engine _warm = null!;
-    private Prepared<Script> _forOfArray;
-    private Prepared<Script> _forOfMap;
-    private Prepared<Script> _forOfSet;
-    private Prepared<Script> _spreadArray;
-    private Prepared<Script> _arrayFromIterable;
+    private IsolatedScript _forOfArray;
+    private IsolatedScript _forOfMap;
+    private IsolatedScript _forOfSet;
+    private IsolatedScript _spreadArray;
+    private IsolatedScript _arrayFromIterable;
 
     [GlobalSetup]
     public void GlobalSetup()
     {
-        _forOfArray = Engine.PrepareScript("var a = [1,2,3,4,5,6,7,8,9,10]; var s = 0; for (var i = 0; i < 100; i++) for (var x of a) s += x; s");
-        _forOfMap   = Engine.PrepareScript("var m = new Map([['a',1],['b',2],['c',3],['d',4],['e',5]]); var s = 0; for (var i = 0; i < 100; i++) for (var [k,v] of m) s += v; s");
-        _forOfSet   = Engine.PrepareScript("var z = new Set([1,2,3,4,5,6,7,8,9,10]); var s = 0; for (var i = 0; i < 100; i++) for (var x of z) s += x; s");
-        _spreadArray      = Engine.PrepareScript("var a = [1,2,3,4,5,6,7,8,9,10]; var b = [...a]; b.length");
-        _arrayFromIterable = Engine.PrepareScript("var a = new Set([1,2,3,4,5,6,7,8,9,10]); Array.from(a).length");
-
-        _warm = new Engine();
-        _warm.Evaluate(_forOfArray);
-        _warm.Evaluate(_forOfMap);
-        _warm.Evaluate(_forOfSet);
-        _warm.Evaluate(_spreadArray);
-        _warm.Evaluate(_arrayFromIterable);
+        _forOfArray = IsolatedScript.Warm("var a = [1,2,3,4,5,6,7,8,9,10]; var s = 0; for (var i = 0; i < 100; i++) for (var x of a) s += x; s");
+        _forOfMap   = IsolatedScript.Warm("var m = new Map([['a',1],['b',2],['c',3],['d',4],['e',5]]); var s = 0; for (var i = 0; i < 100; i++) for (var [k,v] of m) s += v; s");
+        _forOfSet   = IsolatedScript.Warm("var z = new Set([1,2,3,4,5,6,7,8,9,10]); var s = 0; for (var i = 0; i < 100; i++) for (var x of z) s += x; s");
+        _spreadArray      = IsolatedScript.Warm("var a = [1,2,3,4,5,6,7,8,9,10]; var b = [...a]; b.length");
+        _arrayFromIterable = IsolatedScript.Warm("var a = new Set([1,2,3,4,5,6,7,8,9,10]); Array.from(a).length");
     }
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue Warm_ForOf_Array() => _warm.Evaluate(_forOfArray);
+    public JsValue Warm_ForOf_Array() => _forOfArray.Run();
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue Warm_ForOf_Map() => _warm.Evaluate(_forOfMap);
+    public JsValue Warm_ForOf_Map() => _forOfMap.Run();
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue Warm_ForOf_Set() => _warm.Evaluate(_forOfSet);
+    public JsValue Warm_ForOf_Set() => _forOfSet.Run();
 
-    [Benchmark] public JsValue Warm_SpreadArray() => _warm.Evaluate(_spreadArray);
-    [Benchmark] public JsValue Warm_ArrayFromIterable() => _warm.Evaluate(_arrayFromIterable);
+    [Benchmark] public JsValue Warm_SpreadArray() => _spreadArray.Run();
+    [Benchmark] public JsValue Warm_ArrayFromIterable() => _arrayFromIterable.Run();
 }

--- a/Jint.Benchmark/InteropAccessibleBenchmarks.cs
+++ b/Jint.Benchmark/InteropAccessibleBenchmarks.cs
@@ -20,6 +20,15 @@ namespace Jint.Benchmark;
 /// The benchmark types live inside this class — same pattern as InteropBenchmark.Person —
 /// so when [JsAccessible] lands the same source files can grow `[JsAccessible]` on Player and
 /// the bench runs both paths.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine, warmed with that row's own script and
+/// nothing else. It used to be four engines for seven rows: the three property-get rows shared one
+/// engine warmed with <c>p.Score; p.Name; p.Alive</c> and the two method rows shared one warmed with
+/// <c>p.AddPoints(1); p.Describe()</c>, so each of those rows was measured on an engine whose
+/// member-resolution and wrapper state had been established by its siblings. The rows still measure warm
+/// dispatch, and engine construction and warm-up stay in <c>[GlobalSetup]</c>, outside the measurement.
+/// The per-scenario Player values are preserved exactly. <b>Numbers from this class are not comparable
+/// to any published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 public class InteropAccessibleBenchmarks
@@ -36,51 +45,63 @@ public class InteropAccessibleBenchmarks
         public string Describe() => $"{Name}:{Score}";
     }
 
-    private Engine _engineGet = null!;
+    private Engine _engineGetInt = null!;
+    private Engine _engineGetString = null!;
+    private Engine _engineGetBool = null!;
     private Engine _engineSet = null!;
-    private Engine _engineMethod = null!;
+    private Engine _engineMethodOneArg = null!;
+    private Engine _engineMethodNoArgs = null!;
     private Engine _engineMixed = null!;
+
+    /// <summary>
+    /// Builds a fresh engine exposing one Player as <c>p</c>. One Engine per row keeps property-access
+    /// caches monomorphic on the same Player instance — eliminates accidental polymorphism noise across
+    /// benchmarks — and stops a row inheriting the state a sibling row's warm-up established.
+    /// </summary>
+    private static Engine CreateEngine(Player player)
+    {
+        var engine = new Engine(cfg => cfg.AllowClr(typeof(Player).GetTypeInfo().Assembly));
+        engine.SetValue("p", player);
+        return engine;
+    }
 
     [GlobalSetup]
     public void GlobalSetup()
     {
-        // One Engine per scenario keeps property-access caches monomorphic on the same Player
-        // instance — eliminates accidental polymorphism noise across benchmarks.
-        _engineGet = new Engine(cfg => cfg.AllowClr(typeof(Player).GetTypeInfo().Assembly));
-        _engineGet.SetValue("p", new Player { Name = "alice", Score = 42, Alive = true });
+        _engineGetInt = CreateEngine(new Player { Name = "alice", Score = 42, Alive = true });
+        _engineGetString = CreateEngine(new Player { Name = "alice", Score = 42, Alive = true });
+        _engineGetBool = CreateEngine(new Player { Name = "alice", Score = 42, Alive = true });
+        _engineSet = CreateEngine(new Player { Name = "bob", Score = 0, Alive = true });
+        _engineMethodOneArg = CreateEngine(new Player { Name = "carol", Score = 0, Alive = true });
+        _engineMethodNoArgs = CreateEngine(new Player { Name = "carol", Score = 0, Alive = true });
+        _engineMixed = CreateEngine(new Player { Name = "dave", Score = 0, Alive = true });
 
-        _engineSet = new Engine(cfg => cfg.AllowClr(typeof(Player).GetTypeInfo().Assembly));
-        _engineSet.SetValue("p", new Player { Name = "bob", Score = 0, Alive = true });
-
-        _engineMethod = new Engine(cfg => cfg.AllowClr(typeof(Player).GetTypeInfo().Assembly));
-        _engineMethod.SetValue("p", new Player { Name = "carol", Score = 0, Alive = true });
-
-        _engineMixed = new Engine(cfg => cfg.AllowClr(typeof(Player).GetTypeInfo().Assembly));
-        _engineMixed.SetValue("p", new Player { Name = "dave", Score = 0, Alive = true });
-
-        // Warm the access caches.
-        _engineGet.Execute("p.Score; p.Name; p.Alive");
+        // Warm the access caches — each engine with its own row's script and nothing else.
+        _engineGetInt.Execute("p.Score");
+        _engineGetString.Execute("p.Name");
+        _engineGetBool.Execute("p.Alive");
         _engineSet.Execute("p.Score = 1");
-        _engineMethod.Execute("p.AddPoints(1); p.Describe()");
-        _engineMixed.Execute("p.Score; p.AddPoints(1); p.Describe()");
+        _engineMethodOneArg.Execute("p.AddPoints(1)");
+        _engineMethodNoArgs.Execute("p.Describe()");
+        _engineMixed.Execute("p.Name; p.Describe()");
     }
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
     public void PropertyGet_Int()
     {
-        for (var i = 0; i < OperationsPerInvoke; i++) _engineGet.Execute("p.Score");
+        for (var i = 0; i < OperationsPerInvoke; i++) _engineGetInt.Execute("p.Score");
     }
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
     public void PropertyGet_String()
     {
-        for (var i = 0; i < OperationsPerInvoke; i++) _engineGet.Execute("p.Name");
+        for (var i = 0; i < OperationsPerInvoke; i++) _engineGetString.Execute("p.Name");
     }
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
     public void PropertyGet_Bool()
     {
-        for (var i = 0; i < OperationsPerInvoke; i++) _engineGet.Execute("p.Alive");
+        for (var i = 0; i < OperationsPerInvoke; i++) _engineGetBool.Execute("p.Alive");
     }
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
@@ -92,13 +113,13 @@ public class InteropAccessibleBenchmarks
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
     public void MethodInvoke_OneArg()
     {
-        for (var i = 0; i < OperationsPerInvoke; i++) _engineMethod.Execute("p.AddPoints(1)");
+        for (var i = 0; i < OperationsPerInvoke; i++) _engineMethodOneArg.Execute("p.AddPoints(1)");
     }
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
     public void MethodInvoke_NoArgs()
     {
-        for (var i = 0; i < OperationsPerInvoke; i++) _engineMethod.Execute("p.Describe()");
+        for (var i = 0; i < OperationsPerInvoke; i++) _engineMethodNoArgs.Execute("p.Describe()");
     }
 
     /// <summary>Mixed get + method-invoke pattern — the realistic interop call site. The script

--- a/Jint.Benchmark/InteropBulkConversionBenchmark.cs
+++ b/Jint.Benchmark/InteropBulkConversionBenchmark.cs
@@ -6,6 +6,13 @@ namespace Jint.Benchmark;
 /// Bulk JS-array → CLR collection argument conversion — exercises DefaultTypeConverter's
 /// object[]-to-generic-collection path (Activator.CreateInstance(List&lt;&gt;) + per-element
 /// recursive Convert).
+///
+/// <para><b>Engine isolation.</b> Both rows get their own engine — built by <see cref="CreateEngine"/>,
+/// which re-runs the fixture script so each engine owns its own <c>data</c> array — warmed with that
+/// row's own script and nothing else. It used to be one engine warmed with
+/// <c>sink.TakeList(data); sink.TakeArray(data);</c>, so each row was measured with the other row's
+/// conversion caches already populated. The rows still measure warm conversion, and engine construction
+/// and warm-up stay in <c>[GlobalSetup]</c>, outside the measurement.</para>
 /// </summary>
 [MemoryDiagnoser]
 public class InteropBulkConversionBenchmark
@@ -18,28 +25,38 @@ public class InteropBulkConversionBenchmark
         public void TakeArray(int[] values) => Count = values.Length;
     }
 
-    private Engine _engine = null!;
+    private Engine _engineList = null!;
+    private Engine _engineArray = null!;
+
+    /// <summary>Builds a fresh engine carrying the fixture both rows need, and nothing else.</summary>
+    private static Engine CreateEngine()
+    {
+        var engine = new Engine();
+        engine.SetValue("sink", new Sink());
+        engine.Execute("const data = []; for (let i = 0; i < 1000; i++) data.push(i);");
+        return engine;
+    }
 
     [GlobalSetup]
     public void GlobalSetup()
     {
-        _engine = new Engine();
-        _engine.SetValue("sink", new Sink());
-        _engine.Execute("const data = []; for (let i = 0; i < 1000; i++) data.push(i);");
+        // Warm the conversion caches — each engine with its own row's script and nothing else.
+        _engineList = CreateEngine();
+        _engineList.Execute("sink.TakeList(data)");
 
-        // Warm the conversion caches.
-        _engine.Execute("sink.TakeList(data); sink.TakeArray(data);");
+        _engineArray = CreateEngine();
+        _engineArray.Execute("sink.TakeArray(data)");
     }
 
     [Benchmark]
     public void JsArrayToListOfInt()
     {
-        _engine.Execute("sink.TakeList(data)");
+        _engineList.Execute("sink.TakeList(data)");
     }
 
     [Benchmark]
     public void JsArrayToIntArray()
     {
-        _engine.Execute("sink.TakeArray(data)");
+        _engineArray.Execute("sink.TakeArray(data)");
     }
 }

--- a/Jint.Benchmark/InteropConstructorBenchmark.cs
+++ b/Jint.Benchmark/InteropConstructorBenchmark.cs
@@ -8,6 +8,14 @@ namespace Jint.Benchmark;
 /// CLR constructor invocation from JS via TypeReference — the MethodDescriptor.Call path
 /// (TypeReference.Construct → InteropHelper.FindBestMatch → MethodDescriptor.Call), which has
 /// its own per-call object[] parameter array and reflective ConstructorInfo.Invoke.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine — built by <see cref="CreateEngine"/>,
+/// which installs both type references — warmed with that row's own script and nothing else. It used to
+/// be one engine warmed with <c>new RefTarget(); new RefTarget(1, 'x'); new ValueTarget(1)</c>, so each
+/// row was measured with all three rows' overload-resolution caches already resolved, and the
+/// no-arg/two-arg rows in particular shared the same <c>RefTarget</c> constructor group. The rows still
+/// measure warm construction, and engine construction and warm-up stay in <c>[GlobalSetup]</c>, outside
+/// the measurement.</para>
 /// </summary>
 [MemoryDiagnoser]
 public class InteropConstructorBenchmark
@@ -40,34 +48,48 @@ public class InteropConstructorBenchmark
         public int Id { get; }
     }
 
-    private Engine _engine = null!;
+    private Engine _engineNoArg = null!;
+    private Engine _engineTwoArgs = null!;
+    private Engine _engineValueType = null!;
+
+    /// <summary>Builds a fresh engine carrying the type references every row needs, and nothing else.</summary>
+    private static Engine CreateEngine()
+    {
+        var engine = new Engine(cfg => cfg.AllowClr(typeof(RefTarget).Assembly));
+        engine.SetValue("RefTarget", TypeReference.CreateTypeReference<RefTarget>(engine));
+        engine.SetValue("ValueTarget", TypeReference.CreateTypeReference<ValueTarget>(engine));
+        return engine;
+    }
 
     [GlobalSetup]
     public void GlobalSetup()
     {
-        _engine = new Engine(cfg => cfg.AllowClr(typeof(RefTarget).Assembly));
-        _engine.SetValue("RefTarget", TypeReference.CreateTypeReference<RefTarget>(_engine));
-        _engine.SetValue("ValueTarget", TypeReference.CreateTypeReference<ValueTarget>(_engine));
+        // Warm constructor caches — each engine with its own row's script and nothing else.
+        _engineNoArg = CreateEngine();
+        _engineNoArg.Execute("new RefTarget()");
 
-        // Warm constructor caches.
-        _engine.Execute("new RefTarget(); new RefTarget(1, 'x'); new ValueTarget(1)");
+        _engineTwoArgs = CreateEngine();
+        _engineTwoArgs.Execute("new RefTarget(1, 'x')");
+
+        _engineValueType = CreateEngine();
+        _engineValueType.Execute("new ValueTarget(1)");
     }
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
     public void Construct_NoArg()
     {
-        for (var i = 0; i < OperationsPerInvoke; i++) _engine.Execute("new RefTarget()");
+        for (var i = 0; i < OperationsPerInvoke; i++) _engineNoArg.Execute("new RefTarget()");
     }
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
     public void Construct_TwoArgs()
     {
-        for (var i = 0; i < OperationsPerInvoke; i++) _engine.Execute("new RefTarget(1, 'x')");
+        for (var i = 0; i < OperationsPerInvoke; i++) _engineTwoArgs.Execute("new RefTarget(1, 'x')");
     }
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
     public void Construct_ValueType_OneArg()
     {
-        for (var i = 0; i < OperationsPerInvoke; i++) _engine.Execute("new ValueTarget(1)");
+        for (var i = 0; i < OperationsPerInvoke; i++) _engineValueType.Execute("new ValueTarget(1)");
     }
 }

--- a/Jint.Benchmark/InteropIndexerBenchmark.cs
+++ b/Jint.Benchmark/InteropIndexerBenchmark.cs
@@ -6,6 +6,13 @@ namespace Jint.Benchmark;
 /// Custom-indexer access from JS — the IndexerAccessor reflection path. Plain List&lt;T&gt; and
 /// string-keyed generic dictionaries take specialized wrapper paths (GenericListWrapper /
 /// TypeDescriptor) and never hit IndexerAccessor; a custom this[string] / this[int] type does.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine and its own bag, warmed with that row's
+/// own script and nothing else. The two string-key rows used to share one engine warmed with
+/// <c>bag['alpha']; bag['alpha'] = 1;</c>, so the get row was measured with the setter lane already
+/// resolved and the set row with the getter lane already resolved. The rows still measure warm indexer
+/// access, and engine construction and warm-up stay in <c>[GlobalSetup]</c>, outside the
+/// measurement.</para>
 /// </summary>
 [MemoryDiagnoser]
 public class InteropIndexerBenchmark
@@ -36,36 +43,55 @@ public class InteropIndexerBenchmark
         }
     }
 
-    private Engine _engineString = null!;
-    private Engine _engineInt = null!;
+    private Engine _engineStringGet = null!;
+    private Engine _engineStringSet = null!;
+    private Engine _engineIntGet = null!;
+
+    /// <summary>Builds a fresh engine exposing a string-indexed bag as <c>bag</c>.</summary>
+    private static Engine CreateStringEngine()
+    {
+        var engine = new Engine();
+        engine.SetValue("bag", new StringIndexedBag());
+        return engine;
+    }
+
+    /// <summary>Builds a fresh engine exposing an int-indexed bag as <c>bag</c>.</summary>
+    private static Engine CreateIntEngine()
+    {
+        var engine = new Engine();
+        engine.SetValue("bag", new IntIndexedBag());
+        return engine;
+    }
 
     [GlobalSetup]
     public void GlobalSetup()
     {
-        _engineString = new Engine();
-        _engineString.SetValue("bag", new StringIndexedBag());
-        _engineString.Execute("bag['alpha']; bag['alpha'] = 1;");
+        // Warm the indexer accessors — each engine with its own row's script and nothing else.
+        _engineStringGet = CreateStringEngine();
+        _engineStringGet.Execute("bag['alpha']");
 
-        _engineInt = new Engine();
-        _engineInt.SetValue("bag", new IntIndexedBag());
-        _engineInt.Execute("bag[1]; bag[1] = 2;");
+        _engineStringSet = CreateStringEngine();
+        _engineStringSet.Execute("bag['alpha'] = 1");
+
+        _engineIntGet = CreateIntEngine();
+        _engineIntGet.Execute("bag[1]");
     }
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
     public void IndexerGet_StringKey()
     {
-        for (var i = 0; i < OperationsPerInvoke; i++) _engineString.Execute("bag['alpha']");
+        for (var i = 0; i < OperationsPerInvoke; i++) _engineStringGet.Execute("bag['alpha']");
     }
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
     public void IndexerSet_StringKey()
     {
-        for (var i = 0; i < OperationsPerInvoke; i++) _engineString.Execute("bag['alpha'] = 1");
+        for (var i = 0; i < OperationsPerInvoke; i++) _engineStringSet.Execute("bag['alpha'] = 1");
     }
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
     public void IndexerGet_IntKey()
     {
-        for (var i = 0; i < OperationsPerInvoke; i++) _engineInt.Execute("bag[1]");
+        for (var i = 0; i < OperationsPerInvoke; i++) _engineIntGet.Execute("bag[1]");
     }
 }

--- a/Jint.Benchmark/InteropLambdaBenchmark.cs
+++ b/Jint.Benchmark/InteropLambdaBenchmark.cs
@@ -9,6 +9,19 @@ using Jint.Native.Function;
 
 namespace Jint.Benchmark;
 
+/// <summary>
+/// Finding a record in a host-supplied collection, across the four shapes an embedder hands over
+/// (<see cref="TestDataType"/>) and the five ways a host can drive the script function.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine, carrying only that row's own
+/// <c>findIt</c>. It used to be one engine on which <c>[GlobalSetup]</c> evaluated <em>both</em> script
+/// variants — and since both declare <c>function findIt</c> at global scope, the second install even
+/// overwrote the first's global binding — so every row was measured on an engine carrying the other
+/// variant's handler-tree, call-site and wrapper-cache state. The rows still measure the same warm
+/// invocation paths, and engine construction and function compilation stay in <c>[GlobalSetup]</c>,
+/// outside the measurement. <b>Numbers from this class are not comparable to any published before the
+/// harness changed.</b></para>
+/// </summary>
 [RankColumn]
 [MemoryDiagnoser]
 [Orderer(SummaryOrderPolicy.FastestToSlowest)]
@@ -21,8 +34,6 @@ public class InteropLambdaBenchmark
     private const string FindValue = "SomeKind22222";
 
     private const int Iterations = 10;
-
-    private Engine _engine;
 
     private const string ScriptInline = """
                                         function findIt(data, value) {
@@ -45,9 +56,22 @@ public class InteropLambdaBenchmark
                                          }
                                          """;
 
-    private Function _forLoopFunction;
+    // One (engine, findIt) pair per row: the function is engine-affine, so isolating the engine means
+    // compiling that row's own script on it.
+    private Engine _inlineEngineInvokeEngine;
+    private Function _inlineEngineInvokeFunction;
+
+    private Engine _inlineEngine;
     private Function _inlineFunction;
+
+    private Engine _inlineCSharpEngine;
     private Func<JsValue, JsValue[], JsValue> _inlineCSharpFunction;
+
+    private Engine _forLoopEngine;
+    private Function _forLoopFunction;
+
+    private Engine _forLoopEngineInvokeEngine;
+    private Function _forLoopEngineInvokeFunction;
 
     [Params(TestDataType.ClrObject, TestDataType.Dictionary, TestDataType.JsonNode, TestDataType.JsValue)]
     public TestDataType Type { get; set; }
@@ -55,8 +79,6 @@ public class InteropLambdaBenchmark
     [GlobalSetup]
     public void GlobalSetup()
     {
-        _engine = new Engine();
-
         _testArray = [new TestData("SomeKind00000"), new TestData("SomeKind1111"), new TestData(FindValue)];
         _root = new TestDataRoot(_testArray);
 
@@ -77,9 +99,22 @@ public class InteropLambdaBenchmark
             _data = JsonSerializer.Deserialize<JsObject>(JsonSerializer.Serialize(_root, JsonDefaults.JsonSerializerOptions), JsonDefaults.JsonSerializerOptions);
         }
 
-        _inlineFunction = (Function) _engine.Evaluate(ScriptInline + "findIt;");
-        _inlineCSharpFunction = (Func<JsValue, JsValue[], JsValue>) _inlineFunction.ToObject();
-        _forLoopFunction = (Function) _engine.Evaluate(ScriptForLoop + "findIt;");
+        // Each row compiles its own findIt on its own engine, so no row inherits the other script
+        // variant's handler-tree, call-site or wrapper-cache state.
+        _inlineEngineInvokeEngine = new Engine();
+        _inlineEngineInvokeFunction = (Function) _inlineEngineInvokeEngine.Evaluate(ScriptInline + "findIt;");
+
+        _inlineEngine = new Engine();
+        _inlineFunction = (Function) _inlineEngine.Evaluate(ScriptInline + "findIt;");
+
+        _inlineCSharpEngine = new Engine();
+        _inlineCSharpFunction = (Func<JsValue, JsValue[], JsValue>) ((Function) _inlineCSharpEngine.Evaluate(ScriptInline + "findIt;")).ToObject();
+
+        _forLoopEngine = new Engine();
+        _forLoopFunction = (Function) _forLoopEngine.Evaluate(ScriptForLoop + "findIt;");
+
+        _forLoopEngineInvokeEngine = new Engine();
+        _forLoopEngineInvokeFunction = (Function) _forLoopEngineInvokeEngine.Evaluate(ScriptForLoop + "findIt;");
     }
 
     [Benchmark]
@@ -87,7 +122,7 @@ public class InteropLambdaBenchmark
     {
         for (var i = 0; i < Iterations; i++)
         {
-            var value = _engine.Invoke(_inlineFunction!, [_data, FindValue]).ToObject();
+            var value = _inlineEngineInvokeEngine.Invoke(_inlineEngineInvokeFunction!, [_data, FindValue]).ToObject();
         }
     }
 
@@ -96,7 +131,7 @@ public class InteropLambdaBenchmark
     {
         for (var i = 0; i < Iterations; i++)
         {
-            var value = _inlineFunction!.Call(JsValue.FromObject(_engine, _data), JsValue.FromObject(_engine, FindValue)).ToObject();
+            var value = _inlineFunction!.Call(JsValue.FromObject(_inlineEngine, _data), JsValue.FromObject(_inlineEngine, FindValue)).ToObject();
         }
     }
 
@@ -105,7 +140,7 @@ public class InteropLambdaBenchmark
     {
         for (var i = 0; i < Iterations; i++)
         {
-            var value = _inlineCSharpFunction(JsValue.Undefined, [JsValue.FromObject(_engine, _data), JsValue.FromObject(_engine, FindValue)]).ToObject();
+            var value = _inlineCSharpFunction(JsValue.Undefined, [JsValue.FromObject(_inlineCSharpEngine, _data), JsValue.FromObject(_inlineCSharpEngine, FindValue)]).ToObject();
         }
     }
 
@@ -114,7 +149,7 @@ public class InteropLambdaBenchmark
     {
         for (var i = 0; i < Iterations; i++)
         {
-            var value = _forLoopFunction!.Call(JsValue.FromObject(_engine, _data), JsValue.FromObject(_engine, FindValue)).ToObject();
+            var value = _forLoopFunction!.Call(JsValue.FromObject(_forLoopEngine, _data), JsValue.FromObject(_forLoopEngine, FindValue)).ToObject();
         }
     }
 
@@ -123,7 +158,7 @@ public class InteropLambdaBenchmark
     {
         for (var i = 0; i < Iterations; i++)
         {
-            var value = _engine.Invoke(_forLoopFunction!, [_data, FindValue]).ToObject();
+            var value = _forLoopEngineInvokeEngine.Invoke(_forLoopEngineInvokeFunction!, [_data, FindValue]).ToObject();
         }
     }
 }

--- a/Jint.Benchmark/InteropWrapperChurnBenchmark.cs
+++ b/Jint.Benchmark/InteropWrapperChurnBenchmark.cs
@@ -8,6 +8,17 @@ namespace Jint.Benchmark;
 /// (CacheRecentObjectWrappers), so repeated crossings reuse the wrapper; the NoCache rows opt out
 /// to measure the fresh-wrapper-per-crossing path, and the identity-flag rows measure the
 /// ConditionalWeakTable variant. Together they bracket the design space for wrapper reuse.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine, in its own scenario's interop
+/// configuration, warmed with that row's script and nothing else. It used to be five engines for ten
+/// rows: each configuration's object-churn row and its array-traversal row(s) shared one engine, and
+/// every one of those engines was warmed with <c>h.Payload.Value</c> — the churn row's script — so the
+/// array rows were measured with the <c>Payload</c> wrapper already resident in the very cache
+/// (recent-wrapper ring or CWT) the row exists to characterize. The default-configuration engine carried
+/// three rows, whose scripts also collide on the globals <c>s</c> and <c>i</c>. The rows still measure
+/// warm crossings, and engine construction and warm-up stay in <c>[GlobalSetup]</c>, outside the
+/// measurement. <b>Numbers from this class are not comparable to any published before the harness
+/// changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 public class InteropWrapperChurnBenchmark
@@ -31,11 +42,16 @@ public class InteropWrapperChurnBenchmark
         public int Value { get; set; }
     }
 
-    private Engine _engineDefault = null!;
-    private Engine _engineNoCache = null!;
-    private Engine _engineIdentity = null!;
-    private Engine _engineRecentCache = null!;
-    private Engine _engineCopy = null!;
+    private Engine _engineChurnDefault = null!;
+    private Engine _engineChurnNoCache = null!;
+    private Engine _engineChurnIdentity = null!;
+    private Engine _engineChurnRecentCache = null!;
+    private Engine _engineArrayDefault = null!;
+    private Engine _engineArrayNoCache = null!;
+    private Engine _engineArrayHoistedDefault = null!;
+    private Engine _engineArrayCopy = null!;
+    private Engine _engineArrayIdentity = null!;
+    private Engine _engineArrayRecentCache = null!;
 
     [GlobalSetup]
     public void GlobalSetup()
@@ -44,69 +60,116 @@ public class InteropWrapperChurnBenchmark
 
         // the out-of-the-box engine: since 4.14 ArrayConversion defaults to LiveView and
         // CacheRecentObjectWrappers defaults to true (repeated crossings reuse the wrapper)
-        _engineDefault = new Engine();
-        _engineDefault.SetValue("h", holder);
-        _engineDefault.Execute("h.Payload.Value");
+        Engine CreateDefault()
+        {
+            var engine = new Engine();
+            engine.SetValue("h", holder);
+            return engine;
+        }
 
         // opt out of the recent-wrapper cache: every crossing builds a fresh wrapper
-        _engineNoCache = new Engine(cfg => cfg.Interop.CacheRecentObjectWrappers = false);
-        _engineNoCache.SetValue("h", holder);
-        _engineNoCache.Execute("h.Payload.Value");
+        Engine CreateNoCache()
+        {
+            var engine = new Engine(cfg => cfg.Interop.CacheRecentObjectWrappers = false);
+            engine.SetValue("h", holder);
+            return engine;
+        }
 
         // the identity flags are most interesting on top of Copy, where they let the otherwise
         // per-read deep-copied JsArray snapshot be reused across crossings (pin Copy so the array
         // traversal rows below measure exactly that; the object-churn rows are array-mode agnostic).
         // The recent cache is disabled in the CWT lane so each row measures a single mechanism.
-        _engineIdentity = new Engine(cfg =>
+        Engine CreateIdentity()
         {
-            cfg.Interop.ArrayConversion = ArrayConversionMode.Copy;
-            cfg.Interop.TrackObjectWrapperIdentity = true;
-            cfg.Interop.CacheRecentObjectWrappers = false;
-        });
-        _engineIdentity.SetValue("h", holder);
-        _engineIdentity.Execute("h.Payload.Value");
+            var engine = new Engine(cfg =>
+            {
+                cfg.Interop.ArrayConversion = ArrayConversionMode.Copy;
+                cfg.Interop.TrackObjectWrapperIdentity = true;
+                cfg.Interop.CacheRecentObjectWrappers = false;
+            });
+            engine.SetValue("h", holder);
+            return engine;
+        }
 
-        _engineRecentCache = new Engine(cfg =>
+        Engine CreateRecentCache()
         {
-            cfg.Interop.ArrayConversion = ArrayConversionMode.Copy;
-            cfg.Interop.CacheRecentObjectWrappers = true;
-        });
-        _engineRecentCache.SetValue("h", holder);
-        _engineRecentCache.Execute("h.Payload.Value");
+            var engine = new Engine(cfg =>
+            {
+                cfg.Interop.ArrayConversion = ArrayConversionMode.Copy;
+                cfg.Interop.CacheRecentObjectWrappers = true;
+            });
+            engine.SetValue("h", holder);
+            return engine;
+        }
 
         // the pre-4.14 default: every array crossing deep-copies into a fresh JsArray snapshot
         // (the cache opt-out keeps this row measuring the copy itself)
-        _engineCopy = new Engine(cfg =>
+        Engine CreateCopy()
         {
-            cfg.Interop.ArrayConversion = ArrayConversionMode.Copy;
-            cfg.Interop.CacheRecentObjectWrappers = false;
-        });
-        _engineCopy.SetValue("h", holder);
-        _engineCopy.Execute("h.Payload.Value");
+            var engine = new Engine(cfg =>
+            {
+                cfg.Interop.ArrayConversion = ArrayConversionMode.Copy;
+                cfg.Interop.CacheRecentObjectWrappers = false;
+            });
+            engine.SetValue("h", holder);
+            return engine;
+        }
+
+        // Each row's engine is warmed with that row's own script, so no row starts with another
+        // row's wrapper already in the cache it is measuring.
+        _engineChurnDefault = CreateDefault();
+        _engineChurnDefault.Execute("h.Payload.Value");
+
+        _engineChurnNoCache = CreateNoCache();
+        _engineChurnNoCache.Execute("h.Payload.Value");
+
+        _engineChurnIdentity = CreateIdentity();
+        _engineChurnIdentity.Execute("h.Payload.Value");
+
+        _engineChurnRecentCache = CreateRecentCache();
+        _engineChurnRecentCache.Execute("h.Payload.Value");
+
+        _engineArrayDefault = CreateDefault();
+        _engineArrayDefault.Execute(_arrayTraversal);
+
+        _engineArrayNoCache = CreateNoCache();
+        _engineArrayNoCache.Execute(_arrayTraversal);
+
+        _engineArrayHoistedDefault = CreateDefault();
+        _engineArrayHoistedDefault.Execute(_arrayHoistedTraversal);
+
+        _engineArrayCopy = CreateCopy();
+        _engineArrayCopy.Execute(_arrayTraversal);
+
+        _engineArrayIdentity = CreateIdentity();
+        _engineArrayIdentity.Execute(_arrayTraversal);
+
+        _engineArrayRecentCache = CreateRecentCache();
+        _engineArrayRecentCache.Execute(_arrayTraversal);
     }
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
     public void SameObjectReturnedInLoop_DefaultFlag()
     {
-        for (var i = 0; i < OperationsPerInvoke; i++) _engineDefault.Execute("h.Payload.Value");
+        for (var i = 0; i < OperationsPerInvoke; i++) _engineChurnDefault.Execute("h.Payload.Value");
     }
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
     public void SameObjectReturnedInLoop_NoCache()
     {
-        for (var i = 0; i < OperationsPerInvoke; i++) _engineNoCache.Execute("h.Payload.Value");
+        for (var i = 0; i < OperationsPerInvoke; i++) _engineChurnNoCache.Execute("h.Payload.Value");
     }
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
     public void SameObjectReturnedInLoop_IdentityFlag()
     {
-        for (var i = 0; i < OperationsPerInvoke; i++) _engineIdentity.Execute("h.Payload.Value");
+        for (var i = 0; i < OperationsPerInvoke; i++) _engineChurnIdentity.Execute("h.Payload.Value");
     }
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
     public void SameObjectReturnedInLoop_RecentCache()
     {
-        for (var i = 0; i < OperationsPerInvoke; i++) _engineRecentCache.Execute("h.Payload.Value");
+        for (var i = 0; i < OperationsPerInvoke; i++) _engineChurnRecentCache.Execute("h.Payload.Value");
     }
 
     // A CLR array member read repeatedly inside the loop. Under the default (LiveView) each h.Numbers
@@ -118,13 +181,13 @@ public class InteropWrapperChurnBenchmark
     [Benchmark]
     public void ArrayMemberTraversal_DefaultLiveView()
     {
-        _engineDefault.Execute(_arrayTraversal);
+        _engineArrayDefault.Execute(_arrayTraversal);
     }
 
     [Benchmark]
     public void ArrayMemberTraversal_LiveViewNoCache()
     {
-        _engineNoCache.Execute(_arrayTraversal);
+        _engineArrayNoCache.Execute(_arrayTraversal);
     }
 
     // The README-recommended pattern: hoist the collection into a local so the wrapper is created
@@ -135,24 +198,24 @@ public class InteropWrapperChurnBenchmark
     [Benchmark]
     public void ArrayHoistedTraversal_DefaultLiveView()
     {
-        _engineDefault.Execute(_arrayHoistedTraversal);
+        _engineArrayHoistedDefault.Execute(_arrayHoistedTraversal);
     }
 
     [Benchmark]
     public void ArrayMemberTraversal_CopyMode()
     {
-        _engineCopy.Execute(_arrayTraversal);
+        _engineArrayCopy.Execute(_arrayTraversal);
     }
 
     [Benchmark]
     public void ArrayMemberTraversal_CopyIdentityFlag()
     {
-        _engineIdentity.Execute(_arrayTraversal);
+        _engineArrayIdentity.Execute(_arrayTraversal);
     }
 
     [Benchmark]
     public void ArrayMemberTraversal_CopyRecentCache()
     {
-        _engineRecentCache.Execute(_arrayTraversal);
+        _engineArrayRecentCache.Execute(_arrayTraversal);
     }
 }

--- a/Jint.Benchmark/IsolatedScript.cs
+++ b/Jint.Benchmark/IsolatedScript.cs
@@ -1,0 +1,75 @@
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// One benchmark row's workload: the script the row measures, together with the <see cref="Jint.Engine"/>
+/// that row — and only that row — ever runs it on.
+///
+/// <para>It exists to stop a whole family of measurement defects. A benchmark class that builds one
+/// engine in <c>[GlobalSetup]</c> and warms it with <em>every</em> row's script hands each row an engine
+/// carrying the other rows' state: their globals on the shared global object (nearly every row here
+/// declares <c>var i</c>, <c>var s</c> or <c>function f</c>, so they collide outright), their entries in
+/// the engine-owned handler-tree caches (<c>Engine._functionDefinitions</c>, <c>_scriptStatementLists</c>),
+/// their per-call-site monomorphic caches, and their environment-reuse and constructor-shape state. A
+/// row's number then depends on which sibling rows exist and what a change did to <em>them</em> — which
+/// is how a call-path change that was 2.5-3.0% faster in isolation was reported by
+/// <see cref="MethodCallBenchmark"/> as +5.6..+9.2% slower on three rows, reproducibly and in both A/B
+/// orderings.</para>
+///
+/// <para>BenchmarkDotNet runs every benchmark case in its own process, so the leak is not the field being
+/// shared — it is <c>[GlobalSetup]</c> doing other rows' work on the engine this row is about to be
+/// measured on. Giving each row its own engine closes it at the source and is robust to that detail
+/// changing.</para>
+///
+/// <para>Warming is preserved deliberately: these rows measure <em>warm</em> dispatch, and dropping the
+/// warm-up would silently turn them into cold-start benchmarks and change what the suite is for. Only
+/// the row's own script is evaluated, so engine construction and warm-up stay in <c>[GlobalSetup]</c>
+/// and never enter the measurement. Where a benchmark genuinely wants cold-start behaviour, build the
+/// engine inside the benchmark method instead (see <see cref="DromaeoBenchmark"/> and
+/// <see cref="SunSpiderBenchmark"/>) — never with <c>[IterationSetup]</c>.</para>
+/// </summary>
+internal readonly struct IsolatedScript
+{
+    private readonly Engine _engine;
+    private readonly Prepared<Script> _script;
+
+    private IsolatedScript(Engine engine, Prepared<Script> script)
+    {
+        _engine = engine;
+        _script = script;
+    }
+
+    /// <summary>The row's private engine, for the rare case a caller needs it after construction.</summary>
+    public Engine Engine => _engine;
+
+    /// <summary>
+    /// Gives <paramref name="script"/> a private default engine and warms it by evaluating the script once.
+    /// </summary>
+    public static IsolatedScript Warm(Prepared<Script> script) => Warm(script, static () => new Engine());
+
+    /// <summary>
+    /// Gives <paramref name="script"/> a private engine built by <paramref name="engineFactory"/> — which
+    /// must build a fresh engine per call, including any fixture every row shares — and warms it by
+    /// evaluating the script once.
+    /// </summary>
+    public static IsolatedScript Warm(Prepared<Script> script, Func<Engine> engineFactory)
+    {
+        var engine = engineFactory();
+        engine.Evaluate(script);
+        return new IsolatedScript(engine, script);
+    }
+
+    /// <summary>Prepares <paramref name="source"/> and warms it on a private default engine.</summary>
+    public static IsolatedScript Warm(string source) => Warm(Engine.PrepareScript(source));
+
+    /// <summary>Prepares <paramref name="source"/> and warms it on a private engine from <paramref name="engineFactory"/>.</summary>
+    public static IsolatedScript Warm(string source, Func<Engine> engineFactory)
+        => Warm(Engine.PrepareScript(source), engineFactory);
+
+    /// <summary>Evaluates the row's script on the row's engine and returns the completion value.</summary>
+    public JsValue Run() => _engine.Evaluate(_script);
+
+    /// <summary>Evaluates the row's script on the row's engine, discarding the completion value.</summary>
+    public void Execute() => _engine.Execute(_script);
+}

--- a/Jint.Benchmark/JsonBenchmark.cs
+++ b/Jint.Benchmark/JsonBenchmark.cs
@@ -4,10 +4,24 @@ using Jint.Native.Json;
 
 namespace Jint.Benchmark;
 
+/// <summary>
+/// Drives the internal C# <see cref="JsonParser"/> / <see cref="JsonSerializer"/> over two real-world
+/// documents downloaded once into the temp directory.
+///
+/// <para><b>Engine isolation.</b> Each row gets its own engine, and only the current
+/// <see cref="FileName"/>'s document is parsed onto one. It used to be a single engine on which
+/// <c>[GlobalSetup]</c> parsed <em>both</em> documents — the exact work <see cref="Parse"/> measures —
+/// and retained both graphs for the lifetime of the run, so the <c>Parse</c> row was measured against
+/// the <c>Stringify</c> row's fixture (and against the other parameter's fixture as well), with the
+/// resulting heap pressure folded into its number. <c>Stringify</c> still gets the parsed document it
+/// needs, on its own engine; <c>Parse</c> gets an engine warmed with one parse of its own document,
+/// which is then discarded rather than retained.</para>
+/// </summary>
 [MemoryDiagnoser]
 public class JsonBenchmark
 {
-    private Engine _engine;
+    private Engine _parseEngine;
+    private Engine _stringifyEngine;
 
     private readonly Dictionary<string, string> _sources = new()
     {
@@ -21,7 +35,8 @@ public class JsonBenchmark
     [GlobalSetup]
     public async Task GlobalSetup()
     {
-        _engine = new Engine();
+        _parseEngine = new Engine();
+        _stringifyEngine = new Engine();
 
         foreach (var source in _sources)
         {
@@ -37,10 +52,15 @@ public class JsonBenchmark
 
             var json = await File.ReadAllTextAsync(filePath);
             _json[source.Key] = json;
-
-            var parser = new JsonParser(_engine);
-            _parsedInstance[source.Key] = parser.Parse(json);
         }
+
+        // The Stringify row's fixture, on the Stringify row's engine — only for the document this case
+        // is parameterized on, so the other document's graph is never resident.
+        _parsedInstance[FileName] = new JsonParser(_stringifyEngine).Parse(_json[FileName]);
+
+        // Warm the Parse row's own engine with its own work; the result is discarded rather than
+        // retained, so the row is not measured against a graph it did not build.
+        new JsonParser(_parseEngine).Parse(_json[FileName]);
     }
 
     public IEnumerable<string> FileNames()
@@ -57,14 +77,14 @@ public class JsonBenchmark
     [Benchmark]
     public JsValue Parse()
     {
-        var parser = new JsonParser(_engine);
+        var parser = new JsonParser(_parseEngine);
         return parser.Parse(_json[FileName]);
     }
 
     [Benchmark]
     public JsValue Stringify()
     {
-        var serializer = new JsonSerializer(_engine);
+        var serializer = new JsonSerializer(_stringifyEngine);
         return serializer.Serialize(_parsedInstance[FileName]);
     }
 }

--- a/Jint.Benchmark/JsonJsBenchmark.cs
+++ b/Jint.Benchmark/JsonJsBenchmark.cs
@@ -11,18 +11,29 @@ namespace Jint.Benchmark;
 /// internal C# JsonParser/JsonSerializer over fixtures downloaded from the network), the payloads
 /// here are generated deterministically offline, so rows are stable gates. One parse or stringify
 /// per op — the Allocated column is the per-document allocation cost.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine — built by <see cref="CreateEngine"/>,
+/// which re-runs <see cref="SetupSource"/> so each engine owns its own <c>records</c>/<c>config</c>
+/// graphs — and warmed with its own script and nothing else (see <see cref="IsolatedScript"/>). It used
+/// to be one engine warmed with all six row scripts, so each row was measured on an engine carrying the
+/// other five rows' handler-tree, call-site and object-shape state, plus the retained result graphs their
+/// warm-up left behind. The rows still measure warm parse/stringify, and engine construction and warm-up
+/// stay in <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from this class are not comparable
+/// to any published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]
 public class JsonJsBenchmark
 {
-    private Engine _engine = null!;
-    private Prepared<Script> _parseRecords;
-    private Prepared<Script> _parseConfig;
-    private Prepared<Script> _parseBigObject;
-    private Prepared<Script> _stringifyRecords;
-    private Prepared<Script> _stringifyConfig;
-    private Prepared<Script> _roundTripRecords;
+    private string _recordsJson = null!;
+    private string _configJson = null!;
+    private string _bigObjectJson = null!;
+    private IsolatedScript _parseRecords;
+    private IsolatedScript _parseConfig;
+    private IsolatedScript _parseBigObject;
+    private IsolatedScript _stringifyRecords;
+    private IsolatedScript _stringifyConfig;
+    private IsolatedScript _roundTripRecords;
 
     internal const string ParseRecordsSource = "JSON.parse(recordsJson);";
     internal const string ParseConfigSource = "JSON.parse(configJson);";
@@ -126,45 +137,51 @@ public class JsonJsBenchmark
         return sb.ToString();
     }
 
+    /// <summary>
+    /// Builds a fresh engine carrying the fixture every row needs, and nothing else. The three payloads
+    /// are generated once in <see cref="Setup"/> and handed to every engine, so the deterministic
+    /// builders stay a one-off setup cost rather than running once per row.
+    /// </summary>
+    private Engine CreateEngine()
+    {
+        var engine = new Engine();
+        engine.SetValue("recordsJson", _recordsJson);
+        engine.SetValue("configJson", _configJson);
+        engine.SetValue("bigObjectJson", _bigObjectJson);
+        engine.Execute(SetupSource);
+        return engine;
+    }
+
     [GlobalSetup]
     public void Setup()
     {
-        _engine = new Engine();
-        _engine.SetValue("recordsJson", BuildRecordsJson());
-        _engine.SetValue("configJson", BuildConfigJson());
-        _engine.SetValue("bigObjectJson", BuildBigObjectJson());
-        _engine.Execute(SetupSource);
+        _recordsJson = BuildRecordsJson();
+        _configJson = BuildConfigJson();
+        _bigObjectJson = BuildBigObjectJson();
 
-        _parseRecords = Engine.PrepareScript(ParseRecordsSource);
-        _parseConfig = Engine.PrepareScript(ParseConfigSource);
-        _parseBigObject = Engine.PrepareScript(ParseBigObjectSource);
-        _stringifyRecords = Engine.PrepareScript(StringifyRecordsSource);
-        _stringifyConfig = Engine.PrepareScript(StringifyConfigSource);
-        _roundTripRecords = Engine.PrepareScript(RoundTripRecordsSource);
-
-        _engine.Evaluate(_parseRecords);
-        _engine.Evaluate(_parseConfig);
-        _engine.Evaluate(_parseBigObject);
-        _engine.Evaluate(_stringifyRecords);
-        _engine.Evaluate(_stringifyConfig);
-        _engine.Evaluate(_roundTripRecords);
+        _parseRecords = IsolatedScript.Warm(Engine.PrepareScript(ParseRecordsSource), CreateEngine);
+        _parseConfig = IsolatedScript.Warm(Engine.PrepareScript(ParseConfigSource), CreateEngine);
+        _parseBigObject = IsolatedScript.Warm(Engine.PrepareScript(ParseBigObjectSource), CreateEngine);
+        _stringifyRecords = IsolatedScript.Warm(Engine.PrepareScript(StringifyRecordsSource), CreateEngine);
+        _stringifyConfig = IsolatedScript.Warm(Engine.PrepareScript(StringifyConfigSource), CreateEngine);
+        _roundTripRecords = IsolatedScript.Warm(Engine.PrepareScript(RoundTripRecordsSource), CreateEngine);
     }
 
     [Benchmark]
-    public JsValue ParseRecords() => _engine.Evaluate(_parseRecords);
+    public JsValue ParseRecords() => _parseRecords.Run();
 
     [Benchmark]
-    public JsValue ParseConfig() => _engine.Evaluate(_parseConfig);
+    public JsValue ParseConfig() => _parseConfig.Run();
 
     [Benchmark]
-    public JsValue ParseBigObject() => _engine.Evaluate(_parseBigObject);
+    public JsValue ParseBigObject() => _parseBigObject.Run();
 
     [Benchmark]
-    public JsValue StringifyRecords() => _engine.Evaluate(_stringifyRecords);
+    public JsValue StringifyRecords() => _stringifyRecords.Run();
 
     [Benchmark]
-    public JsValue StringifyConfig() => _engine.Evaluate(_stringifyConfig);
+    public JsValue StringifyConfig() => _stringifyConfig.Run();
 
     [Benchmark]
-    public JsValue RoundTripRecords() => _engine.Evaluate(_roundTripRecords);
+    public JsValue RoundTripRecords() => _roundTripRecords.Run();
 }

--- a/Jint.Benchmark/LoopDispatchBenchmarks.cs
+++ b/Jint.Benchmark/LoopDispatchBenchmarks.cs
@@ -8,87 +8,97 @@ namespace Jint.Benchmark;
 /// (fixed slots, pooled env, slot caches, unboxed counters): the empty loop isolates the
 /// for-statement machinery (test, update, statement dispatch), and each body row adds exactly
 /// one statement on top so the delta attributes cost to that construct. 100k iterations per op.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine, warmed with its own script and
+/// nothing else (see <see cref="IsolatedScript"/>). It used to be one engine warmed with all
+/// fourteen row scripts, so each row was measured on an engine carrying the other thirteen rows'
+/// globals — every one of them declares <c>function f</c>, so they collided outright, and the last
+/// warm-up won — plus their handler-tree, call-site and environment-reuse state. A row's number then
+/// depends on which siblings exist and on what a change did to <em>them</em>, which is exactly the
+/// defect that made a call-path improvement read as a regression on
+/// <see cref="MethodCallBenchmark"/>. The rows still measure warm dispatch, and engine construction
+/// and warm-up stay in <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from this class are
+/// not comparable to any published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]
 public class LoopDispatchBenchmarks
 {
-    private Engine _engine = null!;
-    private Prepared<Script> _emptyLoop;
-    private Prepared<Script> _variableBoundLoop;
-    private Prepared<Script> _counterAdd;
-    private Prepared<Script> _localCopy;
-    private Prepared<Script> _stringAppend;
-    private Prepared<Script> _comparisonOnly;
-    private Prepared<Script> _strictEqualTest;
-    private Prepared<Script> _looseEqualTest;
-    private Prepared<Script> _moduloEqualTest;
-    private Prepared<Script> _ifChainLoop;
-    private Prepared<Script> _varDeclBody;
-    private Prepared<Script> _xorAssignLoop;
-    private Prepared<Script> _arrayLengthBound;
-    private Prepared<Script> _stringLengthBound;
+    private IsolatedScript _emptyLoop;
+    private IsolatedScript _variableBoundLoop;
+    private IsolatedScript _counterAdd;
+    private IsolatedScript _localCopy;
+    private IsolatedScript _stringAppend;
+    private IsolatedScript _comparisonOnly;
+    private IsolatedScript _strictEqualTest;
+    private IsolatedScript _looseEqualTest;
+    private IsolatedScript _moduloEqualTest;
+    private IsolatedScript _ifChainLoop;
+    private IsolatedScript _varDeclBody;
+    private IsolatedScript _xorAssignLoop;
+    private IsolatedScript _arrayLengthBound;
+    private IsolatedScript _stringLengthBound;
 
     [GlobalSetup]
     public void Setup()
     {
         // pure loop machinery: test + update + (empty) body dispatch
-        _emptyLoop = Engine.PrepareScript("""
+        _emptyLoop = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() { for (var i = 0; i < 100000; i++) { } return i; }
             f();
-            """);
+            """));
 
         // same machinery with a variable bound (i < n over two locals)
-        _variableBoundLoop = Engine.PrepareScript("""
+        _variableBoundLoop = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() { var n = 100000; for (var i = 0; i < n; i++) { } return i; }
             f();
-            """);
+            """));
 
         // + one numeric compound assignment (unboxed discard lane)
-        _counterAdd = Engine.PrepareScript("""
+        _counterAdd = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() { var n = 0; for (var i = 0; i < 100000; i++) { n += 1; } return n; }
             f();
-            """);
+            """));
 
         // + one plain slot-to-slot assignment
-        _localCopy = Engine.PrepareScript("""
+        _localCopy = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() { var a = 1, b = 0; for (var i = 0; i < 100000; i++) { b = a; } return b; }
             f();
-            """);
+            """));
 
         // + one string compound assignment (rope append, slot lane) — the dromaeo-core-eval body shape
-        _stringAppend = Engine.PrepareScript("""
+        _stringAppend = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() { var s = ''; for (var i = 0; i < 100000; i++) { s += 'a'; } return s.length; }
             f();
-            """);
+            """));
 
         // + one comparison whose result is discarded through an if with empty branches
-        _comparisonOnly = Engine.PrepareScript("""
+        _comparisonOnly = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() { var n = 0; for (var i = 0; i < 100000; i++) { if (i < 50000) { } } return n; }
             f();
-            """);
+            """));
 
         // + one strict-equality test (=== over a slot and a constant)
-        _strictEqualTest = Engine.PrepareScript("""
+        _strictEqualTest = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() { var n = 0; for (var i = 0; i < 100000; i++) { if (i === 50000) { } } return n; }
             f();
-            """);
+            """));
 
         // + one loose-equality test (== over a slot and a constant)
-        _looseEqualTest = Engine.PrepareScript("""
+        _looseEqualTest = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() { var n = 0; for (var i = 0; i < 100000; i++) { if (i == 50000) { } } return n; }
             f();
-            """);
+            """));
 
         // + the stopwatch.js if-chain shape: modulo of a slot vs a constant, loosely compared
-        _moduloEqualTest = Engine.PrepareScript("""
+        _moduloEqualTest = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() { var n = 0; for (var i = 0; i < 100000; i++) { if (i % 2 == 0) { } } return n; }
             f();
-            """);
+            """));
 
         // the full stopwatch.js body shape: var-decl + 4-way modulo else-if chain whose branches
         // call tiny closures + two dead member-read var-decls
-        _ifChainLoop = Engine.PrepareScript("""
+        _ifChainLoop = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var c = { n: 0, a: function () { this.n++; }, b: function () { this.n--; } };
                 for (var i = 0; i < 100000; i++) {
@@ -102,91 +112,75 @@ public class LoopDispatchBenchmarks
                 return c.n;
             }
             f();
-            """);
+            """));
 
         // + one var declaration with an initializer (the `var z = x ^ y` statement alone)
-        _varDeclBody = Engine.PrepareScript("""
+        _varDeclBody = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() { var n = 0; for (var i = 0; i < 100000; i++) { var z = i ^ 3; } return n; }
             f();
-            """);
+            """));
 
         // + identifier ^ identifier over two slot numbers (the stopwatch `var z = x ^ y` shape;
         // z stays inside the small-int cache so the measurement is operand handling, not boxing)
-        _xorAssignLoop = Engine.PrepareScript("""
+        _xorAssignLoop = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() { var m = 3; var n = 0; for (var i = 0; i < 100000; i++) { var z = i ^ m; } return n; }
             f();
-            """);
+            """));
 
         // the member-bound loop test: `i < a.length` re-reads the live length every iteration
         // (6250 × 16 = 100k inner iterations)
-        _arrayLengthBound = Engine.PrepareScript("""
+        _arrayLengthBound = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() { var a = []; for (var k = 0; k < 16; k++) a[k] = k; var n = 0; for (var r = 0; r < 6250; r++) { for (var i = 0; i < a.length; i++) { n++; } } return n; }
             f();
-            """);
+            """));
 
         // string variant: a 20k-char string's length exceeds the small-int cache, so the boxed
         // read allocates a JsNumber per iteration without the lane (5 × 20k = 100k iterations)
-        _stringLengthBound = Engine.PrepareScript("""
+        _stringLengthBound = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() { var s = 'x'.repeat(20000); var n = 0; for (var r = 0; r < 5; r++) { for (var i = 0; i < s.length; i++) { n++; } } return n; }
             f();
-            """);
-
-        _engine = new Engine();
-        _engine.Evaluate(_emptyLoop);
-        _engine.Evaluate(_variableBoundLoop);
-        _engine.Evaluate(_counterAdd);
-        _engine.Evaluate(_localCopy);
-        _engine.Evaluate(_stringAppend);
-        _engine.Evaluate(_comparisonOnly);
-        _engine.Evaluate(_strictEqualTest);
-        _engine.Evaluate(_looseEqualTest);
-        _engine.Evaluate(_moduloEqualTest);
-        _engine.Evaluate(_ifChainLoop);
-        _engine.Evaluate(_varDeclBody);
-        _engine.Evaluate(_xorAssignLoop);
-        _engine.Evaluate(_arrayLengthBound);
-        _engine.Evaluate(_stringLengthBound);
+            """));
     }
 
     [Benchmark(Baseline = true)]
-    public JsValue EmptyLoop() => _engine.Evaluate(_emptyLoop);
+    public JsValue EmptyLoop() => _emptyLoop.Run();
 
     [Benchmark]
-    public JsValue VariableBoundLoop() => _engine.Evaluate(_variableBoundLoop);
+    public JsValue VariableBoundLoop() => _variableBoundLoop.Run();
 
     [Benchmark]
-    public JsValue CounterAdd() => _engine.Evaluate(_counterAdd);
+    public JsValue CounterAdd() => _counterAdd.Run();
 
     [Benchmark]
-    public JsValue LocalCopy() => _engine.Evaluate(_localCopy);
+    public JsValue LocalCopy() => _localCopy.Run();
 
     [Benchmark]
-    public JsValue StringAppend() => _engine.Evaluate(_stringAppend);
+    public JsValue StringAppend() => _stringAppend.Run();
 
     [Benchmark]
-    public JsValue ComparisonOnly() => _engine.Evaluate(_comparisonOnly);
+    public JsValue ComparisonOnly() => _comparisonOnly.Run();
 
     [Benchmark]
-    public JsValue StrictEqualTest() => _engine.Evaluate(_strictEqualTest);
+    public JsValue StrictEqualTest() => _strictEqualTest.Run();
 
     [Benchmark]
-    public JsValue LooseEqualTest() => _engine.Evaluate(_looseEqualTest);
+    public JsValue LooseEqualTest() => _looseEqualTest.Run();
 
     [Benchmark]
-    public JsValue ModuloEqualTest() => _engine.Evaluate(_moduloEqualTest);
+    public JsValue ModuloEqualTest() => _moduloEqualTest.Run();
 
     [Benchmark]
-    public JsValue IfChainLoop() => _engine.Evaluate(_ifChainLoop);
+    public JsValue IfChainLoop() => _ifChainLoop.Run();
 
     [Benchmark]
-    public JsValue VarDeclBody() => _engine.Evaluate(_varDeclBody);
+    public JsValue VarDeclBody() => _varDeclBody.Run();
 
     [Benchmark]
-    public JsValue XorAssignLoop() => _engine.Evaluate(_xorAssignLoop);
+    public JsValue XorAssignLoop() => _xorAssignLoop.Run();
 
     [Benchmark]
-    public JsValue ArrayLengthBound() => _engine.Evaluate(_arrayLengthBound);
+    public JsValue ArrayLengthBound() => _arrayLengthBound.Run();
 
     [Benchmark]
-    public JsValue StringLengthBound() => _engine.Evaluate(_stringLengthBound);
+    public JsValue StringLengthBound() => _stringLengthBound.Run();
 }

--- a/Jint.Benchmark/MapSetLookupBenchmark.cs
+++ b/Jint.Benchmark/MapSetLookupBenchmark.cs
@@ -8,18 +8,27 @@ namespace Jint.Benchmark;
 /// Probe keys are prebuilt and selected with an inline LCG (50% absent on the Mixed rows) so rows
 /// measure the lookup path, not key construction, and the branch predictor cannot memorize hits.
 /// 100k operations per op inside a function frame.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine — built by <see cref="CreateEngine"/>,
+/// which re-runs <see cref="SetupSource"/> so each engine owns its own maps, sets and probe-key arrays —
+/// and warmed with its own script and nothing else (see <see cref="IsolatedScript"/>). It used to be one
+/// engine warmed with all six row scripts, so each row was measured on an engine carrying the other five
+/// rows' globals (every one of them declares <c>function f</c>, so they collided outright) plus their
+/// handler-tree and call-site state — and <see cref="MemoizePattern"/>'s warm-up additionally left the
+/// shared <c>cache</c> map fully populated for everyone else. The rows still measure warm lookups, and
+/// engine construction and warm-up stay in <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from
+/// this class are not comparable to any published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]
 public class MapSetLookupBenchmark
 {
-    private Engine _engine = null!;
-    private Prepared<Script> _mapGetHit;
-    private Prepared<Script> _mapGetMixed;
-    private Prepared<Script> _mapHasMixed;
-    private Prepared<Script> _setHasMixed;
-    private Prepared<Script> _mapSetDeleteChurn;
-    private Prepared<Script> _memoizePattern;
+    private IsolatedScript _mapGetHit;
+    private IsolatedScript _mapGetMixed;
+    private IsolatedScript _mapHasMixed;
+    private IsolatedScript _setHasMixed;
+    private IsolatedScript _mapSetDeleteChurn;
+    private IsolatedScript _memoizePattern;
 
     // Mixing is precomputed at setup into `order` (see ModernOperatorsBenchmark note): a
     // per-iteration JS LCG boxes JsNumber transients that would dominate these lookup rows.
@@ -80,16 +89,21 @@ public class MapSetLookupBenchmark
         f();
         """;
 
+    /// <summary>Builds a fresh engine carrying the fixture every row needs, and nothing else.</summary>
+    private static Engine CreateEngine()
+    {
+        var engine = new Engine();
+        engine.Execute(SetupSource);
+        return engine;
+    }
+
     [GlobalSetup]
     public void Setup()
     {
-        _engine = new Engine();
-        _engine.Execute(SetupSource);
-
-        _mapGetHit = Engine.PrepareScript(MapGetHitSource);
+        _mapGetHit = IsolatedScript.Warm(Engine.PrepareScript(MapGetHitSource), CreateEngine);
 
         // ~50% of probe keys are absent
-        _mapGetMixed = Engine.PrepareScript("""
+        _mapGetMixed = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
@@ -99,9 +113,9 @@ public class MapSetLookupBenchmark
                 return s;
             }
             f();
-            """);
+            """), CreateEngine);
 
-        _mapHasMixed = Engine.PrepareScript("""
+        _mapHasMixed = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
@@ -110,10 +124,10 @@ public class MapSetLookupBenchmark
                 return s;
             }
             f();
-            """);
+            """), CreateEngine);
 
         // int keys: no key allocation at all
-        _setHasMixed = Engine.PrepareScript("""
+        _setHasMixed = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
@@ -122,10 +136,10 @@ public class MapSetLookupBenchmark
                 return s;
             }
             f();
-            """);
+            """), CreateEngine);
 
         // sliding window: add + delete keeping ~1k live entries
-        _mapSetDeleteChurn = Engine.PrepareScript("""
+        _mapSetDeleteChurn = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var w = new Map();
                 for (var i = 0; i < 100000; i++) {
@@ -135,33 +149,26 @@ public class MapSetLookupBenchmark
                 return w.size;
             }
             f();
-            """);
+            """), CreateEngine);
 
-        _memoizePattern = Engine.PrepareScript(MemoizePatternSource);
-
-        _engine.Evaluate(_mapGetHit);
-        _engine.Evaluate(_mapGetMixed);
-        _engine.Evaluate(_mapHasMixed);
-        _engine.Evaluate(_setHasMixed);
-        _engine.Evaluate(_mapSetDeleteChurn);
-        _engine.Evaluate(_memoizePattern);
+        _memoizePattern = IsolatedScript.Warm(Engine.PrepareScript(MemoizePatternSource), CreateEngine);
     }
 
     [Benchmark]
-    public JsValue MapGetHit() => _engine.Evaluate(_mapGetHit);
+    public JsValue MapGetHit() => _mapGetHit.Run();
 
     [Benchmark]
-    public JsValue MapGetMixed() => _engine.Evaluate(_mapGetMixed);
+    public JsValue MapGetMixed() => _mapGetMixed.Run();
 
     [Benchmark]
-    public JsValue MapHasMixed() => _engine.Evaluate(_mapHasMixed);
+    public JsValue MapHasMixed() => _mapHasMixed.Run();
 
     [Benchmark]
-    public JsValue SetHasMixed() => _engine.Evaluate(_setHasMixed);
+    public JsValue SetHasMixed() => _setHasMixed.Run();
 
     [Benchmark]
-    public JsValue MapSetDeleteChurn() => _engine.Evaluate(_mapSetDeleteChurn);
+    public JsValue MapSetDeleteChurn() => _mapSetDeleteChurn.Run();
 
     [Benchmark]
-    public JsValue MemoizePattern() => _engine.Evaluate(_memoizePattern);
+    public JsValue MemoizePattern() => _memoizePattern.Run();
 }

--- a/Jint.Benchmark/MathBenchmarks.cs
+++ b/Jint.Benchmark/MathBenchmarks.cs
@@ -6,31 +6,41 @@ namespace Jint.Benchmark;
 /// <summary>
 /// Compares cold/warm Math intrinsic costs for the source-generator branch versus upstream main.
 /// Run alone (no parallel workloads) per project memory; intended to be diff'd between branches.
+///
+/// <para><b>Engine isolation.</b> Each Warm_ row gets its own engine, warmed with its own script and
+/// nothing else (see <see cref="IsolatedScript"/>). It used to be one shared <c>_warm</c> engine warmed
+/// with all four scripts, so every warm row was measured on an engine already carrying the other rows'
+/// handler-tree and call-site state. The Cold_ rows are unchanged — they build their engine inside the
+/// benchmark method, which is what they are for. <b>Numbers from the warm rows are not comparable to any
+/// published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 public class MathBenchmarks
 {
-    private Engine _warm = null!;
+    // Shared by the Cold_ rows, which build their own engine per invocation.
     private Prepared<Script> _abs;
     private Prepared<Script> _pi;
-    private Prepared<Script> _max;
     private Prepared<Script> _tenMethods;
+
+    private IsolatedScript _warmAbs;
+    private IsolatedScript _warmPi;
+    private IsolatedScript _warmMax;
+    private IsolatedScript _warmTenMethods;
 
     [GlobalSetup]
     public void GlobalSetup()
     {
         _abs = Engine.PrepareScript("Math.abs(-5)");
         _pi = Engine.PrepareScript("Math.PI");
-        _max = Engine.PrepareScript("Math.max(1, 2, 3, 4, 5)");
+        var max = Engine.PrepareScript("Math.max(1, 2, 3, 4, 5)");
         _tenMethods = Engine.PrepareScript(
             "Math.abs(-1) + Math.cos(0) + Math.sin(0) + Math.exp(1) + Math.log(1) + " +
             "Math.sqrt(4) + Math.tan(0) + Math.atan(0) + Math.ceil(1.5) + Math.floor(1.5)");
 
-        _warm = new Engine();
-        _warm.Evaluate(_abs);
-        _warm.Evaluate(_pi);
-        _warm.Evaluate(_max);
-        _warm.Evaluate(_tenMethods);
+        _warmAbs = IsolatedScript.Warm(_abs);
+        _warmPi = IsolatedScript.Warm(_pi);
+        _warmMax = IsolatedScript.Warm(max);
+        _warmTenMethods = IsolatedScript.Warm(_tenMethods);
     }
 
     // ---------- Cold paths (include engine + Math intrinsic init) ----------
@@ -62,14 +72,14 @@ public class MathBenchmarks
     // ---------- Warm paths (inline-cache hot) ----------
 
     [Benchmark]
-    public JsValue Warm_MathPi() => _warm.Evaluate(_pi);
+    public JsValue Warm_MathPi() => _warmPi.Run();
 
     [Benchmark]
-    public JsValue Warm_MathAbs() => _warm.Evaluate(_abs);
+    public JsValue Warm_MathAbs() => _warmAbs.Run();
 
     [Benchmark]
-    public JsValue Warm_MathMaxVarargs() => _warm.Evaluate(_max);
+    public JsValue Warm_MathMaxVarargs() => _warmMax.Run();
 
     [Benchmark]
-    public JsValue Warm_TenMethodsCombined() => _warm.Evaluate(_tenMethods);
+    public JsValue Warm_TenMethodsCombined() => _warmTenMethods.Run();
 }

--- a/Jint.Benchmark/MathHotPathBenchmarks.cs
+++ b/Jint.Benchmark/MathHotPathBenchmarks.cs
@@ -12,49 +12,48 @@ namespace Jint.Benchmark;
 ///
 /// Each tight loop runs 1000 calls inside one prepared script so we measure dispatch + call cost,
 /// not script-eval/parse overhead. OperationsPerInvoke amortises BDN's per-iteration noise.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine, warmed with its own script and nothing
+/// else (see <see cref="IsolatedScript"/>). It used to be one shared <c>_warm</c> engine warmed with all
+/// six scripts, so each row was measured on an engine carrying its siblings' globals (the two tight-loop
+/// scripts both declare <c>s</c> and <c>i</c>) plus their handler-tree and call-site state. The rows still
+/// measure warm dispatch, and engine construction and warm-up stay in <c>[GlobalSetup]</c>, outside the
+/// measurement. <b>Numbers from this class are not comparable to any published before the harness
+/// changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 public class MathHotPathBenchmarks
 {
     private const int OperationsPerInvoke = 1_000;
 
-    private Engine _warm = null!;
-    private Prepared<Script> _abs;
-    private Prepared<Script> _floor;
-    private Prepared<Script> _sqrt;
-    private Prepared<Script> _max2;
-    private Prepared<Script> _absInLoop;
-    private Prepared<Script> _maxInLoop;
+    private IsolatedScript _abs;
+    private IsolatedScript _floor;
+    private IsolatedScript _sqrt;
+    private IsolatedScript _max2;
+    private IsolatedScript _absInLoop;
+    private IsolatedScript _maxInLoop;
 
     [GlobalSetup]
     public void GlobalSetup()
     {
-        _abs   = Engine.PrepareScript("Math.abs(-1.5)");
-        _floor = Engine.PrepareScript("Math.floor(3.7)");
-        _sqrt  = Engine.PrepareScript("Math.sqrt(2.0)");
-        _max2  = Engine.PrepareScript("Math.max(1, 2)");
+        _abs   = IsolatedScript.Warm("Math.abs(-1.5)");
+        _floor = IsolatedScript.Warm("Math.floor(3.7)");
+        _sqrt  = IsolatedScript.Warm("Math.sqrt(2.0)");
+        _max2  = IsolatedScript.Warm("Math.max(1, 2)");
 
         // Tight-loop variants: amortises script-eval cost, isolates dispatch + body.
-        _absInLoop = Engine.PrepareScript("var s = 0; for (var i = 0; i < 1000; i++) s += Math.abs(i - 500); s");
-        _maxInLoop = Engine.PrepareScript("var s = 0; for (var i = 0; i < 1000; i++) s += Math.max(i, 500); s");
-
-        _warm = new Engine();
-        _warm.Evaluate(_abs);
-        _warm.Evaluate(_floor);
-        _warm.Evaluate(_sqrt);
-        _warm.Evaluate(_max2);
-        _warm.Evaluate(_absInLoop);
-        _warm.Evaluate(_maxInLoop);
+        _absInLoop = IsolatedScript.Warm("var s = 0; for (var i = 0; i < 1000; i++) s += Math.abs(i - 500); s");
+        _maxInLoop = IsolatedScript.Warm("var s = 0; for (var i = 0; i < 1000; i++) s += Math.max(i, 500); s");
     }
 
-    [Benchmark] public JsValue Warm_Abs() => _warm.Evaluate(_abs);
-    [Benchmark] public JsValue Warm_Floor() => _warm.Evaluate(_floor);
-    [Benchmark] public JsValue Warm_Sqrt() => _warm.Evaluate(_sqrt);
-    [Benchmark] public JsValue Warm_Max2() => _warm.Evaluate(_max2);
+    [Benchmark] public JsValue Warm_Abs() => _abs.Run();
+    [Benchmark] public JsValue Warm_Floor() => _floor.Run();
+    [Benchmark] public JsValue Warm_Sqrt() => _sqrt.Run();
+    [Benchmark] public JsValue Warm_Max2() => _max2.Run();
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue Warm_AbsTightLoop() => _warm.Evaluate(_absInLoop);
+    public JsValue Warm_AbsTightLoop() => _absInLoop.Run();
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue Warm_MaxTightLoop() => _warm.Evaluate(_maxInLoop);
+    public JsValue Warm_MaxTightLoop() => _maxInLoop.Run();
 }

--- a/Jint.Benchmark/MethodCallBenchmark.cs
+++ b/Jint.Benchmark/MethodCallBenchmark.cs
@@ -10,15 +10,28 @@ namespace Jint.Benchmark;
 /// reads/writes <c>this</c> state; <see cref="MethodCallCaptured"/> reads/writes closure-captured
 /// state (the exact Stopwatch shape). <see cref="FreeFunctionCall"/> is the guard: plain
 /// (non-member) calls must not regress.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine, warmed with its own script and
+/// nothing else (see <see cref="IsolatedScript"/>). This class is where the defect that motivated
+/// that was caught: it used to warm one shared engine with all five scripts, which put five sets of
+/// colliding globals (<c>s</c> and <c>i</c> are declared by every one of them) and five rows' worth
+/// of handler-tree and call-site caches on the engine each row was then measured on. A call-path
+/// change that a faithful single-workload reproduction showed to be 2.5-3.0% <em>faster</em> was
+/// reported here as <c>UserPrototypeMethod</c> +9.2%, <c>ArrayPushPop</c> +5.6% and
+/// <c>MethodCallThis</c> +5.8% — reproducibly, in both A/B orderings. The rows still measure warm
+/// dispatch, and engine construction and warm-up stay in <c>[GlobalSetup]</c>, outside the
+/// measurement. <b>Numbers from this class are not comparable to any published before the harness
+/// changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]
 public class MethodCallBenchmark
 {
-    private Engine _engine = null!;
-    private Prepared<Script> _methodCallThis;
-    private Prepared<Script> _methodCallCaptured;
-    private Prepared<Script> _freeFunctionCall;
+    private IsolatedScript _methodCallThis;
+    private IsolatedScript _methodCallCaptured;
+    private IsolatedScript _freeFunctionCall;
+
+    private static Engine CreateEngine() => new(static options => options.Strict());
 
     [GlobalSetup]
     public void Setup()
@@ -26,14 +39,14 @@ public class MethodCallBenchmark
         // Values are masked to stay in the small-integer cache so JsNumber boxing does not
         // dominate/perturb the measurement — the signal is the call-dispatch + property
         // resolution cost, which the fast path removes (Reference rent + descriptor re-resolution).
-        _methodCallThis = Engine.PrepareScript("""
+        _methodCallThis = IsolatedScript.Warm(Engine.PrepareScript("""
             var o = { n: 0, tick: function () { this.n = (this.n + 1) & 1023; return this.n; } };
             var s = 0;
             for (var i = 0; i < 1000000; i++) { s = (s + o.tick()) & 1023; }
             s;
-            """, strict: true);
+            """, strict: true), CreateEngine);
 
-        _methodCallCaptured = Engine.PrepareScript("""
+        _methodCallCaptured = IsolatedScript.Warm(Engine.PrepareScript("""
             function makeCounter() {
                 var n = 0;
                 return { inc: function () { n = (n + 1) & 1023; return n; } };
@@ -42,50 +55,43 @@ public class MethodCallBenchmark
             var s = 0;
             for (var i = 0; i < 1000000; i++) { s = (s + c.inc()) & 1023; }
             s;
-            """, strict: true);
+            """, strict: true), CreateEngine);
 
-        _freeFunctionCall = Engine.PrepareScript("""
+        _freeFunctionCall = IsolatedScript.Warm(Engine.PrepareScript("""
             function f(x) { return (x + 1) & 1023; }
             var s = 0;
             for (var i = 0; i < 1000000; i++) { s = f(s); }
             s;
-            """, strict: true);
+            """, strict: true), CreateEngine);
 
-        _arrayPushPop = Engine.PrepareScript(
-            "var a = []; for (var i = 0; i < 1000000; i++) { a.push(i); a.pop(); } a.length;", strict: true);
-        _userProtoMethod = Engine.PrepareScript("""
+        _arrayPushPop = IsolatedScript.Warm(Engine.PrepareScript(
+            "var a = []; for (var i = 0; i < 1000000; i++) { a.push(i); a.pop(); } a.length;", strict: true), CreateEngine);
+        _userProtoMethod = IsolatedScript.Warm(Engine.PrepareScript("""
             function C() { this.v = 0; }
             C.prototype.inc = function () { this.v = (this.v + 1) & 1023; return this.v; };
             var c = new C(); var s = 0;
             for (var i = 0; i < 1000000; i++) { s = (s + c.inc()) & 1023; }
             s;
-            """, strict: true);
-
-        _engine = new Engine(static options => options.Strict());
-        _engine.Evaluate(_methodCallThis);
-        _engine.Evaluate(_methodCallCaptured);
-        _engine.Evaluate(_freeFunctionCall);
-        _engine.Evaluate(_arrayPushPop);
-        _engine.Evaluate(_userProtoMethod);
+            """, strict: true), CreateEngine);
     }
 
     [Benchmark]
-    public JsValue MethodCallThis() => _engine.Evaluate(_methodCallThis);
+    public JsValue MethodCallThis() => _methodCallThis.Run();
 
     [Benchmark]
-    public JsValue MethodCallCaptured() => _engine.Evaluate(_methodCallCaptured);
+    public JsValue MethodCallCaptured() => _methodCallCaptured.Run();
 
     [Benchmark]
-    public JsValue FreeFunctionCall() => _engine.Evaluate(_freeFunctionCall);
+    public JsValue FreeFunctionCall() => _freeFunctionCall.Run();
 
     // Prototype-method calls — resolved on the receiver's prototype, the case the prototype-method inline
     // cache targets (own-method calls above already hit the own-property cache). Prepared in Setup().
-    private Prepared<Script> _arrayPushPop;
-    private Prepared<Script> _userProtoMethod;
+    private IsolatedScript _arrayPushPop;
+    private IsolatedScript _userProtoMethod;
 
     [Benchmark]
-    public JsValue ArrayPushPop() => _engine.Evaluate(_arrayPushPop);
+    public JsValue ArrayPushPop() => _arrayPushPop.Run();
 
     [Benchmark]
-    public JsValue UserPrototypeMethod() => _engine.Evaluate(_userProtoMethod);
+    public JsValue UserPrototypeMethod() => _userProtoMethod.Run();
 }

--- a/Jint.Benchmark/ModernOperatorsBenchmark.cs
+++ b/Jint.Benchmark/ModernOperatorsBenchmark.cs
@@ -8,17 +8,25 @@ namespace Jint.Benchmark;
 /// LCG (~50% present / 50% short-circuiting) so the branch predictor cannot memorize the outcome —
 /// the modern null-guard idioms that pervade current JS but appear in no other benchmark.
 /// 100k iterations per op inside a function frame.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine, built by <c>CreateEngine</c> (which
+/// installs the shared <see cref="SetupSource"/> fixture every row needs) and warmed with its own script
+/// and nothing else (see <see cref="IsolatedScript"/>). It used to be one shared engine warmed with all
+/// five scripts, so each row was measured on an engine carrying its siblings' globals (every script
+/// declares <c>f</c>, <c>s</c> and <c>i</c>) and their handler-tree and call-site state. The rows still
+/// measure warm dispatch, and engine construction and warm-up stay in <c>[GlobalSetup]</c>, outside the
+/// measurement. <b>Numbers from this class are not comparable to any published before the harness
+/// changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]
 public class ModernOperatorsBenchmark
 {
-    private Engine _engine = null!;
-    private Prepared<Script> _optionalChainHit;
-    private Prepared<Script> _optionalChainMiss;
-    private Prepared<Script> _nullishCoalesce;
-    private Prepared<Script> _nullishAssign;
-    private Prepared<Script> _logicalOrAssign;
+    private IsolatedScript _optionalChainHit;
+    private IsolatedScript _optionalChainMiss;
+    private IsolatedScript _nullishCoalesce;
+    private IsolatedScript _nullishAssign;
+    private IsolatedScript _logicalOrAssign;
 
     // Mixing is precomputed at setup into `order` (8,192 small-int indices) because a per-iteration
     // JS LCG boxes JsNumber transients (~120 B/iter) that would dominate what these rows measure.
@@ -77,27 +85,32 @@ public class ModernOperatorsBenchmark
         f();
         """;
 
+    /// <summary>Builds a fresh engine carrying the shared <see cref="SetupSource"/> fixture every row needs.</summary>
+    private static Engine CreateEngine()
+    {
+        var engine = new Engine();
+        engine.Execute(SetupSource);
+        return engine;
+    }
+
     [GlobalSetup]
     public void Setup()
     {
-        _engine = new Engine();
-        _engine.Execute(SetupSource);
-
         // all links present: the chain always completes
-        _optionalChainHit = Engine.PrepareScript("""
+        _optionalChainHit = IsolatedScript.Warm("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 100000; i++) { s += present?.a?.b?.c; }
                 return s;
             }
             f();
-            """);
+            """, CreateEngine);
 
-        _optionalChainMiss = Engine.PrepareScript(OptionalChainMissSource);
-        _nullishCoalesce = Engine.PrepareScript(NullishCoalesceSource);
+        _optionalChainMiss = IsolatedScript.Warm(OptionalChainMissSource, CreateEngine);
+        _nullishCoalesce = IsolatedScript.Warm(NullishCoalesceSource, CreateEngine);
 
         // ??= on a local that is null/undefined/number in unpredictable rotation (~50% nullish)
-        _nullishAssign = Engine.PrepareScript("""
+        _nullishAssign = IsolatedScript.Warm("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
@@ -108,10 +121,10 @@ public class ModernOperatorsBenchmark
                 return s;
             }
             f();
-            """);
+            """, CreateEngine);
 
         // ||= over a 50/50 truthy/falsy local
-        _logicalOrAssign = Engine.PrepareScript("""
+        _logicalOrAssign = IsolatedScript.Warm("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
@@ -122,27 +135,21 @@ public class ModernOperatorsBenchmark
                 return s;
             }
             f();
-            """);
-
-        _engine.Evaluate(_optionalChainHit);
-        _engine.Evaluate(_optionalChainMiss);
-        _engine.Evaluate(_nullishCoalesce);
-        _engine.Evaluate(_nullishAssign);
-        _engine.Evaluate(_logicalOrAssign);
+            """, CreateEngine);
     }
 
     [Benchmark]
-    public JsValue OptionalChainHit() => _engine.Evaluate(_optionalChainHit);
+    public JsValue OptionalChainHit() => _optionalChainHit.Run();
 
     [Benchmark]
-    public JsValue OptionalChainMiss() => _engine.Evaluate(_optionalChainMiss);
+    public JsValue OptionalChainMiss() => _optionalChainMiss.Run();
 
     [Benchmark]
-    public JsValue NullishCoalesce() => _engine.Evaluate(_nullishCoalesce);
+    public JsValue NullishCoalesce() => _nullishCoalesce.Run();
 
     [Benchmark]
-    public JsValue NullishAssign() => _engine.Evaluate(_nullishAssign);
+    public JsValue NullishAssign() => _nullishAssign.Run();
 
     [Benchmark]
-    public JsValue LogicalOrAssign() => _engine.Evaluate(_logicalOrAssign);
+    public JsValue LogicalOrAssign() => _logicalOrAssign.Run();
 }

--- a/Jint.Benchmark/NullCheckBenchmark.cs
+++ b/Jint.Benchmark/NullCheckBenchmark.cs
@@ -8,14 +8,21 @@ namespace Jint.Benchmark;
 /// `== null` form — the shape the build-time loose-equality fusion targets. The array mixes
 /// null/undefined holes with numbers and objects so the branch is not memorizable, exercising the
 /// fused single type test against the generic evaluate-both-sides + IsLooselyEqual dispatch.
+///
+/// <para><b>Engine isolation.</b> Both rows get their own engine, built by <c>CreateEngine</c> (which
+/// installs the shared <c>arr</c> fixture) and warmed with their own script and nothing else (see
+/// <see cref="IsolatedScript"/>). It used to be one shared engine warmed with both scripts, so each row
+/// was measured on an engine carrying the other's globals (both declare <c>f</c>) and its handler-tree
+/// and call-site state. The rows still measure warm dispatch, and engine construction and warm-up stay in
+/// <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from this class are not comparable to any
+/// published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]
 public class NullCheckBenchmark
 {
-    private Engine _engine = null!;
-    private Prepared<Script> _looseNotEqualNull;
-    private Prepared<Script> _looseEqualNull;
+    private IsolatedScript _looseNotEqualNull;
+    private IsolatedScript _looseEqualNull;
 
     private const string SetupSource = """
         var arr = [];
@@ -32,13 +39,18 @@ public class NullCheckBenchmark
         })();
         """;
 
+    /// <summary>Builds a fresh engine carrying the shared <c>arr</c> fixture every row needs.</summary>
+    private static Engine CreateEngine()
+    {
+        var engine = new Engine();
+        engine.Execute(SetupSource);
+        return engine;
+    }
+
     [GlobalSetup]
     public void Setup()
     {
-        _engine = new Engine();
-        _engine.Execute(SetupSource);
-
-        _looseNotEqualNull = Engine.PrepareScript("""
+        _looseNotEqualNull = IsolatedScript.Warm("""
             function f() {
                 var sum = 0;
                 for (var pass = 0; pass < 100; pass++) {
@@ -49,9 +61,9 @@ public class NullCheckBenchmark
                 return sum;
             }
             f();
-            """);
+            """, CreateEngine);
 
-        _looseEqualNull = Engine.PrepareScript("""
+        _looseEqualNull = IsolatedScript.Warm("""
             function f() {
                 var sum = 0;
                 for (var pass = 0; pass < 100; pass++) {
@@ -62,15 +74,12 @@ public class NullCheckBenchmark
                 return sum;
             }
             f();
-            """);
-
-        _engine.Evaluate(_looseNotEqualNull);
-        _engine.Evaluate(_looseEqualNull);
+            """, CreateEngine);
     }
 
     [Benchmark]
-    public JsValue LooseNotEqualNull() => _engine.Evaluate(_looseNotEqualNull);
+    public JsValue LooseNotEqualNull() => _looseNotEqualNull.Run();
 
     [Benchmark]
-    public JsValue LooseEqualNull() => _engine.Evaluate(_looseEqualNull);
+    public JsValue LooseEqualNull() => _looseEqualNull.Run();
 }

--- a/Jint.Benchmark/NumberBenchmarks.cs
+++ b/Jint.Benchmark/NumberBenchmarks.cs
@@ -7,29 +7,36 @@ namespace Jint.Benchmark;
 /// Source-gen sentinel for Number.prototype methods. Pre-source-gen the prototype used handwritten
 /// PropertyDictionary + ClrFunction registration; post-source-gen it's [JsObject] + [JsFunction] +
 /// [ToInteger] for digit args. The warm-path numbers should be equivalent.
+///
+/// <para><b>Engine isolation.</b> Each Warm_ row gets its own engine, warmed with its own script and
+/// nothing else (see <see cref="IsolatedScript"/>). It used to be one shared <c>_warm</c> engine warmed
+/// with all four scripts, so every warm row was measured on an engine already carrying the other rows'
+/// handler-tree and call-site state. The Cold_ rows are unchanged — they build their engine inside the
+/// benchmark method, which is what they are for. <b>Numbers from the warm rows are not comparable to any
+/// published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 public class NumberBenchmarks
 {
-    private Engine _warm = null!;
+    // Shared by the Cold_ rows, which build their own engine per invocation.
     private Prepared<Script> _toFixed;
-    private Prepared<Script> _toString10;
     private Prepared<Script> _toString2;
-    private Prepared<Script> _valueOf;
+
+    private IsolatedScript _warmToFixed;
+    private IsolatedScript _warmToString10;
+    private IsolatedScript _warmToString2;
+    private IsolatedScript _warmValueOf;
 
     [GlobalSetup]
     public void GlobalSetup()
     {
         _toFixed = Engine.PrepareScript("(3.14159).toFixed(2)");
-        _toString10 = Engine.PrepareScript("(255).toString()");
         _toString2 = Engine.PrepareScript("(255).toString(2)");
-        _valueOf = Engine.PrepareScript("(42).valueOf()");
 
-        _warm = new Engine();
-        _warm.Evaluate(_toFixed);
-        _warm.Evaluate(_toString10);
-        _warm.Evaluate(_toString2);
-        _warm.Evaluate(_valueOf);
+        _warmToFixed = IsolatedScript.Warm(_toFixed);
+        _warmToString10 = IsolatedScript.Warm("(255).toString()");
+        _warmToString2 = IsolatedScript.Warm(_toString2);
+        _warmValueOf = IsolatedScript.Warm("(42).valueOf()");
     }
 
     // Cold paths exercise lazy NumberPrototype init + method dispatcher allocation.
@@ -51,14 +58,14 @@ public class NumberBenchmarks
     // Warm paths exercise the inline cache hot path; should be equivalent before/after.
 
     [Benchmark]
-    public JsValue Warm_ToFixed() => _warm.Evaluate(_toFixed);
+    public JsValue Warm_ToFixed() => _warmToFixed.Run();
 
     [Benchmark]
-    public JsValue Warm_ToString10() => _warm.Evaluate(_toString10);
+    public JsValue Warm_ToString10() => _warmToString10.Run();
 
     [Benchmark]
-    public JsValue Warm_ToString2() => _warm.Evaluate(_toString2);
+    public JsValue Warm_ToString2() => _warmToString2.Run();
 
     [Benchmark]
-    public JsValue Warm_ValueOf() => _warm.Evaluate(_valueOf);
+    public JsValue Warm_ValueOf() => _warmValueOf.Run();
 }

--- a/Jint.Benchmark/NumberParseBenchmark.cs
+++ b/Jint.Benchmark/NumberParseBenchmark.cs
@@ -7,17 +7,25 @@ namespace Jint.Benchmark;
 /// Number parsing and formatting in loops — the CSV/JSON-ingestion and UI-formatting shapes:
 /// parseInt/parseFloat/Number() over prebuilt LCG-varied numeric strings, and
 /// toFixed/toString(radix) over varied doubles. 100k operations per op.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine, built by <c>CreateEngine</c> (which
+/// installs the shared <see cref="SetupSource"/> fixture every row needs) and warmed with its own script
+/// and nothing else (see <see cref="IsolatedScript"/>). It used to be one shared engine warmed with all
+/// five scripts, so each row was measured on an engine carrying its siblings' globals (every script
+/// declares <c>f</c>, <c>s</c> and <c>i</c>) and their handler-tree and call-site state. The rows still
+/// measure warm dispatch, and engine construction and warm-up stay in <c>[GlobalSetup]</c>, outside the
+/// measurement. <b>Numbers from this class are not comparable to any published before the harness
+/// changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]
 public class NumberParseBenchmark
 {
-    private Engine _engine = null!;
-    private Prepared<Script> _parseIntLoop;
-    private Prepared<Script> _parseFloatLoop;
-    private Prepared<Script> _numberCoerce;
-    private Prepared<Script> _toFixedLoop;
-    private Prepared<Script> _toStringRadix;
+    private IsolatedScript _parseIntLoop;
+    private IsolatedScript _parseFloatLoop;
+    private IsolatedScript _numberCoerce;
+    private IsolatedScript _toFixedLoop;
+    private IsolatedScript _toStringRadix;
 
     // Mixing is precomputed at setup into `order` (see ModernOperatorsBenchmark note): a
     // per-iteration JS LCG boxes JsNumber transients that would dominate these rows.
@@ -65,15 +73,20 @@ public class NumberParseBenchmark
         f();
         """;
 
+    /// <summary>Builds a fresh engine carrying the shared <see cref="SetupSource"/> fixture every row needs.</summary>
+    private static Engine CreateEngine()
+    {
+        var engine = new Engine();
+        engine.Execute(SetupSource);
+        return engine;
+    }
+
     [GlobalSetup]
     public void Setup()
     {
-        _engine = new Engine();
-        _engine.Execute(SetupSource);
+        _parseIntLoop = IsolatedScript.Warm(ParseIntLoopSource, CreateEngine);
 
-        _parseIntLoop = Engine.PrepareScript(ParseIntLoopSource);
-
-        _parseFloatLoop = Engine.PrepareScript("""
+        _parseFloatLoop = IsolatedScript.Warm("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
@@ -82,9 +95,9 @@ public class NumberParseBenchmark
                 return s;
             }
             f();
-            """);
+            """, CreateEngine);
 
-        _numberCoerce = Engine.PrepareScript("""
+        _numberCoerce = IsolatedScript.Warm("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
@@ -93,11 +106,11 @@ public class NumberParseBenchmark
                 return s;
             }
             f();
-            """);
+            """, CreateEngine);
 
-        _toFixedLoop = Engine.PrepareScript(ToFixedLoopSource);
+        _toFixedLoop = IsolatedScript.Warm(ToFixedLoopSource, CreateEngine);
 
-        _toStringRadix = Engine.PrepareScript("""
+        _toStringRadix = IsolatedScript.Warm("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
@@ -106,27 +119,21 @@ public class NumberParseBenchmark
                 return s;
             }
             f();
-            """);
-
-        _engine.Evaluate(_parseIntLoop);
-        _engine.Evaluate(_parseFloatLoop);
-        _engine.Evaluate(_numberCoerce);
-        _engine.Evaluate(_toFixedLoop);
-        _engine.Evaluate(_toStringRadix);
+            """, CreateEngine);
     }
 
     [Benchmark]
-    public JsValue ParseIntLoop() => _engine.Evaluate(_parseIntLoop);
+    public JsValue ParseIntLoop() => _parseIntLoop.Run();
 
     [Benchmark]
-    public JsValue ParseFloatLoop() => _engine.Evaluate(_parseFloatLoop);
+    public JsValue ParseFloatLoop() => _parseFloatLoop.Run();
 
     [Benchmark]
-    public JsValue NumberCoerce() => _engine.Evaluate(_numberCoerce);
+    public JsValue NumberCoerce() => _numberCoerce.Run();
 
     [Benchmark]
-    public JsValue ToFixedLoop() => _engine.Evaluate(_toFixedLoop);
+    public JsValue ToFixedLoop() => _toFixedLoop.Run();
 
     [Benchmark]
-    public JsValue ToStringRadix() => _engine.Evaluate(_toStringRadix);
+    public JsValue ToStringRadix() => _toStringRadix.Run();
 }

--- a/Jint.Benchmark/ObjectPrototypeBenchmarks.cs
+++ b/Jint.Benchmark/ObjectPrototypeBenchmarks.cs
@@ -7,46 +7,45 @@ namespace Jint.Benchmark;
 /// Source-gen sentinel for Object.prototype.{toString,hasOwnProperty,valueOf} and the __proto__
 /// accessor. Post-source-gen the prototype uses [JsFunction] for the methods and [JsAccessor] for
 /// __proto__'s get/set pair. Warm-path numbers should match the pre-source-gen baseline.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine, warmed with its own script and nothing
+/// else (see <see cref="IsolatedScript"/>). It used to be one shared <c>_warm</c> engine warmed with all
+/// five scripts, so each row was measured on an engine already carrying the other rows' handler-tree and
+/// call-site state. The rows still measure warm dispatch, and engine construction and warm-up stay in
+/// <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from this class are not comparable to any
+/// published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 public class ObjectPrototypeBenchmarks
 {
-    private Engine _warm = null!;
-    private Prepared<Script> _toString;
-    private Prepared<Script> _hasOwn;
-    private Prepared<Script> _isPrototypeOf;
-    private Prepared<Script> _protoGet;
-    private Prepared<Script> _propertyIsEnumerable;
+    private IsolatedScript _toString;
+    private IsolatedScript _hasOwn;
+    private IsolatedScript _isPrototypeOf;
+    private IsolatedScript _protoGet;
+    private IsolatedScript _propertyIsEnumerable;
 
     [GlobalSetup]
     public void GlobalSetup()
     {
-        _toString             = Engine.PrepareScript("({a:1}).toString()");
-        _hasOwn               = Engine.PrepareScript("({a:1}).hasOwnProperty('a')");
-        _isPrototypeOf        = Engine.PrepareScript("Object.prototype.isPrototypeOf({a:1})");
-        _protoGet             = Engine.PrepareScript("({a:1}).__proto__");
-        _propertyIsEnumerable = Engine.PrepareScript("({a:1}).propertyIsEnumerable('a')");
-
-        _warm = new Engine();
-        _warm.Evaluate(_toString);
-        _warm.Evaluate(_hasOwn);
-        _warm.Evaluate(_isPrototypeOf);
-        _warm.Evaluate(_protoGet);
-        _warm.Evaluate(_propertyIsEnumerable);
+        _toString             = IsolatedScript.Warm("({a:1}).toString()");
+        _hasOwn               = IsolatedScript.Warm("({a:1}).hasOwnProperty('a')");
+        _isPrototypeOf        = IsolatedScript.Warm("Object.prototype.isPrototypeOf({a:1})");
+        _protoGet             = IsolatedScript.Warm("({a:1}).__proto__");
+        _propertyIsEnumerable = IsolatedScript.Warm("({a:1}).propertyIsEnumerable('a')");
     }
 
     [Benchmark]
-    public JsValue Warm_ToString() => _warm.Evaluate(_toString);
+    public JsValue Warm_ToString() => _toString.Run();
 
     [Benchmark]
-    public JsValue Warm_HasOwnProperty() => _warm.Evaluate(_hasOwn);
+    public JsValue Warm_HasOwnProperty() => _hasOwn.Run();
 
     [Benchmark]
-    public JsValue Warm_IsPrototypeOf() => _warm.Evaluate(_isPrototypeOf);
+    public JsValue Warm_IsPrototypeOf() => _isPrototypeOf.Run();
 
     [Benchmark]
-    public JsValue Warm_ProtoGet() => _warm.Evaluate(_protoGet);
+    public JsValue Warm_ProtoGet() => _protoGet.Run();
 
     [Benchmark]
-    public JsValue Warm_PropertyIsEnumerable() => _warm.Evaluate(_propertyIsEnumerable);
+    public JsValue Warm_PropertyIsEnumerable() => _propertyIsEnumerable.Run();
 }

--- a/Jint.Benchmark/ObjectSpreadBenchmark.cs
+++ b/Jint.Benchmark/ObjectSpreadBenchmark.cs
@@ -8,21 +8,30 @@ namespace Jint.Benchmark;
 /// <c>Object.fromEntries</c>, all copying from stable source objects in a hot loop.
 /// <see cref="LiteralClone"/> is the baseline — a plain shaped literal with the same four
 /// properties — so every other row reads as a multiple of the layout-equivalent literal cost.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine, built by <c>CreateEngine</c> (which
+/// installs the shared <see cref="SetupSource"/> fixture every row needs) and warmed with its own script
+/// and nothing else (see <see cref="IsolatedScript"/>). It used to be one shared engine warmed with all
+/// nine scripts, so each row was measured on an engine carrying its siblings' globals (every script
+/// declares <c>f</c>, <c>c</c> and <c>i</c>) and their handler-tree, call-site and object-shape state —
+/// and <see cref="AssignExistingTarget"/> mutates the shared <c>acc</c> fixture, which every other row's
+/// warm-up then saw. The rows still measure warm dispatch, and engine construction and warm-up stay in
+/// <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from this class are not comparable to any
+/// published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]
 public class ObjectSpreadBenchmark
 {
-    private Engine _engine = null!;
-    private Prepared<Script> _literalClone;
-    private Prepared<Script> _spreadSmall;
-    private Prepared<Script> _spreadSmallOverride;
-    private Prepared<Script> _spreadLarge;
-    private Prepared<Script> _spreadTwoSources;
-    private Prepared<Script> _assignFreshTarget;
-    private Prepared<Script> _assignExistingTarget;
-    private Prepared<Script> _restDestructuring;
-    private Prepared<Script> _fromEntriesPairs;
+    private IsolatedScript _literalClone;
+    private IsolatedScript _spreadSmall;
+    private IsolatedScript _spreadSmallOverride;
+    private IsolatedScript _spreadLarge;
+    private IsolatedScript _spreadTwoSources;
+    private IsolatedScript _assignFreshTarget;
+    private IsolatedScript _assignExistingTarget;
+    private IsolatedScript _restDestructuring;
+    private IsolatedScript _fromEntriesPairs;
 
     internal const string SetupSource = """
         var o = { a: 1, b: 2, c: 3, d: 4 };
@@ -52,88 +61,83 @@ public class ObjectSpreadBenchmark
         f();
         """;
 
+    /// <summary>Builds a fresh engine carrying the shared <see cref="SetupSource"/> fixture every row needs.</summary>
+    private static Engine CreateEngine()
+    {
+        var engine = new Engine();
+        engine.Execute(SetupSource);
+        return engine;
+    }
+
     [GlobalSetup]
     public void Setup()
     {
-        _engine = new Engine();
-        _engine.Execute(SetupSource);
-
         // the layout-equivalent shaped literal: what a 4-prop copy costs when built as a literal
-        _literalClone = Engine.PrepareScript("""
+        _literalClone = IsolatedScript.Warm("""
             function f() { var c; for (var i = 0; i < 100000; i++) { c = { a: o.a, b: o.b, c: o.c, d: o.d }; } return c.d; }
             f();
-            """);
+            """, CreateEngine);
 
-        _spreadSmall = Engine.PrepareScript(SpreadSmallSource);
+        _spreadSmall = IsolatedScript.Warm(SpreadSmallSource, CreateEngine);
 
         // spread + trailing static override — the {...defaults, x} config-merge shape
-        _spreadSmallOverride = Engine.PrepareScript("""
+        _spreadSmallOverride = IsolatedScript.Warm("""
             function f() { var c; for (var i = 0; i < 100000; i++) { c = { ...o, d: i }; } return c.d; }
             f();
-            """);
+            """, CreateEngine);
 
         // 24-prop source: beyond the 4-slot inline capacity and the 16-key linear-scan limit
-        _spreadLarge = Engine.PrepareScript("""
+        _spreadLarge = IsolatedScript.Warm("""
             function f() { var c; for (var i = 0; i < 10000; i++) { c = { ...wide }; } return c.p23; }
             f();
-            """);
+            """, CreateEngine);
 
         // the two-source options-merge shape
-        _spreadTwoSources = Engine.PrepareScript("""
+        _spreadTwoSources = IsolatedScript.Warm("""
             function f() { var c; for (var i = 0; i < 100000; i++) { c = { ...half1, ...half2 }; } return c.d; }
             f();
-            """);
+            """, CreateEngine);
 
-        _assignFreshTarget = Engine.PrepareScript(AssignFreshTargetSource);
+        _assignFreshTarget = IsolatedScript.Warm(AssignFreshTargetSource, CreateEngine);
 
         // assign onto a long-lived target: pure overwrite, no object creation
-        _assignExistingTarget = Engine.PrepareScript("""
+        _assignExistingTarget = IsolatedScript.Warm("""
             function f() { for (var i = 0; i < 100000; i++) { Object.assign(acc, o); } return acc.d; }
             f();
-            """);
+            """, CreateEngine);
 
-        _restDestructuring = Engine.PrepareScript(RestDestructuringSource);
+        _restDestructuring = IsolatedScript.Warm(RestDestructuringSource, CreateEngine);
 
-        _fromEntriesPairs = Engine.PrepareScript("""
+        _fromEntriesPairs = IsolatedScript.Warm("""
             function f() { var c; for (var i = 0; i < 10000; i++) { c = Object.fromEntries(pairs); } return c.d; }
             f();
-            """);
-
-        _engine.Evaluate(_literalClone);
-        _engine.Evaluate(_spreadSmall);
-        _engine.Evaluate(_spreadSmallOverride);
-        _engine.Evaluate(_spreadLarge);
-        _engine.Evaluate(_spreadTwoSources);
-        _engine.Evaluate(_assignFreshTarget);
-        _engine.Evaluate(_assignExistingTarget);
-        _engine.Evaluate(_restDestructuring);
-        _engine.Evaluate(_fromEntriesPairs);
+            """, CreateEngine);
     }
 
     [Benchmark(Baseline = true)]
-    public JsValue LiteralClone() => _engine.Evaluate(_literalClone);
+    public JsValue LiteralClone() => _literalClone.Run();
 
     [Benchmark]
-    public JsValue SpreadSmall() => _engine.Evaluate(_spreadSmall);
+    public JsValue SpreadSmall() => _spreadSmall.Run();
 
     [Benchmark]
-    public JsValue SpreadSmallOverride() => _engine.Evaluate(_spreadSmallOverride);
+    public JsValue SpreadSmallOverride() => _spreadSmallOverride.Run();
 
     [Benchmark]
-    public JsValue SpreadLarge() => _engine.Evaluate(_spreadLarge);
+    public JsValue SpreadLarge() => _spreadLarge.Run();
 
     [Benchmark]
-    public JsValue SpreadTwoSources() => _engine.Evaluate(_spreadTwoSources);
+    public JsValue SpreadTwoSources() => _spreadTwoSources.Run();
 
     [Benchmark]
-    public JsValue AssignFreshTarget() => _engine.Evaluate(_assignFreshTarget);
+    public JsValue AssignFreshTarget() => _assignFreshTarget.Run();
 
     [Benchmark]
-    public JsValue AssignExistingTarget() => _engine.Evaluate(_assignExistingTarget);
+    public JsValue AssignExistingTarget() => _assignExistingTarget.Run();
 
     [Benchmark]
-    public JsValue RestDestructuring() => _engine.Evaluate(_restDestructuring);
+    public JsValue RestDestructuring() => _restDestructuring.Run();
 
     [Benchmark]
-    public JsValue FromEntriesPairs() => _engine.Evaluate(_fromEntriesPairs);
+    public JsValue FromEntriesPairs() => _fromEntriesPairs.Run();
 }

--- a/Jint.Benchmark/PlainNumericAssignBenchmark.cs
+++ b/Jint.Benchmark/PlainNumericAssignBenchmark.cs
@@ -7,42 +7,43 @@ namespace Jint.Benchmark;
 /// Function-local plain numeric assignment `lhs = a op b` (NOT compound `+=`, which already has an
 /// unboxed slot path). The accumulator `s = s + i` is the micro-loop-sum shape: every iteration's
 /// result is an uncached double that otherwise materializes a JsNumber.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine, warmed with its own script and nothing
+/// else (see <see cref="IsolatedScript"/>). It used to be one shared engine warmed with all three
+/// scripts, so each row was measured on an engine carrying its siblings' globals (all three declare
+/// <c>f</c>) and their handler-tree and call-site state. The rows still measure warm dispatch, and engine
+/// construction and warm-up stay in <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from this
+/// class are not comparable to any published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 [HideColumns("Error", "StdDev", "Median", "Gen0", "Gen1", "Gen2")]
 public class PlainNumericAssignBenchmark
 {
-    private Engine _engine = null!;
-    private Prepared<Script> _sumAssign;
-    private Prepared<Script> _divAssign;
-    private Prepared<Script> _mixed;
+    private IsolatedScript _sumAssign;
+    private IsolatedScript _divAssign;
+    private IsolatedScript _mixed;
 
     [GlobalSetup]
     public void Setup()
     {
-        _sumAssign = Engine.PrepareScript("""
+        _sumAssign = IsolatedScript.Warm("""
             function f() { var s = 0.5; for (var i = 0; i < 1000000; i++) { s = s + i; } return s; }
             f();
             """);
 
-        _divAssign = Engine.PrepareScript("""
+        _divAssign = IsolatedScript.Warm("""
             function f() { var s = 1e30, h = 1.0000001; for (var i = 0; i < 1000000; i++) { s = s / h; if (s < 1) s = 1e30; } return s; }
             f();
             """);
 
         // lhs distinct from rhs operands: d = a - b with a moving accumulator
-        _mixed = Engine.PrepareScript("""
+        _mixed = IsolatedScript.Warm("""
             function f() { var a = 0.0, b = 0.25, d = 0.0; for (var i = 0; i < 1000000; i++) { a = a + b; d = a - b; } return d; }
             f();
             """);
-
-        _engine = new Engine();
-        _engine.Evaluate(_sumAssign);
-        _engine.Evaluate(_divAssign);
-        _engine.Evaluate(_mixed);
     }
 
-    [Benchmark] public JsValue SumAssign() => _engine.Evaluate(_sumAssign);
-    [Benchmark] public JsValue DivAssign() => _engine.Evaluate(_divAssign);
-    [Benchmark] public JsValue Mixed() => _engine.Evaluate(_mixed);
+    [Benchmark] public JsValue SumAssign() => _sumAssign.Run();
+    [Benchmark] public JsValue DivAssign() => _divAssign.Run();
+    [Benchmark] public JsValue Mixed() => _mixed.Run();
 }

--- a/Jint.Benchmark/PropertyKeyInternBenchmarks.cs
+++ b/Jint.Benchmark/PropertyKeyInternBenchmarks.cs
@@ -15,25 +15,33 @@ namespace Jint.Benchmark;
 ///   - Mixed common/rare: half hit, half miss → measures the miss path's cost (which still hashes
 ///     and probes via the existing dictionary).
 ///   - All-rare keys (user-domain names): all-miss baseline. Phase 4 should leave this unchanged.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine, warmed with its own script and nothing
+/// else (see <see cref="IsolatedScript"/>). It used to be one shared <c>_warm</c> engine warmed with all
+/// five scripts, so each row was measured on an engine carrying its siblings' globals (four of the five
+/// scripts declare <c>o</c>, <c>s</c> and <c>i</c>) and their handler-tree and call-site state — which on
+/// a property-name bench also meant the other rows' key set was already interned. The rows still measure
+/// warm dispatch, and engine construction and warm-up stay in <c>[GlobalSetup]</c>, outside the
+/// measurement. <b>Numbers from this class are not comparable to any published before the harness
+/// changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 public class PropertyKeyInternBenchmarks
 {
     private const int OperationsPerInvoke = 1_000;
 
-    private Engine _warm = null!;
-    private Prepared<Script> _commonKeys;
-    private Prepared<Script> _rareKeys;
-    private Prepared<Script> _mixedKeys;
-    private Prepared<Script> _arrayLengthTightLoop;
-    private Prepared<Script> _objectKeysTightLoop;
+    private IsolatedScript _commonKeys;
+    private IsolatedScript _rareKeys;
+    private IsolatedScript _mixedKeys;
+    private IsolatedScript _arrayLengthTightLoop;
+    private IsolatedScript _objectKeysTightLoop;
 
     [GlobalSetup]
     public void GlobalSetup()
     {
         // Common keys: every name appears in built-in surfaces, so they're prime candidates for
         // the perfect-hash hit path.
-        _commonKeys = Engine.PrepareScript(@"
+        _commonKeys = IsolatedScript.Warm(@"
             var o = {length:1, value:2, next:3, constructor:4, name:5, prototype:6};
             var s = 0;
             for (var i = 0; i < 1000; i++) {
@@ -43,7 +51,7 @@ public class PropertyKeyInternBenchmarks
         ");
 
         // Rare keys: user-domain names that won't be in the perfect-hash table.
-        _rareKeys = Engine.PrepareScript(@"
+        _rareKeys = IsolatedScript.Warm(@"
             var o = {alpha:1, bravo:2, charlie:3, delta:4, echo:5, foxtrot:6};
             var s = 0;
             for (var i = 0; i < 1000; i++) {
@@ -53,7 +61,7 @@ public class PropertyKeyInternBenchmarks
         ");
 
         // Mixed: 3 common, 3 rare.
-        _mixedKeys = Engine.PrepareScript(@"
+        _mixedKeys = IsolatedScript.Warm(@"
             var o = {length:1, value:2, next:3, alpha:4, bravo:5, charlie:6};
             var s = 0;
             for (var i = 0; i < 1000; i++) {
@@ -63,36 +71,29 @@ public class PropertyKeyInternBenchmarks
         ");
 
         // .length is the single most common property access — measure it in isolation.
-        _arrayLengthTightLoop = Engine.PrepareScript("var a = [1,2,3,4,5]; var s = 0; for (var i = 0; i < 1000; i++) s += a.length; s");
+        _arrayLengthTightLoop = IsolatedScript.Warm("var a = [1,2,3,4,5]; var s = 0; for (var i = 0; i < 1000; i++) s += a.length; s");
 
         // Object.keys returns a list of property names — exercises the name-allocation path.
-        _objectKeysTightLoop = Engine.PrepareScript(@"
+        _objectKeysTightLoop = IsolatedScript.Warm(@"
             var o = {a:1, b:2, c:3, d:4, e:5};
             var n = 0;
             for (var i = 0; i < 1000; i++) n += Object.keys(o).length;
             n
         ");
-
-        _warm = new Engine();
-        _warm.Evaluate(_commonKeys);
-        _warm.Evaluate(_rareKeys);
-        _warm.Evaluate(_mixedKeys);
-        _warm.Evaluate(_arrayLengthTightLoop);
-        _warm.Evaluate(_objectKeysTightLoop);
     }
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue Warm_CommonKeys() => _warm.Evaluate(_commonKeys);
+    public JsValue Warm_CommonKeys() => _commonKeys.Run();
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue Warm_RareKeys() => _warm.Evaluate(_rareKeys);
+    public JsValue Warm_RareKeys() => _rareKeys.Run();
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue Warm_MixedKeys() => _warm.Evaluate(_mixedKeys);
+    public JsValue Warm_MixedKeys() => _mixedKeys.Run();
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue Warm_ArrayLength() => _warm.Evaluate(_arrayLengthTightLoop);
+    public JsValue Warm_ArrayLength() => _arrayLengthTightLoop.Run();
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue Warm_ObjectKeys() => _warm.Evaluate(_objectKeysTightLoop);
+    public JsValue Warm_ObjectKeys() => _objectKeysTightLoop.Run();
 }

--- a/Jint.Benchmark/ProxyBenchmark.cs
+++ b/Jint.Benchmark/ProxyBenchmark.cs
@@ -14,30 +14,42 @@ namespace Jint.Benchmark;
 /// per-operation trap machinery — handler lookup, trap invocation and invariant checks.
 /// The Clr* rows mirror the JS-handler rows 1:1 using the .NET <see cref="ProxyHandler"/>
 /// trap API (Engine.Advanced.CreateProxy) over the same target objects.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine, built by <c>CreateEngine</c> (which
+/// installs the shared <see cref="SetupSource"/> fixture and the three CLR-handler proxies every row
+/// needs) and warmed with its own script and nothing else (see <see cref="IsolatedScript"/>). It used to
+/// be one shared engine warmed with all eighteen scripts, so each row was measured on an engine carrying
+/// seventeen siblings' globals (every script declares <c>f</c>, <c>s</c> and <c>i</c>) plus their
+/// handler-tree and call-site state. It also coupled the rows through the fixture: the set lanes drive
+/// <c>target.x</c> to 99999, which every get lane then read. Isolation gives each row a pristine
+/// <c>target.x === 1</c>, which is why the ClrTrapGet/ClrForwardGet sanity expectations below are now
+/// 100000 rather than 9999900000 — the same 100000 reads, of 1 instead of 99999. The rows still measure
+/// warm dispatch, and engine construction and warm-up stay in <c>[GlobalSetup]</c>, outside the
+/// measurement. <b>Numbers from this class are not comparable to any published before the harness
+/// changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]
 public class ProxyBenchmark
 {
-    private Engine _engine = null!;
-    private Prepared<Script> _trapGet;
-    private Prepared<Script> _trapSet;
-    private Prepared<Script> _trapHas;
-    private Prepared<Script> _forwardGet;
-    private Prepared<Script> _forwardSet;
-    private Prepared<Script> _ownKeysTrap;
-    private Prepared<Script> _ownKeysForward;
-    private Prepared<Script> _applyTrap;
-    private Prepared<Script> _applyForward;
-    private Prepared<Script> _constructTrap;
-    private Prepared<Script> _revocableCreate;
-    private Prepared<Script> _revokedTypeof;
-    private Prepared<Script> _clrTrapGet;
-    private Prepared<Script> _clrTrapSet;
-    private Prepared<Script> _clrTrapHas;
-    private Prepared<Script> _clrForwardGet;
-    private Prepared<Script> _clrApplyTrap;
-    private Prepared<Script> _clrConstructTrap;
+    private IsolatedScript _trapGet;
+    private IsolatedScript _trapSet;
+    private IsolatedScript _trapHas;
+    private IsolatedScript _forwardGet;
+    private IsolatedScript _forwardSet;
+    private IsolatedScript _ownKeysTrap;
+    private IsolatedScript _ownKeysForward;
+    private IsolatedScript _applyTrap;
+    private IsolatedScript _applyForward;
+    private IsolatedScript _constructTrap;
+    private IsolatedScript _revocableCreate;
+    private IsolatedScript _revokedTypeof;
+    private IsolatedScript _clrTrapGet;
+    private IsolatedScript _clrTrapSet;
+    private IsolatedScript _clrTrapHas;
+    private IsolatedScript _clrForwardGet;
+    private IsolatedScript _clrApplyTrap;
+    private IsolatedScript _clrConstructTrap;
 
     private const string SetupSource = """
         var target = { x: 1, a: 2, b: 3, c: 4, d: 5, e: 6, f: 7, g: 8, h: 9, k: 10 };
@@ -58,20 +70,28 @@ public class ProxyBenchmark
         revokedFn.revoke();
         """;
 
+    /// <summary>
+    /// Builds a fresh engine carrying the shared <see cref="SetupSource"/> fixture and the CLR-handler
+    /// proxies every row needs.
+    /// </summary>
+    private static Engine CreateEngine()
+    {
+        var engine = new Engine();
+        engine.Execute(SetupSource);
+
+        // CLR-handler proxies over the same targets as the JS-handler lanes
+        var target = (ObjectInstance) engine.GetValue("target");
+        var fnTarget = (ObjectInstance) engine.GetValue("fnTarget");
+        engine.SetValue("pClrTrap", engine.Advanced.CreateProxy(target, new TrappingClrHandler()));
+        engine.SetValue("pClrForward", engine.Advanced.CreateProxy(target, new ForwardingClrHandler()));
+        engine.SetValue("fClrTrap", engine.Advanced.CreateProxy(fnTarget, new ApplyClrHandler()));
+        return engine;
+    }
+
     [GlobalSetup]
     public void Setup()
     {
-        _engine = new Engine();
-        _engine.Execute(SetupSource);
-
-        // CLR-handler proxies over the same targets as the JS-handler lanes
-        var target = (ObjectInstance) _engine.GetValue("target");
-        var fnTarget = (ObjectInstance) _engine.GetValue("fnTarget");
-        _engine.SetValue("pClrTrap", _engine.Advanced.CreateProxy(target, new TrappingClrHandler()));
-        _engine.SetValue("pClrForward", _engine.Advanced.CreateProxy(target, new ForwardingClrHandler()));
-        _engine.SetValue("fClrTrap", _engine.Advanced.CreateProxy(fnTarget, new ApplyClrHandler()));
-
-        _trapGet = Engine.PrepareScript("""
+        _trapGet = IsolatedScript.Warm("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
@@ -80,9 +100,9 @@ public class ProxyBenchmark
                 return s;
             }
             f();
-            """);
+            """, CreateEngine);
 
-        _trapSet = Engine.PrepareScript("""
+        _trapSet = IsolatedScript.Warm("""
             function f() {
                 for (var i = 0; i < 100000; i++) {
                     pTrap.x = i;
@@ -90,9 +110,9 @@ public class ProxyBenchmark
                 return pTrap.x;
             }
             f();
-            """);
+            """, CreateEngine);
 
-        _trapHas = Engine.PrepareScript("""
+        _trapHas = IsolatedScript.Warm("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
@@ -101,9 +121,9 @@ public class ProxyBenchmark
                 return s;
             }
             f();
-            """);
+            """, CreateEngine);
 
-        _forwardGet = Engine.PrepareScript("""
+        _forwardGet = IsolatedScript.Warm("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
@@ -112,9 +132,9 @@ public class ProxyBenchmark
                 return s;
             }
             f();
-            """);
+            """, CreateEngine);
 
-        _forwardSet = Engine.PrepareScript("""
+        _forwardSet = IsolatedScript.Warm("""
             function f() {
                 for (var i = 0; i < 100000; i++) {
                     pForward.x = i;
@@ -122,9 +142,9 @@ public class ProxyBenchmark
                 return pForward.x;
             }
             f();
-            """);
+            """, CreateEngine);
 
-        _ownKeysTrap = Engine.PrepareScript("""
+        _ownKeysTrap = IsolatedScript.Warm("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 10000; i++) {
@@ -133,9 +153,9 @@ public class ProxyBenchmark
                 return s;
             }
             f();
-            """);
+            """, CreateEngine);
 
-        _ownKeysForward = Engine.PrepareScript("""
+        _ownKeysForward = IsolatedScript.Warm("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 10000; i++) {
@@ -144,9 +164,9 @@ public class ProxyBenchmark
                 return s;
             }
             f();
-            """);
+            """, CreateEngine);
 
-        _applyTrap = Engine.PrepareScript("""
+        _applyTrap = IsolatedScript.Warm("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
@@ -155,9 +175,9 @@ public class ProxyBenchmark
                 return s;
             }
             f();
-            """);
+            """, CreateEngine);
 
-        _applyForward = Engine.PrepareScript("""
+        _applyForward = IsolatedScript.Warm("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
@@ -166,11 +186,11 @@ public class ProxyBenchmark
                 return s;
             }
             f();
-            """);
+            """, CreateEngine);
 
         // two arguments on purpose: a single numeric ctor argument currently trips Array(n)
         // length semantics when JsProxy builds the trap's argumentsList (see JsProxy.Construct)
-        _constructTrap = Engine.PrepareScript("""
+        _constructTrap = IsolatedScript.Warm("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 10000; i++) {
@@ -179,9 +199,9 @@ public class ProxyBenchmark
                 return s;
             }
             f();
-            """);
+            """, CreateEngine);
 
-        _revocableCreate = Engine.PrepareScript("""
+        _revocableCreate = IsolatedScript.Warm("""
             function f() {
                 var n = 0;
                 for (var i = 0; i < 10000; i++) {
@@ -192,10 +212,10 @@ public class ProxyBenchmark
                 return n;
             }
             f();
-            """);
+            """, CreateEngine);
 
         // typeof does not consult the handler; it must stay 'function' and not throw after revoke
-        _revokedTypeof = Engine.PrepareScript("""
+        _revokedTypeof = IsolatedScript.Warm("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
@@ -204,9 +224,9 @@ public class ProxyBenchmark
                 return s;
             }
             f();
-            """);
+            """, CreateEngine);
 
-        _clrTrapGet = Engine.PrepareScript("""
+        _clrTrapGet = IsolatedScript.Warm("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
@@ -215,9 +235,9 @@ public class ProxyBenchmark
                 return s;
             }
             f();
-            """);
+            """, CreateEngine);
 
-        _clrTrapSet = Engine.PrepareScript("""
+        _clrTrapSet = IsolatedScript.Warm("""
             function f() {
                 for (var i = 0; i < 100000; i++) {
                     pClrTrap.x = i;
@@ -225,9 +245,9 @@ public class ProxyBenchmark
                 return pClrTrap.x;
             }
             f();
-            """);
+            """, CreateEngine);
 
-        _clrTrapHas = Engine.PrepareScript("""
+        _clrTrapHas = IsolatedScript.Warm("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
@@ -236,9 +256,9 @@ public class ProxyBenchmark
                 return s;
             }
             f();
-            """);
+            """, CreateEngine);
 
-        _clrForwardGet = Engine.PrepareScript("""
+        _clrForwardGet = IsolatedScript.Warm("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
@@ -247,9 +267,9 @@ public class ProxyBenchmark
                 return s;
             }
             f();
-            """);
+            """, CreateEngine);
 
-        _clrApplyTrap = Engine.PrepareScript("""
+        _clrApplyTrap = IsolatedScript.Warm("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
@@ -258,9 +278,9 @@ public class ProxyBenchmark
                 return s;
             }
             f();
-            """);
+            """, CreateEngine);
 
-        _clrConstructTrap = Engine.PrepareScript("""
+        _clrConstructTrap = IsolatedScript.Warm("""
             function f() {
                 var s = 0;
                 for (var i = 0; i < 10000; i++) {
@@ -269,29 +289,18 @@ public class ProxyBenchmark
                 return s;
             }
             f();
-            """);
+            """, CreateEngine);
 
-        _engine.Evaluate(_trapGet);
-        _engine.Evaluate(_trapSet);
-        _engine.Evaluate(_trapHas);
-        _engine.Evaluate(_forwardGet);
-        _engine.Evaluate(_forwardSet);
-        _engine.Evaluate(_ownKeysTrap);
-        _engine.Evaluate(_ownKeysForward);
-        _engine.Evaluate(_applyTrap);
-        _engine.Evaluate(_applyForward);
-        _engine.Evaluate(_constructTrap);
-        _engine.Evaluate(_revocableCreate);
-        _engine.Evaluate(_revokedTypeof);
-
-        // warm the CLR lanes and sanity-check the trap wiring; ClrTrapSet runs first so
-        // target.x is a known 99999 before the get lanes read it
-        AssertResult(_engine.Evaluate(_clrTrapSet), 99_999, nameof(ClrTrapSet));
-        AssertResult(_engine.Evaluate(_clrTrapGet), 9_999_900_000, nameof(ClrTrapGet));
-        AssertResult(_engine.Evaluate(_clrTrapHas), 100_000, nameof(ClrTrapHas));
-        AssertResult(_engine.Evaluate(_clrForwardGet), 9_999_900_000, nameof(ClrForwardGet));
-        AssertResult(_engine.Evaluate(_clrApplyTrap), 5_000_050_000, nameof(ClrApplyTrap));
-        AssertResult(_engine.Evaluate(_clrConstructTrap), 49_995_000, nameof(ClrConstructTrap));
+        // Sanity-check the CLR trap wiring. Each lane re-runs its own script on its own already-warmed
+        // engine, so no lane's fixture state can reach another's — which is why the get lanes now expect
+        // 100000 (100000 reads of the pristine target.x === 1) instead of the 9999900000 they returned
+        // when ClrTrapSet had first driven the shared target.x to 99999.
+        AssertResult(_clrTrapSet.Run(), 99_999, nameof(ClrTrapSet));
+        AssertResult(_clrTrapGet.Run(), 100_000, nameof(ClrTrapGet));
+        AssertResult(_clrTrapHas.Run(), 100_000, nameof(ClrTrapHas));
+        AssertResult(_clrForwardGet.Run(), 100_000, nameof(ClrForwardGet));
+        AssertResult(_clrApplyTrap.Run(), 5_000_050_000, nameof(ClrApplyTrap));
+        AssertResult(_clrConstructTrap.Run(), 49_995_000, nameof(ClrConstructTrap));
     }
 
     private static void AssertResult(JsValue actual, double expected, string lane)
@@ -303,58 +312,58 @@ public class ProxyBenchmark
     }
 
     [Benchmark]
-    public JsValue TrapGet() => _engine.Evaluate(_trapGet);
+    public JsValue TrapGet() => _trapGet.Run();
 
     [Benchmark]
-    public JsValue TrapSet() => _engine.Evaluate(_trapSet);
+    public JsValue TrapSet() => _trapSet.Run();
 
     [Benchmark]
-    public JsValue TrapHas() => _engine.Evaluate(_trapHas);
+    public JsValue TrapHas() => _trapHas.Run();
 
     [Benchmark]
-    public JsValue ForwardGet() => _engine.Evaluate(_forwardGet);
+    public JsValue ForwardGet() => _forwardGet.Run();
 
     [Benchmark]
-    public JsValue ForwardSet() => _engine.Evaluate(_forwardSet);
+    public JsValue ForwardSet() => _forwardSet.Run();
 
     [Benchmark]
-    public JsValue OwnKeysTrap() => _engine.Evaluate(_ownKeysTrap);
+    public JsValue OwnKeysTrap() => _ownKeysTrap.Run();
 
     [Benchmark]
-    public JsValue OwnKeysForward() => _engine.Evaluate(_ownKeysForward);
+    public JsValue OwnKeysForward() => _ownKeysForward.Run();
 
     [Benchmark]
-    public JsValue ApplyTrap() => _engine.Evaluate(_applyTrap);
+    public JsValue ApplyTrap() => _applyTrap.Run();
 
     [Benchmark]
-    public JsValue ApplyForward() => _engine.Evaluate(_applyForward);
+    public JsValue ApplyForward() => _applyForward.Run();
 
     [Benchmark]
-    public JsValue ConstructTrap() => _engine.Evaluate(_constructTrap);
+    public JsValue ConstructTrap() => _constructTrap.Run();
 
     [Benchmark]
-    public JsValue RevocableCreate() => _engine.Evaluate(_revocableCreate);
+    public JsValue RevocableCreate() => _revocableCreate.Run();
 
     [Benchmark]
-    public JsValue RevokedTypeof() => _engine.Evaluate(_revokedTypeof);
+    public JsValue RevokedTypeof() => _revokedTypeof.Run();
 
     [Benchmark]
-    public JsValue ClrTrapGet() => _engine.Evaluate(_clrTrapGet);
+    public JsValue ClrTrapGet() => _clrTrapGet.Run();
 
     [Benchmark]
-    public JsValue ClrTrapSet() => _engine.Evaluate(_clrTrapSet);
+    public JsValue ClrTrapSet() => _clrTrapSet.Run();
 
     [Benchmark]
-    public JsValue ClrTrapHas() => _engine.Evaluate(_clrTrapHas);
+    public JsValue ClrTrapHas() => _clrTrapHas.Run();
 
     [Benchmark]
-    public JsValue ClrForwardGet() => _engine.Evaluate(_clrForwardGet);
+    public JsValue ClrForwardGet() => _clrForwardGet.Run();
 
     [Benchmark]
-    public JsValue ClrApplyTrap() => _engine.Evaluate(_clrApplyTrap);
+    public JsValue ClrApplyTrap() => _clrApplyTrap.Run();
 
     [Benchmark]
-    public JsValue ClrConstructTrap() => _engine.Evaluate(_clrConstructTrap);
+    public JsValue ClrConstructTrap() => _clrConstructTrap.Run();
 
     /// <summary>
     /// CLR equivalent of the JS handler <c>{ get: (t, k) => t[k], set: (t, k, v) => (t[k] = v, true), has: (t, k) => k in t }</c>.

--- a/Jint.Benchmark/RegExpExecLoopBenchmark.cs
+++ b/Jint.Benchmark/RegExpExecLoopBenchmark.cs
@@ -8,16 +8,25 @@ namespace Jint.Benchmark;
 /// <c>exec()</c> while-loop, <c>matchAll</c> iteration, named-group access per match, and a
 /// sticky-flag scanner. Text is synthesized deterministically (~100 KB with embedded tokens);
 /// one full scan per op.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine — built by <c>CreateEngine</c>, which
+/// re-runs <see cref="SetupSource"/> so each engine owns its own <c>text</c>/<c>tokenText</c> — and
+/// warmed with its own script and nothing else (see <see cref="IsolatedScript"/>). It used to be one
+/// engine warmed with all four row scripts, so each row was measured on an engine carrying the other
+/// three rows' globals (every one of them declares <c>f</c>, so they collide outright), their
+/// handler-tree entries and their per-call-site caches, which makes a row's number depend on which
+/// siblings exist and on what a change did to <em>them</em>. The rows still measure warm scanning, and
+/// engine construction and warm-up stay in <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers
+/// from this class are not comparable to any published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]
 public class RegExpExecLoopBenchmark
 {
-    private Engine _engine = null!;
-    private Prepared<Script> _execWhileLoop;
-    private Prepared<Script> _matchAllIterate;
-    private Prepared<Script> _namedGroupsAccess;
-    private Prepared<Script> _stickyExec;
+    private IsolatedScript _execWhileLoop;
+    private IsolatedScript _matchAllIterate;
+    private IsolatedScript _namedGroupsAccess;
+    private IsolatedScript _stickyExec;
 
     internal const string SetupSource = """
         var text;
@@ -63,27 +72,32 @@ public class RegExpExecLoopBenchmark
         f();
         """;
 
+    /// <summary>Builds a fresh engine carrying the fixture every row needs, and nothing else.</summary>
+    private static Engine CreateEngine()
+    {
+        var engine = new Engine();
+        engine.Execute(SetupSource);
+        return engine;
+    }
+
     [GlobalSetup]
     public void Setup()
     {
-        _engine = new Engine();
-        _engine.Execute(SetupSource);
+        _execWhileLoop = IsolatedScript.Warm(Engine.PrepareScript(ExecWhileLoopSource), CreateEngine);
 
-        _execWhileLoop = Engine.PrepareScript(ExecWhileLoopSource);
-
-        _matchAllIterate = Engine.PrepareScript("""
+        _matchAllIterate = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var n = 0;
                 for (var m of text.matchAll(/id-(\d+)/g)) { n += m[1].length; }
                 return n;
             }
             f();
-            """);
+            """), CreateEngine);
 
-        _namedGroupsAccess = Engine.PrepareScript(NamedGroupsAccessSource);
+        _namedGroupsAccess = IsolatedScript.Warm(Engine.PrepareScript(NamedGroupsAccessSource), CreateEngine);
 
         // sticky scanner: every exec must match exactly at lastIndex
-        _stickyExec = Engine.PrepareScript("""
+        _stickyExec = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var re = /\w+ /y;
                 var n = 0;
@@ -92,23 +106,18 @@ public class RegExpExecLoopBenchmark
                 return n;
             }
             f();
-            """);
-
-        _engine.Evaluate(_execWhileLoop);
-        _engine.Evaluate(_matchAllIterate);
-        _engine.Evaluate(_namedGroupsAccess);
-        _engine.Evaluate(_stickyExec);
+            """), CreateEngine);
     }
 
     [Benchmark]
-    public JsValue ExecWhileLoop() => _engine.Evaluate(_execWhileLoop);
+    public JsValue ExecWhileLoop() => _execWhileLoop.Run();
 
     [Benchmark]
-    public JsValue MatchAllIterate() => _engine.Evaluate(_matchAllIterate);
+    public JsValue MatchAllIterate() => _matchAllIterate.Run();
 
     [Benchmark]
-    public JsValue NamedGroupsAccess() => _engine.Evaluate(_namedGroupsAccess);
+    public JsValue NamedGroupsAccess() => _namedGroupsAccess.Run();
 
     [Benchmark]
-    public JsValue StickyExec() => _engine.Evaluate(_stickyExec);
+    public JsValue StickyExec() => _stickyExec.Run();
 }

--- a/Jint.Benchmark/SingletonAccessBenchmarks.cs
+++ b/Jint.Benchmark/SingletonAccessBenchmarks.cs
@@ -12,48 +12,50 @@ namespace Jint.Benchmark;
 /// Object.prototype, String.prototype (libraries do extend those).
 ///
 /// Each scenario reads the same property in a tight loop so the inline cache's hit path dominates.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine, warmed with its own script and
+/// nothing else (see <see cref="IsolatedScript"/>). It used to be one engine warmed with all five row
+/// scripts, so each row was measured on an engine carrying the other four rows' globals (four of the
+/// five declare <c>s</c> and <c>i</c>, so they collide outright), their handler-tree entries and their
+/// per-call-site inline-cache state — which is exactly the state these rows exist to measure, so a
+/// row's number depended on which siblings existed and on what a change did to <em>them</em>. The rows
+/// still measure warm reads, and engine construction and warm-up stay in <c>[GlobalSetup]</c>, outside
+/// the measurement. <b>Numbers from this class are not comparable to any published before the harness
+/// changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 public class SingletonAccessBenchmarks
 {
     private const int OperationsPerInvoke = 1_000;
 
-    private Engine _warm = null!;
-    private Prepared<Script> _mathPi;
-    private Prepared<Script> _mathPiTightLoop;
-    private Prepared<Script> _jsonStringifyTightLoop;
-    private Prepared<Script> _reflectHasTightLoop;
-    private Prepared<Script> _symbolIteratorTightLoop;
+    private IsolatedScript _mathPi;
+    private IsolatedScript _mathPiTightLoop;
+    private IsolatedScript _jsonStringifyTightLoop;
+    private IsolatedScript _reflectHasTightLoop;
+    private IsolatedScript _symbolIteratorTightLoop;
 
     [GlobalSetup]
     public void GlobalSetup()
     {
-        _mathPi = Engine.PrepareScript("Math.PI");
+        _mathPi = IsolatedScript.Warm("Math.PI");
 
-        _mathPiTightLoop         = Engine.PrepareScript("var s = 0; for (var i = 0; i < 1000; i++) s += Math.PI; s");
-        _jsonStringifyTightLoop  = Engine.PrepareScript("var s = ''; for (var i = 0; i < 1000; i++) s = JSON.stringify(i); s");
-        _reflectHasTightLoop     = Engine.PrepareScript("var o = {a:1}; var s = 0; for (var i = 0; i < 1000; i++) if (Reflect.has(o, 'a')) s++; s");
-        _symbolIteratorTightLoop = Engine.PrepareScript("var s = 0; for (var i = 0; i < 1000; i++) if (Symbol.iterator) s++; s");
-
-        _warm = new Engine();
-        _warm.Evaluate(_mathPi);
-        _warm.Evaluate(_mathPiTightLoop);
-        _warm.Evaluate(_jsonStringifyTightLoop);
-        _warm.Evaluate(_reflectHasTightLoop);
-        _warm.Evaluate(_symbolIteratorTightLoop);
+        _mathPiTightLoop         = IsolatedScript.Warm("var s = 0; for (var i = 0; i < 1000; i++) s += Math.PI; s");
+        _jsonStringifyTightLoop  = IsolatedScript.Warm("var s = ''; for (var i = 0; i < 1000; i++) s = JSON.stringify(i); s");
+        _reflectHasTightLoop     = IsolatedScript.Warm("var o = {a:1}; var s = 0; for (var i = 0; i < 1000; i++) if (Reflect.has(o, 'a')) s++; s");
+        _symbolIteratorTightLoop = IsolatedScript.Warm("var s = 0; for (var i = 0; i < 1000; i++) if (Symbol.iterator) s++; s");
     }
 
-    [Benchmark] public JsValue Warm_MathPi() => _warm.Evaluate(_mathPi);
+    [Benchmark] public JsValue Warm_MathPi() => _mathPi.Run();
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue Warm_MathPi_TightLoop() => _warm.Evaluate(_mathPiTightLoop);
+    public JsValue Warm_MathPi_TightLoop() => _mathPiTightLoop.Run();
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue Warm_JsonStringify_TightLoop() => _warm.Evaluate(_jsonStringifyTightLoop);
+    public JsValue Warm_JsonStringify_TightLoop() => _jsonStringifyTightLoop.Run();
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue Warm_ReflectHas_TightLoop() => _warm.Evaluate(_reflectHasTightLoop);
+    public JsValue Warm_ReflectHas_TightLoop() => _reflectHasTightLoop.Run();
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-    public JsValue Warm_SymbolIterator_TightLoop() => _warm.Evaluate(_symbolIteratorTightLoop);
+    public JsValue Warm_SymbolIterator_TightLoop() => _symbolIteratorTightLoop.Run();
 }

--- a/Jint.Benchmark/StringConcatLargeBenchmark.cs
+++ b/Jint.Benchmark/StringConcatLargeBenchmark.cs
@@ -16,20 +16,28 @@ namespace Jint.Benchmark;
 /// ChainLargeThree shows the win when the skipped intermediate is large, and ChainNumericThree
 /// guards the numeric fast lanes that must survive on chains that never become strings.
 /// </para>
+/// <para><b>Engine isolation.</b> Every row gets its own engine — built by <c>CreateEngine</c>, which
+/// re-runs <see cref="SetupSource"/> so each engine owns its own <c>chunk16</c>/<c>chunk4k</c>/
+/// <c>big64k</c> — and warmed with its own script and nothing else (see <see cref="IsolatedScript"/>).
+/// It used to be one engine warmed with all eight row scripts, so each row was measured on an engine
+/// carrying the other seven rows' globals (every one of them declares <c>f</c>, three also <c>g</c>)
+/// and their handler-tree and call-site state, which makes a row's number depend on which siblings
+/// exist and on what a change did to <em>them</em>. The rows still measure warm string building, and
+/// engine construction and warm-up stay in <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers
+/// from this class are not comparable to any published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]
 public class StringConcatLargeBenchmark
 {
-    private Engine _engine = null!;
-    private Prepared<Script> _appendSmallChunks;
-    private Prepared<Script> _appendLargeChunks;
-    private Prepared<Script> _concatLargePair;
-    private Prepared<Script> _buildLargeThenScan;
-    private Prepared<Script> _chainSmallThree;
-    private Prepared<Script> _chainSmallSix;
-    private Prepared<Script> _chainLargeThree;
-    private Prepared<Script> _chainNumericThree;
+    private IsolatedScript _appendSmallChunks;
+    private IsolatedScript _appendLargeChunks;
+    private IsolatedScript _concatLargePair;
+    private IsolatedScript _buildLargeThenScan;
+    private IsolatedScript _chainSmallThree;
+    private IsolatedScript _chainSmallSix;
+    private IsolatedScript _chainLargeThree;
+    private IsolatedScript _chainNumericThree;
 
     private const string SetupSource = """
         var chunk16 = 'abcdefghijklmnop';
@@ -45,34 +53,39 @@ public class StringConcatLargeBenchmark
         })();
         """;
 
+    /// <summary>Builds a fresh engine carrying the fixture every row needs, and nothing else.</summary>
+    private static Engine CreateEngine()
+    {
+        var engine = new Engine();
+        engine.Execute(SetupSource);
+        return engine;
+    }
+
     [GlobalSetup]
     public void Setup()
     {
-        _engine = new Engine();
-        _engine.Execute(SetupSource);
-
         // 4,096 x 16 chars -> 64 KB result; the established fast case
-        _appendSmallChunks = Engine.PrepareScript("""
+        _appendSmallChunks = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var s = '';
                 for (var i = 0; i < 4096; i++) { s += chunk16; }
                 return s.length;
             }
             f();
-            """);
+            """), CreateEngine);
 
         // 256 x 4 KB -> 1 MB result; every append copies the whole chunk today
-        _appendLargeChunks = Engine.PrepareScript("""
+        _appendLargeChunks = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var s = '';
                 for (var i = 0; i < 256; i++) { s += chunk4k; }
                 return s.length;
             }
             f();
-            """);
+            """), CreateEngine);
 
         // one-shot big + big, repeated; O(1) for a rope, O(n) copy today
-        _concatLargePair = Engine.PrepareScript("""
+        _concatLargePair = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var total = 0;
                 for (var i = 0; i < 64; i++) {
@@ -82,11 +95,11 @@ public class StringConcatLargeBenchmark
                 return total;
             }
             f();
-            """);
+            """), CreateEngine);
 
         // build 256 KB from large chunks, then charAt-scan it — the pattern a lazy
         // representation must not regress
-        _buildLargeThenScan = Engine.PrepareScript("""
+        _buildLargeThenScan = IsolatedScript.Warm(Engine.PrepareScript("""
             function f() {
                 var s = '';
                 for (var i = 0; i < 64; i++) { s += chunk4k; }
@@ -95,13 +108,13 @@ public class StringConcatLargeBenchmark
                 return acc;
             }
             f();
-            """);
+            """), CreateEngine);
 
         // a + b + c over SMALL strings, no string literal among the operands. The dominant real-world
         // chain shape, and the one most exposed to per-evaluation overhead in the flattened path:
         // the saved intermediate is tiny here, so this lane is the guard against paying more than we
         // save on short chains.
-        _chainSmallThree = Engine.PrepareScript("""
+        _chainSmallThree = IsolatedScript.Warm(Engine.PrepareScript("""
             function f(a, b, c) { return a + b + c; }
             function g() {
                 var n = 0;
@@ -109,10 +122,10 @@ public class StringConcatLargeBenchmark
                 return n;
             }
             g();
-            """);
+            """), CreateEngine);
 
         // six-operand chain: exercises the string[] path rather than the string.Concat overloads
-        _chainSmallSix = Engine.PrepareScript("""
+        _chainSmallSix = IsolatedScript.Warm(Engine.PrepareScript("""
             function f(a, b, c, d, e, g) { return a + b + c + d + e + g; }
             function h() {
                 var n = 0;
@@ -120,10 +133,10 @@ public class StringConcatLargeBenchmark
                 return n;
             }
             h();
-            """);
+            """), CreateEngine);
 
         // a + b + c over 64 KB operands: the shape where the skipped intermediate dominates
-        _chainLargeThree = Engine.PrepareScript("""
+        _chainLargeThree = IsolatedScript.Warm(Engine.PrepareScript("""
             function f(a, b, c) { return a + b + c; }
             function g() {
                 var n = 0;
@@ -131,10 +144,10 @@ public class StringConcatLargeBenchmark
                 return n;
             }
             g();
-            """);
+            """), CreateEngine);
 
         // numeric 3-operand chain: must keep PlusBinaryExpression's unboxed numeric lanes
-        _chainNumericThree = Engine.PrepareScript("""
+        _chainNumericThree = IsolatedScript.Warm(Engine.PrepareScript("""
             function f(a, b, c) { return a + b + c; }
             function g() {
                 var n = 0;
@@ -142,39 +155,30 @@ public class StringConcatLargeBenchmark
                 return n;
             }
             g();
-            """);
-
-        _engine.Evaluate(_appendSmallChunks);
-        _engine.Evaluate(_appendLargeChunks);
-        _engine.Evaluate(_concatLargePair);
-        _engine.Evaluate(_buildLargeThenScan);
-        _engine.Evaluate(_chainSmallThree);
-        _engine.Evaluate(_chainSmallSix);
-        _engine.Evaluate(_chainLargeThree);
-        _engine.Evaluate(_chainNumericThree);
+            """), CreateEngine);
     }
 
     [Benchmark]
-    public JsValue AppendSmallChunks() => _engine.Evaluate(_appendSmallChunks);
+    public JsValue AppendSmallChunks() => _appendSmallChunks.Run();
 
     [Benchmark]
-    public JsValue AppendLargeChunks() => _engine.Evaluate(_appendLargeChunks);
+    public JsValue AppendLargeChunks() => _appendLargeChunks.Run();
 
     [Benchmark]
-    public JsValue ConcatLargePair() => _engine.Evaluate(_concatLargePair);
+    public JsValue ConcatLargePair() => _concatLargePair.Run();
 
     [Benchmark]
-    public JsValue BuildLargeThenScan() => _engine.Evaluate(_buildLargeThenScan);
+    public JsValue BuildLargeThenScan() => _buildLargeThenScan.Run();
 
     [Benchmark]
-    public JsValue ChainSmallThree() => _engine.Evaluate(_chainSmallThree);
+    public JsValue ChainSmallThree() => _chainSmallThree.Run();
 
     [Benchmark]
-    public JsValue ChainSmallSix() => _engine.Evaluate(_chainSmallSix);
+    public JsValue ChainSmallSix() => _chainSmallSix.Run();
 
     [Benchmark]
-    public JsValue ChainLargeThree() => _engine.Evaluate(_chainLargeThree);
+    public JsValue ChainLargeThree() => _chainLargeThree.Run();
 
     [Benchmark]
-    public JsValue ChainNumericThree() => _engine.Evaluate(_chainNumericThree);
+    public JsValue ChainNumericThree() => _chainNumericThree.Run();
 }

--- a/Jint.Benchmark/StringSliceBenchmarks.cs
+++ b/Jint.Benchmark/StringSliceBenchmarks.cs
@@ -16,24 +16,48 @@ namespace Jint.Benchmark;
 /// on every call. With zero-copy span search overrides this drops to ~0 allocation.
 /// SliceOfSlice slices a large view of a view: without receiver unwrapping the second slice
 /// materializes the intermediate view; with it, it rebases straight onto the backing string.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine — built by <c>CreateEngine</c>, which
+/// re-runs the fixture so each engine owns its own <c>str</c> — and warmed with its own script and
+/// nothing else (see <see cref="IsolatedScript"/>). It used to be one engine warmed with all seven row
+/// scripts, so each row was measured on an engine carrying the other six rows' handler-tree entries,
+/// per-call-site caches and — because these rows differ precisely in whether a result is a flat string
+/// or a zero-copy view — their string-representation history. That makes a row's number depend on which
+/// siblings exist and on what a change did to <em>them</em>. The rows still measure warm slicing, and
+/// engine construction and warm-up stay in <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers
+/// from this class are not comparable to any published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]
 public class StringSliceBenchmarks
 {
-    private Engine _engine = null!;
-    private Prepared<Script> _sliceLargeDiscard;
-    private Prepared<Script> _substringLargeDiscard;
-    private Prepared<Script> _sliceSmall;
-    private Prepared<Script> _sliceThenRead;
-    private Prepared<Script> _searchOnSlice;
-    private Prepared<Script> _searchOnFlat;
-    private Prepared<Script> _sliceOfSlice;
+    private IsolatedScript _sliceLargeDiscard;
+    private IsolatedScript _substringLargeDiscard;
+    private IsolatedScript _sliceSmall;
+    private IsolatedScript _sliceThenRead;
+    private IsolatedScript _searchOnSlice;
+    private IsolatedScript _searchOnFlat;
+    private IsolatedScript _sliceOfSlice;
+
+    /// <summary>Builds a fresh engine carrying the fixture every row needs, and nothing else.</summary>
+    private static Engine CreateEngine()
+    {
+        var engine = new Engine(static options => options.Strict());
+        // Build the shared ~128K char base string once (dromaeo-style doubling) — once per row's
+        // own engine, so no row ever observes another row's string representations.
+        engine.Execute("""
+            var str = "aB3$xQ9pLm0_kEwZ";
+            while (str.length < 131072) {
+                str += str;
+            }
+            """);
+        return engine;
+    }
 
     [GlobalSetup]
     public void Setup()
     {
-        _sliceLargeDiscard = Engine.PrepareScript("""
+        _sliceLargeDiscard = IsolatedScript.Warm(Engine.PrepareScript("""
             (function() {
                 var ret = null;
                 for (var i = 0; i < 5000; i++) {
@@ -42,9 +66,9 @@ public class StringSliceBenchmarks
                 }
                 return ret.length;
             })();
-            """, strict: true);
+            """, strict: true), CreateEngine);
 
-        _substringLargeDiscard = Engine.PrepareScript("""
+        _substringLargeDiscard = IsolatedScript.Warm(Engine.PrepareScript("""
             (function() {
                 var ret = null;
                 for (var i = 0; i < 5000; i++) {
@@ -53,9 +77,9 @@ public class StringSliceBenchmarks
                 }
                 return ret.length;
             })();
-            """, strict: true);
+            """, strict: true), CreateEngine);
 
-        _sliceSmall = Engine.PrepareScript("""
+        _sliceSmall = IsolatedScript.Warm(Engine.PrepareScript("""
             (function() {
                 var ret = null;
                 for (var i = 0; i < 5000; i++) {
@@ -65,9 +89,9 @@ public class StringSliceBenchmarks
                 }
                 return ret.length;
             })();
-            """, strict: true);
+            """, strict: true), CreateEngine);
 
-        _sliceThenRead = Engine.PrepareScript("""
+        _sliceThenRead = IsolatedScript.Warm(Engine.PrepareScript("""
             (function() {
                 var n = 0;
                 for (var i = 0; i < 5000; i++) {
@@ -77,9 +101,9 @@ public class StringSliceBenchmarks
                 }
                 return n;
             })();
-            """, strict: true);
+            """, strict: true), CreateEngine);
 
-        _searchOnSlice = Engine.PrepareScript("""
+        _searchOnSlice = IsolatedScript.Warm(Engine.PrepareScript("""
             (function() {
                 var hits = 0;
                 for (var i = 0; i < 5000; i++) {
@@ -91,14 +115,14 @@ public class StringSliceBenchmarks
                 }
                 return hits;
             })();
-            """, strict: true);
+            """, strict: true), CreateEngine);
 
         // Guard: searching a plain (non-view) JsString must not regress from making the base
         // search methods virtual. str.slice(0) returns a flat JsString, not a SlicedString.
         // Deliberately dispatch-bound (many cheap short searches that hit early / compare only the
         // needle) so the measurement isolates per-call dispatch overhead rather than the highly
         // thermal-sensitive throughput of one giant not-found scan.
-        _searchOnFlat = Engine.PrepareScript("""
+        _searchOnFlat = IsolatedScript.Warm(Engine.PrepareScript("""
             (function() {
                 var hits = 0;
                 var flat = str.slice(0);
@@ -110,12 +134,12 @@ public class StringSliceBenchmarks
                 }
                 return hits;
             })();
-            """, strict: true);
+            """, strict: true), CreateEngine);
 
         // Slice-of-slice: the first slice returns a large zero-copy view; the second slices that view.
         // Without receiver unwrapping the second slice materializes the intermediate view first; with
         // it, the second slice rebases straight onto the original backing string.
-        _sliceOfSlice = Engine.PrepareScript("""
+        _sliceOfSlice = IsolatedScript.Warm(Engine.PrepareScript("""
             (function() {
                 var ret = null;
                 for (var i = 0; i < 5000; i++) {
@@ -124,43 +148,27 @@ public class StringSliceBenchmarks
                 }
                 return ret.length;
             })();
-            """, strict: true);
-
-        _engine = new Engine(static options => options.Strict());
-        // Build the shared ~128K char base string once (dromaeo-style doubling).
-        _engine.Execute("""
-            var str = "aB3$xQ9pLm0_kEwZ";
-            while (str.length < 131072) {
-                str += str;
-            }
-            """);
-        _engine.Evaluate(_sliceLargeDiscard);
-        _engine.Evaluate(_substringLargeDiscard);
-        _engine.Evaluate(_sliceSmall);
-        _engine.Evaluate(_sliceThenRead);
-        _engine.Evaluate(_searchOnSlice);
-        _engine.Evaluate(_searchOnFlat);
-        _engine.Evaluate(_sliceOfSlice);
+            """, strict: true), CreateEngine);
     }
 
     [Benchmark]
-    public JsValue SliceLargeDiscard() => _engine.Evaluate(_sliceLargeDiscard);
+    public JsValue SliceLargeDiscard() => _sliceLargeDiscard.Run();
 
     [Benchmark]
-    public JsValue SubstringLargeDiscard() => _engine.Evaluate(_substringLargeDiscard);
+    public JsValue SubstringLargeDiscard() => _substringLargeDiscard.Run();
 
     [Benchmark]
-    public JsValue SliceSmall() => _engine.Evaluate(_sliceSmall);
+    public JsValue SliceSmall() => _sliceSmall.Run();
 
     [Benchmark]
-    public JsValue SliceThenRead() => _engine.Evaluate(_sliceThenRead);
+    public JsValue SliceThenRead() => _sliceThenRead.Run();
 
     [Benchmark]
-    public JsValue SearchOnSlice() => _engine.Evaluate(_searchOnSlice);
+    public JsValue SearchOnSlice() => _searchOnSlice.Run();
 
     [Benchmark]
-    public JsValue SearchOnFlat() => _engine.Evaluate(_searchOnFlat);
+    public JsValue SearchOnFlat() => _searchOnFlat.Run();
 
     [Benchmark]
-    public JsValue SliceOfSlice() => _engine.Evaluate(_sliceOfSlice);
+    public JsValue SliceOfSlice() => _sliceOfSlice.Run();
 }

--- a/Jint.Benchmark/StringSplitBenchmark.cs
+++ b/Jint.Benchmark/StringSplitBenchmark.cs
@@ -12,64 +12,33 @@ namespace Jint.Benchmark;
 /// SplitOnChar/SplitOnMultiChar guard the segment-production cost; SplitEmpty guards the
 /// already-optimal single-char branch (cached single-char JsStrings); SplitThenJoin guards the
 /// consume-the-result case (segments are materialized) so the production change stays neutral there.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine — built by <c>CreateEngine</c>, which
+/// re-runs the fixture so each engine owns its own <c>bigstr</c> — and warmed with its own script and
+/// nothing else (see <see cref="IsolatedScript"/>). It used to be one engine warmed with all four row
+/// scripts, so each row was measured on an engine carrying the other three rows' handler-tree entries
+/// and per-call-site caches, and on a <c>bigstr</c> whose string representation the other rows had
+/// already touched — which makes a row's number depend on which siblings exist and on what a change did
+/// to <em>them</em>. The rows still measure warm splitting, and engine construction and warm-up stay in
+/// <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from this class are not comparable to any
+/// published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]
 public class StringSplitBenchmark
 {
-    private Engine _engine = null!;
-    private Prepared<Script> _splitOnChar;
-    private Prepared<Script> _splitOnMultiChar;
-    private Prepared<Script> _splitEmpty;
-    private Prepared<Script> _splitThenJoin;
+    private IsolatedScript _splitOnChar;
+    private IsolatedScript _splitOnMultiChar;
+    private IsolatedScript _splitEmpty;
+    private IsolatedScript _splitThenJoin;
 
-    [GlobalSetup]
-    public void Setup()
+    /// <summary>Builds a fresh engine carrying the fixture every row needs, and nothing else.</summary>
+    private static Engine CreateEngine()
     {
-        _splitOnChar = Engine.PrepareScript("""
-            (function() {
-                var ret = null;
-                for (var i = 0; i < 20; i++) {
-                    ret = bigstr.split("a");
-                }
-                return ret.length;
-            })();
-            """, strict: true);
-
-        _splitOnMultiChar = Engine.PrepareScript("""
-            (function() {
-                var ret = null;
-                for (var i = 0; i < 20; i++) {
-                    ret = bigstr.split("xy");
-                }
-                return ret.length;
-            })();
-            """, strict: true);
-
-        _splitEmpty = Engine.PrepareScript("""
-            (function() {
-                var ret = null;
-                for (var i = 0; i < 5; i++) {
-                    ret = bigstr.split("");
-                }
-                return ret.length;
-            })();
-            """, strict: true);
-
-        _splitThenJoin = Engine.PrepareScript("""
-            (function() {
-                var ret = null;
-                for (var i = 0; i < 20; i++) {
-                    ret = bigstr.split("a").join("a");
-                }
-                return ret.length;
-            })();
-            """, strict: true);
-
-        _engine = new Engine(static options => options.Strict());
+        var engine = new Engine(static options => options.Strict());
         // Deterministic ~1M char source cycling 'a'..'y' (dromaeo-style: 'a' every 25 chars,
         // average 24-char segments; "xy" also appears once per cycle).
-        _engine.Execute("""
+        engine.Execute("""
             var bigstr = "";
             for (var i = 0; i < 16384; i++) {
                 bigstr += String.fromCharCode(97 + (i % 25));
@@ -78,21 +47,62 @@ public class StringSplitBenchmark
                 bigstr += bigstr;
             }
             """);
-        _engine.Evaluate(_splitOnChar);
-        _engine.Evaluate(_splitOnMultiChar);
-        _engine.Evaluate(_splitEmpty);
-        _engine.Evaluate(_splitThenJoin);
+        return engine;
+    }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _splitOnChar = IsolatedScript.Warm(Engine.PrepareScript("""
+            (function() {
+                var ret = null;
+                for (var i = 0; i < 20; i++) {
+                    ret = bigstr.split("a");
+                }
+                return ret.length;
+            })();
+            """, strict: true), CreateEngine);
+
+        _splitOnMultiChar = IsolatedScript.Warm(Engine.PrepareScript("""
+            (function() {
+                var ret = null;
+                for (var i = 0; i < 20; i++) {
+                    ret = bigstr.split("xy");
+                }
+                return ret.length;
+            })();
+            """, strict: true), CreateEngine);
+
+        _splitEmpty = IsolatedScript.Warm(Engine.PrepareScript("""
+            (function() {
+                var ret = null;
+                for (var i = 0; i < 5; i++) {
+                    ret = bigstr.split("");
+                }
+                return ret.length;
+            })();
+            """, strict: true), CreateEngine);
+
+        _splitThenJoin = IsolatedScript.Warm(Engine.PrepareScript("""
+            (function() {
+                var ret = null;
+                for (var i = 0; i < 20; i++) {
+                    ret = bigstr.split("a").join("a");
+                }
+                return ret.length;
+            })();
+            """, strict: true), CreateEngine);
     }
 
     [Benchmark]
-    public JsValue SplitOnChar() => _engine.Evaluate(_splitOnChar);
+    public JsValue SplitOnChar() => _splitOnChar.Run();
 
     [Benchmark]
-    public JsValue SplitOnMultiChar() => _engine.Evaluate(_splitOnMultiChar);
+    public JsValue SplitOnMultiChar() => _splitOnMultiChar.Run();
 
     [Benchmark]
-    public JsValue SplitEmpty() => _engine.Evaluate(_splitEmpty);
+    public JsValue SplitEmpty() => _splitEmpty.Run();
 
     [Benchmark]
-    public JsValue SplitThenJoin() => _engine.Evaluate(_splitThenJoin);
+    public JsValue SplitThenJoin() => _splitThenJoin.Run();
 }

--- a/Jint.Benchmark/SunSpiderBenchmark.cs
+++ b/Jint.Benchmark/SunSpiderBenchmark.cs
@@ -1,7 +1,29 @@
-﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Attributes;
 
 namespace Jint.Benchmark;
 
+/// <summary>
+/// The SunSpider suite, one row per script.
+///
+/// <para><b>Engine isolation.</b> The engine is built inside the benchmark method, so each op runs its
+/// script on an engine that has never seen anything else — the same choice, and for the same reasons,
+/// as <see cref="DromaeoBenchmark"/>. This class used to build one engine in <c>[GlobalSetup]</c> and
+/// execute the row's script on it over and over. That is a shared-state measurement even though only
+/// one script per row ever touches it: the source is re-parsed on every op, so every op adds a fresh
+/// set of AST nodes to the engine-owned handler-tree caches (<c>Engine._functionDefinitions</c>,
+/// <c>Engine._scriptStatementLists</c>) that nothing ever evicts, on top of the globals each re-run
+/// redeclares. Per-op cost therefore drifted with the invocation index, and the invocation count is
+/// picked by a pilot whose answer depends on the very change being measured — so a row could move
+/// several percent, in either direction, on a change that could not have touched it.</para>
+///
+/// <para>Engine construction now counts toward the measurement: roughly 0.1-0.3 ms against ops that run
+/// from a few ms to tens of ms. It is constant across revisions, so A/B comparisons stay valid, but it
+/// is a larger share of the shortest rows (the <c>bitops-*</c> family) than of the longest.
+/// Deliberately <em>not</em> an <c>[IterationSetup]</c>: that forces <c>InvocationCount=1</c>, which
+/// leaks tiered-JIT warmup into the measured iterations — see the comment in
+/// <see cref="DromaeoBenchmark"/> for the full account. <b>Numbers from this class are not comparable
+/// to any published before the harness changed.</b></para>
+/// </summary>
 [MemoryDiagnoser]
 public class SunSpiderBenchmark
 {
@@ -35,8 +57,6 @@ public class SunSpiderBenchmark
         {"string-validate-input", null}
     };
 
-    private Engine engine;
-
     [GlobalSetup]
     public void Setup()
     {
@@ -44,10 +64,6 @@ public class SunSpiderBenchmark
         {
             files[fileName] = File.ReadAllText($"Scripts/{fileName}.js");
         }
-
-        engine = new Engine()
-            .SetValue("log", new Action<object>(Console.WriteLine))
-            .SetValue("assert", new Action<bool>(b => { }));
     }
 
     [ParamsSource(nameof(FileNames))]
@@ -64,6 +80,10 @@ public class SunSpiderBenchmark
     [Benchmark]
     public void Run()
     {
+        var engine = new Engine()
+            .SetValue("log", new Action<object>(Console.WriteLine))
+            .SetValue("assert", new Action<bool>(b => { }));
+
         engine.Execute(files[FileName]);
     }
 }

--- a/Jint.Benchmark/TemplateLiteralBenchmark.cs
+++ b/Jint.Benchmark/TemplateLiteralBenchmark.cs
@@ -7,16 +7,25 @@ namespace Jint.Benchmark;
 /// Template-literal building beyond the trivial single-interpolation case: many slots, nesting,
 /// number-to-string interpolation, and tagged templates (whose spec-cached strings array should
 /// not be re-materialized per call). 100k evaluations per op inside a function frame.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine, warmed with its own script and
+/// nothing else (see <see cref="IsolatedScript"/>). It used to be one engine warmed with all four row
+/// scripts, so each row was measured on an engine carrying the other three rows' globals (every one of
+/// them declares <c>f</c>, so they collide outright), their handler-tree entries and their per-call-site
+/// caches — including the per-site tagged-template strings cache this class exists to observe. That
+/// makes a row's number depend on which siblings exist and on what a change did to <em>them</em>. The
+/// rows still measure warm template building, and engine construction and warm-up stay in
+/// <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from this class are not comparable to any
+/// published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]
 public class TemplateLiteralBenchmark
 {
-    private Engine _engine = null!;
-    private Prepared<Script> _manyInterpolations;
-    private Prepared<Script> _nestedTemplate;
-    private Prepared<Script> _numberInterpolation;
-    private Prepared<Script> _taggedTemplate;
+    private IsolatedScript _manyInterpolations;
+    private IsolatedScript _nestedTemplate;
+    private IsolatedScript _numberInterpolation;
+    private IsolatedScript _taggedTemplate;
 
     internal const string ManyInterpolationsSource = """
         function f() {
@@ -47,12 +56,10 @@ public class TemplateLiteralBenchmark
     [GlobalSetup]
     public void Setup()
     {
-        _engine = new Engine();
-
-        _manyInterpolations = Engine.PrepareScript(ManyInterpolationsSource);
+        _manyInterpolations = IsolatedScript.Warm(ManyInterpolationsSource);
 
         // a template whose interpolated expression is itself a template
-        _nestedTemplate = Engine.PrepareScript("""
+        _nestedTemplate = IsolatedScript.Warm("""
             function f() {
                 var x = 'x';
                 var n = 0;
@@ -66,7 +73,7 @@ public class TemplateLiteralBenchmark
             """);
 
         // number-to-string per iteration
-        _numberInterpolation = Engine.PrepareScript("""
+        _numberInterpolation = IsolatedScript.Warm("""
             function f() {
                 var n = 0;
                 for (var i = 0; i < 100000; i++) {
@@ -78,23 +85,18 @@ public class TemplateLiteralBenchmark
             f();
             """);
 
-        _taggedTemplate = Engine.PrepareScript(TaggedTemplateSource);
-
-        _engine.Evaluate(_manyInterpolations);
-        _engine.Evaluate(_nestedTemplate);
-        _engine.Evaluate(_numberInterpolation);
-        _engine.Evaluate(_taggedTemplate);
+        _taggedTemplate = IsolatedScript.Warm(TaggedTemplateSource);
     }
 
     [Benchmark]
-    public JsValue ManyInterpolations() => _engine.Evaluate(_manyInterpolations);
+    public JsValue ManyInterpolations() => _manyInterpolations.Run();
 
     [Benchmark]
-    public JsValue NestedTemplate() => _engine.Evaluate(_nestedTemplate);
+    public JsValue NestedTemplate() => _nestedTemplate.Run();
 
     [Benchmark]
-    public JsValue NumberInterpolation() => _engine.Evaluate(_numberInterpolation);
+    public JsValue NumberInterpolation() => _numberInterpolation.Run();
 
     [Benchmark]
-    public JsValue TaggedTemplate() => _engine.Evaluate(_taggedTemplate);
+    public JsValue TaggedTemplate() => _taggedTemplate.Run();
 }

--- a/Jint.Benchmark/UpdateExpressionValueBenchmark.cs
+++ b/Jint.Benchmark/UpdateExpressionValueBenchmark.cs
@@ -9,21 +9,30 @@ namespace Jint.Benchmark;
 /// <c>acc += i++</c>, <c>while (n--)</c>, <c>++i</c>), so evaluation cannot take the discard-mode
 /// fast path and instead resolves the counter through the identifier slot cache. Complements
 /// <see cref="FunctionLocalNumberLoopBenchmark"/>, whose <c>i++</c> updates are all discarded.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine, warmed with its own script and
+/// nothing else (see <see cref="IsolatedScript"/>). It used to be one engine warmed with all four row
+/// scripts, so each row was measured on an engine carrying the other three rows' globals (every one of
+/// them declares <c>f</c>, so they collide outright), their handler-tree entries and their
+/// identifier-slot and environment-reuse caches — which is exactly the state these rows exist to
+/// measure. That makes a row's number depend on which siblings exist and on what a change did to
+/// <em>them</em>. The rows still measure warm updates, and engine construction and warm-up stay in
+/// <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from this class are not comparable to any
+/// published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 public class UpdateExpressionValueBenchmark
 {
-    private Engine _engine = null!;
-    private Prepared<Script> _postfixAccumulate;
-    private Prepared<Script> _prefixAccumulate;
-    private Prepared<Script> _arrayIndexPostInc;
-    private Prepared<Script> _whileCountdown;
+    private IsolatedScript _postfixAccumulate;
+    private IsolatedScript _prefixAccumulate;
+    private IsolatedScript _arrayIndexPostInc;
+    private IsolatedScript _whileCountdown;
 
     [GlobalSetup]
     public void GlobalSetup()
     {
         // postfix i++ consumed as a value every iteration (acc += i++)
-        _postfixAccumulate = Engine.PrepareScript("""
+        _postfixAccumulate = IsolatedScript.Warm("""
             function f() {
                 var i = 0;
                 var acc = 0;
@@ -36,7 +45,7 @@ public class UpdateExpressionValueBenchmark
             """);
 
         // prefix ++i consumed as a value every iteration (acc += ++i)
-        _prefixAccumulate = Engine.PrepareScript("""
+        _prefixAccumulate = IsolatedScript.Warm("""
             function f() {
                 var i = 0;
                 var acc = 0;
@@ -49,7 +58,7 @@ public class UpdateExpressionValueBenchmark
             """);
 
         // sum += arr[i++]: the post-increment result indexes the array and advances the counter
-        _arrayIndexPostInc = Engine.PrepareScript("""
+        _arrayIndexPostInc = IsolatedScript.Warm("""
             function f() {
                 var arr = new Array(100000);
                 for (var k = 0; k < 100000; k++) { arr[k] = k & 7; }
@@ -64,7 +73,7 @@ public class UpdateExpressionValueBenchmark
             """);
 
         // while (n--): the post-decrement value drives the loop condition
-        _whileCountdown = Engine.PrepareScript("""
+        _whileCountdown = IsolatedScript.Warm("""
             function f() {
                 var n = 100000;
                 var count = 0;
@@ -75,23 +84,17 @@ public class UpdateExpressionValueBenchmark
             }
             f();
             """);
-
-        _engine = new Engine();
-        _engine.Evaluate(_postfixAccumulate);
-        _engine.Evaluate(_prefixAccumulate);
-        _engine.Evaluate(_arrayIndexPostInc);
-        _engine.Evaluate(_whileCountdown);
     }
 
     [Benchmark]
-    public JsValue PostfixAccumulate() => _engine.Evaluate(_postfixAccumulate);
+    public JsValue PostfixAccumulate() => _postfixAccumulate.Run();
 
     [Benchmark]
-    public JsValue PrefixAccumulate() => _engine.Evaluate(_prefixAccumulate);
+    public JsValue PrefixAccumulate() => _prefixAccumulate.Run();
 
     [Benchmark]
-    public JsValue ArrayIndexPostInc() => _engine.Evaluate(_arrayIndexPostInc);
+    public JsValue ArrayIndexPostInc() => _arrayIndexPostInc.Run();
 
     [Benchmark]
-    public JsValue WhileCountdown() => _engine.Evaluate(_whileCountdown);
+    public JsValue WhileCountdown() => _whileCountdown.Run();
 }

--- a/Jint.Benchmark/VariadicCoercionBenchmarks.cs
+++ b/Jint.Benchmark/VariadicCoercionBenchmarks.cs
@@ -12,43 +12,43 @@ namespace Jint.Benchmark;
 ///   - 64 args: forced rent from ArrayPool&lt;double&gt;.Shared.
 /// All three should win equally from [Coerced&lt;T&gt;] vs the current emit which boxes into
 /// arguments[] and re-coerces inside the host method.
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine, warmed with its own script and
+/// nothing else (see <see cref="IsolatedScript"/>). It used to be one engine warmed with all six row
+/// scripts, so each row was measured on an engine carrying the other five rows' handler-tree entries
+/// and their per-call-site caches on <c>Math</c> — the very state that decides whether a variadic call
+/// takes the fast lane — which makes a row's number depend on which siblings exist and on what a change
+/// did to <em>them</em>. The rows still measure warm variadic dispatch, and engine construction and
+/// warm-up stay in <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from this class are not
+/// comparable to any published before the harness changed.</b></para>
 /// </summary>
 [MemoryDiagnoser]
 public class VariadicCoercionBenchmarks
 {
-    private Engine _warm = null!;
-    private Prepared<Script> _max2;
-    private Prepared<Script> _max4;
-    private Prepared<Script> _max16;
-    private Prepared<Script> _max64;
-    private Prepared<Script> _min4;
-    private Prepared<Script> _hypot4;
+    private IsolatedScript _max2;
+    private IsolatedScript _max4;
+    private IsolatedScript _max16;
+    private IsolatedScript _max64;
+    private IsolatedScript _min4;
+    private IsolatedScript _hypot4;
 
     [GlobalSetup]
     public void GlobalSetup()
     {
-        _max2  = Engine.PrepareScript("Math.max(1, 2)");
-        _max4  = Engine.PrepareScript("Math.max(1, 2, 3, 4)");
-        _max16 = Engine.PrepareScript("Math.max(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)");
-        _max64 = Engine.PrepareScript(BuildVariadicCall("Math.max", 64));
-        _min4  = Engine.PrepareScript("Math.min(1, 2, 3, 4)");
-        _hypot4 = Engine.PrepareScript("Math.hypot(1, 2, 3, 4)");
-
-        _warm = new Engine();
-        _warm.Evaluate(_max2);
-        _warm.Evaluate(_max4);
-        _warm.Evaluate(_max16);
-        _warm.Evaluate(_max64);
-        _warm.Evaluate(_min4);
-        _warm.Evaluate(_hypot4);
+        _max2  = IsolatedScript.Warm("Math.max(1, 2)");
+        _max4  = IsolatedScript.Warm("Math.max(1, 2, 3, 4)");
+        _max16 = IsolatedScript.Warm("Math.max(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)");
+        _max64 = IsolatedScript.Warm(BuildVariadicCall("Math.max", 64));
+        _min4  = IsolatedScript.Warm("Math.min(1, 2, 3, 4)");
+        _hypot4 = IsolatedScript.Warm("Math.hypot(1, 2, 3, 4)");
     }
 
-    [Benchmark] public JsValue Warm_Max2() => _warm.Evaluate(_max2);
-    [Benchmark] public JsValue Warm_Max4() => _warm.Evaluate(_max4);
-    [Benchmark] public JsValue Warm_Max16() => _warm.Evaluate(_max16);
-    [Benchmark] public JsValue Warm_Max64() => _warm.Evaluate(_max64);
-    [Benchmark] public JsValue Warm_Min4() => _warm.Evaluate(_min4);
-    [Benchmark] public JsValue Warm_Hypot4() => _warm.Evaluate(_hypot4);
+    [Benchmark] public JsValue Warm_Max2() => _max2.Run();
+    [Benchmark] public JsValue Warm_Max4() => _max4.Run();
+    [Benchmark] public JsValue Warm_Max16() => _max16.Run();
+    [Benchmark] public JsValue Warm_Max64() => _max64.Run();
+    [Benchmark] public JsValue Warm_Min4() => _min4.Run();
+    [Benchmark] public JsValue Warm_Hypot4() => _hypot4.Run();
 
     private static string BuildVariadicCall(string fn, int arity)
     {


### PR DESCRIPTION
Several benchmark classes build **one `Engine` in `[GlobalSetup]` and warm it with every row's script**, then measure each `[Benchmark]` row against it. Each row therefore runs on an engine carrying its siblings' state — their globals on the shared global object (nearly every micro-script here declares `var i`, `var s` or `function f`, so they collide outright), their entries in `Engine._functionDefinitions` / `_scriptStatementLists`, their per-call-site monomorphic caches, and the environment-reuse and constructor-shape state behind them.

**A row's number then depends on which sibling rows exist, and on what a change did to *them*.**

## This is measured, not theoretical

While gating an interpreter call-path change, `MethodCallBenchmark` reported `UserPrototypeMethod` **+9.2%**, `ArrayPushPop` **+5.6%** and `MethodCallThis` **+5.8%** — reproducibly, and in *both* A/B orderings, which is normally the signature of a real effect. A faithful reproduction of the same five workloads in a single isolated process showed the change was in fact **2.5–3.0% faster**.

Reversing the A/B order does not catch this. BenchmarkDotNet runs every case in its own process, so nothing leaks through the shared field; the channel is `[GlobalSetup]` doing *other rows'* work on the engine this row is about to be measured on. Reversal controls for thermal/scheduler drift only, so a systematic cross-row effect reproduces identically both ways and looks maximally credible.

The clearest proof the coupling was load-bearing is in the suite's own assertions: **`ProxyBenchmark`'s get-lane sanity checks expected `9999900000`, and were only correct because `ClrTrapSet` ran first on the shared engine and drove `target.x` from 1 to 99999.** After isolation the same 100,000 reads correctly assert `100000`. A correctness check had silently encoded row ordering.

## What changed

118 benchmark classes audited. **57 fixed, 61 already sound.**

- **54 classes → one engine per row**, built in `[GlobalSetup]` and warmed with that row's script and nothing else, via the new `IsolatedScript` helper — or plain per-row `Engine` fields where a row's workload is not a `Prepared<Script>`, following `InteropMethodDispatchBenchmark`, which already did this. This preserves each row's **warm-dispatch** character (which is what most of these classes exist to measure — making them cold would silently change what the suite is for) and keeps engine construction and warm-up out of the measurement.
- **`SunSpiderBenchmark` → engine built inside the benchmark method**, following `DromaeoBenchmark`. It re-parses its script every op, so every op added a fresh set of AST nodes to engine-owned caches that nothing evicts. Engine construction (~0.1–0.3 ms) now counts toward those ops — a larger share of the short `bitops-*` rows than of the long ones.
- Classes whose `[GlobalSetup]` only builds a fixture every row needs, and those already per-row or per-op, are untouched.
- **No `[IterationSetup]` was introduced anywhere.** It forces `InvocationCount=1` and leaks tiered-JIT warmup into the measured iterations — the failure `DromaeoBenchmark`'s comment already documents, where identical code reported 2.489 ms and 9.811 ms in different runs.

`AGENTS.md` gains a **"Never warm one engine with more than one row's workload"** section so the convention lands where new benchmarks get written, including what the rule does *not* forbid (a shared fixture is fine; re-evaluating one row's own script many times is fine).

## Verification

- **`--list flat` is byte-identical: 572 benchmarks.** No row added, removed, renamed, or re-parameterised — the harness changed, the suite's shape did not.
- `dotnet build -c Release`: 0 warnings.
- `Jint.Tests` 4660/0/4 (net10.0), 4579/0/4 (net472).

## Note for anyone comparing history

**Numbers from the changed classes are not comparable to previously published figures.** That is the point of the change rather than a side effect — the old numbers included cross-row coupling. `DromaeoBenchmark` and `RecursionBenchmark` were already sound and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G24ppn8iSgjo1APp3YkzTK
