### PR TITLE
Delete the evaluation context's dead completion channel

### DIFF
--- a/Jint/Runtime/Interpreter/EvaluationContext.cs
+++ b/Jint/Runtime/Interpreter/EvaluationContext.cs
@@ -100,9 +100,6 @@ internal sealed class EvaluationContext
     /// </summary>
     public bool CompletionValuesObservable = true;
 
-    // completion record information
-    public CompletionType Completion;
-
     public void RunBeforeExecuteStatementChecks(StatementOrExpression statement)
     {
         if (_shouldRunPerStatementChecks)
@@ -158,13 +155,13 @@ internal sealed class EvaluationContext
         }
     }
 
+    /// <summary>
+    /// Establishes <paramref name="node"/> as the node an error would be reported against. This is
+    /// the whole of the per-node ceremony: abrupt completions travel out of band (as a
+    /// <see cref="JavaScriptException"/> or through <see cref="Engine._error"/>) and a break or
+    /// continue label travels on the <see cref="Completion"/> it belongs to, so there is no
+    /// completion state on the context left to reset.
+    /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void PrepareFor(Node node)
-    {
-        LastSyntaxElement = node;
-        Completion = CompletionType.Normal;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool IsAbrupt() => Completion != CompletionType.Normal;
+    public void PrepareFor(Node node) => LastSyntaxElement = node;
 }

--- a/Jint/Runtime/Interpreter/Expressions/DestructuringPatternAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/DestructuringPatternAssignmentExpression.cs
@@ -20,17 +20,7 @@ internal sealed class DestructuringPatternAssignmentExpression : JintExpression
     protected override object EvaluateInternal(EvaluationContext context)
     {
         var rightValue = _right.GetValue(context);
-        if (context.IsAbrupt())
-        {
-            return rightValue;
-        }
-
-        var completion = ProcessPatterns(context, _pattern, rightValue, null);
-        if (context.IsAbrupt())
-        {
-            return completion;
-        }
-
+        ProcessPatterns(context, _pattern, rightValue, null);
         return rightValue;
     }
 
@@ -501,10 +491,6 @@ internal sealed class DestructuringPatternAssignmentExpression : JintExpression
                 {
                     var keyExpression = Build(p.Key);
                     var value = keyExpression.GetValue(context);
-                    if (context.IsAbrupt())
-                    {
-                        return value;
-                    }
                     sourceKey = TypeConverter.ToPropertyKey(value);
                 }
                 else
@@ -539,10 +525,6 @@ internal sealed class DestructuringPatternAssignmentExpression : JintExpression
                     {
                         var jintExpression = Build(assignmentPattern.Right);
                         var completion = jintExpression.GetValue(context);
-                        if (context.IsAbrupt())
-                        {
-                            return completion;
-                        }
                         // Check for async/generator suspension after evaluating default value
                         if (context.IsSuspended())
                         {

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -836,7 +836,7 @@ internal sealed class JintAssignmentExpression : JintExpression
                 completion = right.GetValue(context);
             }
 
-            if (context.IsAbrupt() || context.IsGeneratorAborted())
+            if (context.IsGeneratorAborted())
             {
                 result = completion;
                 return true;
@@ -1064,11 +1064,6 @@ internal sealed class JintAssignmentExpression : JintExpression
                     completion = right.GetValue(context);
                 }
 
-                if (context.IsAbrupt())
-                {
-                    return completion;
-                }
-
                 // If generator suspended or return requested during right-hand side evaluation, don't assign.
                 // IsSuspended also covers an async function suspending at an `await` in the right-hand side
                 // (see the note in SetValue): storing the suspension sentinel here permanently clobbers the
@@ -1133,11 +1128,6 @@ internal sealed class JintAssignmentExpression : JintExpression
             else
             {
                 completion = right.GetValue(context);
-            }
-
-            if (context.IsAbrupt())
-            {
-                return completion;
             }
 
             // If generator suspended or return requested during right-hand side evaluation, don't assign.

--- a/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
@@ -451,10 +451,6 @@ internal sealed class JintObjectExpression : JintExpression
             if (propName is null)
             {
                 var value = property.TryGetKey(engine);
-                if (context.IsAbrupt())
-                {
-                    return value;
-                }
 
                 // Check for generator suspension after evaluating computed property key
                 if (context.IsSuspended())

--- a/Jint/Runtime/Interpreter/Statements/JintClassDeclarationStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintClassDeclarationStatement.cs
@@ -18,11 +18,6 @@ internal sealed class JintClassDeclarationStatement : JintStatement<ClassDeclara
         var env = engine.ExecutionContext.LexicalEnvironment;
         var value = _classDefinition.BuildConstructor(context, env);
 
-        if (context.IsAbrupt())
-        {
-            return new Completion(context.Completion, value, _statement);
-        }
-
         var classBinding = _classDefinition._className;
         if (classBinding != null)
         {

--- a/Jint/Runtime/Interpreter/Statements/JintExpressionStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintExpressionStatement.cs
@@ -33,11 +33,11 @@ internal sealed class JintExpressionStatement : JintStatement<ExpressionStatemen
                 ? _identifierExpression.GetValue(context)
                 : _expression.GetValue(context);
 
-            return new Completion(context.Completion, value, _statement);
+            return new Completion(CompletionType.Normal, value, _statement);
         }
 
         _expression.EvaluateAndDiscard(context);
-        return new Completion(context.Completion, JsValue.Undefined, _statement);
+        return new Completion(CompletionType.Normal, JsValue.Undefined, _statement);
     }
 
     /// <summary>

--- a/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
@@ -603,7 +603,6 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                 close = true;
 
                 var valueForResume = nextValue;
-                var status = CompletionType.Normal;
 
                 // Skip lhs setup (env creation, BindingInstantiation, destructuring/init) on body
                 // resume — bindings already exist in the restored iterationEnv. Re-running
@@ -655,11 +654,6 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                         {
                             // single bound name -> slot 0; ChangeValue preserves the const/let flags
                             iterationEnv!.InitializeSlotBinding(0, nextValue);
-                        }
-                        else if (context.IsAbrupt())
-                        {
-                            close = true;
-                            status = context.Completion;
                         }
                         else
                         {
@@ -720,8 +714,6 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                             return new Completion(CompletionType.Return, returnValue, _statement!);
                         }
 
-                        status = context.Completion;
-
                         if (lhsKind == LhsKind.Assignment)
                         {
                             // DestructuringAssignmentEvaluation of assignmentPattern using nextValue as the argument.
@@ -737,25 +729,6 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                         }
 #pragma warning restore MA0140
                     }
