### PR TITLE
Format machine-readable output invariantly, not in the host's culture

### DIFF
--- a/Jint.Tests.PublicInterface/HostCultureInvarianceTests.cs
+++ b/Jint.Tests.PublicInterface/HostCultureInvarianceTests.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// Jint runs inside a host process whose <see cref="CultureInfo.CurrentCulture"/> is none of Jint's business:
+/// an ASP.NET request can set it per user, a desktop app inherits it from the OS. None of it may reach what a
+/// script sees. Everything asserted here is machine-readable output — JSON, ISO 8601 dates, stack traces,
+/// <c>Number.prototype</c> conversions — which ECMAScript specifies down to the character, so the only correct
+/// answer under every culture is the same ASCII one.
+///
+/// <para>
+/// The failure this pins is not hypothetical. Several ICU locales — sv-SE, fi-FI, nb-NO, lt-LT, et-EE — spell
+/// <c>NumberFormatInfo.NegativeSign</c> as U+2212 MINUS SIGN rather than U+002D, and ar-SA prefixes it with
+/// U+061C ARABIC LETTER MARK. A formatting call that took its provider from the ambient culture therefore made
+/// <c>JSON.stringify(-1)</c> emit a string no JSON parser accepts, and did so inconsistently: integers went
+/// through the cultured path while doubles did not, so <c>{"a":-1,"b":-2.5}</c> came back with one of its two
+/// minus signs replaced.
+/// </para>
+///
+/// <para>
+/// These tests live in the public-interface suite because that is the vantage point that matters — an embedder
+/// sets a culture and calls <see cref="Engine.Evaluate(string)"/>, and nothing here needs internals. They run on
+/// net472 as well as net10.0, which is what covers both halves of <c>ValueStringBuilder</c>'s target-framework
+/// split.
+/// </para>
+/// </summary>
+// CultureInfo.CurrentCulture is ambient state, so this class must not run beside anything else: it is
+// restored in a finally, but a test running concurrently would observe it in between. Same reasoning, and
+// the same shape, as GarbageCollectionTests over in Jint.Tests.
+[CollectionDefinition(nameof(HostCultureInvarianceTests), DisableParallelization = true)]
+[Collection(nameof(HostCultureInvarianceTests))]
+public class HostCultureInvarianceTests
+{
+    /// <summary>
+    /// A culture built in the test rather than looked up, whose negative sign is U+2212 and whose decimal
+    /// separator is a comma whatever the machine says. The named cultures below only carry a non-ASCII sign
+    /// under ICU: net472 resolves them through NLS, and a host can put the whole process into invariant
+    /// globalization mode. Without this row the theory would pass vacuously on exactly the configurations it
+    /// exists to cover, and it would also be hostage to a CLDR release changing sv-SE's mind.
+    /// </summary>
+    private const string Hostile = "<hostile>";
+
+    public static TheoryData<string> Cultures() =>
+    [
+        "en-US",
+        "sv-SE",
+        "fi-FI",
+        "ar-SA",
+        "de-DE",
+        Hostile,
+    ];
+
+    [Theory]
+    [MemberData(nameof(Cultures))]
+    public void JsonStringifyOfNegativeNumbersIsAscii(string cultureName)
+    {
+        RunUnderCulture(cultureName, engine =>
+        {
+            // Bare, nested in an object, and inside an array. The three used to disagree with each other.
+            AssertEvaluates(engine, "JSON.stringify(-1)", "-1");
+            AssertEvaluates(engine, "JSON.stringify([-1,-2,-3])", "[-1,-2,-3]");
+            AssertEvaluates(engine, "JSON.stringify({a:-1,b:[-2,-3],c:{d:-42}})", """{"a":-1,"b":[-2,-3],"c":{"d":-42}}""");
+
+            // The inconsistency that made the bug obvious: -1 took the integer path and -2.5 did not.
+            AssertEvaluates(engine, "JSON.stringify({a:-1,b:-2.5,c:[-3]})", """{"a":-1,"b":-2.5,"c":[-3]}""");
+
+            // Widths either side of Int32, since int and long format through separate BCL entry points.
+            AssertEvaluates(engine, "JSON.stringify([-2147483648,-2147483649,-9007199254740991])", "[-2147483648,-2147483649,-9007199254740991]");
+        });
+    }
+
+    [Theory]
+    [MemberData(nameof(Cultures))]
+    public void ErrorStackLineAndColumnAreAscii(string cultureName)
+    {
+        RunUnderCulture(cultureName, engine =>
+        {
+            var stack = engine.Evaluate("function a(){b()} function b(){throw new Error('x')} try{a()}catch(e){e.stack}").AsString();
+
+            AssertAscii(stack, "e.stack");
+            // Both frames must carry a machine-parseable file:line:column, which is what a source-map
+            // consumer reads back out of a stack trace.
+            Regex.Matches(stack, @":\d+:\d+").Count.Should().Be(3, "each of the three frames reports line:column");
+        });
+    }
+
+    [Theory]
+    [MemberData(nameof(Cultures))]
+    public void ToIsoStringIsAscii(string cultureName)
+    {
+        RunUnderCulture(cultureName, engine =>
+        {
+            AssertEvaluates(engine, "new Date(0).toISOString()", "1970-01-01T00:00:00.000Z");
+            AssertEvaluates(engine, "new Date(Date.UTC(2020,0,1,2,3,4,5)).toISOString()", "2020-01-01T02:03:04.005Z");
+
+            // A negative year is the only hole in this format that can carry a sign.
+            AssertEvaluates(engine, "new Date(Date.UTC(-1,0,1)).toISOString()", "-0001-01-01T00:00:00.000Z");
+            AssertEvaluates(engine, "new Date(-8639999999999999).toISOString()", "-271821-04-20T00:00:00.001Z");
+
+            // And the expanded year above 9999, whose sign this code writes itself.
+            AssertEvaluates(engine, "new Date(8639999999999999).toISOString()", "+275760-09-12T23:59:59.999Z");
+
+            // toJSON and JSON.stringify both go through toISOString.
+            AssertEvaluates(engine, "JSON.stringify(new Date(Date.UTC(-1,0,1)))", "\"-0001-01-01T00:00:00.000Z\"");
+        });
+    }
+
+    [Theory]
+    [MemberData(nameof(Cultures))]
+    public void ToExponentialIsAscii(string cultureName)
+    {
+        RunUnderCulture(cultureName, engine =>
+        {
+            AssertEvaluates(engine, "(0.0001).toExponential()", "1e-4");
+            AssertEvaluates(engine, "(0.0001).toExponential(3)", "1.000e-4");
+            AssertEvaluates(engine, "(-1.5e21).toExponential()", "-1.5e+21");
+            AssertEvaluates(engine, "(123.456).toPrecision(2)", "1.2e+2");
+            AssertEvaluates(engine, "(-1.5).toFixed(1)", "-1.5");
+        });
+    }
+
+    [Theory]
+    [MemberData(nameof(Cultures))]
+    public void NumberToStringWithRadixIsAscii(string cultureName)
+    {
+        RunUnderCulture(cultureName, engine =>
+        {
+            AssertEvaluates(engine, "(-1).toString()", "-1");
+            AssertEvaluates(engine, "(-1).toString(2)", "-1");
+            AssertEvaluates(engine, "(-255).toString(16)", "-ff");
+            AssertEvaluates(engine, "(-1.5).toString(36)", "-1.i");
+            AssertEvaluates(engine, "(-1e21).toString()", "-1e+21");
+            AssertEvaluates(engine, "(-1e-7).toString()", "-1e-7");
+            AssertEvaluates(engine, "String(-1)", "-1");
+            AssertEvaluates(engine, "[-1,-2].join()", "-1,-2");
+        });
+    }
+
+    /// <summary>
+    /// Unlike everything above, an <c>Intl.NumberFormat</c>'s output is <em>supposed</em> to be locale-sensitive:
+    /// PartitionNotationSubPattern takes the exponent's minus sign from locale data
+    /// (<see href="https://tc39.es/ecma402/#sec-partitionnotationsubpattern"/>). The locale it must come from is
+    /// the one the object resolved, though — never the host process's. So the assertion here is not that the
+    /// output is ASCII, but that it does not move when the ambient culture does.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Cultures))]
+    public void IntlNumberFormatExponentFollowsTheResolvedLocaleNotTheAmbientOne(string cultureName)
+    {
+        RunUnderCulture(cultureName, engine =>
+        {
+            // en-US spells its negative sign U+002D, so this stays ASCII under every host culture.
+            AssertEvaluates(engine, "new Intl.NumberFormat('en-US',{notation:'scientific'}).format(0.00012)", "1.2E-4");
+            AssertEvaluates(engine, "new Intl.NumberFormat('en-US',{notation:'engineering'}).format(0.00012)", "120E-6");
+            AssertEvaluates(engine, "new Intl.NumberFormat('en-US',{notation:'scientific'}).format(12000)", "1.2E4");
+        });
+    }
+
+    private static void AssertEvaluates(Engine engine, string script, string expected)
+    {
+        var actual = engine.Evaluate(script).AsString();
+        actual.Should().Be(expected, "`{0}` must not depend on CultureInfo.CurrentCulture (got {1})", script, Describe(actual));
+    }
+
+    private static void AssertAscii(string value, string what)
+    {
+        foreach (var c in value)
+        {
+            if (c > 0x7e)
+            {
+                throw new Xunit.Sdk.XunitException($"{what} contains the non-ASCII character U+{(int) c:X4}: {Describe(value)}");
+            }
+        }
+    }
+
+    private static string Describe(string value)
+    {
+        var sb = new System.Text.StringBuilder(value.Length + 2);
+        sb.Append('"');
+        foreach (var c in value)
+        {
+            if (c is < (char) 0x20 or > (char) 0x7e)
+            {
+                sb.Append("\\u").Append(((int) c).ToString("X4", CultureInfo.InvariantCulture));
+            }
+            else
+            {
+                sb.Append(c);
+            }
+        }
+        return sb.Append('"').ToString();
+    }
+
+    private static void RunUnderCulture(string cultureName, Action<Engine> assertions)
+    {
+        var previous = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = CreateCulture(cultureName);
+
+            // Built inside the block so that anything the engine formats while starting up is covered too.
+            assertions(new Engine());
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previous;
+        }
+    }
+
+    private static CultureInfo CreateCulture(string cultureName)
+    {
+        if (!string.Equals(cultureName, Hostile, StringComparison.Ordinal))
+        {
+            return CultureInfo.GetCultureInfo(cultureName);
+        }
+
+        var culture = (CultureInfo) CultureInfo.GetCultureInfo("en-US").Clone();
+        culture.NumberFormat.NegativeSign = "−";
+        culture.NumberFormat.PositiveSign = "➕";
+        culture.NumberFormat.NumberDecimalSeparator = ",";
+        culture.NumberFormat.NumberGroupSeparator = ".";
+        return culture;
+    }
+}

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -1910,8 +1910,11 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
 
     public sealed override string ToString()
     {
-        // debugger can make things hard when evaluates computed values
-        return "(" + GetJsNumberLength()._value + ")[]";
+        // debugger can make things hard when evaluates computed values.
+        // Render the JsNumber rather than its raw double: that routes through TypeConverter.ToString,
+        // which is Jint's own number-to-string and independent of the host's ambient culture, where
+        // double.ToString() would take both the format and the negative sign from CultureInfo.CurrentCulture.
+        return "(" + GetJsNumberLength() + ")[]";
     }
 
     internal static void ThrowMaximumArraySizeReachedException(Engine engine, uint capacity)

