### PR TITLE
Stop caching hoisting scopes for modules and block state for function bodies

### DIFF
--- a/Jint.Tests/Runtime/DeclarationScopeTests.cs
+++ b/Jint.Tests/Runtime/DeclarationScopeTests.cs
@@ -130,12 +130,14 @@ public class DeclarationScopeTests
     [Fact]
     public void APreparedModulesCachedScopeAgreesWithTheModuleWalk()
     {
-        // An Acornima Module reports NodeType.Program, so preparing one builds a CachedHoistingScope through
-        // GetProgramLevelDeclarations as well - two walks over one AST. Nothing reads the cached one for a module
-        // today, because SourceTextModule.InitializeEnvironment re-walks and every reader of the cached scope is
-        // Script-typed. The two answers must still agree: the moment they do not, the obvious cleanup - having the
-        // module consume the scope prepare time already built - silently drops every exported lexical declaration.
+        // An Acornima Module reports NodeType.Program, but preparing one no longer caches a scope on the root at
+        // all: every reader of a cached scope is Script-typed and SourceTextModule.InitializeEnvironment re-walks,
+        // so the walk prepare time used to do was thrown away. The two walks must still agree: the moment they do
+        // not, the obvious cleanup - having the module consume a scope built at prepare time - silently drops every
+        // exported lexical declaration.
         var program = Engine.PrepareModule("export const a = 1; export class B {} const c = 2;").Program;
+
+        program.UserData.Should().BeNull();
 
         var moduleWalk = HoistingScope.GetModuleLevelDeclarations((Acornima.Ast.Module) program);
         var programWalk = HoistingScope.GetProgramLevelDeclarations(program, collectVarNames: true);

--- a/Jint.Tests/Runtime/ScriptModulePreparationTests.ScriptPreparation.cs
+++ b/Jint.Tests/Runtime/ScriptModulePreparationTests.ScriptPreparation.cs
@@ -69,6 +69,50 @@ public class ScriptModulePreparationTests
     }
 
     [Fact]
