### PR TITLE
Use the span-taking text APIs on every target framework

### DIFF
--- a/Jint/Extensions/Polyfills.cs
+++ b/Jint/Extensions/Polyfills.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Numerics;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace Jint;
 
@@ -89,6 +90,93 @@ internal static class Polyfills
 #if NETFRAMEWORK
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
     internal static bool Contains(this ReadOnlySpan<string> source, string c) => source.IndexOf(c) != -1;
+#endif
+
+#if NETFRAMEWORK || NETSTANDARD2_0
+    // The span overloads below arrived in .NET Core 2.1 / netstandard2.1. Each forwards to the
+    // pointer-based overload that net462 and netstandard2.0 do have, so none of them allocates -- the
+    // obvious `Append(value.ToString())` shape would, on paths that exist to avoid exactly that.
+
+    internal static unsafe StringBuilder Append(this StringBuilder builder, ReadOnlySpan<char> value)
+    {
+        // Pinning an empty span yields a null pointer, and Append(char*, int) rejects null even for a
+        // zero count, where the real span overload simply does nothing. Short-circuit so the polyfill
+        // cannot differ from it.
+        if (value.IsEmpty)
+        {
+            return builder;
+        }
+
+        fixed (char* p = &MemoryMarshal.GetReference(value))
+        {
+            return builder.Append(p, value.Length);
+        }
+    }
+
+    internal static unsafe string GetString(this Encoding encoding, ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.IsEmpty)
+        {
+            return string.Empty;
+        }
+
+        fixed (byte* p = &MemoryMarshal.GetReference(bytes))
+        {
+            return encoding.GetString(p, bytes.Length);
+        }
+    }
+
+    internal static unsafe void Convert(
+        this Encoder encoder,
+        ReadOnlySpan<char> chars,
+        Span<byte> bytes,
+        bool flush,
+        out int charsUsed,
+        out int bytesUsed,
+        out bool completed)
+    {
+        // Encoder.Convert(char*, ...) rejects a null pointer, and pinning an empty span produces one.
+        // Route an empty side through a one-element scratch buffer, still passing the real length of 0,
+        // so the call behaves as the span overload does rather than throwing.
+        Span<char> charScratch = stackalloc char[1];
+        Span<byte> byteScratch = stackalloc byte[1];
+        var charSource = chars.IsEmpty ? (ReadOnlySpan<char>) charScratch : chars;
+        var byteSource = bytes.IsEmpty ? byteScratch : bytes;
+
+        fixed (char* charsPtr = &MemoryMarshal.GetReference(charSource))
+        fixed (byte* bytesPtr = &MemoryMarshal.GetReference(byteSource))
+        {
+            encoder.Convert(charsPtr, chars.Length, bytesPtr, bytes.Length, flush, out charsUsed, out bytesUsed, out completed);
+        }
+    }
+#endif
+
+#if !NET8_0_OR_GREATER
+    // string.GetHashCode(ReadOnlySpan<char>, StringComparison) arrived in .NET Core 2.1 but was not
+    // exposed by netstandard2.1. The contract that matters here is only that a sliced string hash
+    // equal the flat string's within one process, and StringComparer.Ordinal.GetHashCode(s) is
+    // s.GetHashCode() on every target framework, so this is exact. It does materialize the slice,
+    // which is the cost these targets already paid.
+    extension(string)
+    {
+        public static int GetHashCode(ReadOnlySpan<char> value, StringComparison comparisonType)
+        {
+            // StringComparer.FromComparison is itself netstandard2.1+, so the mapping is spelled out.
+            var s = value.ToString();
+            switch (comparisonType)
+            {
+                case StringComparison.Ordinal: return StringComparer.Ordinal.GetHashCode(s);
+                case StringComparison.OrdinalIgnoreCase: return StringComparer.OrdinalIgnoreCase.GetHashCode(s);
+                case StringComparison.CurrentCulture: return StringComparer.CurrentCulture.GetHashCode(s);
+                case StringComparison.CurrentCultureIgnoreCase: return StringComparer.CurrentCultureIgnoreCase.GetHashCode(s);
+                case StringComparison.InvariantCulture: return StringComparer.InvariantCulture.GetHashCode(s);
+                case StringComparison.InvariantCultureIgnoreCase: return StringComparer.InvariantCultureIgnoreCase.GetHashCode(s);
+                default:
+                    Jint.Runtime.Throw.ArgumentException("The string comparison type passed in is currently not supported.", nameof(comparisonType));
+                    return 0;
+            }
+        }
+    }
 #endif
 
 #if !NET8_0_OR_GREATER

