### PR TITLE
Make the lazy-global re-arm on restore a contract instead of an accident

### DIFF
--- a/Jint.Tests.PublicInterface/LazyGlobalRestoreContractTests.cs
+++ b/Jint.Tests.PublicInterface/LazyGlobalRestoreContractTests.cs
@@ -1,0 +1,172 @@
+#nullable enable
+
+using Jint;
+using Jint.Native;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// Pins the one guarantee an engine-pooling host bets correctness on: a lazily declared global that had not
+/// been read when a snapshot was captured is returned to its unread state by a restore, so its factory runs
+/// again and produces a value for the request that is reading it now.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These are contract tests rather than coverage. The behaviour is currently produced by an internal
+/// arrangement — the descriptor the registration installs is one the restore path recognizes as owning its
+/// value in the inherited field, and reverts. A host cannot see that arrangement, cannot assert it, and has
+/// no way to notice if it changes.
+/// </para>
+/// <para>
+/// What it would cost is the reason these exist. Were such a descriptor reinstated by reference with its
+/// materialized value intact, an engine reused across requests would hand the next request a global closed
+/// over the previous request's state — a scoped service provider, a user, a tenant. Nothing throws, nothing
+/// logs, and the only symptom is an answer computed against the wrong request. A test that fails loudly here
+/// is the difference between that being caught in CI and being found in production.
+/// </para>
+/// </remarks>
+public class LazyGlobalRestoreContractTests
+{
+    [Fact]
+    public void AnUnreadOptionsGlobalIsRebuiltAfterARestore()
+    {
+        var built = 0;
+        var current = "first";
+
+        // The shape a pooling host has: one Options for the process, the per-request part reached through
+        // the factory rather than captured, and a snapshot taken before anything has run.
+        var options = new Options().AddLazyGlobal("contextual", engine =>
+        {
+            built++;
+            return JsValue.FromObject(engine, current);
+        });
+
+        var engine = new Engine(options);
+        var clean = engine.Advanced.CaptureGlobalSnapshot();
+
+        engine.Evaluate("contextual").AsString().Should().Be("first");
+        built.Should().Be(1);
+
+        // Next "request": same engine, different ambient state.
+        engine.Advanced.RestoreGlobalSnapshot(clean);
+        current = "second";
+
+        engine.Evaluate("contextual").AsString().Should()
+            .Be("second", "a restore must re-arm a global that was unread at capture, or a reused engine serves the previous request's value");
+        built.Should().Be(2);
+    }
+
+    [Fact]
+    public void TheSameHoldsForAPerEngineRegistration()
+    {
+        var built = 0;
+        var current = "first";
+
+        var engine = new Engine();
+        var clean = engine.Advanced.CaptureGlobalSnapshot();
+
+        engine.Advanced.AddLazyGlobal("contextual", e =>
+        {
+            built++;
+            return JsValue.FromObject(e, current);
+        });
+
+        engine.Evaluate("contextual").AsString().Should().Be("first");
+        built.Should().Be(1);
+
+        // A per-engine declaration made *after* the capture is removed by the restore rather than re-armed,
+        // so the host declares it again per rental. Both halves matter to a pool: this is why the
+        // declaration belongs with the rental and not with the engine's construction.
+        engine.Advanced.RestoreGlobalSnapshot(clean);
+        engine.Evaluate("typeof contextual").AsString().Should().Be("undefined");
+
+        current = "second";
+        engine.Advanced.AddLazyGlobal("contextual", e =>
+        {
+            built++;
+            return JsValue.FromObject(e, current);
+        });
+
+        engine.Evaluate("contextual").AsString().Should().Be("second");
+        built.Should().Be(2);
+    }
+
+    [Fact]
+    public void AGlobalAlreadyReadAtCaptureIsRestoredToThatValue()
+    {
+        // The other side of the same rule, and the one a host must not get wrong in the opposite direction:
+        // once a value is part of the captured surface it is restored, not rebuilt.
+        var built = 0;
+        var current = "first";
+
+        var options = new Options().AddLazyGlobal("contextual", engine =>
+        {
+            built++;
+            return JsValue.FromObject(engine, current);
+        });
+
+        var engine = new Engine(options);
+
+        engine.Evaluate("contextual").AsString().Should().Be("first");
+        built.Should().Be(1);
+
+        var afterFirstRead = engine.Advanced.CaptureGlobalSnapshot();
+        current = "second";
+
+        engine.Advanced.RestoreGlobalSnapshot(afterFirstRead);
+
+        engine.Evaluate("contextual").AsString().Should()
+            .Be("first", "the value was part of the captured surface, so it is reinstated rather than recomputed");
+        built.Should().Be(1);
+    }
+
+    [Fact]
+    public void ScriptStateFromThePreviousEvaluationDoesNotSurvive()
+    {
+        // The rest of what a pool relies on, in one place: a global declared by a script, a redeclarable
+        // top-level lexical binding, and a mutated built-in prototype are the three things a host would
+        // otherwise have to build a fresh engine to be rid of. The third is deliberately included as the
+        // documented non-guarantee — RestoreGlobalSnapshot reverts the global binding table, not intrinsics.
+        var engine = new Engine();
+        var clean = engine.Advanced.CaptureGlobalSnapshot();
+
+        engine.Evaluate("var leaked = 1; globalThis.alsoLeaked = 2; let lexical = 3;");
+        engine.Evaluate("Array.prototype.mutated = 4;");
+
+        engine.Advanced.RestoreGlobalSnapshot(clean);
+
+        engine.Evaluate("typeof leaked").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof globalThis.alsoLeaked").AsString().Should().Be("undefined");
+
+        // Redeclaring the same lexical name is the sharpest check: without the reset this throws.
+        engine.Evaluate("let lexical = 5; lexical").AsNumber().Should().Be(5);
+
+        engine.Evaluate("[].mutated").AsNumber().Should()
+            .Be(4, "a restore reverts global bindings and explicitly not intrinsic mutations — a pool is a configuration-reuse primitive, not an isolation boundary");
+    }
+
+    [Fact]
+    public void APropertyFlagOnARestoredGlobalIsRevertedToo()
+    {
+        // A host that declares its globals non-enumerable, as a delegate registration would, needs the
+        // attributes back as well as the value — otherwise Object.keys(globalThis) drifts across rentals.
+        var options = new Options().AddLazyGlobal(
+            "hidden",
+            static engine => JsValue.FromObject(engine, "value"),
+            PropertyFlag.NonEnumerable);
+
+        var engine = new Engine(options);
+        var clean = engine.Advanced.CaptureGlobalSnapshot();
+
+        engine.Evaluate("Object.keys(globalThis).indexOf('hidden')").AsNumber().Should().Be(-1);
+        engine.Evaluate("Object.defineProperty(globalThis, 'hidden', { enumerable: true, value: 'x' });");
+        engine.Evaluate("Object.keys(globalThis).indexOf('hidden')").AsNumber().Should().NotBe(-1);
+
+        engine.Advanced.RestoreGlobalSnapshot(clean);
+
+        engine.Evaluate("Object.keys(globalThis).indexOf('hidden')").AsNumber().Should()
+            .Be(-1, "the attributes are part of the captured surface, not just the value");
+        engine.Evaluate("hidden").AsString().Should().Be("value");
+    }
+}

