### PR TITLE
Park a break or continue across the finally that suspends

### DIFF
--- a/Jint.Tests/Runtime/SuspendedJumpCompletionTests.cs
+++ b/Jint.Tests/Runtime/SuspendedJumpCompletionTests.cs
@@ -1,0 +1,683 @@
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// A <c>break</c> or <c>continue</c> whose <c>finally</c> block suspends — on a <c>yield</c> or an
+/// <c>await</c> — must still perform its jump when the block resumes and completes normally, exactly
+/// as the non-suspending case does.
+/// <para>
+/// Only Throw and Return used to be parked across the suspension, so the jump was discarded: the
+/// resume found no pending completion, returned a normal one, and the enclosing loops ran their
+/// remaining iterations while the statements the jump was meant to skip executed. Parking the whole
+/// completion record — the jump statement included, since that is where
+/// <see cref="Jint.Runtime.Completion.Target"/> reads the label from — is what carries the target
+/// across the suspension.
+/// </para>
+/// <para>
+/// <see cref="LabelledJumpTests"/> is the non-suspending sibling: the same jumps through a non-empty
+/// finalizer with no generator or async function in sight.
+/// </para>
+/// </summary>
+public class SuspendedJumpCompletionTests
+{
+    // Every drain is bounded so a regression that never terminates fails with RUNAWAY in the
+    // produced sequence rather than hanging the run.
+    private const string Drain = """
+        function drain(it) {
+          var out = [], guard = 0;
+          var r = it.next();
+          while (!r.done) {
+            out.push(r.value);
+            if (++guard > 12) { out.push('RUNAWAY'); break; }
+            r = it.next();
+          }
+          return out;
+        }
+        """;
+
+    private static string Run(string source) => new Engine().Evaluate(source).AsString();
+
+    private static string RunAsync(string source) => new Engine().Evaluate(source).UnwrapIfPromise().AsString();
+
+    // ---------------------------------------------------------------- generators
+
+    [Fact]
+    public void UnlabelledBreakThroughAYieldingFinally()
+    {
+        Run($$"""
+            {{Drain}}
+            var log = [];
+            function* g() {
+              for (var j = 0; j < 2; j++) {
+                try { break; } finally { yield 'f'; }
+              }
+              log.push('end');
+            }
+            drain(g()).join(',') + '|' + log.join(',');
+            """).Should().Be("f|end");
+    }
+
+    [Fact]
+    public void LabelledBreakThroughAYieldingFinally()
+    {
+        Run($$"""
+            {{Drain}}
+            var log = [];
+            function* g() {
+              outer: for (var i = 0; i < 2; i++) {
+                for (var j = 0; j < 2; j++) {
+                  try { break outer; } finally { yield 'f'; }
+                }
+                log.push('after-inner');
+              }
+              log.push('end');
+            }
+            drain(g()).join(',') + '|' + log.join(',');
+            """).Should().Be("f|end");
+    }
+
+    [Fact]
+    public void UnlabelledContinueThroughAYieldingFinally()
+    {
+        Run($$"""
+            {{Drain}}
+            var log = [];
+            function* g() {
+              for (var j = 0; j < 2; j++) {
+                try { continue; } finally { yield 'f'; }
+                log.push('never');
+              }
+              log.push('end');
+            }
+            drain(g()).join(',') + '|' + log.join(',');
+            """).Should().Be("f,f|end");
+    }
+
+    [Fact]
+    public void LabelledContinueThroughAYieldingFinally()
+    {
+        Run($$"""
+            {{Drain}}
+            var log = [];
+            function* g() {
+              outer: for (var i = 0; i < 2; i++) {
+                for (var j = 0; j < 2; j++) {
+                  try { continue outer; } finally { yield 'f'; }
+                  log.push('never-inner');
+                }
+                log.push('never-outer');
+              }
+              log.push('end');
+            }
+            drain(g()).join(',') + '|' + log.join(',');
+            """).Should().Be("f,f|end");
+    }
+
+    [Fact]
+    public void BreakOutOfALabelledBlockThroughAYieldingFinally()
+    {
+        Run($$"""
+            {{Drain}}
+            var log = [];
+            function* g() {
+              outer: {
+                for (var j = 0; j < 2; j++) {
+                  try { break outer; } finally { yield 'f'; }
+                }
+                log.push('after-inner');
+              }
+              log.push('end');
+            }
+            drain(g()).join(',') + '|' + log.join(',');
+            """).Should().Be("f|end");
+    }
+
+    [Fact]
+    public void ABreakTargetingAnInnerLabelIsNotConsumedByAnOuterLoopAcrossAYield()
+    {
+        // The label has to survive the suspension in the other direction too: an inner target read
+        // as unlabelled would break the same loop here, so only the outer loop's iteration count
+        // tells the two apart.
+        Run($$"""
+            {{Drain}}
+            var log = [];
+            function* g() {
+              for (var i = 0; i < 2; i++) {
+                inner: for (var j = 0; j < 2; j++) {
+                  try { break inner; } finally { yield 'f'; }
+                }
+                log.push('after-inner');
+              }
+              log.push('end');
+            }
+            drain(g()).join(',') + '|' + log.join(',');
+            """).Should().Be("f,f|after-inner,after-inner,end");
+    }
+
+    [Fact]
+    public void ALabelledBreakAcrossThreeLevelsThroughAYieldingFinally()
+    {
+        Run($$"""
+            {{Drain}}
+            var log = [];
+            function* g() {
+              a: for (var i = 0; i < 2; i++) {
+                b: for (var j = 0; j < 2; j++) {
+                  for (var k = 0; k < 2; k++) {
+                    try { break a; } finally { yield 'f'; }
+                  }
+                  log.push('after-k');
+                }
+                log.push('after-j');
+              }
+              log.push('end');
+            }
+            drain(g()).join(',') + '|' + log.join(',');
+            """).Should().Be("f|end");
+    }
+
+    [Fact]
+    public void AJumpInTheFinallyOverridesThePendingJump()
+    {
+        // Step 3 keeps B only when F is a normal completion; an abrupt finalizer wins outright.
+        Run($$"""
+            {{Drain}}
+            var log = [];
+            function* g() {
+              outer: for (var i = 0; i < 2; i++) {
+                try { break outer; } finally { yield 'f'; continue outer; }
+              }
+              log.push('end');
+            }
+            drain(g()).join(',') + '|' + log.join(',');
+            """).Should().Be("f,f|end");
+    }
+
+    [Fact]
+    public void AReturnInTheFinallyOverridesThePendingJump()
+    {
+        Run($$"""
+            var log = [];
+            function* g() {
+              outer: for (var i = 0; i < 2; i++) {
+                try { break outer; } finally { yield 'f'; return 'R'; }
+              }
+              log.push('end');
+            }
+            var it = g();
+            var a = it.next();
+            var b = it.next();
+            a.value + '|' + b.value + '|' + b.done + '|' + log.join(',');
+            """).Should().Be("f|R|true|");
+    }
+
+    [Fact]
+    public void ABreakThroughTwoNestedYieldingFinallyBlocks()
+    {
+        Run($$"""
+            {{Drain}}
+            var log = [];
+            function* g() {
+              outer: for (var i = 0; i < 2; i++) {
+                try {
+                  try { break outer; } finally { yield 'inner'; }
+                } finally { yield 'outer'; }
+              }
+              log.push('end');
+            }
+            drain(g()).join(',') + '|' + log.join(',');
+            """).Should().Be("inner,outer|end");
+    }
+
+    [Fact]
+    public void ABreakThroughAYieldingFinallyInsideASwitch()
+    {
+        Run($$"""
+            {{Drain}}
+            var log = [];
+            function* g() {
+              outer: for (var i = 0; i < 2; i++) {
+                switch (i) {
+                  case 0:
+                    try { break outer; } finally { yield 'f'; }
+                }
+                log.push('after-switch');
+              }
+              log.push('end');
+            }
+            drain(g()).join(',') + '|' + log.join(',');
+            """).Should().Be("f|end");
+    }
+
+    [Fact]
+    public void AnUnlabelledBreakInsideASwitchStillBreaksTheSwitchOnlyAcrossAYield()
+    {
+        Run($$"""
+            {{Drain}}
+            var log = [];
+            function* g() {
+              for (var i = 0; i < 2; i++) {
+                switch (i) {
+                  case 0:
+                    try { break; } finally { yield 'f'; }
+                }
+                log.push('after-switch');
+              }
+              log.push('end');
+            }
+            drain(g()).join(',') + '|' + log.join(',');
+            """).Should().Be("f|after-switch,after-switch,end");
+    }
+
+    [Fact]
+    public void AContinueThroughAYieldingFinallyInAWhileLoop()
+    {
+        Run($$"""
+            {{Drain}}
+            var log = [];
+            function* g() {
+              var j = 0;
+              while (j < 2) {
+                j++;
+                try { continue; } finally { yield 'f'; }
+                log.push('never');
+              }
+              log.push('end');
+            }
+            drain(g()).join(',') + '|' + log.join(',');
+            """).Should().Be("f,f|end");
+    }
+
+    [Fact]
+    public void ABreakThroughAYieldingFinallyInAForOfLoop()
+    {
+        Run($$"""
+            {{Drain}}
+            var log = [];
+            function* g() {
+              outer: for (var i = 0; i < 2; i++) {
+                for (var x of [1, 2]) {
+                  try { break outer; } finally { yield 'f'; }
+                }
+                log.push('after-inner');
+              }
+              log.push('end');
+            }
+            drain(g()).join(',') + '|' + log.join(',');
+            """).Should().Be("f|end");
+    }
+
+    // A finalizer may contain another try statement that parks a completion of its own before
+    // suspending, so the park cannot live in one slot on the generator. These three are what a
+    // single slot got wrong: the inner park consumed the outer's, which cost the outer jump its
+    // target and silently swallowed a pending return or throw.
+
+    [Fact]
+    public void AFinallyContainingAnotherParkingTryKeepsItsOwnPendingBreak()
+    {
+        Run($$"""
+            {{Drain}}
+            var log = [];
+            function* g() {
+              outer: for (var i = 0; i < 2; i++) {
+                try { break outer; }
+                finally {
+                  inner: for (var k = 0; k < 1; k++) {
+                    try { break inner; } finally { yield 'x'; }
+                  }
+                }
+              }
+              log.push('end');
+            }
+            drain(g()).join(',') + '|' + log.join(',');
+            """).Should().Be("x|end");
+    }
+
+    [Fact]
+    public void AFinallyContainingAnotherParkingTryKeepsItsOwnPendingReturn()
+    {
+        Run("""
+            function* g() {
+              try { return 'R'; }
+              finally {
+                inner: for (var k = 0; k < 1; k++) {
+                  try { break inner; } finally { yield 'x'; }
+                }
+              }
+            }
+            var it = g();
+            var a = it.next();
+            var b = it.next();
+            a.value + '|' + b.value + '|' + b.done;
+            """).Should().Be("x|R|true");
+    }
+
+    [Fact]
+    public void AFinallyContainingAnotherParkingTryKeepsItsOwnPendingThrow()
+    {
+        Run("""
+            function* g() {
+              try { throw 'T'; }
+              finally {
+                inner: for (var k = 0; k < 1; k++) {
+                  try { break inner; } finally { yield 'x'; }
+                }
+              }
+            }
+            var it = g();
+            var a = it.next();
+            var caught = 'none';
+            try { it.next(); } catch (e) { caught = e; }
+            a.value + '|' + caught;
+            """).Should().Be("x|T");
+    }
+
+    // ------------------------------------------------------- async functions
+
+    [Fact]
+    public void UnlabelledBreakThroughAnAwaitingFinally()
+    {
+        RunAsync("""
+            (async function () {
+              var log = [];
+              for (var j = 0; j < 2; j++) {
+                try { break; } finally { await 0; log.push('f'); }
+              }
+              log.push('end');
+              return log.join(',');
+            })()
+            """).Should().Be("f,end");
+    }
+
+    [Fact]
+    public void LabelledBreakThroughAnAwaitingFinally()
+    {
+        RunAsync("""
+            (async function () {
+              var log = [];
+              outer: for (var i = 0; i < 2; i++) {
+                for (var j = 0; j < 2; j++) {
+                  try { break outer; } finally { await 0; log.push('f'); }
+                }
+                log.push('after-inner');
+              }
+              log.push('end');
+              return log.join(',');
+            })()
+            """).Should().Be("f,end");
+    }
+
+    [Fact]
+    public void UnlabelledContinueThroughAnAwaitingFinally()
+    {
+        RunAsync("""
+            (async function () {
+              var log = [];
+              for (var j = 0; j < 2; j++) {
+                try { continue; } finally { await 0; log.push('f'); }
+                log.push('never');
+              }
+              log.push('end');
+              return log.join(',');
+            })()
+            """).Should().Be("f,f,end");
+    }
+
+    [Fact]
+    public void LabelledContinueThroughAnAwaitingFinally()
+    {
+        RunAsync("""
+            (async function () {
+              var log = [];
+              outer: for (var i = 0; i < 2; i++) {
+                for (var j = 0; j < 2; j++) {
+                  try { continue outer; } finally { await 0; log.push('f'); }
+                  log.push('never-inner');
+                }
+                log.push('never-outer');
+              }
+              log.push('end');
+              return log.join(',');
+            })()
+            """).Should().Be("f,f,end");
+    }
+
+    [Fact]
+    public void AJumpInAnAwaitingFinallyOverridesThePendingJump()
+    {
+        RunAsync("""
+            (async function () {
+              var log = [];
+              outer: for (var i = 0; i < 2; i++) {
+                try { break outer; } finally { await 0; log.push('f'); continue outer; }
+              }
+              log.push('end');
+              return log.join(',');
+            })()
+            """).Should().Be("f,f,end");
+    }
+
+    [Fact]
+    public void ABreakThroughAnAwaitingFinallyInAForAwaitLoop()
+    {
+        RunAsync("""
+            (async function () {
+              var log = [];
+              outer: for (var i = 0; i < 2; i++) {
+                for await (var x of [1, 2]) {
+                  try { break outer; } finally { await 0; log.push('f'); }
+                }
+                log.push('after-inner');
+              }
+              log.push('end');
+              return log.join(',');
+            })()
+            """).Should().Be("f,end");
+    }
+
+    // ------------------------------------------------------ async generators
+
+    [Fact]
+    public void UnlabelledBreakThroughAYieldingFinallyInAnAsyncGenerator()
+    {
+        RunAsync("""
+            (async function () {
+              var log = [];
+              async function* g() {
+                for (var j = 0; j < 2; j++) {
+                  try { break; } finally { yield 'f'; }
+                }
+                log.push('end');
+              }
+              var out = [], guard = 0;
+              for await (var v of g()) {
+                out.push(v);
+                if (++guard > 12) { out.push('RUNAWAY'); break; }
+              }
+              return out.join(',') + '|' + log.join(',');
+            })()
+            """).Should().Be("f|end");
+    }
+
+    [Fact]
+    public void LabelledBreakThroughAYieldingFinallyInAnAsyncGenerator()
+    {
+        RunAsync("""
+            (async function () {
+              var log = [];
+              async function* g() {
+                outer: for (var i = 0; i < 2; i++) {
+                  for (var j = 0; j < 2; j++) {
+                    try { break outer; } finally { yield 'f'; }
+                  }
+                  log.push('after-inner');
+                }
+                log.push('end');
+              }
+              var out = [], guard = 0;
+              for await (var v of g()) {
+                out.push(v);
+                if (++guard > 12) { out.push('RUNAWAY'); break; }
+              }
+              return out.join(',') + '|' + log.join(',');
+            })()
+            """).Should().Be("f|end");
+    }
+
+    [Fact]
+    public void ContinueThroughAYieldingFinallyInAnAsyncGenerator()
+    {
+        RunAsync("""
+            (async function () {
+              var log = [];
+              async function* g() {
+                for (var j = 0; j < 2; j++) {
+                  try { continue; } finally { yield 'f'; }
+                  log.push('never');
+                }
+                log.push('end');
+              }
+              var out = [], guard = 0;
+              for await (var v of g()) {
+                out.push(v);
+                if (++guard > 12) { out.push('RUNAWAY'); break; }
+              }
+              return out.join(',') + '|' + log.join(',');
+            })()
+            """).Should().Be("f,f|end");
+    }
+
+    [Fact]
+    public void AwaitInAFinallyOfAnAsyncGeneratorStillCarriesTheJump()
+    {
+        RunAsync("""
+            (async function () {
+              var log = [];
+              async function* g() {
+                outer: for (var i = 0; i < 2; i++) {
+                  for (var j = 0; j < 2; j++) {
+                    try { break outer; } finally { await 0; log.push('f'); }
+                  }
+                  log.push('after-inner');
+                }
+                log.push('end');
+                yield 'done';
+              }
+              var out = [], guard = 0;
+              for await (var v of g()) {
+                out.push(v);
+                if (++guard > 12) { out.push('RUNAWAY'); break; }
+              }
+              return out.join(',') + '|' + log.join(',');
+            })()
+            """).Should().Be("done|f,end");
+    }
+
+    // ------------------------------------------------------------- controls
+    // Return and Throw were already parked across a suspension, and the non-suspending jump was
+    // fixed separately (LabelledJumpTests). These pin that widening the park changed neither.
+
+    [Fact]
+    public void APendingReturnStillSurvivesAYieldingFinally()
+    {
+        Run("""
+            function* g() { try { return 'R'; } finally { yield 'f'; } }
+            var it = g();
+            var a = it.next();
+            var b = it.next();
+            a.value + '|' + b.value + '|' + b.done;
+            """).Should().Be("f|R|true");
+    }
+
+    [Fact]
+    public void APendingThrowStillSurvivesAYieldingFinally()
+    {
+        Run("""
+            function* g() { try { throw 'T'; } finally { yield 'f'; } }
+            var it = g();
+            var a = it.next();
+            var caught = 'none';
+            try { it.next(); } catch (e) { caught = e; }
+            a.value + '|' + caught;
+            """).Should().Be("f|T");
+    }
+
+    [Fact]
+    public void APendingReturnStillSurvivesAnAwaitingFinally()
+    {
+        RunAsync("""
+            (async function () {
+              var log = [];
+              async function f() { try { return 'R'; } finally { await 0; log.push('f'); } }
+              log.push(await f());
+              return log.join(',');
+            })()
+            """).Should().Be("f,R");
+    }
+
+    [Fact]
+    public void APendingThrowStillSurvivesAnAwaitingFinally()
+    {
+        RunAsync("""
+            (async function () {
+              var log = [];
+              async function f() { try { throw 'T'; } finally { await 0; log.push('f'); } }
+              try { await f(); } catch (e) { log.push('caught:' + e); }
+              return log.join(',');
+            })()
+            """).Should().Be("f,caught:T");
+    }
+
+    [Fact]
+    public void AYieldInsideACatchFollowedByABreakIsUnchanged()
+    {
+        Run($$"""
+            {{Drain}}
+            var log = [];
+            function* g() {
+              for (var i = 0; i < 3; i++) {
+                try { throw 'x'; } catch (e) { yield 'c'; }
+                break;
+              }
+              log.push('end');
+            }
+            drain(g()).join(',') + '|' + log.join(',');
+            """).Should().Be("c|end");
+    }
+
+    [Fact]
+    public void TheNonSuspendingLabelledBreakThroughANonEmptyFinallyIsUnchanged()
+    {
+        Run("""
+            var log = [];
+            outer: for (var i = 0; i < 2; i++) {
+              for (var j = 0; j < 2; j++) {
+                try { break outer; } finally { log.push('f'); }
+              }
+              log.push('after-inner');
+            }
+            log.join(',');
+            """).Should().Be("f");
+    }
+
+    [Fact]
+    public void AYieldBeforeTheTryStatementIsUnchanged()
+    {
+        // The jump is not parked at all here: the suspension is outside the finalizer, so the
+        // whole try/finally runs to completion on one resume.
+        Run($$"""
+            {{Drain}}
+            var log = [];
+            function* g() {
+              outer: for (var i = 0; i < 2; i++) {
+                for (var j = 0; j < 2; j++) {
+                  yield 'y';
+                  try { break outer; } finally { log.push('f'); }
+                }
+                log.push('after-inner');
+              }
+              log.push('end');
+            }
+            drain(g()).join(',') + '|' + log.join(',');
+            """).Should().Be("y|f,end");
+    }
+}