+    public void ScriptPreparationCachesTheHoistingScopeOfAScriptRootOnly()
+    {
+        // A script root's cached scope is what GlobalDeclarationInstantiation, direct eval and ShadowRealm read.
+        Engine.PrepareScript("var a = 1; const b = 2;").Program.UserData.Should().BeOfType<CachedHoistingScope>();
+
+        // A module root reports the same node type but has no reader: SourceTextModule walks its own
+        // declarations, so caching a scope for it was a whole-AST walk nothing consumed.
+        Engine.PrepareModule("export const a = 1; const b = 2;").Program.UserData.Should().BeNull();
+    }
+
+    [Fact]
+    public void ScriptPreparationBuildsNoBlockStateForFunctionBodies()
+    {
+        // A function body is a BlockStatement by node type, but the only reader of a block's UserData takes a
+        // NestedBlockStatement - the statement list wraps a function body without consulting UserData at all.
+        // Retained function source text rides the function node, never its body, so the body stays clean.
+        var preparedScript = Engine.PrepareScript("function f() { let a = 1; return a; } f();");
+        var declaration = preparedScript.Program.Body[0].Should().BeOfType<FunctionDeclaration>().Which;
+        var body = declaration.Body.Should().BeOfType<FunctionBody>().Which;
+
+        body.UserData.Should().BeNull();
+
+        // and executing the body does not lazily fill it in either - the cost is gone, not deferred
+        new Engine().Evaluate(preparedScript).AsNumber().Should().Be(1);
+        body.UserData.Should().BeNull();
+    }
+
+    [Fact]
+    public void ScriptPreparationBuildsBlockStateForNestedBlocks()
+    {
+        var preparedScript = Engine.PrepareScript("{ let outer = 1; } function f() { { let inner = 2; return inner; } } f();");
+
+        var topLevelBlock = preparedScript.Program.Body[0].Should().BeOfType<NestedBlockStatement>().Which;
+        topLevelBlock.UserData.Should().BeOfType<JintBlockStatement.BlockState>();
+
+        var declaration = preparedScript.Program.Body[1].Should().BeOfType<FunctionDeclaration>().Which;
+        var body = declaration.Body.Should().BeOfType<FunctionBody>().Which;
+        var blockInFunction = body.Body[0].Should().BeOfType<NestedBlockStatement>().Which;
+        blockInFunction.UserData.Should().BeOfType<JintBlockStatement.BlockState>();
+
+        new Engine().Evaluate(preparedScript).AsNumber().Should().Be(2);
+    }
+
+    [Fact]
     public void CompiledRegexShouldProduceSameResultAsNonCompiled()
     {
         const string Script = """JSON.stringify(/(.*?)a(?!(a+)b\2c)\2(.*)/.exec("baaabaac"))""";

--- a/Jint/Engine.Ast.cs
+++ b/Jint/Engine.Ast.cs
@@ -135,7 +135,13 @@ public partial class Engine
                     break;
 
                 case NodeType.Program:
-                    node.UserData = new CachedHoistingScope((Program) node);
+                    // A module root is a Program by node type, but nothing reads a module's cached scope —
+                    // every reader of it is Script-typed and SourceTextModule walks its own declarations —
+                    // so caching one for a module was a second full walk of the AST that never got consumed.
+                    if (node is Script script)
+                    {
+                        node.UserData = new CachedHoistingScope(script);
+                    }
                     break;
 
                 case NodeType.UnaryExpression:
@@ -183,7 +189,14 @@ public partial class Engine
                     break;
 
                 case NodeType.BlockStatement:
-                    node.UserData = JintBlockStatement.BuildState((BlockStatement) node);
+                    // A function body is a BlockStatement by node type, but nothing reads a function body's
+                    // BlockState — the statement list wraps it without consulting UserData, and the only
+                    // reader, JintBlockStatement, takes a NestedBlockStatement — so building one per function
+                    // bought nothing. A class static block reports NodeType.StaticBlock and never lands here.
+                    if (node is NestedBlockStatement nestedBlockStatement)
+                    {
+                        node.UserData = JintBlockStatement.BuildState(nestedBlockStatement);
+                    }
                     break;
             }
         }
