### PR TITLE
Stop allocating a JsString for every inherited-global resolution

### DIFF
--- a/Jint.Benchmark/GlobalAccessBenchmarks.cs
+++ b/Jint.Benchmark/GlobalAccessBenchmarks.cs
@@ -27,12 +27,28 @@ public class GlobalAccessBenchmarks
     private IsolatedScript _globalUpdateLoop;
     private IsolatedScript _nestedGlobalReadLoop;
     private IsolatedScript _nestedGlobalWriteLoop;
+    private IsolatedScript _inheritedGlobalReadLoop;
+    private IsolatedScript _inheritedGlobalDestructureLoop;
 
     /// <summary>Builds a fresh engine carrying the fixture every row needs, and nothing else.</summary>
     private static Engine CreateEngine()
     {
         var engine = new Engine(static options => options.Strict());
         engine.Execute("var gx = 0; var gy = 0; var gz = 0; var gobj = null; var gsum = 0; var gval = 0;");
+        return engine;
+    }
+
+    /// <summary>
+    /// The fixture for the two inherited-name rows, and for them alone: a prototype on the global object
+    /// carrying names that resolve as bare identifiers without being own properties of the global — the
+    /// shape a host gets from projecting an object as the global's [[Prototype]]. Installing it in
+    /// <see cref="CreateEngine"/> instead would change what every other row measures, since their own
+    /// identifier misses would start walking a prototype chain.
+    /// </summary>
+    private static Engine CreateEngineWithGlobalPrototype()
+    {
+        var engine = CreateEngine();
+        engine.Execute("Object.setPrototypeOf(globalThis, { ipg: 1, set ist(v) { }, get ist() { return 1; } });");
         return engine;
     }
 
