### PR TITLE
Drop the five Temporal members the proposal removed

### DIFF
--- a/Jint.Tests/Runtime/TemporalRemovedMembersTests.cs
+++ b/Jint.Tests/Runtime/TemporalRemovedMembersTests.cs
@@ -1,0 +1,69 @@
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// The Temporal reduction of 2024-05-24 also took five members off the <c>Temporal.PlainDateTime</c> and
+/// <c>Temporal.ZonedDateTime</c> prototypes, across three normative commits: <c>withPlainDate</c>,
+/// <c>epochSeconds</c>, <c>epochMicroseconds</c>, <c>toPlainYearMonth</c> and <c>toPlainMonthDay</c>.
+/// Neither prototype object
+/// lists them any more — https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plaindatetime-prototype-object
+/// and https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-zoneddatetime-prototype-object.
+/// test262 asserts their absence in <c>staging/Temporal/removed-methods.js</c>, which Jint's harness does not
+/// generate, so the property lists are pinned here instead.
+/// </summary>
+public class TemporalRemovedMembersTests
+{
+    [Fact]
+    public void PlainDateTimePrototypeExposesExactlyTheMembersTheProposalDefines()
+    {
+        new Engine().Evaluate("Object.getOwnPropertyNames(Temporal.PlainDateTime.prototype).sort().join()")
+            .AsString().Should().Be(
+                "add,calendarId,constructor,day,dayOfWeek,dayOfYear,daysInMonth,daysInWeek,daysInYear,equals,era," +
+                "eraYear,hour,inLeapYear,microsecond,millisecond,minute,month,monthCode,monthsInYear,nanosecond," +
+                "round,second,since,subtract,toJSON,toLocaleString,toPlainDate,toPlainTime,toString,toZonedDateTime," +
+                "until,valueOf,weekOfYear,with,withCalendar,withPlainTime,year,yearOfWeek");
+    }
+
+    [Fact]
+    public void ZonedDateTimePrototypeExposesExactlyTheMembersTheProposalDefines()
+    {
+        new Engine().Evaluate("Object.getOwnPropertyNames(Temporal.ZonedDateTime.prototype).sort().join()")
+            .AsString().Should().Be(
+                "add,calendarId,constructor,day,dayOfWeek,dayOfYear,daysInMonth,daysInWeek,daysInYear," +
+                "epochMilliseconds,epochNanoseconds,equals,era,eraYear,getTimeZoneTransition,hour,hoursInDay," +
+                "inLeapYear,microsecond,millisecond,minute,month,monthCode,monthsInYear,nanosecond,offset," +
+                "offsetNanoseconds,round,second,since,startOfDay,subtract,timeZoneId,toInstant,toJSON,toLocaleString," +
+                "toPlainDate,toPlainDateTime,toPlainTime,toString,until,valueOf,weekOfYear,with,withCalendar," +
+                "withPlainTime,withTimeZone,year,yearOfWeek");
+    }
+
+    [Theory]
+    [InlineData("Temporal.PlainDateTime", "withPlainDate")]
+    [InlineData("Temporal.ZonedDateTime", "epochSeconds")]
+    [InlineData("Temporal.ZonedDateTime", "epochMicroseconds")]
+    [InlineData("Temporal.ZonedDateTime", "toPlainYearMonth")]
+    [InlineData("Temporal.ZonedDateTime", "toPlainMonthDay")]
+    public void DoesNotExposeTheRemovedMembers(string type, string removed)
+    {
+        var engine = new Engine();
+
+        engine.Evaluate($"'{removed}' in {type}.prototype").AsBoolean().Should().BeFalse();
+        engine.Evaluate($"{type}.prototype.{removed} === undefined").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void StillAnswersThroughTheSurvivingMembers()
+    {
+        new Engine().Evaluate("""
+            const zdt = Temporal.Instant.fromEpochMilliseconds(1000).toZonedDateTimeISO('UTC');
+            const pdt = new Temporal.PlainDateTime(2026, 8, 14, 12, 30, 45);
+            [
+                pdt.withPlainTime(new Temporal.PlainTime(1, 2, 3)).toString(),
+                zdt.epochMilliseconds,
+                zdt.epochNanoseconds,
+                zdt.toPlainDate().toString(),
+                zdt.toPlainDateTime().toString(),
+                zdt.toPlainTime().toString(),
+            ].join();
+            """).AsString().Should().Be("2026-08-14T01:02:03,1000,1000000000,1970-01-01,1970-01-01T00:00:01,00:00:01");
+    }
+}

--- a/Jint/Native/Temporal/PlainDateTime/PlainDateTimePrototype.cs
+++ b/Jint/Native/Temporal/PlainDateTime/PlainDateTimePrototype.cs
@@ -394,17 +394,6 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     }
 
     /// <summary>
