### PR TITLE
Drop the Temporal.Now methods the proposal removed

### DIFF
--- a/Jint.Tests/Runtime/TemporalNowTests.cs
+++ b/Jint.Tests/Runtime/TemporalNowTests.cs
@@ -1,0 +1,53 @@
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// The <c>Temporal.Now</c> namespace object — https://tc39.es/proposal-temporal/#sec-temporal-now-object.
+/// The June 2024 removals took the calendar-taking <c>plainDate</c>, <c>plainDateTime</c> and
+/// <c>zonedDateTime</c> out; only the <c>*ISO</c> forms plus <c>instant</c> and <c>timeZoneId</c> remain.
+/// test262 asserts their absence in <c>staging/Temporal/removed-methods.js</c>, which Jint's harness does not
+/// generate, so the property list is pinned here instead.
+/// </summary>
+public class TemporalNowTests
+{
+    [Fact]
+    public void ExposesExactlyTheMembersTheProposalDefines()
+    {
+        new Engine().Evaluate("Object.getOwnPropertyNames(Temporal.Now).sort().join()")
+            .AsString().Should().Be("instant,plainDateISO,plainDateTimeISO,plainTimeISO,timeZoneId,zonedDateTimeISO");
+    }
+
+    [Theory]
+    [InlineData("plainDate")]
+    [InlineData("plainDateTime")]
+    [InlineData("zonedDateTime")]
+    public void DoesNotExposeTheRemovedCalendarTakingForms(string removed)
+    {
+        var engine = new Engine();
+
+        engine.Evaluate($"'{removed}' in Temporal.Now").AsBoolean().Should().BeFalse();
+        engine.Evaluate($"Temporal.Now.{removed} === undefined").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void StillAnswersThroughTheIsoForms()
+    {
+        new Engine().Evaluate("""
+            [
+                Temporal.Now.instant() instanceof Temporal.Instant,
+                Temporal.Now.plainDateISO() instanceof Temporal.PlainDate,
+                Temporal.Now.plainDateTimeISO() instanceof Temporal.PlainDateTime,
+                Temporal.Now.plainTimeISO() instanceof Temporal.PlainTime,
+                Temporal.Now.zonedDateTimeISO() instanceof Temporal.ZonedDateTime,
+                typeof Temporal.Now.timeZoneId() === 'string',
+                Temporal.Now.plainDateISO().calendarId === 'iso8601',
+            ].join();
+            """).AsString().Should().Be("true,true,true,true,true,true,true");
+    }
+
+    [Fact]
+    public void CarriesTheNamespaceToStringTag()
+    {
+        new Engine().Evaluate("Temporal.Now[Symbol.toStringTag] + '/' + Object.prototype.toString.call(Temporal.Now)")
+            .AsString().Should().Be("Temporal.Now/[object Temporal.Now]");
+    }
+}

--- a/Jint/Native/Temporal/Now/TemporalNow.cs
+++ b/Jint/Native/Temporal/Now/TemporalNow.cs
@@ -53,21 +53,6 @@ internal sealed partial class TemporalNow : BuiltinShapeObject
     }
 
     /// <summary>
-    /// https://tc39.es/proposal-temporal/#sec-temporal.now.plaindatetime
-    /// </summary>
-    [JsFunction(Length = 1)]
-    private JsPlainDateTime PlainDateTime(JsValue thisObject, JsValue calendarLike, JsValue temporalTimeZoneLike)
-    {
-        var calendar = ToTemporalCalendarIdentifier(calendarLike);
-        var timeZoneId = ToTemporalTimeZoneIdentifier(temporalTimeZoneLike);
-
-        var epochNs = SystemUTCEpochNanoseconds();
-        var isoDateTime = GetIsoDateTimeFor(timeZoneId, epochNs);
-
-        return new JsPlainDateTime(_engine, _realm.Intrinsics.TemporalPlainDateTime.PrototypeObject, isoDateTime, calendar);
-    }
-
-    /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.now.plaindatetimeiso
     /// </summary>
     [JsFunction(Length = 0)]
