### PR TITLE
Tag iterator helper objects as Iterator Helper

### DIFF
--- a/Jint.Tests/Runtime/IteratorHelpersTests.cs
+++ b/Jint.Tests/Runtime/IteratorHelpersTests.cs
@@ -1014,4 +1014,84 @@ public class IteratorHelpersTests
     {
         OutOfRangeLimitMessage(expression).Should().Be(expected);
     }
+
+    [Fact]
+    public void EveryHelperObjectIsTaggedIteratorHelper()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            const tag = v => Object.prototype.toString.call(v);
+            JSON.stringify([
+                tag([1].values().map(x => x)),
+                tag([1].values().filter(() => true)),
+                tag([1].values().take(1)),
+                tag([1].values().drop(0)),
+                tag([1].values().flatMap(x => [x])),
+                tag([1].values().chunks(1)),
+                tag([1].values().windows(1)),
+                // concat and zip share %IteratorHelperPrototype%, so they are tagged with it too
+                tag(Iterator.concat([1].values())),
+                tag(Iterator.zip([[1].values()])),
+                tag(Iterator.zipKeyed({ a: [1].values() }))
+            ]);
+            """).AsString();
+
+        result.Should().Be(
+            """["[object Iterator Helper]","[object Iterator Helper]","[object Iterator Helper]","[object Iterator Helper]","[object Iterator Helper]","[object Iterator Helper]","[object Iterator Helper]","[object Iterator Helper]","[object Iterator Helper]","[object Iterator Helper]"]""");
+    }
+
+    [Fact]
+    public void AnAsyncHelperObjectIsTaggedAsyncIteratorHelper()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            const asyncIter = { __proto__: AsyncIterator.prototype, next() { return Promise.resolve({ done: true }); } };
+            const tag = v => Object.prototype.toString.call(v);
+            const of = method => tag(AsyncIterator.prototype[method].call(asyncIter, x => x));
+            JSON.stringify([of('map'), of('filter'), of('flatMap'), tag(AsyncIterator.prototype.take.call(asyncIter, 1))]);
+            """).AsString();
+
+        result.Should().Be(
+            """["[object Async Iterator Helper]","[object Async Iterator Helper]","[object Async Iterator Helper]","[object Async Iterator Helper]"]""");
+    }
+
+    [Theory]
+    // The tag is a data property on the helper prototype, shadowing the accessor pair that
+    // %Iterator.prototype% and %AsyncIterator.prototype% carry, with the usual toStringTag
+    // attributes: { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+    [InlineData("Object.getPrototypeOf([1].values().map(x => x))", "Iterator Helper")]
+    [InlineData("Object.getPrototypeOf(AsyncIterator.prototype.map.call(asyncIter, x => x))", "Async Iterator Helper")]
+    public void TheHelperToStringTagIsANonWritableConfigurableDataProperty(string prototype, string tag)
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate($$"""
+            const asyncIter = { __proto__: AsyncIterator.prototype, next() { return Promise.resolve({ done: true }); } };
+            const proto = {{prototype}};
+            const d = Object.getOwnPropertyDescriptor(proto, Symbol.toStringTag);
+            JSON.stringify([
+                Object.getOwnPropertySymbols(proto).length,
+                d.value,
+                d.writable,
+                d.enumerable,
+                d.configurable,
+                typeof d.get,
+                typeof d.set
+            ]);
+            """).AsString();
+
+        result.Should().Be($$"""[1,"{{tag}}",false,false,true,"undefined","undefined"]""");
+    }
+
+    [Fact]
+    public void TheReceiverOfAHelperKeepsItsOwnToStringTag()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            const tag = v => Object.prototype.toString.call(v);
+            function* gen() { yield 1; }
+            JSON.stringify([tag(Iterator.prototype), tag([1].values()), tag(gen()), tag(AsyncIterator.prototype)]);
+            """).AsString();
+
+        result.Should().Be("""["[object Iterator]","[object Array Iterator]","[object Generator]","[object AsyncIterator]"]""");
+    }
 }

--- a/Jint/Native/Iterator/AsyncIteratorHelperPrototype.cs
+++ b/Jint/Native/Iterator/AsyncIteratorHelperPrototype.cs
@@ -10,6 +10,12 @@ namespace Jint.Native.Iterator;
 [JsObject(UseShape = true)]
 internal sealed partial class AsyncIteratorHelperPrototype : Prototype
 {
+    /// <summary>
+    /// https://tc39.es/proposal-async-iterator-helpers/#sec-%asynciteratorhelperprototype%-@@tostringtag
+    /// A data property, so it shadows the accessor pair %AsyncIterator.prototype% carries.
+    /// </summary>
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString AsyncIteratorHelperToStringTag = new("Async Iterator Helper");
+
     internal AsyncIteratorHelperPrototype(
         Engine engine,
         Realm realm,
@@ -18,7 +24,11 @@ internal sealed partial class AsyncIteratorHelperPrototype : Prototype
         _prototype = asyncIteratorPrototype;
     }
 
-    protected override void Initialize() => CreateProperties_Generated();
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
 
     /// <summary>
     /// %AsyncIteratorHelperPrototype%.next()

--- a/Jint/Native/Iterator/IteratorHelperPrototype.cs
+++ b/Jint/Native/Iterator/IteratorHelperPrototype.cs
@@ -10,6 +10,12 @@ namespace Jint.Native.Iterator;
 [JsObject(UseShape = true)]
 internal sealed partial class IteratorHelperPrototype : Prototype
 {
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-%iteratorhelperprototype%-%symbol.tostringtag%
+    /// A data property, so it shadows the accessor pair %Iterator.prototype% carries.
+    /// </summary>
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString IteratorHelperToStringTag = new("Iterator Helper");
+
     private readonly IteratorPrototype _iteratorPrototype;
 
     internal IteratorHelperPrototype(
@@ -21,7 +27,11 @@ internal sealed partial class IteratorHelperPrototype : Prototype
         _prototype = iteratorPrototype;
     }
 
-    protected override void Initialize() => CreateProperties_Generated();
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%iteratorhelperprototype%.next


### PR DESCRIPTION
`%IteratorHelperPrototype%` declared only `next` and `return`, so every helper inherited `"Iterator"` from `%IteratorPrototype%`:

```js
Object.prototype.toString.call([1].values().map(x => x))
// Jint: "[object Iterator]"    node: "[object Iterator Helper]"
```

[27.1.4.1.3](https://tc39.es/ecma262/#sec-%25iteratorhelperprototype%25-%40%40tostringtag): the initial value is the String `"Iterator Helper"`, `{ [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }`. The async proposal specifies `"Async Iterator Helper"` for its counterpart. Both prototypes gain the property; `Iterator.concat` and `Iterator.zip` share the prototype and are covered by the tests. test262 has no coverage for either tag.

Red 4 / green 70, both TFMs. Test262 exactly 99,738 / 0 / 157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)