### PR TITLE
Strip the sign before testing parseInt's argument for a hex prefix

### DIFF
--- a/Jint.Tests/Runtime/GlobalTests.cs
+++ b/Jint.Tests/Runtime/GlobalTests.cs
@@ -13,4 +13,84 @@ public class GlobalTests
         e.Evaluate("unescape('%u0040');").AsString().Should().Be("@");
         e.Evaluate("unescape('%u0040%u0040');").AsString().Should().Be("@@");
     }
+
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-parseint-string-radix — steps 4-5 remove the leading sign from S
+    /// before step 10 tests S for a "0x"/"0X" prefix, so a signed hexadecimal string is hexadecimal.
+    /// Expectations checked against node v24.
+    /// </summary>
+    [Theory]
+    [InlineData("parseInt('  -0X10 ')", -16d)]
+    [InlineData("parseInt('-0x10')", -16d)]
+    [InlineData("parseInt('+0x10')", 16d)]
+    [InlineData("parseInt('  +0X10  ')", 16d)]
+    [InlineData("parseInt('-0X1f')", -31d)]
+    [InlineData("parseInt('-0x10', 16)", -16d)]
+    [InlineData("parseInt('+0x10', 16)", 16d)]
+    [InlineData("parseInt('-0X10', 0)", -16d)]
+    [InlineData("parseInt('-0x7ffffffff')", -34359738367d)]
+    // radix 36 is not 16, so stripPrefix is false and "0Xz" is read as a base-36 numeral
+    [InlineData("parseInt('-0Xz', 36)", -1223d)]
+    // the unsigned path was always right, and a signed decimal never went near the prefix test
+    [InlineData("parseInt('0x10')", 16d)]
+    [InlineData("parseInt('-10')", -10d)]
+    public void ParseIntStripsTheSignBeforeTestingForAHexPrefix(string source, double expected)
+    {
+        new Engine().Evaluate(source).AsNumber().Should().Be(expected);
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-parseint-string-radix step 13 — an empty Z is NaN, whether the
+    /// string ran out after the sign, after the stripped prefix, or on a digit the radix rejects.
+    /// </summary>
+    [Theory]
+    [InlineData("parseInt('-0xg')")]
+    [InlineData("parseInt('-0x', 16)")]
+    [InlineData("parseInt('-0X')")]
+    [InlineData("parseInt('-', 16)")]
+    [InlineData("parseInt('-')")]
+    [InlineData("parseInt('+')")]
+    [InlineData("parseInt('0x')")]
+    [InlineData("parseInt('- 0x10')")]
+    [InlineData("parseInt('--0x10')")]
+    public void ParseIntReturnsNaNWhenNoDigitFollowsTheSign(string source)
+    {
+        new Engine().Evaluate(source).AsNumber().Should().Be(double.NaN);
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-parseint-string-radix step 15 — a zero magnitude carrying a
+    /// recorded minus sign is -0, not +0.
+    /// </summary>
+    [Theory]
+    [InlineData("parseInt('-0')")]
+    [InlineData("parseInt('-0', 10)")]
+    [InlineData("parseInt('-0.9')")]
+    [InlineData("parseInt('-0b11')")]
+    [InlineData("parseInt('-00x10')")]
+    [InlineData("parseInt('-0x0')")]
+    [InlineData("parseInt('-0x0', 16)")]
+    [InlineData("parseInt('-0x10', 8)")]
+    [InlineData("parseInt('-0x10', 10)")]
+    public void ParseIntReturnsNegativeZeroForAZeroMagnitudeWithAMinusSign(string source)
+    {
+        var value = new Engine().Evaluate(source).AsNumber();
+        value.Should().Be(0d);
+        IsNegativeZero(value).Should().BeTrue("the spec returns -0 when mathInt is 0 and sign is -1");
+    }
+
+    [Theory]
+    [InlineData("parseInt('0')")]
+    [InlineData("parseInt('+0')")]
+    [InlineData("parseInt('+0x0')")]
+    [InlineData("parseInt('0.9')")]
+    public void ParseIntReturnsPositiveZeroWithoutAMinusSign(string source)
+    {
+        var value = new Engine().Evaluate(source).AsNumber();
+        value.Should().Be(0d);
+        IsNegativeZero(value).Should().BeFalse();
+    }
+
+    private static bool IsNegativeZero(double value)
+        => BitConverter.DoubleToInt64Bits(value) == BitConverter.DoubleToInt64Bits(-0d);
 }

--- a/Jint/Native/Global/GlobalObject.cs
+++ b/Jint/Native/Global/GlobalObject.cs
@@ -39,29 +39,8 @@ public sealed partial class GlobalObject : ObjectInstance
         var trimmed = StringPrototype.TrimEx(inputString);
         var s = trimmed.AsSpan();
 
-        var radix = arguments.Length > 1 ? TypeConverter.ToInt32(arguments[1]) : 0;
-        var hexStart = s.Length > 1 && trimmed.StartsWith("0x", StringComparison.OrdinalIgnoreCase);
-
-        var stripPrefix = true;
-        if (radix == 0)
-        {
-            radix = hexStart ? 16 : 10;
-        }
-        else if (radix < 2 || radix > 36)
-        {
-            return JsNumber.DoubleNaN;
-        }
-        else if (radix != 16)
-        {
-            stripPrefix = false;
-        }
-
-        // check fast case
-        if (radix == 10 && int.TryParse(trimmed, NumberStyles.Integer, CultureInfo.InvariantCulture, out var number))
-        {
-            return JsNumber.Create(number);
-        }
-
+        // Steps 6-8: the sign is recorded and removed before anything else reads the string, because
+        // the "0x" test in step 9 is against the string the sign has already left.
         var sign = 1;
         if (s.Length > 0)
         {
@@ -77,16 +56,48 @@ public sealed partial class GlobalObject : ObjectInstance
             }
         }
 
