### PR TITLE
Let a recursion-limit failure out of a module load instead of rejecting

### DIFF
--- a/Jint.Tests.PublicInterface/HostModuleLoadConstraintTests.cs
+++ b/Jint.Tests.PublicInterface/HostModuleLoadConstraintTests.cs
@@ -1,0 +1,112 @@
+#nullable enable
+
+using System;
+using Jint.Runtime;
+using Jint.Runtime.Modules;
+
+using Module = Jint.Runtime.Modules.Module;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// A module load can fail in two very different ways, and the module pipeline deliberately treats them
+/// differently. A load that failed — the file is missing, the loader refused the specifier, the source did
+/// not parse — becomes a rejection of the importing promise, because there is often no caller left to throw
+/// to. A failure that exists to <em>bound</em> execution must not: a constraint that turns into a rejection
+/// no longer bounds anything, because script catches it and carries on, in a loop if it likes.
+///
+/// <para>
+/// The loads that hit this are the ones where the loader itself re-enters the engine — a resolve hook or a
+/// virtual file system implemented in script, which is a shape hosts really do use.
+/// </para>
+/// </summary>
+public class HostModuleLoadConstraintTests
+{
+    private const string DeepRecursion = """
+        globalThis.deep = function deep(n) { return 1 + deep(n + 1); };
+        """;
+
+    /// <summary>A loader that asks script for the module source, the JS-implemented virtual file system.</summary>
+    private sealed class ScriptSourcedModuleLoader : IAsyncModuleLoader
+    {
+        private readonly Action<Engine>? _beforeSource;
+
+        public ScriptSourcedModuleLoader(Action<Engine>? beforeSource = null) => _beforeSource = beforeSource;
+
+        public ResolvedSpecifier Resolve(string? referencingModuleLocation, ModuleRequest moduleRequest)
+            => new(moduleRequest, moduleRequest.Specifier, Uri: null, SpecifierType.Bare);
+
+        public Module LoadModule(Engine engine, ResolvedSpecifier resolved)
+            => throw new InvalidOperationException("The engine must not take the synchronous path for an IAsyncModuleLoader.");
+
+        public void LoadModuleAsync(Engine engine, ResolvedSpecifier resolved, ModuleLoadCompletion completion)
+        {
+            _beforeSource?.Invoke(engine);
+            completion.SetSource("export const v = 1;");
+        }
+    }
+
+    /// <summary>A loader whose resolve hook is a script function — an import map written in JavaScript.</summary>
+    private sealed class ScriptResolvingModuleLoader : ModuleLoader
+    {
+        public Engine Engine { get; set; } = null!;
+
+        public override ResolvedSpecifier Resolve(string? referencingModuleLocation, ModuleRequest moduleRequest)
+        {
+            var key = Engine.Invoke("resolveModule", moduleRequest.Specifier).AsString();
+            return new(moduleRequest, key, Uri: null, SpecifierType.Bare);
+        }
+
+        protected override string LoadModuleContents(Engine engine, ResolvedSpecifier resolved) => "export const v = 1;";
+    }
+
+    [Fact]
+    public void ARecursionLimitReachedInsideAnAsynchronousLoaderIsNotFlattenedIntoARejection()
+    {
+        var engine = new Engine(options =>
+        {
+            options.Constraints.MaxRecursionDepth = 20;
+            options.EnableModules(new ScriptSourcedModuleLoader(e => e.Invoke("deep", 0)));
+        });
+
+        engine.Execute(DeepRecursion + "globalThis.caught = 'none';");
+
+        Invoking(() => engine.Execute("import('m').catch(e => { globalThis.caught = String(e); });"))
+            .Should().Throw<RecursionDepthOverflowException>("a recursion limit that script can catch bounds nothing");
+
+        engine.Evaluate("globalThis.caught").AsString().Should().Be("none");
+    }
+
+    [Fact]
+    public void ARecursionLimitReachedInsideResolveIsNotFlattenedIntoAFailedOperation()
+    {
+        var loader = new ScriptResolvingModuleLoader();
+        var engine = new Engine(options =>
+        {
+            options.Constraints.MaxRecursionDepth = 20;
+            options.EnableModules(loader);
+        });
+        loader.Engine = engine;
+
+        engine.Execute(DeepRecursion + "globalThis.resolveModule = function (s) { return deep(0); };");
+
+        Invoking(() => engine.Modules.StartImport("m")).Should().Throw<RecursionDepthOverflowException>();
+    }
+
+    [Fact]
+    public void AnOrdinaryLoaderFailureStillBecomesARejection()
+    {
+        var engine = new Engine(options =>
+        {
+            options.Constraints.MaxRecursionDepth = 20;
+            options.EnableModules(new ScriptSourcedModuleLoader(_ => throw new InvalidOperationException("the asset pipeline is down")));
+        });
+
+        var operation = engine.Modules.StartImport("m");
+        engine.Advanced.ProcessTasks();
+
+        operation.IsCompleted.Should().BeTrue();
+        operation.IsFaulted.Should().BeTrue();
+        operation.Error!.ToString().Should().Contain("the asset pipeline is down");
+    }
+}

