### PR TITLE
Give the iterator helpers return's real state machine

### DIFF
--- a/Jint.Tests/Runtime/IteratorHelpersTests.cs
+++ b/Jint.Tests/Runtime/IteratorHelpersTests.cs
@@ -1082,6 +1082,151 @@ public class IteratorHelpersTests
         result.Should().Be($$"""[1,"{{tag}}",false,false,true,"undefined","undefined"]""");
     }
 
+    // %IteratorHelperPrototype%.return is a state machine over [[GeneratorState]]
+    // (https://tc39.es/ecma262/#sec-%iteratorhelperprototype%.return), and the four tests below cover the
+    // states it can be called in. Every expectation was taken from node (V8) running the same script.
+
+    [Theory]
+    [InlineData("map", "x")]
+    [InlineData("filter", "true")]
+    [InlineData("flatMap", "[x]")]
+    public void ReturnWhileExecutingIsATypeErrorAndClosesNothing(string method, string mapped)
+    {
+        // Step 6 hands an executing helper to GeneratorResumeAbrupt, whose GeneratorValidate rejects it.
+        // Closing the underlying iterator instead would invoke "return" where the spec invokes nothing —
+        // and leave the helper yielding from an iterator it had already closed.
+        var engine = new Engine();
+        var result = engine.Evaluate($$"""
+            const trace = [];
+            let i = 0;
+            const src = {
+                __proto__: Iterator.prototype,
+                next() { trace.push('next'); return { value: ++i, done: false }; },
+                return(v) { trace.push('return'); return { value: v, done: true }; }
+            };
+            let h;
+            h = src.{{method}}(x => {
+                try { h.return(); trace.push('inner-return-ok'); }
+                catch (e) { trace.push('inner-' + e.constructor.name); }
+                return {{mapped}};
+            });
+            trace.push('next1=' + JSON.stringify(h.next()));
+            JSON.stringify(trace);
+            """).AsString();
+
+        result.Should().Be("""["next","inner-TypeError","next1={\"value\":1,\"done\":false}"]""");
+    }
+
+    [Fact]
+    public void ReturnWhileExecutingRejectsTheHelperBeingStepped()
+    {
+        // A helper stacked on another only makes the executing one observable from further away.
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            const trace = [];
+            let i = 0;
+            const src = {
+                __proto__: Iterator.prototype,
+                next() { trace.push('next'); return { value: ++i, done: false }; },
+                return(v) { trace.push('return'); return { value: v, done: true }; }
+            };
+            let inner;
+            inner = src.map(x => {
+                try { inner.return(); trace.push('inner-return-ok'); }
+                catch (e) { trace.push('inner-' + e.constructor.name); }
+                return x;
+            });
+            const outer = inner.map(x => x);
+            trace.push('outer-next=' + JSON.stringify(outer.next()));
+            JSON.stringify(trace);
+            """).AsString();
+
+        result.Should().Be("""["next","inner-TypeError","outer-next={\"value\":1,\"done\":false}"]""");
+    }
+
+    [Fact]
+    public void ReturnOnACompletedHelperClosesNothing()
+    {
+        // GeneratorResumeAbrupt answers a completed generator with a done result and resumes no body, so
+        // nothing is left to close. flatMap is where that is observable: an inner iterator whose step threw
+        // is already done — IteratorStepValue marked it so and closed nothing — and the abrupt step closed
+        // the outer on its way out. A return afterwards must touch neither.
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            const trace = [];
+            let innerCount = 0;
+            const inner = {
+                next() { trace.push('inner-next'); if (++innerCount > 1) { throw new RangeError('inner boom'); } return { value: 'a', done: false }; },
+                return(v) { trace.push('inner-return'); return { value: v, done: true }; },
+                [Symbol.iterator]() { return this; }
+            };
+            const outer = {
+                __proto__: Iterator.prototype,
+                next() { trace.push('outer-next'); return { value: inner, done: false }; },
+                return(v) { trace.push('outer-return'); return { value: v, done: true }; }
+            };
+            const h = outer.flatMap(x => x);
+            trace.push('next1=' + JSON.stringify(h.next()));
+            try { h.next(); } catch (e) { trace.push('next2-' + e.constructor.name); }
+            trace.push('return=' + JSON.stringify(h.return()));
+            trace.push('return2=' + JSON.stringify(h.return()));
+            JSON.stringify(trace);
+            """).AsString();
+
+        result.Should().Be("""["outer-next","inner-next","next1={\"value\":\"a\",\"done\":false}","inner-next","outer-return","next2-RangeError","return={\"done\":true}","return2={\"done\":true}"]""");
+    }
+
+    [Fact]
+    public void ReturnBeforeTheFirstNextClosesTheUnderlyingIterator()
+    {
+        // Step 4's suspended-start branch: the body never ran, so the close is the whole of the work.
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            const trace = [];
+            const src = {
+                __proto__: Iterator.prototype,
+                next() { trace.push('next'); return { value: 1, done: false }; },
+                return(v) { trace.push('return'); return { value: v, done: true }; }
+            };
+            const h = src.map(x => x);
+            trace.push('return=' + JSON.stringify(h.return()));
+            trace.push('next=' + JSON.stringify(h.next()));
+            trace.push('return2=' + JSON.stringify(h.return()));
+            JSON.stringify(trace);
+            """).AsString();
+
+        result.Should().Be("""["return","return={\"done\":true}","next={\"done\":true}","return2={\"done\":true}"]""");
+    }
+
+    [Fact]
+    public void ReturnFromInsideTheUnderlyingCloseSeesACompletedHelper()
+    {
+        // The state moves to completed *before* the close runs, so a "return" that re-enters the helper
+        // from inside the underlying iterator's own "return" is answered rather than rejected. This is what
+        // stops the executing check above from turning an ordinary close into a TypeError.
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            const trace = [];
+            let h;
+            const src = {
+                __proto__: Iterator.prototype,
+                next() { trace.push('next'); return { value: 1, done: false }; },
+                return(v) {
+                    trace.push('src-return');
+                    try { trace.push('nested=' + JSON.stringify(h.return())); }
+                    catch (e) { trace.push('nested-' + e.constructor.name); }
+                    return { value: v, done: true };
+                }
+            };
+            h = src.map(x => x);
+            trace.push('next1=' + JSON.stringify(h.next()));
+            trace.push('outer-return=' + JSON.stringify(h.return()));
+            JSON.stringify(trace);
+            """).AsString();
+
+        result.Should().Be("""["next","next1={\"value\":1,\"done\":false}","src-return","nested={\"done\":true}","outer-return={\"done\":true}"]""");
+    }
+
     [Fact]
     public void TheReceiverOfAHelperKeepsItsOwnToStringTag()
     {

--- a/Jint/Native/Iterator/IteratorHelper.cs
+++ b/Jint/Native/Iterator/IteratorHelper.cs
@@ -81,23 +81,55 @@ internal abstract class IteratorHelper : ObjectInstance
 
     /// <summary>
     /// Called by IteratorHelperPrototype.return() to close the helper.
+    /// https://tc39.es/ecma262/#sec-%iteratorhelperprototype%.return
     /// </summary>
-    public virtual ObjectInstance Return()
+    /// <remarks>
+    /// The three reachable [[GeneratorState]]s answer differently, and each difference is observable:
+    /// <list type="bullet">
+    /// <item>executing - step 6 hands the helper to GeneratorResumeAbrupt, whose GeneratorValidate rejects a
+    /// running generator. That is a return re-entering the helper from inside its own mapper or predicate;
+    /// closing the underlying iterator there would invoke "return" where the spec invokes nothing, and would
+    /// leave the helper going on to yield from an iterator it had just closed.</item>
+    /// <item>completed - GeneratorResumeAbrupt answers a return completion with a done result and resumes no
+    /// body, so nothing is left to close. This is not the same question as <see cref="Exhausted"/>, which is
+    /// about the underlying record: a flatMap whose inner iterator stepped abruptly is completed while still
+    /// holding that inner iterator, and closing it here is precisely what the spec does not do.</item>
+    /// <item>suspended-start / suspended-yield - close, which is step 4c for the former and the body's own
+    /// IfAbruptCloseIterator for the latter. Both are an IteratorClose with a non-throw completion, so the
+    /// difference between the spec's normal and return completions is not observable here.</item>
+    /// </list>
+    /// The state moves to completed <em>before</em> the close, so a return that re-enters from inside the
+    /// underlying iterator's own "return" lands in the completed arm rather than the executing one.
+    /// </remarks>
+    public ObjectInstance Return()
     {
-        // 3. Assert: O has an [[UnderlyingIterator]] internal slot.
-        // 4. Let iterator be O.[[UnderlyingIterator]].[[Iterator]].
-        // 5. Set O.[[GeneratorState]] to completed.
-        State = GeneratorState.Completed;
+        if (State == GeneratorState.Executing)
+        {
+            Throw.TypeError(_engine.Realm, "Generator is already executing");
+        }
 
-        // 6. Let innerIterator be O.[[UnderlyingIterator]].
-        // 7. Return ? IteratorClose(innerIterator, NormalCompletion(undefined)).
-        // Only close if not already exhausted
+        if (State != GeneratorState.Completed)
+        {
+            State = GeneratorState.Completed;
+            CloseOnReturn();
+        }
+
+        return CreateIteratorResult(Undefined, done: true);
+    }
+
+    /// <summary>
+    /// Closes whatever this helper still holds open, for a <see cref="Return"/> that reached a suspended
+    /// helper. <see cref="Exhausted"/> is what says the underlying record is already done - the step reported
+    /// DONE, the step itself completed abruptly, or the helper ran an IteratorClose of its own - and closing
+    /// again would invoke "return" a second time.
+    /// </summary>
+    protected virtual void CloseOnReturn()
+    {
         if (!Exhausted)
         {
-            Exhausted = true; // Prevent subsequent calls from forwarding
+            Exhausted = true;
             CloseIterator(CompletionType.Return);
         }
-        return CreateIteratorResult(Undefined, done: true);
     }
 
     /// <summary>
@@ -462,28 +494,18 @@ internal sealed class FlatMapIterator : IteratorHelper
     }
 
     /// <summary>
