### PR TITLE
Evaluate a module Import finds in any state ModuleEvaluation accepts

### DIFF
--- a/Jint.Tests.PublicInterface/HostModuleImportStateTests.cs
+++ b/Jint.Tests.PublicInterface/HostModuleImportStateTests.cs
@@ -1,0 +1,93 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Jint.Runtime;
+using Jint.Runtime.Modules;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// <c>Engine.Modules.Import</c> is the host's spelling of a dynamic <c>import()</c>, and the spec's
+/// <see href="https://tc39.es/ecma262/#sec-ContinueDynamicImport">ContinueDynamicImport</see> hands the
+/// module record to <c>Evaluate()</c> unconditionally. So every state <c>Evaluate()</c> accepts —
+/// <see href="https://tc39.es/ecma262/#sec-moduleevaluation">its step 2</see> lists linked, evaluating-async
+/// and evaluated — has to reach it, not just the two an entry-point import happens to produce.
+///
+/// <para>
+/// The two states a host runs into are the ones some <em>other</em> operation left the module in: a
+/// <c>import defer</c> elsewhere in the graph leaves it linked-but-unevaluated, and an import still
+/// suspended on a top-level <c>await</c> leaves it evaluating-async. Handing back a namespace over either
+/// gives the host uninitialised bindings.
+/// </para>
+/// </summary>
+public class HostModuleImportStateTests
+{
+    private sealed class DictionaryModuleLoader : ModuleLoader
+    {
+        private readonly Dictionary<string, string> _sources;
+
+        public DictionaryModuleLoader(Dictionary<string, string> sources) => _sources = sources;
+
+        public override ResolvedSpecifier Resolve(string? referencingModuleLocation, ModuleRequest moduleRequest)
+            => new(moduleRequest, moduleRequest.Specifier, Uri: null, SpecifierType.Bare);
+
+        protected override string LoadModuleContents(Engine engine, ResolvedSpecifier resolved) => _sources[resolved.Key];
+    }
+
+    [Fact]
+    public void ImportingAModuleADeferredImportLeftLinkedEvaluatesIt()
+    {
+        var engine = new Engine(options => options.EnableModules(new DictionaryModuleLoader(new Dictionary<string, string>
+        {
+            ["main"] = "import defer * as d from 'dep'; export const touch = () => d.v;",
+            ["dep"] = "globalThis.depEvaluations = (globalThis.depEvaluations ?? 0) + 1; export const v = 5;",
+        })));
+
+        engine.Modules.Import("main");
+        engine.Evaluate("globalThis.depEvaluations ?? 0").AsNumber().Should().Be(0, "a deferred import must not evaluate its target");
+
+        var dep = engine.Modules.Import("dep");
+
+        dep.Get("v").AsNumber().Should().Be(5);
+        engine.Evaluate("globalThis.depEvaluations").AsNumber().Should().Be(1, "the import that needs the value is what evaluates it");
+    }
+
+    [Fact]
+    public void ImportingAModuleStillSuspendedOnTopLevelAwaitWaitsForIt()
+    {
+        var gate = new TaskCompletionSource<int>();
+
+        var engine = new Engine(options =>
+        {
+            options.ExperimentalFeatures = ExperimentalFeature.TaskInterop;
+            options.Constraints.PromiseTimeout = TimeSpan.FromSeconds(30);
+            options.EnableModules(new DictionaryModuleLoader(new Dictionary<string, string>
+            {
+                ["m"] = "const x = await gate(); export const v = x;",
+            }));
+        });
+        engine.SetValue("gate", new Func<Task<int>>(() => gate.Task));
+
+        // The host loop StartImport documents: start, then give the engine turns. One turn takes the module
+        // through link and into its body, where it suspends on the top-level await.
+        var operation = engine.Modules.StartImport("m");
+        engine.Advanced.ProcessTasks();
+        operation.IsCompleted.Should().BeFalse();
+
+        // Settled a good while later, so that nothing is queued when the blocking import starts and the
+        // continuations it runs on the way out cannot finish the module for it. Waiting the top-level await
+        // out has to be the import's own doing.
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(300).ConfigureAwait(false);
+            gate.SetResult(7);
+        });
+
+        var ns = engine.Modules.Import("m");
+
+        ns.Get("v").AsNumber().Should().Be(7);
+        operation.IsCompleted.Should().BeTrue();
+    }
+}

