### PR TITLE
Wake the blocking promise wait on the work-arrived signal instead of polling

### DIFF
--- a/Jint.Tests.PublicInterface/AsyncModuleLoaderTests.cs
+++ b/Jint.Tests.PublicInterface/AsyncModuleLoaderTests.cs
@@ -220,7 +220,7 @@ public class AsyncModuleLoaderTests
     }
 
     [Fact]
-    public void AHostCanFinishALoadFromAnotherThread()
+    public Task AHostCanFinishALoadFromAnotherThread() => DedicatedThread.RunAsync(() =>
     {
         var loader = new DeferredModuleLoader();
         var engine = new Engine(options => options.EnableModules(loader));
@@ -238,7 +238,7 @@ public class AsyncModuleLoaderTests
 
         engine.Advanced.ProcessTasks();
         engine.Evaluate("value").AsNumber().Should().Be(99);
-    }
+    });
 
     [Fact]
     public void TheLoaderIsAskedOncePerReferrerAndSpecifier()
@@ -325,7 +325,7 @@ public class AsyncModuleLoaderTests
     }
 
     [Fact]
-    public void StartImportIsDrivenByTheHostsOwnPump()
+    public Task StartImportIsDrivenByTheHostsOwnPump() => DedicatedThread.RunAsync(() =>
     {
         // The game-loop shape: start the import, then hand the engine a turn per frame and watch the operation.
         // Nothing here blocks, and no engine work happens on any thread but this one.
@@ -352,7 +352,7 @@ public class AsyncModuleLoaderTests
         import.IsFaulted.Should().BeFalse();
         import.GetResult().Get("value").AsString().Should().Be("ready");
         frames.Should().BeGreaterThan(1, "the load should not have completed on the turn that started it");
-    }
+    });
 
     [Fact]
     public void AFailedPumpedImportReportsTheErrorRatherThanThrowingOutOfThePump()
@@ -499,7 +499,7 @@ public class AsyncModuleLoaderTests
     }
 
     [Fact]
-    public void ACanceledFetchRejectsTheImportAsCanceled()
+    public Task ACanceledFetchRejectsTheImportAsCanceled() => DedicatedThread.RunAsync(() =>
     {
         // Task.IsCanceled is not Task.IsFaulted - there is no exception object to take a message from - so
         // the base class has to say what happened itself.
@@ -522,7 +522,7 @@ public class AsyncModuleLoaderTests
         import.IsCompleted.Should().BeTrue();
         import.IsFaulted.Should().BeTrue();
         import.Error!.Get("message").AsString().Should().Be("Loading module './doomed.js' was canceled.");
-    }
+    });
 
     /// <summary>
     /// Records the cancellation token the engine hands the fetch, and never finishes on its own: the fetch
@@ -598,7 +598,7 @@ public class AsyncModuleLoaderTests
     }
 
     [Fact]
-    public void TheSynchronousImportIsWokenByASettleFromABackgroundThread()
+    public Task TheSynchronousImportIsWokenByASettleFromABackgroundThread() => DedicatedThread.RunAsync(() =>
     {
         // The blocking Import drains the event loop while the load is in flight; a settle arriving from
         // another thread - the shape every real fetch has - only enqueues, and the drain on this thread has
@@ -609,7 +609,7 @@ public class AsyncModuleLoaderTests
         var ns = engine.Modules.Import("./bg.js");
 
         ns.Get("value").AsString().Should().Be("from-background");
-    }
+    });
 
     private sealed class BackgroundThreadLoader : IAsyncModuleLoader
     {
@@ -686,7 +686,7 @@ public class AsyncModuleLoaderTests
     }
 
     [Fact]
-    public void AGraphMixingWarmAndTrulyAsynchronousAnswersStillLoadsThroughTheBlockingImport()
+    public Task AGraphMixingWarmAndTrulyAsynchronousAnswersStillLoadsThroughTheBlockingImport() => DedicatedThread.RunAsync(() =>
     {
         // The root settles inline on the import's own stack; its dependency arrives from the thread pool
         // later. The blocking Import has to switch from the synchronous continuation to draining the event
@@ -700,7 +700,7 @@ public class AsyncModuleLoaderTests
         var engine = new Engine(options => options.EnableModules(loader));
 
         engine.Modules.Import("./root.js").Get("value").AsString().Should().Be("root+slow");
-    }
+    });
 
     /// <summary>
     /// Answers from an in-memory dictionary with an already-completed task — the cache-hit shape — except
@@ -987,7 +987,7 @@ public class AsyncModuleLoaderTests
     }
 
     [Fact]
-    public void AThrowingModuleSourceHookRejectsTheImportInsteadOfStrandingIt()
+    public Task AThrowingModuleSourceHookRejectsTheImportInsteadOfStrandingIt() => DedicatedThread.RunAsync(() =>
     {
         // GetModuleSource is a host hook that runs inside the queued build of an asynchronously delivered
         // module. A failure there has no caller to erupt to; escaping would leave every waiter permanently
@@ -1008,7 +1008,7 @@ public class AsyncModuleLoaderTests
         import.IsCompleted.Should().BeTrue("the hook failure must settle the import rather than strand it");
         import.IsFaulted.Should().BeTrue();
         import.Error!.Get("message").AsString().Should().Contain("source hook failed");
-    }
+    });
 
     private sealed class ThrowingModuleSourceLoader : AsyncModuleLoader
     {
@@ -1066,7 +1066,7 @@ public class AsyncModuleLoaderTests
     }
 
     [Fact]
