### PR TITLE
Implement Iterator Includes

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -5,11 +5,7 @@
   "Namespace": "Jint.Tests.Test262",
   "Parallel": true,
   "ExcludedFeatures": [
-    "tail-call-optimization",
-
-    // Parked until the implementation lands.
-    // https://tc39.es/proposal-iterator-includes/ - Iterator.prototype.includes
-    "iterator-includes"
+    "tail-call-optimization"
   ],
   "ExcludedFlags": [
   ],

--- a/Jint.Tests/Runtime/IteratorHelpersTests.cs
+++ b/Jint.Tests/Runtime/IteratorHelpersTests.cs
@@ -637,4 +637,158 @@ public class IteratorHelpersTests
         // return() after exhaustion must not forward either.
         result.Should().Be("[1,1]");
     }
+
+    [Fact]
+    public void IncludesFindsAValueAndSkipsLeadingElements()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            function* gen() { yield 1; yield 2; yield 3; }
+            JSON.stringify([
+                gen().includes(2),
+                gen().includes(9),
+                gen().includes(1),
+                gen().includes(1, 1),
+                gen().includes(3, 2),
+                gen().includes(3, 3)
+            ]);
+            """).AsString();
+
+        result.Should().Be("[true,false,true,false,true,false]");
+    }
+
+    [Fact]
+    public void IncludesComparesWithSameValueZero()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            const sym = Symbol();
+            JSON.stringify([
+                [NaN].values().includes(NaN),
+                [0].values().includes(-0),
+                [-0].values().includes(0),
+                [{}].values().includes({}),
+                [sym].values().includes(sym)
+            ]);
+            """).AsString();
+
+        // SameValueZero: NaN matches itself and the two zeroes match, but objects are by identity.
+        result.Should().Be("[true,true,true,false,true]");
+    }
+
+    [Fact]
+    public void IncludesSkippedElementsIsNotCoerced()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            function* gen() { yield 1; }
+            const raised = f => { try { f(); return 'no throw'; } catch (e) { return e.constructor.name; } };
+            const values = [NaN, 0.1, -0.1, '1', true, null, {}, Symbol(), [2]];
+            JSON.stringify(values.map(v => raised(() => gen().includes(0, v))));
+            """).AsString();
+
+        // Only +/-Infinity and integral Numbers are accepted, so NaN is a TypeError and not a
+        // RangeError - there is no ToNumber step that could turn a string into a number first.
+        result.Should().Be("""["TypeError","TypeError","TypeError","TypeError","TypeError","TypeError","TypeError","TypeError","TypeError"]""");
+    }
+
+    [Fact]
+    public void IncludesRejectsNegativeAndOversizedSkippedElements()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            function* gen() { yield 1; }
+            const raised = f => { try { f(); return 'ok'; } catch (e) { return e.constructor.name; } };
+            JSON.stringify([
+                raised(() => gen().includes(0, -1)),
+                raised(() => gen().includes(0, -Infinity)),
+                raised(() => gen().includes(0, Number.MAX_SAFE_INTEGER + 1)),
+                raised(() => gen().includes(0, -0)),
+                raised(() => gen().includes(0, 0)),
+                raised(() => gen().includes(0, Infinity)),
+                raised(() => gen().includes(0, Number.MAX_SAFE_INTEGER))
+            ]);
+            """).AsString();
+
+        // -0 passes because -0 < -0 is false, and +Infinity is exempt from the upper bound.
+        result.Should().Be("""["RangeError","RangeError","RangeError","ok","ok","ok","ok"]""");
+    }
+
+    [Fact]
+    public void IncludesClosesOnAMatchButNotOnExhaustion()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            let closed = 0;
+            const source = () => ({
+                __proto__: Iterator.prototype,
+                i: 0,
+                next() { return this.i < 3 ? { done: false, value: this.i++ } : { done: true }; },
+                return() { closed++; return {}; }
+            });
+
+            const matched = source().includes(1);
+            const afterMatch = closed;
+            const missed = source().includes(99);
+            JSON.stringify([matched, afterMatch, missed, closed]);
+            """).AsString();
+
+        result.Should().Be("[true,1,false,1]");
+    }
+
+    [Fact]
+    public void IncludesValidationFailureClosesTheReceiverWithoutReadingNext()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            let closed = 0;
+            const closable = () => ({
+                __proto__: Iterator.prototype,
+                get next() { throw new Error('next must not be read'); },
+                return() { closed++; return {}; }
+            });
+
+            const raised = f => { try { f(); return 'no throw'; } catch (e) { return e.constructor.name; } };
+            const type = raised(() => closable().includes(0, NaN));
+            const range = raised(() => closable().includes(0, -1));
+            JSON.stringify([type, range, closed]);
+            """).AsString();
+
+        result.Should().Be("""["TypeError","RangeError",2]""");
+    }
+
+    [Fact]
+    public void IncludesWithInfiniteSkipNeverMatches()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            let returnCalls = 0;
+            let count = 0;
+            const iter = {
+                __proto__: Iterator.prototype,
+                next() { return ++count < 4 ? { done: false, value: count } : { done: true }; },
+                return() { returnCalls++; return {}; }
+            };
+
+            JSON.stringify([iter.includes(1, Infinity), returnCalls, count]);
+            """).AsString();
+
+        // Every element is skipped, so the iterator runs to natural exhaustion and is not closed.
+        result.Should().Be("[false,0,4]");
+    }
+
+    [Fact]
+    public void IncludesComposesWithTheOtherHelpers()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            JSON.stringify([
+                [1, 2, 3, 4, 5].values().map(x => x * 2).includes(6),
+                [1, 2, 3, 4, 5].values().drop(3).includes(1),
+                [1, 2, 3, 4, 5].values().filter(x => x % 2 === 0).includes(4)
+            ]);
+            """).AsString();
+
+        result.Should().Be("[true,false,true]");
+    }
 }

