### PR TITLE
Give the evaluation context to the engine, and "is evaluating" its own signal

### DIFF
--- a/Jint.Tests.PublicInterface/GlobalSnapshotTests.cs
+++ b/Jint.Tests.PublicInterface/GlobalSnapshotTests.cs
@@ -696,6 +696,52 @@ public class GlobalSnapshotTests
     }
 
     [Fact]
+    public void RestoringFromInsideAHostCallWithNoScriptOnTheStackIsRejected()
+    {
+        // The sibling above re-enters from a callback invoked BY script, so the engine has an
+        // execution context pushed. This one calls the delegate directly through Engine.Call: a
+        // ClrFunction pushes no execution context at all, so execution-context depth alone cannot
+        // see it and the rejection rests on the host-entry count instead.
+        var engine = new Engine();
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+
+        Exception? caught = null;
+        engine.SetValue("reenter", new Action(() =>
+        {
+            try
+            {
+                engine.Advanced.RestoreGlobalSnapshot(snapshot);
+            }
+            catch (Exception e)
+            {
+                caught = e;
+            }
+        }));
+
+        engine.Invoke("reenter");
+
+        caught.Should().BeOfType<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void RestoringAfterEveryHostCallHasReturnedIsAllowed()
+    {
+        // The counterpart to the two above: once the entry has unwound the engine is idle again and
+        // a restore must be accepted, so the guard cannot simply latch.
+        var engine = new Engine();
+        engine.Execute("var marker = 1;");
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+
+        engine.SetValue("noop", new Action(() => { }));
+        engine.Invoke("noop");
+        engine.Evaluate("marker = 2;");
+
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        engine.Evaluate("marker").AsNumber().Should().Be(1);
+    }
+
+    [Fact]
     public void RestoringTwiceInARowIsANoOpTheSecondTime()
     {
         var engine = new Engine();

--- a/Jint.Tests/Runtime/Debugger/AsyncDebuggerTests.cs
+++ b/Jint.Tests/Runtime/Debugger/AsyncDebuggerTests.cs
@@ -1,0 +1,192 @@
+﻿using Jint.Native;
+using Jint.Native.Promise;
+using Jint.Runtime.Debugger;
+
+namespace Jint.Tests.Runtime.Debugger;
+
+/// <summary>
+/// Debugging across an event-loop drain — the window in which the engine is running script with no
+/// host entry on the stack, because the host's call has already returned and a promise settled
+/// later. The debugger used to be blind here: it asked whether an evaluation context happened to be
+/// installed on the engine, and async and generator resumes ran script without installing one, so
+/// <see cref="DebugHandler.Evaluate(string, ScriptParsingOptions)"/> threw. For a watch expression
+/// that surfaced as an exception; for a conditional breakpoint it was worse, because
+/// <c>BreakPointCollection.FindMatch</c> catches <see cref="DebugEvaluationException"/> and reports
+/// "condition false" — so the breakpoint was silently skipped with no diagnostic at all.
+/// <para>
+/// Note the shape every test here shares: the drain must be driven by <em>settling a promise the
+/// host holds</em>, not by <c>engine.Execute</c>. A drain that happens on the way out of Execute is
+/// still inside the host entry and always worked.
+/// </para>
+/// </summary>
+public class AsyncDebuggerTests
+{
+    // 1 async function run(gate) {
+    // 2 var before = 1;
+    // 3 await gate;
+    // 4 var after = before + 1;
+    // 5 return after;
+    // 6 }
+    // 7 run(gate);
+    private const string AwaitScript = @"async function run(gate) {
+var before = 1;
+await gate;
+var after = before + 1;
+return after;
+}
+run(gate);";
+
+    private static Engine CreateEngine(out ManualPromise gate)
+    {
+        var engine = new Engine(options => options.DebugMode());
+        gate = engine.Advanced.RegisterPromise();
+        engine.SetValue("gate", gate.Promise);
+        return engine;
+    }
+
+    [Fact]
+    public void ConditionalBreakPointFiresAfterAnAwaitResumedFromTheHost()
+    {
+        var engine = CreateEngine(out var gate);
+
+        var hits = 0;
+        engine.Debugger.Break += (sender, info) =>
+        {
+            info.Location.Start.Line.Should().Be(4);
+            hits++;
+            return StepMode.None;
+        };
+        engine.Debugger.BreakPoints.Set(new BreakPoint(4, 0, "before === 1"));
+
+        engine.Execute(AwaitScript);
+        hits.Should().Be(0, "execution is still suspended at the await");
+
+        gate.Resolve(JsValue.Undefined);
+        hits.Should().Be(1, "the resumed frame's breakpoint condition must be evaluated, not swallowed");
+    }
+
+    [Fact]
+    public void ConditionalBreakPointAfterAnAwaitStillHonoursAFalseCondition()
+    {
+        var engine = CreateEngine(out var gate);
+
+        var hits = 0;
+        engine.Debugger.Break += (sender, info) =>
+        {
+            hits++;
+            return StepMode.None;
+        };
+        engine.Debugger.BreakPoints.Set(new BreakPoint(4, 0, "before === 999"));
+
+        engine.Execute(AwaitScript);
+        gate.Resolve(JsValue.Undefined);
+
+        hits.Should().Be(0, "a condition that evaluates to false must not break");
+    }
+
+    [Fact]
+    public void WatchExpressionResolvesInAFrameResumedFromTheHost()
+    {
+        var engine = CreateEngine(out var gate);
+
+        JsValue observed = null;
+        engine.Debugger.Break += (sender, info) =>
+        {
+            observed = engine.Debugger.Evaluate("before");
+            return StepMode.None;
+        };
+        engine.Debugger.BreakPoints.Set(new BreakPoint(4, 0));
+
+        engine.Execute(AwaitScript);
+        gate.Resolve(JsValue.Undefined);
+
+        observed.Should().NotBeNull("the Break handler must have run after the await");
+        observed.AsNumber().Should().Be(1, "the watch expression resolves against the resumed frame");
+    }
+
+    [Fact]
+    public void BreakPointFiresInsideAThenCallbackReachedFromADrain()
+    {
+        // 1 var value = 41;
+        // 2 gate.then(function (x) {
+        // 3 value = value + 1;
+        // 4 });
+        var script = @"var value = 41;
+gate.then(function (x) {
+value = value + 1;
+});";
+
+        var engine = CreateEngine(out var gate);
+
+        var hits = 0;
+        engine.Debugger.Break += (sender, info) =>
+        {
+            engine.Debugger.Evaluate("value").AsNumber().Should().Be(41);
+            hits++;
+            return StepMode.None;
+        };
+        engine.Debugger.BreakPoints.Set(new BreakPoint(3, 0, "value === 41"));
+
+        engine.Execute(script);
+        hits.Should().Be(0);
+
+        gate.Resolve(JsValue.Undefined);
+        hits.Should().Be(1);
+    }
+
+    [Fact]
+    public void AsyncGeneratorResumeFromTheHostCanEvaluateAWatchExpression()
+    {
+        // 1 var seen = 0;
+        // 2 async function* produce(gate) {
+        // 3 var local = 7;
+        // 4 await gate;
+        // 5 seen = local;
+        // 6 yield local;
+        // 7 }
+        // 8 var it = produce(gate);
+        // 9 it.next();
+        var script = @"var seen = 0;
+async function* produce(gate) {
+var local = 7;
+await gate;
+seen = local;
+yield local;
+}
+var it = produce(gate);
+it.next();";
+
+        var engine = CreateEngine(out var gate);
+
+        JsValue observed = null;
+        engine.Debugger.Break += (sender, info) =>
+        {
+            observed = engine.Debugger.Evaluate("local");
+            return StepMode.None;
+        };
+        engine.Debugger.BreakPoints.Set(new BreakPoint(5, 0));
+
+        engine.Execute(script);
+        gate.Resolve(JsValue.Undefined);
+
+        observed.Should().NotBeNull("the async generator body must have resumed past the await");
+        observed.AsNumber().Should().Be(7);
+    }
+
+    [Fact]
+    public void AnIdleEngineStillRefusesToEvaluate()
+    {
+        var engine = new Engine(options => options.DebugMode());
+
+        Invoking(() => engine.Debugger.Evaluate("1 + 1"))
+            .Should().ThrowExactly<DebugEvaluationException>()
+            .Which.InnerException.Should().BeNull();
+
+        // ...and still refuses once an evaluation has run to completion and unwound.
+        engine.Execute("var x = 1;");
+
+        Invoking(() => engine.Debugger.Evaluate("x"))
+            .Should().ThrowExactly<DebugEvaluationException>()
+            .Which.InnerException.Should().BeNull();
+    }
+}

--- a/Jint/AstExtensions.cs
+++ b/Jint/AstExtensions.cs
@@ -72,7 +72,7 @@ public static class AstExtensions
         // allowlist of node types with a silent JsValue.Undefined fallback, which made keys like
         // `{ [(sideEffect(), "k")]: v }` (SequenceExpression) or `{ [new Key()]: v }` bind the
         // property "undefined" without running the key expression at all.
-        var context = engine._activeEvaluationContext ?? new EvaluationContext(engine);
+        var context = engine._evaluationContext;
         var result = JintExpression.Build(expression).GetValue(context);
 
         // If the expression suspended the generator (e.g., yield in computed property name),

--- a/Jint/Engine.GlobalSnapshot.cs
+++ b/Jint/Engine.GlobalSnapshot.cs
@@ -168,20 +168,17 @@ public partial class Engine
                 Throw.ArgumentException("The snapshot was captured from a different engine.", nameof(snapshot));
             }
 