-    public void AResolutionFailureReachesTheBlockingImportAsTheOriginalException()
+    public Task AResolutionFailureReachesTheBlockingImportAsTheOriginalException() => DedicatedThread.RunAsync(() =>
     {
         // With a synchronous loader, Resolve throwing ModuleResolutionException propagates out of Import as
         // itself. The asynchronous pipeline reduces it to a rejection on the way through the event loop — the
@@ -1084,7 +1084,7 @@ public class AsyncModuleLoaderTests
         Invoking(() => engine.Modules.Import("./root.js"))
             .Should().Throw<ModuleResolutionException>()
             .Which.Specifier.Should().Be("./forbidden.js");
-    }
+    });
 
     /// <summary>
     /// Serves from a dictionary, always from a background thread — the shape of a real fetch, and the only

--- a/Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj
+++ b/Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj
@@ -38,6 +38,12 @@
       AppContext switch can still be observed.
     -->
     <Compile Include="..\Jint.Tests\HostContractVerificationSwitch.cs" Link="HostContractVerificationSwitch.cs" />
+    <!--
+      Shared so that both suites keep a blocking wait on wall-clock asynchronous work off the thread pool
+      the same way. See DedicatedThread.RunAsync for why blocking a pool worker to wait for a continuation
+      that itself needs one is the shortage to avoid.
+    -->
+    <Compile Include="..\Jint.Tests\DedicatedThread.cs" Link="DedicatedThread.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jint.Tests/DedicatedThread.cs
+++ b/Jint.Tests/DedicatedThread.cs
@@ -8,14 +8,16 @@ namespace Jint.Tests;
 /// <summary>
 /// Runs a test body on a dedicated thread, rather than on the xUnit worker thread.
 /// <para>
-/// Two unrelated reasons to want one, both served here so there is a single implementation. Deep
+/// Three unrelated reasons to want one, all served here so there is a single implementation. Deep
 /// recursion needs a larger stack than the default thread provides
-/// (<see cref="LargeStackSize"/>). And a test whose failure mode is a <em>non-terminating</em>
+/// (<see cref="LargeStackSize"/>). A test whose failure mode is a <em>non-terminating</em>
 /// engine — an uninterruptible walk over a corrupt lexical environment chain, say — needs
 /// <paramref name="joinTimeout"/>: an execution constraint cannot stop one of those, because Jint
 /// does not evaluate constraints for event-loop jobs and so cannot interrupt a continuation.
 /// Without a timeout a single regression wedges the whole class (xUnit runs a class's tests
-/// sequentially) and CI hangs instead of reporting.
+/// sequentially) and CI hangs instead of reporting. And a body that <em>blocks</em> on wall-clock
+/// asynchronous work must not do so on a thread-pool thread — that is <see cref="RunAsync"/>, whose
+/// doc explains why it is the asynchronous one that solves it.
 /// </para>
 /// <para>
 /// The exception is re-thrown through <see cref="ExceptionDispatchInfo"/>, which preserves its
@@ -29,6 +31,55 @@ internal static class DedicatedThread
     /// Enough stack for the deep-recursion tests; the platform default is far smaller.
     /// </summary>
     public const int LargeStackSize = 16 * 1024 * 1024;
+
+    /// <summary>
+    /// The platform default stack, which is what a body wanting the thread rather than the stack should
+    /// ask for. <see cref="LargeStackSize"/> reserves 16 MB of address space per concurrent test, and the
+    /// tests that need it are a small, deliberate set.
+    /// </summary>
+    public const int DefaultStackSize = 0;
+
+    /// <summary>
+    /// Runs <paramref name="action"/> on a dedicated thread and hands back a task that completes with it,
+    /// so a <c>Task</c>-returning test releases its thread-pool worker for the whole time the body blocks.
+    /// <para>
+    /// That release is the entire point, and it is why the synchronous <see cref="Run"/> cannot be used
+    /// for this: xUnit runs test bodies on <c>.NET TP Worker</c> threads, so a <see cref="Thread.Join()"/>
+    /// keeps the pool exactly one worker short — the same shortage the body was moved off the pool to
+    /// avoid. A test that blocks on wall-clock asynchronous work is waiting on a continuation that itself
+    /// needs a pool worker (a <see cref="Task.Delay(int)"/> resumption, a <c>CancelAfter</c> callback, an
+    /// asynchronous module load settling), so blocking a worker to wait for one is a resource inversion:
+    /// under enough parallelism the pool's injection rate — order one thread per 500 ms once saturated —
+    /// decides whether the test's promise budget is met, and on a small CI runner it is not. Returning the
+    /// task instead costs the pool nothing while the body waits.
+    /// </para>
+    /// </summary>
+    public static Task RunAsync(Action action, int maxStackSize = DefaultStackSize)
+    {
+        var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var thread = new Thread(
+            () =>
+            {
+                try
+                {
+                    action();
+                    completion.SetResult(true);
+                }
+                catch (Exception e)
+                {
+                    completion.SetException(e);
+                }
+            },
+            maxStackSize)
+        {
+            IsBackground = true,
+        };
+
+        thread.Start();
+
+        return completion.Task;
+    }
 
     public static void Run(Action action, TimeSpan? joinTimeout = null, string? timeoutMessage = null, int maxStackSize = LargeStackSize)
     {

--- a/Jint.Tests/Runtime/AsyncTests.cs
+++ b/Jint.Tests/Runtime/AsyncTests.cs
@@ -14,6 +14,12 @@ public class AsyncTests
     // BEHAVIOR of the task-interop / async-wake path — not latency — use this budget so they
     // cannot lose that race; tests that assert a timeout FIRES keep tight budgets (starvation
     // only helps the timeout fire).
+    //
+    // The budget is the second line of defence, not the first. What causes that starvation is that a
+    // blocking wait here runs on a .NET TP Worker while the continuation it waits for needs one too,
+    // so every test in this file that blocks on wall-clock asynchronous work hands its body to
+    // DedicatedThread.RunAsync and returns the task: the pool keeps its worker for the whole wait.
+    // Raising a budget only buys time against a shortage the test was itself contributing to.
     private static readonly TimeSpan GenerousPromiseTimeout = TimeSpan.FromMinutes(2);
 
     [Fact]
@@ -812,7 +818,7 @@ public class AsyncTests
     }
 
     [Fact]