--- a/Jint/Native/Iterator/IteratorPrototype.cs
+++ b/Jint/Native/Iterator/IteratorPrototype.cs
@@ -689,6 +689,102 @@ internal partial class IteratorPrototype : Prototype
     }
 
     /// <summary>
+    /// https://tc39.es/proposal-iterator-includes/#sec-iterator.prototype.includes
+    /// </summary>
+    [JsFunction(Length = 1)]
+    private JsValue Includes(JsValue thisObject, JsValue searchElement, JsValue skippedElements)
+    {
+        // 1. Let O be the this value.
+        // 2. If O is not an Object, throw a TypeError exception.
+        if (thisObject is not ObjectInstance o)
+        {
+            Throw.TypeError(_realm, "Iterator.prototype.includes called on non-object");
+            return Undefined;
+        }
+
+        // 3. Let iterated be the Iterator Record { [[Iterator]]: O, [[NextMethod]]: undefined, [[Done]]: false }.
+        //    As in take/drop, the receiver alone stands in for the record: every close below runs
+        //    before GetIteratorDirect and so reaches "return" without reading "next".
+        // 4. If skippedElements is undefined, let toSkip be 0.
+        var toSkip = 0d;
+        if (!skippedElements.IsUndefined())
+        {
+            // 5. Else if skippedElements is not one of +INFINITY, -INFINITY, or an integral Number,
+            //    close the iterator and throw a TypeError exception. The value is inspected as-is,
+            //    with no ToNumber coercion, which is where NaN lands.
+            if (skippedElements is not JsNumber number
+                || (!double.IsInfinity(number._value) && !TypeConverter.IsIntegralNumber(number._value)))
+            {
+                IteratorClose(o, CompletionType.Throw);
+                Throw.TypeError(_realm, "skippedElements must be an integral Number or +/-Infinity");
+                return Undefined;
+            }
+
+            // 6. Else, let toSkip be skippedElements.
+            toSkip = number._value;
+        }
+
+        // 7. If toSkip < -0, close the iterator and throw a RangeError exception. -0 itself passes,
+        //    since -0 < -0 is false; -Infinity does not.
+        if (toSkip < 0)
+        {
+            IteratorClose(o, CompletionType.Throw);
+            Throw.RangeError(_realm, "skippedElements must not be negative");
+            return Undefined;
+        }
+
+        // 8. If toSkip is finite and toSkip > 𝔽(2**53 - 1), close the iterator and throw a
+        //    RangeError exception. +Infinity is exempt and simply skips every element.
+        if (double.IsFinite(toSkip) && toSkip > NumberConstructor.MaxSafeInteger)
+        {
+            IteratorClose(o, CompletionType.Throw);
+            Throw.RangeError(_realm, $"{toSkip} exceeds the maximum safe integer");
+            return Undefined;
+        }
+
+        // 9. Let skipped be 0.
+        var skipped = 0d;
+
+        // 10. Set iterated to ? GetIteratorDirect(O).
+        var iterated = GetIteratorDirect(o);
+
+        // 11. Repeat, stepping the iterator until it is exhausted or the search element is found.
+        var iterations = 0;
+        while (iterated.TryIteratorStep(out var iteratorResult))
+        {
+            try
+            {
+                var value = iteratorResult.Get(CommonProperties.Value);
+
+                if (skipped < toSkip)
+                {
+                    skipped++;
+                }
+                else if (SameValueZeroComparer.Equals(value, searchElement))
+                {
+                    // A match closes the iterator; natural exhaustion below deliberately does not.
+                    iterated.Close(CompletionType.Normal);
+                    return JsBoolean.True;
+                }
+
+                // skippedElements may be +Infinity, so this loop is unbounded even for a well
+                // behaved iterator; keep the engine interruptible.
+                if (++iterations % Engine.ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
+            }
+            catch
+            {
+                iterated.Close(CompletionType.Throw);
+                throw;
+            }
+        }
+
+        return JsBoolean.False;
+    }
+
+    /// <summary>
     /// https://tc39.es/ecma262/#sec-iterator.prototype.every
     /// </summary>
     [JsFunction]

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ and many more.
 - ✔ Immutable Arraybuffers
 - ✔ Import Bytes (`import x from './file' with { type: 'bytes' }`)
 - ✔ Iterator Chunking (`Iterator.prototype.chunks`, `Iterator.prototype.windows`)
+- ✔ Iterator Includes (`Iterator.prototype.includes`)
 - ✔ Iterator Join (`Iterator.prototype.join`)
 - ✔ Iterator Sequencing
 - ✔ Joint Iteration


### PR DESCRIPTION
## Summary

Implement Iterator Includes — `Iterator.prototype.includes`.

## Details

Implements https://tc39.es/proposal-iterator-includes/, unparking the last feature the suite bump excluded. `ExcludedFeatures` is back to just `tail-call-optimization`, so there is again **no test262 debt outside `intl402/`**.

The method walks the iterator comparing with SameValueZero, so `NaN` matches itself and the two zeroes match each other. A match closes the iterator and returns `true`; natural exhaustion returns `false` **without** closing.

### The part that is easy to get wrong

The optional `skippedElements` argument is where this proposal departs from the iterator helpers already in the engine: the value is inspected **verbatim, with no `ToNumber` step**.

| Input | Result | Note |
| --- | --- | --- |
| `undefined` | `0` | |
| `NaN` | **`TypeError`** | not a `RangeError` — `take`/`drop` give it one, this does not |
| `'1'`, `true`, `{}`, `Symbol()`, `0.1` | `TypeError` | no coercion, so a numeric string never becomes a number |
| `-1`, `-Infinity` | `RangeError` | |
| finite `> 2**53 - 1` | `RangeError` | |
| `-0` | **accepted** | `-0 < -0` is false |
| `+Infinity` | accepted | exempt from the upper bound; skips every element, returns `false` at exhaustion |

Every validation failure closes the receiver through `return` without reading `next`, matching the pre-`GetIteratorDirect` Iterator Record the spec describes. Because `skippedElements` may be `+Infinity`, the walk carries the usual periodic constraint check so an unbounded iterator stays interruptible.

## Linked issue

Refs #

## Test plan

- [x] Added or updated unit tests in `Jint.Tests`
- [x] Ran `dotnet test --configuration Release` locally
- [x] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no regressions
- [ ] For interop changes: covered in `Jint.Tests/Runtime/Interop`
- [ ] For perf changes: included before/after numbers from `Jint.Benchmark`

**99,895 cases: 99,738 passed, 0 failed.** Ignored count drops 245 → 157, exactly the 44 `includes` files × 2 modes, and 157 is the intl402 baseline.
8 new unit tests in `IteratorHelpersTests`, `Jint.Tests` 4693 / 4612 green.

## Breaking change?

No — new built-in only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
