### PR TITLE
Backfill the remaining one-member API gaps

### DIFF
--- a/Jint/Constraints/MemoryLimitConstraint.cs
+++ b/Jint/Constraints/MemoryLimitConstraint.cs
@@ -1,4 +1,4 @@
-using Jint.Runtime;
+﻿using Jint.Runtime;
 
 namespace Jint.Constraints;
 
@@ -7,20 +7,6 @@ public sealed class MemoryLimitConstraint : Constraint
     private readonly long _memoryLimit;
     private long _initialMemoryUsage;
     private int _initialThreadId;
-
-#if !NET8_0_OR_GREATER
-    private static readonly Func<long>? _getAllocatedBytesForCurrentThread;
-
-    static MemoryLimitConstraint()
-    {
-        var methodInfo = typeof(GC).GetMethod("GetAllocatedBytesForCurrentThread");
-
-        if (methodInfo != null)
-        {
-            _getAllocatedBytesForCurrentThread = (Func<long>) Delegate.CreateDelegate(typeof(Func<long>), null, methodInfo);
-        }
-    }
-#endif
 
     internal MemoryLimitConstraint(long memoryLimit)
     {
@@ -52,16 +38,7 @@ public sealed class MemoryLimitConstraint : Constraint
             return;
         }
 
-#if NET8_0_OR_GREATER
         var usage = GC.GetAllocatedBytesForCurrentThread();
-#else
-        if (_getAllocatedBytesForCurrentThread == null)
-        {
-            Throw.PlatformNotSupportedException("The current platform doesn't support MemoryLimit.");
-        }
-
-        var usage = _getAllocatedBytesForCurrentThread();
-#endif
         if (usage - _initialMemoryUsage > _memoryLimit)
         {
             Throw.MemoryLimitExceededException($"Script has allocated {usage - _initialMemoryUsage} but is limited to {_memoryLimit}");
@@ -71,10 +48,6 @@ public sealed class MemoryLimitConstraint : Constraint
     public override void Reset()
     {
         _initialThreadId = Environment.CurrentManagedThreadId;
-#if NET8_0_OR_GREATER
         _initialMemoryUsage = GC.GetAllocatedBytesForCurrentThread();
-#else
-        _initialMemoryUsage = _getAllocatedBytesForCurrentThread?.Invoke() ?? 0;
-#endif
     }
 }

--- a/Jint/Extensions/Polyfills.cs
+++ b/Jint/Extensions/Polyfills.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -388,6 +389,89 @@ internal static class BigIntegerPolyfills
         {
             return BigInteger.TryParse(value.ToString(), style, provider, out result);
         }
+#endif
+    }
+}
+
+internal static class RuntimeHelpersPolyfills
+{
+    extension(RuntimeHelpers)
+    {
+#if NETFRAMEWORK || NETSTANDARD2_0
+        // RuntimeHelpers.TryEnsureSufficientExecutionStack arrived in .NET Core 2.0 / netstandard2.1. The
+        // older frameworks only have the throwing form, so this is the try/catch the call site was
+        // writing itself -- an exception per failed probe, which is why the real API exists.
+        public static bool TryEnsureSufficientExecutionStack()
+        {
+            try
+            {
+                RuntimeHelpers.EnsureSufficientExecutionStack();
+                return true;
+            }
+            catch (InsufficientExecutionStackException)
+            {
+                return false;
+            }
+        }
+#endif
+    }
+}
+
+internal static class MathPolyfills
+{
+    extension(Math)
+    {
+#if NETFRAMEWORK || NETSTANDARD2_0
+        // Math.Clamp arrived in .NET Core 2.0 / netstandard2.1.
+        public static int Clamp(int value, int min, int max) => value < min ? min : value > max ? max : value;
+#endif
+    }
+}
+
+internal static class GCPolyfills
+{
+    extension(GC)
+    {
+#if NETFRAMEWORK || NETSTANDARD2_0
+        // GC.GetAllocatedBytesForCurrentThread became public in .NET Core 3.0 / netstandard2.1. It exists
+        // on .NET Framework as a non-public method, so reflection reaches it there; where even that fails
+        // the caller has no way to measure allocation and says so.
+        public static long GetAllocatedBytesForCurrentThread()
+        {
+            var getter = AllocatedBytesForCurrentThread;
+            if (getter is null)
+            {
+                Jint.Runtime.Throw.PlatformNotSupportedException("The current platform doesn't support MemoryLimit.");
+            }
+
+            return getter();
+        }
+#endif
+    }
+
+#if NETFRAMEWORK || NETSTANDARD2_0
+    private static readonly Func<long>? AllocatedBytesForCurrentThread = ResolveAllocatedBytesForCurrentThread();
+
+    private static Func<long>? ResolveAllocatedBytesForCurrentThread()
+    {
+        var methodInfo = typeof(GC).GetMethod("GetAllocatedBytesForCurrentThread");
+        return methodInfo is null ? null : (Func<long>) Delegate.CreateDelegate(typeof(Func<long>), null, methodInfo);
+    }
+#endif
+}
+
+internal static class CharUnicodeInfoPolyfills
+{
+    extension(CharUnicodeInfo)
+    {
+#if NETFRAMEWORK || NETSTANDARD2_0
+        // CharUnicodeInfo.GetUnicodeCategory(int) arrived in .NET Core 3.0 / netstandard2.1. Below that a
+        // supplementary code point has to be materialized as a surrogate pair first, which is the
+        // allocation this overload exists to avoid; BMP code points still avoid it.
+        public static UnicodeCategory GetUnicodeCategory(int codePoint)
+            => codePoint <= 0xFFFF
+                ? CharUnicodeInfo.GetUnicodeCategory((char) codePoint)
+                : CharUnicodeInfo.GetUnicodeCategory(char.ConvertFromUtf32(codePoint), 0);
 #endif
     }
 }

