### PR TITLE
Build strings from spans, and retire SUPPORTS_SPAN_PARSE

### DIFF
--- a/Jint/Jint.csproj
+++ b/Jint/Jint.csproj
@@ -34,13 +34,15 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' != 'net462' and '$(TargetFramework)' != 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);SUPPORTS_SPAN_PARSE;SUPPORTS_WEAK_TABLE_ADD_OR_UPDATE;SUPPORTS_WEAK_TABLE_CLEAR;SUPPORTS_ASYNC_DISPOSE</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_WEAK_TABLE_ADD_OR_UPDATE;SUPPORTS_WEAK_TABLE_CLEAR;SUPPORTS_ASYNC_DISPOSE</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
-    <!-- SUPPORTS_UTF8_TRANSCODE: System.Text.Unicode.Utf8 (OperationStatus-based, allocation-free
-         transcoding). It is a .NET Core 3.0+ type and is NOT part of netstandard2.1, so it cannot ride
-         along on SUPPORTS_SPAN_PARSE. -->
+    <!-- These name absent TYPES, which is the only thing a SUPPORTS_ constant is for: an absent member
+         is backfilled in Polyfills.cs instead, so its call sites need no guard. SUPPORTS_HALF is
+         System.Half and SUPPORTS_UTF8_TRANSCODE is System.Text.Unicode.Utf8 (OperationStatus-based,
+         allocation-free transcoding); both are .NET Core 3.0+ types that netstandard2.1 does not carry,
+         which is why they cannot ride along on the group above. -->
     <DefineConstants>$(DefineConstants);SUPPORTS_HALF;SUPPORTS_UTF8_TRANSCODE</DefineConstants>
   </PropertyGroup>
 

--- a/Jint/Native/String/StringConstructor.cs
+++ b/Jint/Native/String/StringConstructor.cs
@@ -57,11 +57,7 @@ internal sealed partial class StringConstructor : Constructor
 
         // length is arguments.Length, already bounded by the materialized arguments array, so no
         // size cap is needed here (unlike padStart/repeat whose length comes from a JS number).
-#if SUPPORTS_SPAN_PARSE
-        var elements = length < 512 ? stackalloc char[length] : new char[length];
-#else
-        var elements = new char[length];
-#endif
+        Span<char> elements = length < 512 ? stackalloc char[length] : new char[length];
         for (var i = 0; i < elements.Length; i++)
         {
             // Spread can inflate the argument count; check constraints periodically.
@@ -74,7 +70,7 @@ internal sealed partial class StringConstructor : Constructor
             elements[i] = (char) nextCu;
         }
 
-        return JsString.Create(new string(elements));
+        return JsString.Create(elements.ToString());
     }
 
     /// <summary>

--- a/Jint/Runtime/RegExp/RegExpInterpreter.cs
+++ b/Jint/Runtime/RegExp/RegExpInterpreter.cs
@@ -773,11 +773,7 @@ internal static class RegExpInterpreter
 
                 if (litLen > 1)
                 {
-#if NETFRAMEWORK || NETSTANDARD2_0
                     literal = litBuf.Slice(0, litLen).ToString();
-#else
-                    literal = new string(litBuf.Slice(0, litLen));
-#endif
                 }
             }
 
@@ -820,11 +816,7 @@ internal static class RegExpInterpreter
 
                     if (litLen > 1)
                     {
-#if NETFRAMEWORK || NETSTANDARD2_0
                         literal = litBuf.Slice(0, litLen).ToString();
-#else
-                        literal = new string(litBuf.Slice(0, litLen));
-#endif
                     }
                 }
 


### PR DESCRIPTION
Stacked on #2910.

`new string(ReadOnlySpan<char>)` is a **constructor**, so unlike every other gap in this series it cannot be backfilled as an extension member. It doesn't need to be: `ReadOnlySpan<char>.ToString()` is the same operation with the same single allocation on every target framework — `System.Memory` special-cases `char` exactly as the runtime does — so one spelling works everywhere.

- **`RegExpInterpreter`**'s two literal-scan blocks were already writing both branches, and the branches were textually different ways of saying the same thing. They collapse with no behaviour change anywhere.
- **`String.fromCharCode`** is the one that gains something. Its `stackalloc` fast path was guarded, so net462 and netstandard2.0 allocated a `char[]` for every call regardless of size. Typing the local as `Span<char>` hands them the same stack buffer the modern targets already had.

### `SUPPORTS_SPAN_PARSE` is gone

With that it has no users left. The remaining `SUPPORTS_` constants all name absent **types** — `System.Half`, `IAsyncDisposable`, `System.Text.Unicode.Utf8` — which is the only thing they are for: an absent *member* gets backfilled in `Polyfills.cs` and its call sites need no guard at all. The comment in `Jint.csproj` now says that, and no longer refers to the constant this change removes.

### Verification

| Check | Result |
| --- | --- |
| `dotnet build -c Release Jint/Jint.csproj` (all 5 TFMs) | 0 warnings, 0 errors |
| `Jint.Tests` net10.0 / net472 | 4745 / 4664 passed, 0 failed |
| `Jint.Tests.CommonScripts` net10.0 / net472 | 28 / 28 passed |
| `Jint.Tests.PublicInterface` net10.0 / net472 | 1277 / 1276 passed |
| `Jint.Tests.Test262` | 99738 passed, 0 failed |

This does change net10.0 codegen (`new string(span)` → `span.ToString()`), but both sites are cold with respect to the benchmark suites: `AnalyzeScanLoop` runs once per compiled pattern rather than per match, and Dromaeo's `String.fromCharCode` calls are all single-argument and exit at the `arguments.Length == 1` early-out before this block. test262 is the gate.
