### PR TITLE
Make the Math.Clamp polyfill reject inverted bounds like the BCL does

### DIFF
--- a/Jint.Tests/Runtime/NonIsoCalendarTests.cs
+++ b/Jint.Tests/Runtime/NonIsoCalendarTests.cs
@@ -1,0 +1,76 @@
+#nullable enable
+
+using System.Text;
+using Jint.Native.Temporal;
+
+namespace Jint.Tests.Runtime;
+
+public class NonIsoCalendarTests
+{
+    private static readonly string[] Calendars =
+    [
+        "chinese", "dangi", "hebrew", "persian", "coptic", "ethiopic", "ethioaa",
+        "indian", "islamic-umalqura", "islamic-civil", "islamic-tbla"
+    ];
+
+    // Well-formed codes only, valid and invalid. A malformed short code such as "M1" never reaches this
+    // helper -- Temporal's month-code grammar rejects it with a RangeError first -- and the helper reads
+    // the two display digits by slicing, so it assumes the length its callers guarantee.
+    private static readonly string?[] MonthCodes =
+    [
+        null, "M01", "M02", "M05", "M06", "M12", "M13", "M01L", "M02L", "M05L", "M12L", "M99", "X01"
+    ];
+
+    private static readonly int[] Years = [-1, 1, 2, 1000, 5779, 5780, 9999, 10000];
+
+    private static readonly int[] Days = [0, 1, 29, 30, 31];
+
+    /// <summary>
+    /// Every field combination has to come back as a date or as null. A CLR exception here escapes
+    /// engine.Evaluate, where a script sees neither a value nor a catchable JavaScript error.
+    /// </summary>
+    /// <remarks>
+    /// The hazard this covers is Math.Clamp, which throws ArgumentException for inverted bounds: these
+    /// conversions clamp a day against a computed days-in-month, and a Hebrew year where .NET's
+    /// HebrewCalendar and the algorithmic leap-year predicate disagreed would drive that maximum to
+    /// zero. The combination is not reachable today, which is why this sweep passes either way; it is
+    /// here so that a future widening of a year range or a change to a leap-year rule cannot make it
+    /// reachable unnoticed.
+    /// </remarks>
+    [Theory]
+    [InlineData("constrain")]
+    [InlineData("reject")]
+    public void CalendarDateToIsoNeverThrowsForAnyFieldCombination(string overflow)
+    {
+        var failures = new StringBuilder();
+        var combinations = 0;
+
+        foreach (var calendar in Calendars)
+        {
+            foreach (var year in Years)
+            {
+                foreach (var monthCode in MonthCodes)
+                {
+                    for (var month = 0; month <= 14; month++)
+                    {
+                        foreach (var day in Days)
+                        {
+                            combinations++;
+                            try
+                            {
+                                _ = NonIsoCalendars.CalendarDateToIso(calendar, year, monthCode, month, day, overflow);
+                            }
+                            catch (Exception e)
+                            {
+                                failures.AppendLine($"{calendar} year={year} monthCode={monthCode ?? "<null>"} month={month} day={day}: {e.GetType().Name}: {e.Message}");
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        combinations.Should().Be(Calendars.Length * Years.Length * MonthCodes.Length * 15 * Days.Length);
+        failures.ToString().Should().BeEmpty();
+    }
+}

--- a/Jint.Tests/Runtime/PolyfillTests.cs
+++ b/Jint.Tests/Runtime/PolyfillTests.cs
@@ -1,0 +1,30 @@
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// A polyfill has to match the downlevel API's behaviour, not merely its signature. Every test here
+/// binds the real BCL member on net10.0 and the backfilled one on net472, so a single assertion that
+/// holds on both legs is the whole point: an assertion that has to be written twice would mean the
+/// two have already diverged.
+/// </summary>
+public class PolyfillTests
+{
+    [Fact]
+    public void MathClampRejectsInvertedBounds()
+    {
+        // Math.Clamp validates its bounds -- "'1' cannot be greater than 0." -- rather than quietly
+        // preferring one of them. A polyfill returning min instead would make the same call answer
+        // differently per target framework, and nothing that executes could see the split, since the
+        // real Math.Clamp binds from netstandard2.1 upwards.
+        Invoking(() => System.Math.Clamp(5, 1, 0)).Should().Throw<ArgumentException>();
+    }
+
+    [Theory]
+    [InlineData(5, 1, 10, 5)]
+    [InlineData(-5, 1, 10, 1)]
+    [InlineData(50, 1, 10, 10)]
+    [InlineData(7, 7, 7, 7)]
+    public void MathClampAgreesOnValidBounds(int value, int min, int max, int expected)
+    {
+        System.Math.Clamp(value, min, max).Should().Be(expected);
+    }
+}

--- a/Jint/Extensions/Polyfills.cs
+++ b/Jint/Extensions/Polyfills.cs
@@ -423,7 +423,21 @@ internal static class MathPolyfills
     {
 #if NETFRAMEWORK || NETSTANDARD2_0
         // Math.Clamp arrived in .NET Core 2.0 / netstandard2.1.
-        public static int Clamp(int value, int min, int max) => value < min ? min : value > max ? max : value;
+        //
+        // The bounds check is not decoration: the real Math.Clamp throws for min > max rather than
+        // silently preferring one of them, and the message it throws with is reproduced verbatim. Without
+        // it, net462 and netstandard2.0 would answer an inverted-bounds call with a number while
+        // netstandard2.1 and up threw -- and no target framework this repository executes tests on could
+        // ever see the split, since netstandard2.1 binds the real member.
+        public static int Clamp(int value, int min, int max)
+        {
+            if (min > max)
+            {
+                Jint.Runtime.Throw.ArgumentException($"'{min}' cannot be greater than {max}.");
+            }
+
+            return value < min ? min : value > max ? max : value;
+        }
 #endif
     }
 }

--- a/Jint/Native/Temporal/NonIsoCalendars.cs
+++ b/Jint/Native/Temporal/NonIsoCalendars.cs
@@ -1067,7 +1067,14 @@ internal static class NonIsoCalendars
                 case 12: return 29; // Elul
             }
         }
-        return 0;
+
+        // Unreachable while .NET's HebrewCalendar and IsHebrewLeapYearAlgorithmic agree about a year:
+        // every caller has already clamped or rejected the ordinal against 13-if-leap-else-12, and
+        // ordinal 13 exists only in a leap year. The fallback is nevertheless the shortest Hebrew month
+        // rather than 0, because this value becomes the max of Math.Clamp(day, 1, maxDay) -- and a max
+        // of 0 is inverted bounds, which is an ArgumentException escaping engine.Evaluate rather than a
+        // constrained date. 29 never lengthens a month, so a day is still constrained, never admitted.
+        return 29;
     }
 
     private static int HebrewMonthCodeToOrdinal(int year, string monthCode)


### PR DESCRIPTION
`MathPolyfills.Clamp` is `value < min ? min : value > max ? max : value` under `#if NETFRAMEWORK || NETSTANDARD2_0`, while the BCL `Math.Clamp(int,int,int)` **throws `ArgumentException` when `min > max`**. So `{net462, netstandard2.0}` silently returned `min` and `{netstandard2.1, net8.0, net10.0}` threw — netstandard2.1 sitting with the modern group because the real `Math.Clamp` binds there. **No executing test leg can see that split**, which is exactly the shape AGENTS.md's *"a polyfill must match the downlevel API's behaviour, not just its signature"* rule exists to catch.

It became reachable in principle when #2910 deleted two private non-throwing `Clamp` helpers and routed ~30 Temporal sites to `System.Math.Clamp`.

The polyfill now throws, with the BCL's own message verbatim. The test is a single assertion that runs on both legs — one that had to be written twice would mean they had already diverged: red on net472 only (`Failed: 1, Passed: 4`), green on both after.

**And the latent path is closed rather than just documented.** `NonIsoCalendars.HebrewDaysInMonthOrdinal` returned `0` for ordinal 0, 13-in-a-non-leap-year and 14, and that value feeds `Math.Clamp(day, 1, maxDay)`. It now returns **29**, the shortest Hebrew month: it never lengthens a month, so a day is still constrained rather than admitted, and it cannot invert the clamp's bounds. Worth noting the old behaviour was not benign on the downlevel side either — `Clamp(day, 1, 0)` returns `0` there, a day-zero date. The other consumer of that return value, `HebrewAlgorithmicToIso`'s day accumulation, only sums ordinals 1…12 or 1…13, all covered by the switches.

A sweep is committed as `Jint.Tests/Runtime/NonIsoCalendarTests.cs`: 85,800 field combinations per overflow mode (11 non-ISO calendars × 8 years × 13 month codes × months 0–14 × 5 days), asserting `CalendarDateToIso` answers with a date or `null` and never a CLR exception. Green before and after — which confirms the case is unreachable today — so it is committed as the net against a future year-range widening or leap-rule change, not as a fix's proof.

Test262 99,738 / 0 / 157.

**Found but deliberately not fixed here:** `CalendarDateToIso` throws `ArgumentOutOfRangeException` for a malformed short month code (`monthCode.AsSpan(1, 2)` on `"M1"`) on all 11 calendars. Not reachable from script — `Temporal.PlainDate.from` rejects `M1` upstream with a `RangeError` — so it is an internal-API hazard and a separate issue. The sweep's month-code list documents the precondition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)