### PR TITLE
Resume an awaiting for-let loop into the environment it suspended in

### DIFF
--- a/Jint.Tests/DedicatedThread.cs
+++ b/Jint.Tests/DedicatedThread.cs
@@ -1,0 +1,76 @@
+#nullable enable
+
+using System.Runtime.ExceptionServices;
+using Xunit.Sdk;
+
+namespace Jint.Tests;
+
+/// <summary>
+/// Runs a test body on a dedicated thread, rather than on the xUnit worker thread.
+/// <para>
+/// Two unrelated reasons to want one, both served here so there is a single implementation. Deep
+/// recursion needs a larger stack than the default thread provides
+/// (<see cref="LargeStackSize"/>). And a test whose failure mode is a <em>non-terminating</em>
+/// engine — an uninterruptible walk over a corrupt lexical environment chain, say — needs
+/// <paramref name="joinTimeout"/>: an execution constraint cannot stop one of those, because Jint
+/// does not evaluate constraints for event-loop jobs and so cannot interrupt a continuation.
+/// Without a timeout a single regression wedges the whole class (xUnit runs a class's tests
+/// sequentially) and CI hangs instead of reporting.
+/// </para>
+/// <para>
+/// The exception is re-thrown through <see cref="ExceptionDispatchInfo"/>, which preserves its
+/// type, its original stack trace and its <see cref="Exception.Data"/> — a regression surfaces in
+/// CI as a navigable failure rather than as a flattened string.
+/// </para>
+/// </summary>
+internal static class DedicatedThread
+{
+    /// <summary>
+    /// Enough stack for the deep-recursion tests; the platform default is far smaller.
+    /// </summary>
+    public const int LargeStackSize = 16 * 1024 * 1024;
+
+    public static void Run(Action action, TimeSpan? joinTimeout = null, string? timeoutMessage = null, int maxStackSize = LargeStackSize)
+    {
+        ExceptionDispatchInfo? exception = null;
+
+        var thread = new Thread(
+            () =>
+            {
+                try
+                {
+                    action();
+                }
+                catch (Exception e)
+                {
+                    exception = ExceptionDispatchInfo.Capture(e);
+                }
+            },
+            maxStackSize)
+        {
+            // A thread that outlives its join must not keep the process alive...
+            IsBackground = true,
+
+            // ...and must not compete with the rest of the run for a core while it does. Background
+            // only governs process exit; a spinning thread goes on burning CPU until then, which is
+            // exactly the condition the suite's known wall-clock flakes fail under.
+            Priority = ThreadPriority.Lowest,
+        };
+
+        thread.Start();
+
+        if (joinTimeout is { } timeout)
+        {
+            if (!thread.Join(timeout))
+            {
+                throw new XunitException(timeoutMessage ?? $"the test body did not complete within {timeout}");
+            }
+        }
+        else
+        {
+            thread.Join();
+        }
+
+        exception?.Throw();
+    }
+}

--- a/Jint.Tests/Runtime/EngineLimitTests.cs
+++ b/Jint.Tests/Runtime/EngineLimitTests.cs
@@ -27,7 +27,7 @@ public class EngineLimitTests
         // is deliberately generous: StackOverflowException is uncatchable and would kill the whole test
         // process, so this is a functional smoke test of deep call chains, not a per-frame native-stack
         // budget test (platforms differ too much in frame size for a tight budget to be safe).
-        RunOnDedicatedThread(static () =>
+        DedicatedThread.Run(static () =>
         {
             var script = GenerateCallTree(FunctionNestingCount);
 
@@ -36,25 +36,6 @@ public class EngineLimitTests
             engine.Evaluate("func1(123);").AsNumber().Should().Be(123);
             engine.Evaluate("x").AsNumber().Should().Be(FunctionNestingCount);
         });
-    }
-
-    private static void RunOnDedicatedThread(Action action)
-    {
-        ExceptionDispatchInfo? exception = null;
-        var thread = new Thread(() =>
-        {
-            try
-            {
-                action();
-            }
-            catch (Exception e)
-            {
-                exception = ExceptionDispatchInfo.Capture(e);
-            }
-        }, maxStackSize: 16 * 1024 * 1024);
-        thread.Start();
-        thread.Join();
-        exception?.Throw();
     }
 
     [Fact]