--- a/Jint/Native/Date/DatePrototype.cs
+++ b/Jint/Native/Date/DatePrototype.cs
@@ -954,13 +954,21 @@ internal sealed partial class DatePrototype : Prototype
         var (year, month, day) = YearMonthDayFromTime(t);
         month++;
 
-        var formatted = $"{year:0000}-{month:00}-{day:00}T{h:00}:{m:00}:{s:00}.{ms:000}Z";
-        if (year > 9999)
+        // Step 6 writes the sign itself and zero-pads abs(y), so the digits never carry one. Letting
+        // the year's own formatting produce it would take the sign from the ambient culture, which is
+        // U+2212 MINUS SIGN in sv-SE and friends - not something a date parser accepts. Every other
+        // hole here is non-negative by construction and formats to ASCII digits under any culture.
+        var yearSign = "";
+        if (year < 0)
         {
-            formatted = "+" + formatted;
+            yearSign = "-";
+        }
+        else if (year > 9999)
+        {
+            yearSign = "+";
         }
 
-        return formatted;
+        return $"{yearSign}{System.Math.Abs(year):0000}-{month:00}-{day:00}T{h:00}:{m:00}:{s:00}.{ms:000}Z";
     }
 
     [JsFunction(Length = 1, Name = "toJSON")]

