### PR TITLE
Implement proper tail calls for strict functions

### DIFF
--- a/Jint.Benchmark/TailCallBenchmark.cs
+++ b/Jint.Benchmark/TailCallBenchmark.cs
@@ -1,0 +1,74 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Strict-mode proper tail-call shapes compared with an equivalent loop. Each row owns one engine,
+/// installs only its own workload in <see cref="Setup"/>, and warms that workload before measurement,
+/// so engine construction and function declaration do not enter the measurement. At depth 1,000 the
+/// operation is long enough to dominate the sub-microsecond Engine.Evaluate entry cost while remaining
+/// representative of host code that repeatedly invokes an already-installed function.
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+public class TailCallBenchmark
+{
+    private Engine _directEngine = null!;
+    private Engine _mutualEngine = null!;
+    private Engine _loopEngine = null!;
+    private Prepared<Script> _directCall;
+    private Prepared<Script> _mutualCall;
+    private Prepared<Script> _loopCall;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _directEngine = CreateEngine("""
+            function sum(n, total) {
+                return n === 0 ? total : sum(n - 1, total + n);
+            }
+            """);
+        _directCall = Engine.PrepareScript("sum(1000, 0);", strict: true);
+        _directEngine.Evaluate(_directCall);
+
+        _mutualEngine = CreateEngine("""
+            function even(n) {
+                return n === 0 || odd(n - 1);
+            }
+            function odd(n) {
+                return n !== 0 && even(n - 1);
+            }
+            """);
+        _mutualCall = Engine.PrepareScript("even(1000);", strict: true);
+        _mutualEngine.Evaluate(_mutualCall);
+
+        _loopEngine = CreateEngine("""
+            function sumLoop(n) {
+                let total = 0;
+                while (n !== 0) {
+                    total += n--;
+                }
+                return total;
+            }
+            """);
+        _loopCall = Engine.PrepareScript("sumLoop(1000);", strict: true);
+        _loopEngine.Evaluate(_loopCall);
+    }
+
+    [Benchmark]
+    public JsValue DirectTailRecursion() => _directEngine.Evaluate(_directCall);
+
+    [Benchmark]
+    public JsValue MutualTailRecursion() => _mutualEngine.Evaluate(_mutualCall);
+
+    [Benchmark(Baseline = true)]
+    public JsValue IterativeLoop() => _loopEngine.Evaluate(_loopCall);
+
+    private static Engine CreateEngine(string definitions)
+    {
+        var engine = new Engine(static options => options.Strict());
+        engine.Execute(definitions);
+        return engine;
+    }
+}

--- a/Jint.Benchmark/TailCallBenchmark.cs
+++ b/Jint.Benchmark/TailCallBenchmark.cs
@@ -6,7 +6,7 @@ namespace Jint.Benchmark;
 /// <summary>
 /// Strict-mode proper tail-call shapes compared with an equivalent loop. Each row owns one engine,
 /// installs only its own workload in <see cref="Setup"/>, and warms that workload before measurement,
-/// so engine construction and function declaration do not enter the measurement. At depth 1,000 the
+/// so engine construction and function declaration do not enter the measurement. At depth 500 the
 /// operation is long enough to dominate the sub-microsecond Engine.Evaluate entry cost while remaining
 /// representative of host code that repeatedly invokes an already-installed function.
 /// </summary>
@@ -29,7 +29,7 @@ public class TailCallBenchmark
                 return n === 0 ? total : sum(n - 1, total + n);
             }
             """);
-        _directCall = Engine.PrepareScript("sum(1000, 0);", strict: true);
+        _directCall = Engine.PrepareScript("sum(500, 0);", strict: true);
         _directEngine.Evaluate(_directCall);
 
         _mutualEngine = CreateEngine("""
@@ -40,7 +40,7 @@ public class TailCallBenchmark
                 return n !== 0 && even(n - 1);
             }
             """);
-        _mutualCall = Engine.PrepareScript("even(1000);", strict: true);
+        _mutualCall = Engine.PrepareScript("even(500);", strict: true);
         _mutualEngine.Evaluate(_mutualCall);
 
         _loopEngine = CreateEngine("""
