### PR TITLE
Tell a wrong receiver apart from a host method that threw TargetException itself

### DIFF
--- a/Jint.Tests.PublicInterface/HostClrExceptionTests.cs
+++ b/Jint.Tests.PublicInterface/HostClrExceptionTests.cs
@@ -1,9 +1,127 @@
 #nullable enable
 
+using System.Reflection;
 using Jint.Native;
 using Jint.Runtime;
+using Jint.Runtime.Interop;
 
 namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// A host method that itself uses reflection and gets a target wrong raises <see cref="TargetException"/> from
+/// inside its own body. Once <c>MethodBase.Invoke</c> has been entered that is indistinguishable from the
+/// <see cref="TargetException"/> the invoke raises when <em>Jint's</em> receiver is wrong, so classifying it
+/// from the exception rewrote the host's own failure into a TypeError and threw the CLR exception away — the
+/// exact thing <see cref="JintException.TryGetClrException"/> exists to preserve. Receiver compatibility is
+/// therefore decided before the invoke, and everything coming out of it is the host's.
+/// </summary>
+public class HostReflectingMethodTests
+{
+    private sealed class ReflectingHost
+    {
+        /// <summary>
+        /// Two overloads keep the call on the reflection invoke lane on every target framework: the
+        /// compiled-invoker fast lane is single-candidate only, and net472 has no such lane at all.
+        /// </summary>
+        public string Reflect() => Misdirect();
+
+        public string Reflect(int unused) => Misdirect();
+
+        private string Misdirect()
+        {
+            var method = typeof(string).GetMethod(nameof(string.ToUpperInvariant), Type.EmptyTypes)!;
+            // deliberately the wrong target — the TargetException raises inside this method, not in Jint
+            return (string) method.Invoke(this, null)!;
+        }
+    }
+
+    private sealed class SingleMethodReflectingHost
+    {
+        public string Reflect()
+        {
+            var method = typeof(string).GetMethod(nameof(string.ToUpperInvariant), Type.EmptyTypes)!;
+            return (string) method.Invoke(this, null)!;
+        }
+    }
+
+    private sealed class UnrelatedHost
+    {
+        public int Unrelated => 1;
+    }
+
+    /// <summary>
+    /// Behaves exactly like the default one, but is not it — enough for the engine to decline the compiled
+    /// invoker lane, which is the configuration a host with any custom converter is in.
+    /// </summary>
+    private sealed class CustomTypeConverter(Engine engine) : DefaultTypeConverter(engine);
+
+    [Fact]
+    public void AHostMethodsOwnTargetExceptionIsNotMistakenForAReceiverMismatch()
+    {
+        var engine = new Engine(options => options.CatchClrExceptions());
+        engine.SetValue("host", new ReflectingHost());
+
+        var exception = Invoking(() => engine.Evaluate("host.Reflect()")).Should().Throw<JavaScriptException>().Which;
+
+        exception.Message.Should().NotBe("Method 'Reflect' called on incompatible receiver");
+        JintException.TryGetClrException(exception, out var clrException).Should().BeTrue();
+        clrException.Should().BeAssignableTo<TargetException>();
+    }
+
+    [Fact]
+    public void TheSameHoldsWhenACustomTypeConverterDeclinesTheCompiledInvokerLane()
+    {
+        var engine = new Engine(options =>
+        {
+            options.CatchClrExceptions();
+            options.SetTypeConverter(e => new CustomTypeConverter(e));
+        });
+        engine.SetValue("host", new SingleMethodReflectingHost());
+
+        var exception = Invoking(() => engine.Evaluate("host.Reflect()")).Should().Throw<JavaScriptException>().Which;
+
+        exception.Message.Should().NotBe("Method 'Reflect' called on incompatible receiver");
+        JintException.TryGetClrException(exception, out var clrException).Should().BeTrue();
+        clrException.Should().BeAssignableTo<TargetException>();
+    }
+
+    [Fact]
+    public void TheHostExceptionAlsoReachesAScriptCatchUnchanged()
+    {
+        var engine = new Engine(options => options.CatchClrExceptions());
+        engine.SetValue("host", new ReflectingHost());
+
+        engine.Evaluate("try { host.Reflect(); 'no error' } catch (e) { e instanceof TypeError }")
+            .AsBoolean().Should().BeFalse("the host's own failure is not a receiver mismatch");
+    }
+
+    [Fact]
+    public void AForeignReceiverStillSurfacesACatchableTypeErrorOnTheReflectionLane()
+    {
+        var engine = new Engine(options => options.CatchClrExceptions());
+        engine.SetValue("host", new ReflectingHost());
+        engine.SetValue("other", new UnrelatedHost());
+
+        var exception = Invoking(() => engine.Evaluate("var f = host.Reflect; f.call(other)"))
+            .Should().ThrowExactly<JavaScriptException>().Which;
+        exception.Message.Should().Be("Method 'Reflect' called on incompatible receiver");
+
+        engine.Evaluate("var g = host.Reflect; try { g.call(other); 'no error' } catch (e) { e instanceof TypeError }")
+            .AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void AForeignReceiverIsATypeErrorForASingleCandidateMethodToo()
+    {
+        var engine = new Engine(options => options.CatchClrExceptions());
+        engine.SetValue("host", new SingleMethodReflectingHost());
+        engine.SetValue("other", new UnrelatedHost());
+
+        var exception = Invoking(() => engine.Evaluate("var f = host.Reflect; f.call(other)"))
+            .Should().ThrowExactly<JavaScriptException>().Which;
+        exception.Message.Should().Be("Method 'Reflect' called on incompatible receiver");
+    }
+}
 
 /// <summary>
 /// Behaviour contract for the originating CLR exception behind a JavaScript error. When

--- a/Jint/Runtime/Interop/MethodInfoFunction.cs
+++ b/Jint/Runtime/Interop/MethodInfoFunction.cs
@@ -418,6 +418,19 @@ internal sealed class MethodInfoFunction : Function
             }
         }
 
