### PR TITLE
Expose the module-location rule a host has to match

### DIFF
--- a/Jint.Tests.PublicInterface/ModuleLoaderTests.cs
+++ b/Jint.Tests.PublicInterface/ModuleLoaderTests.cs
@@ -277,4 +277,157 @@ public class ModuleLoaderTests
 
         ns.Get("answer").AsNumber().Should().Be(42);
     }
+
+    /// <summary>
+    /// A <c>file:</c> uri is the one case where the module's name is not the loader's key: it is reduced to
+    /// <see cref="Uri.LocalPath"/>, which is exactly the rule a host preparing modules itself has to match.
+    /// </summary>
+    [Fact]
+    public void LocationOfNamesTheBuiltModuleForAnAbsoluteFileUri()
+    {
+        var uri = new Uri("file:///lib/a.js");
+        var resolved = new ResolvedSpecifier(new ModuleRequest("a.js", []), uri.ToString(), uri, SpecifierType.RelativeOrAbsolute);
+
+        var location = ModuleFactory.LocationOf(resolved);
+
+        location.Should().Be(uri.LocalPath).And.NotBe(resolved.Key);
+        LocationOfShouldNameTheBuiltModule(resolved);
+    }
+
+    /// <summary>
+    /// Every other scheme leaves the loader's key alone, uri or no uri - the uri is consulted for nothing but
+    /// the "is this a file?" question.
+    /// </summary>
+    [Fact]
+    public void LocationOfNamesTheBuiltModuleByItsKeyForANonFileUri()
+    {
+        var uri = new Uri("app:///x.js");
+        var resolved = new ResolvedSpecifier(new ModuleRequest("x.js", []), uri.ToString(), uri, SpecifierType.RelativeOrAbsolute);
+
+        ModuleFactory.LocationOf(resolved).Should().Be(resolved.Key);
+        LocationOfShouldNameTheBuiltModule(resolved);
+
+        // The key is taken verbatim rather than derived from the uri, so a loader whose key is not the uri's
+        // own string still names the module by the key.
+        var divergent = new ResolvedSpecifier(new ModuleRequest("x.js", []), "app:the-x-module", uri, SpecifierType.Bare);
+
+        ModuleFactory.LocationOf(divergent).Should().Be("app:the-x-module");
+        LocationOfShouldNameTheBuiltModule(divergent);
+    }
+
+    [Fact]
+    public void LocationOfNamesTheBuiltModuleByItsKeyWhenTheLoaderReturnsNoUri()
+    {
+        var resolved = new ResolvedSpecifier(new ModuleRequest("____main____", []), "____main____", null, SpecifierType.Bare);
+
+        ModuleFactory.LocationOf(resolved).Should().Be("____main____");
+        LocationOfShouldNameTheBuiltModule(resolved);
+    }
+
+    private static void LocationOfShouldNameTheBuiltModule(ResolvedSpecifier resolved)
+    {
+        var engine = new Engine();
+        var module = ModuleFactory.BuildSourceTextModule(engine, resolved, "export const value = 1;");
+
+        module.Location.Should().Be(ModuleFactory.LocationOf(resolved));
+    }
+
+    /// <summary>
+    /// The use case <see cref="ModuleFactory.LocationOf"/> is public for: a loader that prepares each module
+    /// once and shares the prepared AST across engines has to name the module before any module exists, and
+    /// the name has to be the one the engine would have derived - it is what the module's own relative
+    /// imports are resolved against.
+    /// </summary>
+    [Fact]
+    public void PreparedModulesNamedByLocationOfResolveTheirRelativeImports()
+    {
+        var loader = new SharedPreparedModuleLoader(new Dictionary<string, string>
+        {
+            ["file:///modules/main.js"] = "import { value } from './lib/dep.js'; export const result = value + '!';",
+            ["file:///modules/lib/dep.js"] = "export const value = 'shared';",
+        });
+
+        foreach (var _ in Enumerable.Range(0, 3))
+        {
+            var engine = new Engine(options => options.EnableModules(loader));
+
+            var ns = engine.Modules.Import("file:///modules/main.js");
+
+            ns.Get("result").AsString().Should().Be("shared!");
+        }
+
+        // One prepared AST per module, reused by all three engines.
+        loader.PreparedLocations.Should().HaveCount(2);
+
+        // The nested import was resolved against the very name PrepareModule was handed, and for a file: uri
+        // that name is the reduced path rather than the url the source is keyed under.
+        var mainLocation = loader.PreparedLocations[0];
+        mainLocation.Should().NotBe("file:///modules/main.js");
+        loader.Resolutions.Should().Contain(r => r.Specifier == "./lib/dep.js" && r.Referencing == mainLocation);
+    }
+
+    /// <summary>
+    /// Prepares every module once and shares the prepared <see cref="AstModule"/> across engines, naming each
+    /// one with <see cref="ModuleFactory.LocationOf"/> so it carries the identity the string-loading overloads
+    /// of <see cref="ModuleFactory"/> would have produced. The same string is the cache key, so a module and
+    /// its cache entry cannot drift apart.
+    /// </summary>
+    private sealed class SharedPreparedModuleLoader : IModuleLoader
+    {
+        private static readonly Uri Root = new("file:///modules/");
+
+        private readonly IReadOnlyDictionary<string, string> _sources;
+        private readonly Dictionary<string, Prepared<AstModule>> _prepared = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, Uri> _urisByLocation = new(StringComparer.Ordinal);
+        private readonly List<(string? Referencing, string Specifier)> _resolutions = new();
+        private readonly List<string> _preparedLocations = new();
+
+        public SharedPreparedModuleLoader(IReadOnlyDictionary<string, string> sources)
+        {
+            _sources = sources;
+        }
+
+        public IReadOnlyList<(string? Referencing, string Specifier)> Resolutions => _resolutions;
+
+        public IReadOnlyList<string> PreparedLocations => _preparedLocations;
+
+        public ResolvedSpecifier Resolve(string? referencingModuleLocation, ModuleRequest moduleRequest)
+        {
+            _resolutions.Add((referencingModuleLocation, moduleRequest.Specifier));
+
+            Uri uri;
+            if (Uri.TryCreate(moduleRequest.Specifier, UriKind.Absolute, out var absolute))
+            {
+                uri = absolute;
+            }
+            else
+            {
+                // A module loaded from a file: uri knows itself by a path with no scheme left to resolve a
+                // relative import against, so the loader reconstructs the origin - here from the uri it
+                // handed out for that location.
+                var origin = referencingModuleLocation is not null && _urisByLocation.TryGetValue(referencingModuleLocation, out var known)
+                    ? known
+                    : Root;
+                uri = new Uri(origin, moduleRequest.Specifier);
+            }
+
+            var resolved = new ResolvedSpecifier(moduleRequest, uri.ToString(), uri, SpecifierType.RelativeOrAbsolute);
+            _urisByLocation[ModuleFactory.LocationOf(resolved)] = uri;
+            return resolved;
+        }
+
+        public Module LoadModule(Engine engine, ResolvedSpecifier resolved)
+        {
+            // Both the cache key and the prepared module's name are the location the engine derives itself.
+            var location = ModuleFactory.LocationOf(resolved);
+            if (!_prepared.TryGetValue(location, out var prepared))
+            {
+                prepared = Engine.PrepareModule(_sources[resolved.Key], location);
+                _prepared[location] = prepared;
+                _preparedLocations.Add(location);
+            }
+
+            return ModuleFactory.BuildSourceTextModule(engine, prepared);
+        }
+    }
 }