-    public void ShouldTaskConvertedToPromiseInJS()
+    public Task ShouldTaskConvertedToPromiseInJS() => DedicatedThread.RunAsync(() =>
     {
         Engine engine = new();
         engine.SetValue("callable", Callable);
@@ -826,7 +832,7 @@ public class AsyncTests
             true.Should().BeTrue();
             return 1;
         }
-    }
+    });
 
     private static string EvaluateAsyncJson(string body)
     {
@@ -839,14 +845,14 @@ public class AsyncTests
     }
 
     [Fact]
-    public void ShouldReturnedTaskConvertedToPromiseInJS()
+    public Task ShouldReturnedTaskConvertedToPromiseInJS() => DedicatedThread.RunAsync(() =>
     {
         Engine engine = new(options => options.ExperimentalFeatures = ExperimentalFeature.TaskInterop);
         engine.SetValue("asyncTestClass", new AsyncTestClass());
         var result = engine.Evaluate("asyncTestClass.ReturnDelayedTaskAsync().then(x=>x)");
         result = result.UnwrapIfPromise();
         result.Should().Be(AsyncTestClass.TestString);
-    }
+    });
 
     [Fact]
     public void ShouldRespectCustomProvidedTimeoutWhenUnwrapping()
@@ -862,7 +868,7 @@ public class AsyncTests
     }
 
     [Fact]
-    public void ShouldAwaitUnwrapPromiseWithCustomTimeout()
+    public Task ShouldAwaitUnwrapPromiseWithCustomTimeout() => DedicatedThread.RunAsync(() =>
     {
         // the custom budget must be generous: this asserts the SUCCESS path, and a tight budget
         // races the delayed task's continuation scheduling under CI load
@@ -875,7 +881,7 @@ public class AsyncTests
         """);
         var result = engine.Invoke("test").UnwrapIfPromise(GenerousPromiseTimeout);
         result.Should().Be(AsyncTestClass.TestString);
-    }
+    });
 
     [Fact]
     public void ShouldReturnedCompletedTaskConvertedToPromiseInJS()
@@ -925,7 +931,7 @@ public class AsyncTests
     }
 
     [Fact]
-    public void ShouldTaskCatchWhenThrowError()
+    public Task ShouldTaskCatchWhenThrowError() => DedicatedThread.RunAsync(() =>
     {
         Engine engine = new(options => options.ExperimentalFeatures = ExperimentalFeature.TaskInterop);
 
@@ -941,10 +947,10 @@ public class AsyncTests
             await Task.Delay(10);
             throw new Exception();
         }
-    }
+    });
 
     [Fact]
-    public void ShouldReturnedTaskCatchWhenThrowError()
+    public Task ShouldReturnedTaskCatchWhenThrowError() => DedicatedThread.RunAsync(() =>
     {
         Engine engine = new(options => options.ExperimentalFeatures = ExperimentalFeature.TaskInterop);
 
@@ -953,10 +959,10 @@ public class AsyncTests
 
         engine.Evaluate("asyncTestClass.ThrowAfterDelayAsync().then(_ => cancelled = false).catch(_ => cancelled = true)").UnwrapIfPromise();
         engine.Evaluate("cancelled").AsBoolean().Should().BeTrue();
-    }
+    });
 
     [Fact]
-    public void ShouldTaskAwaitCurrentStack()
+    public Task ShouldTaskAwaitCurrentStack() => DedicatedThread.RunAsync(() =>
     {
         //https://github.com/sebastienros/jint/issues/514#issuecomment-1507127509
         Engine engine = new(options => options.ExperimentalFeatures = ExperimentalFeature.TaskInterop);
@@ -976,10 +982,10 @@ public class AsyncTests
         engine.Evaluate("async function hello() {await myAsyncMethod();mySyncMethod2();await asyncTestClass.AddToStringDelayedAsync(\"3\")} hello();").UnwrapIfPromise();
 
         asyncTestClass.StringToAppend.Should().Be("123");
-    }
+    });
 
     [Fact]
-    public void ShouldCompleteWithAsyncTaskCallbacks()
+    public Task ShouldCompleteWithAsyncTaskCallbacks() => DedicatedThread.RunAsync(() =>
     {
         Engine engine = new(options =>
         {
@@ -993,10 +999,10 @@ public class AsyncTests
         result = result.UnwrapIfPromise(TimeSpan.FromSeconds(30));
 
         result.Should().Be("Hello World");
-    }
+    });
 
     [Fact]
-    public void ShouldFromAsyncTaskCallbacks()
+    public Task ShouldFromAsyncTaskCallbacks() => DedicatedThread.RunAsync(() =>
     {
         Engine engine = new(options =>
         {
@@ -1010,7 +1016,7 @@ public class AsyncTests
         result = result.UnwrapIfPromise(TimeSpan.FromSeconds(30));
 
         result.Should().Be("Hello World");
-    }
+    });
 
     [Fact]
     public void ShouldAllowLetReassignmentInsideAsyncLoop()
@@ -1043,7 +1049,7 @@ public class AsyncTests
     }
 
     [Fact]
-    public void ShouldResolveTopLevelAwaitOfDelayedTaskInModule()
+    public Task ShouldResolveTopLevelAwaitOfDelayedTaskInModule() => DedicatedThread.RunAsync(() =>
     {
         // #2663: top-level await of a .NET Task<T> in a module must block Modules.Import until the
         // Task completes on a ThreadPool thread, instead of giving up in a tight microsecond loop
@@ -1069,10 +1075,10 @@ public class AsyncTests
         var ns = engine.Modules.Import("main");
 
         ns.Get("answer").AsInteger().Should().Be(42);
-    }
+    });
 
     [Fact]
-    public void ShouldPropagateRejectionOfTopLevelAwaitedTaskInModule()
+    public Task ShouldPropagateRejectionOfTopLevelAwaitedTaskInModule() => DedicatedThread.RunAsync(() =>
     {
         // The rejection path of the same #2663 flow: a faulted top-level awaited Task must surface
         // as a JavaScript error out of Modules.Import, not hang or report a spurious pending state.
@@ -1094,10 +1100,10 @@ public class AsyncTests
             """);
 
         Invoking(() => engine.Modules.Import("main")).Should().ThrowExactly<JavaScriptException>();
-    }
+    });
 
     [Fact]
