### PR TITLE
Offer a stack-overflow guard that turns a process kill into a RangeError

### DIFF
--- a/Jint.Tests.PublicInterface/HostStackOverflowGuardTests.cs
+++ b/Jint.Tests.PublicInterface/HostStackOverflowGuardTests.cs
@@ -1,0 +1,174 @@
+using Jint;
+using Jint.Runtime;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// What an embedder running untrusted script gets from <c>options.Constraints.StackOverflowGuard</c> when
+/// that script recurses without bound: the promise a browser makes, a catchable <c>RangeError</c> and an
+/// engine that is still usable afterwards, instead of a process that disappears.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The guard is opt-in, so every engine here but one asks for it. The exception is
+/// <see cref="ADefaultEngineDoesNotProbeAtAll"/>, which pins the other half of the decision: a default
+/// engine pays nothing and therefore protects nothing.
+/// </para>
+/// <para>
+/// Every body runs on a dedicated thread with an explicit 1 MB stack, the size a thread-pool worker or an
+/// IIS request thread actually has. The suite's other deep-recursion tests use 16 MB, which is generous
+/// enough to hide the failure this file exists for.
+/// </para>
+/// </remarks>
+public class HostStackOverflowGuardTests
+{
+    private const int SmallStack = 1024 * 1024;
+
+    private static Engine Guarded() => new(options => options.Constraints.StackOverflowGuard = true);
+
+    public static TheoryData<string, string> UnboundedRecursions => new()
+    {
+        { "call", "function f() { return f(); } f();" },
+        { "new", "function F() { new F(); } new F();" },
+        { "accessor", "var o = { get x() { return o.x; } }; o.x;" },
+        { "coercion", "var o = { valueOf: function () { return o + 1; } }; o + 1;" },
+        { "proxy trap", "var p = new Proxy({}, { get: function (t, k) { return p[k]; } }); p.a;" },
+    };
+
+    [Theory]
+    [MemberData(nameof(UnboundedRecursions))]
+    public void AnUnboundedRecursionIsACatchableError(string route, string script)
+    {
+        _ = route;
+
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = Guarded();
+
+                var exception = Assert.Throws<JavaScriptException>(() => engine.Execute(script));
+                exception.Message.Should().Be("Maximum call stack size exceeded");
+                exception.Error.Get("name").AsString().Should().Be("RangeError");
+            },
+            maxStackSize: SmallStack);
+    }
+
+    [Fact]
+    public void TheEngineKeepsWorkingAfterOne()
+    {
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = Guarded();
+                engine.SetValue("factor", 3);
+                engine.Execute("function runaway() { return runaway(); }");
+
+                for (var attempt = 0; attempt < 3; attempt++)
+                {
+                    Assert.Throws<JavaScriptException>(() => engine.Evaluate("runaway()"));
+
+                    engine.Evaluate("[1, 2, 3].map(function (x) { return x * factor; }).join(',')")
+                        .AsString().Should().Be("3,6,9");
+                    engine.Evaluate("JSON.stringify({ ok: true })").AsString().Should().Be("{\"ok\":true}");
+                }
+            },
+            maxStackSize: SmallStack);
+    }
+
+    /// <summary>
+    /// A host callback that re-enters the engine is the shape an embedder is most likely to build a cycle
+    /// out of by accident, and the one furthest from a call expression.
+    /// </summary>
+    [Fact]
+    public void HostReEntryIsGuardedToo()
+    {
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = Guarded();
+                engine.SetValue("callBackIn", new Action(() => engine.Invoke("f")));
+                engine.Execute("function f() { callBackIn(); }");
+
+                Assert.Throws<JavaScriptException>(() => engine.Invoke("f"));
+
+                engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
+            },
+            maxStackSize: SmallStack);
+    }
+
+    [Fact]
+    public void ScriptCodeCanCatchItAndCarryOn()
+    {
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = Guarded();
+                var result = engine.Evaluate(
+                    """
+                    function runaway() { return runaway(); }
+                    var caught = null;
+                    try { runaway(); } catch (e) { caught = e; }
+                    caught instanceof RangeError && caught.message === 'Maximum call stack size exceeded'
+                        ? 'recovered: ' + [1, 2, 3].reduce(function (a, b) { return a + b; }, 0)
+                        : 'wrong error: ' + caught;
+                    """);
+
+                result.AsString().Should().Be("recovered: 6");
+            },
+            maxStackSize: SmallStack);
+    }
+
+    /// <summary>
+    /// The stack the engine is running on decides the depth, not a number the host had to guess, so a
+    /// thread with more stack gets proportionally more frames. That is what makes the guard safe to enable
+    /// at all: it never takes depth away from a host that provisioned for it.
+    /// </summary>
+    [Fact]
+    public void TheDepthFollowsTheStackTheEngineRunsOn()
+    {
+        var small = MeasureGuardedDepth(SmallStack);
+        var large = MeasureGuardedDepth(8 * 1024 * 1024);
+
+        large.Should().BeGreaterThan(small * 4, "eight times the stack must buy substantially more depth");
+    }
+
+    /// <summary>
+    /// The default is off, and this is the only way to say so from a test: a default engine is run past
+    /// the depth at which a guarded engine on the same 1 MB stack would have thrown, and must complete
+    /// the recursion normally instead. The run itself happens on a 16 MB stack, sixteen times what that
+    /// depth was measured against, because the assertion is about the absence of the guard's
+    /// <c>RangeError</c> and not about how much stack a default engine really has. Pinning the other
+    /// direction is impossible in-process: what a default engine does past its own limit is end the
+    /// process, and no test can assert on that.
+    /// </summary>
+    [Fact]
+    public void ADefaultEngineDoesNotProbeAtAll()
+    {
+        var guardedDepth = (int) MeasureGuardedDepth(SmallStack);
+
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = new Engine();
+                engine.Execute("function f(n) { return n === 0 ? 0 : 1 + f(n - 1); }");
+
+                engine.Evaluate($"f({guardedDepth})").AsNumber().Should().Be(guardedDepth);
+            },
+            maxStackSize: DedicatedThread.LargeStackSize);
+    }
+
+    private static double MeasureGuardedDepth(int stackSize)
+    {
+        double depth = 0;
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = Guarded();
+                engine.Execute("var depth = 0; function f() { depth++; return f(); }");
+                Assert.Throws<JavaScriptException>(() => engine.Evaluate("f()"));
+                depth = engine.Evaluate("depth").AsNumber();
+            },
+            maxStackSize: stackSize);
+        return depth;
+    }
+}