@@ -52,7 +52,7 @@ public class TailCallBenchmark
                 return total;
             }
             """);
-        _loopCall = Engine.PrepareScript("sumLoop(1000);", strict: true);
+        _loopCall = Engine.PrepareScript("sumLoop(500);", strict: true);
         _loopEngine.Evaluate(_loopCall);
     }
 
@@ -71,4 +71,54 @@ public class TailCallBenchmark
         engine.Execute(definitions);
         return engine;
     }
+}
+
+/// <summary>
+/// A shallow strict tail delegation exercised repeatedly on one isolated, warmed engine. The
+/// benchmark keeps engine construction and function declarations out of the measurement and
+/// specifically guards the register-argument tail-request path used by everyday wrappers.
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+public class TailCallDelegationBenchmark
+{
+    private Engine _engine = null!;
+    private Engine _limitedEngine = null!;
+    private Prepared<Script> _call;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = CreateEngine(static options => options.Strict());
+        _limitedEngine = CreateEngine(static options => options.Strict().LimitRecursion(100_000));
+        _call = Engine.PrepareScript("""
+            var value = 0;
+            for (var i = 0; i < 10000; i++) {
+                value = delegate(value);
+            }
+            value;
+            """, strict: true);
+        _engine.Evaluate(_call);
+        _limitedEngine.Evaluate(_call);
+    }
+
+    private static Engine CreateEngine(Action<Options> configure)
+    {
+        var engine = new Engine(configure);
+        engine.Execute("""
+            function helper(value) {
+                return (value + 1) & 1023;
+            }
+            function delegate(value) {
+                return helper(value);
+            }
+            """);
+        return engine;
+    }
+
+    [Benchmark(Baseline = true)]
+    public JsValue StrictDelegation() => _engine.Evaluate(_call);
+
+    [Benchmark]
+    public JsValue StrictDelegationWithRecursionLimit() => _limitedEngine.Evaluate(_call);
 }

--- a/Jint.Tests.PublicInterface/HostTailCallTests.cs
+++ b/Jint.Tests.PublicInterface/HostTailCallTests.cs
@@ -1,0 +1,53 @@
+using Jint.Runtime;
+
+namespace Jint.Tests.PublicInterface;
+
+public class HostTailCallTests
+{
+    [Fact]
+    public void StrictTailRecursionHonorsRecursionLimit()
+    {
+        var engine = new Engine(options => options
+            .LimitRecursion(8)
+            .TimeoutInterval(TimeSpan.FromSeconds(1)));
+
+        Invoking(() => engine.Evaluate("""
+            "use strict";
+            function recurse() {
+                return recurse();
+            }
+            recurse();
+            """)).Should().ThrowExactly<RecursionDepthOverflowException>();
+    }
+
+    [Fact]
+    public void StrictTailRecursionWithoutLimitDoesNotConsumeCallStack()
+    {
+        var result = new Engine().Evaluate("""
+            "use strict";
+            function sum(n, total) {
+                return n === 0 ? total : sum(n - 1, total + n);
+            }
+            sum(10_000, 0);
+            """);
+
+        result.Should().Be(50_005_000);
+    }
+
+    [Fact]
+    public void DistinctTailDelegationDoesNotCountAsRecursion()
+    {
+        var result = new Engine(options => options.LimitRecursion(0)).Evaluate("""
+            "use strict";
+            function first() {
+                return second();
+            }
+            function second() {
+                return 42;
+            }
+            first();
+            """);
+
+        result.Should().Be(42);
+    }
+}

--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -5,7 +5,6 @@
   "Namespace": "Jint.Tests.Test262",
   "Parallel": true,
   "ExcludedFeatures": [
-    "tail-call-optimization"
   ],
   "ExcludedFlags": [
   ],

--- a/Jint.Tests/Runtime/TailCallOptimizationTests.cs
+++ b/Jint.Tests/Runtime/TailCallOptimizationTests.cs
@@ -1,0 +1,430 @@
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
+
+public class TailCallOptimizationTests
+{
+    [Fact]
+    public void OptimizesStrictDirectTailRecursion()
+    {
+        var engine = new Engine(options => options.LimitRecursion(1));
+
+        var result = engine.Evaluate("""
+            "use strict";
+            function sum(n, total) {
+                return n === 0 ? total : sum(n - 1, total + n);
+            }
+            sum(10_000, 0);
+            """);
+
+        result.Should().Be(50_005_000);
+    }
+
+    [Fact]
+    public void OptimizesStrictMutualTailRecursion()
+    {
+        var engine = new Engine(options => options.LimitRecursion(1));
+
+        var result = engine.Evaluate("""
+            "use strict";
+            function even(n) {
+                return n === 0 || odd(n - 1);
+            }
+            function odd(n) {
+                return n !== 0 && even(n - 1);
+            }
+            even(10_000);
+            """);
+
+        result.Should().Be(true);
+    }
+
+    [Fact]
+    public void OptimizesStrictConciseArrowTailRecursion()
+    {
+        var engine = new Engine(options => options.LimitRecursion(1));
+
+        var result = engine.Evaluate("""
+            "use strict";
+            let count;
+            count = n => n === 0 ? 0 : count(n - 1);
+            count(10_000);
+            """);
+
+        result.Should().Be(0);
+    }
+
+    [Fact]
+    public void OptimizesTailRecursionInvokedByHost()
+    {
+        var engine = new Engine(options => options.LimitRecursion(1));
+        engine.Execute("""
+            "use strict";
+            function count(n) {
+                return n === 0 ? 0 : count(n - 1);
+            }
+            """);
+
+        engine.Invoke("count", 10_000).Should().Be(0);
+    }
+
+    [Fact]
+    public void OptimizesTailRecursionFromWarmedRegisterCallSite()
+    {
+        var engine = new Engine(options => options.LimitRecursion(1));
+
+        var result = engine.Evaluate("""
+            "use strict";
+            function count(n) {
+                return n === 0 ? 0 : count(n - 1);
+            }
+            let result;
+            for (let i = 0; i < 2; i++) {
+                result = count(i === 0 ? 1 : 10_000);
+            }
+            result;
+            """);
+
+        result.Should().Be(0);
+    }
+
+    [Fact]
+    public void DoesNotOptimizeSloppyTailRecursion()
+    {
+        var engine = new Engine(options => options.LimitRecursion(20));
+
+        Invoking(() => engine.Evaluate("""
+            function recurse(n) {
+                return n === 0 ? 0 : recurse(n - 1);
+            }
+            recurse(100);
+            """)).Should().ThrowExactly<RecursionDepthOverflowException>();
+    }
+
+    [Fact]
+    public void DoesNotOptimizeNonTailRecursion()
+    {
+        var engine = new Engine(options => options.LimitRecursion(20));
+
+        Invoking(() => engine.Evaluate("""
+            "use strict";
+            function fibonacci(n) {
+                return n < 2 ? n : fibonacci(n - 1) + fibonacci(n - 2);
+            }
+            fibonacci(100);
+            """)).Should().ThrowExactly<RecursionDepthOverflowException>();
+    }
+
+    [Fact]
+    public void DoesNotMoveTailCallPastFinally()
+    {
+        var engine = new Engine(options => options.LimitRecursion(20));
+
+        Invoking(() => engine.Evaluate("""
+            "use strict";
+            function recurse(n) {
+                try {
+                    return n === 0 ? 0 : recurse(n - 1);
+                } finally {
+                    globalThis.finallyCount = (globalThis.finallyCount ?? 0) + 1;
+                }
+            }
+            recurse(100);
+            """)).Should().ThrowExactly<RecursionDepthOverflowException>();
+    }
+
+    [Fact]
+    public void DoesNotMoveTailCallPastCatch()
+    {
+        var engine = new Engine(options => options.LimitRecursion(1));
+
+        var result = engine.Evaluate("""
+            "use strict";
+            function fail() {
+                throw new Error("expected");
+            }
+            function invoke() {
+                try {
+                    return fail();
+                } catch {
+                    return 42;
+                }
+            }
+            invoke();
+            """);
+
+        result.Should().Be(42);
+    }
+
+    [Fact]
+    public void PreservesUsingDisposalOrder()
+    {
+        var engine = new Engine(options => options.LimitRecursion(1));
+
+        var result = engine.Evaluate("""
+            "use strict";
+            const log = [];
+            function target() {
+                log.push("target");
+                return 1;
+            }
+            function invoke() {
+                using resource = {
+                    [Symbol.dispose]() {
+                        log.push("dispose");
+                    }
+                };
+                return target();
+            }
+            invoke();
+            log.join(",");
+            """);
+
+        result.Should().Be("target,dispose");
+    }
+
+    [Fact]
+    public void PreservesIteratorCloseOrder()
+    {
+        var engine = new Engine(options => options.LimitRecursion(1));
+
+        var result = engine.Evaluate("""
+            "use strict";
+            const log = [];
+            const iterable = {
+                [Symbol.iterator]() {
+                    return {
+                        next() {
+                            return { value: 1, done: false };
+                        },
+                        return() {
+                            log.push("close");
+                            return { done: true };
+                        }
+                    };
+                }
+            };
+            function target() {
+                log.push("target");
+                return 1;
+            }
+            function invoke() {
+                for (const value of iterable) {
+                    return target();
+                }
+            }
+            invoke();
+            log.join(",");
+            """);
+
+        result.Should().Be("target,close");
+    }
+
+    [Fact]
+    public void ResolvesTailCallReturnValueFromConstructor()
+    {
+        var engine = new Engine(options => options.LimitRecursion(1));
+
+        var result = engine.Evaluate("""
+            "use strict";
+            function makeResult() {
+                return { expected: true };
+            }
+            function Constructor() {
+                return makeResult();
+            }
+            const value = new Constructor();
+            value.expected && !(value instanceof Constructor);
+            """);
+
+        result.Should().Be(true);
+    }
+
+    [Fact]
+    public void AppliesDerivedConstructorReturnValidationAfterTailCall()
+    {
+        var engine = new Engine(options => options.LimitRecursion(1));
+
+        Invoking(() => engine.Evaluate("""
+            function primitive() {
+                return 42;
+            }
+            class Base {}
+            class Derived extends Base {
+                constructor() {
+                    super();
+                    return primitive();
+                }
+            }
+            new Derived();
+            """)).Should().Throw<JavaScriptException>();
+    }
+
+    [Fact]
+    public void TailCallFromFramelessCallbackPreservesBuiltinFrame()
+    {
+        var engine = new Engine();
+
+        var stack = engine.Evaluate("""
+            "use strict";
+            function target() {
+                return new Error("expected").stack;
+            }
+            function callback(value) {
+                return target();
+            }
+            [1].map(callback)[0];
+            """).AsString();
+
+        stack.Should().Contain("at target");
+        stack.Should().Contain("at map");
+        stack.Should().NotContain("at callback");
+    }
+
+    [Fact]
+    public void ConstructorTailCallReplacesConstructorFrame()
+    {
+        var engine = new Engine();
+
+        var stack = engine.Evaluate("""
+            "use strict";
+            function target() {
+                return { stack: new Error("expected").stack };
+            }
+            function Constructor() {
+                return target();
+            }
+            new Constructor().stack;
+            """).AsString();
+
+        stack.Should().Contain("at target");
+        stack.Should().NotContain("at Constructor");
+    }
+
+    [Fact]
+    public void ConstructorTailCallWorksThroughFramelessWrappers()
+    {
+        var engine = new Engine();
+
+        var result = engine.Evaluate("""
+            "use strict";
+            function target() {
+                return { expected: true };
+            }
+            function Constructor() {
+                return target();
+            }
+            const ProxyConstructor = new Proxy(Constructor, {});
+            const proxyValue = new ProxyConstructor();
+            const boundValue = new (Constructor.bind(null))();
+            proxyValue.expected && boundValue.expected;
+            """);
+
+        result.Should().Be(true);
+        engine.CallStack.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void BaseConstructorTailCallDoesNotReplaceDerivedFrame()
+    {
+        var engine = new Engine();
+
+        var result = engine.Evaluate("""
+            "use strict";
+            function target() {
+                return { expected: true };
+            }
+            class Base {
+                constructor() {
+                    return target();
+                }
+            }
+            class Derived extends Base {}
+            new Derived().expected;
+            """);
+
+        result.Should().Be(true);
+        engine.CallStack.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void TailCallRecoversAfterNestedEvaluationResetsCallStack()
+    {
+        var engine = new Engine();
+        engine.SetValue("resetCallStack", new Action(() =>
+        {
+            try
+            {
+                engine.Evaluate("throw new Error('expected')");
+            }
+            catch (JavaScriptException)
+            {
+            }
+        }));
+
+        var result = engine.Evaluate("""
+            "use strict";
+            function target() {
+                return 42;
+            }
+            function invoke() {
+                resetCallStack();
+                return target();
+            }
+            invoke();
+            """);
+
+        result.Should().Be(42);
+        engine.CallStack.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void ConstructorTailCallRecoversAfterNestedEvaluationResetsCallStack()
+    {
+        var engine = new Engine();
+        engine.SetValue("resetCallStack", new Action(() =>
+        {
+            try
+            {
+                engine.Evaluate("throw new Error('expected')");
+            }
+            catch (JavaScriptException)
+            {
+            }
+        }));
+
+        var result = engine.Evaluate("""
+            "use strict";
+            function target() {
+                return { expected: true };
+            }
+            function Constructor() {
+                resetCallStack();
+                return target();
+            }
+            new Constructor().expected;
+            """);
+
+        result.Should().Be(true);
+        engine.CallStack.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void RecursionLimitFailureLeavesCallStackBalanced()
+    {
+        var engine = new Engine(options => options.LimitRecursion(0));
+
+        Invoking(() => engine.Evaluate("""
+            "use strict";
+            function recurse(n) {
+                return n === 0 ? 0 : 1 + bridge(n - 1);
+            }
+            function bridge(n) {
+                return recurse(n);
+            }
+            recurse(100);
+            """)).Should().ThrowExactly<RecursionDepthOverflowException>();
+
+        engine.CallStack.Count.Should().Be(0);
+    }
+}

--- a/Jint.Tests/Runtime/TailCallOptimizationTests.cs
+++ b/Jint.Tests/Runtime/TailCallOptimizationTests.cs
@@ -1,4 +1,5 @@
 using Jint.Runtime;
+using Jint.Native.Function;
 
 namespace Jint.Tests.Runtime;
 
@@ -7,7 +8,7 @@ public class TailCallOptimizationTests
     [Fact]
     public void OptimizesStrictDirectTailRecursion()
     {
-        var engine = new Engine(options => options.LimitRecursion(1));
+        var engine = new Engine();
 
         var result = engine.Evaluate("""
             "use strict";