-    public void ShouldObserveCancellationDuringTopLevelAwaitOfNeverCompletingTaskInModule()
+    public Task ShouldObserveCancellationDuringTopLevelAwaitOfNeverCompletingTaskInModule() => DedicatedThread.RunAsync(() =>
     {
         // Robustness gap in the #2663 drain: when an embedder registers a cancellation-based
         // constraint (options.CancellationToken) and cancels it while a module's top-level await is
@@ -1133,10 +1139,10 @@ public class AsyncTests
         sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10), $"Cancellation was not observed promptly: took {sw.Elapsed}.");
 
         neverCompletes.TrySetCanceled();
-    }
+    });
 
     [Fact]
-    public void ShouldTimeOutTopLevelAwaitOfNeverCompletingTaskInModuleWithoutCancellation()
+    public Task ShouldTimeOutTopLevelAwaitOfNeverCompletingTaskInModuleWithoutCancellation() => DedicatedThread.RunAsync(() =>
     {
         // Invariant: with NO cancellation registered, a genuinely never-settling top-level await must
         // still be BOUNDED by PromiseTimeout (not hang), surfacing as an error out of Modules.Import.
@@ -1163,12 +1169,12 @@ public class AsyncTests
         sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(30), $"Never-settling await was not bounded: took {sw.Elapsed}.");
 
         neverCompletes.TrySetCanceled();
-    }
+    });
 
 #if !NETFRAMEWORK
 
     [Fact]
-    public void ShouldCompleteWithAsyncValueTaskCallbacks()
+    public Task ShouldCompleteWithAsyncValueTaskCallbacks() => DedicatedThread.RunAsync(() =>
     {
         Engine engine = new(options =>
         {
@@ -1181,10 +1187,10 @@ public class AsyncTests
         var result = engine.Evaluate("async function hello() {return await asyncTestMethod(async () =>{ await asyncWork(); })} hello();");
         result = result.UnwrapIfPromise(TimeSpan.FromSeconds(30));
         result.Should().Be("Hello World");
-    }
+    });
 
     [Fact]
-    public void ShouldFromAsyncValueTaskCallbacks()
+    public Task ShouldFromAsyncValueTaskCallbacks() => DedicatedThread.RunAsync(() =>
     {
         Engine engine = new(options =>
         {
@@ -1197,10 +1203,10 @@ public class AsyncTests
         var result = engine.Evaluate("async function hello() {return await asyncTestMethod(async () =>{ return await asyncWork(); })} hello();");
         result = result.UnwrapIfPromise(TimeSpan.FromSeconds(30));
         result.Should().Be("Hello World");
-    }
+    });
 
     [Fact]
-    public void ShouldValueTaskConvertedToPromiseInJS()
+    public Task ShouldValueTaskConvertedToPromiseInJS() => DedicatedThread.RunAsync(() =>
     {
         Engine engine = new();
         engine.SetValue("callable", Callable);
@@ -1214,7 +1220,7 @@ public class AsyncTests
             true.Should().BeTrue();
             return 1;
         }
-    }
+    });
 
     [Fact]
     public void ShouldValueTaskCatchWhenCancelled()