-                }
-
-                if (status != CompletionType.Normal)
-                {
-                    engine.UpdateLexicalEnvironment(oldEnv);
-                    suspendable?.Data.Clear(this);
-                    if (_iterationKind == IterationKind.AsyncIterate)
-                    {
-                        iteratorRecord.Close(status);
-                        return new Completion(status, nextValue, context.LastSyntaxElement);
-                    }
-
-                    if (iterationKind == IterationKind.Enumerate)
-                    {
-                        return new Completion(status, nextValue, context.LastSyntaxElement);
-                    }
-
-                    iteratorRecord.Close(status);
-                    return new Completion(status, nextValue, context.LastSyntaxElement);
                 }
 
                 // Before executing body, save state in case of yield/await suspension.

--- a/Jint/Runtime/Interpreter/Statements/JintVariableDeclaration.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintVariableDeclaration.cs
@@ -90,11 +90,9 @@ internal sealed class JintVariableDeclaration : JintStatement<VariableDeclaratio
     /// <summary>
     /// Tight-loop entry; see <see cref="JintStatement.ExecuteDiscarded"/>. Declarations complete
     /// with an Empty Normal value on every path, so only the Execute wrapper ceremony is skipped;
-    /// the current node still needs tracking for error locations. Skipping PrepareFor is safe:
-    /// <see cref="EvaluationContext.Completion"/> is written nowhere but PrepareFor (never abrupt),
-    /// and a break/continue label rides on the completion that carries it
-    /// (<see cref="Jint.Runtime.Completion.Target"/>), so no jump state survives on the context for
-    /// PrepareFor to reset or for this lane to leave stale.
+    /// the current node still needs tracking for error locations. Skipping PrepareFor is safe
+    /// because PrepareFor no longer does anything else: it only tracks the node, which this lane
+    /// does itself below.
     /// </summary>
     internal override void ExecuteDiscarded(EvaluationContext context)
     {


### PR DESCRIPTION
## Summary

Removes `EvaluationContext.Completion`, which could only ever hold `Normal`, and its dead consumers.

## Details

The single assignment to `EvaluationContext.Completion` anywhere in the repository is `Completion = CompletionType.Normal` inside `PrepareFor`. So `IsAbrupt()` always returned false and its consumers were **unreachable**, not merely untaken.

### It has been dead since the day it was written

- #1291 (2022-09-10) moved the abrupt-completion check off `ExpressionResult` onto the context.
- #1292, the next day, deleted `ExpressionResult` — and with it the only code that ever wrote a non-Normal value.

Abrupt expression completions have travelled by `JavaScriptException` or through the deferred `Engine._error` slot ever since. No behaviour was lost then and none is restored here.

### What goes

The field, `IsAbrupt()`, and fourteen consumers across class declarations, destructuring, assignment and object expressions.

In `JintForInForOfStatement` the reach is larger than the call sites suggest: the `status` local was fed only from this channel, so its guard block — three `new Completion(status, …)` returns and two `iteratorRecord.Close(status)` calls — went with it.

### Why bother

Two reasons beyond tidiness.

`JintVariableDeclaration`'s tight-loop `ExecuteDiscarded` documents its own correctness as resting on this field never being abrupt. A dead field whose deadness is load-bearing for a fast path is a trap for whoever next decides to "fix" it by writing to it.

And `PrepareFor` now collapses to a single store. It runs on every non-block statement and, via `JintExpression.Evaluate`, on every expression node in the program. `context.IsAbrupt()` was also a field load and compare on the simple-assignment path, which every `x = y` travels.

## Linked issue

None on file — found while auditing `EvaluationContext`.

## Test plan

- [x] Ran `dotnet test --configuration Release` locally (all projects, net10.0 + net472)
- [x] Ran `Jint.Tests.Test262` — 99,738 passed, 0 failed, identical to the parent commit
- [ ] Perf numbers pending — this touches `PrepareFor` and the assignment path, so a SunSpider + Dromaeo table is owed before merge

No new tests: this is dead-code removal, and the existing suite is what proves the branches were unreachable.

## Breaking change?

No. `EvaluationContext` is `internal`.