--- a/Jint.Tests/Runtime/StackOverflowGuardTests.cs
+++ b/Jint.Tests/Runtime/StackOverflowGuardTests.cs
@@ -1,0 +1,271 @@
+#nullable enable
+
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// The opt-in backstop against unbounded script recursion
+/// (<see cref="Options.ConstraintOptions.StackOverflowGuard"/>). Without it every script below ends the
+/// host process with a native stack overflow, which no <c>catch</c> can see and no test can assert on —
+/// so the value of these tests is that they run at all.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every engine here is built with the guard on, because it is off by default: the benchmark gate priced
+/// the probe at 1.7–2.3% on the recursion rows, above the 1% the decision rule allowed for shipping it on
+/// by default. <c>Jint.Tests.PublicInterface.HostStackOverflowGuardTests</c> owns the other half of that
+/// verdict, the pin that a default engine really does not probe.
+/// </para>
+/// <para>
+/// Every body runs on a dedicated thread with an explicit 1 MB stack: the platform default the guard has
+/// to work on, small enough to reach in well under a second, and deliberately not
+/// <see cref="DedicatedThread.LargeStackSize"/>, whose 16 MB is what has been hiding this whole class of
+/// failure from the suite. Running in-process is safe precisely because the guard works; if it regresses,
+/// the symptom is a dead test host, which is the honest report.
+/// </para>
+/// </remarks>
+public class StackOverflowGuardTests
+{
+    private const int SmallStack = 1024 * 1024;
+
+    private static Engine Guarded(Action<Options>? configure = null) => new(options =>
+    {
+        options.Constraints.StackOverflowGuard = true;
+        configure?.Invoke(options);
+    });
+
+    /// <summary>
+    /// One entry per route into a function body that does not go through a call expression. Every one of
+    /// them kills the process unguarded, and four of them do so even with
+    /// <see cref="Options.ConstraintOptions.MaxExecutionStackCount"/> configured, because the only probe
+    /// that option arms sits in <c>JintCallExpression</c>. All of them are sloppy-mode deliberately:
+    /// proper tail calls apply to strict functions only, so none of these is trampolined and every one
+    /// really does grow the native stack.
+    /// </summary>
+    public static TheoryData<string, string> UnboundedRecursions => new()
+    {
+        { "call", "function f() { return f(); } f();" },
+        { "new", "function F() { new F(); } new F();" },
+        { "accessor", "var o = { get x() { return o.x; } }; o.x;" },
+        { "coercion", "var o = { valueOf: function () { return o + 1; } }; o + 1;" },
+        { "proxy trap", "var p = new Proxy({}, { get: function (t, k) { return p[k]; } }); p.a;" },
+        { "method", "var o = { m: function () { return this.m(); } }; o.m();" },
+        { "apply", "function f() { return f.apply(null, []); } f();" },
+        { "class field", "class C { x = new C(); } new C();" },
+    };
+
+    [Theory]
+    [MemberData(nameof(UnboundedRecursions))]
+    public void UnboundedRecursionThrowsARangeErrorInsteadOfKillingTheProcess(string route, string script)
+    {
+        _ = route;
+
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = Guarded();
+
+                var exception = Assert.Throws<JavaScriptException>(() => engine.Execute(script));
+                exception.Message.Should().Be("Maximum call stack size exceeded");
+                exception.Error.Get("name").AsString().Should().Be("RangeError");
+            },
+            maxStackSize: SmallStack);
+    }
+
+    [Theory]
+    [MemberData(nameof(UnboundedRecursions))]
+    public void ScriptCanCatchTheRangeErrorItself(string route, string script)
+    {
+        _ = route;
+
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = Guarded();
+                var caught = engine.Evaluate($"(function () {{ try {{ {script} }} catch (e) {{ return e instanceof RangeError; }} }})()");
+                caught.AsBoolean().Should().BeTrue();
+            },
+            maxStackSize: SmallStack);
+    }
+
+    /// <summary>
+    /// The recovery test the guard lives or dies by: catching near-exhaustion has to leave the engine in
+    /// the state it was in before, not merely alive. Firing at the very same depth on three successive
+    /// runs is the strongest single signal available here — a frame, an execution context or a native
+    /// stack slot left behind by the unwind would move the third run's number.
+    /// </summary>
+    [Fact]
+    public void TheEngineIsUnchangedAfterTheGuardFires()
+    {
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = Guarded();
+                engine.Execute("var depth = 0; function f() { depth++; return f(); }");
+                engine.Execute("function fib(n) { return n < 2 ? n : fib(n - 1) + fib(n - 2); }");
+
+                var depths = new List<double>();
+                for (var round = 0; round < 3; round++)
+                {
+                    engine.Evaluate("depth = 0");
+                    Assert.Throws<JavaScriptException>(() => engine.Evaluate("f()"));
+
+                    depths.Add(engine.Evaluate("depth").AsNumber());
+
+                    // the interpreter still works, and the call stack it works on is the one it started with
+                    engine.Evaluate("fib(20)").AsNumber().Should().Be(6765);
+                    engine.CallStack.Count.Should().Be(0);
+                    engine.IsEvaluationInProgress.Should().BeFalse();
+                }
+
+                depths.Should().AllBeEquivalentTo(depths[0], "an unwind that left anything behind would shorten the next run");
+                depths[0].Should().BeGreaterThan(100, "a guard that fires this early would be a limit, not a backstop");
+            },
+            maxStackSize: SmallStack);
+    }
+
+    /// <summary>
+    /// A throw out of a callee skips the pool returns the normal path performs — that is true of every
+    /// JavaScript <c>throw</c> and is not new here — so what matters is that the pools stay <em>usable</em>:
+    /// a balanced workload run afterwards must settle back at the pool's capacity instead of allocating a
+    /// fresh instance per rent forever.
+    /// </summary>
+    [Fact]
+    public void ThePoolsStillRecycleAfterTheGuardFires()
+    {
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = Guarded();
+                engine.Execute("function f(a, b, c) { return f(a, b, c); }");
+                engine.Execute("function add(a, b, c) { return a + b + c; }");
+
+                Assert.Throws<JavaScriptException>(() => engine.Evaluate("f(1, 2, 3)"));
+
+                // warm, then measure: a balanced rent/return workload must not create a single new instance
+                engine.Evaluate("(function () { var t = 0; for (var i = 0; i < 1000; i++) { t += add(i, 1, 2); } return t; })()");
+                var createdBefore = engine._referencePool.CreatedCount;
+                var total = engine.Evaluate("(function () { var t = 0; for (var i = 0; i < 10000; i++) { t += add(i, 1, 2); } return t; })()");
+
+                total.AsNumber().Should().Be(50025000);
+                engine._referencePool.CreatedCount.Should().Be(createdBefore, "the reference pool must recycle again once the unwind is over");
+            },
+            maxStackSize: SmallStack);
+    }
+
+    /// <summary>
+    /// The guard is a backstop, not a policy. <see cref="Options.ConstraintOptions.MaxRecursionDepth"/>
+    /// counts frames and is checked before the callee is entered, so it is what a host configuring both
+    /// gets to see.
+    /// </summary>
+    [Fact]
+    public void ARecursionLimitStillFiresFirst()
+    {
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = Guarded(options => options.LimitRecursion(20));
+                Assert.Throws<RecursionDepthOverflowException>(() => engine.Execute("function f() { return f(); } f();"));
+            },
+            maxStackSize: SmallStack);
+    }
+
+    /// <summary>
+    /// A recursion limit set well above what the native stack can hold is a limit in name only — the
+    /// process dies before the count is reached. The backstop is what answers instead, which is the point
+    /// of it being a backstop rather than a replacement.
+    /// </summary>
+    [Fact]
+    public void AnUnreachableRecursionLimitFallsThroughToTheGuard()
+    {
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = Guarded(options => options.LimitRecursion(1_000_000));
+                var exception = Assert.Throws<JavaScriptException>(() => engine.Execute("function f() { return f(); } f();"));
+                exception.Message.Should().Be("Maximum call stack size exceeded");
+            },
+            maxStackSize: SmallStack);
+    }
+
+    /// <summary>
+    /// A proper tail call replaces the caller's frame instead of stacking one on top of it, so a strict
+    /// tail recursion consumes no native stack however deep it goes and there is nothing for the guard to
+    /// fire on. That is why the probe sits on the entry points that add a frame — <c>Call</c>,
+    /// <c>CallWithStackFrame</c>, <c>CallFromRegisters</c>, <c>Construct</c> — and not inside
+    /// <c>CallOnce</c>/<c>CallCore</c>, which the tail-call trampoline re-enters from a loop. Put it there
+    /// and this recursion would pay a probe per hop for a stack that never moves.
+    /// </summary>
+    [Fact]
+    public void AProperTailCallIsNotGuardedBecauseItGrowsNoStack()
+    {
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = Guarded();
+
+                var result = engine.Evaluate(
+                    """
+                    "use strict";
+                    function sum(n, total) {
+                        return n === 0 ? total : sum(n - 1, total + n);
+                    }
+                    sum(100000, 0);
+                    """);
+
+                result.AsNumber().Should().Be(5000050000);
+            },
+            maxStackSize: SmallStack);
+    }
+
+    /// <summary>
+    /// The other half of the pair: strict mode alone buys nothing, because <c>1 + f(n - 1)</c> is not a
+    /// tail position. This recursion does grow the stack, and the guard is what answers.
+    /// </summary>
+    [Fact]
+    public void AStrictRecursionOutOfTailPositionStillReachesTheGuard()
+    {
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = Guarded();
+
+                var exception = Assert.Throws<JavaScriptException>(() => engine.Execute(
+                    """
+                    "use strict";
+                    function f(n) { return 1 + f(n - 1); }
+                    f(1);
+                    """));
+
+                exception.Message.Should().Be("Maximum call stack size exceeded");
+            },
+            maxStackSize: SmallStack);
+    }
+
+    /// <summary>
+    /// <see cref="Options.ConstraintOptions.MaxExecutionStackCount"/> selects the older lane, which
+    /// continues the call chain on a fresh thread rather than throwing, and it takes precedence over the
+    /// guard even when a host asks for both — the two answer the same question differently, and the guard,
+    /// sitting a few frames deeper, would always reach the condition first and leave the older lane
+    /// nothing to hop with. This pins that the older lane still behaves as it did.
+    /// </summary>
+    [Fact]
+    public void MaxExecutionStackCountTakesPrecedenceOverTheGuard()
+    {
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = Guarded(options => options.Constraints.MaxExecutionStackCount = 2500);
+
+                // deeper than a 1 MB stack holds: the older lane hops threads instead of throwing
+                engine.Execute("var depth = 0; function f(n) { depth++; return n === 0 ? depth : f(n - 1); }");
+                engine.Evaluate("f(2000)").AsNumber().Should().Be(2001);
+
+                // and it still throws its RangeError once the configured count is passed
+                var exception = Assert.Throws<JavaScriptException>(() => engine.Evaluate("(function g() { return g(); })()"));
+                exception.Message.Should().Be("Maximum call stack size exceeded");
+            },
+            maxStackSize: SmallStack);
+    }
+}

