### PR TITLE
Stop charging closures for per-engine lazy globals

### DIFF
--- a/Jint.Benchmark/FreshEngineGlobalsBenchmark.cs
+++ b/Jint.Benchmark/FreshEngineGlobalsBenchmark.cs
@@ -80,7 +80,7 @@ public class FreshEngineGlobalsBenchmark
     [Params(1, 10, 40)]
     public int GlobalCount { get; set; }
 
-    [Params(GlobalKind.Delegate, GlobalKind.ClrFunction, GlobalKind.Lazy)]
+    [Params(GlobalKind.Delegate, GlobalKind.ClrFunction, GlobalKind.Lazy, GlobalKind.LazyPerEngine)]
     public GlobalKind Kind { get; set; }
 
     [GlobalSetup]
@@ -139,6 +139,14 @@ public class FreshEngineGlobalsBenchmark
             if (Kind == GlobalKind.Delegate)
             {
                 engine.SetValue(name, CreateDelegate(i));
+            }
+            else if (Kind == GlobalKind.LazyPerEngine)
+            {
+                // Declared on this engine, so the factory may close over per-request state. The closure is
+                // built here rather than hoisted for the same reason the Delegate row builds its delegates
+                // here: a host whose globals depend on the request has nothing to hoist.
+                var index = i;
+                engine.Advanced.AddLazyGlobal(name, e => CreateClrFunction(e, name, index));
             }
             else
             {
@@ -212,4 +220,19 @@ public enum GlobalKind
     /// a per-<i>used</i>-global one.
     /// </summary>
     Lazy,
+
+    /// <summary>
+    /// The same declaration made on the engine itself through
+    /// <see cref="Engine.AdvancedOperations.AddLazyGlobal"/>, which is what a host must use when the value
+    /// depends on per-request state a shared <see cref="Options"/> cannot hold — a scoped service provider,
+    /// a request, a workflow context.
+    /// <para>
+    /// It is a genuinely different cost from <see cref="Lazy"/> rather than a restatement of it. The options
+    /// registration happens once for the process and the engine only replays it, so its factory delegates are
+    /// created once; this one runs the registration itself on every engine, so anything the API allocates per
+    /// call is a per-request cost. That makes this the row that decides whether declaring a per-request global
+    /// is cheaper than simply building it.
+    /// </para>
+    /// </summary>
+    LazyPerEngine,
 }

--- a/Jint.Benchmark/FreshEngineGlobalsBenchmark.cs
+++ b/Jint.Benchmark/FreshEngineGlobalsBenchmark.cs
@@ -80,7 +80,7 @@ public class FreshEngineGlobalsBenchmark
     [Params(1, 10, 40)]
     public int GlobalCount { get; set; }
 
-    [Params(GlobalKind.Delegate, GlobalKind.ClrFunction, GlobalKind.Lazy, GlobalKind.LazyPerEngine)]
+    [Params(GlobalKind.Delegate, GlobalKind.ClrFunction, GlobalKind.Lazy, GlobalKind.LazyPerEngine, GlobalKind.LazyPerEngineWithState)]
     public GlobalKind Kind { get; set; }
 
     [GlobalSetup]
@@ -147,6 +147,15 @@ public class FreshEngineGlobalsBenchmark
                 // here: a host whose globals depend on the request has nothing to hoist.
                 var index = i;
                 engine.Advanced.AddLazyGlobal(name, e => CreateClrFunction(e, name, index));
+            }
+            else if (Kind == GlobalKind.LazyPerEngineWithState)
+            {
+                // The same registration with the per-request data passed through instead of captured, so the
+                // factory is static and the descriptor is the only thing allocated.
+                engine.Advanced.AddLazyGlobal(
+                    name,
+                    (Owner: this, Name: name, Index: i),
+                    static (e, s) => s.Owner.CreateClrFunction(e, s.Name, s.Index));
             }
             else
             {
@@ -235,4 +244,12 @@ public enum GlobalKind
     /// </para>
     /// </summary>
     LazyPerEngine,
+
+    /// <summary>
+    /// <see cref="LazyPerEngine"/> registered through the state-taking overload, so the factory is a
+    /// <see langword="static"/> lambda rather than a closure. The gap between the two rows is exactly what a
+    /// capturing factory costs a host that registers per engine — nothing else about the two differs, the
+    /// same function objects are built at the same moment.
+    /// </summary>
+    LazyPerEngineWithState,
 }

--- a/Jint.Tests.PublicInterface/LazyGlobalRegistrationTests.cs
+++ b/Jint.Tests.PublicInterface/LazyGlobalRegistrationTests.cs
@@ -435,4 +435,87 @@ public class LazyGlobalRegistrationTests
         Invoking(() => engine.Advanced.AddLazyGlobal("name", null!))
             .Should().Throw<System.ArgumentNullException>();
     }
