### PR TITLE
Invoke a CLR method inherited through the prototype chain on its owning instance

### DIFF
--- a/Jint.Tests.PublicInterface/HostGlobalPrototypeTests.cs
+++ b/Jint.Tests.PublicInterface/HostGlobalPrototypeTests.cs
@@ -1,0 +1,75 @@
+using Jint.Native;
+using Jint.Native.Object;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// A wrapped CLR object installed as the prototype of <c>globalThis</c> (issue #2925). Only the global
+/// object participates in bare-identifier resolution, so this is where the spec-shaped
+/// GlobalEnvironmentRecord lanes (HasBinding/GetBindingValue walking the prototype chain) meet interop:
+/// members inherited from the host must resolve as free identifiers, through <c>typeof</c>, and as calls.
+/// </summary>
+public class HostGlobalPrototypeTests
+{
+    public sealed class GlobalHost
+    {
+        public string Greeting => "hello";
+        public int Compute(int a, int b) => a + b;
+    }
+
+    [Fact]
+    public void MembersInheritedFromAHostGlobalPrototypeResolveAsBareIdentifiers()
+    {
+        var engine = new Engine();
+        engine.SetValue("host", new GlobalHost());
+        engine.Execute("Object.setPrototypeOf(globalThis, host);");
+
+        engine.Evaluate("Greeting").AsString().Should().Be("hello");
+        engine.Evaluate("typeof Greeting").AsString().Should().Be("string");
+        engine.Evaluate("typeof Compute").AsString().Should().Be("function");
+        engine.Evaluate("Compute(40, 2)").AsNumber().Should().Be(42);
+        engine.Evaluate("globalThis.Compute(40, 2)").AsNumber().Should().Be(42);
+    }
+
+    [Fact]
+    public void HostSidePrototypeAssignmentBehavesTheSame()
+    {
+        var engine = new Engine();
+        var host = new GlobalHost();
+        engine.Global.Prototype = (ObjectInstance) JsValue.FromObject(engine, host);
+
+        engine.Evaluate("typeof Compute").AsString().Should().Be("function");
+        engine.Evaluate("Compute(40, 2)").AsNumber().Should().Be(42);
+    }
+
+    [Fact]
+    public void HostMembersResolveFromDeeperInThePrototypeChain()
+    {
+        var engine = new Engine();
+        engine.SetValue("host", new GlobalHost());
+        // host sits one level below the direct prototype
+        engine.Execute("Object.setPrototypeOf(globalThis, Object.create(host));");
+
+        engine.Evaluate("Greeting").AsString().Should().Be("hello");
+        engine.Evaluate("typeof Compute").AsString().Should().Be("function");
+        engine.Evaluate("Compute(40, 2)").AsNumber().Should().Be(42);
+    }
+
+    [Fact]
+    public void OwnGlobalsAndDeclarationsStillShadowInheritedHostMembers()
+    {
+        var engine = new Engine();
+        engine.SetValue("host", new GlobalHost());
+        engine.Execute("Object.setPrototypeOf(globalThis, host);");
+
+        // a getter-only CLR property surfaces as inherited non-writable data: sloppy assignment
+        // is a silent no-op per OrdinarySet, so no shadowing own property appears
+        engine.Evaluate("globalThis.Greeting = 'own'; Greeting").AsString().Should().Be("hello");
+        engine.Evaluate("globalThis.hasOwnProperty('Greeting')").AsBoolean().Should().BeFalse();
+
+        // defineProperty and var hoisting create own bindings that shadow the host
+        engine.Evaluate("Object.defineProperty(globalThis, 'Greeting', { value: 'own', writable: true, configurable: true }); Greeting").AsString().Should().Be("own");
+        engine.Execute("var Compute = 1;");
+        engine.Evaluate("typeof Compute").AsString().Should().Be("number");
+    }
+}

