### PR TITLE
Remove the rest-parameter state an arguments object can never carry

### DIFF
--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1978,8 +1978,9 @@ public sealed partial class Engine : IDisposable
             else
             {
                 // NOTE: mapped argument object is only provided for non-strict functions that don't have a rest parameter,
-                // any parameter default value initializers, or any destructured parameters.
-                ao = CreateMappedArgumentsObject(function, parameterNames, argumentsList, env, configuration.HasRestParameter);
+                // any parameter default value initializers, or any destructured parameters — all three make the
+                // parameter list non-simple, which is what the arm above already selected on.
+                ao = CreateMappedArgumentsObject(function, parameterNames, argumentsList, env);
             }
 
             if (strict)
@@ -2167,10 +2168,9 @@ public sealed partial class Engine : IDisposable
         Function func,
         Key[] formals,
         JsCallArguments argumentsList,
-        DeclarativeEnvironment envRec,
-        bool hasRestParameter)
+        DeclarativeEnvironment envRec)
     {
-        return _argumentsInstancePool.Rent(func, formals, argumentsList, envRec, hasRestParameter);
+        return _argumentsInstancePool.Rent(func, formals, argumentsList, envRec);
     }
 
     private JsArguments CreateUnmappedArgumentsObject(JsCallArguments argumentsList)

--- a/Jint/Native/JsArguments.cs
+++ b/Jint/Native/JsArguments.cs
@@ -19,7 +19,6 @@ public sealed class JsArguments : ObjectInstance
     private DeclarativeEnvironment _env = null!;
     private Realm _realm = null!;
     private bool _canReturnToPool;
-    private bool _hasRestParameter;
     private bool _materialized;
 
     // Virtual read mode: while set, in-range index reads, length, @@iterator and (mapped) callee
@@ -50,14 +49,12 @@ public sealed class JsArguments : ObjectInstance
         Function.Function func,
         Key[] names,
         JsValue[] args,
