### PR TITLE
Stop closing an iterator whose step completed abruptly

### DIFF
--- a/Jint.Tests/Runtime/IteratorHelpersTests.cs
+++ b/Jint.Tests/Runtime/IteratorHelpersTests.cs
@@ -854,4 +854,109 @@ public class IteratorHelpersTests
         // IteratorClose step 6 raises the TypeError itself, so the close is still a single call.
         result.Should().Be("""[1,"TypeError: Iterator returned non-object"]""");
     }
+
+    // IteratorStepValue marks the record done on every abrupt completion - a throwing next(), a
+    // non-object result, a throwing "done" getter, a throwing "value" getter - and returns it. Every
+    // helper spells the step as a bare `? IteratorStepValue(iterated)`, outside any
+    // IfAbruptCloseIterator, so none of them may invoke "return".
+    private const string AbruptStepReceiver = """
+        let closed = 0;
+        const it = {
+            __proto__: Iterator.prototype,
+            next() { return NEXT_RESULT; },
+            return() { closed++; return { done: true }; },
+            [Symbol.iterator]() { return this; }
+        };
+        let outcome = 'no throw';
+        try { CALL; } catch (e) { outcome = e.message; }
+        JSON.stringify([closed, outcome]);
+        """;
+
+    private static string AbruptStepScript(string call, string nextResult) =>
+        AbruptStepReceiver.Replace("NEXT_RESULT", nextResult).Replace("CALL", call);
+
+    // Every helper that consumes the underlying iterator, eager and lazy alike, plus Iterator.concat.
+    // join was already right; it is kept as the control the others are brought level with.
+    public static TheoryData<string> ConsumingHelpers() =>
+    [
+        "it.includes(1)",
+        "it.join(',')",
+        "it.some(() => true)",
+        "it.every(() => true)",
+        "it.find(() => true)",
+        "it.forEach(() => {})",
+        "it.reduce((a, b) => a, 0)",
+        "it.toArray()",
+        "it.map(x => x).next()",
+        "it.filter(() => true).next()",
+        "it.take(5).next()",
+        "it.drop(0).next()",
+        "it.flatMap(x => [x]).next()",
+        "it.chunks(2).next()",
+        "it.windows(2).next()",
+        "Iterator.concat(it).next()",
+    ];
+
+    [Theory]
+    [MemberData(nameof(ConsumingHelpers))]
+    public void AThrowingValueGetterDoesNotCloseTheIterator(string call)
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate(
+            AbruptStepScript(call, "{ done: false, get value() { throw new Error('value getter'); } }")).AsString();
+
+        result.Should().Be("""[0,"value getter"]""");
+    }
+
+    [Theory]
+    [MemberData(nameof(ConsumingHelpers))]
+    public void AThrowingNextDoesNotCloseTheIterator(string call)
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate(
+            AbruptStepScript(call, "(() => { throw new Error('next'); })()")).AsString();
+
+        result.Should().Be("""[0,"next"]""");
+    }
+
+    [Theory]
+    [MemberData(nameof(ConsumingHelpers))]
+    public void ANonObjectStepResultDoesNotCloseTheIterator(string call)
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate(AbruptStepScript(call, "7")).AsString();
+
+        result.Should().Be("""[0,"Iterator result 7 is not an object"]""");
+    }
+
+    [Theory]
+    [MemberData(nameof(ConsumingHelpers))]
+    public void AThrowingDoneGetterDoesNotCloseTheIterator(string call)
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate(
+            AbruptStepScript(call, "{ get done() { throw new Error('done getter'); } }")).AsString();
+
+        result.Should().Be("""[0,"done getter"]""");
+    }
+
+    [Theory]
+    // A step that completed abruptly left the record done and the helper's generator completed, so
+    // %IteratorHelperPrototype%.return resumes nothing and forwards nothing either.
+    [InlineData("it.map(x => x)")]
+    [InlineData("it.filter(() => true)")]
+    [InlineData("it.take(5)")]
+    [InlineData("it.drop(0)")]
+    [InlineData("it.flatMap(x => [x])")]
+    [InlineData("it.chunks(2)")]
+    [InlineData("it.windows(2)")]
+    public void ReturnIsNotForwardedAfterAnAbruptStep(string helper)
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate(AbruptStepScript(
+            $"const h = {helper}; try {{ h.next(); }} catch (e) {{ }} h.return()",
+            "{ done: false, get value() { throw new Error('value getter'); } }")).AsString();
+
+        result.Should().Be("""[0,"no throw"]""");
+    }
 }