--- a/Jint/Native/Intl/JsDurationFormat.cs
+++ b/Jint/Native/Intl/JsDurationFormat.cs
@@ -252,11 +252,7 @@ internal sealed class JsDurationFormat : ObjectInstance
                     var formatStr = "F" + digits;
                     var fractionalStr = fractionalPart.ToString(formatStr, CultureInfo.InvariantCulture);
                     // Remove leading "0" to get just ".xxx"
-#if !NETFRAMEWORK && !NETSTANDARD2_0
                     sb.Append(fractionalStr.AsSpan(1));
-#else
-                    sb.Append(fractionalStr, 1, fractionalStr.Length - 1);
-#endif
                 }
             }
             else if (fractionalPart > 0)
@@ -273,11 +269,7 @@ internal sealed class JsDurationFormat : ObjectInstance
                 }
                 if (endIndex > startIndex + 1) // More than just "."
                 {
-#if !NETFRAMEWORK && !NETSTANDARD2_0
                     sb.Append(fractionalStr.AsSpan(startIndex, endIndex - startIndex));
-#else
-                    sb.Append(fractionalStr, startIndex, endIndex - startIndex);
-#endif
                 }
             }
         }
@@ -514,11 +506,7 @@ internal sealed class JsDurationFormat : ObjectInstance
                                 var formatStr = "F" + digits;
                                 var fractionalStr = totalSubSeconds.ToString(formatStr, CultureInfo.InvariantCulture);
                                 // Remove leading "0" to get just ".xxx"
-#if !NETFRAMEWORK && !NETSTANDARD2_0
                                 sb.Append(fractionalStr.AsSpan(1));
-#else
-                                sb.Append(fractionalStr, 1, fractionalStr.Length - 1);
-#endif
                             }
                         }
                         else if (totalSubSeconds > 0)
@@ -534,11 +522,7 @@ internal sealed class JsDurationFormat : ObjectInstance
                             }
                             if (endIndex > startIndex + 1) // More than just "."
                             {
-#if !NETFRAMEWORK && !NETSTANDARD2_0
                                 sb.Append(fractionalStr.AsSpan(startIndex, endIndex - startIndex));
-#else
-                                sb.Append(fractionalStr, startIndex, endIndex - startIndex);
-#endif
                             }
                         }
                         subSecondsConsumed = true;

--- a/Jint/Native/JsString.cs
+++ b/Jint/Native/JsString.cs
@@ -697,13 +697,8 @@ public class JsString : JsValue, IEquatable<JsString>, IEquatable<string>
 
         public override int GetHashCode()
         {
-#if !NET8_0_OR_GREATER
-            // netstandard2.1 lacks the (ReadOnlySpan<char>, StringComparison) overload
-            return StringComparer.Ordinal.GetHashCode(ToString());
-#else
             // same hash as the equivalent flat string instance
             return string.GetHashCode(AsSpan(), StringComparison.Ordinal);
-#endif
         }
     }
 }

--- a/Jint/Native/Json/JsonSerializer.cs
+++ b/Jint/Native/Json/JsonSerializer.cs
@@ -236,7 +236,7 @@ public sealed class JsonSerializer
     /// chunk's worth of destination space, however large the document is. The stateful encoder carries a
     /// surrogate pair split across a chunk boundary into the next round.
     /// </summary>
