### PR TITLE
Emit a six-digit expanded year from Date.prototype.toISOString

### DIFF
--- a/Jint.Tests.PublicInterface/HostCultureInvarianceTests.cs
+++ b/Jint.Tests.PublicInterface/HostCultureInvarianceTests.cs
@@ -97,14 +97,14 @@ public class HostCultureInvarianceTests
             AssertEvaluates(engine, "new Date(Date.UTC(2020,0,1,2,3,4,5)).toISOString()", "2020-01-01T02:03:04.005Z");
 
             // A negative year is the only hole in this format that can carry a sign.
-            AssertEvaluates(engine, "new Date(Date.UTC(-1,0,1)).toISOString()", "-0001-01-01T00:00:00.000Z");
+            AssertEvaluates(engine, "new Date(Date.UTC(-1,0,1)).toISOString()", "-000001-01-01T00:00:00.000Z");
             AssertEvaluates(engine, "new Date(-8639999999999999).toISOString()", "-271821-04-20T00:00:00.001Z");
 
             // And the expanded year above 9999, whose sign this code writes itself.
             AssertEvaluates(engine, "new Date(8639999999999999).toISOString()", "+275760-09-12T23:59:59.999Z");
 
             // toJSON and JSON.stringify both go through toISOString.
-            AssertEvaluates(engine, "JSON.stringify(new Date(Date.UTC(-1,0,1)))", "\"-0001-01-01T00:00:00.000Z\"");
+            AssertEvaluates(engine, "JSON.stringify(new Date(Date.UTC(-1,0,1)))", "\"-000001-01-01T00:00:00.000Z\"");
         });
     }
 

