### PR TITLE
Let the cheapest builtin calls run frameless

### DIFF
--- a/Jint.Benchmark/FastCallLaneBenchmarks.cs
+++ b/Jint.Benchmark/FastCallLaneBenchmarks.cs
@@ -1,4 +1,4 @@
-using BenchmarkDotNet.Attributes;
+﻿using BenchmarkDotNet.Attributes;
 using Jint.Native;
 
 namespace Jint.Benchmark;
@@ -59,6 +59,18 @@ namespace Jint.Benchmark;
 /// <c>Substring_Object</c> is flat to better. Conforming arguments win roughly −5%, and the variadic
 /// rows −12..−22%. If a future change makes an object argument materially worse than this, that is a
 /// regression; the single-digit standing cost is the trade.</para>
+///
+/// <para><b>Predicates and searches.</b> The third group covers the built-ins whose bodies are a type
+/// test or a search rather than a coercion. <c>Number.isInteger</c> and its siblings inspect the
+/// argument and never coerce it, so they are declared <c>FastCallGuard.AnyValue</c> and take the
+/// frameless branch for every value — which is why <c>NumberIsInteger_Object</c> is the one
+/// <c>*_Object</c> row in this class that is <em>not</em> a control: it is expected to improve with
+/// its guarded sibling, and it is here to show that a body which only inspects its argument costs an
+/// object nothing extra. Every other <c>*_Object</c> row is a control in the usual sense.
+/// <c>IsNaN_String</c> is included because the global pair's guard admits strings, where the
+/// String.prototype rows admit numbers, so it is the only row that exercises that arm.
+/// <c>ArrayIsArray_Object</c> is a true control twice over: the guard names our own arrays, so a
+/// plain object both fails it and is the answer-is-false case the frame still has to cover.</para>
 ///
 /// Every row runs its call 1000 times inside one prepared script on an engine that has already
 /// evaluated it, so what is measured is dispatch plus body rather than parse or first-call warmup —