@@ -23,7 +24,7 @@ public class TailCallOptimizationTests
     [Fact]
     public void OptimizesStrictMutualTailRecursion()
     {
-        var engine = new Engine(options => options.LimitRecursion(1));
+        var engine = new Engine();
 
         var result = engine.Evaluate("""
             "use strict";
@@ -42,7 +43,7 @@ public class TailCallOptimizationTests
     [Fact]
     public void OptimizesStrictConciseArrowTailRecursion()
     {
-        var engine = new Engine(options => options.LimitRecursion(1));
+        var engine = new Engine();
 
         var result = engine.Evaluate("""
             "use strict";
@@ -57,7 +58,7 @@ public class TailCallOptimizationTests
     [Fact]
     public void OptimizesTailRecursionInvokedByHost()
     {
-        var engine = new Engine(options => options.LimitRecursion(1));
+        var engine = new Engine();
         engine.Execute("""
             "use strict";
             function count(n) {
@@ -71,7 +72,7 @@ public class TailCallOptimizationTests
     [Fact]
     public void OptimizesTailRecursionFromWarmedRegisterCallSite()
     {
-        var engine = new Engine(options => options.LimitRecursion(1));
+        var engine = new Engine();
 
         var result = engine.Evaluate("""
             "use strict";
@@ -181,6 +182,30 @@ public class TailCallOptimizationTests
             """);
 
         result.Should().Be("target,dispose");
+    }
+
+    [Fact]
+    public void UsingDeclarationOnlyBlocksFollowingReturns()
+    {
+        var stack = new Engine().Evaluate("""
+            "use strict";
+            function target() {
+                return new Error("expected").stack;
+            }
+            function invoke(returnEarly) {
+                if (returnEarly) {
+                    return target();
+                }
+                using resource = {
+                    [Symbol.dispose]() {}
+                };
+                return "late";
+            }
+            invoke(true);
+            """).AsString();
+
+        stack.Should().Contain("at target");
+        stack.Should().NotContain("at invoke");
     }
 
     [Fact]
@@ -426,5 +451,121 @@ public class TailCallOptimizationTests
             """)).Should().ThrowExactly<RecursionDepthOverflowException>();
 
         engine.CallStack.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void InfiniteStrictTailRecursionHonorsRecursionLimit()
+    {
+        var engine = new Engine(options => options.LimitRecursion(8));
+
+        Invoking(() => engine.Evaluate("""
+            "use strict";
+            function recurse() {
+                return recurse();
+            }
+            recurse();
+            """)).Should().ThrowExactly<RecursionDepthOverflowException>();
+
+        engine.CallStack.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void MultiFunctionTailCycleHonorsRecursionLimit()
+    {
+        var engine = new Engine(options => options.LimitRecursion(1));
+
+        Invoking(() => engine.Evaluate("""
+            "use strict";
+            function first() {
+                return second();
+            }
+            function second() {
+                return third();
+            }
+            function third() {
+                return first();
+            }
+            first();
+            """)).Should().ThrowExactly<RecursionDepthOverflowException>();
+
+        engine.CallStack.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void DebugModeKeepsTailCallerFrame()
+    {
+        var stack = new Engine(options => options.DebugMode()).Evaluate("""
+            "use strict";
+            function target() {
+                return new Error("expected").stack;
+            }
+            function invoke() {
+                return target();
+            }
+            invoke();
+            """).AsString();
+
+        stack.Should().Contain("at target");
+        stack.Should().Contain("at invoke");
+    }
+
+    [Fact]
+    public void GeneratorDoesNotReceiveTailCallRequest()
+    {
+        var result = new Engine().Evaluate("""
+            function target() {
+                return 42;
+            }
+            function* invoke() {
+                "use strict";
+                return target();
+            }
+            invoke().next().value;
+            """);
+
+        result.Should().Be(42);
+    }
+
+    [Fact]
+    public async Task AsyncFunctionDoesNotReceiveTailCallRequest()
+    {
+        var result = await new Engine().EvaluateAsync("""
+            function target() {
+                return 42;
+            }
+            async function invoke() {
+                "use strict";
+                return target();
+            }
+            invoke();
+            """);
+
+        result.Should().Be(42);
+    }
+
+    [Fact]
+    public void SharedPreparedTailCallMarkersArePublishedBeforeHandlerConstruction()
+    {
+        var prepared = Engine.PrepareScript("""
+            "use strict";
+            function sum(n, total) {
+                return n === 0 ? total : sum(n - 1, total + n);
+            }
+            sum(2_000, 0);
+            """);
+        var results = new double[16];
+
+        Parallel.For(0, results.Length, i => results[i] = new Engine().Evaluate(prepared).AsNumber());
+
+        results.Should().AllSatisfy(result => result.Should().Be(2_001_000));
+    }
+
+    [Fact]
+    public void TailCallRequestCannotMasqueradeAsUndefined()
+    {
+        var request = new TailCallRequest();
+
+        request.IsUndefined().Should().BeFalse();
+        Invoking(request.ToObject).Should().ThrowExactly<InvalidOperationException>();
     }
 }

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -318,6 +318,7 @@ public sealed partial class Engine : IDisposable
     internal readonly ArgumentsInstancePool _argumentsInstancePool;
     internal readonly JsValueArrayPool _jsValueArrayPool;
     internal readonly ObjectTraverseStackPool _objectTraverseStackPool;
+    internal TailCallRequest? _tailCallRequest;
     internal readonly ExtensionMethodCache _extensionMethods;
 
     private ITypeConverter _typeConverter = null!;
@@ -1585,10 +1586,7 @@ public sealed partial class Engine : IDisposable
                 finally
                 {
                     // if call stack was reset due to recursive call to engine or similar, we might not have it anymore
-                    if (callStack.Count > 0)
-                    {
-                        callStack.Pop();
-                    }
+                    callStack.TryPop(out _);
                 }
             }
             else
@@ -2626,10 +2624,7 @@ public sealed partial class Engine : IDisposable
         finally
         {
             // if call stack was reset due to recursive call to engine or similar, we might not have it anymore
-            if (CallStack.Count > 0)
-            {
-                CallStack.Pop();
-            }
+            CallStack.TryPop(out _);
         }
 
         return result;
@@ -2661,10 +2656,7 @@ public sealed partial class Engine : IDisposable
         finally
         {
             // if call stack was reset due to recursive call to engine or similar, we might not have it anymore
-            if (CallStack.Count > 0)
-            {
-                CallStack.Pop();
-            }
+            CallStack.TryPop(out _);
         }
 
         return result;

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1578,7 +1578,9 @@ public sealed partial class Engine : IDisposable
                 callStack.Push(functionInstance, expression: null, ExecutionContext);
                 try
                 {
-                    result = functionInstance.Call(thisObject, items);
+                    result = functionInstance is ScriptFunction scriptFunction
+                        ? scriptFunction.CallWithStackFrame(thisObject, items)
+                        : functionInstance.Call(thisObject, items);
                 }
                 finally
                 {
@@ -2617,7 +2619,9 @@ public sealed partial class Engine : IDisposable
         JsValue result;
         try
         {
-            result = function.Call(thisObject, arguments);
+            result = function is ScriptFunction scriptFunction
+                ? scriptFunction.CallWithStackFrame(thisObject, arguments)
+                : function.Call(thisObject, arguments);
         }
         finally
         {
@@ -2650,11 +2654,17 @@ public sealed partial class Engine : IDisposable
         ObjectInstance result;
         try
         {
-            result = ((IConstructor) function).Construct(arguments, newTarget);
+            result = function is ScriptFunction scriptFunction
+                ? scriptFunction.ConstructWithStackFrame(arguments, newTarget)
+                : ((IConstructor) function).Construct(arguments, newTarget);
         }
         finally
         {
-            CallStack.Pop();
+            // if call stack was reset due to recursive call to engine or similar, we might not have it anymore
+            if (CallStack.Count > 0)
+            {
+                CallStack.Pop();
+            }
         }
 
         return result;

--- a/Jint/Native/CallbackInvoker.cs
+++ b/Jint/Native/CallbackInvoker.cs
@@ -136,7 +136,15 @@ internal readonly struct CallbackInvoker
 
         if (_registerTarget is not null)
         {
-            return _registerTarget.CallFromRegisters(thisArgument, argument0, _lastArgument, JsValue.Undefined, JsValue.Undefined, _argumentCount, _registerState!);
+            return _registerTarget.CallFromRegisters(
+                thisArgument,
+                argument0,
+                _lastArgument,
+                JsValue.Undefined,
+                JsValue.Undefined,
+                _argumentCount,
+                _registerState!,
+                ownsFrame: false);
         }
 
         var arguments = _arguments;
@@ -155,7 +163,15 @@ internal readonly struct CallbackInvoker
 
         if (_registerTarget is not null)
         {
-            return _registerTarget.CallFromRegisters(thisArgument, argument0, argument1, _lastArgument, JsValue.Undefined, _argumentCount, _registerState!);
+            return _registerTarget.CallFromRegisters(
+                thisArgument,
+                argument0,
+                argument1,
+                _lastArgument,
+                JsValue.Undefined,
+                _argumentCount,
+                _registerState!,
+                ownsFrame: false);
         }
 
         var arguments = _arguments;
@@ -175,7 +191,15 @@ internal readonly struct CallbackInvoker
 
         if (_registerTarget is not null)
         {
-            return _registerTarget.CallFromRegisters(thisArgument, argument0, argument1, argument2, _lastArgument, _argumentCount, _registerState!);
+            return _registerTarget.CallFromRegisters(
+                thisArgument,
+                argument0,
+                argument1,
+                argument2,
+                _lastArgument,
+                _argumentCount,
+                _registerState!,
+                ownsFrame: false);
         }
 
         var arguments = _arguments;

--- a/Jint/Native/Function/ScriptFunction.cs
+++ b/Jint/Native/Function/ScriptFunction.cs
@@ -1,10 +1,12 @@
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Jint.Native.Object;
+using Jint.Pooling;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Environments;
 using Jint.Runtime.Interpreter;
+using Jint.Runtime.Interpreter.Expressions;
 using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Native.Function;
@@ -146,7 +148,21 @@ public sealed class ScriptFunction : Function, IConstructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-ecmascript-function-objects-call-thisargument-argumentslist
     /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected internal override JsValue Call(JsValue thisObject, JsCallArguments arguments)
+    {
+        var result = CallOnce(thisObject, arguments);
+        return result is TailCallRequest ? ContinueTailCalls(result, ownsFrame: false) : result;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal JsValue CallWithStackFrame(JsValue thisObject, JsCallArguments arguments)
+    {
+        var result = CallOnce(thisObject, arguments);
+        return result is TailCallRequest ? ContinueTailCalls(result, ownsFrame: true) : result;
+    }
+
+    private JsValue CallOnce(JsValue thisObject, JsCallArguments arguments)
     {
         var state = _functionDefinition!.Initialize();
         var strict = _strict;
@@ -385,9 +401,80 @@ public sealed class ScriptFunction : Function, IConstructor
         JsValue arg2,
         JsValue arg3,
         int argCount,
-        JintFunctionDefinition.State state)
+        JintFunctionDefinition.State state,
+        bool ownsFrame)
     {
-        return CallCore(thisObject, new RegisterArguments(arg0, arg1, arg2, arg3, argCount), state);
+        var result = CallCore(thisObject, new RegisterArguments(arg0, arg1, arg2, arg3, argCount), state);
+        return result is TailCallRequest ? ContinueTailCalls(result, ownsFrame) : result;
+    }
+
+    /// <summary>
+    /// Runs interpreted proper tail calls as a trampoline, after the caller's execution context and
+    /// environment have unwound. Replacing the visible frame keeps error stacks and recursion tracking
+    /// aligned with the execution-context replacement required by PrepareForTailCall.
+    /// </summary>
+    private JsValue ContinueTailCalls(JsValue result, bool ownsFrame)
+    {
+        var engine = _engine;
+        var callStack = engine.CallStack;
+        var pushedFrame = false;
+        Function? currentFrame = ownsFrame ? this : null;
+
+        try
+        {
+            while (result is TailCallRequest request)
+            {
+                var target = request.Target;
+                var thisObject = request.ThisObject;
+                var arguments = request.Arguments;
+                var argumentsRented = request.ArgumentsRented;
+                var expression = request.Expression;
+                TailCallRequestPool.Return(request);
+
+                try
+                {
+                    int recursionDepth;
+                    if (currentFrame is not null
+                        && callStack.TryPeek(out var topFrame)
+                        && ReferenceEquals(topFrame.Function, currentFrame))
+                    {
+                        recursionDepth = callStack.ReplaceTop(target, expression);
+                        if (recursionDepth > engine._maxRecursionDepth)
+                        {
+                            Throw.RecursionDepthOverflowException(callStack, preserveTop: true);
+                        }
+                    }
+                    else
+                    {
+                        recursionDepth = callStack.Push(target, expression, engine.ExecutionContext);
+                        if (recursionDepth > engine._maxRecursionDepth)
+                        {
+                            Throw.RecursionDepthOverflowException(callStack);
+                        }
+                        pushedFrame = true;
+                    }
+
+                    currentFrame = target;
+                    result = target.CallOnce(thisObject, arguments);
+                }
+                finally
+                {
+                    if (argumentsRented)
+                    {
+                        engine._jsValueArrayPool.ReturnArray(arguments);
+                    }
+                }
+            }
+
+            return result;
+        }
+        finally
+        {
+            if (pushedFrame && callStack.Count > 0)
+            {
+                callStack.Pop();
+            }
+        }
     }
 
     /// <summary>
@@ -443,6 +530,12 @@ public sealed class ScriptFunction : Function, IConstructor
     /// https://tc39.es/ecma262/#sec-ecmascript-function-objects-construct-argumentslist-newtarget
     /// </summary>
     ObjectInstance IConstructor.Construct(JsCallArguments arguments, JsValue newTarget)
+        => Construct(arguments, newTarget, ownsFrame: false);
+
+    internal ObjectInstance ConstructWithStackFrame(JsCallArguments arguments, JsValue newTarget)
+        => Construct(arguments, newTarget, ownsFrame: true);
+
+    private ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget, bool ownsFrame)
     {
         var state = _functionDefinition!.Initialize();
         var callerContext = _engine.ExecutionContext;
@@ -497,6 +590,7 @@ public sealed class ScriptFunction : Function, IConstructor
         var strict = _thisMode == FunctionThisMode.Strict;
         ref readonly var calleeContext = ref PrepareForOrdinaryCall(newTarget, state, strict);
         var constructorEnv = (FunctionEnvironment) calleeContext.LexicalEnvironment;
+        TailCallRequest? tailCallRequest = null;
 
         try
         {
@@ -526,7 +620,11 @@ public sealed class ScriptFunction : Function, IConstructor
                 );
             }
 
-            if (result.Type == CompletionType.Return)
+            if (result is { Type: CompletionType.Return, Value: TailCallRequest request })
+            {
+                tailCallRequest = request;
+            }
+            else if (result.Type == CompletionType.Return)
             {
                 if (result.Value is ObjectInstance oi)
                 {
@@ -551,6 +649,25 @@ public sealed class ScriptFunction : Function, IConstructor
         finally
         {
             _engine.LeaveExecutionContext();
+        }
+
+        if (tailCallRequest is not null)
+        {
+            var value = ContinueTailCalls(tailCallRequest, ownsFrame);
+            if (value is ObjectInstance oi)
+            {
+                return oi;
+            }
+
+            if (kind == ConstructorKind.Base)
+            {
+                return (ObjectInstance) thisArgument;
+            }
+
+            if (!value.IsUndefined())
+            {
+                Throw.TypeError(callerContext.Realm);
+            }
         }
 
         return (ObjectInstance) constructorEnv.GetThisBinding();
@@ -650,5 +767,70 @@ public sealed class ScriptFunction : Function, IConstructor
     internal void MakeClassConstructor()
     {
         _isClassConstructor = true;
+    }
+}
+
+/// <summary>
+/// Internal completion payload used to transfer an interpreted tail call to the trampoline.
+/// It is represented as a non-empty JsValue so ordinary Completion propagation carries it unchanged.
+/// </summary>
+internal sealed class TailCallRequest : JsValue
+{
+    internal TailCallRequest()
+        : base(Types.Undefined)
+    {
+    }
+
+    internal TailCallRequest Reassign(
+        ScriptFunction target,
+        JsValue thisObject,
+        JsValue[] arguments,
+        bool argumentsRented,
+        JintExpression expression)
+    {
+        Target = target;
+        ThisObject = thisObject;
+        Arguments = arguments;
+        ArgumentsRented = argumentsRented;
+        Expression = expression;
+        return this;
+    }
+
+    internal ScriptFunction Target = null!;
+    internal JsValue ThisObject = null!;
+    internal JsValue[] Arguments = null!;
+    internal bool ArgumentsRented;
+    internal JintExpression Expression = null!;
+
+    public override object? ToObject() => null;
+}
+
+/// <summary>
+/// Process-wide because a returned request has all engine-affine references cleared before reuse.
+/// </summary>
+internal static class TailCallRequestPool
+{
+    private static readonly ConcurrentObjectPool<TailCallRequest> _pool = new(static () => new TailCallRequest(), 4);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static TailCallRequest Rent(
+        ScriptFunction target,
+        JsValue thisObject,
+        JsValue[] arguments,
+        bool argumentsRented,
+        JintExpression expression)
+    {
+        return _pool.Allocate().Reassign(target, thisObject, arguments, argumentsRented, expression);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void Return(TailCallRequest request)
+    {
+        request.Target = null!;
+        request.ThisObject = null!;
+        request.Arguments = null!;
+        request.ArgumentsRented = false;
+        request.Expression = null!;
+        _pool.Free(request);
     }
 }

--- a/Jint/Native/Function/ScriptFunction.cs
+++ b/Jint/Native/Function/ScriptFunction.cs
@@ -463,9 +463,7 @@ public sealed class ScriptFunction : Function, IConstructor
 
                 try
                 {
-                    if (currentFrame is not null
-                        && callStack.TryPeek(out var topFrame)
-                        && ReferenceEquals(topFrame.Function, currentFrame))
+                    if (currentFrame is not null && callStack.TopIs(currentFrame))
                     {
                         callStack.ReplaceTop(target, expression);
                     }

--- a/Jint/Native/Function/ScriptFunction.cs
+++ b/Jint/Native/Function/ScriptFunction.cs
@@ -166,6 +166,7 @@ public sealed class ScriptFunction : Function, IConstructor
     {
         var state = _functionDefinition!.Initialize();
         var strict = _strict;
+        _functionDefinition.EnsureTailCallMarkers(state, strict);
 
         // Env-less leaf call: no bindings to create, no this/arguments/new.target route, no
         // closures — the callee FunctionEnvironment would exist only as a chain pointer, so the
@@ -404,8 +405,19 @@ public sealed class ScriptFunction : Function, IConstructor
         JintFunctionDefinition.State state,
         bool ownsFrame)
     {
+        _functionDefinition!.EnsureTailCallMarkers(state, _strict);
         var result = CallCore(thisObject, new RegisterArguments(arg0, arg1, arg2, arg3, argCount), state);
         return result is TailCallRequest ? ContinueTailCalls(result, ownsFrame) : result;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool CanPrepareTailCall(EvaluationContext context, bool isTailPosition)
+    {
+        var engine = context.Engine;
+        return isTailPosition
+               && engine.ExecutionContext.Strict
+               && engine.ExecutionContext.Suspendable is null
+               && !engine._isDebugMode;
     }
 
     /// <summary>
@@ -419,6 +431,18 @@ public sealed class ScriptFunction : Function, IConstructor
         var callStack = engine.CallStack;
         var pushedFrame = false;
         Function? currentFrame = ownsFrame ? this : null;
+        JintFunctionDefinition? depthDefinition0 = null;
+        JintFunctionDefinition? depthDefinition1 = null;
+        var depth0 = 0;
+        var depth1 = 0;
+        Dictionary<JintFunctionDefinition, int>? tailDepths = null;
+        if (engine._maxRecursionDepth >= 0)
+        {
+            depthDefinition0 = _functionDefinition!;
+            depth0 = ownsFrame
+                ? callStack.GetRecursionDepth(this)
+                : callStack.GetNextRecursionDepth(this);
+        }
 
         try
         {
@@ -429,33 +453,77 @@ public sealed class ScriptFunction : Function, IConstructor
                 var arguments = request.Arguments;
                 var argumentsRented = request.ArgumentsRented;
                 var expression = request.Expression;
-                TailCallRequestPool.Return(request);
+                var registerState = request.RegisterState;
+                var arg0 = request.Arg0;
+                var arg1 = request.Arg1;
+                var arg2 = request.Arg2;
+                var arg3 = request.Arg3;
+                var argCount = request.ArgCount;
+                engine.ReturnTailCallRequest(request);
 
                 try
                 {
-                    int recursionDepth;
                     if (currentFrame is not null
                         && callStack.TryPeek(out var topFrame)
                         && ReferenceEquals(topFrame.Function, currentFrame))
                     {
-                        recursionDepth = callStack.ReplaceTop(target, expression);
+                        callStack.ReplaceTop(target, expression);
+                    }
+                    else
+                    {
+                        callStack.Push(target, expression, engine.ExecutionContext);
+                        pushedFrame = true;
+                    }
+
+                    currentFrame = target;
+                    if (depthDefinition0 is not null)
+                    {
+                        var definition = target._functionDefinition!;
+                        int recursionDepth;
+                        if (ReferenceEquals(definition, depthDefinition0))
+                        {
+                            recursionDepth = ++depth0;
+                        }
+                        else if (ReferenceEquals(definition, depthDefinition1))
+                        {
+                            recursionDepth = ++depth1;
+                        }
+                        else if (depthDefinition1 is null)
+                        {
+                            depthDefinition1 = definition;
+                            recursionDepth = depth1 = callStack.GetRecursionDepth(target);
+                        }
+                        else
+                        {
+                            tailDepths ??= new Dictionary<JintFunctionDefinition, int>
+                            {
+                                [depthDefinition0] = depth0,
+                                [depthDefinition1] = depth1
+                            };
+
+                            if (tailDepths.TryGetValue(definition, out var previousDepth))
+                            {
+                                recursionDepth = previousDepth + 1;
+                            }
+                            else
+                            {
+                                recursionDepth = callStack.GetRecursionDepth(target);
+                            }
+                            tailDepths[definition] = recursionDepth;
+                        }
+
                         if (recursionDepth > engine._maxRecursionDepth)
                         {
                             Throw.RecursionDepthOverflowException(callStack, preserveTop: true);
                         }
                     }
-                    else
-                    {
-                        recursionDepth = callStack.Push(target, expression, engine.ExecutionContext);
-                        if (recursionDepth > engine._maxRecursionDepth)
-                        {
-                            Throw.RecursionDepthOverflowException(callStack);
-                        }
-                        pushedFrame = true;
-                    }
 
-                    currentFrame = target;
-                    result = target.CallOnce(thisObject, arguments);
+                    result = registerState is null
+                        ? target.CallOnce(thisObject, arguments)
+                        : target.CallCore(
+                            thisObject,
+                            new RegisterArguments(arg0, arg1, arg2, arg3, argCount),
+                            registerState);
                 }
                 finally
                 {
@@ -470,9 +538,9 @@ public sealed class ScriptFunction : Function, IConstructor
         }
         finally
         {
-            if (pushedFrame && callStack.Count > 0)
+            if (pushedFrame)
             {
-                callStack.Pop();
+                callStack.TryPop(out _);
             }
         }
     }
@@ -538,6 +606,7 @@ public sealed class ScriptFunction : Function, IConstructor
     private ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget, bool ownsFrame)
     {
         var state = _functionDefinition!.Initialize();
+        _functionDefinition.EnsureTailCallMarkers(state, _strict);
         var callerContext = _engine.ExecutionContext;
         var kind = _constructorKind;
 
@@ -626,19 +695,9 @@ public sealed class ScriptFunction : Function, IConstructor
             }
             else if (result.Type == CompletionType.Return)
             {
-                if (result.Value is ObjectInstance oi)
+                if (ResolveConstructorReturn(result.Value, kind, thisArgument, callerContext.Realm) is { } returnObject)
                 {
-                    return oi;
-                }
-
-                if (kind == ConstructorKind.Base)
-                {
-                    return (ObjectInstance) thisArgument;
-                }
-
-                if (!result.Value.IsUndefined())
-                {
-                    Throw.TypeError(callerContext.Realm);
+                    return returnObject;
                 }
             }
             else if (result.Type == CompletionType.Throw)
@@ -654,23 +713,37 @@ public sealed class ScriptFunction : Function, IConstructor
         if (tailCallRequest is not null)
         {
             var value = ContinueTailCalls(tailCallRequest, ownsFrame);
-            if (value is ObjectInstance oi)
+            if (ResolveConstructorReturn(value, kind, thisArgument, callerContext.Realm) is { } returnObject)
             {
-                return oi;
-            }
-
-            if (kind == ConstructorKind.Base)
-            {
-                return (ObjectInstance) thisArgument;
-            }
-
-            if (!value.IsUndefined())
-            {
-                Throw.TypeError(callerContext.Realm);
+                return returnObject;
             }
         }
 
         return (ObjectInstance) constructorEnv.GetThisBinding();
+    }
+
+    private static ObjectInstance? ResolveConstructorReturn(
+        JsValue value,
+        ConstructorKind kind,
+        JsValue thisArgument,
+        Realm callerRealm)
+    {
+        if (value is ObjectInstance objectValue)
+        {
+            return objectValue;
+        }
+
+        if (kind == ConstructorKind.Base)
+        {
+            return (ObjectInstance) thisArgument;
+        }
+
+        if (!value.IsUndefined())
+        {
+            Throw.TypeError(callerRealm);
+        }
+
+        return null;
     }
 
     /// <summary>
@@ -777,7 +850,7 @@ public sealed class ScriptFunction : Function, IConstructor
 internal sealed class TailCallRequest : JsValue
 {
     internal TailCallRequest()
-        : base(Types.Undefined)
+        : base(InternalTypes.TailCall)
     {
     }
 
@@ -792,6 +865,32 @@ internal sealed class TailCallRequest : JsValue
         ThisObject = thisObject;
         Arguments = arguments;
         ArgumentsRented = argumentsRented;
+        RegisterState = null;
+        Expression = expression;
+        return this;
+    }
+
+    internal TailCallRequest Reassign(
+        ScriptFunction target,
+        JsValue thisObject,
+        JsValue arg0,
+        JsValue arg1,
+        JsValue arg2,
+        JsValue arg3,
+        int argCount,
+        JintFunctionDefinition.State state,
+        JintExpression expression)
+    {
+        Target = target;
+        ThisObject = thisObject;
+        Arguments = null!;
+        ArgumentsRented = false;
+        Arg0 = arg0;
+        Arg1 = arg1;
+        Arg2 = arg2;
+        Arg3 = arg3;
+        ArgCount = argCount;
+        RegisterState = state;
         Expression = expression;
         return this;
     }
@@ -800,37 +899,74 @@ internal sealed class TailCallRequest : JsValue
     internal JsValue ThisObject = null!;
     internal JsValue[] Arguments = null!;
     internal bool ArgumentsRented;
+    internal JsValue Arg0 = null!;
+    internal JsValue Arg1 = null!;
+    internal JsValue Arg2 = null!;
+    internal JsValue Arg3 = null!;
+    internal int ArgCount;
+    internal JintFunctionDefinition.State? RegisterState;
     internal JintExpression Expression = null!;
 
-    public override object? ToObject() => null;
+    public override object? ToObject() => throw new InvalidOperationException("A tail-call request escaped the interpreter trampoline.");
 }
 
-/// <summary>
-/// Process-wide because a returned request has all engine-affine references cleared before reuse.
-/// </summary>
-internal static class TailCallRequestPool
+internal static class TailCallRequestReuse
 {
-    private static readonly ConcurrentObjectPool<TailCallRequest> _pool = new(static () => new TailCallRequest(), 4);
-
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static TailCallRequest Rent(
+    internal static TailCallRequest RentTailCallRequest(
+        this Engine engine,
         ScriptFunction target,
         JsValue thisObject,
         JsValue[] arguments,
         bool argumentsRented,
         JintExpression expression)
     {
-        return _pool.Allocate().Reassign(target, thisObject, arguments, argumentsRented, expression);
+        var request = engine._tailCallRequest;
+        engine._tailCallRequest = null;
+        return (request ?? new TailCallRequest()).Reassign(target, thisObject, arguments, argumentsRented, expression);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void Return(TailCallRequest request)
+    internal static TailCallRequest RentTailCallRequest(
+        this Engine engine,
+        ScriptFunction target,
+        JsValue thisObject,
+        JsValue arg0,
+        JsValue arg1,
+        JsValue arg2,
+        JsValue arg3,
+        int argCount,
+        JintFunctionDefinition.State state,
+        JintExpression expression)
+    {
+        var request = engine._tailCallRequest;
+        engine._tailCallRequest = null;
+        return (request ?? new TailCallRequest()).Reassign(
+            target,
+            thisObject,
+            arg0,
+            arg1,
+            arg2,
+            arg3,
+            argCount,
+            state,
+            expression);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void ReturnTailCallRequest(this Engine engine, TailCallRequest request)
     {
         request.Target = null!;
         request.ThisObject = null!;
         request.Arguments = null!;
         request.ArgumentsRented = false;
+        request.Arg0 = null!;
+        request.Arg1 = null!;
+        request.Arg2 = null!;
+        request.Arg3 = null!;
+        request.ArgCount = 0;
+        request.RegisterState = null;
         request.Expression = null!;
-        _pool.Free(request);
+        engine._tailCallRequest = request;
     }
 }

--- a/Jint/Options.Extensions.cs
+++ b/Jint/Options.Extensions.cs
@@ -199,10 +199,15 @@ public static class OptionsExtensions
     /// disables the check, and with it the call-stack depth tracking that feeds it.
     /// </param>
     /// <remarks>
+    /// Proper tail calls do not consume native or interpreter call-stack frames, but repeated tail
+    /// transfers are still included in this limit so an infinite strict tail-recursive function
+    /// terminates with <see cref="RecursionDepthOverflowException"/>.
+    /// <para>
     /// Unlike the constraint helpers in <see cref="ConstraintsOptionsExtensions"/>, this one does not
     /// treat a saturated value as "no limit": any non-negative depth — <see cref="int.MaxValue"/>
     /// included — turns depth tracking on, so a limit chosen to be unreachable still costs what
     /// enforcement costs while never failing. Pass a negative depth to mean unlimited.
+    /// </para>
     /// </remarks>
     /// <returns>Options instance for fluent syntax</returns>
     public static Options LimitRecursion(this Options options, int maxRecursionDepth = 0)

--- a/Jint/Runtime/CallStack/JintCallStack.cs
+++ b/Jint/Runtime/CallStack/JintCallStack.cs
@@ -110,11 +110,62 @@ internal sealed class JintCallStack
         return item;
     }
 
-    public int ReplaceTop(Function function, JintExpression? expression)
+    public bool TryPop([NotNullWhen(true)] out CallStackElement item)
     {
-        var previous = Pop();
+        if (_stack._size == 0)
+        {
+            item = default;
+            return false;
+        }
+
+        item = Pop();
+        return true;
+    }
+
+    public void ReplaceTop(Function function, JintExpression? expression)
+    {
+        var previous = _stack.Pop();
         var replacement = new CallStackElement(function, expression, in previous.CallingExecutionContext);
-        return Push(in replacement);
+
+        if (_statistics is not null && !CallStackElementComparer.Instance.Equals(previous, replacement))
+        {
+            if (_statistics[previous] == 0)
+            {
+                _statistics.Remove(previous);
+            }
+            else
+            {
+                _statistics[previous]--;
+            }
+
+            if (_statistics.TryGetValue(replacement, out var depth))
+            {
+                _statistics[replacement] = depth + 1;
+            }
+            else
+            {
+                _statistics.Add(replacement, 0);
+            }
+        }
+
+        _stack.Push(in replacement);
+    }
+
+    internal int GetRecursionDepth(Function function)
+    {
+        if (_statistics is null)
+        {
+            return -1;
+        }
+
+        var item = new CallStackElement(function, null, default);
+        return _statistics.TryGetValue(item, out var depth) ? depth : -1;
+    }
+
+    internal int GetNextRecursionDepth(Function function)
+    {
+        var depth = GetRecursionDepth(function);
+        return depth < 0 ? 0 : depth + 1;
     }
 
     public bool TryPeek([NotNullWhen(true)] out CallStackElement item)

--- a/Jint/Runtime/CallStack/JintCallStack.cs
+++ b/Jint/Runtime/CallStack/JintCallStack.cs
@@ -61,6 +61,11 @@ internal sealed class JintCallStack
         Native.Function.LeafCallGuard.AssertNotInLeafCall("a nested call (JintCallStack.Push)");
 
         var item = new CallStackElement(function, expression, new CallStackExecutionContext(in executionContext));
+        return Push(in item);
+    }
+
+    private int Push(in CallStackElement item)
+    {
         _stack.Push(in item);
         if (_statistics is not null)
         {
@@ -82,6 +87,11 @@ internal sealed class JintCallStack
         return -1;
     }
 
+    internal void RestoreTop(in CallStackElement item)
+    {
+        Push(in item);
+    }
+
     public CallStackElement Pop()
     {
         var item = _stack.Pop();
@@ -98,6 +108,13 @@ internal sealed class JintCallStack
         }
 
         return item;
+    }
+
+    public int ReplaceTop(Function function, JintExpression? expression)
+    {
+        var previous = Pop();
+        var replacement = new CallStackElement(function, expression, in previous.CallingExecutionContext);
+        return Push(in replacement);
     }
 
     public bool TryPeek([NotNullWhen(true)] out CallStackElement item)

--- a/Jint/Runtime/CallStack/JintCallStack.cs
+++ b/Jint/Runtime/CallStack/JintCallStack.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Jint.Collections;
 using Jint.Native.Function;
@@ -124,7 +125,8 @@ internal sealed class JintCallStack
 
     public void ReplaceTop(Function function, JintExpression? expression)
     {
-        var previous = _stack.Pop();
+        ref var top = ref _stack._array[_stack._size - 1];
+        var previous = top;
         var replacement = new CallStackElement(function, expression, in previous.CallingExecutionContext);
 
         if (_statistics is not null && !CallStackElementComparer.Instance.Equals(previous, replacement))
@@ -148,8 +150,12 @@ internal sealed class JintCallStack
             }
         }
 
-        _stack.Push(in replacement);
+        top = replacement;
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal bool TopIs(Function function)
+        => _stack._size > 0 && ReferenceEquals(_stack._array[_stack._size - 1].Function, function);
 
     internal int GetRecursionDepth(Function function)
     {

--- a/Jint/Runtime/InternalTypes.cs
+++ b/Jint/Runtime/InternalTypes.cs
@@ -105,7 +105,11 @@ internal enum InternalTypes
     // (Function and StringInstance do), which suppresses this flag at derivation. Derived in
     // InitializeBuiltinShape, cleared on deopt, and only meaningful while BuiltinShapeMode is set.
     BuiltinShapeIndexAuthoritative = 33554432,
+    // Internal trampoline payload. Deliberately neither Undefined nor any other ECMAScript type:
+    // if a tail request escapes its completion-only path, ordinary value operations must fail
+    // rather than silently observing a pooled request as `undefined`.
+    TailCall = 67108864,
 
     Primitive = Boolean | String | Number | Integer | BigInt | Symbol,
-    InternalFlags = ObjectEnvironmentRecord | RequiresCloning | PlainObject | Array | Module | IsHTMLDDA | ShapeMode | ShapeBuilding | ExoticGet | BuiltinShapeMode | Callable | Function | OrdinaryGet | OwnValueHook | HasLazySlots | BuiltinShapeIndexAuthoritative
+    InternalFlags = ObjectEnvironmentRecord | RequiresCloning | PlainObject | Array | Module | IsHTMLDDA | ShapeMode | ShapeBuilding | ExoticGet | BuiltinShapeMode | Callable | Function | OrdinaryGet | OwnValueHook | HasLazySlots | BuiltinShapeIndexAuthoritative | TailCall
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -316,8 +316,14 @@ internal sealed class JintCallExpression : JintExpression
                 engine._referencePool.Return(referenceRecord);
             }
 
+            var tailTarget = (ScriptFunction) func;
+            if (_regLaneEligible && !ReferenceEquals(tailTarget, _regProbedCallee))
+            {
+                ProbeRegisterCallee(engine, tailTarget);
+            }
+
             return engine.RentTailCallRequest(
-                (ScriptFunction) func,
+                tailTarget,
                 thisObject,
                 arguments,
                 rented,

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -116,10 +116,7 @@ internal sealed class JintCallExpression : JintExpression
         // balance their context push/pop), so capture it once and probe the reference instead
         // of re-reading the execution context after every sub-expression.
         var suspendable = engine.ExecutionContext.Suspendable;
-        var tailPosition = _isTailPosition
-            && engine.ExecutionContext.Strict
-            && suspendable is null
-            && !engine._isDebugMode;
+        var tailPosition = ScriptFunction.CanPrepareTailCall(context, _isTailPosition);
 
         object reference;
         Reference? referenceRecord;
@@ -245,7 +242,6 @@ internal sealed class JintCallExpression : JintExpression
         // are excluded because argument evaluation there must go through ExpressionCache's resume
         // buffer rather than straight into locals.
         if (_fastArgsEligible
-            && !tailCall
             && suspendable is null
             && ReferenceEquals(func, _fastCallee)
             && _fastShape.Supported
@@ -280,9 +276,9 @@ internal sealed class JintCallExpression : JintExpression
         // still differ between two evaluations of the same node (argument evaluation there must go
         // through ExpressionCache's resume buffer rather than straight into locals), so they stay a
         // runtime test — second, because it can only exclude a site the compare already accepted.
-        if (!tailCall && ReferenceEquals(func, _regCallee) && suspendable is null)
+        if (ReferenceEquals(func, _regCallee) && suspendable is null)
         {
-            return RegisterLaneCall(context, engine, Unsafe.As<ScriptFunction>(func), thisObject, referenceRecord);
+            return RegisterLaneCall(context, engine, Unsafe.As<ScriptFunction>(func), thisObject, referenceRecord, tailCall);
         }
 
         var arguments = this._arguments.ArgumentListEvaluation(context, this, out var rented);
@@ -320,7 +316,7 @@ internal sealed class JintCallExpression : JintExpression
                 engine._referencePool.Return(referenceRecord);
             }
 
-            return TailCallRequestPool.Rent(
+            return engine.RentTailCallRequest(
                 (ScriptFunction) func,
                 thisObject,
                 arguments,
@@ -354,10 +350,7 @@ internal sealed class JintCallExpression : JintExpression
             finally
             {
                 // if call stack was reset due to recursive call to engine or similar, we might not have it anymore
-                if (callStack.Count > 0)
-                {
-                    callStack.Pop();
-                }
+                callStack.TryPop(out _);
             }
 
             // Populate the fast-call cache after a successful dispatch, so the *next* evaluation of
@@ -467,7 +460,8 @@ internal sealed class JintCallExpression : JintExpression
         Engine engine,
         ScriptFunction target,
         JsValue thisObject,
-        Reference? referenceRecord)
+        Reference? referenceRecord,
+        bool tailCall)
     {
         var state = _regState!;
 
@@ -482,6 +476,20 @@ internal sealed class JintCallExpression : JintExpression
         if (referenceRecord is not null)
         {
             engine._referencePool.Return(referenceRecord);
+        }
+
+        if (tailCall)
+        {
+            return engine.RentTailCallRequest(
+                target,
+                thisObject,
+                arg0,
+                arg1,
+                arg2,
+                arg3,
+                _argCount,
+                state,
+                _calleeExpression);
         }
 
         var callStack = engine.CallStack;
@@ -508,10 +516,7 @@ internal sealed class JintCallExpression : JintExpression
         finally
         {
             // if call stack was reset due to recursive call to engine or similar, we might not have it anymore
-            if (callStack.Count > 0)
-            {
-                callStack.Pop();
-            }
+            callStack.TryPop(out _);
         }
     }
 
@@ -603,10 +608,7 @@ internal sealed class JintCallExpression : JintExpression
         }
         finally
         {
-            if (callStack.Count > 0)
-            {
-                callStack.Pop();
-            }
+            callStack.TryPop(out _);
         }
     }
 
@@ -711,10 +713,7 @@ internal sealed class JintCallExpression : JintExpression
         }
         finally
         {
-            if (callStack.Count > 0)
-            {
-                callStack.Pop();
-            }
+            callStack.TryPop(out _);
         }
     }
 

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -21,6 +21,7 @@ internal sealed class JintCallExpression : JintExpression
     // `_calleeMember` doubles as the already-narrowed receiver for the fast member-call lane.
     private readonly bool _calleeIsSuper;
     private readonly JintMemberExpression? _calleeMember;
+    private readonly bool _isTailPosition;
 
     // Monomorphic fast-call cache: the callee seen by the last evaluation plus its verdict for this
     // site's arity. Identity is what makes the verdict safe to reuse — re-assigning the property
@@ -87,6 +88,7 @@ internal sealed class JintCallExpression : JintExpression
         _calleeExpression = Build(expression.Callee);
         _calleeIsSuper = _calleeExpression._expression.Type == NodeType.Super;
         _calleeMember = _calleeExpression as JintMemberExpression;
+        _isTailPosition = ReferenceEquals(expression.UserData, TailCallMarker.Instance);
 
         _argCount = expression.Arguments.Count;
         _fastArgsEligible = !_arguments.HasSpreads && _argCount <= 2;
@@ -114,6 +116,10 @@ internal sealed class JintCallExpression : JintExpression
         // balance their context push/pop), so capture it once and probe the reference instead
         // of re-reading the execution context after every sub-expression.
         var suspendable = engine.ExecutionContext.Suspendable;
+        var tailPosition = _isTailPosition
+            && engine.ExecutionContext.Strict
+            && suspendable is null
+            && !engine._isDebugMode;
 
         object reference;
         Reference? referenceRecord;
@@ -231,12 +237,15 @@ internal sealed class JintCallExpression : JintExpression
             reference = calleeReference;
         }
 
