### PR TITLE
Parse the year the formatter is required to emit

### DIFF
--- a/Jint.Tests/Runtime/DateTests.cs
+++ b/Jint.Tests/Runtime/DateTests.cs
@@ -386,6 +386,39 @@ public class DateTests
     }
 
     /// <summary>
+    /// Date.parse("0000-01-01T00:00:00.000Z") answered NaN, and that string is exactly what
+    /// Date.prototype.toISOString emits for the instant, so the engine could not read back what it had
+    /// just written. https://tc39.es/ecma262/#sec-date-time-string-format admits 0000 as one of the four
+    /// digit years, and https://tc39.es/ecma262/#sec-expanded-years spells the same year "+000000"; both
+    /// mean year 0, which is 1 BC. <see cref="DateTime"/> has no year 0 at all, and nothing routed the
+    /// four-digit spelling to the path that does its own arithmetic.
+    ///
+    /// NaN was not the worst of it. Falling through to the loose invariant parser, some of these came
+    /// back as year 2000 — "0000-01-01" as 946684800000 and "0000-02-29" as 951782400000 — which is a
+    /// wrong answer where NaN would at least have been an honest one.
+    /// </summary>
+    [Theory]
+    [InlineData("0000-01-01T00:00:00.000Z", -62167219200000)]
+    [InlineData("0000-01-01T00:00:00Z", -62167219200000)]
+    [InlineData("0000-01-01", -62167219200000)]
+    [InlineData("0000-01", -62167219200000)]
+    [InlineData("0000", -62167219200000)]
+    // Year 0 is a leap year, so the substitute year the parser borrows has to be one too.
+    [InlineData("0000-02-29", -62162121600000)]
+    [InlineData("0000-03-01", -62162035200000)]
+    [InlineData("0000-12-31T23:59:59.999Z", -62135596800001)]
+    // An offset in the string still applies, and here it crosses back into the year before.
+    [InlineData("0000-01-01T00:00:00.000+02:00", -62167226400000)]
+    // The expanded spelling of the same year.
+    [InlineData("+000000-01-01T00:00:00.000Z", -62167219200000)]
+    [InlineData("+000000-01-01", -62167219200000)]
+    [InlineData("+000000", -62167219200000)]
+    public void ParseAcceptsYearZeroInEverySpellingTheGrammarAdmits(string input, long expected)
+    {
+        _engine.Evaluate($"Date.parse('{input}')").AsNumber().Should().Be(expected);
+    }
+
+    /// <summary>
     /// The MimeKit fallback in the same method read the same property, so a string only it can parse —
     /// a named US zone, which DateTime.TryParse does not accept — landed a millisecond early too. It
     /// floored where the other site truncated, and the fix keeps that difference.
@@ -506,6 +539,66 @@ public class DateTests
             .Should().NotBe(engine.Evaluate("new Date(253402300799999).toDateString()").AsString());
         engine.Evaluate("new Date(253402300800001).toLocaleDateString('en-US')").AsString()
             .Should().Be(engine.Evaluate("new Date(253402300800001).toDateString()").AsString());
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-expanded-years: "The year 0 is considered positive and must be
+    /// prefixed with a + sign. The representation of the year 0 as -000000 is invalid." test262 pins the
+    /// three date-time forms in built-ins/Date/parse/year-zero.js; the bare year obeys the same rule, and
+    /// a rejected year must not fall through to a parser that would read it as something else.
+    /// </summary>
+    [Theory]
+    [InlineData("-000000")]
+    [InlineData("-000000-01-01")]
+    [InlineData("-000000-01-01T00:00:00.000Z")]
+    [InlineData("-000000-03-31T00:45Z")]
+    public void ParseRejectsMinusZeroAsAnExpandedYear(string input)
+    {
+        double.IsNaN(_engine.Evaluate($"Date.parse('{input}')").AsNumber()).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The round trip year 0 could not make, and its neighbour one millisecond below year 1.
+    /// </summary>
+    [Fact]
+    public void ToIsoStringOfYearZeroParsesBack()
+    {
+        _engine.Evaluate("Date.parse(new Date(-62167219200000).toISOString())").AsNumber().Should().Be(-62167219200000);
+        _engine.Evaluate("Date.parse(new Date(-62135596800001).toISOString())").AsNumber().Should().Be(-62135596800001);
+    }
+
+    /// <summary>
+    /// Reaching year 0 meant rebuilding the expanded-year path, which was wrong for every year it already
+    /// handled whenever the string did not carry an explicit offset. It converted the parse to UTC and
+    /// then read the fields back out, so the date-only-means-UTC rule of
+    /// https://tc39.es/ecma262/#sec-date-time-string-format was lost, and where the shift crossed
+    /// midnight the reconstruction kept the target year with the shifted month and day: "+010000-01-01"
+    /// came back as 253433916000000, which is the last day of year 10000 rather than the first. The
+    /// offset-bearing rows are the ones that always worked and have to stay put.
+    /// </summary>
+    [Theory]
+    [InlineData("+010000-01-01T00:00:00.000Z", 253402300800000)]
+    [InlineData("+010000-01-01", 253402300800000)]
+    [InlineData("+000001-01-01", -62135596800000)]
+    [InlineData("-000001-01-01", -62198755200000)]
+    [InlineData("-000001-01-01T00:00:00.000Z", -62198755200000)]
+    [InlineData("+002000-02-29", 951782400000)]
+    [InlineData("+275760-09-13T00:00:00.000Z", 8640000000000000)]
+    [InlineData("-271821-04-20T00:00:00.000Z", -8640000000000000)]
+    public void ParseReadsADateOnlyExpandedYearAsUtc(string input, long expected)
+    {
+        _engine.Evaluate($"Date.parse('{input}')").AsNumber().Should().Be(expected);
+    }
+
+    /// <summary>
+    /// A four-digit 0000 followed by anything the grammar does not put there stays on the loose parser,
+    /// where V8 reads it as year 2000 through its own legacy fallback. Routing on the separator is what
+    /// keeps the two engines agreeing about a string neither format defines.
+    /// </summary>
+    [Fact]
+    public void ParseLeavesNonGrammarYearZeroFormsOnTheLooseParser()
+    {
+        _engine.Evaluate("new Date(Date.parse('0000/01/01')).getUTCFullYear()").AsNumber().Should().Be(2000);
     }
 
     [Fact]

--- a/Jint/Runtime/DefaultTimeSystem.cs
+++ b/Jint/Runtime/DefaultTimeSystem.cs
@@ -43,6 +43,8 @@ public class DefaultTimeSystem : ITimeSystem
         "THHK"
     ];
 
