### PR TITLE
Reject a trailing comma everywhere JSON is parsed

### DIFF
--- a/Jint.Tests/Runtime/JsonTests.cs
+++ b/Jint.Tests/Runtime/JsonTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using System.Text;
 using Jint.Native;
 using Jint.Native.Json;
 using Jint.Native.Object;
@@ -117,6 +118,15 @@ public class JsonTests
     [InlineData(".1", "Unexpected token '.' in JSON at position 0")]
     [InlineData("\"\\u", "Expected hexadecimal digit in JSON at position 3")] // truncated \u escape at end of input
     [InlineData("\"\\u1\"", "Expected hexadecimal digit in JSON at position 4")] // \u with only 1 hex digit
+    // The JSON grammar has no trailing comma: a ',' must be followed by another element or member.
+    [InlineData("[1,]", "Unexpected token ']' in JSON at position 3")]
+    [InlineData("[1,2,]", "Unexpected token ']' in JSON at position 5")]
+    [InlineData("[1, ]", "Unexpected token ']' in JSON at position 4")] // whitespace does not excuse it
+    [InlineData("[[1,],2]", "Unexpected token ']' in JSON at position 4")] // nested array
+    [InlineData("{\"a\":1,}", "Unexpected token '}' in JSON at position 7")]
+    [InlineData("{\"a\":1,\"b\":2,}", "Unexpected token '}' in JSON at position 13")]
+    [InlineData("{\"a\":{\"b\":1,}}", "Unexpected token '}' in JSON at position 12")] // nested object
+    [InlineData("[{\"a\":1,}]", "Unexpected token '}' in JSON at position 8")] // object nested in an array
     public void ShouldReportHelpfulSyntaxErrorForInvalidJson(string json, string expectedMessage)
     {
         var engine = new Engine();
@@ -131,6 +141,46 @@ public class JsonTests
         var error = ex.Error as Native.Error.ErrorInstance;
         error.Should().NotBeNull();
         error.Get("name").Should().Be("SyntaxError");
+    }
+
+    [Fact]
+    public void EveryParseEntryPointRejectsATrailingCommaIdentically()
+    {
+        const string TrailingCommaArray = "[1,]";
+        const string TrailingCommaObject = "{\"a\":1,}";
+        const string ArrayMessage = "Unexpected token ']' in JSON at position 3";
+        const string ObjectMessage = "Unexpected token '}' in JSON at position 7";
+
+        var engine = new Engine();
+        var parser = new JsonParser(engine);
+
+        // The three host-facing overloads read one grammar: string, UTF-16 span, UTF-8 bytes.
+        SyntaxErrorMessage(() => parser.Parse(TrailingCommaArray)).Should().Be(ArrayMessage);
+        SyntaxErrorMessage(() => parser.Parse(TrailingCommaArray.AsSpan())).Should().Be(ArrayMessage);
+        SyntaxErrorMessage(() => parser.Parse(Encoding.UTF8.GetBytes(TrailingCommaArray))).Should().Be(ArrayMessage);
+
+        SyntaxErrorMessage(() => parser.Parse(TrailingCommaObject)).Should().Be(ObjectMessage);
+        SyntaxErrorMessage(() => parser.Parse(TrailingCommaObject.AsSpan())).Should().Be(ObjectMessage);
+        SyntaxErrorMessage(() => parser.Parse(Encoding.UTF8.GetBytes(TrailingCommaObject))).Should().Be(ObjectMessage);
+
+        // And so does script-visible JSON.parse, with and without a reviver -- a reviver switches the
+        // parser to the source-tracking descent used by the json-parse-with-source proposal, which walks
+        // its own element and member loops.
+        SyntaxErrorMessage(() => engine.Evaluate("JSON.parse('[1,]')")).Should().Be(ArrayMessage);
+        SyntaxErrorMessage(() => engine.Evaluate("JSON.parse('[1,]', function (k, v) { return v; })")).Should().Be(ArrayMessage);
+        SyntaxErrorMessage(() => engine.Evaluate("JSON.parse('{\"a\":1,}')")).Should().Be(ObjectMessage);
+        SyntaxErrorMessage(() => engine.Evaluate("JSON.parse('{\"a\":1,}', function (k, v) { return v; })")).Should().Be(ObjectMessage);
+
+        // The reviver descent also has to keep accepting what the grammar allows.
+        engine.Evaluate("JSON.stringify(JSON.parse('[1,{\"a\":2}]', function (k, v) { return v; }))")
+            .AsString().Should().Be("[1,{\"a\":2}]");
+
+        static string SyntaxErrorMessage(Func<JsValue> parse)
+        {
+            var ex = Invoking(parse).Should().Throw<JavaScriptException>().Which;
+            (ex.Error as ObjectInstance)!.Get("name").Should().Be("SyntaxError");
+            return ex.Message;
+        }
     }
 
     [Theory]

