### PR TITLE
Mark a global created through an inherited write as a mutable binding

### DIFF
--- a/Jint.Tests/Runtime/GlobalPrototypeBindingTests.cs
+++ b/Jint.Tests/Runtime/GlobalPrototypeBindingTests.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using Jint.Runtime;
+using Jint.Runtime.Descriptors;
 
 namespace Jint.Tests.Runtime;
 
@@ -117,6 +118,90 @@ public class GlobalPrototypeBindingTests
         engine.Evaluate("globalThis.hasOwnProperty('nw')").AsBoolean().Should().BeFalse();
         engine.Evaluate("(function () { 'use strict'; try { nw = 9; return 'no error'; } catch (e) { return e instanceof TypeError ? 'TypeError' : 'other'; } })()").AsString().Should().Be("TypeError");
     }
+
+    private static PropertyFlag GlobalPropertyFlags(Engine engine, string name)
+        => engine.Realm.GlobalObject.GetOwnProperty(name).Flags;
+
+    [Fact]
+    public void ShadowingAnInheritedNameCreatesAMutableBindingLikeAVarDeclarationDoes()
+    {
+        // Assigning to a name that resolves on the global's prototype shadows it, and the shadow is a
+        // global binding like any other. It is created by ordinary [[Set]] though, which knows nothing
+        // about bindings and left off the marker that lets the two stores in GlobalObject write the
+        // descriptor's value in place — so every write after the first took the validate-and-apply path,
+        // permanently. An eval-scoped `var` produces the same configurable/enumerable/writable property
+        // through the binding machinery's own helper, so the two must be indistinguishable.
+        var engine = new Engine();
+        engine.Execute("Object.setPrototypeOf(globalThis, { shadowed: 1 });");
+        engine.Execute("shadowed = 5; (0, eval)('var declared = 5');");
+
+        var shadowed = GlobalPropertyFlags(engine, "shadowed");
+
+        shadowed.Should().HaveFlag(PropertyFlag.MutableBinding);
+        shadowed.Should().Be(GlobalPropertyFlags(engine, "declared"));
+    }
+
+    [Fact]
+    public void TheMutableBindingMarkerDoesNotChangeHowAShadowedGlobalBehaves()
+    {
+        var engine = new Engine();
+        engine.Execute("Object.setPrototypeOf(globalThis, { w: 1 }); w = 5;");
+
+        // the marker is internal: the property describes itself exactly as [[Set]] left it
+        engine.Evaluate("JSON.stringify(Object.getOwnPropertyDescriptor(globalThis, 'w'))").AsString()
+            .Should().Be("""{"value":5,"writable":true,"enumerable":true,"configurable":true}""");
+
+        // clearing writable is still honoured — the in-place store the marker enables sits behind the
+        // writable check, not in front of it
+        engine.Execute("Object.defineProperty(globalThis, 'w', { writable: false });");
+        engine.Execute("w = 9;");
+        engine.Evaluate("w").AsNumber().Should().Be(5);
+        engine.Evaluate("(function () { 'use strict'; try { w = 9; return 'no error'; } catch (e) { return e instanceof TypeError ? 'TypeError' : 'other'; } })()")
+            .AsString().Should().Be("TypeError");
+
+        // redefining it as an accessor still routes assignment to the setter
+        engine.Execute("Object.defineProperty(globalThis, 'w', { get: function () { return 'got'; }, set: function (v) { globalThis.observed = v; } });");
+        engine.Evaluate("w").AsString().Should().Be("got");
+        engine.Execute("w = 11;");
+        engine.Evaluate("observed").AsNumber().Should().Be(11);
+
+        // and the marker is not a claim that the property cannot be deleted
+        engine.Evaluate("delete w").AsBoolean().Should().BeTrue();
+        engine.Evaluate("globalThis.hasOwnProperty('w')").AsBoolean().Should().BeFalse();
+        engine.Evaluate("w").AsNumber().Should().Be(1, "the inherited property is visible again");
+    }
+
+#if NET
+    [Fact]
+    public void RepeatedWritesToAShadowedGlobalStoreInPlace()
+    {
+        // A destructuring assignment target has no per-site write cache, so every iteration goes through
+        // GlobalObject.SetFromMutableBinding — the store the marker decides. Without it each write built
+        // a fresh PropertyDescriptor and a fresh key for ValidateAndApplyPropertyDescriptor to consume.
+        const int iterations = 20_000;
+
+        var engine = new Engine();
+        engine.Execute("Object.setPrototypeOf(globalThis, { acc: 0 }); acc = 0;");
+
+        var prepared = Engine.PrepareScript($$"""
+            var src = [7];
+            (function () {
+                for (var i = 0; i < {{iterations}}; i++) { [acc] = src; }
+            })();
+            """);
+        engine.Evaluate(prepared);
+        engine.Evaluate(prepared);
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        engine.Evaluate(prepared);
+        var perWrite = (double) (GC.GetAllocatedBytesForCurrentThread() - before) / iterations;
+
+        // Array destructuring legitimately allocates an iterator and its result objects per iteration
+        // (104 bytes when this was written). The validate-and-apply path added exactly 64 on top of
+        // that, every write: one PropertyDescriptor to carry the new value and one JsString key.
+        perWrite.Should().BeLessThan(130, $"writing a shadowed global allocated {perWrite} bytes per write");
+    }
+#endif
 
     [Fact]
     public void ProtoAssignmentAtGlobalScopeStillRunsTheInheritedSetter()