--- a/Jint.Tests/Runtime/DateTests.cs
+++ b/Jint.Tests/Runtime/DateTests.cs
@@ -64,6 +64,75 @@ public class DateTests
         result.ToString().Should().Be("{\"date\":null}");
     }
 
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-date-time-string-format says YYYY is "four decimal digits from 0000
+    /// to 9999, or as an expanded year of "+" or "-" followed by six decimal digits", and
+    /// https://tc39.es/ecma262/#sec-expanded-years fixes the boundary: a year outside 0000-9999 gets the
+    /// expanded form and nothing else does. Only years whose absolute value already runs to six digits
+    /// used to come out right, which is why the two rows test262 pins by string - the ±8.64e15 extremes
+    /// in built-ins/Date/parse/time-value-maximum-range.js - never caught it.
+    /// </summary>
+    [Theory]
+    // Unchanged: six digits either way.
+    [InlineData(-8640000000000000, "-271821-04-20T00:00:00.000Z")]
+    [InlineData(-3217862419200000, "-100000-01-01T00:00:00.000Z")]
+    // Five digits before, six now.
+    [InlineData(-377736739200000, "-010000-01-01T00:00:00.000Z")]
+    // Four digits before, six now. A negative year is always expanded, however small.
+    [InlineData(-62198755200000, "-000001-01-01T00:00:00.000Z")]
+    [InlineData(-62167219200001, "-000001-12-31T23:59:59.999Z")]
+    // Year 0 is inside 0000-9999, so it keeps the plain four-digit form and takes no sign at all.
+    [InlineData(-62167219200000, "0000-01-01T00:00:00.000Z")]
+    [InlineData(-62135596800000, "0001-01-01T00:00:00.000Z")]
+    [InlineData(0, "1970-01-01T00:00:00.000Z")]
+    [InlineData(253402300799999, "9999-12-31T23:59:59.999Z")]
+    // One millisecond earlier is the first instant of year 10000, which a separate defect makes throw a
+    // CLR exception; this row shows the expanded year without depending on that one.
+    [InlineData(253402300800001, "+010000-01-01T00:00:00.001Z")]
+    [InlineData(3093527980800000, "+100000-01-01T00:00:00.000Z")]
+    [InlineData(8640000000000000, "+275760-09-13T00:00:00.000Z")]
+    public void ToIsoStringExpandsYearsOutsideFourDigits(long timeValue, string expected)
+    {
+        _engine.Evaluate($"new Date({timeValue}).toISOString()").AsString().Should().Be(expected);
+    }
+
+    /// <summary>
+    /// toJSON has no year formatting of its own - https://tc39.es/ecma262/#sec-date.prototype.tojson
+    /// invokes toISOString - so the fix has to reach JSON.stringify too, which is where an embedder
+    /// serializing a Date actually meets it.
+    /// </summary>
+    [Fact]
+    public void ToJsonExpandsYearsOutsideFourDigits()
+    {
+        _engine.Evaluate("new Date(-62198755200000).toJSON()").AsString().Should().Be("-000001-01-01T00:00:00.000Z");
+        _engine.Evaluate("JSON.stringify(new Date(-62198755200000))").AsString().Should().Be("\"-000001-01-01T00:00:00.000Z\"");
+        _engine.Evaluate("JSON.stringify({ d: new Date(253402300800001) })").AsString().Should().Be("{\"d\":\"+010000-01-01T00:00:00.001Z\"}");
+    }
+
+    /// <summary>
+    /// The practical damage: Jint's own parser implements the format correctly, so the four- and
+    /// five-digit strings the formatter used to emit came back as NaN from Date.parse.
+    /// </summary>
+    [Fact]
+    public void ToIsoStringOfAnExpandedYearParsesBack()
+    {
+        _engine.Evaluate("Date.parse(new Date(-62198755200000).toISOString())").AsNumber().Should().Be(-62198755200000);
+        _engine.Evaluate("Date.parse(new Date(253402300800001).toISOString())").AsNumber().Should().Be(253402300800001);
+    }
+
+    /// <summary>
+    /// The neighbouring formatters deliberately do not expand. https://tc39.es/ecma262/#sec-datestring
+    /// and https://tc39.es/ecma262/#sec-date.prototype.toutcstring both write a sign followed by
+    /// ToZeroPaddedDecimalString(abs(yv), 4), where four is a minimum and not a width, so -0001 and
+    /// 10000 are the correct answers there and must stay put.
+    /// </summary>
+    [Fact]
+    public void ToUtcStringDoesNotExpandTheYear()
+    {
+        _engine.Evaluate("new Date(-62198755200000).toUTCString()").AsString().Should().Be("Fri, 01 Jan -0001 00:00:00 GMT");
+        _engine.Evaluate("new Date(253402300800001).toUTCString()").AsString().Should().Be("Sat, 01 Jan 10000 00:00:00 GMT");
+    }
+
     [Fact]
     public void ValuePrecisionIsIntegral()
     {

--- a/Jint/Native/Date/DatePrototype.cs
+++ b/Jint/Native/Date/DatePrototype.cs
@@ -8,6 +8,7 @@ using Jint.Native.Intl;
 using Jint.Native.Function;
 using Jint.Native.Object;
 using Jint.Native.Symbol;
+using Jint.Native.Temporal;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Interop;
@@ -954,21 +955,12 @@ internal sealed partial class DatePrototype : Prototype
         var (year, month, day) = YearMonthDayFromTime(t);
         month++;
 
-        // Step 6 writes the sign itself and zero-pads abs(y), so the digits never carry one. Letting
-        // the year's own formatting produce it would take the sign from the ambient culture, which is
-        // U+2212 MINUS SIGN in sv-SE and friends - not something a date parser accepts. Every other
-        // hole here is non-negative by construction and formats to ASCII digits under any culture.
-        var yearSign = "";
-        if (year < 0)
-        {
-            yearSign = "-";
-        }
-        else if (year > 9999)
-        {
-            yearSign = "+";
-        }
-
-        return $"{yearSign}{System.Math.Abs(year):0000}-{month:00}-{day:00}T{h:00}:{m:00}:{s:00}.{ms:000}Z";
+        // https://tc39.es/ecma262/#sec-expanded-years: a year outside 0000-9999 is written as a sign
+        // followed by six digits, so -1 is "-000001" and 10000 is "+010000", and the four-digit form
+        // takes no sign at all. Sharing Temporal's implementation of that rule is what stops the two
+        // disagreeing: this used to emit whatever `0000` padded the year to, which is right only once
+        // the year has six digits of its own.
+        return $"{TemporalHelpers.PadIsoYear(year)}-{month:00}-{day:00}T{h:00}:{m:00}:{s:00}.{ms:000}Z";
     }
 
     [JsFunction(Length = 1, Name = "toJSON")]

