### PR TITLE
Back the vectorized MemoryExtensions searches used by String, RegExp and URI code

### DIFF
--- a/Jint/Extensions/Polyfills.cs
+++ b/Jint/Extensions/Polyfills.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Buffers;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Numerics;
@@ -88,6 +89,64 @@ internal static class Polyfills
 #if NETFRAMEWORK
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
     internal static bool Contains(this ReadOnlySpan<string> source, string c) => source.IndexOf(c) != -1;
+#endif
+
+#if !NET8_0_OR_GREATER
+    // The vectorized MemoryExtensions searches below arrived in .NET 8 and are not in netstandard2.1.
+    // Each fallback is the character-at-a-time scan the call site used to spell out in its own #else,
+    // so behaviour is identical everywhere and only the throughput differs -- which is exactly the
+    // trade these call sites were already making, just written once instead of at every site.
+    //
+    // ContainsAny is the odd one out: MemoryExtensions.IndexOfAny(span, T, T) exists on every target
+    // framework, so this one is vectorized downlevel too.
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+    internal static bool ContainsAny(this ReadOnlySpan<char> span, char value0, char value1)
+        => span.IndexOfAny(value0, value1) >= 0;
+
+    internal static int IndexOfAnyInRange(this ReadOnlySpan<char> span, char lowInclusive, char highInclusive)
+    {
+        for (var i = 0; i < span.Length; i++)
+        {
+            if ((uint) (span[i] - lowInclusive) <= (uint) (highInclusive - lowInclusive))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    internal static int IndexOfAnyExceptInRange(this ReadOnlySpan<char> span, char lowInclusive, char highInclusive)
+    {
+        for (var i = 0; i < span.Length; i++)
+        {
+            if ((uint) (span[i] - lowInclusive) > (uint) (highInclusive - lowInclusive))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    internal static bool ContainsAnyInRange(this ReadOnlySpan<char> span, char lowInclusive, char highInclusive)
+        => span.IndexOfAnyInRange(lowInclusive, highInclusive) >= 0;
+
+    internal static bool ContainsAnyExceptInRange(this ReadOnlySpan<char> span, char lowInclusive, char highInclusive)
+        => span.IndexOfAnyExceptInRange(lowInclusive, highInclusive) >= 0;
+
+    internal static int IndexOfAnyExcept(this ReadOnlySpan<char> span, SearchValues<char> values)
+    {
+        for (var i = 0; i < span.Length; i++)
+        {
+            if (!values.Contains(span[i]))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
 #endif
 }
 

--- a/Jint/Native/Global/GlobalObject.cs
+++ b/Jint/Native/Global/GlobalObject.cs
@@ -403,25 +403,13 @@ uriError:
 
     /// <summary>
     /// Index of the first character <paramref name="allowed"/> does not cover, or -1 when it covers every
-    /// one of them. Vectorized where the runtime provides it; the fallback is the character-at-a-time scan
-    /// this replaced.
+    /// one of them. Vectorized where the runtime provides it, and a character-at-a-time scan through the
+    /// polyfill everywhere else.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int IndexOfFirstDisallowed(ReadOnlySpan<char> value, SearchValues<char> allowed)
     {
-#if NET8_0_OR_GREATER
         return value.IndexOfAnyExcept(allowed);
-#else
-        for (var i = 0; i < value.Length; i++)
-        {
-            if (!allowed.Contains(value[i]))
-            {
-                return i;
-            }
-        }
-
-        return -1;
-#endif
     }
 
     [JsFunction(Name = "decodeURI")]

--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -544,6 +544,11 @@ public sealed class JsonParser
     // Portable fallback: the vectorized IndexOfAny locates the next quote/backslash, then we make sure
     // no control character (< 0x20) appears earlier, so the returned index matches the NET8
     // SearchValues path.
+    //
+    // Deliberately NOT routed through an IndexOfAny(SearchValues<char>) polyfill, even though one
+    // exists. This keeps the vectorized IndexOfAny that every target framework has and only walks the
+    // span up to the quote; a polyfilled SearchValues search would test every character one at a time
+    // over the whole run, which is a real regression in the hottest parser here. The #if stays.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int IndexOfStringStop(ReadOnlySpan<char> span)
     {

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -284,7 +284,6 @@ internal sealed partial class StringPrototype : StringInstance
 
     private static bool NeedsUpperSpecialCasing(string s)
     {
-#if NET8_0_OR_GREATER
         // No SpecialCasing.txt expansion exists below U+00DF — exactly the short-circuit
         // GetSpecialUpperCasing already performs per character. Asking that question once with a
         // vectorized range scan rejects any string made only of such characters (ASCII text being
@@ -294,7 +293,6 @@ internal sealed partial class StringPrototype : StringInstance
         {
             return false;
         }
-#endif
 
         foreach (var c in s)
         {
@@ -592,19 +590,8 @@ internal sealed partial class StringPrototype : StringInstance
     /// </summary>
     private static bool NeedsSpecialCasing(string s)
     {
-#if NET8_0_OR_GREATER
         // GREEK CAPITAL LETTER SIGMA (Final_Sigma) and LATIN CAPITAL LETTER I WITH DOT ABOVE.
         return s.AsSpan().ContainsAny('\u03A3', '\u0130');
-#else
-        foreach (var c in s)
-        {
-            if (c == '\u03A3' || c == '\u0130')
-            {
-                return true;
-            }
-        }
-        return false;
-#endif
     }
 
     /// <summary>
@@ -2078,14 +2065,12 @@ internal sealed partial class StringPrototype : StringInstance
 
     private static bool IsStringWellFormedUnicode(string s)
     {
-#if NET8_0_OR_GREATER
         // Only a surrogate code unit can make a string ill-formed, and most strings contain none.
         // One vectorized range scan settles those, leaving the pairing walk below for the rest.
         if (!s.AsSpan().ContainsAnyInRange('\uD800', '\uDFFF'))
         {
             return true;
         }
-#endif
 
         for (var i = 0; i < s.Length; ++i)
         {

--- a/Jint/Runtime/RegExp/RegExpInterpreter.cs
+++ b/Jint/Runtime/RegExp/RegExpInterpreter.cs
@@ -839,7 +839,6 @@ internal static class RegExpInterpreter
             }
         }
 
-#if NET8_0_OR_GREATER
         // Single-pair character range: [a-z], \d, etc.
         // Use IndexOfAnyInRange for SIMD-accelerated scanning.
         if (firstOp == (byte) RegExpOpcode.Range && bc.Length >= 20)
@@ -858,7 +857,6 @@ internal static class RegExpInterpreter
                 }
             }
         }
-#endif
 
         return default;
     }
@@ -879,13 +877,11 @@ internal static class RegExpInterpreter
             return input.IndexOf(info.ScanLiteral, startIndex, comparison);
         }
 
-#if NET8_0_OR_GREATER
         if (info.IsRange)
         {
             var idx = input.AsSpan(startIndex).IndexOfAnyInRange(info.RangeLow, info.RangeHigh);
             return idx < 0 ? -1 : idx + startIndex;
         }
-#endif
 
         if (info.ScanCharAlt == '\0' || info.ScanCharAlt == info.ScanChar)
         {
@@ -1191,22 +1187,8 @@ internal static class RegExpInterpreter
                                     char low = (char) ReadU16(bc, gotoTarget + 3);
                                     char high = (char) ReadU16(bc, gotoTarget + 5);
 
-                                    int scanEnd;
-#if NET8_0_OR_GREATER
-                                    int skipLen = input.AsSpan(cindex).IndexOfAnyExceptInRange(low, high);
-                                    scanEnd = skipLen < 0 ? inputEnd : cindex + skipLen;
-#else
-                                    scanEnd = cindex;
-                                    while (scanEnd < inputEnd)
-                                    {
-                                        char ch = input[scanEnd];
-                                        if (ch < low || ch > high)
-                                        {
-                                            break;
-                                        }
-                                        scanEnd++;
-                                    }
-#endif
+                                    var skipLen = input.AsSpan(cindex).IndexOfAnyExceptInRange(low, high);
+                                    var scanEnd = skipLen < 0 ? inputEnd : cindex + skipLen;
                                     PushFrame(ref stackBuf, ref stackPooled, ref sp, ref bp,
                                         capture, allocCount, pc1, scanEnd, ExecStateType.Split);
                                     cindex = scanEnd;


### PR DESCRIPTION
Stacked on #2905.

Seven sites took a vectorized `MemoryExtensions` search on net8.0/net10.0 and something else below. Three wrote out a character-at-a-time `#else`; four **skipped the fast path entirely**, so netstandard2.1 and older did more work than they had to for no reason anyone had chosen.

`ContainsAny`, `ContainsAnyInRange`, `ContainsAnyExceptInRange`, `IndexOfAnyInRange`, `IndexOfAnyExceptInRange` and `IndexOfAnyExcept(SearchValues<char>)` arrived in .NET 8 and are not in netstandard2.1, so they are backfilled with exactly the scans the call sites used to spell out. Behaviour is identical on every target framework and only throughput differs — which is the trade those sites were already making, now written once instead of at each one.

`ContainsAny` is the exception worth noting: `MemoryExtensions.IndexOfAny(span, T, T)` exists everywhere, so that one stays **vectorized downlevel too**.

### Two sites change behaviour below net8.0, both by gaining a fast path

- `RegExpInterpreter`'s single-range scan (`[a-z]`, `\d`) was compiled out altogether below net8.0 — `TryDetectScanLoop` never even reported `IsRange`. Those patterns now take the same scan loop on every target framework.
- `IsStringWellFormedUnicode` and `NeedsUpperSpecialCasing` get their early-outs.

The **net472 unit and CommonScripts legs are what cover this**; test262 runs on net10.0 only, where nothing here changed.

### `JsonParser` is deliberately left alone

Its `#else` is not a naive fallback — it uses the vectorized `IndexOfAny('"', '\')` that every target framework has, then bounds a control-character scan. Routing it through a `SearchValues` polyfill would replace a vectorized scan with a per-character one in the hottest parser in the codebase. Comment added at the site recording that, so the next sweep does not "finish the job".

### Verification

Rebased onto latest `main` (through #2896) and re-verified:

| Check | Result |
| --- | --- |
| `dotnet build -c Release Jint/Jint.csproj` (all 5 TFMs) | 0 warnings, 0 errors |
| `Jint.Tests` net10.0 / net472 | 4745 / 4664 passed, 0 failed |
| `Jint.Tests.CommonScripts` net10.0 / net472 | 28 / 28 passed |
| `Jint.Tests.PublicInterface` net10.0 / net472 | 1277 / 1276 passed |
| `Jint.Tests.Test262` | 99738 passed, 0 failed |

No benchmark: net8.0 and net10.0 are unchanged — every surviving line is the text that was already their branch.