--- a/Jint/Native/AsyncFunction/AsyncFunctionInstance.cs
+++ b/Jint/Native/AsyncFunction/AsyncFunctionInstance.cs
@@ -85,16 +85,6 @@ internal sealed class AsyncFunctionInstance : ISuspendable, IPromiseContinuation
     bool ISuspendable.ReturnRequested => false; // Async functions don't have return() like generators
 
     /// <summary>
-    /// Tracks the pending completion type when suspended in a finally block.
-    /// </summary>
-    CompletionType ISuspendable.PendingCompletionType { get; set; }
-
-    /// <summary>
-    /// Tracks the pending completion value when suspended in a finally block.
-    /// </summary>
-    JsValue? ISuspendable.PendingCompletionValue { get; set; }
-
-    /// <summary>
     /// The try statement whose finally block we're currently executing.
     /// Used to properly resume execution in finally blocks.
     /// </summary>

--- a/Jint/Native/AsyncGenerator/AsyncGeneratorInstance.cs
+++ b/Jint/Native/AsyncGenerator/AsyncGeneratorInstance.cs
@@ -74,10 +74,6 @@ internal sealed class AsyncGeneratorInstance : ObjectInstance, ISuspendable
 
     bool ISuspendable.ReturnRequested => _returnRequested;
 
