### PR TITLE
Keep both CLR facts when an error carries resolution info and an exception

### DIFF
--- a/Jint.Tests/Runtime/InteropTests.ErrorMessages.cs
+++ b/Jint.Tests/Runtime/InteropTests.ErrorMessages.cs
@@ -270,6 +270,43 @@ public partial class InteropTests
         capturedInfo.Arguments[0].AsString().Should().Be("Hello");
         capturedInfo.Arguments[1].AsString().Should().Be("World");
     }
+
+    /// <summary>
+    /// The two host-facing CLR facts an error can carry — where a failed resolution came from, and the CLR
+    /// exception the error stands in for — are independent, and recording one must not erase the other.
+    /// No in-box path reaches both setters on one error today, because each of the three call sites
+    /// constructs the error it annotates, so the test drives them directly: this is the regression net for
+    /// folding the facts behind one record, whose replace-wholesale shape made them mutually exclusive.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ClrResolutionInfoAndClrExceptionCoexistOnOneError(bool resolutionInfoFirst)
+    {
+        var engine = new Engine();
+        var error = (Jint.Native.Error.ErrorInstance) engine.Realm.Intrinsics.TypeError.Construct("boom");
+        var clrException = new InvalidOperationException("host blew up");
+
+        if (resolutionInfoFirst)
+        {
+            error.SetClrResolutionInfo(typeof(Speaker), "Say");
+            error.SetClrException(clrException);
+        }
+        else
+        {
+            error.SetClrException(clrException);
+            error.SetClrResolutionInfo(typeof(Speaker), "Say");
+        }
+
+        var ex = new JavaScriptException(error);
+
+        JintException.TryGetClrType(ex, out var type).Should().BeTrue();
+        type.Should().Be(typeof(Speaker));
+        JintException.TryGetClrMemberName(ex, out var member).Should().BeTrue();
+        member.Should().Be("Say");
+        JintException.TryGetClrException(ex, out var recovered).Should().BeTrue();
+        recovered.Should().BeSameAs(clrException);
+    }
 }
 
 public class Speaker

--- a/Jint/Native/Error/ErrorInstance.cs
+++ b/Jint/Native/Error/ErrorInstance.cs
@@ -38,14 +38,29 @@ public class ErrorInstance : ObjectInstance
     /// </summary>
     internal Exception? ClrException => _clrContext?.ClrException;
 
+    /// <summary>
+    /// Records where a failed CLR resolution came from, keeping any exception already recorded.
+    /// </summary>
+    /// <remarks>
+    /// The facts behind <see cref="ClrErrorContext"/> are independent, and each setter owns only its own.
+    /// No in-box path reaches both on one error — the three call sites each construct the error they
+    /// annotate — so this is defensive; it is the record that made it worth stating, because folding one
+    /// field per fact behind a single reference turned "set the other fact" into "replace every fact",
+    /// where before the fields were separate and one setter could not reach the other's.
+    /// </remarks>
     internal void SetClrResolutionInfo(Type clrType, string? memberName)
     {
-        _clrContext = new ClrErrorContext(clrType, memberName, ClrException: null);
+        _clrContext = new ClrErrorContext(clrType, memberName, _clrContext?.ClrException);
     }
 
+    /// <summary>
+    /// Records the CLR exception this error stands in for, keeping any resolution origin already recorded.
+    /// See <see cref="SetClrResolutionInfo"/> for why the two must not clobber each other.
+    /// </summary>
     internal void SetClrException(Exception clrException)
     {
-        _clrContext = new ClrErrorContext(ResolutionType: null, ResolutionMemberName: null, clrException);
+        var existing = _clrContext;
+        _clrContext = new ClrErrorContext(existing?.ResolutionType, existing?.ResolutionMemberName, clrException);
     }
 
     /// <summary>


### PR DESCRIPTION
`ErrorInstance`'s two host-facing setters clobbered each other — `SetClrResolutionInfo` nulled `ClrException` and vice versa — because #2916 folded three fields into one `ClrErrorContext` record replaced wholesale.

**The interleaving verdict the review demanded: no real path exists.** All three call sites construct the error they annotate (`Throw.InteropResolutionError`, `Throw.FromClrException`, the public `JavaScriptException` ctor), and no API attaches either fact to a pre-existing error — so this is a **defensive** fix, stated as such in the commit message and setter docs, making the record merge instead of replace. The test lives in `Jint.Tests` (the setters are internal), asserting through the public `TryGetClr*` accessors, red both interleaving orders.

test262 standalone baseline-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)