-        if (stripPrefix && hexStart)
+        // Steps 2-3 and 10. stripPrefix captures step 9's "radixMV is 0 or 16" before step 10
+        // defaults it to 10; the spec validates the range at step 3, before trimming, which is a
+        // reordering nothing can observe because no user code runs in between.
+        var radix = arguments.Length > 1 ? TypeConverter.ToInt32(arguments[1]) : 0;
+        var stripPrefix = true;
+        if (radix == 0)
+        {
+            radix = 10;
+        }
+        else if (radix < 2 || radix > 36)
+        {
+            return JsNumber.DoubleNaN;
+        }
+        else if (radix != 16)
+        {
+            stripPrefix = false;
+        }
+
+        // Step 9. Only 'x' and 'X' fold onto each other under bit 0x20, so the two comparisons are
+        // the whole of the spec's "0x" or "0X" test.
+        if (stripPrefix && s.Length > 1 && s[0] == '0' && (s[1] | 0x20) == 'x')
         {
             s = s.Slice(2);
+            radix = 16;
         }
 
+        // check fast case
+        if (radix == 10 && int.TryParse(trimmed, NumberStyles.Integer, CultureInfo.InvariantCulture, out var number))
+        {
+            // Step 15: zero keeps a recorded minus sign, and the cached integers are all positive.
+            return number == 0 && sign == -1 ? JsNumber.NegativeZero : JsNumber.Create(number);
+        }
+
+        // Step 5, deferred to here: an input that is empty, or empty once the sign and prefix are
+        // gone, has no digits to read.
         if (s.Length == 0)
         {
-            return double.NaN;
+            return JsNumber.DoubleNaN;
         }
 
+        // Steps 11-14: numberString is the longest radix-R digit prefix. Accumulating from the end
+        // and resetting on every non-digit leaves exactly that prefix standing at index 0.
         var hasResult = false;
         double result = 0;
         double pow = 1;
@@ -116,6 +127,7 @@ public sealed partial class GlobalObject : ObjectInstance
             pow *= radix;
         }
 
+        // Steps 15-16: sign * 0 is already -0 in IEEE 754, and JsNumber.Create keeps that sign.
         return hasResult ? JsNumber.Create(sign * result) : JsNumber.DoubleNaN;
     }
 


### PR DESCRIPTION
`parseInt` computed the `0x`/`0X` prefix test on the string that still carried its leading `+`/`-`, so **every signed hex string parsed as 0**.

| | Jint | node |
|---|---|---|
| `parseInt("-0x10")` | `0` | `-16` |
| `parseInt("+0x10")` | `0` | `16` |
| `parseInt("  -0X10 ")` | `0` | `-16` |
| `parseInt("-0xg")` | `0` | `NaN` |
| `parseInt("-0x10", 16)` | `0` | `-16` |

[sec-parseint-string-radix](https://tc39.es/ecma262/#sec-parseint-string-radix): step 7-8 record the sign and drop it from *S*, and only step 9 tests *S* for `"0x"`. Jint ran step 9's test first, so the prefix was never stripped and the leading `0` became the whole answer.

Fixing that surfaced a second defect on the same algorithm. **`parseInt("-0")` and `parseInt("-0", 10)` returned `+0`**: the decimal fast path ends in `JsNumber.Create(number)`, and `JsNumber.Create(int)` serves zero from the positive-integer cache, discarding the recorded sign. Step 15 asks for `-0`. The slow path was already right, because `JsNumber.Create(double)` excludes negative zero from its integer fast path.

Both are pre-existing — the line is byte-identical to v4.15.3.

**Neither is testable upstream today, and both are asserted in the pinned tree.** All 55 files under `test/built-ins/parseInt/` use unsigned hex, and none asserts `-0`. But at the pinned SHA `b363f29d3c`, `test/staging/sm/global/parseInt-01.js:117` asserts `parseInt("-0x10", 16) === -16` and `:60` asserts `parseInt("-0", 10)` is `-0`. The harness generates only `annexB`, `built-ins`, `intl402` and `language`, so `staging/` is never emitted even though `ExcludedDirectories` is empty — the coverage exists and is structurally unreachable. Turning it on means thousands of imported SpiderMonkey and V8 tests, so that stays a separate call.

35 cases in `Jint.Tests/Runtime/GlobalTests.cs`, 14 red on `main` on both net10.0 and net472. Test262 unchanged.

On the hot path, `NumberParseBenchmark.ParseIntLoop` (explicit radix 10, unsigned) **loses** a call: `trimmed.StartsWith("0x", OrdinalIgnoreCase)` used to run on every invocation because the prefix flag had to be computed before radix defaulting, and it is now inside a branch whose first operand is false for radix 10. It gains the sign test — two char comparisons that fail — and one `number == 0` compare. No new allocation on any path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)