--- a/Jint.Tests.PublicInterface/HostObjectAsPrototypeTests.cs
+++ b/Jint.Tests.PublicInterface/HostObjectAsPrototypeTests.cs
@@ -1,0 +1,132 @@
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// A wrapped CLR object installed as the <c>[[Prototype]]</c> of a JS object (issue #2925). Inherited
+/// property reads always worked because <c>ReflectionDescriptor</c> ignores the JS receiver and reads
+/// from the instance it was resolved from; inherited <em>method calls</em> now do the same — a receiver
+/// with no CLR identity of its own (a plain JS object, whose <c>ToObject</c> would synthesize a stand-in)
+/// invokes on the owning instance. A receiver that unwraps to a genuinely different CLR object stays an
+/// error, surfaced as a catchable TypeError rather than a raw <c>TargetException</c>.
+/// </summary>
+public class HostObjectAsPrototypeTests
+{
+    public sealed class PrototypeHost
+    {
+        public string Greeting => "hello";
+        public int Compute(int a, int b) => a + b;
+        public static int StaticCompute(int a, int b) => a + b;
+    }
+
+    public sealed class UnrelatedHost
+    {
+        public int Unrelated => 1;
+    }
+
+    private static Engine CreateEngine()
+    {
+        var engine = new Engine();
+        engine.SetValue("host", new PrototypeHost());
+        engine.SetValue("other", new UnrelatedHost());
+        return engine;
+    }
+
+    [Fact]
+    public void InheritedPropertyResolvesThroughThePrototypeChain()
+    {
+        var engine = CreateEngine();
+        engine.Evaluate("var obj = {}; Object.setPrototypeOf(obj, host); obj.Greeting").AsString().Should().Be("hello");
+    }
+
+    [Fact]
+    public void InheritedMethodInvokesOnTheOwningInstance()
+    {
+        var engine = CreateEngine();
+        engine.Execute("var obj = {}; Object.setPrototypeOf(obj, host);");
+        engine.Evaluate("obj.Compute(40, 2)").AsNumber().Should().Be(42);
+
+        // warm repeat: the compiled fast lane engages once the receiver resolves to the owning instance
+        engine.Evaluate("var sum = 0; for (var i = 0; i < 100; i++) { sum += obj.Compute(i, 1); } sum").AsNumber().Should().Be(5050);
+    }
+
+    [Fact]
+    public void InheritedMethodWorksThroughDunderProto()
+    {
+        var engine = CreateEngine();
+        engine.Evaluate("var obj = {}; obj.__proto__ = host; obj.Compute(40, 2)").AsNumber().Should().Be(42);
+    }
+
+    [Fact]
+    public void InheritedMethodWorksThroughObjectCreate()
+    {
+        var engine = CreateEngine();
+        engine.Evaluate("Object.create(host).Compute(40, 2)").AsNumber().Should().Be(42);
+    }
+
+    [Fact]
+    public void InheritedMethodWorksWhenPrototypeIsSetFromTheHostSide()
+    {
+        var engine = new Engine();
+        var host = new PrototypeHost();
+        engine.Execute("var obj = {};");
+        var obj = engine.Evaluate("obj").AsObject();
+        obj.Prototype = (ObjectInstance) JsValue.FromObject(engine, host);
+
+        engine.Evaluate("obj.Greeting").AsString().Should().Be("hello");
+        engine.Evaluate("obj.Compute(40, 2)").AsNumber().Should().Be(42);
+    }
+
+    [Fact]
+    public void ExtractedMethodRetargetedOntoAPlainJsReceiverUsesTheOwningInstance()
+    {
+        var engine = CreateEngine();
+        engine.Evaluate("var f = host.Compute; f.call({}, 40, 2)").AsNumber().Should().Be(42);
+        engine.Evaluate("host.Compute.bind({})(40, 2)").AsNumber().Should().Be(42);
+        engine.Evaluate("Reflect.apply(host.Compute, {}, [40, 2])").AsNumber().Should().Be(42);
+
+        // undefined receiver already fell back to the owning instance and still does
+        engine.Evaluate("var g = host.Compute; g(40, 2)").AsNumber().Should().Be(42);
+    }
+
+    [Fact]
+    public void ForeignClrReceiverSurfacesACatchableTypeError()
+    {
+        var engine = CreateEngine();
+
+        engine.Evaluate("var f = host.Compute; try { f.call(other, 40, 2); 'no error' } catch (e) { e instanceof TypeError }").AsBoolean().Should().BeTrue();
+
+        var ex = Invoking(() => engine.Evaluate("var h = host.Compute; h.call(other, 40, 2)")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Be("Method 'Compute' called on incompatible receiver");
+    }
+
+    [Fact]
+    public void StaticMethodIgnoresTheReceiverEntirely()
+    {
+        var engine = CreateEngine();
+        engine.Evaluate("var s = host.StaticCompute; s.call(other, 40, 2)").AsNumber().Should().Be(42);
+        engine.Evaluate("var obj = Object.create(host); obj.StaticCompute(40, 2)").AsNumber().Should().Be(42);
+    }
+
+    [Fact]
+    public void ProxyReceiverUnwrapsToTheProxiedInstance()
+    {
+        var engine = CreateEngine();
+        engine.Evaluate("new Proxy(host, {}).Compute(40, 2)").AsNumber().Should().Be(42);
+        engine.Evaluate("var f = host.Compute; f.call(new Proxy(host, {}), 40, 2)").AsNumber().Should().Be(42);
+    }
+
+    [Fact]
+    public void RevokedProxyReceiverSurfacesACatchableTypeError()
+    {
+        var engine = CreateEngine();
+        engine.Evaluate("""
+            var f = host.Compute;
+            var r = Proxy.revocable({}, {});
+            r.revoke();
+            try { f.call(r.proxy, 40, 2); 'no error' } catch (e) { e instanceof TypeError }
+            """).AsBoolean().Should().BeTrue();
+    }
+}

--- a/Jint.Tests/Runtime/GlobalPrototypeBindingTests.cs
+++ b/Jint.Tests/Runtime/GlobalPrototypeBindingTests.cs
@@ -1,0 +1,158 @@
+#nullable enable
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Bare-identifier resolution through the global object's prototype chain (issue #2925).
+/// GlobalEnvironmentRecord.HasBinding and GetBindingValue are spec'd in terms of [[HasProperty]] /
+/// [[Get]] on the global (https://tc39.es/ecma262/#sec-global-environment-records-hasbinding-n), so a
+/// name inherited from the global's prototype is a resolvable binding — for reads, <c>typeof</c>,
+/// calls and assignment alike — while everything the spec keeps own-only (var/function declaration
+/// hoisting, delete, restricted-property checks) must keep ignoring inherited names.
+/// </summary>
+public class GlobalPrototypeBindingTests
+{
+    [Fact]
+    public void MembersOnTheGlobalPrototypeResolveAsBareIdentifiers()
+    {
+        var engine = new Engine();
+        engine.Execute("Object.setPrototypeOf(globalThis, { answer: 42, fn: function () { return this === globalThis; } });");
+
+        engine.Evaluate("answer").AsNumber().Should().Be(42);
+        engine.Evaluate("typeof answer").AsString().Should().Be("number");
+        engine.Evaluate("typeof fn").AsString().Should().Be("function");
+        engine.Evaluate("fn()").AsBoolean().Should().BeTrue("a sloppy-mode call through a global binding coerces this to globalThis");
+    }
+
+    [Fact]
+    public void MembersTwoLevelsUpTheChainResolveToo()
+    {
+        var engine = new Engine();
+        engine.Execute("Object.setPrototypeOf(globalThis, Object.create({ deep: 7 }));");
+
+        engine.Evaluate("deep").AsNumber().Should().Be(7);
+        engine.Evaluate("typeof deep").AsString().Should().Be("number");
+        engine.Evaluate("(function () { return deep; })()").AsNumber().Should().Be(7);
+    }
+
+    [Fact]
+    public void ObjectPrototypeMembersAreVisibleAtGlobalScope()
+    {
+        // Object.prototype is the global object's default prototype, so this holds without any setup
+        var engine = new Engine();
+        engine.Evaluate("typeof toString").AsString().Should().Be("function");
+        engine.Evaluate("toString()").AsString().Should().Be("[object Undefined]", "the this value of an environment-record reference is undefined");
+    }
+
+    [Fact]
+    public void GenuinelyAbsentNamesStillBehaveAsBefore()
+    {
+        var engine = new Engine();
+        engine.Evaluate("typeof missingName").AsString().Should().Be("undefined");
+
+        Invoking(() => engine.Evaluate("missingName")).Should().ThrowExactly<JavaScriptException>().WithMessage("missingName is not defined");
+        Invoking(() => engine.Evaluate("'use strict'; missingName")).Should().ThrowExactly<JavaScriptException>().WithMessage("missingName is not defined");
+    }
+
+    [Fact]
+    public void InheritedAccessorGetsTheGlobalAsReceiver()
+    {
+        var engine = new Engine();
+        engine.Execute("Object.setPrototypeOf(globalThis, { get self() { return this; } });");
+
+        engine.Evaluate("self === globalThis").AsBoolean().Should().BeTrue();
+        engine.Evaluate("(function () { return self; })() === globalThis").AsBoolean().Should().BeTrue();
+
+        // and two levels up
+        engine.Execute("Object.setPrototypeOf(globalThis, Object.create({ get deepSelf() { return this; } }));");
+        engine.Evaluate("deepSelf === globalThis").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void OwnAndDeclaredBindingsShadowInheritedOnes()
+    {
+        var engine = new Engine();
+        engine.Execute("Object.setPrototypeOf(globalThis, { x: 1, v: 1, lx: 1 });");
+
+        engine.Evaluate("globalThis.x = 2; x").AsNumber().Should().Be(2);
+
+        // var hoisting is own-only by spec (CreateGlobalVarBinding), so the declaration shadows with undefined
+        engine.Evaluate("(0, eval)('var v; typeof v')").AsString().Should().Be("undefined");
+
+        engine.Evaluate("let lx = 2; lx").AsNumber().Should().Be(2);
+    }
+
+    [Fact]
+    public void DeleteOfAnInheritedNameSucceedsWithoutTouchingThePrototype()
+    {
+        var engine = new Engine();
+        engine.Execute("Object.setPrototypeOf(globalThis, { d: 1 });");
+
+        engine.Evaluate("delete d").AsBoolean().Should().BeTrue("DeleteBinding is own-only by spec");
+        engine.Evaluate("d").AsNumber().Should().Be(1);
+    }
+
+    [Fact]
+    public void AssignmentToAnInheritedNameFollowsOrdinarySetSemantics()
+    {
+        var engine = new Engine();
+
+        // inherited setter runs with the global as receiver, and no own property is created
+        engine.Execute("Object.setPrototypeOf(globalThis, { set s(v) { this.observed = v; }, get s() { return 'live'; } });");
+        engine.Execute("s = 42;");
+        engine.Evaluate("observed").AsNumber().Should().Be(42);
+        engine.Evaluate("globalThis.hasOwnProperty('s')").AsBoolean().Should().BeFalse();
+        engine.Evaluate("s").AsString().Should().Be("live");
+
+        // strict assignment to an inherited writable data property is not a ReferenceError; it shadows
+        engine.Execute("Object.setPrototypeOf(globalThis, { w: 1 });");
+        engine.Execute("(function () { 'use strict'; w = 5; })();");
+        engine.Evaluate("globalThis.hasOwnProperty('w') && w === 5").AsBoolean().Should().BeTrue();
+
+        // inherited non-writable data: sloppy is a silent no-op, strict is a TypeError
+        engine.Execute("var proto = Object.defineProperty({}, 'nw', { value: 1, writable: false }); Object.setPrototypeOf(globalThis, proto);");
+        engine.Execute("nw = 9;");
+        engine.Evaluate("nw").AsNumber().Should().Be(1);
+        engine.Evaluate("globalThis.hasOwnProperty('nw')").AsBoolean().Should().BeFalse();
+        engine.Evaluate("(function () { 'use strict'; try { nw = 9; return 'no error'; } catch (e) { return e instanceof TypeError ? 'TypeError' : 'other'; } })()").AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void ProtoAssignmentAtGlobalScopeStillRunsTheInheritedSetter()
+    {
+        // __proto__ lives on Object.prototype, i.e. on the global's prototype chain: the bare
+        // assignment must keep routing through the inherited setter and actually swap the prototype
+        var engine = new Engine();
+        engine.Execute("__proto__ = { marker: 123 };");
+        engine.Evaluate("Object.getPrototypeOf(globalThis).marker").AsNumber().Should().Be(123);
+        engine.Evaluate("marker").AsNumber().Should().Be(123);
+    }
+
+    [Fact]
+    public void NoCacheServesStalePrototypeValues()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            Object.setPrototypeOf(globalThis, { cs: 1 });
+            var r1 = 0;
+            for (var i = 0; i < 100; i++) { r1 = cs; }
+            Object.getPrototypeOf(globalThis).cs = 2;
+            var r2 = cs;
+            delete Object.getPrototypeOf(globalThis).cs;
+            var t = typeof cs;
+            globalThis.cs = 3;
+            [r1, r2, t, cs].join(',');
+            """).AsString();
+
+        result.Should().Be("1,2,undefined,3");
+    }
+
+    [Fact]
+    public void DirectEvalResolvesInheritedNames()
+    {
+        var engine = new Engine();
+        engine.Execute("Object.setPrototypeOf(globalThis, { ev: 9 });");
+        engine.Evaluate("eval('ev')").AsNumber().Should().Be(9);
+    }
+}

--- a/Jint.Tests/Runtime/InteropCompiledInvokerTests.cs
+++ b/Jint.Tests/Runtime/InteropCompiledInvokerTests.cs
@@ -449,17 +449,20 @@ public class InteropCompiledInvokerTests
     }
 
     [Fact]
-    public void WrongTypedThisSurfacesReflectionPathException()
+    public void WrongTypedThisSurfacesCatchableTypeError()
     {
-        // an extracted method invoked with a foreign receiver must decline the fast lane so the
-        // host observes the same TargetException the reflection path always produced (not the
-        // compiled cast's InvalidCastException) — ExceptionHandler predicates key on the type
+        // an extracted method invoked with a foreign CLR receiver must decline the fast lane so the
+        // reflection path can classify the receiver mismatch — surfaced as a JavaScript TypeError,
+        // catchable by script, never a raw TargetException (or the compiled cast's
+        // InvalidCastException); Interop.ExceptionHandler is not consulted for this binding failure
         var engine = new Engine(options => options.Interop.ExceptionHandler = _ => false);
         engine.SetValue("host", new Host());
         engine.SetValue("other", new OtherHost());
 
-        var ex = Invoking(() => engine.Evaluate("var f = host.TimesTwo; f.call(other, 21)")).Should().Throw<Exception>().Which;
-        ex.Should().BeAssignableTo<System.Reflection.TargetException>();
+        var ex = Invoking(() => engine.Evaluate("var f = host.TimesTwo; f.call(other, 21)")).Should().ThrowExactly<Jint.Runtime.JavaScriptException>().Which;
+        ex.Message.Should().Be("Method 'TimesTwo' called on incompatible receiver");
+
+        engine.Evaluate("var f2 = host.TimesTwo; try { f2.call(other, 21); 'no error' } catch (e) { e instanceof TypeError }").AsBoolean().Should().BeTrue();
 
         // a correctly-typed extracted call still uses the fast lane and works
         engine.Evaluate("var g = host.TimesTwo; g.call(host, 21)").AsNumber().Should().Be(42);
@@ -848,15 +851,15 @@ public class InteropCompiledInvokerTests
     }
 
     [Fact]
-    public void ExtractedInstanceMethodWithWrongReceiverKeepsSurfacingTargetException()
+    public void ExtractedInstanceMethodWithWrongReceiverSurfacesCatchableTypeError()
     {
-        // same guarantee as WrongTypedThisSurfacesReflectionPathException, but for a method whose
-        // receiver check now reads the cached DeclaringType instead of the reflection property
+        // same guarantee as WrongTypedThisSurfacesCatchableTypeError, but for a method whose
+        // receiver check reads the cached DeclaringType instead of the reflection property
         var engine = new Engine(options => options.Interop.ExceptionHandler = _ => false);
         engine.SetValue("host", new Host());
         engine.SetValue("other", new OtherHost());
 
-        var ex = Invoking(() => engine.Evaluate("var f = host.IdentityInt; f.call(other, 3)")).Should().Throw<Exception>().Which;
-        ex.Should().BeAssignableTo<System.Reflection.TargetException>();
+        var ex = Invoking(() => engine.Evaluate("var f = host.IdentityInt; f.call(other, 3)")).Should().ThrowExactly<Jint.Runtime.JavaScriptException>().Which;
+        ex.Message.Should().Be("Method 'IdentityInt' called on incompatible receiver");
     }
 }

--- a/Jint.Tests/Runtime/ProxyTests.cs
+++ b/Jint.Tests/Runtime/ProxyTests.cs
@@ -671,8 +671,8 @@ public class ProxyTests
                  const name = p.Name;  // works
                  const s = p.GetX();   // works because method does NOT exist on clr object
 
-                 p.SayHello();          // throws System.Reflection.TargetException: 'Object does not match target type.'
-                 const t = p.Add(5,3);  // throws System.Reflection.TargetException: 'Object does not match target type.'
+                 p.SayHello();          // once threw a raw TargetException; the proxy receiver unwraps to the CLR instance
+                 const t = p.Add(5,3);  // ditto
              """);
 
     }

--- a/Jint/Native/Global/GlobalObject.cs
+++ b/Jint/Native/Global/GlobalObject.cs
@@ -728,7 +728,7 @@ uriError:
 
     // optimized versions with string parameter and without virtual dispatch for global environment usage
 
-    internal bool HasProperty(Key property)
+    internal bool HasOwnProperty(Key property)
     {
         return GetOwnProperty(property) != PropertyDescriptor.Undefined;
     }
@@ -808,6 +808,10 @@ uriError:
 
         if (existingDescriptor is null)
         {
+            if (_prototype is not null && TrySetThroughPrototype(property, value, out var setResult))
+            {
+                return setResult;
+            }
             if (strict)
             {
                 Throw.ReferenceNameError(_realm, property.Name);
@@ -849,6 +853,26 @@ uriError:
 
         setter.Call(this, value);
 
+        return true;
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-object-environment-records-setmutablebinding-n-v-s — a name
+    /// that exists on the global's prototype chain assigns through [[Set]] with the global as
+    /// receiver (running inherited setters, respecting inherited non-writable data) instead of
+    /// blindly creating an own property.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private bool TrySetThroughPrototype(Key property, JsValue value, out bool result)
+    {
+        var jsName = JsString.Create(property.Name);
+        if (!_prototype!.HasProperty(jsName))
+        {
+            result = false;
+            return false;
+        }
+
+        result = Set(jsName, value, this);
         return true;
     }
 }

--- a/Jint/Runtime/Environments/GlobalEnvironment.cs
+++ b/Jint/Runtime/Environments/GlobalEnvironment.cs
@@ -43,6 +43,10 @@ internal sealed class GlobalEnvironment : Environment
 
     public ObjectInstance GlobalThisValue => _global;
 
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-global-environment-records-hasbinding-n — routes through
+    /// [[HasProperty]] on the global, so names inherited from its prototype chain bind too.
+    /// </summary>
     internal override bool HasBinding(Key name)
     {
         if (_declarativeRecord.HasBinding(name))
@@ -52,12 +56,13 @@ internal sealed class GlobalEnvironment : Environment
 
         if (_globalObject is not null)
         {
-            return _globalObject.HasProperty(name);
+            return _globalObject.HasOwnProperty(name) || HasBindingOnGlobalPrototype(JsString.Create(name.Name));
         }
 
         return _global.HasProperty(new JsString(name));
     }
 
+    /// <inheritdoc cref="HasBinding(Key)" />
     internal override bool HasBinding(BindingName name)
     {
         if (_declarativeRecord.HasBinding(name))
@@ -67,10 +72,37 @@ internal sealed class GlobalEnvironment : Environment
 
         if (_globalObject is not null)
         {
-            return _globalObject.HasProperty(name.Key);
+            return _globalObject.HasOwnProperty(name.Key) || HasBindingOnGlobalPrototype(name.Value);
         }
 
         return _global.HasProperty(name.Value);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private bool HasBindingOnGlobalPrototype(JsValue name)
+    {
+        return _global._prototype?.HasProperty(name) == true;
+    }
+
+    /// <summary>
+    /// The AnnexB block-function copy check re-derives "GlobalDeclarationInstantiation created a
+    /// global var binding for F" (https://tc39.es/ecma262/#sec-web-compat-globaldeclarationinstantiation),
+    /// which is an own-property fact; <see cref="HasBinding(Key)"/> is spec-shaped and also sees
+    /// names inherited from the global's prototype, which must not trigger the copy.
+    /// </summary>
+    internal bool HasOwnBinding(Key name)
+    {
+        if (_declarativeRecord.HasBinding(name))
+        {
+            return true;
+        }
+
+        if (_globalObject is not null)
+        {
+            return _globalObject.HasOwnProperty(name);
+        }
+
+        return _global.HasOwnProperty(JsString.Create(name.Name));
     }
 
     internal override bool TryGetBinding(BindingName name, bool strict, [NotNullWhen(true)] out JsValue? value)
@@ -106,15 +138,15 @@ internal sealed class GlobalEnvironment : Environment
 
         if (_global._prototype is not null)
         {
-            return TryGetBindingForGlobalParent(name, out value);
+            return TryGetFromGlobalPrototype(name.Value, out value);
         }
 
         return false;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private bool TryGetBindingForGlobalParent(
-        BindingName name,
+    private bool TryGetFromGlobalPrototype(
+        JsValue name,
         [NotNullWhen(true)] out JsValue? value)
     {
         // TryGetOwnPropertyValue's base body is exactly what this used to spell out — GetOwnProperty,
@@ -122,7 +154,24 @@ internal sealed class GlobalEnvironment : Environment
         // in-box prototype the two are the same call. Asking through the hook additionally lets a host
         // object installed as the global's prototype answer from its own state without building a
         // descriptor it would only throw away.
-        return _global._prototype!.TryGetOwnPropertyValue(name.Value, _global, out value);
+        var prototype = _global._prototype!;
+        if (prototype.TryGetOwnPropertyValue(name, _global, out var found))
+        {
+            value = found;
+            return true;
+        }
+
+        // deeper levels are colder: spec-shaped [[HasProperty]] + [[Get]] with the global as
+        // receiver, so a Proxy or exotic object below the direct prototype sees its real traps
+        var parent = prototype.GetPrototypeOf();
+        if (parent is not null && parent.HasProperty(name))
+        {
+            value = parent.Get(name, _global);
+            return true;
+        }
+
+        value = null;
+        return false;
     }
 
     /// <summary>
@@ -234,6 +283,11 @@ internal sealed class GlobalEnvironment : Environment
         _global.Set(jsString, value);
     }
 
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-object-environment-records-getbindingvalue-n-s — resolves
+    /// through the global's whole prototype chain; only a name absent everywhere is a
+    /// ReferenceError in strict mode.
+    /// </summary>
     internal override JsValue GetBindingValue(Key name, bool strict)
     {
         if (_declarativeRecord.HasBinding(name))
@@ -241,7 +295,6 @@ internal sealed class GlobalEnvironment : Environment
             return _declarativeRecord.GetBindingValue(name, strict);
         }
 
-        // see ObjectEnvironmentRecord.GetBindingValue
         PropertyDescriptor desc;
         if (_globalObject is not null)
         {
@@ -253,12 +306,28 @@ internal sealed class GlobalEnvironment : Environment
             desc = _global.GetOwnProperty(name.Name);
         }
 
-        if (strict && desc == PropertyDescriptor.Undefined)
+        if (desc == PropertyDescriptor.Undefined)
+        {
+            return GetBindingValueUnlikely(name, strict);
+        }
+
+        return ObjectInstance.UnwrapJsValue(desc, _global);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private JsValue GetBindingValueUnlikely(Key name, bool strict)
+    {
+        if (_global._prototype is not null && TryGetFromGlobalPrototype(JsString.Create(name.Name), out var value))
+        {
+            return value;
+        }
+
+        if (strict)
         {
             Throw.ReferenceNameError(_engine.Realm, name);
         }
 
-        return ObjectInstance.UnwrapJsValue(desc, _global);
+        return Undefined;
     }
 
     internal override bool DeleteBinding(Key name)
@@ -321,7 +390,7 @@ internal sealed class GlobalEnvironment : Environment
     private bool HasShapedGlobalOwnProperty(Key name)
     {
         return _globalObject is not null
-            ? _globalObject.HasProperty(name)
+            ? _globalObject.HasOwnProperty(name)
             : _global.HasOwnProperty(name.Name);
     }
 

--- a/Jint/Runtime/Interop/MethodInfoFunction.cs
+++ b/Jint/Runtime/Interop/MethodInfoFunction.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using Jint.Extensions;
 using Jint.Native;
 using Jint.Native.Function;
+using Jint.Native.Object;
 
 #pragma warning disable IL2067
 #pragma warning disable IL2072
@@ -154,7 +155,7 @@ internal sealed class MethodInfoFunction : Function
     protected internal override JsValue Call(JsValue thisObject, JsCallArguments jsArguments)
     {
         var converter = Engine.TypeConverter;
-        var thisObj = thisObject.ToObject() ?? _target;
+        var thisObj = ResolveThisObject(thisObject);
         var state = new MethodResolverState(_engine, thisObject, jsArguments);
 
         if (_methods.Length == 1)
@@ -180,7 +181,7 @@ internal sealed class MethodInfoFunction : Function
                 // when a custom ITypeConverter is installed because the slow path consults it for some
                 // exact-type conversions (e.g. bool) that the compiled lane performs directly. A
                 // wrong-typed receiver (extracted method invoked via .call on a foreign this) also
-                // declines so the reflection path surfaces the same TargetException it always did.
+                // declines so the reflection path can surface the receiver mismatch as a TypeError.
                 var converterTypeFilter = _engine._objectConverterTypeFilter;
                 if ((converterTypeFilter is null
                         || method.ReturnValueIsInvisibleToObjectConverters
@@ -240,6 +241,53 @@ internal sealed class MethodInfoFunction : Function
             : "No public methods with the specified arguments were found.";
         Throw.InteropResolutionError(_engine.Realm, message, _targetType, _name, jsArguments, _methods);
         return null;
+    }
+
+    /// <summary>
+    /// Derives the CLR instance the reflected method is invoked on. A receiver wrapping a real CLR
+    /// object (<see cref="ObjectWrapper"/>, any <see cref="IObjectWrapper"/>, a Proxy over one)
+    /// unwraps to it; a plain JS receiver — e.g. an object whose prototype chain contains the
+    /// wrapper — has no CLR identity of its own (ToObject would synthesize a stand-in such as an
+    /// ExpandoObject), so the method operates on the instance it was resolved from, exactly as
+    /// <see cref="Descriptors.Specialized.ReflectionDescriptor"/> ignores the JS receiver for property reads.
+    /// </summary>
+    private object? ResolveThisObject(JsValue thisObject)
+    {
+        // hot path: a member call on the wrapper itself
+        if (thisObject is ObjectWrapper wrapper)
+        {
+            return wrapper.Target;
+        }
+
+        var receiver = thisObject;
+        while (receiver is JsProxy proxy)
+        {
+            if (proxy.IsRevoked)
+            {
+                Throw.TypeError(_engine.Realm, $"Cannot perform '{_name}' on a proxy that has been revoked");
+            }
+
+            receiver = proxy._target;
+        }
+
+        if (receiver is ObjectInstance objectInstance)
+        {
+            if (objectInstance is IObjectWrapper hostWrapper)
+            {
+                return hostWrapper.Target;
+            }
+
+            return _target ?? objectInstance.ToObject();
+        }
+
+        // undefined/null unwrap to null and fall back to the owning instance; primitives keep converting
+        return receiver.ToObject() ?? _target;
+    }
+
+    [DoesNotReturn]
+    private void ThrowIncompatibleReceiver()
+    {
+        Throw.TypeError(_engine.Realm, $"Method '{_name}' called on incompatible receiver");
     }
 
     private static JsCallArguments ArgumentProvider(MethodDescriptor method, in MethodResolverState state)
@@ -387,9 +435,23 @@ internal sealed class MethodInfoFunction : Function
             _engine.CheckAmortizedConstraintsAtHostBoundary();
             return true;
         }
+        catch (TargetException)
+        {
+            // receiver mismatch: netfx MethodBase.Invoke and the generic-definition path above throw
+            // it unwrapped; surface a catchable TypeError instead of a raw CLR crash
+            _engine.CheckAmortizedConstraintsAtHostBoundary();
+            ThrowIncompatibleReceiver();
+            return false;
+        }
         catch (TargetInvocationException exception)
         {
             _engine.CheckAmortizedConstraintsAtHostBoundary();
+            if (exception.InnerException is TargetException)
+            {
+                // net8+: MethodDescriptor.Invoke normalizes the sibling TargetException into the
+                // TargetInvocationException shape; still a receiver mismatch, not the method throwing
+                ThrowIncompatibleReceiver();
+            }
             Throw.MeaningfulException(_engine, exception);
             return false;
         }

--- a/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
@@ -397,6 +397,9 @@ internal sealed class JintIdentifierExpression : JintExpression
     /// may then use the descriptor directly while the versions hold; writers must re-check
     /// <see cref="Runtime.Descriptors.PropertyDescriptor.Writable"/> through the cached
     /// reference because defineProperty flips flags in place without bumping the versions.
+    /// Re-probing the global's own storage here is also what keeps a name resolved from the
+    /// global's prototype chain out of the cache: a prototype mutation bumps no global version,
+    /// so caching such a descriptor would serve stale values.
     /// </summary>
     internal void TryRememberGlobalBinding(GlobalEnvironment globalEnv)
     {

--- a/Jint/Runtime/Interpreter/JintStatementList.cs
+++ b/Jint/Runtime/Interpreter/JintStatementList.cs
@@ -356,7 +356,7 @@ internal sealed class JintStatementList
                         else if (varEnv is GlobalEnvironment globalEnv)
                         {
                             // Global/eval scope: copy if not a lexical declaration
-                            shouldCopy = !globalEnv.HasLexicalDeclaration(fn) && globalEnv.HasBinding(fn);
+                            shouldCopy = !globalEnv.HasLexicalDeclaration(fn) && globalEnv.HasOwnBinding(fn);
                         }
                         else
                         {

--- a/Jint/Runtime/Interpreter/Statements/JintIfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintIfStatement.cs
@@ -138,7 +138,7 @@ internal sealed class JintIfStatement : JintStatement<IfStatement>
             }
             else if (varEnv is GlobalEnvironment globalEnv)
             {
-                shouldCopy = !globalEnv.HasLexicalDeclaration(fn) && globalEnv.HasBinding(fn);
+                shouldCopy = !globalEnv.HasLexicalDeclaration(fn) && globalEnv.HasOwnBinding(fn);
             }
             else
             {


### PR DESCRIPTION
Closes #2925.

A wrapped CLR object installed as the `[[Prototype]]` of a JS object resolved inherited **property** reads but not inherited **method** calls, and the failure escaped as a raw `System.Reflection.TargetException` that bypassed `JavaScriptException`/JS `try-catch` entirely. Separately, on `globalThis` a member inherited from the global's prototype read fine as a bare identifier but never resolved through `typeof`, a call, or assignment.

## Interop: receiver derivation and error surfacing

`MethodInfoFunction.Call` derived the reflection target as `thisObject.ToObject() ?? _target`. A plain JS receiver — e.g. an object whose prototype chain contains the wrapper — synthesizes a stand-in (`ExpandoObject`), so the owning instance stored on the function never won and `MethodInfo.Invoke` crashed. Now:

- A receiver wrapping a real CLR object (`ObjectWrapper`, any `IObjectWrapper`, a Proxy chain over one) unwraps to it, as before.
- A plain JS receiver has no CLR identity of its own, so the method invokes on the instance it was resolved from — exactly as `ReflectionDescriptor` already ignores the JS receiver for inherited property reads. Inherited calls also reach the compiled fast lane, since the receiver-type gate now passes.
- A receiver that unwraps to a genuinely **different** CLR object surfaces as a catchable JS `TypeError` (`Method 'X' called on incompatible receiver`) on every target framework. Previously netfx and the generic-method path let the raw `TargetException` escape even with `ExceptionHandler = _ => true`; net8+ rethrew it raw after unwrapping.

## Global environment: spec-shaped prototype-chain resolution

`GlobalEnvironment.HasBinding` and `GetBindingValue` were own-only where the spec routes them through `[[HasProperty]]`/`[[Get]]` on the global ([HasBinding](https://tc39.es/ecma262/#sec-global-environment-records-hasbinding-n), [GetBindingValue](https://tc39.es/ecma262/#sec-object-environment-records-getbindingvalue-n-s)), and `TryGetBinding` looked only one prototype level deep — which is why a plain read worked while `typeof`/calls did not. All three lanes now resolve through the whole chain (own-hit fast paths unchanged; the miss tails moved behind `NoInlining` helpers). Consequences handled in the same change:

- The AnnexB block-function copy check re-derives an own-property fact, so it now asks a new own-only `HasOwnBinding` and does not flip on inherited names.
- The write lane: `GlobalObject.SetFromMutableBinding`'s own-miss branch now routes a name that exists on the chain through `[[Set]]` with the global as receiver (inherited setters run, inherited non-writable data is respected, `__proto__ = x` at sloppy global scope keeps working). Everything the spec keeps own-only (var/function hoisting checks, `delete`, restricted-property checks) deliberately stays own-only.
- The global-identifier inline cache cannot serve prototype-sourced values: it re-probes the global's own storage before caching, now documented as the invariant plus a staleness regression test.
- Bare `toString()` / `typeof toString` at global scope now behave like other engines, since `Object.prototype` is the global's default prototype.

## Deliberate behavior changes

- Two tests pinning the raw `TargetException` for `f.call(otherWrapper)` now pin the catchable `TypeError` instead. The `TypeError` is thrown without consulting `Interop.ExceptionHandler` — it is a binding failure of the call, not the host method throwing.
- An extracted instance method retargeted onto a convertible JS receiver (`f.call([])`, `f.call({})`) now binds the owning instance instead of the synthesized copy.
- Names on the global's prototype chain are no longer unresolvable references (a spec-conforming narrowing also visible to `IReferenceResolver`).

## Verification

- `Jint.Tests` 4839/4758 (net10/net472), `Jint.Tests.PublicInterface` 1334/1333, `Jint.Tests.CommonScripts` 28/28 — all green, plus both `JINT_HOST_CONTRACT_VERIFICATION=1` legs.
- Full test262 at the pinned SHA: 99738 passed, 0 failed, 157 skipped (all pre-existing exclusions).
- New tests: `HostObjectAsPrototypeTests` + `HostGlobalPrototypeTests` (public-interface, cover all three issue repros on net10 and net472) and `GlobalPrototypeBindingTests` (language semantics: depth-2 resolution, accessor receiver, shadowing, delete, write-lane semantics, cache staleness, direct eval).

## Benchmarks

Paired A/B runs (default job, serial, idle machine): baseline = `main` @ 4f7297d43, PR = this branch. Every class ran at least two full pairs; any row exceeding +1% in the same direction twice was re-measured in isolation. **Allocations are byte-identical on every row of every class.** No structural regression found; details per class below.

### InteropMethodDispatchBenchmark (3 pairs)

| Row | main p1 | PR p1 | Δp1 | Δp2 | isolated |
|---|---:|---:|---:|---:|---:|
| SingleOverload_NoArg | 1.841 us | 1.882 us | +2.2% | −0.9% | — |
| SingleOverload_OneIntArg | 2.240 us | 2.242 us | +0.1% | +1.7% | — |
| SingleOverload_OneDoubleArg | 2.373 us | 2.408 us | +1.5% | +1.7% | **−1.0%** |
| SingleOverload_OneStringArg | 2.257 us | 2.322 us | +2.9% | +0.7% | — |
| SingleOverload_TwoArgs_IntString | 2.521 us | 2.570 us | +1.9% | −0.8% | — |
| Overloaded_MixedArgs | 7.920 us | 7.881 us | −0.5% | −2.7% | — |
| ParamsMethod_Spread | 3.109 us | 3.117 us | +0.3% | −0.3% | 2.7 KB alloc both sides |

The one row consistent across both full pairs (OneDoubleArg) flips to −1.0% when run in isolation — cross-row JIT layout, not work. The wrapper-receiver hot path is unchanged by construction (`thisObject is ObjectWrapper` type test replacing a virtual `ToObject()` call).

### GlobalAccessBenchmarks (2 pairs)

| Row | main p1 | PR p1 | Δp1 | Δp2 |
|---|---:|---:|---:|---:|
| GlobalVarLoop | 31.495 ms | 31.724 ms | +0.7% | +3.3% |
| LocalVarLoop *(control, no globals)* | 25.651 ms | 27.424 ms | +6.9% | −8.8% |
| GlobalUpdateLoop | 51.621 ms | 51.817 ms | +0.4% | +0.8% |
| NestedGlobalReadLoop | 24.955 ms | 25.849 ms | +3.6% | −11.3% |
| NestedGlobalWriteLoop | 7.977 ms | 7.036 ms | −11.8% | −1.1% |

The untouched control row swings ±9% between pairs — that is this machine's cross-process layout floor for these tight loops. The row most directly through the changed own-hit lanes (GlobalUpdateLoop) is the most stable of all: +0.4% / +0.8%.

### SunSpider (2 full pairs + isolation)

| Script | main p1 | PR p1 | Δp1 | Δp2 |
|---|---:|---:|---:|---:|
| 3d-cube | 30.62 ms | 30.15 ms | -1.5% | -0.4% |
| 3d-morph | 63.98 ms | 63.70 ms | -0.4% | -1.4% |
| 3d-raytrace | 62.57 ms | 62.67 ms | +0.2% | -1.5% |
| access-binary-trees | 40.33 ms | 40.63 ms | +0.7% | +4.9% |
| access-fannkuch | 156.08 ms | 156.74 ms | +0.4% | +0.9% |
| access-nbody | 64.00 ms | 61.46 ms | -4.0% | +2.9% |
| access-nsieve | 42.37 ms | 42.13 ms | -0.6% | -0.4% |
| bitop(...)-byte [24] | 57.25 ms | 53.82 ms | -6.0% | -4.9% |
| bitops-bits-in-byte | 43.66 ms | 44.15 ms | +1.1% | -4.8% |
| bitops-bitwise-and | 56.44 ms | 57.07 ms | +1.1% | -0.2% |
| bitops-nsieve-bits | 73.05 ms | 75.43 ms | +3.3% | -6.2% |
| contr(...)rsive [21] | 47.69 ms | 48.41 ms | +1.5% | -0.9% |
| crypto-aes | 41.40 ms | 42.07 ms | +1.6% | -1.7% |
| crypto-md5 | 41.94 ms | 41.42 ms | -1.2% | -1.4% |
| crypto-sha1 | 40.46 ms | 39.44 ms | -2.5% | -0.1% |
| date-format-tofte | 35.20 ms | 35.96 ms | +2.2% | -2.4% |
| date-format-xparb | 22.23 ms | 22.28 ms | +0.2% | -1.8% |
| math-cordic | 84.95 ms | 86.20 ms | +1.5% | -0.3% |
| math-partial-sums | 39.72 ms | 41.05 ms | +3.3% | -2.5% |
| math-spectral-norm | 37.94 ms | 38.76 ms | +2.2% | +3.3% |
| regexp-dna | 11.12 ms | 11.12 ms | +0.0% | +0.5% |
| string-base64 | 24.95 ms | 26.16 ms | +4.8% | +2.6% |
| string-fasta | 57.93 ms | 54.72 ms | -5.5% | -1.2% |
| string-tagcloud | 29.92 ms | 30.13 ms | +0.7% | +1.2% |
| string-unpack-code | 36.53 ms | 36.98 ms | +1.2% | -4.1% |
| strin(...)input [21] | 20.67 ms | 19.87 ms | -3.9% | +0.0% |

Three rows repeated >+1% across both pairs (access-binary-trees, math-spectral-norm, string-base64); all three flip negative in an isolated pair (−0.8%, −2.0%, −3.6%) with tight error bars — layout context, not added work. Consistent *improvements* on untouched scripts (bitops-3bit-bits-in-byte −6.0/−4.9%) confirm the same drift in the lucky direction.

### Dromaeo (2 full pairs + mode analysis)

| Row (Modern, Prepared) | main p1 | PR p1 | Δp1 | Δp2 |
|---|---:|---:|---:|---:|
| CoreEvalFalseFalse | 1.771 ms | 1.715 ms | -3.2% | +2.2% |
| CoreEvalFalseTrue | 1.730 ms | 1.798 ms | +3.9% | +12.1% |
| CoreEvalTrueFalse | 1.642 ms | 1.668 ms | +1.6% | +1.8% |
| CoreEvalTrueTrue | 1.659 ms | 1.642 ms | -1.0% | -0.5% |
| CubeFalseFalse | 5.019 ms | 4.927 ms | -1.8% | +0.2% |
| CubeFalseTrue | 4.518 ms | 4.589 ms | +1.6% | -0.8% |
| CubeTrueFalse | 4.934 ms | 4.918 ms | -0.3% | +0.7% |
| CubeTrueTrue | 4.597 ms | 4.536 ms | -1.3% | +0.9% |
| ObjectArrayFalseFalse | 10.005 ms | 10.553 ms | +5.5% | -2.1% |
| ObjectArrayFalseTrue | 9.995 ms | 10.429 ms | +4.3% | +1.5% |
| ObjectArrayTrueFalse | 14.205 ms | 13.483 ms | -5.1% | +5.3% |
| ObjectArrayTrueTrue | 14.098 ms | 13.975 ms | -0.9% | +1.9% |

The CoreEval (Modern=False, Prepared=True) row is **process-modal**: over 7 processes per side, baseline sampled 1.686–1.730 ms while the PR sampled a fast mode {1.681, 1.698, 1.702} — at or below the baseline floor — and a slow mode {1.783–1.938} in 4/7 draws. With `DOTNET_TieredPGO=0` the baseline itself scatters 2.777–3.217 ms (14%) and the PR lands inside that spread, fastest sample of all. The changed code executes ~16 times per 1.7 ms iteration (global-env hits during `ret = str`), orders of magnitude below the mode delta; the mode lives in the untouched eval-parse/string-concat loop and its per-process selection is a layout/PGO lottery both binaries play. Floor unchanged, allocations identical.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