-            // The base global execution context is pushed once at realm initialization and never popped, so
-            // a depth above it means script is on the stack — a re-entrant host callback trying to reset the
-            // globals out from under the code that called it. _activeEvaluationContext catches the same case
-            // for paths that do not push a context of their own.
+            // IsEvaluationInProgress covers script on the stack — a re-entrant host callback trying to reset
+            // the globals out from under the code that called it — and host entries that run without pushing
+            // an execution context of their own, such as Engine.Call of a pure ClrFunction.
             //
-            // Neither of those sees a suspended EvaluateAsync: its synchronous phase has already run to
-            // completion, so the stack is unwound to the base context and the ambient field is null while
-            // the settlement loop sits in its await. Restoring there would either strand the loop on a
-            // promise whose settle got discarded (a bogus PromiseTimeout, or a hang when timeouts are off)
-            // or let it resume the previous cycle against the restored globals and complete the host's Task
-            // with a value computed across two global states. The counter is the only signal that sees it.
-            if (engine._activeEvaluationContext is not null
-                || engine._executionContexts.Count > 1
-                || engine.HasPendingAsyncOperations)
+            // It does not see a suspended EvaluateAsync: its synchronous phase has already run to completion,
+            // so the stack is unwound to the base context and the host entry has been popped while the
+            // settlement loop sits in its await. Restoring there would either strand the loop on a promise
+            // whose settle got discarded (a bogus PromiseTimeout, or a hang when timeouts are off) or let it
+            // resume the previous cycle against the restored globals and complete the host's Task with a
+            // value computed across two global states. The counter is the only signal that sees it.
+            if (engine.IsEvaluationInProgress || engine.HasPendingAsyncOperations)
             {
                 Throw.InvalidOperationException("The global snapshot cannot be restored while an evaluation is in progress.");
             }

