### PR TITLE
Let a for-of frame decline the unwind it can only rethrow

### DIFF
--- a/Jint.Tests/Runtime/ExecutionConstraintTests.cs
+++ b/Jint.Tests/Runtime/ExecutionConstraintTests.cs
@@ -625,6 +625,103 @@ myarr[0](0);
             maxStackSize: SmallStack);
     }
 
+    // A for-of on the recursion path puts a JintForInForOfStatement frame on the stack once per
+    // JavaScript frame, and that frame kept the catch { bookkeep; throw; } the statement lists shed —
+    // so this shape went on dying at a fraction of the depth it can reach forward, long after the rest
+    // of the unwind was fixed. Measured on the 1 MB stack these run on: the loop reaches 219 frames
+    // forward, and the constraint's unwind used to survive only 78 of them. Every limit below sits
+    // between the two, so a regression is a dead test host rather than a smaller number.
+    private const string ForOfRecursion = "var depth = 0; function f() { depth++; for (const x of [1]) { return f(); } }";
+
+    [Fact]
+    public void RecursionLimitFiringInsideAForOfBodyUnwindsToTheHost()
+    {
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = new Engine(o => o.LimitRecursion(130));
+                engine.Execute(ForOfRecursion);
+
+                Invoking(() => engine.Evaluate("f()")).Should().ThrowExactly<RecursionDepthOverflowException>();
+                engine.CallStack.Count.Should().Be(0);
+            },
+            maxStackSize: SmallStack);
+    }
+
+    [Fact]
+    public void ClrExceptionFromHostCodeUnwindsADeepForOfRecursion()
+    {
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = new Engine();
+                engine.SetValue("bang", new Action(() => throw new InvalidOperationException("bang")));
+                engine.Execute("function f(n) { if (n <= 0) { bang(); } for (const x of [1]) { return f(n - 1); } }");
+
+                var thrown = Invoking(() => engine.Evaluate("f(130)"))
+                    .Should().ThrowExactly<InvalidOperationException>().Which;
+
+                JintException.TryGetJavaScriptCallStack(thrown, out var callStack).Should().BeTrue();
+                callStack.Should().Contain("at f");
+            },
+            maxStackSize: SmallStack);
+    }
+
+    [Fact]
+    public void EngineStaysUsableAfterAForOfRecursionLimitUnwind()
+    {
+        DedicatedThread.Run(
+            () =>
+            {
+                var engine = new Engine(o => o.LimitRecursion(130));
+                engine.Execute(ForOfRecursion);
+                engine.Execute("function fib(n) { return n < 2 ? n : fib(n - 1) + fib(n - 2); }");
+
+                var depths = new List<double>();
+                for (var round = 0; round < 3; round++)
+                {
+                    engine.Evaluate("depth = 0");
+                    Invoking(() => engine.Evaluate("f()")).Should().ThrowExactly<RecursionDepthOverflowException>();
+
+                    // Every one of those frames also owned an iteration environment and an iterator to
+                    // close on the way out, so a leak here is more likely than in the plain-call shape.
+                    depths.Add(engine.Evaluate("depth").AsNumber());
+                    engine.CallStack.Count.Should().Be(0);
+                    engine.Evaluate("fib(20)").AsNumber().Should().Be(6765);
+                }
+
+                depths.Should().AllBeEquivalentTo(depths[0], "an unwind that left anything behind would move the next round's number");
+            },
+            maxStackSize: SmallStack);
+    }
+
+    [Fact]
+    public void AnExceptionUnwindingAForOfStillClosesTheIteratorWithAThrowCompletion()
+    {
+        // The completion the loop's finally performs IteratorClose with is what the filter has to assign
+        // before it declines: a throw completion swallows a failing return(), per step 5 of IteratorClose,
+        // while any other completion would let that failure replace the exception actually in flight.
+        // No recursion needed — one frame is enough to see which completion was recorded.
+        var engine = new Engine();
+        engine.SetValue("bang", new Action(() => throw new InvalidOperationException("bang")));
+        engine.Execute("""
+            var returned = false;
+            var it = {
+                [Symbol.iterator]: function () {
+                    return {
+                        next: function () { return { value: 1, done: false }; },
+                        return: function () { returned = true; throw new Error('from return'); }
+                    };
+                }
+            };
+            """);
+
+        Invoking(() => engine.Evaluate("(function () { for (const x of it) { bang(); } })()"))
+            .Should().ThrowExactly<InvalidOperationException>().WithMessage("bang");
+
+        engine.Evaluate("returned").AsBoolean().Should().BeTrue();
+    }
+
     [Fact]
     public void ShouldLimitArraySizeForConcat()
     {

--- a/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
@@ -912,10 +912,10 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                 }
             }
         }