--- a/Jint/Engine.Advanced.cs
+++ b/Jint/Engine.Advanced.cs
@@ -402,9 +402,10 @@ public partial class Engine
         /// <b>Interaction with <see cref="CaptureGlobalSnapshot"/>.</b> A restore returns the binding to its
         /// state at capture, which cuts both ways: a global installed after the capture is gone after the
         /// restore, and one installed before it whose factory had <em>not</em> yet run at capture time is
-        /// returned to that unmaterialized state — so the factory may run again on the next read. That is
-        /// the point rather than an artifact: it is what lets a pooled engine keep the laziness across
-        /// evaluations. A factory whose result must survive a restore has to be installed after it.
+        /// returned to that unmaterialized state, so the factory <b>runs again</b> on the next read. That is
+        /// a contract rather than an artifact — it is what lets a pooled engine keep the laziness across
+        /// evaluations, and a host that reuses engines depends on it to stop one request's value being
+        /// served to the next. A factory whose result must survive a restore has to be installed after it.
         /// </para>
         /// </remarks>
         /// <example>

--- a/Jint/Options.Extensions.cs
+++ b/Jint/Options.Extensions.cs
@@ -526,6 +526,26 @@ public static class OptionsExtensions
     /// it is not.
     /// </para>
     /// <para>
