### PR TITLE
Keep the memory-limit constraint's reset total so it cannot replace a script error

### DIFF
--- a/Jint.Tests/Runtime/ExecutionConstraintTests.cs
+++ b/Jint.Tests/Runtime/ExecutionConstraintTests.cs
@@ -86,6 +86,56 @@ public class ExecutionConstraintTests
         Invoking(() => new Engine(cfg => cfg.LimitMemory(2048)).Evaluate("a=[]; while(true){ a.push(0); }")).Should().ThrowExactly<MemoryLimitExceededException>();
     }
 
+    private sealed class ThrowOnResetAfterCheckConstraint : Constraint
+    {
+        private bool _checked;
+
+        public override void Check() => _checked = true;
+
+        public override void Reset()
+        {
+            if (_checked)
+            {
+                throw new PlatformNotSupportedException("the constraint's own reset failed");
+            }
+        }
+    }
+
+    [Fact]
+    public void AConstraintResetThatThrowsOnTheWayOutReplacesTheScriptsOwnError()
+    {
+        // This is why a Reset() has to be total. ExecuteWithConstraints resets the constraints from a
+        // finally, so an exception raised there unwinds in place of the one the run was already carrying:
+        // the script's error never reaches the host, and what does reach it names the reset instead.
+        var engine = new Engine(cfg => cfg.Constraint(new ThrowOnResetAfterCheckConstraint()));
+
+        Invoking(() => engine.Evaluate("throw new Error('the script error');"))
+            .Should().ThrowExactly<PlatformNotSupportedException>();
+    }
+
+    [Fact]
+    public void MemoryLimitConstraintResetIsTotal()
+    {
+        // MemoryLimitConstraint.Reset() reads the thread's allocation counter, which is reachable only
+        // through reflection below netstandard2.1 and can come back missing. Establishing the baseline
+        // must not throw for that; reporting the platform is Check()'s job, and Check() still does it.
+        var constraint = new MemoryLimitConstraint(4_000_000);
+
+        Invoking(constraint.Reset).Should().NotThrow();
+        Invoking(constraint.Reset).Should().NotThrow();
+        Invoking(constraint.Check).Should().NotThrow();
+    }
+
+    [Fact]
+    public void AllocatedBytesForCurrentThreadIsReachableOnEveryExecutingTargetFramework()
+    {
+        // net472 resolves GC.GetAllocatedBytesForCurrentThread by reflection with the default binding
+        // flags, which see public members only; net10.0 calls it outright. Both have to answer, or
+        // LimitMemory is a no-op that reports itself as an unsupported platform.
+        GCPolyfills.TryGetAllocatedBytesForCurrentThread(out var allocatedBytes).Should().BeTrue();
+        allocatedBytes.Should().BePositive();
+    }
+
     [Fact]
     public void ShouldThrowTimeout()
     {

--- a/Jint/Constraints/MemoryLimitConstraint.cs
+++ b/Jint/Constraints/MemoryLimitConstraint.cs
@@ -48,6 +48,13 @@ public sealed class MemoryLimitConstraint : Constraint
     public override void Reset()
     {
         _initialThreadId = Environment.CurrentManagedThreadId;
-        _initialMemoryUsage = GC.GetAllocatedBytesForCurrentThread();
+
+        // Total on purpose. Engine.ExecuteWithConstraints resets the constraints from a finally, so an
+        // exception raised here unwinds in place of the one the run is already carrying: the script's own
+        // error disappears and the host is told about the platform instead. On a platform where the
+        // allocation counter cannot be reached at all -- netstandard2.0 on a runtime that predates it, or
+        // one whose linker removed it -- the baseline is simply unknown. Check() is where such a platform
+        // gets reported, and it still reports it on the very first check.
+        _initialMemoryUsage = GCPolyfills.TryGetAllocatedBytesForCurrentThread(out var allocatedBytes) ? allocatedBytes : 0;
     }
 }

