### PR TITLE
Keep the chained CLR stack out of the JavaScript error string

### DIFF
--- a/Jint.Tests.PublicInterface/HostClrExceptionTests.cs
+++ b/Jint.Tests.PublicInterface/HostClrExceptionTests.cs
@@ -282,6 +282,54 @@ public class HostClrExceptionTests
     }
 
     [Fact]
+    public void ChainingKeepsTheClrStackOutOfTheJavaScriptErrorString()
+    {
+        var engine = new Engine(options =>
+        {
+            options.CatchClrExceptions();
+            options.ChainClrExceptions();
+        });
+        engine.SetValue("boom", new Action(() => throw new HostFailure("host blew up", new InvalidOperationException("root cause"))));
+
+        var exception = Invoking(() => engine.Evaluate("function inner() { boom(); } inner();"))
+            .Should().Throw<JavaScriptException>().Which;
+
+        // GetJavaScriptErrorString is what a host shows a script author: the JavaScript error and its
+        // JavaScript frames, never the host's .NET stack
+        var errorString = exception.GetJavaScriptErrorString();
+        errorString.Should().StartWith("Error: host blew up");
+        errorString.Should().Contain("at inner", "the JavaScript frames are what this accessor is for");
+        errorString.Should().NotContain(nameof(HostFailure));
+        errorString.Should().NotContain("root cause");
+        errorString.Should().NotContain("End of inner exception stack trace");
+
+        // and everything the option promises is untouched
+        exception.ToString().Should().Contain(nameof(HostFailure));
+        exception.InnerException!.InnerException.Should().BeOfType<HostFailure>();
+        JintException.TryGetClrException(exception, out var clrException).Should().BeTrue();
+        clrException.Should().BeOfType<HostFailure>();
+    }
+
+    [Fact]
+    public void TheJavaScriptErrorStringIsTheSameWhetherChainingIsOnOrOff()
+    {
+        static string Render(bool chain)
+        {
+            var engine = new Engine(options =>
+            {
+                options.CatchClrExceptions();
+                options.ChainClrExceptions(chain);
+            });
+            engine.SetValue("boom", new Action(() => throw new HostFailure("host blew up")));
+
+            return Invoking(() => engine.Evaluate("function inner() { boom(); } inner();"))
+                .Should().Throw<JavaScriptException>().Which.GetJavaScriptErrorString();
+        }
+
+        Render(chain: true).Should().Be(Render(chain: false));
+    }
+
+    [Fact]
     public void ChainingLeavesGetBaseExceptionAlone()
     {
         var engine = new Engine(options =>

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -470,6 +470,11 @@ public class Options
         /// presents itself to the host; the originating exception is recorded either way and can always be read
         /// with <see cref="JintException.TryGetClrException"/>, and a running script sees neither.
         /// </para>
+        /// <para>
+        /// <see cref="JavaScriptException.GetJavaScriptErrorString"/> is exempt and renders the same string
+        /// either way. It is the accessor a host uses to show a <em>script author</em> what went wrong, so the
+        /// chain would put the host's .NET frames in front of the JavaScript ones there.
+        /// </para>
         /// </summary>
         public bool ChainClrExceptionAsInnerException { get; set; }
 

--- a/Jint/Runtime/JavaScriptException.cs
+++ b/Jint/Runtime/JavaScriptException.cs
@@ -99,7 +99,17 @@ public class JavaScriptException : JintException
             : null;
     }
 
-    public string GetJavaScriptErrorString() => _jsErrorException.ToString();
+    /// <summary>
+    /// The JavaScript error and its JavaScript stack, as a script author would read it.
+    /// <para>
+    /// Deliberately never the CLR side of the story: a chained CLR exception
+    /// (<see cref="Options.InteropOptions.ChainClrExceptionAsInnerException"/>) is rendered by
+    /// <see cref="object.ToString"/> on this exception, which is the host-facing string form, and is reachable
+    /// through <see cref="Exception.InnerException"/> and <see cref="JintException.TryGetClrException"/>. This
+    /// accessor renders the same thing whether that option is on or off.
+    /// </para>
+    /// </summary>
+    public string GetJavaScriptErrorString() => _jsErrorException.Render(includeChainedClrException: false);
 
     /// <summary>
     /// Returns this exception as the base exception.
@@ -196,7 +206,14 @@ public class JavaScriptException : JintException
             }
         }
 
-        public override string ToString()
+        public override string ToString() => Render(includeChainedClrException: true);
+
+        /// <summary>
+        /// <paramref name="includeChainedClrException"/> is false for
+        /// <see cref="JavaScriptException.GetJavaScriptErrorString"/>, which promises the JavaScript error and
+        /// nothing else; the string form of the exception itself keeps the chain.
+        /// </summary>
+        internal string Render(bool includeChainedClrException)
         {
             var sb = new ValueStringBuilder();
 
@@ -211,7 +228,7 @@ public class JavaScriptException : JintException
             // Exception.ToString() renders an inner exception between the message and the frames. This override
             // replaces that rendering wholesale, so a chained CLR exception has to be spelled out here or it
             // would be reachable through InnerException and yet invisible in every log line.
-            if (InnerException is { } innerException)
+            if (includeChainedClrException && InnerException is { } innerException)
             {
                 sb.Append(" ---> ");
                 sb.Append(innerException.ToString());


### PR DESCRIPTION
With `Options.Interop.ChainClrExceptionAsInnerException` on, `JavaScriptException.GetJavaScriptErrorString()` returned the chained CLR exception's full .NET stack trace ahead of the JS frames:

```
Error: host blew up ---> …HostFailure: host blew up
 ---> System.InvalidOperationException: root cause
   --- End of inner exception stack trace ---
   at …<lambda>() in D:\…\Tests.cs:line 285
   at Jint.Runtime.Interop.DelegateWrapper.Invoke(Object[] parameters) in …
   --- End of inner exception stack trace ---
    at delegate (<anonymous>:1:15)
    at f (<anonymous>:1:15)
```

The `ToString()` override that renders the chain lives on the wrapper, and `GetJavaScriptErrorString()` is `_jsErrorException.ToString()`.

The two renderings have different audiences, and the option's own doc already draws that line — it scopes itself to "`object.ToString()` on that exception", the host-facing string a log line consumes, which is the point of the option. `GetJavaScriptErrorString` is the accessor a host uses to show a **script author** what their script did, and prefixing the host's .NET frames there is the same category of leak the option's own "treat it like developer exception details" warning is about.

Nothing is lost: the chain stays in `ToString()`, under `InnerException`, and through `TryGetClrException`. This removes a duplicate rendering, not a capability. Documenting it instead would have left the only JS-scoped accessor in the API as the one place the JS scope does not hold.

`JavaScriptErrorWrapperException.ToString()` becomes `Render(bool includeChainedClrException)`; `ToString()` passes true, `GetJavaScriptErrorString()` passes false. `GetJavaScriptErrorString` also gains the XML doc it never had, and the option names the exemption.

2 tests, both red on `main` on both TFMs; the second pins that the two renderings agree when chaining is off. The other two `GetJavaScriptErrorString` callers in `ErrorTests.cs` do not enable chaining and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)