--- a/Jint/Native/Global/GlobalObject.cs
+++ b/Jint/Native/Global/GlobalObject.cs
@@ -886,6 +886,42 @@ uriError:
         }
 
         result = Set(jsName, value, this);
+
+        if (result)
+        {
+            MarkBindingPropertyCreatedByShadowing(property);
+        }
+
         return true;
+    }
+
+    /// <summary>
+    /// Where the inherited property is writable data, [[Set]] shadows it by creating an own property on
+    /// the receiver through CreateDataProperty. That gives the right attributes but not
+    /// <see cref="PropertyFlag.MutableBinding"/>, which is the marker telling the two stores above they
+    /// may write the descriptor's value in place. So a property the binding machinery had itself just
+    /// created sent every later write of that name down the validate-and-apply path instead — allocating
+    /// a descriptor and a key each time, and for the rest of the engine's life, since nothing ever puts
+    /// the marker on afterwards. Both of the record's other ways of creating a global property mark it:
+    /// CreateGlobalVarBinding for a <c>var</c> declaration, and the branch just above for a binding that
+    /// resolves to nothing on the prototype either.
+    /// </summary>
+    /// <remarks>
+    /// <para>Only the exact descriptor CreateDataProperty leaves behind is marked. The caller has already
+    /// established that the global had no own property of this name before the [[Set]], so whatever is
+    /// there now was created by it — but an inherited setter is free to have defined something of its
+    /// own shape during the call, and that is left alone.</para>
+    /// <para>A sloppy assignment to a name that resolves nowhere at all is a different route with the
+    /// same shortfall, and is deliberately not covered here: the reference is unresolvable, so PutValue
+    /// never reaches this record and assigns through the global object's plain [[Set]] instead.</para>
+    /// </remarks>
+    private void MarkBindingPropertyCreatedByShadowing(Key property)
+    {
+        var created = GetOwnProperty(property);
+        if (created != PropertyDescriptor.Undefined
+            && created._flags == PropertyFlag.ConfigurableEnumerableWritable)
+        {
+            created._flags |= PropertyFlag.MutableBinding;
+        }
     }
 }


### PR DESCRIPTION
A global created by assignment resolving through the prototype (`TrySetThroughPrototype` → `[[Set]]` with the global as receiver, per #2928's semantics) got a plain data descriptor without `PropertyFlag.MutableBinding`, so every later write missed `SetFromMutableBinding`'s in-place fast path **forever**: counters showed the slow path taken 999/1000 times for destructuring and `x += 1` after the shadow, versus 1000/1000 in-place for a `var`-created global. A warmed simple-assignment site hides it behind its own per-site cache; everything without one pays.

The flag-reader audit the review demanded came back clean — **exactly two behavioural readers**, both the in-place value store in `GlobalObject`, both already gated on `IsDataDescriptor() && Writable`; the private `DefineOwnProperty` arm is unreachable-with-flag, `FromPropertyDescriptor` cannot make the flag script-observable, and data→accessor redefinition routes on `NonData` regardless. Writers already span three origins, so nothing distinguishes them. The marking is guarded on the descriptor being exactly what `CreateDataProperty` leaves, so an inherited setter that defined something of its own shape is untouched.

Red/green: the flag assertion fails red and passes green; the allocation probe drops **168.05 → 104.05** bytes per destructuring write — one discarded `PropertyDescriptor` plus its `JsString` key. The semantics pin (`getOwnPropertyDescriptor` output, `writable:false` honoured, accessor redefinition, `delete`) passes on **both** sides, as it must.

**Recorded follow-up, deliberately out of scope:** a sloppy assignment to a name resolving *nowhere* has the same shortfall by a different route (`PutValue` → `Engine.SetValue` → ordinary `[[Set]]`, no marker) — documented in code and commit message.

test262 at baseline. Merges cleanly alongside the sibling perf PR despite sharing a test file — insertions at different points, verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)