### PR TITLE
Hold an error's CLR origin behind one reference

### DIFF
--- a/Jint/Native/Error/ErrorInstance.cs
+++ b/Jint/Native/Error/ErrorInstance.cs
@@ -3,6 +3,13 @@ using Jint.Runtime;
 
 namespace Jint.Native.Error;
 
+/// <summary>
+/// Host-only facts about the CLR origin of an <see cref="ErrorInstance"/>, held behind a single reference
+/// rather than as one field per fact. Errors that came out of CLR interop are a small minority of the errors
+/// an engine builds, so a field per fact would have every error object carrying the ones it never fills.
+/// </summary>
+internal sealed record ClrErrorContext(Type? ResolutionType, string? ResolutionMemberName);
+
 public class ErrorInstance : ObjectInstance
 {
     private protected ErrorInstance(Engine engine, ObjectClass objectClass)
@@ -11,18 +18,23 @@ public class ErrorInstance : ObjectInstance
     }
 
     /// <summary>
-    /// When this error was produced by a failed CLR interop method or constructor resolution, the
-    /// originating CLR type. These are plain CLR fields (not JavaScript properties), so a running script
-    /// cannot observe them; the host reads them via <see cref="JintException.TryGetClrType"/>.
+    /// Host-only facts about the CLR origin of this error, or null for an error that has none. This is plain
+    /// CLR state and not JavaScript properties, so a running script cannot observe it; the host reads it
+    /// through the <see cref="JintException"/> accessors.
     /// </summary>
-    internal Type? ClrResolutionType { get; private set; }
+    private ClrErrorContext? _clrContext;
 
-    internal string? ClrResolutionMemberName { get; private set; }
+    /// <summary>
+    /// When this error was produced by a failed CLR interop method or constructor resolution, the
+    /// originating CLR type. Read host-side via <see cref="JintException.TryGetClrType"/>.
+    /// </summary>
+    internal Type? ClrResolutionType => _clrContext?.ResolutionType;
+
+    internal string? ClrResolutionMemberName => _clrContext?.ResolutionMemberName;
 
     internal void SetClrResolutionInfo(Type clrType, string? memberName)
     {
-        ClrResolutionType = clrType;
-        ClrResolutionMemberName = memberName;
+        _clrContext = new ClrErrorContext(clrType, memberName);
     }
 
     /// <summary>


### PR DESCRIPTION
An `ErrorInstance` carries two host-only facts about where it came from: the CLR type whose member resolution failed, and that member's name. They were two auto-property fields, so every error object in the engine paid 16 bytes for facts that only interop-originated errors ever fill — a small minority.

Both move behind a single `ClrErrorContext` reference. An error with no CLR origin now holds one null field instead of two, and the resolution-error path pays one small allocation on a path that already builds an error object and a message string.

Behaviour is unchanged. `ClrResolutionType` and `ClrResolutionMemberName` stay as internal properties reading through the context, so `JintException.TryGetClrType` and `TryGetClrMemberName` resolve exactly as before.

This is groundwork for #2906 (surfacing the CLR exception behind a caught interop error), which adds a third such fact and would otherwise have widened every error object again — the follow-up PR fits it into the reference this one frees.

Not billed as a perf improvement and no benchmark tables attached: error objects are not on any benchmark's hot path, and the point here is the shape, not a measured win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
