### PR TITLE
Derive the supported collations from the per-locale lists

### DIFF
--- a/Jint.Tests/Runtime/IntlTests.cs
+++ b/Jint.Tests/Runtime/IntlTests.cs
@@ -1052,4 +1052,48 @@ public class IntlTests
                 .AsString().Should().Be(collation, "the Collator must accept every collation getCollations reports");
         }
     }
+
+    [Fact]
+    public void SupportedValuesOfCollationIsTheUnionOfEveryLocalesCollations()
+    {
+        // AvailableCanonicalCollations (https://tc39.es/ecma402/#sec-availablecanonicalcollations)
+        // contains "the collations for which the implementation provides the functionality of
+        // Intl.Collator objects", which is the union of the one [[co]] list every locale has and
+        // nothing besides. Both inclusions matter and each has a way of going wrong on its own: a
+        // value listed here that no locale resolves is what
+        // intl402/Intl/supportedValuesOf/collations-accepted-by-Collator.js fails on, and a
+        // collation some locale reports but this omits is invisible to test262 entirely.
+        var result = _engine.Evaluate("""
+            // Every language Jint carries collation data for, plus five that carry none.
+            const tags = ['ar', 'de', 'es', 'fi', 'ja', 'ko', 'ln', 'si', 'sv', 'vi', 'zh',
+                          'da', 'en', 'fr', 'hi', 'tr', 'und'];
+            const union = new Set();
+            for (const tag of tags) {
+                for (const collation of new Intl.Locale(tag).getCollations()) {
+                    union.add(collation);
+                }
+            }
+            JSON.stringify([...union].sort());
+            """);
+
+        var supported = _engine.Evaluate("JSON.stringify(Intl.supportedValuesOf('collation'))");
+        supported.AsString().Should().Be(result.AsString());
+    }
+
+    [Fact]
+    public void SupportedValuesOfCollationIsSortedUniqueAndFreeOfTheUnrequestableTypes()
+    {
+        // The three properties intl402/Intl/supportedValuesOf/collations.js checks, restated here so
+        // the derivation cannot lose one of them quietly.
+        var result = _engine.Evaluate("""
+            const collations = Intl.supportedValuesOf('collation');
+            const sorted = JSON.stringify(collations) === JSON.stringify([...collations].sort());
+            const unique = new Set(collations).size === collations.length;
+            const clean = !collations.includes('standard') && !collations.includes('search')
+                && !collations.includes('default');
+            [sorted, unique, clean, collations.join(',')].join(' ');
+            """);
+        result.AsString().Should().Be(
+            "true true true compat,dict,emoji,eor,phonebk,phonetic,pinyin,searchjl,stroke,trad,unihan,zhuyin");
+    }
 }

--- a/Jint/Native/Intl/CollatorConstructor.cs
+++ b/Jint/Native/Intl/CollatorConstructor.cs
@@ -93,6 +93,33 @@ internal sealed partial class CollatorConstructor : Constructor
         return result;
     }
 
+    // https://tc39.es/ecma402/#sec-availablecanonicalcollations - the collations "for which the
+    // implementation provides the functionality of Intl.Collator objects", unique and in
+    // lexicographic code unit order. That is the union of the one [[co]] list every locale has, so
+    // it is read off LocaleCollations rather than written out a second time: a hand-kept copy can
+    // list a collation no locale resolves, which is what
+    // intl402/Intl/supportedValuesOf/collations-accepted-by-Collator.js fails on, or omit one some
+    // locale reports, which nothing in test262 would notice. Both are the drift #2974 removed from
+    // the two views this makes a third of. "standard", "search" and "default" need no exclusion of
+    // their own: IsReportableCollation already kept them out of every list this unions.
+    internal static readonly string[] AvailableCanonicalCollations = BuildAvailableCanonicalCollations();
+
+    private static string[] BuildAvailableCanonicalCollations()
+    {
+        var all = new HashSet<string>(RootCollations, StringComparer.Ordinal);
+        foreach (var collations in LocaleCollations.Values)
+        {
+            foreach (var collation in collations)
+            {
+                all.Add(collation);
+            }
+        }
+
+        var result = new List<string>(all);
+        result.Sort(StringComparer.Ordinal);
+        return result.ToArray();
+    }
+
     /// <summary>
     /// Whether an identifier may appear in a locale's [[co]] list. "standard" and "search" may not:
     /// https://tc39.es/ecma402/#sec-intl-collator-internal-slots (10.2.3) forbids either from being

--- a/Jint/Native/Intl/DefaultCldrProvider.cs
+++ b/Jint/Native/Intl/DefaultCldrProvider.cs
@@ -531,16 +531,10 @@ public sealed class DefaultCldrProvider : ICldrProvider
 
     public IReadOnlyCollection<string> GetSupportedCollations()
     {
-        // https://tc39.es/ecma402/#sec-availablecanonicalcollations returns the collations for which
-        // the implementation provides Intl.Collator functionality, so this list has to stay the union
-        // of what CollatorConstructor accepts - "big5han", "direct", "gb2312" and "reformed" are
-        // deprecated in CLDR's common/bcp47/collation.xml and "ducet" is defined by no locale, so no
-        // locale reports any of the five and none belongs here.
-        return new[]
-        {
-            "compat", "dict", "emoji", "eor", "phonebk", "phonetic",
-            "pinyin", "searchjl", "stroke", "trad", "unihan", "zhuyin"
-        };
+        // https://tc39.es/ecma402/#sec-availablecanonicalcollations wants the collations the
+        // implementation provides Intl.Collator functionality for, which is the union of the one
+        // [[co]] list every locale has - so it is read off that data rather than restated here.
+        return CollatorConstructor.AvailableCanonicalCollations;
     }
 
     public IReadOnlyCollection<string> GetSupportedCurrencies()


### PR DESCRIPTION
The follow-up #2989's commit message promised: `Intl.supportedValuesOf("collation")` was backed by `DefaultCldrProvider.GetSupportedCollations()`, a third hand-kept list not derived from `LocaleCollationSupport` — consistent today only because #2989 edited it in the same commit, and free to drift exactly the way the #2974 bug did. It is now the union of every per-language list plus the root pair, per [AvailableCanonicalCollations](https://tc39.es/ecma402/#sec-availablecanonicalcollations): sorted in ascending code-unit order, unique, with `standard`/`search` excluded at derivation (the `IsReportableCollation` filter, so a future table edit cannot reintroduce them).

A behavioural red is impossible — #2989 already made the hand-kept list agree — so the test's teeth were proven by injection: adding one fake collation to the table makes `SupportedValuesOfCollationIsTheUnionOfEveryLocalesCollations` fail against a hardcoded list and pass once derived. Injection reverted; the reported values are unchanged at the same twelve. test262's `collations-accepted-by-Collator.js` stays green.

Rebased onto current main after #2989's merge; IntlTests 171/171 on both TFMs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)