--- a/Jint/Jint.csproj
+++ b/Jint/Jint.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <NeutralLanguage>en-US</NeutralLanguage>
     <TargetFrameworks>net462;netstandard2.0;netstandard2.1;net8.0;net10.0</TargetFrameworks>
@@ -34,7 +34,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' != 'net462' and '$(TargetFramework)' != 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);SUPPORTS_SPAN_PARSE;SUPPORTS_WEAK_TABLE_ADD_OR_UPDATE;SUPPORTS_WEAK_TABLE_CLEAR;SUPPORTS_ASYNC_DISPOSE;SUPPORTS_UNICODE_CATEGORY_INT</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_SPAN_PARSE;SUPPORTS_WEAK_TABLE_ADD_OR_UPDATE;SUPPORTS_WEAK_TABLE_CLEAR;SUPPORTS_ASYNC_DISPOSE</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">

--- a/Jint/Native/Atomics/AtomicsInstance.cs
+++ b/Jint/Native/Atomics/AtomicsInstance.cs
@@ -1344,8 +1344,10 @@ internal sealed partial class AtomicsInstance : BuiltinShapeObject
         buffer[byteIndex + 7] = (byte) (value >> 56);
     }
 
-    // Interlocked.And/Or/Xor are only available in .NET 5.0+
-    // For older frameworks, we use CompareExchange loops
+    // Interlocked.And/Or are only available in .NET 5.0+; for older frameworks these use
+    // CompareExchange loops. Deliberately kept as local helpers rather than routed through
+    // extension-member backfills of Interlocked: Interlocked.Xor has no BCL equivalent on any
+    // framework, so backfilling only two of the three would split a trio that reads as one unit.
 #if NET8_0_OR_GREATER
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int InterlockedAnd(ref int location, int value)

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -836,12 +836,7 @@ internal sealed partial class StringPrototype : StringInstance
             return char.IsLetter(c) && (char.IsLower(c) || char.IsUpper(c) || CharUnicodeInfo.GetUnicodeCategory(c) == UnicodeCategory.TitlecaseLetter);
         }
 
-#if SUPPORTS_UNICODE_CATEGORY_INT
         var category = CharUnicodeInfo.GetUnicodeCategory(cp);
-#else
-        // net462 / netstandard2.0 lack the int overload; the 2-char string allocation is unavoidable here.
-        var category = CharUnicodeInfo.GetUnicodeCategory(char.ConvertFromUtf32(cp), 0);
-#endif
         return category is UnicodeCategory.LowercaseLetter
             or UnicodeCategory.UppercaseLetter
             or UnicodeCategory.TitlecaseLetter;
