### PR TITLE
Give the target-framework guards one vocabulary

### DIFF
--- a/Jint.Tests.PublicInterface/ConstraintUsageTests.cs
+++ b/Jint.Tests.PublicInterface/ConstraintUsageTests.cs
@@ -3,52 +3,6 @@
 [Collection("ConstraintUsageTests")]
 public class ConstraintUsageTests
 {
-// this test case is problematic due to nature of cancellation token source in old framework
-// in NET 6 it's better designed and signals more reliably
-
-// TODO NET 8 also has problems with this
-#if NET6_0
-    [Fact]
-    public void CanFindAndResetCancellationConstraint()
-    {
-        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
-        var engine = new Engine(new Options().CancellationToken(cts.Token));
-
-        // expect constraint to abort execution due to timeout
-        Invoking(WaitAndCompute).Should().ThrowExactly<ExecutionCanceledException>();
-
-        // ensure constraint can be obtained publicly
-        var cancellationConstraint = engine.FindConstraint<CancellationConstraint>();
-        cancellationConstraint.Should().NotBeNull();
-
-        // reset constraint, expect computation to finish this time
-        using var cts2 = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
-        cancellationConstraint.Reset(cts2.Token);
-        WaitAndCompute().Should().Be("done");
-
-        string WaitAndCompute()
-        {
-            var result = engine.Evaluate(@"
-                function sleep(millisecondsTimeout) {
-                    var totalMilliseconds = new Date().getTime() + millisecondsTimeout;
-                    var now = new Date().getTime();
-                    while (now < totalMilliseconds) {
-                        // simulate some work
-                        now = new Date().getTime();
-                        now = new Date().getTime();
-                        now = new Date().getTime();
-                        now = new Date().getTime();
-                        now = new Date().getTime();
-                    }
-                }
-                sleep(300);
-                return 'done';
-            ");
-            return result.AsString();
-        }
-    }
-#endif
-
     [Fact]
     public void CanObserveConstraintsFromCustomCode()
     {

--- a/Jint/Extensions/SearchValues.cs
+++ b/Jint/Extensions/SearchValues.cs
@@ -1,4 +1,4 @@
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
 namespace System.Buffers;
 
@@ -48,7 +48,7 @@ file sealed class CharSearchValues : SearchValues<char>
 }
 #endif
 
-#if !NET9_0_OR_GREATER
+#if !NET10_0_OR_GREATER
 internal readonly struct StringSearchValues
 {
     private readonly HashSet<string> _data;

--- a/Jint/Extensions/WebEncoders.cs
+++ b/Jint/Extensions/WebEncoders.cs
@@ -1,4 +1,4 @@
-// modified from
+﻿// modified from
 // https://github.com/dotnet/aspnetcore/blob/fd060ce8c36ffe195b9e9a69a1bbd8fb53cc6d7c/src/Shared/WebEncoders/WebEncoders.cs
 //
 // Retire this file when net8.0 is dropped -- System.Buffers.Text.Base64Url is in-box from .NET 9.
@@ -6,7 +6,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NETCOREAPP
+#if NET8_0_OR_GREATER
 using System.Buffers;
 #endif
 using System.Diagnostics;
@@ -135,7 +135,7 @@ internal static class WebEncoders
             throw new ArgumentNullException(nameof(input));
         }
 
-#if NETCOREAPP
+#if NET8_0_OR_GREATER
         return Base64UrlEncode(input.AsSpan(offset, count), omitPadding);
 #else
         // Special-case empty input
@@ -192,7 +192,7 @@ internal static class WebEncoders
             throw new ArgumentException("invalid", nameof(count));
         }
 
-#if NETCOREAPP
+#if NET8_0_OR_GREATER
         return Base64UrlEncode(input.AsSpan(offset, count), output.AsSpan(outputOffset), omitPadding);
 #else
         // Special-case empty input.
@@ -243,7 +243,7 @@ internal static class WebEncoders
         return checked(numWholeOrPartialInputBlocks * 4);
     }
 
