### PR TITLE
Let an Atomics waiter go when nothing can ever notify it again

### DIFF
--- a/Jint.Tests/Runtime/AtomicsWaiterRegistryTests.cs
+++ b/Jint.Tests/Runtime/AtomicsWaiterRegistryTests.cs
@@ -1,0 +1,178 @@
+#nullable enable
+using System.Runtime.CompilerServices;
+using Jint.Native;
+using Jint.Native.Atomics;
+using Jint.Native.Object;
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// The registry every <c>Atomics.wait</c> and <c>Atomics.waitAsync</c> registers in used to be a process-wide
+/// static keyed on the shared data block, and nothing ever removed anything from it. An async waiter holds its
+/// engine — that is how it resolves its promise back onto the right event loop — so a wait nobody ever notifies
+/// kept that engine, its realm and everything they root alive for the life of the process. A wait that
+/// <i>ended</i> was no better off at the other end: its entry key held the shared data block itself forever.
+/// </summary>
+// Shares the garbage-collection collection: these tests read GC state, which cannot be isolated from tests
+// running in parallel with them.
+[Collection(nameof(GarbageCollectionTests))]
+public class AtomicsWaiterRegistryTests
+{
+    [Fact]
+    public void AWaitAsyncNobodyNotifiesDoesNotKeepItsEngineAlive()
+    {
+        // The three lines #3025 reports. The wait asks for no timeout, so it never resolves and nothing ever
+        // removes it from the list it was added to.
+        var reference = WaitAsyncForeverAndForget();
+
+        Collect();
+
+        reference.IsAlive.Should().BeFalse("an Atomics.waitAsync nobody can ever notify must not outlive its engine");
+
+        // NoInlining so the engine reference cannot be stack-rooted in this frame across the GC.Collect calls.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static WeakReference WaitAsyncForeverAndForget()
+        {
+            var engine = new Engine();
+            engine.Execute("""
+                var i32a = new Int32Array(new SharedArrayBuffer(8));
+                Atomics.waitAsync(i32a, 0, 0);
+                """);
+            return new WeakReference(engine);
+        }
+    }
+
+    [Fact]
+    public void AWaitThatEndedDoesNotKeepItsSharedDataBlockAlive()
+    {
+        // The registry key is the shared data block itself, so an entry left behind pins the whole block —
+        // eight bytes here, but the script chooses the size. A wait that timed out immediately is enough to
+        // create the entry: the waiter is added to the list before the zero timeout is examined.
+        var reference = WaitAndForgetTheBlock();
+
+        Collect();
+
+        reference.IsAlive.Should().BeFalse("a completed Atomics.wait must not pin the SharedArrayBuffer's data block");
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static WeakReference WaitAndForgetTheBlock()
+        {
+            var engine = new Engine();
+            engine.Execute("""
+                var sab = new SharedArrayBuffer(8);
+                var i32a = new Int32Array(sab);
+                Atomics.wait(i32a, 0, 0, 0);
+                """);
+            return new WeakReference(BlockOf(engine, "sab"));
+        }
+    }
+
+    [Fact]
+    public void AWaiterStaysVisibleToAnotherAgentThatCanStillReachTheSharedBlock()
+    {
+        // The deliberate half of the lifetime decision. A waiter belongs to the shared data block, not to the
+        // reachability of the agent that registered it: as long as any agent can still reach the block it can
+        // still call Atomics.notify, and the entry — and the engine it resolves into — has to survive to be
+        // woken. Only when the block itself is unreachable can nobody notify it again, which is when the tests
+        // above expect the entry to go.
+        var owner = new Engine();
+        owner.Execute("var sab = new SharedArrayBuffer(8); var i32a = new Int32Array(sab);");
+        var block = BlockOf(owner, "sab");
+
+        var reference = WaitAsyncForeverInASecondAgentAndForget(block);
+
+        Collect();
+
+        reference.IsAlive.Should().BeTrue("an agent that can still be notified must not be collected");
+        owner.Evaluate("Atomics.notify(i32a, 0)").AsNumber().Should().Be(1, "the other agent's waiter must still be there to wake");
+
+        GC.KeepAlive(block);
+
+        // NoInlining so the second engine cannot be stack-rooted in this frame across the GC.Collect calls.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static WeakReference WaitAsyncForeverInASecondAgentAndForget(byte[] block)
+        {
+            var engine = new Engine();
+            engine.SetValue("i32a", SharedView(engine, block));
+            engine.Execute("Atomics.waitAsync(i32a, 0, 0);");
+            return new WeakReference(engine);
+        }
+    }
+
+    [Fact]
+    public void AWaitRegisteredAfterAnEarlierOneEndedIsStillNotified()
+    {
+        // Removing the emptied list is only safe if the next wait on the same index builds a new one and the
+        // notify that follows finds it. Nothing observable may depend on whether a previous wait pruned.
+        var engine = new Engine();
+        engine.Execute("""
+            var i32a = new Int32Array(new SharedArrayBuffer(8));
+            Atomics.wait(i32a, 0, 0, 0);
+            var outcome = 'pending';
+            Atomics.waitAsync(i32a, 0, 0, 180000).value.then(function (v) { outcome = v; });
+            var notified = Atomics.notify(i32a, 0);
+            """);
+
+        engine.Evaluate("notified").AsNumber().Should().Be(1);
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+        while (DateTime.UtcNow < deadline && engine.Evaluate("outcome").AsString() == "pending")
+        {
+            engine.Advanced.ProcessTasks();
+            Thread.Sleep(5);
+        }
+
+        engine.Evaluate("outcome").AsString().Should().Be("ok");
+    }
+
+    [Fact]
+    public void AWaiterListThatHasEmptiedIsRemoved()
+    {
+        // Every index ever waited on used to leave its own list behind, for as long as the block lived. The
+        // block below stays reachable throughout, so nothing but the pruning can bring the count back down.
+        var engine = new Engine();
+        engine.Execute("var sab = new SharedArrayBuffer(4096); var i32a = new Int32Array(sab);");
+        var block = BlockOf(engine, "sab");
+
+        AtomicsInstance.WaiterListCount(block).Should().Be(0);
+
+        engine.Execute("for (var i = 0; i < i32a.length; i++) { Atomics.wait(i32a, i, 0, 0); }");
+
+        AtomicsInstance.WaiterListCount(block).Should().Be(0, "a wait that has ended leaves nobody in its list");
+
+        // A waiter that is still waiting of course keeps its list, and gives it up when it is woken.
+        engine.Execute("Atomics.waitAsync(i32a, 0, 0);");
+        AtomicsInstance.WaiterListCount(block).Should().Be(1);
+
+        engine.Evaluate("Atomics.notify(i32a, 0)").AsNumber().Should().Be(1);
+        AtomicsInstance.WaiterListCount(block).Should().Be(0, "a notified waiter leaves its list empty too");
+
+        GC.KeepAlive(block);
+    }
+
+    private static byte[] BlockOf(Engine engine, string name)
+    {
+        return ((JsArrayBuffer) engine.Evaluate(name))._arrayBufferData!;
+    }
+
+    /// <summary>
+    /// A SharedArrayBuffer in <paramref name="engine"/> viewing a data block another engine allocated, which is
+    /// what makes two engines one agent cluster. It is how <c>Test262AgentManager</c> hands a broadcast buffer
+    /// to an agent, and the only way to build one: <see cref="JsSharedArrayBuffer"/> is internal, so nothing an
+    /// embedder can call creates a view over a block another engine allocated.
+    /// </summary>
+    private static JsValue SharedView(Engine engine, byte[] block)
+    {
+        var prototype = (ObjectInstance) engine.Realm.Intrinsics.SharedArrayBuffer.Get(CommonProperties.Prototype);
+        var sab = new JsSharedArrayBuffer(engine, block, null, (uint) block.Length) { _prototype = prototype };
+        return engine.Realm.Intrinsics.Int32Array.Construct([sab], engine.Realm.Intrinsics.Int32Array);
+    }
+
+    private static void Collect()
+    {
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+    }
+}