@@ -105,6 +121,31 @@ public class GlobalAccessBenchmarks
                 return gval;
             })();
             """, strict: true), CreateEngine);
+
+        // The two rows below are the only ones that leave the global object's own properties. Every
+        // other row in this class resolves to a name the global owns, so none of them ever reaches the
+        // prototype-chain lane the global environment record is spec'd around — a gap worth closing,
+        // because that lane is what a host projecting an object as the global's [[Prototype]] runs on.
+
+        // Reads that go out through a Reference — typeof and a call are the two shapes — enter
+        // GetBindingValue with a Key. The name is never shadowed, so the miss repeats on every read.
+        _inheritedGlobalReadLoop = IsolatedScript.Warm(Engine.PrepareScript("""
+            (function () {
+                var t;
+                for (var i = 0; i < 200000; i++) { t = typeof ipg; }
+                return t;
+            })();
+            """, strict: true), CreateEngineWithGlobalPrototype);
+
+        // A destructuring assignment target resolves through ResolveBinding, the other Key-only entry
+        // point into the record. The target is an inherited accessor, so the assignment runs the setter
+        // rather than shadowing the name, and the own-property miss repeats too.
+        _inheritedGlobalDestructureLoop = IsolatedScript.Warm(Engine.PrepareScript("""
+            var isrc = [7];
+            (function () {
+                for (var i = 0; i < 50000; i++) { [ist] = isrc; }
+            })();
+            """, strict: true), CreateEngineWithGlobalPrototype);
     }
 
     [Benchmark]
@@ -121,4 +162,10 @@ public class GlobalAccessBenchmarks
 
     [Benchmark]
     public JsValue NestedGlobalWriteLoop() => _nestedGlobalWriteLoop.Run();
+
+    [Benchmark]
+    public JsValue InheritedGlobalReadLoop() => _inheritedGlobalReadLoop.Run();
+
+    [Benchmark]
+    public JsValue InheritedGlobalDestructureLoop() => _inheritedGlobalDestructureLoop.Run();
 }

--- a/Jint.Tests/Runtime/GlobalPrototypeBindingTests.cs
+++ b/Jint.Tests/Runtime/GlobalPrototypeBindingTests.cs
@@ -240,4 +240,83 @@ public class GlobalPrototypeBindingTests
         engine.Execute("Object.setPrototypeOf(globalThis, { ev: 9 });");
         engine.Evaluate("eval('ev')").AsNumber().Should().Be(9);
     }
+
+#if NET
+    // Asking the global's prototype chain about a name needs the name as a JsValue, but the two entry
+    // points below hand the global environment record a Key. Rebuilding a JsString from it cost one
+    // 32-byte object per operation, and forever: neither shape here ever gains an own property that
+    // would end the miss. The iteration count is high enough that 32 bytes apiece is unmistakable.
+    private const int InheritedNameProbeIterations = 20_000;
+
+    /// <summary>
+    /// Runs <paramref name="source"/> twice to warm the engine's handler trees, then reports what a
+    /// third evaluation allocates per loop iteration.
+    /// </summary>
+    private static double AllocatedBytesPerIteration(Engine engine, string source)
+    {
+        var prepared = Engine.PrepareScript(source);
+        engine.Evaluate(prepared);
+        engine.Evaluate(prepared);
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        engine.Evaluate(prepared);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        return (double) allocated / InheritedNameProbeIterations;
+    }
+
+    [Fact]
+    public void ReadingAnInheritedNameDoesNotBuildItsNameStringPerRead()
+    {
+        // typeof and a call both resolve the identifier to a Reference and read it back through
+        // Engine.GetValue, which is where the Key-only GetBindingValue overload is entered; the
+        // reference already carries the name as a JsString. (A plain read never had the problem: it
+        // goes through TryGetBinding, whose BindingName carries the same string.)
+        var engine = new Engine();
+        engine.Execute("Object.setPrototypeOf(globalThis, { pg: 1, pf: function () { return 1; } });");
+
+        var typeOfBytes = AllocatedBytesPerIteration(engine, $$"""
+            (function () {
+                var t;
+                for (var i = 0; i < {{InheritedNameProbeIterations}}; i++) { t = typeof pg; }
+                return t;
+            })();
+            """);
+
+        var callBytes = AllocatedBytesPerIteration(engine, $$"""
+            (function () {
+                var t;
+                for (var i = 0; i < {{InheritedNameProbeIterations}}; i++) { t = pf(); }
+                return t;
+            })();
+            """);
+
+        // Both loops allocate nothing else at all, so the whole 32 bytes was the discarded name.
+        typeOfBytes.Should().BeLessThan(4, $"typeof of an inherited global allocated {typeOfBytes} bytes per read");
+        callBytes.Should().BeLessThan(4, $"calling an inherited global allocated {callBytes} bytes per call");
+    }
+
+    [Fact]
+    public void ProbingAnInheritedNameDoesNotBuildItsNameStringPerProbe()
+    {
+        // A destructuring assignment target goes through ResolveBinding, which walks the chain with a
+        // Key and ends at the global environment; its own-property miss falls through to
+        // [[HasProperty]] on the prototype. An inherited accessor is the shape that keeps missing —
+        // the assignment runs the setter instead of shadowing, so no own property ever appears.
+        var engine = new Engine();
+        engine.Execute("Object.setPrototypeOf(globalThis, { set st(v) { }, get st() { return 1; } });");
+
+        var bytes = AllocatedBytesPerIteration(engine, $$"""
+            var src = [7];
+            (function () {
+                for (var i = 0; i < {{InheritedNameProbeIterations}}; i++) { [st] = src; }
+            })();
+            """);
+
+        // Array destructuring legitimately allocates an iterator and its result objects per iteration
+        // (168 bytes when this was written), so the budget is that plus headroom and still well under
+        // the 200 bytes the extra name cost.
+        bytes.Should().BeLessThan(184, $"destructuring into an inherited accessor allocated {bytes} bytes per assignment");
+    }
+#endif
 }

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1443,7 +1443,15 @@ public sealed partial class Engine : IDisposable
         }
 
         var record = (Environment) baseValue;
-        var bindingValue = record.GetBindingValue(reference.ReferencedName.ToString(), reference.Strict);
+
+        // A reference built for an identifier already carries its name as a JsString, and the global
+        // environment is the one record whose miss path needs exactly that — a name resolving on the
+        // global's prototype reaches [[Get]] with a JsValue key on every read. Hand the reference's
+        // own string over instead of letting each read build a second one; everything else keeps the
+        // Key-only entry point it always used.
+        var bindingValue = record is GlobalEnvironment globalEnvironment && reference.ReferencedName is JsString bindingName
+            ? globalEnvironment.GetBindingValue(bindingName, reference.Strict)
+            : record.GetBindingValue(reference.ReferencedName.ToString(), reference.Strict);
 
         if (returnReferenceToPool)
         {
@@ -1775,16 +1783,28 @@ public sealed partial class Engine : IDisposable
     private static Reference GetIdentifierReference(Environment? env, string name, bool strict)
     {
         Key key = name;
+
+        // Every exit from this loop hands the name to a Reference as a JsString, so build it once up
+        // front rather than at each return. The global environment — always the last link of the chain
+        // walked here — then gets it for free on the probe that needs a JsValue key: its own-property
+        // miss falls through to [[HasProperty]] on the global's prototype chain, and a name that lives
+        // there (an inherited accessor or non-writable data property, which assignment never shadows)
+        // is probed again on every single evaluation.
+        var nameValue = JsString.Create(name);
         while (true)
         {
             if (env is null)
             {
-                return new Reference(Reference.Unresolvable, name, strict);
+                return new Reference(Reference.Unresolvable, nameValue, strict);
             }
 
-            if (env.HasBinding(key))
+            var found = env is GlobalEnvironment globalEnvironment
+                ? globalEnvironment.HasBinding(key, nameValue)
+                : env.HasBinding(key);
+
+            if (found)
             {
-                return new Reference(env, name, strict);
+                return new Reference(env, nameValue, strict);
             }
 
             env = env._outerEnv;

--- a/Jint/Runtime/Environments/GlobalEnvironment.cs
+++ b/Jint/Runtime/Environments/GlobalEnvironment.cs
@@ -47,7 +47,16 @@ internal sealed class GlobalEnvironment : Environment
     /// https://tc39.es/ecma262/#sec-global-environment-records-hasbinding-n — routes through
     /// [[HasProperty]] on the global, so names inherited from its prototype chain bind too.
     /// </summary>
-    internal override bool HasBinding(Key name)
+    internal override bool HasBinding(Key name) => HasBinding(name, nameValue: null);
+
+    /// <summary>
+    /// <see cref="HasBinding(Key)"/> for a caller that already holds the name as a
+    /// <see cref="JsString"/>. Only the paths that leave the global's own properties need one —
+    /// [[HasProperty]] takes a <see cref="JsValue"/> key — so handing the caller's over is what keeps
+    /// a repeated miss from building the same string object again on every probe. A caller without
+    /// one passes <see langword="null"/> and pays exactly what it did before.
+    /// </summary>
+    internal bool HasBinding(Key name, JsString? nameValue)
     {
         if (_declarativeRecord.HasBinding(name))
         {
@@ -56,10 +65,10 @@ internal sealed class GlobalEnvironment : Environment
 
         if (_globalObject is not null)
         {
-            return _globalObject.HasOwnProperty(name) || HasBindingOnGlobalPrototype(JsString.Create(name.Name));
+            return _globalObject.HasOwnProperty(name) || HasBindingOnGlobalPrototype(nameValue ?? JsString.Create(name.Name));
         }
 
-        return _global.HasProperty(new JsString(name));
+        return _global.HasProperty(nameValue ?? JsString.Create(name.Name));
     }
 
     /// <inheritdoc cref="HasBinding(Key)" />
@@ -313,7 +322,17 @@ internal sealed class GlobalEnvironment : Environment
     /// through the global's whole prototype chain; only a name absent everywhere is a
     /// ReferenceError in strict mode.
     /// </summary>
-    internal override JsValue GetBindingValue(Key name, bool strict)
+    internal override JsValue GetBindingValue(Key name, bool strict) => GetBindingValue(name, nameValue: null, strict);
+
+    /// <summary>
+    /// <see cref="GetBindingValue(Key, bool)"/> for a caller that already holds the name as a
+    /// <see cref="JsString"/> — every reference the interpreter builds for an identifier carries one.
+    /// A name that resolves on the global's prototype rather than on the global itself reaches
+    /// [[Get]], which needs a <see cref="JsValue"/> key, on every single read.
+    /// </summary>
+    internal JsValue GetBindingValue(JsString name, bool strict) => GetBindingValue(name.ToString(), name, strict);
+
+    private JsValue GetBindingValue(Key name, JsString? nameValue, bool strict)
     {
         if (_declarativeRecord.HasBinding(name))
         {
@@ -333,16 +352,16 @@ internal sealed class GlobalEnvironment : Environment
 
         if (desc == PropertyDescriptor.Undefined)
         {
-            return GetBindingValueUnlikely(name, strict);
+            return GetBindingValueUnlikely(name, nameValue, strict);
         }
 
         return ObjectInstance.UnwrapJsValue(desc, _global);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private JsValue GetBindingValueUnlikely(Key name, bool strict)
+    private JsValue GetBindingValueUnlikely(Key name, JsString? nameValue, bool strict)
     {
-        if (_global._prototype is not null && TryGetFromGlobalPrototype(JsString.Create(name.Name), out var value))
+        if (_global._prototype is not null && TryGetFromGlobalPrototype(nameValue ?? JsString.Create(name.Name), out var value))
         {
             return value;
         }


### PR DESCRIPTION
> Draft until its gate lands — the two new benchmark rows plus `GlobalAccessBenchmarks` flat-check run in the release measurement block.

`GlobalEnvironment.HasBinding(Key)` and `GetBindingValueUnlikely` called `JsString.Create(name.Name)` on the prototype-resolution path — a fresh 32-byte `JsString` per miss. The review flagged it; **instrumentation then corrected the review's own probe**: `typeof undeclared` never reaches either site (it resolves through the `BindingName` overloads into an unresolvable reference). The shapes that actually pay, measured with counters over 1000 iterations:

| workload | `HasBinding(Key)` | `GetBindingValueUnlikely` |
|---|---|---|
| `typeof valueOf` (no host setup — `Object.prototype` is the global's default prototype) | 0 | **1000** |
| call of an inherited global | 0 | **1000** |
| destructure into an inherited accessor / non-writable target | **1000** | 0 |

Both callers already hold the name as a `JsString` — `Engine.GetValue` in the reference it is reading, `GetIdentifierReference` in the reference it was about to allocate anyway. Threaded through via `GlobalEnvironment`-only internal overloads plus one `is GlobalEnvironment` test at the two call sites: no new vtable slot, `Key`-only entry points unchanged.

Alloc probe (`#if NET`, per the in-repo precedent), bytes per operation over 20,000 iterations: `typeof` inherited **32.03 → 0.03**, call of inherited **32.03 → 0.03**, destructure into accessor **200.05 → 168.05** — exactly one `JsString` per operation, gone.

`GlobalAccessBenchmarks` had **no row exercising the miss path** (all five resolve names the global owns); two are added with their own prototype-bearing fixture — `InheritedGlobalReadLoop` and `InheritedGlobalDestructureLoop` — smoke-checked through the REPL for genuine per-iteration misses, not run. The gate also checks the pre-existing five rows for the cost of the new type test on the hit path.

test262 at baseline (the 8-test S7.8.5 load flake identical on unmodified `cf3c048de`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)