### PR TITLE
Call an iterator's return exactly once when a helper exits early

### DIFF
--- a/Jint.Tests/Runtime/IteratorHelpersTests.cs
+++ b/Jint.Tests/Runtime/IteratorHelpersTests.cs
@@ -791,4 +791,67 @@ public class IteratorHelpersTests
 
         result.Should().Be("[true,false,true]");
     }
+
+    // An early exit runs `Return ? IteratorClose(iterated, NormalCompletion(...))` as its final step,
+    // which sits *outside* the IfAbruptCloseIterator guard covering the predicate call. "return" is
+    // therefore invoked exactly once and whatever it raises is the error the caller sees - it must not
+    // be re-entered by the close that guards the abrupt predicate.
+    private const string EarlyExitReceiver = """
+        let calls = 0;
+        const it = {
+            __proto__: Iterator.prototype,
+            i: 0,
+            next() { return this.i++ === 0 ? { done: false, value: 42 } : { done: true }; },
+            return() { calls++; return RETURN_RESULT; }
+        };
+        let outcome = 'no throw';
+        try { CALL; } catch (e) { outcome = e.constructor.name + ': ' + e.message; }
+        JSON.stringify([calls, outcome]);
+        """;
+
+    private static string EarlyExitScript(string call, string returnResult) =>
+        EarlyExitReceiver.Replace("RETURN_RESULT", returnResult).Replace("CALL", call);
+
+    [Theory]
+    [InlineData("it.includes(42)")]
+    [InlineData("it.some(() => true)")]
+    [InlineData("it.every(() => false)")]
+    [InlineData("it.find(() => true)")]
+    [InlineData("it.take(0).next()")]
+    public void AnEarlyExitCallsReturnExactlyOnce(string call)
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate(EarlyExitScript(call, "{ done: true }")).AsString();
+
+        result.Should().Be("""[1,"no throw"]""");
+    }
+
+    [Theory]
+    [InlineData("it.includes(42)")]
+    [InlineData("it.some(() => true)")]
+    [InlineData("it.every(() => false)")]
+    [InlineData("it.find(() => true)")]
+    [InlineData("it.take(0).next()")]
+    public void AnEarlyExitDoesNotReenterAThrowingReturn(string call)
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate(EarlyExitScript(call, "(() => { throw new Error('boom'); })()")).AsString();
+
+        result.Should().Be("""[1,"Error: boom"]""");
+    }
+
+    [Theory]
+    [InlineData("it.includes(42)")]
+    [InlineData("it.some(() => true)")]
+    [InlineData("it.every(() => false)")]
+    [InlineData("it.find(() => true)")]
+    [InlineData("it.take(0).next()")]
+    public void AnEarlyExitDoesNotReenterAReturnThatYieldsANonObject(string call)
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate(EarlyExitScript(call, "7")).AsString();
+
+        // IteratorClose step 6 raises the TypeError itself, so the close is still a single call.
+        result.Should().Be("""[1,"TypeError: Iterator returned non-object"]""");
+    }
 }

--- a/Jint/Native/Iterator/IteratorHelper.cs
+++ b/Jint/Native/Iterator/IteratorHelper.cs
@@ -61,7 +61,18 @@ internal abstract class IteratorHelper : ObjectInstance
         catch
         {
             State = GeneratorState.Completed;
-            CloseIterator(CompletionType.Throw);
+
+            // IfAbruptCloseIterator only applies while the underlying record is still open. Exhausted
+            // says it is not - either the step reported DONE, or the helper already ran an
+            // IteratorClose of its own, which is take's `Return ? IteratorClose(iterated,
+            // ReturnCompletion(undefined))` for a spent limit. Closing again would invoke "return" a
+            // second time and swallow whatever the first invocation raised.
+            if (!Exhausted)
+            {
+                Exhausted = true;
+                CloseIterator(CompletionType.Throw);
+            }
+
             throw;
         }
     }

--- a/Jint/Native/Iterator/IteratorPrototype.cs
+++ b/Jint/Native/Iterator/IteratorPrototype.cs
@@ -666,23 +666,30 @@ internal partial class IteratorPrototype : Prototype
         var counter = 0;
         while (iterated.TryIteratorStep(out var iteratorResult))
         {
+            bool matched;
             try
             {
                 var value = iteratorResult.Get(CommonProperties.Value);
                 var result = predicateCallable.Call(Undefined, [value, counter]);
-                if (TypeConverter.ToBoolean(result))
-                {
-                    iterated.Close(CompletionType.Normal);
-                    return JsBoolean.True;
-                }
-
-                counter++;
+                matched = TypeConverter.ToBoolean(result);
             }
             catch
             {
                 iterated.Close(CompletionType.Throw);
                 throw;
             }
+
+            if (matched)
+            {
+                // The closing step is `Return ? IteratorClose(iterated, NormalCompletion(true))`, which
+                // sits outside the IfAbruptCloseIterator guarding the predicate call above: "return" is
+                // invoked once and whatever it raises stands. Closing from inside that guard would call
+                // it a second time.
+                iterated.Close(CompletionType.Normal);
+                return JsBoolean.True;
+            }
+
+            counter++;
         }
 
         return JsBoolean.False;
