### PR TITLE
Pin generic type arguments from the receiver, and snapshot lazy sequences on request

### DIFF
--- a/Jint.Tests/Runtime/DefaultTypeConverterTests.cs
+++ b/Jint.Tests/Runtime/DefaultTypeConverterTests.cs
@@ -102,4 +102,73 @@ public class DefaultTypeConverterTests
 
         Invoking(() => engine.Execute("callInt('not a number')")).Should().ThrowExactly<FormatException>();
     }
+
+    /// <summary>
+    /// The generic pass-through matches on the generic type *definition*, so on its own it would call a
+    /// <c>List&lt;object&gt;</c> assignable to <c>IEnumerable&lt;string&gt;</c> and hand it over unconverted -
+    /// which then dies inside a reflection invoke as a raw ArgumentException
+    /// (https://github.com/sebastienros/jint/issues/2987).
+    /// </summary>
+    [Fact]
+    public void ShouldNotPassIncompatibleTypeArgumentsThrough()
+    {
+        var converter = new DefaultTypeConverter(new Engine());
+
+        converter.TryConvert(new List<object> { "a" }, typeof(IEnumerable<string>), CultureInfo.InvariantCulture, out _)
+            .Should().BeFalse();
+        converter.TryConvert(new List<int> { 1 }, typeof(IEnumerable<object>), CultureInfo.InvariantCulture, out _)
+            .Should().BeFalse("boxing is not variance");
+    }
+
+    [Fact]
+    public void ShouldStillPassGenuinelyAssignableValuesThrough()
+    {
+        var converter = new DefaultTypeConverter(new Engine());
+
+        // reference-type covariance is real assignability and short-circuits before the generic check
+        var source = new List<string> { "a" };
+        converter.TryConvert(source, typeof(IEnumerable<object>), CultureInfo.InvariantCulture, out var covariant)
+            .Should().BeTrue();
+        covariant.Should().BeSameAs(source);
+
+        IDictionary<string, object?> expando = new ExpandoObject();
+        converter.TryConvert(expando, typeof(IDictionary<string, object?>), CultureInfo.InvariantCulture, out var same)
+            .Should().BeTrue();
+        same.Should().BeSameAs(expando);
+
+        // a JS array still materializes into the requested collection type, that branch runs first
+        converter.TryConvert(new object?[] { 1d, 2d }, typeof(IList<int>), CultureInfo.InvariantCulture, out var list)
+            .Should().BeTrue();
+        list.Should().BeOfType<List<int>>().Which.Should().Equal(1, 2);
+    }
+
+    /// <summary>
+    /// Accepted consequence of the tightened pass-through: a member the value cannot legally be assigned to
+    /// used to be converted "successfully" and then silently dropped by ReflectionExtensions.SetValue.
+    /// An error is the better answer, but it is a behavior change worth pinning.
+    /// </summary>
+    [Fact]
+    public void ObjectLiteralMemberThatCannotBeAssignedNowErrorsInsteadOfBeingDropped()
+    {
+        var engine = new Engine();
+        engine.SetValue("Holder", typeof(SequenceHolder));
+        engine.SetValue("objects", new List<object> { "a", "b" });
+
+        // a List<object> is not an IEnumerable<string>, and unlike a JS array it has no element-wise
+        // conversion path - it used to be "converted" unchanged and then dropped by the member write
+        Invoking(() => engine.Evaluate("Holder.Describe({ Items: objects })"))
+            .Should().Throw<Exception>();
+
+        // the assignable shapes still map
+        engine.Evaluate("Holder.Describe({ Items: ['a', 'b'] })").AsString().Should().Be("a,b");
+        engine.SetValue("strings", new List<string> { "a", "b" });
+        engine.Evaluate("Holder.Describe({ Items: strings })").AsString().Should().Be("a,b");
+    }
+
+    public class SequenceHolder
+    {
+        public IEnumerable<string>? Items { get; set; }
+
+        public static string Describe(SequenceHolder holder) => string.Join(",", holder.Items ?? []);
+    }
 }

