### PR TITLE
Stop shipping the numeric polyfill hosts as public API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,7 +257,7 @@ Global usings for Acornima and `Acornima.Ast` are defined in `Directory.Build.pr
 Use a C# extension member so the call reads identically on every target framework, and guard it with the narrowest symbol for the frameworks that actually lack the API:
 
 ```csharp
-public static class DoubleExtensions
+internal static class DoublePolyfills
 {
     extension(double)
     {
@@ -268,6 +268,12 @@ public static class DoubleExtensions
     }
 }
 ```
+
+Two things about that shape are load-bearing. The container is **`internal`**: it exists only to host polyfills, and a `public` one both leaks a type whose members differ per target framework and invites `CS0104` in any embedder that has a class of the same name and a `using Jint;`. And there is **one container per receiver type** — a *static* extension member lowers into its containing class with the receiver type erased from the signature, so `int.Parse(ReadOnlySpan<char>, IFormatProvider?)` and `long.Parse(ReadOnlySpan<char>, IFormatProvider?)` differ only by return type and collide with `CS0111` if they share a class. Hence `Int32Polyfills`, `Int64Polyfills`, `DoublePolyfills` are separate; instance extension members have no such constraint and all live on `Polyfills`.
+
+**Mirror the BCL signature exactly, defaults included.** An optional parameter the real API does not have changes overload resolution on the frameworks that *do* have it, so the polyfill quietly stops being one — `int.Parse(ReadOnlySpan<char>, IFormatProvider?)` takes no default on `provider` precisely because the BCL's doesn't.
+
+**A polyfill must match the downlevel API's *behaviour*, not just its signature.** `Polyfills.Order` is a hand-written merge sort rather than a call to `OrderBy` because LINQ's sort on .NET Framework is a quicksort with no depth limit and no fallback, so an inconsistent comparer — which a JavaScript comparison function is allowed to be — makes it spin forever instead of terminating. Sorting and searching are where downlevel implementations differ most; check them rather than assuming the older framework's version is merely slower.
 
 A real member always beats an extension member, so on the frameworks that *do* have the API the BCL implementation is what binds — usually the better one (`double.IsFinite` is a single exponent-bits test where the polyfill is two calls). There is no ambiguity to resolve, and nothing to undo when a target framework is eventually dropped: delete the guarded block and every call site is already correct.
 

--- a/Jint/Extensions/Polyfills.cs
+++ b/Jint/Extensions/Polyfills.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 
@@ -87,63 +87,71 @@ internal static class Polyfills
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
     internal static bool Contains(this ReadOnlySpan<string> source, string c) => source.IndexOf(c) != -1;
 #endif
+
 }
 
-public static class Int32Extensions
+// One container per receiver type is required, not stylistic. A static extension member lowers into
+// its containing class with the receiver type erased from the signature, so int.Parse, long.Parse and
+// double.Parse -- identical parameters, differing only in return type -- collide with CS0111 if they
+// share one class. Same reason applies to any future static polyfill whose signature is shared across
+// receivers.
+//
+// Each member mirrors its BCL counterpart exactly, defaults included: an extra optional parameter the
+// real API does not have would change overload resolution on the frameworks that do have it, which is
+// how a polyfill silently stops being a polyfill. The span-taking numeric overloads arrived in two
+// waves -- the NumberStyles ones in .NET Core 2.1 / netstandard2.1, the IFormatProvider ones with
+// IParsable<T> in .NET 7 -- hence the two different guards.
+internal static class Int32Polyfills
 {
     extension(int)
     {
 #if NETFRAMEWORK || NETSTANDARD2_0
-        public static bool TryParse(ReadOnlySpan<char> span, NumberStyles style, IFormatProvider provider, out int value)
+        public static bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out int result)
         {
-            return int.TryParse(span.ToString(), style, provider, out value);
+            return int.TryParse(s.ToString(), style, provider, out result);
+        }
+
+        public static int Parse(ReadOnlySpan<char> s, NumberStyles style = NumberStyles.Integer, IFormatProvider? provider = null)
+        {
+            return int.Parse(s.ToString(), style, provider);
         }
 #endif
 
-#if NETFRAMEWORK || NETSTANDARD
-        public static int Parse(ReadOnlySpan<char> span, IFormatProvider? provider = null)
+#if !NET8_0_OR_GREATER
+        public static int Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
         {
-            return int.Parse(span.ToString(), NumberStyles.Integer, provider);
-        }
-#endif
-
-#if NETFRAMEWORK || NETSTANDARD2_0
-        public static int Parse(ReadOnlySpan<char> span, NumberStyles style = NumberStyles.Integer, IFormatProvider? provider = null)
-        {
-            return int.Parse(span.ToString(), style, provider);
+            return int.Parse(s.ToString(), NumberStyles.Integer, provider);
         }
 #endif
     }
 }
 
-public static class Int64Extensions
+internal static class Int64Polyfills
 {
     extension(long)
     {
 #if NETFRAMEWORK || NETSTANDARD2_0
-        public static bool TryParse(ReadOnlySpan<char> span, NumberStyles style, IFormatProvider formatProvider, out long value)
+        public static bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out long result)
         {
-            return long.TryParse(span.ToString(), style, formatProvider, out value);
+            return long.TryParse(s.ToString(), style, provider, out result);
+        }
+
+        public static long Parse(ReadOnlySpan<char> s, NumberStyles style = NumberStyles.Integer, IFormatProvider? provider = null)
+        {
+            return long.Parse(s.ToString(), style, provider);
         }
 #endif
 
-#if NETFRAMEWORK || NETSTANDARD
-        public static long Parse(ReadOnlySpan<char> span, IFormatProvider? provider = null)
+#if !NET8_0_OR_GREATER
+        public static long Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
         {
-            return long.Parse(span.ToString(), NumberStyles.Integer, provider);
-        }
-#endif
-
-#if NETFRAMEWORK || NETSTANDARD2_0
-        public static long Parse(ReadOnlySpan<char> span, NumberStyles style = NumberStyles.Integer, IFormatProvider? provider = null)
-        {
-            return long.Parse(span.ToString(), style, provider);
+            return long.Parse(s.ToString(), NumberStyles.Integer, provider);
         }
 #endif
     }
 }
 
-public static class DoubleExtensions
+internal static class DoublePolyfills
 {
     extension(double)
     {
@@ -152,19 +160,17 @@ public static class DoubleExtensions
         // phrased as "if x is finite" read the same on every target framework.
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public static bool IsFinite(double value) => !double.IsNaN(value) && !double.IsInfinity(value);
-#endif
 
-#if NETFRAMEWORK || NETSTANDARD
-        public static double Parse(ReadOnlySpan<char> span, IFormatProvider? provider = null)
+        public static double Parse(ReadOnlySpan<char> s, NumberStyles style = NumberStyles.Float | NumberStyles.AllowThousands, IFormatProvider? provider = null)
         {
-            return double.Parse(span.ToString(), NumberStyles.Float | NumberStyles.AllowThousands, provider);
+            return double.Parse(s.ToString(), style, provider);
         }
 #endif
 
-#if NETFRAMEWORK || NETSTANDARD2_0
-        public static double Parse(ReadOnlySpan<char> span, NumberStyles style = NumberStyles.Float | NumberStyles.AllowThousands, IFormatProvider? provider = null)
+#if !NET8_0_OR_GREATER
+        public static double Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
         {
-            return double.Parse(span.ToString(), style, provider);
+            return double.Parse(s.ToString(), NumberStyles.Float | NumberStyles.AllowThousands, provider);
         }
 #endif
     }


### PR DESCRIPTION
Stacked on #2899.

`Int32Extensions`, `Int64Extensions` and `DoubleExtensions` are **public** types in the `Jint` namespace that exist only to host framework polyfills. Every member is `#if`-guarded, so:

- **net8.0 and net10.0 ship three empty public classes**, and the public surface differs by target framework — the worst property a versioned API can have.
- They invite `CS0104` in any embedder with `using Jint;` and a class of the same name. `Jint.Tests` already declares its own `DoubleExtensions` and avoids the collision only by namespace proximity.

All three are now `internal`, renamed to `Int32Polyfills` / `Int64Polyfills` / `DoublePolyfills`. `Jint.Tests.PublicInterface` — the one test project without `InternalsVisibleTo` — still passes, which is what proves nothing outside the assembly bound to them.

### Why they stay three classes

Folding them into `Polyfills` does not compile. A **static** extension member lowers into its containing class with the receiver type erased from the signature, so

```csharp
extension(int)    { public static int    Parse(ReadOnlySpan<char> s, IFormatProvider? provider); }
extension(long)   { public static long   Parse(ReadOnlySpan<char> s, IFormatProvider? provider); }
extension(double) { public static double Parse(ReadOnlySpan<char> s, IFormatProvider? provider); }
```

differ only by return type and collide with `CS0111` if they share a class. The existing three-class split was load-bearing. Instance extension members have no such constraint and still live on `Polyfills`.

### Signatures now mirror the BCL exactly

The `IFormatProvider` overloads carried a `= null` default the real API does not have. On netstandard2.1 the BCL supplies `Parse(ReadOnlySpan<char>, NumberStyles = …, IFormatProvider? = null)` while the polyfill supplied `Parse(ReadOnlySpan<char>, IFormatProvider? = null)`, so a one-argument `int.Parse(span)` was **ambiguous**. Nothing called it that way yet, so this was latent rather than broken. Parameter names are aligned to the BCL's too, so named arguments behave.

Verified by compiling `int.Parse(s)`, `int.Parse(s, p)`, `int.Parse(s, NumberStyles.Integer, p)` and the `long`/`double` equivalents on all five target frameworks.

### AGENTS.md

The documented recipe showed the `public` form, so the convention itself taught the leak. It now shows the `internal` one and records both constraints above, plus the rule that a polyfill has to match the downlevel API's *behaviour* and not merely its signature.

### Verification

| Check | Result |
| --- | --- |
| `dotnet build -c Release Jint/Jint.csproj` (all 5 TFMs) | 0 warnings, 0 errors |
| `Jint.Tests` net10.0 / net472 | 4721 / 4640 passed, 0 failed |
| `Jint.Tests.PublicInterface` net10.0 / net472 | 1263 / 1262 passed, 0 failed |

No benchmark: every member changed is behind a guard that is false on net8.0 and net10.0, so the measured target frameworks compile to exactly what they did before.
