### PR TITLE
Render a locale string for every date the spec calls valid

### DIFF
--- a/Jint.Tests/Runtime/DateTests.cs
+++ b/Jint.Tests/Runtime/DateTests.cs
@@ -420,6 +420,94 @@ public class DateTests
         _engine.Evaluate(Script).AsNumber().Should().Be(0);
     }
 
+    /// Every toLocale* method converted the time value with DatePresentation.ToDateTime() before handing
+    /// it to the ECMA-402 formatting path, and that conversion is unguarded.
+    /// <see cref="DateTime"/> spans years 1 through 9999; https://tc39.es/ecma262/#sec-timeclip admits
+    /// every time value up to 8.64e15, which is years -271821 through 275760. Both ends therefore threw
+    /// ArgumentOutOfRangeException straight out of engine.Evaluate — a CLR exception, so script
+    /// try/catch never saw it, the same escape #2954 closed for sort and #2965 for the first instant of
+    /// year 10000.
+    ///
+    /// These years have no representation in any .NET calendar, so there is no locale-aware string to
+    /// produce; each method answers with what its culture-independent sibling renders instead, which is
+    /// the rendering https://tc39.es/ecma262/#sec-datestring already gives these values from toString.
+    /// </summary>
+    [Theory]
+    [InlineData(8640000000000000)] // the maximum time value, year 275760
+    [InlineData(253402300800001)] // one past what DateTime can hold, year 10000
+    [InlineData(-62135596800001)] // one before what DateTime can hold, year 0
+    [InlineData(-8640000000000000)] // the minimum time value, year -271821
+    public void ToLocaleStringOutsideDateTimeRangeRendersTheCultureIndependentString(long timeValue)
+    {
+        var engine = new Engine(options => options.LocalTimeZone(TimeZoneInfo.Utc));
+
+        engine.Evaluate($"new Date({timeValue}).toLocaleString()").AsString()
+            .Should().Be(engine.Evaluate($"new Date({timeValue}).toString()").AsString());
+
+        engine.Evaluate($"new Date({timeValue}).toLocaleDateString()").AsString()
+            .Should().Be(engine.Evaluate($"new Date({timeValue}).toDateString()").AsString());
+
+        engine.Evaluate($"new Date({timeValue}).toLocaleTimeString()").AsString()
+            .Should().Be(engine.Evaluate($"new Date({timeValue}).toTimeString()").AsString());
+
+        // A locale and an options bag are still read and validated; they simply cannot change the answer.
+        engine.Evaluate($"new Date({timeValue}).toLocaleString('de-DE', {{ month: 'long' }})").AsString()
+            .Should().Be(engine.Evaluate($"new Date({timeValue}).toString()").AsString());
+    }
+
+    /// <summary>
+    /// The escape itself. A CLR exception leaves engine.Evaluate without passing through any JavaScript
+    /// catch clause, so the only way to show the difference is from inside script.
+    /// </summary>
+    [Fact]
+    public void ToLocaleStringOutsideDateTimeRangeDoesNotThrowAClrException()
+    {
+        var engine = new Engine(options => options.LocalTimeZone(TimeZoneInfo.Utc));
+
+        engine.Evaluate("(function () { try { return new Date(8640000000000000).toLocaleString(); } catch (e) { return 'caught'; } })()")
+            .AsString().Should().Contain("275760");
+
+        engine.Evaluate("(function () { try { return new Date(-8640000000000000).toLocaleDateString(); } catch (e) { return 'caught'; } })()")
+            .AsString().Should().Contain("-271821");
+    }
+
+    /// <summary>
+    /// An explicit numeric offset shifts the wall clock past the end of <see cref="DateTime"/> for a time
+    /// value that is itself inside it, so the addition applying the offset threw where every other
+    /// conversion on the path succeeded. TimeZoneInfo.ConvertTimeFromUtc — the named-zone branch beside
+    /// it — saturates rather than throwing, and the offset branch now does the same.
+    /// </summary>
+    [Fact]
+    public void ToLocaleStringAtTheDateTimeBoundaryWithAnOffsetTimeZoneDoesNotThrowAClrException()
+    {
+        var engine = new Engine(options => options.LocalTimeZone(TimeZoneInfo.Utc));
+
+        engine.Evaluate("new Date(253402300799999).toLocaleString('en-US', { timeZone: '+03:00' })").AsString()
+            .Should().NotBeEmpty();
+        engine.Evaluate("new Date(-62135596800000).toLocaleString('en-US', { timeZone: '-03:00' })").AsString()
+            .Should().NotBeEmpty();
+    }
+
+    /// <summary>
+    /// The fallback is reached only where the locale path cannot go. A date .NET can represent is still
+    /// formatted by ECMA-402, and the two renderings do not look alike.
+    /// </summary>
+    [Fact]
+    public void ToLocaleStringInsideDateTimeRangeIsStillLocaleFormatted()
+    {
+        var engine = new Engine(options => options.LocalTimeZone(TimeZoneInfo.Utc));
+
+        var localeString = engine.Evaluate("new Date(0).toLocaleString('en-US')").AsString();
+        localeString.Should().NotBe(engine.Evaluate("new Date(0).toString()").AsString());
+        localeString.Should().Contain("1970");
+
+        // The two instants either side of DateTime.MaxValue land on opposite sides of the switch.
+        engine.Evaluate("new Date(253402300799999).toLocaleDateString('en-US')").AsString()
+            .Should().NotBe(engine.Evaluate("new Date(253402300799999).toDateString()").AsString());
+        engine.Evaluate("new Date(253402300800001).toLocaleDateString('en-US')").AsString()
+            .Should().Be(engine.Evaluate("new Date(253402300800001).toDateString()").AsString());
+    }
+
     [Fact]
     public void DstTransitionShouldUseCorrectOffset()
     {

--- a/Jint/Native/Date/DatePrototype.cs
+++ b/Jint/Native/Date/DatePrototype.cs
@@ -170,6 +170,29 @@ internal sealed partial class DatePrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-date.prototype.tolocalestring
     /// https://tc39.es/ecma402/#sup-date.prototype.tolocalestring
+    ///
+    /// ECMA-402's FormatDateTime is defined for every valid time value, but the machinery behind it here
+    /// is <see cref="DateTime"/> and the .NET calendars, which reach from year 1 to year 9999 and no
+    /// further. https://tc39.es/ecma262/#sec-timeclip admits every time value up to 8.64e15 — years
+    /// -271821 through 275760 — so a legal Date can name a year no calendar on the platform can hold.
+    /// Converting one of those threw ArgumentOutOfRangeException out of engine.Evaluate, and a CLR
+    /// exception is not something a script try/catch can see.
+    ///
+    /// What the three toLocale* methods answer with instead is the culture-independent rendering their
+    /// non-locale siblings already give the same value: https://tc39.es/ecma262/#sec-datestring and
+    /// https://tc39.es/ecma262/#sec-timestring are pure integer arithmetic on the time value and render
+    /// year 275760 as readily as year 2026. Two alternatives were weighed and rejected. Clamping the
+    /// DateTime to MinValue/MaxValue and overriding only the year — which is what the format method on
+    /// Intl.DateTimeFormat does today — keeps the locale's shape but takes month, day and time from the
+    /// clamp, so new Date(8640000000000000) renders as December 31 rather than September 13. And
+    /// carrying the real fields in on a substitute year congruent mod 400 would need the whole component
+    /// pipeline to learn about overrides it does not have, for a band of years no non-Gregorian calendar
+    /// can express anyway. Being wrong in the locale's shape is worse than being right in nobody's, and
+    /// the string a caller gets now is the one Date.prototype.toString would have given them.
+    ///
+    /// The formatter is still constructed first: CreateDateTimeFormat reads the locale list and the
+    /// options bag and rejects what the spec says to reject, and none of that may be skipped just
+    /// because the year is out of reach.
     /// </summary>
     [JsFunction]
     private JsValue ToLocaleString(JsValue thisObject, JsCallArguments arguments)
@@ -207,12 +230,20 @@ internal sealed partial class DatePrototype : Prototype
         // Use Intl.DateTimeFormat for locale-aware formatting
         // Pass UTC time; DTF handles timezone conversion based on its timeZone option
         var dateTimeFormat = (JsDateTimeFormat) Engine.Realm.Intrinsics.DateTimeFormat.Construct([locales, options], Engine.Realm.Intrinsics.DateTimeFormat);
+
+        if (!dateInstance.DateTimeRangeValid)
+        {
+            return ToDateString(dateInstance);
+        }
+
         return dateTimeFormat.Format(dateInstance.ToDateTime());
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-date.prototype.tolocaledatestring
     /// https://tc39.es/ecma402/#sup-date.prototype.tolocaledatestring
+    /// Out-of-range years fall back to https://tc39.es/ecma262/#sec-datestring; see
+    /// <see cref="ToLocaleString"/> for why.
     /// </summary>
     [JsFunction]
     private JsValue ToLocaleDateString(JsValue thisObject, JsCallArguments arguments)
@@ -247,12 +278,20 @@ internal sealed partial class DatePrototype : Prototype
         // Use Intl.DateTimeFormat for locale-aware formatting
         // Pass UTC time; DTF handles timezone conversion based on its timeZone option
         var dateTimeFormat = (JsDateTimeFormat) Engine.Realm.Intrinsics.DateTimeFormat.Construct([locales, options], Engine.Realm.Intrinsics.DateTimeFormat);
+
+        if (!dateInstance.DateTimeRangeValid)
+        {
+            return DateString(LocalTime(dateInstance));
+        }
+
         return dateTimeFormat.Format(dateInstance.ToDateTime());
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-date.prototype.tolocaletimestring
     /// https://tc39.es/ecma402/#sup-date.prototype.tolocaletimestring
+    /// Out-of-range years fall back to https://tc39.es/ecma262/#sec-timestring; see
+    /// <see cref="ToLocaleString"/> for why.
     /// </summary>
     [JsFunction]
     private JsValue ToLocaleTimeString(JsValue thisObject, JsCallArguments arguments)
@@ -287,6 +326,12 @@ internal sealed partial class DatePrototype : Prototype
         // Use Intl.DateTimeFormat for locale-aware formatting
         // Pass UTC time; DTF handles timezone conversion based on its timeZone option
         var dateTimeFormat = (JsDateTimeFormat) Engine.Realm.Intrinsics.DateTimeFormat.Construct([locales, options], Engine.Realm.Intrinsics.DateTimeFormat);
+
+        if (!dateInstance.DateTimeRangeValid)
+        {
+            return TimeString(LocalTime(dateInstance)) + TimeZoneString(dateInstance);
+        }
+
         return dateTimeFormat.Format(dateInstance.ToDateTime());
     }
 

