### PR TITLE
Parse from spans on every target framework

### DIFF
--- a/Jint/Extensions/Polyfills.cs
+++ b/Jint/Extensions/Polyfills.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Numerics;
 using System.Runtime.InteropServices;
 
 namespace Jint;
@@ -185,12 +186,45 @@ internal static class DoublePolyfills
         {
             return double.Parse(s.ToString(), style, provider);
         }
+
+        public static bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out double result)
+        {
+            return double.TryParse(s.ToString(), style, provider, out result);
+        }
 #endif
 
 #if !NET8_0_OR_GREATER
         public static double Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
         {
             return double.Parse(s.ToString(), NumberStyles.Float | NumberStyles.AllowThousands, provider);
+        }
+#endif
+    }
+}
+
+internal static class BytePolyfills
+{
+    extension(byte)
+    {
+#if NETFRAMEWORK || NETSTANDARD2_0
+        // byte.Parse(ReadOnlySpan<char>, ...) arrived in .NET Core 2.1 / netstandard2.1.
+        public static byte Parse(ReadOnlySpan<char> s, NumberStyles style = NumberStyles.Integer, IFormatProvider? provider = null)
+        {
+            return byte.Parse(s.ToString(), style, provider);
+        }
+#endif
+    }
+}
+
+internal static class BigIntegerPolyfills
+{
+    extension(BigInteger)
+    {
+#if NETFRAMEWORK || NETSTANDARD2_0
+        // BigInteger.TryParse(ReadOnlySpan<char>, ...) arrived in .NET Core 2.1 / netstandard2.1.
+        public static bool TryParse(ReadOnlySpan<char> value, NumberStyles style, IFormatProvider? provider, out BigInteger result)
+        {
+            return BigInteger.TryParse(value.ToString(), style, provider, out result);
         }
 #endif
     }

--- a/Jint/Native/Global/GlobalObject.cs
+++ b/Jint/Native/Global/GlobalObject.cs
@@ -225,11 +225,7 @@ public sealed partial class GlobalObject : ObjectInstance
 
         // we should now have proper input part
 
-#if SUPPORTS_SPAN_PARSE
         var substring = trimmedString.AsSpan(0, i);
-#else
-        var substring = trimmedString.Substring(0, i);
-#endif
 
         const NumberStyles Styles = NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent | NumberStyles.AllowLeadingSign;
         if (double.TryParse(substring, Styles, CultureInfo.InvariantCulture, out var d))
@@ -738,11 +734,7 @@ uriError:
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static char ParseHexString(ReadOnlySpan<char> input)
         {
-#if NET8_0_OR_GREATER
             return (char) int.Parse(input, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture);
-#else
-            return (char) int.Parse(input.ToString(), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture);
-#endif
         }
     }
 

--- a/Jint/Native/Intl/JsCollator.cs
+++ b/Jint/Native/Intl/JsCollator.cs
@@ -137,13 +137,8 @@ internal sealed class JsCollator : ObjectInstance
                 while (yi < y.Length && char.IsDigit(y[yi])) yi++;
 
                 // Compare numeric values
-#if NET8_0_OR_GREATER
                 var xNum = long.Parse(x.AsSpan(xStart, xi - xStart), System.Globalization.CultureInfo.InvariantCulture);
                 var yNum = long.Parse(y.AsSpan(yStart, yi - yStart), System.Globalization.CultureInfo.InvariantCulture);
-#else
-                var xNum = long.Parse(x.Substring(xStart, xi - xStart), System.Globalization.CultureInfo.InvariantCulture);
-                var yNum = long.Parse(y.Substring(yStart, yi - yStart), System.Globalization.CultureInfo.InvariantCulture);
-#endif
 
                 int numCompare = xNum.CompareTo(yNum);
                 if (numCompare != 0) return numCompare < 0 ? -1 : 1;

--- a/Jint/Native/Intl/NumberFormatPrototype.cs
+++ b/Jint/Native/Intl/NumberFormatPrototype.cs
@@ -186,13 +186,8 @@ internal sealed partial class NumberFormatPrototype : Prototype
                 return false;
         }
 
-#if NET8_0_OR_GREATER
         if (!BigInteger.TryParse(s.AsSpan(i), NumberStyles.None, CultureInfo.InvariantCulture, out value))
             return false;
-#else
-        if (!BigInteger.TryParse(i == 0 ? s : s.Substring(i), NumberStyles.None, CultureInfo.InvariantCulture, out value))
-            return false;
-#endif
 
         if (negative)
             value = -value;

