### PR TITLE
Take the operator-overloading reading after the options are applied

### DIFF
--- a/Jint.Tests.PublicInterface/OperatorOverloadingConfigurationTests.cs
+++ b/Jint.Tests.PublicInterface/OperatorOverloadingConfigurationTests.cs
@@ -1,0 +1,100 @@
+using Jint.Native;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// Pins when <see cref="Options.InteropOptions.AllowOperatorOverloading"/> is read.
+/// <para>
+/// The engine snapshots it once instead of consulting <see cref="Options"/> on every evaluation, so
+/// the moment it takes the reading is observable to a host: everything that runs before it is
+/// honoured, everything after it is not. The snapshot is taken after <c>Options.Apply</c>, which is
+/// what runs a host's <c>Configure</c> callbacks, so both documented ways of setting the option at
+/// construction time work. Mutating the <see cref="Options"/> instance <em>after</em> the engine
+/// exists deliberately does not — see the test that says so.
+/// </para>
+/// </summary>
+public class OperatorOverloadingConfigurationTests
+{
+    /// <summary>
+    /// A CLR type whose <c>+</c> is only reachable through operator overloading. With the option off
+    /// the addition falls back to string concatenation, so the result has no <c>Value</c> at all —
+    /// which makes <c>undefined</c> the answer that means "the option was not in effect".
+    /// </summary>
+    public sealed class Amount
+    {
+        public Amount(int value) => Value = value;
+
+        public int Value { get; }
+
+        public static Amount operator +(Amount left, Amount right) => new Amount(left.Value + right.Value);
+    }
+
+    private static JsValue Add(Engine engine)
+    {
+        engine.SetValue("a", new Amount(1));
+        engine.SetValue("b", new Amount(2));
+        return engine.Evaluate("(a + b).Value");
+    }
+
+    [Fact]
+    public void TheConstructorConfigureDelegateEnablesIt()
+    {
+        Add(new Engine(options => options.AllowOperatorOverloading())).Should().Be(3);
+    }
+
+    [Fact]
+    public void AnOptionsInstanceConfiguredBeforeConstructionEnablesIt()
+    {
+        var options = new Options().AllowOperatorOverloading();
+
+        Add(new Engine(options)).Should().Be(3);
+    }
+
+    [Fact]
+    public void AConfigureCallbackEnablesIt()
+    {
+        // Configure callbacks run from Options.Apply, i.e. later in the constructor than the point
+        // at which the option used to be read. Registering one is the documented way to defer setup
+        // to construction time, so a host that enables the option from there has to be honoured.
+        var options = new Options();
+        options.Configure(_ => options.AllowOperatorOverloading());
+
+        Add(new Engine(options)).Should().Be(3);
+    }
+
+    [Fact]
+    public void ItIsOffByDefault()
+    {
+        Add(new Engine()).Should().Be(JsValue.Undefined);
+    }
+
+    [Fact]
+    public void ADisablingConfigureCallbackWinsOverAnEarlierEnable()
+    {
+        // The reading is taken once, at the end of construction, so the last writer before that wins
+        // in both directions rather than only in the enabling one.
+        var options = new Options().AllowOperatorOverloading();
+        options.Configure(_ => options.AllowOperatorOverloading(allow: false));
+
+        Add(new Engine(options)).Should().Be(JsValue.Undefined);
+    }
+
+    [Fact]
+    public void MutatingTheOptionsAfterConstructionDoesNotReachTheEngine()
+    {
+        // Deliberate: the reading belongs to the engine, not to the Options instance it was built
+        // from. One Options instance is meant to be shared by many engines, including concurrently
+        // running ones, so a live read would let one host thread change how another engine's already
+        // running script evaluates `+`. Every other option the engine cares about is snapshotted the
+        // same way. A host that wants the option has to ask for it before the engine exists.
+        var options = new Options();
+        var engine = new Engine(options);
+
+        options.AllowOperatorOverloading();
+
+        Add(engine).Should().Be(JsValue.Undefined);
+
+        // ... and the same Options instance still configures the next engine built from it.
+        Add(new Engine(options)).Should().Be(3);
+    }
+}

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -307,6 +307,13 @@ public sealed partial class Engine : IDisposable
     // track depth at all from the same value (see the JintCallStack construction below).
     internal readonly int _maxRecursionDepth;
 