--- a/Jint/Native/Iterator/IteratorHelper.cs
+++ b/Jint/Native/Iterator/IteratorHelper.cs
@@ -62,11 +62,13 @@ internal abstract class IteratorHelper : ObjectInstance
         {
             State = GeneratorState.Completed;
 
-            // IfAbruptCloseIterator only applies while the underlying record is still open. Exhausted
-            // says it is not - either the step reported DONE, or the helper already ran an
-            // IteratorClose of its own, which is take's `Return ? IteratorClose(iterated,
-            // ReturnCompletion(undefined))` for a spent limit. Closing again would invoke "return" a
-            // second time and swallow whatever the first invocation raised.
+            // IfAbruptCloseIterator covers the mapper/predicate call, not the step that fed it, and
+            // only applies while the underlying record is still open. Exhausted says it is not: the
+            // step reported DONE, the step itself completed abruptly (which marks the record done and
+            // closes nothing), or the helper already ran an IteratorClose of its own - take's
+            // `Return ? IteratorClose(iterated, ReturnCompletion(undefined))` for a spent limit.
+            // Closing again would invoke "return" where the spec invokes nothing, or a second time,
+            // swallowing whatever the first invocation raised.
             if (!Exhausted)
             {
                 Exhausted = true;
@@ -104,18 +106,33 @@ internal abstract class IteratorHelper : ObjectInstance
     protected abstract StepResult ExecuteStep();
 
     /// <summary>
+    /// https://tc39.es/ecma262/#sec-iteratorstepvalue
     /// Gets the next value from the underlying iterator.
     /// Returns (value, false) if a value is available, or (undefined, true) if done.
     /// </summary>
+    /// <remarks>
+    /// Every abrupt completion here - a throwing next(), a result that is not an Object, a throwing
+    /// "done" getter, a throwing "value" getter - sets the record's [[Done]] to true and is returned
+    /// as-is, with no IteratorClose. Every helper spells the step `? IteratorStepValue(iterated)`,
+    /// outside the IfAbruptCloseIterator that guards the call it feeds, so marking the record
+    /// Exhausted is what keeps the close in Next from invoking "return" on it.
+    /// </remarks>
     protected StepResult IteratorStepValue()
     {
-        if (!Iterated.TryIteratorStep(out var result))
+        try
         {
-            return StepResult.DoneResult;
-        }
+            if (!Iterated.TryIteratorStep(out var result))
+            {
+                return StepResult.DoneResult;
+            }
 
-        var value = result.Get(CommonProperties.Value);
-        return new StepResult(value, false);
+            return new StepResult(result.Get(CommonProperties.Value), false);
+        }
+        catch
+        {
+            Exhausted = true;
+            throw;
+        }
     }
 
     /// <summary>
@@ -593,14 +610,31 @@ internal sealed class ConcatIterator : ObjectInstance
                 // If we have an active inner iterator, get next from it
                 if (_currentIterator is not null)
                 {
-                    if (_currentIterator.TryIteratorStep(out var result))
+                    // Per spec, use IteratorStepValue, which reads the value property (may throw) and
+                    // Yield creates a fresh iterator result object. The step is a bare
+                    // `? IteratorStepValue(iteratorRecord)`, so an abrupt one marks the record done
+                    // and propagates without an IteratorClose - hence dropping the record here rather
+                    // than letting the catch below close it.
+                    bool alive;
+                    JsValue innerValue;
+                    try
+                    {
+                        alive = _currentIterator.TryIteratorStep(out var result);
+                        innerValue = alive ? result.Get(CommonProperties.Value) : Undefined;
+                    }
+                    catch
+                    {
+                        _currentIterator = null;
+                        _exhausted = true;
+                        throw;
+                    }
+
+                    if (alive)
                     {
                         _state = GeneratorState.SuspendedYield;
-                        // Per spec, use IteratorStepValue which reads value property (may throw)
-                        // and Yield creates a fresh iterator result object
-                        var innerValue = result.Get(CommonProperties.Value);
                         return CreateIteratorResult(innerValue, done: false);
                     }
+
                     // Current iterator exhausted, move to next
                     _currentIterator = null;
                 }

--- a/Jint/Native/Iterator/IteratorPrototype.cs
+++ b/Jint/Native/Iterator/IteratorPrototype.cs
@@ -524,11 +524,13 @@ internal partial class IteratorPrototype : Prototype
         // 7. Repeat,
         while (iterated.TryIteratorStep(out var iteratorResult))
         {
+            // a. Let value be ? IteratorStepValue(iterated). A throwing "value" getter marks the
+            //    record done and propagates; the step is not inside the IfAbruptCloseIterator below.
+            // b. If value is done, return accumulator.
+            var value = iteratorResult.Get(CommonProperties.Value);
+
             try
             {
-                var value = iteratorResult.Get(CommonProperties.Value);
-                // a. Let value be ? IteratorStepValue(iterated).
-                // b. If value is done, return accumulator.
                 // c. Set accumulator to ? Call(reducer, undefined, « accumulator, value, 𝔽(counter) »).
                 accumulator = reducer.Call(Undefined, [accumulator, value, counter]);
                 // d. Set counter to counter + 1.
@@ -563,6 +565,10 @@ internal partial class IteratorPrototype : Prototype
             var iterations = 0;
             while (iterated.TryIteratorStep(out var iteratorResult))
             {
+                // `? IteratorStepValue(iterated)`: a throwing "value" getter marks the record done and
+                // propagates, so the read stays outside the closing try.
+                var value = iteratorResult.Get(CommonProperties.Value);
+
                 try
                 {
                     // Check constraints periodically so a huge (or native-backed) iterator
@@ -572,7 +578,6 @@ internal partial class IteratorPrototype : Prototype
                         _engine.Constraints.Check();
                     }
 
-                    var value = iteratorResult.Get(CommonProperties.Value);
                     builder.Add(value);
                 }
                 catch
@@ -620,9 +625,12 @@ internal partial class IteratorPrototype : Prototype
         var counter = 0;
         while (iterated.TryIteratorStep(out var iteratorResult))
         {
+            // `? IteratorStepValue(iterated)`: a throwing "value" getter marks the record done and
+            // propagates, so the read stays outside the closing try.
+            var value = iteratorResult.Get(CommonProperties.Value);
+
             try
             {
-                var value = iteratorResult.Get(CommonProperties.Value);
                 procedureCallable.Call(Undefined, [value, counter]);
                 counter++;
             }
@@ -666,10 +674,13 @@ internal partial class IteratorPrototype : Prototype
         var counter = 0;
         while (iterated.TryIteratorStep(out var iteratorResult))
         {
+            // `? IteratorStepValue(iterated)`: a throwing "value" getter marks the record done and
+            // propagates, so the read stays outside the closing try.
+            var value = iteratorResult.Get(CommonProperties.Value);
+
             bool matched;
             try
             {
-                var value = iteratorResult.Get(CommonProperties.Value);
                 var result = predicateCallable.Call(Undefined, [value, counter]);
                 matched = TypeConverter.ToBoolean(result);
             }
@@ -759,11 +770,13 @@ internal partial class IteratorPrototype : Prototype
         var iterations = 0;
         while (iterated.TryIteratorStep(out var iteratorResult))
         {
+            // a. Let value be ? IteratorStepValue(iterated). A throwing "value" getter marks the record
+            //    done and propagates: the step is not inside the IfAbruptCloseIterator below.
+            var value = iteratorResult.Get(CommonProperties.Value);
+
             bool found;
             try
             {
-                var value = iteratorResult.Get(CommonProperties.Value);
-
                 if (skipped < toSkip)
                 {
                     skipped++;
@@ -834,10 +847,13 @@ internal partial class IteratorPrototype : Prototype
         var counter = 0;
         while (iterated.TryIteratorStep(out var iteratorResult))
         {
+            // `? IteratorStepValue(iterated)`: a throwing "value" getter marks the record done and
+            // propagates, so the read stays outside the closing try.
+            var value = iteratorResult.Get(CommonProperties.Value);
+
             bool satisfied;
             try
             {
-                var value = iteratorResult.Get(CommonProperties.Value);
                 var result = predicateCallable.Call(Undefined, [value, counter]);
                 satisfied = TypeConverter.ToBoolean(result);
             }
@@ -891,11 +907,13 @@ internal partial class IteratorPrototype : Prototype
         var counter = 0;
         while (iterated.TryIteratorStep(out var iteratorResult))
         {
-            JsValue value;
+            // `? IteratorStepValue(iterated)`: a throwing "value" getter marks the record done and
+            // propagates, so the read stays outside the closing try.
+            var value = iteratorResult.Get(CommonProperties.Value);
+
             bool matched;
             try
             {
-                value = iteratorResult.Get(CommonProperties.Value);
                 var result = predicateCallable.Call(Undefined, [value, counter]);
                 matched = TypeConverter.ToBoolean(result);
             }


### PR DESCRIPTION
A throwing `value` getter on a step result triggered an `IteratorClose` the spec does not perform: [IteratorStepValue](https://tc39.es/ecma262/#sec-iteratorstepvalue) steps 8–10 set `[[Done]]` and propagate the completion, with **no** close. Jint closed the receiver — observable as an extra `return` call — in `includes` and in the lazy helpers.

`join` was the only method written correctly (its commit reasons about exactly this), which was the internal inconsistency to resolve. The fix extends to **sixteen helpers and all four abrupt kinds**, deliberately beyond the minimal three new methods:

- the pre-existing siblings (`map`/`filter`/`take`/`drop`/`flatMap`/`some`/`every`/`find`/`forEach`/`reduce`/`toArray`/`concat`) are the same one-line move — fixing 3 of 16 would have left `join` and the new methods correct against twelve wrong ones;
- for the lazy helpers the whole step sat inside the closing `try`, so a throwing `next()`, a non-object result and a throwing `done` getter closed too — node reports 0 `return` calls for all four kinds. Marking the record exhausted on any abrupt `IteratorStepValue` covers them all, and is also what stops a later `.return()` forwarding (node: 0 there too).

Deliberately untouched, with the spec's reasons: `Iterator.zip`/`zipKeyed` **do** close on an abrupt step (`IteratorCloseAll`, pinned by test262) and Jint is already right; `flatMap`'s inner-iterator read is `IfAbruptCloseIterator`, which closes the outer, and Jint does.

test262 misses this because its `next-method-returns-throwing-value.js` files use a throwing `return` **getter**, whose error the close swallows under a throw completion — the extra call is invisible. The new tests observe `return` directly.

Red 46 / green 136, both TFMs; the REPL matrix matches node row for row. Test262 exactly 99,738 / 0 / 157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)