--- a/Jint/Native/Intl/JsDateTimeFormat.cs
+++ b/Jint/Native/Intl/JsDateTimeFormat.cs
@@ -188,8 +188,22 @@ internal sealed class JsDateTimeFormat : ObjectInstance
             }
             dateTime = DateTime.SpecifyKind(dateTime, DateTimeKind.Utc);
 
-            // Apply the offset
-            return dateTime.Add(offset.Value);
+            // Apply the offset, saturating rather than throwing. The last instant DateTime can hold has no
+            // DateTime to land on once a positive offset is added, and Add answers that with an
+            // ArgumentOutOfRangeException — a CLR exception, which leaves engine.Evaluate without ever
+            // reaching a script try/catch. TimeZoneInfo.ConvertTimeFromUtc, the named-zone branch below,
+            // clamps at MinValue/MaxValue in exactly this situation, so the two branches now agree.
+            var shiftedTicks = dateTime.Ticks + offset.Value.Ticks;
+            if (shiftedTicks < DateTime.MinValue.Ticks)
+            {
+                shiftedTicks = DateTime.MinValue.Ticks;
+            }
+            else if (shiftedTicks > DateTime.MaxValue.Ticks)
+            {
+                shiftedTicks = DateTime.MaxValue.Ticks;
+            }
+
+            return new DateTime(shiftedTicks, DateTimeKind.Utc);
         }
 
         try


