### PR TITLE
Record what a delta from the module-graph benchmark is worth

### DIFF
--- a/Jint.Benchmark/ModuleGraphEmbeddingBenchmark.cs
+++ b/Jint.Benchmark/ModuleGraphEmbeddingBenchmark.cs
@@ -112,6 +112,35 @@ namespace Jint.Benchmark;
 /// lifecycle, not about how the cost scales with graph size, and a slope in module count is already visible by
 /// dividing <see cref="PrepareModuleGraph"/> by ten.
 /// </para>
+///
+/// <para><b>How to read a delta from this class: allocation is the signal, time needs medians.</b></para>
+/// <para>
+/// Every row here builds engines and walks a module graph, so its time is far noisier between processes than
+/// BenchmarkDotNet's own <c>StdDev</c> column suggests — that column measures one warm process, which these
+/// rows are not. Thirty consecutive default-job runs of one unmodified binary, serial on an idle machine,
+/// gave this envelope, where <i>p95 pairwise</i> is the 95th percentile of the absolute difference between
+/// two runs of <b>identical code</b> — i.e. what a single before/after pair can report from nothing at all:
+/// </para>
+/// <list type="table">
+/// <listheader><term>Row</term><description>p95 pairwise / full spread (time)</description></listheader>
+/// <item><term><see cref="WarmRedraw_ReusedEngine"/></term><description>6.8% / 9.2%</description></item>
+/// <item><term><see cref="PrepareModuleGraph"/></term><description>5.3% / 6.7%</description></item>
+/// <item><term><see cref="ColdImport_PreparedPerOp"/></term><description>5.3% / 7.4%</description></item>
+/// <item><term><see cref="ColdImport_PreparedShared"/></term><description>3.3% / 5.0%</description></item>
+/// <item><term><see cref="ColdImport_SourcePerEngine"/></term><description>3.3% / 5.2%</description></item>
+/// <item><term><see cref="PoolFill_PreparedShared"/></term><description>2.5% / 3.6%</description></item>
+/// </list>
+/// <para>
+/// So a single pair's time delta below those numbers carries no information, and a gate threshold under them
+/// fires on noise. Two controls make the point concretely: adding a semantically inert internal class to the
+/// engine, and adding an unused method to <c>Throw</c>, each moved <see cref="WarmRedraw_ReusedEngine"/> by
+/// about 3% without changing a single executed instruction. To see a smaller effect than the envelope, compare
+/// the <b>median of five runs per side</b> rather than one pair.
+/// </para>
+/// <para>
+/// The <c>Allocated</c> column has no such problem: it was byte-identical across all thirty runs, on every
+/// row. Where a change should show up in allocation, that column is the one to gate on and the one to quote.
+/// </para>
 /// </summary>
 [MemoryDiagnoser]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]


### PR DESCRIPTION
Follow-up to #2926, documentation only — no code, no rows, no behaviour.

While using that class as a gate for module-preparation work I read a single before/after pair as
a regression, twice, on rows the change under test could not execute. The rows are noisier
between processes than they look, and the class said nothing about it, so anyone reaching for it
next would make the same mistake.

Thirty consecutive default-job runs of one unmodified binary, serial on an otherwise idle
machine, give the envelope now recorded in the class doc — where *p95 pairwise* is the 95th
percentile of the absolute difference between two runs of **identical code**, which is exactly
what a single before/after pair can report from nothing at all:

| Row | BDN StdDev | p95 pairwise | full spread |
| --- | ---: | ---: | ---: |
| WarmRedraw_ReusedEngine | 0.2-0.4% | **6.8%** | 9.2% |
| PrepareModuleGraph | 0.2-1.7% | **5.3%** | 6.7% |
| ColdImport_PreparedPerOp | 0.5-2.0% | **5.3%** | 7.4% |
| ColdImport_PreparedShared | 0.1-0.9% | **3.3%** | 5.0% |
| ColdImport_SourcePerEngine | 0.6-2.1% | **3.3%** | 5.2% |
| PoolFill_PreparedShared | 2.3-12.4% | **2.5%** | 3.6% |

The `StdDev` column is not wrong, it is answering a different question: it measures one warm
process, and these rows build engines and walk a module graph, so most of their variation is
*between* processes and never appears in it.

Two controls make it concrete. Adding a semantically inert internal class to the engine moved
`WarmRedraw_ReusedEngine` by +3.1%, and adding an unused method to `Throw` moved it by +2.7% —
neither changes a single executed instruction on that path.

`Allocated` has no such problem: byte-identical across all thirty runs, on every row. So the doc
now says plainly what to do with a result from this class — gate on allocation where the change
should show there, treat a single pair's time delta below the envelope as no information, and
compare the median of five runs per side when a smaller time effect has to be resolved.
