### PR TITLE
Reject concurrent Engine use

### DIFF
--- a/.github/THREAT_MODEL.md
+++ b/.github/THREAT_MODEL.md
@@ -411,8 +411,9 @@ incorrect authorization context, cross-request disclosure, crashes, or hangs.
 - Public engine, module, constraint, and advanced-operation entries claim exclusive ownership
   and fail fast with `InvalidOperationException` when another thread or outstanding async host
   operation owns the engine.
-- Same-thread callback re-entry is allowed. Async APIs reserve ownership for the lifetime of
-  their returned `Task` and transfer the active thread when a continuation resumes.
+- Same-thread synchronous callback re-entry is allowed. Async entry from inside an active
+  engine call is rejected before work starts; top-level async APIs reserve ownership for the
+  lifetime of their returned `Task` and transfer the active thread when a continuation resumes.
 - Background Task and module completions only enqueue work; an owning host turn drains it.
 
 **Missing or residual mitigation.**

--- a/.github/THREAT_MODEL.md
+++ b/.github/THREAT_MODEL.md
@@ -89,6 +89,7 @@ Defaults are compatibility choices, not a hardened profile.
 | Maximum array size | `uint.MaxValue` | Effectively unbounded for hostile input |
 | Regex timeout | 10 seconds | Bounds an individual regular expression operation |
 | Promise wait timeout | 10 seconds | Bounds host APIs that wait for promise or module settlement |
+| Concurrent `Engine` use | Rejected | Public host entries throw instead of racing or silently serializing |
 | Dynamic `eval` / `Function` compilation | Enabled | Script can create and parse additional source at runtime |
 | `Atomics.wait` suspension | Enabled | Script may block the engine thread, including indefinitely |
 | Debugger | Disabled | Debug callbacks and debugger expressions are inactive |
@@ -407,17 +408,25 @@ incorrect authorization context, cross-request disclosure, crashes, or hangs.
 
 **Existing mitigations.**
 
-- Async completion paths queue work to the event loop and guard which waiter drains it.
-- Documentation states that an engine is single-threaded.
+- Public engine, module, constraint, and advanced-operation entries claim exclusive ownership
+  and fail fast with `InvalidOperationException` when another thread or outstanding async host
+  operation owns the engine.
+- Same-thread callback re-entry is allowed. Async APIs reserve ownership for the lifetime of
+  their returned `Task` and transfer the active thread when a continuation resumes.
+- Background Task and module completions only enqueue work; an owning host turn drains it.
 
 **Missing or residual mitigation.**
 
-- General concurrent use is not serialized or rejected automatically.
-- Event-loop thread-safety does not make the engine safe for concurrent host calls.
+- The guard covers Jint's public host entry points, not direct calls on engine-owned objects
+  already handed to the host, such as mutating `engine.Global` or a retained `ObjectInstance`.
+- Fail-fast detection prevents concurrent state corruption; it does not make one engine a
+  tenant-isolation boundary or repair host state mutated before an exception.
+- A host can still share projected CLR objects across otherwise separate engines.
 
-**Required host action.** Give an engine exclusive ownership for its entire lifetime, or
-serialize the complete execution and async drain with one gate. Never return a pooled engine
-while asynchronous work is outstanding.
+**Required host action.** Give an engine exclusive ownership for each complete operation and
+treat a concurrency exception as an integration bug, not a retry signal. Await every async
+engine call before returning a pooled engine, and do not mutate retained engine-owned objects
+from another thread. Use separate engines for mutually distrusting requests.
 
 ### TM-14: Regular expression denial of service
 

--- a/.github/THREAT_MODEL.md
+++ b/.github/THREAT_MODEL.md
@@ -414,6 +414,10 @@ incorrect authorization context, cross-request disclosure, crashes, or hangs.
 - Same-thread synchronous callback re-entry is allowed. Async entry from inside an active
   engine call is rejected before work starts; top-level async APIs reserve ownership for the
   lifetime of their returned `Task` and transfer the active thread when a continuation resumes.
+- JavaScript callbacks converted to CLR delegates carry operation-scoped authorization. A host
+  may dispatch one to another thread while its CLR call or async operation is outstanding; Jint
+  yields and transfers the reserved engine one callback turn at a time without admitting unrelated
+  public callers.
 - Background Task and module completions only enqueue work; an owning host turn drains it.
 
 **Missing or residual mitigation.**
@@ -422,6 +426,9 @@ incorrect authorization context, cross-request disclosure, crashes, or hangs.
   already handed to the host, such as mutating `engine.Global` or a retained `ObjectInstance`.
 - Fail-fast detection prevents concurrent state corruption; it does not make one engine a
   tenant-isolation boundary or repair host state mutated before an exception.
+- Authorized callback transfers may wait for the preceding callback turn to release ownership.
+  The fail-fast guarantee applies to unrelated public host entries, not this explicitly serialized
+  continuation of the operation that already owns the engine.
 - A host can still share projected CLR objects across otherwise separate engines.
 
 **Required host action.** Give an engine exclusive ownership for each complete operation and

--- a/Jint.Tests.PublicInterface/GlobalSnapshotTests.cs
+++ b/Jint.Tests.PublicInterface/GlobalSnapshotTests.cs
@@ -459,7 +459,7 @@ public class GlobalSnapshotTests
 
         Invoking(() => engine.Advanced.RestoreGlobalSnapshot(snapshot))
             .Should().Throw<InvalidOperationException>()
-            .WithMessage("*evaluation is in progress*");
+            .WithMessage("*asynchronous operation in progress*");
 
         gate.SetResult(1);
         (await pending).AsNumber().Should().Be(42);

--- a/Jint.Tests.PublicInterface/HostEngineConcurrencyTests.cs
+++ b/Jint.Tests.PublicInterface/HostEngineConcurrencyTests.cs
@@ -2,6 +2,7 @@
 
 using Jint.Native;
 using Jint.Runtime;
+using Jint.Runtime.Debugger;
 using Jint.Runtime.Modules;
 
 using Module = Jint.Runtime.Modules.Module;
@@ -150,16 +151,20 @@ public class HostEngineConcurrencyTests
     }
 
     [Fact]
-    public void ConsecutiveSynchronousAsyncCallsCanReenterOnTheOwningThread()
+    public void AsyncEntryFromAHostCallbackFailsBeforeStartingWork()
     {
         var engine = new Engine();
+        engine.SetValue("completed", false);
         engine.SetValue("reenter", new Action(() =>
         {
-            engine.EvaluateAsync("1").GetAwaiter().GetResult().AsNumber().Should().Be(1);
-            engine.EvaluateAsync("2").GetAwaiter().GetResult().AsNumber().Should().Be(2);
+            Action nested = () => _ = engine.EvaluateAsync("completed = true");
+            Invoking(nested)
+                .Should().Throw<InvalidOperationException>()
+                .WithMessage(ConcurrentUseMessage);
         }));
 
         engine.Execute("reenter()");
+        engine.Evaluate("completed").AsBoolean().Should().BeFalse();
     }
 
     [Fact]
@@ -316,6 +321,50 @@ public class HostEngineConcurrencyTests
         }
 
         await running;
+    }
+
+    [Fact]
+    public async Task BreakpointsCanBeAdministeredWhileTheEngineIsRunning()
+    {
+        using var entered = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        var engine = new Engine(options => options.Debugger.Enabled = true);
+        engine.SetValue("block", new Action(() =>
+        {
+            entered.Set();
+            release.Wait();
+        }));
+        var running = Task.Run(() => engine.Execute("block()"));
+
+        entered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+        try
+        {
+            engine.Debugger.BreakPoints.Set(new BreakPoint(1, 0));
+            engine.Debugger.BreakPoints.Count.Should().Be(1);
+        }
+        finally
+        {
+            release.Set();
+        }
+
+        await running;
+    }
+
+    [Fact]
+    public async Task DisposeFailsFastWhileAnAsyncOperationOwnsTheEngine()
+    {
+        var gate = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var engine = new Engine();
+        engine.SetValue("hostWork", new Func<Task<int>>(() => gate.Task));
+        var pending = engine.EvaluateAsync("(async () => await hostWork())()");
+
+        Invoking(engine.Dispose)
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage(ConcurrentUseMessage);
+
+        gate.SetResult(42);
+        (await pending).AsNumber().Should().Be(42);
+        engine.Dispose();
     }
 
     [Fact]

--- a/Jint.Tests.PublicInterface/HostEngineConcurrencyTests.cs
+++ b/Jint.Tests.PublicInterface/HostEngineConcurrencyTests.cs
@@ -151,6 +151,69 @@ public class HostEngineConcurrencyTests
     }
 
     [Fact]
+    public void HostCanSynchronouslyDispatchAJsCallbackToAnotherThread()
+    {
+        var engine = new Engine();
+        engine.SetValue("onOtherThread", new Func<Func<int, int>, int>(callback =>
+        {
+            Exception? error = null;
+            var result = 0;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    result = callback(41);
+                }
+                catch (Exception exception)
+                {
+                    error = exception;
+                }
+            });
+            thread.Start();
+            thread.Join();
+            if (error is not null)
+            {
+                throw error;
+            }
+
+            return result;
+        }));
+
+        engine.Evaluate("onOtherThread(x => x + 1)").AsNumber().Should().Be(42);
+        engine.Evaluate("20 + 22").AsNumber().Should().Be(42);
+    }
+
+    [Fact]
+    public void ReflectedHostMethodCanDispatchAJsCallbackToAnotherThread()
+    {
+        var engine = new Engine();
+        engine.SetValue("host", new CallbackHost());
+
+        engine.Evaluate("host.OnOtherThread(x => x + 1)").AsNumber().Should().Be(42);
+        engine.Evaluate("20 + 22").AsNumber().Should().Be(42);
+    }
+
+    [Fact]
+    public void ReflectedHostMethodCanDispatchAJsCallbackFromAParamsArray()
+    {
+        var engine = new Engine();
+        engine.SetValue("host", new CallbackHost());
+
+        engine.Evaluate("host.OnOtherThreadFromArray(() => 42)").AsNumber().Should().Be(42);
+        engine.Evaluate("20 + 22").AsNumber().Should().Be(42);
+    }
+
+    [Fact]
+    public void HostReceivingAJsCallbackCanReenterOnTheSameThread()
+    {
+        var engine = new Engine();
+        engine.SetValue("reenter", new Func<Func<int>, int>(callback =>
+            (int) engine.Evaluate("20 + 21").AsNumber() + callback()));
+
+        engine.Evaluate("reenter(() => 1)").AsNumber().Should().Be(42);
+    }
+
+    [Fact]
     public void AsyncEntryFromAHostCallbackFailsBeforeStartingWork()
     {
         var engine = new Engine();
@@ -187,6 +250,61 @@ public class HostEngineConcurrencyTests
         await Task.Run(() => gate.SetResult(41));
         (await pending).AsNumber().Should().Be(42);
         engine.Evaluate("6 * 7").AsNumber().Should().Be(42);
+    }
+
+    [Fact]
+    public async Task AsyncHostMethodCanInvokeItsJsCallbackFromAnotherThread()
+    {
+        var callbackReady = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var invokeCallback = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var engine = new Engine();
+        engine.SetValue("schedule", new Func<Func<int>, Task<int>>(callback =>
+        {
+            callbackReady.SetResult(true);
+            return Task.Run(async () =>
+            {
+                await invokeCallback.Task;
+                return callback();
+            });
+        }));
+
+        var pending = engine.EvaluateAsync("(async () => (await schedule(() => 42)))()");
+        await callbackReady.Task;
+        invokeCallback.SetResult(true);
+
+        (await pending).AsNumber().Should().Be(42);
+        engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ImmediateCrossThreadCallbacksDoNotLeakAsyncOwnership()
+    {
+        var engine = new Engine();
+        engine.SetValue("schedule", new Func<Func<int>, Task<int>>(callback => Task.Run(callback)));
+
+        for (var i = 0; i < 50; i++)
+        {
+            (await engine.EvaluateAsync("(async () => await schedule(() => 42))()"))
+                .AsNumber().Should().Be(42);
+        }
+
+        engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
+    }
+
+    [Fact]
+    public void DelayedCrossThreadCallbackReleasesBlockingPromiseOwnership()
+    {
+        var engine = new Engine();
+        engine.SetValue("later", new Action<Action>(callback =>
+            Task.Delay(50).ContinueWith(_ => callback(), TaskScheduler.Default)));
+
+        engine.Evaluate("new Promise(resolve => later(() => resolve(42)))")
+            .UnwrapIfPromise()
+            .AsNumber()
+            .Should()
+            .Be(42);
+
+        engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
     }
 
     [Fact]
@@ -235,6 +353,32 @@ public class HostEngineConcurrencyTests
         var module = await pending;
         module.Get("value").AsNumber().Should().Be(42);
         engine.Evaluate("1").AsNumber().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ExecuteAsyncReportsInitialFailureThroughItsTask()
+    {
+        Task<Engine>? task = null;
+        Action start = () => task = new Engine().ExecuteAsync("const =");
+
+        Invoking(start)
+            .Should().NotThrow();
+
+        await Awaiting(() => task!).Should().ThrowAsync<Exception>();
+    }
+
+    [Fact]
+    public async Task ImportAsyncReportsInitialFailureThroughItsTask()
+    {
+        var engine = new Engine(options => options.EnableModules(new RejectingModuleLoader()));
+        Task<Jint.Native.Object.ObjectInstance>? task = null;
+        Action start = () => task = engine.Modules.ImportAsync("blocked");
+
+        Invoking(start)
+            .Should().NotThrow();
+
+        await Awaiting(() => task!).Should().ThrowAsync<PromiseRejectedException>();
+        engine.Evaluate("20 + 22").AsNumber().Should().Be(42);
     }
 
     [Fact]
@@ -423,6 +567,68 @@ public class HostEngineConcurrencyTests
         public void LoadModuleAsync(Engine engine, ResolvedSpecifier resolved, ModuleLoadCompletion completion)
         {
             Completion = completion;
+        }
+    }
+
+    private sealed class RejectingModuleLoader : IModuleLoader
+    {
+        public ResolvedSpecifier Resolve(string? referencingModuleLocation, ModuleRequest moduleRequest)
+            => throw new ModuleResolutionException("blocked", moduleRequest.Specifier, referencingModuleLocation, filePath: null);
+
+        public Module LoadModule(Engine engine, ResolvedSpecifier resolved)
+            => throw new InvalidOperationException("Resolve should reject the import.");
+    }
+
+    private sealed class CallbackHost
+    {
+        public int OnOtherThread(Func<int, int> callback)
+        {
+            Exception? error = null;
+            var result = 0;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    result = callback(41);
+                }
+                catch (Exception exception)
+                {
+                    error = exception;
+                }
+            });
+            thread.Start();
+            thread.Join();
+            if (error is not null)
+            {
+                throw error;
+            }
+
+            return result;
+        }
+
+        public int OnOtherThreadFromArray(params Func<int>[] callbacks)
+        {
+            Exception? error = null;
+            var result = 0;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    result = callbacks[0]();
+                }
+                catch (Exception exception)
+                {
+                    error = exception;
+                }
+            });
+            thread.Start();
+            thread.Join();
+            if (error is not null)
+            {
+                throw error;
+            }
+
+            return result;
         }
     }
 }