@@ -1236,7 +1242,7 @@ public class AsyncTests
     }
 
     [Fact]
-    public void ShouldValueTaskCatchWhenThrowError()
+    public Task ShouldValueTaskCatchWhenThrowError() => DedicatedThread.RunAsync(() =>
     {
         Engine engine = new();
 
@@ -1251,10 +1257,10 @@ public class AsyncTests
             await Task.Delay(10);
             throw new Exception();
         }
-    }
+    });
 
     [Fact]
-    public void ShouldValueTaskAwaitCurrentStack()
+    public Task ShouldValueTaskAwaitCurrentStack() => DedicatedThread.RunAsync(() =>
     {
         //https://github.com/sebastienros/jint/issues/514#issuecomment-1507127509
         Engine engine = new();
@@ -1271,17 +1277,17 @@ public class AsyncTests
         var result = engine.Evaluate("async function hello() {await myAsyncMethod();myAsyncMethod2();} hello();");
         result.UnwrapIfPromise();
         log.Should().Be("12");
-    }
+    });
 
     [Fact]
-    public void ShouldReturnedValueTaskOfTConvertedToPromiseInJS()
+    public Task ShouldReturnedValueTaskOfTConvertedToPromiseInJS() => DedicatedThread.RunAsync(() =>
     {
         Engine engine = new(options => options.ExperimentalFeatures = ExperimentalFeature.TaskInterop);
         engine.SetValue("asyncTestClass", new AsyncTestClass());
         var result = engine.Evaluate("asyncTestClass.ReturnDelayedValueTaskAsync().then(x=>x)");
         result = result.UnwrapIfPromise();
         result.Should().Be(AsyncTestClass.TestString);
-    }
+    });
 
     [Fact]
     public void ShouldReturnedCompletedValueTaskOfTConvertedToPromiseInJS()
@@ -1310,7 +1316,7 @@ public class AsyncTests
     }
 
     [Fact]
-    public void ShouldReturnedValueTaskOfTCatchWhenThrowError()
+    public Task ShouldReturnedValueTaskOfTCatchWhenThrowError() => DedicatedThread.RunAsync(() =>
     {
         Engine engine = new(options => options.ExperimentalFeatures = ExperimentalFeature.TaskInterop);
 
@@ -1319,10 +1325,10 @@ public class AsyncTests
 
         engine.Evaluate("asyncTestClass.ThrowAfterDelayValueTaskAsync().then(_ => cancelled = false).catch(_ => cancelled = true)").UnwrapIfPromise();
         engine.Evaluate("cancelled").AsBoolean().Should().BeTrue();
-    }
+    });
 
     [Fact]
-    public void ShouldAwaitUnwrapValueTaskOfTPromiseWithCustomTimeout()
+    public Task ShouldAwaitUnwrapValueTaskOfTPromiseWithCustomTimeout() => DedicatedThread.RunAsync(() =>
     {
         // see ShouldAwaitUnwrapPromiseWithCustomTimeout — success path must not race CI load
         Engine engine = new(options => { options.ExperimentalFeatures = ExperimentalFeature.TaskInterop; options.Constraints.PromiseTimeout = GenerousPromiseTimeout; });
@@ -1334,10 +1340,10 @@ public class AsyncTests
         """);
         var result = engine.Invoke("test").UnwrapIfPromise(GenerousPromiseTimeout);
         result.Should().Be(AsyncTestClass.TestString);
-    }
+    });
 
     [Fact]
-    public void ShouldIterateOverAsyncEnumeratorConvertedToPromiseInJS()
+    public Task ShouldIterateOverAsyncEnumeratorConvertedToPromiseInJS() => DedicatedThread.RunAsync(() =>
     {
         Engine engine = new(options => options.ExperimentalFeatures = ExperimentalFeature.TaskInterop);
         engine.SetValue("asyncTestClass", new AsyncTestClass());
@@ -1353,7 +1359,7 @@ public class AsyncTests
         """);
         var result = engine.Invoke("test").UnwrapIfPromise();
         result.Should().Be(AsyncTestClass.TestString);
-    }
+    });
 #endif
 
     [Fact]
@@ -1417,7 +1423,7 @@ public class AsyncTests
     }
 
     [Fact]
-    public void ShouldPromiseBeResolved2()
+    public Task ShouldPromiseBeResolved2() => DedicatedThread.RunAsync(() =>
     {
         Engine engine = new();
         engine.SetValue("setTimeout",
@@ -1436,7 +1442,7 @@ public class AsyncTests
         var result = engine.Execute(Script);
         var val = result.GetValue("main").Call();
         val.UnwrapIfPromise().AsInteger().Should().Be(1);
-    }
+    });
 
 #if !NETFRAMEWORK // we are having trouble with timeouts on .NET Framework CI runs
     [Fact]