-#if NETCOREAPP
+#if NET8_0_OR_GREATER
     /// <summary>
     /// Encodes <paramref name="input"/> using base64url encoding.
     /// </summary>

--- a/Jint/Native/Atomics/AtomicsInstance.cs
+++ b/Jint/Native/Atomics/AtomicsInstance.cs
@@ -1,4 +1,4 @@
-#pragma warning disable CA1859 // Use concrete types when possible for improved performance -- most of methods return JsValue
+﻿#pragma warning disable CA1859 // Use concrete types when possible for improved performance -- most of methods return JsValue
 
 using System.Collections.Concurrent;
 using System.Numerics;
@@ -1346,7 +1346,7 @@ internal sealed partial class AtomicsInstance : BuiltinShapeObject
 
     // Interlocked.And/Or/Xor are only available in .NET 5.0+
     // For older frameworks, we use CompareExchange loops
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int InterlockedAnd(ref int location, int value)
     {

--- a/Jint/Native/Global/GlobalObject.cs
+++ b/Jint/Native/Global/GlobalObject.cs
@@ -1,4 +1,4 @@
-using System.Buffers;
+﻿using System.Buffers;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -738,7 +738,7 @@ uriError:
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static char ParseHexString(ReadOnlySpan<char> input)
         {
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
             return (char) int.Parse(input, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture);
 #else
             return (char) int.Parse(input.ToString(), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture);

--- a/Jint/Native/Intl/DateTimeFormatPrototype.cs
+++ b/Jint/Native/Intl/DateTimeFormatPrototype.cs
@@ -1,4 +1,4 @@
-using System.Numerics;
+﻿using System.Numerics;
 using Jint.Native.Object;
 using Jint.Native.Temporal;
 using Jint.Runtime;
@@ -1270,7 +1270,7 @@ internal sealed partial class DateTimeFormatPrototype : Prototype
             return timeZoneId;
         }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
         // Try to convert Windows ID to IANA
         if (TimeZoneInfo.TryConvertWindowsIdToIanaId(timeZoneId, out var ianaId))
         {
@@ -1288,7 +1288,7 @@ internal sealed partial class DateTimeFormatPrototype : Prototype
         try
         {
             var tz = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
             // On .NET 6+, check if HasIanaId is available
             if (tz.HasIanaId)
             {

--- a/Jint/Native/Intl/IntlUtilities.cs
+++ b/Jint/Native/Intl/IntlUtilities.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using Jint.Native.Function;
@@ -1629,7 +1629,7 @@ internal static class IntlUtilities
 
         if (endIndex < locale.Length)
         {
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
             return string.Concat(locale.AsSpan(0, extensionIndex), locale.AsSpan(endIndex));
 #else
             return locale.Substring(0, extensionIndex) + locale.Substring(endIndex);

--- a/Jint/Native/Intl/JsCollator.cs
+++ b/Jint/Native/Intl/JsCollator.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using Jint.Native.Object;
 
 namespace Jint.Native.Intl;
@@ -137,7 +137,7 @@ internal sealed class JsCollator : ObjectInstance
                 while (yi < y.Length && char.IsDigit(y[yi])) yi++;
 
                 // Compare numeric values
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
                 var xNum = long.Parse(x.AsSpan(xStart, xi - xStart), System.Globalization.CultureInfo.InvariantCulture);
                 var yNum = long.Parse(y.AsSpan(yStart, yi - yStart), System.Globalization.CultureInfo.InvariantCulture);
 #else

--- a/Jint/Native/Intl/JsDateTimeFormat.cs
+++ b/Jint/Native/Intl/JsDateTimeFormat.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Text;
 using Jint.Native.Object;
 using Jint.Native.Temporal;
@@ -1650,7 +1650,7 @@ internal sealed class JsDateTimeFormat : ObjectInstance
         // Try to get an IANA timezone ID for the CLDR lookup.
         // The IanaToMetaZone table also includes Windows timezone ID aliases for .NET Framework compatibility.
         var defaultTzId = defaultTz.Id;
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
         if (!defaultTz.HasIanaId && TimeZoneInfo.TryConvertWindowsIdToIanaId(defaultTzId, out var defaultIanaId))
         {
             defaultTzId = defaultIanaId;

--- a/Jint/Native/Intl/JsDurationFormat.cs
+++ b/Jint/Native/Intl/JsDurationFormat.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Text;
 using Jint.Native.Object;
 
@@ -252,7 +252,7 @@ internal sealed class JsDurationFormat : ObjectInstance
                     var formatStr = "F" + digits;
                     var fractionalStr = fractionalPart.ToString(formatStr, CultureInfo.InvariantCulture);
                     // Remove leading "0" to get just ".xxx"
-#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+#if !NETFRAMEWORK && !NETSTANDARD2_0
                     sb.Append(fractionalStr.AsSpan(1));
 #else
                     sb.Append(fractionalStr, 1, fractionalStr.Length - 1);
@@ -273,7 +273,7 @@ internal sealed class JsDurationFormat : ObjectInstance
                 }
                 if (endIndex > startIndex + 1) // More than just "."
                 {
-#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+#if !NETFRAMEWORK && !NETSTANDARD2_0
                     sb.Append(fractionalStr.AsSpan(startIndex, endIndex - startIndex));
 #else
                     sb.Append(fractionalStr, startIndex, endIndex - startIndex);
@@ -514,7 +514,7 @@ internal sealed class JsDurationFormat : ObjectInstance
                                 var formatStr = "F" + digits;
                                 var fractionalStr = totalSubSeconds.ToString(formatStr, CultureInfo.InvariantCulture);
                                 // Remove leading "0" to get just ".xxx"
-#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+#if !NETFRAMEWORK && !NETSTANDARD2_0
                                 sb.Append(fractionalStr.AsSpan(1));
 #else
                                 sb.Append(fractionalStr, 1, fractionalStr.Length - 1);
@@ -534,7 +534,7 @@ internal sealed class JsDurationFormat : ObjectInstance
                             }
                             if (endIndex > startIndex + 1) // More than just "."
                             {
-#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+#if !NETFRAMEWORK && !NETSTANDARD2_0
                                 sb.Append(fractionalStr.AsSpan(startIndex, endIndex - startIndex));
 #else
                                 sb.Append(fractionalStr, startIndex, endIndex - startIndex);

--- a/Jint/Native/Intl/NumberFormatPrototype.cs
+++ b/Jint/Native/Intl/NumberFormatPrototype.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Numerics;
 using Jint.Native.BigInt;
 using Jint.Native.Object;
@@ -186,7 +186,7 @@ internal sealed partial class NumberFormatPrototype : Prototype
                 return false;
         }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
         if (!BigInteger.TryParse(s.AsSpan(i), NumberStyles.None, CultureInfo.InvariantCulture, out value))
             return false;
 #else

--- a/Jint/Native/JsString.cs
+++ b/Jint/Native/JsString.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
@@ -697,7 +697,7 @@ public class JsString : JsValue, IEquatable<JsString>, IEquatable<string>
 
         public override int GetHashCode()
         {
-#if NETFRAMEWORK || NETSTANDARD2_0 || NETSTANDARD2_1
+#if !NET8_0_OR_GREATER
             // netstandard2.1 lacks the (ReadOnlySpan<char>, StringComparison) overload
             return StringComparer.Ordinal.GetHashCode(ToString());
 #else

--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
@@ -169,7 +169,7 @@ public abstract partial class JsValue : IEquatable<JsValue>
             return ConvertTaskToPromise(engine, task);
         }
 
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP
+#if !NETFRAMEWORK && !NETSTANDARD2_0
         if (obj is ValueTask valueTask)
         {
             return ConvertTaskToPromise(engine, valueTask.AsTask());

--- a/Jint/Native/Json/JsonSerializer.cs
+++ b/Jint/Native/Json/JsonSerializer.cs
@@ -1,4 +1,4 @@
-using System.Buffers;
+﻿using System.Buffers;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -570,7 +570,7 @@ public sealed class JsonSerializer
 
         json.Append('"');
 
-#if NETCOREAPP1_0_OR_GREATER
+#if NET8_0_OR_GREATER
         fixed (char* ptr = value)
         {
             int remainingLength = value.Length;
@@ -641,7 +641,7 @@ public sealed class JsonSerializer
             default:
                 if (char.IsSurrogatePair(value, index))
                 {
-#if NETCOREAPP1_0_OR_GREATER
+#if NET8_0_OR_GREATER
                     json.Append(value.AsSpan(index, 2));
                     index++;
 #else

--- a/Jint/Native/RegExp/RegExpConstructor.cs
+++ b/Jint/Native/RegExp/RegExpConstructor.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using Jint.Collections;
@@ -818,7 +818,7 @@ public sealed partial class RegExpConstructor : Constructor
                                 var name = pattern.Substring(nameStart, nameEnd - nameStart);
                                 namedGroupNumbers ??= new(StringComparer.Ordinal);
 
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_0_OR_GREATER
+#if !NETFRAMEWORK && !NETSTANDARD2_0
                                 if (!namedGroupNumbers.TryAdd(name, groupNumber))
                                 {
                                     // Duplicate named group

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -1,4 +1,4 @@
-#pragma warning disable CA1859 // Use concrete types when possible for improved performance -- most of prototype methods return JsValue
+﻿#pragma warning disable CA1859 // Use concrete types when possible for improved performance -- most of prototype methods return JsValue
 
 using System.Globalization;
 using System.Runtime.CompilerServices;
@@ -217,7 +217,7 @@ internal sealed partial class StringPrototype : StringInstance
         if (string.Equals("lt", culture.Name, StringComparison.OrdinalIgnoreCase))
         {
             s = StringInlHelper.LithuanianStringProcessor(s);
-#if NET462
+#if NETFRAMEWORK
             // Code specific to .NET Framework 4.6.2.
             // For no good reason this verison does not upper case these characters correctly.
             return new JsString(ToUpperCaseWithSpecialCasing(s, culture)

--- a/Jint/Native/Temporal/DefaultTimeZoneProvider.cs
+++ b/Jint/Native/Temporal/DefaultTimeZoneProvider.cs
@@ -1,7 +1,7 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Linq;
 using System.Numerics;
-#if NETSTANDARD
+#if !NET8_0_OR_GREATER && !NETFRAMEWORK
 using System.Runtime.InteropServices;
 #endif
 
@@ -19,13 +19,14 @@ public sealed class DefaultTimeZoneProvider : ITimeZoneProvider
 {
     private static bool IsWindowsPlatform()
     {
-#if NET5_0_OR_GREATER
+        // Not an API gap but a genuine three-way: OperatingSystem arrived in .NET 5, netstandard has
+        // to ask the runtime, and net462 only ever runs on Windows.
+#if NET8_0_OR_GREATER
         return OperatingSystem.IsWindows();
-#elif NETSTANDARD
-        return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-#else
-        // net462 only runs on Windows
+#elif NETFRAMEWORK
         return true;
+#else
+        return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 #endif
     }
 
@@ -639,7 +640,7 @@ public sealed class DefaultTimeZoneProvider : ITimeZoneProvider
             return CanonicalizeTimeZone(timeZoneId);
         }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
         // Use .NET's IANA→Windows mapping to find the primary identifier
         // Both "Asia/Calcutta" and "Asia/Kolkata" map to "India Standard Time"
         // Then convert back to get the primary IANA name
@@ -720,7 +721,7 @@ public sealed class DefaultTimeZoneProvider : ITimeZoneProvider
                 }
             }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
             // Case-insensitive fallback: try all system timezones
             foreach (var systemTz in TimeZoneInfo.GetSystemTimeZones())
             {
@@ -871,8 +872,8 @@ public sealed class DefaultTimeZoneProvider : ITimeZoneProvider
             dict[key] = key;
         }
 
-#if NET6_0_OR_GREATER
-        // Also add system timezone IDs (on .NET 6+ these include IANA IDs)
+#if NET8_0_OR_GREATER
+        // Also add system timezone IDs (from .NET 6 onwards these include IANA IDs)
         foreach (var tz in TimeZoneInfo.GetSystemTimeZones())
         {
             if (!dict.ContainsKey(tz.Id))

--- a/Jint/Native/Temporal/TemporalHelpers.cs
+++ b/Jint/Native/Temporal/TemporalHelpers.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -3452,7 +3452,7 @@ internal static class TemporalHelpers
 
     private static int GetBigIntegerBitLength(BigInteger abs)
     {
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
         return (int) abs.GetBitLength();
 #else
         // Convert to byte array (little-endian, unsigned)

--- a/Jint/Native/TypedArray/Uint8ArrayPrototype.cs
+++ b/Jint/Native/TypedArray/Uint8ArrayPrototype.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using Jint.Extensions;
 using Jint.Native.ArrayBuffer;
 using Jint.Runtime;
@@ -118,7 +118,7 @@ internal sealed partial class Uint8ArrayPrototype : Prototype
         var alphabet = Uint8ArrayConstructor.GetAndValidateAlphabetOption(_engine, opts);
 
         var omitPadding = TypeConverter.ToBoolean(opts.Get("omitPadding"));
-#if NETCOREAPP
+#if NET8_0_OR_GREATER
         var toEncode = GetUint8ArrayBytes(o);
 #else
         var toEncode = GetUint8ArrayBytes(o).ToArray();

--- a/Jint/Pooling/ValueStringBuilder.cs
+++ b/Jint/Pooling/ValueStringBuilder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
@@ -165,7 +165,7 @@ internal ref struct ValueStringBuilder
         int remaining = _pos - index;
         _chars.Slice(index, remaining).CopyTo(_chars.Slice(index + count));
         s
-#if !NETCOREAPP
+#if !NET8_0_OR_GREATER
             .AsSpan()
 #endif
             .CopyTo(_chars.Slice(index));
@@ -220,7 +220,7 @@ internal ref struct ValueStringBuilder
         }
     }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Append<T>(T value) where T : ISpanFormattable
     {
@@ -256,7 +256,7 @@ internal ref struct ValueStringBuilder
         }
 
         s
-#if !NETCOREAPP
+#if !NET8_0_OR_GREATER
             .AsSpan()
 #endif
             .CopyTo(_chars.Slice(pos));

--- a/Jint/Runtime/Interop/DefaultObjectConverter.cs
+++ b/Jint/Runtime/Interop/DefaultObjectConverter.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Jint.Native;
@@ -116,7 +116,7 @@ internal static class DefaultObjectConverter
                     return result is not null;
                 }
 
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP
+#if !NETFRAMEWORK && !NETSTANDARD2_0
                 if (value is ValueTask valueTask)
                 {
                     result = JsValue.ConvertAwaitableToPromise(engine, valueTask);

--- a/Jint/Runtime/Interop/DefaultTypeConverter.cs
+++ b/Jint/Runtime/Interop/DefaultTypeConverter.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
@@ -37,7 +37,7 @@ public class DefaultTypeConverter : ITypeConverter
     private static readonly Type taskType = typeof(Task);
     private static readonly Type genTaskType = typeof(Task<>);
     private static readonly MethodInfo taskFromResultInfo = taskType.GetMethod("FromResult")!;
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP
+#if !NETFRAMEWORK && !NETSTANDARD2_0
     private static readonly Type valueTaskType = typeof(ValueTask);
     private static readonly Type genValueTaskType = typeof(ValueTask<>);
     private static readonly MethodInfo valueTaskFromResultInfo = valueTaskType.GetMethod("FromResult")!;
@@ -368,7 +368,7 @@ public class DefaultTypeConverter : ITypeConverter
             return false;
         }
 
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP
+#if !NETFRAMEWORK && !NETSTANDARD2_0
         return Enum.TryParse(enumType, value, ignoreCase: false, out result!);
 #else
         try
@@ -488,7 +488,7 @@ public class DefaultTypeConverter : ITypeConverter
             return Task.CompletedTask;
         }
 
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP
+#if !NETFRAMEWORK && !NETSTANDARD2_0
         if (conversionType == valueTaskType)
         {
             return default(ValueTask);
@@ -505,7 +505,7 @@ public class DefaultTypeConverter : ITypeConverter
             }
         }
 
-#if NETCOREAPP
+#if NET8_0_OR_GREATER
         if (conversionType.IsGenericType && conversionType.GetGenericTypeDefinition() == genValueTaskType)
         {
             var key = new TypeConversionKey(conversionType.GetGenericArguments()[0], genValueTaskType);
@@ -526,7 +526,7 @@ public class DefaultTypeConverter : ITypeConverter
     private static MethodInfo? GetFromResultMethod(TypeConversionKey key)
     {
         var (target, taskType) = key;
-#if NETCOREAPP
+#if NET8_0_OR_GREATER
         if (taskType == genValueTaskType)
         {
             return valueTaskFromResultInfo.MakeGenericMethod(target);

--- a/Jint/Runtime/Interop/DelegateWrapper.cs
+++ b/Jint/Runtime/Interop/DelegateWrapper.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
@@ -397,7 +397,7 @@ internal sealed class DelegateWrapper : Function
         {
             return true;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP
+#if !NETFRAMEWORK && !NETSTANDARD2_0
         if (obj is ValueTask)
         {
             return true;

--- a/Jint/Runtime/Interop/TypeReference.cs
+++ b/Jint/Runtime/Interop/TypeReference.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Jint.Native;
@@ -354,7 +354,7 @@ public sealed class TypeReference : Constructor, IObjectWrapper
         {
             var memberNameComparer = typeResolver.MemberNameComparer;
             var typeResolverMemberNameCreator = typeResolver.MemberNameCreator;
-#if NET7_0_OR_GREATER
+#if NET8_0_OR_GREATER
             var enumValues = type.GetEnumValuesAsUnderlyingType();
 #else
             var enumValues = Enum.GetValues(type);

--- a/Jint/Runtime/RegExp/RegExpInterpreter.cs
+++ b/Jint/Runtime/RegExp/RegExpInterpreter.cs
@@ -1,4 +1,4 @@
-// IDE0055: formatting rules conflict with try/finally wrapping a pre-existing ~600 line while loop
+﻿// IDE0055: formatting rules conflict with try/finally wrapping a pre-existing ~600 line while loop
 #pragma warning disable IDE0055
 
 // Ported from QuickJS libregexp.c - Bytecode Interpreter
@@ -248,7 +248,7 @@ internal static class RegExpInterpreter
 
             if (end > offset)
             {
-#if NETSTANDARD2_0 || NET462
+#if NETFRAMEWORK || NETSTANDARD2_0
                 names[i] = Encoding.UTF8.GetString(bytecode.Slice(offset, end - offset).ToArray());
 #else
                 names[i] = Encoding.UTF8.GetString(bytecode.Slice(offset, end - offset));
@@ -777,7 +777,7 @@ internal static class RegExpInterpreter
 
                 if (litLen > 1)
                 {
-#if NETSTANDARD2_0 || NET462
+#if NETFRAMEWORK || NETSTANDARD2_0
                     literal = litBuf.Slice(0, litLen).ToString();
 #else
                     literal = new string(litBuf.Slice(0, litLen));
@@ -824,7 +824,7 @@ internal static class RegExpInterpreter
 
                     if (litLen > 1)
                     {
-#if NETSTANDARD2_0 || NET462
+#if NETFRAMEWORK || NETSTANDARD2_0
                         literal = litBuf.Slice(0, litLen).ToString();
 #else
                         literal = new string(litBuf.Slice(0, litLen));


### PR DESCRIPTION
Stacked on #2902.

`Jint/` used **21 distinct `#if` spellings for 5 target frameworks**. Most were synonyms. Over `net462;netstandard2.0;netstandard2.1;net8.0;net10.0`:

- `NETCOREAPP`, `NETCOREAPP1_0_OR_GREATER`, `NETCOREAPP2_0_OR_GREATER`, `NET5_0_OR_GREATER`, `NET6_0_OR_GREATER` and `NET7_0_OR_GREATER` all select exactly `{net8.0, net10.0}`
- the three orderings of `NETSTANDARD2_1_OR_GREATER || NETCOREAPP` all select exactly `{netstandard2.1, net8.0, net10.0}`
- `NET462` ≡ `NETFRAMEWORK`, and `!NET9_0_OR_GREATER` ≡ `!NET10_0_OR_GREATER` (there is no net9.0 target)

**Every substitution is set-identical over the five targets, so no leg's preprocessed source changes.**

What is left is five expressions, each naming a framework Jint actually targets:

| Guard | Selects |
| --- | --- |
| `#if NETFRAMEWORK \|\| NETSTANDARD2_0` | net462, netstandard2.0 |
| `#if !NET8_0_OR_GREATER` | + netstandard2.1 |
| `#if !NET10_0_OR_GREATER` | + net8.0 |
| `#if NETFRAMEWORK` | net462, for behaviour quirks rather than API gaps |
| `#if !NETFRAMEWORK && !NETSTANDARD2_0` | the complement of the first |

That is what makes dropping a target framework mechanical later: every guard names a target the project has, so grepping for a symbol finds every site that must be revisited, and nothing hides behind a synonym for a framework that was never in the list.

### Two sites are not substitutions

`DefaultTimeZoneProvider.IsWindowsPlatform` is a real three-way — `OperatingSystem` arrived in .NET 5, netstandard has to ask the runtime, net462 only ever runs on Windows — so it is spelled out rather than collapsed, and its `using System.Runtime.InteropServices;` is guarded to the two netstandard legs that actually need it.

`Extensions/Lock.cs` is left alone. It is vendored verbatim from SimonCropp/Polyfill so it can be re-synced by copying over it, and rewriting its guards would defeat that.

### A dead test, and what it was hiding

`ConstraintUsageTests.CanFindAndResetCancellationConstraint` was guarded with `#if NET6_0`. No project has targeted net6.0, so it had **never compiled**. It cannot simply be re-enabled: it calls `Engine.FindConstraint<T>()`, a public API that has since been removed — which nothing noticed, precisely because the test was invisible. It was also timing-sensitive by construction, racing a 100 ms `CancellationTokenSource` against a busy-wait. Removed.

### Verification

| Check | Result |
| --- | --- |
| `dotnet build -c Release Jint/Jint.csproj` (all 5 TFMs) | 0 warnings, 0 errors |
| `Jint.Tests` net10.0 / net472 | 4721 / 4640 passed, 0 failed |
| `Jint.Tests.CommonScripts` net10.0 / net472 | 28 / 28 passed |
| `Jint.Tests.PublicInterface` net10.0 / net472 | 1263 / 1262 passed |
| `Jint.Tests.Test262` | 99738 passed, 0 failed |

Acceptance test for the vocabulary itself:

```bash
grep -rhoE "^\s*#(if|elif) .*" --include=*.cs Jint/ --exclude=Lock.cs \
  | sed -E 's/^\s+//' | grep -vE "DEBUG|SUPPORTS_" | sort | uniq -c | sort -rn
```

goes from 21 rows to 7 — the five above, plus the two hand-written `DefaultTimeZoneProvider` lines.

No benchmark: the substitutions leave every target framework's preprocessed source byte-identical.
