### PR TITLE
Mark a global created by an unresolvable assignment, and stop a waitAsync timeout outliving its engine

### DIFF
--- a/Jint.Tests/Runtime/AtomicsWaitAsyncTests.cs
+++ b/Jint.Tests/Runtime/AtomicsWaitAsyncTests.cs
@@ -1,0 +1,122 @@
+#nullable enable
+using System.Runtime.CompilerServices;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// A finite <c>Atomics.waitAsync</c> timeout is a thread-pool task, and the task used to be
+/// unstoppable: it slept out the whole interval whatever happened to the wait, holding the waiter —
+/// and through it the engine, its realm and the promise capability — alive in its closure, then
+/// enqueued a resolution onto an event loop whose engine the host had long finished with. The
+/// interval is whatever the script asked for, so nothing bounded it but the script.
+/// </summary>
+// Shares the garbage-collection collection: the retention test below reads GC state, which cannot be
+// isolated from tests running in parallel with it.
+[Collection(nameof(GarbageCollectionTests))]
+public class AtomicsWaitAsyncTests
+{
+    [Fact]
+    public void AWaitWokenByNotifyDoesNotLeaveItsTimeoutTimerHoldingTheEngine()
+    {
+        // The wait below asks for three minutes and is woken within microseconds. Anything still holding
+        // the engine after that is the timeout timer, because there is nothing else left to hold it.
+        var reference = WaitNotifyAndForget();
+
+        CollectUntilDead(reference, TimeSpan.FromSeconds(10))
+            .Should().BeTrue("the timeout timer of a woken Atomics.waitAsync still pins the engine that owned it");
+
+        // NoInlining so the engine reference cannot be stack-rooted in this frame across the GC.Collect calls.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static WeakReference WaitNotifyAndForget()
+        {
+            var engine = new Engine();
+            engine.Execute("""
+                var i32a = new Int32Array(new SharedArrayBuffer(8));
+                Atomics.waitAsync(i32a, 0, 0, 180000);
+                Atomics.notify(i32a, 0);
+                """);
+            engine.Advanced.ProcessTasks();
+            return new WeakReference(engine);
+        }
+    }
+
+    [Fact]
+    public void AWaitNobodyWakesStillTimesOut()
+    {
+        // The control for the test above: cancelling the timer on a wake must not stop it firing when
+        // there is no wake, and the promise must still settle with "timed-out".
+        var engine = new Engine();
+        engine.Execute("""
+            var i32a = new Int32Array(new SharedArrayBuffer(8));
+            var outcome = 'pending';
+            Atomics.waitAsync(i32a, 0, 0, 50).value.then(function (v) { outcome = v; });
+            """);
+
+        DrainUntil(engine, "outcome !== 'pending'", TimeSpan.FromSeconds(10));
+
+        engine.Evaluate("outcome").AsString().Should().Be("timed-out");
+    }
+
+    [Fact]
+    public void AWaitWokenByNotifyResolvesWithOk()
+    {
+        // The other control: a wake still wins the race against a timeout that has not elapsed.
+        var engine = new Engine();
+        engine.Execute("""
+            var i32a = new Int32Array(new SharedArrayBuffer(8));
+            var outcome = 'pending';
+            Atomics.waitAsync(i32a, 0, 0, 180000).value.then(function (v) { outcome = v; });
+            var notified = Atomics.notify(i32a, 0);
+            """);
+
+        engine.Evaluate("notified").AsNumber().Should().Be(1);
+
+        DrainUntil(engine, "outcome !== 'pending'", TimeSpan.FromSeconds(10));
+
+        engine.Evaluate("outcome").AsString().Should().Be("ok");
+    }
+
+    private static void DrainUntil(Engine engine, string condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            engine.Advanced.ProcessTasks();
+            if (engine.Evaluate(condition).AsBoolean())
+            {
+                return;
+            }
+
+            Thread.Sleep(5);
+        }
+    }
+
+    /// <summary>
+    /// Collects until <paramref name="reference"/> dies or <paramref name="timeout"/> elapses. The retry is
+    /// not a weaker assertion: the timer task observes its cancellation on a thread pool thread, so there is
+    /// a short window in which its state machine is still reachable. Without the fix the engine stays alive
+    /// for the wait's full three minutes, which no plausible window covers.
+    /// </summary>
+    private static bool CollectUntilDead(WeakReference reference, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (true)
+        {
+            GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+            GC.WaitForPendingFinalizers();
+            GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+
+            if (!reference.IsAlive)
+            {
+                return true;
+            }
+
+            if (DateTime.UtcNow >= deadline)
+            {
+                return false;
+            }
+
+            Thread.Sleep(25);
+        }
+    }
+}

--- a/Jint.Tests/Runtime/GlobalPrototypeBindingTests.cs
+++ b/Jint.Tests/Runtime/GlobalPrototypeBindingTests.cs
@@ -171,6 +171,67 @@ public class GlobalPrototypeBindingTests
         engine.Evaluate("w").AsNumber().Should().Be(1, "the inherited property is visible again");
     }
 