--- a/Jint.Tests/Runtime/ForLoopIterationEnvironmentAwaitTests.cs
+++ b/Jint.Tests/Runtime/ForLoopIterationEnvironmentAwaitTests.cs
@@ -1,0 +1,572 @@
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// A C-style <c>for</c> loop restores, on exit, the environment that was current when it was
+/// entered. It used to read that environment from the execution context on every entry —
+/// including a re-entry that is an async <em>replay</em>.
+///
+/// That is unsound for an async function, because <c>JintAwaitExpression.SuspendForAwait</c>
+/// re-captures <c>_savedContext</c> at <em>every</em> await, so the environment current at the top
+/// of a replayed body is the one that was live at the await. When the body declares a
+/// <c>let</c>/<c>const</c>, that is the body block's environment, and the loop took it as its own
+/// outer environment — then restored it on exit.
+///
+/// Three observable failures followed, the first two loud and the third silent:
+/// reading an outer binding after the loop threw <see cref="InvalidCastException"/> from
+/// <c>JintEnvironment.TryGetIdentifierEnvironmentWithBindingValue</c>, which casts to
+/// <c>GlobalEnvironment</c> on the assumption that only the global environment has a null
+/// <c>_outerEnv</c> — but a block environment parked into <c>JintBlockStatement._cachedEnv</c> is
+/// detached (<c>_outerEnv = null</c>) at park time, and has exactly that shape; reading
+/// <c>this</c> hung forever in <c>ExecutionContext.GetThisEnvironment()</c>, whose
+/// <c>while (true)</c> walk relies on the chain ending at the global environment; and the block's
+/// own bindings stayed visible after the loop.
+///
+/// A closure anywhere in the loop body masked the first two entirely — not by disabling the
+/// iteration-environment reuse optimisation (forcing that off changes nothing), but because
+/// <c>BlockState</c> only takes slot-backed storage when
+/// <c>EnvironmentEscapeAstVisitor.MayEscape</c> is false, and only a slot-backed block
+/// environment is ever parked and detached. The wrong environment was restored either way, which
+/// is why the closure shapes below assert the block's bindings are gone rather than merely that
+/// nothing threw.
+///
+/// The fix mirrors <c>JintForInForOfStatement.BodyEvaluation</c>, which restores its
+/// <c>oldEnv</c> from <c>ForOfSuspendData.OuterEnv</c> for this same reason (commit f089071fc).
+/// Generators need no such thing: they capture their context once at GeneratorStart and re-enter
+/// that same function-level context on every resume.
+/// </summary>
+public class ForLoopIterationEnvironmentAwaitTests
+{
+    /// <summary>
+    /// Evaluates <paramref name="script"/> on a dedicated background thread and fails on a join
+    /// timeout rather than hanging the run.
+    /// <para>
+    /// This is not defensive padding. One manifestation of the defect these tests cover is an
+    /// infinite walk in <c>ExecutionContext.GetThisEnvironment()</c>, and a <c>TimeoutInterval</c>
+    /// constraint cannot stop it — Jint does not evaluate constraints for event-loop jobs, so it
+    /// cannot interrupt a continuation. Without this, a single regression wedges the whole test
+    /// class (xUnit runs a class's tests sequentially) and CI hangs instead of reporting.
+    /// </para>
+    /// </summary>
+    private static JsValue RunAsync(string script)
+    {
+        JsValue result = null;
+        Exception failure = null;
+
+        var worker = new Thread(() =>
+        {
+            try
+            {
+                result = new Engine().Evaluate(script).UnwrapIfPromise();
+            }
+            catch (Exception ex)
+            {
+                failure = ex;
+            }
+        })
+        {
+            // If it is spinning, it must not keep the test process alive.
+            IsBackground = true,
+        };
+
+        worker.Start();
+
+        if (!worker.Join(TimeSpan.FromSeconds(30)))
+        {
+            throw new Xunit.Sdk.XunitException(
+                "evaluation did not complete within 30s — the lexical environment chain is most "
+                + "likely corrupt, leaving GetThisEnvironment() or an identifier walk spinning");
+        }
+
+        if (failure is not null)
+        {
+            throw new Xunit.Sdk.XunitException($"evaluation threw: {failure}");
+        }
+
+        return result;
+    }
+
+    [Fact]
+    public void ShouldSeeOuterBindingAfterAwaitingLoopWithBlockScopedDeclaration()
+    {
+        var result = RunAsync("""
+            const OUTER = 'outer-visible';
+            (async () => {
+                for (let i = 0; i < 1; i++) {
+                    await Promise.resolve();
+                    const x = i + 1;
+                    void x;
+                }
+                return OUTER;
+            })()
+            """);
+
+        result.Should().Be("outer-visible");
+    }
+
+    [Fact]
+    public void ShouldSeeOuterBindingWhenDeclarationPrecedesTheAwait()
+    {
+        var result = RunAsync("""
+            const OUTER = 'outer-visible';
+            (async () => {
+                for (let i = 0; i < 1; i++) {
+                    const x = i + 1;
+                    void x;
+                    await Promise.resolve();
+                }
+                return OUTER;
+            })()
+            """);
+
+        result.Should().Be("outer-visible");
+    }
+
+    [Fact]
+    public void ShouldSeeOuterBindingWithLetDeclarationInBody()
+    {
+        var result = RunAsync("""
+            const OUTER = 'outer-visible';
+            (async () => {
+                for (let i = 0; i < 1; i++) {
+                    await Promise.resolve();
+                    let x = i + 1;
+                    void x;
+                }
+                return OUTER;
+            })()
+            """);
+
+        result.Should().Be("outer-visible");
+    }
+
+    [Fact]
+    public void ShouldSeeOuterBindingWhenAwaitIsNestedDeeperThanTheDeclaration()
+    {
+        var result = RunAsync("""
+            const OUTER = 'outer-visible';
+            (async () => {
+                for (let i = 0; i < 1; i++) {
+                    const x = i + 1;
+                    if (x > 0) { if (x > 0) { await Promise.resolve(); } }
+                }
+                return OUTER;
+            })()
+            """);
+
+        result.Should().Be("outer-visible");
+    }
+
+    [Fact]
+    public void ShouldSeeOuterBindingWhenDeclarationAndAwaitShareANestedBlock()
+    {
+        var result = RunAsync("""
+            const OUTER = 'outer-visible';
+            (async () => {
+                for (let i = 0; i < 1; i++) {
+                    { const x = i + 1; void x; await Promise.resolve(); }
+                }
+                return OUTER;
+            })()
+            """);
+
+        result.Should().Be("outer-visible");
+    }
+
+    /// <summary>
+    /// The <c>this</c> manifestation. Before the fix this did not throw — it spun forever in
+    /// <c>ExecutionContext.GetThisEnvironment()</c>. A <c>TimeoutInterval</c> constraint does NOT
+    /// help: Jint does not evaluate constraints for event-loop jobs, so it cannot interrupt a
+    /// continuation, which is precisely the case here. The evaluation therefore runs on its own
+    /// background thread and the test fails on a join timeout instead of hanging the run.
+    /// </summary>
+    [Fact]
+    public void ShouldReadThisAfterAwaitingLoopWithBlockScopedDeclaration()
+    {
+        var result = RunAsync("""
+            class K {
+                async leaf() { return 1; }
+                async run() {
+                    for (let i = 0; i < 1; i++) {
+                        const x = i;
+                        void x;
+                        await this.leaf();
+                    }
+                    return await this.leaf();
+                }
+            }
+            new K().run()
+            """);
+
+        result.Should().Be(1);
+    }
+
+    [Fact]
+    public void ShouldPreserveLoopVariableSemanticsAcrossAwait()
+    {
+        // The per-iteration environment must still be per-iteration: each iteration's `i` is a
+        // distinct binding. Guards against "fix it by never creating the environment".
+        var result = RunAsync("""
+            (async () => {
+                const seen = [];
+                for (let i = 0; i < 3; i++) {
+                    await Promise.resolve();
+                    const doubled = i * 2;
+                    seen.push(doubled);
+                }
+                return seen.join(',');
+            })()
+            """);
+
+        result.Should().Be("0,2,4");
+    }
+
+    [Fact]
+    public void ShouldStillCaptureDistinctBindingsPerIterationWhenBodyAwaits()
+    {
+        // The reuse optimisation exists to avoid allocating an environment per iteration when
+        // nothing captures it. Where something DOES capture it, each closure must still see its
+        // own `i` — the classic per-iteration-binding guarantee — even with an await in the body.
+        var result = RunAsync("""
+            (async () => {
+                const fns = [];
+                for (let i = 0; i < 3; i++) {
+                    await Promise.resolve();
+                    const captured = i;
+                    fns.push(() => `${i}:${captured}`);
+                }
+                return fns.map(f => f()).join(',');
+            })()
+            """);
+
+        result.Should().Be("0:0,1:1,2:2");
+    }
+
+    [Fact]
+    public void ShouldHandleNestedForLoopsWhereOnlyTheInnerOneAwaits()
+    {
+        var result = RunAsync("""
+            const OUTER = 'outer-visible';
+            (async () => {
+                for (let i = 0; i < 2; i++) {
+                    for (let j = 0; j < 2; j++) {
+                        await Promise.resolve();
+                        const x = j;
+                        void x;
+                    }
+                }
+                return OUTER;
+            })()
+            """);
+
+        result.Should().Be("outer-visible");
+    }
+
+    [Fact]
+    public void ShouldSeeOuterBindingAfterAForAwaitOfInsideAForLoopBody()
+    {
+        // `for await...of` carries an implicit await, so it suspends the body the same way.
+        var result = RunAsync("""
+            const OUTER = 'outer-visible';
+            async function* gen() { yield 1; }
+            (async () => {
+                for (let i = 0; i < 1; i++) {
+                    const x = i;
+                    void x;
+                    for await (const v of gen()) { void v; }
+                }
+                return OUTER;
+            })()
+            """);
+
+        result.Should().Be("outer-visible");
+    }
+
+    /// <summary>
+    /// The silent manifestation. A closure in the body keeps the block environment out of the
+    /// park-and-detach path, so nothing throws — but the loop still restored the block's
+    /// environment on exit, leaving the block's own bindings resolvable afterwards. Asserting
+    /// only "it did not throw" passes over this, which is why it is asserted directly.
+    /// </summary>
+    [Fact]
+    public void ShouldNotLeakBlockScopedDeclarationPastTheLoopWhenAClosureMasksTheThrow()
+    {
+        var result = RunAsync("""
+            (async () => {
+                for (let i = 0; i < 1; i++) {
+                    const g = () => i;
+                    void g;
+                    await Promise.resolve();
+                    const leaked = i + 1;
+                    void leaked;
+                }
+                try { return 'LEAKED:' + leaked; }
+                catch (e) { return e.name; }
+            })()
+            """);
+
+        result.Should().Be("ReferenceError");
+    }
+
+    [Fact]
+    public void ShouldNotLeakBlockScopedDeclarationPastTheLoopWithoutAClosure()
+    {
+        var result = RunAsync("""
+            (async () => {
+                for (let i = 0; i < 1; i++) {
+                    await Promise.resolve();
+                    const leaked = i + 1;
+                    void leaked;
+                }
+                try { return 'LEAKED:' + leaked; }
+                catch (e) { return e.name; }
+            })()
+            """);
+
+        result.Should().Be("ReferenceError");
+    }
+
+    /// <summary>
+    /// The header suspends rather than the body, so no block environment is involved and nothing
+    /// is ever parked — but the loop still took the suspension-point environment (here its own
+    /// iteration environment) as its outer one, and restored it on exit. That leaves the loop
+    /// variable itself resolvable afterwards.
+    /// </summary>
+    [Fact]
+    public void ShouldNotLeakTheLoopVariableWhenTheTestExpressionAwaits()
+    {
+        var result = RunAsync("""
+            (async () => {
+                for (let i = 0; i < await Promise.resolve(1); i++) { }
+                try { return 'LEAKED:' + i; }
+                catch (e) { return e.name; }
+            })()
+            """);
+
+        result.Should().Be("ReferenceError");
+    }
+
+    [Fact]
+    public void ShouldNotLeakTheLoopVariableWhenTheUpdateExpressionAwaits()
+    {
+        var result = RunAsync("""
+            (async () => {
+                for (let i = 0; i < 2; i = i + await Promise.resolve(1)) { }
+                try { return 'LEAKED:' + i; }
+                catch (e) { return e.name; }
+            })()
+            """);
+
+        result.Should().Be("ReferenceError");
+    }
+
+    /// <summary>
+    /// The loop must restore its outer environment across more than one suspension — the saved
+    /// outer environment has to stay stable when it is re-saved on each subsequent await.
+    /// </summary>
+    [Fact]
+    public void ShouldRestoreTheOuterEnvironmentAcrossManyIterationsThatEachAwait()
+    {
+        var result = RunAsync("""
+            const OUTER = 'outer-visible';
+            (async () => {
+                for (let i = 0; i < 5; i++) {
+                    await Promise.resolve();
+                    const x = i;
+                    await Promise.resolve();
+                    void x;
+                }
+                return OUTER;
+            })()
+            """);
+
+        result.Should().Be("outer-visible");
+    }
+
+    /// <summary>
+    /// An outer binding declared in a block between the function and the loop must still resolve
+    /// after the loop: the restored environment has to be the loop's real outer environment, not
+    /// merely some environment that happens to reach the global one.
+    /// </summary>
+    [Fact]
+    public void ShouldSeeAnEnclosingBlockBindingAfterTheLoop()
+    {
+        var result = RunAsync("""
+            (async () => {
+                {
+                    const enclosing = 'enclosing-visible';
+                    for (let i = 0; i < 1; i++) {
+                        await Promise.resolve();
+                        const x = i;
+                        void x;
+                    }
+                    return enclosing;
+                }
+            })()
+            """);
+
+        result.Should().Be("enclosing-visible");
+    }
+
+    /// <summary>
+    /// A closure created in the body BEFORE the await captures that iteration's environment, so a
+    /// write to the loop variable AFTER the await must be visible through it. Rebuilding the
+    /// iteration environment on resume — instead of resuming into the one the suspension left —
+    /// stranded the closure on the old environment and silently lost the write. Node returns 42.
+    /// </summary>
+    [Fact]
+    public void ShouldSeeAPostAwaitWriteThroughAClosureCapturedBeforeTheAwait()
+    {
+        var result = RunAsync("""
+            (async () => {
+                let get;
+                for (let i = 0; i < 1; i++) {
+                    get = function () { return i; };
+                    await Promise.resolve();
+                    i = 42;
+                }
+                return get();
+            })()
+            """);
+
+        result.Should().Be(42);
+    }
+
+    /// <summary>
+    /// The same lost write, but observed as control flow: writing the loop variable through a
+    /// closure after the await must end the loop. Before the fix the write went to an abandoned
+    /// environment, the loop's own test kept reading the live one, and it ran the full four trips.
+    /// </summary>
+    [Fact]
+    public void ShouldEndTheLoopWhenAClosureWritesTheLoopVariableAfterTheAwait()
+    {
+        var result = RunAsync("""
+            (async () => {
+                let setter = null, trips = 0;
+                for (let i = 0; i < 4; i++) {
+                    if (!setter) { setter = function (v) { i = v; }; }
+                    await Promise.resolve();
+                    setter(100);
+                    trips++;
+                }
+                return trips;
+            })()
+            """);
+
+        result.Should().Be(1);
+    }
+
+    /// <summary>
+    /// A resume lands mid-iteration, where the spec creates no new per-iteration environment.
+    /// Creating one anyway forks away from the environment the body already captured, so closures
+    /// pushed on either side of the await must still agree on the iteration they belong to.
+    /// </summary>
+    [Fact]
+    public void ShouldKeepClosuresOnBothSidesOfTheAwaitInTheSameIteration()
+    {
+        var result = RunAsync("""
+            (async () => {
+                const before = [], after = [];
+                for (let i = 0; i < 3; i++) {
+                    before.push(() => i);
+                    await Promise.resolve();
+                    after.push(() => i);
+                }
+                return before.map(f => f()).join(',') + '|' + after.map(f => f()).join(',');
+            })()
+            """);
+
+        result.Should().Be("0,1,2|0,1,2");
+    }
+
+    // ---- shapes that already worked; kept so a fix cannot regress them ----
+
+    [Fact]
+    public void ShouldSeeOuterBindingWhenLoopBodyHasNoDeclaration()
+    {
+        var result = RunAsync("""
+            const OUTER = 'outer-visible';
+            (async () => {
+                for (let i = 0; i < 256; i++) { await Promise.resolve(); }
+                return OUTER;
+            })()
+            """);
+
+        result.Should().Be("outer-visible");
+    }
+
+    [Fact]
+    public void ShouldSeeOuterBindingWhenDeclarationBlockClosesBeforeTheAwait()
+    {
+        var result = RunAsync("""
+            const OUTER = 'outer-visible';
+            (async () => {
+                for (let i = 0; i < 1; i++) {
+                    if (i >= 0) { const x = i; void x; }
+                    await Promise.resolve();
+                }
+                return OUTER;
+            })()
+            """);
+
+        result.Should().Be("outer-visible");
+    }
+
+    [Fact]
+    public void ShouldSeeOuterBindingWithVarInitialiser()
+    {
+        var result = RunAsync("""
+            const OUTER = 'outer-visible';
+            (async () => {
+                for (var i = 0; i < 1; i++) {
+                    await Promise.resolve();
+                    const x = i + 1;
+                    void x;
+                }
+                return OUTER;
+            })()
+            """);
+
+        result.Should().Be("outer-visible");
+    }
+
+    [Fact]
+    public void ShouldSeeOuterBindingWhenBodyContainsAClosure()
+    {
+        var result = RunAsync("""
+            const OUTER = 'outer-visible';
+            (async () => {
+                for (let i = 0; i < 1; i++) {
+                    const f = () => i;
+                    void f();
+                    await Promise.resolve();
+                }
+                return OUTER;
+            })()
+            """);
+
+        result.Should().Be("outer-visible");
+    }
+
+    [Fact]
+    public void ShouldSeeOuterBindingFromAGeneratorLoopThatYields()
+    {
+        var result = RunAsync("""
+            const OUTER = 'outer-visible';
+            (async () => {
+                function* g() {
+                    for (let i = 0; i < 1; i++) { yield i; const x = i + 1; void x; }
+                    return OUTER;
+                }
+                const it = g();
+                let r = it.next();
+                while (!r.done) r = it.next();
+                return r.value;
+            })()
+            """);
+
+        result.Should().Be("outer-visible");
+    }
+}

--- a/Jint.Tests/Runtime/ForLoopIterationEnvironmentAwaitTests.cs
+++ b/Jint.Tests/Runtime/ForLoopIterationEnvironmentAwaitTests.cs
@@ -37,6 +37,16 @@ namespace Jint.Tests.Runtime;
 /// Generators need no such thing: they capture their context once at GeneratorStart and re-enter
 /// that same function-level context on every resume.
 /// </summary>
