### PR TITLE
Backfill Dictionary.TryAdd, and stop lowercasing to look up a time zone

### DIFF
--- a/Jint/Extensions/Polyfills.cs
+++ b/Jint/Extensions/Polyfills.cs
@@ -97,6 +97,21 @@ internal static class Polyfills
     // pointer-based overload that net462 and netstandard2.0 do have, so none of them allocates -- the
     // obvious `Append(value.ToString())` shape would, on paths that exist to avoid exactly that.
 
+    // Dictionary<,>.TryAdd arrived in .NET Core 2.0 / netstandard2.1. Jint's own HybridDictionary and
+    // StringDictionarySlim already expose TryAdd unconditionally, so without this the codebase
+    // contradicts itself about whether the method exists.
+    internal static bool TryAdd<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, TValue value)
+        where TKey : notnull
+    {
+        if (dictionary.ContainsKey(key))
+        {
+            return false;
+        }
+
+        dictionary.Add(key, value);
+        return true;
+    }
+
     internal static unsafe StringBuilder Append(this StringBuilder builder, ReadOnlySpan<char> value)
     {
         // Pinning an empty span yields a null pointer, and Append(char*, int) rejects null even for a

--- a/Jint/Native/Intl/Data/TimeZoneData.cs
+++ b/Jint/Native/Intl/Data/TimeZoneData.cs
@@ -1,4 +1,4 @@
-using System.Threading;
+﻿using System.Threading;
 
 namespace Jint.Native.Intl.Data;
 
@@ -355,7 +355,7 @@ internal static class TimeZoneData
     public static string? FindCanonical(string timeZone)
     {
         EnsureLookupInitialized();
-        return _caseInsensitiveLookup!.TryGetValue(timeZone.ToLowerInvariant(), out var canonical)
+        return _caseInsensitiveLookup!.TryGetValue(timeZone, out var canonical)
             ? canonical
             : null;
     }
@@ -366,7 +366,7 @@ internal static class TimeZoneData
     public static bool IsSupported(string timeZone)
     {
         EnsureLookupInitialized();
-        return _caseInsensitiveLookup!.ContainsKey(timeZone.ToLowerInvariant());
+        return _caseInsensitiveLookup!.ContainsKey(timeZone);
     }
 
     private static void EnsureLookupInitialized()
@@ -377,10 +377,13 @@ internal static class TimeZoneData
         {
             if (_caseInsensitiveLookup != null) return;
 
-            var lookup = new Dictionary<string, string>(AllTimeZones.Length, StringComparer.Ordinal);
+            // Keyed case-insensitively rather than pre-lowered, so a lookup no longer has to allocate a
+            // lowercased copy of the caller's identifier. IANA identifiers are ASCII, where
+            // OrdinalIgnoreCase and ToLowerInvariant agree exactly.
+            var lookup = new Dictionary<string, string>(AllTimeZones.Length, StringComparer.OrdinalIgnoreCase);
             foreach (var tz in AllTimeZones)
             {
-                lookup[tz.ToLowerInvariant()] = tz;
+                lookup[tz] = tz;
             }
             _caseInsensitiveLookup = lookup;
         }

--- a/Jint/Native/RegExp/RegExpConstructor.cs
+++ b/Jint/Native/RegExp/RegExpConstructor.cs
@@ -818,19 +818,11 @@ public sealed partial class RegExpConstructor : Constructor
                                 var name = pattern.Substring(nameStart, nameEnd - nameStart);
                                 namedGroupNumbers ??= new(StringComparer.Ordinal);
 
-#if !NETFRAMEWORK && !NETSTANDARD2_0
                                 if (!namedGroupNumbers.TryAdd(name, groupNumber))
                                 {
                                     // Duplicate named group
                                     return true;
                                 }
-#else
-                                if (namedGroupNumbers.ContainsKey(name))
-                                {
-                                    return true;
-                                }
-                                namedGroupNumbers.Add(name, groupNumber);
-#endif
 
                                 i = nameEnd;
                             }


### PR DESCRIPTION
Stacked on #2908.

### `Dictionary<,>.TryAdd`

It arrived in .NET Core 2.0 / netstandard2.1, and `RegExpConstructor`'s duplicate-named-group check forked on target framework to use it.

Jint's own `HybridDictionary` and `StringDictionarySlim` have exposed `TryAdd` **unconditionally** for a long time, so the codebase contradicted itself about whether the method exists. Now it doesn't.

### `TimeZoneData` lowercased a string to probe a dictionary

The case-insensitive lookup was built **pre-lowered** under `StringComparer.Ordinal`:

```csharp
lookup[tz.ToLowerInvariant()] = tz;              // build
… _caseInsensitiveLookup.ContainsKey(timeZone.ToLowerInvariant())   // probe
```

so `FindCanonical` and `IsSupported` each allocated a lowercased copy of the caller's identifier on every call, purely to probe. Keying with `StringComparer.OrdinalIgnoreCase` removes both the allocation and the `ToLowerInvariant`.

IANA identifiers are ASCII, where `OrdinalIgnoreCase` and `ToLowerInvariant` agree exactly, so nothing observable changes — and Temporal's time zone resolution is exercised heavily by test262's Temporal coverage.

### Verification

| Check | Result |
| --- | --- |
| `dotnet build -c Release Jint/Jint.csproj` (all 5 TFMs) | 0 warnings, 0 errors |
| `Jint.Tests` net10.0 / net472 | 4745 / 4664 passed, 0 failed |
| `Jint.Tests.CommonScripts` net10.0 / net472 | 28 / 28 passed |
| `Jint.Tests.PublicInterface` net10.0 / net472 | 1277 / 1276 passed |
| `Jint.Tests.Test262` | 99738 passed, 0 failed |

The `TryAdd` half leaves net8.0/net10.0 unchanged. The `TimeZoneData` half does change them, but it is cold with respect to the SunSpider and Dromaeo suites (no row touches `Intl` or `Temporal`), so test262 is the gate rather than a benchmark sweep.
