### PR TITLE
Serve Map and Set size from the prototype accessor the spec defines

### DIFF
--- a/Jint.Tests/Runtime/MapSetSizeAccessorTests.cs
+++ b/Jint.Tests/Runtime/MapSetSizeAccessorTests.cs
@@ -1,0 +1,185 @@
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// <c>size</c> is an accessor on <c>Map.prototype</c> / <c>Set.prototype</c> and lives nowhere else —
+/// https://tc39.es/ecma262/#sec-get-map.prototype.size and
+/// https://tc39.es/ecma262/#sec-get-set.prototype.size. Both halves of that used to be wrong at once, from one
+/// cause: the prototype getter was a brand check with a hard-coded <c>0</c> for a body, and the real count was
+/// served instead from an own data descriptor <c>JsMap</c> / <c>JsSet</c> synthesized inside
+/// <c>GetOwnProperty</c>. So the getter answered 0 for a valid receiver, and every instance reported an own
+/// non-configurable <c>size</c> that no key enumeration ever listed.
+/// </summary>
+public class MapSetSizeAccessorTests
+{
+    private const string Map = "new Map([[1, 'a'], [2, 'b'], [3, 'c']])";
+    private const string Set = "new Set([1, 2, 3])";
+
+    [Theory]
+    [InlineData("Map", Map)]
+    [InlineData("Set", Set)]
+    public void TheExtractedPrototypeGetterReadsItsReceiver(string kind, string create)
+    {
+        new Engine().Evaluate($$"""
+            var c = {{create}};
+            var get = Object.getOwnPropertyDescriptor({{kind}}.prototype, 'size').get;
+            get.call(c);
+            """).AsNumber().Should().Be(3);
+    }
+
+    [Theory]
+    [InlineData("Map", Map)]
+    [InlineData("Set", Set)]
+    public void TheExtractedPrototypeGetterTracksLaterMutations(string kind, string create)
+    {
+        new Engine().Evaluate($$"""
+            var c = {{create}};
+            var get = Object.getOwnPropertyDescriptor({{kind}}.prototype, 'size').get;
+            var before = get.call(c);
+            c.clear();
+            before + '/' + get.call(c);
+            """).AsString().Should().Be("3/0");
+    }
+
+    [Theory]
+    [InlineData("Map")]
+    [InlineData("Set")]
+    public void TheExtractedPrototypeGetterKeepsItsBrandCheck(string kind)
+    {
+        // The other collection is the interesting negative: it has a `size` of its own, so only a real
+        // [[MapData]] / [[SetData]] check can tell the two apart.
+        var other = string.Equals(kind, "Map", StringComparison.Ordinal) ? "new Set([1])" : "new Map()";
+
+        var engine = new Engine();
+        engine.Execute($"var get = Object.getOwnPropertyDescriptor({kind}.prototype, 'size').get;");
+
+        foreach (var receiver in new[] { "{}", "[]", "undefined", $"{kind}.prototype", other })
+        {
+            Invoking(() => engine.Evaluate($"get.call({receiver});"))
+                .Should().ThrowExactly<JavaScriptException>(receiver)
+                .WithMessage($"Method {kind}.prototype.get size called on incompatible receiver *");
+        }
+    }
+
+    [Theory]
+    [InlineData("Map", Map)]
+    [InlineData("Set", Set)]
+    public void AnInstanceHasNoOwnSize(string kind, string create)
+    {
+        _ = kind;
+        var engine = new Engine();
+        engine.Execute($"var c = {create};");
+
+        engine.Evaluate("c.hasOwnProperty('size')").AsBoolean().Should().BeFalse();
+        engine.Evaluate("Object.getOwnPropertyDescriptor(c, 'size')").IsUndefined().Should().BeTrue();
+        engine.Evaluate("Object.getOwnPropertyNames(c).length").AsNumber().Should().Be(0);
+        engine.Evaluate("Reflect.ownKeys(c).length").AsNumber().Should().Be(0);
+        engine.Evaluate("Object.keys(c).length").AsNumber().Should().Be(0);
+        engine.Evaluate("JSON.stringify(c)").AsString().Should().Be("{}");
+
+        // ...but it is still reachable, and still reads, through the prototype.
+        engine.Evaluate("'size' in c").AsBoolean().Should().BeTrue();
+        engine.Evaluate("c.size").AsNumber().Should().Be(3);
+    }
+
+    [Theory]
+    [InlineData("Map", Map)]
+    [InlineData("Set", Set)]
+    public void AnOwnShadowingAccessorCanBeDefinedAndDeleted(string kind, string create)
+    {
+        _ = kind;
+
+        // Defining `size` on an instance is legal — the phantom own descriptor used to be non-configurable
+        // and turned this into a TypeError.
+        new Engine().Evaluate($$"""
+            var c = {{create}};
+            Object.defineProperty(c, 'size', { get: function () { return 99; }, configurable: true });
+            var shadowed = c.size + '/' + c.hasOwnProperty('size') + '/' + Object.keys(c).length;
+            var removed = delete c.size;
+            shadowed + '|' + removed + '|' + c.size + '/' + c.hasOwnProperty('size');
+            """).AsString().Should().Be("99/true/0|true|3/false");
+    }
+
+    [Theory]
+    [InlineData("Map", Map)]
+    [InlineData("Set", Set)]
+    public void AnOwnShadowingDataPropertyCanBeDefinedAndDeleted(string kind, string create)
+    {
+        _ = kind;
+        new Engine().Evaluate($$"""
+            var c = {{create}};
+            Object.defineProperty(c, 'size', { value: 7, writable: true, enumerable: true, configurable: true });
+            var shadowed = c.size + '/' + Object.keys(c).join();
+            delete c.size;
+            shadowed + '|' + c.size;
+            """).AsString().Should().Be("7/size|3");
+    }
+
+    [Theory]
+    [InlineData("Map", Map)]
+    [InlineData("Set", Set)]
+    public void DeletingSizeFromAnInstanceThatNeverDefinedItSucceeds(string kind, string create)
+    {
+        _ = kind;
+
+        // No own property, so [[Delete]] is vacuously true — and strict mode agrees. The phantom descriptor
+        // was non-configurable, so this used to answer false / throw.
+        new Engine().Evaluate($$"""
+            'use strict';
+            var c = {{create}};
+            (delete c.size) + '/' + c.size;
+            """).AsString().Should().Be("true/3");
+    }
+
+    [Theory]
+    [InlineData("Map", "class C extends Map {}", "new C([[1, 'a'], [2, 'b'], [3, 'c']])")]
+    [InlineData("Set", "class C extends Set {}", "new C([1, 2, 3])")]
+    public void ASubclassInstanceReadsTheInheritedAccessor(string kind, string declare, string create)
+    {
+        _ = kind;
+        new Engine().Evaluate($$"""
+            {{declare}}
+            var c = {{create}};
+            c.size + '/' + c.hasOwnProperty('size') + '/' + Object.getOwnPropertyNames(c).length;
+            """).AsString().Should().Be("3/false/0");
+    }
+
+    [Theory]
+    [InlineData("Map", Map)]
+    [InlineData("Set", Set)]
+    public void AProxyGetTrapForwardingTheTargetAsReceiverStillReadsSize(string kind, string create)
+    {
+        _ = kind;
+        new Engine().Evaluate($$"""
+            var c = {{create}};
+            var p = new Proxy(c, { get: function (t, k) { return Reflect.get(t, k, t); } });
+            p.size;
+            """).AsNumber().Should().Be(3);
+    }
+
+    [Theory]
+    [InlineData("Map", Map)]
+    [InlineData("Set", Set)]
+    public void ABareProxyIsAnIncompatibleReceiverForSize(string kind, string create)
+    {
+        // A proxy without a `get` trap forwards to the target with the *proxy* as receiver, so the accessor
+        // brand-checks the proxy and refuses it. Reading a `size` served from an own data property never
+        // reached the getter and answered 3 instead.
+        Invoking(() => new Engine().Evaluate($"new Proxy({create}, {{}}).size;"))
+            .Should().ThrowExactly<JavaScriptException>()
+            .WithMessage($"Method {kind}.prototype.get size called on incompatible receiver *");
+    }
+
+    [Theory]
+    [InlineData("Map")]
+    [InlineData("Set")]
+    public void ThePrototypeCarriesTheAccessorItself(string kind)
+    {
+        new Engine().Evaluate($$"""
+            var d = Object.getOwnPropertyDescriptor({{kind}}.prototype, 'size');
+            typeof d.get + '/' + (d.set === undefined) + '/' + d.enumerable + '/' + d.configurable
+                + '/' + d.get.name + '/' + d.get.length;
+            """).AsString().Should().Be("function/true/false/true/get size/0");
+    }
+}