+    // Snapshot of Options.Interop.AllowOperatorOverloading, consulted by the arithmetic, comparison,
+    // update and assignment expressions to decide whether an operand may have a CLR operator behind
+    // it. Like _maxRecursionDepth it is read after Options.Apply, so a Configure callback can still
+    // set it; unlike the Options property it is fixed for the engine's lifetime, which is what lets
+    // one Options instance be shared by engines that are already running.
+    internal readonly bool _operatorOverloadingAllowed;
+
     internal readonly ReferencePool _referencePool;
     internal readonly ArgumentsInstancePool _argumentsInstancePool;
     internal readonly JsValueArrayPool _jsValueArrayPool;
@@ -432,9 +439,10 @@ public sealed partial class Engine : IDisposable
         _amortizedConstraints = partitionedConstraints.Amortized;
         _inlineStatementCounter = partitionedConstraints.InlineStatementCounter;
 
-        // Everything the context snapshots is settled by now (debug mode, the constraint partition,
-        // operator overloading), and it must exist before Options.Apply below, whose configuration
-        // callbacks may execute script.
+        // Everything the context snapshots is settled by now (debug mode, the constraint partition),
+        // and it must exist before Options.Apply below, whose configuration callbacks may execute
+        // script. That is also why the context does not snapshot operator overloading itself: the
+        // engine takes that reading after Apply and the context reads it from there.
         _evaluationContext = new EvaluationContext(this);
 
         _referenceResolver = Options.ReferenceResolver;
@@ -465,6 +473,11 @@ public sealed partial class Engine : IDisposable
         // Read after Options.Apply so the snapshot observes the same value JintCallStack does
         // (Apply runs the user's configuration callbacks, which can still touch Constraints).
         _maxRecursionDepth = Options.Constraints.MaxRecursionDepth;
