### PR TITLE
Treat a non-positive operation budget as no deadline rather than an expired one

### DIFF
--- a/Jint.Tests.PublicInterface/HostCallLoopConstraintTests.cs
+++ b/Jint.Tests.PublicInterface/HostCallLoopConstraintTests.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Jint.Constraints;
 using Jint.Runtime;
@@ -455,6 +455,9 @@ public class HostCallLoopConstraintTests
     /// </summary>
     private static readonly TimeSpan UnreachableBudget = TimeSpan.FromMinutes(10);
 
+    /// <summary>The smallest budget that still arms a deadline: positive, and gone by the first check.</summary>
+    private static readonly TimeSpan ExhaustedBudget = TimeSpan.FromTicks(1);
+
     [Fact]
     public void ADeadlineSpansAHostLoopOfShortCallsAndFailsItOnceTheBudgetIsGone()
     {
@@ -508,8 +511,9 @@ public class HostCallLoopConstraintTests
     public void EndingAnOperationDisarmsTheInstanceAndAFreshBeginArmsItAgain()
     {
         // The pooled shape: one engine and one constraint serve operation after operation. Deterministic
-        // on purpose — an exhausted budget is expressed as one that had already elapsed when it was
-        // handed over, so nothing here depends on how fast the machine is.
+        // on purpose — an exhausted budget is expressed as the smallest positive one there is, which a
+        // single call cannot fit inside, so nothing here depends on how fast the machine is. It cannot be
+        // TimeSpan.Zero: non-positive asks for no deadline at all.
         var deadline = new OperationDeadlineConstraint();
         var engine = CreateDeadlineEngine(deadline);
         var work = engine.GetValue("work");
@@ -529,7 +533,7 @@ public class HostCallLoopConstraintTests
         Invoking(() => work.Call(1)).Should().NotThrow("End() disarmed the constraint");
 
         // operation 2: no time left at all, and the same instance reports it
-        deadline.Begin(TimeSpan.Zero);
+        deadline.Begin(ExhaustedBudget);
         try
         {
             Invoking(() => work.Call(1)).Should().Throw<TimeoutException>();
@@ -641,6 +645,66 @@ public class HostCallLoopConstraintTests
                     work.Call(i);
                 }
             }).Should().NotThrow("a budget of TimeSpan.MaxValue is effectively unlimited, not already spent");
