### PR TITLE
Stop toSorted and %TypedArray%.sort hanging on an inconsistent comparator

### DIFF
--- a/Jint.Tests/Runtime/ArrayTests.cs
+++ b/Jint.Tests/Runtime/ArrayTests.cs
@@ -1108,6 +1108,22 @@ return get + '' === ""length,0,1,2,3"";";
         engine.Evaluate(Script).AsString().Should().Be(string.Join(",", Enumerable.Range(0, 32)));
     }
 
+    [Theory]
+    [InlineData("[5,3,8,1,9,2,7,4,6,0,15,11,13,10,14,12,17,16,19,18].sort(cmp).length")]
+    [InlineData("[5,3,8,1,9,2,7,4,6,0,15,11,13,10,14,12,17,16,19,18].toSorted(cmp).length")]
+    [InlineData("new Int32Array([5,3,8,1,9,2,7,4,6,0,15,11,13,10,14,12,17,16,19,18]).sort(cmp).length")]
+    public void SortTerminatesWithAnInconsistentComparator(string expression)
+    {
+        // A comparison function that never returns 0 and is not antisymmetric is legal JavaScript: the
+        // resulting order is implementation-defined, but the sort still has to finish. LINQ's sort on
+        // .NET Framework is a quicksort with no depth limit and no fallback, so delegating to it here
+        // spins forever instead.
+        var engine = new Engine();
+        engine.Execute("function cmp(a, b) { return a === 1 ? -1 : 1; }");
+
+        engine.Evaluate(expression).AsNumber().Should().Be(20);
+    }
+
     [Fact]
     public void PopWrappedGenericList()
     {

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -2390,7 +2390,9 @@ public sealed partial class ArrayPrototype : ArrayInstance
 
         try
         {
-            return array.OrderBy(x => x, comparer).ToArray();
+            // Order, not OrderBy: the sort must be stable (spec, since ES2019) and must terminate even
+            // when the script's comparison function is inconsistent. See Polyfills.Order.
+            return array.Order(comparer).ToArray();
         }
         catch (InvalidOperationException e)
         {

--- a/Jint/Native/TypedArray/IntrinsicTypedArrayPrototype.cs
+++ b/Jint/Native/TypedArray/IntrinsicTypedArrayPrototype.cs
@@ -1810,7 +1810,9 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
         var operations = ArrayOperations.For(obj, forWrite: false);
         try
         {
-            return operations.OrderBy(x => x, comparer).ToArray();
+            // Order, not OrderBy: the sort must be stable (spec, since ES2019) and must terminate even
+            // when the script's comparison function is inconsistent. See Polyfills.Order.
+            return operations.Order(comparer).ToArray();
         }
         catch (InvalidOperationException e)
         {


### PR DESCRIPTION
Stacked on #2898, which introduces `Polyfills.Order`.

`ArrayPrototype.SortArray` (`Array.prototype.toSorted`) and `IntrinsicTypedArrayPrototype.SortArray` (`%TypedArray%.prototype.sort`) sort with `Enumerable.OrderBy` and **no target-framework guard at all**.

LINQ on .NET Framework sorts with a quicksort that has neither a recursion-depth limit nor a fallback, so an inconsistent comparison function makes it spin forever instead of finishing. .NET Core's introsort escapes to heapsort, which is why only `net462`, `netstandard2.0` and `netstandard2.1` are affected — the three assets no test project executes.

A JavaScript comparison function is allowed to be inconsistent: the spec leaves the resulting order implementation-defined, but the sort still has to terminate. So a script calling

```js
items.toSorted((a, b) => a.id === wanted ? -1 : 1)
```

hangs the host outright on those frameworks — no exception, no timeout, just one core pegged. This was found by accident: it ate 114 minutes of a `Jint.Tests` run on net472 before being traced back.

Both now sort through `Polyfills.Order`, the merge sort added in #2898, which is stable and terminates for any comparer. That also makes all three script-visible sorts behave identically on all five target frameworks.

### Verification

| Check | Result |
| --- | --- |
| `dotnet build -c Release Jint/Jint.csproj` (all 5 TFMs) | 0 warnings, 0 errors |
| `Jint.Tests` net10.0 / net472 | 4721 / 4640 passed, 0 failed |
| `Jint.Tests.CommonScripts` net10.0 / net472 | 28 / 28 passed |
| `Jint.Tests.PublicInterface` net10.0 / net472 | 1263 / 1262 passed |
| `Jint.Tests.Test262` | 99738 passed, 0 failed |

The new `[Theory]` covers all three entry points — `sort`, `toSorted` and `Int32Array.prototype.sort` — with a comparator that never returns `0` and is not antisymmetric. Each case hangs on net472 without this change.

This does alter codegen on net8.0/net10.0 (`OrderBy(x => x, comparer)` becomes `Order(comparer)`), but both sites are cold with respect to the SunSpider and Dromaeo suites — neither exercises `toSorted` or typed-array `sort` — so test262 is the gate rather than a benchmark sweep.
