### PR TITLE
Refuse a JSON document too long to be a string while it is being built

### DIFF
--- a/Jint.Tests/Runtime/StringLengthLimitTests.cs
+++ b/Jint.Tests/Runtime/StringLengthLimitTests.cs
@@ -19,13 +19,13 @@ namespace Jint.Tests.Runtime;
 /// </para>
 /// <para>
 /// Every row below is a path whose limit is decided from small inputs — a repeat count, a pad length,
-/// a replacement pattern's expansion factor — so the throw happens before anything of that size is
-/// allocated and the test costs a few megabytes. The remaining guarded paths (<c>+</c>/<c>+=</c>,
-/// template literals, <c>concat</c>, <c>join</c>, <c>toLocaleString</c>, <c>String.raw</c> and the
-/// accumulators inside <c>replace</c>/<c>replaceAll</c>) accumulate their result one piece at a time,
-/// so their guard can only fire once roughly half a billion characters are already in hand; a test for
-/// those would have to allocate the gigabyte the guard exists to prevent, and there is no cheaper
-/// input that reaches them.
+/// a replacement pattern's expansion factor, an array's <c>length</c> — so the throw happens before
+/// anything of that size is allocated and the test costs a few megabytes. The remaining guarded paths
+/// (<c>+</c>/<c>+=</c>, template literals, <c>concat</c>, <c>join</c>, <c>toLocaleString</c>,
+/// <c>String.raw</c>, the accumulators inside <c>replace</c>/<c>replaceAll</c> and the element-by-element
+/// half of <c>JSON.stringify</c>) accumulate their result one piece at a time, so their guard can only
+/// fire once roughly half a billion characters are already in hand; a test for those would have to
+/// allocate the gigabyte the guard exists to prevent, and there is no cheaper input that reaches them.
 /// </para>
 /// </summary>
 public class StringLengthLimitTests