@@ -855,14 +850,7 @@ internal sealed partial class StringPrototype : StringInstance
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsCaseIgnorable(int cp)
     {
-#if SUPPORTS_UNICODE_CATEGORY_INT
         var category = CharUnicodeInfo.GetUnicodeCategory(cp);
-#else
-        // net462 / netstandard2.0 lack the int overload; supplementary-plane lookups go through a 2-char string.
-        var category = cp <= 0xFFFF
-            ? CharUnicodeInfo.GetUnicodeCategory((char) cp)
-            : CharUnicodeInfo.GetUnicodeCategory(char.ConvertFromUtf32(cp), 0);
-#endif
         return category == UnicodeCategory.NonSpacingMark ||      // Mn
                category == UnicodeCategory.EnclosingMark ||       // Me
                category == UnicodeCategory.Format ||              // Cf (includes U+180E Mongolian Vowel Separator)

--- a/Jint/Native/Temporal/NonIsoCalendars.cs
+++ b/Jint/Native/Temporal/NonIsoCalendars.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Runtime.InteropServices;
 
 namespace Jint.Native.Temporal;
@@ -152,7 +152,7 @@ internal static class NonIsoCalendars
                 : (monthCode is not null
                     ? int.Parse(monthCode.AsSpan(1, 2), System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture)
                     : 1);
-            return TemporalHelpers.RegulateIsoDate(year, Clamp(isoMonth, 1, 12), day, overflow);
+            return TemporalHelpers.RegulateIsoDate(year, System.Math.Clamp(isoMonth, 1, 12), day, overflow);
         }
 
         return result;
@@ -771,7 +771,7 @@ internal static class NonIsoCalendars
             var maxMonths = GetMonthsInYear(calendar, cal, year);
             if (string.Equals(overflow, "constrain", StringComparison.Ordinal))
             {
-                return Clamp(month, 1, maxMonths);
+                return System.Math.Clamp(month, 1, maxMonths);
             }
 
             if (month < 1 || month > maxMonths)
@@ -952,11 +952,6 @@ internal static class NonIsoCalendars
     }
 
     #region Private Helpers
-
-    private static int Clamp(int value, int min, int max)
-    {
-        return value < min ? min : value > max ? max : value;
-    }
 
     /// <summary>
     /// Determines if a Hebrew year is a leap year using the 19-year Metonic cycle.