--- a/Jint/Native/Function/ScriptFunction.cs
+++ b/Jint/Native/Function/ScriptFunction.cs
@@ -151,6 +151,21 @@ public sealed class ScriptFunction : Function, IConstructor
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected internal override JsValue Call(JsValue thisObject, JsCallArguments arguments)
     {
+        // Deliberately the first statement, and deliberately here rather than at the call expression.
+        // A call expression is only one of the routes into a function body — `new`, an accessor, a
+        // valueOf/toString coercion, a Proxy trap and a host Invoke all reach one without evaluating a
+        // CallExpression, and every one of those recursions ends as a native stack overflow when the
+        // only probe in the engine is the call expression's. Being first also keeps it outside the
+        // try/finally in CallOnce: a throw from inside it must not reach a finally that pops an
+        // execution context this frame never pushed. Off unless the host asked for it
+        // (Options.Constraints.StackOverflowGuard), in which case what is left here is one branch on a
+        // cached bool — see StackGuard.EnsureStackHeadroom.
+        //
+        // The probe belongs on the entry points that add a native frame, which is why it is here and in
+        // CallWithStackFrame rather than inside CallOnce: ContinueTailCalls re-enters CallOnce and
+        // CallCore from a loop, and a trampolined tail call consumes no stack to probe for.
+        _engine._stackGuard.EnsureStackHeadroom();
+
         var result = CallOnce(thisObject, arguments);
         return result is TailCallRequest ? ContinueTailCalls(result, ownsFrame: false) : result;
     }