-    /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.withplaindate
-    /// </summary>
-    [JsFunction]
-    private JsPlainDateTime WithPlainDate(JsValue thisObject, JsValue plainDateLike)
-    {
-        var plainDateTime = ValidatePlainDateTime(thisObject);
-        var plainDate = _realm.Intrinsics.TemporalPlainDate.ToTemporalDate(plainDateLike, "constrain");
-        return _constructor.Construct(new IsoDateTime(plainDate.IsoDate, plainDateTime.IsoDateTime.Time), plainDate.Calendar);
-    }
-
-    /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.withplaintime
     /// </summary>
     [JsFunction(Length = 0)]

--- a/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimePrototype.cs
+++ b/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimePrototype.cs
@@ -123,10 +123,6 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
     private JsNumber GetNanosecond(JsValue thisObject) =>
         JsNumber.Create(ValidateZonedDateTime(thisObject).GetIsoDateTime().Nanosecond);
 
-    [JsAccessor("epochSeconds")]
-    private JsNumber GetEpochSeconds(JsValue thisObject) =>
-        JsNumber.Create((double) FloorDivide(ValidateZonedDateTime(thisObject).EpochNanoseconds, 1_000_000_000));
-
     [JsAccessor("epochMilliseconds")]
     private JsNumber GetEpochMilliseconds(JsValue thisObject) =>
         JsNumber.Create((double) FloorDivide(ValidateZonedDateTime(thisObject).EpochNanoseconds, 1_000_000));
@@ -141,10 +137,6 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
 
         return result;
     }
-
-    [JsAccessor("epochMicroseconds")]
-    private JsBigInt GetEpochMicroseconds(JsValue thisObject) =>
-        JsBigInt.Create(ValidateZonedDateTime(thisObject).EpochNanoseconds / 1_000);
 
     [JsAccessor("epochNanoseconds")]
     private JsBigInt GetEpochNanoseconds(JsValue thisObject) =>
@@ -884,22 +876,6 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
         var zdt = ValidateZonedDateTime(thisObject);
         var dt = zdt.GetIsoDateTime();
         return _realm.Intrinsics.TemporalPlainDateTime.Construct(dt, zdt.Calendar);
-    }
-
-    [JsFunction]
-    private JsPlainYearMonth ToPlainYearMonth(JsValue thisObject)
-    {
-        var zdt = ValidateZonedDateTime(thisObject);
-        var dt = zdt.GetIsoDateTime();
-        return _realm.Intrinsics.TemporalPlainYearMonth.Construct(dt.Date, zdt.Calendar);
-    }
-
-    [JsFunction]
-    private JsPlainMonthDay ToPlainMonthDay(JsValue thisObject)
-    {
-        var zdt = ValidateZonedDateTime(thisObject);
-        var dt = zdt.GetIsoDateTime();
-        return _realm.Intrinsics.TemporalPlainMonthDay.Construct(dt.Date, zdt.Calendar);
     }
 
     [JsFunction]


### PR DESCRIPTION
#2996 dropped the `Temporal.Now` methods the proposal removed. Five more members from the same June 2024 removals were still exposed; this takes them out.

- `Temporal.PlainDateTime.prototype.withPlainDate`
- `Temporal.ZonedDateTime.prototype.epochSeconds`
- `Temporal.ZonedDateTime.prototype.epochMicroseconds`
- `Temporal.ZonedDateTime.prototype.toPlainYearMonth`
- `Temporal.ZonedDateTime.prototype.toPlainMonthDay`

None of them appears in the live proposal. [Properties of the Temporal.PlainDateTime Prototype Object](https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plaindatetime-prototype-object) lists 22 accessors and 17 methods, `withPlainTime` among them and no `withPlainDate`. [Properties of the Temporal.ZonedDateTime Prototype Object](https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-zoneddatetime-prototype-object) lists 28 accessors and 21 methods, with `epochMilliseconds` and `epochNanoseconds` the only two epoch accessors and `toPlainDate` / `toPlainTime` / `toPlainDateTime` the only three `toPlain*` methods. With the five gone, `Object.getOwnPropertyNames` reports 39 names on `PlainDateTime.prototype` and 49 on `ZonedDateTime.prototype`, matching those lists name for name.

