### PR TITLE
Ask once per document, not once per key, how to call a JSON replacer or reviver

### DIFF
--- a/Jint.Benchmark/JsonJsBenchmark.cs
+++ b/Jint.Benchmark/JsonJsBenchmark.cs
@@ -12,11 +12,18 @@ namespace Jint.Benchmark;
 /// here are generated deterministically offline, so rows are stable gates. One parse or stringify
 /// per op — the Allocated column is the per-document allocation cost.
 ///
+/// <para><b>Callback rows.</b> <see cref="StringifyRecordsWithReplacer"/> and
+/// <see cref="ParseRecordsWithReviver"/> pass a user function, so <c>JSON.stringify</c> invokes it once
+/// per key of the whole graph and <c>JSON.parse</c> once per key/element it internalizes — the shapes
+/// where a per-key dispatch decision is paid thousands of times per document. Their controls are the
+/// plain <see cref="StringifyRecords"/> and <see cref="ParseRecords"/> rows over the same fixture, which
+/// pass no callback and which a change to callback dispatch therefore cannot move.</para>
+///
 /// <para><b>Engine isolation.</b> Every row gets its own engine — built by <see cref="CreateEngine"/>,
 /// which re-runs <see cref="SetupSource"/> so each engine owns its own <c>records</c>/<c>config</c>
 /// graphs — and warmed with its own script and nothing else (see <see cref="IsolatedScript"/>). It used
-/// to be one engine warmed with all six row scripts, so each row was measured on an engine carrying the
-/// other five rows' handler-tree, call-site and object-shape state, plus the retained result graphs their
+/// to be one engine warmed with every row script, so each row was measured on an engine carrying the
+/// other rows' handler-tree, call-site and object-shape state, plus the retained result graphs their
 /// warm-up left behind. The rows still measure warm parse/stringify, and engine construction and warm-up
 /// stay in <c>[GlobalSetup]</c>, outside the measurement. <b>Numbers from this class are not comparable
 /// to any published before the harness changed.</b></para>
@@ -34,6 +41,8 @@ public class JsonJsBenchmark
     private IsolatedScript _stringifyRecords;
     private IsolatedScript _stringifyConfig;
     private IsolatedScript _roundTripRecords;
+    private IsolatedScript _stringifyRecordsWithReplacer;
+    private IsolatedScript _parseRecordsWithReviver;
 
     internal const string ParseRecordsSource = "JSON.parse(recordsJson);";
     internal const string ParseConfigSource = "JSON.parse(configJson);";
@@ -41,6 +50,12 @@ public class JsonJsBenchmark
     internal const string StringifyRecordsSource = "JSON.stringify(records);";
     internal const string StringifyConfigSource = "JSON.stringify(config);";
     internal const string RoundTripRecordsSource = "JSON.parse(JSON.stringify(records));";
+
+    // The replacer/reviver are declared inside the row's own script rather than in SetupSource: a
+    // global there would land on every other row's engine too, and instantiating one closure per op
+    // is negligible next to the thousands of invocations it then receives.
+    internal const string StringifyRecordsWithReplacerSource = "JSON.stringify(records, function (key, value) { return value; });";
+    internal const string ParseRecordsWithReviverSource = "JSON.parse(recordsJson, function (key, value) { return value; });";
     internal const string SetupSource = "var records = JSON.parse(recordsJson); var config = JSON.parse(configJson);";
 
     /// <summary>1,000 records × 6 mixed-type properties (~90 KB) — the array-of-identical-records shape.</summary>
@@ -165,6 +180,8 @@ public class JsonJsBenchmark
         _stringifyRecords = IsolatedScript.Warm(Engine.PrepareScript(StringifyRecordsSource), CreateEngine);
         _stringifyConfig = IsolatedScript.Warm(Engine.PrepareScript(StringifyConfigSource), CreateEngine);
         _roundTripRecords = IsolatedScript.Warm(Engine.PrepareScript(RoundTripRecordsSource), CreateEngine);
+        _stringifyRecordsWithReplacer = IsolatedScript.Warm(Engine.PrepareScript(StringifyRecordsWithReplacerSource), CreateEngine);
+        _parseRecordsWithReviver = IsolatedScript.Warm(Engine.PrepareScript(ParseRecordsWithReviverSource), CreateEngine);
     }
 
     [Benchmark]
@@ -184,4 +201,12 @@ public class JsonJsBenchmark
 
     [Benchmark]
     public JsValue RoundTripRecords() => _roundTripRecords.Run();
