### PR TITLE
Carry a labelled break/continue target on the completion record

### DIFF
--- a/Jint.Tests/Runtime/LabelledJumpTests.cs
+++ b/Jint.Tests/Runtime/LabelledJumpTests.cs
@@ -1,0 +1,325 @@
+﻿namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Guards the target of a labelled <c>break</c>/<c>continue</c> against code that runs while the
+/// jump is unwinding. The label used to live in a mutable slot on the evaluation context that
+/// <c>PrepareFor</c> cleared on every statement, so any statement executed between the jump and the
+/// loop that consumes it — a non-empty <c>finally</c>, an iterator's <c>return()</c>, a
+/// <c>Symbol.dispose</c> body — silently turned <c>break outer</c> into an unlabelled break of the
+/// innermost loop. It now rides on the completion record itself (<c>Completion.Target</c>), which
+/// nothing in between can touch.
+/// <para>
+/// An <em>empty</em> finalizer never reproduced the bug (a zero-statement list never reaches
+/// PrepareFor), which is why the controls below matter as much as the regressions.
+/// </para>
+/// </summary>
+public class LabelledJumpTests
+{
+    private readonly Engine _engine = new();
+
+    private string Run(string source) => _engine.Evaluate(source).AsString();
+
+    [Fact]
+    public void LabelledBreakSurvivesANonEmptyFinally()
+    {
+        Run("""
+            var log = [];
+            outer: for (var i = 0; i < 2; i++) {
+              for (var j = 0; j < 2; j++) {
+                try { break outer; } finally { log.push('f'); }
+              }
+              log.push('after-inner');
+            }
+            log.join(',');
+            """).Should().Be("f");
+    }
+
+    [Fact]
+    public void LabelledContinueSurvivesANonEmptyFinally()
+    {
+        Run("""
+            var log = [];
+            outer: for (var i = 0; i < 2; i++) {
+              for (var j = 0; j < 2; j++) {
+                try { continue outer; } finally { log.push('f'); }
+              }
+              log.push('after-inner');
+            }
+            log.join(',');
+            """).Should().Be("f,f");
+    }
+
+    [Fact]
+    public void BreakOutOfALabelledBlockSurvivesANonEmptyFinally()
+    {
+        Run("""
+            var log = [];
+            outer: {
+              for (var j = 0; j < 2; j++) {
+                try { break outer; } finally { log.push('f'); }
+              }
+              log.push('after-inner');
+            }
+            log.join(',');
+            """).Should().Be("f");
+    }
+
+    [Fact]
+    public void LabelledBreakSurvivesAFinallyThatCallsAFunction()
+    {
+        Run("""
+            var log = [];
+            function note(x) { log.push(x); }
+            outer: for (var i = 0; i < 2; i++) {
+              for (var j = 0; j < 2; j++) {
+                try { break outer; } finally { note('f'); }
+              }
+              log.push('after-inner');
+            }
+            log.join(',');
+            """).Should().Be("f");
+    }
+
+    [Fact]
+    public void LabelledBreakSurvivesAnIteratorReturnThatRunsStatements()
+    {
+        Run("""
+            var log = [];
+            var iter = {};
+            iter[Symbol.iterator] = function () {
+              var n = 0;
+              return {
+                next: function () { return { value: n++, done: false }; },
+                return: function () { log.push('r'); return { done: true }; }
+              };
+            };
+            outer: for (var i = 0; i < 2; i++) {
+              for (var x of iter) { break outer; }
+              log.push('after-inner');
+            }
+            log.join(',');
+            """).Should().Be("r");
+    }
+
+    [Fact]
+    public void LabelledBreakSurvivesAGeneratorCloseOnTheWayOut()
+    {
+        Run("""
+            var log = [];
+            function* values() { try { yield 1; yield 2; } finally { log.push('c'); } }
+            var it = values();
+            outer: for (var i = 0; i < 2; i++) {
+              for (var x of it) { break outer; }
+              log.push('after-inner');
+            }
+            log.join(',');
+            """).Should().Be("c");
+    }
+
+    [Fact]
+    public void LabelledBreakSurvivesADisposeBody()
+    {
+        Run("""
+            var log = [];
+            outer: for (var i = 0; i < 2; i++) {
+              for (var j = 0; j < 2; j++) {
+                {
+                  using res = { [Symbol.dispose]() { log.push('d'); } };
+                  break outer;
+                }
+              }
+              log.push('after-inner');
+            }
+            log.join(',');
+            """).Should().Be("d");
+    }
+
+    [Fact]
+    public void LabelledBreakOutOfASwitchInsideALabelledLoop()
+    {
+        Run("""
+            var log = [];
+            outer: for (var i = 0; i < 2; i++) {
+              switch (i) {
+                case 0:
+                  try { break outer; } finally { log.push('f'); }
+              }
+              log.push('after-switch');
+            }
+            log.join(',');
+            """).Should().Be("f");
+    }
+
+    [Fact]
+    public void UnlabelledBreakInsideASwitchStillBreaksTheSwitchOnly()
+    {
+        Run("""
+            var log = [];
+            for (var i = 0; i < 2; i++) {
+              switch (i) {
+                case 0:
+                  try { break; } finally { log.push('f'); }
+              }
+              log.push('after-switch');
+            }
+            log.join(',');
+            """).Should().Be("f,after-switch,after-switch");
+    }
+
+    [Fact]
+    public void LabelledBreakAcrossThreeLevels()
+    {
+        Run("""
+            var log = [];
+            a: for (var i = 0; i < 2; i++) {
+              b: for (var j = 0; j < 2; j++) {
+                for (var k = 0; k < 2; k++) {
+                  try { break a; } finally { log.push('f'); }
+                }
+                log.push('after-k');
+              }
+              log.push('after-j');
+            }
+            log.join(',');
+            """).Should().Be("f");
+    }
+
+    [Fact]
+    public void LabelledContinueTargetingAnOuterLoopFromAWhile()
+    {
+        Run("""
+            var log = [];
+            outer: for (var i = 0; i < 2; i++) {
+              var j = 0;
+              while (j < 2) {
+                j++;
+                try { continue outer; } finally { log.push('f'); }
+              }
+              log.push('after-while');
+            }
+            log.join(',');
+            """).Should().Be("f,f");
+    }
+
+    [Fact]
+    public void LabelledContinueTargetingAnOuterLoopFromADoWhile()
+    {
+        Run("""
+            var log = [];
+            outer: for (var i = 0; i < 2; i++) {
+              var j = 0;
+              do {
+                j++;
+                try { continue outer; } finally { log.push('f'); }
+              } while (j < 2);
+              log.push('after-do');
+            }
+            log.join(',');
+            """).Should().Be("f,f");
+    }
+
+    [Fact]
+    public void LabelledJumpsInsideAGeneratorBody()
+    {
+        Run("""
+            var log = [];
+            function* g() {
+              outer: for (var i = 0; i < 2; i++) {
+                for (var j = 0; j < 2; j++) {
+                  yield i;
+                  try { break outer; } finally { log.push('f'); }
+                }
+                log.push('after-inner');
+              }
+            }
+            var it = g();
+            it.next(); it.next();
+            log.join(',');
+            """).Should().Be("f");
+    }
+
+    // Controls: an empty finalizer never reproduced the bug, and neither did the plain shapes.
+    // They pin that the fix did not change the cases that already worked.
+
+    [Fact]
+    public void LabelledBreakThroughAnEmptyFinally()
+    {
+        Run("""
+            var log = [];
+            outer: for (var i = 0; i < 2; i++) {
+              for (var j = 0; j < 2; j++) {
+                try { break outer; } finally { }
+              }
+              log.push('after-inner');
+            }
+            log.join(',');
+            """).Should().Be("");
+    }
+
+    [Fact]
+    public void PlainLabelledBreakAndContinueAreUnchanged()
+    {
+        Run("""
+            var log = [];
+            outer: for (var i = 0; i < 2; i++) {
+              for (var j = 0; j < 2; j++) { break outer; }
+              log.push('after-inner');
+            }
+            log.join(',');
+            """).Should().Be("");
+
+        Run("""
+            var log = [];
+            outer: for (var i = 0; i < 3; i++) {
+              for (var j = 0; j < 2; j++) { continue outer; }
+              log.push('after-inner');
+            }
+            log.join(',');
+            """).Should().Be("");
+    }
+
+    [Fact]
+    public void UnlabelledBreakStillBreaksTheInnermostLoop()
+    {
+        Run("""
+            var log = [];
+            for (var i = 0; i < 2; i++) {
+              for (var j = 0; j < 2; j++) {
+                try { break; } finally { log.push('f'); }
+              }
+              log.push('after-inner');
+            }
+            log.join(',');
+            """).Should().Be("f,after-inner,f,after-inner");
+    }
+
+    [Fact]
+    public void UnlabelledContinueStillContinuesTheInnermostLoop()
+    {
+        Run("""
+            var log = [];
+            for (var i = 0; i < 2; i++) {
+              for (var j = 0; j < 2; j++) {
+                try { continue; } finally { log.push('f'); }
+              }
+              log.push('after-inner');
+            }
+            log.join(',');
+            """).Should().Be("f,f,after-inner,f,f,after-inner");
+    }
+
+    [Fact]
+    public void ABreakTargetingAnInnerLabelIsNotConsumedByAnOuterLoop()
+    {
+        Run("""
+            var log = [];
+            for (var i = 0; i < 2; i++) {
+              inner: for (var j = 0; j < 2; j++) {
+                try { break inner; } finally { log.push('f'); }
+              }
+              log.push('after-inner');
+            }
+            log.join(',');
+            """).Should().Be("f,after-inner,f,after-inner");
+    }
+}