--- a/Jint/Native/Temporal/TemporalHelpers.cs
+++ b/Jint/Native/Temporal/TemporalHelpers.cs
@@ -15,7 +15,12 @@ namespace Jint.Native.Temporal;
 internal static class TemporalHelpers
 {
     /// <summary>
-    /// Formats an ISO year as 4-digit (0000-9999) or 6-digit with sign prefix.
+    /// Formats an ISO year as 4-digit (0000-9999) or 6-digit with sign prefix. This is the one
+    /// implementation of https://tc39.es/ecma262/#sec-expanded-years, which Temporal's ISO strings and
+    /// <c>Date.prototype.toISOString</c> both write, so it lives here rather than once per caller - the
+    /// two used to disagree, and Date was the one that was wrong. The sign is a character literal and
+    /// only a non-negative number is ever formatted, so nothing here can pick up a culture's own
+    /// negative sign.
     /// </summary>
     internal static string PadIsoYear(int year)
     {


### PR DESCRIPTION
`toISOString` formatted the year with `{year:0000}` plus a `"+"` for years above 9999. `0000` is a *minimum* width, so every year outside 0000–9999 with fewer than six digits of its own came out wrong — and Jint's own parser implements the spec format, so **`Date.parse(d.toISOString())` returned `NaN` for every such year**:

| year | before | after |
|---|---|---|
| −1 | `-0001-…` | `-000001-…` |
| −10000 | `-10000-…` | `-010000-…` |
| 10000 | `+10000-…` | `+010000-…` |
| 0, 1, 9999 | four digits, no sign | unchanged |
| ±100000, −271821, +275760 | already six digits | unchanged |

[sec-expanded-years](https://tc39.es/ecma262/#sec-expanded-years): the expanded form covers years before 0 or after 9999, "shall have 6 digits and is always prefixed with a + or - sign", and year 0 is considered positive.

**Why test262 never caught it**: of the 17 files under `built-ins/Date/prototype/toISOString/`, exactly one asserts a whole string — `"1999-10-10T10:10:10.010Z"` — and the only character-exact expanded-year coverage in the suite is `Date/parse/time-value-maximum-range.js`, whose two strings (`-271821…`, `+275760…`) are precisely the two Jint got right by accident of already having six digits.

The fix reuses **`TemporalHelpers.PadIsoYear`**, which already implements this clause correctly — so before this change the engine disagreed with itself: `Temporal.PlainDate` said `-000001-01-01` where `Date` said `-0001-01-01`. Reusing it collapses the disagreement instead of duplicating a corrected copy, and since it writes the sign as a char literal and formats `Math.Abs(year)`, it also carries #2963's culture-invariance intent — this branch is rebased over that merge and updates its two four-digit test expectations, with the full 36-case culture matrix green on both TFMs.

`toJSON`/`JSON.stringify` are fixed by delegation and pinned. `toUTCString`/`toDateString`/`toString` do **not** share the defect — [sec-datestring](https://tc39.es/ecma262/#sec-datestring) wants minimum-four digits there, Jint already matched, and a new test pins that so nobody "fixes" it.

Red 6 / green 44 in `DateTests` on both net10.0 and net472. Test262 exactly 99,738 / 0 / 157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)