--- a/Jint/Engine.Modules.cs
+++ b/Jint/Engine.Modules.cs
@@ -199,8 +199,9 @@ public partial class Engine
 
         private JsValue EvaluateModule(string specifier, Module module)
         {
-            var ownsContext = _engine._activeEvaluationContext is null;
-            _engine._activeEvaluationContext ??= new EvaluationContext(_engine);
+            // Brackets the host entry the same way ExecuteWithConstraints does: Import reaches this
+            // outside that method for a non-cyclic module, so it is an entry in its own right.
+            _engine._hostEntryDepth++;
             JsValue evaluationResult;
             try
             {
@@ -208,10 +209,7 @@ public partial class Engine
             }
             finally
             {
-                if (ownsContext)
-                {
-                    _engine._activeEvaluationContext = null!;
-                }
+                _engine._hostEntryDepth--;
             }
 
             // This should instead be returned and resolved in ImportModule(specifier) only so Host.ImportModuleDynamically can use this promise

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -43,16 +43,64 @@ public sealed partial class Engine : IDisposable
 
     private readonly ExecutionContextStack _executionContexts;
 
-    // Invariant for engine-level ambient mutable fields (e.g. _activeEvaluationContext, _error,
-    // _lastSyntaxElement): they must not hold an in-flight result across a call that can re-enter
-    // the engine (anything that may run RunAvailableContinuations, or a CLR callback that calls
-    // Evaluate/Execute/Invoke). Either save-and-restore around the re-entrant region (see the
-    // ownsContext pattern in ExecuteWithConstraints and ShadowRealm), or carry the value out-of-band
-    // rather than in a field. A script's completion value used to live here as a field and was
-    // clobbered by a re-entrant drain (https://github.com/sebastienros/jint/issues/2492); it is now
-    // returned from ScriptEvaluation as a per-frame local. _error and _lastSyntaxElement are safe
-    // because they are produced and consumed synchronously with no re-entrant drain in between.
-    internal EvaluationContext? _activeEvaluationContext;
+    // Invariant for engine-level ambient mutable fields (e.g. _error, _lastSyntaxElement): they must
+    // not hold an in-flight result across a call that can re-enter the engine (anything that may run
+    // RunAvailableContinuations, or a CLR callback that calls Evaluate/Execute/Invoke). Either
+    // save-and-restore around the re-entrant region, or carry the value out-of-band rather than in a
+    // field. A script's completion value used to live here as a field and was clobbered by a
+    // re-entrant drain (https://github.com/sebastienros/jint/issues/2492); it is now returned from
+    // ScriptEvaluation as a per-frame local. _error and _lastSyntaxElement are safe because they are
+    // produced and consumed synchronously with no re-entrant drain in between.
+
+    /// <summary>
+    /// The context threaded through every statement and expression handler. Per <em>engine</em>, not
+    /// per evaluation: everything it carries is either engine-lifetime-constant configuration (the
+    /// constraint and debug gates, operator overloading) or a facade over engine state, so a context
+    /// built for one entry never differed from one already in flight — which is why the sites that
+    /// could not find an ambient one simply built their own and threw it away.
+    /// <para>
+    /// Built before <see cref="Options.Apply"/>, because a host's <c>options.Configure(e =&gt; …)</c>
+    /// callback runs from there and may execute script.
+    /// </para>
+    /// </summary>
+    internal readonly EvaluationContext _evaluationContext;
+
+    /// <summary>
+    /// How many host entries into the engine are on the stack — every public entry that runs script
+    /// funnels through <see cref="ExecuteWithConstraints{T}"/>, the internal spec <c>Invoke</c>, or
+    /// module evaluation, and each brackets this counter.
+    /// <para>
+    /// It exists because "is this engine running something for someone" used to be answered by
+    /// whether an evaluation context happened to be installed, which stopped being a question about
+    /// the context at all once the context became per-engine — and was never a reliable answer even
+    /// before that, since async and generator resume paths ran script without installing one. It is
+    /// needed <em>in addition</em> to execution-context depth because <see cref="Call(JsValue, JsValue, JsCallArguments)"/>
+    /// of a pure <see cref="Runtime.Interop.ClrFunction"/> pushes no execution context at all.
+    /// </para>
+    /// <para>
+    /// A plain <see cref="int"/>: an engine is single-threaded by contract, and the settlement loop
+    /// behind <c>EvaluateAsync</c> never touches
+    /// this — it runs after the synchronous phase has already returned and decremented. Contrast
+    /// <see cref="HasPendingAsyncOperations"/>, which is a volatile read precisely because it is not
+    /// confined that way.
+    /// </para>
+    /// </summary>
+    private int _hostEntryDepth;
+
+    /// <summary>
+    /// Whether the engine is running something for someone: a host entry is on the stack
+    /// (<see cref="_hostEntryDepth"/>) or an interpreter frame is. The base global execution context
+    /// is pushed once at realm initialization and never popped, so a depth above it means script.
+    /// <para>
+    /// Both terms are needed. A host <see cref="Call(JsValue, JsValue, JsCallArguments)"/> of a pure
+    /// <see cref="Runtime.Interop.ClrFunction"/> pushes no execution context, and every async or
+    /// generator resume — which runs script from an event-loop drain, with no host entry of its own —
+    /// pushes one. Neither alone sees a suspended <c>EvaluateAsync</c>,
+    /// whose synchronous phase has already unwound; callers that care about that add
+    /// <see cref="HasPendingAsyncOperations"/>.
+    /// </para>
+    /// </summary>
+    internal bool IsEvaluationInProgress => _hostEntryDepth > 0 || _executionContexts.Count > 1;
 
     // set by DebugHandler.Evaluate around watch/breakpoint-condition expression evaluation so the
     // host-boundary constraint checks can exempt it (see CheckAmortizedConstraintsAtHostBoundary)
@@ -152,9 +200,10 @@ public sealed partial class Engine : IDisposable
     /// <summary>
     /// How many <c>EvaluateAsync</c>/<c>ExecuteAsync</c>/<c>InvokeAsync</c> settlement loops are outstanding.
     /// Such a loop is an evaluation in progress from the host's point of view, but not from the engine's: the
-    /// synchronous phase has completed, so the execution-context stack is back at base depth and
-    /// <see cref="_activeEvaluationContext"/> is null while the loop sits in its <c>await</c>. Only this
-    /// counter can see it, which is why <see cref="AdvancedOperations.RestoreGlobalSnapshot"/> consults it.
+    /// synchronous phase has completed, so the execution-context stack is back at base depth and the host
+    /// entry has been popped — <see cref="IsEvaluationInProgress"/> is false — while the loop sits in its
+    /// <c>await</c>. Only this counter can see it, which is why
+    /// <see cref="AdvancedOperations.RestoreGlobalSnapshot"/> consults it.
     /// Incremented before the first await and decremented in the loop's finally, both synchronously with
     /// respect to the Task the host holds.
     /// </summary>
@@ -382,6 +431,12 @@ public sealed partial class Engine : IDisposable
         _exactConstraints = partitionedConstraints.Exact;
         _amortizedConstraints = partitionedConstraints.Amortized;
         _inlineStatementCounter = partitionedConstraints.InlineStatementCounter;
+
+        // Everything the context snapshots is settled by now (debug mode, the constraint partition,
+        // operator overloading), and it must exist before Options.Apply below, whose configuration
+        // callbacks may execute script.
+        _evaluationContext = new EvaluationContext(this);
+
         _referenceResolver = Options.ReferenceResolver;
         var resolverInterests = ReferenceEquals(_referenceResolver, DefaultReferenceResolver.Instance)
             ? ReferenceResolverInterests.None
@@ -782,7 +837,7 @@ public sealed partial class Engine : IDisposable
             Completion result;
             try
             {
-                result = list.Execute(_activeEvaluationContext!);
+                result = list.Execute(_evaluationContext);
             }
             catch
             {
@@ -1115,9 +1170,11 @@ public sealed partial class Engine : IDisposable
     /// window constraint state is meaningless: <see cref="Constraints.TimeConstraint"/>'s timer
     /// is re-armed at the end of every run and keeps counting while the engine is idle, and a
     /// cancellation token may be cancelled during normal teardown, so host-initiated access to
-    /// wrapped objects from C# must not observe either. Not keyed on
-    /// <see cref="_activeEvaluationContext"/>: async resume paths create evaluation contexts
-    /// without installing the ambient field, so it can be null mid-drain.</item>
+    /// wrapped objects from C# must not observe either. Deliberately execution-context depth alone
+    /// rather than <see cref="IsEvaluationInProgress"/>: a host <see cref="Call(JsValue, JsValue, JsCallArguments)"/>
+    /// of a pure <see cref="Runtime.Interop.ClrFunction"/> raises <see cref="_hostEntryDepth"/>
+    /// without any script being on the stack, and that is exactly the host-initiated access this
+    /// gate must not fire for.</item>
     /// <item>Not during debugger expression evaluation (<see cref="Runtime.Debugger.DebugHandler.Evaluate(string, ScriptParsingOptions)"/>)
     /// — a debugger paused longer than the timeout would otherwise deterministically fail every
     /// interop read in watch/conditional-breakpoint expressions. Normal debug-mode execution
@@ -1505,8 +1562,7 @@ public sealed partial class Engine : IDisposable
             ResetConstraints();
         }
 
-        var ownsContext = _activeEvaluationContext is null;
-        _activeEvaluationContext ??= new EvaluationContext(this);
+        _hostEntryDepth++;
 
         // Establish the requested strictness on the active (entry) execution context for the
         // callback, mirroring the former non-force StrictModeScope(strict): it can only raise
@@ -1526,10 +1582,7 @@ public sealed partial class Engine : IDisposable
             {
                 ReplaceTopStrict(previousStrict);
             }
-            if (ownsContext)
-            {
-                _activeEvaluationContext = null!;
-            }
+            _hostEntryDepth--;
             if (!isNested)
             {
                 ResetConstraints();
@@ -1543,8 +1596,7 @@ public sealed partial class Engine : IDisposable
     /// </summary>
     internal JsValue Invoke(JsValue v, JsValue p, JsCallArguments arguments)
     {
-        var ownsContext = _activeEvaluationContext is null;
-        _activeEvaluationContext ??= new EvaluationContext(this);
+        _hostEntryDepth++;
         try
         {
             var func = GetV(v, p);
@@ -1558,10 +1610,7 @@ public sealed partial class Engine : IDisposable
         }
         finally
         {
-            if (ownsContext)
-            {
-                _activeEvaluationContext = null!;
-            }
+            _hostEntryDepth--;
         }
     }
 
@@ -1953,9 +2002,6 @@ public sealed partial class Engine : IDisposable
             // At this point, if hasParameterExpressions:
             // - VariableEnvironment = paramEnv (for eval vars during param init)
             // - LexicalEnvironment = paramEnv (for closures to capture)
-            // The caller's context is used instead of the ambient _activeEvaluationContext,
-            // which is null when a function is called from an event-loop drain (e.g. a promise
-            // reaction after awaiting a .NET Task via EvaluateAsync/UnwrapIfPromise).
             env.AddFunctionParameters(context, func.Function, argumentsList);
         }
 

--- a/Jint/Native/AsyncGenerator/AsyncGeneratorInstance.cs
+++ b/Jint/Native/AsyncGenerator/AsyncGeneratorInstance.cs
@@ -252,7 +252,7 @@ internal sealed class AsyncGeneratorInstance : ObjectInstance, ISuspendable
         var genContext = _asyncGeneratorContext;
         _engine.EnterExecutionContext(in genContext);
 
-        var context = _engine._activeEvaluationContext ?? new EvaluationContext(_engine);
+        var context = _engine._evaluationContext;
         Completion result;
 
         try
@@ -475,7 +475,7 @@ internal sealed class AsyncGeneratorInstance : ObjectInstance, ISuspendable
 
         try
         {
-            var evalContext = _engine._activeEvaluationContext ?? new EvaluationContext(_engine);
+            var evalContext = _engine._evaluationContext;
             var bodyResult = _generatorBody.Execute(evalContext);
 
             if (_awaitSuspended)

--- a/Jint/Native/Function/EvalFunction.cs
+++ b/Jint/Native/Function/EvalFunction.cs
@@ -335,7 +335,7 @@ public sealed class EvalFunction : Function
             Engine.EvalDeclarationInstantiation(script, cached.HoistingScope, varEnv, lexEnv, privateEnv, strictEval, bindingsPreInitialized: useSlots);
 
             var statement = cached.JintScript;
-            var context = _engine._activeEvaluationContext ?? new EvaluationContext(_engine);
+            var context = _engine._evaluationContext;
             var result = statement.Execute(context);
 
             var value = result.GetValueOrDefault();

--- a/Jint/Native/Function/ScriptFunction.cs
+++ b/Jint/Native/Function/ScriptFunction.cs
@@ -200,7 +200,7 @@ public sealed class ScriptFunction : Function, IConstructor
             }
 
             // actual call
-            var context = _engine._activeEvaluationContext ?? new EvaluationContext(_engine);
+            var context = _engine._evaluationContext;
 
             var result = _functionDefinition.EvaluateBody(context, this, arguments, state);
 
@@ -335,7 +335,7 @@ public sealed class ScriptFunction : Function, IConstructor
             }
 
             // actual call
