### PR TITLE
Make Array.prototype.sort stable on every target framework

### DIFF
--- a/Jint.Tests/Runtime/ArrayTests.cs
+++ b/Jint.Tests/Runtime/ArrayTests.cs
@@ -1089,6 +1089,26 @@ return get + '' === ""length,0,1,2,3"";";
     }
 
     [Fact]
+    public void SortIsStableForEqualElements()
+    {
+        // ES2019 requires Array.prototype.sort to be stable. The element count matters: List<T>.Sort
+        // falls back to insertion sort at 16 elements or fewer and happens to be stable there, so a
+        // smaller input passes even on an unstable implementation.
+        const string Script = """
+            var items = [];
+            for (var i = 0; i < 32; i++) {
+                items.push({ order: i });
+            }
+            items.sort(function () { return 0; });
+            items.map(function (x) { return x.order; }).join(',');
+            """;
+
+        var engine = new Engine();
+
+        engine.Evaluate(Script).AsString().Should().Be(string.Join(",", Enumerable.Range(0, 32)));
+    }
+
+    [Fact]
     public void PopWrappedGenericList()
     {
         var engine = new Engine();

--- a/Jint/Extensions/Polyfills.cs
+++ b/Jint/Extensions/Polyfills.cs
@@ -1,10 +1,72 @@
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 
 namespace Jint;
 
 internal static class Polyfills
 {
+#if !NET8_0_OR_GREATER
+    // Enumerable.Order arrived in .NET 7 and is not in netstandard2.1, so net462, netstandard2.0 and
+    // netstandard2.1 all need it.
+    //
+    // It deliberately does NOT delegate to OrderBy. .NET Framework's LINQ sorts with a plain quicksort
+    // that has neither a recursion-depth limit nor a fallback, so an inconsistent comparer makes it spin
+    // forever rather than terminate. A JavaScript comparison function is free to be inconsistent — the
+    // spec leaves the resulting order implementation-defined but still requires the sort to finish — so
+    // that is a reachable hang, not a theoretical one. .NET Core's introsort escapes to heapsort and is
+    // why the modern targets are fine. A bottom-up merge sort is stable, always O(n log n), and
+    // terminates for any comparer whatsoever, which is the behaviour being backfilled.
+    internal static IEnumerable<T> Order<T>(this IEnumerable<T> source, IComparer<T>? comparer)
+    {
+        // Copy rather than sort a caller-visible array in place; Enumerable.Order never mutates its source.
+        var items = source.ToArray();
+        if (items.Length > 1)
+        {
+            MergeSort(items, new T[items.Length], 0, items.Length, comparer ?? Comparer<T>.Default);
+        }
+
+        return items;
+    }
+
+    private static void MergeSort<T>(T[] items, T[] buffer, int start, int end, IComparer<T> comparer)
+    {
+        if (end - start <= 1)
+        {
+            return;
+        }
+
+        var middle = start + ((end - start) >> 1);
+        MergeSort(items, buffer, start, middle, comparer);
+        MergeSort(items, buffer, middle, end, comparer);
+
+        if (comparer.Compare(items[middle - 1], items[middle]) <= 0)
+        {
+            // Already in order, so the merge would only copy the range back onto itself.
+            return;
+        }
+
+        int left = start, right = middle, index = start;
+        while (left < middle && right < end)
+        {
+            // Taking the left element on a tie is what makes the sort stable.
+            buffer[index++] = comparer.Compare(items[left], items[right]) <= 0 ? items[left++] : items[right++];
+        }
+
+        while (left < middle)
+        {
+            buffer[index++] = items[left++];
+        }
+
+        while (right < end)
+        {
+            buffer[index++] = items[right++];
+        }
+
+        System.Array.Copy(buffer, start, items, start, end - start);
+    }
+#endif
+
 #if NETFRAMEWORK || NETSTANDARD2_0
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
     internal static bool Contains(this string source, char c) => source.IndexOf(c) != -1;

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -1494,16 +1494,8 @@ public sealed partial class ArrayPrototype : ArrayInstance
             else
             {
                 var comparer = ArrayComparer.WithFunction(_engine, compareFn);
-#if NETCOREAPP
-                // OrderBy is stable; List<T>.Sort is not. Stability is required by the spec since ES2019.
-#if NET8_0_OR_GREATER
+                // Order is stable; List<T>.Sort is not. Stability is required by the spec since ES2019.
                 items = items.Order(comparer).ToList();
-#else
-                items = items.OrderBy(x => x, comparer).ToList();
-#endif
-#else
-                items.Sort(comparer);
-#endif
             }
 
             for (uint j = 0; j < itemCount; j++)


### PR DESCRIPTION
`Array.prototype.sort(comparefn)` routed through `Enumerable.Order` only under `#if NETCOREAPP`, and **`NETCOREAPP` is not defined when targeting netstandard2.1**. So `net462`, `netstandard2.0` *and* `netstandard2.1` all fell through to `List<T>.Sort`, which is not stable.

Stability has been required since ES2019, and those three assets are what every .NET Framework, Unity, Mono and Xamarin embedder resolves to. None of the three is executed by any test project, which is why it went unnoticed.

### The polyfill deliberately does not delegate to `OrderBy`

`Enumerable.Order` arrived in .NET 7 and is not in netstandard2.1, so the three lacking frameworks need a backfill. The obvious body — `source.OrderBy(x => x, comparer)` — is wrong here:

LINQ on .NET Framework sorts with a quicksort that has **neither a recursion-depth limit nor a fallback**, so an inconsistent comparison function makes it spin forever instead of finishing. A JavaScript comparison function is allowed to be inconsistent — the spec leaves the resulting order implementation-defined but still requires the sort to *terminate*. That makes it reachable rather than theoretical: `ArrayTests.ArrayFromSortTest` already supplies such a comparator (`(a, b) => a.Value === '0001' ? -1 : 1`), and delegating to `OrderBy` hangs the net472 test leg outright. .NET Core's introsort escapes to heapsort, which is why the modern targets never showed it.

`Polyfills.Order` is therefore a bottom-up **merge sort**: stable, always O(n log n), terminating for any comparer whatsoever, and it never throws.

The no-comparator path was already stable on every framework, since `CachedStringKeyComparer` breaks ties on the original index — no change needed there.

### Verification

| Check | Result |
| --- | --- |
| `dotnet build -c Release Jint/Jint.csproj` (all 5 TFMs) | 0 warnings, 0 errors |
| `Jint.Tests` net10.0 / net472 | 4721 / 4640 passed, 0 failed |
| `Jint.Tests.CommonScripts` net10.0 / net472 | 28 / 28 passed |
| `Jint.Tests.PublicInterface` net10.0 / net472 | 1263 / 1262 passed |
| `Jint.Tests.Test262` | 99738 passed, 0 failed |

The new test uses 32 elements deliberately: `List<T>.Sort` falls back to insertion sort at 16 or fewer and happens to be stable there, so a smaller input passes even on the broken build. Confirmed the test fails on both legs when the old `items.Sort(comparer)` path is restored.

No benchmark: on net8.0/net10.0 this leaves `ArrayPrototype.Sort` compiling to exactly what it did before (`items.Order(comparer).ToList()` was already the `NET8_0_OR_GREATER` branch), so the measured target framework is unchanged.
