### PR TITLE
Document sharing a module graph across pooled engines

### DIFF
--- a/Jint/PreparationOptions.cs
+++ b/Jint/PreparationOptions.cs
@@ -87,8 +87,11 @@ public sealed record class ScriptPreparationOptions : IPreparationOptions<Script
     /// engine-neutral, which is the same property that lets a prepared program be shared at all. Identifier binding
     /// names, the member-access fast-path value and a script root's hoisting scope are not published that way and
     /// are rebuilt per engine; constant folding of unary and binary expressions likewise happens per engine, since
-    /// the interpreter performs it on its own when it finds nothing prepared. Measured on a module graph: about 8%
-    /// more allocation per engine to materialize the tree, with execution time inside noise.
+    /// the interpreter performs it on its own when it finds nothing prepared. Measured on
+    /// <c>ModuleGraphEmbeddingBenchmark</c>'s ten-module graph, medians of five runs: preparation cost 47.6%
+    /// less time and 27.5% less allocation, while each engine materializing that graph from a shared cache
+    /// paid 4.8% more time and 9.5% more allocation - break-even at about ten engines on time, two on
+    /// allocation, so a long-lived pool should leave this alone.
     /// </para>
     /// <para>
     /// Composes with <see cref="CollectReferencedGlobals"/>, which is gathered by a visitor of its own and is
@@ -163,8 +166,10 @@ public sealed record class ModulePreparationOptions : IPreparationOptions<Module
     /// engine-neutral, which is the same property that lets a prepared program be shared at all. Identifier binding
     /// names and the member-access fast-path value are not published that way and are rebuilt per engine; constant
     /// folding of unary and binary expressions likewise happens per engine, since the interpreter performs it on
-    /// its own when it finds nothing prepared. Measured on a module graph: about 8% more allocation per engine to
-    /// materialize the tree, with execution time inside noise.
+    /// its own when it finds nothing prepared. Measured on <c>ModuleGraphEmbeddingBenchmark</c>'s ten-module graph,
+    /// medians of five runs: preparation cost 47.6% less time and 27.5% less allocation, while each engine
+    /// materializing that graph from a shared cache paid 4.8% more time and 9.5% more allocation - break-even
+    /// at about ten engines on time, two on allocation, so a long-lived pool should leave this alone.
     /// </para>
     /// <para>
     /// Composes with <see cref="CollectReferencedGlobals"/>, which is gathered by a visitor of its own and is

--- a/README.md
+++ b/README.md
@@ -266,6 +266,60 @@ engine per operation never reaches them by design. Note the mirror image if you 
 warmed call site holds a reference to the last receiver it served until it caches a different one, so pooled
 engines can keep host objects alive between runs.
 