+    private const long MillisecondsPerDay = 86_400_000;
+
     private readonly CultureInfo _parsingCulture;
 
     public DefaultTimeSystem(TimeZoneInfo timeZoneInfo, CultureInfo parsingCulture)
@@ -67,11 +69,117 @@ public class DefaultTimeSystem : ITimeSystem
             return false;
         }
 
-        // special check for large years that always require + or - in front and have 6 digit year
-        if ((date[0] == '+' || date[0] == '-') && date.IndexOf('-', 1) == 7)
+        // A year DateTime has no room for is taken off the front and re-applied afterwards.
+        var yearFieldLength = YearFieldBeyondDateTime(date);
+        if (yearFieldLength != 0)
         {
-            return TryParseLargeYear(date, out epochMilliseconds);
+            return TryParseSubstitutingTheYear(date, yearFieldLength, out epochMilliseconds);
         }
+
+        return TryParseThroughDateTime(date, out epochMilliseconds);
+    }
+
+    /// <summary>
+    /// The length of a leading year field <see cref="DateTime"/> cannot hold, or 0 when the string does
+    /// not begin with one. https://tc39.es/ecma262/#sec-date-time-string-format writes the year as four
+    /// digits or — per https://tc39.es/ecma262/#sec-expanded-years — a sign and six digits. DateTime
+    /// covers years 1 through 9999, so what is out of its reach is every expanded year plus the one
+    /// unsigned spelling that names year 0: "0000", which the grammar admits and which means 1 BC.
+    ///
+    /// The character after the field has to be one the grammar puts there, which is what keeps the
+    /// non-standard "0000/01/01" on the loose parser below, where it reads as year 2000 exactly as it
+    /// does in V8.
+    /// </summary>
+    private static int YearFieldBeyondDateTime(string date)
+    {
+        int length;
+        if (date[0] is '+' or '-')
+        {
+            length = 7;
+            if (date.Length < length)
+            {
+                return 0;
+            }
+
+            for (var i = 1; i < length; i++)
+            {
+                if (!char.IsDigit(date[i]))
+                {
+                    return 0;
+                }
+            }
+        }
+        else if (date.StartsWith("0000", StringComparison.Ordinal))
+        {
+            length = 4;
+        }
+        else
+        {
+            return 0;
+        }
+
+        return date.Length == length || date[length] is '-' or 'T' ? length : 0;
+    }
+
+    /// <summary>
+    /// Parses a date whose year is beyond <see cref="DateTime"/> by handing .NET the same string under a
+    /// year it can hold and then moving the answer. The proleptic Gregorian calendar repeats every 400
+    /// years, so a substitute congruent to the real year mod 400 has the same leap status, the same month
+    /// lengths and the same weekdays: February 29 still parses, the substituted string is accepted on
+    /// exactly the terms the original would have been, and the two instants end up a whole number of days
+    /// apart. Landing the substitute in 2000-2399 also keeps it four digits wide, which is what every
+    /// format string here expects.
+    ///
+    /// Deferring to the ordinary path is the point rather than a convenience. What the previous
+    /// implementation got wrong was the UTC rules: it converted its parse to UTC and then read month, day
+    /// and time back out to rebuild the date under the real year, which dropped the date-only-means-UTC
+    /// rule and, when the offset crossed midnight, kept the target year beside the shifted month and day
+    /// — so "+010000-01-01" came back as the last day of year 10000 rather than the first. Here the
+    /// offset and the date-only rule are applied once, by the parser that already implements them, and
+    /// only whole days are added afterwards.
+    /// </summary>
+    private bool TryParseSubstitutingTheYear(string date, int yearFieldLength, out long epochMilliseconds)
+    {
+        epochMilliseconds = long.MinValue;
+
+        if (!int.TryParse(date.AsSpan(0, yearFieldLength), NumberStyles.Integer, CultureInfo.InvariantCulture, out var year))
+        {
+            return false;
+        }
+
+        if (year == 0 && date[0] == '-')
+        {
+            // https://tc39.es/ecma262/#sec-expanded-years: year 0 is considered positive, so "-000000" is
+            // the one expanded year the grammar excludes. It is rejected outright rather than handed on,
+            // because the loose parser below would read it as something else.
+            return false;
+        }
+
+        var substituteYear = 2000 + (year % 400 + 400) % 400;
+#pragma warning disable CA1845
+        var substituteDate = substituteYear.ToString(CultureInfo.InvariantCulture) + date.Substring(yearFieldLength);
+#pragma warning restore CA1845
+
+        if (!TryParseThroughDateTime(substituteDate, out var substituteMilliseconds))
+        {
+            return false;
+        }
+
+        var dayShift = DatePrototype.MakeDay(year, 0, 1) - DatePrototype.MakeDay(substituteYear, 0, 1);
+        if (!double.IsFinite(dayShift))
+        {
+            // MakeDay refuses a year beyond ±1,000,000, which no six-digit field can reach; the guard is
+            // here so a future caller cannot turn NaN into a nonsense number of days.
+            return false;
+        }
+
+        epochMilliseconds = substituteMilliseconds + (long) dayShift * MillisecondsPerDay;
+        return true;
+    }
+
+    private bool TryParseThroughDateTime(string date, out long epochMilliseconds)
+    {
+        epochMilliseconds = long.MinValue;
 
         var startParen = date.IndexOf('(');
         if (startParen != -1)
@@ -141,44 +249,6 @@ public class DefaultTimeSystem : ITimeSystem
             var refinedOffset = GetUtcOffset(estimatedUtc).TotalMilliseconds;
             datePresentation -= refinedOffset;
         }