--- a/Jint/Native/Intl/JsNumberFormat.cs
+++ b/Jint/Native/Intl/JsNumberFormat.cs
@@ -226,8 +226,11 @@ internal sealed class JsNumberFormat : ObjectInstance
             : "0";
         var mantissaStr = mantissa.ToString(mantissaFormat, NumberFormatInfo);
 
-        // Format exponent (no plus sign for positive exponents per spec)
-        return $"{mantissaStr}E{exponent}";
+        // Format exponent (no plus sign for positive exponents per spec). PartitionNotationSubPattern
+        // takes the exponent's minus sign from the resolved locale's data, so it comes from this
+        // object's own NumberFormatInfo - as the mantissa above does - and never from the host's
+        // ambient culture. https://tc39.es/ecma402/#sec-partitionnotationsubpattern
+        return $"{mantissaStr}E{exponent.ToString(NumberFormatInfo)}";
     }
 
     private string FormatEngineering(double value)
@@ -251,8 +254,9 @@ internal sealed class JsNumberFormat : ObjectInstance
             : "0";
         var mantissaStr = mantissa.ToString(mantissaFormat, NumberFormatInfo);
 
-        // Format exponent (no plus sign for positive exponents per spec)
-        return $"{mantissaStr}E{engineeringExponent}";
+        // Format exponent (no plus sign for positive exponents per spec). See FormatScientific for why
+        // the exponent's sign comes from this object's NumberFormatInfo rather than the ambient culture.
+        return $"{mantissaStr}E{engineeringExponent.ToString(NumberFormatInfo)}";
     }
 
     private string FormatCompact(double value)

