### PR TITLE
Clamp the substitution tail the way GetSubstitution specifies

### DIFF
--- a/Jint.Tests/Runtime/StringTests.cs
+++ b/Jint.Tests/Runtime/StringTests.cs
@@ -704,6 +704,93 @@ var big = (s + '|tail').split('|');       // [s, 'tail']: first segment is ~the 
         _engine.Evaluate("""JSON.stringify('abc'.split(/(?:)/, 2))""").AsString().Should().Be("""["a","b"]""");
     }
 
+    [Fact]
+    public void SubstitutionTailIsEmptyWhenTheMatchRunsPastTheEndOfTheString()
+    {
+        // GetSubstitution step 5.e (https://tc39.es/ecma262/#sec-getsubstitution): tailPos is
+        // position + the length of matched, and $' is the substring of str from
+        // min(tailPos, stringLength) -- so a tailPos at or past the end yields the empty string.
+        // tailPos can only exceed stringLength when @@replace ran against an object whose "exec"
+        // is not the intrinsic one, which is exactly what these lying execs are.
+        _engine.Execute("var evil = new RegExp();");
+
+        _engine.Execute("""evil.exec = () => ({ 0: "1234567", length: 1, index: 0 });""");
+        _engine.Evaluate("""'abc'.replace(evil, "$'")""").AsString().Should().Be("");
+
+        _engine.Execute("""evil.exec = () => ({ 0: "x", length: 1, index: 3 });""");
+        _engine.Evaluate("""'abc'.replace(evil, "$'")""").AsString().Should().Be("abc");
+
+        _engine.Execute("""evil.exec = () => ({ 0: "x", length: 1, index: 2 });""");
+        _engine.Evaluate("""'abc'.replace(evil, "$'")""").AsString().Should().Be("ab");
+        _engine.Evaluate("""'abcd'.replace(evil, "$'")""").AsString().Should().Be("abdd");
+        _engine.Evaluate("""'abcde'.replace(evil, "$'")""").AsString().Should().Be("abdede");
+    }
+
+    [Fact]
+    public void SubstitutionClampsAMatchIndexTheExecLiedAbout()
+    {
+        // @@replace step 14.e (https://tc39.es/ecma262/#sec-regexp.prototype-@@replace) clamps
+        // ToIntegerOrInfinity(result.index) between 0 and the length of the string, which is what
+        // establishes GetSubstitution's "position <= stringLength" assertion. The clamp has to happen
+        // before the value is narrowed to an index: an out-of-range double-to-int conversion saturates
+        // on .NET but is unspecified on .NET Framework, where it yields int.MinValue and would turn a
+        // far-right index into 0.
+        _engine.Execute("var evil = new RegExp();");
+
+        _engine.Execute("""evil.exec = () => ({ 0: "x", length: 1, index: 1e300 });""");
+        _engine.Evaluate("""'abc'.replace(evil, "[$`]")""").AsString().Should().Be("abc[abc]");
+        _engine.Evaluate("""'abc'.replace(evil, "[$']")""").AsString().Should().Be("abc[]");
+
+        _engine.Execute("""evil.exec = () => ({ 0: "x", length: 1, index: -5 });""");
+        _engine.Evaluate("""'abc'.replace(evil, "[$`]")""").AsString().Should().Be("[]bc");
+        _engine.Evaluate("""'abc'.replace(evil, "[$']")""").AsString().Should().Be("[bc]bc");
+
+        _engine.Execute("""evil.exec = () => ({ 0: "x", length: 1, index: NaN });""");
+        _engine.Evaluate("""'abc'.replace(evil, "[$`|$']")""").AsString().Should().Be("[|bc]bc");
+    }
+
+    [Fact]
+    public void ReplaceAllRunsTheSameSubstitutionClamps()
+    {
+        // replaceAll reaches GetSubstitution through the very same @@replace, so a lying exec has to be
+        // clamped identically there. The regexp must be global for replaceAll to accept it, and its exec
+        // answers once and then reports exhaustion so the accumulation loop terminates.
+        _engine.Execute("""
+            function lying(match, index) {
+                var re = /x/g;
+                var served = false;
+                re.exec = function () {
+                    if (served) { return null; }
+                    served = true;
+                    return { 0: match, length: 1, index: index };
+                };
+                return re;
+            }
+            """);
+
+        _engine.Evaluate("""'abc'.replaceAll(lying('1234567', 0), "$'")""").AsString().Should().Be("");
+        _engine.Evaluate("""'abc'.replaceAll(lying('x', 3), "[$']")""").AsString().Should().Be("abc[]");
+        _engine.Evaluate("""'abc'.replaceAll(lying('x', 1e300), "[$`]")""").AsString().Should().Be("abc[abc]");
+        _engine.Evaluate("""'abc'.replaceAll(lying('x', -5), "[$`|$']")""").AsString().Should().Be("[|bc]bc");
+    }
+
+    [Fact]
+    public void SubstitutionOfAWellBehavedMatchIsUnchanged()
+    {
+        // The control: an honest exec, so position and matched agree with the string and no clamp bites.
+        _engine.Evaluate("""'abcde'.replace(/c/, "[$`|$&|$']")""").AsString().Should().Be("ab[ab|c|de]de");
+        _engine.Evaluate("""'abcde'.replace(/a/, "[$`|$&|$']")""").AsString().Should().Be("[|a|bcde]bcde");
+        _engine.Evaluate("""'abcde'.replace(/e/, "[$`|$&|$']")""").AsString().Should().Be("abcd[abcd|e|]");
+        _engine.Evaluate("""'abcde'.replaceAll(/[bd]/g, "[$`|$&|$']")""").AsString()
+            .Should().Be("a[a|b|cde]c[abc|d|e]e");
+
+        // $n capture references keep resolving against the captures array, and an out-of-range one is
+        // still emitted literally.
+        _engine.Evaluate("""'2026-08-11'.replace(/(\d+)-(\d+)-(\d+)/, "$3.$2.$1")""").AsString()
+            .Should().Be("11.08.2026");
+        _engine.Evaluate("""'abc'.replace(/b/, "$1$&")""").AsString().Should().Be("a$1bc");
+    }
+
     public static TheoryData<string, string> GetLithuaniaTestsData()
     {
         return new StringTetsLithuaniaData().TestData();

--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -362,8 +362,13 @@ internal sealed partial class RegExpPrototype : Prototype
             nCaptures = System.Math.Max(nCaptures - 1, 0);
             var matched = TypeConverter.ToString(result.Get(0));
             var matchLength = matched.Length;
-            var position = (int) TypeConverter.ToInteger(result.Get(PropertyIndex));
-            position = System.Math.Max(System.Math.Min(position, lengthS), 0);
+            // Step 14.e: clamp the reported index between 0 and lengthS. The clamp is what establishes
+            // GetSubstitution's "position <= stringLength" assertion, so it has to happen while the value
+            // is still a double: narrowing first loses the magnitude, and an out-of-range double-to-int
+            // conversion saturates on .NET but is unspecified on .NET Framework, where it yields
+            // int.MinValue and would turn a far-right index into 0.
+            var reportedIndex = TypeConverter.ToInteger(result.Get(PropertyIndex));
+            var position = (int) System.Math.Max(System.Math.Min(reportedIndex, lengthS), 0);
             uint n = 1;
 
             captures.Clear();
@@ -479,7 +484,13 @@ internal sealed partial class RegExpPrototype : Prototype
                         sb.Append(str.AsSpan(0, position));
                         break;
                     case '\'':
-                        sb.Append(str.AsSpan(position + matched.Length));
+                        // Step 5.e: tailPos is position + the length of matched, and the replacement is
+                        // the substring of str from min(tailPos, stringLength) -- so a match running to
+                        // or past the end contributes nothing. tailPos can only exceed stringLength when
+                        // @@replace ran against an object whose "exec" is not the intrinsic one and which
+                        // reported a matched string longer than what is left of str; the sum is taken as
+                        // a long so a pair of near-int.MaxValue lengths cannot wrap into a negative index.
+                        sb.Append(str.AsSpan((int) System.Math.Min((long) position + matched.Length, str.Length)));
                         break;
                     case '<':
                         var gtPos = replacement.IndexOf('>', i + 1);


### PR DESCRIPTION
`"abc".replace(evil, "$'")` with a lying `exec` (`{0: "1234567", length: 1, index: 0}`) threw `ArgumentOutOfRangeException` out of the engine: [GetSubstitution](https://tc39.es/ecma262/#sec-getsubstitution) says `$'` is empty when `tailPos >= stringLength`, and Jint substringed past the end. Found by running test262's `staging/` suite.

Two fixes, both the spec's own algorithm rather than a blanket guard: step 5.e's `min(tailPos, stringLength)` with the sum taken as a `long` so two near-`int.MaxValue` lengths cannot wrap; and `@@replace` step 14.e's index clamped **while still a double** — narrowing first loses the magnitude, and the red run proved it splits by framework: net472 answered `"[]bc"` where net10.0 answered `"abc[abc]"` from the same source line. `$n` and `$<name>` were audited and already bounds-checked.

Covered through `replace` and `replaceAll`, with indexes `1e300`, `-5` and `NaN`, plus a well-behaved control across ``$` ``/`$&`/`$'` at start, middle and end. The staging file that flagged this verified passing end-to-end through the REPL.

**A different defect found in the sibling staging file, recorded not fixed:** `replace-math.js` reaches an int overflow in `ValueStringBuilder.Grow` when the accumulated result exceeds ~2^31 chars — V8 answers `RangeError: Invalid string length` where Jint leaks `ArrayPool.Rent(minimumLength: -2147483648)`. A proper fix is a max-string-length budget surfacing as a JS `RangeError`, which needs realm access the static helper lacks — its own piece of work.

Gate rows: `StringReplaceBenchmark.ReplaceAll*`; neither clamp is on a `$`-free path and the .NET-Regex fast lane is untouched.

Red 3 / green 922 (StringTests), both TFMs. test262 standalone at baseline: 0 / 99,744 / 157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