### PR DESCRIPTION
`toLocaleString`/`toLocaleDateString`/`toLocaleTimeString` called `ToDateTime()` with no range check, so every date outside `DateTime`'s years-1-to-9999 window threw `ArgumentOutOfRangeException` **out of `engine.Evaluate`** — at both ends: `new Date(8640000000000000).toLocaleString()` (the spec's maximum time value), one past year 9999, one before year 1. Same escaping-CLR-exception class as #2954/#2965.

Out-of-range dates now get **the culture-independent rendering of their non-locale sibling** (`toString`/`toDateString`/`toTimeString`), which is already pure integer arithmetic on the time value and correct across the whole range. The decision was made on measured evidence, not preference:

- ECMA-402's `FormatDateTime` is defined for every valid time value, but the implementation rests on `DateTime` + .NET calendars; ECMA-262 says `toLocaleString` contents are implementation-defined.
- node renders `9/13/275760, 12:00:00 AM` — better in the common case, but ICU renders year 0 as `12/31/1` and −271821 as `4/20/271822`, era-less and ambiguous.
- The clamp+`originalYear` lane `Intl.DateTimeFormat.format` already uses was **measured producing garbage** for these values: `12/31, 27576011:59:59 PM` — month/day/time from `DateTime.MaxValue`, and `BuildFormatString` classifies the quoted year literal as an hour literal, so the separators land wrong too. That mis-rendering is pre-existing, still there, and wants its own fix — noted, not attempted here.

Option validation is preserved (the formatter is constructed first, so `toLocaleString('!!bad!!')` still throws `RangeError`), and a sibling in-range crash rides along: `ConvertToTimeZone`'s explicit-offset branch used `DateTime.Add` and threw for `new Date(253402300799999).toLocaleString('en-US',{timeZone:'+03:00'})` — a **valid** date; it now saturates like the named-zone branch beside it.

Red 7 / green on both TFMs. Test262 at baseline (the S7.8.5 timeout family fails identically on unmodified `cf3c048de` under load and passes on branch code when quiet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)