-        catch
+        catch when (LeavingOnException(suspendable, out completionType))
         {
-            completionType = CompletionType.Throw;
-            suspendable?.Data.Clear(this);
+            // Unreachable: the filter always declines. Kept as a rethrow so that a filter which one day
+            // sometimes accepts still leaves this site behaving exactly as it did before it had one.
             throw;
         }
         finally
@@ -965,6 +965,52 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
 
             engine.UpdateLexicalEnvironment(oldEnv);
         }
+    }
+
+    /// <summary>
+    /// Exception filter for <see cref="BodyEvaluation"/>. It performs the bookkeeping every exception
+    /// leaving the loop owes — recording the throw completion the <c>finally</c> below closes the iterator
+    /// with, and dropping the loop's suspend data — and then <em>always declines</em>, so the frame never
+    /// enters the unwind of an exception it could only rethrow.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Declining is the point, and it is the point <see cref="JintStatementList.ShouldCatch"/> already
+    /// makes for statement lists: a throw from inside a catch handler restarts the two-pass dispatch, so
+    /// the runtime cannot collapse the frames it has already searched and each level costs roughly 10 KB
+    /// that stays live for the rest of the unwind. A <c>for-of</c> on the recursion path contributes one
+    /// such frame per JavaScript call, which is why a constraint exception raised underneath one unwound a
+    /// fraction as far as the same exception raised anywhere else — far enough short of the forward
+    /// ceiling that <c>Options.LimitRecursion</c> went on killing the process for that shape after the
+    /// statement lists had been fixed. A filter is answered in the first pass and leaves nothing behind.
+    /// </para>
+    /// <para>
+    /// Both halves of the bookkeeping are safe to do from that first pass.
+    /// <paramref name="completionType"/> is a local of the invocation being unwound, and its only reader is
+    /// that same invocation's <c>finally</c>, which runs later in the second pass either way — the catch
+    /// handler this replaces also assigned it before that <c>finally</c> could see it. The suspend data
+    /// keyed by this statement is written and read only by <see cref="BodyEvaluation"/> itself, on entry
+    /// and resume paths that cannot be running while an exception is in flight through it; and no script
+    /// code runs in between to reach them, because Jint evaluates a JavaScript <c>finally</c> block as
+    /// forward interpretation of a parked completion (<c>JintTryStatement.ExecuteFinalizer</c>) rather than
+    /// from a CLR <c>finally</c>, so a CLR unwind through the interpreter carries interpreter bookkeeping
+    /// only. Clearing it is a dictionary removal: it does not recurse, does not allocate and cannot throw,
+    /// which is the contract a filter owes here — see
+    /// <see cref="ExceptionDataHelper.HasJavaScriptLocation"/>.
+    /// </para>
+    /// <para>
+    /// What the loop still does on the way out is unchanged. The <c>finally</c> reads the very
+    /// <see cref="CompletionType.Throw"/> written here, so IteratorClose is still performed with a throw
+    /// completion — which is what makes a failing <c>return()</c> swallowed rather than allowed to replace
+    /// the exception in flight, per step 5 of
+    /// <see href="https://tc39.es/ecma262/#sec-iteratorclose">IteratorClose</see>.
+    /// </para>
+    /// </remarks>
+    private bool LeavingOnException(ISuspendable? suspendable, out CompletionType completionType)
+    {
+        completionType = CompletionType.Throw;
+        suspendable?.Data.Clear(this);
+        return false;
     }
 
     /// <summary>


### PR DESCRIPTION
`Options.LimitRecursion` still kills the host process when a `for-of` is on the recursion path. #2994 fixed the general case by turning the two catch-and-rethrow sites in `JintStatementList` and `JintBlockStatement` into exception **filters** — a filter is answered in the first pass, so a frame that declines leaves no handler behind and the runtime can collapse it, where a `throw` from inside a `catch` handler restarts the two-pass dispatch and costs ~10 KB of live stack per level. That PR deliberately left `JintForInForOfStatement`'s sibling `catch { bookkeep; throw; }` alone and named the consequence; this is that follow-up. See #2994 for the full account of the mechanism.

### Measured

1 MB dedicated thread, net10.0, Windows x64, per JavaScript frame, for `function f() { for (const x of [1]) { return f(); } }`. Each number is the largest depth that survives, found by bisection with one process per probe:

| | before | after |
| --- | ---: | ---: |
| `LimitRecursion` | 78 | 215 |
| CLR exception from host code | 78 | 211 |
| JavaScript `throw` | 218 | 219 |
| forward ceiling (`for-of` shape) | 219 | 219 |
| forward ceiling, plain calls | 696 | 696 |

So `LimitRecursion(130)` — comfortably inside what this shape reaches forward — fired at 130 exactly as asked and then died at unwind depth ~78 with `0xC00000FD`, which no host can catch. Afterwards the unwind reaches the forward ceiling.

(The issue quotes 121 of a 285-frame ceiling for this shape; that is the same measurement on a larger stack. Every number in the table above is a 1 MB thread — the stack the tests reserve — and the ratio between the two rows is what matters, not the absolute frame counts.)