--- a/Jint/Extensions/Polyfills.cs
+++ b/Jint/Extensions/Polyfills.cs
@@ -433,9 +433,13 @@ internal static class GCPolyfills
     extension(GC)
     {
 #if NETFRAMEWORK || NETSTANDARD2_0
-        // GC.GetAllocatedBytesForCurrentThread became public in .NET Core 3.0 / netstandard2.1. It exists
-        // on .NET Framework as a non-public method, so reflection reaches it there; where even that fails
-        // the caller has no way to measure allocation and says so.
+        // GC.GetAllocatedBytesForCurrentThread is absent from the net462 and netstandard2.0 reference
+        // assemblies, so it cannot be called directly here. It is a *public* method of System.GC on
+        // every runtime that has one -- .NET Framework since 4.6, .NET Core since 2.0 -- which is what
+        // makes the lookup below work at all: it uses the default binding flags, and those see public
+        // members only. So this reaches the real method wherever one exists, and answers null where none
+        // does: a runtime older than that, or one whose linker removed it. A caller left with null
+        // cannot measure allocation at all, and says so.
         public static long GetAllocatedBytesForCurrentThread()
         {
             var getter = AllocatedBytesForCurrentThread;
@@ -447,6 +451,29 @@ internal static class GCPolyfills
             return getter();
         }
 #endif
+    }
+
+    /// <summary>
+    /// The total form of the above, for a caller that must not throw -- a Reset() invoked from a finally,
+    /// where an exception would unwind in place of the one already in flight. Deliberately not an
+    /// extension member on <see cref="GC"/>: no BCL ever had a TryGet form, and a polyfill that invents
+    /// API has stopped being a polyfill.
+    /// </summary>
+    internal static bool TryGetAllocatedBytesForCurrentThread(out long allocatedBytes)
+    {
+#if NETFRAMEWORK || NETSTANDARD2_0
+        var getter = AllocatedBytesForCurrentThread;
+        if (getter is null)
+        {
+            allocatedBytes = 0;
+            return false;
+        }
+
+        allocatedBytes = getter();
+#else
+        allocatedBytes = GC.GetAllocatedBytesForCurrentThread();
+#endif
+        return true;
     }
 
 #if NETFRAMEWORK || NETSTANDARD2_0


### PR DESCRIPTION
v4.15.3's `MemoryLimitConstraint.Reset()` was `_getAllocatedBytesForCurrentThread?.Invoke() ?? 0` and could not throw. #2910 routed it through `GCPolyfills.GetAllocatedBytesForCurrentThread()`, which throws `PlatformNotSupportedException` when the reflection lookup returns null. `Engine.ExecuteWithConstraints` calls `ResetConstraints()` in a **`finally`**, so on such a platform the finally now throws and **replaces the script's in-flight exception**.

`Reset()` goes back to being total, through a new `GCPolyfills.TryGetAllocatedBytesForCurrentThread(out long)` available on every target framework — deliberately *not* an extension member on `GC`, since no BCL ever had a `TryGet` form and a polyfill that invents API is not one. `Check()` still throws on the first check, so an unsupported platform is still reported, just not from a `finally`.

**There is no red run for this one and I want to be explicit about that**: the failure needs a runtime where the lookup returns null, and neither net10.0 nor net472 is one (it is reachable for a netstandard2.0 consumer on a runtime that lacks the method or strips the reflection — Unity IL2CPP, old Mono). What is pinned instead:

- `AConstraintResetThatThrowsOnTheWayOutReplacesTheScriptsOwnError` — a custom constraint throwing from the finally-side `Reset()`; `engine.Evaluate("throw new Error('the script error')")` surfaces the constraint's exception, not the script's. That **is** the defect, reproduced in miniature, and it passes before the change too because it touches no changed code.
- `MemoryLimitConstraintResetIsTotal` — two resets then a check, no throw.
- `AllocatedBytesForCurrentThreadIsReachableOnEveryExecutingTargetFramework` — returns true with a positive count on net472.

That last one is also the empirical correction to a comment: `Polyfills.cs` claimed the method "exists on .NET Framework as a non-public method, so reflection reaches it there". The code uses default binding flags, which cannot find non-public members — if the comment were true the code would be broken. It has been **public** since .NET Framework 4.6, and being public is precisely what makes the lookup work. Comment corrected.

Test262 99,738 / 0 / 157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)