### PR TITLE
Hand the defineProperty trap the descriptor the caller wrote

### DIFF
--- a/Jint.Tests/Runtime/ProxyTests.cs
+++ b/Jint.Tests/Runtime/ProxyTests.cs
@@ -715,6 +715,82 @@ public class ProxyTests
         res.AsArray().AsEnumerable().Should().Equal(1, 2, 3, 3);
     }
 
+    /// <summary>
+    /// Step 7 of
+    /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc
+    /// hands the trap <c>FromPropertyDescriptor(Desc)</c> of the <em>partial</em> descriptor the caller wrote,
+    /// and FromPropertyDescriptor creates an attribute exactly when the descriptor has that field. Jint used to
+    /// derive the shape from <c>IsDataDescriptor()</c> instead, which invented a "get" beside a lone "set", a
+    /// "writable" beside a "value", and a "get"/"set" pair for a descriptor carrying nothing but attributes.
+    /// Every expectation here was read off node 24.
+    /// </summary>
+    [Theory]
+    [InlineData("{ get: function () {} }", "get")]
+    [InlineData("{ set: function () {} }", "set")]
+    [InlineData("{ get: function () {}, set: function () {} }", "get,set")]
+    [InlineData("{ get: undefined }", "get")]
+    [InlineData("{ value: 1 }", "value")]
+    [InlineData("{ value: undefined }", "value")]
+    [InlineData("{ writable: true }", "writable")]
+    [InlineData("{ configurable: true }", "configurable")]
+    [InlineData("{}", "")]
+    [InlineData("{ value: 1, configurable: true, enumerable: true }", "value,enumerable,configurable")]
+    [InlineData("{ configurable: true, set: function () {} }", "set,configurable")]
+    public void DefinePropertyTrapSeesOnlyTheFieldsTheCallerWrote(string descriptor, string expected)
+    {
+        foreach (var define in new[]
+                 {
+                     "Object.defineProperty(p, 'foo', d)",
+                     "Reflect.defineProperty(p, 'foo', d)",
+                     "Object.defineProperties(p, { foo: d })",
+                 })
+        {
+            var seen = new Engine().Evaluate($$"""
+                var seen;
+                var p = new Proxy({}, { defineProperty(t, k, d) { seen = Object.getOwnPropertyNames(d).join(','); return true; } });
+                var d = {{descriptor}};
+                {{define}};
+                seen;
+                """).AsString();
+
+            seen.Should().Be(expected, because: define);
+        }
+    }
+
+    /// <summary>
+    /// Only the trap <em>argument</em> is the partial descriptor: steps 12-15 still validate <c>Desc</c> itself,
+    /// so a non-configurable definition for a property the target does not have is a TypeError even though the
+    /// trap saw only "value"/"writable"/"enumerable"/"configurable" and returned true.
+    /// </summary>
+    [Fact]
+    public void DefinePropertyTrapValidationStillRunsAgainstTheCallersDescriptor()
+    {
+        var engine = new Engine();
+        engine.Execute("var p = new Proxy({}, { defineProperty() { return true; } });");
+
+        Assert.Throws<JavaScriptException>(
+            () => engine.Execute("Object.defineProperty(p, 'foo', { value: 1, writable: false, enumerable: false, configurable: false });"));
+
+        // a configurable definition of the same shape is accepted
+        engine.Execute("Object.defineProperty(p, 'foo', { value: 1, configurable: true });");
+    }
+
+    /// <summary>
+    /// The completing mode of FromPropertyDescriptor is what <c>Object.getOwnPropertyDescriptor</c> uses, and it
+    /// keeps reporting every attribute of a real property.
+    /// </summary>
+    [Fact]
+    public void GetOwnPropertyDescriptorStillReportsACompleteDescriptor()
+    {
+        var engine = new Engine();
+
+        engine.Evaluate("Object.getOwnPropertyNames(Object.getOwnPropertyDescriptor({ foo: 1 }, 'foo')).join(',')")
+            .AsString().Should().Be("value,writable,enumerable,configurable");
+
+        engine.Evaluate("Object.getOwnPropertyNames(Object.getOwnPropertyDescriptor({ get foo() { return 1; } }, 'foo')).join(',')")
+            .AsString().Should().Be("get,set,enumerable,configurable");
+    }
+
     [Fact]
     public void ProxyClrObjectMethod()
     {

--- a/Jint/Runtime/Descriptors/PropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/PropertyDescriptor.cs
@@ -507,7 +507,42 @@ public class PropertyDescriptor
         // we should have possibility to leave out the properties in property descriptors as newer tests
         // also assert properties to be undefined
 
-        if (desc.IsDataDescriptor())
+        if (strictUndefined)
+        {
+            // Field-driven, as the specification writes it: an attribute is created exactly when the
+            // descriptor *has* that field. This is the mode a partial descriptor is rendered in — the one
+            // ToPropertyDescriptor built from whatever fields the caller actually wrote, and which the Proxy
+            // "defineProperty" trap is handed. `Object.defineProperty(proxy, k, { configurable: true, set() {} })`
+            // must therefore show the trap exactly "set" and "configurable"; deriving the shape from
+            // IsDataDescriptor() instead (below) invents a "get" beside the "set", a "writable" beside a
+            // "value", and a "get"/"set" pair for a descriptor carrying nothing but attributes.
+            // Only the trap *argument* is shaped this way: the post-trap checks in JsProxy still run against
+            // Desc itself, per steps 12-15 of
+            // https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc
+            var value = desc.Value;
+            if (value is not null)
+            {
+                properties["value"] = new PropertyDescriptor(value, PropertyFlag.ConfigurableEnumerableWritable);
+            }
+
+            if (desc.WritableSet)
+            {
+                properties["writable"] = new PropertyDescriptor(desc.Writable, PropertyFlag.ConfigurableEnumerableWritable);
+            }
+
+            var get = desc.Get;
+            if (get is not null)
+            {
+                properties["get"] = new PropertyDescriptor(get, PropertyFlag.ConfigurableEnumerableWritable);
+            }
+
+            var set = desc.Set;
+            if (set is not null)
+            {
+                properties["set"] = new PropertyDescriptor(set, PropertyFlag.ConfigurableEnumerableWritable);
+            }
+        }
+        else if (desc.IsDataDescriptor())
         {
             properties["value"] = new PropertyDescriptor(desc.Value ?? JsValue.Undefined, PropertyFlag.ConfigurableEnumerableWritable);
             if (desc._flags != PropertyFlag.None || desc.WritableSet)


### PR DESCRIPTION
A Proxy's `defineProperty` trap must receive `FromPropertyDescriptor` of the **partial** descriptor as passed; Jint rendered the shape from `IsDataDescriptor()` instead of field *presence*, so `{configurable:true, set(){}}` arrived as `[get, set, configurable]`. Measured against node across 12 shapes × three entry points (`Object.defineProperty`, `Reflect.defineProperty`, `Object.defineProperties`): **8 of 12 were wrong**, not just the reported one — `{}` arrived as `[get, set]`, `{writable:true}` as `[value, writable]`.

The fix is a field-driven branch in `FromPropertyDescriptor`'s strict mode (the one `JsProxy.DefineOwnProperty` uses); the completing mode `Object.getOwnPropertyDescriptor` relies on is byte-identical. Post-trap validation still runs against the completed form per spec steps 12–15 — pinned by a test that proves an incompatible define still throws.

All 12 shapes now match node on every entry point. Red on 8, green 13 new tests, both TFMs. test262 standalone 0 / 99,744 / 157 (an 8-fail intermediate run was the known S7.8.5 load flake; the family is green in isolation and `FromPropertyDescriptor` is not on its path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)