### PR TITLE
Keep the CLR exception behind a caught interop error

### DIFF
--- a/Jint.Tests.PublicInterface/HostClrExceptionTests.cs
+++ b/Jint.Tests.PublicInterface/HostClrExceptionTests.cs
@@ -1,0 +1,258 @@
+#nullable enable
+
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// Behaviour contract for the originating CLR exception behind a JavaScript error. When
+/// <c>CatchClrExceptions</c> turns a host exception into a script-catchable error, the exception itself is
+/// recorded on the error object — host-only CLR state, never a JavaScript property — so it still reaches the
+/// host through <see cref="JintException.TryGetClrException"/> after the error has crossed back out.
+/// <para>
+/// The error <em>value</em> is what carries it, because the .NET exception instance thrown inside the engine is
+/// not the one the host catches: the interpreter reduces a throw to its error value and a fresh
+/// <see cref="JavaScriptException"/> is built from that at the boundary. So these cover the crossings that
+/// reconstruction goes through — nested frames, a script-level catch and rethrow, module evaluation, a rejected
+/// promise — plus the script-visibility and cause-walking obligations the feature takes on.
+/// </para>
+/// </summary>
+public class HostClrExceptionTests
+{
+    private sealed class HostFailure(string message, Exception? inner = null) : Exception(message, inner);
+
+    private static Engine CreateEngine()
+    {
+        var engine = new Engine(options => options.CatchClrExceptions());
+        engine.SetValue("boom", new Action(() => throw new HostFailure("host blew up", new InvalidOperationException("root cause"))));
+        return engine;
+    }
+
+    [Fact]
+    public void UncaughtHostExceptionReachesTheHostThroughTheJavaScriptError()
+    {
+        var engine = CreateEngine();
+
+        var exception = Invoking(() => engine.Evaluate("boom()")).Should().Throw<JavaScriptException>().Which;
+
+        JintException.TryGetClrException(exception, out var clrException).Should().BeTrue();
+        var failure = clrException.Should().BeOfType<HostFailure>().Which;
+        failure.Message.Should().Be("host blew up");
+        failure.InnerException.Should().BeOfType<InvalidOperationException>();
+        failure.StackTrace.Should().NotBeNull("the CLR stack trace is the reason for keeping the exception");
+    }
+
+    [Fact]
+    public void SurvivesNestedScriptFrames()
+    {
+        var engine = CreateEngine();
+
+        var exception = Invoking(() => engine.Evaluate("""
+            function inner() { boom(); }
+            function outer() { inner(); }
+            outer();
+            """)).Should().Throw<JavaScriptException>().Which;
+
+        JintException.TryGetClrException(exception, out var clrException).Should().BeTrue();
+        clrException.Should().BeOfType<HostFailure>();
+    }
+
+    [Fact]
+    public void SurvivesAScriptCatchingAndRethrowingTheSameValue()
+    {
+        var engine = CreateEngine();
+
+        var exception = Invoking(() => engine.Evaluate("try { boom(); } catch (e) { throw e; }"))
+            .Should().Throw<JavaScriptException>().Which;
+
+        JintException.TryGetClrException(exception, out var clrException).Should().BeTrue();
+        clrException.Should().BeOfType<HostFailure>();
+    }
+
+    [Fact]
+    public void SurvivesModuleEvaluation()
+    {
+        var engine = new Engine(options => options.CatchClrExceptions());
+        engine.SetValue("boom", new Action(() => throw new HostFailure("host blew up")));
+        engine.Modules.Add("failing", "boom();");
+
+        var exception = Invoking(() => engine.Modules.Import("failing")).Should().Throw<JavaScriptException>().Which;
+
+        JintException.TryGetClrException(exception, out var clrException).Should().BeTrue();
+        clrException.Should().BeOfType<HostFailure>();
+    }
+
+    [Fact]
+    public void IsReachableThroughARejectedPromise()
+    {
+        var engine = CreateEngine();
+
+        var rejection = Invoking(() => engine.Evaluate("(async () => { boom(); })()").UnwrapIfPromise())
+            .Should().Throw<PromiseRejectedException>().Which;
+
+        JintException.TryGetClrException(rejection, out var clrException).Should().BeTrue();
+        clrException.Should().BeOfType<HostFailure>();
+    }
+
+    [Fact]
+    public void FollowsAnErrorCauseChain()
+    {
+        var engine = CreateEngine();
+
+        var exception = Invoking(() => engine.Evaluate("""
+            try { boom(); } catch (e) { throw new Error('wrapped', { cause: e }); }
+            """)).Should().Throw<JavaScriptException>().Which;
+
+        exception.Message.Should().Be("wrapped");
+        JintException.TryGetClrException(exception, out var clrException).Should().BeTrue();
+        clrException.Should().BeOfType<HostFailure>();
+    }
+
+    [Fact]
+    public void ACauseCycleTerminates()
+    {
+        var engine = CreateEngine();
+
+        var exception = Invoking(() => engine.Evaluate("""
+            const a = new Error('a');
+            const b = new Error('b', { cause: a });
+            a.cause = b;
+            throw b;
+            """)).Should().Throw<JavaScriptException>().Which;
+
+        JintException.TryGetClrException(exception, out var clrException).Should().BeFalse();
+        clrException.Should().BeNull();
+    }
+
+    [Fact]
+    public void AnAccessorValuedCauseIsNeverInvoked()
+    {
+        var engine = CreateEngine();
+
+        var exception = Invoking(() => engine.Evaluate("""
+            globalThis.getterRan = false;
+            const e = new Error('wrapped');
+            Object.defineProperty(e, 'cause', { get() { globalThis.getterRan = true; return new Error('x'); } });
+            throw e;
+            """)).Should().Throw<JavaScriptException>().Which;
+
+        JintException.TryGetClrException(exception, out _).Should().BeFalse();
+        engine.Evaluate("globalThis.getterRan").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void AScriptThatDiscardsTheErrorKeepsNothing()
+    {
+        var engine = CreateEngine();
+
+        var exception = Invoking(() => engine.Evaluate("try { boom(); } catch (e) { throw new Error('unrelated'); }"))
+            .Should().Throw<JavaScriptException>().Which;
+
+        JintException.TryGetClrException(exception, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsInvisibleToTheRunningScript()
+    {
+        var engine = CreateEngine();
+
+        engine.Evaluate("""
+            let caught;
+            try { boom(); } catch (e) { caught = e; }
+            caught;
+            """);
+
+        engine.Evaluate("Object.getOwnPropertyNames(caught).join(',')").AsString()
+            .Should().NotContain("clr", "the exception is CLR state, not a property");
+        engine.Evaluate("Reflect.ownKeys(caught).length").AsNumber()
+            .Should().Be(engine.Evaluate("Object.getOwnPropertyNames(caught).length").AsNumber());
+        engine.Evaluate("Object.getOwnPropertySymbols(caught).length").AsNumber().Should().Be(0);
+        engine.Evaluate("JSON.stringify(caught)").AsString().Should().Be("{}");
+    }
+
+    [Fact]
+    public void ADecoratorSeesTheExceptionAlreadyAttached()
+    {
+        Exception? seenByDecorator = null;
+        var engine = new Engine(options =>
+        {
+            options.CatchClrExceptions();
+            options.DecorateClrExceptionErrors((_, error, clrException) =>
+            {
+                seenByDecorator = clrException;
+                error.Set("code", "E_HOST");
+            });
+        });
+        engine.SetValue("boom", new Action(() => throw new HostFailure("host blew up")));
+
+        var exception = Invoking(() => engine.Evaluate("boom()")).Should().Throw<JavaScriptException>().Which;
+
+        seenByDecorator.Should().BeOfType<HostFailure>();
+        exception.Error.AsObject().Get("code").AsString().Should().Be("E_HOST");
+        JintException.TryGetClrException(exception, out var clrException).Should().BeTrue();
+        clrException.Should().BeSameAs(seenByDecorator);
+    }
+
+    [Fact]
+    public void HostCodeCanThrowAnErrorCarryingItsOwnException()
+    {
+        var engine = new Engine();
+        var original = new HostFailure("XML parsing failed", new InvalidOperationException("unexpected token"));
+
+        engine.SetValue("parse", new Action(() =>
+            throw new JavaScriptException(engine.Intrinsics.Error, "XML parsing failed", original)));
+
+        // Catchable by the script, exactly as an ordinary Error is - and without CatchClrExceptions.
+        engine.Evaluate("let m; try { parse(); } catch (e) { m = e instanceof Error ? e.message : 'not an error'; } m")
+            .AsString().Should().Be("XML parsing failed");
+
+        var exception = Invoking(() => engine.Evaluate("parse()")).Should().Throw<JavaScriptException>().Which;
+        JintException.TryGetClrException(exception, out var clrException).Should().BeTrue();
+        clrException.Should().BeSameAs(original);
+    }
+
+    [Fact]
+    public void HostThrownErrorTakesTheExceptionMessageWhenNoneIsGiven()
+    {
+        var engine = new Engine();
+        var original = new HostFailure("XML parsing failed");
+
+        engine.SetValue("parse", new Action(() =>
+            throw new JavaScriptException(engine.Intrinsics.Error, null, original)));
+
+        var exception = Invoking(() => engine.Evaluate("parse()")).Should().Throw<JavaScriptException>().Which;
+
+        exception.Message.Should().Be("XML parsing failed");
+        exception.Error.AsObject().Get("message").AsString().Should().Be("XML parsing failed");
+    }
+
+    [Fact]
+    public void AnErrorWithNoClrOriginReportsNothing()
+    {
+        var engine = new Engine();
+
+        var exception = Invoking(() => engine.Evaluate("throw new Error('plain')")).Should().Throw<JavaScriptException>().Which;
+
+        JintException.TryGetClrException(exception, out var clrException).Should().BeFalse();
+        clrException.Should().BeNull();
+    }
+
+    [Fact]
+    public void NullAndUnrelatedExceptionsAreAccepted()
+    {
+        JintException.TryGetClrException(null, out _).Should().BeFalse();
+        JintException.TryGetClrException(new InvalidOperationException(), out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void AThrownNonErrorValueReportsNothing()
+    {
+        var engine = new Engine();
+
+        var exception = Invoking(() => engine.Evaluate("throw 'a string'")).Should().Throw<JavaScriptException>().Which;
+
+        exception.Error.Should().BeOfType<JsString>();
+        JintException.TryGetClrException(exception, out _).Should().BeFalse();
+    }
+}

--- a/Jint/JintException.cs
+++ b/Jint/JintException.cs
@@ -107,4 +107,54 @@ public abstract class JintException : Exception
         memberName = null;
         return false;
     }
+
+    /// <summary>
+    /// How far <see cref="TryGetClrException"/> follows <c>cause</c>. The chain is script-controlled, so it can
+    /// be arbitrarily deep or cyclic; the bound is what makes both cases terminate.
+    /// </summary>
+    private const int MaxCauseDepth = 8;
+
+    /// <summary>
+    /// If <paramref name="exception"/> stands in for a CLR exception that was thrown out of host code — a
+    /// delegate, a reflected member, a proxy trap — and turned into a JavaScript error because
+    /// <see cref="Jint.Options.InteropOptions.ExceptionHandler"/> asked for it to be catchable by the script,
+    /// returns that exception, with its message, .NET stack trace and inner chain intact.
+    /// <para>
+    /// The exception is host-only: it is CLR state on the error object rather than a JavaScript property, so a
+    /// running script can neither read it nor strip it. It survives a script catching the error and rethrowing
+    /// the same value, and a script rewrapping with <c>throw new Error(msg, { cause: err })</c>, which this
+    /// method follows. A script that throws an unrelated error instead keeps nothing, which is correct — it
+    /// discarded the original.
+    /// </para>
+    /// <para>
+    /// Note that the error object holds the exception, and so everything the exception's object graph reaches,
+    /// for as long as the script keeps the error reachable.
+    /// </para>
+    /// </summary>
+    public static bool TryGetClrException(Exception? exception, [NotNullWhen(true)] out Exception? clrException)
+    {
+        var value = exception switch
+        {
+            JavaScriptException javaScriptException => javaScriptException.Error,
+            PromiseRejectedException promiseRejectedException => promiseRejectedException.RejectedValue,
+            _ => null
+        };
+
+        for (var depth = 0; depth < MaxCauseDepth && value is ErrorInstance error; depth++)
+        {
+            if (error.ClrException is { } found)
+            {
+                clrException = found;
+                return true;
+            }
+
+            // Own data property only, never Get: following the chain must not run a script getter while the
+            // host is unwinding. An accessor-valued cause simply ends the walk.
+            var cause = error.GetOwnProperty(CommonProperties.Cause);
+            value = cause.IsDataDescriptor() ? cause.Value : null;
+        }
+
+        clrException = null;
+        return false;
+    }
 }

--- a/Jint/Native/Error/ErrorInstance.cs
+++ b/Jint/Native/Error/ErrorInstance.cs
@@ -8,7 +8,7 @@ namespace Jint.Native.Error;
 /// rather than as one field per fact. Errors that came out of CLR interop are a small minority of the errors
 /// an engine builds, so a field per fact would have every error object carrying the ones it never fills.
 /// </summary>
-internal sealed record ClrErrorContext(Type? ResolutionType, string? ResolutionMemberName);
+internal sealed record ClrErrorContext(Type? ResolutionType, string? ResolutionMemberName, Exception? ClrException);
 
 public class ErrorInstance : ObjectInstance
 {
@@ -32,9 +32,20 @@ public class ErrorInstance : ObjectInstance
 
     internal string? ClrResolutionMemberName => _clrContext?.ResolutionMemberName;
 
+    /// <summary>
+    /// When this error stands in for a CLR exception thrown out of host code — a delegate, a reflected member,
+    /// a proxy trap — the exception itself. Read host-side via <see cref="JintException.TryGetClrException"/>.
+    /// </summary>
+    internal Exception? ClrException => _clrContext?.ClrException;
+
     internal void SetClrResolutionInfo(Type clrType, string? memberName)
     {
-        _clrContext = new ClrErrorContext(clrType, memberName);
+        _clrContext = new ClrErrorContext(clrType, memberName, ClrException: null);
+    }
+
+    internal void SetClrException(Exception clrException)
+    {
+        _clrContext = new ClrErrorContext(ResolutionType: null, ResolutionMemberName: null, clrException);
     }
 
     /// <summary>
@@ -42,10 +53,10 @@ public class ErrorInstance : ObjectInstance
     /// </summary>
     internal void InstallErrorCause(JsValue options)
     {
-        if (options is ObjectInstance oi && oi.HasProperty("cause"))
+        if (options is ObjectInstance oi && oi.HasProperty(CommonProperties.Cause))
         {
-            var cause = oi.Get("cause");
-            CreateNonEnumerableDataPropertyOrThrow("cause", cause);
+            var cause = oi.Get(CommonProperties.Cause);
+            CreateNonEnumerableDataPropertyOrThrow(CommonProperties.Cause, cause);
         }
     }
 

--- a/Jint/Runtime/CommonProperties.cs
+++ b/Jint/Runtime/CommonProperties.cs
@@ -8,6 +8,7 @@ internal static class CommonProperties
     internal static readonly JsString Async = JsString.CachedCreate("async");
     internal static readonly JsString Callee = JsString.CachedCreate("callee");
     internal static readonly JsString Caller = JsString.CachedCreate("caller");
+    internal static readonly JsString Cause = JsString.CachedCreate("cause");
     internal static readonly JsString Configurable = JsString.CachedCreate("configurable");
     internal static readonly JsString Constructor = JsString.CachedCreate("constructor");
     internal static readonly JsString Done = JsString.CachedCreate("done");

--- a/Jint/Runtime/JavaScriptException.cs
+++ b/Jint/Runtime/JavaScriptException.cs
@@ -45,6 +45,38 @@ public class JavaScriptException : JintException
         Native.Function.LeafCallGuard.AssertNotInLeafCall("JavaScript error construction");
     }
 
+    /// <summary>
+    /// Creates an exception carrying a JavaScript error that stands in for <paramref name="clrException"/>.
+    /// Throw this from host code — a <see cref="Jint.Runtime.Interop.ClrFunction"/> delegate, a module export —
+    /// to raise an error the script can catch while the originating CLR exception still reaches the host, read
+    /// there with <see cref="JintException.TryGetClrException"/>. A null <paramref name="message"/> takes the
+    /// exception's own message.
+    /// <para>
+    /// Prefer this over projecting the exception into the script
+    /// (<c>new JavaScriptException(JsValue.FromObject(engine, ex))</c>). That value is not an <c>Error</c> — it
+    /// has no <c>stack</c> and fails <c>instanceof Error</c> — and it hands the running script the exception's
+    /// members, including its .NET stack trace and its inner exceptions.
+    /// </para>
+    /// </summary>
+    public JavaScriptException(ErrorConstructor errorConstructor, string? message, Exception clrException)
+        : this(errorConstructor, ResolveClrMessage(message, clrException))
+    {
+        if (Error is ErrorInstance errorInstance)
+        {
+            errorInstance.SetClrException(clrException);
+        }
+    }
+
+    private static string? ResolveClrMessage(string? message, Exception clrException)
+    {
+        if (clrException is null)
+        {
+            Throw.ArgumentNullException(nameof(clrException));
+        }
+
+        return message ?? clrException.Message;
+    }
+
     public JavaScriptException(JsValue error)
         : base(GetMessage(error), new JavaScriptErrorWrapperException(error, GetMessage(error)))
     {

--- a/Jint/Runtime/Throw.cs
+++ b/Jint/Runtime/Throw.cs
@@ -218,6 +218,15 @@ internal static class Throw
     public static void FromClrException(Engine engine, Exception clrException)
     {
         var error = engine.Realm.Intrinsics.Error.Construct(clrException.Message);
+
+        // The error value survives the interpreter's throw-completion reconstruction (the .NET exception
+        // instance does not), so the only place the originating exception can be recorded and still reach
+        // the host is the error object itself. Attached before the decorator runs, so a decorator can read it.
+        if (error is ErrorInstance errorInstance)
+        {
+            errorInstance.SetClrException(clrException);
+        }
+
         engine.Options.Interop.ClrExceptionErrorDecorator?.Invoke(engine, error, clrException);
 
         var jsException = new JavaScriptException(error);


### PR DESCRIPTION
Addresses https://github.com/sebastienros/jint/discussions/2906.

Stacked on #2916 — review that one first.

## The problem

When `Options.Interop.ExceptionHandler` asks for a host exception to be catchable by the script, `Throw.FromClrException` built a JavaScript `Error` from the exception's message and then dropped the exception. A host that later caught the `JavaScriptException` got a message and nothing else — no .NET stack trace, no inner chain, no exception type. The discussion asked for the exception back as an `InnerException`.

## Why not `InnerException`, and why the error object

Two things get in the way of the literal request, and the second one is the interesting one.

`JavaScriptException` already uses its inner-exception slot, for the private `JavaScriptErrorWrapperException` that renders the JavaScript stack in `ToString()`. A CLR exception can only be chained *under* that, never in place of it — and doing so changes `ToString()` for everyone, so it belongs behind a switch. That is the follow-up PR; this one adds nothing to the rendering.

More importantly, the exception instance is the wrong place to record anything. The .NET exception thrown inside the engine is not the one the host catches: the interpreter reduces a throw to its error *value* (`JintStatementList.CreateThrowCompletion` keeps `v.Error` and the location, nothing else), and a fresh `JavaScriptException` is built from that value at the boundary in `Engine.cs` and at some two dozen other reconstruction sites. Anything set on the instance evaporates. The error value is what survives, so that is what carries the exception now — which also means every one of those reconstruction sites gets it for free.

It is recorded as CLR state on the error object, not a JavaScript property, so a running script can neither read it nor strip it, and it does not appear in `Object.getOwnPropertyNames`, `Reflect.ownKeys` or `JSON.stringify`. This follows the existing `ClrResolutionType` precedent exactly, including the `ExposeDetailedResolutionErrors` doc's promise that the CLR type is attached regardless of what the script is allowed to see.

## What it looks like

```c#
catch (JavaScriptException e) when (JintException.TryGetClrException(e, out var clrException))
{
    logger.LogError(clrException, "host call failed");
}
```

It starts from a `JavaScriptException`'s error or a `PromiseRejectedException`'s rejected value, and survives nested frames, a script catching and rethrowing the same value, module evaluation and a rejected promise.

A script that rewraps with `throw new Error(msg, { cause: err })` is followed too — ECMAScript already has a chaining mechanism and there was no reason to invent a second one. The walk reads own data properties only and never `Get`, so following a chain cannot run a script getter while the host is unwinding, and it is depth-bounded, which is also what makes a cyclic `cause` terminate. A script that throws something unrelated instead keeps nothing, which is correct — it discarded the original.

## Raising one from host code

The discussion's author was reaching for `throw new JavaScriptException(JsValue.FromObject(engine, ex))`, and asking whether that was good practice. It isn't: the thrown value is an `ObjectWrapper`, not an `Error` — no `stack`, fails `instanceof Error` — and because the default member comparer ignores first-character casing it hands the script `e.message`, `e.stackTrace`, `e.innerException`, `e.data` and the rest. There was no sanctioned alternative, so this adds one:

```c#
throw new JavaScriptException(engine.Intrinsics.Error, "XML parsing failed", xmlException);
```

## Scope

Nothing here is visible to a script, and nothing about the default bubbling path changes — without `CatchClrExceptions` the original exception still reaches the host untouched, as it always did.

One cost worth stating: the error object holds the exception, and everything the exception's object graph reaches, for as long as the script keeps the error reachable. It is documented on the accessor.

Tests in `Jint.Tests.PublicInterface/HostClrExceptionTests.cs` — the project without `InternalsVisibleTo`, so they prove the surface is actually reachable by a third party.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