--- a/Jint/Engine.Modules.cs
+++ b/Jint/Engine.Modules.cs
@@ -702,16 +702,32 @@ public partial class Engine
                     Throw.NotSupportedException($"Error while evaluating module: Module is in an invalid state: '{cyclicModule.Status}'");
                 }
             }
-            else if (cyclicModule.Status == ModuleStatus.Evaluated)
+            else if (cyclicModule.Status is ModuleStatus.Linked or ModuleStatus.EvaluatingAsync or ModuleStatus.Evaluated)
             {
-                // The module has already been evaluated - either as its own entry point or as a
-                // dependency of some other graph. https://tc39.es/ecma262/#sec-ContinueDynamicImport
-                // evaluates it again regardless, and https://tc39.es/ecma262/#sec-moduleevaluation
-                // makes that a no-op that hands back the already settled promise, with one exception:
-                // a module whose evaluation threw replays its recorded [[EvaluationError]]. Skipping
-                // the call returned a namespace over bindings the failed evaluation never initialized.
+                // The three states https://tc39.es/ecma262/#sec-moduleevaluation step 2 accepts as input, and
+                // https://tc39.es/ecma262/#sec-ContinueDynamicImport hands the record to Evaluate() for every
+                // one of them. A host import is the host's spelling of a dynamic import, so it does too.
+                //
+                // Linked is what some other operation on the graph left behind: an `import defer` elsewhere
+                // loads and links its target without evaluating it, so importing that target for real is what
+                // has to evaluate it. EvaluatingAsync is a graph still suspended on a top-level await, started
+                // by an earlier StartImport; Evaluate() hands back its pending [[TopLevelCapability]] promise
+                // and EvaluateModule waits that out. Both used to fall past this chain and be returned as a
+                // namespace over uninitialized bindings - a read threw "Cannot access 'v' before
+                // initialization" for the first and silently observed a half-run module for the second.
+                //
+                // Evaluated re-enters deliberately: ModuleEvaluation makes the call a no-op that hands back
+                // the already settled promise, with one exception - a module whose evaluation threw replays
+                // its recorded [[EvaluationError]]. Skipping the call returned a namespace over bindings the
+                // failed evaluation never initialized.
                 _engine.ExecuteWithConstraints(true, () => EvaluateModule(request.Specifier, cyclicModule));
             }
+
+            // Linking and Evaluating are deliberately not handled: the module is being worked on further up
+            // this very stack, by a host callback or a loader that re-entered Import, and the spec's own
+            // answer to a self-import mid-evaluation is the pending top-level promise - which this thread
+            // cannot wait for without deadlocking against itself. The namespace is handed back as it stands,
+            // which is what a circular import observes anyway.
 
             _engine.RunAvailableContinuations();
 


### PR DESCRIPTION
`Engine.Modules.Import`'s status chain had arms for `Unlinked` and `Evaluated` only. A module left in `Linked` by a *deferred* import fell past every arm and was handed back as a namespace over uninitialised bindings, so reading an export threw `Cannot access 'v' before initialization` instead of evaluating the module. `EvaluatingAsync` fell through the same way and returned silently.

[ModuleEvaluation](https://tc39.es/ecma262/#sec-moduleevaluation) step 2 accepts `LINKED`, `EVALUATING-ASYNC` and `EVALUATED`; `Linked` and `EvaluatingAsync` now join the `Evaluated` arm rather than falling past the chain.

`Linking` and `Evaluating` stay unhandled deliberately — the module is being worked on further up the same stack, and the spec's answer to a self-import mid-evaluation is a pending promise this thread cannot wait for without deadlocking. That now carries a comment rather than being a silent fall-through.

**One test-design trap worth recording:** the first draft of the `EvaluatingAsync` test *passed against the broken code*. `Import`'s trailing `RunAvailableContinuations()` masks the fall-through whenever the work is already queued, and `StartImport` alone leaves the module `Unlinked`, not `EvaluatingAsync`. The test was rebuilt around `StartImport` plus one `ProcessTasks()` — the host loop that type's own documentation prescribes — with the gate settling on a delay so the import must actually wait.

2 tests, both red on `main` on both TFMs with *"Cannot access 'v' before initialization"*. Pre-existing. Test262 99,738 / 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)