-        DeclarativeEnvironment env,
-        bool hasRestParameter)
+        DeclarativeEnvironment env)
     {
         _func = func;
         _names = names;
         _args = args;
         _env = env;
-        _hasRestParameter = hasRestParameter;
         _canReturnToPool = true;
         _virtualMode = true;
         _mapDetached = false;
@@ -285,26 +282,16 @@ public sealed class JsArguments : ObjectInstance
     /// <c>[0, _args.Length)</c> (ConfigurableEnumerableWritable, in both the mapped and the unmapped
     /// shape), <c>length</c> (NonEnumerable), <c>callee</c> (the function or the %ThrowTypeError% accessor
     /// pair, non-enumerable either way) and <c>@@iterator</c> (Writable | Configurable), and nothing else.
-    /// Both premises of "and nothing else" are checked rather than assumed:
+    /// The premise of "and nothing else" is checked rather than assumed: the property bag must still be
+    /// empty, because every property-adding path routes through <c>EnsureInitialized</c> first but
+    /// <c>FastSetProperty</c> is public and does not, and this object is reachable from a host as a plain
+    /// <c>ObjectInstance</c>. A non-empty bag falls through to the materializing path, i.e. to the previous
+    /// behaviour.
     /// </para>
-    /// <list type="bullet">
-    /// <item>the property bag must still be empty — every property-adding path routes through
-    /// <c>EnsureInitialized</c> first, but <c>FastSetProperty</c> is public and does not, and this object
-    /// is reachable from a host as a plain <c>ObjectInstance</c>;</item>
-    /// <item><c>_hasRestParameter</c> must be false — <see cref="DefineOwnProperty"/> short-circuits to
-    /// <c>true</c> without defining anything when it is set, which would make the
-    /// <c>DefinePropertyOrThrow</c>/<c>CreateDataProperty</c> calls in <c>InitializeCore</c> no-ops and the
-    /// materialized set something other than the set described above. It cannot currently be set — the flag
-    /// is only ever passed by <c>CreateMappedArgumentsObject</c>, reached only for a <em>simple</em>
-    /// parameter list, which by definition has no rest parameter — but the lane does not depend on that
-    /// staying true.</item>
-    /// </list>
-    /// <para>Either premise failing falls through to the materializing path, i.e. to the previous behaviour.</para>
     /// </remarks>
     protected internal override OwnPropertyProbe ProbeOwnProperty(JsValue property)
     {
         if (_virtualMode
-            && !_hasRestParameter
             && _properties is null or { Count: 0 }
             && _symbols is null or { Count: 0 })
         {
@@ -397,12 +384,6 @@ public sealed class JsArguments : ObjectInstance
 
     public override bool DefineOwnProperty(JsValue property, PropertyDescriptor desc)
     {
-        if (_hasRestParameter)
-        {
-            // immutable
-            return true;
-        }
-
         EnsureInitialized();
 
         if (ParameterMap is not null)

--- a/Jint/Pooling/ArgumentsInstancePool.cs
+++ b/Jint/Pooling/ArgumentsInstancePool.cs
@@ -27,17 +27,16 @@ internal sealed class ArgumentsInstancePool
         };
     }
 
-    public JsArguments Rent(JsValue[] argumentsList) => Rent(null, null, argumentsList, null, false);
+    public JsArguments Rent(JsValue[] argumentsList) => Rent(null, null, argumentsList, null);
 
     public JsArguments Rent(
         Function? func,
         Key[]? formals,
         JsValue[] argumentsList,
-        DeclarativeEnvironment? env,
-        bool hasRestParameter)
+        DeclarativeEnvironment? env)
     {
         var obj = _pool.Allocate();
-        obj.Prepare(func!, formals!, argumentsList, env!, hasRestParameter);
+        obj.Prepare(func!, formals!, argumentsList, env!);
         return obj;
     }
 

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -390,7 +390,6 @@ internal sealed class JintFunctionDefinition
 
     internal sealed class State
     {
-        public bool HasRestParameter;
         public int Length;
         public Key[] ParameterNames = null!;
         public bool HasDuplicates;
@@ -1052,7 +1051,6 @@ internal sealed class JintFunctionDefinition
     private static void GetBoundNames(
         Node parameter,
         List<Key> target,
-        ref bool hasRestParameter,
         ref bool hasParameterExpressions,
         ref bool hasDuplicates,
         ref bool hasArguments)
@@ -1071,7 +1069,6 @@ Start:
         {
             if (parameter.Type == NodeType.RestElement)
             {
-                hasRestParameter = true;
                 parameter = ((RestElement) parameter).Argument;
                 continue;
             }
@@ -1087,7 +1084,6 @@ Start:
 
                     if (element.Type == NodeType.RestElement)
                     {
-                        hasRestParameter = true;
                         parameter = ((RestElement) element).Argument;
                         goto Start;
                     }
@@ -1095,7 +1091,6 @@ Start:
                     GetBoundNames(
                         element,
                         target,
-                        ref hasRestParameter,
                         ref hasParameterExpressions,
                         ref hasDuplicates,
                         ref hasArguments);
@@ -1107,7 +1102,6 @@ Start:
                 {
                     if (property.Type == NodeType.RestElement)
                     {
-                        hasRestParameter = true;
                         parameter = ((RestElement) property).Argument;
                         goto Start;
                     }
@@ -1115,7 +1109,6 @@ Start:
                     GetBoundNames(
                         ((AssignmentProperty) property).Value,
                         target,
-                        ref hasRestParameter,
                         ref hasParameterExpressions,
                         ref hasDuplicates,
                         ref hasArguments);
@@ -1165,7 +1158,6 @@ Start:
                 GetBoundNames(
                     parameter,
                     parameterNames,
-                    ref state.HasRestParameter,
                     ref state.HasParameterExpressions,
                     ref state.HasDuplicates,
                     ref hasArguments);


### PR DESCRIPTION
`JsArguments._hasRestParameter` is not literally unread — `DefineOwnProperty` short-circuits on it and the virtual probe lane's guard tests it — but it can never be `true`. The only caller passing anything but `false` sits on the `simpleParameterList` arm of `FunctionDeclarationInstantiation`, and `JintFunctionDefinition.State.HasRestParameter` is set only inside `GetBoundNames`, which `ProcessParameters` reaches only from the branch that has just set `IsSimpleParameterList = false`. A function with a rest parameter never has a simple parameter list, so the two conditions cannot meet.

Removed: the field, the `Prepare`/`Rent`/`CreateMappedArgumentsObject` parameters that fed it, the `DefineOwnProperty` short-circuit that always fell through, the probe-guard term, the now-unread `State.HasRestParameter`, and the `ref bool` threaded through `GetBoundNames`' recursion. The compiler confirmed the cascade — clean build with `TreatWarningsAsErrors` on, and no test or benchmark names any of it.

No benchmark table, deliberately: nothing gains work and no call site takes a different branch — the probe lane loses a byte load and a test from a guard it already evaluated, and the analyzer stops threading a `ref` through a recursive walk. There is no delta to establish, only unchanged behaviour, which the suites cover: full solution green on both TFMs, test262 exactly 99,738 / 0 / 157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)