+    [Fact]
+    public void AssigningToAnUnresolvableNameCreatesAMutableBindingLikeAVarDeclarationDoes()
+    {
+        // The sibling route, and the same shortfall reached by a different expression shape. A name that
+        // resolves nowhere at all — no environment on the chain, no own property on the global, nothing on
+        // its prototype chain either — makes the reference unresolvable, so PutValue never reaches the
+        // global environment record and assigns through the global object's plain [[Set]] instead
+        // (https://tc39.es/ecma262/#sec-putvalue step 2.c). What that creates is a global variable-like
+        // binding, so it must be indistinguishable from the one an eval-scoped `var` creates through
+        // CreateGlobalVarBinding — marker included.
+        var engine = new Engine();
+        engine.Execute("assigned = 5; (0, eval)('var declared = 5');");
+
+        var assigned = GlobalPropertyFlags(engine, "assigned");
+
+        assigned.Should().HaveFlag(PropertyFlag.MutableBinding);
+        assigned.Should().Be(GlobalPropertyFlags(engine, "declared"));
+    }
+
+    [Fact]
+    public void TheMutableBindingMarkerDoesNotChangeHowAnUnresolvableAssignmentGlobalBehaves()
+    {
+        var engine = new Engine();
+        engine.Execute("u = 5;");
+
+        // the marker is internal: the property describes itself exactly as [[Set]] left it
+        engine.Evaluate("JSON.stringify(Object.getOwnPropertyDescriptor(globalThis, 'u'))").AsString()
+            .Should().Be("""{"value":5,"writable":true,"enumerable":true,"configurable":true}""");
+
+        // clearing writable is still honoured, in sloppy and strict mode alike
+        engine.Execute("Object.defineProperty(globalThis, 'u', { writable: false });");
+        engine.Execute("u = 9;");
+        engine.Evaluate("u").AsNumber().Should().Be(5);
+        engine.Evaluate("(function () { 'use strict'; try { u = 9; return 'no error'; } catch (e) { return e instanceof TypeError ? 'TypeError' : 'other'; } })()")
+            .AsString().Should().Be("TypeError");
+
+        // redefining it as an accessor still routes assignment to the setter
+        engine.Execute("Object.defineProperty(globalThis, 'u', { get: function () { return 'got'; }, set: function (v) { globalThis.observed = v; } });");
+        engine.Evaluate("u").AsString().Should().Be("got");
+        engine.Execute("u = 11;");
+        engine.Evaluate("observed").AsNumber().Should().Be(11);
+
+        // and the marker is not a claim that the property cannot be deleted
+        engine.Evaluate("delete u").AsBoolean().Should().BeTrue();
+        engine.Evaluate("globalThis.hasOwnProperty('u')").AsBoolean().Should().BeFalse();
+        engine.Evaluate("typeof u").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void AFailedUnresolvableAssignmentMarksNothing()
+    {
+        // [[Set]] can decline: a non-extensible global has nowhere to put the new property, and the
+        // sloppy assignment is a silent no-op. Nothing was created, so there is nothing to mark.
+        var engine = new Engine();
+        engine.Execute("Object.preventExtensions(globalThis);");
+        engine.Execute("nope = 5;");
+
+        engine.Evaluate("globalThis.hasOwnProperty('nope')").AsBoolean().Should().BeFalse();
+        engine.Evaluate("typeof nope").AsString().Should().Be("undefined");
+    }
+
 #if NET
     [Fact]
     public void RepeatedWritesToAShadowedGlobalStoreInPlace()
@@ -200,6 +261,36 @@ public class GlobalPrototypeBindingTests
         // (104 bytes when this was written). The validate-and-apply path added exactly 64 on top of
         // that, every write: one PropertyDescriptor to carry the new value and one JsString key.
         perWrite.Should().BeLessThan(130, $"writing a shadowed global allocated {perWrite} bytes per write");
+    }
+
+    [Fact]
+    public void RepeatedWritesToAGlobalCreatedByUnresolvableAssignmentStoreInPlace()
+    {
+        // The same measurement for the other creation route: this global exists only because a sloppy
+        // assignment to a name that resolved nowhere created it. Every write after that first one does
+        // resolve, so it reaches GlobalObject.SetFromMutableBinding — and the descriptor the first one
+        // left behind is what decides whether the store happens in place.
+        const int iterations = 20_000;
+
+        var engine = new Engine();
+        engine.Execute("acc = 0;");
+
+        var prepared = Engine.PrepareScript($$"""
+            var src = [7];
+            (function () {
+                for (var i = 0; i < {{iterations}}; i++) { [acc] = src; }
+            })();
+            """);
+        engine.Evaluate(prepared);
+        engine.Evaluate(prepared);
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        engine.Evaluate(prepared);
+        var perWrite = (double) (GC.GetAllocatedBytesForCurrentThread() - before) / iterations;
+
+        // Same budget as the shadowing case above: 104 bytes of iterator machinery the destructuring
+        // legitimately allocates, and none of the 64 the validate-and-apply path adds per write.
+        perWrite.Should().BeLessThan(130, $"writing a global created by an unresolvable assignment allocated {perWrite} bytes per write");
     }
 #endif
 

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -6,6 +6,7 @@ using Jint.Constraints;
 using Jint.Native;
 using Jint.Native.Function;
 using Jint.Native.Generator;
+using Jint.Native.Global;
 using Jint.Native.Object;
 using Jint.Native.Promise;
 using Jint.Native.Symbol;
@@ -1545,7 +1546,22 @@ public sealed partial class Engine : IDisposable
                 Throw.ReferenceError(Realm, reference);
             }
 
