### PR TITLE
Stop sort throwing a CLR ArgumentException at script on net8 and net10

### DIFF
--- a/Jint.Tests/Runtime/ArrayTests.cs
+++ b/Jint.Tests/Runtime/ArrayTests.cs
@@ -1109,17 +1109,27 @@ return get + '' === ""length,0,1,2,3"";";
     }
 
     [Theory]
-    [InlineData("[5,3,8,1,9,2,7,4,6,0,15,11,13,10,14,12,17,16,19,18].sort(cmp).length")]
-    [InlineData("[5,3,8,1,9,2,7,4,6,0,15,11,13,10,14,12,17,16,19,18].toSorted(cmp).length")]
-    [InlineData("new Int32Array([5,3,8,1,9,2,7,4,6,0,15,11,13,10,14,12,17,16,19,18]).sort(cmp).length")]
-    public void SortTerminatesWithAnInconsistentComparator(string expression)
+    [InlineData("items.sort(cmp).length", "a === 1 ? -1 : 1")]
+    [InlineData("items.toSorted(cmp).length", "a === 1 ? -1 : 1")]
+    [InlineData("new Int32Array(items).sort(cmp).length", "a === 1 ? -1 : 1")]
+    [InlineData("items.sort(cmp).length", "-1")]
+    [InlineData("items.toSorted(cmp).length", "-1")]
+    [InlineData("new Int32Array(items).sort(cmp).length", "-1")]
+    public void SortTerminatesWithAnInconsistentComparator(string expression, string comparisonResult)
     {
         // A comparison function that never returns 0 and is not antisymmetric is legal JavaScript: the
-        // resulting order is implementation-defined, but the sort still has to finish. LINQ's sort on
-        // .NET Framework is a quicksort with no depth limit and no fallback, so delegating to it here
-        // spins forever instead.
+        // resulting order is implementation-defined, but the sort still has to finish
+        // (https://tc39.es/ecma262/#sec-sortcompare). Both framework families used to get that wrong,
+        // each in its own way, and neither failure was anything a script could catch. LINQ's sort on
+        // .NET Framework is a quicksort with no depth limit and no fallback, so it spins forever;
+        // .NET Core's introsort detects the inconsistency and throws ArgumentException instead.
+        //
+        // The element count and the bluntness of the comparator both matter. .NET Core insertion-sorts
+        // 16 elements or fewer without ever noticing, and `a === 1 ? -1 : 1` happens not to trip the
+        // detector even above that, so the array has 20 elements and `return -1` is one of the cases.
         var engine = new Engine();
-        engine.Execute("function cmp(a, b) { return a === 1 ? -1 : 1; }");
+        engine.Execute("var items = [5,3,8,1,9,2,7,4,6,0,15,11,13,10,14,12,17,16,19,18];");
+        engine.Execute($"function cmp(a, b) {{ return {comparisonResult}; }}");
 
         engine.Evaluate(expression).AsNumber().Should().Be(20);
     }