--- a/Jint/Runtime/Completion.cs
+++ b/Jint/Runtime/Completion.cs
@@ -29,6 +29,12 @@ public readonly struct Completion
     {
         Debug.Assert(value is not null);
 
+        // Target reads the label back out of the source node, so a Break/Continue completion must
+        // carry the jump statement that produced it. In-box invariant: the only two producers are
+        // JintBreakStatement and JintContinueStatement, which pass their own _statement.
+        Debug.Assert(type != CompletionType.Break || source is BreakStatement);
+        Debug.Assert(type != CompletionType.Continue || source is ContinueStatement);
+
         Type = type;
         Value = value!;
         _source = source;
@@ -37,6 +43,21 @@ public readonly struct Completion
     public readonly CompletionType Type;
     public readonly JsValue Value;
     public readonly ref readonly SourceLocation Location => ref _source.LocationRef;
+
+    /// <summary>
+    /// The spec's Completion Record [[Target]] — the label a <c>break</c>/<c>continue</c> names, or
+    /// null for an unlabelled jump. Recovered from <see cref="_source"/> rather than stored, so it
+    /// costs no space in the struct and, unlike the mutable per-context slot it replaces, cannot be
+    /// clobbered by code that runs while the completion is unwinding (a non-empty <c>finally</c>, an
+    /// iterator's <c>return()</c>, a <c>Symbol.dispose</c> body). Only meaningful for Break and
+    /// Continue; every read site is already guarded on <see cref="Type"/>.
+    /// </summary>
+    internal string? Target => Type switch
+    {
+        CompletionType.Break => ((BreakStatement) _source).Label?.Name,
+        CompletionType.Continue => ((ContinueStatement) _source).Label?.Name,
+        _ => null,
+    };
 
     public static ref readonly Completion Empty() => ref _emptyCompletion;
 

--- a/Jint/Runtime/Interpreter/EvaluationContext.cs
+++ b/Jint/Runtime/Interpreter/EvaluationContext.cs
@@ -101,7 +101,6 @@ internal sealed class EvaluationContext
     public bool CompletionValuesObservable = true;
 
     // completion record information
-    public string? Target;
     public CompletionType Completion;
 
     public void RunBeforeExecuteStatementChecks(StatementOrExpression statement)
@@ -163,7 +162,6 @@ internal sealed class EvaluationContext
     public void PrepareFor(Node node)
     {
         LastSyntaxElement = node;
-        Target = null;
         Completion = CompletionType.Normal;
     }
 

--- a/Jint/Runtime/Interpreter/Statements/JintBreakStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintBreakStatement.cs
@@ -13,7 +13,7 @@ internal sealed class JintBreakStatement : JintStatement<BreakStatement>
 
     protected override Completion ExecuteInternal(EvaluationContext context)
     {
-        context.Target = _statement.Label?.Name;
+        // The label travels on the completion, read back from _statement by Completion.Target.
         return new Completion(CompletionType.Break, JsEmpty.Instance, _statement);
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintContinueStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintContinueStatement.cs
@@ -13,7 +13,7 @@ internal sealed class JintContinueStatement : JintStatement<ContinueStatement>
 
     protected override Completion ExecuteInternal(EvaluationContext context)
     {
-        context.Target = _statement.Label?.Name;
+        // The label travels on the completion, read back from _statement by Completion.Target.
         return new Completion(CompletionType.Continue, JsEmpty.Instance, _statement);
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintDoWhileStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintDoWhileStatement.cs
@@ -84,9 +84,9 @@ internal sealed class JintDoWhileStatement : JintStatement<DoWhileStatement>
                     return new Completion(CompletionType.Return, suspendedValue, _statement);
                 }
 
-                if (completion.Type != CompletionType.Continue || !string.Equals(context.Target, _labelSetName, StringComparison.Ordinal))
+                if (completion.Type != CompletionType.Continue || !string.Equals(completion.Target, _labelSetName, StringComparison.Ordinal))
                 {
-                    if (completion.Type == CompletionType.Break && (context.Target == null || string.Equals(context.Target, _labelSetName, StringComparison.Ordinal)))
+                    if (completion.Type == CompletionType.Break && (completion.Target == null || string.Equals(completion.Target, _labelSetName, StringComparison.Ordinal)))
                     {
                         return new Completion(CompletionType.Normal, v, _statement);
                     }

--- a/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
@@ -920,14 +920,14 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                     return new Completion(CompletionType.Return, returnValue, _statement!);
                 }
 
-                if (result.Type == CompletionType.Break && (context.Target == null || string.Equals(context.Target, _statement?.LabelSet?.Name, StringComparison.Ordinal)))
+                if (result.Type == CompletionType.Break && (result.Target == null || string.Equals(result.Target, _statement?.LabelSet?.Name, StringComparison.Ordinal)))
                 {
                     completionType = CompletionType.Normal;
                     suspendable?.Data.Clear(this);
                     return new Completion(CompletionType.Normal, v, _statement!);
                 }
 
-                if (result.Type != CompletionType.Continue || (context.Target != null && !string.Equals(context.Target, _statement?.LabelSet?.Name, StringComparison.Ordinal)))
+                if (result.Type != CompletionType.Continue || (result.Target != null && !string.Equals(result.Target, _statement?.LabelSet?.Name, StringComparison.Ordinal)))
                 {
                     completionType = result.Type;
                     if (result.IsAbrupt())
@@ -1327,7 +1327,7 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
         }
 
         if (result.Type == CompletionType.Break
-            && (context.Target is null || string.Equals(context.Target, _statement?.LabelSet?.Name, StringComparison.Ordinal)))
+            && (result.Target is null || string.Equals(result.Target, _statement?.LabelSet?.Name, StringComparison.Ordinal)))
         {
             suspendable.Data.Clear(this);
             TryCloseIterator(iteratorRecord, CompletionType.Normal);

--- a/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
@@ -644,13 +644,13 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
                     return new Completion(CompletionType.Return, suspendedValue, ((JintStatement) this)._statement);
                 }
 
-                if (result.Type == CompletionType.Break && (context.Target == null || string.Equals(context.Target, _statement?.LabelSet?.Name, StringComparison.Ordinal)))
+                if (result.Type == CompletionType.Break && (result.Target == null || string.Equals(result.Target, _statement?.LabelSet?.Name, StringComparison.Ordinal)))
                 {
                     suspendable?.Data.Clear(this);
                     return new Completion(CompletionType.Normal, result.Value, ((JintStatement) this)._statement);
                 }
 
-                if (result.Type != CompletionType.Continue || (context.Target != null && !string.Equals(context.Target, _statement?.LabelSet?.Name, StringComparison.Ordinal)))
+                if (result.Type != CompletionType.Continue || (result.Target != null && !string.Equals(result.Target, _statement?.LabelSet?.Name, StringComparison.Ordinal)))
                 {
                     if (result.Type != CompletionType.Normal)
                     {

--- a/Jint/Runtime/Interpreter/Statements/JintLabeledStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintLabeledStatement.cs
@@ -17,7 +17,7 @@ internal sealed class JintLabeledStatement : JintStatement<LabeledStatement>
         // containing label and could keep a table per program with all the labels
         // labeledStatement.Body.LabelSet = labeledStatement.Label;
         var result = _body.Execute(context);
-        if (result.Type == CompletionType.Break && string.Equals(context.Target, _labelName, StringComparison.Ordinal))
+        if (result.Type == CompletionType.Break && string.Equals(result.Target, _labelName, StringComparison.Ordinal))
         {
             var value = result.Value;
             return new Completion(CompletionType.Normal, value, _statement);

--- a/Jint/Runtime/Interpreter/Statements/JintSwitchStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintSwitchStatement.cs
@@ -36,7 +36,7 @@ internal sealed class JintSwitchStatement : JintStatement<SwitchStatement>
     private Completion HandleCompletion(EvaluationContext context, Completion r)
     {
         if (r.Type == CompletionType.Break
-            && (context.Target is null || string.Equals(context.Target, _statement.LabelSet?.Name, StringComparison.Ordinal)))
+            && (r.Target is null || string.Equals(r.Target, _statement.LabelSet?.Name, StringComparison.Ordinal)))
         {
             return new Completion(CompletionType.Normal, r.Value, ((JintStatement) this)._statement);
         }

--- a/Jint/Runtime/Interpreter/Statements/JintVariableDeclaration.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintVariableDeclaration.cs
@@ -91,9 +91,10 @@ internal sealed class JintVariableDeclaration : JintStatement<VariableDeclaratio
     /// Tight-loop entry; see <see cref="JintStatement.ExecuteDiscarded"/>. Declarations complete
     /// with an Empty Normal value on every path, so only the Execute wrapper ceremony is skipped;
     /// the current node still needs tracking for error locations. Skipping PrepareFor is safe:
-    /// <see cref="EvaluationContext.Completion"/> is written nowhere but PrepareFor (never abrupt)
-    /// and a stale <see cref="EvaluationContext.Target"/> is only consumed under Break/Continue
-    /// completions, which the tight shape excludes.
+    /// <see cref="EvaluationContext.Completion"/> is written nowhere but PrepareFor (never abrupt),
+    /// and a break/continue label rides on the completion that carries it
+    /// (<see cref="Jint.Runtime.Completion.Target"/>), so no jump state survives on the context for
+    /// PrepareFor to reset or for this lane to leave stale.
     /// </summary>
     internal override void ExecuteDiscarded(EvaluationContext context)
     {

--- a/Jint/Runtime/Interpreter/Statements/JintWhileStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintWhileStatement.cs
@@ -112,9 +112,9 @@ internal sealed class JintWhileStatement : JintStatement<WhileStatement>
                 return new Completion(CompletionType.Return, suspendedValue, _statement);
             }
 
-            if (completion.Type != CompletionType.Continue || !string.Equals(context.Target, _labelSetName, StringComparison.Ordinal))
+            if (completion.Type != CompletionType.Continue || !string.Equals(completion.Target, _labelSetName, StringComparison.Ordinal))
             {
-                if (completion.Type == CompletionType.Break && (context.Target == null || string.Equals(context.Target, _labelSetName, StringComparison.Ordinal)))
+                if (completion.Type == CompletionType.Break && (completion.Target == null || string.Equals(completion.Target, _labelSetName, StringComparison.Ordinal)))
                 {
                     return new Completion(CompletionType.Normal, v, _statement);
                 }


### PR DESCRIPTION
## Summary

Fixes `break outer;` silently becoming an unlabelled break of the innermost loop.

## Details

The label of a labelled `break`/`continue` lived only in `EvaluationContext.Target`, a mutable slot that `PrepareFor` cleared on **every statement and every expression**. `Completion` has no `[[Target]]`, so nothing else carried it. Any code that ran while the jump was unwinding therefore erased the target before the loop that should consume it ever read it:

- a non-empty `finally` block
- a `Symbol.dispose` body
- a generator or iterator close that executes statements
- a re-entrant host callback

An **empty** `finally {}` was safe — a zero-statement list never reaches `PrepareFor` — which is why test262's only labelled-break-with-finally file (`language/statements/for-of/break-label-from-finally.js`) dodges it, and why nothing ever caught this.

### Scope

Ten of nineteen shapes disagreed with V8. The plainest one:

```js
var log = [];
outer: for (var i = 0; i < 2; i++) {
  for (var j = 0; j < 2; j++) {
    try { break outer; } finally { log.push('f'); }
  }
  log.push('after-inner');
}
// spec / V8: ["f"]
// Jint before: ["f","after-inner","f","after-inner"]
```

`continue outer` through a non-empty `finally`, `break` out of a labelled block, breaking across three loop levels, and the `using`/`Symbol.dispose` variant were all wrong the same way. Every expectation in the new tests was cross-checked against Node v24.

### The fix

The label is already reachable for free. `Completion._source` **is** the `BreakStatement`/`ContinueStatement` node, `UpdateEmpty` preserves `_source`, and every propagation path passes the completion by value. So `Completion.Target` reads the label back out of the node the completion already holds:

```csharp
internal string? Target => Type switch
{
    CompletionType.Break => ((BreakStatement) _source).Label?.Name,
    CompletionType.Continue => ((ContinueStatement) _source).Label?.Name,
    _ => null,
};
```

Zero bytes added to the struct. The eleven read sites — all of which already guard on `Type` — take it from the completion in hand instead of from engine-lifetime state. The only two producers of a Break/Continue completion are the two jump statements, each passing its own node; a `Debug.Assert` in the constructor pins that invariant.

### Side benefit

This *removes* a store from `PrepareFor`, which runs on every non-block statement (`JintStatement.Execute`) and every expression evaluation (`JintExpression.Evaluate`), for a field only `break` and `continue` ever used.

## Linked issue

None on file — found while auditing `EvaluationContext`.

## Test plan

- [x] Added `Jint.Tests/Runtime/LabelledJumpTests.cs` — 18 tests, including four controls pinning the shapes that already worked
- [x] Ran `dotnet test --configuration Release` locally (all projects, net10.0 + net472)
- [x] Ran `Jint.Tests.Test262` — 99,738 passed, 0 failed, no regressions
- [ ] Perf numbers pending — this touches `PrepareFor`, so a SunSpider + Dromaeo table is owed before merge

## Breaking change?

No public API change. Behaviour changes only where it was previously wrong: labelled `break`/`continue` now reaches its intended target.
