### PR TITLE
Stop the first instant of year 10000 throwing a CLR exception out of Date

### DIFF
--- a/Jint.Tests/Runtime/DateTests.cs
+++ b/Jint.Tests/Runtime/DateTests.cs
@@ -228,6 +228,68 @@ public class DateTests
         jsDate._dateValue.Flags.Should().Be(DateFlags.None);
     }
 
+    /// <summary>
+    /// 253402300800000 is the first millisecond of year 10000 — one past the last instant
+    /// <see cref="DateTime"/> can represent, and far inside the legal Date range of
+    /// https://tc39.es/ecma262/#sec-timeclip, so every one of these must produce a string. The bound
+    /// deciding whether a time value could take the DateTime shortcut was rounded up onto this value,
+    /// so the shortcut was taken for a value the conversion behind it then threw
+    /// ArgumentOutOfRangeException on. That is a CLR exception rather than a JavaScriptException, so it
+    /// escaped engine.Evaluate and script try/catch could not see it.
+    /// </summary>
+    [Fact]
+    public void FormattingTheFirstInstantOfYear10000DoesNotThrowAClrException()
+    {
+        // How many digits the expanded year gets is a separate defect; what this asserts is that a
+        // string comes back at all.
+        _engine.Evaluate("new Date(253402300800000).toISOString()").AsString().Should().EndWith("10000-01-01T00:00:00.000Z");
+        _engine.Evaluate("new Date(253402300800000).toJSON()").AsString().Should().EndWith("10000-01-01T00:00:00.000Z");
+        _engine.Evaluate("JSON.stringify({ d: new Date(253402300800000) })").AsString().Should().EndWith("10000-01-01T00:00:00.000Z\"}");
+        _engine.Evaluate("new Date(253402300800000).getUTCFullYear()").AsNumber().Should().Be(10000);
+
+        // toUTCString reached the same value through DateTimeOffset.FromUnixTimeMilliseconds, whose own
+        // message names 253402300799999 as the largest it accepts. toString renders in local time, so
+        // only the year is worth asserting there.
+        _engine.Evaluate("new Date(253402300800000).toUTCString()").AsString().Should().Be("Sat, 01 Jan 10000 00:00:00 GMT");
+        _engine.Evaluate("new Date(253402300800000).toString()").AsString().Should().Contain("10000");
+
+        // The escape itself: a CLR exception is invisible to script, so this used to throw out of
+        // Evaluate rather than run the catch clause or return a value.
+        _engine.Evaluate("(function () { try { return new Date(253402300800000).toISOString(); } catch (e) { return 'caught'; } })()")
+            .AsString().Should().EndWith("10000-01-01T00:00:00.000Z");
+    }
+
+    /// <summary>
+    /// The neighbours on both sides always worked, which is what made the failing band exactly one
+    /// millisecond wide and easy to miss.
+    /// </summary>
+    [Fact]
+    public void ToIsoStringWorksOnBothSidesOfTheDateTimeUpperBound()
+    {
+        _engine.Evaluate("new Date(253402300799998).toISOString()").AsString().Should().Be("9999-12-31T23:59:59.998Z");
+        _engine.Evaluate("new Date(253402300799999).toISOString()").AsString().Should().Be("9999-12-31T23:59:59.999Z");
+        _engine.Evaluate("new Date(253402300800001).toISOString()").AsString().Should().EndWith("10000-01-01T00:00:00.001Z");
+    }
+
+    /// <summary>
+    /// The bound itself. DateTime.MaxValue is 9999-12-31T23:59:59.9999999, so the last millisecond it
+    /// can represent is 253402300799999, and rounding that up is what handed a host passing
+    /// DateTime.MaxValue a Date sitting in year 10000. The low end never had the problem: the epoch is
+    /// a whole number of milliseconds after DateTime.MinValue, so that division comes out exact.
+    /// </summary>
+    [Fact]
+    public void DateTimeMaxValueBecomesTheLastMillisecondItCanRepresent()
+    {
+        var jsDate = new JsDate(_engine, DateTime.MaxValue);
+        jsDate.DateValue.Should().Be(253402300799999d);
+        jsDate.ToDateTime().Should().Be(DateTime.MaxValue);
+
+        _engine.SetValue("d", jsDate);
+        _engine.Evaluate("d.toISOString()").AsString().Should().Be("9999-12-31T23:59:59.999Z");
+
+        new JsDate(_engine, DateTime.MinValue).DateValue.Should().Be(-62135596800000d);
+    }
+
     [Fact]
     public void DstTransitionShouldUseCorrectOffset()
     {

--- a/Jint/Native/JsDate.cs
+++ b/Jint/Native/JsDate.cs
@@ -6,11 +6,17 @@ namespace Jint.Native;
 
 public sealed class JsDate : ObjectInstance
 {
-    // Maximum allowed value to prevent DateTime overflow
-    internal static readonly long Max = (long) (DateTime.MaxValue - DateConstructor.Epoch).TotalMilliseconds;
+    // Maximum allowed value to prevent DateTime overflow. Counted in ticks rather than read off
+    // TimeSpan.TotalMilliseconds: that property is a double division, and the correctly rounded quotient
+    // for DateTime.MaxValue (9999-12-31T23:59:59.9999999, so 253402300799999.9999 ms) is 253402300800000
+    // exactly - the first millisecond of year 10000, which DateTime cannot represent at all. The bound
+    // therefore used to admit one value that every conversion behind it threw ArgumentOutOfRangeException
+    // on, and a CLR exception escapes engine.Evaluate rather than reaching script as a JavaScriptException.
+    internal static readonly long Max = (DateTime.MaxValue - DateConstructor.Epoch).Ticks / TimeSpan.TicksPerMillisecond;
 
-    // Minimum allowed value to prevent DateTime overflow
-    internal static readonly long Min = (long) -(DateConstructor.Epoch - DateTime.MinValue).TotalMilliseconds;
+    // Minimum allowed value to prevent DateTime overflow. The epoch is a whole number of milliseconds
+    // after DateTime.MinValue, so this one was never off; it is counted the same way for symmetry.
+    internal static readonly long Min = -((DateConstructor.Epoch - DateTime.MinValue).Ticks / TimeSpan.TicksPerMillisecond);
 
     // The clipped time value is decomposed into a long + a DateFlags byte rather than stored as the
     // 16-byte DatePresentation struct: the flag byte rides in the object's existing field padding, so


### PR DESCRIPTION
`new Date(253402300800000).toISOString()` threw `ArgumentOutOfRangeException: The added or subtracted value results in an un-representable DateTime` **out of `engine.Evaluate`** — a CLR exception script `try/catch` cannot see. That time value is the first millisecond of year 10000 and is well inside the legal Date range ([sec-timeclip](https://tc39.es/ecma262/#sec-timeclip): `|t| ≤ 8.64e15`), so it must produce a valid ISO string.

**The failing band is exactly one time value.** `253402300799999` worked, `253402300800001` worked, and the negative end has no band at all. That precision is the tell for the root cause:

`JsDate.Max` was `(long)(DateTime.MaxValue - Epoch).TotalMilliseconds`. `TotalMilliseconds` is `Ticks / 10000.0` — a **double** division. The tick count is 2,534,023,007,999,999,999, the true quotient 253402300799999.9999…, and doubles at that magnitude are spaced 0.03125 apart, so the correctly rounded result is `253402300800000.0` exactly. The bound therefore sat one millisecond **above** the last instant `DateTime` can hold, `DateTimeRangeValid` answered true for a value it cannot, and both conversions behind that gate threw — `Epoch.AddMilliseconds` (reached by `toISOString`'s shortcut, `toJSON`, `JSON.stringify`) and `DateTimeOffset.FromUnixTimeMilliseconds` (reached by `toString`, whose own error message names the correct bound).

Fix: count the bound in integers — `(DateTime.MaxValue - Epoch).Ticks / TimeSpan.TicksPerMillisecond`. `Min` is counted the same way for symmetry and does not move.

One observable side effect, deliberate: `new JsDate(engine, DateTime.MaxValue)` used to hand a host a Date in year 10000 whose `toISOString()` then threw; it now clamps to `9999-12-31T23:59:59.999Z`, while `ToDateTime()` still returns `DateTime.MaxValue` exactly.

With #2964 merged alongside, the value round-trips: `+010000-01-01T00:00:00.000Z` → `Date.parse` → `253402300800000`. The test asserts `EndsWith("10000-01-01T00:00:00.000Z")` so the two PRs merge in either order.

Red 2 / green 32 on both TFMs. Test262 exactly 99,738 / 0 / 157.

**Found and deliberately left, same defect class but wider:** `toLocaleString` calls `ToDateTime()` with **no** range check, so every date outside `DateTime`'s range throws the same CLR exception at both ends — before and after this change. Needs its own fix. Also recorded: `Date.parse('0000-01-01…')` → `NaN` (the formatter's correct output for year 0 does not round-trip), `Date.parse('9999-12-31T23:59:59.999Z')` off by one millisecond, and `DateConstructor.FromDateTime` carrying the same double-rounding artefact — changing that one alters sub-millisecond rounding for every input, a wider decision than this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)