--- a/Jint/Pooling/ValueStringBuilder.cs
+++ b/Jint/Pooling/ValueStringBuilder.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -221,29 +222,38 @@ internal ref struct ValueStringBuilder
     }
 
 #if NET8_0_OR_GREATER
+    /// <summary>
+    /// Appends a formattable value using the invariant culture, which every caller of this builder
+    /// wants: what it produces is machine-readable output — JSON, ISO 8601 dates, stack traces —
+    /// not text for a user to read. A null provider would mean <see cref="NumberFormatInfo.CurrentInfo"/>,
+    /// i.e. the host's ambient <see cref="CultureInfo.CurrentCulture"/>, whose <c>NegativeSign</c> is
+    /// U+2212 MINUS SIGN in sv-SE, fi-FI, nb-NO and others, and carries a U+061C ARABIC LETTER MARK
+    /// in ar-SA. Both routes are cultured, and both are taken: the <c>TryFormat</c> attempt fails on
+    /// an empty or nearly full buffer, which is exactly the state of a freshly constructed builder.
+    /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Append<T>(T value) where T : ISpanFormattable
     {
-        if (value.TryFormat(_chars.Slice(_pos), out var charsWritten, format: default, provider: null))
+        if (value.TryFormat(_chars.Slice(_pos), out var charsWritten, format: default, provider: CultureInfo.InvariantCulture))
         {
             _pos += charsWritten;
         }
         else
         {
-            Append(value.ToString());
+            Append(value.ToString(format: null, CultureInfo.InvariantCulture));
         }
     }
 #else
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Append(int value)
     {
-        Append(value.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        Append(value.ToString(CultureInfo.InvariantCulture));
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Append(long value)
     {
-        Append(value.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        Append(value.ToString(CultureInfo.InvariantCulture));
     }
 #endif
 

--- a/Jint/Runtime/JintOrderedDictionary.cs
+++ b/Jint/Runtime/JintOrderedDictionary.cs
@@ -359,7 +359,7 @@ internal sealed class JintOrderedDictionary<TKey, TValue>
         }
         if (arrayIndex < 0)
         {
-            Throw.ArgumentOutOfRangeException(nameof(arrayIndex), string.Format(CultureInfo.CurrentCulture, TooSmall, 0));
+            Throw.ArgumentOutOfRangeException(nameof(arrayIndex), string.Format(CultureInfo.InvariantCulture, TooSmall, 0));
         }
         if (dictionary.Count > array.Length - arrayIndex)
         {


### PR DESCRIPTION
`ValueStringBuilder.Append<T>` passed `provider: null` to `TryFormat`, and a null provider means `NumberFormatInfo.CurrentInfo` — the host's ambient `CultureInfo.CurrentCulture`. Its own downlevel siblings two lines below already used `InvariantCulture`, so the modern path was the odd one out. Several ICU locales use **U+2212 MINUS SIGN** as `NegativeSign`, and `ar-SA` prefixes **U+061C ARABIC LETTER MARK**, so on net8.0/net10.0 Jint emitted JSON no parser accepts:

```
sv-SE   JSON.stringify(-1)                      →  \u22121
ar-SA   JSON.stringify(-1)                      →  \u061C-1
sv-SE   JSON.stringify({a:-1,b:-2.5,c:[-3]})    →  {"a":\u22121,"b":-2.5,"c":[\u22123]}
sv-SE   new Date(Date.UTC(-1,0,1)).toISOString() →  \u22120001-01-01T00:00:00.000Z
```

Note how it is *inconsistently* wrong — the integers corrupted, `-2.5` intact — because doubles take a different formatting path. Pre-existing; `provider: null` predates v4.15.3 and #2903 only renamed the guard around it.

The `value.ToString()` fallback at `:233` was cultured too, and that is the arm a **fresh** builder always takes, its span being empty — which is why `JSON.stringify(-1)` broke at all.

A differential probe over 81 script surfaces × 10 cultures: **15 diverged before, 0 after.**

**Sites fixed:** `ValueStringBuilder` (both arms), `JsonSerializer.cs:408,417`, `DatePrototype.cs:957`, plus two that are not script-visible but are the same defect class — `ArrayInstance.ToString` (which was also bypassing `TypeConverter.ToString`; rendering the `JsNumber` fixes both) and `JintOrderedDictionary.cs:362`, now matching its twin at `:520`.

**`Intl` is fixed differently, and deliberately.** [PartitionNotationSubPattern](https://tc39.es/ecma402/#sec-partitionnotationsubpattern) emits `exponentMinusSign` from **locale data**, so a locale-dependent sign is *correct* there — the bug was *which* locale. `JsNumberFormat`'s exponents now use the object's own `NumberFormatInfo`, built from the resolved locale, as the adjacent mantissa line already did. `Intl.NumberFormat('en-US', …)` now answers `1.2E-4` under every host culture and `Intl.NumberFormat('sv-SE', …)` keeps `1,2E−4` under every host culture; before, both moved with the host.

**Refuted and left alone**, each verified rather than assumed: `JintCallStack` line/column, `NumberPrototype`'s `toExponential`/`toString(radix)` exponents, `JsDurationFormat`, `JsDateTimeFormat`/`DateTimeFormatConstructor` GMT offsets, Temporal's `PadIsoYear`, offset formatters and `monthCode` builders, and the error-message interpolations. Every one takes `Math.Abs` and writes its own sign, or is non-negative by construction. None diverged across ten cultures on the unfixed build, and the new tests pin them as invariants.

Call sites were enumerated with the compiler — marking `Append<T>` `[Obsolete]` and reading the `CS0618` list — rather than by grep: there are exactly six. Temporarily enabling CA1305/MA0011 produced **zero** hits across the assembly, i.e. every explicit `ToString`/`Format`/`Parse` already passes a provider. Neither analyzer inspects interpolated strings, which is where all three script-visible defects lived.

Tests: 6 theories × 6 cultures in `Jint.Tests.PublicInterface`, including a **synthetic hostile culture** (`NegativeSign = "−"`, `PositiveSign = "➕"`, decimal `,`). That row is load-bearing on net472, where NLS resolves sv-SE with an ASCII sign and the five named cultures pass vacuously. Red 12/36 on net10.0 and 2/36 on net472; green 36/36 on both.

**Hot path:** `TryFormat`'s empty-format fast path sends a non-negative value straight to the unsigned decimal writer and never consults the provider, so the majority of JSON integer appends do bit-for-bit the same work. Only a negative value reads it, once, and `InvariantCulture` takes `NumberFormatInfo.GetInstance`'s `is CultureInfo` branch — a type test and a cached field read — where `null` routed to `CurrentInfo`'s ambient lookup. No allocation either way.

Test262 99,738 / 0 / 157.

**Two pre-existing `Date` defects found and deliberately left for their own PR** (this change leaves both character-for-character identical): expanded years are not six digits — the spec wants `-000001` and `+010000` where Jint emits `-0001`, and Temporal's own `PadIsoYear` already disagrees with `Date` about this — and `new Date(253402300800000).toISOString()` throws `ArgumentOutOfRangeException` out of the engine, one millisecond past `DateTime.MaxValue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)