### PR TITLE
Let a host ask for the CLR exception in the inner-exception chain

### DIFF
--- a/Jint.Tests.PublicInterface/HostClrExceptionTests.cs
+++ b/Jint.Tests.PublicInterface/HostClrExceptionTests.cs
@@ -246,6 +246,74 @@ public class HostClrExceptionTests
     }
 
     [Fact]
+    public void ChainingIsOffByDefault()
+    {
+        var engine = CreateEngine();
+
+        var exception = Invoking(() => engine.Evaluate("boom()")).Should().Throw<JavaScriptException>().Which;
+
+        // The inner exception is the private wrapper carrying the JavaScript stack, and nothing beyond it.
+        exception.InnerException.Should().NotBeNull();
+        exception.InnerException!.InnerException.Should().BeNull();
+        exception.ToString().Should().NotContain("HostFailure");
+        exception.ToString().Should().NotContain("--- End of inner exception stack trace ---\r\n   --- End of");
+    }
+
+    [Fact]
+    public void ChainingSurfacesTheExceptionToInnerExceptionWalkers()
+    {
+        var engine = new Engine(options =>
+        {
+            options.CatchClrExceptions();
+            options.ChainClrExceptions();
+        });
+        engine.SetValue("boom", new Action(() => throw new HostFailure("host blew up", new InvalidOperationException("root cause"))));
+
+        var exception = Invoking(() => engine.Evaluate("boom()")).Should().Throw<JavaScriptException>().Which;
+
+        // JavaScriptException -> wrapper (JavaScript stack) -> the host exception -> its own inner chain.
+        var chained = exception.InnerException!.InnerException.Should().BeOfType<HostFailure>().Which;
+        chained.InnerException.Should().BeOfType<InvalidOperationException>();
+
+        var rendered = exception.ToString();
+        rendered.Should().Contain("host blew up");
+        rendered.Should().Contain(nameof(HostFailure));
+        rendered.Should().Contain("root cause");
+    }
+
+    [Fact]
+    public void ChainingLeavesGetBaseExceptionAlone()
+    {
+        var engine = new Engine(options =>
+        {
+            options.CatchClrExceptions();
+            options.ChainClrExceptions();
+        });
+        engine.SetValue("boom", new Action(() => throw new HostFailure("host blew up")));
+
+        var exception = Invoking(() => engine.Evaluate("boom()")).Should().Throw<JavaScriptException>().Which;
+
+        exception.GetBaseException().Should().BeSameAs(exception);
+    }
+
+    [Fact]
+    public void ChainingDoesNotChangeWhatTheScriptSees()
+    {
+        var engine = new Engine(options =>
+        {
+            options.CatchClrExceptions();
+            options.ChainClrExceptions();
+        });
+        engine.SetValue("boom", new Action(() => throw new HostFailure("host blew up")));
+
+        engine.Evaluate("let caught; try { boom(); } catch (e) { caught = e; }");
+
+        engine.Evaluate("caught instanceof Error").AsBoolean().Should().BeTrue();
+        engine.Evaluate("caught.message").AsString().Should().Be("host blew up");
+        engine.Evaluate("JSON.stringify(caught)").AsString().Should().Be("{}");
+    }
+
+    [Fact]
     public void AThrownNonErrorValueReportsNothing()
     {
         var engine = new Engine();

--- a/Jint/Options.Extensions.cs
+++ b/Jint/Options.Extensions.cs
@@ -331,6 +331,18 @@ public static class OptionsExtensions
     }
 
     /// <summary>
+    /// Chains the CLR exception behind a caught interop error into the <see cref="Exception.InnerException"/> of
+    /// the <see cref="JavaScriptException"/> the host catches, so that logging which walks the inner-exception
+    /// chain surfaces it. Off by default, because it puts host .NET stack traces into whatever consumes the
+    /// exception's string form. Only meaningful together with <see cref="CatchClrExceptions(Options)"/>.
+    /// </summary>
+    public static Options ChainClrExceptions(this Options options, bool chain = true)
+    {
+        options.Interop.ChainClrExceptionAsInnerException = chain;
+        return options;
+    }
+
+    /// <summary>
     /// Sets a decorator function that is called after a JavaScript error object is created from a CLR exception.
     /// The decorator can add custom properties, modify the error message, or enrich the error with additional context.
     /// This is only called when <see cref="CatchClrExceptions(Options)"/> is enabled and the exception is caught.

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -459,6 +459,21 @@ public class Options
         public ExceptionHandlerDelegate ExceptionHandler { get; set; } = _defaultExceptionHandler;
 
         /// <summary>
+        /// Whether the CLR exception behind a caught interop error is also chained into the
+        /// <see cref="Exception.InnerException"/> of the <see cref="JavaScriptException"/> the host catches, so
+        /// that logging which walks the inner-exception chain surfaces it. Defaults to false, which leaves
+        /// <see cref="object.ToString"/> on that exception rendering exactly the JavaScript error and stack it
+        /// renders today.
+        /// <para>
+        /// Turning this on puts the host's own .NET stack traces into whatever consumes that string, so treat it
+        /// the way an ASP.NET application treats developer exception details. It changes only how the exception
+        /// presents itself to the host; the originating exception is recorded either way and can always be read
+        /// with <see cref="JintException.TryGetClrException"/>, and a running script sees neither.
+        /// </para>
+        /// </summary>
+        public bool ChainClrExceptionAsInnerException { get; set; }
+
+        /// <summary>
         /// Called after a JavaScript error object is created from a CLR exception (when <see cref="ExceptionHandler"/> returns true).
         /// Allows decorating the error object with additional properties or modifying its state.
         /// The decorator receives the engine instance, the created error object, and the original CLR exception.

