### PR TITLE
Canonicalize u-extension options and format every date the spec allows

### DIFF
--- a/Jint.Tests/Runtime/DateTests.cs
+++ b/Jint.Tests/Runtime/DateTests.cs
@@ -461,31 +461,49 @@ public class DateTests
     /// try/catch never saw it, the same escape #2954 closed for sort and #2965 for the first instant of
     /// year 10000.
     ///
-    /// These years have no representation in any .NET calendar, so there is no locale-aware string to
-    /// produce; each method answers with what its culture-independent sibling renders instead, which is
-    /// the rendering https://tc39.es/ecma262/#sec-datestring already gives these values from toString.
+    /// #2981 answered those years with the culture-independent rendering their non-locale siblings give,
+    /// because the alternative it wanted — carrying the real fields in on a substitute year congruent
+    /// mod 400 — "needs the whole component pipeline to learn about per-field overrides it does not
+    /// have". It has them now, so these methods produce a real locale string again: the substitute year
+    /// preserves month, day, time and weekday, and the formatter prints the true year over it.
     /// </summary>
     [Theory]
-    [InlineData(8640000000000000)] // the maximum time value, year 275760
-    [InlineData(253402300800001)] // one past what DateTime can hold, year 10000
-    [InlineData(-62135596800001)] // one before what DateTime can hold, year 0
-    [InlineData(-8640000000000000)] // the minimum time value, year -271821
-    public void ToLocaleStringOutsideDateTimeRangeRendersTheCultureIndependentString(long timeValue)
+    // the maximum time value, 275760-09-13T00:00:00.000Z
+    [InlineData(8640000000000000, "9/13/275760, 12:00:00 AM", "9/13/275760", "12:00:00 AM")]
+    // one past what DateTime can hold, +010000-01-01T00:00:00.001Z
+    [InlineData(253402300800001, "1/1/10000, 12:00:00 AM", "1/1/10000", "12:00:00 AM")]
+    // one before what DateTime can hold, 0000-12-31T23:59:59.999Z
+    [InlineData(-62135596800001, "12/31/0, 11:59:59 PM", "12/31/0", "11:59:59 PM")]
+    // the minimum time value, -271821-04-20T00:00:00.000Z
+    [InlineData(-8640000000000000, "4/20/-271821, 12:00:00 AM", "4/20/-271821", "12:00:00 AM")]
+    public void ToLocaleStringOutsideDateTimeRangeRendersALocaleString(
+        long timeValue, string expectedDateTime, string expectedDate, string expectedTime)
     {
         var engine = new Engine(options => options.LocalTimeZone(TimeZoneInfo.Utc));
 
-        engine.Evaluate($"new Date({timeValue}).toLocaleString()").AsString()
-            .Should().Be(engine.Evaluate($"new Date({timeValue}).toString()").AsString());
+        engine.Evaluate($"new Date({timeValue}).toLocaleString('en-US')").AsString().Should().Be(expectedDateTime);
+        engine.Evaluate($"new Date({timeValue}).toLocaleDateString('en-US')").AsString().Should().Be(expectedDate);
+        engine.Evaluate($"new Date({timeValue}).toLocaleTimeString('en-US')").AsString().Should().Be(expectedTime);
+    }
 
-        engine.Evaluate($"new Date({timeValue}).toLocaleDateString()").AsString()
-            .Should().Be(engine.Evaluate($"new Date({timeValue}).toDateString()").AsString());
+    /// <summary>
+    /// The options bag reaches these years now rather than being read, validated and discarded.
+    /// </summary>
+    [Fact]
+    public void ToLocaleStringOutsideDateTimeRangeHonoursTheOptionsBag()
+    {
+        var engine = new Engine(options => options.LocalTimeZone(TimeZoneInfo.Utc));
 
-        engine.Evaluate($"new Date({timeValue}).toLocaleTimeString()").AsString()
-            .Should().Be(engine.Evaluate($"new Date({timeValue}).toTimeString()").AsString());
+        engine.Evaluate("new Date(8640000000000000).toLocaleString('en-US', { month: 'long' })")
+            .AsString().Should().Be("September");
 
-        // A locale and an options bag are still read and validated; they simply cannot change the answer.
-        engine.Evaluate($"new Date({timeValue}).toLocaleString('de-DE', {{ month: 'long' }})").AsString()
-            .Should().Be(engine.Evaluate($"new Date({timeValue}).toString()").AsString());
+        engine.Evaluate("new Date(8640000000000000).toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })")
+            .AsString().Should().Be("Saturday September 13, 275760");
+
+        // A malformed locale is still a RangeError: the formatter is constructed before anything is
+        // rendered, and none of its validation may be skipped.
+        engine.Evaluate("(function () { try { return new Date(8640000000000000).toLocaleString('!!bad!!'); } catch (e) { return e.constructor.name; } })()")
+            .AsString().Should().Be("RangeError");
     }
 
     /// <summary>
@@ -522,11 +540,13 @@ public class DateTests
     }
 
     /// <summary>
-    /// The fallback is reached only where the locale path cannot go. A date .NET can represent is still
-    /// formatted by ECMA-402, and the two renderings do not look alike.
+    /// There is no switch left to land on the wrong side of: the millisecond either side of the end of
+    /// <see cref="DateTime"/>'s range is formatted by ECMA-402, and neither looks like what
+    /// https://tc39.es/ecma262/#sec-datestring renders. #2981 made the second of these two answer with
+    /// the culture-independent string, and that is the 4.16.0 behaviour this changes.
     /// </summary>
     [Fact]
-    public void ToLocaleStringInsideDateTimeRangeIsStillLocaleFormatted()
+    public void ToLocaleStringIsLocaleFormattedOnBothSidesOfTheDateTimeBoundary()
     {
         var engine = new Engine(options => options.LocalTimeZone(TimeZoneInfo.Utc));
 
@@ -534,11 +554,16 @@ public class DateTests
         localeString.Should().NotBe(engine.Evaluate("new Date(0).toString()").AsString());
         localeString.Should().Contain("1970");
 
-        // The two instants either side of DateTime.MaxValue land on opposite sides of the switch.
         engine.Evaluate("new Date(253402300799999).toLocaleDateString('en-US')").AsString()
-            .Should().NotBe(engine.Evaluate("new Date(253402300799999).toDateString()").AsString());
+            .Should().Be("12/31/9999");
         engine.Evaluate("new Date(253402300800001).toLocaleDateString('en-US')").AsString()
-            .Should().Be(engine.Evaluate("new Date(253402300800001).toDateString()").AsString());
+            .Should().Be("1/1/10000");
+
+        foreach (var timeValue in new[] { "253402300799999", "253402300800001" })
+        {
+            engine.Evaluate($"new Date({timeValue}).toLocaleDateString('en-US')").AsString()
+                .Should().NotBe(engine.Evaluate($"new Date({timeValue}).toDateString()").AsString());
+        }
     }
 
     /// <summary>

--- a/Jint.Tests/Runtime/IntlTests.cs
+++ b/Jint.Tests/Runtime/IntlTests.cs
@@ -375,12 +375,37 @@ public class IntlTests
         // The "type" nonterminal is built from alphanum, [0-9 A-Z a-z], and Unicode locale
         // identifiers are case-insensitive, so casing cannot make a value unmatchable and 9.2.8
         // step 6.d.ii cannot fire on it. Which collation such a value then resolves to is
-        // ResolveLocale's business, not this check's: 9.2.7 step 10 runs the option value through
-        // CanonicalizeUValue before comparing it against the [[co]] list, which Jint does not yet
-        // do, so 'PHONEBK' still falls back to "default" where the spec resolves it to "phonebk".
-        // That is a separate defect and is deliberately not pinned here.
+        // ResolveLocale's business, not this check's; that half is pinned by
+        // CollatorCanonicalizesACollationOptionBeforeMatchingIt below.
         _engine.Evaluate($"(() => {{ try {{ new Intl.Collator('de', {{ collation: '{collation}' }}); return 'no throw'; }} catch (e) {{ return e.constructor.name; }} }})()")
             .AsString().Should().Be("no throw");
+    }
+
+    [Theory]
+    [InlineData("phonebk")]
+    [InlineData("PHONEBK")]
+    [InlineData("Phonebk")]
+    [InlineData("pHoNeBk")]
+    public void CollatorCanonicalizesACollationOptionBeforeMatchingIt(string collation)
+    {
+        // https://tc39.es/ecma402/#sec-resolvelocale (9.2.7) step 10 runs an option value through
+        // CanonicalizeUValue before asking whether keyLocaleData contains it, and
+        // https://tc39.es/ecma402/#sec-canonicalizeuvalue (9.2.2) step 1 is "Let lowerValue be the
+        // ASCII-lowercase of uvalue". Jint compared the raw string against the [[co]] list with
+        // StringComparison.Ordinal, so every spelling but the all-lowercase one missed the list and
+        // fell through to "default" - a silently wrong collator rather than an error.
+        _engine.Evaluate($"new Intl.Collator('de', {{ collation: '{collation}' }}).resolvedOptions().collation")
+            .AsString().Should().Be("phonebk");
+    }
+
+    [Fact]
+    public void CollatorKeepsAnOptionSourcedCollationOutOfTheResolvedLocale()
+    {
+        // ResolveLocale only copies a keyword onto [[locale]] when the value came from the requested
+        // locale's own extension sequence (supportedKeyword is set to empty as soon as an options
+        // value supersedes it), so canonicalizing the option must not start emitting "-u-co-".
+        _engine.Evaluate("new Intl.Collator('de', { collation: 'PHONEBK' }).resolvedOptions().locale")
+            .AsString().Should().Be("de");
     }
 
     // Intl.NumberFormat tests