@@ -752,6 +759,7 @@ internal partial class IteratorPrototype : Prototype
         var iterations = 0;
         while (iterated.TryIteratorStep(out var iteratorResult))
         {
+            bool found;
             try
             {
                 var value = iteratorResult.Get(CommonProperties.Value);
@@ -759,25 +767,37 @@ internal partial class IteratorPrototype : Prototype
                 if (skipped < toSkip)
                 {
                     skipped++;
+                    found = false;
                 }
-                else if (SameValueZeroComparer.Equals(value, searchElement))
+                else
                 {
-                    // A match closes the iterator; natural exhaustion below deliberately does not.
-                    iterated.Close(CompletionType.Normal);
-                    return JsBoolean.True;
+                    found = SameValueZeroComparer.Equals(value, searchElement);
                 }
 
-                // skippedElements may be +Infinity, so this loop is unbounded even for a well
-                // behaved iterator; keep the engine interruptible.
-                if (++iterations % Engine.ConstraintCheckInterval == 0)
+                if (!found)
                 {
-                    _engine.Constraints.Check();
+                    // skippedElements may be +Infinity, so this loop is unbounded even for a well
+                    // behaved iterator; keep the engine interruptible.
+                    if (++iterations % Engine.ConstraintCheckInterval == 0)
+                    {
+                        _engine.Constraints.Check();
+                    }
                 }
             }
             catch
             {
                 iterated.Close(CompletionType.Throw);
                 throw;
+            }
+
+            if (found)
+            {
+                // A match closes the iterator; natural exhaustion below deliberately does not. The
+                // Repeat's last step is `Return ? IteratorClose(iterated, NormalCompletion(true))`,
+                // outside the IfAbruptCloseIterator above, so "return" is invoked exactly once and a
+                // throwing one is reported rather than swallowed by a second close.
+                iterated.Close(CompletionType.Normal);
+                return JsBoolean.True;
             }
         }
 
@@ -814,23 +834,28 @@ internal partial class IteratorPrototype : Prototype
         var counter = 0;
         while (iterated.TryIteratorStep(out var iteratorResult))
         {
+            bool satisfied;
             try
             {
                 var value = iteratorResult.Get(CommonProperties.Value);
                 var result = predicateCallable.Call(Undefined, [value, counter]);
-                if (!TypeConverter.ToBoolean(result))
-                {
-                    iterated.Close(CompletionType.Normal);
-                    return JsBoolean.False;
-                }
-
-                counter++;
+                satisfied = TypeConverter.ToBoolean(result);
             }
             catch
             {
                 iterated.Close(CompletionType.Throw);
                 throw;
             }
+
+            if (!satisfied)
+            {
+                // See Some: `Return ? IteratorClose(iterated, NormalCompletion(false))` is outside the
+                // IfAbruptCloseIterator guard, so "return" runs exactly once.
+                iterated.Close(CompletionType.Normal);
+                return JsBoolean.False;
+            }
+
+            counter++;
         }
 
         return JsBoolean.True;
@@ -866,23 +891,29 @@ internal partial class IteratorPrototype : Prototype
         var counter = 0;
         while (iterated.TryIteratorStep(out var iteratorResult))
         {
+            JsValue value;
+            bool matched;
             try
             {
-                var value = iteratorResult.Get(CommonProperties.Value);
+                value = iteratorResult.Get(CommonProperties.Value);
                 var result = predicateCallable.Call(Undefined, [value, counter]);
-                if (TypeConverter.ToBoolean(result))
-                {
-                    iterated.Close(CompletionType.Normal);
-                    return value;
-                }
-
-                counter++;
+                matched = TypeConverter.ToBoolean(result);
             }
             catch
             {
                 iterated.Close(CompletionType.Throw);
                 throw;
             }
+
+            if (matched)
+            {
+                // See Some: `Return ? IteratorClose(iterated, NormalCompletion(value))` is outside the
+                // IfAbruptCloseIterator guard, so "return" runs exactly once.
+                iterated.Close(CompletionType.Normal);
+                return value;
+            }
+
+            counter++;
         }
 
         return Undefined;


### PR DESCRIPTION
When `Iterator.prototype.includes` found its element and the receiver's `return` threw (or returned a non-object), `return` was invoked a **second** time: the success-path `Close(CompletionType.Normal)` sat inside the `try` whose `catch` closes again. [IteratorClose](https://tc39.es/ecma262/#sec-iteratorclose) calls `return` once and lets its throw propagate.

The same shape was **pre-existing in `some`, `every` and `find`** — node calls `return` once on a throwing close for `find`, Jint called it twice — and `take(0)` had a variant of it: its own spec-mandated close ran inside `ExecuteStep`, whose caller closed again. All five are fixed together, since it is one pattern; leaving three siblings wrong while fixing the new method would have been the worse outcome.

test262 does not catch this — `includes/iterator-return-method-throws.js` asserts the error *type*, never the call count. The new tests count calls for a happy, a throwing and a non-object `return` across all five methods.

Red 10 / green 80 (whole `IteratorHelpersTests`), both TFMs. Test262 exactly 99,738 / 0 / 157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)