@@ -148,6 +160,22 @@ public class FastCallLaneBenchmarks
         }
         """;
 
+    private IsolatedScript _numberIsIntegerNumber;
+    private IsolatedScript _numberIsIntegerObject;
+    private IsolatedScript _indexOfGuarded;
+    private IsolatedScript _indexOfObject;
+    private IsolatedScript _startsWithGuarded;
+    private IsolatedScript _includesGuarded;
+    private IsolatedScript _includesObject;
+    private IsolatedScript _atGuarded;
+    private IsolatedScript _substrGuarded;
+    private IsolatedScript _atObject;
+    private IsolatedScript _isNaNNumber;
+    private IsolatedScript _isNaNString;
+    private IsolatedScript _isNaNObject;
+    private IsolatedScript _isArrayArray;
+    private IsolatedScript _isArrayObject;
+
     [GlobalSetup]
     public void GlobalSetup()
     {
@@ -192,6 +220,26 @@ public class FastCallLaneBenchmarks
         // Controls: same shape and same register lane, frame never elided, untouched by this change.
         _weakMapHas = CollectionLoop("if (wm.has(objKeys[i & 1023])) { s++; }");
         _weakSetHas = CollectionLoop("if (ws.has(objKeys[i & 1023])) { s++; }");
+
+        // Predicates and searches. Number's four predicates share one shape, so isInteger stands for
+        // the group; its object row takes the lane too, unlike every other *_Object row here.
+        _numberIsIntegerNumber = Loop("if (Number.isInteger(i)) s++");
+        _numberIsIntegerObject = Loop("if (Number.isInteger(o)) s++", prelude: "var o = { valueOf: function () { return 3; } };");
+        _indexOfGuarded = Loop("s += \"abcdefghij\".indexOf(\"gh\", i % 5)");
+        _indexOfObject = Loop("s += \"abcdefghij\".indexOf(o)", prelude: "var o = { toString: function () { return \"gh\"; } };");
+        // startsWith stands beside includes because it reads the position register unconditionally
+        // where includes tests it for undefined first.
+        _startsWithGuarded = Loop("if (\"abcdefghij\".startsWith(\"cd\", i % 5)) s++");
+        _includesGuarded = Loop("if (\"abcdefghij\".includes(\"gh\", i % 5)) s++");
+        _includesObject = Loop("if (\"abcdefghij\".includes(o)) s++", prelude: "var o = { toString: function () { return \"gh\"; } };");
+        _atGuarded = Loop("s += \"abcdefghij\".at(i % 10).length");
+        _substrGuarded = Loop("s += \"abcdefghij\".substr(i % 5, 3).length");
+        _atObject = Loop("s += \"abcdefghij\".at(o).length", prelude: "var o = { valueOf: function () { return 3; } };");
+        _isNaNNumber = Loop("if (isNaN(i)) s++");
+        _isNaNString = Loop("if (isNaN(\"12\")) s++");
+        _isNaNObject = Loop("if (isNaN(o)) s++", prelude: "var o = { valueOf: function () { return 3; } };");
+        _isArrayArray = Loop("if (Array.isArray(a)) s++", prelude: "var a = [1, 2, 3];");
+        _isArrayObject = Loop("if (Array.isArray(o)) s++", prelude: "var o = { length: 3 };");
     }
 
     /// <summary>
@@ -259,4 +307,20 @@ public class FastCallLaneBenchmarks
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue SetAdd_Churn() => _setAddChurn.Run();
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue WeakMapHas_Framed() => _weakMapHas.Run();
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue WeakSetHas_Framed() => _weakSetHas.Run();
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue NumberIsInteger_Number() => _numberIsIntegerNumber.Run();
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue NumberIsInteger_Object() => _numberIsIntegerObject.Run();
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue StringIndexOf_Guarded() => _indexOfGuarded.Run();
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue StringIndexOf_Object() => _indexOfObject.Run();
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue StringStartsWith_Guarded() => _startsWithGuarded.Run();
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue StringIncludes_Guarded() => _includesGuarded.Run();
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue StringIncludes_Object() => _includesObject.Run();
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue StringAt_Guarded() => _atGuarded.Run();
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue StringSubstr_Guarded() => _substrGuarded.Run();
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue StringAt_Object() => _atObject.Run();
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue IsNaN_Number() => _isNaNNumber.Run();
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue IsNaN_String() => _isNaNString.Run();
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue IsNaN_Object() => _isNaNObject.Run();
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue ArrayIsArray_Array() => _isArrayArray.Run();
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)] public JsValue ArrayIsArray_Object() => _isArrayObject.Run();
 }

--- a/Jint.SourceGenerators/Attributes.cs
+++ b/Jint.SourceGenerators/Attributes.cs
@@ -1,4 +1,4 @@
-namespace Jint.SourceGenerators;
+﻿namespace Jint.SourceGenerators;
 
 internal static class Attributes
 {
@@ -109,7 +109,10 @@ internal static class Attributes
             /// <para>
             /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
             /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-            /// guard silently costs the lane every call site that omits the argument.
+            /// guard silently costs the lane every call site that omits the argument. Where the body
+            /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+            /// <c>false</c> for everything that is not already a number — declare
+            /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
             /// </para>
             /// <para>
             /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/ObjectGeneratorTests.cs
+++ b/Jint.Tests.SourceGenerators/ObjectGeneratorTests.cs
@@ -1259,6 +1259,12 @@ public class ObjectGeneratorTests
         // two-parameter method. A parameter that already derives a guard from its conversion ignores
         // a declared one — an explicit value must never be able to weaken a derived guard.
         //
+        // Unguarded is the declaration for a parameter that needs no precondition at all, because the
+        // body inspects the value instead of coercing it. It is the only guard that is not emitted:
+        // the runtime spells "every value satisfies this" and "there is nothing to test" the same
+        // way, as Any, so Unguarded lowers to Any and the difference survives only where it matters,
+        // in whether the generator accepts Leaf for a raw JsValue at all.
+        //
         // FastCallGuard is internal to Jint and this compilation is not on its InternalsVisibleTo
         // list, so the test declares its own — source wins over an inaccessible imported type, and
         // the values are what the generator reads back. They have to be the real ones: the guard
@@ -1281,6 +1287,7 @@ public class ObjectGeneratorTests
                     String = 8,
                     Number = 16 | 32,
                     Array = 16384,
+                    Unguarded = 1 << 29,
                     Date = 1 << 30,
                 }
             }
@@ -1302,6 +1309,9 @@ public class ObjectGeneratorTests
 
                 [JsFunction(Length = 1, Leaf = true, LeafArg0 = FastCallGuard.String)]
                 private static JsValue Derived(JsValue thisObject, [ToNumber] double x) => JsNumber.Create(x);
+
+                [JsFunction(Length = 1, Leaf = true, LeafArg0 = FastCallGuard.Unguarded)]
+                private static JsValue Inspected(JsValue thisObject, JsValue value) => value is JsNumber ? JsNumber.Create(1) : JsValue.Undefined;
 
                 protected override void Initialize() => CreateProperties_Generated();
             }

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterAndSetter#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterAndSetter#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterOnly#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterOnly#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorWrongArity_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorWrongArity_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ArgCountParameter#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ArgCountParameter#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.CoercedRestSpan#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.CoercedRestSpan#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.CoercedRestSpanTypeMismatch_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.CoercedRestSpanTypeMismatch_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConflictingAccessorFlags_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConflictingAccessorFlags_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConflictingConversionAttrs_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConflictingConversionAttrs_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConversionTypeMismatch_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConversionTypeMismatch_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.DuplicateIntrinsicReference_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.DuplicateIntrinsicReference_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.DuplicateThrower_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.DuplicateThrower_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallDeclaredArgumentGuards#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallDeclaredArgumentGuards#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallDeclaredArgumentGuards#Sample.Foo.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallDeclaredArgumentGuards#Sample.Foo.g.verified.cs
@@ -9,14 +9,16 @@ internal sealed partial class Foo
 {
     private static readonly global::Jint.Key __Key_charCodeAt = "charCodeAt";
     private static readonly global::Jint.Key __Key_derived = "derived";
+    private static readonly global::Jint.Key __Key_inspected = "inspected";
     private static readonly global::Jint.Key __Key_substring = "substring";
 
     /// <summary>Generated property registration. Call from <c>Initialize()</c>.</summary>
     private void CreateProperties_Generated()
     {
-        var properties = new global::Jint.Collections.StringDictionarySlim<global::Jint.Runtime.Descriptors.PropertyDescriptor>(3);
+        var properties = new global::Jint.Collections.StringDictionarySlim<global::Jint.Runtime.Descriptors.PropertyDescriptor>(4);
         properties.AddDangerous(__Key_charCodeAt, new global::Jint.Runtime.Descriptors.Specialized.LazyPropertyDescriptor<Foo>(this, static host => new __FooFunction(host, __FooFunction.Slot.CharCodeAt), global::Jint.Runtime.Descriptors.PropertyFlag.NonEnumerable));
         properties.AddDangerous(__Key_derived, new global::Jint.Runtime.Descriptors.Specialized.LazyPropertyDescriptor<Foo>(this, static host => new __FooFunction(host, __FooFunction.Slot.Derived), global::Jint.Runtime.Descriptors.PropertyFlag.NonEnumerable));
+        properties.AddDangerous(__Key_inspected, new global::Jint.Runtime.Descriptors.Specialized.LazyPropertyDescriptor<Foo>(this, static host => new __FooFunction(host, __FooFunction.Slot.Inspected), global::Jint.Runtime.Descriptors.PropertyFlag.NonEnumerable));
         properties.AddDangerous(__Key_substring, new global::Jint.Runtime.Descriptors.Specialized.LazyPropertyDescriptor<Foo>(this, static host => new __FooFunction(host, __FooFunction.Slot.Substring), global::Jint.Runtime.Descriptors.PropertyFlag.NonEnumerable));
         SetProperties(properties);
     }
@@ -27,6 +29,7 @@ internal sealed partial class Foo
         {
             CharCodeAt,
             Derived,
+            Inspected,
             Substring,
         }
 
@@ -48,6 +51,7 @@ internal sealed partial class Foo
             {
                 case Slot.CharCodeAt: return Foo.CharCodeAt(thisObject, global::Jint.Runtime.Arguments.At(arguments, 0));
                 case Slot.Derived: return Foo.Derived(thisObject, global::Jint.Runtime.TypeConverter.ToNumber(global::Jint.Runtime.Arguments.At(arguments, 0)));
+                case Slot.Inspected: return Foo.Inspected(thisObject, global::Jint.Runtime.Arguments.At(arguments, 0));
                 case Slot.Substring: return Foo.Substring(thisObject, global::Jint.Runtime.Arguments.At(arguments, 0), global::Jint.Runtime.Arguments.At(arguments, 1));
                 default: throw UnknownSlot(_slot);
             }
@@ -59,6 +63,7 @@ internal sealed partial class Foo
             {
                 case Slot.CharCodeAt: return global::Jint.Native.JsString.CachedCreate("charCodeAt");
                 case Slot.Derived: return global::Jint.Native.JsString.CachedCreate("derived");
+                case Slot.Inspected: return global::Jint.Native.JsString.CachedCreate("inspected");
                 case Slot.Substring: return global::Jint.Native.JsString.CachedCreate("substring");
                 default: throw UnknownSlot(slot);
             }
@@ -70,6 +75,7 @@ internal sealed partial class Foo
             {
                 case Slot.CharCodeAt: return 1;
                 case Slot.Derived: return 1;
+                case Slot.Inspected: return 1;
                 case Slot.Substring: return 2;
                 default: throw UnknownSlot(slot);
             }
@@ -84,6 +90,7 @@ internal sealed partial class Foo
             {
                 case Slot.CharCodeAt: return new global::Jint.Native.Function.FastCallShape(true, true, false, global::Jint.Native.Function.FastCallGuard.String, global::Jint.Native.Function.FastCallGuard.Number, global::Jint.Native.Function.FastCallGuard.Any);
                 case Slot.Derived: return new global::Jint.Native.Function.FastCallShape(true, true, false, global::Jint.Native.Function.FastCallGuard.Any, global::Jint.Native.Function.FastCallGuard.Number, global::Jint.Native.Function.FastCallGuard.Any);
+                case Slot.Inspected: return new global::Jint.Native.Function.FastCallShape(true, true, false, global::Jint.Native.Function.FastCallGuard.Any, global::Jint.Native.Function.FastCallGuard.Any, global::Jint.Native.Function.FastCallGuard.Any);
                 case Slot.Substring: return new global::Jint.Native.Function.FastCallShape(true, true, false, global::Jint.Native.Function.FastCallGuard.String, global::Jint.Native.Function.FastCallGuard.Number | global::Jint.Native.Function.FastCallGuard.Undefined, global::Jint.Native.Function.FastCallGuard.Number | global::Jint.Native.Function.FastCallGuard.Undefined);
                 default: return default;
             }
@@ -95,6 +102,7 @@ internal sealed partial class Foo
             {
                 case Slot.CharCodeAt: return Foo.CharCodeAt(thisObject, arg0);
                 case Slot.Derived: return Foo.Derived(thisObject, global::Jint.Runtime.TypeConverter.ToNumber(arg0));
+                case Slot.Inspected: return Foo.Inspected(thisObject, arg0);
                 case Slot.Substring: return Foo.Substring(thisObject, arg0, arg1);
                 default: return base.CallFast(thisObject, arg0, arg1);
             }

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallKeyedCollectionGuards#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallKeyedCollectionGuards#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallLanes#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallLanes#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallOnArgCount_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallOnArgCount_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallOnOverlongArity_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallOnOverlongArity_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallOnRawArguments_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallOnRawArguments_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallSingleSlot#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallSingleSlot#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallTypedReceiver#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallTypedReceiver#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallVariadicLanes#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallVariadicLanes#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallVariadicSingleSlot#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallVariadicSingleSlot#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FunctionCaptureField#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FunctionCaptureField#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.InstanceMethod#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.InstanceMethod#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntegerConversions#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntegerConversions#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntrinsicReference#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntrinsicReference#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntrinsicReferenceWithoutRealmField_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntrinsicReferenceWithoutRealmField_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.LeafOnUncoercedRest_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.LeafOnUncoercedRest_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.LeafOnUnguardableHazards_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.LeafOnUnguardableHazards_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.MinimalClass#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.MinimalClass#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.MissingRealmField_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.MissingRealmField_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.NotPartial_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.NotPartial_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.OverloadCollision_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.OverloadCollision_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.PassthroughArguments#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.PassthroughArguments#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.PropertyConstants#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.PropertyConstants#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RestParameter#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RestParameter#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RichConversions#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RichConversions#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ShapeAliasAndInstanceSlot#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ShapeAliasAndInstanceSlot#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ShapeFunctionCaptureField#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ShapeFunctionCaptureField#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ShapeIntrinsicReference#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ShapeIntrinsicReference#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ShapeSymbolAlias#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ShapeSymbolAlias#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ShapeThrowerAccessor#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ShapeThrowerAccessor#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.StringAliasSharesDescriptor#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.StringAliasSharesDescriptor#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolAccessorGetterOnly#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolAccessorGetterOnly#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolAlias#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolAlias#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolFunctionCaptureField#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolFunctionCaptureField#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolFunctionMethod#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolFunctionMethod#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolMember#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolMember#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToCallable#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToCallable#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToObjectInstance#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToObjectInstance#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThrowerAccessor#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThrowerAccessor#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ToNumberConversion#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ToNumberConversion#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.UnsupportedReturnType_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.UnsupportedReturnType_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -105,7 +105,10 @@ internal sealed class JsFunctionAttribute : global::System.Attribute
     /// <para>
     /// Include <c>FastCallGuard.Undefined</c> when the body is also safe for an omitted
     /// argument; the call site pads the registers with <c>undefined</c>, so a Number-only
-    /// guard silently costs the lane every call site that omits the argument.
+    /// guard silently costs the lane every call site that omits the argument. Where the body
+    /// only inspects the value and never coerces it — <c>Number.isInteger</c> answers
+    /// <c>false</c> for everything that is not already a number — declare
+    /// <c>FastCallGuard.AnyValue</c>, which vouches for the parameter without narrowing it.
     /// </para>
     /// <para>
     /// Only consulted for a parameter that derives no guard of its own. A declared conversion

--- a/Jint.Tests/Runtime/FastCallLaneTests.cs
+++ b/Jint.Tests/Runtime/FastCallLaneTests.cs
@@ -1,4 +1,4 @@
-using Jint.Native;
+﻿using Jint.Native;
 using Jint.Native.Function;
 using Jint.Runtime;
 
@@ -154,6 +154,15 @@ public class FastCallLaneTests
     [InlineData("\"abc\".substring(0, p)", "substring")]
     [InlineData("\"abc\".slice(p)", "slice")]
     [InlineData("\"abc\".slice(0, p)", "slice")]
+    [InlineData("\"abc\".at(p)", "at")]
+    [InlineData("\"abc\".substr(p)", "substr")]
+    [InlineData("\"abc\".substr(0, p)", "substr")]
+    [InlineData("\"abc\".indexOf(\"b\", p)", "indexOf")]
+    [InlineData("\"abc\".startsWith(\"b\", p)", "startsWith")]
+    [InlineData("\"abc\".endsWith(\"b\", p)", "endsWith")]
+    [InlineData("\"abc\".includes(\"b\", p)", "includes")]
+    [InlineData("isNaN(p)", "isNaN")]
+    [InlineData("isFinite(p)", "isFinite")]
     [InlineData("parseInt(\"10\", p)", "parseInt")]
     public void AWarmedSiteKeepsTheBuiltinFrameWhenAnArgumentCoercesThroughUserCode(string call, string builtin)
     {
@@ -170,16 +179,23 @@ public class FastCallLaneTests
     }
 
     /// <summary>
-    /// The same invariant for the argument these two coerce with <c>ToString</c> rather than
+    /// The same invariant for the arguments these coerce with <c>ToString</c> rather than
     /// <c>ToNumber</c>, which the theory above cannot express: an object carrying only a throwing
     /// <c>valueOf</c> is coerced through <c>Object.prototype.toString</c> and never throws, so the
     /// thrower has to be the <c>toString</c>. Their first argument's guard is String, and a warmed
     /// site handed anything else must keep the frame the user code can read off <c>error.stack</c>.
+    /// The warm-up value conforms, so each of these sites takes the frameless branch twice before the
+    /// call that has to decline it.
     /// </summary>
     [Theory]
     [InlineData("parseInt(p)", "parseInt")]
     [InlineData("parseInt(p, 16)", "parseInt")]
     [InlineData("parseFloat(p)", "parseFloat")]
+    [InlineData("\"abc\".indexOf(p)", "indexOf")]
+    [InlineData("\"abc\".indexOf(p, 0)", "indexOf")]
+    [InlineData("\"abc\".startsWith(p)", "startsWith")]
+    [InlineData("\"abc\".endsWith(p)", "endsWith")]
+    [InlineData("\"abc\".includes(p)", "includes")]
     public void AWarmedSiteKeepsTheBuiltinFrameWhenTheStringArgumentCoercesThroughUserCode(string call, string builtin)
     {
         var engine = new Engine();
@@ -341,7 +357,8 @@ public class FastCallLaneTests
         // Date is the one kind with no bit of its own, so it borrows one above every InternalTypes
         // flag; AnyValue, which the generator resolves away and no shape ever carries, borrows the
         // next one down. If a future flag reached either, every guard naming it would start matching
-        // values carrying that flag instead of being answered the way it is meant to be.
+        // values carrying that flag instead of being answered the way it is meant to be — so both
+        // borrowed bits are checked against the union of every flag the enum declares.
         var everyInternalType = InternalTypes.Empty;
         foreach (InternalTypes value in Enum.GetValues(typeof(InternalTypes)))
         {
@@ -350,6 +367,7 @@ public class FastCallLaneTests
 
         (everyInternalType & (InternalTypes) FastCallGuard.Date).Should().Be(InternalTypes.Empty);
         (everyInternalType & (InternalTypes) FastCallGuard.AnyValue).Should().Be(InternalTypes.Empty);
+        (FastCallGuard.AnyValue & FastCallGuard.Date).Should().Be(FastCallGuard.Any);
     }
 
     /// <summary>
@@ -528,6 +546,187 @@ public class FastCallLaneTests
         result.Should().Be("2,2,!3,true,1");
     }
 
+    private static FastCallShape ShapeOf(Engine engine, string expression, int argumentCount)
+        => ((Function) engine.Evaluate(expression)).GetFastCallShape(argumentCount);
+
+    /// <summary>
+    /// A guard-passing call is, by construction, unable to report that its frame was elided: the
+    /// built-ins annotated <c>Leaf</c> run no user code and raise no error, so there is nothing left
+    /// inside the frameless window for a script to observe. The claims are therefore pinned where
+    /// they are decided — the shape the call site reads, and the per-call guard test it runs against
+    /// the values it is about to pass — with a conforming set that must take the branch and a
+    /// non-conforming one that must not. The behaviour on both sides is pinned by the theories
+    /// around this one; what this adds is that the branch exists and admits what it says it does.
+    /// </summary>
+    [Fact]
+    public void TheDeclaredGuardsAdmitExactlyTheValuesTheirBodiesAreLeafFor()
+    {
+        var engine = new Engine();
+
+        JsValue str = new JsString("abc");
+        JsValue num = JsNumber.Create(1);
+        var undefined = JsValue.Undefined;
+        var coercible = engine.Evaluate("({ valueOf: function () { return 1; }, toString: function () { return \"1\"; } })");
+        var array = engine.Evaluate("[]");
+        var symbol = engine.Evaluate("Symbol()");
+
+        // Number's four predicates inspect the argument and never coerce it, so their guard is the
+        // one that names every value: no argument at all can reach user code through them.
+        foreach (var predicate in new[] { "isFinite", "isInteger", "isNaN", "isSafeInteger" })
+        {
+            var shape = ShapeOf(engine, "Number." + predicate, 1);
+            shape.Leaf.Should().BeTrue("Number.{0} is leaf", predicate);
+            shape.IsLeafFor(undefined, num, undefined).Should().BeTrue();
+            shape.IsLeafFor(undefined, coercible, undefined).Should().BeTrue("Number.{0} never coerces", predicate);
+            shape.IsLeafFor(undefined, symbol, undefined).Should().BeTrue();
+        }
+
+        // The global pair is a single ToNumber, which is a no-op for a number, a parse for a string
+        // and NaN for undefined — and user code or a TypeError for everything else.
+        foreach (var global in new[] { "isNaN", "isFinite" })
+        {
+            var shape = ShapeOf(engine, global, 1);
+            shape.Leaf.Should().BeTrue("{0} is leaf", global);
+            shape.IsLeafFor(undefined, num, undefined).Should().BeTrue();
+            shape.IsLeafFor(undefined, str, undefined).Should().BeTrue();
+            shape.IsLeafFor(undefined, undefined, undefined).Should().BeTrue();
+            shape.IsLeafFor(undefined, coercible, undefined).Should().BeFalse("an object's valueOf is user code");
+            shape.IsLeafFor(undefined, symbol, undefined).Should().BeFalse("ToNumber of a Symbol is a TypeError");
+        }
+
+        // The search-string family: a string receiver, a string needle, a numeric or absent position.
+        foreach (var method in new[] { "indexOf", "startsWith", "endsWith", "includes" })
+        {
+            var shape = ShapeOf(engine, "String.prototype." + method, 2);
+            shape.Leaf.Should().BeTrue("String.prototype.{0} is leaf", method);
+            shape.IsLeafFor(str, str, num).Should().BeTrue();
+            shape.IsLeafFor(str, str, undefined).Should().BeTrue();
+            shape.IsLeafFor(str, num, undefined).Should().BeFalse("only a string needle makes ToString a no-op");
+            shape.IsLeafFor(str, coercible, undefined).Should().BeFalse();
+            shape.IsLeafFor(str, str, coercible).Should().BeFalse();
+            shape.IsLeafFor(coercible, str, num).Should().BeFalse("a hosted receiver coerces through user code");
+        }
+
+        // The index family, which takes numbers where the family above takes a string.
+        foreach (var method in new[] { "at", "substr" })
+        {
+            var shape = ShapeOf(engine, "String.prototype." + method, 2);
+            shape.Leaf.Should().BeTrue("String.prototype.{0} is leaf", method);
+            shape.IsLeafFor(str, num, undefined).Should().BeTrue();
+            shape.IsLeafFor(str, undefined, undefined).Should().BeTrue();
+            shape.IsLeafFor(str, coercible, undefined).Should().BeFalse();
+            shape.IsLeafFor(coercible, num, undefined).Should().BeFalse();
+        }
+
+        // Array.isArray is leaf only where the answer is yes: an ArrayInstance settles it outright,
+        // and everything else — a revoked Proxy above all — is left to the framed path.
+        var isArray = ShapeOf(engine, "Array.isArray", 1);
+        isArray.Leaf.Should().BeTrue();
+        isArray.IsLeafFor(undefined, array, undefined).Should().BeTrue();
+        isArray.IsLeafFor(undefined, coercible, undefined).Should().BeFalse();
+        isArray.IsLeafFor(undefined, str, undefined).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Each newly leaf built-in, called at a warmed site with arguments its guard admits — the state
+    /// and the values the frameless branch is reachable from. Every row is asserted cold as well, so
+    /// the lane cannot change an answer, and in a Debug build the leaf audit brackets each of these
+    /// calls: a body that reached user code or raised a JavaScript error frameless would fail here
+    /// before the value ever got compared.
+    /// </summary>
+    [Theory]
+    [InlineData("\"abcdef\".indexOf(\"cd\")", "2")]
+    [InlineData("\"abcdef\".indexOf(\"cd\", 3)", "-1")]
+    [InlineData("\"abcdef\".indexOf(\"\", 99)", "6")]
+    [InlineData("\"abcdef\".startsWith(\"ab\")", "true")]
+    [InlineData("\"abcdef\".startsWith(\"cd\", 2)", "true")]
+    [InlineData("\"abcdef\".startsWith(\"cd\", -1)", "false")]
+    [InlineData("\"abcdef\".endsWith(\"ef\")", "true")]
+    [InlineData("\"abcdef\".endsWith(\"cd\", 4)", "true")]
+    [InlineData("\"abcdef\".endsWith(\"ef\", 99)", "true")]
+    [InlineData("\"abcdef\".includes(\"cd\")", "true")]
+    [InlineData("\"abcdef\".includes(\"cd\", 3)", "false")]
+    [InlineData("\"abcdef\".includes(\"cd\", 1e10)", "false")]
+    [InlineData("\"abcdef\".at(1)", "b")]
+    [InlineData("\"abcdef\".at(-1)", "f")]
+    [InlineData("\"abcdef\".at()", "a")]
+    [InlineData("\"abcdef\".at(99)", "undefined")]
+    [InlineData("\"abcdef\".substr(1, 2)", "bc")]
+    [InlineData("\"abcdef\".substr(-2)", "ef")]
+    [InlineData("\"abcdef\".substr(2)", "cdef")]
+    [InlineData("Number.isFinite(1)", "true")]
+    [InlineData("Number.isFinite(Infinity)", "false")]
+    [InlineData("Number.isFinite(\"1\")", "false")]
+    [InlineData("Number.isInteger(1.5)", "false")]
+    [InlineData("Number.isInteger(2)", "true")]
+    [InlineData("Number.isNaN(NaN)", "true")]
+    [InlineData("Number.isNaN(\"NaN\")", "false")]
+    [InlineData("Number.isSafeInteger(9007199254740992)", "false")]
+    [InlineData("Number.isSafeInteger(9007199254740991)", "true")]
+    [InlineData("isNaN(NaN)", "true")]
+    [InlineData("isNaN(\"12\")", "false")]
+    [InlineData("isNaN(\"nope\")", "true")]
+    [InlineData("isNaN()", "true")]
+    [InlineData("isFinite(\"12\")", "true")]
+    [InlineData("isFinite(\"1e400\")", "false")]
+    [InlineData("isFinite()", "false")]
+    [InlineData("Array.isArray([])", "true")]
+    [InlineData("Array.isArray(\"[]\")", "false")]
+    public void ANewlyLeafBuiltinGivesTheSameAnswerWarmAsCold(string expression, string expected)
+    {
+        var engine = new Engine();
+
+        engine.Evaluate($"function f() {{ return String({expression}); }} f();").AsString().Should().Be(expected);
+        engine.Evaluate($"function g() {{ return String({expression}); }} g(); g(); g();").AsString().Should().Be(expected);
+    }
+
+    /// <summary>
+    /// What <c>FastCallGuard.AnyValue</c> claims about <c>Number</c>'s four predicates, stated as
+    /// behaviour: they inspect the argument and never coerce it, so no value a call site can pass
+    /// reaches user code — which is why they take the frameless branch for every argument, an object
+    /// included. A body that started coercing would show up here as a <c>valueOf</c> that ran, and in
+    /// a Debug build would have tripped the leaf audit first.
+    /// </summary>
+    [Fact]
+    public void TheNumberPredicatesAnswerAnObjectWithoutCoercingIt()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            let calls = 0;
+            const o = { valueOf: function () { calls++; return 1; }, toString: function () { calls++; return "1"; } };
+            function f(p) { return [Number.isFinite(p), Number.isInteger(p), Number.isNaN(p), Number.isSafeInteger(p)].join(","); }
+            f(1); f(1);
+            f(o) + "|" + calls;
+            """).AsString();
+
+        result.Should().Be("false,false,false,false|0");
+    }
+
+    /// <summary>
+    /// <c>Array.isArray</c> is leaf for one shape of argument: one of the engine's own arrays, which
+    /// carries <c>InternalTypes.Array</c> and answers the question without consulting anything. The
+    /// argument its guard exists to turn away is a revoked Proxy, whose TypeError needs the frame —
+    /// and the site is warmed on the leaf branch first, so the declining call is made from the state
+    /// the lane has to get right.
+    /// </summary>
+    [Fact]
+    public void IsArrayKeepsItsFrameForTheRevokedProxyItsGuardTurnsAway()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            function f(v) { return Array.isArray(v); }
+            const warm = [f([]), f([]), f([])].join(",");
+            const r = Proxy.revocable([], {});
+            r.revoke();
+            let name = "";
+            let stack = "";
+            try { f(r.proxy); } catch (e) { name = e.constructor.name; stack = e.stack; }
+            [warm, f({}), name, stack.indexOf("at isArray") >= 0].join("|");
+            """).AsString();
+
+        result.Should().Be("true,true,true|false|TypeError|true");
+    }
+
     /// <summary>
     /// A declared argument guard is a claim about values, not about the method, so the receiver guard
     /// still has to hold independently: a boxed or hosted receiver coerces through user code and must
@@ -580,6 +779,13 @@ public class FastCallLaneTests
     [InlineData("\"abc\".slice(0, p)")]
     [InlineData("\"abc\".charCodeAt(p)")]
     [InlineData("\"abc\".charAt(p)")]
+    [InlineData("\"abc\".at(p)")]
+    [InlineData("\"abc\".substr(p)")]
+    [InlineData("\"abc\".indexOf(p)")]
+    [InlineData("\"abc\".startsWith(p)")]
+    [InlineData("\"abc\".includes(\"b\", p)")]
+    [InlineData("isNaN(p)")]
+    [InlineData("isFinite(p)")]
     public void ASymbolArgumentStillRaisesACatchableTypeErrorAtAWarmedSite(string call)
     {
         var engine = new Engine();

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -776,10 +776,14 @@ public sealed partial class ArrayConstructor : Constructor
     [JsSymbolAccessor("Species")]
     private static JsValue Species(JsValue thisObject) => thisObject;
 
-    // Lane 1 only, deliberately NOT Leaf: IsArray on a revoked Proxy throws a TypeError
-    // (JsProxy.IsArray -> AssertNotRevoked), and "argument is not a revoked proxy" is not something
-    // a FastCallGuard can express. Skipping the frame would drop this call out of that error's stack.
-    [JsFunction(Length = 1, FastCall = true)]
+    // Leaf for exactly one shape of argument, and framed for every other. IsArray on a revoked Proxy
+    // throws a TypeError (JsProxy.IsArray -> AssertNotRevoked), and "argument is not a revoked proxy"
+    // is not something a FastCallGuard can express — but "argument is one of our own arrays" is, and
+    // it settles the question outright: InternalTypes.Array is set by ArrayInstance's constructors
+    // and nothing else, and ArrayInstance seals IsArray() to true. So a guarded call is a flag test
+    // and a return, while the answer-is-false calls the guard turns away — including the proxy whose
+    // TypeError needs the frame — take the framed path exactly as before.
+    [JsFunction(Length = 1, Leaf = true, LeafArg0 = FastCallGuard.Array)]
     private static JsValue IsArray(JsValue thisObject, JsValue o)
     {
         return IsArray(o);

--- a/Jint/Native/Global/GlobalObject.cs
+++ b/Jint/Native/Global/GlobalObject.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Jint.Extensions;
+using Jint.Native.Function;
 using Jint.Native.Object;
 using Jint.Native.String;
 using Jint.Runtime;
@@ -252,7 +253,12 @@ public sealed partial class GlobalObject : ObjectInstance
     /// <summary>
     /// http://www.ecma-international.org/ecma-262/5.1/#sec-15.1.2.4
     /// </summary>
-    [JsFunction(FastCall = true)]
+    // The body is one ToNumber, so the guard is the set of values that conversion answers without
+    // asking the value anything: a number is itself, a string is parsed — an unparseable one is NaN,
+    // not a throw — and undefined is NaN. Symbol and BigInt are the two primitives ToNumber raises a
+    // TypeError for and an object reaches user code through valueOf, so both keep the frame. The
+    // receiver is not read.
+    [JsFunction(Leaf = true, LeafArg0 = FastCallGuard.Number | FastCallGuard.String | FastCallGuard.Undefined)]
     private static JsValue IsNaN(JsValue thisObject, JsValue value)
     {
         if (ReferenceEquals(value, JsNumber.DoubleNaN))
@@ -267,7 +273,8 @@ public sealed partial class GlobalObject : ObjectInstance
     /// <summary>
     /// http://www.ecma-international.org/ecma-262/5.1/#sec-15.1.2.5
     /// </summary>
-    [JsFunction(FastCall = true)]
+    // Same single ToNumber, same guard.
+    [JsFunction(Leaf = true, LeafArg0 = FastCallGuard.Number | FastCallGuard.String | FastCallGuard.Undefined)]
     private static JsValue IsFinite(JsValue thisObject, JsValue value)
     {
         var n = TypeConverter.ToNumber(value);

--- a/Jint/Native/Number/NumberConstructor.cs
+++ b/Jint/Native/Number/NumberConstructor.cs
@@ -1,4 +1,4 @@
-using Jint.Native.Function;
+﻿using Jint.Native.Function;
 using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
@@ -49,7 +49,14 @@ internal sealed partial class NumberConstructor : Constructor
         CreateProperties_Generated();
     }
 
-    [JsFunction(Length = 1, FastCall = true)]
+    // https://tc39.es/ecma262/#sec-number.isfinite and its three siblings are the whole reason
+    // FastCallGuard.AnyValue exists. Each is a type test and nothing else: a value that is not
+    // already a JsNumber is answered false on the spot — no ToNumber, so no user valueOf — and the
+    // arithmetic the number branch then does raises nothing. The receiver is not read at all. So
+    // every argument is leaf-safe, including the object one, and narrowing the guard to Number
+    // would have cost the frame elision to exactly the calls these four exist for: validating a
+    // value whose type is not yet known.
+    [JsFunction(Length = 1, Leaf = true, LeafArg0 = FastCallGuard.AnyValue)]
     private static JsValue IsFinite(JsValue thisObject, JsValue arg0)
     {
         if (!(arg0 is JsNumber num))
@@ -60,7 +67,7 @@ internal sealed partial class NumberConstructor : Constructor
         return double.IsInfinity(num._value) || double.IsNaN(num._value) ? JsBoolean.False : JsBoolean.True;
     }
 
-    [JsFunction(Length = 1, FastCall = true)]
+    [JsFunction(Length = 1, Leaf = true, LeafArg0 = FastCallGuard.AnyValue)]
     private static JsValue IsInteger(JsValue thisObject, JsValue arg0)
     {
         if (!(arg0 is JsNumber num))
@@ -78,7 +85,7 @@ internal sealed partial class NumberConstructor : Constructor
         return integer == num._value;
     }
 
-    [JsFunction(Length = 1, FastCall = true)]
+    [JsFunction(Length = 1, Leaf = true, LeafArg0 = FastCallGuard.AnyValue)]
     private static JsValue IsNaN(JsValue thisObject, JsValue arg0)
     {
         if (!(arg0 is JsNumber num))
@@ -89,7 +96,7 @@ internal sealed partial class NumberConstructor : Constructor
         return double.IsNaN(num._value);
     }
 
-    [JsFunction(Length = 1, FastCall = true)]
+    [JsFunction(Length = 1, Leaf = true, LeafArg0 = FastCallGuard.AnyValue)]
     private static JsValue IsSafeInteger(JsValue thisObject, JsValue arg0)
     {
         if (!(arg0 is JsNumber num))

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -953,7 +953,11 @@ internal sealed partial class StringPrototype : StringInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-string.prototype.substr
     /// </summary>
-    [JsFunction(Length = 2, FastCall = true)]
+    // Leaf under declared argument guards — same reasoning as substring, including the second
+    // argument's undefined, which the body reads as "to the end of the string" rather than coercing.
+    [JsFunction(Length = 2, Leaf = true, LeafReceiver = FastCallGuard.String,
+        LeafArg0 = FastCallGuard.Number | FastCallGuard.Undefined,
+        LeafArg1 = FastCallGuard.Number | FastCallGuard.Undefined)]
     [RequireObjectCoercible]
     private static JsValue Substr(JsValue thisObject, JsValue arg0, JsValue arg1)
     {
@@ -1204,7 +1208,12 @@ internal sealed partial class StringPrototype : StringInstance
     /// <summary>
     /// https://tc39.es/proposal-relative-indexing-method/#sec-string-prototype-additions
     /// </summary>
-    [JsFunction(Length = 1, FastCall = true)]
+    // Leaf under declared argument guards — same reasoning as charAt: the index stays a raw JsValue
+    // so its ToInteger keeps running after step 2's ToString of the receiver, and the declaration
+    // names the values that coercion cannot reach user code for. An out-of-range index is undefined,
+    // not a throw.
+    [JsFunction(Length = 1, Leaf = true, LeafReceiver = FastCallGuard.String,
+        LeafArg0 = FastCallGuard.Number | FastCallGuard.Undefined)]
     [RequireObjectCoercible]
     private static JsValue At(JsValue thisObject, JsValue arg0)
     {
@@ -1573,7 +1582,12 @@ internal sealed partial class StringPrototype : StringInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-string.prototype.indexof
     /// </summary>
-    [JsFunction(Length = 1, FastCall = true)]
+    // Three coercions, each a no-op under its guard: ToJsString of a JsString receiver, ToString of
+    // a JsString search value, and ToInteger of a number — with undefined admitted on the position
+    // because the body reads it as "search from 0" and a one-argument site pads the register with it.
+    [JsFunction(Length = 1, Leaf = true, LeafReceiver = FastCallGuard.String,
+        LeafArg0 = FastCallGuard.String,
+        LeafArg1 = FastCallGuard.Number | FastCallGuard.Undefined)]
     [RequireObjectCoercible]
     private static JsValue IndexOf(JsValue thisObject, JsValue searchArg, JsValue posArg)
     {
@@ -1813,7 +1827,16 @@ internal sealed partial class StringPrototype : StringInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-string.prototype.startswith
     /// </summary>
-    [JsFunction(Length = 1, FastCall = true)]
+    // The TypeError below reads as the thing that blocks Leaf, and it is not: IsRegExp returns false
+    // for anything that is not an ObjectInstance before it looks at a single property, and a
+    // JsString never is one. So under the String guard on arg0 the @@match read never happens — not
+    // even a String.prototype[Symbol.match] could make it happen, because that lookup is on the
+    // argument and the argument is a primitive — and the throw is unreachable. Everything left is
+    // ToString of a JsString and ToInt32 of a number or of the undefined a one-argument site pads
+    // the second register with.
+    [JsFunction(Length = 1, Leaf = true, LeafReceiver = FastCallGuard.String,
+        LeafArg0 = FastCallGuard.String,
+        LeafArg1 = FastCallGuard.Number | FastCallGuard.Undefined)]
     [RequireObjectCoercible]
     private JsValue StartsWith(JsValue thisObject, JsValue arg0, JsValue arg1)
     {
@@ -1845,7 +1868,10 @@ internal sealed partial class StringPrototype : StringInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-string.prototype.endswith
     /// </summary>
-    [JsFunction(Length = 1, FastCall = true)]
+    // Same guards and the same unreachable TypeError as startsWith.
+    [JsFunction(Length = 1, Leaf = true, LeafReceiver = FastCallGuard.String,
+        LeafArg0 = FastCallGuard.String,
+        LeafArg1 = FastCallGuard.Number | FastCallGuard.Undefined)]
     [RequireObjectCoercible]
     private JsValue EndsWith(JsValue thisObject, JsValue arg0, JsValue arg1)
     {
@@ -1880,7 +1906,10 @@ internal sealed partial class StringPrototype : StringInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-string.prototype.includes
     /// </summary>
-    [JsFunction(Length = 1, FastCall = true)]
+    // Same guards and the same unreachable TypeError as startsWith.
+    [JsFunction(Length = 1, Leaf = true, LeafReceiver = FastCallGuard.String,
+        LeafArg0 = FastCallGuard.String,
+        LeafArg1 = FastCallGuard.Number | FastCallGuard.Undefined)]
     [RequireObjectCoercible]
     private JsValue Includes(JsValue thisObject, JsValue arg0, JsValue arg1)
     {


### PR DESCRIPTION
> Draft until its benchmark gate lands — the release measurement block runs the new `FastCallLaneBenchmarks` rows plus the wide tables against this.

Extends the leaf fast-call lane to the Tier 1 candidates from the release campaign's scouting note. Every premise was re-verified in source; one was refuted **as written** and fixed properly, one was refuted in the other direction.

**The missing mechanism first.** "Unconditional `Leaf` with `Any` guards" was unimplementable: the generator refuses `Leaf` for a plain `JsValue` parameter, and `FastCallGuard.Any` cannot un-refuse it because `Any` *is* the absence of a declaration. The new spelling `FastCallGuard.Unguarded` is declaration-only — the generator lowers it to `Any` in the emitted shape, byte-identical to an unguarded position (snapshot-pinned), zero runtime cost.

**Shipped:**
- `Number.isFinite/isInteger/isNaN/isSafeInteger` — type test first, no `ToNumber`, receiver unread; `Leaf` + `Unguarded`, so even the object-argument calls take the lane (they are validation calls, which is what these functions are for).
- `String.prototype.indexOf/startsWith/endsWith/includes/at/substr` — the `charAt`/`substring` guard shape. The `IsRegExp` unreachability claim for `startsWith`-family was **verified in source, not trusted**: `IsRegExp` answers false for a non-`ObjectInstance` before any `@@match` read, and a guard-passing `JsString` is never one; a `String.prototype[Symbol.match]` cannot change that because the lookup would be on the *argument*, which is a primitive.
- Global `isNaN`/`isFinite` — `Number | String | Undefined` (Symbol/BigInt TypeErrors and object `valueOf` excluded by the guard). The scouting note's registration worry was refuted: these are generated dispatchers, never `ClrFunction`, no identity twin, no `length` change.
- `Array.isArray` — the note called it marginal; the old comment said `Leaf` was impossible. "Not a revoked proxy" is indeed inexpressible, but "one of our own arrays" is exact: `InternalTypes.Array` + the sealed `IsArray()` override make `LeafArg0 = Array` a flag test and a return, and a proxy fails the guard into the frame its TypeError needs.

**Leaf claims were proven by falsification, not by green Debug runs.** A green Debug leg only says no assert fired; each claim was temporarily falsified (guard widened, or a `ToNumber` probe inserted) and the `LeafCallGuard` assert shown to fire across all four call-site shapes, then reverted — the failure transcripts are in the commit history of this PR's preparation. Final Debug legs green everywhere including a 79,489-test Debug test262 with zero leaf-audit failures.

**Behaviour changes: none of #2968's kind.** No identity, `length`, `name` or attribute moves. The one inherent observable — a guard-passing call no longer charges `LimitRecursion` — is invisible (such a call provably runs no user code and raises no JS error), and recursion through user code still charges, pinned by the pre-existing test.

New pins include `valueOf`-count-zero for the Number predicates, the revoked-proxy frame for `isArray`, 38 warm-vs-cold agreement rows, and a warmed `indexOf` handed a throwing `toString` still showing `at indexOf` in `error.stack`.

Release build 0 warnings; test262 byte-identical to the `cf3c048de` baseline (same 8 pre-existing load-flake timeouts on this box, identical on both sides). Gate rows and expectations are listed in the PR preparation notes; >1% on any wide-table row blocks, with the caveat that `indexOf`/`includes`/`isNaN`/`isArray` appear inside the suite scripts themselves, so small improvements there are results, not drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)