@@ -1095,5 +1120,193 @@ public class IntlTests
             """);
         result.AsString().Should().Be(
             "true true true compat,dict,emoji,eor,phonebk,phonetic,pinyin,searchjl,stroke,trad,unihan,zhuyin");
+    }
+
+    [Theory]
+    // Case folding alone.
+    [InlineData("de", "collation", "PHONEBK", "de-u-co-phonebk")]
+    [InlineData("en", "calendar", "GREGORY", "en-u-ca-gregory")]
+    [InlineData("en", "numberingSystem", "LATN", "en-u-nu-latn")]
+    // Alias substitution, which already worked, kept here so a regression in either half shows.
+    [InlineData("en", "calendar", "islamicc", "en-u-ca-islamic-civil")]
+    [InlineData("en", "calendar", "ethiopic-amete-alem", "en-u-ca-ethioaa")]
+    // Both at once: the fold has to happen before the alias lookup, not instead of it.
+    [InlineData("en", "calendar", "ISLAMICC", "en-u-ca-islamic-civil")]
+    [InlineData("en", "calendar", "Ethiopic-Amete-Alem", "en-u-ca-ethioaa")]
+    public void LocaleCanonicalizesAUnicodeExtensionOptionValue(string tag, string option, string value, string expected)
+    {
+        // https://tc39.es/ecma402/#sec-makelocalerecord (15.1.3) sets the keyword's value to
+        // CanonicalizeUValue(key, overrideValue) for every option that overrides the tag, so the
+        // extension sequence Intl.Locale builds carries the canonical spelling and never the one the
+        // caller happened to type.
+        _engine.Evaluate($"new Intl.Locale('{tag}', {{ {option}: '{value}' }}).toString()")
+            .AsString().Should().Be(expected);
+    }
+
+    [Fact]
+    public void LocaleReportsACanonicalizedOptionValueFromItsAccessors()
+    {
+        // The accessors read the same [[Collation]]/[[NumberingSystem]] slots MakeLocaleRecord filled,
+        // so an uncanonicalized option leaked out of getCollations() as well - Intl.Locale advertising
+        // a collation identifier that exists in no CLDR data at all.
+        _engine.Evaluate("new Intl.Locale('de', { collation: 'PHONEBK' }).collation").AsString().Should().Be("phonebk");
+        _engine.Evaluate("JSON.stringify(new Intl.Locale('de', { collation: 'PHONEBK' }).getCollations())")
+            .AsString().Should().Be("""["phonebk"]""");
+        _engine.Evaluate("new Intl.Locale('en', { numberingSystem: 'LATN' }).numberingSystem").AsString().Should().Be("latn");
+        _engine.Evaluate("new Intl.Locale('en', { calendar: 'GREGORY' }).calendar").AsString().Should().Be("gregory");
+    }
+
+    [Theory]
+    [InlineData("latn", "latn")]
+    [InlineData("LATN", "latn")]
+    [InlineData("Latn", "latn")]
+    [InlineData("arab", "arab")]
+    [InlineData("ARAB", "arab")]
+    // Well formed by the "type" nonterminal and matched by no numbering system: 9.2.7 step 10 only
+    // replaces the resolved value when keyLocaleData contains the canonicalized option, so this has
+    // to fall back to the locale's default rather than throw.
+    [InlineData("abc-def", "latn")]
+    [InlineData("zzzzz", "latn")]
+    public void NumberFormatCanonicalizesANumberingSystemOption(string numberingSystem, string expected)
+    {
+        // The validator here was stricter than the grammar it was standing in for: it required
+        // char.IsAsciiLetterLower, so "LATN" was a RangeError instead of "latn", and it rejected the
+        // hyphen outright, so a well-formed multi-subtag value threw where it should merely have
+        // failed to match.
+        _engine.Evaluate($"new Intl.NumberFormat('en', {{ numberingSystem: '{numberingSystem}' }}).resolvedOptions().numberingSystem")
+            .AsString().Should().Be(expected);
+    }
+
+    [Theory]
+    // The invalid list of intl402/NumberFormat/constructor-options-numberingSystem-invalid.js: what
+    // relaxing the validator must not start accepting.
+    [InlineData("")]
+    [InlineData("a")]
+    [InlineData("ab")]
+    [InlineData("abcdefghi")]
+    [InlineData("abc-abcdefghi")]
+    [InlineData("!invalid!")]
+    [InlineData("-latn-")]
+    [InlineData("latn-")]
+    [InlineData("latn--")]
+    [InlineData("latn-ca")]
+    [InlineData("latn-ca-")]
+    [InlineData("latn-ca-gregory")]
+    public void NumberFormatRejectsANumberingSystemOptionTheTypeNonterminalDoesNotMatch(string numberingSystem)
+    {
+        _engine.Evaluate($"(() => {{ try {{ new Intl.NumberFormat('en', {{ numberingSystem: '{numberingSystem}' }}); return 'no throw'; }} catch (e) {{ return e.constructor.name; }} }})()")
+            .AsString().Should().Be("RangeError");
+    }
+
+    [Theory]
+    [InlineData("LATN", "latn")]
+    [InlineData("ARAB", "arab")]
+    [InlineData("arab", "arab")]
+    public void DurationFormatCanonicalizesANumberingSystemOption(string numberingSystem, string expected)
+    {
+        _engine.Evaluate($"new Intl.DurationFormat('en', {{ numberingSystem: '{numberingSystem}' }}).resolvedOptions().numberingSystem")
+            .AsString().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("LATN", "latn")]
+    [InlineData("ARAB", "arab")]
+    [InlineData("arab", "arab")]
+    public void RelativeTimeFormatCanonicalizesANumberingSystemOption(string numberingSystem, string expected)
+    {
+        _engine.Evaluate($"new Intl.RelativeTimeFormat('en', {{ numberingSystem: '{numberingSystem}' }}).resolvedOptions().numberingSystem")
+            .AsString().Should().Be(expected);
+    }
+
+    [Fact]
+    public void DateTimeFormatCanonicalizesItsUnicodeExtensionOptions()
+    {
+        // DateTimeFormat already adopted the canonical spelling, because it matches an option against
+        // its supported list with StringComparison.OrdinalIgnoreCase and then keeps the list's entry
+        // rather than the caller's. Pinned so the shared helper cannot regress it.
+        _engine.Evaluate("new Intl.DateTimeFormat('en', { numberingSystem: 'LATN' }).resolvedOptions().numberingSystem")
+            .AsString().Should().Be("latn");
+        _engine.Evaluate("new Intl.DateTimeFormat('en', { calendar: 'GREGORY' }).resolvedOptions().calendar")
+            .AsString().Should().Be("gregory");
+    }
+
+    [Theory]
+    // The maximum time value: 275760-09-13T00:00:00.000Z.
+    [InlineData(8640000000000000L, "9/13/275760")]
+    // The minimum time value: -271821-04-20T00:00:00.000Z.
+    [InlineData(-8640000000000000L, "4/20/-271821")]
+    // One millisecond past what DateTime can hold: +010000-01-01T00:00:00.001Z.
+    [InlineData(253402300800001L, "1/1/10000")]
+    // One millisecond before it: 0000-12-31T23:59:59.999Z.
+    [InlineData(-62135596800001L, "12/31/0")]
+    public void DateTimeFormatKeepsEveryDateFieldOfAValueOutsideDateTimeRange(long timeValue, string expected)
+    {
+        // The conversion clamped an out-of-range time value to DateTime.MinValue/MaxValue and carried
+        // only the year out beside it, so month and day came from the clamp: the maximum time value
+        // formatted as December 31 rather than September 13. It now decomposes the time value itself
+        // and formats on a representative year congruent mod 400, which is where the real month, day,
+        // time and weekday survive.
+        _engine.Evaluate($"new Intl.DateTimeFormat('en-US', {{ timeZone: 'UTC' }}).format(new Date({timeValue}))")
+            .AsString().Should().Be(expected);
+    }
+
+    [Fact]
+    public void DateTimeFormatKeepsTheTimeFieldsOfAValueOutsideDateTimeRange()
+    {
+        // The year was re-inserted as a quoted literal, and BuildFormatString classifies a part whose
+        // first character is an apostrophe as an hour - so it inserted the date/time separator in front
+        // of the year and then ran the real time fields together behind it:
+        // "12/31, 27576011:59:59 PM".
+        _engine.Evaluate("""
+            new Intl.DateTimeFormat('en-US', {
+                timeZone: 'UTC', year: 'numeric', month: 'numeric', day: 'numeric',
+                hour: 'numeric', minute: 'numeric', second: 'numeric'
+            }).format(new Date(8640000000000000))
+            """).AsString().Should().Be("9/13/275760, 12:00:00 AM");
+
+        _engine.Evaluate("""
+            new Intl.DateTimeFormat('en-US', {
+                timeZone: 'UTC', year: 'numeric', month: 'numeric', day: 'numeric',
+                hour: 'numeric', minute: 'numeric', second: 'numeric'
+            }).format(new Date(-62135596800001))
+            """).AsString().Should().Be("12/31/0, 11:59:59 PM");
+    }
+
+    [Fact]
+    public void DateTimeFormatToPartsReportsTheRealFieldsOfAValueOutsideDateTimeRange()
+    {
+        _engine.Evaluate("""
+            JSON.stringify(new Intl.DateTimeFormat('en-US', { timeZone: 'UTC' })
+                .formatToParts(new Date(8640000000000000))
+                .filter(p => p.type !== 'literal')
+                .map(p => p.type + '=' + p.value))
+            """).AsString().Should().Be("""["month=9","day=13","year=275760"]""");
+    }
+
+    [Fact]
+    public void DateTimeFormatCarriesTheRealYearThroughDateStyle()
+    {
+        // FormatStyleToParts took originalYear and dropped it on the floor, so a styled format of an
+        // out-of-range date printed the clamp's year 9999 with no sign that anything was wrong.
+        _engine.Evaluate("new Intl.DateTimeFormat('en-US', { timeZone: 'UTC', dateStyle: 'long' }).format(new Date(8640000000000000))")
+            .AsString().Should().Be("September 13, 275760");
+
+        // "full" additionally pins the weekday, which is what the representative year being congruent
+        // mod 400 buys: the maximum time value really is a Saturday.
+        _engine.Evaluate("new Intl.DateTimeFormat('en-US', { timeZone: 'UTC', dateStyle: 'full' }).format(new Date(8640000000000000))")
+            .AsString().Should().Be("Saturday, September 13, 275760");
+
+        _engine.Evaluate("new Intl.DateTimeFormat('en-US', { timeZone: 'UTC', dateStyle: 'full', timeStyle: 'short' }).format(new Date(8640000000000000))")
+            .AsString().Should().Be("Saturday, September 13, 275760, 12:00 AM");
+    }
+
+    [Fact]
+    public void DateTimeFormatStillAgreesWithItselfInsideDateTimeRange()
+    {
+        // The control: nothing above may move a date the platform can hold.
+        _engine.Evaluate("new Intl.DateTimeFormat('en-US', { timeZone: 'UTC' }).format(new Date(Date.UTC(2024, 2, 15)))")
+            .AsString().Should().Be("3/15/2024");
+        _engine.Evaluate("new Intl.DateTimeFormat('en-US', { timeZone: 'UTC', dateStyle: 'full' }).format(new Date(Date.UTC(2024, 2, 15)))")
+            .AsString().Should().Be("Friday, March 15, 2024");
     }
 }

--- a/Jint/Native/Date/DatePrototype.cs
+++ b/Jint/Native/Date/DatePrototype.cs
@@ -168,8 +168,8 @@ internal sealed partial class DatePrototype : Prototype
     }
 
     /// <summary>
-    /// https://tc39.es/ecma262/#sec-date.prototype.tolocalestring
-    /// https://tc39.es/ecma402/#sup-date.prototype.tolocalestring
+    /// The time value a toLocale* method hands to <see cref="JsDateTimeFormat"/>, plus the real year
+    /// when that is one no <see cref="DateTime"/> can hold.
     ///
     /// ECMA-402's FormatDateTime is defined for every valid time value, but the machinery behind it here
     /// is <see cref="DateTime"/> and the .NET calendars, which reach from year 1 to year 9999 and no
@@ -178,21 +178,30 @@ internal sealed partial class DatePrototype : Prototype
     /// Converting one of those threw ArgumentOutOfRangeException out of engine.Evaluate, and a CLR
     /// exception is not something a script try/catch can see.
     ///
-    /// What the three toLocale* methods answer with instead is the culture-independent rendering their
-    /// non-locale siblings already give the same value: https://tc39.es/ecma262/#sec-datestring and
-    /// https://tc39.es/ecma262/#sec-timestring are pure integer arithmetic on the time value and render
-    /// year 275760 as readily as year 2026. Two alternatives were weighed and rejected. Clamping the
-    /// DateTime to MinValue/MaxValue and overriding only the year — which is what the format method on
-    /// Intl.DateTimeFormat does today — keeps the locale's shape but takes month, day and time from the
-    /// clamp, so new Date(8640000000000000) renders as December 31 rather than September 13. And
-    /// carrying the real fields in on a substitute year congruent mod 400 would need the whole component
-    /// pipeline to learn about overrides it does not have, for a band of years no non-Gregorian calendar
-    /// can express anyway. Being wrong in the locale's shape is worse than being right in nobody's, and
-    /// the string a caller gets now is the one Date.prototype.toString would have given them.
+    /// #2981 closed that escape by answering those years with the culture-independent rendering their
+    /// non-locale siblings give, because the alternative it preferred — carrying the real fields in on a
+    /// substitute year congruent mod 400 — "needs the whole component pipeline to learn about per-field
+    /// overrides it does not have". It has them now, so that alternative is what happens instead: the
+    /// substitute carries month, day, time and weekday, and the formatter prints the real year over it.
+    /// </summary>
+    private static DateTime ToFormattableDateTime(DatePresentation t, out int? originalYear)
+    {
+        if (t.DateTimeRangeValid)
+        {
+            originalYear = null;
+            return t.ToDateTime();
+        }
+
+        return DateTimeFormatPrototype.FromTimeValueUtc(t, out originalYear);
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-date.prototype.tolocalestring
+    /// https://tc39.es/ecma402/#sup-date.prototype.tolocalestring
     ///
-    /// The formatter is still constructed first: CreateDateTimeFormat reads the locale list and the
-    /// options bag and rejects what the spec says to reject, and none of that may be skipped just
-    /// because the year is out of reach.
+    /// The formatter is constructed before anything is rendered: CreateDateTimeFormat reads the locale
+    /// list and the options bag and rejects what the spec says to reject, and none of that may be
+    /// skipped. See <see cref="ToFormattableDateTime"/> for the years the platform cannot hold.
     /// </summary>
     [JsFunction]
     private JsValue ToLocaleString(JsValue thisObject, JsCallArguments arguments)
@@ -231,12 +240,8 @@ internal sealed partial class DatePrototype : Prototype
         // Pass UTC time; DTF handles timezone conversion based on its timeZone option
         var dateTimeFormat = (JsDateTimeFormat) Engine.Realm.Intrinsics.DateTimeFormat.Construct([locales, options], Engine.Realm.Intrinsics.DateTimeFormat);
 
-        if (!dateInstance.DateTimeRangeValid)
-        {
-            return ToDateString(dateInstance);
-        }
-
-        return dateTimeFormat.Format(dateInstance.ToDateTime());
+        var dateTime = ToFormattableDateTime(dateInstance, out var originalYear);
+        return dateTimeFormat.Format(dateTime, originalYear);
     }
 
     /// <summary>
@@ -279,12 +284,8 @@ internal sealed partial class DatePrototype : Prototype
         // Pass UTC time; DTF handles timezone conversion based on its timeZone option
         var dateTimeFormat = (JsDateTimeFormat) Engine.Realm.Intrinsics.DateTimeFormat.Construct([locales, options], Engine.Realm.Intrinsics.DateTimeFormat);
 
-        if (!dateInstance.DateTimeRangeValid)
-        {
-            return DateString(LocalTime(dateInstance));
-        }
-
-        return dateTimeFormat.Format(dateInstance.ToDateTime());
+        var dateTime = ToFormattableDateTime(dateInstance, out var originalYear);
+        return dateTimeFormat.Format(dateTime, originalYear);
     }
 
     /// <summary>
@@ -327,12 +328,8 @@ internal sealed partial class DatePrototype : Prototype
         // Pass UTC time; DTF handles timezone conversion based on its timeZone option
         var dateTimeFormat = (JsDateTimeFormat) Engine.Realm.Intrinsics.DateTimeFormat.Construct([locales, options], Engine.Realm.Intrinsics.DateTimeFormat);
 
-        if (!dateInstance.DateTimeRangeValid)
-        {
-            return TimeString(LocalTime(dateInstance)) + TimeZoneString(dateInstance);
-        }
-
-        return dateTimeFormat.Format(dateInstance.ToDateTime());
+        var dateTime = ToFormattableDateTime(dateInstance, out var originalYear);
+        return dateTimeFormat.Format(dateTime, originalYear);
     }
 
     /// <summary>
@@ -1478,6 +1475,28 @@ internal sealed partial class DatePrototype : Prototype
 
     [StructLayout(LayoutKind.Auto)]
     private readonly record struct Date(int Year, int Month, int Day);
+
+    /// <summary>
+    /// The calendar fields of a time value, with <see cref="Month"/> 1-based as every consumer outside
+    /// this class wants it (<see cref="Date.Month"/> is the spec's 0-based MonthFromTime).
+    /// </summary>
+    [StructLayout(LayoutKind.Auto)]
+    internal readonly record struct TimeValueFields(int Year, int Month, int Day, int Hour, int Minute, int Second, int Millisecond);
+
+    /// <summary>
+    /// Decomposes a time value into its ECMAScript calendar fields, for the whole range
+    /// https://tc39.es/ecma262/#sec-timeclip admits — years -271821 through 275760, which is far wider
+    /// than any <see cref="DateTime"/> can hold. Exposed because Intl.DateTimeFormat needs exactly this
+    /// for a value it cannot convert, and its own partial copy of the arithmetic (a YearFromTime built
+    /// on a floating-point estimate plus a linear search) was a third implementation of what
+    /// <see cref="YearMonthDayFromDays"/> already does correctly, negative years included.
+    /// </summary>
+    internal static TimeValueFields FieldsFromTimeValue(DatePresentation t)
+    {
+        var date = YearMonthDayFromTime(t);
+        return new TimeValueFields(date.Year, date.Month + 1, date.Day,
+            HourFromTime(t), MinFromTime(t), SecFromTime(t), MsFromTime(t));
+    }
 
     private static readonly int[] kDaysInMonths = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 

--- a/Jint/Native/Intl/CollatorConstructor.cs
+++ b/Jint/Native/Intl/CollatorConstructor.cs
@@ -408,6 +408,13 @@ internal sealed partial class CollatorConstructor : Constructor
                 Throw.RangeError(_realm, $"Invalid value '{collation}' for option 'collation'");
             }
 
+            // 9.2.7 step 10 canonicalizes the option value before asking whether the [[co]] list
+            // contains it, and CanonicalizeUValue (9.2.2) starts by ASCII-lowercasing. Without this
+            // every spelling but the all-lowercase one missed the list below - which compares
+            // ordinally, as it must, now that what reaches it is canonical - and fell through to
+            // "default", so 'PHONEBK' silently produced a collator 'phonebk' would not have.
+            collation = IntlUtilities.CanonicalizeUValue("co", collation);
+
             if (IsCollationSupportedForLocale(langCode, collation))
             {
                 return collation;

--- a/Jint/Native/Intl/DateTimeFormatPrototype.cs
+++ b/Jint/Native/Intl/DateTimeFormatPrototype.cs
@@ -1,4 +1,5 @@
 ﻿using System.Numerics;
+using Jint.Native.Date;
 using Jint.Native.Object;
 using Jint.Native.Temporal;
 using Jint.Runtime;
@@ -451,8 +452,22 @@ internal sealed partial class DateTimeFormatPrototype : Prototype
     }
 
     /// <summary>
-    /// Creates a DateTime, using a representative year if the actual year is outside .NET's 1-9999 range.
-    /// The representative year preserves leap year status and day-of-week alignment (Gregorian 400-year cycle).
+    /// Creates a <see cref="DateTime"/>, substituting a representative year when the real one is
+    /// outside .NET's 1-9999 range and reporting the real one through <paramref name="originalYear"/>
+    /// for the formatter to print over it.
+    ///
+    /// The representative is congruent to the real year modulo 400, the length of the Gregorian cycle,
+    /// so leap status, weekday and every day-of-year alignment carry over untouched — the proleptic
+    /// Gregorian leap rule reads nothing but the year mod 400, for negative years as much as positive
+    /// ones, and 400 years is a whole number of weeks (146097 days = 20871 weeks). Everything except
+    /// the year itself is therefore already right on the substitute, which is what lets a single
+    /// per-field override carry the whole date.
+    ///
+    /// The representative is taken from 401-800 rather than 1-400 for one reason: what the formatter
+    /// does next is convert this value into the resolved time zone, and <see cref="TimeZoneInfo"/>
+    /// saturates at <see cref="DateTime.MinValue"/>/<see cref="DateTime.MaxValue"/> rather than
+    /// wrapping, so a representative sitting on the first day of year 1 would lose its time and its day
+    /// to the clamp for any zone behind UTC.
     /// </summary>
     private static DateTime CreateDateTimeSafe(int year, int month, int day, int hour, int minute, int second, int millisecond, out int? originalYear)
     {
@@ -463,29 +478,11 @@ internal sealed partial class DateTimeFormatPrototype : Prototype
         }
 
         originalYear = year;
-        // Map to representative year in 1-400 range preserving leap year and day-of-week
-        var repYear = ((year - 1) % 400 + 400) % 400 + 1;
+        var repYear = ((year - 1) % 400 + 400) % 400 + 401;
 
-        // Ensure leap year match: if the original year is a leap year but repYear isn't (or vice versa),
-        // adjust by searching nearby in the 400-year cycle
-        var needLeap = DateTime.IsLeapYear(IsLeapYearISO(year) ? 4 : 1); // use IsLeapYearISO for negative years
-        if (IsLeapYearISO(year) != DateTime.IsLeapYear(repYear))
-        {
-            // Shift to nearest matching leap year status within valid range
-            // Leap years in a 400-year cycle: every 4 except 100 except 400
-            for (var offset = 1; offset <= 400; offset++)
-            {
-                var candidate = repYear + offset;
-                if (candidate > 400) candidate -= 400;
-                if (DateTime.IsLeapYear(candidate) == IsLeapYearISO(year))
-                {
-                    repYear = candidate;
-                    break;
-                }
-            }
-        }
-
-        // For non-leap year rep when day is 29 Feb, constrain to 28
+        // 29 February exists in the representative year exactly when it exists in the real one, by the
+        // congruence above. The guard stays as an assertion of that rather than as a fix-up: if it ever
+        // fires, the representative has stopped being congruent and the weekday is wrong too.
         if (month == 2 && day == 29 && !DateTime.IsLeapYear(repYear))
         {
             day = 28;
@@ -495,13 +492,21 @@ internal sealed partial class DateTimeFormatPrototype : Prototype
     }
 
     /// <summary>
-    /// ISO 8601 leap year calculation (works for negative years).
+    /// The UTC instant a time value names, as a <see cref="DateTime"/> the platform can hold: the real
+    /// one when the year fits, and otherwise the representative <see cref="CreateDateTimeSafe"/> builds
+    /// with the real year handed back through <paramref name="originalYear"/>.
+    ///
+    /// Deliberately unconverted and <see cref="DateTimeKind.Utc"/>: the formatter's own timezone step
+    /// converts it into the resolved zone, which is the only place that knows what
+    /// <c>options.timeZone</c> resolved to, and it converts an out-of-range value on exactly the terms
+    /// it converts an in-range one.
     /// </summary>
-    private static bool IsLeapYearISO(int year)
+    internal static DateTime FromTimeValueUtc(DatePresentation timeValue, out int? originalYear)
     {
-        // For negative years, convert to proleptic Gregorian
-        var y = year > 0 ? year : 1 - year; // year 0 = 1 BC, -1 = 2 BC, etc.
-        return (y % 4 == 0) && (y % 100 != 0 || y % 400 == 0);
+        var fields = DatePrototype.FieldsFromTimeValue(timeValue);
+        var dateTime = CreateDateTimeSafe(fields.Year, fields.Month, fields.Day,
+            fields.Hour, fields.Minute, fields.Second, fields.Millisecond, out originalYear);
+        return DateTime.SpecifyKind(dateTime, DateTimeKind.Utc);
     }
 
     /// <summary>
@@ -633,8 +638,15 @@ internal sealed partial class DateTimeFormatPrototype : Prototype
     }
 
     /// <summary>
-    /// Converts a JavaScript value to DateTime, returning the original JavaScript year
-    /// when the date is outside .NET DateTime range (for proper era formatting).
+    /// Converts a JavaScript value to a <see cref="DateTime"/> the formatter can work on, reporting the
+    /// real JavaScript year through <paramref name="originalYear"/> when it is one no
+    /// <see cref="DateTime"/> can hold.
+    ///
+    /// An out-of-range value used to be clamped to <see cref="DateTime.MinValue"/>/
+    /// <see cref="DateTime.MaxValue"/> with only the year carried out beside it, so month, day and every
+    /// time field came from the clamp: the maximum time value formatted as December 31 rather than
+    /// September 13. It is decomposed instead, onto a representative year that keeps all of them —
+    /// see <see cref="FromTimeValueUtc"/>.
     /// </summary>
     private DateTime ToDateTimeWithOriginalYear(JsValue value, out int? originalYear)
     {
@@ -646,13 +658,19 @@ internal sealed partial class DateTimeFormatPrototype : Prototype
 
         if (value is JsDate jsDate)
         {
-            // Check if date is within .NET DateTime range
+            // ToDateTimeFormattable keeps a Date object as itself where the spec converts it to a
+            // Number, so HandleDateTimeValue's "If x is not a finite Number, throw a RangeError" has to
+            // be made here as well. It reached the Number branch below and nothing else, which was
+            // invisible only because the year the clamp produced for a NaN time value was garbage
+            // either way; decomposing the time value would have answered 1/1/1970 instead.
+            if (double.IsNaN(jsDate.DateValue))
+            {
+                Throw.RangeError(_realm, "Invalid time value");
+            }
+
             if (!jsDate.DateTimeRangeValid)
             {
-                // Extract the original JavaScript year from the date value
-                originalYear = GetJavaScriptYear(jsDate.DateValue);
-                // Date is outside .NET range - return min/max based on sign
-                return jsDate.DateValue < 0 ? DateTime.MinValue : DateTime.MaxValue;
+                return FromTimeValueUtc(jsDate.DateValue, out originalYear);
             }
 
             // ECMA-402 requires formatting in local time unless a specific timezone is provided
@@ -674,62 +692,13 @@ internal sealed partial class DateTimeFormatPrototype : Prototype
             Throw.RangeError(_realm, "Invalid time value");
         }
 
-        // Clamp to .NET DateTime range if necessary
-        if (presentation.Value < JsDate.Min)
+        if (!presentation.DateTimeRangeValid)
         {
-            originalYear = GetJavaScriptYear(presentation.Value);
-            return DateTime.MinValue;
-        }
-
-        if (presentation.Value > JsDate.Max)
-        {
-            originalYear = GetJavaScriptYear(presentation.Value);
-            return DateTime.MaxValue;
+            return FromTimeValueUtc(presentation, out originalYear);
         }
 
         originalYear = null;
         return presentation.ToDateTime().ToLocalTime();
-    }
-
-    /// <summary>
-    /// Extracts the JavaScript year from a timestamp value using the ECMAScript algorithm.
-    /// JavaScript Date uses milliseconds since Unix epoch (1970-01-01).
-    /// </summary>
-    private static int GetJavaScriptYear(double timeValue)
-    {
-        // ECMAScript YearFromTime algorithm
-        // https://tc39.es/ecma262/#sec-yearfromtime
-        const double msPerDay = 86400000;
-
-        // Day number from epoch
-        var day = System.Math.Floor(timeValue / msPerDay);
-
-        // Estimate year (rough approximation to start binary search)
-        var year = (int) (1970 + day / 365.2425);
-
-        // Binary search refinement for exact year
-        while (DayFromYear(year + 1) <= day)
-        {
-            year++;
-        }
-        while (DayFromYear(year) > day)
-        {
-            year--;
-        }
-
-        return year;
-    }
-
-    /// <summary>
-    /// Returns the day number of the first day of a given year (ECMAScript algorithm).
-    /// </summary>
-    private static double DayFromYear(int year)
-    {
-        // https://tc39.es/ecma262/#sec-dayfromyear
-        return 365.0 * (year - 1970)
-               + System.Math.Floor((year - 1969) / 4.0)
-               - System.Math.Floor((year - 1901) / 100.0)
-               + System.Math.Floor((year - 1601) / 400.0);
     }
 
     /// <summary>

--- a/Jint/Native/Intl/DurationFormatConstructor.cs
+++ b/Jint/Native/Intl/DurationFormatConstructor.cs
@@ -283,7 +283,10 @@ internal sealed partial class DurationFormatConstructor : Constructor
             Throw.RangeError(_realm, $"Invalid numbering system: {stringValue}");
         }
 
-        return stringValue;
+        // 9.2.7 step 10. ResolveNumberingSystem below probes NumberingSystemData.Digits, which is keyed
+        // OrdinalIgnoreCase, so an uncanonicalized 'LATN' was accepted and then reported back verbatim
+        // from resolvedOptions() as a numbering system identifier that does not exist.
+        return IntlUtilities.CanonicalizeUValue("nu", stringValue);
     }
 
     private static string? ParseNumberingSystemExtension(string locale)

--- a/Jint/Native/Intl/IntlUtilities.cs
+++ b/Jint/Native/Intl/IntlUtilities.cs
@@ -869,6 +869,98 @@ internal static class IntlUtilities
     }
 
     /// <summary>
+    /// https://tc39.es/ecma402/#sec-canonicalizeuvalue (9.2.2) — the canonical, case-regularized form
+    /// of <paramref name="value"/> read as a value of the Unicode extension key
+    /// <paramref name="unicodeKey"/>: step 1 ASCII-lowercases it, step 2 canonicalizes it per UTS #35
+    /// Annex C, and the note names the CLDR <c>common/bcp47</c> data as what to canonicalize against —
+    /// which is what <see cref="LocaleData.UnicodeMappings"/> carries.
+    ///
+    /// Every path that reads a Unicode extension value out of a locale <em>tag</em> already got both
+    /// halves, because the tag parsers lowercase as they go and CanonicalizeUnicodeLocaleId applies the
+    /// same alias data to the extension sequence. The options bag had neither, so
+    /// https://tc39.es/ecma402/#sec-resolvelocale (9.2.7) step 10 — "Set optionsValue to
+    /// CanonicalizeUValue(ukey, optionsValue)", immediately before asking whether keyLocaleData contains
+    /// it — and https://tc39.es/ecma402/#sec-makelocalerecord (15.1.3), which does the same for
+    /// Intl.Locale, both compared the caller's spelling instead of the canonical one.
+    ///
+    /// The value is expected to have passed <see cref="IsValidUnicodeExtensionValue"/> first: that is
+    /// https://tc39.es/ecma402/#sec-resolveoptions (9.2.8) step 6.d.ii, and the two are deliberately
+    /// separate, because an ill-formed value is a RangeError however the locale would have resolved a
+    /// well-formed one.
+    /// </summary>
+    internal static string CanonicalizeUValue(string unicodeKey, string value)
+    {
+        var lowerValue = AsciiLowercase(value);
+
+        if (!LocaleData.UnicodeMappings.TryGetValue(unicodeKey, out var aliases))
+        {
+            // No bcp47 alias data for this key — "co" and "nu" have none, so the fold is the whole of
+            // their canonicalization. A key gaining data later is picked up here without a code change.
+            return lowerValue;
+        }
+
+        // The whole value first, so a hyphenated alias such as "ethiopic-amete-alem" is matched as the
+        // one key it is, then subtag by subtag — the same order CanonicalizeUnicodeLocaleId applies to
+        // a tag's own extension sequence.
+        if (aliases.TryGetValue(lowerValue, out var canonical))
+        {
+            return canonical;
+        }
+
+        if (lowerValue.IndexOf('-') < 0)
+        {
+            return lowerValue;
+        }
+
+        var parts = lowerValue.Split('-');
+        var replaced = false;
+        for (var i = 0; i < parts.Length; i++)
+        {
+            if (aliases.TryGetValue(parts[i], out var partAlias))
+            {
+                parts[i] = partAlias;
+                replaced = true;
+            }
+        }
+
+        return replaced ? string.Join('-', parts) : lowerValue;
+    }
+
+    /// <summary>
+    /// The ASCII-lowercase of <paramref name="value"/>, returning the argument itself when it already
+    /// is one. Deliberately not ToLowerInvariant: the spec says ASCII-lowercase, and a Unicode value
+    /// the syntax check let through is ASCII by construction, so nothing outside A-Z may move.
+    /// </summary>
+    private static string AsciiLowercase(string value)
+    {
+        var first = -1;
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (char.IsAsciiLetterUpper(value[i]))
+            {
+                first = i;
+                break;
+            }
+        }
+
+        if (first < 0)
+        {
+            return value;
+        }
+
+        var chars = value.ToCharArray();
+        for (var i = first; i < chars.Length; i++)
+        {
+            if (char.IsAsciiLetterUpper(chars[i]))
+            {
+                chars[i] = (char) (chars[i] + 32);
+            }
+        }
+
+        return new string(chars);
+    }
+
+    /// <summary>
     /// https://tc39.es/ecma402/#sec-canonicalizeunicodelocaleid
     /// Canonicalizes a Unicode locale identifier.
     /// </summary>

--- a/Jint/Native/Intl/JsDateTimeFormat.cs
+++ b/Jint/Native/Intl/JsDateTimeFormat.cs
@@ -113,7 +113,13 @@ internal sealed class JsDateTimeFormat : ObjectInstance
             && !string.Equals(Calendar, "iso8601", StringComparison.OrdinalIgnoreCase)
             && !string.Equals(Calendar, "gregory", StringComparison.OrdinalIgnoreCase);
 
-        if (isLunisolarCalendar || hasEra || isNonIsoCalendar)
+        // A year no DateTime can hold arrives on a representative year with an override beside it, and
+        // the parts lane is the one that knows what to do with a per-field override - AddYearPart reads
+        // originalYear, FormatDateStyleToParts reads it, and neither .NET format strings nor the
+        // literal-splicing FormatWithComponents used to do can express a year outside 1-9999 at all.
+        // This is the same delegation era and the non-Gregorian calendars already take, and for the
+        // same reason.
+        if (isLunisolarCalendar || hasEra || isNonIsoCalendar || originalYear.HasValue)
         {
             var parts = FormatToParts(dateTime, originalYear, isPlain);
             var sb = new StringBuilder();
@@ -294,12 +300,35 @@ internal sealed class JsDateTimeFormat : ObjectInstance
             "hebrew" => GetHebrewEra(style, eraNames),
             "persian" => GetPersianEra(style, eraNames),
             "indian" => GetIndianEra(style, eraNames),
-            "ethiopic" => GetEthiopicEra(dateTime, style, eraNames),
+            "ethiopic" => GetEthiopicEra(effectiveYear, style, eraNames),
             "ethioaa" => GetEthioAaEra(style, eraNames),
             "coptic" => GetCopticEra(effectiveYear, style, eraNames),
-            "islamic" or "islamic-civil" or "islamic-tbla" or "islamic-umalqura" => GetIslamicEra(dateTime, style, eraNames),
+            "islamic" or "islamic-civil" or "islamic-tbla" or "islamic-umalqura" => GetIslamicEra(effectiveYear, dateTime, style, eraNames),
             _ => GetGregorianEra(effectiveYear, style, eraNames) // Default to Gregorian
         };
+    }
+
+    /// <summary>
+    /// Whether the date <paramref name="year"/> names, taking its month and day from
+    /// <paramref name="dateTime"/>, falls on or after the given proleptic Gregorian date.
+    ///
+    /// The year has to come in separately because <paramref name="dateTime"/> may be standing on a
+    /// representative year — congruent to the real one mod 400, so its month, day and weekday are the
+    /// real ones and its year is not. Every era boundary here is an absolute date, so comparing against
+    /// the substitute's year answers about a year 275760 years away from the one asked about. It used to
+    /// happen to work, because the clamp this replaces put such a value on year 9999 or year 1, which
+    /// is on the right side of every one of these boundaries by accident.
+    /// </summary>
+    private static bool IsOnOrAfter(int year, DateTime dateTime, int boundaryYear, int boundaryMonth, int boundaryDay)
+    {
+        if (year != boundaryYear)
+        {
+            return year > boundaryYear;
+        }
+
+        // A year DateTime can hold is never substituted, so within the boundary year the month and day
+        // beside it are the real ones.
+        return dateTime.Month > boundaryMonth || (dateTime.Month == boundaryMonth && dateTime.Day >= boundaryDay);
     }
 
     private static string GetGregorianEra(int year, string style, string[]? eraNames)
@@ -333,28 +362,27 @@ internal sealed class JsDateTimeFormat : ObjectInstance
         // For Japanese eras, short and long use the same full name
         var isNarrow = string.Equals(style, "narrow", StringComparison.Ordinal);
 
-        // Check for dates within .NET DateTime range using actual DateTime comparison
-        if (effectiveYear >= 2019 && dateTime >= new DateTime(2019, 5, 1))
+        if (IsOnOrAfter(effectiveYear, dateTime, 2019, 5, 1))
         {
             return isNarrow ? "R" : "Reiwa";
         }
 
-        if (effectiveYear >= 1989 && dateTime >= new DateTime(1989, 1, 8))
+        if (IsOnOrAfter(effectiveYear, dateTime, 1989, 1, 8))
         {
             return isNarrow ? "H" : "Heisei";
         }
 
-        if (effectiveYear >= 1926 && dateTime >= new DateTime(1926, 12, 25))
+        if (IsOnOrAfter(effectiveYear, dateTime, 1926, 12, 25))
         {
             return isNarrow ? "S" : "Shōwa";
         }
 
-        if (effectiveYear >= 1912 && dateTime >= new DateTime(1912, 7, 30))
+        if (IsOnOrAfter(effectiveYear, dateTime, 1912, 7, 30))
         {
             return isNarrow ? "T" : "Taishō";
         }
 
-        if (effectiveYear >= 1868 && dateTime >= new DateTime(1868, 1, 25))
+        if (IsOnOrAfter(effectiveYear, dateTime, 1868, 1, 25))
         {
             return isNarrow ? "M" : "Meiji";
         }
@@ -429,12 +457,12 @@ internal sealed class JsDateTimeFormat : ObjectInstance
         };
     }
 
-    private static string GetEthiopicEra(DateTime dateTime, string style, string[]? eraNames)
+    private static string GetEthiopicEra(int year, string style, string[]? eraNames)
     {
         // Ethiopic has two eras: Anno Mundi (AA) for Ethiopic years ≤ 0, Era of the Incarnation
         // (AM) for Ethiopic years ≥ 1. Ethiopic year 1 starts roughly ISO 8 CE; the easy
         // approximation that suffices here is "ISO year ≥ 8 → AM, otherwise AA".
-        var isAm = dateTime.Year >= 8;
+        var isAm = year >= 8;
         return style switch
         {
             "long" => isAm ? "Era of the Incarnation" : "Anno Mundi",
@@ -469,11 +497,11 @@ internal sealed class JsDateTimeFormat : ObjectInstance
         };
     }
 
-    private static string GetIslamicEra(DateTime dateTime, string style, string[]? eraNames)
+    private static string GetIslamicEra(int year, DateTime dateTime, string style, string[]? eraNames)
     {
         // Islamic has two eras: AH (Anno Hegirae) for dates ≥ 622-07-16 CE Gregorian (the Hijra
         // epoch) and BH (Before Hijra) for earlier dates.
-        var isAh = dateTime.Year > 622 || (dateTime.Year == 622 && (dateTime.Month > 7 || (dateTime.Month == 7 && dateTime.Day >= 16)));
+        var isAh = IsOnOrAfter(year, dateTime, 622, 7, 16);
         return style switch
         {
             "long" => isAh ? "Anno Hegirae" : "Before Hijra",
@@ -593,19 +621,22 @@ internal sealed class JsDateTimeFormat : ObjectInstance
         if (string.Equals(Calendar, "japanese", StringComparison.OrdinalIgnoreCase))
         {
             // For Japanese, the displayed year is the era year of whichever era contains the
-            // given date. Pre-Meiji dates fall back to the Gregorian year.
+            // given date. Pre-Meiji dates fall back to the Gregorian year. The comparisons read
+            // sourceYear rather than dateTime.Year for the reason IsOnOrAfter gives: a year outside
+            // DateTime's range arrives on a substitute congruent mod 400, whose month and day are real
+            // and whose year is not.
             var dt = dateTime;
             int? eraYear = null;
-            if (dt.Year > 2019 || (dt.Year == 2019 && (dt.Month > 5 || (dt.Month == 5 && dt.Day >= 1))))
-                eraYear = dt.Year - 2018; // Reiwa
-            else if (dt.Year > 1989 || (dt.Year == 1989 && (dt.Month > 1 || (dt.Month == 1 && dt.Day >= 8))))
-                eraYear = dt.Year - 1988; // Heisei
-            else if (dt.Year > 1926 || (dt.Year == 1926 && (dt.Month > 12 || (dt.Month == 12 && dt.Day >= 25))))
-                eraYear = dt.Year - 1925; // Showa
-            else if (dt.Year > 1912 || (dt.Year == 1912 && (dt.Month > 7 || (dt.Month == 7 && dt.Day >= 30))))
-                eraYear = dt.Year - 1911; // Taisho
-            else if (dt.Year > 1868 || (dt.Year == 1868 && (dt.Month > 1 || (dt.Month == 1 && dt.Day >= 25))))
-                eraYear = dt.Year - 1867; // Meiji
+            if (IsOnOrAfter(sourceYear, dt, 2019, 5, 1))
+                eraYear = sourceYear - 2018; // Reiwa
+            else if (IsOnOrAfter(sourceYear, dt, 1989, 1, 8))
+                eraYear = sourceYear - 1988; // Heisei
+            else if (IsOnOrAfter(sourceYear, dt, 1926, 12, 25))
+                eraYear = sourceYear - 1925; // Showa
+            else if (IsOnOrAfter(sourceYear, dt, 1912, 7, 30))
+                eraYear = sourceYear - 1911; // Taisho
+            else if (IsOnOrAfter(sourceYear, dt, 1868, 1, 25))
+                eraYear = sourceYear - 1867; // Meiji
             if (eraYear.HasValue)
             {
                 year = eraYear;
@@ -986,35 +1017,17 @@ internal sealed class JsDateTimeFormat : ObjectInstance
                     });
                     break;
                 case 'y' when Year != null:
-                    if (originalYear.HasValue)
+                    // No originalYear branch here: Format routes a value carrying one through
+                    // FormatToParts instead. Splicing the real year in as a quoted literal is what this
+                    // used to do, and BuildFormatString reads a part beginning with an apostrophe as an
+                    // hour - so it put the date/time separator in front of the year and then ran the
+                    // real time fields together behind it: "12/31, 27576011:59:59 PM".
+                    parts.Add(Year switch
                     {
-                        // Use original year as escaped literal to avoid .NET formatting the representative year
-                        var yearVal = originalYear.Value;
-                        int displayYear;
-                        if (Era != null && yearVal <= 0)
-                        {
-                            displayYear = 1 - yearVal; // Convert to era-relative positive year
-                        }
-                        else
-                        {
-                            displayYear = yearVal; // Keep sign for iso8601/gregorian without era
-                        }
-                        var yearStr = Year switch
-                        {
-                            "2-digit" => (System.Math.Abs(displayYear) % 100).ToString("00", CultureInfo),
-                            _ => displayYear.ToString(CultureInfo)
-                        };
-                        parts.Add("'" + yearStr + "'");
-                    }
-                    else
-                    {
-                        parts.Add(Year switch
-                        {
-                            "numeric" => "yyyy",
-                            "2-digit" => "yy",
-                            _ => "yyyy"
-                        });
-                    }
+                        "numeric" => "yyyy",
+                        "2-digit" => "yy",
+                        _ => "yyyy"
+                    });
                     break;
             }
         }
@@ -1379,6 +1392,7 @@ internal sealed class JsDateTimeFormat : ObjectInstance
         // For plain Temporal types (isPlain=true), skip timezone conversion
         if (!isPlain)
         {
+            var beforeConversion = dateTime;
             if (TimeZone != null)
             {
                 dateTime = ConvertToTimeZone(dateTime, TimeZone);
@@ -1388,6 +1402,15 @@ internal sealed class JsDateTimeFormat : ObjectInstance
                 // No explicit timezone: convert UTC to engine's default timezone
                 var defaultTz = _engine.Options.TimeSystem.DefaultTimeZone;
                 dateTime = TimeZoneInfo.ConvertTimeFromUtc(dateTime, defaultTz);
+            }
+
+            // A conversion can carry the representative date over a year boundary - an instant just
+            // after midnight on 1 January in a zone behind UTC belongs to the previous year - and
+            // originalYear names the year of the value that went in. Move it by what the substitute
+            // moved by, so the printed year is the one the wall clock is actually in.
+            if (originalYear.HasValue && dateTime.Year != beforeConversion.Year)
+            {
+                originalYear += dateTime.Year - beforeConversion.Year;
             }
         }
 
@@ -1429,7 +1452,7 @@ internal sealed class JsDateTimeFormat : ObjectInstance
 
         if (hasDate)
         {
-            FormatDateStyleToParts(dateTime, result);
+            FormatDateStyleToParts(dateTime, result, originalYear);
         }
 
         if (hasDate && hasTime)
@@ -1444,9 +1467,16 @@ internal sealed class JsDateTimeFormat : ObjectInstance
         }
     }
 
-    private void FormatDateStyleToParts(DateTime dateTime, List<DateTimePart> result)
+    /// <summary>
+    /// The date half of a dateStyle format. <c>originalYear</c> is the real year when
+    /// <c>dateTime</c> stands on a representative one: FormatStyleToParts took it and dropped it, so a
+    /// styled format of a date outside DateTime's range printed the substitute's year - 9999 - with
+    /// nothing to say it had.
+    /// </summary>
+    private void FormatDateStyleToParts(DateTime dateTime, List<DateTimePart> result, int? originalYear = null)
     {
         var style = DateStyle;
+        var year = originalYear ?? dateTime.Year;
 
         // Check if using Chinese or Dangi calendar
         var isChineseCalendar = string.Equals(Calendar, "chinese", StringComparison.OrdinalIgnoreCase);
@@ -1486,7 +1516,7 @@ internal sealed class JsDateTimeFormat : ObjectInstance
                 result.Add(new DateTimePart("literal", " "));
                 result.Add(new DateTimePart("day", dateTime.Day.ToString(CultureInfo)));
                 result.Add(new DateTimePart("literal", ", "));
-                result.Add(new DateTimePart("year", dateTime.Year.ToString(CultureInfo)));
+                result.Add(new DateTimePart("year", year.ToString(CultureInfo)));
             }
         }
         else if (string.Equals(style, "medium", StringComparison.Ordinal))
@@ -1501,7 +1531,7 @@ internal sealed class JsDateTimeFormat : ObjectInstance
                 result.Add(new DateTimePart("literal", " "));
                 result.Add(new DateTimePart("day", dateTime.Day.ToString(CultureInfo)));
                 result.Add(new DateTimePart("literal", ", "));
-                result.Add(new DateTimePart("year", dateTime.Year.ToString(CultureInfo)));
+                result.Add(new DateTimePart("year", year.ToString(CultureInfo)));
             }
         }
         else // short
@@ -1516,7 +1546,7 @@ internal sealed class JsDateTimeFormat : ObjectInstance
                 result.Add(new DateTimePart("literal", "/"));
                 result.Add(new DateTimePart("day", dateTime.Day.ToString(CultureInfo)));
                 result.Add(new DateTimePart("literal", "/"));
-                result.Add(new DateTimePart("year", (dateTime.Year % 100).ToString("D2", CultureInfo)));
+                result.Add(new DateTimePart("year", (year % 100).ToString("D2", CultureInfo)));
             }
         }
     }

--- a/Jint/Native/Intl/LocaleConstructor.cs
+++ b/Jint/Native/Intl/LocaleConstructor.cs
@@ -106,14 +106,14 @@ internal sealed class LocaleConstructor : Constructor
         // Apply variant aliasing (e.g., arevela → language:hy, aaland → region:AX)
         ApplyVariantMappings(ref language, ref script, ref region, ref variants);
 
-        var calendar = GetUnicodeExtensionOption(optionsObj, "calendar", parsedLocale.Calendar);
-        var collation = GetUnicodeExtensionOption(optionsObj, "collation", parsedLocale.Collation);
+        var calendar = GetUnicodeExtensionOption(optionsObj, "calendar", "ca", parsedLocale.Calendar);
+        var collation = GetUnicodeExtensionOption(optionsObj, "collation", "co", parsedLocale.Collation);
         var firstDayOfWeek = GetFirstDayOfWeekOption(optionsObj, parsedLocale.FirstDayOfWeek);
         var hourCycle = GetOptionString(optionsObj, "hourCycle", parsedLocale.HourCycle, in HourCycleValues);
         var caseFirst = GetOptionString(optionsObj, "caseFirst", parsedLocale.CaseFirst, in CaseFirstValues);
         var numericValue = IntlUtilities.GetOption(_engine, optionsObj, "numeric", IntlUtilities.OptionType.Boolean, null, JsValue.Undefined);
         bool? numeric = numericValue.IsUndefined() ? parsedLocale.Numeric : TypeConverter.ToBoolean(numericValue);
-        var numberingSystem = GetUnicodeExtensionOption(optionsObj, "numberingSystem", parsedLocale.NumberingSystem);
+        var numberingSystem = GetUnicodeExtensionOption(optionsObj, "numberingSystem", "nu", parsedLocale.NumberingSystem);
 
         // Build the canonical locale string
         var canonicalLocale = BuildLocaleString(language, script, region, variants, parsedLocale.Attributes, calendar, caseFirst, collation, firstDayOfWeek, hourCycle, numberingSystem, numeric, parsedLocale.OtherUnicodeExtensions, parsedLocale.OtherExtensions);
@@ -164,19 +164,23 @@ internal sealed class LocaleConstructor : Constructor
     }
 
     /// <summary>
-    /// Gets a Unicode extension option value and validates it matches the pattern (3*8alphanum) *("-" (3*8alphanum))
+    /// Reads the option for a Unicode extension key, checks it against the <c>type</c> nonterminal and
+    /// returns it in canonical form. https://tc39.es/ecma402/#sec-makelocalerecord (15.1.3) is where an
+    /// option supersedes the tag's own keyword, and it does so through
+    /// <c>CanonicalizeUValue(key, overrideValue)</c> — so the extension sequence Intl.Locale builds
+    /// carries the canonical spelling of the value and never the one the caller happened to type.
+    /// The local canonicalization this used to do covered only the CLDR alias substitution and never
+    /// the case fold that precedes it, and its "collation" arm could not fire at all because
+    /// <c>LocaleData.UnicodeMappings</c> has no "co" table.
     /// </summary>
-    private string? GetUnicodeExtensionOption(ObjectInstance options, string property, string? fallback)
+    private string? GetUnicodeExtensionOption(ObjectInstance options, string property, string unicodeKey, string? fallback)
     {
         var value = options.Get(property);
         if (value.IsUndefined())
         {
-            // Also canonicalize the fallback value (from parsed tag)
-            if (fallback != null)
-            {
-                return CanonicalizeUnicodeExtensionValue(property, fallback);
-            }
-            return fallback;
+            // The fallback comes from the parsed tag, which the parser has already lowercased and
+            // aliased; running it through again is idempotent and keeps the two sources in one shape.
+            return fallback != null ? IntlUtilities.CanonicalizeUValue(unicodeKey, fallback) : null;
         }
 
         var stringValue = TypeConverter.ToString(value);
@@ -187,42 +191,7 @@ internal sealed class LocaleConstructor : Constructor
             Throw.RangeError(_realm, $"Invalid value '{stringValue}' for option '{property}'");
         }
 
-        // Canonicalize using Unicode mappings (e.g., "islamicc" → "islamic-civil")
-        stringValue = CanonicalizeUnicodeExtensionValue(property, stringValue);
-
-        return stringValue;
-    }
-
-    /// <summary>
-    /// Canonicalizes a Unicode extension value using CLDR data.
-    /// Maps the property name to its Unicode extension key (e.g., "calendar" → "ca").
-    /// </summary>
-    private static string CanonicalizeUnicodeExtensionValue(string property, string value)
-    {
-        // Map property names to Unicode extension keys
-        var unicodeKey = property switch
-        {
-            "calendar" => "ca",
-            "collation" => "co",
-            "numberingSystem" => "nu",
-            _ => null
-        };
-
-        if (unicodeKey == null)
-        {
-            return value;
-        }
-
-        // Look up the mapping in UnicodeMappings
-        if (Data.LocaleData.UnicodeMappings.TryGetValue(unicodeKey, out var mappings))
-        {
-            if (mappings.TryGetValue(value, out var canonicalValue))
-            {
-                return canonicalValue;
-            }
-        }
-
-        return value;
+        return IntlUtilities.CanonicalizeUValue(unicodeKey, stringValue);
     }
 
     /// <summary>

--- a/Jint/Native/Intl/NumberFormatConstructor.cs
+++ b/Jint/Native/Intl/NumberFormatConstructor.cs
@@ -79,10 +79,20 @@ internal sealed partial class NumberFormatConstructor : Constructor
         if (!numberingSystemValue.IsUndefined())
         {
             numberingSystem = TypeConverter.ToString(numberingSystemValue);
-            if (string.IsNullOrEmpty(numberingSystem) || !IsValidNumberingSystem(numberingSystem))
+
+            // https://tc39.es/ecma402/#sec-resolveoptions (9.2.8) step 6.d.ii: the check is the "type"
+            // Unicode locale nonterminal, alphanum{3,8} (sep alphanum{3,8})*, and nothing narrower.
+            // The hand-rolled check this replaces was narrower in two ways that both misreported:
+            // char.IsAsciiLetterLower made 'LATN' a RangeError where the nonterminal matches it, and no
+            // hyphen was admitted at all, so a well-formed multi-subtag value threw where it should
+            // simply have matched no numbering system and left the default in place.
+            if (!IntlUtilities.IsValidUnicodeExtensionValue(numberingSystem))
             {
                 Throw.RangeError(_realm, $"Invalid numberingSystem: {numberingSystem}");
             }
+
+            // 9.2.7 step 10, immediately before the keyLocaleData lookup below.
+            numberingSystem = IntlUtilities.CanonicalizeUValue("nu", numberingSystem);
         }
 
         // Resolve locale using already-read localeMatcher
@@ -436,25 +446,6 @@ internal sealed partial class NumberFormatConstructor : Constructor
         }
 
         return null;
-    }
-
-    private static bool IsValidNumberingSystem(string numberingSystem)
-    {
-        // Basic validation: must be 3-8 lowercase alphanumeric characters
-        if (numberingSystem.Length < 3 || numberingSystem.Length > 8)
-        {
-            return false;
-        }
-
-        foreach (var c in numberingSystem)
-        {
-            if (!char.IsAsciiLetterLower(c) && !char.IsAsciiDigit(c))
-            {
-                return false;
-            }
-        }
-
-        return true;
     }
 
     private static bool IsSupportedNumberingSystem(string numberingSystem)

--- a/Jint/Native/Intl/RelativeTimeFormatConstructor.cs
+++ b/Jint/Native/Intl/RelativeTimeFormatConstructor.cs
@@ -66,10 +66,14 @@ internal sealed partial class RelativeTimeFormatConstructor : Constructor
         if (!numberingSystemValue.IsUndefined())
         {
             numberingSystem = TypeConverter.ToString(numberingSystemValue);
-            if (string.IsNullOrEmpty(numberingSystem) || !IsWellFormedNumberingSystem(numberingSystem))
+            if (!IntlUtilities.IsValidUnicodeExtensionValue(numberingSystem))
             {
                 Throw.RangeError(_realm, $"Invalid numberingSystem: {numberingSystem}");
             }
+
+            // 9.2.7 step 10. IsSupportedNumberingSystem below is an OrdinalIgnoreCase dictionary probe,
+            // so 'LATN' was accepted and then reported verbatim from resolvedOptions().
+            numberingSystem = IntlUtilities.CanonicalizeUValue("nu", numberingSystem);
         }
 
         // Step 16: style
@@ -192,35 +196,6 @@ internal sealed partial class RelativeTimeFormatConstructor : Constructor
         }
 
         return null;
-    }
-
-    private static bool IsWellFormedNumberingSystem(string numberingSystem)
-    {
-        // Unicode numbering system identifier can be a sequence of subtags separated by '-'
-        // Each subtag must be 3-8 alphanumeric characters
-        if (string.IsNullOrEmpty(numberingSystem))
-        {
-            return false;
-        }
-
-        var subtags = numberingSystem.Split('-');
-        foreach (var subtag in subtags)
-        {
-            if (subtag.Length < 3 || subtag.Length > 8)
-            {
-                return false;
-            }
-
-            foreach (var c in subtag)
-            {
-                if (!char.IsAsciiLetterOrDigit(c))
-                {
-                    return false;
-                }
-            }
-        }
-
-        return true;
     }
 
     private static bool IsSupportedNumberingSystem(string numberingSystem)


### PR DESCRIPTION
Two unrelated Intl defects, both filed as #3009: option values for Unicode extension keys were never canonicalized before being matched, and `Intl.DateTimeFormat.prototype.format` mis-rendered every date outside `System.DateTime`'s range.

### Two corrections to the issue text

**`CanonicalizeUValue` does not exist in Jint.** It is an ECMA-402 abstract operation ([9.2.2](https://tc39.es/ecma402/#sec-canonicalizeuvalue)), not a Jint method. The nearest thing in the codebase was `LocaleConstructor.CanonicalizeUnicodeExtensionValue`, which did the CLDR alias substitution only — it never case-folded — and whose `"collation" => "co"` arm was dead code, because `Data.LocaleData.UnicodeMappings` has no `co` table at all (its keys are `ca`, `kb`, `kc`, `kh`, `kk`, `kn`, `ks`, `ms`, `rg`, `sd`, `tz`). Its `"numberingSystem" => "nu"` arm was equally dead for the same reason. This PR adds the operation under the spec's name and deletes the local one.

**The repro in the issue does not reproduce.** `new Intl.Collator('en', { collation: 'PHONEBK' })` cannot show the bug: `en` has no `phonebk` in any casing — it gets only `RootCollations` (`emoji`, `eor`), so `'phonebk'` resolves to `"default"` too. The locale that shows it is **`de`**, which is what the existing test at `Jint.Tests/Runtime/IntlTests.cs:370-384` uses.

---

## Cluster A — u-extension option values are not canonicalized before matching

### The shared root cause

[ResolveLocale (9.2.7)](https://tc39.es/ecma402/#sec-resolvelocale) step 10, for each relevant extension key:

> If *optionsValue* is a String, then
> a. Let *ukey* be the ASCII-lowercase of *key*.
> b. Set *optionsValue* to CanonicalizeUValue(*ukey*, *optionsValue*).
> …
> If SameValue(*optionsValue*, *value*) is false and *keyLocaleData* contains *optionsValue*, then …

and [CanonicalizeUValue (9.2.2)](https://tc39.es/ecma402/#sec-canonicalizeuvalue):

> 1. Let *lowerValue* be the ASCII-lowercase of *uvalue*.
> 2. Let *canonicalized* be … canonicalizing *lowerValue* as a value of key *ukey* per UTS #35 Part 1 Core, Annex C …
> 3. NOTE: It is recommended that implementations use the `u` extension data in `common/bcp47` provided by the CLDR.

[MakeLocaleRecord (15.1.3)](https://tc39.es/ecma402/#sec-makelocalerecord) says the same for `Intl.Locale`: *"If overrideValue is not undefined, then set value to CanonicalizeUValue(key, overrideValue)."*

Jint got both halves for free on the locale-**tag** path — every parser lowercases as it goes (`IntlUtilities.ParseLanguageTag`, `LocaleConstructor.ParseLanguageTag`) and `CanonicalizeUnicodeLocaleId` applies the alias data to the extension sequence. The **options bag** had neither step.

`IntlUtilities.CanonicalizeUValue(unicodeKey, value)` is now that operation, placed next to `IsValidUnicodeExtensionValue` — which is the separate check of [ResolveOptions (9.2.8)](https://tc39.es/ecma402/#sec-resolveoptions) step 6.d.ii (*"If value cannot be matched by the `type` Unicode locale nonterminal, throw a RangeError exception"*). The two stay separate deliberately: an ill-formed value is a `RangeError` however the locale would have resolved a well-formed one.

### A1 — Collator

`CollatorConstructor.GetCollationOption` read the value raw, syntax-checked it, then matched it against the locale's `[[co]]` list with `StringComparison.Ordinal` (`IsCollationSupportedForLocale`), so every spelling but the all-lowercase one missed the list and fell silently through to `"default"` — a wrong collator rather than an error.

```js
new Intl.Collator('de', { collation: 'PHONEBK' }).resolvedOptions().collation
// before: "default"      after: "phonebk"
```

The ordinal comparison in `IsCollationSupportedForLocale` and in `BuildLocaleWithExtensions` stays, and is now correct: what reaches it is canonical.

### A2 — Locale

`LocaleConstructor.GetUnicodeExtensionOption` folded nothing, so the raw value flowed into `BuildLocaleString` and was emitted verbatim.

```js
new Intl.Locale('de', { collation: 'PHONEBK' }).toString()
// before: "de-u-co-PHONEBK"   after: "de-u-co-phonebk"
new Intl.Locale('de', { collation: 'PHONEBK' }).getCollations()
// before: ["PHONEBK"]         after: ["phonebk"]
new Intl.Locale('en', { calendar: 'GREGORY' }).toString()
// before: "en-u-ca-GREGORY"   after: "en-u-ca-gregory"
new Intl.Locale('en', { numberingSystem: 'LATN' }).toString()
// before: "en-u-nu-LATN"      after: "en-u-nu-latn"
```

`CanonicalizeUnicodeExtensionValue` is deleted; the property→ukey mapping moves to the three call sites, which now pass `"ca"` / `"co"` / `"nu"` explicitly. Alias substitution that already worked (`islamicc` → `islamic-civil`, `ethiopic-amete-alem` → `ethioaa`) is unchanged and pinned, including the combination `'ISLAMICC'` → `islamic-civil`, which needs the fold to happen *before* the alias lookup.

`firstDayOfWeek` needed nothing: `GetFirstDayOfWeekOption` already lowercases (`'MON'` → `en-u-fw-mon`). `hourCycle`, `caseFirst` and `numeric` are `GetOption` calls with a fixed value list, which the spec matches case-sensitively.

### A3 — NumberFormat

`IsValidNumberingSystem` was standing in for the `type` nonterminal (`alphanum{3,8} (sep alphanum{3,8})*`) and was stricter than it in two ways that both misreported:

```js
new Intl.NumberFormat('en', { numberingSystem: 'LATN' })     // RangeError -> "latn"
new Intl.NumberFormat('en', { numberingSystem: 'ARAB' })     // RangeError -> "arab"
new Intl.NumberFormat('en', { numberingSystem: 'abc-def' })  // RangeError -> "latn"
```

`char.IsAsciiLetterLower` made `'LATN'` a syntax error where the nonterminal matches it, and the hyphen was rejected outright, so a well-formed multi-subtag value threw where 9.2.7 step 10 says it should simply match nothing and leave the resolved value alone. It is replaced by `IntlUtilities.IsValidUnicodeExtensionValue` + `CanonicalizeUValue`, the shape `DateTimeFormatConstructor` already uses. `IsSupportedNumberingSystem` is an exact-case-insensitive dictionary probe and now receives the folded value. Everything on `intl402/NumberFormat/constructor-options-numberingSystem-invalid.js`'s list still throws, pinned by a test.

### DurationFormat — asked about explicitly: yes, it needed the same fold

`DurationFormatConstructor.GetNumberingSystemOption` syntax-checked and returned the raw string; `ResolveNumberingSystem` then probes `NumberingSystemData.Digits`, which is keyed `OrdinalIgnoreCase`, so `'LATN'` was *accepted* and reported straight back:

```js
new Intl.DurationFormat('en', { numberingSystem: 'LATN' }).resolvedOptions().numberingSystem
// before: "LATN"   after: "latn"
```

**`Intl.RelativeTimeFormat` has the identical defect** and is fixed the same way — its `IsWellFormedNumberingSystem` was a third copy of `IsValidUnicodeExtensionValue` and is deleted.

**`Intl.DateTimeFormat` needed no change** and is only pinned: it matches an option against its supported list with `OrdinalIgnoreCase` and then keeps the *list's* entry rather than the caller's, so `'LATN'` → `latn` and `'ISLAMICC'` → `islamic-civil` already worked. `Intl.PluralRules` and `Intl.Segmenter` have no `numberingSystem` option.

---

## Cluster B — `Intl.DateTimeFormat.format` outside `System.DateTime`'s range

#2981's commit message ends with *"Left alone: Intl.DateTimeFormat.prototype.format still mis-renders these years through the clamp-plus-originalYear lane described above."* This is that.

### The chain, verified link by link

1. **`DateTimeFormatPrototype.ToDateTimeWithOriginalYear` clamped.** An out-of-range time value became `DateTime.MinValue`/`MaxValue` with only the year carried out through `out originalYear` — month, day and every time field came from the clamp.
2. **`JsDateTimeFormat.FormatWithComponents` re-inserted that year as a quoted literal**, `parts.Add("'" + yearStr + "'")`.
3. **`BuildFormatString` classifies a part whose first character is `'` as an hour** (`isHourLiteral`) and therefore emitted the date/time separator `", "` in front of it — and then, `hasTime` already being set, ran the real time fields in behind it with no separator.
4. **`FormatWithStyles` never received `originalYear`** (`Format:150` did not pass it, `FormatStyleToParts:1432` dropped it), so a styled format printed the clamp's year.

```js
const d = new Date(8640000000000000);            // 275760-09-13T00:00:00.000Z
new Intl.DateTimeFormat("en-US", { timeZone: "UTC" }).format(d)
// before: "12/31, 275760"                    after: "9/13/275760"
new Intl.DateTimeFormat("en-US", { timeZone: "UTC", year: "numeric", month: "numeric",
    day: "numeric", hour: "numeric", minute: "numeric", second: "numeric" }).format(d)
// before: "12/31, 27576011:59:59 PM"         after: "9/13/275760, 12:00:00 AM"
new Intl.DateTimeFormat("en-US", { timeZone: "UTC" }).formatToParts(d)
// before: month=12, day=31, year=275760      after: month=9, day=13, year=275760
new Intl.DateTimeFormat("en-US", { timeZone: "UTC", dateStyle: "long" }).format(d)
// before: "December 31, 9999"                after: "September 13, 275760"
new Intl.DateTimeFormat("en-US", { timeZone: "UTC", dateStyle: "short" }).format(d)
// before: "12/31/99"                         after: "9/13/60"
new Intl.DateTimeFormat("en-US", { timeZone: "UTC", dateStyle: "full" }).format(d)
//                                            after: "Saturday, September 13, 275760"
new Intl.DateTimeFormat("en-US", { timeZone: "UTC" }).format(new Date(-8640000000000000))
// before: "1/1, -271821"                     after: "4/20/-271821"
```

Note that `formatToParts` was wrong on month and day too — the clamp is upstream of both lanes.

### The fix

**Stop clamping; reuse the Temporal lane.** `CreateDateTimeSafe` already maps an out-of-range year to a representative one congruent mod 400, which is exactly right: the proleptic Gregorian leap rule reads nothing but the year mod 400 (for negative years as much as positive ones), and 400 years is a whole number of weeks (146097 days = 20871 weeks), so leap status, weekday and every day-of-year alignment are the *real* ones and only the year has to be printed over.

Three things about it changed:

* Its ad-hoc leap-status search is gone. The search existed because `IsLeapYearISO` used BC-style year numbering (`y = 1 - year`), which disagrees with the engine's own `DatePrototype.DaysInYear` for non-positive years — astronomical year 0 *is* a leap year — so it fired for those and shifted the representative off its congruence, breaking exactly the weekday alignment the method's doc promises. With the congruence, leap status can never disagree, so the search is unreachable by construction and `IsLeapYearISO` is deleted. The 29-February guard stays as an assertion of that rather than as a fix-up.
* The representative comes from **401-800** rather than 1-400. What the formatter does next is convert into the resolved zone, and `TimeZoneInfo` saturates at `DateTime.MinValue`/`MaxValue` rather than wrapping, so a representative on the first day of year 1 would lose its time and its day to the clamp in any zone behind UTC. 401-800 is congruent mod 400 and far from both ends.
* `FromTimeValueUtc` is the new entry point: it decomposes the time value, builds the representative and hands it back **unconverted and `DateTimeKind.Utc`**, so the formatter's own timezone step converts it — the only place that knows what `options.timeZone` resolved to, and on exactly the terms it converts an in-range value.

**One decomposition, not a third copy.** `DateTimeFormatPrototype.GetJavaScriptYear` + `DayFromYear` were a partial reimplementation (a floating-point year estimate plus a linear search, year only). They are deleted in favour of `DatePrototype.FieldsFromTimeValue`, a new `internal static` over the authoritative `YearMonthDayFromTime` → `YearMonthDayFromDays` (the V8 400-year-cycle algorithm, correct for negative years) plus `HourFromTime`/`MinFromTime`/`SecFromTime`/`MsFromTime`. Widening the correct one beat keeping two.

**No quoted-literal splicing.** `Format` routes a value carrying an `originalYear` through `FormatToParts`, joining the parts — the same delegation era, the lunisolar calendars and the non-Gregorian calendars already take, and for the same reason: the parts lane is the one that understands per-field overrides (`AddYearPart` reads `originalYear` and `overrideYear`; `AddMonthPart`/`AddDayPart` read `overrideMonth`/`overrideDay`). The `originalYear` branch of `FormatWithComponents` is deleted rather than reworked, and the escaped-literal hazard in `BuildFormatString` goes with it.

**`FormatDateStyleToParts` now takes `originalYear`**, which closes the `dateStyle` half.

**A timezone conversion can move the year.** An instant just after midnight on 1 January, converted into a zone behind UTC, belongs to the previous year — and `originalYear` names the year of the value that went *in*. `FormatToParts` moves it by whatever the substitute moved by, so `new Date(253402300800001)` (`+010000-01-01T00:00:00.001Z`) prints `12/31/9999` in `America/New_York` and `1/1/10000` in UTC.

**Absolute-year comparisons had to start reading the real year.** Since the substitute is meaningful only mod 400, every comparison against an absolute date had to be re-based: the Ethiopic era boundary (`dateTime.Year >= 8`), the Islamic one (`> 622-07-16`), the five Japanese era boundaries, and the Japanese era-*year* in `ResolveCalendarFieldsForFormatting`. All of them were right only by accident of where the clamp had put the value (year 9999 or year 1 is on the convenient side of every one of them). `intl402/DateTimeFormat/prototype/formatToParts/era.js` catches exactly this and was the one test262 failure of the first iteration; a shared `IsOnOrAfter(year, dateTime, y, m, d)` fixes all four sites.

### Behaviour change: `Date.prototype.toLocale*` (please read)

`DatePrototype.ToLocaleString` / `ToLocaleDateString` / `ToLocaleTimeString` short-circuited to the `Date.prototype.toString` shape whenever `!DateTimeRangeValid`. That guard existed **only** because the formatter was broken, and the long XML doc on `ToLocaleString` says so in as many words — it names *"carrying the real fields in on a substitute year congruent mod 400"* as the alternative it wanted and rejected because it *"would need the whole component pipeline to learn about overrides it does not have"*. The pipeline has them now, so the guard is gone:

```js
// engine with LocalTimeZone(TimeZoneInfo.Utc)
new Date(8640000000000000).toLocaleString('en-US')
// 4.16.0: "Sat Sep 13 275760 00:00:00 GMT+0000 (UTC)"
// now:    "9/13/275760, 12:00:00 AM"
new Date(8640000000000000).toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })
// 4.16.0: "Sat Sep 13 275760"        (the options bag was read, validated and discarded)
// now:    "Saturday September 13, 275760"
```

**This changes a 4.16.0 output string.** It rewrites `Jint.Tests/Runtime/DateTests.cs`'s `ToLocaleStringOutsideDateTimeRange…` theory (four `[InlineData]` rows) and `ToLocaleStringInsideDateTimeRangeIsStillLocaleFormatted`, whose last assertion pinned the switch that no longer exists. The escape #2981 actually closed — a CLR `ArgumentOutOfRangeException` leaving `engine.Evaluate` — stays closed, and its test (`ToLocaleStringOutsideDateTimeRangeDoesNotThrowAClrException`) is untouched and still passes.

### One more, on the same lines

`ToDateTimeFormattable` keeps a `Date` object as itself where [the spec](https://tc39.es/ecma402/#sec-todatetimeformattable) converts it to a Number, so `HandleDateTimeValue`'s *"If x is not a finite Number, throw a RangeError"* never ran for one. `new Intl.DateTimeFormat('en-US').format(new Date(NaN))` answered with an arbitrary date instead of throwing; it throws now, as `format(NaN)` always did. test262 covers the Number spelling only (`throws-value-non-finite.js`, `date-is-nan-throws.js`), which is why it was invisible.

---

## The "time zone applied twice" lead: unconfirmed, and it is not a double application

`DateTimeFormatPrototype.ToDateTimeWithOriginalYear` calls `jsDate.ToDateTime()` — which itself converts when `Options.Interop.DateTimeKind == Local` (`JsDate.cs:84-88`) — and then `.ToLocalTime()`, and `JsDateTimeFormat.Format` would convert a third time. Neither doubling can actually happen, and the guards are the reason:

* When `DateTimeKind == Local`, `ToDateTime()` returns a `Local`-kind value, and `ToDateTimeWithOriginalYear`'s `if (Kind == Utc || Kind == Unspecified)` skips its `ToLocalTime()`.
* Under the default `DateTimeKind.Utc`, `ToDateTime()` returns `Utc` and `ToLocalTime()` makes it `Local`; `Format`'s `else if (dateTime.Kind == DateTimeKind.Utc)` then does not fire, and its `TimeZone != null` branch converts `Local → UTC → target`, which *undoes* the `ToLocalTime()` rather than compounding it.

So there is nothing to fix there, and nothing was changed. What the reading did turn up is a real but **separate** discrepancy, deliberately left alone: the in-range `format` path converts with `DateTime.ToLocalTime()` — the **OS** zone — where everything else in the formatter uses `Options.TimeSystem.DefaultTimeZone`, the **engine's** configured zone. A host that sets `options.LocalTimeZone(...)` to anything other than the machine's zone gets the machine's for `Intl.DateTimeFormat.format` with no `timeZone` option, and its own for `toLocaleString`. Fixing that moves output for every default-zone format and belongs in its own PR.

## Known residual

For an out-of-range value in a DST zone with no explicit `timeZone` option, `Intl.DateTimeFormat.format` and `Date.prototype.getHours` can disagree by an hour: the formatter converts the representative through `TimeZoneInfo`, which extrapolates the zone's DST rule (what V8 does), while `DefaultTimeSystem.GetUtcOffset` short-circuits to `BaseUtcOffset` outside `DateTimeOffset`'s range. Before this PR the formatter applied no meaningful conversion at all, so it agreed with nothing; this is a pre-existing approximation in `DefaultTimeSystem`, not something introduced here. Every test added below is timezone-independent (`timeZone: 'UTC'` or `LocalTimeZone(TimeZoneInfo.Utc)`).

---

## test262

`Jint.Tests.Test262/Test262Harness.settings.json` is **unchanged**: no exclusion added, none removed.

* **Nothing to add.** The suite is green at the pinned SHA `3655e746` — 99779 passed / 0 failed / 122 skipped, byte-identical to the pre-change baseline I took on `upstream/main@ff980b7bc` before touching anything.
* **Nothing to remove.** The four upstream files the issue flagged as likely to move are all *already active* (not excluded) and were already passing: `intl402/Locale/constructor-options-canonicalized.js` and `constructor-options-collation-valid.js` use all-lowercase option values throughout, and `intl402/NumberFormat/casing-numbering-system-options.js` tests casing in the locale **tag** (`-u-nu-lATn`), which the tag parsers already folded. `constructor-options-numberingSystem-invalid.js` lists only values the `type` nonterminal genuinely rejects, so relaxing the validator did not affect it. The whole `intl402/DateTimeFormat/prototype/format` family passes unchanged.
* **The commented-out entries stay commented.** `//"intl402/NumberFormat/prototype/format/format-significant-digits.js"` and its eight siblings are already inactive and already passing; there is nothing to un-comment.
* The one file that *did* move is `intl402/DateTimeFormat/prototype/formatToParts/era.js`, which failed the first iteration of cluster B and is fixed in the code rather than excluded — see the absolute-year paragraph above.

## Verification

Pre-fix failures — every new test was run against unfixed code first (27 failures, all new tests, no pre-existing test failing):

```
IntlTests.CollatorCanonicalizesACollationOptionBeforeMatchingIt(PHONEBK)      "default"  != "phonebk"
IntlTests.LocaleCanonicalizesAUnicodeExtensionOptionValue(de,collation,…)     "de-u-co-PHONEBK" != "de-u-co-phonebk"
IntlTests.LocaleReportsACanonicalizedOptionValueFromItsAccessors             "PHONEBK"  != "phonebk"
IntlTests.NumberFormatCanonicalizesANumberingSystemOption(LATN)              RangeError: Invalid numberingSystem: LATN
IntlTests.NumberFormatCanonicalizesANumberingSystemOption(abc-def)           RangeError: Invalid numberingSystem: abc-def
IntlTests.DurationFormatCanonicalizesANumberingSystemOption(LATN)            "LATN"     != "latn"
IntlTests.RelativeTimeFormatCanonicalizesANumberingSystemOption(ARAB)        "ARAB"     != "arab"
IntlTests.DateTimeFormatKeepsEveryDateFieldOfAValueOutsideDateTimeRange      "12/31, 275760" != "9/13/275760"
IntlTests.DateTimeFormatKeepsTheTimeFieldsOfAValueOutsideDateTimeRange       "12/31, 27576011:59:59 PM" != "9/13/275760, 12:00:00 AM"
IntlTests.DateTimeFormatToPartsReportsTheRealFieldsOfAValueOutsideDateTimeRange
                                                        ["month=12","day=31",…] != ["month=9","day=13",…]
IntlTests.DateTimeFormatCarriesTheRealYearThroughDateStyle                   "December 31, 9999" != "September 13, 275760"
DateTests.ToLocaleStringOutsideDateTimeRangeRendersALocaleString(8.64e15)    "Sat Sep 13 275760 00:00:00 GMT+0000 (UTC)" != "9/13/275760, 12:00:00 AM"
DateTests.ToLocaleStringOutsideDateTimeRangeHonoursTheOptionsBag             "Sat Sep 13 275760 00:00:00 GMT+0000 (UTC)" != "September"
```

After (Release, no `--no-build`, `TreatWarningsAsErrors` clean):

| suite | result |
| --- | --- |
| `Jint.Tests` (net10.0 / net472) | 5708 / 5624 passed, 0 failed |
| `Jint.Tests.PublicInterface` (net10.0 / net472) | 1486 / 1485 passed, 0 failed |
| `Jint.Tests.CommonScripts` (net10.0 / net472) | 28 / 28 passed, 0 failed |
| `Jint.Tests.SourceGenerators` | 52 passed, 0 failed |
| `Jint.Tests.Test262` | **99779 passed, 0 failed, 122 skipped** — identical to baseline |
| `JINT_HOST_CONTRACT_VERIFICATION=1` leg | `Jint.Tests` 5708/5624, `Jint.Tests.PublicInterface` 1490/1489, 0 failed |

No benchmark run: nothing here is on a hot path — `CanonicalizeUValue` runs once per `Intl.*` construction and returns its argument unchanged when it is already canonical, and the date changes are confined to the out-of-range branch.

Closes #3009

🤖 Generated with [Claude Code](https://claude.com/claude-code)