--- a/Jint/Runtime/Modules/ModuleFactory.cs
+++ b/Jint/Runtime/Modules/ModuleFactory.cs
@@ -9,14 +9,28 @@ namespace Jint.Runtime.Modules;
 public static class ModuleFactory
 {
     /// <summary>
-    /// The name a module knows itself by: <see cref="ResolvedSpecifier.Key"/>, the string the loader
-    /// itself chose, with one exception for a <c>file:</c> uri. Reducing a url to <see cref="Uri.LocalPath"/>
-    /// drops its scheme, host and query, so a module that knows itself as <c>/lib/a.js</c> has no origin
-    /// left for a relative import of its own to resolve against - and this name is exactly what comes
-    /// back as <c>referencingModuleLocation</c> on the next <see cref="ModuleLoader.Resolve"/> - nor one
-    /// to report through <c>import.meta.url</c>.
+    /// The name a module resolved to <paramref name="resolved"/> knows itself by: <see cref="ResolvedSpecifier.Key"/>,
+    /// the string the loader itself chose, with one exception for a <c>file:</c> uri. This is the
+    /// <see cref="Module.Location"/> every <c>Build*Module</c> overload taking a <see cref="ResolvedSpecifier"/>
+    /// gives the module it builds, and it is never null.
     /// </summary>
+    /// <param name="resolved">The specifier a <see cref="ModuleLoader"/> resolved a module request to.</param>
+    /// <returns>The location the engine names a module built from <paramref name="resolved"/> by.</returns>
     /// <remarks>
+    /// <para>
+    /// A host that shares one prepared module across pooled engines has to name the module before any module
+    /// exists, and the name has to be exactly the one the engine would have derived - it becomes
+    /// <see cref="Module.Location"/> and therefore the <c>referencingModuleLocation</c> echoed back into
+    /// <see cref="ModuleLoader.Resolve"/> for the module's own imports, so a mismatch breaks relative-import
+    /// resolution with no error to point at. Pass this as the <c>source</c> argument of
+    /// <see cref="Engine.PrepareModule"/> and a shared prepared AST carries the same identity the
+    /// string-loading overloads of this factory would have produced.
+    /// </para>
+    /// <para>
+    /// Reducing a url to <see cref="Uri.LocalPath"/> drops its scheme, host and query, so a module that knows
+    /// itself as <c>/lib/a.js</c> has no origin left for a relative import of its own to resolve against, nor
+    /// one to report through <c>import.meta.url</c>. Hence the key, except for <c>file:</c>.
+    /// </para>
     /// <para>
     /// The key is deliberately preferred over <see cref="Uri.AbsoluteUri"/>, which is not the url the host
     /// gave us: it strips a default port, lowercases the host, collapses dot segments and percent-encodes,
@@ -38,8 +52,15 @@ public static class ModuleFactory
     /// <see cref="InvalidOperationException"/> on one. It now builds a module named by its key, which is
     /// the same shape a loader returning no uri at all has always produced.
     /// </para>
+    /// <para>
+    /// This rule governs the loader path only. A module registered through <c>Engine.Modules.Add</c> and a
+    /// <see cref="ModuleBuilder"/> is named by its resolved <see cref="ResolvedSpecifier.Key"/> alone, with
+    /// no <c>file:</c> reduction - deliberately, since such a module has no loaded url behind it - and that
+    /// difference is documented behavior of the registration path rather than something this method smooths
+    /// over.
+    /// </para>
     /// </remarks>
-    private static string LocationOf(ResolvedSpecifier resolved)
+    public static string LocationOf(ResolvedSpecifier resolved)
     {
         var uri = resolved.Uri;
         if (uri is not null && uri.IsAbsoluteUri && uri.IsFile)


### PR DESCRIPTION
`ModuleFactory.LocationOf` computes the name a module knows itself by — the string that becomes
`Module.Location` and therefore the `referencingModuleLocation` the engine echoes back into
`IModuleLoader.Resolve` when that module's own relative imports are resolved. Every
`Build*Module` overload taking a `ResolvedSpecifier` calls it. It was private.

That is fine until a host prepares a module once and shares it across a pool of engines. Then it
must name the module *before* any module exists, because `Engine.PrepareModule(code, source)`
takes the name up front and `ModuleFactory.BuildSourceTextModule(engine, in prepared)` uses what
the prepared AST already carries. If that name differs from what the engine would have derived,
relative imports inside the module resolve against the wrong base and fail with nothing to point
at. So the host reimplements the rule — `resolved.Uri?.LocalPath ?? resolved.Key`, or some
approximation of it — and the approximation is load-bearing.

The rule is also not obvious, and it has moved: preferring `Key` over `Uri.AbsoluteUri` is
deliberate (AbsoluteUri strips default ports, lowercases hosts, collapses dot segments and
percent-encodes, and the .NET Framework and .NET Core parsers disagree on parts of that), and the
`file:`-only `LocalPath` reduction is a backwards-compatibility carve-out rather than a principle.
A host cannot infer either from the outside.

This makes the method public with its implementation untouched, and moves the rationale that was
sitting in a comment into the XML doc, including the prepared-module use case and one honest
caveat: a module registered through `Engine.Modules.Add` and a `ModuleBuilder` is named by its
resolved `Key` alone with no `file:` reduction — deliberately, since such a module has no loaded
url behind it — and that difference is documented behaviour of the registration path, not
something this method smooths over.

## Testing

Four facts in `Jint.Tests.PublicInterface/ModuleLoaderTests.cs`. Three pin `LocationOf` against
the location of a module actually built from the same `ResolvedSpecifier`, for an absolute `file:`
uri (asserting the result differs from `Key`, so the reduction demonstrably fires), a non-file
absolute uri whose `Key` is deliberately not derivable from its uri, and a specifier with no uri
at all. The fourth is the shape this exists for: a caching loader that keys prepared modules by
`LocationOf` and passes the same string to `PrepareModule`, shared by three engines — asserting
the script result, that exactly two ASTs were prepared across the three engines, and that the
nested import's `referencingModuleLocation` equals the name `PrepareModule` was handed.

Full suites green on both target frameworks including the `JINT_HOST_CONTRACT_VERIFICATION=1`
leg; test262 unchanged with the exclusion set untouched.

`CachedModuleLoader` in that same file was left alone on purpose: it names modules by their url
rather than by this rule, which is what makes its own relative resolution work, so converting it
would have changed what its existing tests cover.

## Measurements

The change is a visibility modifier and documentation; no executed path differs. The module-graph
benchmark was run regardless and every row's `Allocated` is byte-identical to main. Its time
columns moved up to +7.7% on rows nothing here can reach — that suite's rows have a cross-run
envelope of 3.9–7.7% (p95 |pairwise delta| over 30 consecutive runs of one unmodified binary), so
single-pair time deltas of that size say nothing; the byte-stable allocation columns are the
channel that would have shown a real change, and they are flat.
