### PR TITLE
Keep a static block's declarations out of the enclosing scope, and a class name in it

### DIFF
--- a/Jint.Tests/Runtime/DeclarationScopeTests.cs
+++ b/Jint.Tests/Runtime/DeclarationScopeTests.cs
@@ -1,0 +1,129 @@
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Which scope a declaration actually reaches. <see cref="HoistingScope"/> answers that once per script,
+/// function body or module at prepare time, and two of its answers were wrong in the same direction: a
+/// declaration was collected into a scope that does not own it.
+/// </summary>
+public class DeclarationScopeTests
+{
+    // https://tc39.es/ecma262/#sec-class-static-block-definitions
+    // A ClassStaticBlockBody is its own var scope, hoisted as a function body of its own by
+    // ClassStaticBlockDefinitionEvaluation, so nothing it declares reaches the enclosing scope.
+
+    [Fact]
+    public void AFunctionDeclaredInAStaticBlockDoesNotReachTheEnclosingScope()
+    {
+        var engine = new Engine();
+
+        engine.Evaluate("class C { static { function f() {} } } typeof f;").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void AVarDeclaredInAStaticBlockDoesNotReachTheEnclosingScope()
+    {
+        var engine = new Engine();
+
+        // The quieter half: the leaked binding was created in the enclosing scope but assigned inside the
+        // static block's own, so it stayed `undefined` rather than throwing - a feature detect of the shape
+        // `if (sv)` silently took the false branch instead of failing loudly.
+        engine.Evaluate("class C { static { var sv = 1; } } Object.getOwnPropertyNames(globalThis).indexOf('sv') >= 0;")
+            .AsBoolean().Should().BeFalse();
+        engine.Evaluate("typeof sv;").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void AStaticBlockOfAClassExpressionDoesNotLeakEither()
+    {
+        var engine = new Engine();
+
+        engine.Evaluate("var C = class { static { var q = 1; function qf() {} } }; typeof q + ' ' + typeof qf;")
+            .AsString().Should().Be("undefined undefined");
+    }
+
+    [Fact]
+    public void AStaticBlockInsideAFunctionDoesNotReachThatFunctionsScope()
+    {
+        var engine = new Engine();
+
+        engine.Evaluate("(function () { class C { static { var x = 1; function xf() {} } } return typeof x + ' ' + typeof xf; })();")
+            .AsString().Should().Be("undefined undefined");
+    }
+
+    [Fact]
+    public void AStaticBlockStillHoistsWithinItself()
+    {
+        // The control: not reaching the enclosing scope must not mean not being hoisted at all. Both
+        // declarations are used before their own position inside the block.
+        var engine = new Engine();
+
+        engine.Evaluate("class C { static { C.v = h(); C.w = iv; function h() { return 7; } var iv; iv = 3; } } C.v + ',' + typeof C.w;")
+            .AsString().Should().Be("7,undefined");
+        engine.Evaluate("class D { static { function h() { return 7; } var iv = 3; D.v = h() + iv; } } D.v;")
+            .AsInteger().Should().Be(10);
+    }
+
+    // https://tc39.es/ecma262/#sec-web-compat-functiondeclarationinstantiation
+    // B.3.2.1 skips the var-hoisting of a block-level function declaration when the name is already
+    // lexically declared in the function body - and a class declaration is a lexical declaration.
+
+    [Fact]
+    public void AClassNameBlocksAnnexBHoistingOfASameNamedBlockFunction()
+    {
+        var engine = new Engine();
+
+        engine.Evaluate("(function () { class f { static tag = 'class'; } { function f() {} } return String(f.tag); })();")
+            .AsString().Should().Be("class");
+    }
+
+    [Fact]
+    public void ALetNameBlocksAnnexBHoistingOfASameNamedBlockFunction()
+    {
+        // The `let` analogue was always correct: the variable-declaration branch of the walk collected the
+        // bound name where the class branch did not.
+        var engine = new Engine();
+
+        engine.Evaluate("(function () { let f = 'lex'; { function f() {} } return String(f); })();")
+            .AsString().Should().Be("lex");
+    }
+
+    [Fact]
+    public void AClassNameAtGlobalScopeAlreadyBlockedAnnexBHoisting()
+    {
+        // The second control, and why this only ever showed up inside a function: the script path asks
+        // GlobalEnvironment.HasLexicalDeclaration, which is built from the declarations rather than from the
+        // collected names, so it saw classes all along.
+        var engine = new Engine();
+
+        engine.Evaluate("class f { static tag = 'class'; } { function f() {} } String(f.tag);")
+            .AsString().Should().Be("class");
+    }
+
+    [Fact]
+    public void AnnexBStillHoistsABlockFunctionWhoseNameIsFree()
+    {
+        // The third control: the conflict filter must not have become a blanket refusal.
+        var engine = new Engine();
+
+        engine.Evaluate("(function () { { function g() { return 'hoisted'; } } return typeof g === 'function' ? g() : 'not hoisted'; })();")
+            .AsString().Should().Be("hoisted");
+    }
+
+    [Fact]
+    public void AClassDeclarationDoesNotSuppressTheArgumentsObject()
+    {
+        // The collected lexical names have a second reader: FunctionDeclarationInstantiation skips creating the
+        // arguments object when the body lexically declares that name. Class names now reach that set, so this
+        // pins that they only matter when the name actually is `arguments` - which for a class is unreachable,
+        // since a class body is always strict and `class arguments {}` is therefore a syntax error in any mode.
+        var engine = new Engine();
+
+        engine.Evaluate("(function () { class other {} return typeof arguments; })();")
+            .AsString().Should().Be("object");
+        Invoking(() => engine.Evaluate("(function () { class arguments {} })();"))
+            .Should().Throw<JavaScriptException>()
+            .WithMessage("Unexpected eval or arguments in strict mode*");
+    }
+}

--- a/Jint/HoistingScope.cs
+++ b/Jint/HoistingScope.cs
@@ -351,13 +351,26 @@ internal sealed class HoistingScope
                 }
                 else if (childType == NodeType.ClassDeclaration && parent is null or AstModule)
                 {
+                    var classDeclaration = (ClassDeclaration) childNode;
                     _lexicalDeclarations ??= [];
-                    _lexicalDeclarations.Add((Declaration) childNode);
+                    _lexicalDeclarations.Add(classDeclaration);
+
+                    // A class name is a lexically declared name of this scope just as a let/const one is, and
+                    // B.3.2.1 skips the var-hoisting of a block-level function whose name is lexically declared.
+                    // The Id is null for `export default class {}`, which binds *default* rather than a name.
+                    if (_collectLexicalNames && classDeclaration.Id is not null)
+                    {
+                        _lexicalNames ??= [];
+                        _lexicalNames.Add(classDeclaration.Id.Name);
+                    }
                 }
 
+                // A class static block is its own var scope — ClassStaticBlockDefinitionEvaluation hoists it as a
+                // function body of its own — so its `var` and `function` declarations must not reach this one.
                 if (childType != NodeType.FunctionDeclaration
                     && childType != NodeType.ArrowFunctionExpression
                     && childType != NodeType.FunctionExpression
+                    && childType != NodeType.StaticBlock
                     && !childNode.ChildNodes.IsEmpty())
                 {
                     Visit(childNode, node, effectiveLexicalNames);


### PR DESCRIPTION
Two independent answers `HoistingScope.ScriptWalker` gives are wrong in the same direction: a declaration is attributed to a scope that does not own it. Both were spotted by @lahma while reviewing #2869 and are split out of it deliberately — that PR is about which declarations a *module* binds, and these two affect scripts and function bodies.

## A class static block is its own var scope

`NodeType.StaticBlock` appeared neither in the block-position list the Annex B function-declaration branch tests against nor in the recursion stop-list, so the walk descended into a static block and collected its declarations for the enclosing scope:

```js
class C { static { function f() {} } }
typeof f            // was "function", must be "undefined"

class C { static { var sv = 1; } }
Object.getOwnPropertyNames(globalThis).indexOf('sv') >= 0   // was true
```

A [ClassStaticBlockBody has its own var scope](https://tc39.es/ecma262/#sec-class-static-block-definitions): the block is hoisted as a function body of its own, by `ClassStaticBlockDefinitionEvaluation` wrapping it in a `ClassStaticBlockFunction` whose `Body` goes through `GetFunctionLevelDeclarations`. So the enclosing walk has to stop there for the same reason it already stops at a function declaration, expression or arrow. `ReferencedGlobalsCollector.CanIntroduceScope` already listed `NodeType.StaticBlock` for exactly this reason.

The `var` half is the quieter one, and it is also why test262 misses it. The leaked binding was created in the enclosing scope but assigned inside the static block's own, so it stayed `undefined` rather than throwing — a downstream `if (sv)` feature detect silently took the false branch. That is precisely what `language/statements/class/static-init-scope-var-close.js` asserts is *not* observable from outside, and Jint passed it before this change, because the leaked binding never receives the value the test would have seen.

## A class name is a lexically declared name

The `ClassDeclaration` branch added the node to `_lexicalDeclarations` but, unlike its `VariableDeclaration` sibling, never added the bound name under `_collectLexicalNames`. `JintFunctionDefinition.BuildState` uses that list as the B.3.2.1 conflict filter, so a class in a function body failed to block Annex B var-hoisting of a same-named block-level function:

```js
(function () { class f { static tag = 'class'; } { function f() {} } return String(f.tag); })()
// was "undefined" — the block function won; B.3.2.1 forbids the hoist
```

Two controls locate it. The `let` analogue was always correct, because that name went through the variable-declaration branch. And the same case at global scope was correct too, because the script path consults `GlobalEnvironment.HasLexicalDeclaration`, built from `_lexicalDeclarations`, which did see classes. Only the function-body path reads the names, which is why this hid inside a function.

`_lexicalNames` is collected only by `GetFunctionLevelDeclarations` — the program- and module-level callers all leave `collectLexicalNames` false — so the blast radius is that one path. It has a second reader, FunctionDeclarationInstantiation suppressing the arguments object when the body lexically declares `arguments`, which turns out to be unreachable for a class: a class body is always strict, so `class arguments {}` is a syntax error in any mode. A test pins that too, since the collection now feeds it.

## Coverage

test262 is green before and after (99484 passed, 0 failed), and covers neither case: its annexB `function-code` suite has no class-conflict variant at all — every `skip-early-err` case uses `let` — and the static-block scoping tests pass over the leak for the reason above.

The new `Jint.Tests/Runtime/DeclarationScopeTests.cs` facts are therefore the whole regression net, and each was checked against the mutation that would break it: removing the `StaticBlock` stop fails four, disabling the class-name collection fails one, in both cases only the tests naming that behaviour. Alongside them are the controls that matter more than the fixes — a static block still hoists within itself (a function called before its own position, a `var` read before its initializer), a class expression's static block behaves like a declaration's, Annex B still hoists a block function whose name is free, and the arguments object still appears for an unrelated class.

`Jint.Tests` is green apart from two pre-existing `DateTests`/`EngineTests` timezone failures that fail identically on unmodified `main` on this machine.