-            var context = _engine._activeEvaluationContext ?? new EvaluationContext(_engine);
+            var context = _engine._evaluationContext;
 
             var result = _functionDefinition!.EvaluateBodyFast(context, in args, state);
 
@@ -406,7 +406,7 @@ public sealed class ScriptFunction : Function, IConstructor
         engine.EnterLeafCallExecutionContext(_scriptOrModule, _environment!, _privateEnvironment, _realm, this, strict);
         try
         {
-            var context = engine._activeEvaluationContext ?? new EvaluationContext(engine);
+            var context = engine._evaluationContext;
             var result = _functionDefinition!.EvaluateLeafBody(context);
 
             if (result.Type == CompletionType.Throw)
@@ -506,7 +506,7 @@ public sealed class ScriptFunction : Function, IConstructor
                 ((ObjectInstance) thisArgument).InitializeInstanceElements(this);
             }
 
-            var context = _engine._activeEvaluationContext ?? new EvaluationContext(_engine);
+            var context = _engine._evaluationContext;
 
             var result = _functionDefinition.EvaluateBody(context, this, arguments, state);
             result = constructorEnv.DisposeResources(result);

--- a/Jint/Native/Generator/GeneratorInstance.cs
+++ b/Jint/Native/Generator/GeneratorInstance.cs
@@ -185,8 +185,7 @@ internal sealed class GeneratorInstance : ObjectInstance, ISuspendable
         // Clear the suspended value from previous suspension
         _suspendedValue = null;
 