--- a/Jint.Tests/Runtime/InteropDisposeTests.cs
+++ b/Jint.Tests/Runtime/InteropDisposeTests.cs
@@ -251,7 +251,7 @@ public class InteropDisposeTests
     /// SourceTextModule's TLA execution path.
     /// </summary>
     [Fact]
-    public void ShouldAsyncDisposeInTopLevelAwaitModule()
+    public Task ShouldAsyncDisposeInTopLevelAwaitModule() => DedicatedThread.RunAsync(() =>
     {
         var engine = new Engine(o => o.ExperimentalFeatures = ExperimentalFeature.TaskInterop);
         var disposable = new AsyncDisposable();
@@ -261,7 +261,7 @@ public class InteropDisposeTests
         engine.Modules.Import("tla-dispose");
 
         disposable.Disposed.Should().BeTrue();
-    }
+    });
 
     /// <summary>
     /// TLA module with a genuinely-async dispose (Task.Delay). Confirms the module's
@@ -270,7 +270,7 @@ public class InteropDisposeTests
     /// engine stack.
     /// </summary>
     [Fact]
-    public void ShouldAsyncDisposeInTopLevelAwaitModuleWithGenuinelyAsyncTask()
+    public Task ShouldAsyncDisposeInTopLevelAwaitModuleWithGenuinelyAsyncTask() => DedicatedThread.RunAsync(() =>
     {
         var engine = new Engine(o => o.ExperimentalFeatures = ExperimentalFeature.TaskInterop);
         var disposable = new DelayedAsyncDisposable();
@@ -280,7 +280,7 @@ public class InteropDisposeTests
         engine.Modules.Import("tla-dispose-delayed");
 
         disposable.Disposed.Should().BeTrue();
-    }
+    });
 
     /// <summary>
     /// `for (await using x of arr)` inside an async function with a genuinely-async

--- a/Jint.Tests/Runtime/PromiseTests.cs
+++ b/Jint.Tests/Runtime/PromiseTests.cs
@@ -573,7 +573,7 @@ return Promise.all(promiseArray);") // Returning and array through Promise.any()
     }
 
     [Fact]
