### PR TITLE
Say char.IsAsciiDigit where the locale parsers spelled out the range

### DIFF
--- a/Jint/Extensions/Polyfills.cs
+++ b/Jint/Extensions/Polyfills.cs
@@ -460,6 +460,35 @@ internal static class GCPolyfills
 #endif
 }
 
+internal static class CharPolyfills
+{
+    extension(char)
+    {
+#if !NET8_0_OR_GREATER
+        // The char.IsAscii* family arrived in .NET 7 and is not in netstandard2.1, so net462,
+        // netstandard2.0 and netstandard2.1 all need it. Each body is the BCL's own shape: a single
+        // unsigned-cast range test, and for the letter predicates an OR with 0x20 that folds the two
+        // cases together before the one comparison.
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public static bool IsAsciiDigit(char c) => (uint) (c - '0') <= '9' - '0';
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public static bool IsAsciiLetter(char c) => (uint) ((c | 0x20) - 'a') <= 'z' - 'a';
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public static bool IsAsciiLetterLower(char c) => (uint) (c - 'a') <= 'z' - 'a';
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public static bool IsAsciiLetterUpper(char c) => (uint) (c - 'A') <= 'Z' - 'A';
+
+        // Non-short-circuiting `|` on purpose, as the BCL has it: both operands are branchless, so
+        // evaluating them unconditionally is cheaper than the branch a `||` would introduce.
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public static bool IsAsciiLetterOrDigit(char c) => char.IsAsciiLetter(c) | ((uint) (c - '0') <= '9' - '0');
+#endif
+    }
+}
+
 internal static class CharUnicodeInfoPolyfills
 {
     extension(CharUnicodeInfo)

--- a/Jint/Native/Intl/Data/LikelySubtags.cs
+++ b/Jint/Native/Intl/Data/LikelySubtags.cs
@@ -280,7 +280,7 @@ internal static class LikelySubtags
     {
         foreach (var c in s)
         {
-            if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')))
+            if (!char.IsAsciiLetter(c))
             {
                 return false;
             }
@@ -292,7 +292,7 @@ internal static class LikelySubtags
     {
         foreach (var c in s)
         {
-            if (c < '0' || c > '9')
+            if (!char.IsAsciiDigit(c))
             {
                 return false;
             }
@@ -308,7 +308,7 @@ internal static class LikelySubtags
         }
 
         // 4 characters starting with digit
-        if (s.Length == 4 && s[0] >= '0' && s[0] <= '9')
+        if (s.Length == 4 && char.IsAsciiDigit(s[0]))
         {
             return IsAllAlphanumeric(s);
         }
@@ -326,7 +326,7 @@ internal static class LikelySubtags
     {
         foreach (var c in s)
         {
-            if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')))
+            if (!char.IsAsciiLetterOrDigit(c))
             {
                 return false;
             }

--- a/Jint/Native/Intl/Data/NumberingSystemData.cs
+++ b/Jint/Native/Intl/Data/NumberingSystemData.cs
@@ -135,7 +135,7 @@ internal static class NumberingSystemData
 
         foreach (var c in input)
         {
-            if (c >= '0' && c <= '9')
+            if (char.IsAsciiDigit(c))
             {
                 // Replace Latin digit with target numbering system digit
                 var digitIndex = c - '0';

--- a/Jint/Native/Intl/DefaultCldrProvider.cs
+++ b/Jint/Native/Intl/DefaultCldrProvider.cs
@@ -576,11 +576,6 @@ public sealed class DefaultCldrProvider : ICldrProvider
         return locale.StartsWith("en", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static bool IsUpperAsciiLetter(char c)
-    {
-        return c >= 'A' && c <= 'Z';
-    }
-
     private static string RemoveExtensions(string locale)
     {
         var uIndex = locale.IndexOf("-u-", StringComparison.OrdinalIgnoreCase);
@@ -768,9 +763,9 @@ public sealed class DefaultCldrProvider : ICldrProvider
                 var currencyCode = region.ISOCurrencySymbol;
 
                 if (currencyCode.Length == 3 &&
-                    IsUpperAsciiLetter(currencyCode[0]) &&
-                    IsUpperAsciiLetter(currencyCode[1]) &&
-                    IsUpperAsciiLetter(currencyCode[2]) &&
+                    char.IsAsciiLetterUpper(currencyCode[0]) &&
+                    char.IsAsciiLetterUpper(currencyCode[1]) &&
+                    char.IsAsciiLetterUpper(currencyCode[2]) &&
                     !string.Equals(currencyCode, "XXX", StringComparison.Ordinal))
                 {
                     currencies.Add(currencyCode);

--- a/Jint/Native/Intl/DisplayNamesPrototype.cs
+++ b/Jint/Native/Intl/DisplayNamesPrototype.cs
@@ -126,7 +126,7 @@ internal sealed partial class DisplayNamesPrototype : Prototype
         // Must contain only valid characters
         foreach (var c in code)
         {
-            if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-'))
+            if (!char.IsAsciiLetterOrDigit(c) && c != '-')
             {
                 return false;
             }
@@ -362,7 +362,7 @@ internal sealed partial class DisplayNamesPrototype : Prototype
             // Each segment must be ASCII alphanumeric only
             foreach (var c in segment)
             {
-                if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')))
+                if (!char.IsAsciiLetterOrDigit(c))
                 {
                     return false;
                 }

--- a/Jint/Native/Intl/IntlUtilities.cs
+++ b/Jint/Native/Intl/IntlUtilities.cs
@@ -858,7 +858,7 @@ internal static class IntlUtilities
             foreach (var c in part)
             {
                 // Must be ASCII alphanumeric only (a-z, A-Z, 0-9)
-                if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')))
+                if (!char.IsAsciiLetterOrDigit(c))
                 {
                     return false;
                 }

--- a/Jint/Native/Intl/JsNumberFormat.cs
+++ b/Jint/Native/Intl/JsNumberFormat.cs
@@ -1623,7 +1623,7 @@ internal sealed class JsNumberFormat : ObjectInstance
             }
 
             // Handle ASCII digits 0-9
-            if (c >= '0' && c <= '9')
+            if (char.IsAsciiDigit(c))
             {
                 sb.Append(c);
                 continue;

--- a/Jint/Native/Intl/LocaleConstructor.cs
+++ b/Jint/Native/Intl/LocaleConstructor.cs
@@ -336,7 +336,7 @@ internal sealed class LocaleConstructor : Constructor
         // Must be all ASCII letters (no hyphens, digits, etc.)
         foreach (var c in value)
         {
-            if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')))
+            if (!char.IsAsciiLetter(c))
             {
                 return false;
             }
@@ -364,16 +364,13 @@ internal sealed class LocaleConstructor : Constructor
         // 2 letters
         if (value.Length == 2)
         {
-            return ((value[0] >= 'a' && value[0] <= 'z') || (value[0] >= 'A' && value[0] <= 'Z')) &&
-                   ((value[1] >= 'a' && value[1] <= 'z') || (value[1] >= 'A' && value[1] <= 'Z'));
+            return char.IsAsciiLetter(value[0]) && char.IsAsciiLetter(value[1]);
         }
 
         // 3 digits
         if (value.Length == 3)
         {
-            return value[0] >= '0' && value[0] <= '9' &&
-                   value[1] >= '0' && value[1] <= '9' &&
-                   value[2] >= '0' && value[2] <= '9';
+            return char.IsAsciiDigit(value[0]) && char.IsAsciiDigit(value[1]) && char.IsAsciiDigit(value[2]);
         }
 
         return false;
@@ -391,7 +388,7 @@ internal sealed class LocaleConstructor : Constructor
 
         foreach (var c in value)
         {
-            if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')))
+            if (!char.IsAsciiLetter(c))
             {
                 return false;
             }

--- a/Jint/Native/Intl/NumberFormatConstructor.cs
+++ b/Jint/Native/Intl/NumberFormatConstructor.cs
@@ -448,7 +448,7 @@ internal sealed partial class NumberFormatConstructor : Constructor
 
         foreach (var c in numberingSystem)
         {
-            if (!((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')))
+            if (!char.IsAsciiLetterLower(c) && !char.IsAsciiDigit(c))
             {
                 return false;
             }
@@ -849,14 +849,9 @@ internal sealed partial class NumberFormatConstructor : Constructor
     {
         // Per spec: currency code must be exactly 3 ASCII letters (A-Z, a-z)
         return currency.Length == 3 &&
-               IsAsciiLetter(currency[0]) &&
-               IsAsciiLetter(currency[1]) &&
-               IsAsciiLetter(currency[2]);
-    }
-
-    private static bool IsAsciiLetter(char c)
-    {
-        return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+               char.IsAsciiLetter(currency[0]) &&
+               char.IsAsciiLetter(currency[1]) &&
+               char.IsAsciiLetter(currency[2]);
     }
 
     private static readonly StringSearchValues SanctionedUnits = new(

--- a/Jint/Native/Intl/NumberFormatPrototype.cs
+++ b/Jint/Native/Intl/NumberFormatPrototype.cs
@@ -130,7 +130,7 @@ internal sealed partial class NumberFormatPrototype : Prototype
                 if (dotPos != -1) return false;
                 dotPos = j;
             }
-            else if (s[j] < '0' || s[j] > '9')
+            else if (!char.IsAsciiDigit(s[j]))
             {
                 return false;
             }
@@ -182,7 +182,7 @@ internal sealed partial class NumberFormatPrototype : Prototype
 
         for (var j = i; j < s.Length; j++)
         {
-            if (s[j] < '0' || s[j] > '9')
+            if (!char.IsAsciiDigit(s[j]))
                 return false;
         }
 

--- a/Jint/Native/Intl/RelativeTimeFormatConstructor.cs
+++ b/Jint/Native/Intl/RelativeTimeFormatConstructor.cs
@@ -213,7 +213,7 @@ internal sealed partial class RelativeTimeFormatConstructor : Constructor
 
             foreach (var c in subtag)
             {
-                if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')))
+                if (!char.IsAsciiLetterOrDigit(c))
                 {
                     return false;
                 }

--- a/Jint/Native/Temporal/TemporalHelpers.cs
+++ b/Jint/Native/Temporal/TemporalHelpers.cs
@@ -651,7 +651,7 @@ internal static class TemporalHelpers
         for (var i = 0; i < key.Length; i++)
         {
             var c = key[i];
-            if (!((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-' || c == '_'))
+            if (!char.IsAsciiLetterLower(c) && !char.IsAsciiDigit(c) && c != '-' && c != '_')
             {
                 return false;
             }
@@ -2635,7 +2635,7 @@ internal static class TemporalHelpers
         {
             var c = input[i];
             // Only convert ASCII uppercase A-Z to lowercase a-z
-            if (c >= 'A' && c <= 'Z')
+            if (char.IsAsciiLetterUpper(c))
                 result[i] = (char) (c + 32);
             else
                 result[i] = c;


### PR DESCRIPTION
The locale and Temporal parsers spelled out ASCII character classes by hand — `(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')` appears verbatim several times, and the negated digit form `c < '0' || c > '9'` several more. `char.IsAsciiDigit` and its siblings arrived in **.NET 7** and are not in netstandard2.1, so all three downlevel targets need a backfill; `CharPolyfills` supplies five members with the BCL's own bodies, and 23 sites across 11 files now say what they mean.

Two private helpers go with them: `NumberFormatConstructor.IsAsciiLetter` and `DefaultCldrProvider.IsUpperAsciiLetter`, which were the same predicates under local names.

### Deliberately not touched

- **The ~60 `char.IsDigit` / `char.IsLetter` / `char.IsLetterOrDigit` calls in `Native/Intl`.** These are Unicode-aware, so swapping them for the ASCII members would be a *behaviour* change — Devanagari digits would stop matching. They are arguably wrong for BCP 47 grammars, which are ASCII-only, but that is a spec-conformance question with test262 consequences and belongs in its own change.
- **`JsNumberFormat`'s `٠`–`٩` and `۰`–`۹` tests** — Arabic-Indic and Extended Arabic-Indic digit ranges. Range tests, but not ASCII ones.
- **Everything hot.** `Runtime/RegExp`, `Native/RegExp`, `TypeConverter`, `Native/Date` (including `MimeKit`), `Native/Json` and `Runtime/Interpreter` are reached by SunSpider's `regexp-dna`, `string-unpack-code` and `date-format-*` rows and by Dromaeo's `object-regexp`, so converting them is a benchmark-gated change rather than this one. `Jint/Extensions/Character.cs` is left intact for the same reason — `RegExpCompiler`'s own private `IsAsciiDigit` is a textbook candidate, and also hot.

### Verification

| Check | Result |
| --- | --- |
| `dotnet build -c Release Jint/Jint.csproj` (all 5 TFMs) | 0 warnings, 0 errors |
| `Jint.Tests` net10.0 / net472 | 4745 / 4664 passed, 0 failed |
| `Jint.Tests.CommonScripts` net10.0 / net472 | 28 / 28 passed |
| `Jint.Tests.Test262` | 99738 passed, 0 failed |

test262 is the gate here rather than a benchmark: everything changed is cold with respect to the SunSpider and Dromaeo suites, and Intl and Temporal are heavily covered there.