-        var context = _engine._activeEvaluationContext;
-        return ResumeExecution(in genContext, context ?? new EvaluationContext(_engine));
+        return ResumeExecution(in genContext, _engine._evaluationContext);
     }
 
     /// <summary>
@@ -231,8 +230,7 @@ internal sealed class GeneratorInstance : ObjectInstance, ISuspendable
         // Clear the suspended value from previous suspension
         _suspendedValue = null;
 
-        var context = _engine._activeEvaluationContext;
-        return ResumeExecution(in genContext, context ?? new EvaluationContext(_engine));
+        return ResumeExecution(in genContext, _engine._evaluationContext);
     }
 
     private ObjectInstance ResumeExecution(in ExecutionContext genContext, EvaluationContext context)

--- a/Jint/Native/ShadowRealm/ShadowRealm.cs
+++ b/Jint/Native/ShadowRealm/ShadowRealm.cs
@@ -172,19 +172,12 @@ public sealed class ShadowRealm : ObjectInstance
         {
             _engine.EvalDeclarationInstantiation(script, script.GetHoistingScope(), varEnv, lexEnv, privateEnv: null, strictEval);
 
-            // _activeEvaluationContext must be set or e.g. a nested eval could lead to NullReferenceException...
-
-            // TODO: is this correct or should we join the current EvaluationContext if any?
-            var originalEvaluationContext = _engine._activeEvaluationContext;
-            _engine._activeEvaluationContext = new EvaluationContext(_engine);
-            try
-            {
-                result = new JintScript(script).Execute(_engine._activeEvaluationContext);
-            }
-            finally
-            {
-                _engine._activeEvaluationContext = originalEvaluationContext;
-            }
+            // Joins the engine's context rather than substituting a fresh one. The old code did the
+            // latter, with a TODO asking which was correct: a fresh context differed only in the
+            // completion-observability flag, which the shadow script's own statement list sets on
+            // entry and restores in a finally. The shadow realm itself arrives through the execution
+            // context pushed above, which the evaluation context knows nothing about.
+            result = new JintScript(script).Execute(_engine._evaluationContext);
 
             if (result.Type == CompletionType.Throw)
             {

--- a/Jint/Runtime/Debugger/DebugHandler.cs
+++ b/Jint/Runtime/Debugger/DebugHandler.cs
@@ -97,11 +97,12 @@ public class DebugHandler
             Throw.InvalidPreparedScriptArgumentException(nameof(preparedScript));
         }
 
-        var context = _engine._activeEvaluationContext;
-        if (context == null)
+        if (!_engine.IsEvaluationInProgress)
         {
             throw new DebugEvaluationException("Jint has no active evaluation context");
         }
+
+        var context = _engine._evaluationContext;
         var callStackSize = _engine.CallStack.Count;
 
         var list = new JintStatementList(null, preparedScript.Program.Body);

--- a/Jint/Runtime/Interpreter/Expressions/JintAwaitExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAwaitExpression.cs
@@ -227,7 +227,7 @@ internal sealed class JintAwaitExpression : JintExpression
 
         engine.EnterExecutionContext(in asyncInstance._savedContext);
 
-        var context = engine._activeEvaluationContext ?? new EvaluationContext(engine);
+        var context = engine._evaluationContext;
 
         Completion result;
         try

--- a/Jint/Runtime/Modules/SourceTextModule.cs
+++ b/Jint/Runtime/Modules/SourceTextModule.cs
@@ -375,7 +375,7 @@ internal class SourceTextModule : CyclicModule
                 var statementList = new JintStatementList(statement: null, _source.Body);
 
                 //Create new evaluation context when called from e.g. module tests
-                var context = _engine._activeEvaluationContext ?? new EvaluationContext(_engine);
+                var context = _engine._evaluationContext;
 
                 result = statementList.Execute(context);
             }