-    CompletionType ISuspendable.PendingCompletionType { get; set; }
-
-    JsValue? ISuspendable.PendingCompletionValue { get; set; }
-
     object? ISuspendable.CurrentFinallyStatement
     {
         get => _currentFinallyStatement;

--- a/Jint/Native/Generator/GeneratorInstance.cs
+++ b/Jint/Native/Generator/GeneratorInstance.cs
@@ -90,18 +90,6 @@ internal sealed class GeneratorInstance : ObjectInstance, ISuspendable
     internal CompletionType _resumeCompletionType;
 
     /// <summary>
-    /// Tracks a pending completion (throw/return) that needs to be processed after a finally block
-    /// that yielded. When a finally block yields, we need to remember any pending completion
-    /// so we can restore it after the finally block completes.
-    /// </summary>
-    internal CompletionType _pendingCompletionType;
-
-    /// <summary>
-    /// The value associated with the pending completion (the thrown error or return value).
-    /// </summary>
-    internal JsValue? _pendingCompletionValue;
-
-    /// <summary>
     /// Tracks which try statement's finally block we're currently inside.
     /// Used to properly restore pending completion after finally completes.
     /// </summary>
@@ -123,18 +111,6 @@ internal sealed class GeneratorInstance : ObjectInstance, ISuspendable
     object? ISuspendable.LastSuspensionNode => _lastYieldNode;
 
     bool ISuspendable.ReturnRequested => _returnRequested;
-
-    CompletionType ISuspendable.PendingCompletionType
-    {
-        get => _pendingCompletionType;
-        set => _pendingCompletionType = value;
-    }
-
-    JsValue? ISuspendable.PendingCompletionValue
-    {
-        get => _pendingCompletionValue;
-        set => _pendingCompletionValue = value;
-    }
 
     object? ISuspendable.CurrentFinallyStatement
     {

--- a/Jint/Runtime/ISuspendable.cs
+++ b/Jint/Runtime/ISuspendable.cs
@@ -41,19 +41,14 @@ internal interface ISuspendable
     bool ReturnRequested { get; }
 
     /// <summary>
-    /// Tracks the pending completion type when suspended in a finally block.
-    /// </summary>
-    CompletionType PendingCompletionType { get; set; }
-
-    /// <summary>
-    /// Tracks the pending completion value when suspended in a finally block.
-    /// </summary>
-    JsValue? PendingCompletionValue { get; set; }
-
-    /// <summary>
     /// The try statement whose finally block we're currently executing.
     /// Used to properly resume execution in finally blocks.
     /// </summary>
+    /// <remarks>
+    /// This is a dispatch hint only, and one slot is enough for it: the completion a finalizer
+    /// interrupted is parked per try statement, in <see cref="Data"/>, because nested finalizers can
+    /// each have one in flight. See <see cref="TrySuspendData.PendingCompletion"/>.
+    /// </remarks>
     object? CurrentFinallyStatement { get; set; }
 
     /// <summary>

--- a/Jint/Runtime/Interpreter/Statements/JintTryStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintTryStatement.cs
@@ -98,7 +98,7 @@ internal sealed class JintTryStatement : JintStatement<TryStatement>
 
         var engine = context.Engine;
         var suspendable = engine.ExecutionContext.Suspendable;
-        var suspendData = GetCatchSuspendData(suspendable);
+        var suspendData = GetTrySuspendData(suspendable);
         if (suspendData?.CatchEnvironment is not null)
         {
             engine.UpdateLexicalEnvironment(suspendData.CatchEnvironment);
@@ -131,26 +131,23 @@ internal sealed class JintTryStatement : JintStatement<TryStatement>
             return f;
         }
 
-        // After finally completes normally, restore the pending completion
-        if (f.Type == CompletionType.Normal)
+        // "If finallyResult is a normal completion, set finallyResult to blockResult" — the parked
+        // record goes back whatever its type, so a Break or Continue resumes its jump here exactly
+        // as ExecuteFinalizer performs it when nothing suspended. Returning the record itself, and
+        // not a fresh one built from a type and a value, is what carries the jump's [[Target]]:
+        // Completion.Target reads the label out of the jump statement the record carries.
+        var suspendData = GetTrySuspendData(suspendable);
+        var pending = suspendData?.PendingCompletion;
+        if (suspendData is not null)
         {
-            var pendingType = suspendable.PendingCompletionType;
-            var pendingValue = suspendable.PendingCompletionValue;
+            suspendData.PendingCompletion = null;
+        }
 
-            // Clear the pending completion
-            suspendable.PendingCompletionType = CompletionType.Normal;
-            suspendable.PendingCompletionValue = null;
-            suspendable.CurrentFinallyStatement = null;
+        ReleaseFinallyDispatchHint(suspendable);
 
-            if (pendingType == CompletionType.Throw)
-            {
-                return new Completion(CompletionType.Throw, pendingValue ?? JsValue.Undefined, _statement);
-            }
-
-            if (pendingType == CompletionType.Return)
-            {
-                return new Completion(CompletionType.Return, pendingValue ?? JsValue.Undefined, _statement);
-            }
+        if (f.Type == CompletionType.Normal && pending is { } b)
+        {
+            return b.UpdateEmpty(JsValue.Undefined);
         }
 
         return f.UpdateEmpty(JsValue.Undefined);
@@ -221,7 +218,7 @@ internal sealed class JintTryStatement : JintStatement<TryStatement>
 
             if (context.IsSuspended() && suspendable is not null)
             {
-                var suspendData = suspendable.Data.GetOrCreate<CatchSuspendData>(this);
+                var suspendData = suspendable.Data.GetOrCreate<TrySuspendData>(this);
                 suspendData.CatchEnvironment = catchEnv;
                 suspendData.OuterEnvironment = oldEnv;
             }
@@ -252,13 +249,17 @@ internal sealed class JintTryStatement : JintStatement<TryStatement>
             return b.UpdateEmpty(JsValue.Undefined);
         }
 
-        // Save the pending completion before running finally. If finally awaits,
-        // ExecuteFinallyResume restores this completion after the await resumes.
-        if (suspendable is not null && (b.Type == CompletionType.Throw || b.Type == CompletionType.Return))
+        // Save the pending completion before running finally. If finally suspends,
+        // ExecuteFinallyResume reinstates this completion after the yield/await resumes.
+        // Every abrupt type is parked, Break and Continue included: step 3 of
+        // https://tc39.es/ecma262/#sec-try-statement-runtime-semantics-evaluation restores
+        // blockResult whatever its type, and a jump dropped here silently lets the enclosing
+        // loops run the iterations it was meant to skip.
+        var parkedOn = suspendable is not null && b.Type != CompletionType.Normal ? suspendable : null;
+        if (parkedOn is not null)
         {
-            suspendable.PendingCompletionType = b.Type;
-            suspendable.PendingCompletionValue = b.Value;
-            suspendable.CurrentFinallyStatement = this;
+            parkedOn.Data.GetOrCreate<TrySuspendData>(this).PendingCompletion = b;
+            parkedOn.CurrentFinallyStatement = this;
         }
 
         // Clear _returnRequested before running finally block.
@@ -285,12 +286,18 @@ internal sealed class JintTryStatement : JintStatement<TryStatement>
             return f;
         }
 