+        var tailCall = tailPosition && func is ScriptFunction;
+
         // Fast-call lane. Gated on callee identity, so a re-assigned or shadowed built-in, a different
         // engine's instance, or any non-built-in callee simply misses and takes the path below.
         // Debug mode is excluded because the debugger walks the call stack, and generator/async frames
         // are excluded because argument evaluation there must go through ExpressionCache's resume
         // buffer rather than straight into locals.
         if (_fastArgsEligible
+            && !tailCall
             && suspendable is null
             && ReferenceEquals(func, _fastCallee)
             && _fastShape.Supported
@@ -271,12 +280,10 @@ internal sealed class JintCallExpression : JintExpression
         // still differ between two evaluations of the same node (argument evaluation there must go
         // through ExpressionCache's resume buffer rather than straight into locals), so they stay a
         // runtime test — second, because it can only exclude a site the compare already accepted.
-        if (ReferenceEquals(func, _regCallee) && suspendable is null)
+        if (!tailCall && ReferenceEquals(func, _regCallee) && suspendable is null)
         {
             return RegisterLaneCall(context, engine, Unsafe.As<ScriptFunction>(func), thisObject, referenceRecord);
         }
-
-        var tailCall = IsInTailPosition((CallExpression) _expression);
 
         var arguments = this._arguments.ArgumentListEvaluation(context, this, out var rented);
 
@@ -306,13 +313,22 @@ internal sealed class JintCallExpression : JintExpression
             ThrowReferenceNotFunction(referenceRecord, reference, engine);
         }
 