-
-        epochMilliseconds = datePresentation.Value;
-        return true;
-    }
-
-    /// <summary>
-    /// Supports parsing of large (> 10 000) and negative years, should not be needed that often...
-    /// </summary>
-    private static bool TryParseLargeYear(string date, out long epochMilliseconds)
-    {
-        epochMilliseconds = long.MinValue;
-
-        var yearString = date.Substring(0, 7);
-        if (!int.TryParse(yearString, NumberStyles.Integer, CultureInfo.InvariantCulture, out var year))
-        {
-            return false;
-        }
-
-        if (year == 0 && date[0] == '-')
-        {
-            // cannot be negative zero ever
-            return false;
-        }
-
-        // create replacement string
-#pragma warning disable CA1845
-        var dateToParse = "2000" + date.Substring(7);
-#pragma warning restore CA1845
-        if (!DateTime.TryParse(dateToParse, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out var parsed))
-        {
-            return false;
-        }
-
-        var dateTime = parsed.ToUniversalTime();
-        var datePresentation = DatePrototype.MakeDate(
-            DatePrototype.MakeDay(year, dateTime.Month - 1, dateTime.Day),
-            DatePrototype.MakeTime(dateTime.Hour, dateTime.Minute, dateTime.Second, dateTime.Millisecond)
-        );
 
         epochMilliseconds = datePresentation.Value;
         return true;


### PR DESCRIPTION
`Date.parse('0000-01-01T00:00:00.000Z')` returned `NaN`: the format grammar admits `0000`, [sec-expanded-years](https://tc39.es/ecma262/#sec-expanded-years) says year 0 is considered positive — `+000000` is equally legal and `-000000` is explicitly invalid — and since #2964 the formatter emits what the parser then refused to read back.

All three spellings now behave per spec: `0000-…` and `+000000-…` parse to −62167219200000 (matching node), `-000000-…` stays `NaN` in every form, rejected outright rather than handed to the loose parser.

One deliberate preservation, pinned by test: `0000/01/01` — slashes, not the spec grammar — **still reads as year 2000** through the loose parser, which is exactly what V8 answers through its own legacy fallback. The routing keys on the grammar's separators so the spec path and the legacy path cannot bleed into each other.

Known limitation recorded, not fixed: an offsetless date-*time* at year 0 uses the zone's base offset rather than its historical LMT (node: Helsinki +1:39:49, Jint: +02:00) — `GetUtcOffset` falls back outside `DateTime`'s range; that is time-zone data, not the parser.

Red 16 / green on both TFMs. Test262 at baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)