@@ -421,7 +421,7 @@ internal class SourceTextModule : CyclicModule
             _engine.EnterExecutionContext(in asyncContext);
 
             // Create evaluation context
-            var context = _engine._activeEvaluationContext ?? new EvaluationContext(_engine);
+            var context = _engine._evaluationContext;
 
             Completion result;
             try


### PR DESCRIPTION
## Summary

One `EvaluationContext` per engine, and a real signal for "an evaluation is in progress" — which fixes conditional breakpoints after an `await`.

## Details

Thirteen call sites read `engine._activeEvaluationContext ?? new EvaluationContext(engine)` and threw the result away without installing it. The idiom came from f5a042f49, *"fix null reference on activeEvaluationContext"* — a `NullReferenceException` band-aid rather than a decision. Every later site copied it.

### Why it spread

`EvaluationContext` has not carried anything per-evaluation for years. Every field is either a readonly snapshot of engine-lifetime-constant configuration — the constraint and debug gates, operator overloading, all derived from `readonly` engine fields — or a facade over engine state. A context built for one entry was never distinguishable from one already in flight, which is exactly why building a fresh one worked.

### Why it was not harmless

The ambient field had quietly acquired a second, unrelated job: *"an evaluation is in progress on this engine"*, consulted by `DebugHandler.Evaluate` and `RestoreGlobalSnapshot`. Thirteen sites not installing made that answer wrong precisely where script runs hardest.