@@ -192,11 +205,13 @@ public partial class Engine
 
 internal sealed class CachedHoistingScope
 {
-    public CachedHoistingScope(Program program)
+    // Script, not Program: a module's cached scope has no reader, so the analyzer only builds
+    // one for a script root, and the parameter type is what keeps it that way.
+    public CachedHoistingScope(Script script)
     {
         // Collecting during the walk makes the walker produce the bound-name list the
         // separate GatherVarNames re-walk used to build; null means the program has no vars.
-        Scope = HoistingScope.GetProgramLevelDeclarations(program, collectVarNames: true);
+        Scope = HoistingScope.GetProgramLevelDeclarations(script, collectVarNames: true);
         VarNames = Scope._varNames ?? [];
 
         LexNames = DeclarationCacheBuilder.Build(Scope._lexicalDeclarations);

--- a/Jint/HoistingScope.cs
+++ b/Jint/HoistingScope.cs
@@ -38,10 +38,9 @@ internal sealed class HoistingScope
         bool collectVarNames = false,
         bool collectLexicalNames = false)
     {
-        // A module root is a Program too, and AstAnalyzer builds a CachedHoistingScope through here for a
-        // prepared module, so the flag has to be derived from the node rather than defaulted - otherwise the
-        // same AST answers differently depending on which factory was called, and the module's own exported
-        // lexical declarations go missing from the cached scope.
+        // A module root is a Program too, so the flag has to be derived from the node rather than defaulted -
+        // otherwise the same AST answers differently depending on which factory was called, and the module's
+        // own exported lexical declarations go missing from the scope this returns.
         var treeWalker = new ScriptWalker(collectVarNames, collectLexicalNames, module: script is AstModule);
         treeWalker.Visit(script, null);
 


### PR DESCRIPTION
Preparing a script or module builds per-node state for the interpreter ahead of time, and two
of the things it builds have no reader at all:

- **A function body's block state.** A function body is a `BlockStatement` by node type, so the
  analyzer built a `BlockState` for every function — but the only reader of a block's `UserData`
  is `JintBlockStatement`, whose constructor takes a `NestedBlockStatement`, and the statement
  list wraps a function body without consulting `UserData`. Every function in every prepared
  script paid a declaration-cache walk for nothing. (A class `static` block reports
  `NodeType.StaticBlock` and was never involved.)
- **A module's cached hoisting scope.** A module root is a `Program` by node type, so preparing
  a module cached a hoisting scope on it — but every reader of that cache is `Script`-typed
  (global declaration instantiation, direct eval, ShadowRealm), and `SourceTextModule` walks
  its own declarations. Preparing a module did a second full walk of the AST that nothing
  consumed. `DeclarationScopeTests` already documented this; now the analyzer just doesn't do it.

Both cases are now gated on the node types the readers actually take, and
`CachedHoistingScope`'s constructor takes `Script` rather than `Program`, so the invariant is
compiler-enforced rather than convention-enforced.

New tests pin the negative space (a prepared module's root and a prepared function body carry
no annotation — including after execution, so the cost is gone, not deferred) and the positive
space (nested blocks inside and outside functions still carry their state; a script root still
carries its scope). I verified the pins are not vacuous: with the `Engine.Ast.cs` change
reverted, all three new negative-space assertions fail.

Test262: 99,738 passed, 0 failed, exclusion set untouched.

## Measurements

`ModuleGraphEmbeddingBenchmark` (#2926), default job, serial on an idle machine:

| Row | main | this PR | Time | Allocated |
| --- | ---: | ---: | ---: | ---: |
| PrepareModuleGraph | 118.88 μs / 140.41 KB | 109.41 μs / 135.75 KB | **−8.0%** | **−3.3%** |
| ColdImport_SourcePerEngine | 255.21 μs / 350.11 KB | 256.29 μs / 350.11 KB | +0.4% | = |
| ColdImport_PreparedShared | 127.86 μs / 218.74 KB | 129.00 μs / 218.74 KB | +0.9% | = |
| ColdImport_PreparedPerOp | 272.50 μs / 362.09 KB | 278.35 μs / 357.44 KB | +2.1%¹ | **−1.3%** |
| PoolFill_PreparedShared | 1,040.84 μs / 1,749.94 KB | 1,043.71 μs / 1,749.94 KB | +0.3% | = |
| WarmRedraw_ReusedEngine | 47.19 μs / 47.68 KB | 48.72 μs / 47.68 KB | +3.2%¹ | = |

¹ Neither survived a confirming pair (−0.3% and −1.9% respectively on the re-run); the
allocation columns, which are byte-stable run to run, carry the real signal.

Preparing this ten-module graph got 8% cheaper and allocates 3.3% less; on a script-heavy
corpus (`PreparedAnomalyBenchmarks`) the shared-prepared row improved ~6% in both measurement
pairs. Every other suite in the standing gate — SunSpider (26 rows), Dromaeo (24 rows),
`PreparedScriptBenchmark`, `ColdConstructorBenchmark`, `FreshEngineGlobalsBenchmark`,
`EvalExecutionBenchmarks` — shows allocations flat or improved on every row across two full
A/B sessions.

Full disclosure on time columns: across the sessions a handful of rows on paths this change
cannot reach (they execute no preparation, and their allocations are byte-identical) showed
>1% time deltas. An A/A control — the same baseline binary on both sides — reproduced swings
up to +14.6% on the Dromaeo `ObjectRegExp`/`ObjectString` family and +6.9% on the
regex-compilation row, i.e. those rows' cross-process noise floor is well above the deltas
observed. The one residual: `FreshEngineGlobalsBenchmark`'s `Delegate` row repeated +1.5-3.0%
across three pairs while being A/A-tight (+0.4%); with byte-identical allocations on an
unreachable path, the plausible cause is binary code-layout shift, disclosed here rather than
hidden in an average.