-    /// Override Return to also close the inner iterator if present.
+    /// A flatMap suspended inside an inner iterator holds two open records, and the body's
+    /// IfAbruptCloseIterator closes the inner one before the outer.
     /// </summary>
-    public override ObjectInstance Return()
+    protected override void CloseOnReturn()
     {
-        // Set state to completed first
-        State = GeneratorState.Completed;
-
-        // Close the inner iterator if there is one and it hasn't been closed yet
         if (_innerIterator is not null && !_innerIteratorClosed)
         {
             _innerIteratorClosed = true;
             _innerIterator.Close(CompletionType.Return);
         }
 
-        // Close the outer iterator
-        if (!Exhausted)
-        {
-            Exhausted = true;
-            CloseIterator(CompletionType.Return);
-        }
-
-        return CreateIteratorResult(Undefined, done: true);
+        base.CloseOnReturn();
     }
 
     protected override StepResult ExecuteStep()


### PR DESCRIPTION
The refute-if-node-agrees probe found **two observable divergences**, so this shipped as a fix rather than a refutation:

- **`executing`** — `h.return()` re-entered from inside its own mapper/predicate. Node: `TypeError`, source `return` never invoked. Jint closed the source, answered `{done:true}`, then **went on yielding from the iterator it had just closed** and closed it again on the next call. Reproduced on `map`, `filter`, `flatMap` and through a stacked helper.
- **`completed`** — a flatMap whose inner iterator's step threw emitted an extra `inner-return` on a later `return()`; `Exhausted` covers the underlying *record*, not the generator state.

All 16 probes across the four states are now byte-identical to node except the non-normative TypeError wording (`Generator is already executing`, Jint's existing phrasing from `Next()`). The ordering that makes it hold is load-bearing and now explicit: the state moves to `completed` *before* the close, which is why a `return` re-entering from inside the source's own `return()` sees a completed helper instead of tripping the new `executing` check. `Return` is no longer `virtual`; `FlatMapIterator` overrides only the new `CloseOnReturn`, which is what it actually varies.

Left alone with reasons: `ConcatIterator`/`ZipIterator` set `Executing` *during* their close where `IteratorHelper` must not — node has neither API, so nothing can adjudicate; outside the brief.

Red 5 / green 199 for the class, both TFMs. test262 standalone baseline-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)