### PR TITLE
Update test262 suite and adopt the new take/drop RangeError

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -1,11 +1,17 @@
 {
-  "SuiteGitSha": "defaaf1571cd13b183e3f505c6a06e8db316e593",
+  "SuiteGitSha": "b363f29d3c43c626dc852744ad64a0b48a003693",
   //"SuiteDirectory": "//mnt/c/work/test262",
   "TargetPath": "./Generated",
   "Namespace": "Jint.Tests.Test262",
   "Parallel": true,
   "ExcludedFeatures": [
-    "tail-call-optimization"
+    "tail-call-optimization",
+
+    // Parked until the implementation lands; both arrived with this suite bump.
+    // https://tc39.es/proposal-iterator-chunking/ - Iterator.prototype.chunks / .windows
+    "iterator-chunking",
+    // https://tc39.es/proposal-iterator-includes/ - Iterator.prototype.includes
+    "iterator-includes"
   ],
   "ExcludedFlags": [
   ],

--- a/Jint.Tests/Runtime/IteratorHelpersTests.cs
+++ b/Jint.Tests/Runtime/IteratorHelpersTests.cs
@@ -310,4 +310,89 @@ public class IteratorHelpersTests
 
         result.Should().Be(2);
     }
+
+    [Theory]
+    [InlineData("take")]
+    [InlineData("drop")]
+    public void LimitAtOrBelowMaxSafeIntegerIsAccepted(string method)
+    {
+        // Number.MAX_SAFE_INTEGER is the inclusive upper bound, and Infinity is exempt from the
+        // bound entirely because the spec step only rejects a *finite* limit above it.
+        var engine = new Engine();
+        var result = engine.Evaluate($$"""
+            function* gen() {}
+            const raised = f => { try { f(); return 'ok'; } catch (e) { return e.constructor.name; } };
+            JSON.stringify([
+                raised(() => gen().{{method}}(0)),
+                raised(() => gen().{{method}}(Number.MAX_SAFE_INTEGER)),
+                raised(() => gen().{{method}}(Infinity))
+            ]);
+            """).AsString();
+
+        result.Should().Be("""["ok","ok","ok"]""");
+    }
+
+    [Theory]
+    [InlineData("take")]
+    [InlineData("drop")]
+    public void FiniteLimitAboveMaxSafeIntegerThrowsRangeError(string method)
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate($$"""
+            function* gen() {}
+            const raised = f => { try { f(); return 'no throw'; } catch (e) { return e.constructor.name; } };
+            JSON.stringify([
+                raised(() => gen().{{method}}(Number.MAX_SAFE_INTEGER + 1)),
+                raised(() => gen().{{method}}(Number.MAX_SAFE_INTEGER + 3)),
+                raised(() => gen().{{method}}(2 ** 53))
+            ]);
+            """).AsString();
+
+        result.Should().Be("""["RangeError","RangeError","RangeError"]""");
+    }
+
+    [Theory]
+    [InlineData("take")]
+    [InlineData("drop")]
+    public void AnOversizedLimitClosesTheReceiverWithoutReadingNext(string method)
+    {
+        // The spec validates against an Iterator Record whose [[NextMethod]] is still undefined, so
+        // the close must reach "return" while "next" stays untouched.
+        var engine = new Engine();
+        var result = engine.Evaluate($$"""
+            let closed = 0;
+            const closable = {
+                __proto__: Iterator.prototype,
+                get next() { throw new Error('next must not be read'); },
+                return() { closed++; return {}; }
+            };
+
+            const raised = f => { try { f(); return 'no throw'; } catch (e) { return e.constructor.name; } };
+            const error = raised(() => closable.{{method}}(Number.MAX_SAFE_INTEGER + 1));
+            JSON.stringify([error, closed]);
+            """).AsString();
+
+        result.Should().Be("""["RangeError",1]""");
+    }
+
+    [Theory]
+    [InlineData("take")]
+    [InlineData("drop")]
+    public void AsyncFiniteLimitAboveMaxSafeIntegerThrowsRangeError(string method)
+    {
+        // Nothing in test262 covers AsyncIterator, so this is what keeps the two limit validators
+        // from drifting apart.
+        var engine = new Engine();
+        var result = engine.Evaluate($$"""
+            const raised = f => { try { f(); return 'no throw'; } catch (e) { return e.constructor.name; } };
+            const iter = { __proto__: AsyncIterator.prototype, next() { return Promise.resolve({ done: true }); } };
+            JSON.stringify([
+                raised(() => AsyncIterator.prototype.{{method}}.call(iter, Number.MAX_SAFE_INTEGER + 1)),
+                raised(() => AsyncIterator.prototype.{{method}}.call(iter, Number.MAX_SAFE_INTEGER)),
+                raised(() => AsyncIterator.prototype.{{method}}.call(iter, Infinity))
+            ]);
+            """).AsString();
+
+        result.Should().Be("""["RangeError","no throw","no throw"]""");
+    }
 }

