### PR TITLE
Ask an exotic global prototype for a bare identifier through [[Get]]

### DIFF
--- a/Jint.Tests.PublicInterface/HostGlobalPrototypeTests.cs
+++ b/Jint.Tests.PublicInterface/HostGlobalPrototypeTests.cs
@@ -4,6 +4,191 @@ using Jint.Native.Object;
 namespace Jint.Tests.PublicInterface;
 
 /// <summary>
+/// A Proxy or a host object with a <c>get</c> hook installed as the prototype of <c>globalThis</c>. A bare
+/// identifier resolves through the global's prototype chain, so a name such an object only produces from
+/// its <c>[[Get]]</c> has to reach the identifier lane too — <c>[[GetOwnProperty]]</c> fires a Proxy's
+/// <c>getOwnPropertyDescriptor</c> trap and never <c>get</c>, which would leave the read disagreeing with
+/// <c>in</c>, with <c>typeof</c> and with the same read spelled <c>globalThis.name</c>.
+/// </summary>
+public class ExoticGlobalPrototypeTests
+{
+    /// <summary>
+    /// Produces a value from <see cref="ObjectInstance.Get"/> for a name it owns no descriptor for — the
+    /// derived <see cref="PropertyAccessSemantics.Exotic"/> shape, and exactly a Proxy's problem. It
+    /// declares nothing: the engine derives the semantics from the override itself.
+    /// </summary>
+    private sealed class SynthesizingHost : ObjectInstance
+    {
+        private const string Virtual = "virt";
+
+        public SynthesizingHost(Engine engine) : base(engine)
+        {
+        }
+
+        public int Gets { get; private set; }
+
+        public JsValue LastReceiver { get; private set; } = JsValue.Undefined;
+
+        private static bool IsVirtual(JsValue property)
+            => property.IsString() && string.Equals(property.AsString(), Virtual, StringComparison.Ordinal);
+
+        public override JsValue Get(JsValue property, JsValue receiver)
+        {
+            if (IsVirtual(property))
+            {
+                Gets++;
+                LastReceiver = receiver;
+                return "VIRTUAL";
+            }
+
+            return base.Get(property, receiver);
+        }
+
+        public override bool HasProperty(JsValue property) => IsVirtual(property) || base.HasProperty(property);
+    }
+
+    private const string InstallProxy = """
+        var proxy = new Proxy({}, {
+            has: function (t, k) { return k === 'virt' || Reflect.has(t, k); },
+            get: function (t, k, r) { if (k === 'virt') { gets++; receiver = r; return 'VIRTUAL'; } return Reflect.get(t, k, r); },
+            set: function (t, k, v, r) { sets++; setReceiver = r; return Reflect.set(t, k, v, r); }
+        });
+        var gets = 0, sets = 0, receiver = null, setReceiver = null;
+        Object.setPrototypeOf(globalThis, proxy);
+        """;
+
+    [Fact]
+    public void AProxyPrototypeSeesItsGetTrapForABareIdentifier()
+    {
+        var engine = new Engine();
+        engine.Execute(InstallProxy);
+
+        engine.Evaluate("virt").AsString().Should().Be("VIRTUAL");
+        engine.Evaluate("gets").AsNumber().Should().Be(1);
+        engine.Evaluate("receiver === globalThis").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void AProxyPrototypeAnswersTypeofTheReadAndTheMemberReadAlike()
+    {
+        var engine = new Engine();
+        engine.Execute(InstallProxy);
+
+        engine.Evaluate("typeof virt").AsString().Should().Be("string");
+        engine.Evaluate("'virt' in globalThis").AsBoolean().Should().BeTrue();
+        engine.Evaluate("globalThis.virt").AsString().Should().Be("VIRTUAL");
+        engine.Evaluate("virt").AsString().Should().Be("VIRTUAL");
+    }
+
+    [Fact]
+    public void AProxyPrototypeSeesItsSetTrapForABareAssignment()
+    {
+        var engine = new Engine();
+        engine.Execute(InstallProxy);
+
+        engine.Execute("virt = 12;");
+
+        engine.Evaluate("sets").AsNumber().Should().Be(1);
+        engine.Evaluate("setReceiver === globalThis").AsBoolean().Should().BeTrue();
+        // Reflect.set forwarded onto the global receiver, so the name is now an own global that shadows
+        engine.Evaluate("globalThis.hasOwnProperty('virt')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("virt").AsNumber().Should().Be(12);
+    }
+
+    /// <summary>
+    /// staging/sm/Proxy/global-receiver.js from test262, which the generated suite does not cover because
+    /// the harness only generates annexB, built-ins, intl402 and language.
+    /// </summary>
+    [Fact]
+    public void Test262StagingGlobalReceiver()
+    {
+        var engine = new Engine();
+        engine.Execute("""
+            var global = this;
+            var proto = Object.getPrototypeOf(global);
+            var gets = 0, sets = 0, getReceiver = null, setReceiver = null;
+
+            Object.setPrototypeOf(global, new Proxy(proto, {
+                has(t, id) { return id === "bareword" || Reflect.has(t, id); },
+                get(t, id, r) { gets++; getReceiver = r; return Reflect.get(t, id, r); },
+                set(t, id, v, r) { sets++; setReceiver = r; return Reflect.set(t, id, v, r); }
+            }));
+            """);
+
+        engine.Evaluate("bareword").Should().Be(JsValue.Undefined);
+        engine.Evaluate("gets").AsNumber().Should().Be(1);
+        engine.Evaluate("getReceiver === global").AsBoolean().Should().BeTrue();
+
+        engine.Execute("bareword = 12;");
+        engine.Evaluate("sets").AsNumber().Should().Be(1);
+        engine.Evaluate("setReceiver === global").AsBoolean().Should().BeTrue();
+        engine.Evaluate("global.bareword").AsNumber().Should().Be(12);
+    }
+
+    [Fact]
+    public void AHostPrototypeThatOverridesGetIsAskedThroughGet()
+    {
+        var engine = new Engine();
+        var host = new SynthesizingHost(engine);
+        engine.Global.Prototype = host;
+
+        engine.Evaluate("virt").AsString().Should().Be("VIRTUAL");
+        engine.Evaluate("typeof virt").AsString().Should().Be("string");
+        engine.Evaluate("'virt' in globalThis").AsBoolean().Should().BeTrue();
+        engine.Evaluate("globalThis.virt").AsString().Should().Be("VIRTUAL");
+
+        host.Gets.Should().BeGreaterThan(0);
+        ReferenceEquals(host.LastReceiver, engine.Global).Should().BeTrue();
+    }
+
+    [Fact]
+    public void AProxyBelowTheDirectPrototypeStillResolves()
+    {
+        var engine = new Engine();
+        engine.Execute(InstallProxy);
+        engine.Execute("Object.setPrototypeOf(globalThis, Object.create(proxy));");
+
+        engine.Evaluate("virt").AsString().Should().Be("VIRTUAL");
+        engine.Evaluate("typeof virt").AsString().Should().Be("string");
+    }
+
+    [Fact]
+    public void AnOrdinaryPrototypeIsUnaffected()
+    {
+        var engine = new Engine();
+        engine.Execute("""
+            var plain = Object.create(null);
+            plain.plainName = 'PLAIN';
+            Object.defineProperty(plain, 'accessor', { get: function () { return this === globalThis ? 'RECEIVER' : 'OTHER'; } });
+            Object.setPrototypeOf(globalThis, plain);
+            """);
+
+        engine.Evaluate("plainName").AsString().Should().Be("PLAIN");
+        engine.Evaluate("typeof plainName").AsString().Should().Be("string");
+        engine.Evaluate("globalThis.plainName").AsString().Should().Be("PLAIN");
+        // an inherited accessor is still invoked with the global as its `this`
+        engine.Evaluate("accessor").AsString().Should().Be("RECEIVER");
+        // and a name absent from the whole chain is still unresolvable
+        engine.Evaluate("typeof missing").AsString().Should().Be("undefined");
+        Invoking(() => engine.Evaluate("missing")).Should().Throw<Jint.Runtime.JavaScriptException>();
+    }
+
+    [Fact]
+    public void AnOrdinaryPrototypeTwoLevelsDeepIsUnaffected()
+    {
+        var engine = new Engine();
+        engine.Execute("""
+            var base = Object.create(null);
+            base.deepName = 'DEEP';
+            Object.setPrototypeOf(globalThis, Object.create(base));
+            """);
+
+        engine.Evaluate("deepName").AsString().Should().Be("DEEP");
+        engine.Evaluate("typeof deepName").AsString().Should().Be("string");
+    }
+}
+
+/// <summary>
 /// A wrapped CLR object installed as the prototype of <c>globalThis</c> (issue #2925). Only the global
 /// object participates in bare-identifier resolution, so this is where the spec-shaped
 /// GlobalEnvironmentRecord lanes (HasBinding/GetBindingValue walking the prototype chain) meet interop:

--- a/Jint/Runtime/Environments/GlobalEnvironment.cs
+++ b/Jint/Runtime/Environments/GlobalEnvironment.cs
@@ -149,12 +149,25 @@ internal sealed class GlobalEnvironment : Environment
         JsValue name,
         [NotNullWhen(true)] out JsValue? value)
     {
+        var prototype = _global._prototype!;
+
+        // An own-property question is not a read for an object whose [[Get]] deviates from the ordinary
+        // one — PropertyAccessSemantics.Exotic, which the engine derives per type and the exotic built-ins
+        // state outright. A Proxy answers [[GetOwnProperty]] from its getOwnPropertyDescriptor trap and
+        // never its get trap, and a host object that synthesises a value in Get owns no descriptor for it
+        // at all, so either would resolve to nothing here while HasBinding — a real [[HasProperty]] chain
+        // walk — has already said the binding exists. Hand those the same spec-shaped pair the deeper
+        // levels get, one level higher up.
+        if ((prototype._type & InternalTypes.ExoticGet) != InternalTypes.Empty)
+        {
+            return TryGetFromPrototypeChain(prototype, name, out value);
+        }
+
         // TryGetOwnPropertyValue's base body is exactly what this used to spell out — GetOwnProperty,
         // Undefined means no, otherwise UnwrapJsValue against the global as receiver — so for every
         // in-box prototype the two are the same call. Asking through the hook additionally lets a host
         // object installed as the global's prototype answer from its own state without building a
         // descriptor it would only throw away.
-        var prototype = _global._prototype!;
         if (prototype.TryGetOwnPropertyValue(name, _global, out var found))
         {
             value = found;
@@ -163,10 +176,22 @@ internal sealed class GlobalEnvironment : Environment
 
         // deeper levels are colder: spec-shaped [[HasProperty]] + [[Get]] with the global as
         // receiver, so a Proxy or exotic object below the direct prototype sees its real traps
-        var parent = prototype.GetPrototypeOf();
-        if (parent is not null && parent.HasProperty(name))
+        return TryGetFromPrototypeChain(prototype.GetPrototypeOf(), name, out value);
+    }
+
+    /// <summary>
+    /// [[HasProperty]] to decide whether the name resolves at all, then [[Get]] with the global as the
+    /// receiver — the spec's GlobalEnvironmentRecord.GetBindingValue shape, which the shortcut above can
+    /// only stand in for when the object it asks has ordinary read semantics.
+    /// </summary>
+    private bool TryGetFromPrototypeChain(
+        ObjectInstance? start,
+        JsValue name,
+        [NotNullWhen(true)] out JsValue? value)
+    {
+        if (start is not null && start.HasProperty(name))
         {
-            value = parent.Get(name, _global);
+            value = start.Get(name, _global);
             return true;
         }
 


### PR DESCRIPTION
`GlobalEnvironment.TryGetFromGlobalPrototype` resolved the **direct** prototype with `TryGetOwnPropertyValue` — that is `[[GetOwnProperty]]`, so a `Proxy` installed as the global's prototype saw its `getOwnPropertyDescriptor` trap and never its `get`. Levels two and deeper were already spec-shaped (`HasProperty` + `Get(name, global)`), so the defect was exactly one level deep — and it made `HasBinding` and the value read contradict each other:

```js
var p = new Proxy({}, { has: (t, k) => k === 'virt', get: () => 'VIRTUAL' });
Object.setPrototypeOf(globalThis, p);
typeof virt           // node: "string"    Jint: "undefined"
virt                  // node: "VIRTUAL"   Jint: ReferenceError: virt is not defined
'virt' in globalThis  // both: true
globalThis.virt       // both: "VIRTUAL"
```

Pre-existing, but aggravated by #2928: before it, `typeof` also answered `"undefined"`, so the engine was at least self-consistent. Now it reports the binding exists and the read throws.

**test262 covers this and we do not run it.** `test/staging/sm/Proxy/global-receiver.js` asserts the global is the receiver handed to a Proxy's `get` and `set` traps when the Proxy is the global's prototype. Run by hand through the REPL: before, `ReferenceError: bareword is not defined` at the first assertion; after, `PASS gets=1 sets=1`. The harness emits only `annexB`, `built-ins`, `intl402` and `language`, so `staging/` never reaches the suite. It is now pinned in-repo as `ExoticGlobalPrototypeTests.Test262StagingGlobalReceiver`.

The gate is `InternalTypes.ExoticGet` — the bit behind `PropertyAccessSemantics.Exotic` — not a `is JsProxy` type test, so a **host** object that overrides `Get` gets the same answer, and one that overrides `Get` but declares `Ordinary` keeps the shortcut, which is exactly what that declaration promises. Level 1 and levels 2+ now share one body.

The shortcut is kept for ordinary prototypes because it is load-bearing: it lets a host prototype answer without building a descriptor it would throw away. An ordinary prototype now additionally executes a load of `prototype._type`, an `AND` with a constant and a not-taken branch — a same-cache-line load feeding a predictable branch, on a method that is already `NoInlining` and is reached only after the global's own lookup and its shape lookup have both missed. No new call, no new allocation, no change in virtual dispatch count.

8 new tests, 4 red on `main` on both net10.0 and net472. The 4 that passed cold were the set-trap and level-2 cases, isolating the defect. Verification leg green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)