--- a/Jint/Native/Atomics/AtomicsInstance.cs
+++ b/Jint/Native/Atomics/AtomicsInstance.cs
@@ -1,6 +1,5 @@
 ﻿#pragma warning disable CA1859 // Use concrete types when possible for improved performance -- most of methods return JsValue
 
-using System.Collections.Concurrent;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -24,145 +23,118 @@ internal sealed partial class AtomicsInstance : BuiltinShapeObject
     [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString AtomicsToStringTag = new("Atomics");
 
     /// <summary>
-    /// Global waiters list for Atomics.wait/notify.
-    /// Key is (buffer identity, byte index), value is list of waiting threads.
+    /// The waiter lists of every shared data block this process has waited on, one entry per block, each
+    /// holding one list per byte index — the spec's store of WaiterList Records, "indexed by (block, i)" and
+    /// "agent-independent" (https://tc39.es/ecma262/#sec-waiterlist-records).
     /// </summary>
-    private static readonly ConcurrentDictionary<WaiterKey, WaiterList> _waiters = new();
+    /// <remarks>
+    /// The table is keyed <b>weakly</b> on the block, and that is what bounds a waiter's lifetime. An async
+    /// waiter holds its engine — that is how it resolves its promise back onto the right event loop — and a
+    /// wait asking for no timeout never resolves and is never removed, so keying this strongly kept the engine,
+    /// its realm and everything they root alive for the life of the process. Weakly it lives exactly as long as
+    /// the block, which is the lifetime the spec gives it: while any agent can still reach the block it can
+    /// still call <c>Atomics.notify</c>, so the entry has to survive to be woken; once no agent can, nothing
+    /// can ever notify it again and the whole cycle — block, engine, waiter — is collected together. The engine
+    /// reference stays strong on purpose, so what <c>Atomics.notify</c> counts never depends on when a
+    /// collection happened to run.
+    /// <para>
+    /// A block whose lists have all been pruned keeps an empty entry here until the block itself dies. Removing
+    /// it would race a thread that already holds the <see cref="WaiterBlock"/> and is about to add to it, and
+    /// what it would save is one empty object per block that is about to be collected anyway.
+    /// </para>
+    /// </remarks>
+    private static readonly ConditionalWeakTable<byte[], WaiterBlock> _blocks = new();
 
-    private readonly struct WaiterKey : IEquatable<WaiterKey>
-    {
-        public readonly object Buffer;
-        public readonly int ByteIndex;
+    private static readonly ConditionalWeakTable<byte[], WaiterBlock>.CreateValueCallback _createWaiterBlock = static _ => new WaiterBlock();
 
-        public WaiterKey(object buffer, int byteIndex)
-        {
-            Buffer = buffer;
-            ByteIndex = byteIndex;
-        }
+    /// <summary>
+    /// How many per-index waiter lists the registry currently holds for a shared data block. Nothing in the
+    /// engine reads this; it exists so the pruning invariant — a list that has emptied is removed — can be
+    /// asserted from a test.
+    /// </summary>
+    internal static int WaiterListCount(byte[] block) => _blocks.TryGetValue(block, out var waiters) ? waiters.Count : 0;
 
-        public bool Equals(WaiterKey other) => ReferenceEquals(Buffer, other.Buffer) && ByteIndex == other.ByteIndex;
-        public override bool Equals(object? obj) => obj is WaiterKey other && Equals(other);
-        public override int GetHashCode() => System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(Buffer) ^ ByteIndex;
-    }
-
-    private sealed class WaiterList
+    /// <summary>
+    /// The waiter lists of one shared data block, indexed by byte index.
+    /// </summary>
+    /// <remarks>
+    /// One lock guards both this dictionary and the contents of every list in it, which is what makes creating
+    /// a list and adding the waiter that needed it a single step. Two steps could not be made safe: a list
+    /// obtained from the dictionary and added to afterwards can be pruned in between, and the waiter then joins
+    /// a list nothing can find. The order is block lock → <see cref="Waiter.SyncRoot"/>, never the reverse: a
+    /// suspended agent releases its own monitor before it asks for this one.
+    /// </remarks>
+    private sealed class WaiterBlock
     {
         private readonly Lock _lock = new();
-        private readonly List<Waiter> _syncWaiters = [];
-        private readonly List<AsyncWaiter> _asyncWaiters = [];
+        private readonly Dictionary<int, WaiterList> _lists = new();
 
-        public int SyncCount
+        public int Count
         {
             get
             {
                 lock (_lock)
                 {
-                    return _syncWaiters.Count;
+                    return _lists.Count;
                 }
             }
         }
 
-        public int AddSync(Waiter waiter)
+        public WaiterList AddSync(int byteIndex, Waiter waiter)
         {
             lock (_lock)
             {
-                _syncWaiters.Add(waiter);
-                return _syncWaiters.Count;
+                var list = GetOrCreate(byteIndex);
+                list.SyncWaiters.Add(waiter);
+                return list;
             }
         }
 
-        public void RemoveSync(Waiter waiter)
+        public WaiterList AddAsync(int byteIndex, AsyncWaiter waiter)
         {
             lock (_lock)
             {
-                _syncWaiters.Remove(waiter);
+                var list = GetOrCreate(byteIndex);
+                list.AsyncWaiters.Add(waiter);
+                return list;
             }
         }
 
-        public void AddAsync(AsyncWaiter waiter)
+        public void RemoveSync(WaiterList list, Waiter waiter)
         {
             lock (_lock)
             {
-                _asyncWaiters.Add(waiter);
+                list.SyncWaiters.Remove(waiter);
+                PruneIfEmpty(list);
             }
         }
 
-        public void RemoveAsync(AsyncWaiter waiter)
+        public void RemoveAsync(WaiterList list, AsyncWaiter waiter)
         {
             lock (_lock)
             {
-                _asyncWaiters.Remove(waiter);
+                list.AsyncWaiters.Remove(waiter);
+                PruneIfEmpty(list);
             }
         }
 
-        public int NotifyWaiters(int count)
+        /// <summary>
+        /// https://tc39.es/ecma262/#sec-notifywaiter
+        /// </summary>
+        public int Notify(int byteIndex, int count)
         {
-            var notified = 0;
-            List<Waiter>? syncToRemove = null;
-            List<AsyncWaiter>? asyncToNotify = null;
+            int notified;
+            List<AsyncWaiter>? asyncToNotify;
 
             lock (_lock)
             {
-                // First notify sync waiters
-                foreach (var waiter in _syncWaiters)
+                if (!_lists.TryGetValue(byteIndex, out var list))
                 {
-                    if (notified >= count)
-                    {
-                        break;
-                    }
-
-                    lock (waiter.SyncRoot)
-                    {
-                        // Skip if already notified (handles race where waiter hasn't been removed yet)
-                        if (waiter.Notified)
-                        {
-                            continue;
-                        }
-
-                        waiter.Notified = true;
-                        Monitor.Pulse(waiter.SyncRoot);
-                    }
-                    notified++;
-
-                    // Mark for removal from the list
-                    syncToRemove ??= [];
-                    syncToRemove.Add(waiter);
+                    return 0;
                 }
 
-                // Remove notified sync waiters from the list
-                // This prevents double-counting in subsequent Notify calls
-                if (syncToRemove != null)
-                {
-                    foreach (var waiter in syncToRemove)
-                    {
-                        _syncWaiters.Remove(waiter);
-                    }
-                }
-
-                // Then notify async waiters
-                foreach (var waiter in _asyncWaiters)
-                {
-                    if (notified >= count)
-                    {
-                        break;
-                    }
-
-                    if (!waiter.Resolved)
-                    {
-                        asyncToNotify ??= [];
-                        asyncToNotify.Add(waiter);
-                        notified++;
-                    }
-                }
-
-                // Remove notified async waiters from the list
-                if (asyncToNotify != null)
-                {
-                    foreach (var waiter in asyncToNotify)
-                    {
-                        _asyncWaiters.Remove(waiter);
-                    }
-                }
+                notified = NotifyWaiters(list, count, out asyncToNotify);
+                PruneIfEmpty(list);
             }
 
             // Resolve async waiters outside the lock to avoid deadlocks
@@ -176,6 +148,116 @@ internal sealed partial class AtomicsInstance : BuiltinShapeObject
 
             return notified;
         }
+
+        private static int NotifyWaiters(WaiterList list, int count, out List<AsyncWaiter>? asyncToNotify)
+        {
+            var notified = 0;
+            List<Waiter>? syncToRemove = null;
+            asyncToNotify = null;
+
+            // First notify sync waiters
+            foreach (var waiter in list.SyncWaiters)
+            {
+                if (notified >= count)
+                {
+                    break;
+                }
+
+                lock (waiter.SyncRoot)
+                {
+                    // Skip if already notified (handles race where waiter hasn't been removed yet)
+                    if (waiter.Notified)
+                    {
+                        continue;
+                    }
+
+                    waiter.Notified = true;
+                    Monitor.Pulse(waiter.SyncRoot);
+                }
+                notified++;
+
+                // Mark for removal from the list
+                syncToRemove ??= [];
+                syncToRemove.Add(waiter);
+            }
+
+            // Remove notified sync waiters from the list
+            // This prevents double-counting in subsequent Notify calls
+            if (syncToRemove != null)
+            {
+                foreach (var waiter in syncToRemove)
+                {
+                    list.SyncWaiters.Remove(waiter);
+                }
+            }
+
+            // Then notify async waiters
+            foreach (var waiter in list.AsyncWaiters)
+            {
+                if (notified >= count)
+                {
+                    break;
+                }
+
+                if (!waiter.Resolved)
+                {
+                    asyncToNotify ??= [];
+                    asyncToNotify.Add(waiter);
+                    notified++;
+                }
+            }
+
+            // Remove notified async waiters from the list
+            if (asyncToNotify != null)
+            {
+                foreach (var waiter in asyncToNotify)
+                {
+                    list.AsyncWaiters.Remove(waiter);
+                }
+            }
+
+            return notified;
+        }
+
+        private WaiterList GetOrCreate(int byteIndex)
+        {
+            if (!_lists.TryGetValue(byteIndex, out var list))
+            {
+                list = new WaiterList(byteIndex);
+                _lists[byteIndex] = list;
+            }
+
+            return list;
+        }
+
+        /// <summary>
+        /// Drops a list nobody is waiting in any more. Every wait that ever ended used to leave its list here
+        /// forever, one per index the script touched. The caller holds the lock, so no waiter can be joining
+        /// the list being examined, and the identity check keeps a stale reference — a list already pruned and
+        /// replaced by a later wait on the same index — from removing its successor.
+        /// </summary>
+        private void PruneIfEmpty(WaiterList list)
+        {
+            if (list.SyncWaiters.Count != 0 || list.AsyncWaiters.Count != 0)
+            {
+                return;
+            }
+
+            if (_lists.TryGetValue(list.ByteIndex, out var current) && ReferenceEquals(current, list))
+            {
+                _lists.Remove(list.ByteIndex);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The waiters of one byte index. Both lists are guarded by the owning <see cref="WaiterBlock"/>'s lock.
+    /// </summary>
+    private sealed class WaiterList(int byteIndex)
+    {
+        public int ByteIndex { get; } = byteIndex;
+        public List<Waiter> SyncWaiters { get; } = [];
+        public List<AsyncWaiter> AsyncWaiters { get; } = [];
     }
 
     private sealed class Waiter
@@ -388,11 +470,9 @@ internal sealed partial class AtomicsInstance : BuiltinShapeObject
         // Ensure we see the latest updates from other threads (important for ARM memory model)
         Thread.MemoryBarrier();
 
-        var key = new WaiterKey(bufferData, byteIndexInBuffer);
-        if (_waiters.TryGetValue(key, out var waiterList))
+        if (_blocks.TryGetValue(bufferData, out var waiters))
         {
-            var notified = waiterList.NotifyWaiters(c);
-            return JsNumber.Create(notified);
+            return JsNumber.Create(waiters.Notify(byteIndexInBuffer, c));
         }
 
         return JsNumber.PositiveZero;
@@ -557,10 +637,9 @@ internal sealed partial class AtomicsInstance : BuiltinShapeObject
         }
 
         // Value matches - add ourselves to the waiters list and block
-        var key = new WaiterKey(bufferData, byteIndexInBuffer);
-        var waiterList = _waiters.GetOrAdd(key, _ => new WaiterList());
+        var waiters = _blocks.GetValue(bufferData, _createWaiterBlock);
         var waiter = new Waiter();
-        waiterList.AddSync(waiter);
+        var waiterList = waiters.AddSync(byteIndexInBuffer, waiter);
 
         // Ensure the waiter addition is visible to other threads (important for ARM memory model)
         Thread.MemoryBarrier();
@@ -605,7 +684,7 @@ internal sealed partial class AtomicsInstance : BuiltinShapeObject
         }
         finally
         {
-            waiterList.RemoveSync(waiter);
+            waiters.RemoveSync(waiterList, waiter);
         }
     }
 
@@ -687,16 +766,16 @@ internal sealed partial class AtomicsInstance : BuiltinShapeObject
 
         if (bufferData is not null)
         {
-            var key = new WaiterKey(bufferData, byteIndexInBuffer);
-            var waiterList = _waiters.GetOrAdd(key, _ => new WaiterList());
+            var waiters = _blocks.GetValue(bufferData, _createWaiterBlock);
             var hasTimeout = !double.IsPositiveInfinity(q);
             var asyncWaiter = new AsyncWaiter(_engine, promiseCapability, hasTimeout);
-            waiterList.AddAsync(asyncWaiter);
+            var waiterList = waiters.AddAsync(byteIndexInBuffer, asyncWaiter);
 
             // Handle timeout
             if (hasTimeout)
             {
                 var timeoutMs = (int) System.Math.Min(System.Math.Ceiling(q), int.MaxValue);
+                var capturedWaiters = waiters;
                 var capturedWaiterList = waiterList;
                 var capturedAsyncWaiter = asyncWaiter;
                 var timeoutToken = asyncWaiter.TimeoutToken;
@@ -737,7 +816,7 @@ internal sealed partial class AtomicsInstance : BuiltinShapeObject
 
                     if (!capturedAsyncWaiter.Resolved)
                     {
-                        capturedWaiterList.RemoveAsync(capturedAsyncWaiter);
+                        capturedWaiters.RemoveAsync(capturedWaiterList, capturedAsyncWaiter);
                         capturedAsyncWaiter.Resolve("timed-out");
                     }
                 }, timeoutToken);


### PR DESCRIPTION
Every `Atomics.wait` and `Atomics.waitAsync` registered itself in a process-wide static dictionary keyed on the `SharedArrayBuffer`'s data block and the byte index, and nothing ever removed anything from it. An `AsyncWaiter` holds its `Engine` — that is how it resolves its promise back onto the right event loop — so a wait that asks for no timeout never resolves, is never removed, and keeps that engine, its realm and everything they root alive for the life of the **process**:

```js
const sab = new SharedArrayBuffer(8);
const i32 = new Int32Array(sab);
Atomics.waitAsync(i32, 0, 0);   // no timeout: waits forever
```

Three lines of untrusted script, one leaked engine per request. #3019 fixed the adjacent half — the finite timeout was a fire-and-forget task that outlived its engine, and now stops when the wait ends — but a wait with no timeout has no timer to stop. The other end of the same defect is quieter and needs no live waiter at all: the key held the data block, so a wait that had long since returned pinned the whole shared block, whatever size the script chose.

## Lifetime: the waiter belongs to the block, not to the engine

The registry is now a `ConditionalWeakTable` keyed on the data block, and that is what bounds a waiter's life.

The choice was between scoping a waiter to the block it waits on and scoping it to the engine that registered it, and the spec makes the block the honest answer. §25.4.2 puts the store on the agent *cluster*, "indexed by (block, i)", and says WaiterList Records are "agent-independent" — a lookup by `(block, i)` "will result in the same WaiterList Record in any agent in the agent cluster" (<https://tc39.es/ecma262/#sec-waiterlist-records>). While any agent can still reach the block it can still call `Atomics.notify`, so the entry — and the engine whose event loop it resolves into — has to survive to be woken. Once no agent can reach the block, nothing can ever notify it again, and block, engine and waiter are one unreachable cycle that a dependent handle collects together.

The engine reference deliberately stays **strong**. Holding it weakly would drop a waiter the moment its engine became unreachable, which is a collection deciding what `Atomics.notify` returns to a script in another agent — GC timing made script-observable. Under the block key that can never happen: reaching `notify` at all means holding a typed array over the block, so every entry that existed still exists.

`Engine.Dispose` is not the hook either. It clears the interop wrapper caches and leaves the engine completely usable, so it is not a termination, and a host need never call it — the repro above does not. Nothing an embedder can call builds a `SharedArrayBuffer` over a block another engine allocated (`JsSharedArrayBuffer` is internal; `Test262AgentManager` is the only thing in the tree that does it), so for an embedder the block dies with the engine that made it and a deterministic hook would have nothing left to do.

## Pruning: one lock per block, so creating a list and joining it is one step

The per-index lists are pruned as they empty, which they never were. One lock now guards a block's whole index-to-list dictionary *and* the contents of every list in it, and that is what makes pruning safe: creating a list and adding the waiter that needed it is a single step, so there is no window between a lookup and its use for a prune to slip into — which is exactly the shape the old `GetOrAdd`-then-`AddSync` had. A list is only dropped when the same lock proves it empty, and only if the dictionary still maps its index to that same instance, so a stale reference cannot remove a successor a later wait created. The lock order is block, then `Waiter.SyncRoot`, and a suspended agent releases its own monitor before it asks for the block's, so `notify`'s pulse cannot deadlock against the thread it is waking.

A block whose lists have all gone keeps an empty entry until the block itself dies. Removing it would race a thread that already holds the block and is about to add to it, to save one empty object that is about to be collected anyway.

## Verification

Five tests in `Jint.Tests/Runtime/AtomicsWaiterRegistryTests.cs`. Two of them fail on the code before this change, on `net10.0` and `net472` alike:

```
Failed Jint.Tests.Runtime.AtomicsWaiterRegistryTests.AWaitAsyncNobodyNotifiesDoesNotKeepItsEngineAlive
  Expected reference.IsAlive to be False because an Atomics.waitAsync nobody can ever
  notify must not outlive its engine, but found True.

Failed Jint.Tests.Runtime.AtomicsWaiterRegistryTests.AWaitThatEndedDoesNotKeepItsSharedDataBlockAlive
  Expected reference.IsAlive to be False because a completed Atomics.wait must not pin
  the SharedArrayBuffer's data block, but found True.
```

Two more pin what must *not* change and pass before and after: a waiter is still visible to another agent that can reach the block (asserted through a second engine viewing the same block, the `Test262AgentManager` shape), and a wait registered after an earlier one pruned is still notified. The fifth watches the per-index list count for a block that stays reachable throughout, so only the pruning can bring it down.

- `Jint.Tests` — 5752 / 5667 passed (net10.0 / net472), 0 failed
- `Jint.Tests.PublicInterface` — 1488 / 1487 passed, 0 failed
- Both again with `JINT_HOST_CONTRACT_VERIFICATION=1` — 0 failed
- `Jint.Tests.Test262` — **7 of 10 runs clean** on this change, and **4 of 5** on the code without it (same machine, run serially)

Every failure on either side is a wall-clock assertion:

| Side | Test | What it says |
| --- | --- | --- |
| change ×2, **base ×2** | `staging/sm/Array/toSpliced-dense.js` | `TimeoutException` at 33 s, 34 s twice and 35 s against the engine's 30 s default — the test takes 27–28 s when the machine is idle |
| change ×1 | `built-ins/Atomics/notify/bigint/notify-all-on-loc.js` | `"W timeout before Atomics.notify"` — the main agent had not reached its `Atomics.store` within the 1000 ms (`$262.agent.timeouts.long`) the waiting agent asked for |

The first fails on **both** sides, so it classifies itself. The second is a race between agent start-up and the waiter's own timeout, not between waiters: the notify in that very run passed its `assert.sameValue(Atomics.notify(...), NUMAGENT)`, so all three waiters were found and woken, and what had drifted was how long the other agents took to get going. `Test262Harness.settings.json` already records that this suite produces "non-deterministic failures even though the implementation is correct" on a loaded machine — that note is why `Atomics` and `Atomics.waitAsync` are in `NonParallelFeatures` — and an `Atomics/wait` test failed the same way on this machine on 2026-08-14, before any of this existed.

No benchmark table: nothing outside `AtomicsInstance` changed, and no benchmark script calls `Atomics`. The registry is touched once per `wait`/`waitAsync`/`notify`, all of which are already thread-blocking or promise-allocating.

Closes #3025

🤖 Generated with [Claude Code](https://claude.com/claude-code)