-    public void UnwrapIfPromise_WithCancellationToken_ThrowsOperationCanceledException()
+    public Task UnwrapIfPromise_WithCancellationToken_ThrowsOperationCanceledException() => DedicatedThread.RunAsync(() =>
     {
         var engine = new Engine();
         engine.SetValue("f", new Func<JsValue>(() =>
@@ -588,7 +588,7 @@ return Promise.all(promiseArray);") // Returning and array through Promise.any()
         cts.CancelAfter(TimeSpan.FromMilliseconds(50));
 
         Invoking(() => promise.UnwrapIfPromise(cts.Token)).Should().ThrowExactly<OperationCanceledException>();
-    }
+    });
 
     [Fact]
     public void UnwrapIfPromise_WithCancellationToken_NonPromiseReturnsValue()

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1055,8 +1055,15 @@ public sealed partial class Engine : IDisposable
     /// same way per-statement execution surfaces cancellation) instead of blocking up to the full
     /// timeout while awaiting a never-settling Task.
     /// </remarks>
-    internal void DrainEventLoopUntilSettled(JsPromise promise, TimeSpan timeout)
-        => DrainEventLoopUntil(static state => ((JsPromise) state).State != PromiseState.Pending, promise, promise.CompletedEvent, timeout);
+    /// <param name="promise">The promise to wait for.</param>
+    /// <param name="timeout">Non-positive means wait indefinitely.</param>
+    /// <param name="cancellationToken">
+    /// A token supplied by the caller, distinct from the engine's own cancellation constraint; see
+    /// <see cref="DrainEventLoopUntil"/>.
+    /// </param>
+    /// <returns>Whether the promise had settled when the drain ended, i.e. false on timeout.</returns>
+    internal bool DrainEventLoopUntilSettled(JsPromise promise, TimeSpan timeout, System.Threading.CancellationToken cancellationToken = default)
+        => DrainEventLoopUntil(static state => ((JsPromise) state).State != PromiseState.Pending, promise, promise.CompletedEvent, timeout, cancellationToken);
 
     /// <summary>
     /// The general form of <see cref="DrainEventLoopUntilSettled"/>: drives the event loop until
@@ -1071,8 +1078,22 @@ public sealed partial class Engine : IDisposable
     /// running that work on this thread is the only way the condition can advance.
     /// </param>
     /// <param name="timeout">Non-positive means wait indefinitely.</param>
+    /// <param name="cancellationToken">
+    /// A token supplied by the caller, kept deliberately separate from the engine's own
+    /// <see cref="Constraints.CancellationConstraint"/> because the two carry different contracts: this one
+    /// belongs to whoever asked for the wait and is reported back to them as an
+    /// <see cref="OperationCanceledException"/>, while the constraint means the engine itself was cancelled
+    /// and surfaces as <see cref="ExecutionCanceledException"/>, exactly as per-statement execution reports
+    /// it. Both end the wait; the catch below decides which contract applies. The two are linked only when
+    /// both can actually fire, so every caller that passes nothing allocates nothing.
+    /// </param>
     /// <returns>Whether the condition held when the drain ended, i.e. false on timeout.</returns>
-    internal bool DrainEventLoopUntil(Func<object, bool> isSettled, object state, System.Threading.ManualResetEventSlim? completedEvent, TimeSpan timeout)
+    internal bool DrainEventLoopUntil(
+        Func<object, bool> isSettled,
+        object state,
+        System.Threading.ManualResetEventSlim? completedEvent,
+        TimeSpan timeout,
+        System.Threading.CancellationToken cancellationToken = default)
     {
         // Claim this thread as the one draining the loop so background threads (Task completions)
         // don't race to execute JavaScript continuations on the engine. Save/restore to support
@@ -1085,7 +1106,22 @@ public sealed partial class Engine : IDisposable
         // fire; without this, cancelling the engine while a top-level await hangs on a never-settling
         // Task would go unnoticed until PromiseTimeout. Defaults to CancellationToken.None when no
         // such constraint is registered, which leaves the wait behavior unchanged.
-        var cancellationToken = Constraints.Find<CancellationConstraint>()?.Token ?? default;
+        var constraintToken = Constraints.Find<CancellationConstraint>()?.Token ?? default;
+
+        System.Threading.CancellationTokenSource? linkedTokenSource = null;
+        var waitToken = constraintToken;
+        if (cancellationToken.CanBeCanceled)
+        {
+            if (constraintToken.CanBeCanceled)
+            {
+                linkedTokenSource = System.Threading.CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, constraintToken);
+                waitToken = linkedTokenSource.Token;
+            }
+            else
+            {
+                waitToken = cancellationToken;
+            }
+        }
 
         try
         {
@@ -1095,6 +1131,11 @@ public sealed partial class Engine : IDisposable
 
             while (!isSettled(state))
             {
+                // The caller's token is checked before any work is run, so an already-cancelled token
+                // fails the wait rather than being masked by a drain that happens to settle the
+                // condition on its first turn.
+                cancellationToken.ThrowIfCancellationRequested();
+
                 RunAvailableContinuations();
 
                 if (isSettled(state))
@@ -1123,12 +1164,20 @@ public sealed partial class Engine : IDisposable
                     // settle arriving from a background thread only enqueues, and this thread is the one that
                     // has to run it — before the wake it idled out the rest of the poll slice first, which a
                     // chain of sequential asynchronous loads paid on every hop.
-                    _eventLoop.WaitForWork(completedEvent, waitInterval, cancellationToken);
+                    _eventLoop.WaitForWork(completedEvent, waitInterval, waitToken);
                 }
                 catch (OperationCanceledException)
                 {
-                    // The registered CancellationConstraint's token was cancelled during the idle wait.
-                    // Surface it exactly as per-statement execution does (CancellationConstraint.Check),
+                    // The caller's own token keeps its own contract: whoever asked for the wait gets an
+                    // OperationCanceledException back, which is what the public UnwrapIfPromise overload
+                    // taking a token documents.
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        throw;
+                    }
+
+                    // Otherwise the registered CancellationConstraint's token was cancelled during the idle
+                    // wait. Surface it exactly as per-statement execution does (CancellationConstraint.Check),
                     // rather than swallowing it and letting the drain fall through to a silent timeout.
                     Throw.ExecutionCanceledException();
                 }
@@ -1138,6 +1187,7 @@ public sealed partial class Engine : IDisposable
         }
         finally
         {
+            linkedTokenSource?.Dispose();
             _eventLoop._waitingThreadId = previousWaitingThreadId;
         }
     }

--- a/Jint/JsValueExtensions.cs
+++ b/Jint/JsValueExtensions.cs
@@ -748,71 +748,32 @@ public static class JsValueExtensions
     {
         if (value is JsPromise promise)
         {
-            var engine = promise.Engine;
-            var completedEvent = promise.CompletedEvent;
-            var eventLoop = engine.EventLoop;
-
-            // Mark this thread as the one waiting on the promise. This prevents
-            // background threads (from Task completions) from executing JavaScript
-            // continuations - only this waiting thread is allowed to process them.
-            var previousWaitingThreadId = eventLoop._waitingThreadId;
-            eventLoop._waitingThreadId = System.Environment.CurrentManagedThreadId;
-
-            try
+            // Delegate to the engine's own drain rather than polling here. This used to be a
+            // near-duplicate of it that predated EventLoop's work-arrived signal: it woke only on the
+            // promise's own completion event, which a settle enqueued from a background thread never
+            // sets, so every hop of an asynchronous chain idled out the full poll slice before this
+            // thread ran the continuation that could advance it. DrainEventLoopUntilSettled waits on the
+            // enqueue signal too - running that work on this thread is the only way the promise can
+            // settle - and already carries the _waitingThreadId save/restore, its nesting, and the
+            // engine's cancellation constraint.
+            if (!promise.Engine.DrainEventLoopUntilSettled(promise, timeout, cancellationToken))
             {
-                // Process continuations and poll with short intervals to handle
-                // continuations added by background tasks (like setTimeout callbacks)
-                var hasTimeout = timeout > TimeSpan.Zero;
-                var deadline = hasTimeout ? DateTime.UtcNow + timeout : DateTime.MaxValue;
-                var pollInterval = TimeSpan.FromMilliseconds(10);
-
-                while (promise.State == PromiseState.Pending)
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-
-                    engine.RunAvailableContinuations();
-
-                    if (promise.State != PromiseState.Pending)
-                    {
-                        break;
-                    }
-
-                    if (hasTimeout)
-                    {
-                        var remaining = deadline - DateTime.UtcNow;
-                        if (remaining <= TimeSpan.Zero)
-                        {
-                            Throw.PromiseRejectedException($"Timeout of {timeout} reached");
-                        }
-
-                        var waitTime = remaining < pollInterval ? remaining : pollInterval;
-                        completedEvent.Wait(waitTime, cancellationToken);
-                    }
-                    else
-                    {
-                        // No timeout - just poll
-                        completedEvent.Wait(pollInterval, cancellationToken);
-                    }
-                }
-
-                switch (promise.State)
-                {
-                    case PromiseState.Pending:
-                        Throw.InvalidOperationException("'UnwrapIfPromise' called before Promise was settled");
-                        return null;
-                    case PromiseState.Fulfilled:
-                        return promise.Value;
-                    case PromiseState.Rejected:
-                        Throw.PromiseRejectedException(promise.Value);
-                        return null;
-                    default:
-                        Throw.ArgumentOutOfRangeException();
-                        return null;
-                }
+                Throw.PromiseRejectedException($"Timeout of {timeout} reached");
             }
-            finally
+
+            switch (promise.State)
             {
-                eventLoop._waitingThreadId = previousWaitingThreadId;
+                case PromiseState.Pending:
+                    Throw.InvalidOperationException("'UnwrapIfPromise' called before Promise was settled");
+                    return null;
+                case PromiseState.Fulfilled:
+                    return promise.Value;
+                case PromiseState.Rejected:
+                    Throw.PromiseRejectedException(promise.Value);
+                    return null;
+                default:
+                    Throw.ArgumentOutOfRangeException();
+                    return null;
             }
         }
 