+        // Classify the receiver here, not from whatever the invoke raises. A TargetException coming out of
+        // MethodBase.Invoke says nothing about who produced it: the host method's own body may have used
+        // reflection and got a target wrong, and on net8+ MethodDescriptor.Invoke normalizes that into the
+        // same TargetInvocationException shape a receiver mismatch takes. Rewriting either into a TypeError
+        // discards the host's exception and defeats JintException.TryGetClrException. This is the predicate
+        // the compiled-invoker lane already gates on; a null DeclaringType (a module-level global method,
+        // which reflection over a Type never yields) is left for the invoke to judge as before.
+        if (!method.IsStatic && method.DeclaringType is { } declaringType && !declaringType.IsInstanceOfType(thisObj))
+        {
+            _engine.CheckAmortizedConstraintsAtHostBoundary();
+            ThrowIncompatibleReceiver();
+        }
+
         try
         {
             if (isGenericDefinition)
@@ -435,23 +448,9 @@ internal sealed class MethodInfoFunction : Function
             _engine.CheckAmortizedConstraintsAtHostBoundary();
             return true;
         }
-        catch (TargetException)
-        {
-            // receiver mismatch: netfx MethodBase.Invoke and the generic-definition path above throw
-            // it unwrapped; surface a catchable TypeError instead of a raw CLR crash
-            _engine.CheckAmortizedConstraintsAtHostBoundary();
-            ThrowIncompatibleReceiver();
-            return false;
-        }
         catch (TargetInvocationException exception)
         {
             _engine.CheckAmortizedConstraintsAtHostBoundary();
-            if (exception.InnerException is TargetException)
-            {
-                // net8+: MethodDescriptor.Invoke normalizes the sibling TargetException into the
-                // TargetInvocationException shape; still a receiver mismatch, not the method throwing
-                ThrowIncompatibleReceiver();
-            }
             Throw.MeaningfulException(_engine, exception);
             return false;
         }


### PR DESCRIPTION
#2928 added `catch (TargetException)` and a `TargetInvocationException` arm whose inner is one, both rewriting into `TypeError: Method 'X' called on incompatible receiver`. Neither can tell a `TargetException` raised **by** `MethodBase.Invoke` because the receiver is wrong from one thrown **inside** the host method — and a host method that itself uses reflection is the realistic trigger. Its exception is destroyed, and `JintException.TryGetClrException` answers `false`, silently defeating the guarantee #2916–#2918 added in the same release.

For one host type whose `Reflect()` body calls `mi.Invoke(<wrong target>, null)`, with `CatchClrExceptions()`:

| | script sees | `TryGetClrException` |
|---|---|---|
| v4.15.3, net472 | `Error: Object does not match target type.` | real `TargetException` |
| main, net472 | `TypeError: … incompatible receiver` | **false** |
| main, net10 + custom `ITypeConverter` | `TypeError: … incompatible receiver` | **false** |
| main, net10 default (compiled lane) | `Error: Object type … does not match target type …` | true |

So one host method reported different things per target framework and per interop configuration. Affected always on net462/netstandard/net472, and on net8+ whenever the compiled-invoker lane declines — a custom `ITypeConverter`, an untyped `IObjectConverter`, an overload set, non-exact arguments, a generic definition.

Receiver compatibility is now decided **before** the invoke, and both `TargetException` arms are gone, restoring v4.15.3's `catch (TargetInvocationException)` shape. One deliberate deviation from the compiled lane's predicate at `MethodInfoFunction.cs:191`: a null `DeclaringType` is treated as compatible and left for the invoke to judge. There, a false answer only declines a fast lane; here it would throw a `TypeError`, so the two cannot be spelled identically.

#2928's intended behaviour is untouched — a genuinely foreign CLR receiver still fails the pre-check and still surfaces a catchable `TypeError` on every target framework. Both `InteropCompiledInvokerTests` pins that #2928 updated keep the new behaviour and pass unchanged.

3 of 5 new tests red on `main`, on both net10.0 and net472; the two that passed cold are the foreign-receiver cases. Verification leg green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)