-    private static unsafe void WriteUtf8(ReadOnlySpan<char> chars, IBufferWriter<byte> writer)
+    private static void WriteUtf8(ReadOnlySpan<char> chars, IBufferWriter<byte> writer)
     {
         const int ChunkLength = 1024;
 
@@ -261,15 +261,7 @@ public sealed class JsonSerializer
 
             int charsUsed;
             int bytesUsed;
-#if SUPPORTS_SPAN_PARSE
             encoder.Convert(chunk, destination, flush, out charsUsed, out bytesUsed, out _);
-#else
-            fixed (char* chunkPtr = chunk)
-            fixed (byte* destinationPtr = destination)
-            {
-                encoder.Convert(chunkPtr, chunk.Length, destinationPtr, destination.Length, flush, out charsUsed, out bytesUsed, out _);
-            }
-#endif
 
             writer.Advance(bytesUsed);
             chars = chars.Slice(charsUsed);

--- a/Jint/Runtime/RegExp/RegExpInterpreter.cs
+++ b/Jint/Runtime/RegExp/RegExpInterpreter.cs
@@ -248,11 +248,7 @@ internal static class RegExpInterpreter
 
             if (end > offset)
             {
-#if NETFRAMEWORK || NETSTANDARD2_0
-                names[i] = Encoding.UTF8.GetString(bytecode.Slice(offset, end - offset).ToArray());
-#else
                 names[i] = Encoding.UTF8.GetString(bytecode.Slice(offset, end - offset));
-#endif
             }
 
             // Skip past NUL terminator + 1 byte scope trailer (LRE_GROUP_NAME_TRAILER_LEN = 2 total)


### PR DESCRIPTION
Stacked on #2907.

Eight sites forked on target framework to reach a span overload of `StringBuilder`, `Encoding`, `Encoder` or `string`.

All four APIs arrived in .NET Core 2.1 / netstandard2.1, and **every one has a pointer-based counterpart that net462 and netstandard2.0 do have** — so the backfills forward to those and none of them allocates. The obvious `Append(value.ToString())` shape would allocate, on paths that exist precisely to avoid that.

### Two `#else` branches were doing real extra work

- `RegExpInterpreter`'s group-name decoder called `.ToArray()` on the byte slice to reach `Encoding.GetString(byte[])` — a genuine extra allocation per named group.
- `JsonSerializer`'s UTF-8 writer opened a `fixed` block per chunk inline. It now goes through the polyfill, and **`WriteUtf8` no longer needs to be `unsafe` at all**.

The other four are `JsDurationFormat`, where the same `sb.Append(str.AsSpan(…))` vs `sb.Append(str, start, len)` block appears identically four times.

### `string.GetHashCode(ReadOnlySpan<char>, StringComparison)`

The interesting one: it exists from .NET Core 2.1 but **netstandard2.1 never exposed it**, so the guard is `!NET8_0_OR_GREATER` rather than the usual `NETFRAMEWORK || NETSTANDARD2_0` pair.

The only contract that matters is that a `SlicedString` hash equal the flat string's *within one process*, and `StringComparer.Ordinal.GetHashCode(s) == s.GetHashCode()` on every target framework — so the backfill is exact. It still materializes the slice, which is the cost those targets already paid. `StringComparer.FromComparison` is itself netstandard2.1+, so the comparison mapping is spelled out rather than delegated.

### Empty spans

Each backfill short-circuits an empty span. Pinning one yields a **null pointer**, and the pointer-based overloads reject null even for a zero count — where the real span overloads simply do nothing. Without the guard the polyfill would throw exactly where the API it stands in for does not.

No current caller passes an empty span, so this is about the polyfill being substitutable rather than about a live bug.

### `SUPPORTS_SPAN_PARSE` is down to one user

Only `StringConstructor`'s `new string(ReadOnlySpan<char>)` is left — a *constructor*, so it cannot be an extension member and needs different treatment.

### Verification

| Check | Result |
| --- | --- |
| `dotnet build -c Release Jint/Jint.csproj` (all 5 TFMs) | 0 warnings, 0 errors |
| `Jint.Tests` net10.0 / net472 | 4745 / 4664 passed, 0 failed |
| `Jint.Tests.CommonScripts` net10.0 / net472 | 28 / 28 passed |
| `Jint.Tests.PublicInterface` net10.0 / net472 | 1277 / 1276 passed |
| `Jint.Tests.Test262` | 99738 passed, 0 failed |

No benchmark: net8.0 and net10.0 are unchanged — every surviving line is the text that was already their branch. The net472 leg is what exercises the new downlevel paths.