+
+    /// <summary>The replacer is invoked once per key of the whole graph; <see cref="StringifyRecords"/> is its control.</summary>
+    [Benchmark]
+    public JsValue StringifyRecordsWithReplacer() => _stringifyRecordsWithReplacer.Run();
+
+    /// <summary>The reviver is invoked once per internalized key/element; <see cref="ParseRecords"/> is its control.</summary>
+    [Benchmark]
+    public JsValue ParseRecordsWithReviver() => _parseRecordsWithReviver.Run();
 }

--- a/Jint.Benchmark/StringReplaceBenchmark.cs
+++ b/Jint.Benchmark/StringReplaceBenchmark.cs
@@ -1,0 +1,70 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Isolates <c>String.prototype.replaceAll</c> over a string with ~8k matches — the shape where the
+/// replacement loop runs often enough for its per-match costs to matter. The interesting row is the
+/// <em>functional</em> replacer: the loop invokes a user callback once per match, so the dispatch
+/// decision (and the argument array behind it) is paid per match unless it is hoisted.
+///
+/// <para><b>Rows.</b> <c>ReplaceAllFunction</c> is the callback row. <c>ReplaceAllPattern</c> is the
+/// control: a string replacement containing <c>$</c>, which defeats the <c>string.Replace</c>
+/// short-circuit and therefore walks the <em>same</em> match loop, appends through the same
+/// <c>ValueStringBuilder</c>, and never constructs or consults a callback invoker at all. A change to
+/// how the callback is dispatched cannot move it — if it does, the delta is measurement noise or an
+/// object-layout effect, not a win. (The single-match <c>String.prototype.replace</c> is deliberately
+/// not covered: one call per invocation leaves nothing to amortise, and on a fixture this size the row
+/// would measure the two substring copies rather than the call.)</para>
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine — built by <c>CreateEngine</c>, which
+/// re-runs the fixture so each engine owns its own <c>haystack</c> — and warmed with its own script and
+/// nothing else (see <see cref="IsolatedScript"/>). Engine construction and warm-up stay in
+/// <c>[GlobalSetup]</c> and never enter the measurement; the rows measure warm replacement.</para>
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+public class StringReplaceBenchmark
+{
+    private IsolatedScript _replaceAllFunction;
+    private IsolatedScript _replaceAllPattern;
+
+    /// <summary>Builds a fresh engine carrying the fixture every row needs, and nothing else.</summary>
+    private static Engine CreateEngine()
+    {
+        var engine = new Engine(static options => options.Strict());
+        // 8192 repetitions of "abcdefgh" (~64K chars) => exactly 8192 non-overlapping "ab" matches.
+        engine.Execute("""
+            var haystack = "";
+            for (var i = 0; i < 8192; i++) {
+                haystack += "abcdefgh";
+            }
+            """);
+        return engine;
+    }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _replaceAllFunction = IsolatedScript.Warm(Engine.PrepareScript("""
+            (function() {
+                return haystack.replaceAll("ab", function (match, offset, whole) { return match; }).length;
+            })();
+            """, strict: true), CreateEngine);
+
+        _replaceAllPattern = IsolatedScript.Warm(Engine.PrepareScript("""
+            (function() {
+                return haystack.replaceAll("ab", "[$&]").length;
+            })();
+            """, strict: true), CreateEngine);
+    }
+
+    /// <summary>~8k invocations of an interpreted callback, one per match.</summary>
+    [Benchmark]
+    public JsValue ReplaceAllFunction() => _replaceAllFunction.Run();
+
+    /// <summary>Control: same match loop, same builder, no callback.</summary>
+    [Benchmark]
+    public JsValue ReplaceAllPattern() => _replaceAllPattern.Run();
+}

--- a/Jint/Native/Json/JsonInstance.cs
+++ b/Jint/Native/Json/JsonInstance.cs
@@ -97,10 +97,18 @@ internal sealed partial class JsonInstance : BuiltinShapeObject
     /// Internalizes a JSON property with source text tracking for the reviver.
     /// https://tc39.es/proposal-json-parse-with-source/#sec-internalizejsonproperty
     /// </summary>