--- a/Jint/Native/TypedArray/TypedArrayConstructor.Uint8Array.cs
+++ b/Jint/Native/TypedArray/TypedArrayConstructor.Uint8Array.cs
@@ -1,4 +1,4 @@
-using System.Buffers;
+﻿using System.Buffers;
 using System.Globalization;
 using Jint.Extensions;
 using Jint.Native.Object;
@@ -328,11 +328,7 @@ public sealed partial class Uint8ArrayConstructor : TypedArrayConstructor
                 return new FromEncodingResult(bytes.AsSpan(0, byteIndex).ToArray(), Throw.CreateSyntaxError(engine.Realm, "Invalid hex value"), read);
             }
 
-#if SUPPORTS_SPAN_PARSE
             var b = byte.Parse(hexits, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-#else
-            var b = byte.Parse(hexits.ToString(), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-#endif
             bytes[byteIndex++] = b;
             read += 2;
         }

--- a/Jint/Runtime/Interop/TypeResolver.cs
+++ b/Jint/Runtime/Interop/TypeResolver.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Dynamic;
 using System.Globalization;
@@ -762,11 +762,7 @@ public sealed class TypeResolver
 
             if (equals && x.Length > 1)
             {
-#if SUPPORTS_SPAN_PARSE
                 equals = x.AsSpan(1).SequenceEqual(y.AsSpan(1));
-#else
-                equals = string.Equals(x.Substring(1), y.Substring(1), StringComparison.Ordinal);
-#endif
             }
 
             return equals;

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using Jint.Native;
@@ -714,11 +714,7 @@ public static class TypeConverter
             if (str.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
             {
                 // we get better precision if we don't hit floating point parsing that is performed by Esprima
-#if SUPPORTS_SPAN_PARSE
                 var source = str.AsSpan(2);
-#else
-                var source = str.Substring(2);
-#endif
 
                 var c = source[0];
                 if (c > 7 && Character.IsHexDigit(c))


### PR DESCRIPTION
Stacked on #2904.

Seven sites forked on target framework purely to choose between a span and a substring.

### Three needed nothing at all

- **`TypeResolver`**'s case-insensitive member-name comparer guarded `x.AsSpan(1).SequenceEqual(y.AsSpan(1))` with `SUPPORTS_SPAN_PARSE`. Nothing there parses, and both sides come from `MemoryExtensions`, which every target framework has. The guard only ever cost net462 and netstandard2.0 **two substring allocations per comparison** — on a path CLR interop takes for every member lookup.
- **`GlobalObject`**'s `\uXXXX` unescape and **`JsCollator`**'s numeric collation guarded `int.Parse`/`long.Parse` over a span. `Polyfills` already backfilled both for net462 and netstandard2.0, and netstandard2.1 has them in the box — so the guards were dead and their `#else` branches unreachable by intent.

### Four needed one backfilled member each

| API | Call site |
| --- | --- |
| `double.TryParse(ReadOnlySpan<char>, …)` | `parseFloat` |
| `BigInteger.TryParse(ReadOnlySpan<char>, …)` | the `0x` BigInt path in `TypeConverter`, and Intl number parsing |
| `byte.Parse(ReadOnlySpan<char>, …)` | `Uint8Array.fromHex` |

Each mirrors its BCL counterpart exactly. Each gets its **own container class**, because a static extension member erases the receiver type when it is lowered — `byte.Parse(ReadOnlySpan<char>, NumberStyles, IFormatProvider?)` and `int.Parse(…)` have identical parameters and differ only by return type, so they collide with `CS0111` if they share one.

### `SUPPORTS_SPAN_PARSE` is down to two users

Both are waiting on unrelated work: `JsonSerializer` wants `Encoder.Convert`'s span overload, and `StringConstructor` wants `new string(ReadOnlySpan<char>)` — a *constructor*, which cannot be an extension member at all. The constant retires with them.

### Verification

| Check | Result |
| --- | --- |
| `dotnet build -c Release Jint/Jint.csproj` (all 5 TFMs) | 0 warnings, 0 errors |
| `Jint.Tests` net10.0 / net472 | 4739 / 4658 passed, 0 failed |
| `Jint.Tests.CommonScripts` net10.0 / net472 | 28 / 28 passed |
| `Jint.Tests.PublicInterface` net10.0 / net472 | 1275 / 1274 passed |
| `Jint.Tests.Test262` | 99738 passed, 0 failed |

No benchmark: net8.0 and net10.0 are unchanged — every surviving line is the text that was already their branch.
