### PR TITLE
Stamp Atomics.waitAsync's settle with the cycle that registered it

### DIFF
--- a/Jint.Tests.PublicInterface/HostEventLoopFenceTests.cs
+++ b/Jint.Tests.PublicInterface/HostEventLoopFenceTests.cs
@@ -1,0 +1,126 @@
+#nullable enable
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using Jint.Native;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// The event loop's generation fence, from the embedder's side. Work a host registers in one evaluation
+/// cycle must not settle into the engine after <c>Engine.Advanced.RestoreGlobalSnapshot</c> has ended that
+/// cycle — otherwise a pooled engine gets the previous request's continuation running against the next
+/// request's globals, the cross-cycle channel a fresh-engine-per-evaluation host never had.
+///
+/// <para>
+/// The awkward cases are the ones whose settle originates off the engine thread, because the generation has
+/// to be captured where the work is <em>registered</em> rather than read where it is enqueued.
+/// <c>Atomics.waitAsync</c> is one: its timeout fires on a timer thread and its wake can arrive from
+/// whichever agent calls <c>Atomics.notify</c> on the shared buffer. Each fenced case is paired with a
+/// control proving the same settle does land when no restore intervenes — a fence that works by never
+/// delivering anything is not a fence.
+/// </para>
+/// </summary>
+public class HostEventLoopFenceTests
+{
+    private const string RegisterTimeoutWait = """
+        const ta = new Int32Array(new SharedArrayBuffer(8));
+        Atomics.waitAsync(ta, 0, 0, 50).value.then(v => { globalThis.settled = v; });
+        """;
+
+    private const string RegisterInfiniteWait = """
+        globalThis.ta = new Int32Array(new SharedArrayBuffer(8));
+        Atomics.waitAsync(globalThis.ta, 0, 0).value.then(v => { globalThis.settled = v; });
+        """;
+
+    private static void Pump(Engine engine, TimeSpan duration)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < duration)
+        {
+            engine.Advanced.ProcessTasks();
+            Thread.Sleep(5);
+        }
+
+        engine.Advanced.ProcessTasks();
+    }
+
+    private static bool PumpUntilSettled(Engine engine, TimeSpan timeout)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < timeout)
+        {
+            engine.Advanced.ProcessTasks();
+            if (!engine.Evaluate("globalThis.settled").IsUndefined())
+            {
+                return true;
+            }
+
+            Thread.Sleep(5);
+        }
+
+        return false;
+    }
+
+    [Fact]
+    public void AtomicsWaitAsyncTimeoutDoesNotSettleAfterAGlobalRestore()
+    {
+        var engine = new Engine();
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+
+        engine.Execute(RegisterTimeoutWait);
+
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        // Far longer than the 50 ms the wait was given, and with turns to spare.
+        Pump(engine, TimeSpan.FromSeconds(2));
+
+        engine.Evaluate("globalThis.settled").Should().Be(JsValue.Undefined);
+    }
+
+    [Fact]
+    public void AtomicsWaitAsyncTimeoutSettlesWhenNoRestoreIntervenes()
+    {
+        var engine = new Engine();
+
+        engine.Execute(RegisterTimeoutWait);
+
+        PumpUntilSettled(engine, TimeSpan.FromSeconds(10)).Should().BeTrue("the timeout must still be delivered when no restore ends the cycle");
+        engine.Evaluate("globalThis.settled").AsString().Should().Be("timed-out");
+    }
+
+    [Fact]
+    public void AtomicsNotifyDoesNotSettleAWaitAsyncFromAnEndedCycle()
+    {
+        var engine = new Engine();
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+
+        engine.Execute(RegisterInfiniteWait);
+
+        // The typed array outlives the restore — a restore reverts global bindings, not object graphs — so
+        // the host can hand it back and wake the waiter registered by the cycle that has now ended.
+        var typedArray = engine.Evaluate("globalThis.ta");
+
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        engine.SetValue("ta", typedArray);
+        engine.Evaluate("Atomics.notify(ta, 0)").AsNumber().Should().Be(1, "the waiter is still on the shared buffer's list");
+
+        Pump(engine, TimeSpan.FromMilliseconds(500));
+
+        engine.Evaluate("globalThis.settled").Should().Be(JsValue.Undefined);
+    }
+
+    [Fact]
+    public void AtomicsNotifySettlesAWaitAsyncWhenNoRestoreIntervenes()
+    {
+        var engine = new Engine();
+
+        engine.Execute(RegisterInfiniteWait);
+        engine.Evaluate("Atomics.notify(globalThis.ta, 0)").AsNumber().Should().Be(1);
+
+        PumpUntilSettled(engine, TimeSpan.FromSeconds(10)).Should().BeTrue("a wake must still be delivered when no restore ends the cycle");
+        engine.Evaluate("globalThis.settled").AsString().Should().Be("ok");
+    }
+}

--- a/Jint/Native/Atomics/AtomicsInstance.cs
+++ b/Jint/Native/Atomics/AtomicsInstance.cs
@@ -188,12 +188,23 @@ internal sealed partial class AtomicsInstance : BuiltinShapeObject
     {
         private readonly PromiseCapability _promiseCapability;
         private readonly Engine _engine;
+
+        /// <summary>
+        /// The evaluation cycle the wait was registered in, read here on the engine thread. Neither of the
+        /// two ways a wait ends runs on that thread: the timeout fires on a timer thread, and a wake arrives
+        /// from whichever agent calls <c>Atomics.notify</c> on the shared buffer. Reading the generation at
+        /// settle time would therefore read whatever cycle the engine is in by then, and a wait registered
+        /// before a <c>RestoreGlobalSnapshot</c> would resolve its promise into the restored engine.
+        /// </summary>
+        private readonly int _generation;
+
         private int _resolved;
 
         public AsyncWaiter(Engine engine, PromiseCapability promiseCapability)
         {
             _engine = engine;
             _promiseCapability = promiseCapability;
+            _generation = engine.EventLoopGeneration;
         }
 
         public bool Resolved => _resolved != 0;
@@ -206,7 +217,7 @@ internal sealed partial class AtomicsInstance : BuiltinShapeObject
                 _engine.AddToEventLoop(() =>
                 {
                     _promiseCapability.Resolve(new JsString(result));
-                });
+                }, _generation);
             }
         }
     }


### PR DESCRIPTION
`AsyncWaiter.Resolve` enqueued through the **unstamped** `Engine.AddToEventLoop(Action)` from a `Task.Delay` continuation on a timer thread, so it read whatever event-loop generation was current when the timer fired rather than the one captured when `waitAsync` was called. A timeout settling after `Engine.Advanced.RestoreGlobalSnapshot` therefore wrote previous-cycle data into the restored engine — exactly the cross-cycle channel the generation fence exists to close, and the one background-thread enqueue that was not stamped. `RegisterPromise`, `RegisterPromiseWithClrValue` and `ModuleLoadCompletion` all capture on the engine thread at registration and use `AddToEventLoop(Action, int)`.

The `AsyncWaiter` now captures `Engine.EventLoopGeneration` in its constructor — which runs on the engine thread inside `waitAsync` — and enqueues with the stamping overload.

**The `notify` path had the same gap**, which the review had not flagged: a wake delivered from another thread after a restore settled into the restored engine too. Both are fixed and both are pinned.

4 tests in `Jint.Tests.PublicInterface/HostEventLoopFenceTests.cs` — two fences and two controls, so the fence cannot pass vacuously. Red `Failed: 2, Passed: 2` on both TFMs (*"Expected … to be undefined, but found timed-out"* and *"…but found ok"*), green after on net10.0 and net472. Test262 99,738 / 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)