--- a/Jint/Extensions/Polyfills.cs
+++ b/Jint/Extensions/Polyfills.cs
@@ -1,7 +1,6 @@
 ﻿using System.Buffers;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -11,67 +10,6 @@ namespace Jint;
 
 internal static class Polyfills
 {
-#if !NET8_0_OR_GREATER
-    // Enumerable.Order arrived in .NET 7 and is not in netstandard2.1, so net462, netstandard2.0 and
-    // netstandard2.1 all need it.
-    //
-    // It deliberately does NOT delegate to OrderBy. .NET Framework's LINQ sorts with a plain quicksort
-    // that has neither a recursion-depth limit nor a fallback, so an inconsistent comparer makes it spin
-    // forever rather than terminate. A JavaScript comparison function is free to be inconsistent — the
-    // spec leaves the resulting order implementation-defined but still requires the sort to finish — so
-    // that is a reachable hang, not a theoretical one. .NET Core's introsort escapes to heapsort and is
-    // why the modern targets are fine. A bottom-up merge sort is stable, always O(n log n), and
-    // terminates for any comparer whatsoever, which is the behaviour being backfilled.
-    internal static IEnumerable<T> Order<T>(this IEnumerable<T> source, IComparer<T>? comparer)
-    {
-        // Copy rather than sort a caller-visible array in place; Enumerable.Order never mutates its source.
-        var items = source.ToArray();
-        if (items.Length > 1)
-        {
-            MergeSort(items, new T[items.Length], 0, items.Length, comparer ?? Comparer<T>.Default);
-        }
-
-        return items;
-    }
-
-    private static void MergeSort<T>(T[] items, T[] buffer, int start, int end, IComparer<T> comparer)
-    {
-        if (end - start <= 1)
-        {
-            return;
-        }
-
-        var middle = start + ((end - start) >> 1);
-        MergeSort(items, buffer, start, middle, comparer);
-        MergeSort(items, buffer, middle, end, comparer);
-
-        if (comparer.Compare(items[middle - 1], items[middle]) <= 0)
-        {
-            // Already in order, so the merge would only copy the range back onto itself.
-            return;
-        }
-
-        int left = start, right = middle, index = start;
-        while (left < middle && right < end)
-        {
-            // Taking the left element on a tie is what makes the sort stable.
-            buffer[index++] = comparer.Compare(items[left], items[right]) <= 0 ? items[left++] : items[right++];
-        }
-
-        while (left < middle)
-        {
-            buffer[index++] = items[left++];
-        }
-
-        while (right < end)
-        {
-            buffer[index++] = items[right++];
-        }
-
-        System.Array.Copy(buffer, start, items, start, end - start);
-    }
-#endif
-
 #if NETFRAMEWORK || NETSTANDARD2_0
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
     internal static bool Contains(this string source, char c) => source.IndexOf(c) != -1;

--- a/Jint/Extensions/SortExtensions.cs
+++ b/Jint/Extensions/SortExtensions.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Jint;
+
+internal static class SortExtensions
+{
+    /// <summary>
+    /// Orders a sequence with the supplied comparer, stably, and terminating for any comparer at all.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately not <c>Enumerable.Order</c> or <c>Enumerable.OrderBy</c>, on any target framework. A
+    /// JavaScript comparison function is free to be inconsistent -- <c>function (x, y) { return -1; }</c> is
+    /// legal, and https://tc39.es/ecma262/#sec-sortcompare leaves the resulting order implementation-defined
+    /// while still requiring the sort to finish -- and neither BCL sort finishes. .NET Framework's LINQ sorts
+    /// with a plain quicksort that has neither a recursion-depth limit nor a fallback, so it spins forever.
+    /// .NET Core's introsort detects the inconsistency and throws <see cref="ArgumentException"/>, which is not
+    /// a <c>JavaScriptException</c>, so it escapes the script's own try/catch and the engine entry point.
+    ///
+    /// A merge sort is stable, always O(n log n), and terminates for any comparer whatsoever, which is the
+    /// behaviour the three script-visible sorts need. Being unconditional, it is also what makes them produce
+    /// one identical order on every target framework.
+    /// </remarks>
+    internal static T[] StableOrder<T>(this IEnumerable<T> source, IComparer<T>? comparer)
+    {
+        // Copy rather than sort in place; the sources here are live views over the array being sorted.
+        var items = source.ToArray();
+        if (items.Length > 1)
+        {
+            MergeSort(items, new T[items.Length], 0, items.Length, comparer ?? Comparer<T>.Default);
+        }
+
+        return items;
+    }
+
+    private static void MergeSort<T>(T[] items, T[] buffer, int start, int end, IComparer<T> comparer)
+    {
+        if (end - start <= 1)
+        {
+            return;
+        }
+
+        var middle = start + ((end - start) >> 1);
+        MergeSort(items, buffer, start, middle, comparer);
+        MergeSort(items, buffer, middle, end, comparer);
+
+        if (comparer.Compare(items[middle - 1], items[middle]) <= 0)
+        {
+            // Already in order, so the merge would only copy the range back onto itself.
+            return;
+        }
+
+        int left = start, right = middle, index = start;
+        while (left < middle && right < end)
+        {
+            // Taking the left element on a tie is what makes the sort stable.
+            buffer[index++] = comparer.Compare(items[left], items[right]) <= 0 ? items[left++] : items[right++];
+        }
+
+        while (left < middle)
+        {
+            buffer[index++] = items[left++];
+        }
+
+        while (right < end)
+        {
+            buffer[index++] = items[right++];
+        }
+
+        System.Array.Copy(buffer, start, items, start, end - start);
+    }
+}

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -1494,8 +1494,10 @@ public sealed partial class ArrayPrototype : ArrayInstance
             else
             {
                 var comparer = ArrayComparer.WithFunction(_engine, compareFn);
-                // Order is stable; List<T>.Sort is not. Stability is required by the spec since ES2019.
-                items = items.Order(comparer).ToList();
+                // StableOrder, not List<T>.Sort: the spec has required stability since ES2019, and the
+                // sort must terminate however inconsistent the script's comparison function is. See
+                // SortExtensions.StableOrder.
+                items = items.StableOrder(comparer).ToList();
             }
 
             for (uint j = 0; j < itemCount; j++)
@@ -2390,9 +2392,10 @@ public sealed partial class ArrayPrototype : ArrayInstance
 
         try
         {
-            // Order, not OrderBy: the sort must be stable (spec, since ES2019) and must terminate even
-            // when the script's comparison function is inconsistent. See Polyfills.Order.
-            return array.Order(comparer).ToArray();
+            // StableOrder, not a BCL sort: the sort must be stable (spec, since ES2019) and must
+            // terminate even when the script's comparison function is inconsistent. See
+            // SortExtensions.StableOrder.
+            return array.StableOrder(comparer);
         }
         catch (InvalidOperationException e)
         {

--- a/Jint/Native/TypedArray/IntrinsicTypedArrayPrototype.cs
+++ b/Jint/Native/TypedArray/IntrinsicTypedArrayPrototype.cs
@@ -1810,9 +1810,10 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
         var operations = ArrayOperations.For(obj, forWrite: false);
         try
         {
-            // Order, not OrderBy: the sort must be stable (spec, since ES2019) and must terminate even
-            // when the script's comparison function is inconsistent. See Polyfills.Order.
-            return operations.Order(comparer).ToArray();
+            // StableOrder, not a BCL sort: the sort must be stable (spec, since ES2019) and must
+            // terminate even when the script's comparison function is inconsistent. See
+            // SortExtensions.StableOrder.
+            return operations.StableOrder(comparer);
         }
         catch (InvalidOperationException e)
         {


### PR DESCRIPTION
> Benchmark table to follow — the release measurement block runs `ArraySortBenchmark` and `ArrayCopyingMethodsBenchmark` against this. Merging should wait for it.

The merge sort #2898/#2899 added is guarded `#if !NET8_0_OR_GREATER`, so on **net8.0 and net10.0** the three script-visible sorts still bind `Enumerable.Order`, whose introsort raises `ArgumentException("Unable to sort because the IComparer.Compare() method returns inconsistent results…")`. That is a CLR exception, not a `JavaScriptException`, so **script `try/catch` cannot see it and it escapes `engine.Evaluate`** — the three call sites unwrap `InvalidOperationException`, and `ArgumentException` is not one.

A comparison function that never returns 0 and is not antisymmetric is legal JavaScript: [sec-sortcompare](https://tc39.es/ecma262/#sec-sortcompare) leaves the order implementation-defined, but the sort must finish.

Two things made this survive review. The throw is **pre-existing** on net8/net10 — v4.15.3 used `Order` for `sort` and `OrderBy` for the other two, same `EnumerableSorter` — so what this release added was the *claim*, in #2899's message, that all three "behave identically on all five target frameworks". And the regression test guarding it **passed vacuously**: `ArrayTests.SortTerminatesWithAnInconsistentComparator` used `a === 1 ? -1 : 1` over 20 elements, which happens not to trip the detector. It is now a 6-row theory (3 sorts × 2 comparators) including `return -1`, and 3 rows are red on `main` on net10.0 while net472 was already green — the split this PR closes.

The merge sort moves out of `Polyfills.cs` — it is not a polyfill any more — into `Jint/Extensions/SortExtensions.cs` as `StableOrder`, unconditional on all five target frameworks. The algorithm is unchanged; it returns `T[]` rather than `IEnumerable<T>`, so `toSorted` and `%TypedArray%.sort` drop their `.ToArray()`. That also delivers what #2899's message promised: one identical result order everywhere.

**What changes on net8/net10, measured by counting rather than timing:**

| workload (n=20 unless noted) | before | after |
|---|---|---|
| shuffled — `sort` / `toSorted` / `Int32Array.sort` | 72 / 72 / 72 | **57 / 57 / 57** |
| ascending — `sort` | 39 | **19** |
| descending — `sort` | 53 | **67** |
| shuffled 1000 — `sort` | 10,917 | **9,285** |

Fewer JS comparator calls on random and already-sorted data, **more on reverse-sorted**. Allocation shifts too: one full-length auxiliary buffer replaces the `int[]` index map, so `sort` is about +4n bytes and `toSorted`/`%TypedArray%.sort` about −4n bytes with one fewer array. net462/netstandard execute exactly what they did before.

Only two benchmark rows reach the change: `ArraySortBenchmark.SortWithComparer_1K` (the other five call `.sort()` with no comparator and go through `SortByCachedStringKeys`, so they are controls), and `ArrayCopyingMethodsBenchmark.ToSorted_Dense`, where the native comparer makes each comparison cheap and the merge sort's own bookkeeping is most exposed.

Test262 99,738 / 0 / 157 — no ordering change surfaces there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)