### PR TITLE
Back GetArrayDataReference so the unchecked write helpers drop their #if

### DIFF
--- a/Jint/Extensions/Polyfills.cs
+++ b/Jint/Extensions/Polyfills.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace Jint;
 
@@ -87,7 +88,26 @@ internal static class Polyfills
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
     internal static bool Contains(this ReadOnlySpan<string> source, string c) => source.IndexOf(c) != -1;
 #endif
+}
 
+internal static class MemoryMarshalPolyfills
+{
+    extension(MemoryMarshal)
+    {
+#if !NET8_0_OR_GREATER
+        // MemoryMarshal.GetArrayDataReference arrived in .NET 5 and is not in netstandard2.1.
+        //
+        // GetReference over the array's span is the same address by construction. It is not the same
+        // cost everywhere: netstandard2.1 gets the runtime's span and so gets the bounds-check and
+        // covariance-check elision the real API is used for, while net462 and netstandard2.0 bind
+        // System.Memory's slower span and land roughly where the plain indexer did. Correct on all of
+        // them, which is what lets the call sites drop their #if.
+        //
+        // Deliberately not `ref array[0]`: ldelema on a reference-type array performs the array-type
+        // check this helper exists to avoid.
+        public static ref T GetArrayDataReference<T>(T[] array) => ref MemoryMarshal.GetReference(array.AsSpan());
+#endif
+    }
 }
 
 // One container per receiver type is required, not stylistic. A static extension member lowers into

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Jint.Native.Object;
@@ -1076,12 +1076,8 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
         System.Diagnostics.Debug.Assert(dense.GetType() == typeof(JsValue[]), "_dense must be an exact JsValue[]");
         System.Diagnostics.Debug.Assert(index < (uint) dense.Length, "index must be within the dense backing");
 
-#if NET8_0_OR_GREATER
         ref var slot = ref System.Runtime.InteropServices.MemoryMarshal.GetArrayDataReference(dense);
         Unsafe.Add(ref slot, (nint) index) = value;
-#else
-        dense[index] = value;
-#endif
     }
 
     /// <summary>

--- a/Jint/Native/JsObject.cs
+++ b/Jint/Native/JsObject.cs
@@ -1,4 +1,4 @@
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using Jint.Native.Object;
 using Jint.Runtime;
 
@@ -99,12 +99,8 @@ public sealed partial class JsObject : ObjectInstance
         System.Diagnostics.Debug.Assert(overflow.GetType() == typeof(JsValue[]), "_overflow must be an exact JsValue[]");
         System.Diagnostics.Debug.Assert((uint) index < (uint) overflow.Length, "overflow index must be in range");
 
-#if NET8_0_OR_GREATER
         ref var slot = ref System.Runtime.InteropServices.MemoryMarshal.GetArrayDataReference(overflow);
         Unsafe.Add(ref slot, (nint) index) = value;
-#else
-        overflow[index] = value;
-#endif
     }
 
     /// <summary>Drops shape mode back to dictionary mode's starting state (clears the shape and slot

--- a/Jint/Pooling/JsValueListBuilder.cs
+++ b/Jint/Pooling/JsValueListBuilder.cs
@@ -1,4 +1,4 @@
-using System.Buffers;
+﻿using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Jint.Native;
@@ -63,12 +63,8 @@ internal ref struct JsValueListBuilder
         Debug.Assert(array.GetType() == typeof(JsValue[]), "backing buffer must be an exact JsValue[]");
         Debug.Assert((uint) index < (uint) array.Length, "index must be within the backing buffer");
 
-#if NET8_0_OR_GREATER
         ref var slot = ref System.Runtime.InteropServices.MemoryMarshal.GetArrayDataReference(array);
         Unsafe.Add(ref slot, (nint) index) = value;
-#else
-        array[index] = value;
-#endif
     }
 
     /// <summary>

--- a/Jint/Runtime/Arguments.cs
+++ b/Jint/Runtime/Arguments.cs
@@ -1,8 +1,6 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Runtime.CompilerServices;
-#if NET8_0_OR_GREATER
 using System.Runtime.InteropServices;
-#endif
 using Jint.Native;
 
 namespace Jint.Runtime;
@@ -68,11 +66,7 @@ public static class Arguments
             Throw.ArgumentOutOfRangeException(nameof(index), "Index was outside the bounds of the array.");
         }
 
-#if NET8_0_OR_GREATER
         Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), index) = value;
-#else
-        array[index] = value;
-#endif
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Stacked on #2903.

Four helpers carried the same five-line `#if`:

- `Arguments.WriteNoTypeCheck` — every argument write
- `JsObject.WriteOverflowUnchecked` — every overflow-slot property write
- `ArrayInstance.WriteDenseUnchecked` — every dense array element write
- `JsValueListBuilder.WriteUnchecked`

Each took `MemoryMarshal.GetArrayDataReference` on net8.0/net10.0 and a bounds-checked indexer everywhere else. These are the hottest write paths in the engine and the fork was pure target-framework noise.

`MemoryMarshal.GetArrayDataReference` arrived in .NET 5 and is not in netstandard2.1, so it is backfilled as `GetReference` over the array's span — the same address by construction.

**It is not the same cost everywhere, and the PR does not claim otherwise.** netstandard2.1 binds the runtime's span and does get the bounds-check and covariance-check elision the real API is used for; net462 and netstandard2.0 bind `System.Memory`'s slower span and land roughly where the plain indexer already did. Correct on all five, which is what lets the call sites stop branching. This repo cannot measure any of those legs in any case — `Jint.Benchmark` targets net10.0 only.

Deliberately not `ref array[0]`: `ldelema` on a reference-type array performs the array-type check these helpers exist to avoid.

### net8.0 and net10.0 are unchanged

Every call site keeps exactly the text that was already its `NET8_0_OR_GREATER` branch, and the new polyfill is guarded off there, so the preprocessed source for the measured targets is byte-identical. No benchmark.

### Verification

| Check | Result |
| --- | --- |
| `dotnet build -c Release Jint/Jint.csproj` (all 5 TFMs) | 0 warnings, 0 errors |
| `Jint.Tests` net10.0 / net472 | 4739 / 4658 passed, 0 failed |
| `Jint.Tests.CommonScripts` net10.0 / net472 | 28 / 28 passed |
| `Jint.Tests.PublicInterface` net10.0 / net472 | 1275 / 1274 passed |
| `Jint.Tests.Test262` | 99738 passed, 0 failed |

Worth noting the net472 leg is the one that matters here: it is the only leg that executes the newly-changed downlevel path, and it drives these four helpers on essentially every script operation.