**The forward-depth control did not move.** The bottom three rows are the control, and unlike #2994 they are not also the cost: `BodyEvaluation`'s prolog is `sub rsp, 696` on both sides (`DOTNET_JitDisasm`), and the plain-call ceiling is 696 on both sides, frame for frame. The filter clause bought a fourth funclet rather than one more zero-initialized slot in the method's own frame, and a funclet frame exists only while the funclet runs. #2994's 1.1–1.4% forward-depth tax does not repeat here.

### How the completion reaches the filter

The `finally` reads `completionType` twice — once to choose the IteratorClose completion, once to decide whether a failing `return()` may replace the exception in flight — so the filter has to assign it before declining. The mechanism is an **`out` parameter**: a filter is compiled into the same method as the `try` it guards, so it can address that method's own locals. `LeavingOnException(ISuspendable?, out CompletionType)` writes `CompletionType.Throw` into the very local the `finally` reads, clears the loop's suspend data, and returns `false`. `ref` compiles here too; `out` is the better half of the pair because it states the fact the `finally` depends on — that the filter always writes. The alternatives put the completion somewhere other than where the `finally` already reads it: a holder object allocates on every entry into a loop this hot, and a capturing local function moves the loop's locals into a display struct for the sake of one enum write.

Doing the bookkeeping in the first pass is safe, and the justification is not the same as `JintStatementList`'s (it is written out on the method, alongside the filter contract in `ExceptionDataHelper`'s remarks — no recursion, no allocation, never throws):

- `completionType` is a local of the invocation being unwound, and its only reader is that invocation's own `finally`, which runs in the second pass either way. The handler this replaces also assigned it before the `finally` could see it.
- The suspend data keyed by the statement is touched only by `BodyEvaluation` itself, on entry and resume paths that cannot be running while an exception is in flight through them — and nothing in between can reach them, because Jint evaluates a JavaScript `finally` block as forward interpretation of a parked completion (`JintTryStatement.ExecuteFinalizer`) rather than from a CLR `finally`. A CLR unwind through the interpreter carries interpreter bookkeeping and no script code at all.

IteratorClose is still performed with a throw completion, so a failing `return()` is still swallowed rather than allowed to replace the exception in flight (IteratorClose step 5). That is pinned by a test needing no recursion at all — one frame is enough to show which completion was recorded. The conditional rethrow inside that same `finally` is untouched on purpose: it rethrows only when the completion is *not* `Throw`, so it never restarts a dispatch on the path this PR is about.

### Still unconverted

Left exactly as #2994 left them, for the reasons it gave: `DestructuringPatternAssignmentExpression` (three sites, `:62`, `:250`, `:460`), `JintAwaitExpression:265`, `JintYieldExpression:963` and `AsyncGeneratorInstance:278`.

### Pre-fix behaviour of the new tests

They run on a 1 MB dedicated thread — the 16 MB `DedicatedThread.LargeStackSize` default is what has been hiding this whole class of failure from CI. On `main` they do not fail, they take the runner with them. Running only `RecursionLimitFiringInsideAForOfBodyUnwindsToTheHost` against the unpatched engine:

```
[xUnit.net 00:01:02.71]     [FATAL ERROR] Xunit.Sdk.TestPipelineException
[xUnit.net 00:01:02.71] Catastrophic failure: Test process crashed with exit code -1073741571.
No test matches the given testcase filter `FullyQualifiedName~RecursionLimitFiringInsideAForOfBodyUnwindsToTheHost` in ...\Jint.Tests\release_net10.0\Jint.Tests.dll

[xUnit.net 00:01:04.08]     [FATAL ERROR] Xunit.Sdk.TestPipelineException
[xUnit.net 00:01:04.08] Catastrophic failure: Test process crashed with exit code -2147023895.
No test matches the given testcase filter `FullyQualifiedName~RecursionLimitFiringInsideAForOfBodyUnwindsToTheHost` in ...\Jint.Tests\release_net472\Jint.Tests.exe
```

The fourth test (`AnExceptionUnwindingAForOfStillClosesTheIteratorWithAThrowCompletion`) passes on both sides by design — it is the guard on the semantics the mechanism has to preserve, not a repro.

### Verification

All Release, all green:

| suite | net10.0 | net472 |
| --- | --- | --- |
| `Jint.Tests` | 5664 passed, 4 skipped | 5580 passed, 4 skipped |
| `Jint.Tests.PublicInterface` | 1486 passed, 9 skipped | 1485 passed, 9 skipped |
| `Jint.Tests.Test262` | 99779 passed, 122 skipped, 0 failed | n/a (net10.0 only) |
| `Jint.Tests.CommonScripts` | 28 passed | 28 passed |

Closes #3012

🤖 Generated with [Claude Code](https://claude.com/claude-code)