+
+        // Likewise after Apply: a configuration callback registered with Options.Configure is a
+        // documented place to finish configuring an engine, and enabling operator overloading from
+        // one has to reach the expressions that consult it.
+        _operatorOverloadingAllowed = Options.Interop.AllowOperatorOverloading;
 
         // likewise after Apply, which is where a custom ITypeConverter gets installed
         _interopResolutionProfile = new InteropResolutionProfile(

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -361,6 +361,11 @@ public class Options
         /// <summary>
         /// Whether operator overloading resolution is allowed, defaults to false.
         /// </summary>
+        /// <remarks>
+        /// Read once per engine, at the end of construction and so after any callback registered with
+        /// <c>Options.Configure</c> has run. Setting it on an <see cref="Options"/> instance an engine
+        /// has already been built from does not reach that engine — only engines built afterwards.
+        /// </remarks>
         public bool AllowOperatorOverloading { get; set; }
 
         /// <summary>

--- a/Jint/Runtime/Interpreter/EvaluationContext.cs
+++ b/Jint/Runtime/Interpreter/EvaluationContext.cs
@@ -28,7 +28,6 @@ internal sealed class EvaluationContext
     public EvaluationContext(Engine engine)
     {
         Engine = engine;
-        OperatorOverloadingAllowed = engine.Options.Interop.AllowOperatorOverloading;
 
         // A lone statement counter does not have to disarm the statement fast paths: it is charged
         // inline instead (see ChargeStatement), once per executed statement, at the same points
@@ -44,7 +43,6 @@ internal sealed class EvaluationContext
     public EvaluationContext()
     {
         Engine = null!;
-        OperatorOverloadingAllowed = false;
         _shouldRunPerStatementChecks = false;
         _hasAmortizedConstraints = false;
         _statementCounter = null;
@@ -89,7 +87,20 @@ internal sealed class EvaluationContext
         set => Engine._lastSyntaxElement = value;
     }
 
-    public readonly bool OperatorOverloadingAllowed;
+    /// <summary>
+    /// Whether an operand may have a CLR operator behind it
+    /// (<c>Options.Interop.AllowOperatorOverloading</c>). Read from the engine rather than
+    /// snapshotted here: this context is built before <c>Options.Apply</c> runs the host's
+    /// configuration callbacks, and one of those may still enable the option — the same reason
+    /// <see cref="Engine._maxRecursionDepth"/> is read after Apply. The engine's field is the
+    /// snapshot, fixed for its lifetime, so this stays a per-engine constant the way the call sites
+    /// assume.
+    /// <para>
+    /// The null test is for the engine-less context above, which constant folding builds at
+    /// preparation time and which has to answer <see langword="false"/> rather than throw.
+    /// </para>
+    /// </summary>
+    public bool OperatorOverloadingAllowed => Engine is { _operatorOverloadingAllowed: true };
 
     /// <summary>
     /// Whether Normal-completion values of statements are observable in the current frame.


### PR DESCRIPTION
#2896 moved `EvaluationContext` construction into the `Engine` constructor, and the context reads `Options.Interop.AllowOperatorOverloading` into a `readonly` field. That read now happens at `Engine.cs:438`, **before** `Options.Apply` at `:457` — so an `Options.Configure(e => …)` callback can no longer enable it:

```csharp
var options = new Options();
options.Configure(_ => options.AllowOperatorOverloading());
new Engine(options).Evaluate("(a + b).Value");   // v4.15.3: 3    main: undefined
```

The commit defended the snapshot by analogy with `_isDebugMode`, `_isStrict` and `_maxRecursionDepth` — but `_maxRecursionDepth` is deliberately read *after* `Options.Apply`, for exactly this reason. The reading moves next to it, as `Engine._operatorOverloadingAllowed`.

`EvaluationContext.OperatorOverloadingAllowed` cannot keep a copy, because the context must exist before `Apply` so that a callback which executes script has one to run in; it reads the engine field instead. The null test in it is deliberate — the engine-less context that constant folding builds at preparation time reaches this member, and folding runs inside a catch-everything, so an NRE there would have quietly stopped folding literals rather than failing anything.

**Deliberately not restored: mutating `Options` after the engine is built.** That also worked before #2896 and does not now.

| | pre-#2896 | main | this PR |
|---|---|---|---|
| `new Engine(o => o.AllowOperatorOverloading())` | 3 | 3 | 3 |
| `options.AllowOperatorOverloading()` before `new Engine(options)` | 3 | 3 | 3 |
| `options.Configure(_ => options.AllowOperatorOverloading())` | **3** | undefined | **3** |
| flip on `options` *after* `new Engine(options)` | **3** | undefined | undefined |

`Options` is documented as shareable across engines including concurrent ones, so a live read lets one host thread change how `+` evaluates inside another engine's running script through an unsynchronized `bool` on a hot path. Every other option the engine cares about is snapshotted — `_isDebugMode`, `_isStrict`, `_enumsAsStrings`, `_maxRecursionDepth`, the constraint partition, `_interopResolutionProfile`, the resolver interests — and this was the last live read, only by accident of where the context happened to be built. Both supported spellings work, and the same `Options` still configures the next engine built from it.

`AllowOperatorOverloading` gains a `<remarks>` saying when it is read, and `MutatingTheOptionsAfterConstructionDoesNotReachTheEngine` pins the choice from outside the assembly so reversing it is deliberate.

2 of 6 new tests red on `main`, both TFMs. Test262 99,738 / 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)