+**Sharing a module graph across pooled engines.** A host whose templates or plugins are ES modules pays for
+that graph per engine: `IModuleLoader.LoadModule` is called by every engine that imports a module, so the
+obvious loader re-reads and re-parses the whole graph for every engine in the pool. Prepare each module once
+per *build* instead — cache the `Prepared<AstModule>` (`AstModule` being Acornima's `Module`, which an alias
+keeps apart from Jint's runtime `Module`) keyed by module location, and hand it to the overload that takes an
+already prepared AST, `ModuleFactory.BuildSourceTextModule(engine, in prepared)`. Name the prepared module
+exactly as the engine would: `Engine.PrepareModule(code, source)` takes the name up front, and it becomes
+`Module.Location` and therefore the `referencingModuleLocation` echoed back into `IModuleLoader.Resolve` for
+that module's own imports — so a name derived by hand that differs from the engine's breaks relative-import
+resolution with nothing to point at. `ModuleFactory.LocationOf(resolved)` *is* that rule; call it rather than
+reimplementing it.
+
+Single-flight the cache. `ConcurrentDictionary.GetOrAdd` does not run its factory under a lock, so N engines
+filling a pool concurrently each prepare the same module and N-1 results are prepared only to be discarded.
+Wrapping the value in a `Lazy<T>` — whose default thread-safety mode is exactly "one factory run, everyone
+else waits" — is enough:
+
+```c#
+using AstModule = Acornima.Ast.Module; // Jint.Runtime.Modules.Module is a different type
+
+private readonly ConcurrentDictionary<string, Lazy<Prepared<AstModule>>> _prepared
+    = new(StringComparer.Ordinal);
+
+public Module LoadModule(Engine engine, ResolvedSpecifier resolved)
+{
+    var location = ModuleFactory.LocationOf(resolved);
+    var prepared = _prepared.GetOrAdd(location,
+        static key => new Lazy<Prepared<AstModule>>(() => Engine.PrepareModule(ReadSource(key), key))).Value;
+
+    return ModuleFactory.BuildSourceTextModule(engine, in prepared);
+}
+```
+
+Invalidate by build, not by file. The prepared ASTs are derived from a compilation, so key the cache to the
+same identity the rest of your host already uses for that compilation and let a rebuild drop the whole set at
+once, rather than expiring entries per file and serving a graph half of which is stale.
+
+Be clear about what the thread-safety of `Prepared<T>` buys. It is safe to share and safe to run concurrently,
+which is what lets one cache serve the pool — it does not make the *engines* shareable (one engine, one
+thread) and it does not make the module registry shared: every engine still builds, links and evaluates its
+own module records from the shared ASTs, and `engine.Modules` is per engine. That per-engine cost is real, and
+it is what the pool pays no matter how much preparation is shared.
+
+`StaticAnalysis` is a trade with a break-even, not a speed-up. Preparing with
+`new ModulePreparationOptions { StaticAnalysis = false }` skips the pass that pre-publishes interpreter state
+onto the parsed tree, leaving preparation at roughly the cost of a plain parse; each engine then rebuilds
+lazily what the pass would have published once for all of them. Measured on `ModuleGraphEmbeddingBenchmark`'s
+ten-module graph, preparation cost -47.6% time and -27.5% allocation, while each engine materializing that
+graph from the shared cache paid +4.8% time and +9.5% allocation — break-even, on that graph, at about ten
+engines on time and about two on allocation. A long-lived pool should therefore keep the default (`true`);
+the option is for preparation that sits on a latency-critical path — a cold start, a rebuild in a dev loop —
+or for a host whose prepared programs outnumber the engines that ever run them.
+`ScriptPreparationOptions.StaticAnalysis` is the same option for scripts.
+
 **Registering only what a script uses.** When the ambient API is large and scripts touch little of it,
 prepare with `ScriptPreparationOptions.CollectReferencedGlobals` and read `Prepared<T>.ReferencedGlobals`:
 the free identifiers the program actually references, resolved per binding site, as an immutable set you can
@@ -689,6 +743,10 @@ var id = ns.Get("result").AsInteger();
 ```
 
 Note that you don't need to `EnableModules` if you only use modules created using `Engine.Modules.Add`.
+
+If you serve the same modules from a pool of engines, see **Sharing a module graph across pooled engines**
+under [Embedding performance](#embedding-performance): a loader that caches prepared modules keeps every
+engine but the first from parsing them again.
 
 ### Loading modules asynchronously
 


### PR DESCRIPTION
Six PRs (#2926, #2929, #2935, #2936, #2937, #2938) went at one embedder shape: a host serving an
ES module graph from a pool of engines — a server-side view engine, a per-request sandbox pool.
The pieces are documented individually, but nothing said how they fit together, and the part that
costs an embedder the most is not any single API: it is that `IModuleLoader.LoadModule` runs per
engine, so the obvious loader re-parses the whole graph for every engine in the pool.

Adds one subsection to "Embedding performance", after the existing **Prepared scripts and engine
reuse.** paragraph, since it extends that idea to modules:

- prepare each module once per *build* and hand the AST to
  `ModuleFactory.BuildSourceTextModule(engine, in prepared)`;
- name the prepared module with `ModuleFactory.LocationOf` rather than by hand, because that name
  becomes `Module.Location` and the `referencingModuleLocation` for its own relative imports;
- single-flight the cache — `ConcurrentDictionary.GetOrAdd` does not run its factory under a lock,
  so a pool filling concurrently prepares the same module N times and throws N−1 away — with a
  short `Lazy<T>` loader snippet, compiled verbatim against this branch;
- invalidate by build rather than per file;
- what `Prepared<T>`'s thread-safety does and does not buy: shareable ASTs, but engines stay
  single-threaded and every engine still builds, links and evaluates its own module records;
- `StaticAnalysis` as a trade with a break-even rather than a speed-up.

Plus a one-line pointer from "Using Modules" to that subsection.

## Also corrects the `StaticAnalysis` figures

The XML docs that shipped with #2938 quote a preliminary measurement — "about 8% more allocation
per engine ... with execution time inside noise". The numbers in the PR that shipped it came from a
later, better measurement: medians of five runs per side, rather than the single pairs the earlier
figure rested on. On `ModuleGraphEmbeddingBenchmark`'s ten-module graph that is −47.6% time and
−27.5% allocation to prepare, against +4.8% time and +9.5% allocation for each engine that then
materializes the graph — and +4.8% is above that row's noise envelope, so calling execution time
"inside noise" understated it.

Both `ScriptPreparationOptions.StaticAnalysis` and `ModulePreparationOptions.StaticAnalysis` now
carry the measured figures, the benchmark they came from, and the break-even they imply — about ten
engines on time and two on allocation, so a long-lived pool should leave the default alone. The
README says the same thing in the same terms, so the two cannot drift.

Documentation only: no code, no behaviour, no new API.
