### PR TITLE
Print a rejected iterator limit the way JavaScript prints numbers

### DIFF
--- a/Jint.Tests/Runtime/IteratorHelpersTests.cs
+++ b/Jint.Tests/Runtime/IteratorHelpersTests.cs
@@ -959,4 +959,59 @@ public class IteratorHelpersTests
 
         result.Should().Be("""[0,"no throw"]""");
     }
+
+    // The number in a range-check message came from script, so the message has to print it the way
+    // JavaScript does. Interpolating the raw double instead formats it with the CLR's shortest
+    // round-trip "G" rules and CultureInfo.CurrentCulture: 9007199254740992 comes out as
+    // "9.007199254740992E+15", Number.MAX_VALUE as "1.7976931348623157E+308", and the separator and
+    // the minus sign move with the ambient culture on top of that.
+    public static TheoryData<string, string> OutOfRangeLimits() =>
+        new()
+        {
+            { "[].values().take(Number.MAX_SAFE_INTEGER + 1)", "9007199254740992 exceeds the maximum safe integer" },
+            { "[].values().drop(Number.MAX_SAFE_INTEGER + 1)", "9007199254740992 exceeds the maximum safe integer" },
+            { "[].values().includes(0, Number.MAX_SAFE_INTEGER + 1)", "9007199254740992 exceeds the maximum safe integer" },
+            { "[].values().take(Number.MAX_VALUE)", "1.7976931348623157e+308 exceeds the maximum safe integer" },
+            { "[].values().drop(Number.MAX_VALUE)", "1.7976931348623157e+308 exceeds the maximum safe integer" },
+            { "[].values().includes(0, Number.MAX_VALUE)", "1.7976931348623157e+308 exceeds the maximum safe integer" },
+            { "[].values().take(-1e21)", "-1e+21 must be positive" },
+            { "[].values().drop(-1e21)", "-1e+21 must be positive" },
+            // Nothing in test262 covers AsyncIterator, so its two validators are pinned here as well.
+            { "AsyncIterator.prototype.take.call(asyncIter, Number.MAX_VALUE)", "1.7976931348623157e+308 exceeds the maximum safe integer" },
+            { "AsyncIterator.prototype.drop.call(asyncIter, Number.MAX_VALUE)", "1.7976931348623157e+308 exceeds the maximum safe integer" },
+            { "AsyncIterator.prototype.take.call(asyncIter, -1e21)", "-1e+21 must be positive" },
+            { "AsyncIterator.prototype.drop.call(asyncIter, -1e21)", "-1e+21 must be positive" },
+        };
+
+    private static string OutOfRangeLimitMessage(string expression)
+    {
+        var engine = new Engine();
+        return engine.Evaluate($$"""
+            const asyncIter = { __proto__: AsyncIterator.prototype, next() { return Promise.resolve({ done: true }); } };
+            (() => { try { {{expression}}; return 'no throw'; } catch (e) { return e.message; } })();
+            """).AsString();
+    }
+
+    [Theory]
+    [MemberData(nameof(OutOfRangeLimits))]
+    public void AnOutOfRangeLimitPrintsTheNumberTheWayJavaScriptDoes(string expression, string expected)
+    {
+        OutOfRangeLimitMessage(expression).Should().Be(expected);
+    }
+
+    [Theory]
+    [MemberData(nameof(OutOfRangeLimits))]
+    [ReplaceCulture("de-DE")]
+    public void AnOutOfRangeLimitIgnoresACommaDecimalSeparatorCulture(string expression, string expected)
+    {
+        OutOfRangeLimitMessage(expression).Should().Be(expected);
+    }
+
+    [Theory]
+    [MemberData(nameof(OutOfRangeLimits))]
+    [ReplaceCulture("sv-SE")]
+    public void AnOutOfRangeLimitIgnoresACultureWithANonAsciiMinusSign(string expression, string expected)
+    {
+        OutOfRangeLimitMessage(expression).Should().Be(expected);
+    }
 }

