### PR TITLE
Return JSON.parse's pooled reviver arguments when the reviver throws

### DIFF
--- a/Jint.Tests/Runtime/JsonPoolingInternalsTests.cs
+++ b/Jint.Tests/Runtime/JsonPoolingInternalsTests.cs
@@ -1,0 +1,39 @@
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// <c>JSON.parse</c> rents its reviver's argument array from the engine's pool for the whole recursive
+/// walk, and that walk exits by exception whenever the reviver throws — which is ordinary JavaScript.
+/// Nothing a script can observe depends on the array coming back, so the bracket is pinned here on the
+/// pool itself rather than in the public-interface suite.
+/// </summary>
+public class JsonPoolingInternalsTests
+{
+    [Fact]
+    public void AThrowingReviverGivesTheRentedArgumentArrayBack()
+    {
+        var engine = new Engine();
+
+        // A bound function is not a ScriptFunction, so the invoker cannot take its register lane and
+        // really does rent the three-element array a script reviver would never need.
+        engine.Execute("function boom() { throw new Error('boom'); } var reviver = boom.bind(null);");
+
+        var pool = engine._jsValueArrayPool;
+
+        // Drain the pool so the array the parse rents is one this test can name, and put exactly that
+        // one back, i.e. leave the pool holding it and nothing else.
+        for (var i = 0; i < 16; i++)
+        {
+            pool.RentArray(3);
+        }
+
+        var primed = new JsValue[3];
+        pool.ReturnArray(primed);
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("JSON.parse('{\"a\":1}', reviver)"));
+
+        pool.RentArray(3).Should().BeSameAs(primed);
+    }
+}

--- a/Jint/Native/Json/JsonInstance.cs
+++ b/Jint/Native/Json/JsonInstance.cs
@@ -203,9 +203,19 @@ internal sealed partial class JsonInstance : BuiltinShapeObject
             // where the reviver's third argument is the context object, and InternalizeJSONProperty
             // constructs and passes one unconditionally (only its "source" property is conditional).
             var invoker = CallbackInvoker.Rent(_engine, (ICallable) reviver, 3);
-            var result = InternalizeJSONProperty(root, rootName, in invoker, parseResult.Node, jsonString);
-            invoker.Return();
-            return result;
+            try
+            {
+                // A reviver throwing is ordinary JavaScript, and so is a Delete on a frozen holder, so
+                // the walk exits this way often enough to bracket the rent: the array would otherwise be
+                // forfeited to the pool and re-created for the next document, losing exactly the
+                // allocation Rent exists to avoid. The finally is affordable here because it wraps one
+                // recursive call rather than a per-element loop.
+                return InternalizeJSONProperty(root, rootName, in invoker, parseResult.Node, jsonString);
+            }
+            finally
+            {
+                invoker.Return();
+            }
         }
         else
         {

--- a/Jint/Native/Json/JsonSerializer.cs
+++ b/Jint/Native/Json/JsonSerializer.cs
@@ -279,10 +279,12 @@ public sealed class JsonSerializer
         {
             // Built once here rather than per key: the replacer is invoked for every key of the whole
             // graph, and how it must be invoked depends only on the callback — which no key, and no
-            // mutation a replacer performs, can change. Create() rather than Rent() because the
-            // invoker lives for the whole recursive walk, which can exit by exception (a cycle, a
-            // BigInt, an execution constraint) from any depth, so there is no one place that could
-            // reliably hand a pooled array back. On the register lane there is no array at all.
+            // mutation a replacer performs, can change. Create() rather than Rent() because this
+            // invoker is a field of a public type a host may hold across calls, assigned here in the
+            // prologue and read by the recursive walk: its lifetime is the serializer's, not one
+            // scope's, so there is no bracket to return it from — not even on the path that succeeds.
+            // Where a scope does exist, JsonInstance.Parse rents and returns in a finally. On the
+            // register lane there is no array either way.
             _replacerInvoker = CallbackInvoker.Create(_engine, (ICallable) oi, 2);
             _hasReplacerFunction = true;
         }


### PR DESCRIPTION
`JsonInstance.Parse` brackets the `InternalizeJSONProperty` recursion with `CallbackInvoker.Rent(...)` and `invoker.Return()` with no `try/finally`, so any exception out of that recursion — a throwing reviver, `Delete` on a frozen holder, an execution constraint — forfeits the rented array.

The consequence is allocation-only, not aliasing: `ObjectPool.Allocate` nulls the slot it takes, so a nested `JSON.parse` inside a reviver always gets a distinct array. The red test says it precisely:

```
Expected pool.RentArray(3) to refer to {a, 1, [object Object]},
but found {<null>, <null>, <null>}.
```

— the leaked array still holding the reviver's three arguments. Observing it needs a **bound function** reviver: a plain script reviver takes `CallbackInvoker`'s register lane, where `Rent` rents nothing at all, so the leak is only reachable through a callee that fails the register gate.

**`Rent` with a `finally`, not `Create`** — and the sibling's comment turns out to argue for the wrong reason. `JsonSerializer.SetupReplacer` says it uses `Create()` because "the recursive walk can exit by exception from any depth", which is true of all ~25 `Rent` sites in the engine: `Array.prototype.filter`, `map`, `Map.prototype.forEach` and the rest all call `Return()` after the loop and forfeit on a throwing callback. What actually decides it there is **lifetime** — `_replacerInvoker` is a field of a public type, assigned in `TryCreateHolder`'s prologue and read by the walk, so there is no scope to return it from even on success. That comment is rewritten to say so.

At `JsonInstance.Parse` the bracket is two lines apart and wraps a single recursive call rather than a per-element loop, so `Create()` would surrender pooling on every document to avoid a `finally` on the exceptional one.

The other 24 `Rent` sites are left alone; the forfeit there is deliberate.

Test262 99,738 / 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)