--- a/Jint/Native/JsMap.cs
+++ b/Jint/Native/JsMap.cs
@@ -1,8 +1,6 @@
 using System.Collections;
-using System.Diagnostics.CodeAnalysis;
 using Jint.Native.Object;
 using Jint.Runtime;
-using Jint.Runtime.Descriptors;
 
 namespace Jint.Native;
 
@@ -17,26 +15,10 @@ public sealed class JsMap : ObjectInstance, IEnumerable<KeyValuePair<JsValue, Js
         _map = new JintOrderedDictionary<JsValue, JsValue>(SameValueZeroComparer.Instance);
     }
 
-    public override PropertyDescriptor GetOwnProperty(JsValue property)
-    {
-        if (CommonProperties.Size.Equals(property))
-        {
-            return new PropertyDescriptor(_map.Count, PropertyFlag.AllForbidden);
-        }
-
-        return base.GetOwnProperty(property);
-    }
-
-    protected override bool TryGetProperty(JsValue property, [NotNullWhen(true)] out PropertyDescriptor? descriptor)
-    {
-        if (CommonProperties.Size.Equals(property))
-        {
-            descriptor = new PropertyDescriptor(_map.Count, PropertyFlag.AllForbidden);
-            return true;
-        }
-
-        return base.TryGetProperty(property, out descriptor);
-    }
+    // No `size` here: it is an accessor on Map.prototype (https://tc39.es/ecma262/#sec-get-map.prototype.size)
+    // and an instance has no own property of that name. Synthesizing one from GetOwnProperty made the
+    // prototype getter unreachable through `m.size` — which is how it went on returning a hard-coded 0 — and
+    // gave every map a phantom own non-configurable `size` that [[OwnPropertyKeys]] never listed.
 
     public int Size => _map.Count;
 

