### PR TITLE
Upgrade the test262 harness tool to 1.1.1

### DIFF
--- a/Jint.Tests.Test262/.config/dotnet-tools.json
+++ b/Jint.Tests.Test262/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "test262harness.console": {
-      "version": "1.1.0",
+      "version": "1.1.1",
       "commands": [
         "test262"
       ]


### PR DESCRIPTION
`Directory.Packages.props` carries `Test262Harness` 1.1.1, but `Jint.Tests.Test262/.config/dotnet-tools.json` still pins the console tool that *generates* the suite at 1.1.0. The drift is not an oversight anyone could have caught by reading a dependabot PR: the nuget updater is configured with `directory: "/"`, so it never sees a tool manifest nested under a project directory, and this pin has simply never been offered an update.

Nothing about the generated suite changes. I regenerated under both versions and diffed the output — the emitted test code is identical apart from the banner recording the generator version, template hash and command line:

```
-//   Generated using the Test262Harness v1.1.1.0
+//   Generated using the Test262Harness v1.1.0.0
```

`v1.1.0..v1.1.1` in the harness repository is entirely that project's own build and CI plumbing (the NUKE→Fallout migration, trusted publishing, and dependency bumps); no generator or template logic is involved.

One incidental difference worth recording: 1.1.1 emits LF line terminators where 1.1.0 emitted CRLF on Windows, a consequence of the template file's own endings changing. It has no effect here — `Generated/` is gitignored and the compiler is indifferent.

Note that the bump does not force a regeneration on an existing checkout: `GenerateTestSuite` keys `_NeedsRegeneration` on the settings-file hash and on `Generated/` being absent, not on the tool version. CI regenerates because it starts from a clean tree; a local checkout keeps its 1.1.0 output until the settings file next changes, which is harmless given the output is identical.

## Verification

- `dotnet test -c Release Jint.Tests.Test262` after deleting `Generated/` so the suite is regenerated by 1.1.1 — **99738 passed, 0 failed, 157 skipped**.

If the drift is worth preventing rather than just correcting, the follow-up would be to let dependabot see the manifest — either by adding `/Jint.Tests.Test262` to the nuget `directories`, or by moving the manifest to the repository root, where `dotnet tool restore` would still resolve it by walking up from the project directory. I left both out of this PR since they are layout changes rather than an upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