@@ -122,6 +122,54 @@ public class StringLengthLimitTests
             """);
 
         Caught("x.replace(/(.+)/g, rep)").Should().Be(InvalidStringLength);
+    }
+
+    /// <summary>
+    /// <c>JSON.stringify</c> builds its document one element at a time, but an array announces up front
+    /// how many elements there are, and every index contributes at least two characters — a separator
+    /// plus at least one character of value text, an absent element being written as <c>null</c>. So an
+    /// array whose <c>length</c> alone puts the document past the limit is refused before the first
+    /// element is written, which is what makes this row cost nothing: the array itself is empty.
+    /// </summary>
+    [Fact]
+    public void JsonStringifyOfAnArrayTooLongToSerializeIsACatchableRangeError()
+    {
+        Caught("JSON.stringify(Object.assign([], { length: 4294967295 }))").Should().Be(InvalidStringLength);
+        Caught($"JSON.stringify(new Array({JsString.MaxLength / 2 + 1}))").Should().Be(InvalidStringLength);
+    }
+
+    /// <summary>
+    /// The estimate above is a lower bound on the finished document, so it can never refuse one that
+    /// would have fit. These are the shapes where over-counting would show up first: an element is
+    /// written as <c>null</c> however it came to have no representation, and indentation only ever
+    /// adds to the count.
+    /// </summary>
+    [Theory]
+    [InlineData("JSON.stringify(new Array(3))", "[null,null,null]")]
+    [InlineData("JSON.stringify([1, undefined, function () {}, Symbol()])", "[1,null,null,null]")]
+    [InlineData("JSON.stringify([1, 2], null, 4).replace(/\\n/g, '|')", "[|    1,|    2|]")]
+    [InlineData("JSON.stringify({ a: undefined, b: 1 })", "{\"b\":1}")]
+    [InlineData("JSON.stringify(['x'.repeat(1 << 20)]).length", "1048580")]
+    public void JsonDocumentsThatFitAreUnaffected(string source, string expected)
+    {
+        _engine.Evaluate(source).ToString().Should().Be(expected);
+    }
+
+    /// <summary>
+    /// <c>JSON.parse</c> needs no guard of its own — a reviver that builds too long a string does it
+    /// through the ordinary string-building paths, which have one — but the error has to reach the
+    /// script's <c>catch</c> through the parse machinery rather than being wrapped or swallowed on the
+    /// way out. Verified with <c>+</c> as well as <c>repeat</c>, in a run that could afford the half
+    /// gigabyte the concatenating shape costs.
+    /// </summary>
+    [Fact]
+    public void JsonParseReviverThatBuildsTooLongAStringIsACatchableRangeError()
+    {
+        Caught($"JSON.parse('{{\"a\":1}}', function (k, v) {{ return typeof v === 'number' ? 'x'.repeat({JsString.MaxLength + 1L}) : v; }})")
+            .Should().Be(InvalidStringLength);
+
+        _engine.Evaluate("JSON.stringify(JSON.parse('{\"a\":1}', function (k, v) { return typeof v === 'number' ? v + 1 : v; }))")
+            .AsString().Should().Be("{\"a\":2}");
     }
 
     /// <summary>

--- a/Jint/Native/Json/JsonSerializer.cs
+++ b/Jint/Native/Json/JsonSerializer.cs
@@ -41,6 +41,14 @@ namespace Jint.Native.Json;
 /// exists to avoid, and added a decode on top.
 /// </para>
 /// <para>
+/// <b>Document length.</b> The <see cref="JsValue"/>-returning overloads produce a JavaScript string and
+/// are bounded by the same maximum length as every other way of building one: a document that would
+/// exceed it raises <c>RangeError: Invalid string length</c>, which a script can catch, and raises it
+/// while the document is being built rather than after it has been paid for. The
+/// <see cref="IBufferWriter{T}"/> overloads produce bytes the host consumes and never a string, so the
+/// language's limit does not apply to them; they remain bounded only by what a CLR array can hold.
+/// </para>
+/// <para>
 /// <b>BigInt.</b> A <c>BigInt</c> that reaches the output throws a
 /// <see cref="Runtime.JavaScriptException"/> carrying a <c>TypeError</c> ("Do not know how to serialize a
 /// BigInt"), as the specification requires. A host using this type as a storage codec has one escape hatch:
@@ -62,6 +70,13 @@ public sealed class JsonSerializer
     private string _gap = string.Empty;
     private List<JsValue>? _propertyList;
     private bool _hasReplacerFunction;
+
+    // The largest document this call is allowed to build. JsString.MaxLength for the overloads whose
+    // result is a JavaScript string, so JSON.stringify can no longer hand back a string the engine's
+    // own limit forbids; the CLR array ceiling for the IBufferWriter overloads, whose result is bytes
+    // the host consumes and never a JsString, so the language's string limit has no business bounding
+    // them and a host writing a gigabyte-sized document to a stream keeps working.
+    private long _maxDocumentLength;
 
     // Declared last: this is the only field that is not read on the per-key hot path (only
     // UnwrapValueSlow touches it, and only when _hasReplacerFunction says there is one), and embedding
@@ -113,12 +128,11 @@ public sealed class JsonSerializer
     /// </returns>
     public JsValue Serialize(JsValue value, JsValue replacer, JsValue space)
     {
-        if (!TryCreateHolder(value, replacer, space, out var wrapper))
+        if (!TryCreateHolder(value, replacer, space, JsString.MaxLength, out var wrapper))
         {
             return JsValue.Undefined;
         }
 
-        string result;
         var json = new ValueStringBuilder();
         try
         {
@@ -126,12 +140,20 @@ public sealed class JsonSerializer
             {
                 return JsValue.Undefined;
             }
+
+            // The walk refuses an over-long document while it is being built; this catches the one
+            // thing a single append can still overshoot by — the expansion of a quoted string's
+            // escapes — before the document is turned into a JsString.
+            ThrowIfDocumentLengthExceeded(json.Length);
+            return new JsString(json.ToString());
         }
         finally
         {
-            result = json.ToString();
+            // Dispose rather than the ToString() this used to end in: on the throwing path that
+            // materialized the whole partial document, which is up to half a billion characters the
+            // caller never sees. ToString() disposes on the way out, so this is a no-op after it.
+            json.Dispose();
         }
-        return new JsString(result);
     }
 
     /// <summary>
@@ -175,7 +197,7 @@ public sealed class JsonSerializer
             Throw.ArgumentNullException(nameof(writer));
         }
 
-        if (!TryCreateHolder(value, replacer, space, out var wrapper))
+        if (!TryCreateHolder(value, replacer, space, ClrLimits.MaxArrayLength, out var wrapper))
         {
             return false;
         }
@@ -202,9 +224,10 @@ public sealed class JsonSerializer
     /// gap, and builds the wrapper object the value is serialized out of. Returns <see langword="false"/>
     /// for the inputs that produce no output at all.
     /// </summary>
-    private bool TryCreateHolder(JsValue value, JsValue replacer, JsValue space, out ObjectInstance wrapper)
+    private bool TryCreateHolder(JsValue value, JsValue replacer, JsValue space, long maxDocumentLength, out ObjectInstance wrapper)
     {
         _stack = new ObjectTraverseStack(_engine);
+        _maxDocumentLength = maxDocumentLength;
 
         // JSON.stringify allocates a serializer per call, but the type is public and a host may hold an
         // instance across calls: every field the prologue only conditionally assigns has to be cleared
@@ -229,6 +252,36 @@ public sealed class JsonSerializer
         wrapper = _engine.Realm.Intrinsics.Object.Construct(Arguments.Empty);
         wrapper.DefineOwnProperty(JsString.Empty, new PropertyDescriptor(value, PropertyFlag.ConfigurableEnumerableWritable));
         return true;
+    }
+
+    /// <summary>
+    /// Throws <c>RangeError: Invalid string length</c> — the same catchable error every other
+    /// string-building path raises — when a document of <paramref name="length"/> characters would
+    /// exceed what this call may produce.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The check does not live in <c>ValueStringBuilder</c>, which also backs URI encoding and the
+    /// Intl/Temporal formatters and has no realm to raise a JavaScript error into. It lives at the
+    /// points where this walk accumulates — once per array element, once per object key and before a
+    /// string is copied in — so a document that cannot fit is refused while it is being built rather
+    /// than after the whole cost has been paid.
+    /// </para>
+    /// <para>
+    /// The length is a <see cref="long"/> so a caller can add what it is about to append, and what the
+    /// elements it has not reached yet must contribute, without the sum wrapping. Every such estimate
+    /// is a lower bound on the finished document, so this can never refuse one that would have fit.
+    /// The realm is read only on the throwing path: <see cref="Engine.Realm"/> peeks the execution
+    /// context stack, which is not something to do once per element.
+    /// </para>
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void ThrowIfDocumentLengthExceeded(long length)
+    {
+        if (length > _maxDocumentLength)
+        {
+            Throw.RangeError(_engine.Realm, "Invalid string length");
+        }
     }
 
     /// <summary>
@@ -397,7 +450,15 @@ public sealed class JsonSerializer
 
         if (value.IsString())
         {
-            QuoteJSONString(value.ToString(), ref json);
+            var stringValue = value.ToString();
+
+            // Quoting adds the two quotes and can only expand what is between them, so the unquoted
+            // length is a lower bound on what this append costs. Checking here refuses a string that
+            // cannot fit before it is copied into the document — including the case where the string
+            // is the whole document.
+            ThrowIfDocumentLengthExceeded(json.Length + 2L + stringValue.Length);
+
+            QuoteJSONString(stringValue, ref json);
             return SerializeResult.NotUndefined;
         }
 
@@ -438,6 +499,10 @@ public sealed class JsonSerializer
             // Handle RawJSON objects - output rawJSON property directly
             if (objectInstance is JsRawJson rawJson)
             {
+                // Raw JSON text and the host hook below are copied through verbatim, so what they
+                // add is exactly their length: both are single appends large enough to be worth
+                // refusing before the copy.
+                ThrowIfDocumentLengthExceeded(json.Length + (long) rawJson.RawJson.Length);
                 json.Append(rawJson.RawJson);
                 return SerializeResult.NotUndefined;
             }
@@ -451,7 +516,14 @@ public sealed class JsonSerializer
             if (objectInstance is IObjectWrapper wrapper
                 && _engine.Options.Interop.SerializeToJson is { } serialize)
             {
-                json.Append(serialize(wrapper.Target, _gap, _indent));
+                // The pattern keeps the append tolerant of a host handing back null, which it has
+                // always been: ValueStringBuilder.Append(string?) returns for null.
+                var hostJson = serialize(wrapper.Target, _gap, _indent);
+                if (hostJson is { Length: > 0 })
+                {
+                    ThrowIfDocumentLengthExceeded(json.Length + (long) hostJson.Length);
+                    json.Append(hostJson);
+                }
                 return SerializeResult.NotUndefined;
             }
 
@@ -686,6 +758,15 @@ public sealed class JsonSerializer
                 _engine.Constraints.Check();
             }
 
+            // What is written so far can no longer be taken back — an array element is never rolled
+            // back the way an object member with no JSON representation is — and every index still to
+            // come adds at least two characters: a separator (or the opening bracket) plus at least
+            // one character of value text, since an element with no representation is written as
+            // null. So this is a lower bound on the finished document, and it is what makes an array
+            // whose length alone puts the result out of reach fail here instead of after half a
+            // billion characters have been built.
+            ThrowIfDocumentLengthExceeded(json.Length + 2L * (len - i));
+
             if (hasPrevious)
             {
                 json.Append(separator);
@@ -767,6 +848,10 @@ public sealed class JsonSerializer
             {
                 _engine.Constraints.Check();
             }
+
+            // Checked before the key's own position is taken: a member with no JSON representation
+            // rewinds the document to that position, so only what precedes it is certainly final.
+            ThrowIfDocumentLengthExceeded(json.Length);
 
             var p = enumeration.Keys[i];
             int position = json.Length;
@@ -868,6 +953,10 @@ public sealed class JsonSerializer
             {
                 _engine.Constraints.Check();
             }
+
+            // Same reasoning as the generic path: only what precedes this member's position is
+            // certainly final, so the check goes before the position is taken.
+            ThrowIfDocumentLengthExceeded(json.Length);
 
             int position = json.Length;
 


### PR DESCRIPTION
#3015 gave JavaScript strings a maximum length — `JsString.MaxLength = (1 << 29) - 24 = 536,870,888`, V8's `String::kMaxLength` — and guarded every path that builds one with a catchable `RangeError: Invalid string length`. `JSON.stringify` was not in that set, so the engine went on producing a string its own rule forbids.

## The inconsistency

```js
var a = new Array(200000).fill("x".repeat(4000));
var s = JSON.stringify(a);
print(s.length);   // 800600001, and 800600001 > 536870888
```

**Pre-fix, on `3bc449ec`: `800600001`, in 2.0 s.** Every path that would later concatenate that string correctly refuses it, so the inconsistency is observable from script; V8 answers `RangeError: Invalid string length` for the same input.

Larger inputs did not merely produce an over-long string. The new test's own row, run against the unfixed serializer, dies like this:

```
Jint.Tests.Runtime.StringLengthLimitTests.JsonStringifyOfAnArrayTooLongToSerializeIsACatchableRangeError [FAIL]
  System.OutOfMemoryException : Insufficient memory to continue the execution of the program.
     at System.String.Ctor(ReadOnlySpan`1 value)
     at System.Span`1.ToString()
     at System.Text.ValueStringBuilder.ToString() in Jint/Pooling/ValueStringBuilder.cs:line 92
     at Jint.Native.Json.JsonSerializer.Serialize(JsValue, JsValue, JsValue) in Jint/Native/Json/JsonSerializer.cs:line 132
```

Nine seconds and about seven gigabytes to reach a CLR exception escaping `Evaluate` past every `catch` in the script — the exact defect class #3015 was about, and thrown from the `finally` discussed below. With an engine timeout in place instead, the same two inputs simply never return: `-t 3` reports `Script execution timed out` for both `JSON.stringify(Object.assign([], { length: 4294967295 }))` and `JSON.stringify(new Array(268435445))`.

Post-fix all three are a `RangeError` the script catches, and the two cheap ones are immediate.

## Where the guard went, and where it did not

Not into `ValueStringBuilder`. #3015 deliberately left that type realm-free — it also backs URI encode/decode, Intl and Temporal ISO formatting, where a JavaScript error would be wrong — hardened `Grow` so the length arithmetic can no longer wrap, and left each JavaScript-semantic caller to guard its own result. This follows that split: one private `ThrowIfDocumentLengthExceeded(long)` on the serializer, raising `Throw.RangeError(_engine.Realm, "Invalid string length")` — the same message every other path already uses. The realm is read only on the throwing path, because `Engine.Realm` peeks the execution context stack and that is not something to do once per element.

It is checked where the walk **accumulates**, not on the finished string:

| Site | Cadence | What is checked |
| --- | --- | --- |
| `SerializeJSONArray` | per element | what is written **plus what the remaining indices must still contribute** |
| `SerializeJSONObject` | per key | what is written and already final |
| `TrySerializeShapedJSONObject` | per key | same |
| `SerializeJSONValue`, string branch | per string value | what is written plus the unquoted length |
| `SerializeJSONValue`, `JsRawJson` / interop `SerializeToJson` | per chunk | what is written plus the chunk's exact length |
| `Serialize` | once per call | the finished document, before it becomes a `JsString` |

Every estimate is a **lower bound** on the finished document, so the guard can never refuse one that would have fit.

The array bound is what makes a hopeless array fail immediately instead of after half a billion characters: an array announces its length, and each index contributes at least two characters — a separator (or the opening bracket) plus at least one character of value text, since an element with no JSON representation is written as `null`. So `JSON.stringify(new Array(268435445))` is refused before the first element is written. Object members carry no such bound — a member whose value has no representation rewinds the document to the position it started at — so those two sites check only the prefix that is already final, which is why the check sits *before* `position` is taken rather than after.

`Serialize`'s `finally` used to end in `result = json.ToString()`. On the throwing path that materialized the whole partial document, i.e. the very allocation the guard exists to avoid — it is literally where the `OutOfMemoryException` above was thrown. It disposes now; `ToString()` disposes on the way out, so the success path is unchanged.

## Hot methods touched — for the gate

`SerializeJSONArray`, `SerializeJSONObject`, `TrySerializeShapedJSONObject` and `SerializeJSONValue` are all hot. Each gains one predictable, not-taken compare per element / per key / per string value (the array site additionally a subtract and a shift-add, on a loop that already does a `%` per element), and the realm is not touched unless it throws. `JsonJsBenchmark` (`StringifyRecords`, `StringifyConfig`, `StringifyRecordsWithReplacer`, `RoundTripRecords`) and `JsonBenchmark.Stringify` are the rows that cover them. **I have not run any benchmark** — measurement is yours, serially and on an idle machine.

## The `IBufferWriter<byte>` overloads keep their old ceiling

Their result is bytes the host consumes and never a `JsString`, so the language's string limit has no business bounding them and a host streaming a gigabyte-sized document keeps working. The limit is per-call state (`_maxDocumentLength`), set from the entry point: `JsString.MaxLength` for the `JsValue`-returning overloads, `ClrLimits.MaxArrayLength` for the writer ones — where the check is all but inert, since `Grow` refuses first, except that a hopeless array now fails at once instead of after minutes. Documented in the type's `<remarks>`.

## `JSON.parse` with a reviver: nothing needed

A reviver that concatenates does it through the ordinary string-building paths, which #3015 already guards, and the error reaches the script's `catch` through the parse machinery unwrapped. Verified both shapes against this branch:

```js
JSON.parse('{"a":1}', (k, v) => typeof v === 'number' ? 'x'.repeat(536870889) : v);
// RangeError: Invalid string length

var big = 'x'.repeat(268435444);
JSON.parse('{"a":1}', (k, v) => typeof v === 'number' ? big + big + 'yy' : v);
// RangeError: Invalid string length
```

The parser itself needs no guard either: it builds each string with a `ValueStringBuilder` from the source text, and escapes only ever shrink, so a parsed string cannot outgrow the document it came from.

## Tests

New rows in `Jint.Tests/Runtime/StringLengthLimitTests.cs`, next to the other limit rows and asserting a **JS-catchable** `RangeError` through the file's existing `Caught` helper, which runs the `try`/`catch` inside the script precisely so a CLR exception escaping the engine fails as an escaping exception rather than being reported as a handled error.

- `JsonStringifyOfAnArrayTooLongToSerializeIsACatchableRangeError` — the two shapes above. They cost nothing: both arrays are empty, only their `length` is large, and the throw happens before the first element is written. `MaxLength / 2 + 1` is the smallest length that triggers it, and the just-under side is deliberately not tested — that one really would have to build the gigabyte.
- `JsonDocumentsThatFitAreUnaffected` — five shapes where an over-counting estimate would show up first: holes, `undefined`/function/symbol elements, indentation, a dropped object member, a 1 MB string value.
- `JsonParseReviverThatBuildsTooLongAStringIsACatchableRangeError` — the reviver finding, in the shape that costs nothing.

The class doc's paragraph about which paths have no cheap test is extended: `JSON.stringify`'s element-by-element half joins `+=`, `join`, `String.raw` and the rest there. Its guard can only fire once roughly half a billion characters are in hand, so a test for it would have to allocate the gigabyte the guard exists to prevent — the array-`length` row is the cheap route to the same guard.

Both non-array rows **pass against the unfixed serializer** (6/6 on net10.0 and net472), which is what makes them honest controls rather than the new coverage.

## Verification

Release throughout, no `--no-build`, zero warnings.

| Suite | Result |
| --- | --- |
| `Jint.Tests` | 5754 passed / 0 failed / 4 skipped (net10.0) · 5669 / 0 / 4 (net472) |
| `Jint.Tests.PublicInterface` | 1488 / 0 / 9 (net10.0) · 1487 / 0 / 9 (net472) |
| `Jint.Tests.Test262` | **102,324 passed / 0 failed** / 343 skipped, 3 m 07 s |
| `Jint.Tests.CommonScripts` | 28 / 0 / 0 on both frameworks |

Closes #3024

🤖 Generated with [Claude Code](https://claude.com/claude-code)