--- a/Jint/Native/Iterator/AsyncIteratorPrototype.cs
+++ b/Jint/Native/Iterator/AsyncIteratorPrototype.cs
@@ -190,7 +190,7 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
         if (double.IsFinite(numLimit) && numLimit > NumberConstructor.MaxSafeInteger)
         {
             IteratorClose(o, CompletionType.Throw);
-            Throw.RangeError(_realm, $"{numLimit} exceeds the maximum safe integer");
+            Throw.RangeError(_realm, $"{TypeConverter.ToString(numLimit)} exceeds the maximum safe integer");
             limit = 0;
             return null!;
         }
@@ -200,7 +200,7 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
         if (integerLimit < 0)
         {
             IteratorClose(o, CompletionType.Throw);
-            Throw.RangeError(_realm, $"{integerLimit} must be positive");
+            Throw.RangeError(_realm, $"{TypeConverter.ToString(integerLimit)} must be positive");
             limit = 0;
             return null!;
         }

--- a/Jint/Native/Iterator/IteratorPrototype.cs
+++ b/Jint/Native/Iterator/IteratorPrototype.cs
@@ -238,7 +238,7 @@ internal partial class IteratorPrototype : Prototype
         if (double.IsFinite(numLimit) && numLimit > NumberConstructor.MaxSafeInteger)
         {
             IteratorClose(o, CompletionType.Throw);
-            Throw.RangeError(_realm, $"{numLimit} exceeds the maximum safe integer");
+            Throw.RangeError(_realm, $"{TypeConverter.ToString(numLimit)} exceeds the maximum safe integer");
             return Undefined;
         }
 
@@ -249,7 +249,7 @@ internal partial class IteratorPrototype : Prototype
         if (integerLimit < 0)
         {
             IteratorClose(o, CompletionType.Throw);
-            Throw.RangeError(_realm, $"{integerLimit} must be positive");
+            Throw.RangeError(_realm, $"{TypeConverter.ToString(integerLimit)} must be positive");
             return Undefined;
         }
 
@@ -304,7 +304,7 @@ internal partial class IteratorPrototype : Prototype
         if (double.IsFinite(numLimit) && numLimit > NumberConstructor.MaxSafeInteger)
         {
             IteratorClose(o, CompletionType.Throw);
-            Throw.RangeError(_realm, $"{numLimit} exceeds the maximum safe integer");
+            Throw.RangeError(_realm, $"{TypeConverter.ToString(numLimit)} exceeds the maximum safe integer");
             return Undefined;
         }
 
@@ -315,7 +315,7 @@ internal partial class IteratorPrototype : Prototype
         if (integerLimit < 0)
         {
             IteratorClose(o, CompletionType.Throw);
-            Throw.RangeError(_realm, $"{integerLimit} must be positive");
+            Throw.RangeError(_realm, $"{TypeConverter.ToString(integerLimit)} must be positive");
             return Undefined;
         }
 
@@ -756,7 +756,7 @@ internal partial class IteratorPrototype : Prototype
         if (double.IsFinite(toSkip) && toSkip > NumberConstructor.MaxSafeInteger)
         {
             IteratorClose(o, CompletionType.Throw);
-            Throw.RangeError(_realm, $"{toSkip} exceeds the maximum safe integer");
+            Throw.RangeError(_realm, $"{TypeConverter.ToString(toSkip)} exceeds the maximum safe integer");
             return Undefined;
         }
 


### PR DESCRIPTION
The `RangeError` for a too-large `take`/`drop`/`includes` limit interpolated a raw `double`, so the message followed `CultureInfo.CurrentCulture`: `1,7976931348623157E+308 exceeds the maximum safe integer` under `de-DE`/`sv-SE` — with sv-SE even rendering the minus sign of the sibling message as U+2212 — and .NET's `E+308` where JavaScript writes `e+308`.

Not a conformance violation (ECMA-262 does not specify message text), but a consistency defect against the engine's own convention of culture-invariant, JS-shaped diagnostics. All seven sites fixed — the four this release added and the three pre-existing siblings (`… must be positive`) — via `TypeConverter.ToString`, which is Jint's own number-to-string and the right choice since the value came from script.

The review's claim that these seven are the only numeric interpolations in the range was verified; the *assembly-wide* audit of the same defect class happened separately in #2963, whose `JSON.stringify`/ISO-date fixes were the script-visible cases.

Red 27 / green 101, both TFMs. Test262 exactly 99,738 / 0 / 157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)