--- a/Jint/Runtime/Modules/ModuleLoadCompletion.cs
+++ b/Jint/Runtime/Modules/ModuleLoadCompletion.cs
@@ -340,12 +340,20 @@ public sealed class ModuleLoadCompletion
     /// <summary>
     /// The failures that must keep propagating rather than become a module-load rejection: each one exists to
     /// bound or abort execution, and a constraint that turns into a rejection no longer bounds anything —
-    /// script observes it as an ordinary failed import and carries on.
+    /// script observes it as an ordinary failed import and carries on, in a loop if it likes.
     /// </summary>
+    /// <remarks>
+    /// <see cref="RecursionDepthOverflowException"/> belongs here for the same reason as the rest, and reaches
+    /// these paths whenever the loader itself re-enters the engine — a resolve hook or a virtual file system
+    /// written in script, which is a shape hosts really do use. It is not raised by anything the load pipeline
+    /// does on its own; a module <em>body</em> that recurses too deeply fails outside every one of these
+    /// catches.
+    /// </remarks>
     internal static bool MustPropagate(Exception exception) => exception
         is ExecutionCanceledException
         or MemoryLimitExceededException
         or StatementsCountOverflowException
+        or RecursionDepthOverflowException
         or TimeoutException
         or OperationCanceledException
         or OutOfMemoryException;


### PR DESCRIPTION
`ModuleLoadCompletion.MustPropagate` omitted `RecursionDepthOverflowException` — the one remaining `JintException` that bounds a resource (`Options.LimitRecursion`) — so a load failing with it became a promise rejection rather than propagating. A constraint that becomes a rejection is a constraint that no longer bounds anything: `import('m').catch(...)` in a loop defeats the limit entirely.

The review had no repro for this one; two were built:

- through `IAsyncModuleLoader.LoadModuleAsync` re-entering script — `no throw; outcome=REJECTED: Error: The recursion is forbidden by script host.` Script caught it and carried on.
- through a synchronous `Resolve` re-entering script, via `StartImport` — `completed=True faulted=True error=Error: The recursion is forbidden by script host.`

Neither site has an `IsRunningJob` gate, so the flattening happened on a synchronous stack with the caller right there. The shape it needs is a loader that calls back into script — a JS-implemented import map or virtual file system, which is a real embedding. Nothing in the pipeline raises it unprompted: a module *body* that recurses fails outside every one of these catches, because `FinishWaiters` is deliberately outside `Build`'s try.

3 tests including a control proving ordinary loader failures still become rejections; 2 red on `main` on both TFMs. Test262 99,738 / 0.

**Recorded, not fixed:** `ModuleLoader.LoadModule` flattens everything out of `LoadModuleContents` into `"Could not load module X"` except `NotSupportedException` — including all five `MustPropagate` types. It is the synchronous sibling of this hole, but `LoadModuleContents`' XML doc *promises* "anything this throws is a failed load", so closing it changes a documented contract on a public abstract member and deserves its own decision. Noted in the commit message so it is not lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)