### PR TITLE
Unpark staging/Temporal/removed-methods.js, which #3014 already fixed

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -57,9 +57,6 @@
     "staging/sm/expressions/nullish-coalescing.js",
     "staging/sm/regress/regress-1507322-deep-weakmap.js",
 
-    // Removed by the fix for #3010: five Temporal members the proposal dropped are still present.
-    "staging/Temporal/removed-methods.js",
-
     // Cross-realm error identity. $262.createRealm() works, but an error Jint raises while running
     // a function belonging to another realm is constructed from the *current* realm's intrinsics,
     // so `e instanceof otherGlobal.TypeError` is false. The realm's global also does not carry its


### PR DESCRIPTION
A four-line deletion, caught while finishing #3011.

#3016 (staging/) was written while #3014 (the Temporal member removals) was still open, so it parked `staging/Temporal/removed-methods.js` with a comment saying *"Removed by the fix for #3010"*. #3014 then merged **first**, on 2026-08-14; #3016 merged after it; and nothing went back to delete the exclusion. So a test that passes has been skipped since `staging/` went live.

That file asserts the absence of 28 members the proposal removed — the five #3014 dropped, plus 23 Jint never had — which makes it the upstream guard for exactly the regression #3014 could reintroduce.

Both modes pass with the entry gone:

```
Passed Temporal("staging/Temporal/removed-methods.js",False) [1 ms]
Passed Temporal("staging/Temporal/removed-methods.js",True)  [1 ms]
```

Full suite: **102,324 passed, 0 failed**.

Worth noting the general shape, since `staging/` is new and this will recur: an exclusion whose comment names the PR that removes it does not remove itself, and the ordering that leaves it stale is the *good* one — the fix landing before the exclusion does. The sibling entry for #3011 is deleted by that PR itself (#3015), which is the pattern to keep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)