-        // Clear the pending completion tracking if we completed normally
-        if (suspendable is not null && ReferenceEquals(suspendable.CurrentFinallyStatement, this))
+        // Nothing suspended after all, so drop the park. The entry itself stays: it holds nothing
+        // live once the completion is out of it, and the next abrupt completion through this
+        // statement reuses it.
+        if (parkedOn is not null)
         {
-            suspendable.CurrentFinallyStatement = null;
-            suspendable.PendingCompletionType = CompletionType.Normal;
-            suspendable.PendingCompletionValue = null;
+            var parkedData = GetTrySuspendData(parkedOn);
+            if (parkedData is not null)
+            {
+                parkedData.PendingCompletion = null;
+            }
+
+            ReleaseFinallyDispatchHint(parkedOn);
         }
 
         if (f.Type == CompletionType.Normal)
@@ -303,14 +310,27 @@ internal sealed class JintTryStatement : JintStatement<TryStatement>
         return f.UpdateEmpty(JsValue.Undefined);
     }
 
-    private CatchSuspendData? GetCatchSuspendData(ISuspendable? suspendable)
+    private TrySuspendData? GetTrySuspendData(ISuspendable? suspendable)
     {
-        return suspendable?.Data.TryGet(this, out CatchSuspendData? suspendData) == true
+        return suspendable?.Data.TryGet(this, out TrySuspendData? suspendData) == true
             ? suspendData
             : null;
     }
 