+/// <remarks>
+/// Its own non-parallel collection, because the failure mode it targets is an uninterruptible spin.
+/// <see cref="DedicatedThread"/> caps the join and drops the runaway thread's priority, but nothing
+/// can stop it, so it keeps a core busy until the process exits. Running this class alone means a
+/// regression cannot land that load on top of unrelated tests — which is the condition the suite's
+/// known wall-clock flakes fail under. Against the unfixed engine a large fraction of these shapes
+/// leave a spinning thread behind, so the load is a real quantity, not a hypothetical one.
+/// </remarks>
+[CollectionDefinition(nameof(ForLoopIterationEnvironmentAwaitTests), DisableParallelization = true)]
+[Collection(nameof(ForLoopIterationEnvironmentAwaitTests))]
 public class ForLoopIterationEnvironmentAwaitTests
 {
     /// <summary>
@@ -53,37 +63,12 @@ public class ForLoopIterationEnvironmentAwaitTests
     private static JsValue RunAsync(string script)
     {
         JsValue result = null;
-        Exception failure = null;
 
-        var worker = new Thread(() =>
-        {
-            try
-            {
-                result = new Engine().Evaluate(script).UnwrapIfPromise();
-            }
-            catch (Exception ex)
-            {
-                failure = ex;
-            }
-        })
-        {
-            // If it is spinning, it must not keep the test process alive.
-            IsBackground = true,
-        };
-
-        worker.Start();
-
-        if (!worker.Join(TimeSpan.FromSeconds(30)))
-        {
-            throw new Xunit.Sdk.XunitException(
-                "evaluation did not complete within 30s — the lexical environment chain is most "
+        DedicatedThread.Run(
+            () => result = new Engine().Evaluate(script).UnwrapIfPromise(),
+            joinTimeout: TimeSpan.FromSeconds(30),
+            timeoutMessage: "evaluation did not complete within 30s — the lexical environment chain is most "
                 + "likely corrupt, leaving GetThisEnvironment() or an identifier walk spinning");
-        }
-
-        if (failure is not null)
-        {
-            throw new Xunit.Sdk.XunitException($"evaluation threw: {failure}");
-        }
 
         return result;
     }
@@ -206,8 +191,12 @@ public class ForLoopIterationEnvironmentAwaitTests
     [Fact]
     public void ShouldPreserveLoopVariableSemanticsAcrossAwait()
     {
-        // The per-iteration environment must still be per-iteration: each iteration's `i` is a
-        // distinct binding. Guards against "fix it by never creating the environment".
+        // Every iteration's body must observe the value the header reached for that trip. This does
+        // NOT pin the per-iteration environment — each read of `i` happens in the iteration that
+        // wrote it, so a single shared environment still produces "0,2,4" and this test still
+        // passes. ShouldStillCaptureDistinctBindingsPerIterationWhenBodyAwaits below is the one
+        // that actually guards against "fix it by never creating the environment", because only a
+        // closure outliving its iteration can tell the two apart.
         var result = RunAsync("""
             (async () => {
                 const seen = [];
@@ -568,5 +557,724 @@ public class ForLoopIterationEnvironmentAwaitTests
             """);
 
         result.Should().Be("outer-visible");
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // An await in the for-INIT.
+    //
+    // The suspension-node range test that decides whether a re-entry is a replay
+    // (IsNodeInsideForStatementExcludingInit) deliberately excludes the init, because a resume
+    // from the init must re-run the init to complete its pending awaits. That exclusion used to
+    // gate the oldEnv restore as well, so an init resume went on taking oldEnv from the ambient
+    // execution context — which on a replay is the environment that was live at the await, i.e.
+    // the ABANDONED first-attempt loop environment, whose header bindings never got past TDZ
+    // (the init suspended part-way through initializing them).
+    //
+    // Restoring that on loop exit leaves a dead environment current after the loop, so a later
+    // read of a name the header shadows resolves into it and throws ReferenceError — including
+    // through `typeof`, which must never throw for an out-of-scope name. It is also
+    // self-compounding: the value restored on exit is the same one written back into the suspend
+    // data, so each further suspension chains another dead loop environment onto the next one's
+    // outer link.
+    //
+    // Every shape below is checked against Node 24. The head is the trigger, so the matrix runs
+    // it in each of its forms — simple, destructured, multi-declarator, multi-await and const —
+    // crossed with whether the body awaits at all, since the defect does not need a body await.
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void ShouldNotLeakTheLoopHeaderNameAfterAnAwaitingInit()
+    {
+        var result = RunAsync("""
+            (async () => {
+                async function P(x) { return x; }
+                for (let i = await P(0); i < 3; i++) { await P(1); }
+                return typeof i;
+            })()
+            """);
+
+        result.Should().Be("undefined");
+    }
+
+    /// <summary>
+    /// The body never awaits, so the loop runs to completion in one go on the init resume. The
+    /// init suspension alone is enough — this shape threw before the iteration-environment work
+    /// too, which is why it is a fix rather than a regression guard.
+    /// </summary>
+    [Fact]
+    public void ShouldNotLeakTheLoopHeaderNameWhenOnlyTheInitAwaits()
+    {
+        var result = RunAsync("""
+            (async () => {
+                async function P(x) { return x; }
+                for (let i = await P(0); i < 3; i++) { }
+                return typeof i;
+            })()
+            """);
+
+        result.Should().Be("undefined");
+    }
+
+    [Fact]
+    public void ShouldNotLeakADestructuredArrayHeadAfterAnAwaitingInit()
+    {
+        var result = RunAsync("""
+            (async () => {
+                async function P(x) { return x; }
+                for (let [a, b] = await P([0, 10]); a < 2; a++, b++) { await P(1); }
+                return typeof a;
+            })()
+            """);
+
+        result.Should().Be("undefined");
+    }
+
+    [Fact]
+    public void ShouldNotLeakADestructuredObjectHeadAfterAnAwaitingInit()
+    {
+        var result = RunAsync("""
+            (async () => {
+                async function P(x) { return x; }
+                for (let { a, b } = await P({ a: 0, b: 10 }); a < 2; a++, b++) { await P(1); }
+                return typeof a;
+            })()
+            """);
+
+        result.Should().Be("undefined");
+    }
+
+    [Fact]
+    public void ShouldNotLeakTheAwaitedDeclaratorOfAMultiDeclaratorHead()
+    {
+        var result = RunAsync("""
+            (async () => {
+                async function P(x) { return x; }
+                for (let i = 0, j = await P(5); i < 3; i++, j++) { await P(1); }
+                return typeof j;
+            })()
+            """);
+
+        result.Should().Be("undefined");
+    }
+
+    /// <summary>
+    /// Two awaits in the init means two consecutive init resumes. The second one is what proves
+    /// the repair happens at the read: the first resume writes its own oldEnv back into the
+    /// suspend data, so an entry left poisoned would be handed straight to the next resume.
+    /// </summary>
+    [Fact]
+    public void ShouldNotLeakTheLoopHeaderNameAfterTwoAwaitsInTheInit()
+    {
+        var result = RunAsync("""
+            (async () => {
+                async function P(x) { return x; }
+                for (let i = (await P(1)) + (await P(2)); i < 6; i++) { await P(1); }
+                return typeof i;
+            })()
+            """);
+
+        result.Should().Be("undefined");
+    }
+
+    [Fact]
+    public void ShouldNotLeakAConstHeadAfterAnAwaitingInit()
+    {
+        var result = RunAsync("""
+            (async () => {
+                async function P(x) { return x; }
+                for (const i = await P(0); i < 3; ) { await P(1); break; }
+                return typeof i;
+            })()
+            """);
+
+        result.Should().Be("undefined");
+    }
+
+    [Fact]
+    public void ShouldNotLeakTheLoopHeaderNameAfterBreakingOutOfAnAwaitingInitLoop()
+    {
+        var result = RunAsync("""
+            (async () => {
+                async function P(x) { return x; }
+                for (let i = await P(0); i < 5; i++) { await P(1); if (i === 1) break; }
+                return typeof i;
+            })()
+            """);
+
+        result.Should().Be("undefined");
+    }
+
+    [Fact]
+    public void ShouldNotLeakTheLoopHeaderNameWhenTheAwaitingInitLoopIsInsideTry()
+    {
+        var result = RunAsync("""
+            (async () => {
+                async function P(x) { return x; }
+                try {
+                    for (let i = await P(0); i < 2; i++) { await P(1); }
+                    return typeof i;
+                } finally { }
+            })()
+            """);
+
+        result.Should().Be("undefined");
+    }
+
+    /// <summary>
+    /// The silent half of the defect. With an outer binding of the same name the dead environment
+    /// shadows it instead of throwing, so the loop's private counter is what a later read sees —
+    /// a wrong value rather than an error, which is the shape an embedder would never notice.
+    /// </summary>
+    [Fact]
+    public void ShouldNotShadowASameNamedOuterBindingAfterAnAwaitingInit()
+    {
+        var result = RunAsync("""
+            (async () => {
+                async function P(x) { return x; }
+                let x = 'outer-visible';
+                for (let x = await P(0); x < 3; x++) { await P(1); }
+                return x;
+            })()
+            """);
+
+        result.Should().Be("outer-visible");
+    }
+
+    [Fact]
+    public void ShouldNotShadowASameNamedOuterBindingWhenOnlyTheInitAwaits()
+    {
+        var result = RunAsync("""
+            (async () => {
+                async function P(x) { return x; }
+                let x = 'outer-visible';
+                for (let x = await P(0); x < 3; x++) { }
+                return x;
+            })()
+            """);
+
+        result.Should().Be("outer-visible");
+    }
+
+    [Fact]
+    public void ShouldNotShadowASameNamedOuterBindingAfterADestructuredAwaitingInit()
+    {
+        var result = RunAsync("""
+            (async () => {
+                async function P(x) { return x; }
+                let a = 'outer-visible';
+                for (let [a, b] = await P([0, 10]); a < 2; a++, b++) { await P(1); }
+                return a;
+            })()
+            """);
+
+        result.Should().Be("outer-visible");
+    }
+
+    /// <summary>
+    /// The loop still has to compute the right answer: the environment repair must not cost the
+    /// header its identity across resumes, or the trip count changes.
+    /// </summary>
+    [Fact]
+    public void ShouldRunTheCorrectTripCountWithAnAwaitingInit()
+    {
+        var result = RunAsync("""
+            (async () => {
+                async function P(x) { return x; }
+                let n = 0;
+                for (let i = await P(0); i < 5; i++) { await P(1); n++; }
+                return n;
+            })()
+            """);
+
+        result.Should().Be(5);
+    }
+
+    [Fact]
+    public void ShouldAccumulateAcrossAnAwaitingInitLoopWithABodyDeclaration()
+    {
+        var result = RunAsync("""
+            (async () => {
+                async function P(x) { return x; }
+                let s = 0;
+                for (let i = await P(0); i < 3; i++) { const k = await P(i + 1); s += k; }
+                return s;
+            })()
+            """);
+
+        result.Should().Be(6);
+    }
+
+    /// <summary>
+    /// Per-iteration bindings still fork correctly when the head awaits: each closure must see
+    /// its own iteration's value, not the last one.
+    /// </summary>
+    [Fact]
+    public void ShouldGivePerIterationClosuresTheirOwnBindingWithAnAwaitingInit()
+    {
+        var result = RunAsync("""
+            (async () => {
+                async function P(x) { return x; }
+                const fs = [];
+                for (let i = await P(0); i < 3; i++) { fs.push(() => i); await P(1); }
+                return fs.map(f => f()).join(',');
+            })()
+            """);
+
+        result.Should().Be("0,1,2");
+    }
+
+    [Fact]
+    public void ShouldReadThisAfterAnAwaitingInitLoop()
+    {
+        var result = RunAsync("""
+            class K {
+                async leaf() { return 1; }
+                async run() {
+                    for (let i = await this.leaf(); i < 3; i++) { await this.leaf(); }
+                    return await this.leaf();
+                }
+            }
+            new K().run()
+            """);
+
+        result.Should().Be(1);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // A suspension in the for-init used to throw its own TDZ error out of the loop.
+    //
+    // The suspend-data save in JintForStatement's finally reads every header binding through
+    // GetBindingValue so a later resume can replay the values. A suspension *inside* the init
+    // reaches that save with the declaration half-done, and GetBindingValue on an uninitialized
+    // binding does not return a placeholder — it throws the TDZ ReferenceError.
+    //
+    // The throw was invisible, because of where it landed. It skipped the rest of the finally
+    // (the lexical environment was never restored) and surfaced in JintStatementList's catch,
+    // which clears the enclosing list's resume position. For an async function body that position
+    // is the only record of how far the replay had progressed, so the next resume restarted the
+    // body from its first statement. Three distinct symptoms followed, all from that one throw:
+    //
+    //   * a silent infinite re-suspension. Restarting the body re-ran any EARLIER awaiting loop,
+    //     whose awaits were no longer memoized (a loop clears _completedAwaits each trip), so it
+    //     suspended again and restarted the body again. `await` in a for-init after any earlier
+    //     awaiting loop never settled — the engine live, making no progress, and a host without a
+    //     TimeoutInterval hanging outright. Constraints do not save it: Jint does not evaluate
+    //     them for event-loop jobs.
+    //   * function-level `let`/`const` re-initialized. A restart re-ran the declarations before
+    //     the loop, so accumulators silently reset mid-run.
+    //   * generators broken by the same read. A generator never re-enters the loop statement, so
+    //     it never reached the environment-restore path at all — the throw was its only symptom.
+    //
+    // Every shape below is checked against Node 24. They assert the exact sequence of awaited
+    // calls, not merely that nothing threw, so a regression that merely re-orders work fails too.
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Bounded probe: the counter throws after a small budget, so a regression to the infinite
+    /// re-suspension fails in milliseconds with the observed sequence rather than spinning until
+    /// <see cref="RunAsync"/>'s 30-second join expires.
+    /// </summary>
+    private const string Probe = """
+        const seq = [];
+        function T(x) {
+            seq.push(x);
+            if (seq.length > 12) { throw new Error('RUNAWAY seq=[' + seq.join(',') + ']'); }
+            return Promise.resolve(x);
+        }
+        """;
+
+    [Fact]
+    public void ShouldSettleAnInitAwaitFollowingAnAwaitingForLoop()
+    {
+        var result = RunAsync($$"""
+            {{Probe}}
+            (async () => {
+                for (let i = 0; i < 2; i++) { await T(1); }
+                for (let i = await T(10); i < 12; i++) { }
+                return seq.join(',');
+            })()
+            """);
+
+        result.Should().Be("1,1,10");
+    }
+
+    [Fact]
+    public void ShouldSettleAnInitAwaitFollowingAnAwaitingWhileLoop()
+    {
+        var result = RunAsync($$"""
+            {{Probe}}
+            (async () => {
+                let k = 0;
+                while (k < 2) { await T(1); k++; }
+                for (let i = await T(10); i < 12; i++) { }
+                return seq.join(',');
+            })()
+            """);
+
+        result.Should().Be("1,1,10");
+    }
+
+    [Fact]
+    public void ShouldSettleAnInitAwaitFollowingAnAwaitingForOfLoop()
+    {
+        var result = RunAsync($$"""
+            {{Probe}}
+            (async () => {
+                for (const v of [1, 2]) { await T(1); }
+                for (let i = await T(10); i < 12; i++) { }
+                return seq.join(',');
+            })()
+            """);
+
+        result.Should().Be("1,1,10");
+    }
+
+    [Fact]
+    public void ShouldSettleAnInitAwaitFollowingAnAwaitingForAwaitOfLoop()
+    {
+        var result = RunAsync($$"""
+            {{Probe}}
+            (async () => {
+                for await (const v of [1, 2]) { await T(1); }
+                for (let i = await T(10); i < 12; i++) { }
+                return seq.join(',');
+            })()
+            """);
+
+        result.Should().Be("1,1,10");
+    }
+
+    [Fact]
+    public void ShouldSettleTwoConsecutiveInitAwaitLoops()
+    {
+        var result = RunAsync($$"""
+            {{Probe}}
+            (async () => {
+                for (let i = await T(0); i < 2; i++) { await T(1); }
+                for (let j = await T(10); j < 12; j++) { await T(2); }
+                return seq.join(',');
+            })()
+            """);
+
+        result.Should().Be("0,1,1,10,2,2");
+    }
+
+    /// <summary>
+    /// The nested shape, where the inner loop's init is what awaits. This is the case that showed
+    /// the restart most clearly: the iterations themselves were all performed, but a function-level
+    /// accumulator declared before the loops was re-initialized part-way through, so only the
+    /// trailing iterations survived in it.
+    /// </summary>
+    [Fact]
+    public void ShouldNotResetFunctionLocalsWhenANestedInitAwaits()
+    {
+        var result = RunAsync("""
+            (async () => {
+                async function P(x) { return x; }
+                const seen = [];
+                for (let i = 0; i < 2; i++) {
+                    for (let j = await P(0); j < 2; j++) { await P(1); seen.push(i + ':' + j); }
+                }
+                return seen.join(' ');
+            })()
+            """);
+
+        result.Should().Be("0:0 0:1 1:0 1:1");
+    }
+
+    [Fact]
+    public void ShouldNotResetFunctionLocalsAcrossAnInitAwaitLoopThatFollowsAnother()
+    {
+        var result = RunAsync("""
+            (async () => {
+                async function P(x) { return x; }
+                const seen = [];
+                for (let i = 0; i < 2; i++) { await P(1); seen.push('a' + i); }
+                for (let j = await P(0); j < 2; j++) { await P(1); seen.push('b' + j); }
+                return seen.join(',');
+            })()
+            """);
+
+        result.Should().Be("a0,a1,b0,b1");
+    }
+
+    [Fact]
+    public void ShouldRunEveryIterationOfNestedInitAwaitLoops()
+    {
+        var result = RunAsync("""
+            (async () => {
+                async function P(x) { return x; }
+                let n = 0;
+                for (let i = await P(0); i < 2; i++) {
+                    for (let j = await P(0); j < 2; j++) { await P(1); n++; }
+                }
+                return n;
+            })()
+            """);
+
+        result.Should().Be(4);
+    }
+
+    /// <summary>
+    /// A generator never re-enters the loop statement — it captures its context once at
+    /// GeneratorStart and resumes inside the loop — so it never reached the environment-restore
+    /// path these tests started with. The suspend-data read is the one part of that path a
+    /// generator does execute, which is why a <c>yield</c> in a for-init failed and a
+    /// <c>yield</c> in the body never did.
+    /// </summary>
+    [Fact]
+    public void ShouldNotLeakTheLoopHeaderNameAfterAGeneratorYieldsInTheInit()
+    {
+        var result = RunAsync("""
+            function* g() { for (let i = yield 0; i < 3; i++) { yield 1; } return typeof i; }
+            const it = g();
+            it.next();
+            it.next(0);
+            let r = it.next();
+            while (!r.done) { r = it.next(); }
+            r.value
+            """);
+
+        result.Should().Be("undefined");
+    }
+
+    [Fact]
+    public void ShouldNotShadowASameNamedOuterBindingAfterAGeneratorYieldsInTheInit()
+    {
+        var result = RunAsync("""
+            function* g() {
+                let x = 'outer-visible';
+                for (let x = yield 0; x < 3; x++) { yield 1; }
+                return x;
+            }
+            const it = g();
+            it.next();
+            it.next(0);
+            let r = it.next();
+            while (!r.done) { r = it.next(); }
+            r.value
+            """);
+
+        result.Should().Be("outer-visible");
+    }
+
+    /// <summary>
+    /// The test is the third resume position, and the only one that legitimately re-runs the test
+    /// from the top — so neither <c>skipTestOnce</c> nor <c>resumeUpdateOnce</c> is set for it, and
+    /// the entry <c>CreatePerIterationEnvironment</c> keyed on those two ran anyway. That forked
+    /// away from the iteration environment the resume had just reinstated, stranding every closure
+    /// the test created before the await at the value its binding held when it was made: each one
+    /// froze one iteration early. Keying the guard on the restored environment instead covers all
+    /// three positions, since a restored environment means an iteration is already in progress.
+    /// </summary>
+    [Fact]
+    public void ShouldNotStrandClosuresCreatedInTheTestBeforeAnAwait()
+    {
+        var result = RunAsync("""
+            (async () => {
+                const fns = [];
+                for (let i = 0; (fns.push(() => i), await Promise.resolve(i < 2)); ) { i++; }
+                return fns.map(f => f()).join(',');
+            })()
+            """);
+
+        result.Should().Be("1,2,2");
+    }
+
+    [Fact]
+    public void ShouldNotStrandClosuresCreatedInTheTestWhenTheLoopHasAnUpdate()
+    {
+        var result = RunAsync("""
+            (async () => {
+                const fns = [];
+                for (let i = 0; (fns.push(() => i), await Promise.resolve(i < 3)); i++) { }
+                return fns.map(f => f()).join(',');
+            })()
+            """);
+
+        result.Should().Be("0,1,2,3");
+    }
+
+    [Fact]
+    public void ShouldKeepClosuresFromBothSidesOfATestAwaitInTheirOwnIterations()
+    {
+        // A closure made in the test and one made in the body of the same iteration must observe
+        // the same binding — the pair moves together from iteration to iteration.
+        var result = RunAsync("""
+            (async () => {
+                const fns = [];
+                for (let i = 0; (fns.push(() => 't' + i), await Promise.resolve(i < 2)); i++) { fns.push(() => 'b' + i); }
+                return fns.map(f => f()).join(',');
+            })()
+            """);
+
+        result.Should().Be("t0,b0,t1,b1,t2");
+    }
+
+    /// <summary>
+    /// The loop's suspension check for the test used to sit inside the <c>if (!testValue)</c>
+    /// branch, so it was only consulted when the test evaluated falsy. A suspending test that
+    /// nevertheless leaves a truthy value behind — the trip straight after a resume, whose memo for
+    /// the suspending expression is not cleared while the loop is still resuming — therefore fell
+    /// through into the body, running one extra iteration per resume. A <c>yield</c> in the test
+    /// showed it as a loop variable incremented twice between two yields (0, 1, 3, …).
+    /// </summary>
+    [Fact]
+    public void ShouldNotRunAnExtraIterationWhenTheTestSuspendsWhileTruthy()
+    {
+        var result = RunAsync("""
+            function* g() {
+                const fns = [];
+                const yields = [];
+                for (let i = 0; (fns.push(() => i), yields.push(i), yield i); ) { i++; }
+                return yields.join(',') + ' / ' + fns.map(f => f()).join(',');
+            }
+            const it = g();
+            it.next();
+            it.next(true);
+            it.next(true);
+            it.next(false).value
+            """);
+
+        result.Should().Be("0,1,2 / 1,2,2");
+    }
+
+    [Fact]
+    public void ShouldRunTheBodyExactlyOncePerIterationWhenTheTestAwaits()
+    {
+        var result = RunAsync("""
+            (async () => {
+                let runs = 0;
+                for (let i = 0; await Promise.resolve(i < 3); i++) { runs++; }
+                return runs;
+            })()
+            """);
+
+        result.Should().Be(3);
+    }
+
+    /// <summary>
+    /// A generator needs the saved iteration environment exactly as much as an async function does.
+    /// The "a generator re-enters one function-level context" argument is about the <em>outer</em>
+    /// environment; the per-iteration environment is rebuilt on a generator's replay just the same.
+    /// The write after the yield must land in the environment the closure captured, so the closure
+    /// sees 42; without the save it is stranded on an abandoned environment and reports the stale 0.
+    /// Pins the field against being guarded on the suspendable being an async function.
+    /// </summary>
+    [Fact]
+    public void ShouldNotStrandAGeneratorClosureOverTheIterationEnvironment()
+    {
+        var result = RunAsync("""
+            function* g() { let get; for (let i = 0; i < 1; i++) { get = () => i; yield i; i = 42; } return get(); }
+            const it = g();
+            it.next();
+            it.next().value
+            """);
+
+        result.Should().Be(42);
+    }
+
+    /// <summary>
+    /// A <c>yield</c> in the head of a generator's for statement. The loop used to read its header
+    /// bindings on every suspension to save them, which threw the TDZ <c>ReferenceError</c> out of
+    /// the finally when the init had not finished initializing them yet. Those saved values had no
+    /// reader, so the read is gone rather than merely guarded.
+    /// </summary>
+    [Fact]
+    public void ShouldCompleteAGeneratorThatYieldsInTheForInit()
+    {
+        var result = RunAsync("""
+            function* g() { for (let i = yield 0; i < 1; i++) { } return 'done'; }
+            const it = g();
+            it.next();
+            it.next(0).value
+            """);
+
+        result.Should().Be("done");
+    }
+
+    /// <summary>
+    /// A <c>with</c> statement inside an async function used to build a fresh object environment on
+    /// every replay, so the loop's saved outer environment pointed at one no longer on the chain.
+    /// Restoring it detached the chain from the global environment, and the next identifier walk
+    /// failed its <c>GlobalEnvironment</c> cast with an <see cref="InvalidCastException"/> — a .NET
+    /// exception, invisible to a script <c>try</c>/<c>catch</c> and to an embedder catching
+    /// <see cref="JavaScriptException"/>, so an embedder took an unhandled crash out of
+    /// <c>Evaluate</c> instead of a rejected promise.
+    /// </summary>
+    [Fact]
+    public void ShouldResumeIntoTheSameWithEnvironmentItSuspendedIn()
+    {
+        var result = RunAsync("""
+            var obj = { v: 'V' };
+            (async () => {
+                var seen = [];
+                with (obj) {
+                    for (let i = 0; i < 2; i++) { let b = i; await Promise.resolve(); seen.push(v + '/' + b); }
+                    seen.push('post:' + v);
+                }
+                return seen.join(',');
+            })()
+            """);
+
+        result.Should().Be("V/0,V/1,post:V");
+    }
+
+    [Fact]
+    public void ShouldKeepTheWithEnvironmentLiveForAForOfBodyThatAwaits()
+    {
+        var result = RunAsync("""
+            var obj = { v: 'V' };
+            (async () => {
+                var seen = [];
+                with (obj) {
+                    for (const x of [1, 2]) { await Promise.resolve(); seen.push(v + x); }
+                    seen.push('post:' + v);
+                }
+                return seen.join(',');
+            })()
+            """);
+
+        result.Should().Be("V1,V2,post:V");
+    }
+
+    [Fact]
+    public void ShouldResumeIntoNestedWithEnvironments()
+    {
+        var result = RunAsync("""
+            var obj = { v: 'V' };
+            (async () => {
+                var o2 = { w: 'W' };
+                var seen = [];
+                with (obj) {
+                    with (o2) { for (let i = 0; i < 2; i++) { await Promise.resolve(); seen.push(v + w + i); } }
+                    seen.push('post:' + v);
+                }
+                return seen.join(',');
+            })()
+            """);
+
+        result.Should().Be("VW0,VW1,post:V");
+    }
+
+    /// <summary>
+    /// The <c>with</c> object expression can itself suspend. Building the environment over the
+    /// placeholder value would run the body before the object is known, and again on resume.
+    /// </summary>
+    [Fact]
+    public void ShouldHandleAnAwaitInTheWithObjectExpression()
+    {
+        var result = RunAsync("""
+            var obj = { v: 'V' };
+            (async () => {
+                var seen = [];
+                with (await Promise.resolve(obj)) {
+                    for (let i = 0; i < 2; i++) { await Promise.resolve(); seen.push(v + i); }
+                }
+                return seen.join(',');
+            })()
+            """);
+
+        result.Should().Be("V0,V1");
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
@@ -271,7 +271,28 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
         {
             oldEnv = engine.ExecutionContext.LexicalEnvironment;
 
-            if (_canPoolLoopEnv && suspendable is null)
+            // When resuming from an await inside a body that declares let/const, the saved
+            // execution context's lexical environment is the one that was current at the await
+            // — the body block's environment — not the loop's outer environment. Taking it as
+            // oldEnv would restore a block environment on loop exit. Restore the real one from
+            // suspend data, exactly as JintForInForOfStatement.BodyEvaluation does.
+            if (resumingInLoop && suspendData?.OuterEnv is not null)
+            {
+                oldEnv = suspendData.OuterEnv;
+                engine.UpdateLexicalEnvironment(oldEnv);
+            }
+
+            if (resumingInLoop && suspendData?.IterationEnv is not null)
+            {
+                // Reuse the very environment the suspension left behind rather than building a
+                // fresh one and copying the bindings' values into it. A closure created before the
+                // await already captured this environment, so a rebuild would strand it: writes
+                // after the await would land in the new environment while the closure kept reading
+                // the old one. ForOfSuspendData.IterationEnv exists for the same reason.
+                loopEnv = suspendData.IterationEnv;
+                engine.UpdateLexicalEnvironment(loopEnv);
+            }
+            else if (_canPoolLoopEnv && suspendable is null)
             {
                 // Pooled fixed-slot environment, reset and reused across loop entries. ResetSlots leaves
                 // every binding uninitialized (TDZ re-established); the for-init then initializes them.
@@ -370,6 +391,17 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
                     var currentEnv = engine.ExecutionContext.LexicalEnvironment;
 
                     var data = suspendable.Data.GetOrCreate<ForLoopSuspendData>(this);
+
+                    // The environment to restore on loop exit, and the live iteration environment
+                    // to resume into. Written on every suspension, but only ever read by a resume
+                    // into the body, test or update — and for those the rewrite is a no-op, since
+                    // such a resume installed exactly these two and the loop went on running in
+                    // them. A suspension in the *init* also lands here and its oldEnv is not the
+                    // loop's outer environment, but nothing reads it as one: resuming from init
+                    // re-runs the init and rebuilds the loop environment from scratch.
+                    data.OuterEnv = oldEnv;
+                    data.IterationEnv = currentEnv as DeclarativeEnvironment;
+
                     data.BoundValues ??= new Dictionary<Key, JsValue>();
                     for (var i = 0; i < _boundNames.Count; i++)
                     {
@@ -577,7 +609,11 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
             return TightForBody(context, flattenActive);
         }
 
-        if (!resumeUpdateOnce && _shouldCreatePerIterationEnvironment && !_canReuseIterationEnvironment)
+        // CreatePerIterationEnvironment runs once before the first iteration (spec ForBodyEvaluation
+        // step 2). A resume into the body or the update lands MID-iteration, where the spec creates
+        // no new per-iteration environment — and creating one anyway would fork away from the
+        // environment a closure made earlier in this same iteration already captured.
+        if (!skipTestOnce && !resumeUpdateOnce && _shouldCreatePerIterationEnvironment && !_canReuseIterationEnvironment)
         {
             CreatePerIterationEnvironment(context);
         }

--- a/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
@@ -249,6 +249,11 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
         DeclarativeEnvironment? loopEnv = null;
         var engine = context.Engine;
 
+        // Set when this entry adopts the iteration environment the suspension left behind instead of
+        // building a fresh one. It is what tells ForBodyEvaluation not to fork away from it again;
+        // see the entry CreatePerIterationEnvironment there.
+        var restoredIterationEnv = false;
+
         // Check if we're resuming from a yield/await inside this for statement
         // If resuming from body, test, or update, skip initialization to avoid resetting loop variables
         // If resuming from init expression, we must re-execute init to complete pending nested awaits
@@ -260,9 +265,10 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
         var resumingInLoop = resumeNode is not null && IsNodeInsideForStatementExcludingInit(resumeNode);
         var resumingInBody = resumeNode is not null && IsNodeInsideRange(resumeNode, _statement.Body.Range);
         var resumingInUpdate = resumeNode is not null && _statement.Update is not null && IsNodeInsideRange(resumeNode, _statement.Update.Range);
+        var resumingInInit = resumeNode is not null && _statement.Init is not null && IsNodeInsideRange(resumeNode, _statement.Init.Range);
 
         ForLoopSuspendData? suspendData = null;
-        if (resumingInLoop)
+        if (resumingInLoop || resumingInInit)
         {
             suspendable?.Data.TryGet(this, out suspendData);
         }
@@ -271,25 +277,45 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
         {
             oldEnv = engine.ExecutionContext.LexicalEnvironment;
 
-            // When resuming from an await inside a body that declares let/const, the saved
-            // execution context's lexical environment is the one that was current at the await
-            // — the body block's environment — not the loop's outer environment. Taking it as
-            // oldEnv would restore a block environment on loop exit. Restore the real one from
-            // suspend data, exactly as JintForInForOfStatement.BodyEvaluation does.
-            if (resumingInLoop && suspendData?.OuterEnv is not null)
+            // The environment current at the top of a replayed body is the one that was live at
+            // the await, not the loop's outer environment, so it cannot be read from the execution
+            // context on any resume into this loop. Resuming into the *body* it is the body block's
+            // environment whenever the body declares let/const; resuming into the *init* it is the
+            // abandoned first-attempt loop environment, whose header bindings are still in TDZ —
+            // reinstating that on exit makes a later read of a same-named outer binding throw
+            // ReferenceError (and `typeof` on an out-of-scope name must never throw). Restore the
+            // real one from suspend data, exactly as JintForInForOfStatement.BodyEvaluation does.
+            //
+            // The init case has to be repaired here, at the read, and not merely tolerated: `oldEnv`
+            // is what the finally below writes back into the suspend data, so leaving it poisoned
+            // lets each further suspension re-poison the entry and chain another dead loop
+            // environment onto the next one's outer link.
+            //
+            // Only the value is taken. JintForInForOfStatement.BodyEvaluation additionally installs
+            // it, because there the iterator step runs in the outer environment before the
+            // iteration environment exists; here every path below ends in
+            // UpdateLexicalEnvironment(loopEnv) and nothing in between reads the environment, so
+            // installing it would be immediately overwritten.
+            if ((resumingInLoop || resumingInInit) && suspendData?.OuterEnv is not null)
             {
                 oldEnv = suspendData.OuterEnv;
-                engine.UpdateLexicalEnvironment(oldEnv);
             }
 
-            if (resumingInLoop && suspendData?.IterationEnv is not null)
+            var resumedIterationEnv = resumingInLoop ? suspendData?.IterationEnv : null;
+            restoredIterationEnv = resumedIterationEnv is not null;
+            if (resumedIterationEnv is not null)
             {
                 // Reuse the very environment the suspension left behind rather than building a
                 // fresh one and copying the bindings' values into it. A closure created before the
                 // await already captured this environment, so a rebuild would strand it: writes
                 // after the await would land in the new environment while the closure kept reading
                 // the old one. ForOfSuspendData.IterationEnv exists for the same reason.
-                loopEnv = suspendData.IterationEnv;
+                //
+                // Deliberately not extended to an init resume, which re-runs the init: its bindings
+                // must start uninitialized so the declaration can initialize them, and a declarator
+                // that already ran before the await would hit an initialized binding in a reused
+                // environment. Only the outer link above is shared with that case.
+                loopEnv = resumedIterationEnv;
                 engine.UpdateLexicalEnvironment(loopEnv);
             }
             else if (_canPoolLoopEnv && suspendable is null)
@@ -334,19 +360,11 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
                 }
 
                 engine.UpdateLexicalEnvironment(loopEnv);
-
-                // Restore loop variable values if resuming
-                if (resumingInLoop && suspendData?.BoundValues is not null)
-                {
-                    foreach (var kvp in suspendData.BoundValues)
-                    {
-                        loopEnvRec.InitializeBinding(kvp.Key, kvp.Value, DisposeHint.Normal);
-                    }
-                }
             }
         }
 
         var completion = Completion.Empty();
+
         try
         {
             // Skip initialization if resuming from inside the loop (body, test, or update)
@@ -376,7 +394,7 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
 
             // body flattening engages only when the pooled combined-slot environment is live
             var flattenActive = _bodyFlattened && loopEnv is not null && _canPoolLoopEnv && suspendable is null;
-            completion = ForBodyEvaluation(context, suspendData?.AccumulatedValue ?? JsValue.Undefined, skipTestOnce: resumingInBody, resumeUpdateOnce: resumingInUpdate, flattenActive);
+            completion = ForBodyEvaluation(context, suspendData?.AccumulatedValue ?? JsValue.Undefined, skipTestOnce: resumingInBody, resumeUpdateOnce: resumingInUpdate, restoredIterationEnv, flattenActive);
             return completion;
         }
         finally
@@ -393,22 +411,20 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
                     var data = suspendable.Data.GetOrCreate<ForLoopSuspendData>(this);
 
                     // The environment to restore on loop exit, and the live iteration environment
-                    // to resume into. Written on every suspension, but only ever read by a resume
-                    // into the body, test or update — and for those the rewrite is a no-op, since
-                    // such a resume installed exactly these two and the loop went on running in
-                    // them. A suspension in the *init* also lands here and its oldEnv is not the
-                    // loop's outer environment, but nothing reads it as one: resuming from init
-                    // re-runs the init and rebuilds the loop environment from scratch.
+                    // to resume into. Both are rewritten on *every* suspension, and that is
+                    // load-bearing rather than idempotent: unless _canReuseIterationEnvironment,
+                    // CreatePerIterationEnvironment installs a fresh environment at the end of
+                    // every iteration, so the environment saved by the second suspension is not the
+                    // one saved by the first. Hoisting these writes to the first suspension, or
+                    // guarding them with `if (data.IterationEnv is null)` as redundant work,
+                    // silently returns iterations 2+ to the stranded-closure behaviour this whole
+                    // mechanism exists to prevent — and no single-iteration test can see it.
+                    //
+                    // oldEnv is sound to write on every path, including a suspension in the init,
+                    // precisely because the read above repairs it first: only the very first entry
+                    // takes it from the execution context, and that one is not a replay.
                     data.OuterEnv = oldEnv;
                     data.IterationEnv = currentEnv as DeclarativeEnvironment;
-
-                    data.BoundValues ??= new Dictionary<Key, JsValue>();
-                    for (var i = 0; i < _boundNames.Count; i++)
-                    {
-                        var name = _boundNames[i];
-                        var value = currentEnv.GetBindingValue(name, strict: false);
-                        data.BoundValues[name] = value;
-                    }
                 }
                 else if (!context.IsSuspended())
                 {
@@ -584,7 +600,7 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
     /// <summary>
     /// https://tc39.es/ecma262/#sec-forbodyevaluation
     /// </summary>
-    private Completion ForBodyEvaluation(EvaluationContext context, JsValue initialValue, bool skipTestOnce, bool resumeUpdateOnce, bool flattenActive = false)
+    private Completion ForBodyEvaluation(EvaluationContext context, JsValue initialValue, bool skipTestOnce, bool resumeUpdateOnce, bool restoredIterationEnv, bool flattenActive = false)
     {
         var v = initialValue;
 
@@ -610,10 +626,19 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
         }
 
         // CreatePerIterationEnvironment runs once before the first iteration (spec ForBodyEvaluation
-        // step 2). A resume into the body or the update lands MID-iteration, where the spec creates
-        // no new per-iteration environment — and creating one anyway would fork away from the
-        // environment a closure made earlier in this same iteration already captured.
-        if (!skipTestOnce && !resumeUpdateOnce && _shouldCreatePerIterationEnvironment && !_canReuseIterationEnvironment)
+        // step 2). A resume into the loop lands MID-iteration, where the spec creates no new
+        // per-iteration environment — and creating one anyway would fork away from the environment a
+        // closure made earlier in this same iteration already captured.
+        //
+        // The key is the restored environment, not the resume position. Keying it on skipTestOnce /
+        // resumeUpdateOnce alone covered a resume into the body or the update but missed the third
+        // position, the test: a test-await is the one resume that legitimately re-runs the test from
+        // the top, so both flags are false, yet the caller has just installed the suspension's own
+        // iteration environment and forking away from it strands every closure the test made before
+        // the await (`for (let i = 0; (fns.push(() => i), await p); )` froze each closure at the value
+        // i held when it was created). Whenever that environment was restored there is by definition
+        // an iteration already in progress to stay inside, whichever position resumed.
+        if (!restoredIterationEnv && !skipTestOnce && !resumeUpdateOnce && _shouldCreatePerIterationEnvironment && !_canReuseIterationEnvironment)
         {
             CreatePerIterationEnvironment(context);
         }
@@ -628,15 +653,23 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
             {
                 debugHandler?.OnStep(_test._expression);
 
-                if (!_test.GetBooleanValue(context))
-                {
-                    // Check for async suspension in test expression
-                    if (context.IsSuspended())
-                    {
-                        SaveAccumulatedValue(context, v);
-                        return new Completion(CompletionType.Return, JsValue.Undefined, ((JintStatement) this)._statement);
-                    }
+                var testHeld = _test.GetBooleanValue(context);
 
+                // The suspension check has to precede the result check, not sit inside its false
+                // branch. A yield/await in the test suspends and yet leaves a *truthy* value behind
+                // whenever the suspending expression's value is the memoized one — which is exactly
+                // what the trip after a resume does, since the resume's memo is not cleared until
+                // the loop stops resuming. Testing the value first let that trip fall through into
+                // the body: the loop ran one extra iteration per resume, incrementing the loop
+                // variable a second time and yielding the wrong value on the next trip.
+                if (context.IsSuspended())
+                {
+                    SaveAccumulatedValue(context, v);
+                    return new Completion(CompletionType.Return, JsValue.Undefined, ((JintStatement) this)._statement);
+                }
+
+                if (!testHeld)
+                {
                     context.Engine.ExecutionContext.Suspendable?.Data.Clear(this);
                     return new Completion(CompletionType.Normal, v, ((JintStatement) this)._statement);
                 }

--- a/Jint/Runtime/Interpreter/Statements/JintWithStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintWithStatement.cs
@@ -1,6 +1,7 @@
 using Jint.Native;
 using Jint.Runtime.Environments;
 using Jint.Runtime.Interpreter.Expressions;
+using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Runtime.Interpreter.Statements;
 
@@ -20,11 +21,44 @@ internal sealed class JintWithStatement : JintStatement<WithStatement>
 
     protected override Completion ExecuteInternal(EvaluationContext context)
     {
-        var jsValue = _object.GetValue(context);
         var engine = context.Engine;
-        var obj = TypeConverter.ToObject(engine.Realm, jsValue);
-        var oldEnv = engine.ExecutionContext.LexicalEnvironment;
-        var newEnv = JintEnvironment.NewObjectEnvironment(engine, obj, oldEnv, provideThis: true, withEnvironment: true);
+        var suspendable = engine.ExecutionContext.Suspendable;
+
+        ObjectEnvironment newEnv;
+        Environment oldEnv;
+
+        // A replay must resume into the environment it suspended in, not a fresh one. Every
+        // environment-owning statement inside the body saves this object environment as its own
+        // outer environment across a suspension and restores it on exit, so a rebuilt one turns
+        // those saves into references to an environment that is no longer on the chain — the
+        // restore then detaches the chain from the global environment. Mirrors JintBlockStatement.
+        if (suspendable is { IsResuming: true }
+            && suspendable.Data.TryGet(this, out WithSuspendData? suspendData)
+            && suspendData?.WithEnvironment is not null)
+        {
+            newEnv = suspendData.WithEnvironment;
+
+            // Captured on suspension; the current environment is the fallback if it is somehow absent.
+            oldEnv = suspendData.OuterEnvironment ?? engine.ExecutionContext.LexicalEnvironment;
+        }
+        else
+        {
+            var jsValue = _object.GetValue(context);
+
+            // The object expression can itself suspend (`with (await p) { … }`). Building an
+            // environment over the placeholder value and running the body against it would be
+            // wrong twice over — the body runs before the object is known, and it runs again on
+            // resume — so unwind and let the replay redo the whole statement.
+            if (context.IsSuspended())
+            {
+                return new Completion(CompletionType.Return, JsValue.Undefined, _statement);
+            }
+
+            var obj = TypeConverter.ToObject(engine.Realm, jsValue);
+            oldEnv = engine.ExecutionContext.LexicalEnvironment;
+            newEnv = JintEnvironment.NewObjectEnvironment(engine, obj, oldEnv, provideThis: true, withEnvironment: true);
+        }
+
         engine.UpdateLexicalEnvironment(newEnv);
 
         Completion c;
@@ -38,6 +72,17 @@ internal sealed class JintWithStatement : JintStatement<WithStatement>
         }
         finally
         {
+            if (context.IsSuspended() && suspendable is not null)
+            {
+                var data = suspendable.Data.GetOrCreate<WithSuspendData>(this);
+                data.WithEnvironment = newEnv;
+                data.OuterEnvironment = oldEnv;
+            }
+            else
+            {
+                suspendable?.Data.Clear(this);
+            }
+
             engine.UpdateLexicalEnvironment(oldEnv);
         }
 

--- a/Jint/Runtime/SuspendData.cs
+++ b/Jint/Runtime/SuspendData.cs
@@ -99,6 +99,44 @@ internal sealed class ForLoopSuspendData : SuspendData
     /// The accumulated completion value from previous iterations.
     /// </summary>
     public JsValue AccumulatedValue { get; set; } = JsValue.Undefined;
+
+    /// <summary>
+    /// The environment that was current when the loop was entered — the one the loop must
+    /// restore on exit.
+    /// <para>
+    /// It cannot be re-read from the execution context on resume. An async function captures
+    /// <c>_savedContext</c> afresh at <em>every</em> await
+    /// (<see cref="Interpreter.Expressions.JintAwaitExpression"/>), so the environment current at
+    /// the top of a replayed body is the one that was live at the await — the body block's
+    /// environment when the body declares let/const, not the loop's outer environment. Restoring
+    /// that instead would leave a block environment current after the loop, which both leaks the
+    /// block's bindings past it and — once the block parks and detaches that environment — leaves
+    /// the chain no longer terminating in the global environment.
+    /// </para>
+    /// <para>
+    /// <see cref="ForOfSuspendData.OuterEnv"/> exists for exactly this reason and is the direct
+    /// precedent; a generator needs neither, because it captures its context once at
+    /// GeneratorStart and re-enters that same function-level context on every resume.
+    /// </para>
+    /// </summary>
+    public Environments.Environment? OuterEnv { get; set; }
+
+    /// <summary>
+    /// The loop's live iteration environment at the moment of suspension, resumed into rather
+    /// than rebuilt.
+    /// <para>
+    /// Rebuilding it and copying <see cref="BoundValues"/> across is not equivalent. A closure
+    /// created in the body before the await has already captured the original environment, so a
+    /// rebuild strands it: assignments to the loop variable after the await land in the new
+    /// environment while the closure — and the loop's own test and update — go on reading the old
+    /// one. That silently loses writes and can change a loop's trip count.
+    /// </para>
+    /// <para>
+    /// <see cref="ForOfSuspendData.IterationEnv"/> is the direct precedent. <see cref="BoundValues"/>
+    /// remains the fallback for a resume that has no saved environment.
+    /// </para>
+    /// </summary>
+    public DeclarativeEnvironment? IterationEnv { get; set; }
 }
 
 internal sealed class SwitchBlockSuspendData : SuspendData

--- a/Jint/Runtime/SuspendData.cs
+++ b/Jint/Runtime/SuspendData.cs
@@ -91,11 +91,6 @@ internal sealed class ForOfSuspendData : SuspendData
 internal sealed class ForLoopSuspendData : SuspendData
 {
     /// <summary>
-    /// The saved values of loop variables (let bindings in for loop init).
-    /// </summary>
-    public Dictionary<Key, JsValue>? BoundValues { get; set; }
-
-    /// <summary>
     /// The accumulated completion value from previous iterations.
     /// </summary>
     public JsValue AccumulatedValue { get; set; } = JsValue.Undefined;
@@ -107,16 +102,31 @@ internal sealed class ForLoopSuspendData : SuspendData
     /// It cannot be re-read from the execution context on resume. An async function captures
     /// <c>_savedContext</c> afresh at <em>every</em> await
     /// (<see cref="Interpreter.Expressions.JintAwaitExpression"/>), so the environment current at
-    /// the top of a replayed body is the one that was live at the await — the body block's
-    /// environment when the body declares let/const, not the loop's outer environment. Restoring
-    /// that instead would leave a block environment current after the loop, which both leaks the
-    /// block's bindings past it and — once the block parks and detaches that environment — leaves
-    /// the chain no longer terminating in the global environment.
+    /// the top of a replayed body is the one that was live at the await, never the loop's outer
+    /// environment. Which wrong environment that is depends on where the loop is resumed:
+    /// </para>
+    /// <para>
+    /// Resuming into the <em>body</em> it is the body block's environment when the body declares
+    /// let/const. Restoring that would leave a block environment current after the loop, which both
+    /// leaks the block's bindings past it and — once the block parks and detaches that environment
+    /// — leaves the chain no longer terminating in the global environment.
+    /// </para>
+    /// <para>
+    /// Resuming into the <em>init</em> it is the abandoned first-attempt loop environment, whose
+    /// header bindings never got past TDZ (the init suspended part-way through initializing them).
+    /// Restoring that leaves a dead environment current after the loop, so reading an outer binding
+    /// the header shadows throws ReferenceError — including through <c>typeof</c>, which must never
+    /// throw for an out-of-scope name. It is also self-compounding: the value restored on exit is
+    /// the same one written back here, so each further suspension chains another dead loop
+    /// environment onto the next one's outer link.
     /// </para>
     /// <para>
     /// <see cref="ForOfSuspendData.OuterEnv"/> exists for exactly this reason and is the direct
-    /// precedent; a generator needs neither, because it captures its context once at
-    /// GeneratorStart and re-enters that same function-level context on every resume.
+    /// precedent. A generator does not need <em>this</em> field — it captures its context once at
+    /// GeneratorStart and re-enters that same function-level context on every resume, so the
+    /// environment it resumes with really is the loop's outer one. That argument is about the outer
+    /// environment only, and emphatically does not extend to <see cref="IterationEnv"/>, which a
+    /// generator needs exactly as much as an async function does; see the note there.
     /// </para>
     /// </summary>
     public Environments.Environment? OuterEnv { get; set; }
@@ -125,15 +135,27 @@ internal sealed class ForLoopSuspendData : SuspendData
     /// The loop's live iteration environment at the moment of suspension, resumed into rather
     /// than rebuilt.
     /// <para>
-    /// Rebuilding it and copying <see cref="BoundValues"/> across is not equivalent. A closure
-    /// created in the body before the await has already captured the original environment, so a
-    /// rebuild strands it: assignments to the loop variable after the await land in the new
-    /// environment while the closure — and the loop's own test and update — go on reading the old
-    /// one. That silently loses writes and can change a loop's trip count.
+    /// Rebuilding it and copying the binding values across is not equivalent. A closure created
+    /// before the await has already captured the original environment, so a rebuild strands
+    /// <em>the closure</em>, and only it: the loop's own test and update run in the environment the
+    /// loop just installed — the new one — and go on agreeing with each other, while the closure
+    /// alone keeps reading the abandoned one. So the loop appears to work and the captured
+    /// function silently reports a stale value.
     /// </para>
     /// <para>
-    /// <see cref="ForOfSuspendData.IterationEnv"/> is the direct precedent. <see cref="BoundValues"/>
-    /// remains the fallback for a resume that has no saved environment.
+    /// This is needed for a generator just as much as for an async function, which is easy to miss
+    /// because the argument on <see cref="OuterEnv"/> above ("a generator re-enters one
+    /// function-level context") does not carry over. That context is the function's, not the
+    /// loop's; the per-iteration environment is rebuilt on a generator's replay exactly as on an
+    /// async function's, and
+    /// <c>function* g() { let get; for (let i = 0; i &lt; 1; i++) { get = () =&gt; i; yield i; i = 42; } return get(); }</c>
+    /// returns 42 with this field — the write after the yield lands in the environment the closure
+    /// captured, as the spec requires — and 0 without it, the closure left reading an abandoned
+    /// environment that never saw the write. Do not guard the save on the suspendable being an
+    /// async function.
+    /// </para>
+    /// <para>
+    /// <see cref="ForOfSuspendData.IterationEnv"/> is the direct precedent.
     /// </para>
     /// </summary>
     public DeclarativeEnvironment? IterationEnv { get; set; }
@@ -394,6 +416,33 @@ internal sealed class BlockSuspendData : SuspendData
     /// to advance the dispose state machine.
     /// </summary>
     public bool DisposeInProgress { get; set; }
+}
+
+/// <summary>
+/// Stores the object environment of a <c>with</c> statement when execution suspends inside its
+/// body, so a replay resumes into that same environment instead of building a fresh one.
+/// <para>
+/// Unlike a block's, this environment is not merely an optimization to preserve: any statement
+/// inside the body that saves its own outer environment across a suspension — every loop, block,
+/// switch and catch clause does — saves <em>this</em> object environment, and restores it when it
+/// exits. Rebuilding it on replay left those saves pointing at an environment no longer on the
+/// chain, so restoring one detached the lexical chain from the global environment and the next
+/// identifier walk failed its <c>GlobalEnvironment</c> cast with an
+/// <see cref="InvalidCastException"/> — a .NET exception, so neither a script <c>try</c>/<c>catch</c>
+/// nor an embedder catching <see cref="JavaScriptException"/> could see it.
+/// </para>
+/// </summary>
+internal sealed class WithSuspendData : SuspendData
+{
+    /// <summary>
+    /// The object environment created for the <c>with</c> body.
+    /// </summary>
+    public ObjectEnvironment? WithEnvironment { get; set; }
+
+    /// <summary>
+    /// The environment to restore once the body completes.
+    /// </summary>
+    public Environments.Environment? OuterEnvironment { get; set; }
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

Resume a suspended `for` and `with` into the state they suspended in.

## Details

An environment-owning statement that can be suspended by `await` or `yield` must resume into the
environment it suspended in. `JintAwaitExpression.SuspendForAwait` re-captures `_savedContext` at
**every** await, so the environment current at the top of a replayed body is the one that was live
*at the await* — never the statement's own outer environment. Two statements did not account for
that: the C-style `for` loop, and `with`.

Two commits: the first is the original `for` fix, the second answers review and closes three more
resume positions plus `with`.

### 1 — `for (let …)` restored the wrong environment on exit (`28fd3bd8f`)

The loop read its outer environment from the execution context on every entry, including a
re-entry that is an async *replay*. Resuming into the body, what it read was the body block's
environment whenever the body declares a `let`/`const`. The loop took that as its own outer
environment and reinstated it on exit.

```js
const OUTER = 'outer-visible';
(async () => {
    for (let i = 0; i < 1; i++) {
        await Promise.resolve();
        const x = i + 1;
        void x;
    }
    return OUTER;          // throws
})()
```

```
InvalidCastException: Unable to cast object of type 'DeclarativeEnvironment'
                      to type 'GlobalEnvironment'
```

**Four failures follow from that one line**, two loud and two silent:

- `InvalidCastException` from `JintEnvironment.TryGetIdentifierEnvironmentWithBindingValue`, which
  casts to `GlobalEnvironment` on the assumption that only the global environment has a null
  `_outerEnv` — but a slot-backed block environment parked into `JintBlockStatement._cachedEnv` is
  detached at park time and has exactly that shape.
- A hang in `ExecutionContext.GetThisEnvironment()`, whose `while (true)` walk relies on the chain
  ending at the global environment. Its own source comment states that invariant; this broke it.
- A silent scope leak — the block's `let`/`const` stayed visible after the loop, and on wider
  shapes even globals became unresolvable.
- A silent lost write, and a quadratic slowdown — a closure created before the await was stranded
  when the replay rebuilt the iteration environment, so writes after the await went to an abandoned
  environment. The rebuild also parented each new environment under the previous one, growing the
  scope chain by one level per await.

`ForLoopSuspendData` gains **`OuterEnv`** (restored on resume instead of re-read from the execution
context) and **`IterationEnv`** (resumed *into* rather than rebuilt, so a closure captured before
the await is not stranded), and `CreatePerIterationEnvironment` no longer runs on a body or update
resume: that lands mid-iteration, where `ForBodyEvaluation` step 2 creates no new per-iteration
environment.

`JintForInForOfStatement.BodyEvaluation` already does the first two, for the same reason — see
f089071fc, whose message describes this defect exactly, but which fixed it for `for-of` and only
for `for-of`.

### 2 — the other two resume positions, and `with` (`8e4e03b43`)

Review found that a `for` loop has three resume positions and the first commit had only handled
one and a half. It also found a statement rebuilding the environment everything inside it had
saved.

**An `await` in the init.** The range test that decides whether a re-entry is a replay
(`IsNodeInsideForStatementExcludingInit`) deliberately excludes the init, because an init resume
must re-run the init to complete its pending awaits — and that exclusion gated the `OuterEnv`
restore too. So an init resume went on taking `oldEnv` from the ambient context, which on a replay
is the *abandoned first-attempt loop environment*, whose header bindings never got past TDZ.
Restoring that on exit makes a later read of a name the header shadows throw `ReferenceError` —
including through `typeof`, which must never throw for an out-of-scope name. `OuterEnv` is repaired
at the read rather than merely tolerated, because it is what the `finally` writes back: leaving it
poisoned chains another dead environment onto the next suspension's outer link. `IterationEnv` is
deliberately *not* extended to an init resume, which re-runs the init and needs its bindings
uninitialized.

**An `await` in the test.** A test resume is the one resume that legitimately re-runs the test from
the top, so neither `skipTestOnce` nor `resumeUpdateOnce` is set and the entry
`CreatePerIterationEnvironment` ran anyway — forking away from the iteration environment the resume
had just reinstated, and stranding every closure the test made before the await:

```js
for (let i = 0; (fns.push(() => i), await p(i < 2)); ) { i++; }
```

gave `0,1,2` where Node 24 gives `1,2,2`. The guard now keys on *the restored environment* rather
than on the resume position, which covers all three positions at once: whenever that environment
was restored there is by definition an iteration already in progress to stay inside.

**A truthy suspension in the test** (pre-existing). The suspension check sat inside the
`if (!testValue)` branch, so a suspension that leaves a *truthy* value behind went unnoticed —
which is exactly what the trip after a resume does, since the resume's memo is not cleared while
the loop is still resuming. The loop fell through into the body and ran one extra iteration per
resume; a `yield` in the test showed it as yields `0, 1, 3` instead of `0, 1, 2`. Only observable
with an `i++`-shaped body, which is why it outlived the first fix.

**`with` rebuilt its environment on every replay.** Every environment-owning statement inside the
body saves that object environment as its own outer one, so a rebuilt one turned those saves into
references to an environment no longer on the chain. The chain then no longer terminated in the
global environment and the next identifier walk failed its `GlobalEnvironment` cast with
`InvalidCastException` — a .NET exception, so neither a script `try`/`catch` nor an embedder
catching `JavaScriptException` could see it, and an embedder took an unhandled crash out of
`Evaluate` where it expected a rejected promise.

```js
var obj = { v: 'V' };
(async () => {
    var seen = [];
    with (obj) {
        for (let i = 0; i < 2; i++) { let b = i; await Promise.resolve(); seen.push(v + '/' + b); }
        seen.push('post:' + v);
    }
    return seen.join(',');
})()
// Node 24: "V/0,V/1,post:V"   main: InvalidCastException out of Evaluate
```

It now carries `WithSuspendData` and resumes into the same environment, mirroring
`JintBlockStatement` — which fixes the case rather than just its symptom, since the shape now
returns Node's answer. `with` was the last environment-owning statement without resume awareness;
block, switch, catch and for-of already had it. Its object expression can itself suspend
(`with (await p) { … }`), so that path unwinds and lets the replay redo the whole statement rather
than building an environment over the placeholder value.

**`ForLoopSuspendData.BoundValues` is gone.** Every resume with suspend data takes the
`IterationEnv` branch, and a resume without it has no saved values either, so the save was paying
`_boundNames.Count` `GetBindingValue` calls plus dictionary stores per await for state nothing
read — confirmed by instrumenting the restore arm and getting zero hits across all of Test262 and
`Jint.Tests`. Removing the save also removes the read that threw a TDZ `ReferenceError` out of the
`finally` on an init suspension, so
`function* g() { for (let i = yield 0; i < 1; i++) { } return 'done'; }` completes instead of
throwing.

### Generators are affected, and only by half of this

Worth stating precisely, because the obvious summary is wrong in one direction.

`OuterEnv` is genuinely an async-only concern: a generator captures its context once at
`GeneratorStart` and re-enters that same function-level context on every resume, so the environment
it resumes with really is the loop's outer one.

**That argument does not extend to `IterationEnv`, which a generator needs exactly as much as an
async function does.** The context a generator re-enters is the *function's*, not the loop's; the
per-iteration environment is rebuilt on a generator's replay exactly as on an async function's:

```js
function* g() { let get; for (let i = 0; i < 1; i++) { get = () => i; yield i; i = 42; } return get(); }
```

returns `42` with the field — the write after the `yield` lands in the environment the closure
captured, as the spec requires — and `0` without it, the closure left reading an abandoned
environment that never saw the write. So do **not** guard the save on the suspendable being an
`AsyncFunctionInstance`. The same holds for the init TDZ throw above, which a generator hits
without ever reaching the environment-restore path at all. This is written up on
`ForLoopSuspendData.IterationEnv`, with the script inline, so the next reader does not re-derive
the wrong half of it.

### Worth reviewers' attention

**Why the `for` fix is not in `JintBlockStatement`.** The block is correct. Its saved
`OuterEnvironment` genuinely is the environment its block env was created under, and restoring it
is exactly what `for-of` does. The fault is one frame up, in the for statement.

**Why a closure in the body masked the crash.** Not by disabling the iteration-environment reuse
optimisation — forcing `_canReuseIterationEnvironment` false changes nothing, which is what made
this hard to find. It is that `BlockState` only takes slot-backed storage when
`EnvironmentEscapeAstVisitor.MayEscape` is false, and only a slot-backed block environment is ever
parked and detached. The wrong environment was restored either way, so the closure hid the crash
while leaving the scope leak and the lost write in place. The tests assert the bindings are gone
rather than merely that nothing threw.

**Why `OuterEnv` and `IterationEnv` are rewritten on every suspension.** That is load-bearing
rather than idempotent: unless `_canReuseIterationEnvironment`, `CreatePerIterationEnvironment`
installs a fresh environment at the end of every iteration, so the environment saved by the second
suspension is not the one saved by the first. Guarding the writes as redundant work silently
returns iterations 2+ to the stranded-closure behaviour — and no single-iteration test can see it.
The comment in the `finally` says so.

**The structural point, deliberately out of scope.** `SuspendForAwait` capturing the live
environment is why six statements have each had to independently re-save their own outer
environment (`JintBlockStatement`, `JintSwitchStatement`, the catch clause,
`JintForInForOfStatement` twice, and now `JintForStatement` and `JintWithStatement`), and every one
of them was found the same way — an `InvalidCastException` to `GlobalEnvironment`, or an
unbreakable spin, in production. Restoring the statement's own outer environment once in the resume
path would make the next environment-owning statement correct by construction. Happy to file that
separately; it is a bigger change than a bug fix should carry.

**Scope.** Splitting the two commits is possible — the first is the crash fix and stands alone —
but they are one mechanism and the second is what makes the first complete. Say the word.

**No new retention.** `Data.Clear(this)` sits in the `finally`'s not-suspended arm for both
statements, so it fires on normal completion, `break`, `return` and `throw` alike. The new
references live only while the statement is genuinely suspended, bounded by the async call's
lifetime.

**Cost on unaffected paths.** The pooled, flattened and tight-body lanes are all gated on
`suspendable is null` and cannot engage in an async frame; the new branches short-circuit on
`resumingInLoop` / `resumingInInit`, false for every synchronous loop. `with` reads
`ExecutionContext.Suspendable` once and takes the existing path when it is null. The two benchmark
controls below measure exactly this.

## Linked issue

Fixes #

## Test plan

- [x] Added or updated unit tests in `Jint.Tests`
- [x] Ran `dotnet test --configuration Release` locally
- [x] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no regressions
- [ ] For interop changes: covered in `Jint.Tests/Runtime/Interop` — n/a, no interop surface touched
- [x] For perf changes: included before/after numbers from `Jint.Benchmark`

`Jint.Tests/Runtime/ForLoopIterationEnvironmentAwaitTests.cs` — **61 tests**:

| group | tests |
| --- | ---: |
| body/test/update resume: the four manifestations, the trigger matrix, and controls a naive fix would break (per-iteration bindings must stay distinct; closures must still capture per-iteration) | 24 |
| `await` in the init: header shapes (simple, destructured, multi-declarator, multi-await, `const`) crossed with whether the body awaits, plus the shadowing and loop-exit cases | 16 |
| the init-suspension TDZ throw and the three symptoms it caused (infinite re-suspension, function-locals reset, generators) | 10 |
| `await`/`yield` in the test: stranded closures, and the extra iteration from a truthy suspension | 5 |
| generator shapes for `IterationEnv` and the init | 2 |
| `with`: same environment on resume, nested, a `for-of` body, and an `await` in the object expression | 4 |

Every evaluation runs on a `DedicatedThread` with a join timeout, and the class has its own
non-parallel collection, because one manifestation is an uninterruptible spin: a `TimeoutInterval`
constraint cannot stop it, since Jint does not evaluate constraints for event-loop jobs. Against
the unfixed engine a large fraction of these shapes leave a spinning thread behind, so that load is
a real quantity, not a hypothetical one.

| suite | result |
| --- | --- |
| `Jint.Tests` | 4721 passed, 0 failed (4 skipped) |
| `Jint.Tests.PublicInterface` | 1240 passed, 0 failed (9 skipped) |
| both under `JINT_HOST_CONTRACT_VERIFICATION=1` | 4721 / 1244 passed, 0 failed |
| `Jint.Tests.CommonScripts` | 28 passed, 0 failed |
| `Jint.Tests.Test262` | 99484 passed, 0 failed (157 skipped) |

Every new shape is pinned against **Node v24**, not against "differs from before" — on several of
these the branch and its parent were each wrong in *different* ways, and on one the expected
polarity is counter-intuitive (the closure must observe the post-`yield` write, so `42` is correct
and `main`'s `0` was the bug). Also differentially tested against Node for the minimal repro, the
lost-write pair, init-await shapes, loop-exit edge cases (`break` / labelled `continue` / `throw` /
nested / sequential / header awaits) and sibling constructs (`while`, `do-while`, `switch`,
`try`/`catch`/`finally`, labelled block, `for-in`, `for-of`) — all matching.

### Performance

Removing the per-resume rebuild takes an awaiting `for (let …)` loop from quadratic to linear in
its trip count. Default BenchmarkDotNet job, idle machine.

| benchmark | before | after | |
| --- | ---: | ---: | --- |
| 250 trips | 589.9 µs | 172.0 µs | 3.4× |
| 1000 trips | 7,540.0 µs | 647.5 µs | 11.6× |
| 2000 trips | 31,098.9 µs | 1,298.6 µs | **24.0×** |
| `var` header (control — changed code unreachable) | 578.9 µs | 560.9 µs | unchanged |
| synchronous loop (control) | 24.78 µs | 24.96 µs | unchanged |

Allocation falls ~43% at every size (1000 trips: 522,622 B → 298,520 B).

> Measured at the first commit against its base. The second commit only *removes* per-await work
> (the `BoundValues` save: `_boundNames.Count` `GetBindingValue` calls plus dictionary stores on
> every suspension), so these are a lower bound on the current branch. Happy to re-run the pair if
> you want the figures restated against today's `main`.

The benchmark is not part of the commit, since it exists only to measure this change. Source to
reproduce:

<details>
<summary><code>Jint.Benchmark/ForLetAwaitBenchmark.cs</code></summary>

```csharp
using BenchmarkDotNet.Attributes;

namespace Jint.Benchmark;

[MemoryDiagnoser]
[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
public class ForLetAwaitBenchmark
{
    private Engine _engine = null!;
    private Prepared<Script> _awaitLetLoop250, _awaitLetLoop, _awaitLetLoop2000;
    private Prepared<Script> _awaitVarLoop, _syncLetLoop;

    private static Prepared<Script> LetLoop(int n) => Engine.PrepareScript($$"""
        async function f() {
            var s = 0;
            for (let i = 0; i < {{n}}; i++) { s += await Promise.resolve(1); }
            return s;
        }
        f();
        """);

    [GlobalSetup]
    public void Setup()
    {
        _engine = new Engine();
        _awaitLetLoop250 = LetLoop(250);
        _awaitLetLoop = LetLoop(1000);
        _awaitLetLoop2000 = LetLoop(2000);

        // control: `var` header, so _boundNames is null and the changed code is unreachable
        _awaitVarLoop = Engine.PrepareScript("""
            async function f() {
                var s = 0;
                for (var i = 0; i < 1000; i++) { s += await Promise.resolve(1); }
                return s;
            }
            f();
            """);

        // control: no async at all
        _syncLetLoop = Engine.PrepareScript("""
            function f() {
                var s = 0;
                for (let i = 0; i < 1000; i++) { s += 1; }
                return s;
            }
            f();
            """);
    }

    [Benchmark] public void AwaitLetLoop250() => _engine.Evaluate(_awaitLetLoop250);
    [Benchmark] public void AwaitLetLoop1000() => _engine.Evaluate(_awaitLetLoop);
    [Benchmark] public void AwaitLetLoop2000() => _engine.Evaluate(_awaitLetLoop2000);
    [Benchmark] public void AwaitVarLoop1000() => _engine.Evaluate(_awaitVarLoop);
    [Benchmark] public void SyncLetLoop1000() => _engine.Evaluate(_syncLetLoop);
}
```

The bodies deliberately declare no `let`/`const`, because that is the only `for-let` + `await`
shape that also runs on the pre-fix engine, so patched and unpatched are comparable.

</details>

## Breaking change?

No. `ForLoopSuspendData`, `WithSuspendData`, `JintForStatement` and `JintWithStatement` are all
`internal`; there are no public API changes. The behaviour change is bug-fix only — the affected
shapes previously threw, hung, or produced results that disagree with the spec and with Node 24.
