### PR TITLE
Label the MyGet previews with the version they are previews of

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     <PackageLicenseExpression>BSD-2-Clause</PackageLicenseExpression>
 
     <BuildNumber Condition="'$(BuildNumber)' == ''">0</BuildNumber>
-    <VersionPrefix>4.15.0</VersionPrefix>
+    <VersionPrefix>4.16.0</VersionPrefix>
     <VersionSuffix>beta-$(BuildNumber)</VersionSuffix>
 
     <PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
`VersionPrefix` has said `4.15.0` since that release, through 4.15.1, 4.15.2 and 4.15.3. The released version comes from the tag — `release.yml` derives it from `GITHUB_REF_NAME` and packs with `-p:Version` — so this property has no say in what lands on nuget.org. But `build.yml` packs with `-p:VersionSuffix=preview-$GITHUB_RUN_NUMBER` and nothing else, so the numeric part of every MyGet preview is `VersionPrefix` verbatim.

A preview of what will be 4.16.0 is therefore published as `4.15.0-preview-N`: it sorts below three versions already on nuget.org, and an embedder pulling one to try an unreleased fix gets a package whose number says the fix should already be in the release sitting next to it.

Bump it to the version main is heading for. Nothing else reads it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)