+
+    [Fact]
+    public void StatefulFactoryReceivesTheStateAndTheEngine()
+    {
+        var engine = new Engine();
+
+        engine.Advanced.AddLazyGlobal(
+            "greeting",
+            "world",
+            static (e, s) => JsValue.FromObject(e, "hello " + s));
+
+        engine.Evaluate("greeting").AsString().Should().Be("hello world");
+    }
+
+    [Fact]
+    public void StatefulFactoryIsStillLazyAndRunsAtMostOnce()
+    {
+        var box = new Box();
+        var engine = new Engine();
+
+        engine.Advanced.AddLazyGlobal(
+            "value",
+            box,
+            static (_, b) =>
+            {
+                b.Calls++;
+                return "built";
+            });
+
+        // The property exists from the moment it is declared; only its value is deferred.
+        engine.Evaluate("'value' in globalThis").AsBoolean().Should().BeTrue();
+        box.Calls.Should().Be(0, "an existence check does not need the value");
+
+        engine.Evaluate("value").AsString().Should().Be("built");
+        engine.Evaluate("value").AsString().Should().Be("built");
+        box.Calls.Should().Be(1);
+    }
+
+    [Fact]
+    public void StatefulFactoryNullResultBecomesUndefinedRatherThanReRunning()
+    {
+        var box = new Box();
+        var engine = new Engine();
+
+        engine.Advanced.AddLazyGlobal(
+            "nothing",
+            box,
+            static (_, b) =>
+            {
+                b.Calls++;
+                return null!;
+            });
+
+        engine.Evaluate("typeof nothing").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof nothing").AsString().Should().Be("undefined");
+        box.Calls.Should().Be(1);
+    }
+
+    [Fact]
+    public void StatefulRegistrationReplacesAnExistingGlobalLikeTheNonGenericOverload()
+    {
+        var engine = new Engine();
+        engine.SetValue("name", "eager");
+
+        engine.Advanced.AddLazyGlobal("name", "lazy", static (e, s) => JsValue.FromObject(e, s));
+
+        engine.Evaluate("name").AsString().Should().Be("lazy");
+    }
+
+    [Fact]
+    public void StatefulNullArgumentsAreRejected()
+    {
+        var engine = new Engine();
+        Invoking(() => engine.Advanced.AddLazyGlobal(null!, 1, static (_, _) => JsValue.Undefined))
+            .Should().Throw<System.ArgumentNullException>();
+        Invoking(() => engine.Advanced.AddLazyGlobal<int>("name", 1, null!))
+            .Should().Throw<System.ArgumentNullException>();
+    }
+
+    private sealed class Box
+    {
+        public int Calls;
+    }
 }

--- a/Jint/Engine.Advanced.cs
+++ b/Jint/Engine.Advanced.cs
@@ -447,10 +447,6 @@ public partial class Engine
 
             var engine = _engine;
 
-            // Resolved once per registration, not per read: LazyPropertyDescriptor treats a null value as
-            // "not materialized yet", so a factory returning null would silently re-run on every read.
-            Func<Engine, JsValue> resolver = e => valueFactory(e) ?? JsValue.Undefined;
-
             // SetProperty, exactly as the options-time registration uses, and for a reason that only bites
             // here: unlike a registration applied during construction, this one lands on an engine whose
             // handler trees may already hold a resolved binding for this very name. Every storage path
@@ -459,7 +455,7 @@ public partial class Engine
             // _propertiesVersion, which is the sole thing the global-identifier and member-read inline
             // caches revalidate against. Installing through anything that skipped that bump would leave a
             // warmed read site serving the previous binding forever.
-            engine.Realm.GlobalObject.SetProperty(name, new LazyPropertyDescriptor<Engine>(engine, resolver, flags));
+            engine.Realm.GlobalObject.SetProperty(name, new LazyPropertyDescriptor<Engine>(engine, valueFactory, flags));
         }
 
         /// <summary>

--- a/Jint/Engine.Advanced.cs
+++ b/Jint/Engine.Advanced.cs
@@ -459,6 +459,72 @@ public partial class Engine
         }
 
         /// <summary>
