### PR TITLE
Read a string's iterator once, with the primitive as receiver

### DIFF
--- a/Jint.Tests/Runtime/StringIterationTests.cs
+++ b/Jint.Tests/Runtime/StringIterationTests.cs
@@ -1,0 +1,244 @@
+#nullable enable
+
+using Jint.Native;
+using Jint.Native.Iterator;
+using Jint.Native.Symbol;
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// <c>GetIterator</c> reads <c>@@iterator</c> once, and the value it read is what decides how the iteration
+/// runs. Jint's string fast lane used to ask a second time: it consulted
+/// <c>StringPrototype.HasOriginalIterator</c> — a read of its own — to decide whether to iterate the text
+/// directly, and then let the general path read again. An accessor on
+/// <c>String.prototype[Symbol.iterator]</c> therefore observed two gets for one <c>Array.from("hello")</c>.
+/// Every expectation here was read off node 24.
+/// </summary>
+public class StringIterationTests
+{
+    /// <summary>
+    /// Installs a counting accessor over <paramref name="prototype"/>'s <c>@@iterator</c>, runs
+    /// <paramref name="consume"/> as a function body over <paramref name="source"/>, and reports how many
+    /// times the accessor ran, what <c>this</c> each call saw, and what the iteration produced.
+    /// </summary>
+    private static string Probe(string prototype, string source, string consume)
+    {
+        return new Engine().Evaluate($$"""
+            var reads = [];
+            var original = {{prototype}}[Symbol.iterator];
+            Object.defineProperty({{prototype}}, Symbol.iterator, {
+                configurable: true,
+                get: function () { 'use strict'; reads.push(typeof this); return original; }
+            });
+            var result = JSON.stringify((function (v) { {{consume}} })({{source}}));
+            'reads=' + reads.length + ' this=' + reads.join(',') + ' result=' + result;
+            """).AsString();
+    }
+
+    private const string SpreadBody = "return [...v];";
+    private const string ArrayFromBody = "return Array.from(v);";
+    private const string ForOfBody = "var r = []; for (var c of v) r.push(c); return r;";
+
+    /// <summary>
+    /// One read, and its receiver is the primitive — <c>GetV(V, @@iterator)</c> resolves on the wrapper with
+    /// V itself as the receiver, and the wrapper carries no own <c>@@iterator</c>, so the lane never has to
+    /// build one.
+    /// </summary>
+    [Theory]
+    [InlineData(ArrayFromBody)]
+    [InlineData(SpreadBody)]
+    [InlineData(ForOfBody)]
+    public void IteratingAPrimitiveStringReadsTheIteratorOnce(string consume)
+    {
+        Probe("String.prototype", "'hi'", consume)
+            .Should().Be("""reads=1 this=string result=["h","i"]""");
+    }
+
+    /// <summary>
+    /// Array destructuring reaches the same single read, but sees a wrapper rather than the primitive:
+    /// <c>HandleArrayPattern</c> performs <c>ToObject</c> on the value before asking for an iterator, so the
+    /// string lane is never entered at all. node reports <c>this</c> as "string" here. Pinned as it is — the
+    /// early boxing is a separate deviation from the read count this class is about.
+    /// </summary>
+    [Fact]
+    public void DestructuringAPrimitiveStringReadsTheIteratorOnceThroughAWrapper()
+    {
+        Probe("String.prototype", "'hi'", "var [a, b] = v; return [a, b];")
+            .Should().Be("""reads=1 this=object result=["h","i"]""");
+    }
+
+    [Theory]
+    [InlineData(ArrayFromBody)]
+    [InlineData(SpreadBody)]
+    [InlineData(ForOfBody)]
+    public void IteratingABoxedStringReadsTheIteratorOnce(string consume)
+    {
+        Probe("String.prototype", "new String('hi')", consume)
+            .Should().Be("""reads=1 this=object result=["h","i"]""");
+    }
+
+    /// <summary>
+    /// A receiver with no fast lane behind it was already reading once; it must stay that way.
+    /// </summary>
+    [Theory]
+    [InlineData(ArrayFromBody)]
+    [InlineData(SpreadBody)]
+    [InlineData(ForOfBody)]
+    public void IteratingANumberReadsTheIteratorOnce(string consume)
+    {
+        new Engine().Evaluate($$"""
+            var reads = 0;
+            Object.defineProperty(Number.prototype, Symbol.iterator, {
+                configurable: true,
+                get: function () { reads++; return function () { return [1, 2][Symbol.iterator](); }; }
+            });
+            var result = JSON.stringify((function (v) { {{consume}} })(5));
+            'reads=' + reads + ' result=' + result;
+            """).AsString().Should().Be("reads=1 result=[1,2]");
+    }
+
+    /// <summary>
+    /// The whole point of resolving the method before deciding: an untouched <c>String.prototype</c> still
+    /// takes the lane that walks the text directly instead of constructing a %StringIteratorPrototype% and
+    /// driving it one <c>next()</c> call per code point. Both entry shapes are covered — the one that has to
+    /// resolve <c>@@iterator</c> itself (spread, for-of) and the one handed an already-resolved method
+    /// (<c>Array.from</c>, <c>Iterator.from</c>), which reaches the lane by identity and reads nothing at all.
+    /// </summary>
+    [Fact]
+    public void AnUntouchedStringPrototypeKeepsTheDirectIterationLane()
+    {
+        var engine = new Engine();
+        var realm = engine.Realm;
+        JsValue value = new JsString("hi");
+
+        value.TryGetIterator(realm, out var resolved).Should().BeTrue();
+        resolved.Should().BeOfType<IteratorInstance.StringIterator>();
+
+        var method = JsValue.GetMethod(realm, value, GlobalSymbolRegistry.Iterator);
+        value.TryGetIterator(realm, out var fromMethod, method: method).Should().BeTrue();
+        fromMethod.Should().BeOfType<IteratorInstance.StringIterator>();
+    }
+
+    /// <summary>
+    /// And the converse: once <c>@@iterator</c> is something else, the lane must not engage — a fast path that
+    /// cannot be turned off is a correctness bug rather than an optimization.
+    /// </summary>
+    [Fact]
+    public void AReplacedStringIteratorLeavesTheDirectLane()
+    {
+        var engine = new Engine();
+        engine.Execute("""
+            Object.defineProperty(String.prototype, Symbol.iterator, {
+                configurable: true, writable: true,
+                value: function () { return ['X', 'Y'][Symbol.iterator](); }
+            });
+            """);
+
+        JsValue value = new JsString("hi");
+        value.TryGetIterator(engine.Realm, out var resolved).Should().BeTrue();
+        resolved.Should().NotBeOfType<IteratorInstance.StringIterator>();
+
+        engine.Evaluate("JSON.stringify([...'hi'])").AsString().Should().Be("""["X","Y"]""");
+        engine.Evaluate("JSON.stringify(Array.from('hi'))").AsString().Should().Be("""["X","Y"]""");
+    }
+
+    [Fact]
+    public void ANonCallableStringIteratorIsATypeError()
+    {
+        var engine = new Engine();
+        engine.Execute("String.prototype[Symbol.iterator] = 42;");
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("[...'hi']"));
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("Array.from('hi')"));
+    }
+
+    /// <summary>
+    /// With <c>@@iterator</c> gone a string is not iterable, but <c>Array.from</c> still has the array-like
+    /// fallback to fall back on.
+    /// </summary>
+    [Fact]
+    public void ADeletedStringIteratorMakesTheStringNonIterable()
+    {
+        var engine = new Engine();
+        engine.Execute("delete String.prototype[Symbol.iterator];");
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("[...'hi']"));
+        engine.Evaluate("JSON.stringify(Array.from('hi'))").AsString().Should().Be("""["h","i"]""");
+    }
+
+    /// <summary>
+    /// The direct lane iterates by code point, not by UTF-16 code unit.
+    /// </summary>
+    [Theory]
+    [InlineData(ArrayFromBody)]
+    [InlineData(SpreadBody)]
+    [InlineData(ForOfBody)]
+    public void TheDirectLaneIteratesBySurrogatePair(string consume)
+    {
+        new Engine().Evaluate($$"""JSON.stringify((function (v) { {{consume}} })('a\u{1F600}b'))""")
+            .AsString().Should().Be("""["a","😀","b"]""");
+    }
+
+    /// <summary>
+    /// The direct lane belongs to the sync hint alone. It used to be taken whatever the hint was, so
+    /// <c>for await</c> over a string ignored an <c>@@asyncIterator</c> installed on
+    /// <c>String.prototype</c> and iterated the text instead; the async lookup order now reaches the base
+    /// implementation, which asks for <c>@@asyncIterator</c> first as
+    /// https://tc39.es/ecma262/#sec-getiterator prescribes.
+    /// </summary>
+    [Fact]
+    public void ForAwaitOverAStringHonoursAnAsyncIterator()
+    {
+        var engine = new Engine();
+        engine.Execute("""
+            var out = null;
+            Object.defineProperty(String.prototype, Symbol.asyncIterator, {
+                configurable: true,
+                value: function () { return ['A', 'B'][Symbol.iterator](); }
+            });
+            (async function () {
+                var r = [];
+                for await (var c of 'hi') r.push(c);
+                out = JSON.stringify(r);
+            })();
+            """);
+
+        engine.Evaluate("out").AsString().Should().Be("""["A","B"]""");
+    }
+
+    /// <summary>
+    /// Without one, <c>for await</c> still walks the string, through the sync-to-async adapter.
+    /// </summary>
+    [Fact]
+    public void ForAwaitOverAStringFallsBackToTheSyncIterator()
+    {
+        var engine = new Engine();
+        engine.Execute("""
+            var out = null;
+            (async function () {
+                var r = [];
+                for await (var c of 'hi') r.push(c);
+                out = JSON.stringify(r);
+            })();
+            """);
+
+        engine.Evaluate("out").AsString().Should().Be("""["h","i"]""");
+    }
+
+    /// <summary>
+    /// <c>String.prototype</c> itself is a String object holding the empty string, and iterating it produces
+    /// nothing whichever lane is chosen. It is worth pinning because it used to be the one object besides a
+    /// primitive string whose <c>HasOriginalIterator</c> answered true, which routed array destructuring of it
+    /// through the array-like shortcut rather than through an iterator.
+    /// </summary>
+    [Fact]
+    public void StringPrototypeIteratesAsTheEmptyString()
+    {
+        var engine = new Engine();
+        engine.Evaluate("JSON.stringify([...String.prototype])").AsString().Should().Be("[]");
+        engine.Evaluate("JSON.stringify(Array.from(String.prototype))").AsString().Should().Be("[]");
+        engine.Evaluate("(function () { var [a] = String.prototype; return a === undefined; })()")
+            .AsBoolean().Should().BeTrue();
+    }
+}

