### PR TITLE
Count parsed times in ticks so the last millisecond of 9999 survives

### DIFF
--- a/Jint.Tests/Runtime/DateTests.cs
+++ b/Jint.Tests/Runtime/DateTests.cs
@@ -359,6 +359,67 @@ public class DateTests
         new JsDate(_engine, DateTime.MinValue).DateValue.Should().Be(-62135596800000d);
     }
 
+    /// <summary>
+    /// Date.parse("9999-12-31T23:59:59.999Z") answered 253402300799998, one millisecond short of the
+    /// value toISOString had just been given, so the two did not round-trip. The parser read the epoch
+    /// distance off TimeSpan.TotalMilliseconds, which is a double division whose numerator — (double) of
+    /// the tick count — stops being exact once the count passes 2^53. The correctly rounded quotient for
+    /// that instant is 253402300799998.96875, and the truncating cast then dropped the fraction. It is
+    /// the same defect #2965 fixed in JsDate.Max, one conversion further along.
+    ///
+    /// The affected band begins in 2427, which is where the spacing between doubles first stops dividing
+    /// the 10000 ticks in a millisecond; below it every quotient was already exact, so the low rows are
+    /// controls that never moved.
+    /// </summary>
+    [Theory]
+    [InlineData("9999-12-31T23:59:59.999Z", 253402300799999)]
+    [InlineData("9999-12-31T23:59:59.000Z", 253402300799000)]
+    [InlineData("2427-01-01T00:00:00.001Z", 14421542400001)]
+    [InlineData("2500-06-15T12:30:45.678Z", 16739526645678)]
+    // Controls from below the band.
+    [InlineData("1970-01-01T00:00:00.000Z", 0)]
+    [InlineData("2000-01-01T00:00:00.001Z", 946684800001)]
+    [InlineData("2026-08-11T12:34:56.789Z", 1786451696789)]
+    public void ParseIsExactToTheMillisecond(string input, long expected)
+    {
+        _engine.Evaluate($"Date.parse('{input}')").AsNumber().Should().Be(expected);
+    }
+
+    /// <summary>
+    /// The MimeKit fallback in the same method read the same property, so a string only it can parse —
+    /// a named US zone, which DateTime.TryParse does not accept — landed a millisecond early too. It
+    /// floored where the other site truncated, and the fix keeps that difference.
+    /// </summary>
+    [Theory]
+    [InlineData("Sat, 15 Jun 5627 12:30:13 PST", 115418118613000)]
+    [InlineData("Sat, 15 Jun 5634 12:30:13 PST", 115639043413000)]
+    [InlineData("Thu, 30 Jan 2020 08:00:00 PST", 1580400000000)]
+    public void ParseThroughTheMimeKitFallbackIsExactToTheMillisecond(string input, long expected)
+    {
+        _engine.Evaluate($"Date.parse('{input}')").AsNumber().Should().Be(expected);
+    }
+
+    /// <summary>
+    /// The pairing that makes it visible from script: a value the engine formatted itself has to come
+    /// back unchanged. Every millisecond of the last second of year 9999 goes through, because roughly
+    /// one in five of them landed low.
+    /// </summary>
+    [Fact]
+    public void EveryMillisecondOfTheLastSecondOfYear9999RoundTripsThroughParse()
+    {
+        const string Script = """
+            (function () {
+                var mismatched = 0;
+                for (var ms = 253402300799000; ms <= 253402300799999; ms++) {
+                    if (Date.parse(new Date(ms).toISOString()) !== ms) { mismatched++; }
+                }
+                return mismatched;
+            })();
+            """;
+
+        _engine.Evaluate(Script).AsNumber().Should().Be(0);
+    }
+
     [Fact]
     public void DstTransitionShouldUseCorrectOffset()
     {

--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -1409,13 +1409,12 @@ var prep = function (fn) { fn(); };
         var minValue = engine.Evaluate("new Date('0001-01-01T00:00:00.000Z')").ToObject();
         minValue.Should().Be(new DateTime(1, 1, 1, 0, 0, 0, DateTimeKind.Utc));
 
+        // The .NET Core arm here used to expect .998. That was never about the framework's date range; it
+        // was the parser losing a millisecond to a double division, and only on the frameworks whose
+        // TotalMilliseconds divides by 10000 rather than multiplying by 1e-4. Counting ticks removes the
+        // split, so both target frameworks now read back the millisecond the string names.
         var maxValue = engine.Evaluate("new Date('9999-12-31T23:59:59.999Z')").ToObject();
-
-#if NETCOREAPP
-            maxValue.Should().Be(new DateTime(9999, 12, 31, 23, 59, 59, 998, DateTimeKind.Utc));
-#else
         maxValue.Should().Be(new DateTime(9999, 12, 31, 23, 59, 59, 999, DateTimeKind.Utc));
-#endif
     }
 
     [Fact]

