### PR TITLE
Stop allocating a string[] to read one language subtag

### DIFF
--- a/Jint/Native/Intl/DateTimeFormatConstructor.cs
+++ b/Jint/Native/Intl/DateTimeFormatConstructor.cs
@@ -1,4 +1,4 @@
-using System.Buffers;
+﻿using System.Buffers;
 using System.Globalization;
 using Jint.Native.Function;
 using Jint.Native.Object;
@@ -290,7 +290,7 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
             {
                 if (hour12.Value)
                 {
-                    var lang = resolvedLocale.Split('-')[0].ToLowerInvariant();
+                    var lang = IntlUtilities.GetLanguageSubtag(resolvedLocale).ToLowerInvariant();
                     hourCycle = string.Equals(lang, "ja", StringComparison.Ordinal) ? "h11" : "h12";
                 }
                 else

--- a/Jint/Native/Intl/DateTimeFormatPrototype.cs
+++ b/Jint/Native/Intl/DateTimeFormatPrototype.cs
@@ -739,7 +739,7 @@ internal sealed partial class DateTimeFormatPrototype : Prototype
     internal static string GetDefaultHourCycle(string locale)
     {
         // Most English-speaking locales use 12-hour format
-        var lang = locale.Split('-')[0].ToLowerInvariant();
+        var lang = IntlUtilities.GetLanguageSubtag(locale).ToLowerInvariant();
 
         // 24-hour format locales
         if (lang is "de" or "fr" or "it" or "es" or "pt" or "nl" or "ru" or "pl" or "sv" or "da" or "nb" or "fi")

--- a/Jint/Native/Intl/IntlUtilities.cs
+++ b/Jint/Native/Intl/IntlUtilities.cs
@@ -16,6 +16,17 @@ namespace Jint.Native.Intl;
 internal static class IntlUtilities
 {
     /// <summary>
+    /// The primary language subtag of a BCP 47 tag, so "es" from "es-ES", and the tag itself when it
+    /// carries no subtags. Equivalent to <c>tag.Split('-')[0]</c> without the string[] that allocates
+    /// to read one element -- including for a leading separator, where Split yields an empty string.
+    /// </summary>
+    internal static string GetLanguageSubtag(string tag)
+    {
+        var dashIndex = tag.IndexOf('-');
+        return dashIndex >= 0 ? tag.Substring(0, dashIndex) : tag;
+    }
+
+    /// <summary>
     /// Implements the normative-optional legacy-constructor chaining behaviour shared by
     /// Intl.Collator, Intl.DateTimeFormat and Intl.NumberFormat (ChainCollator / ChainDateTimeFormat /
     /// ChainNumberFormat). When the constructor is invoked as a plain function (NewTarget is undefined)

--- a/Jint/Native/Intl/JsDateTimeFormat.cs
+++ b/Jint/Native/Intl/JsDateTimeFormat.cs
@@ -727,7 +727,7 @@ internal sealed class JsDateTimeFormat : ObjectInstance
             var yearName = lunisolarDate.Value.YearName;
 
             // Check locale for formatting - zh locale uses "年" suffix
-            var lang = Locale.Split('-')[0].ToLowerInvariant();
+            var lang = IntlUtilities.GetLanguageSubtag(Locale).ToLowerInvariant();
             var isChineseLocale = string.Equals(lang, "zh", StringComparison.Ordinal);
 
             // Add relatedYear part
@@ -820,7 +820,7 @@ internal sealed class JsDateTimeFormat : ObjectInstance
     private string FormatLongDate(DateTime dateTime)
     {
         // Use MMMM d, yyyy for en-US style, or locale-appropriate pattern
-        var lang = Locale.Split('-')[0].ToLowerInvariant();
+        var lang = IntlUtilities.GetLanguageSubtag(Locale).ToLowerInvariant();
         if (string.Equals(lang, "en", StringComparison.Ordinal))
         {
             return dateTime.ToString("MMMM d, yyyy", CultureInfo);
@@ -868,7 +868,7 @@ internal sealed class JsDateTimeFormat : ObjectInstance
     private string FormatShortDate(DateTime dateTime)
     {
         // Use locale's short date pattern but with 2-digit year
-        var lang = Locale.Split('-')[0].ToLowerInvariant();
+        var lang = IntlUtilities.GetLanguageSubtag(Locale).ToLowerInvariant();
         if (string.Equals(lang, "en", StringComparison.Ordinal))
         {
             // US style: M/d/yy with literal slash separator
@@ -1512,7 +1512,7 @@ internal sealed class JsDateTimeFormat : ObjectInstance
     /// </summary>
     private void AddLunisolarDateParts(List<DateTimePart> result, ChineseCalendarHelper.ChineseCalendarDate date, bool textualMonth, bool shortFormat = false)
     {
-        var lang = Locale.Split('-')[0].ToLowerInvariant();
+        var lang = IntlUtilities.GetLanguageSubtag(Locale).ToLowerInvariant();
         var isChineseLocale = string.Equals(lang, "zh", StringComparison.Ordinal);
 
         // Month
@@ -1906,7 +1906,7 @@ internal sealed class JsDateTimeFormat : ObjectInstance
     {
         // For English locale (en), use CLDR day period names
         // Other locales would need locale-specific data
-        var lang = Locale.Split('-')[0];
+        var lang = IntlUtilities.GetLanguageSubtag(Locale);
 
         if (string.Equals(lang, "en", StringComparison.OrdinalIgnoreCase))
         {


### PR DESCRIPTION
Stacked on #2911.

Seven sites in the `DateTimeFormat` code wrote `locale.Split('-')[0]` to get the primary language subtag — allocating a whole `string[]` to read element zero.

Five other files in the same folder (`ListPatternsData`, `CompactPatterns`, `RelativeTimePatternsData`, `UnitPatternsData`, `CollatorConstructor`) already did it with `IndexOf('-')` and a substring, so the codebase carried both idioms side by side and the cheap one was in the minority.

`IntlUtilities.GetLanguageSubtag` now says it once.

### One deliberate detail

It is equivalent to `Split('-')[0]`, **not** to those five open-coded copies. They test `dashIndex > 0` and so return the whole tag for a leading separator, where `Split` yields an empty string:

```csharp
"-x".Split('-')[0]                    // ""
dashIndex > 0 ? Substring(0, i) : tag // "-x"
```

No canonical BCP 47 tag starts with `-`, so nothing observable rests on it today — but a shared helper that quietly disagrees with the expression it replaces is not worth the saving. The five existing copies are left alone rather than silently retargeted at different semantics.

### Verification

| Check | Result |
| --- | --- |
| `dotnet build -c Release Jint/Jint.csproj` (all 5 TFMs) | 0 warnings, 0 errors |
| `Jint.Tests` net10.0 / net472 | 4745 / 4664 passed, 0 failed |
| `Jint.Tests.CommonScripts` net10.0 / net472 | 28 / 28 passed |
| `Jint.Tests.PublicInterface` net10.0 / net472 | 1277 / 1276 passed |
| `Jint.Tests.Test262` | 99738 passed, 0 failed |

Cold with respect to the benchmark suites — no SunSpider or Dromaeo row reaches `Intl` — so test262 is the gate.