--- a/Jint/Extensions/Polyfills.cs
+++ b/Jint/Extensions/Polyfills.cs
@@ -85,6 +85,13 @@ public static class DoubleExtensions
 {
     extension(double)
     {
+#if NETFRAMEWORK || NETSTANDARD2_0
+        // double.IsFinite arrived in .NET Core 3.0 / netstandard2.1. Backfill it so spec steps
+        // phrased as "if x is finite" read the same on every target framework.
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public static bool IsFinite(double value) => !double.IsNaN(value) && !double.IsInfinity(value);
+#endif
+
 #if NETFRAMEWORK || NETSTANDARD
         public static double Parse(ReadOnlySpan<char> span, IFormatProvider? provider = null)
         {

--- a/Jint/Native/Iterator/AsyncIteratorPrototype.cs
+++ b/Jint/Native/Iterator/AsyncIteratorPrototype.cs
@@ -1,3 +1,4 @@
+using Jint.Native.Number;
 using Jint.Native.Object;
 using Jint.Native.Promise;
 using Jint.Native.Symbol;
@@ -179,6 +180,17 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
         {
             IteratorClose(o, CompletionType.Throw);
             Throw.RangeError(_realm, "NaN must be positive");
+            limit = 0;
+            return null!;
+        }
+
+        // Kept in lockstep with the synchronous Iterator.prototype.take/drop: a finite limit above
+        // 2**53 - 1 is a RangeError, while Infinity stays valid as an unbounded limit. test262 has
+        // no AsyncIterator directory, so nothing upstream pins this - the two validators agreeing does.
+        if (double.IsFinite(numLimit) && numLimit > NumberConstructor.MaxSafeInteger)
+        {
+            IteratorClose(o, CompletionType.Throw);
+            Throw.RangeError(_realm, $"{numLimit} exceeds the maximum safe integer");
             limit = 0;
             return null!;
         }

--- a/Jint/Native/Iterator/IteratorPrototype.cs
+++ b/Jint/Native/Iterator/IteratorPrototype.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Jint.Native.Number;
 using Jint.Native.Object;
 using Jint.Native.Symbol;
 using Jint.Pooling;
@@ -208,7 +209,11 @@ internal partial class IteratorPrototype : Prototype
             return Undefined;
         }
 
-        // 3. Let numLimit be ? ToNumber(limit).
+        // 3. Let iterated be the Iterator Record { [[Iterator]]: O, [[NextMethod]]: undefined, [[Done]]: false }.
+        //    The record is modelled by the receiver alone, because every close below happens before
+        //    GetIteratorDirect and so must read "return" without ever touching "next".
+        // 4. Let numLimit be Completion(ToNumber(limit)).
+        // 5. IfAbruptCloseIterator(numLimit, iterated).
         double numLimit;
         try
         {
@@ -220,7 +225,7 @@ internal partial class IteratorPrototype : Prototype
             throw;
         }
 
-        // 4. If numLimit is NaN, throw a RangeError exception.
+        // 6. If numLimit is NaN, close the iterator and throw a RangeError exception.
         if (double.IsNaN(numLimit))
         {
             IteratorClose(o, CompletionType.Throw);
@@ -228,10 +233,19 @@ internal partial class IteratorPrototype : Prototype
             return Undefined;
         }
 
-        // 5. Let integerLimit be ! ToIntegerOrInfinity(numLimit).
+        // 7. If numLimit is finite and numLimit > 𝔽(2**53 - 1), close the iterator and throw a
+        //    RangeError exception. Infinity stays valid and means an unbounded limit.
+        if (double.IsFinite(numLimit) && numLimit > NumberConstructor.MaxSafeInteger)
+        {
+            IteratorClose(o, CompletionType.Throw);
+            Throw.RangeError(_realm, $"{numLimit} exceeds the maximum safe integer");
+            return Undefined;
+        }
+
+        // 8. Let integerLimit be ! ToIntegerOrInfinity(numLimit).
         var integerLimit = TypeConverter.ToIntegerOrInfinity(numLimit);
 
-        // 6. If integerLimit < 0, throw a RangeError exception.
+        // 9. If integerLimit < 0, close the iterator and throw a RangeError exception.
         if (integerLimit < 0)
         {
             IteratorClose(o, CompletionType.Throw);
@@ -239,7 +253,7 @@ internal partial class IteratorPrototype : Prototype
             return Undefined;
         }
 
-        // 7. Let iterated be GetIteratorDirect(O).
+        // 10. Set iterated to ? GetIteratorDirect(O).
         var iterated = GetIteratorDirect(o);
 
         // Create and return take iterator
@@ -261,7 +275,11 @@ internal partial class IteratorPrototype : Prototype
             return Undefined;
         }
 
-        // 3. Let numLimit be ? ToNumber(limit).
+        // 3. Let iterated be the Iterator Record { [[Iterator]]: O, [[NextMethod]]: undefined, [[Done]]: false }.
+        //    The record is modelled by the receiver alone, because every close below happens before
+        //    GetIteratorDirect and so must read "return" without ever touching "next".
+        // 4. Let numLimit be Completion(ToNumber(limit)).
+        // 5. IfAbruptCloseIterator(numLimit, iterated).
         double numLimit;
         try
         {
@@ -273,7 +291,7 @@ internal partial class IteratorPrototype : Prototype
             throw;
         }
 
-        // 4. If numLimit is NaN, throw a RangeError exception.
+        // 6. If numLimit is NaN, close the iterator and throw a RangeError exception.
         if (double.IsNaN(numLimit))
         {
             IteratorClose(o, CompletionType.Throw);
@@ -281,10 +299,19 @@ internal partial class IteratorPrototype : Prototype
             return Undefined;
         }
 
-        // 5. Let integerLimit be ! ToIntegerOrInfinity(numLimit).
+        // 7. If numLimit is finite and numLimit > 𝔽(2**53 - 1), close the iterator and throw a
+        //    RangeError exception. Infinity stays valid and means an unbounded limit.
+        if (double.IsFinite(numLimit) && numLimit > NumberConstructor.MaxSafeInteger)
+        {
+            IteratorClose(o, CompletionType.Throw);
+            Throw.RangeError(_realm, $"{numLimit} exceeds the maximum safe integer");
+            return Undefined;
+        }
+
+        // 8. Let integerLimit be ! ToIntegerOrInfinity(numLimit).
         var integerLimit = TypeConverter.ToIntegerOrInfinity(numLimit);
 
-        // 6. If integerLimit < 0, throw a RangeError exception.
+        // 9. If integerLimit < 0, close the iterator and throw a RangeError exception.
         if (integerLimit < 0)
         {
             IteratorClose(o, CompletionType.Throw);
@@ -292,7 +319,7 @@ internal partial class IteratorPrototype : Prototype
             return Undefined;
         }
 
-        // 7. Let iterated be GetIteratorDirect(O).
+        // 10. Set iterated to ? GetIteratorDirect(O).
         var iterated = GetIteratorDirect(o);
 
         // Create and return drop iterator


### PR DESCRIPTION
## Summary

Update the pinned test262 suite to `b363f29d` and adopt the new `take`/`drop` `RangeError`.

## Details

Moves the pin from `defaaf15` to `b363f29d` (9 upstream commits). One of them is normative rather than additive: [tc39/test262#5065](https://github.com/tc39/test262/pull/5065) restructured `Iterator.prototype.take`/`drop` so a **finite** limit above `2**53 - 1` is now a `RangeError`, checked before `ToIntegerOrInfinity`. Six tests that pass at the old pin fail at the new one without an engine change, so this bump is a code change, not just a pin change.

The restructured algorithm also forms its Iterator Record *before* validating the argument, so a validation failure closes the receiver through `return` without ever reading `next`. Jint already did exactly that via the pre-record `IteratorClose` overload, so only the missing step needed adding. Comments are renumbered to the new step numbering to stay checkable against the spec. `Infinity` remains a valid limit — the step only rejects a *finite* one.

`AsyncIterator.prototype.take`/`drop` share a limit validator with the same gap. test262 has no `AsyncIterator` directory, so nothing upstream pins it; the two validators agreeing is what keeps them from drifting.

`double.IsFinite` arrived in .NET Core 3.0 / netstandard2.1, so it is backfilled in the existing `extension(double)` block for `net462` and `netstandard2.0`. That lets the guard read the way the spec step is phrased on every target framework.

**The other 8 commits need no engine change** — verified rather than assumed:

| Upstream | Area | Status |
| --- | --- | --- |
| `1ee8b3d7e9` | `return` in `for..in` (4 new tests) | already correct — `JintForInForOfStatement` propagates the `Return` completion verbatim, and `ForInIterator` correctly does not close |
| `5ef1e5723b` | `Array.prototype[@@unscopables].at` | already correct — all 16 spec names present with the right attributes |
| `0057878686` | Object primitive args (25 tests) | assertion hardening only; no behaviour change |
| `f963ead90d` | module source invariant | lives in `test/staging/**`, which Test262Harness never generates |

The two brand-new features in this range — **iterator-chunking** and **iterator-includes**, 122 test files between them — are parked in `ExcludedFeatures` so this PR is green on its own. The following PRs in the stack implement them and remove the entries.

## Linked issue

Refs #

## Test plan

- [x] Added or updated unit tests in `Jint.Tests`
- [x] Ran `dotnet test --configuration Release` locally
- [x] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no regressions
- [ ] For interop changes: covered in `Jint.Tests/Runtime/Interop`
- [ ] For perf changes: included before/after numbers from `Jint.Benchmark`

Suite regenerates to **99,654 cases: 99,494 passed, 0 failed**, 160 skipped.
`Jint.Tests` 4668 (net10.0) / 4587 (net472), `Jint.Tests.PublicInterface` 1240 / 1239, all green on the 5 target frameworks.

## Breaking change?

No. `take(Number.MAX_SAFE_INTEGER + 1)` now throws `RangeError` instead of silently accepting an unreachable limit, which is the normative change this adopts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