-        var callable = Unsafe.As<ICallable>(func);
-
         if (tailCall)
         {
-            // TODO tail call
-            // PrepareForTailCall();
+            if (referenceRecord is not null)
+            {
+                engine._referencePool.Return(referenceRecord);
+            }
+
+            return TailCallRequestPool.Rent(
+                (ScriptFunction) func,
+                thisObject,
+                arguments,
+                rented,
+                _calleeExpression);
         }
+
+        var callable = Unsafe.As<ICallable>(func);
 
         // ensure logic is in sync between Call, Construct and JintCallExpression!
 
@@ -331,7 +347,9 @@ internal sealed class JintCallExpression : JintExpression
 
             try
             {
-                result = functionInstance.Call(thisObject, arguments);
+                result = functionInstance is ScriptFunction scriptFunction
+                    ? scriptFunction.CallWithStackFrame(thisObject, arguments)
+                    : functionInstance.Call(thisObject, arguments);
             }
             finally
             {
@@ -477,7 +495,15 @@ internal sealed class JintCallExpression : JintExpression
 
         try
         {
-            return target.CallFromRegisters(thisObject, arg0, arg1, arg2, arg3, _argCount, state);
+            return target.CallFromRegisters(
+                thisObject,
+                arg0,
+                arg1,
+                arg2,
+                arg3,
+                _argCount,
+                state,
+                ownsFrame: true);
         }
         finally
         {
@@ -786,12 +812,13 @@ internal sealed class JintCallExpression : JintExpression
         return superConstructor;
     }
 
-    /// <summary>
-    /// https://tc39.es/ecma262/#sec-isintailposition
-    /// </summary>
-    private static bool IsInTailPosition(CallExpression call)
+}
+
+internal sealed class TailCallMarker
+{
+    internal static readonly TailCallMarker Instance = new();
+
+    private TailCallMarker()
     {
-        // TODO tail calls
-        return false;
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintTaggedTemplateExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintTaggedTemplateExpression.cs
@@ -106,13 +106,10 @@ internal sealed class JintTaggedTemplateExpression : JintExpression
 
         suspendable?.Data.Clear(this);
 
-        if (_isTailPosition
-            && engine.ExecutionContext.Strict
-            && suspendable is null
-            && !engine._isDebugMode
+        if (ScriptFunction.CanPrepareTailCall(context, _isTailPosition)
             && tagger is ScriptFunction tailTarget)
         {
-            return TailCallRequestPool.Rent(
+            return engine.RentTailCallRequest(
                 tailTarget,
                 thisObject,
                 args,

--- a/Jint/Runtime/Interpreter/Expressions/JintTaggedTemplateExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintTaggedTemplateExpression.cs
@@ -1,4 +1,5 @@
 using Jint.Native;
+using Jint.Native.Function;
 using Jint.Native.Object;
 using Jint.Runtime.Descriptors;
 using Environment = Jint.Runtime.Environments.Environment;
@@ -11,11 +12,13 @@ internal sealed class JintTaggedTemplateExpression : JintExpression
 
     private readonly JintExpression _tagIdentifier;
     private readonly JintTemplateLiteralExpression _quasi;
+    private readonly bool _isTailPosition;
 
     public JintTaggedTemplateExpression(TaggedTemplateExpression expression) : base(expression)
     {
         _tagIdentifier = Build(expression.Tag);
         _quasi = new JintTemplateLiteralExpression(expression.Quasi);
+        _isTailPosition = ReferenceEquals(expression.UserData, TailCallMarker.Instance);
     }
 
     protected override object EvaluateInternal(EvaluationContext context)
@@ -101,12 +104,30 @@ internal sealed class JintTaggedTemplateExpression : JintExpression
             }
         }
 
-        var result = tagger.Call(thisObject, args);
-
-        engine._jsValueArrayPool.ReturnArray(args);
         suspendable?.Data.Clear(this);
 
-        return result;
+        if (_isTailPosition
+            && engine.ExecutionContext.Strict
+            && suspendable is null
+            && !engine._isDebugMode
+            && tagger is ScriptFunction tailTarget)
+        {
+            return TailCallRequestPool.Rent(
+                tailTarget,
+                thisObject,
+                args,
+                argumentsRented: true,
+                _tagIdentifier);
+        }
+
+        try
+        {
+            return tagger.Call(thisObject, args);
+        }
+        finally
+        {
+            engine._jsValueArrayPool.ReturnArray(args);
+        }
     }
 
     /// <summary>

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using System.Threading;
 using Jint.Native;
 using Jint.Native.Function;
 using Jint.Native.AsyncFunction;
@@ -383,8 +384,22 @@ internal sealed class JintFunctionDefinition
         var stateOrFullSourceText = node.UserData;
         if (stateOrFullSourceText is not State state)
         {
-            node.UserData = state = BuildState(Function, stateOrFullSourceText as string);
+            lock (node)
+            {
+                stateOrFullSourceText = node.UserData;
+                if (stateOrFullSourceText is not State initializedState)
+                {
+                    initializedState = BuildState(Function, stateOrFullSourceText as string);
+                    Thread.MemoryBarrier();
+                    node.UserData = initializedState;
+                }
+
+                state = initializedState;
+            }
         }
+
+        // Pair with the release barrier above so a shared AST never exposes a partially built State.
+        Thread.MemoryBarrier();
         return state;
     }
 
@@ -495,6 +510,9 @@ internal sealed class JintFunctionDefinition
         /// </summary>
         public bool SupportsRegisterCall;
 
+        // Release/acquire publication for the tail markers stored on child AST nodes.
+        public int TailCallMarkersInitialized;
+
         public bool EnvironmentMayEscape;
         // True when the function body contains a direct call to itself by name. Tight recursion
         // (e.g. fib/ack/tak) keeps several frames live at once, which a single-slot per-call reuse cache
@@ -548,7 +566,6 @@ internal sealed class JintFunctionDefinition
     {
         var state = new State();
 
-        TailCallAstVisitor.Mark(function.Body);
         ProcessParameters(function, state, out var hasArguments);
 
         var strict = function.IsStrict();
@@ -887,6 +904,26 @@ internal sealed class JintFunctionDefinition
         return state;
     }
 
+    internal void EnsureTailCallMarkers(State state, bool strict)
+    {
+        if (!strict
+            || Function.Generator
+            || Function.Async
+            || Volatile.Read(ref state.TailCallMarkersInitialized) != 0)
+        {
+            return;
+        }
+
+        lock ((Node) Function)
+        {
+            if (state.TailCallMarkersInitialized == 0)
+            {
+                TailCallAstVisitor.Mark(Function.Body);
+                Volatile.Write(ref state.TailCallMarkersInitialized, 1);
+            }
+        }
+    }
+
     /// <summary>
     /// https://tc39.es/ecma262/#sec-isintailposition
     /// <para>
@@ -923,7 +960,19 @@ internal sealed class JintFunctionDefinition
                 return;
             }
 
-            blockedByCleanup |= HasUsingDeclaration(node);
+            if (node is BlockStatement block)
+            {
+                var precedingUsing = blockedByCleanup;
+                foreach (var statement in block.Body)
+                {
+                    MarkReturns(statement, precedingUsing);
+                    precedingUsing |= statement is VariableDeclaration
+                    {
+                        Kind: VariableDeclarationKind.Using or VariableDeclarationKind.AwaitUsing
+                    };
+                }
+                return;
+            }
 
             if (node is TryStatement tryStatement)
             {
@@ -949,19 +998,6 @@ internal sealed class JintFunctionDefinition
             {
                 MarkReturns(child, blockedByCleanup);
             }
-        }
-
-        private static bool HasUsingDeclaration(Node node)
-        {
-            foreach (var child in node.ChildNodes)
-            {
-                if (child is VariableDeclaration { Kind: VariableDeclarationKind.Using or VariableDeclarationKind.AwaitUsing })
-                {
-                    return true;
-                }
-            }
-
-            return false;
         }
 
         private static void MarkTailExpression(Expression expression)

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -548,6 +548,7 @@ internal sealed class JintFunctionDefinition
     {
         var state = new State();
 
+        TailCallAstVisitor.Mark(function.Body);
         ProcessParameters(function, state, out var hasArguments);
 
         var strict = function.IsStrict();
@@ -884,6 +885,115 @@ internal sealed class JintFunctionDefinition
         state.SourceText = new SourceText(fullSourceText);
 
         return state;
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-isintailposition
+    /// <para>
+    /// Marks the call expressions for which EvaluateCall performs PrepareForTailCall.
+    /// The marker is immutable AST metadata, so prepared functions can share it across engines.
+    /// </para>
+    /// </summary>
+    private static class TailCallAstVisitor
+    {
+        public static void Mark(Node body)
+        {
+            if (body is Expression expression)
+            {
+                MarkTailExpression(expression);
+                return;
+            }
+
+            MarkReturns(body, blockedByCleanup: false);
+        }
+
+        private static void MarkReturns(Node node, bool blockedByCleanup)
+        {
+            if (node is IFunction)
+            {
+                return;
+            }
+
+            if (node is ReturnStatement returnStatement)
+            {
+                if (!blockedByCleanup && returnStatement.Argument is not null)
+                {
+                    MarkTailExpression(returnStatement.Argument);
+                }
+                return;
+            }
+
+            blockedByCleanup |= HasUsingDeclaration(node);
+
+            if (node is TryStatement tryStatement)
+            {
+                var hasFinalizer = tryStatement.Finalizer is not null;
+                MarkReturns(tryStatement.Block, blockedByCleanup || hasFinalizer || tryStatement.Handler is not null);
+                if (tryStatement.Handler is not null)
+                {
+                    MarkReturns(tryStatement.Handler.Body, blockedByCleanup || hasFinalizer);
+                }
+                if (tryStatement.Finalizer is not null)
+                {
+                    MarkReturns(tryStatement.Finalizer, blockedByCleanup);
+                }
+                return;
+            }
+
+            if (node is ForOfStatement)
+            {
+                blockedByCleanup = true;
+            }
+
+            foreach (var child in node.ChildNodes)
+            {
+                MarkReturns(child, blockedByCleanup);
+            }
+        }
+
+        private static bool HasUsingDeclaration(Node node)
+        {
+            foreach (var child in node.ChildNodes)
+            {
+                if (child is VariableDeclaration { Kind: VariableDeclarationKind.Using or VariableDeclarationKind.AwaitUsing })
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static void MarkTailExpression(Expression expression)
+        {
+            switch (expression)
+            {
+                case CallExpression call:
+                    call.UserData = TailCallMarker.Instance;
+                    break;
+
+                case TaggedTemplateExpression taggedTemplate:
+                    taggedTemplate.UserData = TailCallMarker.Instance;
+                    break;
+
+                case ChainExpression chain:
+                    MarkTailExpression(chain.Expression);
+                    break;
+
+                case ConditionalExpression conditional:
+                    MarkTailExpression(conditional.Consequent);
+                    MarkTailExpression(conditional.Alternate);
+                    break;
+
+                case LogicalExpression logical:
+                    MarkTailExpression(logical.Right);
+                    break;
+
+                case SequenceExpression sequence when sequence.Expressions.Count > 0:
+                    MarkTailExpression(sequence.Expressions[^1]);
+                    break;
+            }
+        }
     }
 
     /// <summary>

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -398,8 +398,6 @@ internal sealed class JintFunctionDefinition
             }
         }
 
-        // Pair with the release barrier above so a shared AST never exposes a partially built State.
-        Thread.MemoryBarrier();
         return state;
     }
 
@@ -904,21 +902,27 @@ internal sealed class JintFunctionDefinition
         return state;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal void EnsureTailCallMarkers(State state, bool strict)
     {
-        if (!strict
-            || Function.Generator
-            || Function.Async
-            || Volatile.Read(ref state.TailCallMarkersInitialized) != 0)
+        if (state.TailCallMarkersInitialized == 0 && strict)
         {
-            return;
+            EnsureTailCallMarkersSlow(state);
         }
+    }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void EnsureTailCallMarkersSlow(State state)
+    {
         lock ((Node) Function)
         {
             if (state.TailCallMarkersInitialized == 0)
             {
-                TailCallAstVisitor.Mark(Function.Body);
+                if (!Function.Generator && !Function.Async)
+                {
+                    TailCallAstVisitor.Mark(Function.Body);
+                }
+
                 Volatile.Write(ref state.TailCallMarkersInitialized, 1);
             }
         }

--- a/Jint/Runtime/Throw.cs
+++ b/Jint/Runtime/Throw.cs
@@ -254,10 +254,15 @@ internal static class Throw
     }
 
     [DoesNotReturn]
-    public static void RecursionDepthOverflowException(JintCallStack currentStack)
+    public static void RecursionDepthOverflowException(JintCallStack currentStack, bool preserveTop = false)
     {
-        var currentExpressionReference = currentStack.Pop().ToString();
-        throw new RecursionDepthOverflowException(currentStack, currentExpressionReference);
+        var current = currentStack.Pop();
+        var exception = new RecursionDepthOverflowException(currentStack, current.ToString());
+        if (preserveTop)
+        {
+            currentStack.RestoreTop(in current);
+        }
+        throw exception;
     }
 
     [DoesNotReturn]

--- a/README.md
+++ b/README.md
@@ -45,10 +45,13 @@ and many more.
 - ✔ Reflect
 - ✔ Proxies
 - ✔ Symbols
-- ❌ Tail calls
+- ✔ Proper tail calls in strict functions
 - ✔ Typed arrays
 - ✔ Unicode
 - ✔ Weakmap and Weakset
+
+Proper tail calls replace the calling strict-function frame, as required by ECMAScript. Consequently,
+intermediate tail callers are intentionally absent from `error.stack` and host stack telemetry.
 
 #### ECMAScript 2016
 


### PR DESCRIPTION
ECMAScript requires proper tail calls in strict code, but Jint previously let eligible recursive calls grow the .NET and JavaScript call stacks until the recursion limit was reached. This adds stack-safe interpreted tail calls and enables the corresponding Test262 feature coverage.

## Implementation

- Mark call and tagged-template expressions in spec-defined tail positions for strict synchronous functions, with release/acquire publication when prepared ASTs are shared across engines.
- Transfer eligible interpreted calls through a per-engine reusable request and trampoline after the caller execution context has unwound.
- Preserve the register-argument dispatch lane for warmed strict tail sites and replace owned JavaScript frames in place.
- Keep `LimitRecursion` effective for direct, mutual, and multi-function tail cycles without counting one-way delegation between distinct functions as recursion.
- Process `using` declarations in source order so only preceding resources block a tail transfer; retain ordinary calls where `catch`/`finally`, iterator closing, or resource disposal still has deferred work.
- Preserve constructor, frameless callback, host invocation, proxy/bound constructor, `super()`, async, generator, and debugger behavior.
- Give internal tail requests a distinct fail-fast value type so a missed trampoline path cannot masquerade as JavaScript `undefined`.

Proper tail calls intentionally replace intermediate strict-function frames. Those callers are therefore absent from `error.stack` and host stack telemetry, as required by ECMAScript.

## Examples

Deep accumulator recursion can now run without growing the call stack:

```js
"use strict";

function sumTo(n, total = 0) {
    return n === 0 ? total : sumTo(n - 1, total + n);
}

sumTo(100_000);
```

Mutually recursive state machines benefit as well:

```js
"use strict";

function isEven(n) {
    return n === 0 || isOdd(n - 1);
}

function isOdd(n) {
    return n !== 0 && isEven(n - 1);
}

isEven(100_000);
```

Fibonacci benefits when expressed in tail-recursive accumulator form:

```js
"use strict";

function fibonacciModulo(n, current = 0, next = 1) {
    return n === 0
        ? current
        : fibonacciModulo(n - 1, next, (current + next) % 1_000_000_007);
}

fibonacciModulo(100_000);
```

Classic `fibonacci(n - 1) + fibonacci(n - 2)` remains non-tail-recursive because addition must occur after both calls return. Automatically rewriting that form would require a different algorithm or an explicit work stack, rather than proper tail-call elimination.

## Validation

- 4,998 Jint tests passed, 4 skipped; 1,466 public-interface tests passed, 9 skipped.
- All 35 Test262 `tail-call-optimization` tests passed.
- Release solution build passed for all target frameworks with no warnings.
- Default BenchmarkDotNet jobs measured direct tail recursion at 2.16x faster with 85% less allocation, and mutual tail recursion at 1.94x faster with 99.9% less allocation.
- Added a portable depth-500 tail benchmark plus a shallow strict-delegation benchmark that covers both ordinary and recursion-limit-enabled dispatch; both delegation rows remain allocation-neutral at 296 B per 10,000 calls.
- The 12-script engine comparison suite and non-tail recursion/call controls showed no reproducible regression.