### PR TITLE
Upgrade Meziantou.Analyzer to 3.0.141

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="Flurl.Http.Signed" Version="4.0.2" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.5" />
     <PackageVersion Include="ICU4N" Version="60.1.0-alpha.440" />
-    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.138" />
+    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.141" />
     <PackageVersion Include="Microsoft.ClearScript.V8" Version="7.5.1" />
     <PackageVersion Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.5.1" />
     <PackageVersion Include="Microsoft.ClearScript.V8.Native.linux-x64" Version="7.5.1" />

--- a/Jint/Native/Date/MimeKit.cs
+++ b/Jint/Native/Date/MimeKit.cs
@@ -525,9 +525,10 @@ internal static class DateUtils
                 int endIndex = tokens[i].Start + tokens[i].Length;
                 int index = tokens[i].Start;
 
-#pragma warning disable CA1806
-                ParseUtils.TryParseInt32(text, ref index, endIndex, out value);
-#pragma warning restore CA1806
+                // The result is discarded deliberately: the token is numeric (every byte is a digit) and
+                // one or two bytes long, so the parse can neither run out of digits nor overflow. Even
+                // if it could, it would leave value at 0, which falls through every range check below.
+                _ = ParseUtils.TryParseInt32(text, ref index, endIndex, out value);
 
                 if (month == null && value > 0 && value <= 12)
                 {


### PR DESCRIPTION
Supersedes #2930, which fails to build on every leg.

3.0.140 [generalized MA0060's do-not-ignore-return-value detection](https://github.com/meziantou/Meziantou.Analyzer/pull/1259), and it now reaches the one deliberately ignored `ParseUtils.TryParseInt32` call in the RFC 822 date parser:

```
Jint/Native/Date/MimeKit.cs(529,17): error MA0060: The return value of 'TryParseInt32' should be used
```

That call site already carried a `#pragma warning disable CA1806` for exactly the same reason, so rather than add a second rule id to the pragma, both are replaced with an explicit discard — which satisfies either rule and puts the intent in the code instead of in a suppression. The accompanying comment records why the result carries no information there: the token is numeric (`IsNumeric` means every byte is `'0'`–`'9'`) and one or two bytes long, so the parse can neither run out of digits nor overflow, and a failure would leave `value` at `0`, which falls through all three range checks that follow.

The remaining 3.0.139/141 changes are a dropped obsolete Roslyn version and a transitive Meziantou.Polyfill bump; neither produces a diagnostic here.

While in the file: nothing else in the repository is behind. Every other entry in `Directory.Packages.props` is already at its latest stable version (`dotnet list package --outdated` is clean apart from the two deliberately pinned prereleases, ICU4N and Okojo), and the workflows are on `checkout@v7` / `setup-dotnet@v6` / `cache@v6`.

## Verification

- `dotnet build -c Release` — clean, 0 warnings across all five target frameworks.
- `dotnet test -c Release Jint.Tests` — 4839 passed (net10.0), 4758 passed (net472).
- `JINT_HOST_CONTRACT_VERIFICATION=1 dotnet test -c Release Jint.Tests` — same, 0 failures.
- `dotnet test -c Release Jint.Tests.PublicInterface` — 1334 passed (net10.0), 1333 passed (net472).

The discard compiles to the same IL as the ignored call, so there is no behavioural change to measure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
