### PR TITLE
Derive the hoisting walk's module flag from the node it walks

### DIFF
--- a/Jint.Tests/Runtime/DeclarationScopeTests.cs
+++ b/Jint.Tests/Runtime/DeclarationScopeTests.cs
@@ -126,4 +126,21 @@ public class DeclarationScopeTests
             .Should().Throw<JavaScriptException>()
             .WithMessage("Unexpected eval or arguments in strict mode*");
     }
+
+    [Fact]
+    public void APreparedModulesCachedScopeAgreesWithTheModuleWalk()
+    {
+        // An Acornima Module reports NodeType.Program, so preparing one builds a CachedHoistingScope through
+        // GetProgramLevelDeclarations as well - two walks over one AST. Nothing reads the cached one for a module
+        // today, because SourceTextModule.InitializeEnvironment re-walks and every reader of the cached scope is
+        // Script-typed. The two answers must still agree: the moment they do not, the obvious cleanup - having the
+        // module consume the scope prepare time already built - silently drops every exported lexical declaration.
+        var program = Engine.PrepareModule("export const a = 1; export class B {} const c = 2;").Program;
+
+        var moduleWalk = HoistingScope.GetModuleLevelDeclarations((Acornima.Ast.Module) program);
+        var programWalk = HoistingScope.GetProgramLevelDeclarations(program, collectVarNames: true);
+
+        moduleWalk._lexicalDeclarations.Should().NotBeNull().And.HaveCount(3);
+        programWalk._lexicalDeclarations.Should().NotBeNull().And.HaveCount(3);
+    }
 }

--- a/Jint.Tests/Runtime/ModuleTests.cs
+++ b/Jint.Tests/Runtime/ModuleTests.cs
@@ -1208,6 +1208,20 @@ export const count = globals.counter;
     }
 
     [Fact]
