### PR TITLE
Stop pure extension methods from shadowing Array.prototype natives

### DIFF
--- a/Jint.Tests/Runtime/ExtensionMethods/ExtensionMethodShadowingTests.cs
+++ b/Jint.Tests/Runtime/ExtensionMethods/ExtensionMethodShadowingTests.cs
@@ -1,0 +1,142 @@
+using Jint.Native;
+
+namespace Jint.Tests.Runtime.ExtensionMethods;
+
+/// <summary>
+/// A member that resolves purely to registered extension methods must not shadow a same-named
+/// Array.prototype native on an indexed array-like wrapper (https://github.com/sebastienros/jint/issues/2976).
+/// Real CLR instance members keep beating the prototype, and extension methods keep winning on
+/// receivers the index-driven natives cannot serve.
+/// </summary>
+public class ExtensionMethodShadowingTests
+{
+    private static Engine CreateEngine(Action<Options> configure = null)
+    {
+        return new Engine(options =>
+        {
+            options.AddExtensionMethods(typeof(ShadowingMapExtensions));
+            configure?.Invoke(options);
+        });
+    }
+
+    [Theory]
+    [InlineData(ArrayConversionMode.LiveView)]
+    [InlineData(ArrayConversionMode.Copy)]
+    public void ArrayPrototypeMapWinsOverExtensionOnWrappedArray(ArrayConversionMode mode)
+    {
+        var engine = CreateEngine(options => options.Interop.ArrayConversion = mode);
+        engine.SetValue("coll", new[] { "Hello", "World" });
+
+        engine.Evaluate("Array.isArray(coll.map(x => x))").AsBoolean().Should().BeTrue();
+        engine.Evaluate("coll.map(x => x).includes('Hello')").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ArrayPrototypeMapWinsOverExtensionOnWrappedList()
+    {
+        var engine = CreateEngine();
+        engine.SetValue("coll", new List<string> { "Hello", "World" });
+
+        engine.Evaluate("Array.isArray(coll.map(x => x))").AsBoolean().Should().BeTrue();
+        engine.Evaluate("coll.map(x => x).includes('Hello')").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ExtensionMethodStillReachableThroughItsClrCasing()
+    {
+        var engine = CreateEngine();
+        engine.SetValue("coll", new List<string> { "Hello", "World" });
+
+        // 'Map' has no exact-cased counterpart among Array.prototype's own keys, so the extension
+        // method binds; its result is a wrapped lazy enumerable, not a JS array
+        engine.Evaluate("Array.isArray(coll.Map(x => x))").AsBoolean().Should().BeFalse();
+        engine.Evaluate("typeof coll.Map(x => x).includes").AsString().Should().Be("undefined");
+        engine.Evaluate("Array.from(coll.Map(x => x + '!')).join()").AsString().Should().Be("Hello!,World!");
+    }
+
+    [Fact]
+    public void ExtensionMethodStillAppliesToPlainEnumerable()
+    {
+        var engine = CreateEngine();
+        IEnumerable<string> lazy = new List<string> { "Hello", "World" }.Where(x => x.Length > 0);
+        engine.SetValue("coll", lazy);
+
+        // no Array.prototype here, the extension method is the only provider of 'map'
+        engine.Evaluate("typeof coll.map").AsString().Should().Be("function");
+        engine.Evaluate("Array.from(coll.map(x => x + '!')).join()").AsString().Should().Be("Hello!,World!");
+    }
+
+    [Fact]
+    public void ExtensionMethodStillAppliesToNonIndexableArrayLike()
+    {
+        var engine = CreateEngine();
+        engine.SetValue("coll", new HashSet<string> { "Hello", "World" });
+
+        // HashSet<T> is array-like enough to carry Array.prototype (it has a Count), but it has
+        // no indexer for the native map to read - the registered extension must keep winning here
+        engine.Evaluate("Object.getPrototypeOf(coll) === Array.prototype").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Array.isArray(coll.map(x => x))").AsBoolean().Should().BeFalse();
+        engine.Evaluate("Array.from(coll.map(x => x + '!')).sort().join()").AsString().Should().Be("Hello!,World!");
+    }
+
+    [Fact]
+    public void ClrInstanceMethodStillWinsWhenMixedWithExtensions()
+    {
+        var engine = new Engine(options => options.AddExtensionMethods(typeof(Enumerable)));
+        var list = new List<int> { 1, 2, 3 };
+        engine.SetValue("list", list);
+
+        // List<T>.Reverse is a real instance method and Enumerable.Reverse a registered extension;
+        // a mixed candidate set keeps CLR-first behavior: void return (null), reversal in place
+        engine.Evaluate("list.reverse()").Should().Be(JsValue.Null);
+        list.Should().Equal(3, 2, 1);
+    }
+
+    [Fact]
+    public void DeferredNameIsInheritedNotOwn()
+    {
+        var engine = CreateEngine();
+        engine.SetValue("coll", new List<string> { "Hello", "World" });
+
+        engine.Evaluate("coll.hasOwnProperty('map')").AsBoolean().Should().BeFalse();
+        engine.Evaluate("'map' in coll").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.keys(coll).every(x => !isNaN(parseInt(x)))").AsBoolean().Should().BeTrue();
+
+        // sloppy-mode assignment does not shadow the deferred native
+        engine.Evaluate("coll.map = function() { return 1; }; Array.isArray(coll.map(x => x))").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void PreferJsPrototypeMethodsUnaffected()
+    {
+        var engine = new Engine(options =>
+        {
+            options.AddExtensionMethods(typeof(Enumerable));
+            options.Interop.PreferJsPrototypeMethods = true;
+        });
+        engine.SetValue("list", new List<int> { 1, 2, 3 });
+
+        engine.Evaluate("list.reverse() === list").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void LinqChainWorksUnderLiveViewDefault()
+    {
+        var engine = new Engine(options => options.AddExtensionMethods(typeof(Enumerable)));
+        engine.SetValue("stringList", new List<string> { "working", "linq" });
+
+        // the ToArray() result is a live array wrapper whose pure-extension 'Enumerable.Join'
+        // candidate defers to native Array.prototype.join
+        var result = engine.Evaluate("stringList.Select((x) => x + 'a').ToArray().join()").AsString();
+        result.Should().Be("workinga,linqa");
+    }
+}
+
+public static class ShadowingMapExtensions
+{
+    // mirrors the lower-case registration from https://github.com/sebastienros/jint/issues/2976
+    public static IEnumerable<TResult> map<T, TResult>(this IEnumerable<T> enumerable, Func<T, TResult> selector)
+    {
+        return enumerable.Select(selector);
+    }
+}

--- a/Jint.Tests/Runtime/ExtensionMethods/ExtensionMethodsTest.cs
+++ b/Jint.Tests/Runtime/ExtensionMethods/ExtensionMethodsTest.cs
@@ -153,11 +153,9 @@ public class ExtensionMethodsTest
     [Fact]
     public void LinqExtensionMethodWithMultipleGenericParameters()
     {
-        // Pin Copy: '.ToArray()' returns a CLR string[], and under the LiveView default the resulting
-        // wrapper's target (string[] : IEnumerable<string>) makes the '.join()' call resolve to the CLR
-        // 'Enumerable.Join' extension method attached to the type rather than falling back to native
-        // 'Array.prototype.join'. Copy produces a native JsArray whose 'join' is the prototype method.
-        // (Under LiveView the equivalent works with Options.Interop.PreferJsPrototypeMethods = true.)
+        // Copy produces a native JsArray whose 'join' is the prototype method. The LiveView default
+        // works too since #2976: the wrapper's pure-extension 'Enumerable.Join' candidate defers to
+        // native 'Array.prototype.join' - ExtensionMethodShadowingTests covers that flavor.
         var engine = GetLinqEngine(opts => opts.Interop.ArrayConversion = ArrayConversionMode.Copy);
         var stringList = new List<string>() { "working", "linq" };
         engine.SetValue("stringList", stringList);

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -564,6 +564,11 @@ public class Options
         /// <c>Array.prototype.reverse</c> returns the array. Has no effect when no JS prototype is attached
         /// (i.e. <see cref="AttachArrayPrototype"/> is false or the wrapped type is not array-like). Defaults to false for backward compatibility.
         /// </summary>
+        /// <remarks>
+        /// A member that resolves purely to registered extension methods (see <see cref="OptionsExtensions.AddExtensionMethods"/>)
+        /// already defers to a same-named <c>Array.prototype</c> method on indexed array-like wrappers by default;
+        /// this option additionally makes real CLR instance methods defer.
+        /// </remarks>
         public bool PreferJsPrototypeMethods { get; set; }
 
         /// <summary>

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 using Jint.Native;
+using Jint.Native.Array;
 using Jint.Native.Iterator;
 using Jint.Native.Object;
 using Jint.Native.Symbol;
@@ -932,6 +933,28 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
                 }
             }
         }
+
+        // A member resolving purely to registered extension methods must not shadow a same-named
+        // Array.prototype native on an indexed array-like view (#2976): return Undefined WITHOUT
+        // caching, so the outer Get falls through to the attached prototype and a later mutation of
+        // Array.prototype stays observable. The probe is an exact-case own-property read on the
+        // prototype itself - a chain Get would also see the extension attachments living on
+        // Object.prototype and defer names like Sum that Array.prototype never carried. The type
+        // tests keep non-indexed array-likes (e.g. HashSet<T>), whose elements the index-driven
+        // natives cannot see, and replaced prototypes on today's extension-first behavior.
+        if (!isDictionary
+            && accessor is MethodAccessor { AllExtensionMethods: true }
+            && this is ArrayLikeWrapper
+            && _prototype is ArrayPrototype arrayPrototype)
+        {
+            var protoDesc = arrayPrototype.GetOwnProperty(property);
+            if (!ReferenceEquals(protoDesc, PropertyDescriptor.Undefined)
+                && protoDesc.Value is { IsCallable: true })
+            {
+                return PropertyDescriptor.Undefined;
+            }
+        }
+
         var descriptor = accessor.CreatePropertyDescriptor(_engine, Target, member, enumerable: !isDictionary);
         if (!isDictionary
             && !ReferenceEquals(descriptor, PropertyDescriptor.Undefined)

--- a/Jint/Runtime/Interop/Reflection/MethodAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/MethodAccessor.cs
@@ -11,7 +11,25 @@ internal sealed class MethodAccessor : ReflectionAccessor
     {
         _targetType = targetType;
         _methods = methods;
+
+        var allExtensionMethods = methods.Length > 0;
+        foreach (var method in methods)
+        {
+            if (!method.IsExtensionMethod)
+            {
+                allExtensionMethods = false;
+                break;
+            }
+        }
+        AllExtensionMethods = allExtensionMethods;
     }
+
+    /// <summary>
+    /// Whether every candidate is a registered extension method, i.e. the member is not a real
+    /// member of the target type. Derived from the descriptors alone, so instances served from
+    /// the shared accessor cache answer identically for every engine.
+    /// </summary>
+    public bool AllExtensionMethods { get; }
 
     public override bool Writable => false;
 


### PR DESCRIPTION
Fixes #2976.

## Root cause

The reported break needs a registered extension method whose name collides with an `Array.prototype` method — the issue's `map<T,TResult>(this IEnumerable<T>, Func<T,TResult>)`.

- **`string[]` receiver — the actual 4.13 → 4.14 regression.** Under 4.13's `ArrayConversion=Copy` a CLR array crossed into script as a real `JsArray`; extension methods can never shadow a native array, so `Array.prototype.map` ran and the chain worked. The 4.14 `LiveView` default (#2728) keeps the array as a live wrapper, and `ObjectWrapper` resolves registered extension methods as own members ahead of the prototype — so the extension `map` shadowed the native. Its return value (a lazy `Select` iterator; `TResult` is uninferrable from a JS lambda, so the declared return type is `IEnumerable<object>`) wraps as a plain `ObjectWrapper` with `Object.prototype`: no `includes`, hence `Property 'includes' of object is not a function`.
- **`List<string>` receiver — the issue's literal repro** — fails identically on 4.13.0 as well (list wrappers and extension-first resolution predate 4.14); verified by running the repro against the 4.13.0/4.14.0/4.15.3 packages. Same shape, so this PR fixes both flavors.

## The fix

A member of an **indexed array-like wrapper** (`ArrayLikeWrapper`: `T[]`, `IList<T>`, `IReadOnlyList<T>`, `IList`) that resolves **purely to registered extension methods** — no real CLR instance member — now defers to a same-named callable among `Array.prototype`'s own properties. `ObjectWrapper.GetOwnProperty` returns `Undefined` for it, without caching, and the read falls through to the attached prototype.

Scoping decisions that keep the blast radius small:

- **Exact-case own-property probe on `Array.prototype`**, never a chain `Get`: the `AttachExtensionMethodsToPrototypes` path parks generic LINQ methods on `Object.prototype` (via `ExpandoObject`'s `IEnumerable<>`), which `Array.prototype` inherits — a chain probe would wrongly defer `intList.Sum()`. PascalCase C# names (`Sum`, `Select`, `ToArray`) never collide with `Array.prototype`'s own keys, which also means **the extension stays reachable through its exact C# casing** (`coll.Map(...)`).
- **`_prototype is ArrayPrototype` type test**, realm-agnostic and robust against `Object.setPrototypeOf`; dispatch afterwards goes to the very object that was probed.
- **`ArrayLikeWrapper` receivers only**: plain `ObjectWrapper` also attaches `Array.prototype` to non-indexed array-likes (`HashSet<T>`, `IReadOnlyCollection<T>`-only views) whose elements the index-driven natives cannot see — those keep the extension method, which is the reason hosts register one in the first place.
- **Mixed candidate sets are untouched**: a name that also matches a real instance method (`list.reverse()` with `Enumerable` registered) keeps today's CLR-first behavior, so `ListReverseDefaultsToClrSemantics` and friends hold. `PreferJsPrototypeMethods` remains the opt-in for making instance methods defer too, and its guard subsumes the new rule when enabled.
- **No caching of the deferral** keeps `hasOwnProperty('map')` false / `'map' in coll` true coherent and keeps later `Array.prototype` mutation observable. The cost class equals what natives on wrappers already pay (a prototype-resolved name was never cached either); the probe is a stored-descriptor hit on the builtin-shaped prototype after first materialization. Hosts without registered extension methods see zero change — `AllExtensionMethods` can only be true when registrations exist.

No new public API and no new option.

## Verification

- New `ExtensionMethodShadowingTests`: both issue flavors under LiveView and Copy, C#-casing escape hatch, plain-enumerable and `HashSet<T>` receivers keeping the extension, mixed-candidate CLR-first pin, own/inherited coherence, `PreferJsPrototypeMethods` interplay, and the LINQ `.Select(...).ToArray().join()` chain now passing under the LiveView default with no pin.
- Full suites green on net10.0 + net472: `Jint.Tests` (5124/5043), `Jint.Tests.PublicInterface` (1473/1472) — both also with `JINT_HOST_CONTRACT_VERIFICATION=1` — `Jint.Tests.CommonScripts`, and Test262 (99,738 passed, 0 failed).
- The issue's console repro run against this branch prints `true` for both `List<string>` and `string[]`.
- Not benchmark-gated: the only hot-path addition is one type test on the reflective member-resolution slow path, and it is reachable only when the host registered extension methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