@@ -1437,7 +1432,7 @@ internal static class NonIsoCalendars
 
         if (string.Equals(overflow, "constrain", StringComparison.Ordinal))
         {
-            ordinalMonth = Clamp(ordinalMonth, 1, maxMonths);
+            ordinalMonth = System.Math.Clamp(ordinalMonth, 1, maxMonths);
         }
         else if (ordinalMonth < 1 || ordinalMonth > maxMonths)
         {
@@ -1457,7 +1452,7 @@ internal static class NonIsoCalendars
 
         if (string.Equals(overflow, "constrain", StringComparison.Ordinal))
         {
-            day = Clamp(day, 1, maxDay);
+            day = System.Math.Clamp(day, 1, maxDay);
         }
         else if (day < 1 || day > maxDay)
         {
@@ -1636,7 +1631,7 @@ internal static class NonIsoCalendars
 
         if (string.Equals(overflow, "constrain", StringComparison.Ordinal))
         {
-            ordinalMonth = Clamp(ordinalMonth, 1, maxMonths);
+            ordinalMonth = System.Math.Clamp(ordinalMonth, 1, maxMonths);
         }
         else if (ordinalMonth < 1 || ordinalMonth > maxMonths)
         {
@@ -1658,7 +1653,7 @@ internal static class NonIsoCalendars
 
         if (string.Equals(overflow, "constrain", StringComparison.Ordinal))
         {
-            day = Clamp(day, 1, maxDay);
+            day = System.Math.Clamp(day, 1, maxDay);
         }
         else if (day < 1 || day > maxDay)
         {
@@ -1822,7 +1817,7 @@ internal static class NonIsoCalendars
         // Constrain month
         if (string.Equals(overflow, "constrain", StringComparison.Ordinal))
         {
-            ordinalMonth = Clamp(ordinalMonth, 1, 12);
+            ordinalMonth = System.Math.Clamp(ordinalMonth, 1, 12);
         }
         else if (ordinalMonth < 1 || ordinalMonth > 12)
         {
@@ -1843,7 +1838,7 @@ internal static class NonIsoCalendars
 
         if (string.Equals(overflow, "constrain", StringComparison.Ordinal))
         {
-            day = Clamp(day, 1, maxDay);
+            day = System.Math.Clamp(day, 1, maxDay);
         }
         else if (day < 1 || day > maxDay)
         {
@@ -2061,7 +2056,7 @@ internal static class NonIsoCalendars
                         return null;
                     }
 
-                    ordinalMonth = Clamp(displayMonth, 1, maxMonth);
+                    ordinalMonth = System.Math.Clamp(displayMonth, 1, maxMonth);
                 }
                 else
                 {
@@ -2081,7 +2076,7 @@ internal static class NonIsoCalendars
         // Constrain month
         if (string.Equals(overflow, "constrain", StringComparison.Ordinal))
         {
-            ordinalMonth = Clamp(ordinalMonth, 1, maxMonth);
+            ordinalMonth = System.Math.Clamp(ordinalMonth, 1, maxMonth);
         }
         else if (ordinalMonth < 1 || ordinalMonth > maxMonth)
         {
@@ -2093,7 +2088,7 @@ internal static class NonIsoCalendars
 
         if (string.Equals(overflow, "constrain", StringComparison.Ordinal))
         {
-            day = Clamp(day, 1, maxDay);
+            day = System.Math.Clamp(day, 1, maxDay);
         }
         else if (day < 1 || day > maxDay)
         {
@@ -2356,7 +2351,7 @@ internal static class NonIsoCalendars
         // Constrain month
         if (string.Equals(overflow, "constrain", StringComparison.Ordinal))
         {
-            ordinalMonth = Clamp(ordinalMonth, 1, 12);
+            ordinalMonth = System.Math.Clamp(ordinalMonth, 1, 12);
         }
         else if (ordinalMonth < 1 || ordinalMonth > 12)
         {
@@ -2368,7 +2363,7 @@ internal static class NonIsoCalendars
 
         if (string.Equals(overflow, "constrain", StringComparison.Ordinal))
         {
-            day = Clamp(day, 1, maxDay);
+            day = System.Math.Clamp(day, 1, maxDay);
         }
         else if (day < 1 || day > maxDay)
         {
@@ -2686,7 +2681,7 @@ internal static class NonIsoCalendars
         // Constrain month
         if (string.Equals(overflow, "constrain", StringComparison.Ordinal))
         {
-            ordinalMonth = Clamp(ordinalMonth, 1, 12);
+            ordinalMonth = System.Math.Clamp(ordinalMonth, 1, 12);
         }
         else if (ordinalMonth < 1 || ordinalMonth > 12)
         {
@@ -2706,7 +2701,7 @@ internal static class NonIsoCalendars
                 var maxDay = cal.GetDaysInMonth(year, ordinalMonth);
                 if (string.Equals(overflow, "constrain", StringComparison.Ordinal))
                 {
-                    day = Clamp(day, 1, maxDay);
+                    day = System.Math.Clamp(day, 1, maxDay);
                 }
                 else if (day < 1 || day > maxDay)
                 {
@@ -2726,7 +2721,7 @@ internal static class NonIsoCalendars
         var maxDayCivil = IslamicCivilDaysInMonth(year, ordinalMonth);
         if (string.Equals(overflow, "constrain", StringComparison.Ordinal))
         {
-            day = Clamp(day, 1, maxDayCivil);
+            day = System.Math.Clamp(day, 1, maxDayCivil);
         }
         else if (day < 1 || day > maxDayCivil)
         {
@@ -2836,7 +2831,7 @@ internal static class NonIsoCalendars
         // Constrain month
         if (string.Equals(overflow, "constrain", StringComparison.Ordinal))
         {
-            ordinalMonth = Clamp(ordinalMonth, 1, 12);
+            ordinalMonth = System.Math.Clamp(ordinalMonth, 1, 12);
         }
         else if (ordinalMonth < 1 || ordinalMonth > 12)
         {
@@ -2847,7 +2842,7 @@ internal static class NonIsoCalendars
         var maxDay = IslamicCivilDaysInMonth(year, ordinalMonth);
         if (string.Equals(overflow, "constrain", StringComparison.Ordinal))
         {
-            day = Clamp(day, 1, maxDay);
+            day = System.Math.Clamp(day, 1, maxDay);
         }
         else if (day < 1 || day > maxDay)
         {

--- a/Jint/Native/Temporal/TemporalHelpers.cs
+++ b/Jint/Native/Temporal/TemporalHelpers.cs
@@ -27,14 +27,6 @@ internal static class TemporalHelpers
         return $"{year:D4}";
     }
 
-    // Polyfill for Math.Clamp which doesn't exist in netstandard2.0
-    private static int Clamp(int value, int min, int max)
-    {
-        if (value < min) return min;
-        if (value > max) return max;
-        return value;
-    }
-
     /// <summary>
     /// Validates that a string doesn't contain non-ASCII minus sign (U+2212).
     /// Only ASCII hyphen-minus (U+002D) is valid in ISO 8601 strings.
@@ -1832,8 +1824,8 @@ internal static class TemporalHelpers
         // Validate/constrain in the Islamic calendar system first
         if (string.Equals(overflow, "constrain", StringComparison.Ordinal))
         {
-            month = Clamp(month, 1, 12);
-            day = Clamp(day, 1, IslamicCivilDaysInMonth(year, month));
+            month = System.Math.Clamp(month, 1, 12);
+            day = System.Math.Clamp(day, 1, IslamicCivilDaysInMonth(year, month));
         }
         else // "reject"
         {
@@ -1858,8 +1850,8 @@ internal static class TemporalHelpers
         // Same leap year and month structure as Islamic Civil
         if (string.Equals(overflow, "constrain", StringComparison.Ordinal))
         {
-            month = Clamp(month, 1, 12);
-            day = Clamp(day, 1, IslamicCivilDaysInMonth(year, month));
+            month = System.Math.Clamp(month, 1, 12);
+            day = System.Math.Clamp(day, 1, IslamicCivilDaysInMonth(year, month));
         }
         else
         {
@@ -2785,9 +2777,9 @@ internal static class TemporalHelpers
     {
         if (string.Equals(overflow, "constrain", StringComparison.Ordinal))
         {
-            month = Clamp(month, 1, 12);
+            month = System.Math.Clamp(month, 1, 12);
             var daysInMonth = IsoDate.IsoDateInMonth(year, month);
-            day = Clamp(day, 1, daysInMonth);
+            day = System.Math.Clamp(day, 1, daysInMonth);
             var date = new IsoDate(year, month, day);
             // Even with constrain, check Temporal limits (unless skipped for PlainMonthDay)
             return skipRangeCheck || IsValidIsoDateTime(year, month, day) ? date : null;
@@ -2815,12 +2807,12 @@ internal static class TemporalHelpers
     {
         if (string.Equals(overflow, "constrain", StringComparison.Ordinal))
         {
-            hour = Clamp(hour, 0, 23);
-            minute = Clamp(minute, 0, 59);
-            second = Clamp(second, 0, 59);
-            millisecond = Clamp(millisecond, 0, 999);
-            microsecond = Clamp(microsecond, 0, 999);
-            nanosecond = Clamp(nanosecond, 0, 999);
+            hour = System.Math.Clamp(hour, 0, 23);
+            minute = System.Math.Clamp(minute, 0, 59);
+            second = System.Math.Clamp(second, 0, 59);
+            millisecond = System.Math.Clamp(millisecond, 0, 999);
+            microsecond = System.Math.Clamp(microsecond, 0, 999);
+            nanosecond = System.Math.Clamp(nanosecond, 0, 999);
             return new IsoTime(hour, minute, second, millisecond, microsecond, nanosecond);
         }
 
@@ -3450,6 +3442,10 @@ internal static class TemporalHelpers
         return result;
     }
 
+    // Not routed through a BigInteger.GetBitLength polyfill (the API is .NET 5+). The real one is
+    // defined over the shortest two's complement representation, so it differs from this magnitude
+    // count for negative values; every caller here passes an absolute value, but a backfill carrying
+    // that discrepancy under the BCL's name is the kind of near-miss that goes unnoticed. Kept local.
     private static int GetBigIntegerBitLength(BigInteger abs)
     {
 #if NET8_0_OR_GREATER

--- a/Jint/Runtime/CallStack/StackGuard.cs
+++ b/Jint/Runtime/CallStack/StackGuard.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // https://github.com/dotnet/runtime/blob/a0964f9e3793cb36cc01d66c14a61e89ada5e7da/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/StackGuard.cs
@@ -35,21 +35,10 @@ internal sealed class StackGuard
             return true;
         }
 
-#if NETFRAMEWORK || NETSTANDARD2_0
-        try
-        {
-            RuntimeHelpers.EnsureSufficientExecutionStack();
-            return true;
-        }
-        catch (InsufficientExecutionStackException)
-        {
-        }
-#else
         if (RuntimeHelpers.TryEnsureSufficientExecutionStack())
         {
             return true;
         }
-#endif
 
         if (_engine.CallStack.Count > _maxExecutionStackCount)
         {
@@ -61,7 +50,7 @@ internal sealed class StackGuard
 
     public static TR RunOnEmptyStack<T1, TR>(Func<T1, TR> action, T1 arg1)
     {
-#if NETFRAMEWORK || NETSTANDARD2_0
+#if NETFRAMEWORK
         return RunOnEmptyStackCore(static s =>
         {
             var t = (Tuple<Func<T1, TR>, T1>) s;


### PR DESCRIPTION
Stacked on #2909.

Five APIs that exist from netstandard2.1 or .NET Core onwards were each being worked around at their call site. Backfilling them removes **eight guards, a reflection-built delegate, a static constructor and two duplicate private helpers**.

### `MemoryLimitConstraint` — the clearest win

Three guards, a `Func<long>` built by reflection and a static constructor collapse into a plain `GC.GetAllocatedBytesForCurrentThread()` call. **The file now has no conditional compilation at all.**

One nuance worth stating explicitly: `Reset` used to swallow an unavailable API and start from a zero baseline, leaving `Check` to throw; now both throw. So the failure surfaces from `ResetConstraints` at the start of execution rather than at the first check — both paths raise the same `PlatformNotSupportedException` out of the same `Execute` call, and the method has been public on .NET Framework since 4.6, so the branch is unreachable for the frameworks Jint targets.

### `StackGuard`

Stops writing its own `try`/`catch` around `RuntimeHelpers.EnsureSufficientExecutionStack`, and its `ValueTuple` guard narrows from `NETFRAMEWORK || NETSTANDARD2_0` to `NETFRAMEWORK` — netstandard2.0 *does* have `ValueTuple`, which the netstandard2.0 leg building green now demonstrates rather than assumes.

### `CharUnicodeInfo.GetUnicodeCategory(int)`

Retires `SUPPORTS_UNICODE_CATEGORY_INT`. The backfill keeps the BMP fast path and only materializes a surrogate pair for supplementary code points — which is what one of the two call sites was doing unconditionally.

### `Math.Clamp`

Replaces two separate private `Clamp` copies. One carried the comment *"Polyfill for Math.Clamp which doesn't exist in netstandard2.0"* **and no guard at all**, so it shadowed the real `Math.Clamp` on every framework including net10.0. Spelled `System.Math.Clamp` because `Jint.Native.Math` shadows the namespace there.

### Two deliberately not backfilled

Both for the same reason — a backfill would carry semantics the real API does not, under the real API's name:

- **`BigInteger.GetBitLength`** is defined over the shortest two's complement representation, so it differs from the local magnitude count for negative values. Every caller passes an absolute value, but a near-miss under the BCL's name is worse than a guard.
- **`Interlocked.And`/`Or`** would split a trio of private helpers whose third member, `Interlocked.Xor`, has no BCL equivalent on any framework.

Both now say so in a comment at the site.

### Verification

| Check | Result |
| --- | --- |
| `dotnet build -c Release Jint/Jint.csproj` (all 5 TFMs) | 0 warnings, 0 errors |
| `Jint.Tests` net10.0 / net472 | 4745 / 4664 passed, 0 failed |
| `Jint.Tests.CommonScripts` net10.0 / net472 | 28 / 28 passed |
| `Jint.Tests.PublicInterface` net10.0 / net472 | 1277 / 1276 passed |
| `Jint.Tests.Test262` | 99738 passed, 0 failed |

`Math.Clamp` and `CharUnicodeInfo` do change net10.0 codegen, but both sit in `Native/Temporal` and `Native/String`'s special-casing paths, which no SunSpider or Dromaeo row reaches — test262 is the gate.