This is the second time that overload has bitten. d7a47c5f5 fixed the first by moving the amortized-constraint countdown off the context onto the engine, because a fresh per-entry context restarted it and made cancellation unobservable across host call loops.

### The change

- **One context per engine**, built in the constructor — before `Options.Apply`, whose configuration callbacks may execute script.
- **`_hostEntryDepth`** brackets the three places that used to install the ambient field, so `IsEvaluationInProgress` is `_hostEntryDepth > 0 || _executionContexts.Count > 1`.

Both terms are needed: `Engine.Call` of a pure `ClrFunction` pushes no execution context, while every async or generator resume pushes one without being a host entry. Neither sees a suspended `EvaluateAsync`, so `RestoreGlobalSnapshot` keeps `HasPendingAsyncOperations` as its third signal.

### Consequences

**A conditional breakpoint placed after an `await` now fires.** It never did. `DebugHandler.Evaluate` threw on the null field, and `BreakPointCollection.FindMatch` catches `DebugEvaluationException` and reports "condition false" — so the breakpoint was skipped with **no diagnostic at all**. Watch expressions in such a frame threw outright. There was no debugger coverage across an async boundary; there is now, and four of the six new tests fail without this change.

**The thirteen sites become a field read** — no null test, and no ~48-byte allocation per JS call on the paths where the ambient really was null: every call inside an awaited continuation or an `Advanced.ProcessTasks` drain, and every host-triggered accessor or `toString`.