--- a/Jint/Runtime/DefaultTimeSystem.cs
+++ b/Jint/Runtime/DefaultTimeSystem.cs
@@ -93,10 +93,19 @@ public class DefaultTimeSystem : ITimeSystem
                         // fall back to trying with MimeKit
                         if (DateUtils.TryParse(date, out var mimeKitResult))
                         {
-                            var dateAsUtc = mimeKitResult.ToUniversalTime();
-#pragma warning disable MA0132
-                            epochMilliseconds = (long) Math.Floor((dateAsUtc - DateConstructor.Epoch).TotalMilliseconds);
-#pragma warning restore MA0132
+                            // Ticks again, and floored the way Math.Floor on the double used to be: the
+                            // same lossy conversion reached this branch too, so "Sat, 15 Jun 5627
+                            // 12:30:13 PST" — a named zone, which only MimeKit parses — came back a
+                            // millisecond early. Floor and truncation differ only below the epoch, and
+                            // only for a sub-millisecond remainder MimeKit cannot produce, but keeping
+                            // the rounding direction means the fix moves nothing but the precision.
+                            var elapsedTicks = mimeKitResult.UtcTicks - DateConstructor.Epoch.Ticks;
+                            epochMilliseconds = elapsedTicks / TimeSpan.TicksPerMillisecond;
+                            if (elapsedTicks < 0 && epochMilliseconds * TimeSpan.TicksPerMillisecond != elapsedTicks)
+                            {
+                                epochMilliseconds--;
+                            }
+
                             return true;
                         }
 
@@ -112,7 +121,16 @@ public class DefaultTimeSystem : ITimeSystem
             ? result.ToUniversalTime()
             : DateTime.SpecifyKind(result, DateTimeKind.Utc);
 
-        DatePresentation datePresentation = (long) (dateAsUtc1 - DateConstructor.Epoch).TotalMilliseconds;
+        // Counted in ticks rather than read off TimeSpan.TotalMilliseconds. That property converts the
+        // tick count to a double first, and above 2^53 the conversion is already lossy: the last instant
+        // of year 9999 is 253402300799999 ms exactly, but on .NET 8/10 the quotient comes back as
+        // 253402300799998.96875 and the truncating cast then dropped the fraction, so
+        // Date.parse("9999-12-31T23:59:59.999Z") answered one millisecond short of what toISOString had
+        // been given. .NET Framework multiplies by 1e-4 where modern .NET divides by 10000 and happens to
+        // round the other way, so the same string parsed to two different numbers depending on the target
+        // framework. Integer division truncates toward zero exactly as the cast did, so nothing else about
+        // the conversion moves. Same defect as the one #2965 fixed in JsDate.Max, one conversion along.
+        DatePresentation datePresentation = (dateAsUtc1.Ticks - DateConstructor.Epoch.Ticks) / TimeSpan.TicksPerMillisecond;
 
         if (convertToUtcAfter)
         {


### PR DESCRIPTION
`Date.parse('9999-12-31T23:59:59.999Z')` answered 253402300799998 — one millisecond short (node: …999). Same double-rounding artefact #2965 fixed in `JsDate.Max`, in the parse path's `(long)(…TotalMilliseconds)` conversions; both are now integer tick arithmetic.

**Why it only reproduced on net10:** `TimeSpan.TotalMilliseconds` multiplies by `1e-4` on .NET Framework and divides by `10000` on modern .NET, and the two round opposite ways — the red test was 3 failures on net10.0 and already green on net472. The engine now answers identically on both.

Two conversion sites fixed: the main ISO conversion, and the MimeKit fallback (floor semantics preserved) — the latter reachable and measured: a named-zone sweep showed **218 off-by-one mismatches**, e.g. `Date.parse('Sat, 15 Jun 5627 12:30:13 PST')`. The lossy band starts in **year 2427**, where double spacing stops dividing 10,000 ticks; roughly 1 in 5 values inside it came back low. The defect was quietly known: `EngineTests.DateShouldAllowEntireDotNetDateRange` carried an `#if NETCOREAPP` expecting `.998` on one framework and `.999` on the other. That conditional is gone.

Inventory of the remaining `TotalMilliseconds` uses, checked and left: `DateConstructor.FromDateTime` (deliberately deferred — changing it alters sub-millisecond rounding for every input; shares no helper with the parse sites), `Date.now()` (2-tick spacing at current epochs; can disagree with `new Date()` by 1 ms — recorded), and the `GetUtcOffset` uses (offsets bounded by a day, exact by construction).

Red 3 / green on net10.0, net472 green throughout. Test262 at baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)