+    public void ShouldGiveANestedBlockItsOwnBindingAtModuleLevel()
+    {
+        // The sibling test above pins that a module-level `var` is not left in the temporal dead zone, but neither of
+        // its observations separates the fix from the equally wrong outcome where the block's `let a = 1` initializes
+        // the module-level binding: `inner` reads 1 and the later `var a = 2` leaves 2 behind under both. Ordering the
+        // `var` first is what separates them, because the outer binding then already holds a different value while the
+        // block runs - 2 when the block has a binding of its own, 1 when it does not.
+        _engine.Modules.Add("my-module", "var a = 2; { let a = 1; } export const value = a;");
+        var ns = _engine.Modules.Import("my-module");
+
+        ns.Get("value").AsInteger().Should().Be(2);
+    }
+
+    [Fact]
     public void ShouldNotBindAForHeadDeclarationAtModuleLevel()
     {
         // The `let` of a for head is scoped to the loop, so nothing it binds reaches module scope, and a module-level

--- a/Jint/HoistingScope.cs
+++ b/Jint/HoistingScope.cs
@@ -38,7 +38,11 @@ internal sealed class HoistingScope
         bool collectVarNames = false,
         bool collectLexicalNames = false)
     {
-        var treeWalker = new ScriptWalker(collectVarNames, collectLexicalNames);
+        // A module root is a Program too, and AstAnalyzer builds a CachedHoistingScope through here for a
+        // prepared module, so the flag has to be derived from the node rather than defaulted - otherwise the
+        // same AST answers differently depending on which factory was called, and the module's own exported
+        // lexical declarations go missing from the cached scope.
+        var treeWalker = new ScriptWalker(collectVarNames, collectLexicalNames, module: script is AstModule);
         treeWalker.Visit(script, null);
 
         return new HoistingScope(
@@ -52,7 +56,8 @@ internal sealed class HoistingScope
 
     public static HoistingScope GetFunctionLevelDeclarations(bool strict, IFunction node)
     {
-        var treeWalker = new ScriptWalker(collectVarNames: true, collectLexicalNames: true);
+        // A function body is never module scope, whatever encloses it: an export declaration cannot appear inside one.
+        var treeWalker = new ScriptWalker(collectVarNames: true, collectLexicalNames: true, module: false);
         treeWalker.Visit(node.Body, null);
 
         return new HoistingScope(
@@ -187,7 +192,8 @@ internal sealed class HoistingScope
 
         /// <summary>
         /// Whether the walk started at an <see cref="AstModule"/>. Only there can an export declaration wrap a
-        /// module-level lexical declaration, so a script or function body walk stops at the root test.
+        /// module-level lexical declaration, so a script or function body walk stops at the root test. It has no
+        /// default: every entry point must state it, because getting it wrong silently drops declarations.
         /// </summary>
         private readonly bool _module;
 
@@ -199,7 +205,7 @@ internal sealed class HoistingScope
         private int _depth;
         private const int MaxDepth = 256;
 
-        public ScriptWalker(bool collectVarNames, bool collectLexicalNames, bool module = false)
+        public ScriptWalker(bool collectVarNames, bool collectLexicalNames, bool module)
         {
             _collectVarNames = collectVarNames;
             _collectLexicalNames = collectLexicalNames;


### PR DESCRIPTION
Follow-up to #2869, taking the two leftovers from my review of it rather than asking for another round — one of them is a consequence of a change I asked for.

## The flag reached two of three entry points

#2869 gave `ScriptWalker` a `_module` flag so a script or function-body walk short-circuits the module-item test instead of paying an `isinst` per visited node. `GetModuleLevelDeclarations` passes `true`; `GetProgramLevelDeclarations` kept the parameter's `false` default.

A module root is a `Program` too. It reports `NodeType.Program`, so `AstAnalyzer` builds a `CachedHoistingScope` for a *prepared module* through exactly that defaulted call — and the cached scope then omits every export-wrapped lexical declaration. Probing `Engine.PrepareModule("export const a = 1; const b = 2;")`:

| walk | before #2869 | after #2869 | this PR |
| --- | --- | --- | --- |
| `GetModuleLevelDeclarations` | 2 | 2 | 2 |
| `GetProgramLevelDeclarations` | 2 | **1** | 2 |

Nothing consumes it today: `SourceTextModule.InitializeEnvironment` re-walks (`SourceTextModule.cs:295`/`321`), and every reader of the cached scope — `GetHoistingScope`, `GetVarNames`, `GetLexNames` at `Engine.cs:1717`/`1752`/`1774`/`2156` and `ShadowRealm.cs:173` — is `Script`-typed, which a `Module` cannot satisfy. So this is latent rather than a live defect.

What makes it worth fixing now is that the walk's answer became a function of *which factory was called* rather than of the AST it was given, and the trap sits exactly where the obvious next cleanup lands. Having modules consume the scope prepare time already built — instead of re-walking on every `InitializeEnvironment`, which for a `Prepared<Module>` linked into N engines is N+1 walks where 1 would do — would silently drop every `export const`, `export let` and `export class` binding, with the suite still green.

So the flag is derived from the node, and the parameter default is gone: a new entry point now has to state which kind of walk it is rather than inherit an answer. The short-circuit survives — it becomes one type test per walk instead of one per node.

## The block test the pair was missing

The two module-level block tests in #2869 cannot separate the fix from the outcome where the block's `let a = 1` initializes the module-level binding: `inner` reads 1 and the later `var a = 2` leaves 2 behind under *both*. Ordering the `var` ahead of the block does separate them, because the outer binding then already holds a different value while the block runs — 2 when the block has a binding of its own, 1 when it does not. Added as its own fact rather than appended to the sibling, so it fails on its own rather than behind an earlier assertion.

## Verification

Both new tests were mutation-checked:

- Restoring `module: false` in `GetProgramLevelDeclarations` fails `APreparedModulesCachedScopeAgreesWithTheModuleWalk` with `Expected collection to contain 3 item(s), but found 1`.
- Restoring the pre-#2869 predicate `parent is null or AstModule` now fails **four** `ModuleTests` rather than three, the new one among them.

Green on `main` at f50dfeff: `Jint.Tests` 4767 passed / 4 skipped, `Jint.Tests.PublicInterface` 1277 passed / 9 skipped, `Jint.Tests.Test262` 99738 passed / 0 failed / 157 skipped. No behaviour change on any shipped path, so no benchmark run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