**`ShadowRealm`'s `// TODO: is this correct or should we join the current EvaluationContext if any?`** is answered by deletion — there is only one to join.

**`RestoreGlobalSnapshot`'s `ClrFunction` case had no test.** It has one now, plus its counterpart asserting the guard does not latch once the entry unwinds.

### One behavioural change worth stating

`OperatorOverloadingAllowed` is snapshotted at construction rather than re-read on each top-level entry. That matches `_isDebugMode`, `_isStrict`, `_maxRecursionDepth` and the constraint partition, all already snapshotted, and `JintBinaryExpression` already documents the value as per-engine constant.

## Linked issue

None on file — found while auditing `EvaluationContext`.

## Test plan

- [x] Added `Jint.Tests/Runtime/Debugger/AsyncDebuggerTests.cs` — 6 tests; **4 fail on `main`**
- [x] Added two `RestoreGlobalSnapshot` tests to `Jint.Tests.PublicInterface/GlobalSnapshotTests.cs`
- [x] Ran `dotnet test --configuration Release` locally (all projects, net10.0 + net472)
- [x] Ran `Jint.Tests.Test262` — 99,738 passed, 0 failed
- [x] Ran the host-contract verification leg (`JINT_HOST_CONTRACT_VERIFICATION=1`) for `Jint.Tests` and `Jint.Tests.PublicInterface`
- [ ] Perf numbers pending — a SunSpider + Dromaeo table is owed before merge

## Breaking change?

No public API change. `EvaluationContext` and the ambient field are `internal`. The one observable difference for an embedder is the `OperatorOverloadingAllowed` snapshot point described above, which only matters to a host mutating a shared `Options` between runs.