+    /// <b>A restore re-arms an unread global, and this is a contract.</b> If
+    /// <see cref="Engine.AdvancedOperations.CaptureGlobalSnapshot"/> is taken while this global has not yet
+    /// been read, <see cref="Engine.AdvancedOperations.RestoreGlobalSnapshot"/> returns it to that
+    /// unmaterialized state, and <paramref name="valueFactory"/> <b>runs again</b> on the next read. It is
+    /// not merely permitted to — a host pooling engines across requests depends on it, since the value the
+    /// factory produced belongs to the request that read it. Capture before the first evaluation and the
+    /// globals of every later one are rebuilt rather than inherited.
+    /// <para>
+    /// The failure this rules out is silent, which is why it is stated rather than left to the
+    /// implementation: were the descriptor reinstated with its materialized value intact, a reused engine
+    /// would serve the next request a value closed over the previous one's state, with nothing to observe
+    /// but the wrong answer.
+    /// </para>
+    /// <para>
+    /// The guarantee covers a global whose factory had <em>not</em> run at capture time. One already read by
+    /// then is part of the captured surface and is restored to that value, which is the same rule seen from
+    /// the other side.
+    /// </para>
+    /// </para>
+    /// <para>
     /// <b>Flags differ from <see cref="Engine.SetValue(string, Delegate)"/>.</b> The default here matches
     /// <see cref="Engine.SetValue(string, JsValue)"/> — configurable, enumerable and writable — whereas
     /// registering a delegate global installs it as <see cref="PropertyFlag.NonEnumerable"/> (configurable


### PR DESCRIPTION
Documentation and tests only — no behaviour change.

## What this pins

A host that reuses engines across requests resets each one with `RestoreGlobalSnapshot` between evaluations. That is safe only because a global declared lazily and **not yet read** at capture time is returned to its unread state, so its factory runs again and produces a value for the request now reading it.

Jint does this today. The mechanism is `ValueIsFieldBacked` in `Engine.GlobalSnapshot.cs` recognizing the descriptor as one that owns its value in the inherited field — via an `internal` interface a host cannot see, assert, or notice changing.

## Why it is worth stating

The failure it rules out is silent. Were such a descriptor reinstated by reference with its materialized value intact, a pooled engine would serve the next request a global closed over the **previous** request's state — a scoped `IServiceProvider`, a user, a tenant. Nothing throws, nothing logs, and the only symptom is an answer computed against the wrong request.

The per-engine `AddLazyGlobal` already mentioned this, hedged as "the factory *may* run again on the next read". It is not a permission — it is what correctness rests on. And it was not stated at all on `OptionsExtensions.AddLazyGlobal`, which is the overload a host uses for globals it declares once for the whole process, and therefore the one whose values most need rebuilding per rental.

So: firm up the wording on the per-engine overload, state the guarantee on the Options one, and back both with tests.

## Tests

`Jint.Tests.PublicInterface/LazyGlobalRestoreContractTests.cs` — that project has no `InternalsVisibleTo`, so these assert from where a host actually sits:

- an unread `Options` global is rebuilt after a restore and picks up the new ambient state (the pooling case);
- a **per-engine** declaration made *after* the capture is removed rather than re-armed — the other half a pool needs, and why such a declaration belongs with the rental rather than with construction;
- a global already read at capture is restored to that value rather than recomputed;
- script-declared globals and top-level lexical bindings do not survive a restore (the `let` redeclaration is the sharp one — it throws without the reset), while an intrinsic mutation deliberately **does**, because a restore reverts the global binding table and is explicitly not an isolation boundary;
- property attributes are reverted along with the value, which a host declaring its globals `NonEnumerable` depends on.

1250 `Jint.Tests.PublicInterface` tests pass on net10.0 and net472; `Jint` builds with no new warnings.

## Where this came from

Auditing Orchard Core's Jint integration. It builds a fresh engine per evaluated expression, and is adding engine reuse on top of `GlobalSnapshot` — its correctness rests entirely on this guarantee, and it had no way to depend on it except by hoping. Follows #2890 and #2891 from the same audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)