### PR TITLE
Name a destructuring default only when the default was evaluated

### DIFF
--- a/Jint.Tests/Runtime/DestructuringTests.cs
+++ b/Jint.Tests/Runtime/DestructuringTests.cs
@@ -181,4 +181,154 @@ public class DestructuringTests
             """);
         result.AsString().Should().Be("3,4");
     }
+
+    [Fact]
+    public void FunctionShapedDefaultDoesNotClaimASuppliedNonFunction()
+    {
+        // The one-liner from the report: the initializer is syntactically a function, the supplied
+        // value is not, and the initializer is therefore never evaluated. Naming used to be selected
+        // on the initializer's syntax alone and applied to whatever got bound, so the cast to
+        // Function threw an InvalidCastException straight out of Evaluate — past any script catch.
+        new Engine().Evaluate("var { a = () => {} } = { a: 1 }; a").AsNumber().Should().Be(1);
+
+        new Engine().Evaluate("""
+            var caught = 'nothing';
+            try { var { a = () => {} } = { a: 1 }; } catch (e) { caught = 'caught'; }
+            caught;
+            """).AsString().Should().Be("nothing");
+    }
+
+    /// <summary>
+    /// Initializer kinds a destructuring default can be written as, paired with the name the bound
+    /// function ends up carrying when the default *is* taken. Anonymous definitions get the bound
+    /// name (NamedEvaluation); a definition that names itself keeps its own name. Every expectation
+    /// here is node v24's answer.
+    /// </summary>
+    private static readonly (string Initializer, string NameWhenTaken)[] DefaultInitializers =
+    [
+        ("() => {}", "a"),
+        ("function () {}", "a"),
+        ("function foo() {}", "foo"),
+        ("function* () {}", "a"),
+        ("function* gen() {}", "gen"),
+        ("class {}", "a"),
+        ("class Kls {}", "Kls"),
+        ("async () => {}", "a"),
+    ];
+
+    /// <summary>
+    /// The five destructuring shapes that share
+    /// <c>DestructuringPatternAssignmentExpression.ProcessPatterns</c>. <c>#DEFAULT#</c> is the
+    /// element carrying the initializer, <c>#VALUE#</c> the value the pattern is fed.
+    /// </summary>
+    public static TheoryData<string> PatternShapes() =>
+    [
+        "var { #DEFAULT# } = { a: #VALUE# }; describe(a)",
+        "var [ #DEFAULT# ] = [ #VALUE# ]; describe(a)",
+        "var a; ({ #DEFAULT# } = { a: #VALUE# }); describe(a)",
+        "var a; ([ #DEFAULT# ] = [ #VALUE# ]); describe(a)",
+        "var r; for (var { #DEFAULT# } of [{ a: #VALUE# }]) { r = a; } describe(r)",
+    ];
+
+    private const string Describe =
+        "function describe(v) { return typeof v === 'function' ? 'fn:' + v.name : typeof v + ':' + String(v); } ";
+
+    [Theory]
+    [MemberData(nameof(PatternShapes))]
+    public void ADefaultIsOnlyNamedWhenTheDefaultIsWhatGotBound(string shape)
+    {
+        // NamedEvaluation applies when the initializer is an anonymous function definition *and* the
+        // supplied value was undefined, so the initializer is the value being bound. A supplied value
+        // is bound as it stands, whatever the initializer looks like.
+        // https://tc39.es/ecma262/#sec-runtime-semantics-keyedbindinginitialization
+        var supplied = new[]
+        {
+            ("1", "number:1"),
+            ("'s'", "string:s"),
+            ("({})", "object:[object Object]"),
+            ("(function supplied() {})", "fn:supplied"),
+        };
+
+        var expected = new List<string>();
+        var actual = new List<string>();
+
+        foreach (var (initializer, nameWhenTaken) in DefaultInitializers)
+        {
+            foreach (var (source, description) in supplied)
+            {
+                Record(initializer, source, description);
+            }
+
+            // undefined is the one supplied value that lets the initializer run.
+            Record(initializer, "undefined", "fn:" + nameWhenTaken);
+        }
+
+        string.Join("\n", actual).Should().Be(string.Join("\n", expected));
+
+        void Record(string initializer, string suppliedSource, string description)
+        {
+            var script = shape
+                .Replace("#DEFAULT#", "a = " + initializer)
+                .Replace("#VALUE#", suppliedSource);
+
+            expected.Add(script + "  =>  " + description);
+
+            string outcome;
+            try
+            {
+                outcome = new Engine().Evaluate(Describe + script).AsString();
+            }
+            catch (Exception ex)
+            {
+                outcome = ex.GetType().Name + ": " + ex.Message;
+            }
+
+            actual.Add(script + "  =>  " + outcome);
+        }
+    }
+
+    [Fact]
+    public void NamedEvaluationOfADefaultFollowsTheBindingTarget()
+    {
+        // Expectations are node v24's. The bound name — not the source key — is what names the
+        // function, a member-expression target is not an identifier reference so nothing is named,
+        // and only undefined lets the initializer run at all.
+        var engine = new Engine();
+        string Describe(string script) => engine.Evaluate(DestructuringTests.Describe + script).AsString();
+
+        Describe("var { a: b = () => {} } = {}; describe(b)").Should().Be("fn:b");
+        Describe("var { a: b = () => {} } = { a: 1 }; describe(b)").Should().Be("number:1");
+        Describe("var b; ({ a: b = () => {} } = {}); describe(b)").Should().Be("fn:b");
+        Describe("var b; ({ a: b = () => {} } = { a: 1 }); describe(b)").Should().Be("number:1");
+
+        Describe("var k = 'a'; var { [k]: a = () => {} } = {}; describe(a)").Should().Be("fn:a");
+        Describe("var k = 'a'; var { [k]: a = () => {} } = { a: 1 }; describe(a)").Should().Be("number:1");
+
+        // A member-expression target gets no NamedEvaluation, so the arrow stays nameless.
+        Describe("var o = {}; ({ a: o.x = () => {} } = {}); describe(o.x)").Should().Be("fn:");
+        Describe("var o = {}; ([ o.x = () => {} ] = []); describe(o.x)").Should().Be("fn:");
+        Describe("var o = {}; ({ a: o.x = () => {} } = { a: 1 }); describe(o.x)").Should().Be("number:1");
+
+        // Nested pattern with its own default.
+        Describe("var [ { a = () => {} } = {} ] = []; describe(a)").Should().Be("fn:a");
+        Describe("var [ { a = () => {} } = {} ] = [{ a: 1 }]; describe(a)").Should().Be("number:1");
+
+        // null is not undefined — the initializer never runs.
+        Describe("var { a = () => {} } = { a: null }; describe(a)").Should().Be("object:null");
+
+        // An initializer that merely produces a function is not a function *definition*, so it is
+        // never a NamedEvaluation candidate and stays nameless even when taken.
+        Describe("var { a = 0 || (() => {}) } = {}; describe(a)").Should().Be("fn:");
+        Describe("var { a = 0 || (() => {}) } = { a: 1 }; describe(a)").Should().Be("number:1");
+
+        // for-of over an array pattern, both ways round.
+        Describe("var r; for (var [ a = () => {} ] of [[]]) { r = a; } describe(r)").Should().Be("fn:a");
+        Describe("var r; for (var [ a = () => {} ] of [[1]]) { r = a; } describe(r)").Should().Be("number:1");
+
+        // Parameter defaults were already correct; pinned so the two paths cannot drift.
+        Describe("function f(a = () => {}) { return a; } describe(f())").Should().Be("fn:a");
+        Describe("function g(a = () => {}) { return a; } describe(g(1))").Should().Be("number:1");
+        Describe("function h({ a = () => {} } = {}) { return a; } describe(h())").Should().Be("fn:a");
+        Describe("function i({ a = () => {} } = {}) { return a; } describe(i({ a: 1 }))").Should().Be("number:1");
+    }
 }

--- a/Jint/Runtime/Interpreter/Expressions/DestructuringPatternAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/DestructuringPatternAssignmentExpression.cs
@@ -373,7 +373,10 @@ internal sealed class DestructuringPatternAssignmentExpression : JintExpression
                         ConsumeFromIterator(iterator!, out value, out done);
                     }
 
-                    if (value.IsUndefined())
+                    // Only an initializer the engine actually ran can be the subject of
+                    // NamedEvaluation below; a supplied value is bound exactly as it came in.
+                    var initializerEvaluated = value.IsUndefined();
+                    if (initializerEvaluated)
                     {
                         var jintExpression = Build(assignmentPattern.Right);
                         value = jintExpression.GetValue(context);
@@ -405,9 +408,13 @@ internal sealed class DestructuringPatternAssignmentExpression : JintExpression
                     }
                     else if (assignmentPattern.Left is Identifier leftIdentifier)
                     {
-                        if (assignmentPattern.Right.IsFunctionDefinition())
+                        // IteratorDestructuringAssignmentEvaluation / IteratorBindingInitialization
+                        // name the initializer's own closure, so both halves of the spec's condition
+                        // have to hold: the initializer was evaluated, and it is an anonymous
+                        // function definition.
+                        if (initializerEvaluated && assignmentPattern.Right.IsAnonymousFunctionDefinition())
                         {
-                            ((Function) value).SetFunctionName(new JsString(leftIdentifier.Name));
+                            ((Function) value).SetFunctionName(leftIdentifier.Name);
                         }
 
                         AssignToIdentifier(engine, leftIdentifier.Name, value, environment, checkReference);
@@ -521,7 +528,11 @@ internal sealed class DestructuringPatternAssignmentExpression : JintExpression
                     }
 
                     var value = source.Get(sourceKey);
-                    if (value.IsUndefined())
+
+                    // Only an initializer the engine actually ran can be the subject of
+                    // NamedEvaluation below; a supplied value is bound exactly as it came in.
+                    var initializerEvaluated = value.IsUndefined();
+                    if (initializerEvaluated)
                     {
                         var jintExpression = Build(assignmentPattern.Right);
                         var completion = jintExpression.GetValue(context);
@@ -545,7 +556,11 @@ internal sealed class DestructuringPatternAssignmentExpression : JintExpression
                     {
                         var target = assignmentPattern.Left as Identifier ?? identifier;
 
-                        if (assignmentPattern.Right.IsFunctionDefinition())
+                        // KeyedDestructuringAssignmentEvaluation / KeyedBindingInitialization name
+                        // the initializer's own closure, so both halves of the spec's condition have
+                        // to hold: the initializer was evaluated, and it is an anonymous function
+                        // definition.
+                        if (initializerEvaluated && assignmentPattern.Right.IsAnonymousFunctionDefinition())
                         {
                             ((Function) value).SetFunctionName(target!.Name);
                         }


### PR DESCRIPTION
`var { a = () => {} } = { a: 1 }` threw `InvalidCastException: Unable to cast 'JsNumber' to 'Function'` **out of `engine.Evaluate`** — script `try/catch` cannot see it — for one of the most common patterns in real JavaScript (`const { onChange = () => {} } = opts`). Found by running test262's `staging/` directory during the release review; long-standing, not a 4.16 regression.

The spec condition has two halves — [KeyedBindingInitialization](https://tc39.es/ecma262/#sec-runtime-semantics-keyedbindinginitialization) step 6: *"If Initializer is present **and v is undefined**"* — and `DestructuringPatternAssignmentExpression`'s two naming sites tested only the first: `if (assignmentPattern.Right.IsFunctionDefinition())` then cast **whatever got bound** to `Function`. The undefined check lived ~40 lines up, guarding initializer evaluation, and the fact was never carried down. The in-repo contrast proves the shape: `FunctionEnvironment.HandleAssignmentPatternOrExpression` writes the identical test *inside* its `IsUndefined()` block — which is exactly why function *parameter* defaults never crashed.

Both sites now carry `initializerEvaluated` down and test `IsAnonymousFunctionDefinition` — the spec's own predicate — instead of `IsFunctionDefinition` (a self-naming definition was already a no-op inside `SetFunctionName`, so that half only drops a pointless cast).

Verified against node v24 with a **200-row matrix** (5 pattern shapes × 8 initializer kinds × 5 supplied values): identical on every row, plus 21 edge cases — renamed target `{ a: b = fn }` names `"b"`, member-expression targets get no name, `null` does not take the default, the cover-grammar pair behaves. Why nothing caught it before: test262 carries **980** `dstr/*fn-name*` cases and *not one supplies a value* — they all test the default-taken direction.

The common case gets marginally cheaper: with a value supplied the `&&` short-circuits and the node-type check no longer runs at all. One stack bool per assignment-pattern element; nothing published to AST `UserData`. Gate row: `DestructuringBenchmark.ObjectWithDefaults`.

Red 7 / green 18, both TFMs. test262 standalone: **0 / 99,744 / 157** — the new post-#2978 baseline, byte-identical before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)