**This is breaking for anyone calling them**, which is why it lands early in the 4.16 cycle rather than late. The replacements are what the proposal points at: `pdt.withPlainDate(d)` becomes `d.toPlainDateTime(pdt.toPlainTime())`, `zdt.epochSeconds` becomes `zdt.epochMilliseconds / 1000` (floored) or `zdt.epochNanoseconds / 1_000_000_000n`, `zdt.epochMicroseconds` becomes `zdt.epochNanoseconds / 1000n`, and `zdt.toPlainYearMonth()` / `zdt.toPlainMonthDay()` become `zdt.toPlainDate().toPlainYearMonth()` / `zdt.toPlainDate().toPlainMonthDay()`, both of which `PlainDate.prototype` keeps.

Nothing is orphaned. `FloorDivide` sits *between* the two removed accessors and still serves `epochMilliseconds`, so the deletion is not one contiguous block. `ToTemporalDate`, and the `IsoDate` overloads of `PlainYearMonthConstructor.Construct` and `PlainMonthDayConstructor.Construct`, all keep other callers. Deleting the attributed method is the whole edit — `Jint.SourceGenerators/ObjectGenerator` emits the property table and computes the `BuiltinShape.Builder` capacity from the attributes, so the regenerated shapes went to 39 and 49 on their own with no hand-written count to decrement.

## test262

No exclusion was needed. At the pinned SHA (`3655e7464de3d52643ecddd4b5f9f4f3e7f62398`) all five test directories are already gone upstream — `built-ins/Temporal/PlainDateTime/prototype/withPlainDate`, and `built-ins/Temporal/ZonedDateTime/prototype/{epochSeconds,epochMicroseconds,toPlainYearMonth,toPlainMonthDay}`. Nothing else in `built-ins/` or `intl402/` reaches these members; the remaining `toPlainYearMonth` / `toPlainMonthDay` hits are all on `PlainDate.prototype`, which keeps them. The only place the suite asserts their absence is `staging/Temporal/removed-methods.js`, and Jint's harness generates `annexB`, `built-ins`, `intl402` and `language` only — so, exactly as in #2996, nothing in the suite was holding the line. `TemporalRemovedMembersTests` pins both full property lists instead, and cites that staging file.

## Pre-fix failure

The test was written first and run against the unfixed engine. 7 of its 8 cases failed; the eighth is the survivors control, which passes either way:

```
Failed Jint.Tests.Runtime.TemporalRemovedMembersTests.DoesNotExposeTheRemovedMembers(type: "Temporal.ZonedDateTime", removed: "epochSeconds")
  Expected engine.Evaluate($"'{removed}' in {type}.prototype").AsBoolean() to be False, but found True.

Failed Jint.Tests.Runtime.TemporalRemovedMembersTests.PlainDateTimePrototypeExposesExactlyTheMembersTheProposalDefines
  Expected string to be the same string, but they differ at index 342:
  "…,withPlainDate,withPlainTime,year,yearOfWeek"   (actual)
  "…,withPlainTime,year,yearOfWeek"                 (expected)

Failed Jint.Tests.Runtime.TemporalRemovedMembersTests.ZonedDateTimePrototypeExposesExactlyTheMembersTheProposalDefines
  Expected string to be the same string, but they differ at index 92:
  "…ar,epochMicroseconds,epochMilliseconds,epochNanose…"   (actual)
  "…ar,epochMilliseconds,epochNanoseconds,equals,era,e…"   (expected)

Failed!  - Failed: 7, Passed: 1, Total: 8
```

## Verification

Release, freshly built, all green:

| Suite | Result |
| --- | --- |
| `dotnet build -c Release` | 0 errors, 0 compiler warnings |
| `Jint.Tests` net10.0 | 5668 passed, 4 skipped |
| `Jint.Tests` net472 | 5584 passed, 4 skipped |
| `Jint.Tests.PublicInterface` net10.0 | 1486 passed, 9 skipped |
| `Jint.Tests.PublicInterface` net472 | 1485 passed, 9 skipped |
| `Jint.Tests.Test262` | 99779 passed, 122 skipped, 0 failed |

Closes #3010

🤖 Generated with [Claude Code](https://claude.com/claude-code)