@@ -82,20 +67,6 @@ internal sealed partial class TemporalNow : BuiltinShapeObject
     }
 
     /// <summary>
-    /// https://tc39.es/proposal-temporal/#sec-temporal.now.zoneddatetime
-    /// </summary>
-    [JsFunction(Length = 1)]
-    private JsZonedDateTime ZonedDateTime(JsValue thisObject, JsValue calendarLike, JsValue temporalTimeZoneLike)
-    {
-        var calendar = ToTemporalCalendarIdentifier(calendarLike);
-        var timeZoneId = ToTemporalTimeZoneIdentifier(temporalTimeZoneLike);
-
-        var epochNs = SystemUTCEpochNanoseconds();
-
-        return new JsZonedDateTime(_engine, _realm.Intrinsics.TemporalZonedDateTime.PrototypeObject, epochNs, timeZoneId, calendar);
-    }
-
-    /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.now.zoneddatetimeiso
     /// </summary>
     [JsFunction(Length = 0)]
@@ -106,21 +77,6 @@ internal sealed partial class TemporalNow : BuiltinShapeObject
         var epochNs = SystemUTCEpochNanoseconds();
 
         return new JsZonedDateTime(_engine, _realm.Intrinsics.TemporalZonedDateTime.PrototypeObject, epochNs, timeZoneId, "iso8601");
-    }
-
-    /// <summary>
-    /// https://tc39.es/proposal-temporal/#sec-temporal.now.plaindate
-    /// </summary>
-    [JsFunction(Length = 1)]
-    private JsPlainDate PlainDate(JsValue thisObject, JsValue calendarLike, JsValue temporalTimeZoneLike)
-    {
-        var calendar = ToTemporalCalendarIdentifier(calendarLike);
-        var timeZoneId = ToTemporalTimeZoneIdentifier(temporalTimeZoneLike);
-
-        var epochNs = SystemUTCEpochNanoseconds();
-        var isoDateTime = GetIsoDateTimeFor(timeZoneId, epochNs);
-
-        return new JsPlainDate(_engine, _realm.Intrinsics.TemporalPlainDate.PrototypeObject, isoDateTime.Date, calendar);
     }
 
     /// <summary>
@@ -171,15 +127,6 @@ internal sealed partial class TemporalNow : BuiltinShapeObject
         var localNs = epochNs + offsetNs;
 
         return TemporalHelpers.EpochNanosecondsToIsoDateTime(localNs);
-    }
-
-    /// <summary>
-    /// Validates and canonicalizes a calendar identifier.
-    /// https://tc39.es/proposal-temporal/#sec-temporal-totemporalcalendar
-    /// </summary>
-    private string ToTemporalCalendarIdentifier(JsValue calendarLike)
-    {
-        return TemporalHelpers.ToTemporalCalendarIdentifier(_realm, calendarLike);
     }
 
     /// <summary>


### PR DESCRIPTION
`Temporal.Now` still carried `plainDate`, `plainDateTime` and `zonedDateTime`; the proposal's namespace defines exactly `timeZoneId`, `instant`, `plainDateTimeISO`, `zonedDateTimeISO`, `plainDateISO`, `plainTimeISO` plus `@@toStringTag` — verified against the proposal text, not the staging file that flagged it. The orphaned private calendar-identifier wrapper goes with them, and the property list is pinned in-repo because **the coverage exists only under test262's `staging/`**, which the harness never generates; nothing under `built-ins/Temporal/Now/` pins the list.

**The sweep found five more removed members still present**, deliberately not fixed here (surface removals each deserving their own look): `PlainDateTime.prototype.withPlainDate`, `ZonedDateTime.prototype.epochSeconds`/`epochMicroseconds`/`toPlainYearMonth`/`toPlainMonthDay`. The similarly-named members that are *not* removals (`toZonedDateTimeISO`, `toPlainDateTime`, …) were checked and are correct.

Red 4 / green 6, both TFMs. test262 standalone at baseline: 0 / 99,744 / 157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)