+        /// Declares a lazy global whose factory is handed a value the caller supplies, so that the factory can
+        /// be a <see langword="static"/> lambda instead of a closure. Behaves in every other way exactly like
+        /// <see cref="AddLazyGlobal(string, Func{Engine, JsValue}, PropertyFlag)"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This overload exists for allocation, not for expressiveness — anything it can express, a closure
+        /// could. The case it serves is a host that installs its globals <em>per engine</em>, which is the
+        /// whole reason the per-engine API exists: the values depend on request state, so the registration
+        /// cannot be hoisted onto <see cref="Options"/> and runs again for every engine. A capturing lambda
+        /// then costs a display class and a delegate per global per engine, which for a host exposing a few
+        /// dozen globals is a per-request cost with nothing to show for it. Passing the state through instead
+        /// leaves the descriptor as the only allocation.
+        /// </para>
+        /// <para>
+        /// Use a value tuple to pass more than one thing:
+        /// <c>AddLazyGlobal("db", (services, key), static (e, s) =&gt; Wrap(e, s.services, s.key))</c>. Keep
+        /// the factory <see langword="static"/>; a lambda that still captures gives the allocation straight
+        /// back and the overload buys nothing.
+        /// </para>
+        /// <para>
+        /// There is deliberately no <see cref="Options"/> counterpart. A registration made there is recorded
+        /// once and merely replayed per engine, so its closure is a one-off for the process and the
+        /// per-engine cost is already just the descriptor.
+        /// </para>
+        /// </remarks>
+        /// <typeparam name="TState">The type of the value handed back to the factory.</typeparam>
+        /// <param name="name">The global property name.</param>
+        /// <param name="state">Passed to <paramref name="valueFactory"/> unchanged when it runs.</param>
+        /// <param name="valueFactory">
+        /// Produces the value, given this engine and <paramref name="state"/>. Invoked lazily, at most once. A
+        /// <see langword="null"/> return is replaced by <see cref="JsValue.Undefined"/>.
+        /// </param>
+        /// <param name="flags">Property attributes; see the non-generic overload.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="name"/> or
+        /// <paramref name="valueFactory"/> is <see langword="null"/>.</exception>
+        public void AddLazyGlobal<TState>(
+            string name,
+            TState state,
+            Func<Engine, TState, JsValue> valueFactory,
+            PropertyFlag flags = PropertyFlag.ConfigurableEnumerableWritable)
+        {
+            if (name is null)
+            {
+                Throw.ArgumentNullException(nameof(name));
+            }
+
+            if (valueFactory is null)
+            {
+                Throw.ArgumentNullException(nameof(valueFactory));
+            }
+
+            var engine = _engine;
+
+            // The resolver is static, so it is cached once per TState instantiation rather than allocated
+            // here, and the state rides inside the descriptor's own field. See the SetProperty note above for
+            // why the installation has to go through it.
+            engine.Realm.GlobalObject.SetProperty(
+                name,
+                new LazyPropertyDescriptor<EngineAndState<TState>>(
+                    new EngineAndState<TState>(engine, state, valueFactory),
+                    static s => s.Factory(s.Engine, s.State),
+                    flags));
+        }
+
+        /// <summary>
         /// Event raised when a promise is rejected without a handler (operation = Reject),
         /// or when a handler is added to a previously unhandled rejected promise (operation = Handle).
         /// This implements the HostPromiseRejectionTracker abstract operation from the TC39 spec.

--- a/Jint/Options.Extensions.cs
+++ b/Jint/Options.Extensions.cs
@@ -576,13 +576,9 @@ public static class OptionsExtensions
             Throw.ArgumentNullException(nameof(valueFactory));
         }
 
-        // Resolved once per registration, not per engine: LazyPropertyDescriptor treats a null value as
-        // "not materialized yet", so a factory returning null would silently re-run on every read.
-        Func<Engine, JsValue> resolver = engine => valueFactory(engine) ?? JsValue.Undefined;
-
         options._configurations.Add(engine => engine.Realm.GlobalObject.SetProperty(
             name,
-            new LazyPropertyDescriptor<Engine>(engine, resolver, flags)));
+            new LazyPropertyDescriptor<Engine>(engine, valueFactory, flags)));
 
         return options;
     }

--- a/Jint/Runtime/Descriptors/Specialized/LazyPropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/LazyPropertyDescriptor.cs
@@ -24,7 +24,13 @@ internal sealed class LazyPropertyDescriptor<T> : PropertyDescriptor, IFieldBack
             var value = _value;
             if (value is null)
             {
-                _value = value = _resolver(_state);
+                // A resolver returning null would leave the pair in its "not materialized yet" state and
+                // re-run on every read. Substituting Undefined here rather than making each caller wrap its
+                // factory in a null-guarding lambda is what lets the registration APIs hand their own
+                // delegate straight to this constructor: a wrapper allocated per registration is one thing,
+                // but Engine.Advanced.AddLazyGlobal registers per engine, so a host installing globals on
+                // every request paid a closure pair for each of them.
+                _value = value = _resolver(_state) ?? JsValue.Undefined;
             }
 
             if (value is not null)

--- a/Jint/Runtime/Descriptors/Specialized/LazyPropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/LazyPropertyDescriptor.cs
@@ -1,7 +1,21 @@
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Jint.Native;
 
 namespace Jint.Runtime.Descriptors.Specialized;