@@ -158,6 +173,8 @@ public sealed class ScriptFunction : Function, IConstructor
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal JsValue CallWithStackFrame(JsValue thisObject, JsCallArguments arguments)
     {
+        _engine._stackGuard.EnsureStackHeadroom();
+
         var result = CallOnce(thisObject, arguments);
         return result is TailCallRequest ? ContinueTailCalls(result, ownsFrame: true) : result;
     }
@@ -421,6 +438,11 @@ public sealed class ScriptFunction : Function, IConstructor
         JintFunctionDefinition.State state,
         bool ownsFrame)
     {
+        // The register lane is dispatched straight from JintCallExpression, so it never passes through
+        // Call above and needs a probe of its own. As there, the probe sits on the entry that adds the
+        // native frame, not on the CallCore the trampoline re-enters.
+        _engine._stackGuard.EnsureStackHeadroom();
+
         _functionDefinition!.EnsureTailCallMarkers(state, _strict);
         var result = CallCore(thisObject, new RegisterArguments(arg0, arg1, arg2, arg3, argCount), state);
         return result is TailCallRequest ? ContinueTailCalls(result, ownsFrame) : result;
@@ -619,6 +641,10 @@ public sealed class ScriptFunction : Function, IConstructor
 
     private ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget, bool ownsFrame)
     {
+        // `function F() { new F(); } new F();` reaches a function body without ever evaluating a
+        // CallExpression, so [[Construct]] carries the probe as [[Call]] does.
+        _engine._stackGuard.EnsureStackHeadroom();
+
         var state = _functionDefinition!.Initialize();
         _functionDefinition.EnsureTailCallMarkers(state, _strict);
         var callerContext = _engine.ExecutionContext;

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -677,8 +677,66 @@ public class Options
         /// When max stack size to be exceeded, Engine throws an exception <see cref="JavaScriptException" />.
         /// Read once, while the engine is being constructed; changing it afterwards has no effect on an
         /// engine that already exists.
+        /// This lane is probed at the call expression only, so a recursion that reaches a function body by
+        /// another route — <c>new</c>, an accessor, a coercion, a Proxy trap — still overflows the native
+        /// stack; <see cref="StackOverflowGuard"/> is the one that covers those, and setting this property
+        /// takes precedence over it.
         /// </remarks>
         public int MaxExecutionStackCount { get; set; } = StackGuard.Disabled;
+
+        /// <summary>
+        /// Whether every entry into an interpreted function probes the remaining native stack and throws a
+        /// catchable <c>RangeError: Maximum call stack size exceeded</c> when it is nearly gone. Defaults to
+        /// <see langword="false"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Turn this on when the engine runs script you did not write. Without it, an unbounded recursion
+        /// ends the host process with a native stack overflow: no <c>catch</c> sees it, no exception is
+        /// raised, nothing is logged, and the process is simply gone. With it, the same script raises an
+        /// ordinary JavaScript error that the script itself can catch and the engine survives to be used
+        /// again. That is the whole trade — a process kill converted into an error value.
+        /// </para>
+        /// <para>
+        /// It measures the stack rather than counting calls, so it covers every route into a function body
+        /// rather than only a call expression: <c>new</c>, a getter or setter, a <c>valueOf</c>/<c>toString</c>
+        /// coercion, a Proxy trap, a callback a built-in invokes, and a host delegate that re-enters the
+        /// engine. Eighteen distinct routes reproduce the overflow, and the engine's older probe sat in the
+        /// call expression, so it saw one of them. Measuring also means the depth follows the stack of the
+        /// thread the engine runs on, instead of a frame count the host had to guess.
+        /// </para>
+        /// <para>
+        /// A proper tail call in a strict function is exempt, and needs to be: it replaces the caller's
+        /// frame rather than stacking one on top, so the recursion runs on a trampoline and consumes no
+        /// native stack at all. The probe sits on the entry points that add a frame, never on the loop the
+        /// trampoline re-enters, so a strict tail recursion neither pays for it nor is stopped by it. What
+        /// remains in scope is everything the trampoline does not carry: sloppy-mode recursion, a call out
+        /// of tail position, and the non-call routes above.
+        /// </para>
+        /// <para>
+        /// It is off by default because it is not free. The probe runs at every entry into an interpreted
+        /// function, and the benchmark gate measured the recursion rows (<c>Fib</c>, <c>DeepSum</c>,
+        /// <c>Tak</c>) 1.7–2.3% slower with it on, agreeing across two order-rotated pairs, with hot shallow
+        /// calls unaffected. The rule fixed before that run was that shipping it on by default needed no
+        /// call row worse than about 1%, so it ships opt-in. A host whose scripts are all its own can bound
+        /// them with <see cref="MaxRecursionDepth"/> and pay nothing; a host sandboxing untrusted input
+        /// generally cannot, and a couple of percent on deep recursion is the price of staying alive.
+        /// </para>
+        /// <para>
+        /// It is a backstop, not a policy. <see cref="MaxRecursionDepth"/> counts frames and is checked
+        /// before the callee is entered, so where both are configured the recursion limit is what fires;
+        /// the probe answers only when no limit was set, or when the limit was set higher than the thread's
+        /// stack can actually hold. <see cref="MaxExecutionStackCount"/> selects the older
+        /// continue-on-a-fresh-thread lane instead, and takes precedence over this flag when both are set,
+        /// because the probe sits a few frames deeper and would reach the condition first — leaving that
+        /// lane nothing to hop with.
+        /// </para>
+        /// <para>
+        /// Read once, while the engine is being constructed; changing it afterwards has no effect on an
+        /// engine that already exists.
+        /// </para>
+        /// </remarks>
+        public bool StackOverflowGuard { get; set; }
 
         /// <summary>
         /// Maximum time a Regex is allowed to run, defaults to 10 seconds.

--- a/Jint/Runtime/CallStack/StackGuard.cs
+++ b/Jint/Runtime/CallStack/StackGuard.cs
@@ -3,6 +3,7 @@
 
 // https://github.com/dotnet/runtime/blob/a0964f9e3793cb36cc01d66c14a61e89ada5e7da/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/StackGuard.cs
 
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -21,11 +22,86 @@ internal sealed class StackGuard
     private readonly int _maxExecutionStackCount;
     private readonly bool _enabled;
 
+    // Snapshot of Options.Constraints.StackOverflowGuard, which is opt-in and therefore false on a
+    // default engine. The two lanes are exclusive, and the reason is ordering rather than taste: the
+    // backstop sits inside ScriptFunction, i.e. a few native frames *below* TryEnterOnCurrentStack's
+    // call site, so on a stack low enough for either to fire the backstop reaches the condition first
+    // and would throw where the older lane wanted to hop. MaxExecutionStackCount is the older and more
+    // specific request, so it wins.
+    private readonly bool _backstopEnabled;
+
     public StackGuard(Engine engine)
     {
         _engine = engine;
         _maxExecutionStackCount = engine.Options.Constraints.MaxExecutionStackCount;
         _enabled = _maxExecutionStackCount != Disabled;
+        _backstopEnabled = !_enabled && engine.Options.Constraints.StackOverflowGuard;
+    }
+
+    /// <summary>
+    /// The opt-in backstop against unbounded script recursion
+    /// (<see cref="Options.ConstraintOptions.StackOverflowGuard"/>), run once per entry into an
+    /// interpreted function that adds a native frame — every route into one, not only a call
+    /// expression. Throws a catchable <c>RangeError</c> while there is still stack left to unwind on,
+    /// which is the whole difference between this and the native stack overflow that ends the process.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Only the branch on the cached flag is inlined into the caller; the probe and the throw are both
+    /// out of line. So the four <see cref="Native.Function.ScriptFunction"/> entry points that call this
+    /// — <c>Call</c>, <c>CallWithStackFrame</c>, <c>CallFromRegisters</c> and <c>Construct</c> — pay one
+    /// predictable test of a <see langword="bool"/> field per call when the guard is off, which is what
+    /// makes it affordable to have the sites there unconditionally: the placement is what covers the
+    /// routes a call expression never sees, and it is worth keeping whether or not this engine opted in.
+    /// </para>
+    /// <para>
+    /// Those four are exactly the entries that grow the native stack, which is why the probe is not in
+    /// <c>CallOnce</c> or <c>CallCore</c> even though every call funnels through them. Both are re-entered
+    /// from <c>ContinueTailCalls</c>' loop, where a proper tail call has replaced the caller's frame
+    /// rather than stacked one on top: there is no stack to probe for, and probing anyway would charge a
+    /// strict tail recursion once per hop.
+    /// </para>
+    /// <para>
+    /// The probe is <c>RuntimeHelpers.TryEnsureSufficientExecutionStack</c>: it asks the runtime
+    /// whether a fixed reserve is still available below the current frame, so it adapts to the thread the
+    /// engine happens to be on instead of to a frame count the host had to guess. The reserve is what pays
+    /// for the unwind, and it is enough because the error thrown is a <see cref="JavaScriptException"/> —
+    /// <see cref="Interpreter.JintStatementList.HandleException"/> turns one into a throw
+    /// <c>Completion</c> at each interpreter level rather than re-throwing it, and a completion costs no
+    /// stack to return. A CLR exception rethrown frame by frame does not have that property: each rethrow
+    /// happens inside a catch handler whose frames the runtime cannot collapse until the dispatch ends, so
+    /// it *consumes* stack per level. Measured on a 1.5 MB stack, a <c>JavaScriptException</c> unwinds
+    /// 1153 interpreter frames where a rethrown CLR exception manages 158.
+    /// </para>
+    /// <para>
+    /// On <c>net462</c>/<c>netstandard2.0</c> the probe is the throwing form wrapped in a try/catch (see
+    /// <c>RuntimeHelpersPolyfills</c>), i.e. one exception on the failing probe only. That is once per
+    /// stack exhaustion, immediately before an exception is thrown anyway.
+    /// </para>
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void EnsureStackHeadroom()
+    {
+        if (_backstopEnabled)
+        {
+            ProbeStackHeadroom();
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ProbeStackHeadroom()
+    {
+        if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+        {
+            ThrowMaximumCallStackSizeExceeded();
+        }
+    }
+
+    [DoesNotReturn]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ThrowMaximumCallStackSizeExceeded()
+    {
+        Throw.RangeError(_engine.Realm, "Maximum call stack size exceeded");
     }
 
     public bool TryEnterOnCurrentStack()

--- a/README.md
+++ b/README.md
@@ -729,6 +729,49 @@ for (var i = 0; i < 10; i++)
 }
 ```
 
+### Surviving an unbounded recursion
+
+A script that recurses without bound does not throw. It exhausts the native stack of the thread it is
+running on, and that ends the host process: no exception, nothing to `catch`, nothing in the log but an
+exit code. Every route into a function body can do it — a call, `new`, a getter or setter, a
+`valueOf`/`toString` coercion, a Proxy trap, a callback a built-in invokes, a host delegate that calls
+back into the engine.
+
+```c#
+var engine = new Engine(options =>
+{
+    options.Constraints.StackOverflowGuard = true;
+});
+```
+
+With the guard on, every entry into a script function first checks that the native stack has not been used
+up, and the same script raises `RangeError: Maximum call stack size exceeded` while there is still room to
+unwind — an ordinary JavaScript error, catchable by the script itself and by your
+`catch (JavaScriptException)`, with the engine still usable afterwards. It measures the remaining stack
+rather than counting calls, so it covers all of those routes and adapts to the thread the engine runs on:
+a host that provisions a larger stack gets proportionally more depth, rather than the frame count someone
+had to guess in advance.
+
+A proper tail call in a strict function is exempt, and does not need the guard: it replaces the caller's
+frame instead of stacking one on top, so the recursion consumes no native stack however deep it runs. The
+check sits on the entries that do add a frame, so a strict tail recursion neither pays for it nor is
+stopped by it. Sloppy-mode recursion, a call out of tail position, and the non-call routes above are what
+remain in scope.
+
+It is off by default because the check runs at every entry into a script function and that is not free.
+The benchmark gate measured recursion-heavy workloads (`Fib`, `DeepSum`, `Tak`) 1.7–2.3% slower with it
+on, with hot shallow calls unaffected. Enable it when the engine runs script you did not write, where a
+couple of percent on deep recursion in exchange for keeping your process is plainly the trade you want.
+Leave it off when every script is yours and you can bound it yourself.
+
+`options.LimitRecursion(n)` answers a different question and composes with it. The recursion limit counts
+frames and is checked before the callee is entered, so where it is configured it is what fires; the guard
+answers only when no limit was set, or when the limit was set higher than the thread's stack can actually
+hold — which is easy to do by accident, since how many frames a stack holds is not something a host can
+see. A third and older setting, `options.Constraints.MaxExecutionStackCount`, continues the call chain on
+a fresh thread instead of throwing; it is checked at call expressions only, so it does not cover the other
+routes above, and it takes precedence over the guard when both are set.
+
 ## Using Modules
 
 You can use modules to `import` and `export` variables from multiple script files:
@@ -1102,6 +1145,8 @@ The following features provide you with a secure, sand-boxed environment to run 
 - Limit number of statements to prevent infinite loops.
 - Limit depth of calls to prevent deep recursion calls.
 - Define a timeout, to prevent scripts from taking too long to finish.
+- Turn an unbounded recursion into a catchable error rather than a stack overflow that ends the process
+  (see [Surviving an unbounded recursion](#surviving-an-unbounded-recursion); off by default).
 
 ## Branches and releases
 


### PR DESCRIPTION
**An unbounded recursion in script kills the host process, and it has eighteen doors.** The release review reproduced the crash — process exit `0xC00000FD`, no `catch`, no exception, nothing logged — through every route into a function body it tried: plain calls, `new`, getters and setters, `valueOf`/`toString` coercions, Proxy traps, sort comparers, `toJSON`, class field initializers, `super` chains, bound functions, `Reflect.apply`, array callbacks, host delegate re-entry. The engine's existing `MaxExecutionStackCount` machinery probes only the call-expression route, so it saw one of the eighteen; every .NET engine except YantraJS crashes the same way by default.

This adds `Options.Constraints.StackOverflowGuard` — a stack-headroom probe (`RuntimeHelpers.TryEnsureSufficientExecutionStack`) at the four frame-adding entries into an interpreted function (`Call`, `CallWithStackFrame`, `CallFromRegisters`, `Construct`), throwing a catchable `RangeError: Maximum call stack size exceeded` at a constant ~83-frame (~115 KB) reserve. The engine survives: call stack empty, pools intact, later evaluations correct — pinned by a recovery battery, including three successive guard hits on one engine firing at the identical depth.

**It ships opt-in, and the reason is a measurement, not a mood.** The decision rule fixed before the gate ran was: default-on needs no call row worse than about 1%. The gate measured the recursion rows (`Fib`, `DeepSum`, `Tak`) at **+1.7–2.3% with the guard on, agreeing across two order-rotated BDN pairs**, corroborated by a 5-rep alternating REPL driver at +0.9% median on deep recursion (hot shallow calls ~0%). Above the line → opt-in, with the option's XML doc quoting the numbers so a host can make the same trade knowingly. A host running untrusted input almost certainly wants it on; a host running its own scripts can use `MaxRecursionDepth` and pay nothing. What inlines into each entry when the option is off is a field load and a never-taken branch to a cold no-inline probe.

**Proper tail calls (#2975) are exempt, and must be.** A strict tail call is re-dispatched by the trampoline without re-entering the probed entries and consumes **no** native stack — so the probe deliberately does not sit in `CallOnce`/`CallCore`, where it would charge a strict tail recursion one probe per hop for a stack that never moves. Post-PTC the guard's scope is sloppy-mode recursion, strict calls out of tail position, and the sixteen non-call routes. Two tests pin exactly this boundary, and the eight route theories are deliberately sloppy-mode with a doc comment saying why.

**Relationship to the existing options, documented and pinned:** `MaxRecursionDepth` counts frames and fires first; `MaxExecutionStackCount` selects the older thread-hop lane and takes precedence when both are set — the hop needs the whole callee evaluation re-dispatched onto a fresh thread, which is only possible at the call expression, so the two lanes cannot compose and the guard's wider coverage is reachable through `StackOverflowGuard` only.

Out-of-process evidence (per-scenario exits, depth bisection): `LimitRecursion(200)`/`(1000)` and unguarded recursion on 1 MB and 1.5 MB stacks — before: `0xC00000FD`; guarded: clean exit with the catchable error. Guard depths: 664 of 747 crash-depth frames on 1 MB, 12,094 of 12,177 on 16 MB — the reserve is constant, so it costs proportionally less the more stack a host provisions.

33 tests across `Jint.Tests` and `Jint.Tests.PublicInterface`, including the default-off pin (`ADefaultEngineDoesNotProbeAtAll`, measured on a 1 MB thread and verified on a 16 MB one, since the other direction's failure mode is ending the process). Full solution green both TFMs; verification legs green; test262 standalone **99,779 / 0 / 122** — byte-identical to the post-#2975 baseline, whose 35 un-parked tail-call tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