+        }
+        finally
+        {
+            deadline.End();
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(BudgetsMeaningNoTimeLimit))]
+    public void ANonPositiveBudgetAsksForNoTimeLimitRatherThanOneAlreadySpent(TimeSpan budget)
+    {
+        // Timeout.InfiniteTimeSpan is -1ms, and TimeoutInterval registers no constraint at all for a
+        // non-positive interval, so a host spelling "no time limit" either way must not get the opposite.
+        // A host that computed "time left" and found none declines to enter the engine instead.
+        var deadline = new OperationDeadlineConstraint();
+        var engine = CreateDeadlineEngine(deadline);
+        var work = engine.GetValue("work");
+
+        deadline.Begin(budget);
+        try
+        {
+            Invoking(() =>
+            {
+                for (var i = 0; i < HostCalls; i++)
+                {
+                    work.Call(i);
+                }
+            }).Should().NotThrow("a non-positive budget asks for no deadline, not for one that has passed");
+        }
+        finally
+        {
+            deadline.End();
+        }
+    }
+
+    public static TheoryData<TimeSpan> BudgetsMeaningNoTimeLimit() =>
+        [Timeout.InfiniteTimeSpan, TimeSpan.Zero, TimeSpan.FromSeconds(-5)];
+
+    [Fact]
+    public void ANonPositiveBudgetStillObservesTheOperationsToken()
+    {
+        // The cancellation-only shape: no wall-clock bound, but the request can still be abandoned.
+        var deadline = new OperationDeadlineConstraint();
+        var engine = CreateDeadlineEngine(deadline);
+        var work = engine.GetValue("work");
+        using var cts = new CancellationTokenSource();
+
+        deadline.Begin(Timeout.InfiniteTimeSpan, cts.Token);
+        try
+        {
+            work.Call(0);
+            cts.Cancel();
+
+            Invoking(() =>
+            {
+                for (var i = 0; i < HostCalls; i++)
+                {
+                    work.Call(i);
+                }
+            }).Should().Throw<OperationCanceledException>("the token is observed whether or not a budget is");
         }
         finally
         {

--- a/Jint/Constraints/OperationDeadlineConstraint.cs
+++ b/Jint/Constraints/OperationDeadlineConstraint.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Threading;
 using Jint.Runtime;
 
@@ -64,8 +64,11 @@ namespace Jint.Constraints;
 /// </remarks>
 public sealed class OperationDeadlineConstraint : Constraint
 {
-    // Stopwatch timestamp the current operation must not pass; 0 means "no operation is in flight", in
-    // which case Check never fails. Mirrors TimeConstraint's not-started sentinel.
+    // No operation is in flight, so the deadline half of Check never fails. Mirrors TimeConstraint's
+    // not-started sentinel, and is also what a non-positive budget arms.
+    private const long Disarmed = 0;
+
+    // Stopwatch timestamp the current operation must not pass, or Disarmed.
     private long _deadline;
 
     private CancellationToken _cancellationToken;
@@ -85,10 +88,12 @@ public sealed class OperationDeadlineConstraint : Constraint
     /// <see cref="End"/> — however many top-level entries that is — shares this one budget.
     /// </summary>
     /// <param name="budget">
-    /// How long the whole operation may run. A budget that has already elapsed by the time it is handed
-    /// over (<see cref="TimeSpan.Zero"/> or negative, which is what a host computing "time left" produces
-    /// when there is none) arms a deadline that has passed, so the next check fails. Very large budgets are
-    /// clamped rather than allowed to overflow the timestamp arithmetic.
+    /// How long the whole operation may run. A non-positive budget - <see cref="TimeSpan.Zero"/>, a negative
+    /// value, or <see cref="Timeout.InfiniteTimeSpan"/> - asks for no time limit at all, the same thing it
+    /// means to <c>TimeoutInterval</c> and to the rest of .NET; the cancellation token is still observed, so
+    /// that is the cancellation-only shape. A host that has computed "time left" and found none should decline
+    /// to enter the engine rather than arm a zero budget. Very large budgets are clamped rather than allowed
+    /// to overflow the timestamp arithmetic.
     /// </param>
     /// <param name="cancellationToken">
     /// An optional token observed for the same window. The default token observes nothing.
@@ -99,11 +104,23 @@ public sealed class OperationDeadlineConstraint : Constraint
     /// </remarks>
     public void Begin(TimeSpan budget, CancellationToken cancellationToken = default)
     {
+        _cancellationToken = cancellationToken;
+
+        if (budget <= TimeSpan.Zero)
+        {
+            // A non-positive budget is how the rest of .NET, and this engine's own TimeoutInterval,
+            // spell "no time limit" - Timeout.InfiniteTimeSpan is -1ms. Arming it arithmetically
+            // would put the deadline at or before the operation's own start and end every operation
+            // the moment it began, which is the opposite of what the caller asked for. The token is
+            // still observed, so Begin(Timeout.InfiniteTimeSpan, token) is the cancellation-only shape.
+            _deadline = Disarmed;
+            return;
+        }
+
         var deadline = Stopwatch.GetTimestamp() + ToStopwatchTicks(budget);
 
-        // 0 is the not-armed sentinel, so never store it as a real deadline
-        _deadline = deadline == 0 ? 1 : deadline;
-        _cancellationToken = cancellationToken;
+        // Disarmed is the not-armed sentinel, so never store it as a real deadline
+        _deadline = deadline == Disarmed ? Disarmed + 1 : deadline;
     }
 
     /// <summary>
@@ -116,7 +133,7 @@ public sealed class OperationDeadlineConstraint : Constraint
     /// </remarks>
     public void End()
     {
-        _deadline = 0;
+        _deadline = Disarmed;
         _cancellationToken = default;
     }
 
@@ -173,12 +190,6 @@ public sealed class OperationDeadlineConstraint : Constraint
     /// </summary>
     private static long ToStopwatchTicks(TimeSpan budget)
     {
-        if (budget <= TimeSpan.Zero)
-        {
-            // no time left: the deadline is now, and the next check fails
-            return 0;
-        }
-
         var ticks = budget.Ticks * ((double) Stopwatch.Frequency / TimeSpan.TicksPerSecond);
         return ticks >= long.MaxValue / 2.0 ? long.MaxValue / 2 : (long) ticks;
     }


### PR DESCRIPTION
Follow-up to #2935, which is not in a release yet, so this is a correction rather than a break.

`OperationDeadlineConstraint.Begin` armed a deadline arithmetically for whatever budget it was
given, and documented a non-positive one as "already elapsed, so the next check fails". That
reading covers a host computing "time left" and finding none. It gets the far more common spelling
exactly backwards:

- `Timeout.InfiniteTimeSpan` **is** `-1ms`. A host writing
  `deadline.Begin(Timeout.InfiniteTimeSpan, requestAborted)` — no time limit, cancellation only —
  got every operation failing on its first check.
- `TimeSpan.Zero` reads the same way to most callers, and `TimeoutInterval(TimeSpan.Zero)` next
  door registers no constraint at all, so the two spellings of "off" behaved oppositely in one
  engine.

A non-positive budget now asks for no deadline, matching both `TimeoutInterval` and the rest of
.NET. The token is still observed, so `Begin(Timeout.InfiniteTimeSpan, token)` is the
cancellation-only shape rather than a trap. A host that really has no time left should decline to
enter the engine rather than arm a zero budget, and the parameter doc now says so.

The very-large-budget clamp is unchanged, and its test still passes: `TimeSpan.MaxValue` remains
"effectively unlimited", it just no longer arrives there by a different route than
`Timeout.InfiniteTimeSpan`.

Found by David Whitney while reviewing an embedder that had copied the hand-rolled version of this
pattern — he hit it as `TimeSpan.Zero` turning a render engine's "no budget" configuration into an
instant failure, and fixed it there before the same shape landed here.

## Testing

`EndingAnOperationDisarmsTheInstanceAndAFreshBeginArmsItAgain` used `Begin(TimeSpan.Zero)` to
express an exhausted budget deterministically, which is precisely the spelling this changes. It now
uses `TimeSpan.FromTicks(1)` — positive, so it still arms, and gone by the first check, so the test
stays deterministic without depending on machine speed. Nothing else in that file moved.

Two new facts: a theory over `Timeout.InfiniteTimeSpan`, `TimeSpan.Zero` and a negative budget
asserting a host loop runs unbounded, and one asserting that the token is still observed under such
a budget. Full suites green on both target frameworks including the
`JINT_HOST_CONTRACT_VERIFICATION=1` leg.
