### PR TITLE
Stop CreateLazy wrapping the factory the descriptor already guards

### DIFF
--- a/Jint.Tests.PublicInterface/LazyPropertyDescriptorTests.cs
+++ b/Jint.Tests.PublicInterface/LazyPropertyDescriptorTests.cs
@@ -214,6 +214,33 @@ public class LazyPropertyDescriptorTests
         calls.Should().Be(1);
     }
 
+    /// <summary>
+    /// The same guarantee for the state overload, which is the one the factory reaches unwrapped: nothing
+    /// stands between a host's delegate and the descriptor, so it is the descriptor that has to read a
+    /// <see langword="null"/> return as <c>undefined</c> rather than as "not resolved yet".
+    /// </summary>
+    [Fact]
+    public void NullFactoryResultFromTheStateOverloadBecomesUndefinedRatherThanReRunning()
+    {
+        var calls = 0;
+        var engine = new Engine();
+        var host = new DescriptorBackedHost(engine);
+        host.Add("nothing", PropertyDescriptor.CreateLazy<string?>("ignored", _ =>
+        {
+            calls++;
+            return null!;
+        }));
+        engine.SetValue("host", host);
+
+        engine.Evaluate("typeof host.nothing").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof host.nothing").AsString().Should().Be("undefined");
+        calls.Should().Be(1);
+
+        // and it is a real own property holding undefined, not an absent one
+        engine.Evaluate("'nothing' in host").AsBoolean().Should().BeTrue();
+        calls.Should().Be(1);
+    }
+
     [Fact]
     public void AThrowingFactoryPropagatesAndLeavesThePropertyUnmaterialized()
     {

--- a/Jint/Runtime/Descriptors/PropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/PropertyDescriptor.cs
@@ -342,11 +342,11 @@ public class PropertyDescriptor
                 nameof(flags));
         }
 
-        // Resolved once here, not per read: the descriptor treats a null value as "not materialized yet", so
-        // a factory returning null would silently re-run on every read instead of memoizing.
-        Func<TState, JsValue> resolver = s => valueFactory!(s) ?? JsValue.Undefined;
-
-        return new LazyPropertyDescriptor<TState>(state, resolver, flags);
+        // Handed over unwrapped. The descriptor treats a null value as "not materialized yet", so the null
+        // return documented above has to become Undefined somewhere - but that substitution lives in
+        // LazyPropertyDescriptor.CustomValue, which every route into the descriptor passes through, so
+        // guarding here too would only add a display class and a delegate per call on a public factory.
+        return new LazyPropertyDescriptor<TState>(state, valueFactory, flags);
     }
 
     /// <summary>


### PR DESCRIPTION
#2890 folded the `?? JsValue.Undefined` guard into `LazyPropertyDescriptor<T>.CustomValue` and dropped the wrapper lambda from both `AddLazyGlobal` overloads, but `PropertyDescriptor.CreateLazy` still allocated `s => valueFactory!(s) ?? JsValue.Undefined` per call — a display class plus a delegate on the **public host-facing** factory, for a guard the descriptor already performs on the only path that ever invokes a resolver. `CreateLazy` has no call site inside the engine, so this cost only embedders. Passed through; the stale comment corrected.

A behavioural red run is impossible — the semantics are identical before and after — so the test's teeth were proven the other way. With the descriptor-level guard temporarily removed, both null-return tests fail with exactly the symptom the guard exists to prevent:

```
NullFactoryResultFromTheStateOverloadBecomesUndefinedRatherThanReRunning — Expected value to be 1, but found 2.
NullFactoryResultBecomesUndefinedRatherThanReRunning                    — Expected calls to be 1, but found 2.
```

— the factory re-running because a null result reads as "not materialized yet". Guard restored, both green.

The new coverage is on the **state** overload, which had no null-return test and is the one that now reaches the descriptor unwrapped. Verification leg green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)