### PR TITLE
Let parseInt and parseFloat take the frameless fast-call lane

### DIFF
--- a/Jint.Tests/Runtime/FastCallLaneTests.cs
+++ b/Jint.Tests/Runtime/FastCallLaneTests.cs
@@ -154,6 +154,7 @@ public class FastCallLaneTests
     [InlineData("\"abc\".substring(0, p)", "substring")]
     [InlineData("\"abc\".slice(p)", "slice")]
     [InlineData("\"abc\".slice(0, p)", "slice")]
+    [InlineData("parseInt(\"10\", p)", "parseInt")]
     public void AWarmedSiteKeepsTheBuiltinFrameWhenAnArgumentCoercesThroughUserCode(string call, string builtin)
     {
         var engine = new Engine();
@@ -162,6 +163,31 @@ public class FastCallLaneTests
             f(1); f(1);
             let captured = "";
             try { f({ valueOf: function () { throw new Error("x"); } }); } catch (e) { captured = e.stack; }
+            captured;
+            """).AsString();
+
+        stack.Should().Contain("at " + builtin, "the built-in frame must survive at a warmed site too");
+    }
+
+    /// <summary>
+    /// The same invariant for the argument these two coerce with <c>ToString</c> rather than
+    /// <c>ToNumber</c>, which the theory above cannot express: an object carrying only a throwing
+    /// <c>valueOf</c> is coerced through <c>Object.prototype.toString</c> and never throws, so the
+    /// thrower has to be the <c>toString</c>. Their first argument's guard is String, and a warmed
+    /// site handed anything else must keep the frame the user code can read off <c>error.stack</c>.
+    /// </summary>
+    [Theory]
+    [InlineData("parseInt(p)", "parseInt")]
+    [InlineData("parseInt(p, 16)", "parseInt")]
+    [InlineData("parseFloat(p)", "parseFloat")]
+    public void AWarmedSiteKeepsTheBuiltinFrameWhenTheStringArgumentCoercesThroughUserCode(string call, string builtin)
+    {
+        var engine = new Engine();
+        var stack = engine.Evaluate($$"""
+            function f(p) { return {{call}}; }
+            f("1"); f("1");
+            let captured = "";
+            try { f({ toString: function () { throw new Error("x"); } }); } catch (e) { captured = e.stack; }
             captured;
             """).AsString();
 
@@ -222,6 +248,13 @@ public class FastCallLaneTests
     [InlineData("\"abc\".charAt()", "a")]
     [InlineData("\"abc\".charAt(undefined)", "a")]
     [InlineData("\"abc\".charAt(NaN)", "a")]
+    [InlineData("String(parseInt(\"0x10\"))", "16")]
+    [InlineData("String(parseInt(\"0x10\", undefined))", "16")]
+    [InlineData("String(parseInt(\"0x10\", NaN))", "16")]
+    [InlineData("String(parseInt(\"10\", 2))", "2")]
+    [InlineData("String(parseInt(\"10\", 1))", "NaN")]
+    [InlineData("String(parseFloat(\"1.5e2x\"))", "150")]
+    [InlineData("String(parseFloat(\"1.5\", 16))", "1.5")]
     public void AbsentNumericArgumentsKeepTheirSpecDefinedMeaning(string expression, string expected)
     {
         var engine = new Engine();

--- a/Jint.Tests/Runtime/GlobalTests.cs
+++ b/Jint.Tests/Runtime/GlobalTests.cs
@@ -91,6 +91,44 @@ public class GlobalTests
         IsNegativeZero(value).Should().BeFalse();
     }
 
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-number.parseint — "the same built-in function object that is the
+    /// value of the parseInt property of the global object". Reference equality, not merely a true
+    /// <c>===</c>: the two used to be distinct ClrFunctions over one delegate, which answered the
+    /// strict-equality test while disagreeing about <c>length</c>.
+    /// </summary>
+    [Fact]
+    public void NumbersParseIntAndParseFloatAreTheGlobalFunctionObjectsThemselves()
+    {
+        var engine = new Engine();
+
+        ReferenceEquals(engine.Evaluate("Number.parseInt"), engine.Evaluate("parseInt")).Should().BeTrue();
+        ReferenceEquals(engine.Evaluate("Number.parseFloat"), engine.Evaluate("parseFloat")).Should().BeTrue();
+
+        engine.Evaluate("[parseInt.length, Number.parseInt.length, parseFloat.length, Number.parseFloat.length].join()")
+            .AsString().Should().Be("2,2,1,1");
+    }
+
+    /// <summary>
+    /// They are realm intrinsics, so a second engine — and a ShadowRealm inside one engine — gets its
+    /// own pair, prototyped on its own %Function.prototype%. The global one used to be built through
+    /// the realm-reading <c>ClrFunction</c> constructor from a lazy factory, so which realm it
+    /// belonged to depended on which one happened to be running when it was first read.
+    /// </summary>
+    [Fact]
+    public void EachRealmHasItsOwnParseIntAndParseFloat()
+    {
+        var engine = new Engine();
+
+        engine.Evaluate("Object.getPrototypeOf(parseInt) === Function.prototype").AsBoolean().Should().BeTrue();
+        engine.Evaluate("""
+            const r = new ShadowRealm();
+            r.evaluate("Object.getPrototypeOf(parseInt) === Function.prototype && Number.parseInt === parseInt");
+            """).AsBoolean().Should().BeTrue();
+
+        ReferenceEquals(engine.Evaluate("parseInt"), new Engine().Evaluate("parseInt")).Should().BeFalse();
+    }
+
     private static bool IsNegativeZero(double value)
         => BitConverter.DoubleToInt64Bits(value) == BitConverter.DoubleToInt64Bits(-0d);
 }

--- a/Jint/Native/Global/GlobalObject.Properties.cs
+++ b/Jint/Native/Global/GlobalObject.Properties.cs
@@ -1,17 +1,16 @@
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Descriptors.Specialized;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Global;
 
-// 56 lazy realm-intrinsic constructor properties on globalThis. Each emits a LazyPropertyDescriptor
-// whose factory body is `host => host._realm.Intrinsics.<IntrinsicMember>` — the constructor object
-// allocates only on first read. Sorted by JsName to match the generator's emit order. Casing
-// overrides via IntrinsicMember:
+// 58 lazy realm-intrinsic properties on globalThis. Each emits a LazyPropertyDescriptor whose factory
+// body is `host => host._realm.Intrinsics.<IntrinsicMember>` — the object allocates only on first
+// read. Sorted by JsName to match the generator's emit order. Casing overrides via IntrinsicMember:
 //   "JSON"     → Intrinsics.Json
 //   "URIError" → Intrinsics.UriError
 //   "Generator" → Intrinsics.GeneratorFunction
 //   "eval"     → Intrinsics.Eval
+//   "parseInt" / "parseFloat" → Intrinsics.ParseInt / ParseFloat, the same two function objects
+//   NumberConstructor installs (see NumberParseFunction)
 [JsIntrinsicReference("AggregateError")]
 [JsIntrinsicReference("Array")]
 [JsIntrinsicReference("ArrayBuffer")]
@@ -68,8 +67,8 @@ namespace Jint.Native.Global;
 [JsIntrinsicReference("WeakRef")]
 [JsIntrinsicReference("WeakSet")]
 [JsIntrinsicReference("eval", IntrinsicMember = "Eval")]
-[JsInstanceSlot("parseInt")]
-[JsInstanceSlot("parseFloat")]
+[JsIntrinsicReference("parseFloat", IntrinsicMember = "ParseFloat")]
+[JsIntrinsicReference("parseInt", IntrinsicMember = "ParseInt")]
 [JsInstanceSlot("globalThis")]
 public partial class GlobalObject
 {
@@ -85,21 +84,12 @@ public partial class GlobalObject
     protected override void Initialize()
     {
         const PropertyFlag PropertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
 
         CreateProperties_Generated();
 
-        // The three entries that can't be expressed declaratively fill reserved [JsInstanceSlot]s.
-        // parseInt / parseFloat are kept hand-rolled because spec requires
-        // Number.parseInt === parseInt (and Number.parseFloat === parseFloat). Pre-source-gen Jint
-        // satisfied that via ClrFunction.Equals comparing the underlying delegate; both globalThis
-        // and NumberConstructor wrap the same GlobalObject.ParseInt/ParseFloat static method.
-        // Migrating to [JsFunction] would emit a distinct __GlobalObjectFunction dispatcher and
-        // break the strict-equality test. NumberConstructor.cs:50 documents the reciprocal half.
-        // globalThis is a self-reference (the GlobalObject instance itself), which can't be
-        // expressed as a static [JsProperty] field or as an intrinsic.
-        SetBuiltinSlotByName("parseInt", new LazyPropertyDescriptor<GlobalObject>(this, static global => new ClrFunction(global._engine, "parseInt", ParseInt, 2, LengthFlags), PropertyFlags));
-        SetBuiltinSlotByName("parseFloat", new LazyPropertyDescriptor<GlobalObject>(this, static global => new ClrFunction(global._engine, "parseFloat", ParseFloat, 1, LengthFlags), PropertyFlags));
+        // The one entry that can't be expressed declaratively fills the reserved [JsInstanceSlot]:
+        // globalThis is a self-reference (the GlobalObject instance itself), which is neither a
+        // static [JsProperty] field nor an intrinsic.
         SetBuiltinSlotByName("globalThis", new PropertyDescriptor(this, PropertyFlags));
     }
 }

--- a/Jint/Native/Global/GlobalObject.cs
+++ b/Jint/Native/Global/GlobalObject.cs
@@ -33,9 +33,9 @@ public sealed partial class GlobalObject : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-parseint-string-radix
     /// </summary>
-    internal static JsValue ParseInt(JsValue thisObject, JsCallArguments arguments)
+    internal static JsValue ParseInt(JsValue value, JsValue radixValue)
     {
-        var inputString = TypeConverter.ToString(arguments.At(0));
+        var inputString = TypeConverter.ToString(value);
         var trimmed = StringPrototype.TrimEx(inputString);
         var s = trimmed.AsSpan();
 
@@ -58,8 +58,9 @@ public sealed partial class GlobalObject : ObjectInstance
 
         // Steps 2-3 and 10. stripPrefix captures step 9's "radixMV is 0 or 16" before step 10
         // defaults it to 10; the spec validates the range at step 3, before trimming, which is a
-        // reordering nothing can observe because no user code runs in between.
-        var radix = arguments.Length > 1 ? TypeConverter.ToInt32(arguments[1]) : 0;
+        // reordering nothing can observe because no user code runs in between. An omitted radix
+        // arrives as undefined, whose ToInt32 is the 0 the absent case produced.
+        var radix = TypeConverter.ToInt32(radixValue);
         var stripPrefix = true;
         if (radix == 0)
         {
@@ -134,9 +135,9 @@ public sealed partial class GlobalObject : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-parsefloat-string
     /// </summary>
-    internal static JsValue ParseFloat(JsValue thisObject, JsCallArguments arguments)
+    internal static JsValue ParseFloat(JsValue value)
     {
-        var inputString = TypeConverter.ToString(arguments.At(0));
+        var inputString = TypeConverter.ToString(value);
         var trimmedString = StringPrototype.TrimStartEx(inputString);
 
         if (string.IsNullOrWhiteSpace(trimmedString))

--- a/Jint/Native/Global/NumberParseFunction.cs
+++ b/Jint/Native/Global/NumberParseFunction.cs
@@ -1,0 +1,93 @@
+using Jint.Native.Function;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.Native.Global;
+
+/// <summary>
+/// %parseInt% and %parseFloat% — one function object per realm each, because
+/// https://tc39.es/ecma262/#sec-number.parseint and https://tc39.es/ecma402/#sec-number.parsefloat
+/// require <c>Number.parseInt</c> and <c>Number.parseFloat</c> to be <em>the same</em> function objects
+/// as the ones on the global object.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both used to be a pair of <see cref="Runtime.Interop.ClrFunction"/>s over the same static method,
+/// one built by <see cref="GlobalObject"/> and one by <c>NumberConstructor</c>, with
+/// <c>ClrFunction.Equals</c> comparing the underlying delegate so that <c>Number.parseInt === parseInt</c>
+/// answered true for two distinct objects. Equal-but-distinct was observable in the one place the two
+/// were not built alike: the constructor's copies declared <c>length</c> 0, so <c>parseInt.length</c>
+/// was 2 while <c>Number.parseInt.length</c> was 0 for a function the same test says is the same
+/// function. Sharing one object makes the sameness real and the lengths agree.
+/// </para>
+/// <para>
+/// Sharing is also what unblocks the fast-call lane, which is the reason for a purpose-built type
+/// rather than a shared <c>ClrFunction</c>. A <c>ClrFunction</c>'s <c>JsCallDelegate</c> takes a
+/// <c>JsValue[]</c>, so it can offer no arity-specialized entry point, and every call to these two
+/// paid the generic arm: a pooled argument array, a call-stack frame, and a virtual hop through the
+/// delegate. <see cref="CallFast"/> takes the arguments in registers, and the shapes below claim
+/// <see cref="FastCallShape.Leaf"/> under guards that make both coercions no-ops, so a warmed
+/// <c>parseInt(s, 10)</c> site elides the frame as well.
+/// </para>
+/// <para>
+/// The guards are what keep <c>Leaf</c> honest. <c>ToString</c> of a <c>JsString</c> and
+/// <c>ToInt32</c> of a number or of the <c>undefined</c> a one-argument site pads the second register
+/// with are both no-ops that cannot reach user code, and neither body raises a JavaScript error —
+/// an unparseable input is <c>NaN</c>, not a throw. Any other argument shape (an object with
+/// <c>valueOf</c>, most of all) fails the guard and keeps its frame.
+/// </para>
+/// </remarks>
+internal sealed class NumberParseFunction : Function.Function
+{
+    private static readonly JsString _parseIntName = new("parseInt");
+    private static readonly JsString _parseFloatName = new("parseFloat");
+
+    /// <summary>
+    /// parseInt reads both registers. parseFloat reads only the first, so its second is
+    /// <see cref="FastCallGuard.Any"/> — the lane always tests both, and a site passing a stray
+    /// second argument to parseFloat must not lose frame elision over a value the body never sees.
+    /// </summary>
+    private static readonly FastCallShape _parseIntShape = new(
+        Supported: true,
+        Leaf: true,
+        Variadic: false,
+        Receiver: FastCallGuard.Any,
+        Arg0: FastCallGuard.String,
+        Arg1: FastCallGuard.Number | FastCallGuard.Undefined);
+
+    private static readonly FastCallShape _parseFloatShape = new(
+        Supported: true,
+        Leaf: true,
+        Variadic: false,
+        Receiver: FastCallGuard.Any,
+        Arg0: FastCallGuard.String,
+        Arg1: FastCallGuard.Any);
+
+    private readonly bool _isParseInt;
+
+    internal NumberParseFunction(Engine engine, Realm realm, FunctionPrototype functionPrototype, bool isParseInt)
+        : base(engine, realm, isParseInt ? _parseIntName : _parseFloatName)
+    {
+        _isParseInt = isParseInt;
+        _prototype = functionPrototype;
+        _length = new PropertyDescriptor(JsNumber.Create(isParseInt ? 2 : 1), PropertyFlag.Configurable);
+    }
+
+    protected internal override JsValue Call(JsValue thisObject, JsCallArguments arguments)
+        => _isParseInt
+            ? GlobalObject.ParseInt(arguments.At(0), arguments.At(1))
+            : GlobalObject.ParseFloat(arguments.At(0));
+
+    /// <remarks>
+    /// The arity is not consulted: both shapes are fixed-arity, and the built-in lane only ever asks
+    /// for a site of at most two arguments, so every arity it can ask about is one the two argument
+    /// registers carry in full.
+    /// </remarks>
+    internal override FastCallShape GetFastCallShape(int argumentCount)
+        => _isParseInt ? _parseIntShape : _parseFloatShape;
+
+    internal override JsValue CallFast(JsValue thisObject, JsValue arg0, JsValue arg1)
+        => _isParseInt
+            ? GlobalObject.ParseInt(arg0, arg1)
+            : GlobalObject.ParseFloat(arg0);
+}

--- a/Jint/Native/Number/NumberConstructor.cs
+++ b/Jint/Native/Number/NumberConstructor.cs
@@ -1,28 +1,23 @@
 using Jint.Native.Function;
-using Jint.Native.Global;
 using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Number;
 
 /// <summary>
 /// https://tc39.es/ecma262/#sec-number-constructor
 /// </summary>
+// Number.parseInt / parseFloat must be the very function objects globalThis.parseInt /
+// globalThis.parseFloat are (https://tc39.es/ecma262/#sec-number.parseint), so both owners install
+// the realm intrinsic rather than each building its own. See NumberParseFunction for what that
+// replaced and why sharing the object is what lets these two reach the fast-call lane.
+[JsIntrinsicReference("parseFloat", IntrinsicMember = "ParseFloat")]
+[JsIntrinsicReference("parseInt", IntrinsicMember = "ParseInt")]
 [JsObject(UseShape = true)]
 internal sealed partial class NumberConstructor : Constructor
 {
     private static readonly JsString _functionName = new JsString("Number");
-
-    // Number.parseInt / parseFloat are the same functions as global parseInt / parseFloat (Jint's
-    // ClrFunction equality compares the underlying delegate). They wrap static delegates with no realm
-    // dependency, so they're per-realm instance slots created in the constructor (like RegExp exec).
-    [JsProperty(Name = "parseInt", Flags = PropertyFlag.Configurable | PropertyFlag.Writable)]
-    private readonly ClrFunction _parseInt;
-
-    [JsProperty(Name = "parseFloat", Flags = PropertyFlag.Configurable | PropertyFlag.Writable)]
-    private readonly ClrFunction _parseFloat;
 
     private const long MinSafeInteger = -9007199254740991;
     internal const long MaxSafeInteger = 9007199254740991;
@@ -47,8 +42,6 @@ internal sealed partial class NumberConstructor : Constructor
         PrototypeObject = new NumberPrototype(engine, realm, this, objectPrototype);
         _length = new PropertyDescriptor(JsNumber.PositiveOne, PropertyFlag.Configurable);
         _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
-        _parseInt = new ClrFunction(engine, "parseInt", GlobalObject.ParseInt, 0, PropertyFlag.Configurable);
-        _parseFloat = new ClrFunction(engine, "parseFloat", GlobalObject.ParseFloat, 0, PropertyFlag.Configurable);
     }
 
     protected override void Initialize()

--- a/Jint/Runtime/Intrinsics.cs
+++ b/Jint/Runtime/Intrinsics.cs
@@ -14,6 +14,7 @@ using Jint.Native.Error;
 using Jint.Native.FinalizationRegistry;
 using Jint.Native.Function;
 using Jint.Native.Generator;
+using Jint.Native.Global;
 using Jint.Native.Iterator;
 using Jint.Native.Json;
 using Jint.Native.Map;
@@ -68,6 +69,8 @@ public sealed partial class Intrinsics
     private ProxyConstructor? _proxy;
     private ReflectInstance? _reflect;
     private EvalFunction? _eval;
+    private NumberParseFunction? _parseInt;
+    private NumberParseFunction? _parseFloat;
     private DateConstructor? _date;
     private IteratorConstructor? _iteratorConstructor;
     private IteratorHelperPrototype? _iteratorHelperPrototype;
@@ -324,6 +327,18 @@ public sealed partial class Intrinsics
 
     public EvalFunction Eval =>
         _eval ??= new EvalFunction(_engine, _realm, Function.PrototypeObject);
+
+    /// <summary>
+    /// %parseInt%. A realm intrinsic rather than a property built by either owner, because
+    /// https://tc39.es/ecma262/#sec-number.parseint requires <c>Number.parseInt</c> to be the very
+    /// function object <c>globalThis.parseInt</c> is — both install this one.
+    /// </summary>
+    internal NumberParseFunction ParseInt =>
+        _parseInt ??= new NumberParseFunction(_engine, _realm, Function.PrototypeObject, isParseInt: true);
+
+    /// <summary>%parseFloat%; the <see cref="ParseInt"/> note applies verbatim.</summary>
+    internal NumberParseFunction ParseFloat =>
+        _parseFloat ??= new NumberParseFunction(_engine, _realm, Function.PrototypeObject, isParseInt: false);
 
     public ErrorConstructor Error =>
         _error ??= new ErrorConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject, _errorFunctionName, static intrinsics => intrinsics.Error.PrototypeObject);


### PR DESCRIPTION
> **Draft-quality until its gate lands**: the benchmark tables (`NumberParseBenchmark` targeted + full SunSpider/Dromaeo) are being measured now and will be posted here before this should merge.

`parseInt(s, 10)` at a warmed call site was eligible for the register lane on argument shape but always declined: `ClrFunction` does not — and cannot — override `GetFastCallShape`, since `JsCallDelegate` takes a `JsValue[]` and offers no arity-specialized entry point. Every call paid the pooled argument array, the call-stack frame and the delegate hop. Giving `ClrFunction` an optional fast hook was rejected: +8 bytes on a type allocated in the promise/iterator/class-definition hot paths (137 `new ClrFunction` sites) to speed up two functions.

**What actually blocked migrating them to `[JsFunction]` was an identity requirement, and it was being satisfied by a leak.** `Number.parseInt === parseInt` held through `ClrFunction.Equals` comparing the underlying delegate across two *distinct* objects — and the distinctness showed: `parseInt.length` was 2 while `Number.parseInt.length` was 0, contradicting the very sameness the equality asserts. They are now one realm intrinsic each (`Intrinsics.ParseInt`/`ParseFloat`, installed by both owners via `[JsIntrinsicReference]`, exactly as `eval` already is), so the sameness is reference identity and the lengths agree at their spec values.

Guards per the `FastCallLaneBenchmarks` precedent: `Arg0 = String` so `ToString` is the identity; `Arg1 = Number | Undefined` on `parseInt` so `ToInt32` is a no-op or the `0` an omitted radix produces; `Arg1 = Any` on `parseFloat`, which never reads it. Neither body raises a JS error. An object argument fails the guard, keeps its frame, and `error.stack` still contains `at parseInt` — both directions pinned by new theories, and the Debug leg (where `LeafCallGuard` is armed) passes.

Two fixes ride along: `NumberConstructor` no longer eagerly allocates two `ClrFunction`s per realm, and the global copy no longer takes its `%Function.prototype%` from whichever realm happened to be running when the lazy factory first ran — a `ShadowRealm` assertion pins it.

Behaviour changes to note: `Number.parseInt.length` 0 → 2 and `Number.parseFloat.length` 0 → 1 (spec-correct; test262 has no length test for either), and the two are no longer `ClrFunction` instances.

Full solution green on both TFMs; test262 exactly 99,738 / 0 / 157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)