--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -857,6 +857,23 @@ public sealed class JsonParser
         ThrowError(token, Messages.UnexpectedToken, TokenText(source, token));
     }
 
+    /// <summary>
+    /// Reports the closing punctuator sitting right after a ',' as the syntax error it is. The JSON
+    /// grammar has no trailing comma — <c>JSONElementList : JSONElementList , JSONValue</c> and
+    /// <c>JSONMemberList : JSONMemberList , JSONMember</c>
+    /// (https://tc39.es/ecma262/#sec-json.parse) both require another element or member after the
+    /// separator — so <c>[1,]</c> and <c>{"a":1,}</c> are as malformed as <c>[,]</c> already was. The
+    /// element and member loops re-test for the closing punctuator at the top, which would otherwise
+    /// read the ',' as harmless and finish the value.
+    /// </summary>
+    private void ThrowOnTrailingComma(ref State state, char closing)
+    {
+        if (Match(closing))
+        {
+            ThrowUnexpected(state.Source, _lookahead);
+        }
+    }
+
     // Expect the next token to match the specified punctuator.
     // If not, an exception will be thrown.
     private void Expect(ref State state, char value)
@@ -902,6 +919,7 @@ public sealed class JsonParser
                 if (!Match(']'))
                 {
                     Expect(ref state, ',');
+                    ThrowOnTrailingComma(ref state, ']');
                 }
             }
 
@@ -957,6 +975,7 @@ public sealed class JsonParser
                 // The token right after ',' is the next key.
                 _expectKey = true;
                 Expect(ref state, ',');
+                ThrowOnTrailingComma(ref state, '}');
             }
         }
 
@@ -1324,6 +1343,7 @@ public sealed class JsonParser
                 if (!Match(']'))
                 {
                     Expect(ref state, ',');
+                    ThrowOnTrailingComma(ref state, ']');
                 }
             }
 
@@ -1397,6 +1417,7 @@ public sealed class JsonParser
                 // The token right after ',' is the next key.
                 _expectKey = true;
                 Expect(ref state, ',');
+                ThrowOnTrailingComma(ref state, '}');
             }
         }
 


### PR DESCRIPTION
`JSON.parse("[1,]")` returned `[1]` and `JSON.parse('{"a":1,}')` returned `{a: 1}` — documents the JSON grammar rejects and every other parser refuses, an interop hazard for a host validating untrusted input. Found by running test262's `staging/` suite. Only `[,]` was rejected, and only because the loop reached `ParseJsonValue` with a comma in hand; the loops re-tested for the closing punctuator at the top, so a `]`/`}` after a comma read as an ordinary end.

One private helper called after every `Expect(',')` in **all four** element/member loops — including the source-tracking pair a reviver switches `JSON.parse` to — reporting through the parser's existing `ThrowUnexpected`, so the `SyntaxError` carries a position in the house style. A test pins that **every parse entry point rejects identically**: `Parse(string)`, the span and UTF-8 overloads, `Engine.Evaluate`, and `JSON.parse` with a reviver.

**The leniency sweep found nothing else**: 30+ probes covering leading `+`, single quotes, unquoted keys, `Infinity`/`NaN`, comments, control characters, numeric malformations — all already rejected — and the legal-JSON cases that must *not* be tightened (raw U+2028, lone-surrogate escapes, duplicate keys, `-0`) all still accepted.

**Release-note behaviour change (strictening):** a host calling `JsonParser.Parse` directly and today accepting such documents will start seeing `SyntaxError` for them; valid JSON is unaffected.

Gate rows: `JsonBenchmark.Parse`, `JsonJsBenchmark.Parse*` incl. the reviver row. Added work is one field read and two comparisons per comma, on the already-taken separator branch.

Red 9 / green 196, both TFMs. test262 standalone at the post-#2978 baseline: 0 / 99,744 / 157, identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
