### PR TITLE
Run PR CI on every pull request, not only those targeting main

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,8 +2,12 @@ name: PR
 
 on:
 
+  # Deliberately no "branches:" filter. That filter matches a pull request's *base*, so restricting
+  # it to main and 3.x silently skipped CI on every layer of a stacked pull request except the
+  # bottom one - the upper layers base on the branch below them, not on main, and showed "no checks
+  # reported" until GitHub retargeted them at merge time. Running on every pull request costs a
+  # little more CI on the rare cross-branch PR and makes a stack reviewable.
   pull_request:
-    branches: [ main, 3.x ]
 
 env:
   DOTNET_NOLOGO: true


### PR DESCRIPTION
## Summary

Drop the `branches: [ main, 3.x ]` filter from `pr.yml` so stacked pull requests get CI.

## Details

The `pull_request` trigger's `branches:` filter matches a pull request's **base**, not its head. A stacked PR bases on the branch below it, so only the bottom of a stack qualified.

Opening the four-layer stack #2877 → #2878 → #2879 → #2880 produced exactly that:

| PR | Base | Checks |
| --- | --- | --- |
| #2877 | `main` | full 4-OS matrix |
| #2878 | `test262-update-2026-08-01` | **no checks reported** |
| #2879 | `iterator-chunking` | **no checks reported** |
| #2880 | `iterator-includes` | ran only via a race — it briefly existed against `main` before `gh stack submit` retargeted it |

It does self-heal: GitHub retargets the next PR to `main` when the one below merges, and CI fires then, so each PR is checked immediately before it lands. But that is the wrong moment. The point of a stack is that the layers are reviewed **in parallel**, and a reviewer looking at an unchecked PR carrying a new feature has no signal at all.

Dropping the filter runs the workflow for every pull request whatever its base. The cost is CI on the occasional PR between two non-main branches; the benefit is that a stack is reviewable.

### Sequencing

For `pull_request`, GitHub evaluates the trigger using the workflow file from the PR's merge ref, so this takes effect for the existing stack only once it has been merged here and the stack rebased onto it (`gh stack sync`). Merging this before the stack is the cheapest order.

## Linked issue

Refs #

## Test plan

- [ ] Added or updated unit tests in `Jint.Tests`
- [ ] Ran `dotnet test --configuration Release` locally
- [ ] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no regressions
- [ ] For interop changes: covered in `Jint.Tests/Runtime/Interop`
- [ ] For perf changes: included before/after numbers from `Jint.Benchmark`

CI configuration only — no code. `pr.yml` still parses to `on: {pull_request: None}`, and this PR itself exercises the workflow. The verification that matters is that the stacked PRs above start reporting checks once this is merged and they are rebased.

## Breaking change?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)