--- a/Jint/Native/JsString.cs
+++ b/Jint/Native/JsString.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Jint.Native.Generator;
 using Jint.Native.Iterator;
+using Jint.Native.Symbol;
 using Jint.Runtime;
 
 namespace Jint.Native;
@@ -405,16 +406,66 @@ public class JsString : JsValue, IEquatable<JsString>, IEquatable<string>
         return ToString().Substring(startIndex);
     }
 
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-getiterator — the @@iterator lookup for a primitive string receiver,
+    /// with the fast lane that iterates the text directly instead of driving %StringIteratorPrototype%.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Exactly one read of @@iterator, and its result is what picks the lane.</b> The lane used to be
+    /// chosen by <c>StringPrototype.HasOriginalIterator</c>, which performed a read of its own and then let
+    /// the general path read again, so an accessor installed on <c>String.prototype[Symbol.iterator]</c> saw
+    /// two gets for one <c>Array.from("hello")</c> where the specification and every other engine produce one.
+    /// </para>
+    /// <para>
+    /// The read resolves off <c>String.prototype</c> with this string as the receiver, which is what
+    /// <c>GetV(V, @@iterator)</c> asks for: the wrapper <c>ToObject(V)</c> would build is fresh and carries no
+    /// own @@iterator, so the property resolves at the same place either way — and a getter observes the
+    /// primitive as its <c>this</c>, as it does in V8, rather than a wrapper this lane never needed to build.
+    /// </para>
+    /// <para>
+    /// A caller that has already resolved the method — <c>Array.from</c> and <c>Iterator.from</c> both perform
+    /// <c>GetMethod</c> first — hands it in, and classifying it by identity costs no read at all. That is the
+    /// second half of the fix: re-reading to answer "is this still the original?" was the extra get.
+    /// </para>
+    /// </remarks>
     internal override bool TryGetIterator(
         Realm realm,
         [NotNullWhen(true)] out IteratorInstance? iterator,
         GeneratorKind hint = GeneratorKind.Sync,
         ICallable? method = null)
     {
-        if (realm.Intrinsics.String.PrototypeObject.HasOriginalIterator)
+        // The async hint looks up @@asyncIterator first and has no string fast lane of its own.
+        if (hint == GeneratorKind.Sync)
         {
-            iterator = new IteratorInstance.StringIterator(realm.GlobalEnv._engine, ToString());
-            return true;
+            var stringPrototype = realm.Intrinsics.String.PrototypeObject;
+
+            if (method is null)
+            {
+                var iteratorMethod = stringPrototype.Get(GlobalSymbolRegistry.Iterator, this);
+                if (ReferenceEquals(iteratorMethod, stringPrototype._originalIteratorFunction))
+                {
+                    iterator = new IteratorInstance.StringIterator(stringPrototype.Engine, ToString());
+                    return true;
+                }
+
+                if (iteratorMethod.IsNullOrUndefined())
+                {
+                    iterator = null;
+                    return false;
+                }
+
+                method = iteratorMethod as ICallable;
+                if (method is null)
+                {
+                    Throw.TypeError(realm, $"Value returned for property '{GlobalSymbolRegistry.Iterator}' of object is not a function");
+                }
+            }
+            else if (ReferenceEquals(method, stringPrototype._originalIteratorFunction))
+            {
+                iterator = new IteratorInstance.StringIterator(stringPrototype.Engine, ToString());
+                return true;
+            }
         }
 
         return base.TryGetIterator(realm, out iterator, hint, method);

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -34,9 +34,10 @@ internal sealed partial class StringPrototype : StringInstance
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly StringConstructor _constructor;
 
-    // Captured by CreateSymbols_Generated (via CaptureField below, which makes @@iterator eager);
-    // HasOriginalIterator identity-compares against this snapshot for the fast-path detection used
-    // by string iteration consumers.
+    // Captured by CreateSymbols_Generated (via CaptureField below, which makes @@iterator eager).
+    // JsString.TryGetIterator identity-compares the @@iterator it resolved against this snapshot to
+    // decide between the direct text-iteration lane and driving %StringIteratorPrototype%; comparing
+    // rather than re-reading is what keeps that decision free of a second observable get.
     internal FunctionInstance? _originalIteratorFunction;
 
     internal StringPrototype(
@@ -57,8 +58,6 @@ internal sealed partial class StringPrototype : StringInstance
         CreateProperties_Generated();
         CreateSymbols_Generated();
     }
-
-    internal override bool HasOriginalIterator => ReferenceEquals(Get(GlobalSymbolRegistry.Iterator), _originalIteratorFunction);
 
     [JsSymbolFunction("Iterator", Flags = PropertyFlag.Configurable | PropertyFlag.Writable, CaptureField = nameof(_originalIteratorFunction))]
     private ObjectInstance Iterator(JsValue thisObject)


### PR DESCRIPTION
Iterating a string read `@@iterator` **twice** — `StringPrototype.HasOriginalIterator` was itself a `Get` used as a probe, after which the general path read again — and handed the *boxed* wrapper as `this` where node passes the primitive. `Array.from("hello")` with a counting getter: reads 2 → 1; spread and `for-of` had the wrong receiver on their single read.

Now one read whose **result** picks the lane: a supplied method is classified by identity against the original iterator function (no read at all — `Array.from`'s `GetMethod` read is no longer wasted), otherwise `stringPrototype.Get(@@iterator, this)` with the primitive receiver per `GetV`. `HasOriginalIterator` had no other caller and is gone. The direct `StringIterator` fast lane stays engaged for an untouched prototype — pinned in both directions.

**Bonus fix that fell out:** the lane used to be taken regardless of the generator hint, so `for await` over a string ignored an `@@asyncIterator` on `String.prototype`; it now honours it, with the sync fallback pinned — node parity.

**Adjacent findings recorded, not fixed here:** array spread reads `@@iterator` twice via the same probe-then-read shape in a different lane (`ArrayInstance.HasOriginalIterator`); `GetIteratorFromMethod` boxes the receiver for a replacement iterator; array destructuring boxes before `GetIterator`.

20 new tests, red on exactly the 3 primitive-string rows. test262 standalone 0 / 99,744 / 157, identical. Gate rows: `ForOfArrayBenchmark`, `IteratorToArrayBenchmark` — noting honestly that no benchmark row iterates a *string*, so the changed lane's direct cost rests on the wide tables' string scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)