### PR TITLE
Accept the collations Intl.Locale.prototype.getCollations reports

### DIFF
--- a/Jint.Tests/Runtime/IntlTests.cs
+++ b/Jint.Tests/Runtime/IntlTests.cs
@@ -774,4 +774,132 @@ public class IntlTests
             """);
         result.AsBoolean().Should().BeTrue();
     }
+
+    [Fact]
+    public void CollatorAcceptsEveryCollationGetCollationsReports()
+    {
+        // ECMA-402 gives a locale one [[co]] list: CollationsOfLocale (15.5.10 step 3.c) reports it,
+        // and ResolveLocale (9.2.7 step 10) — reached from Intl.Collator (10.1.1) through
+        // ResolveOptions — resolves a requested "co" against the same list. So everything
+        // getCollations() advertises has to construct, through the options bag and through the
+        // -u-co- extension alike, and resolve back to itself.
+        var result = _engine.Evaluate("""
+            const tags = ['ar', 'da', 'de', 'en', 'es', 'hi', 'ja', 'ko', 'ln', 'si', 'sv', 'zh', 'tr', 'fr', 'und'];
+            const mismatches = [];
+            for (const tag of tags) {
+                for (const collation of new Intl.Locale(tag).getCollations()) {
+                    const viaOption = new Intl.Collator(tag, { collation }).resolvedOptions().collation;
+                    const viaExtension = new Intl.Collator(`${tag}-u-co-${collation}`).resolvedOptions().collation;
+                    if (viaOption !== collation || viaExtension !== collation) {
+                        mismatches.push(`${tag}/${collation}: option=${viaOption} extension=${viaExtension}`);
+                    }
+                }
+            }
+            JSON.stringify(mismatches);
+            """);
+        result.AsString().Should().Be("[]");
+    }
+
+    [Theory]
+    // The thirteen locales whose getCollations() advertised the root "emoji" collation while
+    // Intl.Collator refused it: the eleven carrying a collation table of their own besides "en",
+    // plus "tr" and "fr", which carry none.
+    [InlineData("ar")]
+    [InlineData("da")]
+    [InlineData("de")]
+    [InlineData("es")]
+    [InlineData("hi")]
+    [InlineData("ja")]
+    [InlineData("ko")]
+    [InlineData("ln")]
+    [InlineData("si")]
+    [InlineData("sv")]
+    [InlineData("zh")]
+    [InlineData("tr")]
+    [InlineData("fr")]
+    // ...plus the two that were already consistent, so the row keeps watching them too.
+    [InlineData("en")]
+    [InlineData("und")]
+    public void CollatorAcceptsTheRootCollationsForEveryLocale(string tag)
+    {
+        var result = _engine.Evaluate($$"""
+            ['emoji', 'eor'].map(collation => [
+                new Intl.Collator('{{tag}}', { collation }).resolvedOptions().collation,
+                new Intl.Collator(`{{tag}}-u-co-${collation}`).resolvedOptions().collation,
+            ].join('/')).join(' ');
+            """);
+        result.AsString().Should().Be("emoji/emoji eor/eor");
+    }
+
+    [Theory]
+    [InlineData("de", "phonebk")]
+    [InlineData("es", "trad")]
+    [InlineData("ko", "searchjl")]
+    [InlineData("zh", "pinyin")]
+    public void CollatorStillAcceptsLocaleSpecificCollations(string tag, string collation)
+    {
+        _engine.Evaluate($"new Intl.Collator('{tag}', {{ collation: '{collation}' }}).resolvedOptions().collation")
+            .AsString().Should().Be(collation);
+        _engine.Evaluate($"new Intl.Collator('{tag}-u-co-{collation}').resolvedOptions().collation")
+            .AsString().Should().Be(collation);
+    }
+
+    [Fact]
+    public void CollatorRefusesACollationTheLocaleDoesNotReport()
+    {
+        // The acceptance set is the reported list, not the union of every collation identifier that
+        // exists: "phonebk" is German data and Turkish never advertises it.
+        _engine.Evaluate("new Intl.Locale('tr').getCollations().includes('phonebk')")
+            .AsBoolean().Should().BeFalse();
+        _engine.Evaluate("new Intl.Collator('tr', { collation: 'phonebk' }).resolvedOptions().collation")
+            .AsString().Should().Be("default");
+        _engine.Evaluate("new Intl.Collator('tr-u-co-phonebk').resolvedOptions().collation")
+            .AsString().Should().Be("default");
+    }
+
+    [Fact]
+    public void CollatorAcceptsDefaultAsARequestThatNoLocaleEverReports()
+    {
+        // "default" is how Intl.Collator (10.1.1) spells a null resolved [[co]], so it stays a
+        // usable request — but it is not an element of any [[co]] list, so 15.5.10 never reports it
+        // and it never reaches the resolved locale.
+        _engine.Evaluate("new Intl.Collator('de', { collation: 'default' }).resolvedOptions().collation")
+            .AsString().Should().Be("default");
+        _engine.Evaluate("new Intl.Collator('de-u-co-default').resolvedOptions().collation")
+            .AsString().Should().Be("default");
+        _engine.Evaluate("new Intl.Collator('de-u-co-default').resolvedOptions().locale")
+            .AsString().Should().Be("de");
+        _engine.Evaluate("['de', 'en', 'zh', 'und'].some(tag => new Intl.Locale(tag).getCollations().includes('default'))")
+            .AsBoolean().Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("standard")]
+    [InlineData("search")]
+    public void CollatorRejectsTheCollationsNoLocaleDataMayContain(string collation)
+    {
+        // ECMA-402 10.2.3: "standard" and "search" must not be used as elements in any
+        // [[SortLocaleData]].[[<locale>]].[[co]] or [[SearchLocaleData]].[[<locale>]].[[co]] List,
+        // which is what makes them unreportable and unrequestable by the same act.
+        _engine.Evaluate($"new Intl.Collator('de', {{ collation: '{collation}' }}).resolvedOptions().collation")
+            .AsString().Should().Be("default");
+        _engine.Evaluate($"new Intl.Collator('de-u-co-{collation}').resolvedOptions().collation")
+            .AsString().Should().Be("default");
+        _engine.Evaluate($"new Intl.Collator('de-u-co-{collation}').resolvedOptions().locale")
+            .AsString().Should().Be("de");
+    }
+
+    [Fact]
+    public void CollatorReflectsAResolvedCollationExtensionInTheResolvedLocale()
+    {
+        // ResolveLocale (9.2.7 step 10) inserts the keyword back into the locale only when it came
+        // from the requested Unicode extension sequence; a value supplied through the options bag
+        // sets supportedKeyword to empty and so is never inserted.
+        _engine.Evaluate("new Intl.Collator('de-u-co-emoji').resolvedOptions().locale")
+            .AsString().Should().Be("de-u-co-emoji");
+        _engine.Evaluate("new Intl.Collator('de-u-co-phonebk').resolvedOptions().locale")
+            .AsString().Should().Be("de-u-co-phonebk");
+        _engine.Evaluate("new Intl.Collator('de', { collation: 'emoji' }).resolvedOptions().locale")
+            .AsString().Should().Be("de");
+    }
 }

--- a/Jint/Native/Intl/CollatorConstructor.cs
+++ b/Jint/Native/Intl/CollatorConstructor.cs
@@ -20,13 +20,6 @@ internal sealed partial class CollatorConstructor : Constructor
     private static readonly StringSearchValues SensitivityValues = new(["base", "accent", "case", "variant"], StringComparison.Ordinal);
     private static readonly StringSearchValues CaseFirstValues = new(["upper", "lower", "false"], StringComparison.Ordinal);
 
-    // Valid collation types per CLDR (excluding "standard" and "search" which are special)
-    private static readonly StringSearchValues ValidCollationTypes = new([
-        "big5han", "compat", "dict", "direct", "ducet", "emoji", "eor",
-        "gb2312", "phonebk", "phonebook", "phonetic", "pinyin", "reformed",
-        "searchjl", "stroke", "trad", "unihan", "zhuyin", "default"
-    ], StringComparison.Ordinal);
-
     // Locale-specific supported collation types (from CLDR)
     // Only locales with non-default collation support are listed
     private static readonly Dictionary<string, HashSet<string>> LocaleCollationSupport = new(StringComparer.OrdinalIgnoreCase)
@@ -44,6 +37,63 @@ internal sealed partial class CollatorConstructor : Constructor
         ["sv"] = new(StringComparer.Ordinal) { "default", "reformed", "eor" },
         ["zh"] = new(StringComparer.Ordinal) { "default", "big5han", "gb2312", "pinyin", "stroke", "unihan", "zhuyin", "eor" },
     };
+
+    // The collations CLDR's root locale contributes to every locale. "standard" and "search" are
+    // deliberately absent, for the reason IsReportableCollation gives.
+    private static readonly string[] RootCollations = ["emoji", "eor"];
+
+    // Each language's [[co]] list minus its leading null, in the lexicographic code unit order
+    // https://tc39.es/ecma402/#sec-collationsoflocale reports it in. ECMA-402 gives a locale exactly
+    // one such list: 15.5.10 step 3.c reports it and 9.2.7 step 10 — reached from 10.1.1 through
+    // ResolveOptions — resolves a requested "co" against it, so deriving both views from this one
+    // table is what keeps Intl.Locale.prototype.getCollations and Intl.Collator from disagreeing
+    // about what a locale supports.
+    private static readonly Dictionary<string, string[]> LocaleCollations = BuildLocaleCollations();
+
+    private static Dictionary<string, string[]> BuildLocaleCollations()
+    {
+        var result = new Dictionary<string, string[]>(LocaleCollationSupport.Count, StringComparer.OrdinalIgnoreCase);
+        foreach (var pair in LocaleCollationSupport)
+        {
+            var list = new List<string>(pair.Value.Count + RootCollations.Length);
+            foreach (var collation in pair.Value)
+            {
+                if (IsReportableCollation(collation))
+                {
+                    list.Add(collation);
+                }
+            }
+
+            foreach (var rootCollation in RootCollations)
+            {
+                if (!list.Contains(rootCollation))
+                {
+                    list.Add(rootCollation);
+                }
+            }
+
+            list.Sort(StringComparer.Ordinal);
+            result[pair.Key] = list.ToArray();
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Whether an identifier may appear in a locale's [[co]] list. "standard" and "search" may not:
+    /// https://tc39.es/ecma402/#sec-intl-collator-internal-slots (10.2.3) forbids either from being
+    /// an element of any [[SortLocaleData]].[[&lt;locale&gt;]].[[co]] or
+    /// [[SearchLocaleData]].[[&lt;locale&gt;]].[[co]] List. Keeping them out of the list itself —
+    /// rather than special-casing them where a request is resolved — is what makes them unreportable
+    /// and unrequestable by the same act. "default" is Jint's placeholder for a null resolved [[co]]
+    /// and is not an identifier a locale can report either.
+    /// </summary>
+    private static bool IsReportableCollation(string collation)
+    {
+        return !string.Equals(collation, "default", StringComparison.Ordinal)
+            && !string.Equals(collation, "standard", StringComparison.Ordinal)
+            && !string.Equals(collation, "search", StringComparison.Ordinal);
+    }
 
     public CollatorConstructor(
         Engine engine,
@@ -298,41 +348,29 @@ internal sealed partial class CollatorConstructor : Constructor
             langCode = resolvedLocale.Substring(0, dashIdx);
         }
 
+        // Both requests are matched against the locale's [[co]] list, and the options value wins
+        // when both resolve — https://tc39.es/ecma402/#sec-resolvelocale (9.2.7) step 10. "standard"
+        // and "search" need no guard of their own: 10.2.3 keeps them out of every [[co]] list, and
+        // IsReportableCollation is where Jint honours that.
         var value = options.Get("collation");
         if (!value.IsUndefined())
         {
             var collation = TypeConverter.ToString(value);
-
-            // Per ECMA-402: "standard" and "search" collations are explicitly disallowed
-            if (string.Equals(collation, "standard", StringComparison.Ordinal) ||
-                string.Equals(collation, "search", StringComparison.Ordinal))
-            {
-                // Fall through to check unicode extension
-            }
-            // Validate against known collation types AND locale-specific support
-            else if (ValidCollationTypes.Contains(collation) && IsCollationSupportedForLocale(langCode, collation))
+            if (IsCollationSupportedForLocale(langCode, collation))
             {
                 return collation;
             }
+
             // Options value is not supported - fall through to check unicode extension
         }
 
-        // Check unicode extension, but disallow "standard", "search", and invalid values
-        if (unicodeExtension != null &&
-            !string.Equals(unicodeExtension, "standard", StringComparison.Ordinal) &&
-            !string.Equals(unicodeExtension, "search", StringComparison.Ordinal) &&
-            ValidCollationTypes.Contains(unicodeExtension) &&
-            IsCollationSupportedForLocale(langCode, unicodeExtension))
+        if (unicodeExtension != null && IsCollationSupportedForLocale(langCode, unicodeExtension))
         {
             return unicodeExtension;
         }
 
         return "default";
     }
-
-    // The collations CLDR's root locale contributes to every locale. "standard" and "search" are
-    // deliberately absent: ECMA-402 forbids either from appearing in a reported collation list.
-    private static readonly string[] RootCollations = ["emoji", "eor"];
 
     /// <summary>
     /// The collation identifiers reported for <paramref name="language"/> by
@@ -343,34 +381,23 @@ internal sealed partial class CollatorConstructor : Constructor
     /// </summary>
     internal static string[] GetCollationsForLanguage(string? language)
     {
-        if (language is null || !LocaleCollationSupport.TryGetValue(language, out var supported))
+        if (language is null || !LocaleCollations.TryGetValue(language, out var collations))
         {
             return RootCollations;
         }
 
-        var list = new List<string>(supported.Count + RootCollations.Length);
-        foreach (var collation in supported)
-        {
-            // "default" is Jint's placeholder for "no explicit collation was requested", not an
-            // identifier a locale can report.
-            if (!string.Equals(collation, "default", StringComparison.Ordinal))
-            {
-                list.Add(collation);
-            }
-        }
-
-        foreach (var rootCollation in RootCollations)
-        {
-            if (!list.Contains(rootCollation))
-            {
-                list.Add(rootCollation);
-            }
-        }
-
-        list.Sort(StringComparer.Ordinal);
-        return list.ToArray();
+        return collations;
     }
 
+    /// <summary>
+    /// Whether <paramref name="collation"/> can be resolved as the "co" value for
+    /// <paramref name="language"/>. This is the acceptance side of the one [[co]] list a locale has,
+    /// so it answers for exactly what <see cref="GetCollationsForLanguage"/> reports — anything else
+    /// leaves Intl.Collator refusing a collation Intl.Locale.prototype.getCollations advertises.
+    /// "default" is accepted on top of that list as a request and never appears in it: it is how
+    /// Jint spells the null [[co]] that https://tc39.es/ecma402/#sec-intl.collator (10.1.1) turns
+    /// into a resolved collation of "default" anyway.
+    /// </summary>
     private static bool IsCollationSupportedForLocale(string language, string collation)
     {
         if (string.Equals(collation, "default", StringComparison.Ordinal))
@@ -378,14 +405,15 @@ internal sealed partial class CollatorConstructor : Constructor
             return true;
         }
 
-        // If we have explicit locale data, check against it
-        if (LocaleCollationSupport.TryGetValue(language, out var supported))
+        foreach (var reported in GetCollationsForLanguage(language))
         {
-            return supported.Contains(collation);
+            if (string.Equals(reported, collation, StringComparison.Ordinal))
+            {
+                return true;
+            }
         }
 
-        // For unlisted locales, only "default" and "eor" are universally supported
-        return string.Equals(collation, "eor", StringComparison.Ordinal);
+        return false;
     }
 
     private static bool GetNumericOption(ObjectInstance options, bool? unicodeExtension)


### PR DESCRIPTION
#2867 made `getCollations()` report real collation data — and exposed that `Intl.Collator` refused `emoji` for 13 of the locales the query advertises it for (`ar da de es hi ja ko ln si sv zh tr fr`): the acceptance predicate's fallback conceded `eor` from the root pair and forgot `emoji`, and its table branch trusted a table that lists `emoji` for `en` alone.

The two views may not legally disagree: [15.5.10 CollationsOfLocale](https://tc39.es/ecma402/#sec-collationsoflocale) reads `[[SortLocaleData]].[[<foundLocale>]].[[co]]`, and [9.2.7 ResolveLocale](https://tc39.es/ecma402/#sec-resolvelocale) step 10 gates **both** the `-u-co-` keyword branch and the options branch on that same list. One `[[co]]` per locale; `getCollations()` and the constructor are two views of it.

The fix makes them one list by construction: `LocaleCollations` is derived once from the table plus the root pair, `GetCollationsForLanguage` hands it out and `IsCollationSupportedForLocale` scans it. `standard`/`search` stay **out of the list** rather than being guarded at resolution time ([10.2.3](https://tc39.es/ecma402/#sec-intl-collator-internal-slots) forbids them as `[[co]]` elements, and filtering at derivation means a future table edit cannot reintroduce this bug class); `default` is accepted as a *request* only — it is the spelling of the null `[[co]]` — and never reported. `ValidCollationTypes`, a second wider whitelist that never changed an answer but could drift exactly the way this bug did, is deleted.

15-tag consistency matrix (everything reported must construct and echo in `resolvedOptions().collation`, options bag **and** `-u-co-`): Jint before **13** inconsistent cells, after **0**. One correction to the review that found this: node is *not* clean on the same matrix — it has 3 inconsistent cells (`zh`/`pinyin` resolves to `default` because pinyin is zh's default, and both `und-u-co-*` forms).

One deliberate non-change, now pinned so nobody "fixes" it toward V8: `resolvedOptions().locale` for an options-bag collation stays `de`, not `de-u-co-emoji` — ResolveLocale sets `supportedKeyword` to empty on the options branch, and test262's `resolved-collation-unicode-extensions-and-options.js` pins exactly that.

Red 15 / green 25 on both TFMs. Test262 exactly 99,738 / 0 / 157; `Test262Harness.settings.json` untouched.

**Found and left for the backlog:** an invalid `collation` option (`{collation:'a'}`) silently falls back where [9.2.8](https://tc39.es/ecma402/#sec-resolveoptions) step 7.d.ii wants a `RangeError` (node throws); the `LocaleCollationSupport` table's CLDR accuracy (`ducet`/`direct`/`big5han`/`reformed`-vs-`trad`) — this consistency fix is the prerequisite for correcting that data, not a substitute; and `Intl.supportedValuesOf("collation")` is backed by a third hardcoded list that is consistent today but can drift the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)