+    /// <remarks>
+    /// The reviver is taken as an already-built <see cref="CallbackInvoker"/>, by <c>in</c> so the walk
+    /// passes a pointer rather than copying the struct down every level. It is built once in
+    /// <see cref="Parse"/> — the reviver is fixed for the whole parse, and nothing a reviver does
+    /// (mutating the holder, deleting keys, throwing, being a revoked proxy) can change how it must be
+    /// invoked. One invoker serves the whole recursion without its argument array being aliased across
+    /// levels: a level fills and invokes only after every child level has finished doing so.
+    /// </remarks>
     private JsValue InternalizeJSONProperty(
         JsValue holder,
         JsValue name,
-        ICallable reviver,
+        in CallbackInvoker reviver,
         JsonParseNode? parseNode,
         string jsonSource)
     {
@@ -117,7 +125,7 @@ internal sealed partial class JsonInstance : BuiltinShapeObject
                 {
                     var prop = JsString.Create(i);
                     var elementNode = elements != null && (int) i < elements.Count ? elements[(int) i] : null;
-                    var newElement = InternalizeJSONProperty(obj, prop, reviver, elementNode, jsonSource);
+                    var newElement = InternalizeJSONProperty(obj, prop, in reviver, elementNode, jsonSource);
                     if (newElement.IsUndefined())
                     {
                         obj.Delete(prop);
@@ -141,7 +149,7 @@ internal sealed partial class JsonInstance : BuiltinShapeObject
                         var keyStr = TypeConverter.ToString(p);
                         entries.TryGetValue(keyStr, out entryNode);
                     }
-                    var newElement = InternalizeJSONProperty(obj, p, reviver, entryNode, jsonSource);
+                    var newElement = InternalizeJSONProperty(obj, p, in reviver, entryNode, jsonSource);
                     if (newElement.IsUndefined())
                     {
                         obj.Delete(p);
@@ -168,6 +176,8 @@ internal sealed partial class JsonInstance : BuiltinShapeObject
             }
         }
 
+        // The context object is built fresh per key (its "source" property depends on this key's parse
+        // node), so all three arguments vary and none of them can be hoisted into the invoker.
         return reviver.Call(holder, name, val, context);
     }
 
@@ -188,7 +198,14 @@ internal sealed partial class JsonInstance : BuiltinShapeObject
             var root = _realm.Intrinsics.Object.Construct(Arguments.Empty);
             var rootName = JsString.Empty;
             root.CreateDataPropertyOrThrow(rootName, parseResult.Value);