--- a/Jint.Tests.PublicInterface/HostEngineConcurrencyTests.cs
+++ b/Jint.Tests.PublicInterface/HostEngineConcurrencyTests.cs
@@ -1,0 +1,379 @@
+#nullable enable
+
+using Jint.Native;
+using Jint.Runtime;
+using Jint.Runtime.Modules;
+
+using Module = Jint.Runtime.Modules.Module;
+
+namespace Jint.Tests.PublicInterface;
+
+public class HostEngineConcurrencyTests
+{
+    private const string ConcurrentUseMessage = "*already in use by another thread or has an asynchronous operation in progress*";
+
+    [Fact]
+    public async Task ConcurrentExecuteIsRejectedAndTheEngineRecovers()
+    {
+        using var entered = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        var engine = CreateBlockingEngine(entered, release);
+        var running = Task.Run(() => engine.Execute("block()"));
+
+        entered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+        try
+        {
+            Invoking(() => engine.Execute("globalThis.concurrent = true"))
+                .Should().Throw<InvalidOperationException>()
+                .WithMessage(ConcurrentUseMessage);
+        }
+        finally
+        {
+            release.Set();
+        }
+
+        await running;
+        engine.Evaluate("typeof concurrent").AsString().Should().Be("undefined");
+        engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ConcurrentEvaluateIsRejected()
+    {
+        using var entered = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        var engine = CreateBlockingEngine(entered, release);
+        var running = Task.Run(() => engine.Evaluate("block()"));
+
+        entered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+        try
+        {
+            Invoking(() => engine.Evaluate("40 + 2"))
+                .Should().Throw<InvalidOperationException>()
+                .WithMessage(ConcurrentUseMessage);
+        }
+        finally
+        {
+            release.Set();
+        }
+
+        await running;
+    }
+
+    [Fact]
+    public async Task ConcurrentInvokeIsRejected()
+    {
+        using var entered = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        var engine = CreateBlockingEngine(entered, release);
+        engine.Execute("function waitForHost() { return block(); }");
+        var running = Task.Run(() => engine.Invoke("waitForHost"));
+
+        entered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+        try
+        {
+            Invoking(() => engine.Invoke("waitForHost"))
+                .Should().Throw<InvalidOperationException>()
+                .WithMessage(ConcurrentUseMessage);
+        }
+        finally
+        {
+            release.Set();
+        }
+
+        await running;
+    }
+
+    [Fact]
+    public async Task ConcurrentMutationIsRejectedBeforeItChangesState()
+    {
+        using var entered = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        var engine = CreateBlockingEngine(entered, release);
+        var running = Task.Run(() => engine.Execute("block()"));
+
+        entered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+        try
+        {
+            Invoking(() => engine.SetValue("leaked", 42))
+                .Should().Throw<InvalidOperationException>()
+                .WithMessage(ConcurrentUseMessage);
+            Invoking(() => JsValue.FromObject(engine, new object()))
+                .Should().Throw<InvalidOperationException>()
+                .WithMessage(ConcurrentUseMessage);
+        }
+        finally
+        {
+            release.Set();
+        }
+
+        await running;
+        engine.Evaluate("typeof leaked").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public async Task ConcurrentAsyncEntryIsRejectedWithoutInterruptingTheOwner()
+    {
+        using var entered = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        var engine = CreateBlockingEngine(entered, release);
+        var running = Task.Run(() => engine.Execute("block(); globalThis.finished = true"));
+
+        entered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+        try
+        {
+            Action concurrent = () => _ = engine.EvaluateAsync("1");
+            Invoking(concurrent)
+                .Should().Throw<InvalidOperationException>()
+                .WithMessage(ConcurrentUseMessage);
+        }
+        finally
+        {
+            release.Set();
+        }
+
+        await running;
+        engine.Evaluate("finished").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void SameThreadHostCallbackCanReenterAndMutateTheEngine()
+    {
+        var engine = new Engine();
+        engine.SetValue("reenter", new Func<int>(() =>
+        {
+            engine.SetValue("nested", 21);
+            return (int) engine.Evaluate("nested * 2").AsNumber();
+        }));
+
+        engine.Evaluate("reenter()").AsNumber().Should().Be(42);
+    }
+
+    [Fact]
+    public void ConsecutiveSynchronousAsyncCallsCanReenterOnTheOwningThread()
+    {
+        var engine = new Engine();
+        engine.SetValue("reenter", new Action(() =>
+        {
+            engine.EvaluateAsync("1").GetAwaiter().GetResult().AsNumber().Should().Be(1);
+            engine.EvaluateAsync("2").GetAwaiter().GetResult().AsNumber().Should().Be(2);
+        }));
+
+        engine.Execute("reenter()");
+    }
+
+    [Fact]
+    public async Task OutstandingEvaluateAsyncOwnsTheEngineUntilItsTaskCompletes()
+    {
+        var gate = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var engine = new Engine();
+        engine.SetValue("hostWork", new Func<Task<int>>(() => gate.Task));
+
+        var pending = engine.EvaluateAsync("(async () => (await hostWork()) + 1)()");
+        pending.IsCompleted.Should().BeFalse();
+
+        Invoking(() => engine.Evaluate("1"))
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage(ConcurrentUseMessage);
+        Invoking(() => engine.SetValue("other", 1))
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage(ConcurrentUseMessage);
+
+        await Task.Run(() => gate.SetResult(41));
+        (await pending).AsNumber().Should().Be(42);
+        engine.Evaluate("6 * 7").AsNumber().Should().Be(42);
+    }
+
+    [Fact]
+    public async Task AsyncRejectionReleasesOwnership()
+    {
+        var gate = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var engine = new Engine();
+        engine.SetValue("hostWork", new Func<Task<int>>(() => gate.Task));
+
+        var pending = engine.EvaluateAsync("(async () => await hostWork())()");
+        gate.SetException(new InvalidOperationException("failed"));
+
+        await Awaiting(() => pending).Should().ThrowAsync<PromiseRejectedException>();
+        engine.Evaluate("20 + 22").AsNumber().Should().Be(42);
+    }
+
+    [Fact]
+    public async Task AsyncCancellationReleasesOwnership()
+    {
+        var gate = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var cancellation = new CancellationTokenSource();
+        var engine = new Engine();
+        engine.SetValue("hostWork", new Func<Task<int>>(() => gate.Task));
+
+        var pending = engine.EvaluateAsync("(async () => await hostWork())()", cancellationToken: cancellation.Token);
+        cancellation.Cancel();
+
+        await Awaiting(() => pending).Should().ThrowAsync<OperationCanceledException>();
+        engine.Evaluate("20 + 22").AsNumber().Should().Be(42);
+    }
+
+    [Fact]
+    public async Task BackgroundModuleCompletionCanFinishTheOwningImport()
+    {
+        var loader = new DeferredModuleLoader();
+        var engine = new Engine(options => options.EnableModules(loader));
+
+        var pending = engine.Modules.ImportAsync("module");
+        pending.IsCompleted.Should().BeFalse();
+        Invoking(() => engine.Execute("1"))
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage(ConcurrentUseMessage);
+
+        await Task.Run(() => loader.Completion!.SetSource("export const value = 42;"));
+
+        var module = await pending;
+        module.Get("value").AsNumber().Should().Be(42);
+        engine.Evaluate("1").AsNumber().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CanonicalJsCallDelegateCannotBypassOwnership()
+    {
+        Func<JsValue, JsValue[], JsValue>? callback = null;
+        using var entered = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        var engine = CreateBlockingEngine(entered, release);
+        engine.SetValue("capture", new Action<Func<JsValue, JsValue[], JsValue>>(value => callback = value));
+        engine.Execute("capture(() => 42)");
+        var running = Task.Run(() => engine.Execute("block()"));
+
+        entered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+        try
+        {
+            Invoking(() => callback!(JsValue.Undefined, []))
+                .Should().Throw<InvalidOperationException>()
+                .WithMessage(ConcurrentUseMessage);
+        }
+        finally
+        {
+            release.Set();
+        }
+
+        await running;
+    }
+
+    [Fact]
+    public async Task SharedPreparedCallbackBinderUsesTheTargetFunctionsEngine()
+    {
+        var prepared = Engine.PrepareScript("capture(() => 42)");
+        Func<int>? callbackA = null;
+        Func<int>? callbackB = null;
+        using var entered = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        var engineA = CreateBlockingEngine(entered, release);
+        var engineB = new Engine();
+        engineA.SetValue("capture", new Action<Func<int>>(value => callbackA = value));
+        engineB.SetValue("capture", new Action<Func<int>>(value => callbackB = value));
+        engineA.Execute(prepared);
+        engineB.Execute(prepared);
+        var running = Task.Run(() => engineA.Execute("block()"));
+
+        entered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+        try
+        {
+            callbackB!().Should().Be(42);
+            Invoking(() => callbackA!())
+                .Should().Throw<InvalidOperationException>()
+                .WithMessage(ConcurrentUseMessage);
+        }
+        finally
+        {
+            release.Set();
+        }
+
+        await running;
+    }
+
+    [Fact]
+    public async Task DebuggerEvaluationCannotBypassOwnership()
+    {
+        using var entered = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        var engine = new Engine(options => options.Debugger.Enabled = true);
+        engine.SetValue("block", new Action(() =>
+        {
+            entered.Set();
+            release.Wait();
+        }));
+        var running = Task.Run(() => engine.Execute("block()"));
+
+        entered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+        try
+        {
+            Invoking(() => engine.Debugger.Evaluate("1"))
+                .Should().Throw<InvalidOperationException>()
+                .WithMessage(ConcurrentUseMessage);
+        }
+        finally
+        {
+            release.Set();
+        }
+
+        await running;
+    }
+
+    [Fact]
+    public async Task ModuleImportPollingCannotRaceAnEngineTurn()
+    {
+        using var entered = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        var loader = new DeferredModuleLoader();
+        var engine = new Engine(options => options.EnableModules(loader));
+        engine.SetValue("block", new Action(() =>
+        {
+            entered.Set();
+            release.Wait();
+        }));
+        var operation = engine.Modules.StartImport("module");
+        loader.Completion!.SetSource("block(); export const value = 42;");
+        var running = Task.Run(engine.Advanced.ProcessTasks);
+
+        entered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+        try
+        {
+            Invoking(() => _ = operation.IsCompleted)
+                .Should().Throw<InvalidOperationException>()
+                .WithMessage(ConcurrentUseMessage);
+        }
+        finally
+        {
+            release.Set();
+        }
+
+        await running;
+        operation.GetResult().Get("value").AsNumber().Should().Be(42);
+    }
+
+    private static Engine CreateBlockingEngine(ManualResetEventSlim entered, ManualResetEventSlim release)
+    {
+        var engine = new Engine();
+        engine.SetValue("block", new Action(() =>
+        {
+            entered.Set();
+            release.Wait();
+        }));
+        return engine;
+    }
+
+    private sealed class DeferredModuleLoader : IAsyncModuleLoader
+    {
+        public ModuleLoadCompletion? Completion { get; private set; }
+
+        public ResolvedSpecifier Resolve(string? referencingModuleLocation, ModuleRequest moduleRequest)
+            => new(moduleRequest, moduleRequest.Specifier, Uri: null, SpecifierType.Bare);
+
+        public Module LoadModule(Engine engine, ResolvedSpecifier resolved)
+            => throw new InvalidOperationException("The asynchronous path should be used.");
+
+        public void LoadModuleAsync(Engine engine, ResolvedSpecifier resolved, ModuleLoadCompletion completion)
+        {
+            Completion = completion;
+        }
+    }
+}

--- a/Jint.Tests/Runtime/EngineConcurrencyTests.cs
+++ b/Jint.Tests/Runtime/EngineConcurrencyTests.cs
@@ -1,0 +1,34 @@
+namespace Jint.Tests.Runtime;
+
+public class EngineConcurrencyTests
+{
+    [Fact]
+    public void BackgroundManualPromiseCompletionOnlyEnqueuesWork()
+    {
+        var engine = new Engine();
+        var promise = engine.Advanced.RegisterPromise();
+        engine.SetValue("hostPromise", promise.Promise);
+        engine.Execute("globalThis.result = 0; hostPromise.then(value => { result = value; });");
+
+        var thread = new Thread(() => promise.Resolve(42));
+        thread.Start();
+        thread.Join();
+
+        engine.GetValue("result").AsNumber().Should().Be(0);
+        engine.Advanced.ProcessTasks();
+        engine.GetValue("result").AsNumber().Should().Be(42);
+    }
+
+    [Fact]
+    public void SameThreadManualPromiseCompletionDrainsInline()
+    {
+        var engine = new Engine();
+        var promise = engine.Advanced.RegisterPromise();
+        engine.SetValue("hostPromise", promise.Promise);
+        engine.Execute("globalThis.result = 0; hostPromise.then(value => { result = value; });");
+
+        promise.Resolve(42);
+
+        engine.GetValue("result").AsNumber().Should().Be(42);
+    }
+}

--- a/Jint.Tests/Runtime/EngineConcurrencyTests.cs
+++ b/Jint.Tests/Runtime/EngineConcurrencyTests.cs
@@ -3,7 +3,34 @@ namespace Jint.Tests.Runtime;
 public class EngineConcurrencyTests
 {
     [Fact]
-    public void BackgroundManualPromiseCompletionOnlyEnqueuesWork()
+    public async Task ConcurrentManualPromiseCompletionOnlyEnqueuesWork()
+    {
+        var engine = new Engine();
+        var promise = engine.Advanced.RegisterPromise();
+        engine.SetValue("hostPromise", promise.Promise);
+        var continued = false;
+        engine.SetValue("markContinued", new Action(() => Volatile.Write(ref continued, true)));
+        using var entered = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        engine.SetValue("block", new Action(() =>
+        {
+            entered.Set();
+            release.Wait();
+        }));
+        engine.Execute("hostPromise.then(markContinued);");
+
+        var running = Task.Run(() => engine.Execute("block()"));
+        entered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+        promise.Resolve(42);
+        Volatile.Read(ref continued).Should().BeFalse();
+
+        release.Set();
+        await running;
+        Volatile.Read(ref continued).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ManualPromiseCompletionDrainsInlineAfterExclusiveThreadHandoff()
     {
         var engine = new Engine();
         var promise = engine.Advanced.RegisterPromise();
@@ -14,8 +41,6 @@ public class EngineConcurrencyTests
         thread.Start();
         thread.Join();
 
-        engine.GetValue("result").AsNumber().Should().Be(0);
-        engine.Advanced.ProcessTasks();
         engine.GetValue("result").AsNumber().Should().Be(42);
     }
 

--- a/Jint/Engine.Advanced.cs
+++ b/Jint/Engine.Advanced.cs
@@ -29,6 +29,7 @@ public partial class Engine
         {
             get
             {
+                using var ownership = _engine.EnterHostCall();
                 var lastSyntaxElement = _engine._lastSyntaxElement;
                 if (lastSyntaxElement is null)
                 {
@@ -55,6 +56,7 @@ public partial class Engine
         /// </remarks>
         public void ResetCallStack()
         {
+            using var ownership = _engine.EnterHostCall();
             _engine.ResetCallStack();
         }
 
@@ -63,6 +65,7 @@ public partial class Engine
         /// </summary>
         public void ProcessTasks()
         {
+            using var ownership = _engine.EnterHostCall();
             _engine.RunAvailableContinuations();
         }
 
@@ -78,6 +81,7 @@ public partial class Engine
         /// <returns>a Promise instance and functions to either resolve or reject it</returns>
         public ManualPromise RegisterPromise()
         {
+            using var ownership = _engine.EnterHostCall();
             return _engine.RegisterPromise();
         }
 
@@ -100,6 +104,7 @@ public partial class Engine
         /// <returns>The proxy object, ready to be passed into script.</returns>
         public ObjectInstance CreateProxy(ObjectInstance target, ProxyHandler handler)
         {
+            using var ownership = _engine.EnterHostCall();
             if (target is null)
             {
                 Throw.ArgumentNullException(nameof(target));
@@ -123,6 +128,7 @@ public partial class Engine
         /// <returns>The proxy paired with its revoke operation.</returns>
         public RevocableProxy CreateRevocableProxy(ObjectInstance target, ProxyHandler handler)
         {
+            using var ownership = _engine.EnterHostCall();
             if (target is null)
             {
                 Throw.ArgumentNullException(nameof(target));
@@ -171,6 +177,7 @@ public partial class Engine
         /// <exception cref="ArgumentException"><paramref name="value"/> belongs to a different engine.</exception>
         public ObjectRepresentation GetObjectRepresentation(ObjectInstance value)
         {
+            using var ownership = _engine.EnterHostCall();
             if (value is null)
             {
                 Throw.ArgumentNullException(nameof(value));
@@ -299,6 +306,7 @@ public partial class Engine
         /// <exception cref="ArgumentException"><paramref name="value"/> belongs to a different engine.</exception>
         public PropertyAccessSemantics GetPropertyAccessSemantics(ObjectInstance value)
         {
+            using var ownership = _engine.EnterHostCall();
             if (value is null)
             {
                 Throw.ArgumentNullException(nameof(value));
@@ -357,7 +365,10 @@ public partial class Engine
         /// </para>
         /// </remarks>
         public InteropConversionDiagnostics GetInteropConversionDiagnostics()
-            => new(_engine._arrayLiveViewConversions, _engine._arrayCopyConversions);
+        {
+            using var ownership = _engine.EnterHostCall();
+            return new(_engine._arrayLiveViewConversions, _engine._arrayCopyConversions);
+        }
 
         /// <summary>
         /// Installs a global on <em>this</em> engine whose value is produced the first time script reads it,
@@ -436,6 +447,7 @@ public partial class Engine
             Func<Engine, JsValue> valueFactory,
             PropertyFlag flags = PropertyFlag.ConfigurableEnumerableWritable)
         {
+            using var ownership = _engine.EnterHostCall();
             if (name is null)
             {
                 Throw.ArgumentNullException(nameof(name));
@@ -502,6 +514,7 @@ public partial class Engine
             Func<Engine, TState, JsValue> valueFactory,
             PropertyFlag flags = PropertyFlag.ConfigurableEnumerableWritable)
         {
+            using var ownership = _engine.EnterHostCall();
             if (name is null)
             {
                 Throw.ArgumentNullException(nameof(name));
@@ -599,8 +612,16 @@ public partial class Engine
         /// </example>
         public object? HostDefined
         {
-            get => _engine._mainRealm.HostDefined;
-            set => _engine._mainRealm.HostDefined = value;
+            get
+            {
+                using var ownership = _engine.EnterHostCall();
+                return _engine._mainRealm.HostDefined;
+            }
+            set
+            {
+                using var ownership = _engine.EnterHostCall();
+                _engine._mainRealm.HostDefined = value;
+            }
         }
 
         /// <summary>

--- a/Jint/Engine.Advanced.cs
+++ b/Jint/Engine.Advanced.cs
@@ -75,8 +75,9 @@ public partial class Engine
         /// Registers a promise within the currently running EventLoop (has to be called within "ExecuteWithEventLoop" call).
         /// Note that ExecuteWithEventLoop will not trigger "onFinished" callback until ALL manual promises are settled.
         ///
-        /// NOTE: that resolve and reject need to be called withing the same thread as "ExecuteWithEventLoop".
-        /// The API assumes that the Engine is called from a single thread.
+        /// Resolve and reject may be called from another thread. Settlement is enqueued safely and drains
+        /// inline only when that thread can claim exclusive engine ownership; otherwise the owning host turn
+        /// or a later <see cref="ProcessTasks"/> call drains it.
         /// </summary>
         /// <returns>a Promise instance and functions to either resolve or reject it</returns>
         public ManualPromise RegisterPromise()

--- a/Jint/Engine.Async.cs
+++ b/Jint/Engine.Async.cs
@@ -31,8 +31,23 @@ public partial class Engine
     /// <returns>The resolved value if the result is a promise, otherwise the direct result.</returns>
     public Task<JsValue> EvaluateAsync(string code, string? source = null, CancellationToken cancellationToken = default)
     {
-        var result = Evaluate(code, source);
-        return UnwrapResultAsync(result, cancellationToken);
+        var owner = ReserveAsyncHostOperation();
+        try
+        {
+            Task<JsValue> task;
+            using (EnterHostCall(owner))
+            {
+                var result = Evaluate(code, source);
+                task = UnwrapResultAsync(result, owner, cancellationToken);
+            }
+
+            return CompleteAsyncHostOperation(task, owner);
+        }
+        catch
+        {
+            ReleaseAsyncHostOperation(owner);
+            throw;
+        }
     }
 
     /// <summary>
@@ -53,8 +68,23 @@ public partial class Engine
     /// <returns>The resolved value if the result is a promise, otherwise the direct result.</returns>
     public Task<JsValue> EvaluateAsync(in Prepared<Script> preparedScript, CancellationToken cancellationToken = default)
     {
-        var result = Evaluate(in preparedScript);
-        return UnwrapResultAsync(result, cancellationToken);
+        var owner = ReserveAsyncHostOperation();
+        try
+        {
+            Task<JsValue> task;
+            using (EnterHostCall(owner))
+            {
+                var result = Evaluate(in preparedScript);
+                task = UnwrapResultAsync(result, owner, cancellationToken);
+            }
+
+            return CompleteAsyncHostOperation(task, owner);
+        }
+        catch
+        {
+            ReleaseAsyncHostOperation(owner);
+            throw;
+        }
     }
 
     /// <summary>
@@ -73,15 +103,25 @@ public partial class Engine
     /// <param name="source">Optional source identifier for debugging.</param>
     /// <param name="cancellationToken">Cancellation token to observe while awaiting promise settlement; see the remarks.</param>
     /// <returns>The engine instance for chaining, after all async work completes.</returns>
-    public async Task<Engine> ExecuteAsync(string code, string? source = null, CancellationToken cancellationToken = default)
+    public Task<Engine> ExecuteAsync(string code, string? source = null, CancellationToken cancellationToken = default)
     {
-        var result = Evaluate(code, source);
-        if (result is JsPromise)
+        var owner = ReserveAsyncHostOperation();
+        try
         {
-            await UnwrapResultAsync(result, cancellationToken).ConfigureAwait(false);
-        }
+            Task<JsValue> task;
+            using (EnterHostCall(owner))
+            {
+                var result = Evaluate(code, source);
+                task = UnwrapResultAsync(result, owner, cancellationToken);
+            }
 
-        return this;
+            return CompleteExecuteAsync(task, owner);
+        }
+        catch
+        {
+            ReleaseAsyncHostOperation(owner);
+            throw;
+        }
     }
 
     /// <summary>
@@ -112,8 +152,48 @@ public partial class Engine
     /// <returns>The resolved value if the function returns a promise, otherwise the direct result.</returns>
     public Task<JsValue> InvokeAsync(string propertyName, CancellationToken cancellationToken, params object?[] arguments)
     {
-        var result = Invoke(propertyName, arguments);
-        return UnwrapResultAsync(result, cancellationToken);
+        var owner = ReserveAsyncHostOperation();
+        try
+        {
+            Task<JsValue> task;
+            using (EnterHostCall(owner))
+            {
+                var result = Invoke(propertyName, arguments);
+                task = UnwrapResultAsync(result, owner, cancellationToken);
+            }
+
+            return CompleteAsyncHostOperation(task, owner);
+        }
+        catch
+        {
+            ReleaseAsyncHostOperation(owner);
+            throw;
+        }
+    }
+
+    private async Task<JsValue> CompleteAsyncHostOperation(Task<JsValue> task, object owner)
+    {
+        try
+        {
+            return await task.ConfigureAwait(false);
+        }
+        finally
+        {
+            ReleaseAsyncHostOperation(owner);
+        }
+    }
+
+    private async Task<Engine> CompleteExecuteAsync(Task<JsValue> task, object owner)
+    {
+        try
+        {
+            await task.ConfigureAwait(false);
+            return this;
+        }
+        finally
+        {
+            ReleaseAsyncHostOperation(owner);
+        }
     }
 
     /// <summary>
@@ -121,6 +201,26 @@ public partial class Engine
     /// without blocking any thread. For non-promise values, returns synchronously.
     /// </summary>
     internal Task<JsValue> UnwrapResultAsync(JsValue result, CancellationToken cancellationToken)
+    {
+        var owner = ReserveAsyncHostOperation();
+        try
+        {
+            Task<JsValue> task;
+            using (EnterHostCall(owner))
+            {
+                task = UnwrapResultAsync(result, owner, cancellationToken);
+            }
+
+            return CompleteAsyncHostOperation(task, owner);
+        }
+        catch
+        {
+            ReleaseAsyncHostOperation(owner);
+            throw;
+        }
+    }
+
+    internal Task<JsValue> UnwrapResultAsync(JsValue result, object owner, CancellationToken cancellationToken)
     {
         if (result is not JsPromise promise)
         {
@@ -143,7 +243,7 @@ public partial class Engine
         // Slow path: promise is pending, use truly async waiting.
         // No thread is consumed during the wait — the event loop wake signal
         // will resume execution when new work arrives (e.g., from Task.ContinueWith).
-        return AwaitPromiseSettlementAsync(promise, cancellationToken);
+        return AwaitPromiseSettlementAsync(promise, owner, cancellationToken);
     }
 
     /// <summary>
@@ -153,7 +253,7 @@ public partial class Engine
     /// to resume on a thread pool thread, process the JS continuation, and either complete
     /// or go back to sleep if another await is hit.
     /// </summary>
-    private async Task<JsValue> AwaitPromiseSettlementAsync(JsPromise promise, CancellationToken cancellationToken)
+    private async Task<JsValue> AwaitPromiseSettlementAsync(JsPromise promise, object owner, CancellationToken cancellationToken)
     {
         var eventLoop = _eventLoop;
         var timeout = Options.Constraints.PromiseTimeout;
@@ -194,41 +294,46 @@ public partial class Engine
 
                 // Truly async wait — releases the thread back to the pool.
                 // Zero threads consumed while waiting for IO to complete.
-                // Work the engine scheduled for itself — a pending Atomics.waitAsync timeout, a pending
-                // web-API timer — is the one thing that can make this loop's condition advance without
-                // anything being enqueued, so the wait has to be bounded by its due time. One Task.Delay per
-                // idle wait, and only while such work pends; an engine with none takes the first branch and
-                // is byte-for-byte what it was.
-                var untilNextWork = TimeUntilNextPumpScheduledWork();
-                if (untilNextWork is not { } untilDue)
-                {
-                    await eventLoop.WaitForEventAsync(effectiveCt).ConfigureAwait(false);
-                }
-                else if (untilDue > TimeSpan.Zero)
-                {
-                    await eventLoop.WaitForEventAsync(untilDue, effectiveCt).ConfigureAwait(false);
-                }
-                else if (eventLoop.IsRunningJob)
-                {
-                    // Due now, but nested inside a job this thread cannot run the queue at all, so waiting is
-                    // what keeps the loop from spinning hot on work nobody present can promote.
-                    await eventLoop.WaitForEventAsync(effectiveCt).ConfigureAwait(false);
-                }
-
-                // Otherwise something is due and can be promoted: fall straight through to the pump.
-
-                // Woke up — take ownership of the event loop for this processing cycle.
-                // Setting _waitingThreadId prevents any other thread from processing
-                // JavaScript continuations while we're running.
-                var previousWaitingThreadId = eventLoop._waitingThreadId;
-                eventLoop._waitingThreadId = Environment.CurrentManagedThreadId;
+                Interlocked.Increment(ref _hostCallbackAdmission);
                 try
                 {
-                    RunAvailableContinuations();
+                    // Work the engine scheduled for itself — a pending Atomics.waitAsync timeout, a pending
+                    // web-API timer — is the one thing that can make this loop's condition advance without
+                    // anything being enqueued, so the wait has to be bounded by its due time.
+                    var untilNextWork = TimeUntilNextPumpScheduledWork();
+                    if (untilNextWork is not { } untilDue)
+                    {
+                        await eventLoop.WaitForEventAsync(effectiveCt).ConfigureAwait(false);
+                    }
+                    else if (untilDue > TimeSpan.Zero)
+                    {
+                        await eventLoop.WaitForEventAsync(untilDue, effectiveCt).ConfigureAwait(false);
+                    }
+                    else if (eventLoop.IsRunningJob)
+                    {
+                        await eventLoop.WaitForEventAsync(effectiveCt).ConfigureAwait(false);
+                    }
                 }
                 finally
                 {
-                    eventLoop._waitingThreadId = previousWaitingThreadId;
+                    Interlocked.Decrement(ref _hostCallbackAdmission);
+                }
+
+                using (EnterTransferredHostCall(owner))
+                {
+                    // Woke up — take ownership of the event loop for this processing cycle.
+                    // Setting _waitingThreadId prevents any other thread from processing
+                    // JavaScript continuations while we're running.
+                    var previousWaitingThreadId = eventLoop._waitingThreadId;
+                    eventLoop._waitingThreadId = Environment.CurrentManagedThreadId;
+                    try
+                    {
+                        RunAvailableContinuations();
+                    }
+                    finally
+                    {
+                        eventLoop._waitingThreadId = previousWaitingThreadId;
+                    }
                 }
             }
         }

--- a/Jint/Engine.Async.cs
+++ b/Jint/Engine.Async.cs
@@ -32,22 +32,22 @@ public partial class Engine
     public Task<JsValue> EvaluateAsync(string code, string? source = null, CancellationToken cancellationToken = default)
     {
         var owner = ReserveAsyncHostOperation();
+        Task<JsValue> task;
         try
         {
-            Task<JsValue> task;
             using (EnterHostCall(owner))
             {
                 var result = Evaluate(code, source);
                 task = UnwrapResultAsync(result, owner, cancellationToken);
             }
-
-            return CompleteAsyncHostOperation(task, owner);
         }
         catch
         {
             ReleaseAsyncHostOperation(owner);
             throw;
         }
+
+        return CompleteAsyncHostOperation(task, owner);
     }
 
     /// <summary>
@@ -69,22 +69,22 @@ public partial class Engine
     public Task<JsValue> EvaluateAsync(in Prepared<Script> preparedScript, CancellationToken cancellationToken = default)
     {
         var owner = ReserveAsyncHostOperation();
+        Task<JsValue> task;
         try
         {
-            Task<JsValue> task;
             using (EnterHostCall(owner))
             {
                 var result = Evaluate(in preparedScript);
                 task = UnwrapResultAsync(result, owner, cancellationToken);
             }
-
-            return CompleteAsyncHostOperation(task, owner);
         }
         catch
         {
             ReleaseAsyncHostOperation(owner);
             throw;
         }
+
+        return CompleteAsyncHostOperation(task, owner);
     }
 
     /// <summary>
@@ -103,25 +103,25 @@ public partial class Engine
     /// <param name="source">Optional source identifier for debugging.</param>
     /// <param name="cancellationToken">Cancellation token to observe while awaiting promise settlement; see the remarks.</param>
     /// <returns>The engine instance for chaining, after all async work completes.</returns>
-    public Task<Engine> ExecuteAsync(string code, string? source = null, CancellationToken cancellationToken = default)
+    public async Task<Engine> ExecuteAsync(string code, string? source = null, CancellationToken cancellationToken = default)
     {
         var owner = ReserveAsyncHostOperation();
+        Task<JsValue> task;
         try
         {
-            Task<JsValue> task;
             using (EnterHostCall(owner))
             {
                 var result = Evaluate(code, source);
                 task = UnwrapResultAsync(result, owner, cancellationToken);
             }
-
-            return CompleteExecuteAsync(task, owner);
         }
         catch
         {
             ReleaseAsyncHostOperation(owner);
             throw;
         }
+
+        return await CompleteExecuteAsync(task, owner).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -153,22 +153,22 @@ public partial class Engine
     public Task<JsValue> InvokeAsync(string propertyName, CancellationToken cancellationToken, params object?[] arguments)
     {
         var owner = ReserveAsyncHostOperation();
+        Task<JsValue> task;
         try
         {
-            Task<JsValue> task;
             using (EnterHostCall(owner))
             {
                 var result = Invoke(propertyName, arguments);
                 task = UnwrapResultAsync(result, owner, cancellationToken);
             }
-
-            return CompleteAsyncHostOperation(task, owner);
         }
         catch
         {
             ReleaseAsyncHostOperation(owner);
             throw;
         }
+
+        return CompleteAsyncHostOperation(task, owner);
     }
 
     private async Task<JsValue> CompleteAsyncHostOperation(Task<JsValue> task, object owner)

--- a/Jint/Engine.Constraints.cs
+++ b/Jint/Engine.Constraints.cs
@@ -122,6 +122,7 @@ public partial class Engine
         /// </summary>
         public void Check()
         {
+            using var ownership = _engine.EnterHostCall();
             foreach (var constraint in _engine._constraints)
             {
                 constraint.Check();
@@ -133,6 +134,7 @@ public partial class Engine
         /// </summary>
         public T? Find<T>() where T : Constraint
         {
+            using var ownership = _engine.EnterHostCall();
             foreach (var constraint in _engine._constraints)
             {
                 if (constraint.GetType() == typeof(T))
@@ -149,6 +151,7 @@ public partial class Engine
         /// </summary>
         public void Reset()
         {
+            using var ownership = _engine.EnterHostCall();
             foreach (var constraint in _engine._constraints)
             {
                 constraint.Reset();

--- a/Jint/Engine.GlobalSnapshot.cs
+++ b/Jint/Engine.GlobalSnapshot.cs
@@ -100,7 +100,11 @@ public partial class Engine
         /// <exception cref="NotSupportedException">The realm's global object overrides one of the property
         /// storage virtuals (<c>GetOwnProperty</c>, <c>Set</c>, …), so it resolves own properties from state
         /// outside the engine's tables and cannot be captured or restored.</exception>
-        public GlobalSnapshot CaptureGlobalSnapshot() => GlobalSnapshot.Capture(_engine);
+        public GlobalSnapshot CaptureGlobalSnapshot()
+        {
+            using var ownership = _engine.EnterHostCall();
+            return GlobalSnapshot.Capture(_engine);
+        }
 
         /// <summary>
         /// Restores the global bindings captured by <see cref="CaptureGlobalSnapshot"/>: global own
@@ -157,6 +161,7 @@ public partial class Engine
         /// engine's realm no longer has the global object the snapshot was taken from.</exception>
         public void RestoreGlobalSnapshot(GlobalSnapshot snapshot)
         {
+            using var ownership = _engine.EnterHostCall();
             if (snapshot is null)
             {
                 Throw.ArgumentNullException(nameof(snapshot));
@@ -206,8 +211,9 @@ public partial class Engine
         /// its own: it is a <see langword="finally"/>, not a sandbox.
         /// </para>
         /// <para>
-        /// An <see cref="Engine"/> is single-threaded, so a host sharing one across requests still needs its
-        /// own lock around the whole call — the restore is only correct if nothing else is evaluating.
+        /// An <see cref="Engine"/> accepts one host operation at a time. A host sharing one across requests
+        /// still needs to serialize the whole call — concurrent entries fail rather than waiting for one
+        /// another, and the restore is only correct if nothing else is evaluating.
         /// Asynchronous work has to be awaited <em>inside</em> <paramref name="action"/>: an
         /// <c>EvaluateAsync</c> whose <see cref="System.Threading.Tasks.Task"/> is still outstanding when the
         /// action returns makes the restore throw.
@@ -227,6 +233,7 @@ public partial class Engine
         /// is <see langword="null"/>.</exception>
         public void WithRestoredGlobals(GlobalSnapshot snapshot, Action action)
         {
+            using var ownership = _engine.EnterHostCall();
             if (snapshot is null)
             {
                 Throw.ArgumentNullException(nameof(snapshot));

--- a/Jint/Engine.Modules.cs
+++ b/Jint/Engine.Modules.cs
@@ -813,25 +813,25 @@ public partial class Engine
             => ImportAsync(specifier, referencingModuleLocation: null, cancellationToken);
 
         /// <inheritdoc cref="ImportAsync(string,CancellationToken)" />
-        public Task<ObjectInstance> ImportAsync(string specifier, string? referencingModuleLocation, CancellationToken cancellationToken = default)
+        public async Task<ObjectInstance> ImportAsync(string specifier, string? referencingModuleLocation, CancellationToken cancellationToken = default)
         {
             var owner = _engine.ReserveAsyncHostOperation();
+            Task<JsValue> task;
             try
             {
-                Task<JsValue> task;
                 using (_engine.EnterHostCall(owner))
                 {
                     var promise = StartImport(specifier, referencingModuleLocation).Promise;
                     task = _engine.UnwrapResultAsync(promise, owner, cancellationToken);
                 }
-
-                return CompleteImportAsync(task, _engine, owner);
             }
             catch
             {
                 _engine.ReleaseAsyncHostOperation(owner);
                 throw;
             }
+
+            return await CompleteImportAsync(task, _engine, owner).ConfigureAwait(false);
         }
 
         private static async Task<ObjectInstance> CompleteImportAsync(Task<JsValue> task, Engine engine, object owner)

--- a/Jint/Engine.Modules.cs
+++ b/Jint/Engine.Modules.cs
@@ -591,6 +591,7 @@ public partial class Engine
         /// <inheritdoc cref="Add(string,ModuleBuilder)" path="/remarks"/>
         public void Add(string specifier, string code)
         {
+            using var ownership = _engine.EnterHostCall();
             var moduleBuilder = new ModuleBuilder(_engine, specifier);
             moduleBuilder.AddSource(code);
             Add(specifier, moduleBuilder);
@@ -602,6 +603,7 @@ public partial class Engine
         /// <inheritdoc cref="Add(string,ModuleBuilder)" path="/remarks"/>
         public void Add(string specifier, Action<ModuleBuilder> buildModule)
         {
+            using var ownership = _engine.EnterHostCall();
             var moduleBuilder = new ModuleBuilder(_engine, specifier);
             buildModule(moduleBuilder);
             Add(specifier, moduleBuilder);
@@ -641,6 +643,7 @@ public partial class Engine
         /// </remarks>
         public void Add(string specifier, ModuleBuilder moduleBuilder)
         {
+            using var ownership = _engine.EnterHostCall();
             _builders.Add(specifier, moduleBuilder);
             _buildersVersion++;
         }
@@ -657,6 +660,7 @@ public partial class Engine
         /// </remarks>
         public ObjectInstance Import(string specifier)
         {
+            using var ownership = _engine.EnterHostCall();
             return Import(specifier, referencingModuleLocation: null);
         }
 
@@ -749,6 +753,7 @@ public partial class Engine
         /// <inheritdoc cref="StartImport(string)" />
         public ModuleImportOperation StartImport(string specifier, string? referencingModuleLocation)
         {
+            using var ownership = _engine.EnterHostCall();
             var request = new ModuleRequest(specifier, []);
             var capability = PromiseConstructor.NewPromiseCapability(_engine, _engine.Realm.Intrinsics.Promise);
             var payload = new DynamicImportPayload(_engine, request, capability);
@@ -808,11 +813,37 @@ public partial class Engine
             => ImportAsync(specifier, referencingModuleLocation: null, cancellationToken);
 
         /// <inheritdoc cref="ImportAsync(string,CancellationToken)" />
-        public async Task<ObjectInstance> ImportAsync(string specifier, string? referencingModuleLocation, CancellationToken cancellationToken = default)
+        public Task<ObjectInstance> ImportAsync(string specifier, string? referencingModuleLocation, CancellationToken cancellationToken = default)
         {
-            var promise = StartImport(specifier, referencingModuleLocation).Promise;
-            var result = await _engine.UnwrapResultAsync(promise, cancellationToken).ConfigureAwait(false);
-            return (ObjectInstance) result;
+            var owner = _engine.ReserveAsyncHostOperation();
+            try
+            {
+                Task<JsValue> task;
+                using (_engine.EnterHostCall(owner))
+                {
+                    var promise = StartImport(specifier, referencingModuleLocation).Promise;
+                    task = _engine.UnwrapResultAsync(promise, owner, cancellationToken);
+                }
+
+                return CompleteImportAsync(task, _engine, owner);
+            }
+            catch
+            {
+                _engine.ReleaseAsyncHostOperation(owner);
+                throw;
+            }
+        }
+
+        private static async Task<ObjectInstance> CompleteImportAsync(Task<JsValue> task, Engine engine, object owner)
+        {
+            try
+            {
+                return (ObjectInstance) await task.ConfigureAwait(false);
+            }
+            finally
+            {
+                engine.ReleaseAsyncHostOperation(owner);
+            }
         }
 
         /// <summary>

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -102,6 +102,7 @@ public sealed partial class Engine : IDisposable
     private int _ownerDepth;
     private object? _ownerToken;
     private object? _asyncOwner;
+    private object? _asyncReleasePending;
     private int _hostCallbackAdmission;
     private ManualResetEventSlim? _ownershipReleased;
 
@@ -143,6 +144,7 @@ public sealed partial class Engine : IDisposable
             || (asyncOwner is not null && !ReferenceEquals(asyncOwner, reservedOwner)))
         {
             Volatile.Write(ref _ownerThreadId, 0);
+            Volatile.Read(ref _ownershipReleased)?.Set();
             Throw.InvalidOperationException(ConcurrentUseMessage);
         }
 
@@ -154,28 +156,56 @@ public sealed partial class Engine : IDisposable
     internal HostCallScope EnterHostCallback()
     {
         var owner = Volatile.Read(ref _asyncOwner);
-        return owner is not null && Volatile.Read(ref _hostCallbackAdmission) > 0
-            ? EnterTransferredHostCall(owner)
-            : EnterHostCall();
+        if (owner is null)
+        {
+            return EnterHostCall();
+        }
+
+        // Claim the admission window before it can close. A count of one after the increment means
+        // there was no open window to claim; a larger count keeps the transfer token alive until
+        // this callback's scope exits.
+        if (Interlocked.Increment(ref _hostCallbackAdmission) == 1
+            || !ReferenceEquals(Volatile.Read(ref _asyncOwner), owner))
+        {
+            ReleaseHostCallbackAdmission(owner);
+            return EnterHostCall();
+        }
+
+        try
+        {
+            return EnterTransferredHostCall(owner, callback: true);
+        }
+        catch
+        {
+            ReleaseHostCallbackAdmission(owner);
+            throw;
+        }
     }
 
-    internal HostCallScope EnterTransferredHostCall(object owner)
+    internal HostCallScope EnterTransferredHostCall(object owner, bool callback = false)
     {
         if (!ReferenceEquals(Volatile.Read(ref _asyncOwner), owner))
         {
-            Throw.InvalidOperationException(ConcurrentUseMessage);
+            return EnterHostCall();
         }
 
         var threadId = System.Environment.CurrentManagedThreadId;
         if (Volatile.Read(ref _ownerThreadId) == threadId)
         {
             _ownerDepth++;
-            return new HostCallScope(this);
+            return new HostCallScope(this, callback ? owner : null);
         }
 
         AcquireHostCall(threadId);
         if (!ReferenceEquals(Volatile.Read(ref _asyncOwner), owner))
         {
+            if (Volatile.Read(ref _asyncOwner) is null)
+            {
+                _ownerDepth = 1;
+                _ownerToken = null;
+                return new HostCallScope(this, callback ? owner : null);
+            }
+
             Volatile.Write(ref _ownerThreadId, 0);
             Volatile.Read(ref _ownershipReleased)?.Set();
             Throw.InvalidOperationException(ConcurrentUseMessage);
@@ -290,18 +320,25 @@ public sealed partial class Engine : IDisposable
         _ownerDepth = depth;
         _ownerToken = owner;
 
-        if (Interlocked.Decrement(ref _hostCallbackAdmission) == 0 && ReferenceEquals(owner, this))
+        ReleaseHostCallbackAdmission(owner);
+    }
+
+    private void ReleaseHostCallbackAdmission(object owner)
+    {
+        if (Interlocked.Decrement(ref _hostCallbackAdmission) == 0
+            && (ReferenceEquals(owner, this)
+                || ReferenceEquals(Volatile.Read(ref _asyncReleasePending), owner)))
         {
             Interlocked.CompareExchange(ref _asyncOwner, null, owner);
+            Interlocked.CompareExchange(ref _asyncReleasePending, null, owner);
             _ownerToken = null;
         }
     }
 
     internal object ReserveAsyncHostOperation()
     {
-        var threadId = System.Environment.CurrentManagedThreadId;
         var activeOwner = Volatile.Read(ref _ownerThreadId);
-        if (activeOwner != 0 && activeOwner != threadId)
+        if (activeOwner != 0)
         {
             Throw.InvalidOperationException(ConcurrentUseMessage);
         }
@@ -313,7 +350,7 @@ public sealed partial class Engine : IDisposable
         }
 
         activeOwner = Volatile.Read(ref _ownerThreadId);
-        if (activeOwner != 0 && activeOwner != threadId)
+        if (activeOwner != 0)
         {
             Interlocked.CompareExchange(ref _asyncOwner, null, owner);
             Throw.InvalidOperationException(ConcurrentUseMessage);
@@ -324,6 +361,22 @@ public sealed partial class Engine : IDisposable
 
     internal void ReleaseAsyncHostOperation(object owner)
     {
+        if (!ReferenceEquals(Volatile.Read(ref _asyncOwner), owner))
+        {
+            return;
+        }
+
+        if (Volatile.Read(ref _hostCallbackAdmission) > 0)
+        {
+            Volatile.Write(ref _asyncReleasePending, owner);
+            if (Volatile.Read(ref _hostCallbackAdmission) > 0)
+            {
+                return;
+            }
+
+            Interlocked.CompareExchange(ref _asyncReleasePending, null, owner);
+        }
+
         if (ReferenceEquals(Interlocked.CompareExchange(ref _asyncOwner, null, owner), owner)
             && Volatile.Read(ref _ownerThreadId) == System.Environment.CurrentManagedThreadId
             && ReferenceEquals(_ownerToken, owner))
@@ -346,14 +399,29 @@ public sealed partial class Engine : IDisposable
     internal readonly struct HostCallScope : IDisposable
     {
         private readonly Engine _engine;
+        private readonly object? _callbackOwner;
 
         internal HostCallScope(Engine engine)
         {
             _engine = engine;
+            _callbackOwner = null;
+        }
+
+        internal HostCallScope(Engine engine, object? callbackOwner)
+        {
+            _engine = engine;
+            _callbackOwner = callbackOwner;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Dispose() => _engine.ExitHostCall();
+        public void Dispose()
+        {
+            _engine.ExitHostCall();
+            if (_callbackOwner is not null)
+            {
+                _engine.ReleaseHostCallbackAdmission(_callbackOwner);
+            }
+        }
     }
 
     private readonly struct HostCallSuspension : IDisposable
@@ -879,8 +947,21 @@ public sealed partial class Engine : IDisposable
     {
         get
         {
+            var debugger = Volatile.Read(ref _debugger);
+            if (debugger is not null)
+            {
+                return debugger;
+            }
+
             using var ownership = EnterHostCall();
-            return _debugger ??= new DebugHandler(this, Options.Debugger.InitialStepMode);
+            debugger = _debugger;
+            if (debugger is null)
+            {
+                debugger = new DebugHandler(this, Options.Debugger.InitialStepMode);
+                Volatile.Write(ref _debugger, debugger);
+            }
+
+            return debugger;
         }
     }
 

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -103,11 +103,14 @@ public sealed partial class Engine : IDisposable
     private object? _ownerToken;
     private object? _asyncOwner;
     private object? _asyncReleasePending;
+    private object? _hostCallbackAdmissionClosed;
     private int _hostCallbackAdmission;
+    private int _hostReentryThreadId;
     private ManualResetEventSlim? _ownershipReleased;
+    private ConditionalWeakTable<ObjectInstance, HostCallbackAuthorization>? _hostCallbackAuthorizations;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal HostCallScope EnterHostCall(object? asyncOwner = null)
+    internal HostCallScope EnterHostCall(object? asyncOwner = null, object? callbackOwner = null)
     {
         var threadId = System.Environment.CurrentManagedThreadId;
         if (Volatile.Read(ref _ownerThreadId) == threadId)
@@ -123,10 +126,17 @@ public sealed partial class Engine : IDisposable
             }
 
             _ownerDepth++;
-            return new HostCallScope(this);
+            return new HostCallScope(this, callbackOwner);
         }
 
         var reservedOwner = Volatile.Read(ref _asyncOwner);
+        if (asyncOwner is null
+            && reservedOwner is not null
+            && Volatile.Read(ref _hostReentryThreadId) == threadId)
+        {
+            return EnterTransferredHostCall(reservedOwner);
+        }
+
         if ((asyncOwner is null && reservedOwner is not null)
             || (asyncOwner is not null && !ReferenceEquals(asyncOwner, reservedOwner)))
         {
@@ -150,25 +160,38 @@ public sealed partial class Engine : IDisposable
 
         _ownerDepth = 1;
         _ownerToken = asyncOwner;
-        return new HostCallScope(this);
+        return new HostCallScope(this, callbackOwner);
     }
 
     internal HostCallScope EnterHostCallback()
+        => EnterHostCall();
+
+    internal HostCallScope EnterTransferredHostCallback(object? expectedOwner)
     {
-        var owner = Volatile.Read(ref _asyncOwner);
-        if (owner is null)
+        if (expectedOwner is null)
         {
             return EnterHostCall();
         }
 
-        // Claim the admission window before it can close. A count of one after the increment means
-        // there was no open window to claim; a larger count keeps the transfer token alive until
-        // this callback's scope exits.
-        if (Interlocked.Increment(ref _hostCallbackAdmission) == 1
-            || !ReferenceEquals(Volatile.Read(ref _asyncOwner), owner))
+        var owner = Volatile.Read(ref _asyncOwner);
+        if (owner is null
+            || (!ReferenceEquals(owner, expectedOwner)
+                && !ReferenceEquals(owner, Volatile.Read(ref _ownershipReleased))))
         {
-            ReleaseHostCallbackAdmission(owner);
             return EnterHostCall();
+        }
+
+        lock (owner)
+        {
+            if (!ReferenceEquals(Volatile.Read(ref _asyncOwner), owner)
+                || ReferenceEquals(Volatile.Read(ref _hostCallbackAdmissionClosed), owner))
+            {
+                return EnterHostCall();
+            }
+
+            // The converted delegate is the capability. Count it under the operation-token lock so
+            // completion cannot close and release the reservation between admission and transfer.
+            Interlocked.Increment(ref _hostCallbackAdmission);
         }
 
         try
@@ -182,11 +205,43 @@ public sealed partial class Engine : IDisposable
         }
     }
 
+    internal object? CaptureHostCallbackOwner()
+    {
+        if (Volatile.Read(ref _ownerThreadId) != System.Environment.CurrentManagedThreadId)
+        {
+            return null;
+        }
+
+        return _ownerToken ??= Volatile.Read(ref _asyncOwner) ?? new object();
+    }
+
+    internal void AuthorizeHostCallback(ObjectInstance callback)
+    {
+        var owner = CaptureHostCallbackOwner();
+        var authorizations = _hostCallbackAuthorizations;
+        if (authorizations is null)
+        {
+            var newAuthorizations = new ConditionalWeakTable<ObjectInstance, HostCallbackAuthorization>();
+            authorizations = Interlocked.CompareExchange(ref _hostCallbackAuthorizations, newAuthorizations, null)
+                ?? newAuthorizations;
+        }
+
+        authorizations.GetOrCreateValue(callback).Owner = owner;
+    }
+
+    internal object? GetHostCallbackOwner(ObjectInstance callback)
+    {
+        var authorizations = _hostCallbackAuthorizations;
+        return authorizations is not null && authorizations.TryGetValue(callback, out var authorization)
+            ? authorization.Owner
+            : null;
+    }
+
     internal HostCallScope EnterTransferredHostCall(object owner, bool callback = false)
     {
         if (!ReferenceEquals(Volatile.Read(ref _asyncOwner), owner))
         {
-            return EnterHostCall();
+            return EnterHostCall(callbackOwner: callback ? owner : null);
         }
 
         var threadId = System.Environment.CurrentManagedThreadId;
@@ -213,7 +268,7 @@ public sealed partial class Engine : IDisposable
 
         _ownerDepth = 1;
         _ownerToken = owner;
-        return new HostCallScope(this);
+        return new HostCallScope(this, callback ? owner : null);
     }
 
     private bool TryEnterHostCall(out HostCallScope scope)
@@ -289,49 +344,90 @@ public sealed partial class Engine : IDisposable
         }
     }
 
-    private HostCallSuspension SuspendHostCallForCallbacks()
+    internal HostCallSuspension SuspendHostCallForCallbacks(bool hasTransferredCallback)
     {
-        var owner = _ownerToken;
-        if (owner is null)
+        if (!hasTransferredCallback)
         {
-            owner = this;
+            return default;
+        }
+
+        var previousOwnerToken = _ownerToken;
+        var owner = previousOwnerToken ?? OwnershipReleasedEvent;
+        var reservedOwner = Volatile.Read(ref _asyncOwner);
+        var ownsReservation = reservedOwner is null;
+        if (ownsReservation)
+        {
             if (Interlocked.CompareExchange(ref _asyncOwner, owner, null) is not null)
             {
                 Throw.InvalidOperationException(ConcurrentUseMessage);
             }
         }
-        else if (!ReferenceEquals(Volatile.Read(ref _asyncOwner), owner))
+        else if (!ReferenceEquals(reservedOwner, owner))
         {
             Throw.InvalidOperationException(ConcurrentUseMessage);
         }
 
-        Interlocked.Increment(ref _hostCallbackAdmission);
         var depth = _ownerDepth;
+        var previousReentryThreadId = Volatile.Read(ref _hostReentryThreadId);
+        Volatile.Write(ref _hostReentryThreadId, System.Environment.CurrentManagedThreadId);
         _ownerDepth = 0;
         _ownerToken = null;
         Volatile.Write(ref _ownerThreadId, 0);
         Volatile.Read(ref _ownershipReleased)?.Set();
-        return new HostCallSuspension(this, owner, depth);
+        return new HostCallSuspension(this, owner, previousOwnerToken, depth, previousReentryThreadId, ownsReservation);
     }
 
-    private void ResumeHostCall(object owner, int depth)
+    private void ResumeHostCall(
+        object owner,
+        object? previousOwnerToken,
+        int depth,
+        int previousReentryThreadId,
+        bool ownsReservation)
     {
-        AcquireHostCall(System.Environment.CurrentManagedThreadId);
-        _ownerDepth = depth;
-        _ownerToken = owner;
+        if (ownsReservation)
+        {
+            lock (owner)
+            {
+                Volatile.Write(ref _hostCallbackAdmissionClosed, owner);
+                while (Volatile.Read(ref _hostCallbackAdmission) > 0)
+                {
+                    Monitor.Wait(owner);
+                }
+            }
+        }
 
-        ReleaseHostCallbackAdmission(owner);
+        AcquireHostCall(System.Environment.CurrentManagedThreadId);
+        if (ownsReservation)
+        {
+            lock (owner)
+            {
+                Interlocked.CompareExchange(ref _asyncOwner, null, owner);
+                Interlocked.CompareExchange(ref _hostCallbackAdmissionClosed, null, owner);
+            }
+        }
+
+        _ownerDepth = depth;
+        _ownerToken = previousOwnerToken;
+        Volatile.Write(ref _hostReentryThreadId, previousReentryThreadId);
     }
 
     private void ReleaseHostCallbackAdmission(object owner)
     {
-        if (Interlocked.Decrement(ref _hostCallbackAdmission) == 0
-            && (ReferenceEquals(owner, this)
-                || ReferenceEquals(Volatile.Read(ref _asyncReleasePending), owner)))
+        if (Interlocked.Decrement(ref _hostCallbackAdmission) != 0)
         {
-            Interlocked.CompareExchange(ref _asyncOwner, null, owner);
-            Interlocked.CompareExchange(ref _asyncReleasePending, null, owner);
-            _ownerToken = null;
+            return;
+        }
+
+        lock (owner)
+        {
+            if (ReferenceEquals(Volatile.Read(ref _asyncReleasePending), owner))
+            {
+                Interlocked.CompareExchange(ref _asyncOwner, null, owner);
+                Interlocked.CompareExchange(ref _asyncReleasePending, null, owner);
+                Interlocked.CompareExchange(ref _hostCallbackAdmissionClosed, null, owner);
+            }
+
+            Monitor.PulseAll(owner);
         }
     }
 
@@ -361,27 +457,27 @@ public sealed partial class Engine : IDisposable
 
     internal void ReleaseAsyncHostOperation(object owner)
     {
-        if (!ReferenceEquals(Volatile.Read(ref _asyncOwner), owner))
+        lock (owner)
         {
-            return;
-        }
-
-        if (Volatile.Read(ref _hostCallbackAdmission) > 0)
-        {
-            Volatile.Write(ref _asyncReleasePending, owner);
-            if (Volatile.Read(ref _hostCallbackAdmission) > 0)
+            if (!ReferenceEquals(Volatile.Read(ref _asyncOwner), owner))
             {
                 return;
             }
 
-            Interlocked.CompareExchange(ref _asyncReleasePending, null, owner);
-        }
+            Volatile.Write(ref _hostCallbackAdmissionClosed, owner);
+            if (Volatile.Read(ref _hostCallbackAdmission) > 0)
+            {
+                Volatile.Write(ref _asyncReleasePending, owner);
+                return;
+            }
 
-        if (ReferenceEquals(Interlocked.CompareExchange(ref _asyncOwner, null, owner), owner)
-            && Volatile.Read(ref _ownerThreadId) == System.Environment.CurrentManagedThreadId
-            && ReferenceEquals(_ownerToken, owner))
-        {
-            _ownerToken = null;
+            Interlocked.CompareExchange(ref _asyncOwner, null, owner);
+            Interlocked.CompareExchange(ref _hostCallbackAdmissionClosed, null, owner);
+            if (Volatile.Read(ref _ownerThreadId) == System.Environment.CurrentManagedThreadId
+                && ReferenceEquals(_ownerToken, owner))
+            {
+                _ownerToken = null;
+            }
         }
     }
 
@@ -424,20 +520,51 @@ public sealed partial class Engine : IDisposable
         }
     }
 
-    private readonly struct HostCallSuspension : IDisposable
+    private sealed class HostCallbackAuthorization
     {
-        private readonly Engine _engine;
-        private readonly object _owner;
-        private readonly int _depth;
+        private object? _owner;
 
-        internal HostCallSuspension(Engine engine, object owner, int depth)
+        internal object? Owner
+        {
+            get => Volatile.Read(ref _owner);
+            set => Volatile.Write(ref _owner, value);
+        }
+    }
+
+    internal readonly struct HostCallSuspension : IDisposable
+    {
+        private readonly Engine? _engine;
+        private readonly object _owner;
+        private readonly object? _previousOwnerToken;
+        private readonly int _depth;
+        private readonly int _previousReentryThreadId;
+        private readonly bool _ownsReservation;
+
+        internal HostCallSuspension(
+            Engine engine,
+            object owner,
+            object? previousOwnerToken,
+            int depth,
+            int previousReentryThreadId,
+            bool ownsReservation)
         {
             _engine = engine;
             _owner = owner;
+            _previousOwnerToken = previousOwnerToken;
             _depth = depth;
+            _previousReentryThreadId = previousReentryThreadId;
+            _ownsReservation = ownsReservation;
         }
 
-        public void Dispose() => _engine.ResumeHostCall(_owner, _depth);
+        public void Dispose()
+        {
+            _engine?.ResumeHostCall(
+                _owner,
+                _previousOwnerToken,
+                _depth,
+                _previousReentryThreadId,
+                _ownsReservation);
+        }
     }
 
     /// <summary>
@@ -1303,8 +1430,8 @@ public sealed partial class Engine : IDisposable
     /// Registers a promise within the currently running EventLoop (has to be called within "ExecuteWithEventLoop" call).
     /// Note that ExecuteWithEventLoop will not trigger "onFinished" callback until ALL manual promises are settled.
     ///
-    /// NOTE: that resolve and reject need to be called withing the same thread as "ExecuteWithEventLoop".
-    /// The API assumes that the Engine is called from a single thread.
+    /// Resolve and reject may be called from another thread. Settlement is enqueued safely and drains
+    /// inline only when that thread can claim exclusive engine ownership.
     /// </summary>
     /// <returns>a Promise instance and functions to either resolve or reject it</returns>
     internal ManualPromise RegisterPromise()
@@ -1322,7 +1449,6 @@ public sealed partial class Engine : IDisposable
         // RestoreGlobalSnapshot has since ended".
         var generation = _eventLoop.Generation;
 
-        var registrationThreadId = System.Environment.CurrentManagedThreadId;
         Action<JsValue> SettleWith(Function settle) => value =>
         {
             // Enqueue to event loop to ensure thread safety - the settle operation
@@ -1336,10 +1462,9 @@ public sealed partial class Engine : IDisposable
             // Signal the CompletedEvent so that UnwrapIfPromise knows there's work to process.
             promise.CompletedEvent.Set();
 
-            // A completion may arrive on any thread. Only drain inline when this thread is already
-            // inside a guarded engine turn; otherwise the next host turn or async waiter owns the drain.
-            if (System.Environment.CurrentManagedThreadId == registrationThreadId
-                && TryEnterHostCall(out var ownership))
+            // A completion may arrive on any thread. Drain inline only when this thread can claim
+            // exclusive ownership; otherwise the next host turn or async waiter owns the drain.
+            if (TryEnterHostCall(out var ownership))
             {
                 using (ownership)
                 {
@@ -1619,7 +1744,7 @@ public sealed partial class Engine : IDisposable
                     // settle arriving from a background thread only enqueues, and this thread is the one that
                     // has to run it — before the wake it idled out the rest of the poll slice first, which a
                     // chain of sequential asynchronous loads paid on every hop.
-                    using (SuspendHostCallForCallbacks())
+                    using (SuspendHostCallForCallbacks(hasTransferredCallback: true))
                     {
                         _eventLoop.WaitForWork(completedEvent, waitInterval, waitToken);
                     }
@@ -3251,6 +3376,7 @@ public sealed partial class Engine : IDisposable
         var clearMethod = _objectWrapperCache.GetType().GetMethod("Clear", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
         clearMethod?.Invoke(_objectWrapperCache, []);
 #endif
+
     }
 
     [DebuggerDisplay("Engine")]

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using Jint.Collections;
 using Jint.Constraints;
 using Jint.Native;
@@ -22,11 +23,13 @@ using Jint.Runtime.Interop.Reflection;
 using Jint.Runtime.Interpreter;
 using Jint.Runtime.Interpreter.Expressions;
 using Environment = Jint.Runtime.Environments.Environment;
+using ExecutionContext = Jint.Runtime.Environments.ExecutionContext;
 
 namespace Jint;
 
 /// <summary>
-/// Engine is the main API to JavaScript interpretation. Engine instances are not thread-safe.
+/// Engine is the main API to JavaScript interpretation. An engine supports one host operation at a time;
+/// concurrent public entries fail with <see cref="InvalidOperationException"/>.
 /// </summary>
 [DebuggerTypeProxy(typeof(EngineDebugView))]
 public sealed partial class Engine : IDisposable
@@ -88,6 +91,286 @@ public sealed partial class Engine : IDisposable
     /// </para>
     /// </summary>
     private int _hostEntryDepth;
+
+    private const string ConcurrentUseMessage =
+        "This Engine is already in use by another thread or has an asynchronous operation in progress. " +
+        "Engine instances may only be used by one host operation at a time.";
+
+    // Same-thread re-entry is allowed. Async APIs reserve the engine while suspended and claim
+    // whichever thread resumes each continuation, without leaving a window for another host call.
+    private int _ownerThreadId;
+    private int _ownerDepth;
+    private object? _ownerToken;
+    private object? _asyncOwner;
+    private int _hostCallbackAdmission;
+    private ManualResetEventSlim? _ownershipReleased;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal HostCallScope EnterHostCall(object? asyncOwner = null)
+    {
+        var threadId = System.Environment.CurrentManagedThreadId;
+        if (Volatile.Read(ref _ownerThreadId) == threadId)
+        {
+            if (asyncOwner is not null)
+            {
+                if (_ownerToken is not null && !ReferenceEquals(_ownerToken, asyncOwner))
+                {
+                    Throw.InvalidOperationException(ConcurrentUseMessage);
+                }
+
+                _ownerToken = asyncOwner;
+            }
+
+            _ownerDepth++;
+            return new HostCallScope(this);
+        }
+
+        var reservedOwner = Volatile.Read(ref _asyncOwner);
+        if ((asyncOwner is null && reservedOwner is not null)
+            || (asyncOwner is not null && !ReferenceEquals(asyncOwner, reservedOwner)))
+        {
+            Throw.InvalidOperationException(ConcurrentUseMessage);
+        }
+
+        if (Interlocked.CompareExchange(ref _ownerThreadId, threadId, 0) != 0)
+        {
+            Throw.InvalidOperationException(ConcurrentUseMessage);
+        }
+
+        // Close the race with an async operation reserving the engine after the first check.
+        reservedOwner = Volatile.Read(ref _asyncOwner);
+        if ((asyncOwner is null && reservedOwner is not null)
+            || (asyncOwner is not null && !ReferenceEquals(asyncOwner, reservedOwner)))
+        {
+            Volatile.Write(ref _ownerThreadId, 0);
+            Throw.InvalidOperationException(ConcurrentUseMessage);
+        }
+
+        _ownerDepth = 1;
+        _ownerToken = asyncOwner;
+        return new HostCallScope(this);
+    }
+
+    internal HostCallScope EnterHostCallback()
+    {
+        var owner = Volatile.Read(ref _asyncOwner);
+        return owner is not null && Volatile.Read(ref _hostCallbackAdmission) > 0
+            ? EnterTransferredHostCall(owner)
+            : EnterHostCall();
+    }
+
+    internal HostCallScope EnterTransferredHostCall(object owner)
+    {
+        if (!ReferenceEquals(Volatile.Read(ref _asyncOwner), owner))
+        {
+            Throw.InvalidOperationException(ConcurrentUseMessage);
+        }
+
+        var threadId = System.Environment.CurrentManagedThreadId;
+        if (Volatile.Read(ref _ownerThreadId) == threadId)
+        {
+            _ownerDepth++;
+            return new HostCallScope(this);
+        }
+
+        AcquireHostCall(threadId);
+        if (!ReferenceEquals(Volatile.Read(ref _asyncOwner), owner))
+        {
+            Volatile.Write(ref _ownerThreadId, 0);
+            Volatile.Read(ref _ownershipReleased)?.Set();
+            Throw.InvalidOperationException(ConcurrentUseMessage);
+        }
+
+        _ownerDepth = 1;
+        _ownerToken = owner;
+        return new HostCallScope(this);
+    }
+
+    private bool TryEnterHostCall(out HostCallScope scope)
+    {
+        var threadId = System.Environment.CurrentManagedThreadId;
+        if (Volatile.Read(ref _ownerThreadId) == threadId)
+        {
+            _ownerDepth++;
+            scope = new HostCallScope(this);
+            return true;
+        }
+
+        if (Volatile.Read(ref _asyncOwner) is not null
+            || Interlocked.CompareExchange(ref _ownerThreadId, threadId, 0) != 0)
+        {
+            scope = default;
+            return false;
+        }
+
+        if (Volatile.Read(ref _asyncOwner) is not null)
+        {
+            Volatile.Write(ref _ownerThreadId, 0);
+            Volatile.Read(ref _ownershipReleased)?.Set();
+            scope = default;
+            return false;
+        }
+
+        _ownerDepth = 1;
+        _ownerToken = null;
+        scope = new HostCallScope(this);
+        return true;
+    }
+
+    private void AcquireHostCall(int threadId)
+    {
+        var spinWait = new SpinWait();
+        while (Interlocked.CompareExchange(ref _ownerThreadId, threadId, 0) != 0)
+        {
+            if (spinWait.NextSpinWillYield)
+            {
+                var released = OwnershipReleasedEvent;
+                released.Reset();
+                if (Volatile.Read(ref _ownerThreadId) != 0)
+                {
+                    released.Wait();
+                }
+            }
+            else
+            {
+                spinWait.SpinOnce();
+            }
+        }
+    }
+
+    private ManualResetEventSlim OwnershipReleasedEvent
+    {
+        get
+        {
+            if (_ownershipReleased is not null)
+            {
+                return _ownershipReleased;
+            }
+
+            var newEvent = new ManualResetEventSlim(false);
+            var existing = Interlocked.CompareExchange(ref _ownershipReleased, newEvent, null);
+            if (existing is not null)
+            {
+                newEvent.Dispose();
+                return existing;
+            }
+
+            return newEvent;
+        }
+    }
+
+    private HostCallSuspension SuspendHostCallForCallbacks()
+    {
+        var owner = _ownerToken;
+        if (owner is null)
+        {
+            owner = this;
+            if (Interlocked.CompareExchange(ref _asyncOwner, owner, null) is not null)
+            {
+                Throw.InvalidOperationException(ConcurrentUseMessage);
+            }
+        }
+        else if (!ReferenceEquals(Volatile.Read(ref _asyncOwner), owner))
+        {
+            Throw.InvalidOperationException(ConcurrentUseMessage);
+        }
+
+        Interlocked.Increment(ref _hostCallbackAdmission);
+        var depth = _ownerDepth;
+        _ownerDepth = 0;
+        _ownerToken = null;
+        Volatile.Write(ref _ownerThreadId, 0);
+        Volatile.Read(ref _ownershipReleased)?.Set();
+        return new HostCallSuspension(this, owner, depth);
+    }
+
+    private void ResumeHostCall(object owner, int depth)
+    {
+        AcquireHostCall(System.Environment.CurrentManagedThreadId);
+        _ownerDepth = depth;
+        _ownerToken = owner;
+
+        if (Interlocked.Decrement(ref _hostCallbackAdmission) == 0 && ReferenceEquals(owner, this))
+        {
+            Interlocked.CompareExchange(ref _asyncOwner, null, owner);
+            _ownerToken = null;
+        }
+    }
+
+    internal object ReserveAsyncHostOperation()
+    {
+        var threadId = System.Environment.CurrentManagedThreadId;
+        var activeOwner = Volatile.Read(ref _ownerThreadId);
+        if (activeOwner != 0 && activeOwner != threadId)
+        {
+            Throw.InvalidOperationException(ConcurrentUseMessage);
+        }
+
+        var owner = new object();
+        if (Interlocked.CompareExchange(ref _asyncOwner, owner, null) is not null)
+        {
+            Throw.InvalidOperationException(ConcurrentUseMessage);
+        }
+
+        activeOwner = Volatile.Read(ref _ownerThreadId);
+        if (activeOwner != 0 && activeOwner != threadId)
+        {
+            Interlocked.CompareExchange(ref _asyncOwner, null, owner);
+            Throw.InvalidOperationException(ConcurrentUseMessage);
+        }
+
+        return owner;
+    }
+
+    internal void ReleaseAsyncHostOperation(object owner)
+    {
+        if (ReferenceEquals(Interlocked.CompareExchange(ref _asyncOwner, null, owner), owner)
+            && Volatile.Read(ref _ownerThreadId) == System.Environment.CurrentManagedThreadId
+            && ReferenceEquals(_ownerToken, owner))
+        {
+            _ownerToken = null;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void ExitHostCall()
+    {
+        if (--_ownerDepth == 0)
+        {
+            _ownerToken = null;
+            Volatile.Write(ref _ownerThreadId, 0);
+            Volatile.Read(ref _ownershipReleased)?.Set();
+        }
+    }
+
+    internal readonly struct HostCallScope : IDisposable
+    {
+        private readonly Engine _engine;
+
+        internal HostCallScope(Engine engine)
+        {
+            _engine = engine;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Dispose() => _engine.ExitHostCall();
+    }
+
+    private readonly struct HostCallSuspension : IDisposable
+    {
+        private readonly Engine _engine;
+        private readonly object _owner;
+        private readonly int _depth;
+
+        internal HostCallSuspension(Engine engine, object owner, int depth)
+        {
+            _engine = engine;
+            _owner = owner;
+            _depth = depth;
+        }
+
+        public void Dispose() => _engine.ResumeHostCall(_owner, _depth);
+    }
 
     /// <summary>
     /// Whether the engine is running something for someone: a host entry is on the stack
@@ -560,12 +843,26 @@ public sealed partial class Engine : IDisposable
     /// <summary>
     /// The well-known intrinsics for this engine instance.
     /// </summary>
-    public Intrinsics Intrinsics => Realm.Intrinsics;
+    public Intrinsics Intrinsics
+    {
+        get
+        {
+            using var ownership = EnterHostCall();
+            return Realm.Intrinsics;
+        }
+    }
 
     /// <summary>
     /// The global object for this engine instance.
     /// </summary>
-    public ObjectInstance Global => Realm.GlobalObject;
+    public ObjectInstance Global
+    {
+        get
+        {
+            using var ownership = EnterHostCall();
+            return Realm.GlobalObject;
+        }
+    }
 
     internal GlobalSymbolRegistry GlobalSymbolRegistry { get; } = new();
 
@@ -578,7 +875,14 @@ public sealed partial class Engine : IDisposable
         private set;
     }
 
-    public DebugHandler Debugger => _debugger ??= new DebugHandler(this, Options.Debugger.InitialStepMode);
+    public DebugHandler Debugger
+    {
+        get
+        {
+            using var ownership = EnterHostCall();
+            return _debugger ??= new DebugHandler(this, Options.Debugger.InitialStepMode);
+        }
+    }
 
     internal ParserOptions DefaultModuleParserOptions => _defaultModuleParserOptions ??=
         (Options.RetainFunctionSourceText ? ModuleParsingOptions.RetainingDefault : ModuleParsingOptions.Default).GetParserOptions(Options);
@@ -653,6 +957,7 @@ public sealed partial class Engine : IDisposable
     /// </summary>
     public Engine SetValue(string name, Delegate value)
     {
+        using var ownership = EnterHostCall();
         Realm.GlobalObject.FastSetProperty(name, new PropertyDescriptor(new DelegateWrapper(this, value), PropertyFlag.NonEnumerable));
         return this;
     }
@@ -694,6 +999,7 @@ public sealed partial class Engine : IDisposable
     /// </summary>
     public Engine SetValue(string name, JsValue value)
     {
+        using var ownership = EnterHostCall();
         Realm.GlobalObject.Set(name, value);
         return this;
     }
@@ -703,6 +1009,7 @@ public sealed partial class Engine : IDisposable
     /// </summary>
     public Engine SetValue(string name, object? obj)
     {
+        using var ownership = EnterHostCall();
         var value = obj is Type t
             ? TypeReference.CreateTypeReference(this, t)
             : JsValue.FromObject(this, obj);
@@ -715,6 +1022,7 @@ public sealed partial class Engine : IDisposable
     /// </summary>
     public Engine SetValue(string name, [DynamicallyAccessedMembers(InteropHelper.DefaultDynamicallyAccessedMemberTypes)] Type type)
     {
+        using var ownership = EnterHostCall();
 #pragma warning disable IL2111
         return SetValue(name, TypeReference.CreateTypeReference(this, type));
 #pragma warning restore IL2111
@@ -725,6 +1033,7 @@ public sealed partial class Engine : IDisposable
     /// </summary>
     public Engine SetValue<[DynamicallyAccessedMembers(InteropHelper.DefaultDynamicallyAccessedMemberTypes)] T>(string name, T? obj)
     {
+        using var ownership = EnterHostCall();
         return obj is Type t
             ? SetValue(name, t)
             : SetValue(name, JsValue.FromObject(this, obj));
@@ -756,6 +1065,7 @@ public sealed partial class Engine : IDisposable
     /// </summary>
     public JsValue Evaluate(string code, string? source = null)
     {
+        using var ownership = EnterHostCall();
         var script = _defaultParser.ParseScriptGuarded(Realm, code, source: source ?? "<anonymous>", strict: _isStrict);
         return Evaluate(new Prepared<Script>(script, _defaultParser.Options));
     }
@@ -771,6 +1081,7 @@ public sealed partial class Engine : IDisposable
     /// </summary>
     public JsValue Evaluate(string code, string source, ScriptParsingOptions parsingOptions)
     {
+        using var ownership = EnterHostCall();
         var parser = GetParserFor(parsingOptions);
         var script = parser.ParseScriptGuarded(Realm, code, parsingOptions.SourceOffset, source, _isStrict);
         return Evaluate(new Prepared<Script>(script, parser.Options));
@@ -787,6 +1098,7 @@ public sealed partial class Engine : IDisposable
     /// </summary>
     public Engine Execute(string code, string? source = null)
     {
+        using var ownership = EnterHostCall();
         var script = _defaultParser.ParseScriptGuarded(Realm, code, source: source ?? "<anonymous>", strict: _isStrict);
         return Execute(new Prepared<Script>(script, _defaultParser.Options));
     }
@@ -802,6 +1114,7 @@ public sealed partial class Engine : IDisposable
     /// </summary>
     public Engine Execute(string code, string source, ScriptParsingOptions parsingOptions)
     {
+        using var ownership = EnterHostCall();
         var parser = GetParserFor(parsingOptions);
         var script = parser.ParseScriptGuarded(Realm, code, parsingOptions.SourceOffset, source, _isStrict);
         return Execute(new Prepared<Script>(script, parser.Options));
@@ -928,6 +1241,7 @@ public sealed partial class Engine : IDisposable
         // RestoreGlobalSnapshot has since ended".
         var generation = _eventLoop.Generation;
 
+        var registrationThreadId = System.Environment.CurrentManagedThreadId;
         Action<JsValue> SettleWith(Function settle) => value =>
         {
             // Enqueue to event loop to ensure thread safety - the settle operation
@@ -941,11 +1255,16 @@ public sealed partial class Engine : IDisposable
             // Signal the CompletedEvent so that UnwrapIfPromise knows there's work to process.
             promise.CompletedEvent.Set();
 
-            // Try to run continuations. If we're on a background thread and there's a
-            // waiting thread (in UnwrapIfPromise), this will be a no-op and the waiting
-            // thread will process instead. If we're on the main thread (direct Resolve call),
-            // this will process the continuations immediately.
-            RunAvailableContinuations();
+            // A completion may arrive on any thread. Only drain inline when this thread is already
+            // inside a guarded engine turn; otherwise the next host turn or async waiter owns the drain.
+            if (System.Environment.CurrentManagedThreadId == registrationThreadId
+                && TryEnterHostCall(out var ownership))
+            {
+                using (ownership)
+                {
+                    _eventLoop.RunAvailableContinuations(this);
+                }
+            }
         };
 
         return new ManualPromise(promise, SettleWith(resolve), SettleWith(reject));
@@ -1061,6 +1380,7 @@ public sealed partial class Engine : IDisposable
 
     internal void RunAvailableContinuations()
     {
+        using var ownership = EnterHostCall();
         _eventLoop.RunAvailableContinuations(this);
     }
 
@@ -1122,6 +1442,8 @@ public sealed partial class Engine : IDisposable
         TimeSpan timeout,
         System.Threading.CancellationToken cancellationToken = default)
     {
+        using var ownership = EnterHostCall();
+
         // Claim this thread as the one draining the loop so background threads (Task completions)
         // don't race to execute JavaScript continuations on the engine. Save/restore to support
         // nesting (e.g. a re-entrant UnwrapIfPromise already waiting).
@@ -1216,7 +1538,10 @@ public sealed partial class Engine : IDisposable
                     // settle arriving from a background thread only enqueues, and this thread is the one that
                     // has to run it — before the wake it idled out the rest of the poll slice first, which a
                     // chain of sequential asynchronous loads paid on every hop.
-                    _eventLoop.WaitForWork(completedEvent, waitInterval, waitToken);
+                    using (SuspendHostCallForCallbacks())
+                    {
+                        _eventLoop.WaitForWork(completedEvent, waitInterval, waitToken);
+                    }
                 }
                 catch (OperationCanceledException)
                 {
@@ -1657,6 +1982,7 @@ public sealed partial class Engine : IDisposable
     /// <returns>The value returned by the function call.</returns>
     public JsValue Invoke(string propertyName, object? thisObj, object?[] arguments)
     {
+        using var ownership = EnterHostCall();
         var value = GetValue(propertyName);
 
         return Invoke(value, thisObj, arguments);
@@ -1682,6 +2008,7 @@ public sealed partial class Engine : IDisposable
     /// <returns>The value returned by the function call.</returns>
     public JsValue Invoke(JsValue value, object? thisObj, object?[] arguments)
     {
+        using var ownership = EnterHostCall();
         var callable = value as ICallable;
         if (callable is null)
         {
@@ -1729,6 +2056,8 @@ public sealed partial class Engine : IDisposable
 
     internal T ExecuteWithConstraints<T>(bool strict, Func<T> callback)
     {
+        using var ownership = EnterHostCall();
+
         // A nested call — a host callback inside a running script calling back into the engine —
         // must not re-arm the outer run's constraints: the outer budget (time/statements) keeps
         // applying to everything the outer script triggers, otherwise `while (true) hostCallback()`
@@ -1815,6 +2144,7 @@ public sealed partial class Engine : IDisposable
     /// <param name="propertyName">The name of the property to return.</param>
     public JsValue GetValue(string propertyName)
     {
+        using var ownership = EnterHostCall();
         return GetValue(Realm.GlobalObject, new JsString(propertyName));
     }
 
@@ -1833,6 +2163,7 @@ public sealed partial class Engine : IDisposable
     /// <param name="property">The name of the property to return.</param>
     public JsValue GetValue(JsValue scope, JsValue property)
     {
+        using var ownership = EnterHostCall();
         var reference = _referencePool.Rent(scope, property, _isStrict, thisValue: null);
         var jsValue = GetValue(reference, returnReferenceToPool: false);
         _referencePool.Return(reference);
@@ -2640,6 +2971,7 @@ public sealed partial class Engine : IDisposable
     /// <returns>The value returned by the call.</returns>
     public JsValue Call(string callableName, params JsCallArguments arguments)
     {
+        using var ownership = EnterHostCall();
         var callable = Evaluate(callableName);
         return Call(callable, arguments);
     }
@@ -2694,6 +3026,7 @@ public sealed partial class Engine : IDisposable
     /// <returns>The value returned by the constructor call.</returns>
     public ObjectInstance Construct(string constructorName, params JsCallArguments arguments)
     {
+        using var ownership = EnterHostCall();
         var constructor = Evaluate(constructorName);
         return Construct(constructor, arguments);
     }
@@ -2818,6 +3151,8 @@ public sealed partial class Engine : IDisposable
 
     public void Dispose()
     {
+        using var ownership = EnterHostCall();
+
         // the recent-wrapper ring (on by default since 4.14) strongly roots its targets and wrappers,
         // so a disposed-but-still-referenced engine must release them
         _recentObjectWrapperCache?.Clear();

--- a/Jint/Native/Function/Function.cs
+++ b/Jint/Native/Function/Function.cs
@@ -601,7 +601,13 @@ public abstract partial class Function : ObjectInstance, ICallable
 
     public sealed override object ToObject()
     {
-        return (JsCallDelegate) Call;
+        return (JsCallDelegate) CallFromHost;
+    }
+
+    private JsValue CallFromHost(JsValue thisObject, JsValue[] arguments)
+    {
+        using var ownership = _engine.EnterHostCallback();
+        return Call(thisObject, arguments);
     }
 
     public override string ToString()

--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -262,6 +262,7 @@ public abstract partial class JsValue : IEquatable<JsValue>
     /// </summary>
     public static JsValue FromObjectWithType(Engine engine, object? value, Type? type)
     {
+        using var ownership = engine.EnterHostCall();
         if (value is null)
         {
             return Null;

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -2295,7 +2295,7 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
             case ObjectClass.Function:
                 if (this is ICallable function)
                 {
-                    converted = (JsCallDelegate) function.Call;
+                    converted = (JsCallDelegate) CallFromHost;
                 }
 
                 break;
@@ -2305,6 +2305,7 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
                 {
                     converted = numberInstance.NumberData._value;
                 }
+
                 break;
 
             case ObjectClass.RegExp:
@@ -2427,6 +2428,12 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
 
         stack.Exit();
         return converted!;
+    }
+
+    private JsValue CallFromHost(JsValue thisObject, JsValue[] arguments)
+    {
+        using var ownership = Engine.EnterHostCallback();
+        return ((ICallable) this).Call(thisObject, arguments);
     }
 
     /// <summary>

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -2293,7 +2293,7 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
                 break;
 
             case ObjectClass.Function:
-                if (this is ICallable function)
+                if (this is ICallable)
                 {
                     converted = (JsCallDelegate) CallFromHost;
                 }

--- a/Jint/Runtime/Debugger/BreakPointCollection.cs
+++ b/Jint/Runtime/Debugger/BreakPointCollection.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Threading;
 
 namespace Jint.Runtime.Debugger;
 
@@ -13,16 +14,11 @@ namespace Jint.Runtime.Debugger;
 public sealed class BreakPointCollection : IEnumerable<BreakPoint>
 {
     private readonly Dictionary<BreakLocation, BreakPoint> _breakPoints = new(new OptionalSourceBreakLocationEqualityComparer());
-    private readonly Engine? _engine;
+    private readonly Lock _lock = new();
     private bool _active = true;
 
     public BreakPointCollection()
     {
-    }
-
-    internal BreakPointCollection(Engine engine)
-    {
-        _engine = engine;
     }
 
     /// <summary>
@@ -32,24 +28,17 @@ public sealed class BreakPointCollection : IEnumerable<BreakPoint>
     {
         get
         {
-            if (_engine is null)
+            lock (_lock)
             {
                 return _active;
             }
-
-            using var ownership = _engine.EnterHostCall();
-            return _active;
         }
         set
         {
-            if (_engine is null)
+            lock (_lock)
             {
                 _active = value;
-                return;
             }
-
-            using var ownership = _engine.EnterHostCall();
-            _active = value;
         }
     }
 
@@ -57,13 +46,10 @@ public sealed class BreakPointCollection : IEnumerable<BreakPoint>
     {
         get
         {
-            if (_engine is null)
+            lock (_lock)
             {
                 return _breakPoints.Count;
             }
-
-            using var ownership = _engine.EnterHostCall();
-            return _breakPoints.Count;
         }
     }
 
@@ -72,14 +58,10 @@ public sealed class BreakPointCollection : IEnumerable<BreakPoint>
     /// </summary>
     public void Set(BreakPoint breakPoint)
     {
-        if (_engine is not null)
+        lock (_lock)
         {
-            using var ownership = _engine.EnterHostCall();
             _breakPoints[breakPoint.Location] = breakPoint;
-            return;
         }
-
-        _breakPoints[breakPoint.Location] = breakPoint;
     }
 
     /// <summary>
@@ -88,13 +70,10 @@ public sealed class BreakPointCollection : IEnumerable<BreakPoint>
     /// </summary>
     public bool RemoveAt(BreakLocation location)
     {
-        if (_engine is not null)
+        lock (_lock)
         {
-            using var ownership = _engine.EnterHostCall();
             return _breakPoints.Remove(location);
         }
-
-        return _breakPoints.Remove(location);
     }
 
     /// <summary>
@@ -103,13 +82,10 @@ public sealed class BreakPointCollection : IEnumerable<BreakPoint>
     /// </summary>
     public bool Contains(BreakLocation location)
     {
-        if (_engine is not null)
+        lock (_lock)
         {
-            using var ownership = _engine.EnterHostCall();
             return _breakPoints.ContainsKey(location);
         }
-
-        return _breakPoints.ContainsKey(location);
     }
 
     /// <summary>
@@ -117,26 +93,21 @@ public sealed class BreakPointCollection : IEnumerable<BreakPoint>
     /// </summary>
     public void Clear()
     {
-        if (_engine is not null)
+        lock (_lock)
         {
-            using var ownership = _engine.EnterHostCall();
             _breakPoints.Clear();
-            return;
         }
-
-        _breakPoints.Clear();
     }
 
     internal BreakPoint? FindMatch(DebugHandler debugger, BreakLocation location)
     {
-        if (!Active)
+        BreakPoint? breakPoint;
+        lock (_lock)
         {
-            return null;
-        }
-
-        if (!_breakPoints.TryGetValue(location, out var breakPoint))
-        {
-            return null;
+            if (!_active || !_breakPoints.TryGetValue(location, out breakPoint))
+            {
+                return null;
+            }
         }
 
         if (!string.IsNullOrEmpty(breakPoint.Condition))
@@ -163,13 +134,10 @@ public sealed class BreakPointCollection : IEnumerable<BreakPoint>
 
     public IEnumerator<BreakPoint> GetEnumerator()
     {
-        if (_engine is not null)
+        lock (_lock)
         {
-            using var ownership = _engine.EnterHostCall();
             return new List<BreakPoint>(_breakPoints.Values).GetEnumerator();
         }
-
-        return _breakPoints.Values.GetEnumerator();
     }
 
     IEnumerator IEnumerable.GetEnumerator()

--- a/Jint/Runtime/Debugger/BreakPointCollection.cs
+++ b/Jint/Runtime/Debugger/BreakPointCollection.cs
@@ -13,23 +13,72 @@ namespace Jint.Runtime.Debugger;
 public sealed class BreakPointCollection : IEnumerable<BreakPoint>
 {
     private readonly Dictionary<BreakLocation, BreakPoint> _breakPoints = new(new OptionalSourceBreakLocationEqualityComparer());
+    private readonly Engine? _engine;
+    private bool _active = true;
 
     public BreakPointCollection()
     {
     }
 
+    internal BreakPointCollection(Engine engine)
+    {
+        _engine = engine;
+    }
+
     /// <summary>
     /// Gets or sets whether breakpoints are activated. When false, all breakpoints will fail to match (and be skipped by the debugger).
     /// </summary>
-    public bool Active { get; set; } = true;
+    public bool Active
+    {
+        get
+        {
+            if (_engine is null)
+            {
+                return _active;
+            }
 
-    public int Count => _breakPoints.Count;
+            using var ownership = _engine.EnterHostCall();
+            return _active;
+        }
+        set
+        {
+            if (_engine is null)
+            {
+                _active = value;
+                return;
+            }
+
+            using var ownership = _engine.EnterHostCall();
+            _active = value;
+        }
+    }
+
+    public int Count
+    {
+        get
+        {
+            if (_engine is null)
+            {
+                return _breakPoints.Count;
+            }
+
+            using var ownership = _engine.EnterHostCall();
+            return _breakPoints.Count;
+        }
+    }
 
     /// <summary>
     /// Sets a new breakpoint. Note that this will replace any breakpoint at the same location (source/column/line).
     /// </summary>
     public void Set(BreakPoint breakPoint)
     {
+        if (_engine is not null)
+        {
+            using var ownership = _engine.EnterHostCall();
+            _breakPoints[breakPoint.Location] = breakPoint;
+            return;
+        }
+
         _breakPoints[breakPoint.Location] = breakPoint;
     }
 
@@ -39,6 +88,12 @@ public sealed class BreakPointCollection : IEnumerable<BreakPoint>
     /// </summary>
     public bool RemoveAt(BreakLocation location)
     {
+        if (_engine is not null)
+        {
+            using var ownership = _engine.EnterHostCall();
+            return _breakPoints.Remove(location);
+        }
+
         return _breakPoints.Remove(location);
     }
 
@@ -48,6 +103,12 @@ public sealed class BreakPointCollection : IEnumerable<BreakPoint>
     /// </summary>
     public bool Contains(BreakLocation location)
     {
+        if (_engine is not null)
+        {
+            using var ownership = _engine.EnterHostCall();
+            return _breakPoints.ContainsKey(location);
+        }
+
         return _breakPoints.ContainsKey(location);
     }
 
@@ -56,6 +117,13 @@ public sealed class BreakPointCollection : IEnumerable<BreakPoint>
     /// </summary>
     public void Clear()
     {
+        if (_engine is not null)
+        {
+            using var ownership = _engine.EnterHostCall();
+            _breakPoints.Clear();
+            return;
+        }
+
         _breakPoints.Clear();
     }
 
@@ -95,11 +163,17 @@ public sealed class BreakPointCollection : IEnumerable<BreakPoint>
 
     public IEnumerator<BreakPoint> GetEnumerator()
     {
+        if (_engine is not null)
+        {
+            using var ownership = _engine.EnterHostCall();
+            return new List<BreakPoint>(_breakPoints.Values).GetEnumerator();
+        }
+
         return _breakPoints.Values.GetEnumerator();
     }
 
     IEnumerator IEnumerable.GetEnumerator()
     {
-        return _breakPoints.GetEnumerator();
+        return GetEnumerator();
     }
 }

--- a/Jint/Runtime/Debugger/CallFrame.cs
+++ b/Jint/Runtime/Debugger/CallFrame.cs
@@ -10,6 +10,7 @@ public sealed class CallFrame
     private SourceLocation _location;
     private readonly CallStackElement? _element;
     private readonly Lazy<DebugScopes> _scopeChain;
+    private readonly Engine _engine;
 
     internal CallFrame(
         CallStackElement? element,
@@ -19,6 +20,7 @@ public sealed class CallFrame
     {
         _element = element;
         _context = context;
+        _engine = context.LexicalEnvironment._engine;
         _location = location;
         ReturnValue = returnValue;
 
@@ -47,7 +49,14 @@ public sealed class CallFrame
     /// <summary>
     /// The scope chain of this call frame.
     /// </summary>
-    public DebugScopes ScopeChain => _scopeChain.Value;
+    public DebugScopes ScopeChain
+    {
+        get
+        {
+            using var ownership = _engine.EnterHostCall();
+            return _scopeChain.Value;
+        }
+    }
 
     /// <summary>
     /// The value of <c>this</c> in this call frame.
@@ -56,6 +65,7 @@ public sealed class CallFrame
     {
         get
         {
+            using var ownership = _engine.EnterHostCall();
             var environment = _context.GetThisEnvironment();
             return environment.GetThisBinding();
         }

--- a/Jint/Runtime/Debugger/DebugHandler.cs
+++ b/Jint/Runtime/Debugger/DebugHandler.cs
@@ -20,6 +20,7 @@ public class DebugHandler
     private readonly Engine _engine;
     private bool _paused;
     private int _steppingDepth;
+    private SourceLocation? _currentLocation;
 
     /// <summary>
     /// Triggered before the engine executes/evaluates the parsed AST of a script or module.
@@ -64,6 +65,7 @@ public class DebugHandler
     internal DebugHandler(Engine engine, StepMode initialStepMode)
     {
         _engine = engine;
+        BreakPoints = new BreakPointCollection(engine);
         HandleNewStepMode(initialStepMode);
     }
 
@@ -76,12 +78,20 @@ public class DebugHandler
     /// The location is available as long as DebugMode is enabled - i.e. even when not stepping
     /// or hitting a breakpoint.
     /// </remarks>
-    public SourceLocation? CurrentLocation { get; private set; }
+    public SourceLocation? CurrentLocation
+    {
+        get
+        {
+            using var ownership = _engine.EnterHostCall();
+            return _currentLocation;
+        }
+        private set => _currentLocation = value;
+    }
 
     /// <summary>
     /// Collection of active breakpoints for the engine.
     /// </summary>
-    public BreakPointCollection BreakPoints { get; } = new BreakPointCollection();
+    public BreakPointCollection BreakPoints { get; }
 
     /// <summary>
     /// Evaluates a script (expression) within the current execution context.
@@ -92,6 +102,7 @@ public class DebugHandler
     /// </remarks>
     public JsValue Evaluate(in Prepared<Script> preparedScript)
     {
+        using var ownership = _engine.EnterHostCall();
         if (!preparedScript.IsValid)
         {
             Throw.InvalidPreparedScriptArgumentException(nameof(preparedScript));
@@ -144,6 +155,7 @@ public class DebugHandler
     /// <inheritdoc cref="Evaluate(in Prepared{Script})" />
     public JsValue Evaluate(string sourceText, ScriptParsingOptions? parsingOptions = null)
     {
+        using var ownership = _engine.EnterHostCall();
         var parserOptions = parsingOptions?.GetParserOptions() ?? _engine.GetActiveParserOptions();
         var parser = _engine.GetParserFor(parserOptions);
         try

--- a/Jint/Runtime/Debugger/DebugHandler.cs
+++ b/Jint/Runtime/Debugger/DebugHandler.cs
@@ -65,7 +65,7 @@ public class DebugHandler
     internal DebugHandler(Engine engine, StepMode initialStepMode)
     {
         _engine = engine;
-        BreakPoints = new BreakPointCollection(engine);
+        BreakPoints = new BreakPointCollection();
         HandleNewStepMode(initialStepMode);
     }
 

--- a/Jint/Runtime/Debugger/DebugInformation.cs
+++ b/Jint/Runtime/Debugger/DebugInformation.cs
@@ -42,8 +42,14 @@ public sealed class DebugInformation : EventArgs
     /// The current call stack.
     /// </summary>
     /// <remarks>This will always include at least a call frame for the global environment.</remarks>
-    public DebugCallStack CallStack =>
-        _callStack ??= new DebugCallStack(_engine, _currentLocation, _engine.CallStack, _returnValue);
+    public DebugCallStack CallStack
+    {
+        get
+        {
+            using var ownership = _engine.EnterHostCall();
+            return _callStack ??= new DebugCallStack(_engine, _currentLocation, _engine.CallStack, _returnValue);
+        }
+    }
 
     /// <summary>
     /// The AST Node that will be executed on next step.

--- a/Jint/Runtime/Debugger/DebugScope.cs
+++ b/Jint/Runtime/Debugger/DebugScope.cs
@@ -10,12 +10,14 @@ namespace Jint.Runtime.Debugger;
 /// </summary>
 public sealed class DebugScope
 {
+    private readonly Engine _engine;
     private readonly Environment _record;
     private string[]? _bindingNames;
 
     internal DebugScope(DebugScopeType type, Environment record, bool isTopLevel)
     {
         ScopeType = type;
+        _engine = record._engine;
         _record = record;
         BindingObject = record is ObjectEnvironment objEnv ? objEnv._bindingObject : null;
         IsTopLevel = isTopLevel;
@@ -39,7 +41,14 @@ public sealed class DebugScope
     /// <summary>
     /// Names of all bindings in the scope.
     /// </summary>
-    public IReadOnlyList<string> BindingNames => _bindingNames ??= _record.GetAllBindingNames();
+    public IReadOnlyList<string> BindingNames
+    {
+        get
+        {
+            using var ownership = _engine.EnterHostCall();
+            return _bindingNames ??= _record.GetAllBindingNames();
+        }
+    }
 
     /// <summary>
     /// Binding object for ObjectEnvironmentRecords - that is, Global scope and With scope. Null for other scopes.
@@ -57,6 +66,7 @@ public sealed class DebugScope
     /// <returns>Value of the binding</returns>
     public JsValue? GetBindingValue(string name)
     {
+        using var ownership = _engine.EnterHostCall();
         _record.TryGetBinding(new Environment.BindingName(name), strict: false, out var result);
         return result;
     }
@@ -68,6 +78,7 @@ public sealed class DebugScope
     /// <param name="value">New value of the binding</param>
     public void SetBindingValue(string name, JsValue value)
     {
+        using var ownership = _engine.EnterHostCall();
         _record.SetMutableBinding(name, value, strict: true);
     }
 }

--- a/Jint/Runtime/Debugger/ExceptionThrownEventArgs.cs
+++ b/Jint/Runtime/Debugger/ExceptionThrownEventArgs.cs
@@ -31,6 +31,12 @@ public sealed class ExceptionThrownEventArgs : EventArgs
     /// <summary>
     /// The call stack at the point the exception was thrown.
     /// </summary>
-    public DebugCallStack CallStack =>
-        _callStack ??= new DebugCallStack(_engine, _location, _engine.CallStack, returnValue: null);
+    public DebugCallStack CallStack
+    {
+        get
+        {
+            using var ownership = _engine.EnterHostCall();
+            return _callStack ??= new DebugCallStack(_engine, _location, _engine.CallStack, returnValue: null);
+        }
+    }
 }

--- a/Jint/Runtime/EventLoop.cs
+++ b/Jint/Runtime/EventLoop.cs
@@ -91,11 +91,8 @@ internal sealed record EventLoop
     /// <summary>
     /// Async wake signals registered by callers of <see cref="WaitForEventAsync(CancellationToken)"/>.
     /// Each call appends its own TCS so that <see cref="Enqueue(in EventLoopJob)"/> can wake every
-    /// outstanding waiter — supporting concurrent awaiters on a single engine
-    /// (e.g. a caller that <c>await</c>s two engine-internal promises in parallel
-    /// via <c>Task.WhenAll</c>). Replaces an earlier single-field design that
-    /// silently dropped the second waiter and could spin until the first one
-    /// happened to resume.
+    /// outstanding waiter. Engine ownership permits only one host async operation at a time, but a list
+    /// keeps registration and wake-up correct if an internal path temporarily has more than one waiter.
     /// </summary>
     private readonly Lock _waitersLock = new();
     private List<TaskCompletionSource<bool>>? _waiters;

--- a/Jint/Runtime/Interop/DefaultTypeConverter.cs
+++ b/Jint/Runtime/Interop/DefaultTypeConverter.cs
@@ -47,8 +47,8 @@ public class DefaultTypeConverter : ITypeConverter
     private static readonly MethodInfo changeTypeIfConvertible = typeof(DefaultTypeConverter).GetMethod(
         nameof(ChangeTypeOnlyIfConvertible), BindingFlags.NonPublic | BindingFlags.Static)!;
     private static readonly MethodInfo jsValueFromObject = jsValueType.GetMethod(nameof(JsValue.FromObject))!;
-    private static readonly MethodInfo enterHostCallback = engineType.GetMethod("EnterTransferredHostCallback", BindingFlags.Instance | BindingFlags.NonPublic)!;
-    private static readonly MethodInfo getHostCallbackOwner = engineType.GetMethod("GetHostCallbackOwner", BindingFlags.Instance | BindingFlags.NonPublic)!;
+    private static readonly MethodInfo enterHostCallback = engineType.GetMethod(nameof(Engine.EnterTransferredHostCallback), BindingFlags.Instance | BindingFlags.NonPublic)!;
+    private static readonly MethodInfo getHostCallbackOwner = engineType.GetMethod(nameof(Engine.GetHostCallbackOwner), BindingFlags.Instance | BindingFlags.NonPublic)!;
     private static readonly MethodInfo exitHostCallback = typeof(Engine.HostCallScope).GetMethod(nameof(IDisposable.Dispose))!;
     private static readonly MethodInfo jsValueToObject = jsValueType.GetMethod(nameof(JsValue.ToObject))!;
 

--- a/Jint/Runtime/Interop/DefaultTypeConverter.cs
+++ b/Jint/Runtime/Interop/DefaultTypeConverter.cs
@@ -9,6 +9,7 @@ using System.Runtime.CompilerServices;
 using Jint.Extensions;
 using Jint.Native;
 using Jint.Native.Function;
+using Jint.Native.Object;
 using Expression = System.Linq.Expressions.Expression;
 
 #pragma warning disable IL2026
@@ -46,6 +47,8 @@ public class DefaultTypeConverter : ITypeConverter
     private static readonly MethodInfo changeTypeIfConvertible = typeof(DefaultTypeConverter).GetMethod(
         nameof(ChangeTypeOnlyIfConvertible), BindingFlags.NonPublic | BindingFlags.Static)!;
     private static readonly MethodInfo jsValueFromObject = jsValueType.GetMethod(nameof(JsValue.FromObject))!;
+    private static readonly MethodInfo enterHostCallback = engineType.GetMethod("EnterHostCallback", BindingFlags.Instance | BindingFlags.NonPublic)!;
+    private static readonly MethodInfo exitHostCallback = typeof(Engine.HostCallScope).GetMethod(nameof(IDisposable.Dispose))!;
     private static readonly MethodInfo jsValueToObject = jsValueType.GetMethod(nameof(JsValue.ToObject))!;
 
 
@@ -395,7 +398,7 @@ public class DefaultTypeConverter : ITypeConverter
 #endif
     }
 
-    private Func<object, Delegate> BuildTargetBinderDelegate(
+    private static Func<object, Delegate> BuildTargetBinderDelegate(
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type delegateType,
         JsCallDelegate function)
     {
@@ -416,7 +419,7 @@ public class DefaultTypeConverter : ITypeConverter
         return (Func<object, Delegate>) curried.Compile();
     }
 
-    private LambdaExpression BuildDelegate(
+    private static LambdaExpression BuildDelegate(
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type type,
         JsCallDelegate function,
         Expression targetExpression)
@@ -431,6 +434,9 @@ public class DefaultTypeConverter : ITypeConverter
         }
 
         var initializers = new List<MethodCallExpression>(parameters.Length);
+        var targetEngine = Expression.Property(
+            Expression.Convert(targetExpression, typeof(ObjectInstance)),
+            nameof(ObjectInstance.Engine));
 
         for (var i = 0; i < parameters.Length; i++)
         {
@@ -438,7 +444,7 @@ public class DefaultTypeConverter : ITypeConverter
             if (param.Type.IsValueType)
             {
                 var boxing = Expression.Convert(param, objectType);
-                initializers.Add(Expression.Call(null, jsValueFromObject, Expression.Constant(_engine, engineType), boxing));
+                initializers.Add(Expression.Call(null, jsValueFromObject, targetEngine, boxing));
             }
             else if (param.Type.IsArray &&
                      arguments[i].GetCustomAttribute<ParamArrayAttribute>() is not null &&
@@ -451,12 +457,12 @@ public class DefaultTypeConverter : ITypeConverter
                     var condition = Expression.IfThen(checkIndex, Expression.Return(returnLabel, Expression.ArrayAccess(param, Expression.Constant(j))));
                     var block = Expression.Block(condition, Expression.Label(returnLabel, Expression.Constant(JsValue.Undefined)));
 
-                    initializers.Add(Expression.Call(null, jsValueFromObject, Expression.Constant(_engine, engineType), block));
+                    initializers.Add(Expression.Call(null, jsValueFromObject, targetEngine, block));
                 }
             }
             else
             {
-                initializers.Add(Expression.Call(null, jsValueFromObject, Expression.Constant(_engine, engineType), param));
+                initializers.Add(Expression.Call(null, jsValueFromObject, targetEngine, param));
             }
         }
 
@@ -468,11 +474,10 @@ public class DefaultTypeConverter : ITypeConverter
             Expression.Constant(JsValue.Undefined, jsValueType),
             vars);
 
+        Expression body;
         if (method.ReturnType != typeof(void))
         {
-            return Expression.Lambda(
-                type,
-                Expression.Convert(
+            body = Expression.Convert(
                     Expression.Call(
                         null,
                         changeTypeIfConvertible,
@@ -480,14 +485,22 @@ public class DefaultTypeConverter : ITypeConverter
                         Expression.Constant(method.ReturnType),
                         Expression.Constant(System.Globalization.CultureInfo.InvariantCulture, typeof(IFormatProvider))
                     ),
-                    method.ReturnType
-                ),
-                new ReadOnlyCollection<ParameterExpression>(parameters));
+                    method.ReturnType);
         }
+        else
+        {
+            body = callExpression;
+        }
+
+        var ownership = Expression.Variable(typeof(Engine.HostCallScope), "ownership");
+        var guardedBody = Expression.Block(
+            [ownership],
+            Expression.Assign(ownership, Expression.Call(targetEngine, enterHostCallback)),
+            Expression.TryFinally(body, Expression.Call(ownership, exitHostCallback)));
 
         return Expression.Lambda(
             type,
-            callExpression,
+            guardedBody,
             new ReadOnlyCollection<ParameterExpression>(parameters));
     }
 

--- a/Jint/Runtime/Interop/DefaultTypeConverter.cs
+++ b/Jint/Runtime/Interop/DefaultTypeConverter.cs
@@ -47,7 +47,8 @@ public class DefaultTypeConverter : ITypeConverter
     private static readonly MethodInfo changeTypeIfConvertible = typeof(DefaultTypeConverter).GetMethod(
         nameof(ChangeTypeOnlyIfConvertible), BindingFlags.NonPublic | BindingFlags.Static)!;
     private static readonly MethodInfo jsValueFromObject = jsValueType.GetMethod(nameof(JsValue.FromObject))!;
-    private static readonly MethodInfo enterHostCallback = engineType.GetMethod("EnterHostCallback", BindingFlags.Instance | BindingFlags.NonPublic)!;
+    private static readonly MethodInfo enterHostCallback = engineType.GetMethod("EnterTransferredHostCallback", BindingFlags.Instance | BindingFlags.NonPublic)!;
+    private static readonly MethodInfo getHostCallbackOwner = engineType.GetMethod("GetHostCallbackOwner", BindingFlags.Instance | BindingFlags.NonPublic)!;
     private static readonly MethodInfo exitHostCallback = typeof(Engine.HostCallScope).GetMethod(nameof(IDisposable.Dispose))!;
     private static readonly MethodInfo jsValueToObject = jsValueType.GetMethod(nameof(JsValue.ToObject))!;
 
@@ -97,6 +98,7 @@ public class DefaultTypeConverter : ITypeConverter
 
     private static readonly ConditionalWeakTable<IFunction, Func<object, Delegate>> _targetBinderDelegateCache = new();
     private static readonly ConditionalWeakTable<object, Delegate> _boundTargetDelegateCache = new();
+    private static readonly ConditionalWeakTable<Delegate, ObjectInstance> _hostCallbackDelegates = new();
 
     private bool TryConvertInternal(
         object? value,
@@ -207,6 +209,10 @@ public class DefaultTypeConverter : ITypeConverter
             {
                 var func = (JsCallDelegate) value;
                 var functionInstance = func.Target;
+                if (functionInstance is ObjectInstance callback)
+                {
+                    callback.Engine.AuthorizeHostCallback(callback);
+                }
 
                 // caching of .NET delegates per function instance is required to be able to support
                 // unregistering event handlers (see ShouldExecuteActionCallbackOnEventChanged)
@@ -223,6 +229,11 @@ public class DefaultTypeConverter : ITypeConverter
                         return targetBinder(target)!;
                     }) :
                     BuildDelegate(type, func, Expression.Constant(functionInstance, functionInstance!.GetType())).Compile();
+
+                if (functionInstance is ObjectInstance callbackTarget)
+                {
+                    _hostCallbackDelegates.GetValue(d, _ => callbackTarget);
+                }
 
                 converted = d;
                 return true;
@@ -419,6 +430,33 @@ public class DefaultTypeConverter : ITypeConverter
         return (Func<object, Delegate>) curried.Compile();
     }
 
+    internal static bool ContainsHostCallback(object?[] parameters)
+    {
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            if (IsHostCallback(parameters[i]))
+            {
+                return true;
+            }
+
+            if (parameters[i] is Array callbacks)
+            {
+                foreach (var callback in callbacks)
+                {
+                    if (IsHostCallback(callback))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    internal static bool IsHostCallback(object? value)
+        => value is Delegate callback && _hostCallbackDelegates.TryGetValue(callback, out _);
+
     private static LambdaExpression BuildDelegate(
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type type,
         JsCallDelegate function,
@@ -495,7 +533,15 @@ public class DefaultTypeConverter : ITypeConverter
         var ownership = Expression.Variable(typeof(Engine.HostCallScope), "ownership");
         var guardedBody = Expression.Block(
             [ownership],
-            Expression.Assign(ownership, Expression.Call(targetEngine, enterHostCallback)),
+            Expression.Assign(
+                ownership,
+                Expression.Call(
+                    targetEngine,
+                    enterHostCallback,
+                    Expression.Call(
+                        targetEngine,
+                        getHostCallbackOwner,
+                        Expression.Convert(targetExpression, typeof(ObjectInstance))))),
             Expression.TryFinally(body, Expression.Call(ownership, exitHostCallback)));
 
         return Expression.Lambda(

--- a/Jint/Runtime/Interop/DelegateWrapper.cs
+++ b/Jint/Runtime/Interop/DelegateWrapper.cs
@@ -309,6 +309,8 @@ internal sealed class DelegateWrapper : Function
 #endif
         try
         {
+            using var suspension = Engine.SuspendHostCallForCallbacks(
+                _metadata.MayReceiveHostCallback && DefaultTypeConverter.ContainsHostCallback(parameters));
 #if NET8_0_OR_GREATER
             result = viaCompiledLane ? invoker!(_d, parameters) : _d.DynamicInvoke(parameters);
 #else
@@ -337,6 +339,8 @@ internal sealed class DelegateWrapper : Function
         object? result;
         try
         {
+            using var suspension = Engine.SuspendHostCallForCallbacks(
+                _metadata.MayReceiveHostCallback && DefaultTypeConverter.IsHostCallback(argument0));
             result = invoker(_d, argument0);
         }
         catch (Exception exception)
@@ -353,6 +357,9 @@ internal sealed class DelegateWrapper : Function
         object? result;
         try
         {
+            using var suspension = Engine.SuspendHostCallForCallbacks(
+                _metadata.MayReceiveHostCallback
+                && (DefaultTypeConverter.IsHostCallback(argument0) || DefaultTypeConverter.IsHostCallback(argument1)));
             result = invoker(_d, argument0, argument1);
         }
         catch (Exception exception)
@@ -467,6 +474,7 @@ internal sealed class DelegateMetadata
 
         ParameterMetadata[] parameters = parameterInfos.Length == 0 ? [] : new ParameterMetadata[parameterInfos.Length];
         var hasParamsArray = false;
+        var mayReceiveHostCallback = false;
         for (var i = 0; i < parameterInfos.Length; i++)
         {
             var parameterInfo = parameterInfos[i];
@@ -478,10 +486,13 @@ internal sealed class DelegateMetadata
                 IsValueType: parameterType.IsValueType);
 
             hasParamsArray |= Attribute.IsDefined(parameterInfo, typeof(ParamArrayAttribute));
+            mayReceiveHostCallback |= typeof(Delegate).IsAssignableFrom(parameterType)
+                || (parameterType.IsArray && typeof(Delegate).IsAssignableFrom(parameterType.GetElementType()!));
         }
 
         Parameters = parameters;
         HasParamsArray = hasParamsArray;
+        MayReceiveHostCallback = mayReceiveHostCallback;
 
         if (hasParamsArray)
         {
@@ -493,6 +504,8 @@ internal sealed class DelegateMetadata
     internal ParameterMetadata[] Parameters { get; }
 
     internal bool HasParamsArray { get; }
+
+    internal bool MayReceiveHostCallback { get; }
 
     /// <summary>Element type of the trailing params array; only meaningful when <see cref="HasParamsArray"/>.</summary>
     internal Type? ParamsElementType { get; }

--- a/Jint/Runtime/Interop/MethodInfoFunction.cs
+++ b/Jint/Runtime/Interop/MethodInfoFunction.cs
@@ -484,6 +484,8 @@ internal sealed class MethodInfoFunction : Function
                 object? result;
                 try
                 {
+                    using var suspension = _engine.SuspendHostCallForCallbacks(
+                        DefaultTypeConverter.ContainsHostCallback(parameters));
                     result = resolvedMethod.Invoke(thisObj, parameters);
                 }
                 catch (ArgumentException)
@@ -503,7 +505,12 @@ internal sealed class MethodInfoFunction : Function
                 return true;
             }
 
-            var invokeResult = method.Invoke(thisObj, parameters);
+            object? invokeResult;
+            using (Engine.SuspendHostCallForCallbacks(
+                       DefaultTypeConverter.ContainsHostCallback(parameters)))
+            {
+                invokeResult = method.Invoke(thisObj, parameters);
+            }
             callResult = FromObjectWithType(Engine, invokeResult, type: method.ReturnType);
             _engine.CheckAmortizedConstraintsAtHostBoundary();
             return true;

--- a/Jint/Runtime/Modules/ModuleImportOperation.cs
+++ b/Jint/Runtime/Modules/ModuleImportOperation.cs
@@ -69,6 +69,7 @@ public sealed class ModuleImportOperation
     {
         get
         {
+            using var ownership = _engine.EnterHostCall();
             ObserveAbandonment();
             return _completed;
         }
@@ -79,6 +80,7 @@ public sealed class ModuleImportOperation
     {
         get
         {
+            using var ownership = _engine.EnterHostCall();
             ObserveAbandonment();
             return _faulted;
         }
@@ -89,6 +91,7 @@ public sealed class ModuleImportOperation
     {
         get
         {
+            using var ownership = _engine.EnterHostCall();
             ObserveAbandonment();
             return _namespace;
         }
@@ -102,6 +105,7 @@ public sealed class ModuleImportOperation
     {
         get
         {
+            using var ownership = _engine.EnterHostCall();
             ObserveAbandonment();
             return _error;
         }
@@ -114,6 +118,7 @@ public sealed class ModuleImportOperation
     /// <exception cref="PromiseRejectedException">The import failed.</exception>
     public ObjectInstance GetResult()
     {
+        using var ownership = _engine.EnterHostCall();
         if (!IsCompleted)
         {
             Throw.InvalidOperationException("The module import has not completed. Give the engine turns with engine.Advanced.ProcessTasks() until IsCompleted is true, or await Engine.Modules.ImportAsync instead.");
@@ -153,8 +158,8 @@ public sealed class ModuleImportOperation
             return;
         }
 
-        _completed = true;
         _namespace = value as ObjectInstance;
+        _completed = true;
     }
 
     internal void Fail(JsValue error)
@@ -164,8 +169,8 @@ public sealed class ModuleImportOperation
             return;
         }
 
-        _completed = true;
         _faulted = true;
         _error = error;
+        _completed = true;
     }
 }

--- a/README.md
+++ b/README.md
@@ -878,7 +878,17 @@ https://docs.microsoft.com/shows/code-conversations/sebastien-ros-on-jint-javasc
 
 ## Thread-safety
 
-Engine instances are not thread-safe and they should not accessed from multiple threads simultaneously. 
+An `Engine` is single-operation, not thread-safe. Public host entries fail fast with
+`InvalidOperationException` when another thread is using the same engine or while one of its async APIs
+is still outstanding; callers are never silently serialized. Same-thread re-entry from a host callback is
+supported, and an awaited async operation may resume on a different thread after ownership transfers.
+Background task and module completions may enqueue work safely, but they do not grant permission for other
+host calls while the owning async operation is pending.
+
+Keep one engine exclusively assigned to one request or operation at a time. If engines are pooled, await
+`EvaluateAsync`, `ExecuteAsync`, `InvokeAsync`, `ImportAsync`, or `UnwrapIfPromiseAsync` before returning an
+engine to the pool. Direct mutation through engine-owned objects such as `engine.Global` remains subject to
+the same contract and cannot be guarded by the `Engine` entry-point check.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -881,14 +881,17 @@ https://docs.microsoft.com/shows/code-conversations/sebastien-ros-on-jint-javasc
 An `Engine` is single-operation, not thread-safe. Public host entries fail fast with
 `InvalidOperationException` when another thread is using the same engine or while one of its async APIs
 is still outstanding; callers are never silently serialized. Same-thread re-entry from a host callback is
-supported, and an awaited async operation may resume on a different thread after ownership transfers.
-Background task and module completions may enqueue work safely, but they do not grant permission for other
-host calls while the owning async operation is pending.
+supported for synchronous APIs. Starting an async engine API from inside an active engine call is rejected:
+the callback must return before ownership can transfer safely. A top-level awaited async operation may
+resume on a different thread after ownership transfers. Background task and module completions may enqueue
+work safely, but they do not grant permission for other host calls while the owning async operation is
+pending.
 
 Keep one engine exclusively assigned to one request or operation at a time. If engines are pooled, await
 `EvaluateAsync`, `ExecuteAsync`, `InvokeAsync`, `ImportAsync`, or `UnwrapIfPromiseAsync` before returning an
 engine to the pool. Direct mutation through engine-owned objects such as `engine.Global` remains subject to
-the same contract and cannot be guarded by the `Engine` entry-point check.
+the same contract and cannot be guarded by the `Engine` entry-point check. `Dispose` also fails fast while
+an operation owns the engine; await or finish that operation before disposing.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -881,17 +881,22 @@ https://docs.microsoft.com/shows/code-conversations/sebastien-ros-on-jint-javasc
 An `Engine` is single-operation, not thread-safe. Public host entries fail fast with
 `InvalidOperationException` when another thread is using the same engine or while one of its async APIs
 is still outstanding; callers are never silently serialized. Same-thread re-entry from a host callback is
-supported for synchronous APIs. Starting an async engine API from inside an active engine call is rejected:
-the callback must return before ownership can transfer safely. A top-level awaited async operation may
-resume on a different thread after ownership transfers. Background task and module completions may enqueue
-work safely, but they do not grant permission for other host calls while the owning async operation is
-pending.
+supported for synchronous APIs. A JavaScript callback converted to a CLR delegate may also be dispatched
+to another thread by the host: while host code is running, or while the async operation that received the
+callback remains outstanding, Jint reserves the engine against unrelated callers and transfers ownership
+to that callback one turn at a time. Such an authorized transfer may wait for the current callback turn;
+ordinary public callers still fail immediately rather than being serialized. Starting an async engine API
+from inside an active engine call is rejected: the callback must return before ownership can transfer
+safely. A top-level awaited async operation may resume on a different thread after ownership transfers.
+Background task and module completions may enqueue work safely, but they do not grant permission for other
+host calls while the owning async operation is pending.
 
 Keep one engine exclusively assigned to one request or operation at a time. If engines are pooled, await
 `EvaluateAsync`, `ExecuteAsync`, `InvokeAsync`, `ImportAsync`, or `UnwrapIfPromiseAsync` before returning an
 engine to the pool. Direct mutation through engine-owned objects such as `engine.Global` remains subject to
 the same contract and cannot be guarded by the `Engine` entry-point check. `Dispose` also fails fast while
-an operation owns the engine; await or finish that operation before disposing.
+an operation owns the engine; await or finish that operation before disposing. This is observable during
+exception unwinding too, so a `using` scope must not outlive an async engine operation.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

Fail fast when one Engine is used by concurrent host operations.

## Details

- Adds non-blocking Engine ownership across execution, mutation, modules, debugger state, conversion, and event-loop entry points.
- Preserves synchronous same-thread callback re-entry, top-level async thread handoff, thread-safe background completion enqueueing, and serialized cross-thread dispatch of JavaScript callbacks converted to CLR delegates.
- Reserves an Engine for the full lifetime of returned async Tasks; nested async entry from an active Engine callback is rejected before work starts.
- Keeps debugger breakpoint administration independently thread-safe and documents pooling, disposal, and remaining direct-object risks.
- Includes the threat-model mitigation originally developed on #3030; after that PR landed, this PR was rebased and now targets `main` directly.

## Linked issue

N/A

## Test plan

- [x] Added runtime and public-contract concurrency tests, including delayed callbacks, synchronous and async cross-thread callback handoff, params-array callbacks, ownership-release races, manual-promise handoff, and recovery after rejection
- [x] Multi-target `dotnet build Jint/Jint.csproj -c Release`: 0 warnings, 0 errors
- [x] `Jint.Tests.PublicInterface` Release: 1796 passed, 9 skipped
- [x] `JINT_HOST_CONTRACT_VERIFICATION=1 Jint.Tests.PublicInterface` Release: 1800 passed, 5 skipped
- [x] `Jint.Tests` Release: 7794 passed, 4 skipped, excluding the timezone-sensitive year-10000 Date test previously confirmed failing on the base
- [x] `git diff --check origin/main...HEAD`
- [x] Prior default-job A/B measurements found no attributable execution regression; Engine construction increased by approximately 30 bytes from ownership state

## Breaking change?

No public API signatures change. Concurrent Engine use was already unsupported; it now throws `InvalidOperationException` deterministically instead of racing or silently serializing. Authorized callbacks belonging to the active operation may transfer ownership one turn at a time, while unrelated callers still fail immediately. Hosts must await async Engine operations before reuse or disposal, and async Engine entry from inside an active callback is rejected.