### PR DESCRIPTION
The flaky 10-second `AsyncTests` timeout on the windows CI leg, fixed at its root. Two commits, deliberately separate, because they fix two different things and bundling them would credit the wrong change with the CI result.

**The mechanism, reproduced on demand rather than theorised.** A harness that caps the thread pool and blocks all but one worker makes the verbatim test body fail at 10.2 s every time. xUnit v3 runs test bodies on pool threads (verified: `IsThreadPoolThread=True`), `UnwrapIfPromise` **blocks** one, and `Task.Delay`'s continuation then waits on pool injection — ~1–2 threads/second once saturated. Ten seconds of that is easy on a 2-core runner. Reproduced in the real host too: with `DOTNET_PROCESSOR_COUNT=2` and 10 of 12 workers blocked, `AsyncTests` fails **7 tests in 268 s**.

**Commit 1 — the engine.** `UnwrapIfPromiseCore` was a near-duplicate of `DrainEventLoopUntil` that predates the work-arrived signal #2872 added: it polled `completedEvent.Wait(10ms)` in a loop. It now delegates to `DrainEventLoopUntilSettled`. A 20-hop chain of CLR tasks completing on the pool goes from **10.2–13.3 ms/hop to 0.01 ms/hop**, and the `_waitingThreadId` save/restore logic exists in one place instead of two. `DrainEventLoopUntil` gains an optional caller token rather than reusing the constraint's — the two carry different contracts (`ExecutionCanceledException` means *the engine* was cancelled, `OperationCanceledException` means *the caller* cancelled), they are linked only when both can cancel, and existing callers allocate nothing. Timeout message, rejection value, pending `InvalidOperationException` and the already-cancelled-token case are all pinned unchanged.

One deliberate behaviour change: `UnwrapIfPromise` now observes a registered `CancellationConstraint`. It previously ignored it and reported a cancelled engine as a 10-second timeout — the wrong reason, and inconsistent with `Evaluate` and the module drain.

**This commit alone does not fix the flake** — applying it leaves the harness failing at the same 10.2 s, which is obvious once said: a poll slice is 10 ms, the failure is 10,000.

**Commit 2 — the suite.** 32 tests that block a thread on wall-clock async work become `Task`-returning via a new `DedicatedThread.RunAsync` (`AsyncTests` 22, `AsyncModuleLoaderTests` 7, `InteropDisposeTests` 2, `PromiseTests` 1; each conversion a two-line diff). The existing `DedicatedThread.Run` **would not have worked**: it moves the body off the pool but its synchronous `Join` keeps the xUnit worker blocked, so the pool is exactly as short — the harness's middle row proves it, failing identically. That trap is now documented on `RunAsync`. The sweep's other verdicts: every `async Task` test was already safe; inline-settling promises have no exposure; `ModuleTests.ShouldSupportConstraints` and the regex-timeout test looked exposed but are not.

**Result:** under the same pressure that produced 7 failures, **50/50 consecutive runs clean**, 9.3 s. The residual bound is named, not hidden: with a *hard* pool cap one test can still time out, because its chain needs a pool continuation a capped pool can never inject — real CI has slow injection, not a cap, and this removes the suite's own contribution to the shortage.

The suite's prior answer was `GenerousPromiseTimeout` (2 minutes), whose comment diagnosed starvation correctly and prescribed a budget bump. It stays as second-line insurance; its comment now names the structural fix.

Full solution green on both TFMs; test262 exactly 99,738 / 0 / 157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)