--- a/Jint/Native/JsSet.cs
+++ b/Jint/Native/JsSet.cs
@@ -1,8 +1,6 @@
 using System.Collections;
-using System.Diagnostics.CodeAnalysis;
 using Jint.Native.Object;
 using Jint.Runtime;
-using Jint.Runtime.Descriptors;
 
 namespace Jint.Native;
 
@@ -20,32 +18,14 @@ public sealed class JsSet : ObjectInstance, IEnumerable<JsValue>
         _prototype = _engine.Realm.Intrinsics.Set.PrototypeObject;
     }
 
+    // No `size` here: it is an accessor on Set.prototype (https://tc39.es/ecma262/#sec-get-set.prototype.size)
+    // and an instance has no own property of that name. See the note in JsMap for what synthesizing one cost.
+
     public int Size => _set.Count;
 
     internal JsValue? this[int index]
     {
         get { return index < _set._list.Count ? _set._list[index] : null; }
-    }
-
-    public override PropertyDescriptor GetOwnProperty(JsValue property)
-    {
-        if (CommonProperties.Size.Equals(property))
-        {
-            return new PropertyDescriptor(_set.Count, PropertyFlag.AllForbidden);
-        }
-
-        return base.GetOwnProperty(property);
-    }
-
-    protected override bool TryGetProperty(JsValue property, [NotNullWhen(true)] out PropertyDescriptor? descriptor)
-    {
-        if (CommonProperties.Size.Equals(property))
-        {
-            descriptor = new PropertyDescriptor(_set.Count, PropertyFlag.AllForbidden);
-            return true;
-        }
-
-        return base.TryGetProperty(property, out descriptor);
     }
 
     public void Add(JsValue value) => _set.Add(SameValueZeroComparer.ToStableKey(value));

