### PR TITLE
Let a constraint exception unwind deep recursion without overflowing

### DIFF
--- a/Jint.Tests/Runtime/ExecutionConstraintTests.cs
+++ b/Jint.Tests/Runtime/ExecutionConstraintTests.cs
@@ -483,6 +483,148 @@ myarr[0](0);
         Invoking(() => engine.Evaluate(code)).Should().ThrowExactly<RecursionDepthOverflowException>();
     }
 
+    // A constraint that fires deep in a recursion has to survive its own unwind. Every one of these
+    // runs on a small dedicated stack, because that is the only place the failure shows: an exception
+    // caught and rethrown at each interpreter level costs a nested exception dispatch per level, and
+    // enough of those overflow the stack on the way out and take the host process down with them
+    // (0xC00000FD, uncatchable). The 16 MB DedicatedThread default hides all of it, which is why CI
+    // never saw it. Every depth below sits well above the pre-fix ceiling (~100 JavaScript frames on
+    // a 1 MB stack) and well below the plain forward-recursion ceiling (~700), so a regression fails
+    // the run rather than merely reporting a smaller number.
+    private const int SmallStack = 1024 * 1024;
+
+    [Fact]
+    public void RecursionLimitFiringAtTwoHundredUnwindsToTheHost()
+    {
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = new Engine(o => o.LimitRecursion(200));
+                Invoking(() => engine.Execute("function f() { return f(); } f();"))
+                    .Should().ThrowExactly<RecursionDepthOverflowException>();
+            },
+            maxStackSize: SmallStack);
+    }
+
+    [Fact]
+    public void RecursionLimitFiringAtAThousandUnwindsToTheHost()
+    {
+        // 4 MB: a thousand frames do not fit forward on 1 MB. The pre-fix unwind ceiling scales with
+        // the stack too (~400 frames here), so a thousand still fails without the fix.
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = new Engine(o => o.LimitRecursion(1000));
+                Invoking(() => engine.Execute("function f() { return f(); } f();"))
+                    .Should().ThrowExactly<RecursionDepthOverflowException>();
+            },
+            maxStackSize: 4 * 1024 * 1024);
+    }
+
+    [Fact]
+    public void EngineStaysUsableAfterARecursionLimitUnwind()
+    {
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = new Engine(o => o.LimitRecursion(300));
+                engine.Execute("function f() { return f(); }");
+                engine.Execute("function fib(n) { return n < 2 ? n : fib(n - 1) + fib(n - 2); }");
+
+                for (var round = 0; round < 3; round++)
+                {
+                    Invoking(() => engine.Evaluate("f()")).Should().ThrowExactly<RecursionDepthOverflowException>();
+
+                    // The frames the unwind passed through are what these assert: the call stack was
+                    // popped back to nothing, so a 20-deep call is not measured against a stale depth.
+                    engine.CallStack.Count.Should().Be(0);
+                    engine.Evaluate("fib(20)").AsNumber().Should().Be(6765);
+
+                    // A host constraint is not a JavaScript error, so a script-level catch never sees it
+                    // — the same reason the mapping switch has no arm for it. Declining to catch changed
+                    // where the frames go, not that.
+                    Invoking(() => engine.Evaluate("(function () { try { f(); return 'no-throw'; } catch (e) { return 'caught'; } })()"))
+                        .Should().ThrowExactly<RecursionDepthOverflowException>();
+                    engine.CallStack.Count.Should().Be(0);
+                }
+            },
+            maxStackSize: SmallStack);
+    }
+
+    [Fact]
+    public void CancellationRaisedDeepInARecursionUnwindsToTheHost()
+    {
+        DedicatedThread.Run(
+            () =>
+            {
+                using var cts = new CancellationTokenSource();
+                var engine = new Engine(o => o.CancellationToken(cts.Token));
+                engine.SetValue("stop", new Action(() => cts.Cancel()));
+                engine.Execute("function f(n) { if (n <= 0) { stop(); var s = 0; for (var i = 0; i < 500; i++) { s += i; } return s; } return f(n - 1); }");
+
+                Invoking(() => engine.Evaluate("f(300)")).Should().ThrowExactly<ExecutionCanceledException>();
+            },
+            maxStackSize: SmallStack);
+    }
+
+    [Fact]
+    public void StatementBudgetExhaustedDeepInARecursionUnwindsToTheHost()
+    {
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = new Engine(o => o.MaxStatements(100_000));
+                engine.Execute("function f(n) { if (n <= 0) { var s = 0; for (var i = 0; i < 200000; i++) { s += i; } return s; } return f(n - 1); }");
+
+                Invoking(() => engine.Evaluate("f(300)")).Should().ThrowExactly<StatementsCountOverflowException>();
+            },
+            maxStackSize: SmallStack);
+    }
+
+    [Fact]
+    public void ClrExceptionFromHostCodeUnwindsADeepRecursionAndKeepsItsJavaScriptLocation()
+    {
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = new Engine();
+                engine.SetValue("bang", new Action(() => throw new InvalidOperationException("bang")));
+                engine.Execute("function f(n) { if (n <= 0) { bang(); } return f(n - 1); }");
+
+                var thrown = Invoking(() => engine.Evaluate("f(300)"))
+                    .Should().ThrowExactly<InvalidOperationException>().Which;
+
+                // The decoration now happens at the innermost interpreter frame only — every frame above
+                // it declines to catch — so what a host reads back has to be unchanged.
+                JintException.TryGetJavaScriptLocation(thrown, out _).Should().BeTrue();
+                JintException.TryGetJavaScriptCallStack(thrown, out var callStack).Should().BeTrue();
+                callStack.Should().Contain("at f");
+            },
+            maxStackSize: SmallStack);
+    }
+
+    [Fact]
+    public void JavaScriptThrowFromADeepRecursionStillBecomesAThrowCompletion()
+    {
+        // The control: a JavaScript throw was never the broken case, and the filter must not change how
+        // it is mapped — at the host boundary or by a script-level catch.
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = new Engine();
+                engine.Execute("function f(n) { if (n <= 0) { throw new RangeError('boom'); } return f(n - 1); }");
+
+                var thrown = Invoking(() => engine.Evaluate("f(300)"))
+                    .Should().ThrowExactly<JavaScriptException>().Which;
+                thrown.Message.Should().Be("boom");
+                thrown.Error.Get("name").AsString().Should().Be("RangeError");
+
+                engine.Evaluate("(function () { try { f(300); } catch (e) { return e.name + ': ' + e.message; } })()")
+                    .Should().Be("RangeError: boom");
+            },
+            maxStackSize: SmallStack);
+    }
+
     [Fact]
     public void ShouldLimitArraySizeForConcat()
     {

--- a/Jint/Runtime/ExceptionDataHelper.cs
+++ b/Jint/Runtime/ExceptionDataHelper.cs
@@ -3,6 +3,33 @@ namespace Jint.Runtime;
 internal static class ExceptionDataHelper
 {
     /// <summary>
+    /// Whether <paramref name="exception"/> already carries the JavaScript location, or can never carry
+    /// it at all. Both answers mean the same thing to a caller: there is nothing left for it to attach.
+    /// </summary>
+    /// <remarks>
+    /// This is read from an exception <em>filter</em>, so it runs in the first pass with the whole
+    /// throwing stack still live: it must not recurse, must not allocate beyond the lazy dictionary
+    /// <see cref="System.Exception.Data"/> creates on first read, and must never throw. Only the
+    /// innermost interpreter frame is answered <c>false</c>; every frame above it then declines to catch
+    /// the exception, which is what lets a CLR exception from host code unwind a deep interpreter stack
+    /// instead of consuming a nested exception dispatch per level.
+    /// </remarks>
+    internal static bool HasJavaScriptLocation(Exception exception)
+    {
+        try
+        {
+            var data = exception.Data;
+            return data is null || data.IsReadOnly || data.Contains(JintExceptionDataKeys.Location);
+        }
+        catch
+        {
+            // Same defensive contract as TryAttachJavaScriptLocation: a Data implementation that throws
+            // is one the location cannot be attached to, which is also "nothing left to do here".
+            return true;
+        }
+    }
+
+    /// <summary>
     /// Best-effort attach JavaScript location and call-stack info to a CLR exception's
     /// <see cref="System.Exception.Data"/> dictionary using the well-known keys defined in
     /// <see cref="JintExceptionDataKeys"/>. Idempotent: the innermost JavaScript site wins

--- a/Jint/Runtime/Interpreter/JintStatementList.cs
+++ b/Jint/Runtime/Interpreter/JintStatementList.cs
@@ -216,10 +216,8 @@ internal sealed class JintStatementList
                 suspendable?.Data.ClearStatementListPosition(this);
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (LeavingOnException(suspendable, ex))
         {
-            suspendable?.Data.ClearStatementListPosition(this);
-
             if (ex is JintException)
             {
                 c = HandleException(context, ex, temp[i].Statement);
@@ -247,6 +245,51 @@ internal sealed class JintStatementList
         return result;
     }
 
+    /// <summary>
+    /// Exception filter for <see cref="Execute"/>. It does the bookkeeping every exception leaving this
+    /// list owes — clearing the resume position, which the old catch-everything handler did — and then
+    /// answers <see cref="ShouldCatch"/>, so that the exceptions this frame would only rethrow are never
+    /// caught here in the first place.
+    /// </summary>
+    private bool LeavingOnException(ISuspendable? suspendable, Exception exception)
+    {
+        // Safe to do from the first pass: nothing between the throw point and this frame reads or writes
+        // this list's saved position — only this method's own suspension path sets it, and that path
+        // cannot be running while an exception is in flight through it.
+        suspendable?.Data.ClearStatementListPosition(this);
+        return ShouldCatch(exception);
+    }
+
+    /// <summary>
+    /// Whether a statement list has anything to do with an exception passing through it, asked from an
+    /// exception filter so that the answer <c>false</c> keeps the frame out of the unwind entirely.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Answering <c>false</c> is the point. A statement list wraps every function body and every block,
+    /// so a deep recursion stacks one of these frames per JavaScript call. Catching an exception the
+    /// handler can only rethrow costs a nested exception dispatch at every one of them — roughly 10 KB
+    /// of stack apiece that the runtime cannot reclaim while the dispatch is live — so the engine's own
+    /// <see cref="RecursionDepthOverflowException"/>, raised at exactly the depth
+    /// <c>Options.LimitRecursion</c> asks for, used to overflow the stack on the way out and take
+    /// the host process with it. A filter that declines is answered in the first pass and leaves nothing
+    /// behind, so the same exception now unwinds as far as a JavaScript <c>throw</c> does.
+    /// </para>
+    /// <para>
+    /// The two <c>true</c> arms are the two things this frame really does, and both have to keep matching
+    /// their handler: the exceptions <see cref="HandleException"/> turns into a Throw completion, and a
+    /// CLR exception that has not been annotated with a JavaScript location yet — the innermost frame
+    /// alone, since the annotation is idempotent and the frames above it would only redo the same test.
+    /// </para>
+    /// </remarks>
+    internal static bool ShouldCatch(Exception exception) => exception switch
+    {
+        // Keep in lock-step with HandleException's switch below.
+        JavaScriptException or TypeErrorException or RangeErrorException or SyntaxErrorException => true,
+        JintException => false,
+        _ => !ExceptionDataHelper.HasJavaScriptLocation(exception),
+    };
+
     internal static Completion HandleException(EvaluationContext context, Exception exception, JintStatement? s)
     {
         var completion = exception switch
@@ -255,6 +298,8 @@ internal sealed class JintStatementList
             TypeErrorException typeErrorException => CreateThrowCompletion(context.Engine.Realm.Intrinsics.TypeError, typeErrorException, typeErrorException.Node ?? s!._statement),
             RangeErrorException rangeErrorException => CreateThrowCompletion(context.Engine.Realm.Intrinsics.RangeError, rangeErrorException, s!._statement),
             SyntaxErrorException syntaxErrorException => CreateThrowCompletion(context.Engine.Realm.Intrinsics.SyntaxError, syntaxErrorException, s!._statement),
+            // Unreachable through the callers, whose filters decline anything this switch cannot map;
+            // kept so the switch stays total and so a future caller without a filter still behaves.
             _ => throw exception
         };
 

--- a/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
@@ -376,7 +376,9 @@ internal sealed class JintBlockStatement : JintStatement<NestedBlockStatement>
                 blockValue = JintStatementList.HandleError(context.Engine, _singleStatement);
             }
         }
-        catch (Exception ex)
+        // The filter is what keeps a single-statement block out of the unwind of an exception it could
+        // only rethrow; see JintStatementList.ShouldCatch for why that matters at recursion depth.
+        catch (Exception ex) when (JintStatementList.ShouldCatch(ex))
         {
             if (ex is JintException)
             {


### PR DESCRIPTION
> The call-path gate rows (`RecursionBenchmark`, `ClosureCallBenchmarks`, `MethodCallBenchmark`, SunSpider `controlflow-recursive`, full wide tables) run in the release measurement block — merging should wait for them.

**`Options.LimitRecursion(N)` killed the host process for most useful values of N.** The constraint fired correctly at depth N — and then the unwind itself overflowed the stack: `JintStatementList.Execute` and `JintBlockStatement.ExecuteSingle` caught `Exception`, mapped four types to a throw completion, and **rethrew everything else from inside the handler at every interpreter level**. A rethrow from a handler restarts two-pass dispatch, so the runtime cannot collapse frames it has already searched — ~10 KB per level, live for the rest of the unwind. A JS `throw` unwound 1,153 frames; a CLR rethrow managed **158**. So `LimitRecursion(100)` worked and **200 through ~1040 crashed the process** — precisely the range a host sandboxing untrusted script picks. CI never saw it because the test helper defaults to 16 MB stacks. Every constraint that unwinds as a CLR exception shared the defect: cancellation and a CLR host exception at depth measured the same ceilings.

The fix is exception **filters** on exactly the two maybe-rethrow sites (the only callers of `HandleException`), so unmappable exceptions pass through uncaught and the runtime keeps one collapsible first-pass search. The filter is four `isinst` tests and a `JintException` check — no allocation, no engine access; filters run one at a time and each funclet returns before the next, so peak extra stack is one funclet frame, not N. Error decoration deliberately stays a *handler*: the innermost frame catches once, decorates, rethrows exactly once for the whole unwind — `BuildCallStackString` never runs in the first pass, and the CLR decoration is byte-identical before/after.

Measured (bisected, out-of-process):

| unwindable JS frames | 1.5 MB apphost | 1 MB thread |
| --- | --- | --- |
| `LimitRecursion` | 154 → **1082** | 102 → **716** |
| cancellation | 154 → **1138** | 102 → **750** |
| CLR host exception | 163 → **1120** | 102 → **735** |
| JS throw (control) | ~unchanged | ~unchanged |

`LimitRecursion(200)`/`(1000)` on both stacks: exit `0xC00000FD` before, clean exit with a catchable `RecursionDepthOverflowException` after, engine reusable (empty call stack, correct `fib(20)` three rounds, a 20,000-call workload exact).

**Codegen, measured not guessed:** `JitDisasm` shows the prolog grow `sub rsp, 152 → 168` — +16 bytes per frame, and a variant whose filter reads nothing measures the same, so it is the cost of having a filter clause at all. The non-throwing instruction sequence is otherwise unchanged. That is what the gate rows adjudicate.

Sites audited and deliberately left: the per-level `catch { bookkeep; throw; }` sites (`for-in/of`, destructuring, await/yield) always rethrow and their bookkeeping must run — converting `for-of`'s would mean assigning the `finally`-read completion from a filter, a separate riskier change; measured improvement for for-of-driven recursion is real but partial (51 → 121 frames) and recorded. `Engine.cs`'s entry catch runs once per entry and keeps `ResetCallStack`.

Seven new tests on 1 MB `DedicatedThread`s; the red run **crashes the test runner** (`0xC00000FD`). Verification legs green; test262 idle-machine standalone 99,738 / 0 / 157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)