+
+/// <summary>
+/// The state of a lazy property whose factory wants both the engine and something the host supplied, packed
+/// so that <see cref="LazyPropertyDescriptor{T}"/> can carry it in its single state field.
+/// </summary>
+/// <remarks>
+/// This exists to keep a per-engine registration allocation-free apart from the descriptor itself. Handing
+/// <see cref="LazyPropertyDescriptor{T}"/> a lambda that closes over the host's state would allocate a display
+/// class and a delegate for every property, on every engine; packing the state into a struct lets the resolver
+/// be a <see langword="static"/> lambda, which the compiler caches once per instantiation.
+/// </remarks>
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct EngineAndState<TState>(Engine Engine, TState State, Func<Engine, TState, JsValue> Factory);
 
 internal sealed class LazyPropertyDescriptor<T> : PropertyDescriptor, IFieldBackedLazyDescriptor
 {


### PR DESCRIPTION
`Engine.Advanced.AddLazyGlobal` exists for values a shared `Options` cannot hold — per-request data, a scoped service provider, a workflow context. That means a host calls it again for **every engine it builds**, so anything the API allocates per call is a per-request cost. Two things it allocated were avoidable.

### 1. The null-guard wrapper (first commit)

A lazy descriptor treats a null value as "not materialized yet", so a factory returning null would silently re-run on every read. Both registration APIs guarded that by wrapping the caller's factory in a null-coalescing lambda first.

On `Options.AddLazyGlobal` that wrapper is a one-off for the process — the options object is built once and the engine only replays the registration. On the per-engine API it was a display class and a delegate **per global per engine**.

The guard belongs in `LazyPropertyDescriptor`, which is the only place that knows what a null resolver result means. Folding it there lets both APIs pass the caller's delegate straight through, and makes the invariant harder to get wrong for any future caller of the constructor — the generated built-in slots reach it too.

### 2. Let the factory take its state (second commit)

`LazyPropertyDescriptor<T>` was already generic over its state; the public API pinned `T` to `Engine`, so a host with per-request data had no choice but to capture. The new overload passes the state through to a `static` factory, so the resolver is cached once per instantiation and the state rides inside the descriptor's existing field. The descriptor becomes the only allocation.

```csharp
engine.Advanced.AddLazyGlobal("db", (services, key), static (e, s) => Wrap(e, s.services, s.key));
```

There is deliberately no `Options` counterpart: a registration made there is recorded once and replayed, so its per-engine cost is already just the descriptor.

## Measurements

`FreshEngineGlobalsBenchmark` grows a `LazyPerEngine` row (and a `LazyPerEngineWithState` one), because nothing measured this path before — the existing `Lazy` row registers on the options, where the per-engine cost is only the descriptor installation. Forty per-engine globals on a fresh engine, of which the script reads one:

| Kind                     | Allocated | vs before |
|--------------------------|----------:|----------:|
| `LazyPerEngine` (before) |  23.49 KB |         — |
| after commit 1           |  20.05 KB |    −14.6% |
| after commit 2           |  18.80 KB |    **−20.0%** |

`Delegate` (32.85 KB), `ClrFunction` (30.55 KB) and `Lazy` (15.99 KB) are **byte-identical** across every run — the change touches only the per-engine lane. Time on the affected row moves 2.844 → 2.553 → 2.516 µs, but the untouched rows drifted up to 4.5% between runs, so allocation is the claim and time is directional.

<details><summary>SunSpider and Dromaeo</summary>

Both carried. Neither can resolve a change this size on my machine: running the **same commit** twice gives a median spread of 1.74% and a max of 17.42% on SunSpider (`string-tagcloud`, 30.08 vs 35.32 ms for identical code). Dromaeo base-vs-branch is median −0.55%, max |Δ| 15.5%, with the deterministic rows (`CoreEval`, `Cube`, `ObjectArray`, `StringBase64`) byte-identical on allocation — the expected signature for a change to lazy-global registration on suites that register no host globals.

Flagging the noise rather than quoting the deltas as results.
</details>

## Why this came up

Auditing Orchard Core's Jint integration. It builds one engine per evaluated expression, and a change to declare its workflow globals lazily instead of building all nine eagerly measured **−9.6% time but +3.2% allocation** — it fails on 4.15.3 because the five allocations per global outweighed the eager path's three. With both commits here, the same host change measures −8.1% time and −7.1% allocation on that row, with three control rows within 0.4% and byte-identical allocation.

`Jint.Tests` (4693) and `Jint.Tests.PublicInterface` (1239) pass on net10.0 and net472. The existing `PostConstructionNullFactoryResultBecomesUndefinedRatherThanReRunning` pins the semantics commit 1 moves and passes unchanged; six new tests cover the overload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)