-            return InternalizeJSONProperty(root, rootName, (ICallable) reviver, parseResult.Node, jsonString);
+
+            // Arity is always three: this implementation follows the json-parse-with-source proposal,
+            // where the reviver's third argument is the context object, and InternalizeJSONProperty
+            // constructs and passes one unconditionally (only its "source" property is conditional).
+            var invoker = CallbackInvoker.Rent(_engine, (ICallable) reviver, 3);
+            var result = InternalizeJSONProperty(root, rootName, in invoker, parseResult.Node, jsonString);
+            invoker.Return();
+            return result;
         }
         else
         {

--- a/Jint/Native/Json/JsonSerializer.cs
+++ b/Jint/Native/Json/JsonSerializer.cs
@@ -61,7 +61,15 @@ public sealed class JsonSerializer
     private string? _indent;
     private string _gap = string.Empty;
     private List<JsValue>? _propertyList;
-    private JsValue _replacerFunction = JsValue.Undefined;
+    private bool _hasReplacerFunction;
+
+    // Declared last: this is the only field that is not read on the per-key hot path (only
+    // UnwrapValueSlow touches it, and only when _hasReplacerFunction says there is one), and embedding
+    // the invoker by value is what keeps the replacer call array-free. It grows the instance by about
+    // one cache line, which is one allocation per Serialize call against a walk of the whole graph —
+    // unlike ArrayPrototype.ArrayComparer, where the same embedding cost ~4% because that object is
+    // dereferenced once per comparison of an n log n sort with almost no work in between.
+    private CallbackInvoker _replacerInvoker;
 
     private static readonly JsString toJsonProperty = new("toJSON");
 
@@ -204,7 +212,8 @@ public sealed class JsonSerializer
         _indent = null;
         _gap = string.Empty;
         _propertyList = null;
-        _replacerFunction = JsValue.Undefined;
+        _hasReplacerFunction = false;
+        _replacerInvoker = default;
 
         // for JSON.stringify(), any function passed as the first argument will return undefined
         // if the replacer is not defined. The function is not called either.
@@ -276,7 +285,14 @@ public sealed class JsonSerializer
 
         if (oi.IsCallable)
         {
-            _replacerFunction = replacer;
+            // Built once here rather than per key: the replacer is invoked for every key of the whole
+            // graph, and how it must be invoked depends only on the callback — which no key, and no
+            // mutation a replacer performs, can change. Create() rather than Rent() because the
+            // invoker lives for the whole recursive walk, which can exit by exception (a cycle, a
+            // BigInt, an execution constraint) from any depth, so there is no one place that could
+            // reliably hand a pooled array back. On the register lane there is no array at all.
+            _replacerInvoker = CallbackInvoker.Create(_engine, (ICallable) oi, 2);
+            _hasReplacerFunction = true;
         }
         else
         {
@@ -457,7 +473,7 @@ public sealed class JsonSerializer
     {
         var value = holder.Get(key);
 
-        if (value._type <= InternalTypes.Integer && _replacerFunction.IsUndefined())
+        if (value._type <= InternalTypes.Integer && !_hasReplacerFunction)
         {
             return value;
         }
@@ -489,10 +505,9 @@ public sealed class JsonSerializer
             }
         }
 
-        if (!_replacerFunction.IsUndefined())
+        if (_hasReplacerFunction)
         {
-            var replacerFunctionCallable = (ICallable) _replacerFunction.AsObject();
-            value = replacerFunctionCallable.Call(holder, TypeConverter.ToPropertyKey(key), value);
+            value = _replacerInvoker.Call(holder, TypeConverter.ToPropertyKey(key), value);
         }
 
         if (value.IsObject())
@@ -894,7 +909,7 @@ public sealed class JsonSerializer
             {
                 // Serializing a member is a value observation, so a lazy layout slot materializes here.
                 member = value.GetSlotForRead(i);
-                if (member._type > InternalTypes.Integer || !_replacerFunction.IsUndefined())
+                if (member._type > InternalTypes.Integer || _hasReplacerFunction)
                 {
                     // the key is observable (toJSON/replacer argument); materialize it only now
                     member = UnwrapValueSlow(new JsString(keys[i].Name), value, member);


### PR DESCRIPTION
`JSON.stringify` with a replacer function, and `JSON.parse` with a reviver, invoke that callback **once per key of the whole object graph** — and remade the dispatch decision every time. `JsonSerializer` additionally re-did `(ICallable) _replacerFunction.AsObject()` per key.

`CallbackInvoker` (added in #2876) asks once, where the callback is established, whether it is a plain interpreted function on the fixed-slot fast path; if so every key goes to `ScriptFunction.CallFromRegisters` and no argument array is materialised. Otherwise it keeps exactly today's rented array and `ICallable.Call`.

## Results

Paired A/B, both orderings, idle machine, one shared benchmark base so both sides run identical benchmark code. Each row judged against **its own build-to-build variance**, with a 1% absolute floor.

| row | r1 | r2 | mean | own var | |
|---|---|---|---|---|---|
| `JsonJsBenchmark.StringifyRecordsWithReplacer` | −25.34% | −31.71% | **−28.52%** | 11.7% | win |
| `JsonJsBenchmark.ParseRecordsWithReviver` | −1.10% | −2.22% | −1.66% | 2.1% | noise |
| `JsonJsBenchmark.StringifyRecords` *(no-callback control)* | −1.87% | +0.78% | −0.55% | 1.5% | **flat** |
| `JsonJsBenchmark.ParseRecords` *(no-callback control)* | −1.38% | −4.13% | −2.75% | 3.7% | flat |

The two no-callback controls are the load-bearing rows. `JsonSerializer` gained a `CallbackInvoker` **field** (~56 bytes on an object read per key), which is the shape that cost `ArrayComparer` +4.27% in #2876 — those controls are what prove it is different in kind here, and they did not move.

## The reviver is kept on mechanism, not on the clock

Its time row is noise, and that is explained rather than hoped: `ICallable.Call(JsValue, params JsCallArguments)` allocated a `JsValue[3]` for **every key** of the parsed graph, and the invoker rents one array for the whole parse or none at all. The row does not move because a parse-with-source reviver spends its per-key budget on the context object `InternalizeJSONProperty` constructs, not on the call. Cost is one `in CallbackInvoker` parameter replacing an `ICallable` one — same width, no copy down the recursion.

The one-invoker-for-the-whole-recursion invariant holds: a level fills and invokes only after every child has finished, and a nested `JSON.parse` inside a reviver rents a different array.

## Benchmark rows

`StringifyRecordsWithReplacer` / `ParseRecordsWithReviver` extend `JsonJsBenchmark`, which already had the records fixture and one engine per row. The replacer and reviver are declared inside each row's own script rather than in shared setup, so no global lands on a sibling row's engine — per the convention added in #2873. `StringReplaceBenchmark` is included for a follow-up change to `String.prototype.replaceAll`; its rows are inert here.

## Verification

`Jint.Tests` 4685/0/4 (net10.0) · 4604/0/4 (net472) · `Jint.Tests.PublicInterface` 1240/0/9 · 1239/0/9 · `Jint.Tests.CommonScripts` 28/0 both TFMs · `Jint.Tests.SourceGenerators` 51/0 · **`Jint.Tests.Test262` 99650 / 0 / 158** · `JINT_HOST_CONTRACT_VERIFICATION=1` leg clean · `dotnet build -c Release` 0 warnings.

Test262 is the real gate — revivers that mutate the holder, throw, delete keys or are revoked proxies are all densely covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G24ppn8iSgjo1APp3YkzTK