--- a/Jint/Native/Map/MapPrototype.cs
+++ b/Jint/Native/Map/MapPrototype.cs
@@ -37,11 +37,14 @@ internal sealed partial class MapPrototype : Prototype
         CreateSymbols_Generated();
     }
 
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-get-map.prototype.size
+    /// </summary>
     [JsAccessor("size")]
     private JsValue Size(JsValue thisObject)
     {
-        AssertMapInstance(thisObject);
-        return JsNumber.Create(0);
+        var map = AssertMapInstance(thisObject);
+        return JsNumber.Create(map.Size);
     }
 
     [JsFunction(Name = "get", FastCall = true)]

--- a/Jint/Native/Set/SetPrototype.cs
+++ b/Jint/Native/Set/SetPrototype.cs
@@ -38,11 +38,14 @@ internal sealed partial class SetPrototype : Prototype
         CreateSymbols_Generated();
     }
 
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-get-set.prototype.size
+    /// </summary>
     [JsAccessor("size")]
     private JsNumber Size(JsValue thisObject)
     {
-        AssertSetInstance(thisObject);
-        return JsNumber.Create(0);
+        var set = AssertSetInstance(thisObject);
+        return JsNumber.Create(set.Size);
     }
 
     [JsFunction(FastCall = true)]


### PR DESCRIPTION
`size` was implemented **twice**, and each half hid the other's defect. The `[JsAccessor]` getter on `MapPrototype`/`SetPrototype` brand-checked its receiver and then `return JsNumber.Create(0);` — a stub that was never filled in. `JsMap`/`JsSet.GetOwnProperty` synthesized a phantom non-configurable **own** `size` data property that shadowed the prototype accessor on every ordinary read — so `s.size` was right, the stub never executed, and the 0 survived. Found by running test262's `staging/` suite.

Observable damage, all fixed and pinned:
- the extracted getter answered 0 for a valid receiver (`Object.getOwnPropertyDescriptor(Set.prototype,'size').get.call(s)`);
- `hasOwnProperty('size')` said true while `getOwnPropertyNames` said no — mechanically, `ProbeOwnProperty` falls through to `GetOwnProperty` while `GetOwnPropertyKeys` reads engine storage;
- a **legal** `Object.defineProperty(s,'size',{get(){…}})` threw;
- `delete s.size` failed, throwing in strict mode;
- `new Proxy(map, {}).size` answered 3 where the accessor must refuse the proxy receiver (`TypeError`, as V8).

**The hot read gets cheaper, not slower.** `m.size` used to burn one synthesized `PropertyDescriptor` allocation per read; it now takes the same single own-probe, misses, and lands in the prototype-method inline cache — `MapPrototype` is `BuiltinShapeMode`, the documented carve-out that lets it hold a cache entry — one probe plus the getter, zero allocation, the same shape as `regexp.global` and `arrayBuffer.byteLength`. Gate row: `MapSetLookupBenchmark` (noting only `MapSetDeleteChurn` reads `.size` at all today, once).

**Rebase note for #2984:** same four files, different members — adjacent except one `MapPrototype.cs` hunk whose leading context is the deleted `return JsNumber.Create(0);` line. Trivial keep-both resolution, flagged so it surprises nobody.

Red 16 / green 22, both TFMs. test262 standalone at the post-#2978 baseline: 0 / 99,744 / 157, identical before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)