-            Realm.GlobalObject.Set(property, value, throwOnError: false);
+            // Step 2.c, Set(globalObj, V.[[ReferencedName]], W, false) — plus, when the global object
+            // is Jint's own, the mutable-binding marking every other route that creates a global
+            // binding does. A host that substituted its own global through Host.CreateGlobalObject
+            // has no such binding storage to mark and just takes the [[Set]]. The cast is the
+            // reference's own invariant: an unresolvable reference is only ever built for an
+            // identifier that resolved on no environment — GetIdentifierReference below and the two
+            // JintIdentifierExpression sites — and all three carry the name as a JsString, the
+            // former through JsString.Create and the latter two through Environment.BindingName.Value.
+            if (Realm.GlobalObject is GlobalObject globalObject)
+            {
+                globalObject.SetFromUnresolvableAssignment((JsString) property, value);
+            }
+            else
+            {
+                Realm.GlobalObject.Set(property, value, throwOnError: false);
+            }
         }
         else if (reference.IsPropertyReference)
         {

--- a/Jint/Native/Atomics/AtomicsInstance.cs
+++ b/Jint/Native/Atomics/AtomicsInstance.cs
@@ -198,21 +198,45 @@ internal sealed partial class AtomicsInstance : BuiltinShapeObject
         /// </summary>
         private readonly int _generation;
 
+        /// <summary>
+        /// Cancelled by whichever route settles this wait first, which is what stops the timeout timer.
+        /// Only a wait with a finite timeout has one — an infinite wait starts no timer, so there is
+        /// nothing to cancel.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately never disposed. Nothing here reaches the two things a <c>CancellationTokenSource</c>
+        /// needs disposing for — <c>CancelAfter</c>'s timer and <c>Token.WaitHandle</c>'s kernel event — so
+        /// the source is plain garbage once the wait has settled, and both ends drop it together. Disposing
+        /// it would have to happen on the timer task, which is the one thread that cannot know whether the
+        /// <c>Cancel</c> that woke it has finished running its registrations.
+        /// </remarks>
+        private readonly CancellationTokenSource? _timeoutCancellation;
+
         private int _resolved;
 
-        public AsyncWaiter(Engine engine, PromiseCapability promiseCapability)
+        public AsyncWaiter(Engine engine, PromiseCapability promiseCapability, bool hasTimeout)
         {
             _engine = engine;
             _promiseCapability = promiseCapability;
             _generation = engine.EventLoopGeneration;
+            _timeoutCancellation = hasTimeout ? new CancellationTokenSource() : null;
         }
 
         public bool Resolved => _resolved != 0;
+
+        public CancellationToken TimeoutToken => _timeoutCancellation?.Token ?? CancellationToken.None;
 
         public void Resolve(string result)
         {
             if (Interlocked.CompareExchange(ref _resolved, 1, 0) == 0)
             {
+                // Stop the timeout timer before anything else. A wake that arrives first would otherwise
+                // leave a thread-pool task sleeping out the rest of the interval with this waiter — and
+                // through it the engine, its realm and the promise capability — alive in its closure, long
+                // after the engine had finished with the wait. Cancelling here is what bounds the timer by
+                // the wait rather than by the clock, whichever of the two routes wins.
+                _timeoutCancellation?.Cancel();
+
                 // Queue microtask to resolve the promise
                 _engine.AddToEventLoop(() =>
                 {
@@ -665,37 +689,58 @@ internal sealed partial class AtomicsInstance : BuiltinShapeObject
         {
             var key = new WaiterKey(bufferData, byteIndexInBuffer);
             var waiterList = _waiters.GetOrAdd(key, _ => new WaiterList());
-            var asyncWaiter = new AsyncWaiter(_engine, promiseCapability);
+            var hasTimeout = !double.IsPositiveInfinity(q);
+            var asyncWaiter = new AsyncWaiter(_engine, promiseCapability, hasTimeout);
             waiterList.AddAsync(asyncWaiter);
 
             // Handle timeout
-            if (!double.IsPositiveInfinity(q))
+            if (hasTimeout)
             {
                 var timeoutMs = (int) System.Math.Min(System.Math.Ceiling(q), int.MaxValue);
                 var capturedWaiterList = waiterList;
                 var capturedAsyncWaiter = asyncWaiter;
+                var timeoutToken = asyncWaiter.TimeoutToken;
 
                 // Use a timer to resolve with "timed-out" after the timeout. Task.Delay can
                 // complete slightly ahead of the requested interval (timer granularity /
                 // coalescing), and the wait must not report timed-out before the timeout has
                 // actually elapsed — script can observe the lapse (test262 asserts
                 // lapse >= timeout) — so re-delay until a monotonic clock agrees.
+                //
+                // The delay observes the waiter's own cancellation, which AsyncWaiter.Resolve
+                // triggers however the wait ends. Without it the task was unstoppable: an
+                // Atomics.notify that woke the wait after a millisecond still left a thread-pool
+                // task sleeping out the whole interval, holding the waiter — and through it the
+                // engine, its realm and the promise capability — alive in its closure, and then
+                // enqueueing onto an event loop whose engine the host had long finished with.
+                // The window is as long as the script asked for, so nothing bounds it but the
+                // script, and a host that builds an engine per request accumulated one such task
+                // per unfinished wait.
                 _ = Task.Run(async () =>
                 {
-                    var stopwatch = System.Diagnostics.Stopwatch.StartNew();
-                    var remainingMs = timeoutMs;
-                    do
+                    try
                     {
-                        await Task.Delay(remainingMs).ConfigureAwait(false);
-                        remainingMs = timeoutMs - (int) stopwatch.ElapsedMilliseconds;
-                    } while (remainingMs > 0);
+                        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+                        var remainingMs = timeoutMs;
+                        do
+                        {
+                            await Task.Delay(remainingMs, timeoutToken).ConfigureAwait(false);
+                            remainingMs = timeoutMs - (int) stopwatch.ElapsedMilliseconds;
+                        } while (remainingMs > 0);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // The wait was settled by another route; it has already been removed from
+                        // the list and its promise already resolved.
+                        return;
+                    }
 
                     if (!capturedAsyncWaiter.Resolved)
                     {
                         capturedWaiterList.RemoveAsync(capturedAsyncWaiter);
                         capturedAsyncWaiter.Resolve("timed-out");
                     }
-                });
+                }, timeoutToken);
             }
         }
         else

--- a/Jint/Native/Global/GlobalObject.cs
+++ b/Jint/Native/Global/GlobalObject.cs
@@ -896,33 +896,59 @@ uriError:
 
         if (result)
         {
-            MarkBindingPropertyCreatedByShadowing(property);
+            MarkBindingPropertyCreatedBySet(property);
         }
 
         return true;
     }
 
     /// <summary>
-    /// Where the inherited property is writable data, [[Set]] shadows it by creating an own property on
-    /// the receiver through CreateDataProperty. That gives the right attributes but not
-    /// <see cref="PropertyFlag.MutableBinding"/>, which is the marker telling the two stores above they
-    /// may write the descriptor's value in place. So a property the binding machinery had itself just
-    /// created sent every later write of that name down the validate-and-apply path instead — allocating
-    /// a descriptor and a key each time, and for the rest of the engine's life, since nothing ever puts
-    /// the marker on afterwards. Both of the record's other ways of creating a global property mark it:
-    /// CreateGlobalVarBinding for a <c>var</c> declaration, and the branch just above for a binding that
-    /// resolves to nothing on the prototype either.
+    /// https://tc39.es/ecma262/#sec-putvalue step 2.c — a sloppy assignment to a name that resolves
+    /// nowhere at all has an unresolvable reference, so PutValue never reaches the global environment
+    /// record and performs Set(globalObj, V.[[ReferencedName]], W, false) here instead. What that
+    /// creates is a global variable-like binding all the same, so it is marked like every other route
+    /// that creates one and comes out indistinguishable from an eval-scoped <c>var</c>'s global.
     /// </summary>
     /// <remarks>
-    /// <para>Only the exact descriptor CreateDataProperty leaves behind is marked. The caller has already
+    /// <para>Unresolvability establishes what <see cref="MarkBindingPropertyCreatedBySet"/> needs: the
+    /// name resolved on no environment of the chain, which for the last of them means neither an own
+    /// property of the global nor anything on its prototype chain, so whatever own property is there
+    /// once [[Set]] returns was created by it. A right-hand side that reached <c>globalThis</c> between
+    /// the reference and the assignment is the one way that is not literally true, and it is covered
+    /// anyway: only the exact descriptor shape CreateDataProperty produces is ever marked, which is a
+    /// plain writable global data property either way.</para>
+    /// <para>The property name of an unresolvable reference is always an identifier name — only
+    /// Engine.GetIdentifierReference produces the unresolvable sentinel, and it always carries a
+    /// <see cref="JsString"/>.</para>
+    /// </remarks>
+    internal void SetFromUnresolvableAssignment(JsString property, JsValue value)
+    {
+        // [[Set]] can still decline - a non-extensible global has nowhere to put the property, and the
+        // sloppy assignment is a silent no-op - in which case there is nothing to mark.
+        if (Set(property, value))
+        {
+            MarkBindingPropertyCreatedBySet(property.ToString());
+        }
+    }
+
+    /// <summary>
+    /// Where a global binding is created by ordinary [[Set]] rather than by the binding machinery's own
+    /// helper, the property comes out with the right attributes but without
+    /// <see cref="PropertyFlag.MutableBinding"/>, the marker telling the two stores above they may write
+    /// the descriptor's value in place. So a property the binding machinery had itself just created sent
+    /// every later write of that name down the validate-and-apply path instead — allocating a descriptor
+    /// and a key each time, and for the rest of the engine's life, since nothing ever puts the marker on
+    /// afterwards. Every other way a global binding comes into being marks it: CreateGlobalVarBinding for
+    /// a <c>var</c> declaration, and the branch above for a binding that resolves to nothing on the
+    /// prototype either.
+    /// </summary>
+    /// <remarks>
+    /// Only the exact descriptor CreateDataProperty leaves behind is marked. Each caller has already
     /// established that the global had no own property of this name before the [[Set]], so whatever is
     /// there now was created by it — but an inherited setter is free to have defined something of its
-    /// own shape during the call, and that is left alone.</para>
-    /// <para>A sloppy assignment to a name that resolves nowhere at all is a different route with the
-    /// same shortfall, and is deliberately not covered here: the reference is unresolvable, so PutValue
-    /// never reaches this record and assigns through the global object's plain [[Set]] instead.</para>
+    /// own shape during the call, and that is left alone.
     /// </remarks>
-    private void MarkBindingPropertyCreatedByShadowing(Key property)
+    private void MarkBindingPropertyCreatedBySet(Key property)
     {
         var created = GetOwnProperty(property);
         if (created != PropertyDescriptor.Undefined

--- a/Jint/Native/Temporal/IsoRecords.cs
+++ b/Jint/Native/Temporal/IsoRecords.cs
@@ -25,6 +25,14 @@ internal readonly record struct IsoDate(int Year, int Month, int Day)
     /// <summary>
     /// Returns the number of days in the given month for the given year.
     /// </summary>
+    /// <remarks>
+    /// A month outside 1-12 answers 0, which is load-bearing for <see cref="IsValid"/> — no day is
+    /// within an interval of zero days — and so stays. It does mean this value cannot be handed to
+    /// <c>System.Math.Clamp(day, 1, ...)</c> without establishing the month range first: Math.Clamp
+    /// throws ArgumentException for inverted bounds, and that exception escapes engine.Evaluate, where
+    /// a script sees neither a value nor a catchable JavaScript error. TemporalHelpers.RegulateIsoDate
+    /// clamps the month on the line above for exactly that reason.
+    /// </remarks>
     public static int IsoDateInMonth(int year, int month)
     {
         return month switch

--- a/Jint/Native/Temporal/NonIsoCalendars.cs
+++ b/Jint/Native/Temporal/NonIsoCalendars.cs
@@ -9,6 +9,19 @@ namespace Jint.Native.Temporal;
 /// Gregorian-based calendars (iso8601, gregory, japanese, roc, buddhist) are handled
 /// directly in TemporalHelpers using ISO arithmetic.
 /// </summary>
+/// <remarks>
+/// Constraining a field here means <c>System.Math.Clamp(value, 1, max)</c> against a computed
+/// months-in-year or days-in-month. Math.Clamp throws ArgumentException when min is greater than max,
+/// where the private clamp helpers it replaced returned min, so a max below 1 is not a badly
+/// constrained date: it is a CLR exception escaping engine.Evaluate, where a script sees neither a
+/// value nor a catchable JavaScript error. Every helper below that produces such a max therefore
+/// states why it cannot answer below 1, and each maximum taken from System.Globalization instead
+/// (Calendar.GetDaysInMonth, GetMonthsInYear, GetLeapMonth, IsLeapYear — all of which either answer 1
+/// or more or throw for a year outside the calendar's range) sits inside a try whose catch answers
+/// with a literal or with one of those helpers. What keeps all of it true is
+/// Jint.Tests/Runtime/NonIsoCalendarTests.cs: 85,800 field combinations per overflow mode across all
+/// eleven calendars, every one of which has to come back as a date or as null rather than throw.
+/// </remarks>
 internal static class NonIsoCalendars
 {
     // Lazy calendar instances to avoid startup overhead
@@ -1243,6 +1256,12 @@ internal static class NonIsoCalendars
     /// <summary>
     /// Gets the number of months in a calendar year.
     /// </summary>
+    /// <remarks>
+    /// Never below 12: every arm answers 12 or 13 outright, and Calendar.GetMonthsInYear answers 12 or
+    /// 13 for the lunisolar calendars that reach it — or throws for a year outside its range, which the
+    /// catch answers with 12 or 13 too. The value becomes the max of Math.Clamp(month, 1, ...); see the
+    /// type's remarks for what an answer below 1 would cost.
+    /// </remarks>
     private static int GetMonthsInYear(string calendar, Calendar? cal, int year)
     {
         if (calendar is "persian" or "indian" or "islamic-umalqura" or "islamic-civil" or "islamic-tbla")
@@ -1710,6 +1729,14 @@ internal static class NonIsoCalendars
         return PersianEpochJdn + cycle * 1029983L + 365L * (yc - 1L) + (yc * 682L - 110L) / 2816L;
     }
 
+    /// <summary>
+    /// Days in a Persian month, computed algorithmically for the years PersianCalendar cannot answer for.
+    /// </summary>
+    /// <remarks>
+    /// Never below 29: 31 for months 1-6, 30 for 7-11, and 30 or 29 for month 12. A month argument
+    /// outside 1-12 answers from one of those arms as well — zero and negatives take the first, 13 and
+    /// above the last. The value becomes the max of Math.Clamp(day, 1, ...); see the type's remarks.
+    /// </remarks>
     private static int PersianAlgorithmicDaysInMonth(int year, int month)
     {
         if (month <= 6) return 31;
@@ -1958,6 +1985,11 @@ internal static class NonIsoCalendars
     /// Returns the number of days in the given month of a fixed-epoch calendar year.
     /// Months 1-12 have 30 days each. Month 13 has 5 days (6 in leap year).
     /// </summary>
+    /// <remarks>
+    /// Never below 5, the length of a common-year epagomenal month, and a month argument outside 1-13
+    /// takes the 30 fallback. The value becomes the max of Math.Clamp(day, 1, ...); see the type's
+    /// remarks.
+    /// </remarks>
     private static int FixedEpochDaysInMonth(int year, int month)
     {
         if (month >= 1 && month <= 12) return 30;
@@ -2250,6 +2282,10 @@ internal static class NonIsoCalendars
     /// Months 2-6: 31 days each.
     /// Months 7-12: 30 days each.
     /// </summary>
+    /// <remarks>
+    /// Never below 30, and the final arm covers a month argument outside 1-12 as well. The value
+    /// becomes the max of Math.Clamp(day, 1, ...); see the type's remarks.
+    /// </remarks>
     private static int IndianDaysInMonth(int sakaYear, int month)
     {
         if (month == 1) return IsIndianLeapYear(sakaYear) ? 31 : 30;
@@ -2628,6 +2664,13 @@ internal static class NonIsoCalendars
         return mod is 2 or 5 or 7 or 10 or 13 or 16 or 18 or 21 or 24 or 26 or 29;
     }
 
+    /// <summary>
+    /// Returns the number of days in the given month of the Islamic Civil (tabular) calendar.
+    /// </summary>
+    /// <remarks>
+    /// Never below 29, and a month argument outside 1-12 answers 30 or 29 from the same two arms. The
+    /// value becomes the max of Math.Clamp(day, 1, ...); see the type's remarks.
+    /// </remarks>
     private static int IslamicCivilDaysInMonth(int year, int month)
     {
         // Odd months have 30 days, even months have 29 days

--- a/Jint/Native/Temporal/TemporalHelpers.cs
+++ b/Jint/Native/Temporal/TemporalHelpers.cs
@@ -1787,6 +1787,18 @@ internal static class TemporalHelpers
     /// Odd months have 30 days, even months have 29 days.
     /// Month 12 has 30 days in leap years.
     /// </summary>
+    /// <remarks>
+    /// This one <em>can</em> answer below 1: a month outside 1-12 has no days, and 0 is what says so.
+    /// Both places that use it as the max of <c>System.Math.Clamp(day, 1, ...)</c> clamp the month to
+    /// 1-12 on the line immediately above, and both places that use it in a range test reach it only
+    /// after <c>month &lt; 1 || month &gt; 12</c> has short-circuited, so the 0 never becomes an
+    /// inverted bound — which Math.Clamp answers with an ArgumentException escaping engine.Evaluate,
+    /// where the private clamp helper it replaced returned min. Anything new that takes this value as
+    /// a maximum has to establish the month range first. Note that all four callers currently sit in
+    /// IslamicCivilDateToISO and IslamicTblaDateToISO, which nothing references — the live islamic-civil
+    /// and islamic-tbla conversions run through NonIsoCalendars.IslamicCivilTabularDateToIso and its own
+    /// IslamicCivilDaysInMonth, which has no out-of-range arm at all.
+    /// </remarks>
     private static int IslamicCivilDaysInMonth(int year, int month)
     {
         if (month <= 0 || month > 12)
@@ -2782,6 +2794,11 @@ internal static class TemporalHelpers
     {
         if (string.Equals(overflow, "constrain", StringComparison.Ordinal))
         {
+            // The month clamp is what keeps the day clamp's bounds the right way round:
+            // IsoDate.IsoDateInMonth answers 0 for a month outside 1-12 (which is what IsoDate.IsValid
+            // reads it for), and a max of 0 is inverted bounds, which Math.Clamp answers with an
+            // ArgumentException escaping engine.Evaluate rather than with a constrained date. The two
+            // lines have to stay in this order.
             month = System.Math.Clamp(month, 1, 12);
             var daysInMonth = IsoDate.IsoDateInMonth(year, month);
             day = System.Math.Clamp(day, 1, daysInMonth);

--- a/Jint/Test262AgentManager.cs
+++ b/Jint/Test262AgentManager.cs
@@ -25,6 +25,7 @@ internal sealed class Test262AgentManager : IDisposable
     private readonly Lock _broadcastLock = new();
     private readonly ManualResetEventSlim _broadcastEvent = new(false);
     private int _broadcastVersion;
+    private volatile bool _disposed;
 
     /// <summary>
     /// Adds the $262.agent object to the engine's $262 object.
@@ -117,6 +118,18 @@ internal sealed class Test262AgentManager : IDisposable
 
     public void Dispose()
     {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        // Release anyone parked in WaitForBroadcast first. A test that failed before it broadcast
+        // leaves its agent waiting for a broadcast that is never coming, and without this the join
+        // below costs the full timeout for a thread that had nothing left to do.
+        _broadcastEvent.Set();
+
         // Wait for all workers to finish
         List<AgentWorker> workers;
         lock (_workers)
@@ -124,16 +137,27 @@ internal sealed class Test262AgentManager : IDisposable
             workers = [.. _workers];
         }
 
+        var allExited = true;
         foreach (var worker in workers)
         {
-            worker.WaitForExit(TimeSpan.FromSeconds(30));
+            allExited &= worker.WaitForExit(TimeSpan.FromSeconds(30));
         }
 
-        _broadcastEvent.Dispose();
+        // Disposing a ManualResetEventSlim while another thread is inside Wait() is undefined -- the
+        // waiter can end up operating on a handle that has already been closed -- and a worker that
+        // outlived the join is exactly such a thread. Nothing here ever asks the event for its
+        // WaitHandle, so an undisposed one holds managed state only; leaving it to the garbage
+        // collector is strictly safer than racing a live waiter.
+        if (allExited)
+        {
+            _broadcastEvent.Dispose();
+        }
     }
 
     private sealed class AgentWorker
     {
+        private static readonly TimeSpan BroadcastPollInterval = TimeSpan.FromMilliseconds(50);
+
         private readonly Test262AgentManager _manager;
         private readonly string _scriptSource;
         private Thread? _thread;
@@ -156,9 +180,13 @@ internal sealed class Test262AgentManager : IDisposable
             _thread.Start();
         }
 
-        public void WaitForExit(TimeSpan timeout)
+        /// <summary>
+        /// Returns whether the worker thread had actually exited by the time the timeout elapsed, which is
+        /// what <see cref="Dispose"/> needs to know before it touches the shared broadcast event.
+        /// </summary>
+        public bool WaitForExit(TimeSpan timeout)
         {
-            _thread?.Join(timeout);
+            return _thread?.Join(timeout) ?? true;
         }
 
         private void Run()
@@ -268,7 +296,23 @@ internal sealed class Test262AgentManager : IDisposable
         {
             while (true)
             {
-                _manager._broadcastEvent.Wait();
+                // Bounded, and re-checked on both sides of the wait: an agent whose test ended before it
+                // broadcast used to park here forever, keeping a thread alive past the test that started
+                // it and costing the manager its whole join timeout on the way out.
+                if (_manager._disposed)
+                {
+                    return;
+                }
+
+                if (!_manager._broadcastEvent.Wait(BroadcastPollInterval))
+                {
+                    continue;
+                }
+
+                if (_manager._disposed)
+                {
+                    return;
+                }
 
                 byte[]? bufferData;
                 int bufferLength;


### PR DESCRIPTION
Walks all five items #3013 recorded, in order. Two of them are already on `main` and are marked as such; the other three are here.

---

### (a) Sloppy assignment to an unresolvable name misses the `MutableBinding` marker — **fixed here**

A sloppy assignment to a name that resolves nowhere at all — no environment on the chain, no own property on the global, nothing on its prototype chain — has an unresolvable reference, so `PutValue` never reaches the global environment record and performs `Set(globalObj, V.[[ReferencedName]], W, false)` on the global object instead ([spec, step 2.c](https://tc39.es/ecma262/#sec-putvalue)). Ordinary `[[Set]]` ends in `CreateDataProperty`, which leaves a configurable/enumerable/writable own property with the right attributes and without `PropertyFlag.MutableBinding` — the marker that lets `GlobalObject`'s two in-place stores write the descriptor's value directly. So every later write of that name took the validate-and-apply path instead, permanently, since nothing puts the marker on afterwards.

This is the sibling #2986's own `<remarks>` named as deliberately uncovered, and it is the plainest global there is: `x = 5` on a fresh engine. `var x = 5` marks it (`CreateGlobalVarBinding`), shadowing an inherited name marks it (#2986), and this one — the only route with no declaration at all — did not.

The marking logic stays in `GlobalObject` and is now shared: `TrySetThroughPrototype` and the new `SetFromUnresolvableAssignment` both end in `MarkBindingPropertyCreatedBySet` (renamed from `…ByShadowing`, which no longer describes both callers). `Engine.PutValue` only names the entry point, and keeps the plain `[[Set]]` for a global a host substituted through `Host.CreateGlobalObject`, which has no binding storage to mark.

**Pre-fix failures**, from the new tests run against unmodified `main`:

```
Jint.Tests.Runtime.GlobalPrototypeBindingTests.AssigningToAnUnresolvableNameCreatesAMutableBindingLikeAVarDeclarationDoes
  Expected the enum to have flag PropertyFlag.MutableBinding {value: 512},
  but found PropertyFlag.ConfigurableEnumerableWritable {value: 21}.

Jint.Tests.Runtime.GlobalPrototypeBindingTests.RepeatedWritesToAGlobalCreatedByUnresolvableAssignmentStoreInPlace
  Expected perWrite to be less than 130.0 because writing a global created by an
  unresolvable assignment allocated 168.0476 bytes per write, but found 168.0476.
```

Both green afterwards, the allocation one at **104.046 bytes per write** — byte for byte what the shadowing route measures post-#2986, the 64 being one `PropertyDescriptor` and one `JsString` key allocated and discarded on every write. Two more tests come along as controls: the marker changes nothing script-observable (descriptor shape, `writable: false`, redefinition as an accessor, `delete`), and a `[[Set]]` that declines — a non-extensible global — marks nothing.

The change is confined to `PutValue`'s unresolvable arm, which runs once per global name created this way; the hot arms are untouched, so there is nothing for SunSpider or Dromaeo to say that the allocation figure above does not.

### (b) A class constructor's name is missing from "cannot be invoked without 'new'" — **already shipped in 4.16.0**

Fixed by #2990, commit `4b5fdcb50`. `ScriptFunction.ClassConstructorWithoutNewMessage` reads the name off the constructor's own `name` property (the constructor *method's* definition has no name for any class) and falls back to the nameless phrasing when a class acquired no name at all. Verified on HEAD:

```
[1].map(class C {})  ->  Class constructor C cannot be invoked without 'new'
[1].map(class {})    ->  Class constructors cannot be invoked without 'new'
class D {}; D()      ->  Class constructor D cannot be invoked without 'new'
```

`Jint.Tests/Runtime/ClassTests.cs` pins all eight shapes, the issue's `[1].map(class C {})` among them. Nothing changed here.

### (c) `ClrErrorContext` is replaced wholesale — **already shipped in 4.16.0**

Fixed by #2991, commit `f65385f9b`. Both `ErrorInstance.SetClrResolutionInfo` and `SetClrException` now rebuild the record carrying the other's fields forward, so whichever runs second keeps the first's facts. `InteropTests.ErrorMessages.ClrResolutionInfoAndClrExceptionCoexistOnOneError` drives them directly in both orders. Nothing changed here.

### (d) `Math.Clamp` can throw where the helpers it replaced could not — **invariant recorded, no behaviour change**

First, an attribution correction: the issue credits **#2901**, which is *Stop shipping the numeric polyfill hosts as public API* and touched only `AGENTS.md` and the polyfill classes. The clamp sweep is **#2910** (`53027d7fb`, *Backfill the remaining one-member API gaps*) — "Math.Clamp replaces two separate private Clamp copies". Worth knowing too that #2955 (`db6dbde24`) has already hardened one site (`HebrewDaysInMonthOrdinal`, whose 0 fallback became 29) and made the polyfill reject inverted bounds like the BCL does.

The invariant is now written once per helper that produces a maximum rather than once per call site: `NonIsoCalendars` carries it for the file (including the maxima that come from `System.Globalization`, each of which sits in a `try` whose `catch` answers with a literal or with one of these helpers), and `GetMonthsInYear`, `PersianAlgorithmicDaysInMonth`, `FixedEpochDaysInMonth`, `IndianDaysInMonth` and `IslamicCivilDaysInMonth` each say why they cannot answer below 1. Every one was read before the claim was written; the floors are 12, 29, 5, 30 and 29, and in each case the arm that catches an out-of-range month argument is the one that keeps it there. `Jint.Tests/Runtime/NonIsoCalendarTests.cs` — 85,800 field combinations per overflow mode across eleven calendars — is named as what keeps it true.

**Two helpers do answer below 1, and are called out rather than glossed:**

- `TemporalHelpers.IslamicCivilDaysInMonth` returns `0` for a month outside 1–12.
- `IsoDate.IsoDateInMonth` returns `0` likewise — and there it is load-bearing, because `IsoDate.IsValid` reads it to decide that no day fits an invalid month. It has to stay.

Neither is reachable: every site that uses one as a `Math.Clamp` maximum clamps the month to 1–12 on the line immediately above, and every site that uses one in a range test reaches it only after `month < 1 || month > 12` has short-circuited. That is a much stronger guard than the Hebrew case #2955 hardened, where what kept the maximum at 29 was two independent leap-year oracles agreeing. So no behaviour changed; the comments say what the guard is and that a new caller has to reproduce it. Related and reported rather than fixed: `TemporalHelpers.IslamicCivilDateToISO` and `IslamicTblaDateToISO` — the only callers of that helper — are private and **unreferenced**; the live `islamic-civil` and `islamic-tbla` conversions run through `NonIsoCalendars.IslamicCivilTabularDateToIso`. Removing them is a separate change.

### (e) `Atomics.waitAsync` agent test intermittently crashes the test host — **engine defect fixed**

`Atomics.waitAsync` with a finite timeout armed `_ = Task.Run(async () => …)` and then had no way to stop it. The task slept out the whole interval whatever happened to the wait, so an `Atomics.notify` that woke the wait after a millisecond still left a thread-pool task holding the `AsyncWaiter` — and through it the engine, its realm and the promise capability — alive in its closure, and then called `AddToEventLoop` on an event loop whose engine the host had long since finished with. The interval is whatever the script asked for, so nothing bounded it but the script, and a host building an engine per request accumulated one such task per unfinished wait.

The delay now observes a `CancellationToken` the waiter owns, which `AsyncWaiter.Resolve` trips however the wait ends — timeout or wake — so the timer is bounded by the wait rather than by the clock. New test `AWaitWokenByNotifyDoesNotLeaveItsTimeoutTimerHoldingTheEngine` asks for a three-minute timeout, wakes the wait immediately, drops the engine and collects. **Pre-fix** (both TFMs):

```
Jint.Tests.Runtime.AtomicsWaitAsyncTests.AWaitWokenByNotifyDoesNotLeaveItsTimeoutTimerHoldingTheEngine
  Expected boolean to be True because the timeout timer of a woken Atomics.waitAsync
  still pins the engine that owned it, but found False.          [10 s]
```

Ten seconds of forced collections could not free it. Post-fix the engine is gone on the first pass and the test finishes in under half a second. Two controls come with it: a wait nobody wakes still settles `"timed-out"`, and a woken wait still settles `"ok"` — both pass before *and* after, which is what makes them controls.

`Jint/Test262AgentManager.cs` — which, note, ships in the production assembly — is hardened alongside, because two things in it turn an agent test that should merely fail into a runner that goes down:

- `Dispose()` disposed the shared `ManualResetEventSlim` unconditionally after a bounded join. Disposing one while another thread is inside `Wait()` is undefined — the waiter can end up on a handle that has already been closed — and a worker that outlived the 30-second join is exactly such a thread. It now disposes only when every worker actually exited, and is idempotent (`Dispose` is reachable twice through the static `_currentAgentManager`).
- `WaitForBroadcast` waited unboundedly, so an agent started by a test that then failed before broadcasting parked forever, keeping a thread alive past its test and costing the manager its whole join timeout on the way out. It is bounded now and checks for shutdown on both sides of the wait; `Dispose` sets the event before joining so parked workers are released rather than waited out.

**Honest limits on this one.** I could not make the crash happen on demand: six isolated runs of `Atomics_waitAsync` (202 cases each) and eight full test262 runs were clean, so I cannot say "this exact change is what stops the crash". What I can say is that the leaked timer is real and demonstrable — the retention test above is the demonstration — and that with `$262.agent.timeouts.small` at 200 ms it is provably still pending when the manager is disposed and the next test starts, which is the window the issue describes. No `ExcludedFiles` entry was added.

`Jint.Tests.Test262/Test262Test.cs`'s `setTimeout` shim has the same fire-and-forget shape, and my judgement is to leave it: it is a ten-line test shim reached only by tests that ask for it, its callback is queued to the event loop and simply dropped if nobody drains, and giving it a cancellation scope means inventing a per-test lifetime the harness does not have. The `waitAsync` timer is different in kind — it is engine code that runs for every `Atomics.waitAsync` call in every embedding. Worth revisiting if the crash survives this PR.

---

**Also noted, not fixed** (pre-existing, and each its own change): `AtomicsInstance._waiters` is a process-wide static dictionary that is never pruned, so a `WaiterList` and its `WaiterKey`'s buffer live for the process; and an `Atomics.waitAsync(…, Infinity)` that is never notified leaves its `AsyncWaiter` — and its engine — in that dictionary forever, since only the timeout and notify paths remove waiters.

### Verification

Release throughout, no `--no-build` on any first run of a changed tree.

| Leg | Result |
| --- | --- |
| `Jint.Tests` (net10.0 / net472) | 5667 / 5582 passed, 4 skipped, 0 failed |
| `Jint.Tests.PublicInterface` (net10.0 / net472) | 1486 / 1485 passed, 9 skipped, 0 failed |
| `Jint.Tests` with `JINT_HOST_CONTRACT_VERIFICATION=1` | 5667 / 5582 passed, 0 failed |
| `Jint.Tests.PublicInterface` with `JINT_HOST_CONTRACT_VERIFICATION=1` | 1490 / 1489 passed, 5 skipped, 0 failed (skips drop 9→5, so the switch really took) |
| `Jint.Tests.Test262` | 99 779 passed, 122 skipped, 0 failed — **8 consecutive runs, all clean** |
| `Jint.Tests.CommonScripts` (net10.0 / net472) | 28 / 28 passed |
| `Jint.Tests.SourceGenerators` | 52 passed |

Closes #3013

🤖 Generated with [Claude Code](https://claude.com/claude-code)