--- a/Jint.Tests/Runtime/ExtensionMethods/EnumerableSnapshotTests.cs
+++ b/Jint.Tests/Runtime/ExtensionMethods/EnumerableSnapshotTests.cs
@@ -1,0 +1,158 @@
+using System.Collections;
+
+namespace Jint.Tests.Runtime.ExtensionMethods;
+
+/// <summary>
+/// <see cref="EnumerableConversionMode.Snapshot"/> gives a sequence that has no count and no indexer the
+/// array-like shape Array.prototype needs, the only way such a sequence can have one
+/// (https://github.com/sebastienros/jint/issues/2987). Everything that already had a count keeps its live
+/// exposure, and the default mode changes nothing.
+/// </summary>
+public class EnumerableSnapshotTests
+{
+    private static Engine CreateEngine(bool snapshot, bool withExtensions = true)
+    {
+        return new Engine(options =>
+        {
+            if (withExtensions)
+            {
+                options.AddExtensionMethods(typeof(ShadowingMapExtensions));
+            }
+
+            if (snapshot)
+            {
+                options.Interop.EnumerableConversion = EnumerableConversionMode.Snapshot;
+            }
+        });
+    }
+
+    [Fact]
+    public void SnapshotMakesTheIssueReproWork()
+    {
+        var engine = CreateEngine(snapshot: true);
+        engine.SetValue("coll", new List<string> { "Hello", "World" }.Select(y => y));
+
+        // the receiver is array-like now, so the registered 'map' defers to Array.prototype.map (#2976) and
+        // the projection is a real JS array carrying the native 'includes'
+        engine.Evaluate("coll.map(x => x).includes('Hello')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("coll.map(x => x).includes('Nope')").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void SnapshotIsArrayLikeButNotAnArray()
+    {
+        var engine = CreateEngine(snapshot: true, withExtensions: false);
+        engine.SetValue("coll", new List<string> { "Hello", "World" }.Where(x => x.Length > 0));
+
+        engine.Evaluate("Array.isArray(coll)").AsBoolean().Should().BeFalse();
+        engine.Evaluate("coll instanceof Array").AsBoolean().Should().BeTrue();
+        engine.Evaluate("coll.length").AsNumber().Should().Be(2);
+        engine.Evaluate("coll[0]").AsString().Should().Be("Hello");
+        engine.Evaluate("coll[5]").Should().Be(Native.JsValue.Undefined);
+        engine.Evaluate("coll.join('-')").AsString().Should().Be("Hello-World");
+        engine.Evaluate("coll.includes('World')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("coll.map(x => x + '!').join()").AsString().Should().Be("Hello!,World!");
+        engine.Evaluate("JSON.stringify(coll)").AsString().Should().Be("""["Hello","World"]""");
+    }
+
+    [Fact]
+    public void SnapshotIsFixedSize()
+    {
+        var engine = CreateEngine(snapshot: true, withExtensions: false);
+        engine.SetValue("coll", new List<string> { "Hello" }.Where(_ => true));
+
+        // the snapshot is an array view, so it behaves like every other fixed-size CLR array view
+        Invoking(() => engine.Evaluate("coll.push('World')")).Should().Throw<Exception>();
+    }
+
+    [Fact]
+    public void SequenceIsEnumeratedExactlyOnce()
+    {
+        var engine = CreateEngine(snapshot: true, withExtensions: false);
+        var source = new CountingEnumerable(["Hello", "World"]);
+        engine.SetValue("coll", source.Where(_ => true));
+
+        source.EnumerationCount.Should().Be(1, "the snapshot is taken when the sequence crosses into script");
+
+        engine.Evaluate("coll.length").AsNumber().Should().Be(2);
+        engine.Evaluate("coll.join()").AsString().Should().Be("Hello,World");
+        engine.Evaluate("[...coll].length").AsNumber().Should().Be(2);
+
+        source.EnumerationCount.Should().Be(1, "every later read comes from the snapshot");
+    }
+
+    [Fact]
+    public void LazyIsTheDefaultAndUnchanged()
+    {
+        var engine = CreateEngine(snapshot: false);
+        var source = new CountingEnumerable(["Hello", "World"]);
+        engine.SetValue("coll", source.Where(_ => true));
+
+        source.EnumerationCount.Should().Be(0, "nothing is enumerated until script asks");
+
+        engine.Evaluate("typeof coll.length").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof coll.includes").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof coll.map").AsString().Should().Be("function", "the registered extension supplies it");
+        engine.Evaluate("Array.from(coll).join()").AsString().Should().Be("Hello,World");
+    }
+
+    [Fact]
+    public void CountedCollectionsAreNotSnapshotted()
+    {
+        var engine = CreateEngine(snapshot: true, withExtensions: false);
+        var set = new HashSet<string> { "Hello" };
+        var list = new List<string> { "Hello" };
+        engine.SetValue("set", set);
+        engine.SetValue("list", list);
+
+        // a HashSet<T> has a Count and already carries Array.prototype; it must stay the live collection
+        engine.Evaluate("set.length").AsNumber().Should().Be(1);
+        set.Add("World");
+        engine.Evaluate("set.length").AsNumber().Should().Be(2);
+
+        engine.Evaluate("list.push('World'); list.length").AsNumber().Should().Be(2);
+        list.Should().Equal("Hello", "World");
+    }
+
+    [Fact]
+    public void DictionariesAreNotSnapshotted()
+    {
+        var engine = CreateEngine(snapshot: true, withExtensions: false);
+        var dictionary = new Dictionary<string, int> { ["a"] = 1 };
+        engine.SetValue("dict", dictionary);
+
+        // a dictionary enumerates as a sequence of pairs, which must not make it look like a list
+        engine.Evaluate("dict.a").AsNumber().Should().Be(1);
+        engine.Evaluate("typeof dict.length").AsString().Should().Be("undefined");
+        dictionary["b"] = 2;
+        engine.Evaluate("dict.b").AsNumber().Should().Be(2);
+    }
+
+    [Fact]
+    public void NonGenericSequenceIsSnapshottedAsObjects()
+    {
+        var engine = CreateEngine(snapshot: true, withExtensions: false);
+        engine.SetValue("coll", new NonGenericSequence());
+
+        engine.Evaluate("coll.length").AsNumber().Should().Be(2);
+        engine.Evaluate("coll.join('-')").AsString().Should().Be("Hello-World");
+    }
+
+    private sealed class CountingEnumerable(string[] items) : IEnumerable<string>
+    {
+        public int EnumerationCount { get; private set; }
+
+        public IEnumerator<string> GetEnumerator()
+        {
+            EnumerationCount++;
+            return ((IEnumerable<string>) items).GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    private sealed class NonGenericSequence : IEnumerable
+    {
+        public IEnumerator GetEnumerator() => new[] { "Hello", "World" }.GetEnumerator();
+    }
+}

--- a/Jint.Tests/Runtime/ExtensionMethods/GenericArgumentInferenceTests.cs
+++ b/Jint.Tests/Runtime/ExtensionMethods/GenericArgumentInferenceTests.cs
@@ -1,0 +1,158 @@
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime.ExtensionMethods;
+
+/// <summary>
+/// Type arguments a generic method's <em>constructed</em> parameter implies (<c>this IEnumerable&lt;T&gt;</c>)
+/// are pinned: that argument is handed to the method unconverted, so a bare <c>T item</c> parameter - whose
+/// argument still goes through the type converter - must not re-infer the position and produce an
+/// instantiation the receiver cannot satisfy (https://github.com/sebastienros/jint/issues/2987).
+/// </summary>
+public class GenericArgumentInferenceTests
+{
+    private static Engine CreateEngine()
+    {
+        return new Engine(options => options.AddExtensionMethods(typeof(InferenceExtensions)));
+    }
+
+    /// <summary>
+    /// The receivers below must be sequences that are only <see cref="IEnumerable{T}"/> - no Count, no
+    /// indexer - or they become array-like wrappers whose Array.prototype natives win over the registered
+    /// extension methods (#2976) and the test silently stops exercising generic inference at all.
+    /// </summary>
+    private static Engine CreateEngineWithLazyReceiver(object receiver)
+    {
+        var engine = CreateEngine();
+        engine.SetValue("coll", receiver);
+        engine.Evaluate("typeof coll.map").AsString().Should().Be("function", "the receiver must not be array-like");
+        return engine;
+    }
+
+    [Fact]
+    public void ChainedGenericExtensionsOverLazyEnumerable()
+    {
+        // the issue's own repro: a LINQ iterator handed to the engine, projected, then searched
+        var engine = CreateEngineWithLazyReceiver(new List<string> { "Hello", "World" }.Select(y => y));
+
+        engine.Evaluate("coll.map(x => x).includes('Hello')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("coll.map(x => x).includes('Nope')").AsBoolean().Should().BeFalse();
+        engine.Evaluate("coll.map(x => x + '!').includes('World!')").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReceiverPinsTypeArgumentOverMoreSpecificArgument()
+    {
+        var engine = CreateEngineWithLazyReceiver(new List<object> { "Hello", "World" }.Where(_ => true));
+
+        // the receiver's element type wins; the 'Hello' argument widens to it instead of re-pinning T
+        engine.Evaluate("coll.inferred('Hello')").AsString().Should().Be("Object");
+        engine.Evaluate("coll.includes('Hello')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("coll.includes('Nope')").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void NumericArgumentDoesNotRepinElementType()
+    {
+        // no LINQ projection and no 'object' element type - a JsNumber's CLR shape is a double, so the
+        // argument alone used to infer includes<double> and then failed to bind its own IEnumerable<int>
+        var engine = CreateEngineWithLazyReceiver(new List<int> { 1, 2, 3 }.Where(x => x > 0));
+
+        engine.Evaluate("coll.inferred(2)").AsString().Should().Be("Int32");
+        engine.Evaluate("coll.includes(2)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("coll.includes(9)").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void BareGenericParameterStillInfersWhenNothingPinsIt()
+    {
+        var engine = CreateEngineWithLazyReceiver(new List<int> { 1, 2, 3 }.Where(x => x > 0));
+
+        // TExtra appears only as a bare parameter, so it is still inferred from its argument
+        engine.Evaluate("coll.inferredBoth('x')").AsString().Should().Be("Int32/String");
+    }
+
+    [Fact]
+    public void ElidedOptionalArgumentInfersNothing()
+    {
+        var engine = CreateEngineWithLazyReceiver(new List<string> { "Hello" }.Where(_ => true));
+
+        // the missing argument used to be stood in for by typeof(object), whose GetType() is RuntimeType
+        engine.Evaluate("coll.inferredOptional()").AsString().Should().Be("String");
+    }
+
+    [Fact]
+    public void ConstraintViolationIsACatchableTypeError()
+    {
+        var engine = CreateEngineWithLazyReceiver(new List<string> { "Hello" }.Where(_ => true));
+
+        // T pins to string, which violates 'where T : struct' - MakeGenericMethod throws and the candidate
+        // has to be declined rather than letting a CLR ArgumentException escape Evaluate
+        var exception = Assert.Throws<JavaScriptException>(() => engine.Evaluate("coll.needsStruct('x')"));
+        exception.Message.Should().Be("No public methods with the specified arguments were found.");
+
+        engine.Evaluate("(() => { try { coll.needsStruct('x'); } catch (e) { return e.constructor.name; } })()")
+            .AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void MismatchedElementTypeIsACatchableTypeError()
+    {
+        var engine = new Engine();
+        engine.SetValue("host", new ElementTypeHost());
+        engine.SetValue("items", new List<object> { "Hello" });
+
+        // a List<object> is not an IEnumerable<string>; the conversion has to decline rather than hand the
+        // value over unconverted and die inside the reflection invoke
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("host.Take(items)"));
+
+        engine.Evaluate("(() => { try { host.Take(items); } catch (e) { return e.constructor.name; } })()")
+            .AsString().Should().Be("TypeError");
+
+        // the compatible call still binds
+        engine.SetValue("strings", new List<string> { "Hello", "World" });
+        engine.Evaluate("host.Take(strings)").AsNumber().Should().Be(2);
+    }
+
+    [Fact]
+    public void GenericExtensionOverAnArrayLikeReceiverIsUnaffected()
+    {
+        // a List<string> receiver reaches Array.prototype.includes (#2976), and the extension stays
+        // reachable through its exact C# casing - inference for it must still pin from the receiver
+        var engine = CreateEngine();
+        engine.SetValue("coll", new List<string> { "Hello", "World" });
+
+        engine.Evaluate("coll.includes('Hello')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("coll.Inferred('Hello')").AsString().Should().Be("String");
+    }
+}
+
+public class ElementTypeHost
+{
+    public int Take(IEnumerable<string> items) => items.Count();
+}
+
+public static class InferenceExtensions
+{
+    // the exact registration from https://github.com/sebastienros/jint/issues/2987
+    public static IEnumerable<TResult> map<T, TResult>(this IEnumerable<T> enumerable, Func<T, TResult> selector)
+    {
+        return enumerable.Select(selector);
+    }
+
+    public static bool includes<T>(this IEnumerable<T> enumerable, T item)
+    {
+        return enumerable.Contains(item);
+    }
+
+    // white-box probes: they report the inferred type argument itself rather than a behavior implying it
+    public static string inferred<T>(this IEnumerable<T> enumerable, T probe) => typeof(T).Name;
+
+    public static string Inferred<T>(this IEnumerable<T> enumerable, T probe) => typeof(T).Name;
+
+    public static string inferredBoth<T, TExtra>(this IEnumerable<T> enumerable, TExtra extra)
+        => typeof(T).Name + "/" + typeof(TExtra).Name;
+
+    public static string inferredOptional<T>(this IEnumerable<T> enumerable, T item = default) => typeof(T).Name;
+
+    public static bool needsStruct<T>(this IEnumerable<T> enumerable, T item) where T : struct => true;
+}

--- a/Jint.Tests/Runtime/GenericMethodTests.cs
+++ b/Jint.Tests/Runtime/GenericMethodTests.cs
@@ -68,6 +68,22 @@ public class GenericMethodTests
         argException.Message.Should().Be("No public methods with the specified arguments were found.");
     }
 
+    [Fact]
+    public void TestGenericConstraintViolationIsACatchableTypeError()
+    {
+        var engine = new Engine();
+        engine.SetValue("testGenericObj", new TestGenericClass());
+
+        // T infers to string, which 'where T : struct' rejects - MakeGenericMethod throws and the candidate
+        // has to be declined rather than letting a CLR ArgumentException escape Evaluate
+        var exception = Invoking(() => engine.Execute("testGenericObj.Constrained('a');"))
+            .Should().ThrowExactly<Jint.Runtime.JavaScriptException>().Which;
+        exception.Message.Should().Be("No public methods with the specified arguments were found.");
+
+        // and the satisfiable instantiation still binds
+        engine.Execute("testGenericObj.Constrained(1);");
+    }
+
     // TPC: TODO: tldr; typescript transpiled to javascript does not include the types in the constructors - JINT should allow you to use generics without specifying type
     // The following doesn't work because JINT currently requires generic classes to be instantiated in a way that doesn't comply with typescript transpile of javascript
     // i.e. we shouldn't have to specify the type of the generic class when we instantiate it.  Since typescript takes the following:
@@ -185,6 +201,10 @@ public class GenericMethodTests
         {
             Console.WriteLine("TestGenericClass: FancyInvoked: t1: " + t1 + "u: " + u + " t2: " + t2);
             FancyInvoked = true;
+        }
+
+        public void Constrained<T>(T value) where T : struct
+        {
         }
     }
 

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -431,6 +431,16 @@ public class Options
         public ArrayConversionMode ArrayConversion { get; set; } = ArrayConversionMode.LiveView;
 
         /// <summary>
+        /// How a CLR sequence that is <em>only</em> an <see cref="System.Collections.Generic.IEnumerable{T}"/> — a LINQ
+        /// iterator, a generator method's result, any lazily computed sequence with no <c>Count</c> and no indexer — is
+        /// exposed to script code. Defaults to <see cref="Jint.EnumerableConversionMode.Lazy"/>, which changes nothing.
+        /// Collections that already have a count (<see cref="System.Collections.Generic.ICollection{T}"/>,
+        /// <see cref="System.Collections.Generic.IList{T}"/>, <c>T[]</c>) and dictionaries are unaffected by this
+        /// option; they are exposed exactly as before. See the enum members.
+        /// </summary>
+        public EnumerableConversionMode EnumerableConversion { get; set; } = EnumerableConversionMode.Lazy;
+
+        /// <summary>
         /// If no known type could be guessed, objects are by default wrapped as an
         /// ObjectInstance using class ObjectWrapper. This function can be used to
         /// change the behavior.
@@ -911,4 +921,35 @@ public enum ArrayConversionMode
     /// </para>
     /// </summary>
     LiveView,
+}
+
+/// <summary>
+/// Strategy for exposing a CLR sequence that is only an <see cref="System.Collections.Generic.IEnumerable{T}"/> to
+/// script code, see <see cref="Options.InteropOptions.EnumerableConversion"/>.
+/// </summary>
+public enum EnumerableConversionMode
+{
+    /// <summary>
+    /// The sequence is exposed as an opaque wrapper carrying <c>Symbol.iterator</c>. It is enumerated only when
+    /// script asks it to be — <c>for-of</c>, spread, <c>Array.from</c> — and each of those enumerates it again,
+    /// exactly as enumerating the sequence from CLR code would. It is not array-like: it has no <c>length</c>, no
+    /// index access, and no <c>Array.prototype</c>, so the natives every JavaScript author expects on a list are
+    /// absent unless a registered extension method supplies them. This is the default.
+    /// </summary>
+    Lazy,
+
+    /// <summary>
+    /// The sequence is enumerated once, when it crosses into script, and exposed as a fixed-size array-like view
+    /// over that snapshot — <c>length</c>, index reads, <c>Array.prototype</c> and JSON serialization as an array
+    /// all work, while <c>Array.isArray</c> stays <c>false</c> just as for a wrapped <c>T[]</c>.
+    /// <para>
+    /// Two consequences follow from enumerating eagerly, and they are the reason this is not the default. The
+    /// sequence's side effects happen at the crossing rather than when script first looks, and a sequence that
+    /// never ends never returns. Later CLR-side changes are not observed either: the view is a snapshot, and
+    /// writes through it reach only the snapshot. Sequences that already have a count
+    /// (<see cref="System.Collections.Generic.ICollection{T}"/>, <see cref="System.Collections.Generic.IList{T}"/>,
+    /// <c>T[]</c>) and dictionaries are never snapshotted; they keep their existing, live exposure.
+    /// </para>
+    /// </summary>
+    Snapshot,
 }

--- a/Jint/Runtime/Interop/DefaultTypeConverter.cs
+++ b/Jint/Runtime/Interop/DefaultTypeConverter.cs
@@ -164,7 +164,18 @@ public class DefaultTypeConverter : ITypeConverter
         if (type.IsGenericType)
         {
             var result = InteropHelper.IsAssignableToGenericType(value.GetType(), type);
-            if (result.IsAssignable)
+
+            // IsAssignableToGenericType matches on the generic type *definition*, so on its own it calls a
+            // List<object> assignable to IEnumerable<string>. Handing such a value straight over would let it
+            // reach a reflection Invoke unconverted and die there as a raw ArgumentException (#2987), so apply
+            // the same rule MethodInfoFunction.IsGenericParameter states: for a fully concrete generic type,
+            // verify the argument really is assignable before assigning it directly. The check is only
+            // skipped for a target that still has open type parameters, where assignability cannot be judged
+            // - the engine's own binding path closes them first, so that is for hosts calling TryConvert
+            // themselves. Note IsInstanceOfType above already accepted everything genuinely assignable,
+            // variance included, which is why nothing legal is lost here.
+            if (result.IsAssignable
+                && (type.ContainsGenericParameters || type.IsAssignableFrom(result.MatchingGivenType)))
             {
                 converted = value;
                 return true;

--- a/Jint/Runtime/Interop/MethodInfoFunction.cs
+++ b/Jint/Runtime/Interop/MethodInfoFunction.cs
@@ -65,52 +65,48 @@ internal sealed class MethodInfoFunction : Function
         return false;
     }
 
-    private static void HandleGenericParameter(object? argObj, Type parameterType, Type[] genericArgTypes)
+    /// <summary>
+    /// Records the type arguments a <em>constructed</em> generic parameter (<c>IEnumerable&lt;T&gt;</c>,
+    /// <c>ISelector&lt;TState, TResult&gt;</c>) implies, read off the constructed base/interface the argument
+    /// actually matches. These are <em>pins</em>: the matching argument is handed to the method unconverted
+    /// (see <see cref="IsGenericParameter"/> and the binding loop in <see cref="TryCall"/>), so only this
+    /// exact instantiation can bind and no other parameter may overrule it.
+    /// </summary>
+    /// <remarks>
+    /// When the argument's type implements the same generic interface more than once
+    /// (<c>class Multi : IEnumerable&lt;string&gt;, IEnumerable&lt;int&gt;</c>) the pin follows whichever
+    /// instantiation <c>Type.GetInterfaces()</c> reports first, which is the same arbitrary choice this
+    /// inference has always made for a method whose type arguments come only from such a parameter.
+    /// </remarks>
+    private static void PinGenericArguments(Type argType, Type parameterType, Type[] pinnedArgTypes)
     {
-        if (argObj is null)
-        {
-            return;
-        }
-
-        var result = InteropHelper.IsAssignableToGenericType(argObj.GetType(), parameterType);
+        var result = InteropHelper.IsAssignableToGenericType(argType, parameterType);
         if (result.Score < 0)
         {
+            // e.g. a JS function, whose CLR shape is always JsCallDelegate, probed against Func<T, TResult>:
+            // nothing about T or TResult can be learned from it
             return;
         }
 
-        if (parameterType.IsGenericParameter)
+        // TPC: maybe we can pull the generic parameters from the arguments?
+        var genericArgs = parameterType.GetGenericArguments();
+        var givenTypeGenericArgs = result.MatchingGivenType.GetGenericArguments();
+        for (var j = 0; j < genericArgs.Length && j < givenTypeGenericArgs.Length; ++j)
         {
-            var genericParamPosition = parameterType.GenericParameterPosition;
-            if (genericParamPosition >= 0)
+            var genericArg = genericArgs[j];
+            if (genericArg.IsGenericParameter)
             {
-                genericArgTypes[genericParamPosition] = argObj.GetType();
-            }
-        }
-        else if (parameterType.IsGenericType)
-        {
-            // TPC: maybe we can pull the generic parameters from the arguments?
-            var genericArgs = parameterType.GetGenericArguments();
-            for (int j = 0; j < genericArgs.Length; ++j)
-            {
-                var genericArg = genericArgs[j];
-                if (genericArg.IsGenericParameter)
+                var position = genericArg.GenericParameterPosition;
+                if ((uint) position < (uint) pinnedArgTypes.Length)
                 {
-                    var genericParamPosition = genericArg.GenericParameterPosition;
-                    if (genericParamPosition >= 0)
-                    {
-                        var givenTypeGenericArgs = result.MatchingGivenType.GetGenericArguments();
-                        genericArgTypes[genericParamPosition] = givenTypeGenericArgs[j];
-                    }
+                    // a position belonging to the declaring type rather than to the method is out of range here
+                    pinnedArgTypes[position] = givenTypeGenericArgs[j];
                 }
             }
         }
-        else
-        {
-            return;
-        }
     }
 
-    private static MethodBase ResolveMethod(MethodDescriptor descriptor, ParameterInfo[] methodParameters, JsCallArguments arguments)
+    private static MethodBase? ResolveMethod(MethodDescriptor descriptor, ParameterInfo[] methodParameters, JsCallArguments arguments)
     {
         var method = descriptor.Method;
         if (!descriptor.IsGenericMethod)
@@ -129,25 +125,68 @@ internal sealed class MethodInfoFunction : Function
         var methodGenericArgs = method.GetGenericArguments();
         var genericArgTypes = new Type[methodGenericArgs.Length];
 
+        // A bare "T item" parameter only *hints* at its type argument: that argument still goes through
+        // ITypeConverter on the way in, so it can widen, while a pin cannot - which is why a hint must never
+        // overrule a pin (#2987: "includes<T>(this IEnumerable<T>, T item)" on an IEnumerable<object> used to
+        // be re-inferred as includes<string> from its argument and then failed to bind its own receiver).
+        // Collected separately, and allocated only for the methods that actually have such a parameter.
+        Type[]? hintedArgTypes = null;
+
         for (var i = 0; i < methodParameters.Length; ++i)
         {
-            var methodParameter = methodParameters[i];
-            var parameterType = methodParameter.ParameterType;
-            var argObj = i < arguments.Length ? arguments[i].ToObject() : typeof(object);
-            HandleGenericParameter(argObj, parameterType, genericArgTypes);
-        }
-
-        for (int i = 0; i < genericArgTypes.Length; ++i)
-        {
-            if (genericArgTypes[i] == null)
+            var parameterType = methodParameters[i].ParameterType;
+            var isGenericParameter = parameterType.IsGenericParameter;
+            if (!isGenericParameter && !parameterType.IsGenericType)
             {
-                // this is how we're dealing with things like "void" return types - you can't use "void" as a type:
-                genericArgTypes[i] = typeof(object);
+                // nothing to infer from this parameter - and skipping it also skips its ToObject(), which
+                // for a JS object literal materializes a CLR object and runs the literal's getters
+                continue;
+            }
+
+            // an elided optional argument contributes nothing; it must not be inferred from a sentinel
+            var argObj = i < arguments.Length ? arguments[i].ToObject() : null;
+            if (argObj is null)
+            {
+                continue;
+            }
+
+            if (isGenericParameter)
+            {
+                // IsAssignableToGenericType answers a constant "score 2, matches the given type" for a bare
+                // generic parameter (it is never IsConstructedGenericType), so it is not consulted here
+                var position = parameterType.GenericParameterPosition;
+                if ((uint) position < (uint) genericArgTypes.Length)
+                {
+                    // last hint wins, as before: Fancy<T, U>(T, U, T) infers T from its final argument
+                    (hintedArgTypes ??= new Type[genericArgTypes.Length])[position] = argObj.GetType();
+                }
+            }
+            else
+            {
+                PinGenericArguments(argObj.GetType(), parameterType, genericArgTypes);
             }
         }
 
-        var genericMethodInfo = methodInfo.MakeGenericMethod(genericArgTypes);
-        return genericMethodInfo;
+        for (var i = 0; i < genericArgTypes.Length; ++i)
+        {
+            // pin, else hint, else object - the last is also how a type argument appearing only in the return
+            // type is closed, since "void" cannot be used as a type argument
+            genericArgTypes[i] ??= hintedArgTypes?[i] ?? typeof(object);
+        }
+
+        try
+        {
+            return methodInfo.MakeGenericMethod(genericArgTypes);
+        }
+        catch (ArgumentException)
+        {
+            // the inferred type arguments violate the method's constraints, so this candidate simply does not
+            // apply. Declining lets overload resolution move on, and an exhausted candidate list becomes a
+            // catchable TypeError instead of a CLR exception escaping Engine.Evaluate. Deliberately not
+            // NotSupportedException, which under NativeAOT means "this instantiation was not rooted" and has
+            // to stay diagnosable.
+            return null;
+        }
     }
 
     private readonly record struct MethodResolverState(Engine Engine, JsValue This, JsCallArguments Arguments);
@@ -340,6 +379,12 @@ internal sealed class MethodInfoFunction : Function
 
         var methodParameters = method.Parameters;
         var resolvedMethod = ResolveMethod(method, methodParameters, arguments);
+        if (resolvedMethod is null)
+        {
+            // the inferred type arguments could not close this generic method - not a candidate
+            return false;
+        }
+
         // We only need to call GetParameters it if this ends up being a generic method (i.e. they will be different in that scenario)
         var isGenericDefinition = false;
         var parameterFlags = method.ParameterFlags;
@@ -436,7 +481,22 @@ internal sealed class MethodInfoFunction : Function
             if (isGenericDefinition)
             {
                 // the resolved generic method differs per call, cannot use the cached invoker
-                var result = resolvedMethod.Invoke(thisObj, parameters);
+                object? result;
+                try
+                {
+                    result = resolvedMethod.Invoke(thisObj, parameters);
+                }
+                catch (ArgumentException)
+                {
+                    // MethodBase.Invoke always wraps what the *body* threw in a TargetInvocationException, so
+                    // a bare ArgumentException out of it can only be the binder rejecting an argument the
+                    // inferred instantiation cannot accept. That is "this candidate does not apply", not a
+                    // host failure - report it as such rather than letting a CLR exception escape Evaluate.
+                    // Only the invoke is guarded; the conversion below has ArgumentException paths of its own.
+                    _engine.CheckAmortizedConstraintsAtHostBoundary();
+                    return false;
+                }
+
                 // conversion before the check so an awaitable result gets its continuation attached
                 callResult = FromObjectWithType(Engine, result, type: (resolvedMethod as MethodInfo)?.ReturnType);
                 _engine.CheckAmortizedConstraintsAtHostBoundary();

--- a/Jint/Runtime/Interop/ObjectWrapper.Specialized.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.Specialized.cs
@@ -36,6 +36,43 @@ internal sealed class ReadOnlyListWrapperFactory<[DynamicallyAccessedMembers(Dyn
         => new ReadOnlyListWrapper<T>(engine, (IReadOnlyList<T>) target, type);
 }
 
+/// <summary>
+/// Enumerates a sequence that has no count and no indexer into the array-backed view
+/// <see cref="EnumerableConversionMode.Snapshot"/> exposes. Resolved once per exposed type, like
+/// <see cref="ArrayLikeWrapperFactory"/>, and deliberately kept in a cache of its own: that one is consulted
+/// for every crossing whatever the engine's options say, while this one exists only for the engines that
+/// asked for snapshots.
+/// </summary>
+internal abstract class EnumerableSnapshotFactory
+{
+    public abstract ArrayLikeWrapper Create(Engine engine, IEnumerable target);
+}
+
+internal sealed class EnumerableSnapshotFactory<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields)] T> : EnumerableSnapshotFactory
+{
+    public override ArrayLikeWrapper Create(Engine engine, IEnumerable target)
+        => new ArrayWrapper<T>(engine, new List<T>((IEnumerable<T>) target).ToArray(), typeof(T[]));
+}
+
+/// <summary>
+/// The snapshot of a sequence whose element type is not known — a non-generic <see cref="IEnumerable"/>.
+/// </summary>
+internal sealed class ObjectEnumerableSnapshotFactory : EnumerableSnapshotFactory
+{
+    internal static readonly ObjectEnumerableSnapshotFactory Instance = new();
+
+    public override ArrayLikeWrapper Create(Engine engine, IEnumerable target)
+    {
+        var items = new List<object?>();
+        foreach (var item in target)
+        {
+            items.Add(item);
+        }
+
+        return new ArrayWrapper<object?>(engine, items.ToArray(), typeof(object?[]));
+    }
+}
+
 internal abstract class ArrayLikeWrapper : ObjectWrapper
 {
     /// <summary>

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -246,8 +246,60 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
             // least specific
             result = new ListWrapper(engine, list, type);
         }
+        else if (engine.Options.Interop.EnumerableConversion == EnumerableConversionMode.Snapshot
+                 && target is IEnumerable enumerable
+                 && target is not string)
+        {
+            // Everything above had a count and an indexer to build a view from. A sequence that has neither -
+            // a LINQ iterator, a generator method's result - can only be given one by enumerating it, which
+            // the host has to ask for because it is eager and one-shot (#2987). Deliberately narrow: the type
+            // descriptor must report neither array-like nor dictionary, so an ICollection<T> such as
+            // HashSet<T> keeps its live exposure and a Dictionary<K, V> is not mistaken for a sequence of
+            // pairs merely because it enumerates as one.
+            var descriptor = TypeDescriptor.Get(type);
+            if (!descriptor.IsArrayLike && !descriptor.IsDictionary)
+            {
+                result = ResolveEnumerableSnapshotFactory(type).Create(engine, enumerable);
+            }
+        }
 
         return result is not null;
+    }
+
+    private static readonly ConcurrentDictionary<Type, EnumerableSnapshotFactory> _enumerableSnapshotResolution = new();
+
+    private static EnumerableSnapshotFactory ResolveEnumerableSnapshotFactory(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type type)
+    {
+        return _enumerableSnapshotResolution.GetOrAdd(type, static t =>
+        {
+#pragma warning disable IL2055
+#pragma warning disable IL2070
+#pragma warning disable IL3050
+            foreach (var i in t.GetInterfaces())
+            {
+                if (i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+                {
+                    try
+                    {
+                        var factoryType = typeof(EnumerableSnapshotFactory<>).MakeGenericType(i.GenericTypeArguments[0]);
+                        return (EnumerableSnapshotFactory) Activator.CreateInstance(factoryType)!;
+                    }
+                    catch (MissingMethodException)
+                    {
+                        // trimmed/AOT: the closed factory was removed, snapshot as objects instead
+                        break;
+                    }
+                }
+            }
+#pragma warning restore IL3050
+#pragma warning restore IL2070
+#pragma warning restore IL2055
+
+            // a type implementing IEnumerable<T> more than once takes the first one, the same arbitrary
+            // choice every other interface scan on this path makes
+            return ObjectEnumerableSnapshotFactory.Instance;
+        });
     }
 
     public object Target { get; }


### PR DESCRIPTION
Follow-up to #2977. That fix made a member resolving purely to registered extension methods defer to a same-named `Array.prototype` native on an **indexed array-like** wrapper. #2987 is the same script failing again when the receiver is a *lazy* LINQ sequence, which is only an `IEnumerable<T>` — no `ICollection`, no indexer — so it is not an `ArrayLikeWrapper` and that rule never applies.

Worse than "does not work": with the reporter's `includes` extension registered, a raw `System.ArgumentException` escaped `Engine.Evaluate` entirely, uncatchable from script.

## What actually went wrong

```csharp
public static IEnumerable<TResult> map<T, TResult>(this IEnumerable<T> e, Func<T, TResult> selector) => e.Select(selector);
public static bool includes<T>(this IEnumerable<T> e, T item) => e.Contains(item);
```

1. `map<T, TResult>` pins `T = string` from `IEnumerable<T>` ← `IEnumerable<string>`. `TResult` is **not inferable from a JS callback** — a JS function's only CLR shape is `JsCallDelegate` (`Func<JsValue, JsValue[], JsValue>`), which `IsAssignableToGenericType` scores −1 against `Func<T, TResult>` — so it falls back to `object`. The result is an `IEnumerable<object>` over a `<string, object>` iterator. That part is sound; `object` is the only answer available.
2. `includes<T>` on that result correctly infers `T = object` from its receiver, and then the bare `T item` parameter **overwrites it with `string`** — `ResolveMethod` was last-write-wins.
3. `MakeGenericMethod(string)` produces `includes<string>(IEnumerable<string>, string)`.
4. Binding the receiver, `DefaultTypeConverter` asked `IsAssignableToGenericType`, which matches on the generic type **definition** alone and so declared `IEnumerable<object>` assignable to `IEnumerable<string>` — passing the value through **unconverted**.
5. `MethodBase.Invoke` threw `ArgumentException`. Not a `TargetInvocationException`, so the `catch` never saw it.

This also explains the reporter's two workarounds exactly: `object item` works because nothing overwrites the pin, and `T item` does not.

Neither defect needs LINQ to reach. On a plain lazy `IEnumerable<int>`, `coll.includes(2)` inferred `includes<double>` — a `JsNumber`'s CLR shape is a `double` — and died the same way.

## The fix

**1. A constructed generic parameter pins its type arguments; a bare `T` only hints.** The argument matching `this IEnumerable<T>` is handed to the method *unconverted*, so only that exact instantiation can bind. The argument matching a bare `T item` still goes through `ITypeConverter` and can widen. So a hint no longer overrules a pin — which is also what C# inference does with an exact bound versus a lower bound. Hint-vs-hint stays last-write-wins (`Fancy<T, U>(T, U, T)` still infers `T` from its final argument, and `TestFancyGenericFail` still fails).

Two inference bugs fixed alongside it: an elided optional argument was stood in for by `typeof(object)` as a *value*, so it inferred `System.RuntimeType`; and `MakeGenericMethod` was unguarded, so type arguments violating a constraint threw a CLR exception through the engine instead of declining the candidate.

**2. The type converter no longer passes an incompatible generic value through.** It now applies the rule `MethodInfoFunction.IsGenericParameter` already states a few lines away — *"for fully concrete generic types, verify the argument is actually assignable to prevent incorrect direct assignment when type arguments differ"*. Nothing legal is lost: `IsInstanceOfType` earlier in the same method already accepted every genuinely assignable value, variance included, so the tightened branch only ever fired on illegal pairs. A target still carrying open type parameters keeps the old behavior, since assignability cannot be judged for it.

One deliberate behavior change: an object-literal member the value cannot be assigned to used to be "converted" successfully and then *silently dropped* by `ReflectionExtensions.SetValue`. It now reports an error. Pinned by a test.

**3. `Options.Interop.EnumerableConversion = Snapshot`, opt-in.** The first two commits make the reporter's own `includes` extension work, but the issue's headline snippet still needs *some* `includes` on a lazy sequence, and a sequence with no count and no indexer can only be given an array-like shape by enumerating it. `Snapshot` does that once, at the crossing, and exposes a fixed-size array-like view — `length`, index reads, `Array.prototype`, JSON serialization, with `Array.isArray` staying `false` exactly as for a wrapped `T[]`. The receiver then *is* array-like, so #2977's rule applies by composition: `map` resolves to `Array.prototype.map`, the result is a real `JsArray`, and `includes` is the native.

Kept opt-in because the enumeration is eager and one-shot: side effects happen at the crossing and a sequence that never ends never returns. Deliberately narrow, too — the type descriptor must report neither array-like nor dictionary, so a `HashSet<T>` keeps its live exposure and a `Dictionary<K, V>` is not mistaken for a sequence of pairs merely because it enumerates as one. The default, `Lazy`, is today's behavior exactly.

## Not fixed, deliberately

`TResult` still resolves to `object` for a JS callback, because `Func<JsValue, JsValue[], JsValue>` is the only CLR shape a JS function has. After commit 1 that is no longer a problem downstream, which is the whole of what the reporter's chain needed. `params T[]` similarly infers nothing (an array type is neither `IsGenericParameter` nor `IsGenericType`) — worth its own issue.

Also worth restating for anyone hitting this: `Array.from(coll)` and `[...coll]` already work on a lazy enumerable today, since `Symbol.iterator` is attached whenever the type descriptor says iterable. `Snapshot` is convenience, not the only route.

## Verification

The new `GenericArgumentInferenceTests` reproduce the issue's host code verbatim. Run against `main` they fail with exactly the message from the issue:

```
System.ArgumentException : Object of type 'System.Linq.Enumerable+ListSelectIterator`2[System.String,System.Object]'
cannot be converted to type 'System.Collections.Generic.IEnumerable`1[System.String]'.
```

6 of the 8 fail on `main`; the 2 that pass are the deliberate control cases (a bare `T` with nothing pinning it, and an array-like receiver), so the pin does not over-apply.

Green on `Jint.Tests` (5450 net10.0 / 5368 net472), `Jint.Tests.PublicInterface`, `Jint.Tests.CommonScripts`, `Jint.Tests.Test262` (99744), and `Jint.Tests` + `Jint.Tests.PublicInterface` with `JINT_HOST_CONTRACT_VERIFICATION=1`.

No perf claim: commit 1 *removes* `ToObject()` calls from the generic binding path rather than adding any (a parameter that can contribute no inference is now skipped before it is materialized, which for a JS object literal also means its getters no longer run twice), commit 2 adds one `IsAssignableFrom` to a cold conversion branch, and commit 3's branch is one enum comparison when the option is off.

Fixes #2987.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