--- a/Jint/Runtime/JavaScriptException.cs
+++ b/Jint/Runtime/JavaScriptException.cs
@@ -78,9 +78,25 @@ public class JavaScriptException : JintException
     }
 
     public JavaScriptException(JsValue error)
-        : base(GetMessage(error), new JavaScriptErrorWrapperException(error, GetMessage(error)))
+        : base(GetMessage(error), new JavaScriptErrorWrapperException(error, GetMessage(error), GetChainedClrException(error)))
     {
         _jsErrorException = (JavaScriptErrorWrapperException) InnerException!;
+    }
+
+    /// <summary>
+    /// The CLR exception to hang under the wrapper, or null when the error carries none or the engine was not
+    /// asked to chain it. Read off the error <em>value</em> here rather than carried on the exception instance,
+    /// because this constructor is what every reconstruction of a thrown error passes through — the interpreter
+    /// keeps only the error value across a throw completion, and the exception the host finally catches is built
+    /// here. Reading it here is therefore what makes the chain appear at all of those sites rather than only
+    /// where the error was originally built.
+    /// </summary>
+    private static Exception? GetChainedClrException(JsValue? error)
+    {
+        return error is ErrorInstance { ClrException: { } clrException } errorInstance
+               && errorInstance.Engine.Options.Interop.ChainClrExceptionAsInnerException
+            ? clrException
+            : null;
     }
 
     public string GetJavaScriptErrorString() => _jsErrorException.ToString();
@@ -108,8 +124,8 @@ public class JavaScriptException : JintException
         private string? _callStack;
         private SourceLocation _location;
 
-        internal JavaScriptErrorWrapperException(JsValue error, string? message = null)
-            : base(message ?? GetMessage(error))
+        internal JavaScriptErrorWrapperException(JsValue error, string? message = null, Exception? clrException = null)
+            : base(message ?? GetMessage(error), clrException)
         {
             Error = error;
         }
@@ -190,6 +206,17 @@ public class JavaScriptException : JintException
             {
                 sb.Append(": ");
                 sb.Append(message);
+            }
+
+            // Exception.ToString() renders an inner exception between the message and the frames. This override
+            // replaces that rendering wholesale, so a chained CLR exception has to be spelled out here or it
+            // would be reachable through InnerException and yet invisible in every log line.
+            if (InnerException is { } innerException)
+            {
+                sb.Append(" ---> ");
+                sb.Append(innerException.ToString());
+                sb.Append(Environment.NewLine);
+                sb.Append("   --- End of inner exception stack trace ---");
             }
 
             var stackTrace = StackTrace;


### PR DESCRIPTION
Addresses https://github.com/sebastienros/jint/discussions/2906.

Stacked on #2917 — review that one first.

#2917 records the CLR exception behind a caught interop error and hands it back through `JintException.TryGetClrException`. But a host has to know to call it, and logging pipelines — `ILogger`, Sentry, Application Insights — walk `InnerException` instead. They were walking into the private wrapper carrying the JavaScript stack and stopping there.

`Options.Interop.ChainClrExceptionAsInnerException`, or `options.ChainClrExceptions()`, hangs the originating exception under that wrapper, so `ToString()` and every chain-walking logger render the host's own frames alongside the JavaScript ones.

## Off by default

Deliberately. Turning it on puts host .NET stack traces into whatever consumes the exception's string form, which is a decision an embedder makes the way an ASP.NET application decides about developer exception details — the position taken in #1164 four years ago. With it off, `ToString()` renders exactly what it rendered before, and there is a test pinning that.

## The discussion's own scenario

A `ModuleBuilder.ExportFunction` delegate calling `XmlDocument.LoadXml` on malformed XML, under `CatchClrExceptions`, imported through `engine.Modules.Import`. Off (unchanged from today):

```
Jint.Runtime.JavaScriptException: XML parsing failed.
 ---> Error: XML parsing failed.
    at parse (start:1:42)
    at start:1:42
   --- End of inner exception stack trace ---
   at Jint.Runtime.Throw.JavaScriptException(...)
   ...
```

On:

```
Jint.Runtime.JavaScriptException: XML parsing failed.
 ---> Error: XML parsing failed. ---> System.ApplicationException: XML parsing failed.
 ---> System.Xml.XmlException: 'value' is an unexpected token. The expected token is '='. Line 1, position 12.
   at System.Xml.XmlTextReaderImpl.Throw(Exception e)
   ...
   at System.Xml.XmlDocument.LoadXml(String xml)
   at Program.<>c.<<Main>$>b__0_3(JsValue[] args) in ...\Program.cs:line 22
   --- End of inner exception stack trace ---
   at Jint.Runtime.Modules.ModuleBuilder...<ExportFunction>b__0(JsValue _, JsValue[] args)
   at Jint.Runtime.Interop.ClrFunction.CallSlow(JsValue thisObject, JsValue[] arguments)
   --- End of inner exception stack trace ---
    at parse (start:1:42)
    at start:1:42
   --- End of inner exception stack trace ---
   at Jint.Runtime.Throw.JavaScriptException(...)
   ...
```

## Two implementation notes

The wrapper's `ToString()` override replaces `Exception.ToString()` wholesale, so it now spells out the inner block itself. Without that the exception would be reachable through `InnerException` and yet invisible in every log line.

The lookup lives in the `JavaScriptException(JsValue)` constructor rather than where the error is first built, because that constructor is what every reconstruction of a thrown error passes through — the interpreter keeps only the error value across a throw completion. Reading it there is what makes the chain appear at all of those sites rather than only at the original throw.

`GetBaseException()` still returns the `JavaScriptException` itself (#2210 is unaffected), and nothing the script sees changes: the error is still an ordinary `Error` with an ordinary message and no extra own properties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