-    private static void RestoreOuterEnvironmentAfterCatchResume(Engine engine, CatchSuspendData? suspendData)
+    /// <summary>
+    /// Drops the resume hint if it still names this statement. A finalizer nested inside this one
+    /// overwrites the single slot with its own, and has already cleared it by the time control gets
+    /// back here — clearing unconditionally would then discard a hint belonging to a third statement.
+    /// </summary>
+    private void ReleaseFinallyDispatchHint(ISuspendable suspendable)
+    {
+        if (ReferenceEquals(suspendable.CurrentFinallyStatement, this))
+        {
+            suspendable.CurrentFinallyStatement = null;
+        }
+    }
+
+    private static void RestoreOuterEnvironmentAfterCatchResume(Engine engine, TrySuspendData? suspendData)
     {
         if (suspendData?.OuterEnvironment is not null)
         {

--- a/Jint/Runtime/SuspendData.cs
+++ b/Jint/Runtime/SuspendData.cs
@@ -186,14 +186,34 @@ internal sealed class LeftOperandSuspendData : SuspendData
 }
 
 /// <summary>
-/// Stores the outer lexical environment for a catch clause when execution suspends
-/// inside the catch body.
+/// Stores what one try statement has to remember across a suspension: the environments of a catch
+/// clause suspended inside its body, and the completion a finalizer suspended inside <em>its</em>
+/// body interrupted.
 /// </summary>
-internal sealed class CatchSuspendData : SuspendData
+internal sealed class TrySuspendData : SuspendData
 {
     public DeclarativeEnvironment? CatchEnvironment { get; set; }
 
     public Environments.Environment? OuterEnvironment { get; set; }
+
+    /// <summary>
+    /// The <c>blockResult</c> of https://tc39.es/ecma262/#sec-try-statement-runtime-semantics-evaluation,
+    /// parked while the finalizer is suspended and reinstated by step 3 when it resumes and completes
+    /// normally.
+    /// <para>
+    /// The whole record is parked rather than a type and a value, because a Break or Continue keeps
+    /// its [[Target]] in <see cref="Completion.Target"/>, which reads the label back out of the jump
+    /// statement the record carries as its source. A type-and-value pair can neither express that
+    /// target nor be turned back into such a completion at all — the constructor requires the
+    /// matching jump statement.
+    /// </para>
+    /// <para>
+    /// It lives here, per try statement, and not in one slot on the suspendable, because a finalizer
+    /// may contain another try statement that parks a completion of its own before suspending; a
+    /// single slot let the inner one consume the outer's.
+    /// </para>
+    /// </summary>
+    public Completion? PendingCompletion { get; set; }
 }
 
 /// <summary>


### PR DESCRIPTION
`JintTryStatement.ExecuteFinalizer` parked a pending completion across a suspension only when it was `Throw` or `Return`, so a `break`/`continue` that reached a `finally` which then yielded or awaited was **discarded**. On resume the finalizer found nothing pending and returned normally: the jump never happened, enclosing loops ran extra iterations, and statements after the jump executed.

```js
function* g() { for (var j = 0; j < 2; j++) { try { break } finally { yield 'f' } } log.push('end') }
// node: one 'f', log = [end]        Jint: two 'f', log = [end]

outer: for (…) { for (…) { try { break outer } finally { yield 'f' } } log.push('after-inner') }
// node: log = [end]                 Jint: log = [after-inner, after-inner, end]
```

Ten scripts across generators, async functions and async generators, labelled and unlabelled, `break` and `continue`, all now byte-identical to Node 24.

Spec: [14.15.3](https://tc39.es/ecma262/#sec-try-statement-runtime-semantics-evaluation) step 3 — *if finallyResult is a normal completion, set finallyResult to blockResult* — draws no distinction by completion type. Pinned upstream by `language/statements/try/cptn-finally-empty-break.js` and `cptn-finally-empty-continue.js`.

This is the sibling of #2894. That PR made `Completion.Target` survive a non-empty `finally`; it does not survive a *suspension*, because `ISuspendable` had no slot for the jump node and a completion rebuilt from a type and a value cannot carry `[[Target]]`.

**The park had to move per statement, not per suspendable.** A first attempt put a single `Completion?` on `ISuspendable`; it passed all twenty original rows and broke a case that worked before — `try { return 'R' } finally { inner: for(;;) { try { break inner } finally { yield 'x' } } }` returned `undefined`, because the inner park consumed the outer's. A finalizer may contain another `try` that parks a completion of its own. So the record now lives in the suspend-data dictionary keyed by the try statement (`CatchSuspendData` → `TrySuspendData`), alongside the catch environments that were already keyed that way. `CurrentFinallyStatement` stays a single slot because it is only a resume hint. Two of the three nested tests pass on `main` and exist to stop the single-slot design coming back.

That also fixed a nested `break outer` case that was wrong on `main` too.

**Cost on the non-suspending path: none.** The guard still short-circuits on `suspendable is not null`. Inside a generator or async function with a non-suspending finalizer, the type test is one comparison rather than two, and the park is a dictionary `GetOrCreate` plus a field write — paid only when an abrupt completion actually passes through a finalizer, and the entry is emptied rather than removed so a loop re-entering the same `try` allocates once.

34 tests in `Jint.Tests/Runtime/SuspendedJumpCompletionTests.cs`; 21 fail on `main` on both net10.0 and net472. Test262 unchanged at 99,738 / 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)