### PR TITLE
Evaluate a computed property key even when it is spelled as a literal

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -95,11 +95,8 @@
 
     // Function source text and inferred names. Function.prototype.toString does not return the
     // original source for class expressions and some method forms, and NamedEvaluation does not
-    // reach every position the spec names (for-in heads, computed method keys, ...). Removed by
-    // carrying the source range and completing NamedEvaluation.
+    // reach the for-in head. Removed by carrying the source range and completing NamedEvaluation.
     "staging/sm/Function/function-name-for.js",
-    "staging/sm/Function/function-name-method.js",
-    "staging/sm/Function/function-name-property.js",
     "staging/sm/class/parenExprToString.js",
     "staging/sm/generators/runtime.js",
 
@@ -218,7 +215,6 @@
     "staging/sm/TypedArray/iterator-next-with-detached.js",
     "staging/sm/class/newTargetDVG.js",
     "staging/sm/class/superPropOrdering.js",
-    "staging/sm/expressions/computed-property-side-effects.js",
     "staging/sm/expressions/optional-chain.js",
     "staging/sm/extensions/extension-methods-reject-null-undefined-this.js",
     "staging/sm/extensions/quote-string-for-nul-character.js",

--- a/Jint.Tests/Runtime/ComputedPropertyKeyTests.cs
+++ b/Jint.Tests/Runtime/ComputedPropertyKeyTests.cs
@@ -1,0 +1,141 @@
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// A ComputedPropertyName is <c>ToPropertyKey(? GetValue(? Evaluation(AssignmentExpression)))</c>
+/// (https://tc39.es/ecma262/#sec-runtime-semantics-propertydefinitionevaluation), so a computed key
+/// whose expression merely happens to be a literal node still has to go through that conversion. The
+/// key-extraction helper used to match <c>Literal</c> before it consulted the computed flag, which made
+/// <c>{ [/a/]: 0 }</c> and <c>{ [true]: 1 }</c> bind CLR-formatted names (<c>"a"</c>, <c>"True"</c>)
+/// and never call a user-visible <c>toString</c>.
+/// </summary>
+public class ComputedPropertyKeyTests
+{
+    [Fact]
+    public void RegExpLiteralComputedKeyUsesRegExpToString()
+    {
+        var engine = new Engine();
+        engine.Evaluate("JSON.stringify(Object.keys({ [/a/]: 0 }))").AsString().Should().Be("[\"/a/\"]");
+        engine.Evaluate("({ [/a/]: 0 })[/a/]").AsNumber().Should().Be(0);
+        engine.Evaluate("JSON.stringify(Object.keys({ [/a/gi]: 0 }))").AsString().Should().Be("[\"/a/gi\"]");
+    }
+
+    [Fact]
+    public void RegExpLiteralComputedKeyHonoursOverriddenToString()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate(@"
+RegExp.prototype.toString = function () { return 'overridden'; };
+JSON.stringify(Object.keys({ [/a/]: 0 }));").AsString();
+
+        result.Should().Be("[\"overridden\"]");
+    }
+
+    [Fact]
+    public void ComputedKeyConversionIsObservableAndCanThrow()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate(@"
+RegExp.prototype.toString = function () { throw 42; };
+var thrown;
+try { ({ [/regex/]: 0 }); } catch (e) { thrown = e; }
+thrown;").AsNumber();
+
+        result.Should().Be(42);
+    }
+
+    [Fact]
+    public void BooleanLiteralComputedKeyUsesJavaScriptSpelling()
+    {
+        var engine = new Engine();
+        engine.Evaluate("JSON.stringify(Object.keys({ [true]: 1, [false]: 2 }))").AsString().Should().Be("[\"true\",\"false\"]");
+        engine.Evaluate("({ [true]: 1 })['true']").AsNumber().Should().Be(1);
+        engine.Evaluate("({ [true]: 1 })[true]").AsNumber().Should().Be(1);
+    }
+
+    [Fact]
+    public void NullLiteralComputedKeyIsNullString()
+    {
+        var engine = new Engine();
+        engine.Evaluate("JSON.stringify(Object.keys({ [null]: 1 }))").AsString().Should().Be("[\"null\"]");
+        engine.Evaluate("({ [null]: 1 })['null']").AsNumber().Should().Be(1);
+    }
+
+    [Fact]
+    public void NonComputedKeywordKeysAreUnaffected()
+    {
+        var engine = new Engine();
+        engine.Evaluate("({ true: 1 }).true").AsNumber().Should().Be(1);
+        engine.Evaluate("JSON.stringify(Object.keys({ true: 1, false: 2, null: 3 }))").AsString().Should().Be("[\"true\",\"false\",\"null\"]");
+        engine.Evaluate("({ true: 1 })['true']").AsNumber().Should().Be(1);
+    }
+
+    [Fact]
+    public void StringAndNumberComputedKeysAreUnchanged()
+    {
+        var engine = new Engine();
+        engine.Evaluate("JSON.stringify(Object.keys({ ['foo']: 1 }))").AsString().Should().Be("[\"foo\"]");
+        engine.Evaluate("({ ['foo']: 1 }).foo").AsNumber().Should().Be(1);
+        engine.Evaluate("JSON.stringify(Object.keys({ [0]: 1 }))").AsString().Should().Be("[\"0\"]");
+        engine.Evaluate("({ [0]: 1 })[0]").AsNumber().Should().Be(1);
+        engine.Evaluate("JSON.stringify(Object.keys({ [1e21]: 1 }))").AsString().Should().Be("[\"1e+21\"]");
+        engine.Evaluate("JSON.stringify(Object.keys({ [1n]: 1 }))").AsString().Should().Be("[\"1\"]");
+        engine.Evaluate("JSON.stringify(Object.keys({ foo: 1, 0: 2, 'bar': 3 }))").AsString().Should().Be("[\"0\",\"foo\",\"bar\"]");
+    }
+
+    [Fact]
+    public void ClassMethodComputedRegExpKey()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate(@"
+class C { [/re/]() { return 7; } }
+JSON.stringify(Object.getOwnPropertyNames(C.prototype)) + '|' + new C()[/re/]() + '|' + C.prototype[/re/].name;").AsString();
+
+        result.Should().Be("[\"constructor\",\"/re/\"]|7|/re/");
+    }
+
+    [Fact]
+    public void ClassMethodComputedBooleanKey()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate(@"
+class C { [true]() { return 8; } }
+JSON.stringify(Object.getOwnPropertyNames(C.prototype)) + '|' + new C()[true]() + '|' + C.prototype[true].name;").AsString();
+
+        result.Should().Be("[\"constructor\",\"true\"]|8|true");
+    }
+
+    [Fact]
+    public void ClassAccessorsAndFieldsUseConvertedComputedKeys()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate(@"
+class C {
+    [/f/] = 1;
+    get [/g/]() { return 2; }
+    static [/s/]() { return 3; }
+}
+var c = new C();
+c[/f/] + '|' + c[/g/] + '|' + C[/s/]() + '|' + Object.getOwnPropertyDescriptor(C.prototype, '/g/').get.name;").AsString();
+
+        result.Should().Be("1|2|3|get /g/");
+    }
+
+    [Fact]
+    public void AnonymousFunctionNamedFromComputedRegExpKey()
+    {
+        var engine = new Engine();
+        engine.Evaluate("({ [/a/]: function () {} })[/a/].name").AsString().Should().Be("/a/");
+        engine.Evaluate("({ [/a/]() {} })[/a/].name").AsString().Should().Be("/a/");
+    }
+
+    [Fact]
+    public void ComputedKeysInDestructuringPatternsAreConverted()
+    {
+        var engine = new Engine();
+        engine.Evaluate("(function ({ [/a/]: x }) { return x; })({ '/a/': 5 })").AsNumber().Should().Be(5);
+        engine.Evaluate("(function ({ [true]: x }) { return x; })({ 'true': 6 })").AsNumber().Should().Be(6);
+
+        var destructured = engine.Evaluate("var y; ({ [/a/]: y } = { '/a/': 9 }); y;").AsNumber();
+        destructured.Should().Be(9);
+    }
+}

--- a/Jint/AstExtensions.cs
+++ b/Jint/AstExtensions.cs
@@ -42,7 +42,7 @@ public static class AstExtensions
     internal static JsValue TryGetKey<T>(this T expression, Engine engine, bool resolveComputed) where T : Expression
     {
         JsValue key;
-        if (expression is Literal literal)
+        if (expression is Literal literal && (!resolveComputed || CanSkipComputedKeyEvaluation(literal)))
         {
             key = literal.Kind == TokenKind.NullLiteral ? JsValue.Null : LiteralKeyToString(literal);
         }
@@ -63,6 +63,34 @@ public static class AstExtensions
             key = JsValue.Undefined;
         }
         return key;
+    }
+
+    /// <summary>
+    /// Whether a computed key spelled as this literal may be turned into its key string directly instead of
+    /// running the full ComputedPropertyName evaluation
+    /// (https://tc39.es/ecma262/#sec-runtime-semantics-propertydefinitionevaluation, which is
+    /// <c>ToPropertyKey(? GetValue(? Evaluation(AssignmentExpression)))</c>).
+    /// <para>
+    /// The line is drawn at exactly the three literal kinds the grammar also admits in a *non-computed* key
+    /// position. Each evaluates to a primitive already, so ToPropertyKey is ToPrimitive (the identity on a
+    /// primitive) followed by ToString, and neither step can reach user code: the shortcut is therefore
+    /// observationally equivalent, and it is what keeps the common <c>{ ["foo"]: 1 }</c> and <c>{ [0]: 1 }</c>
+    /// shapes free of an expression build.
+    /// </para>
+    /// <para>
+    /// The remaining kinds are deliberately excluded. A RegExpLiteral evaluates to an *object*, so its
+    /// ToPropertyKey runs ToPrimitive and calls a user-replaceable <c>RegExp.prototype.toString</c>
+    /// (<c>({ [/a/]: 0 })</c> must key on <c>"/a/"</c>, and an overridden toString must be honoured, and may
+    /// throw). BooleanLiteral and NullLiteral are primitives whose conversion is pure, but there is nothing to
+    /// win — such a key is vanishingly rare — and shortcutting them means hand-spelling a conversion that can
+    /// drift from <see cref="TypeConverter"/>, which is exactly how <c>{ [true]: 1 }</c> came to bind
+    /// <c>"True"</c>. Let the evaluator produce the value and TypeConverter convert it.
+    /// </para>
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool CanSkipComputedKeyEvaluation(Literal literal)
+    {
+        return literal.Kind is TokenKind.StringLiteral or TokenKind.NumericLiteral or TokenKind.BigIntLiteral;
     }
 
     internal static JsValue TryGetComputedPropertyKey<T>(T expression, Engine engine)
@@ -148,6 +176,12 @@ public static class AstExtensions
         return node is IChainElement { Optional: true };
     }
 
+    /// <summary>
+    /// Renders a literal the way JavaScript spells it. The first three branches are the only kinds that can
+    /// reach here as a property key (see <see cref="CanSkipComputedKeyEvaluation"/>); the rest exist for the
+    /// diagnostic callers that render an arbitrary literal — <see cref="JintExpression"/>'s source text for
+    /// error messages, and the call-stack argument rendering.
+    /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static string LiteralKeyToString(Literal literal)
     {
@@ -155,20 +189,40 @@ public static class AstExtensions
         {
             return stringLiteral.Value;
         }
+
         // prevent conversion to scientific notation
-        else if (literal is NumericLiteral numericLiteral)
+        if (literal is NumericLiteral numericLiteral)
         {
             return TypeConverter.ToString(numericLiteral.Value);
         }
-        else if (literal is BigIntLiteral bigIntLiteral)
+
+        if (literal is BigIntLiteral bigIntLiteral)
         {
             return bigIntLiteral.Value.ToString(provider: null);
         }
-        else
+
+        return NonKeyLiteralToString(literal);
+    }
+
+    /// <summary>
+    /// The literal kinds that are never a property key: a non-computed key is a string/numeric/bigint literal
+    /// by grammar, and a computed one is evaluated and converted by <see cref="TypeConverter.ToPropertyKey"/>.
+    /// Only the diagnostic callers land here, and they get the JavaScript spelling rather than a CLR-formatted
+    /// one — <c>Convert.ToString</c> renders a boolean as <c>"True"</c>, and for a regex either the bare
+    /// pattern held by the <see cref="System.Text.RegularExpressions.Regex"/> or, when Acornima did not build
+    /// one, the empty string.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static string NonKeyLiteralToString(Literal literal)
+    {
+        // Raw is the literal's own source text, which for a regex is exactly what
+        // RegExp.prototype.toString produces ("/a/gi").
+        return literal switch
         {
-            // We shouldn't ever reach this line in the case of a literal property key.
-            return Convert.ToString(literal.Value, provider: null) ?? "";
-        }
+            BooleanLiteral booleanLiteral => booleanLiteral.Value ? "true" : "false",
+            NullLiteral => "null",
+            _ => literal.Raw ?? "",
+        };
     }
 
     internal static void GetBoundNames(this VariableDeclaration variableDeclaration, List<Key> target)


### PR DESCRIPTION
A computed property key whose expression happens to be a `Literal` node never reached `ToPropertyKey`, so the spec's ComputedPropertyName evaluation was skipped for it.

`AstExtensions.TryGetKey` matched `expression is Literal` **before** consulting `resolveComputed`:

```csharp
if (expression is Literal literal)          // matched even for a computed key
{
    key = literal.Kind == TokenKind.NullLiteral ? JsValue.Null : LiteralKeyToString(literal);
}
...
else if (resolveComputed) { return TryGetComputedPropertyKey(expression, engine); }
```

[13.2.5.5 PropertyDefinitionEvaluation](https://tc39.es/ecma262/#sec-runtime-semantics-propertydefinitionevaluation) requires `ToPropertyKey(? GetValue(? Evaluation(AssignmentExpression)))`. Two consequences:

```js
Object.keys({ [/a/]: 0 })      // was [""]           -> now ["/a/"]
Object.keys({ [true]: 1 })     // was ["True"]       -> now ["true"]
```

`/a/` is a `RegExpLiteral` whose `Value` is a `Regex?`; Jint never sets Acornima's `RegExpParseMode`, so it is `null` and `Convert.ToString(null)` produced the empty string. An overridden `RegExp.prototype.toString` was never consulted either. `[true]` went through `Convert.ToString(bool)`, which is CLR spelling, not JavaScript's.

The same hazard reached class members (`class C { [/re/](){} }`), class fields, auto-accessors, and object patterns in parameter position.

## The fix

Gate the literal fast path on `!resolveComputed`, keeping a shortcut for exactly the three literal kinds the grammar also admits in a **non-computed** key position — `StringLiteral`, `NumericLiteral`, `BigIntLiteral`. Each evaluates to a primitive, so `ToPropertyKey` is `ToPrimitive` (identity) then `ToString`, and neither step can reach user code: the shortcut is observationally equivalent by construction, and it keeps `{ ["foo"]: 1 }` free of an expression build.

`BooleanLiteral` and `NullLiteral` are pure too and could have been hand-spelled, but that is declined deliberately — a hand-written conversion drifting from `TypeConverter` is exactly how `[true]` came to bind `"True"`.

`LiteralKeyToString`'s `Convert.ToString` fallback is replaced with per-kind JavaScript spelling. It turned out to be **reachable and load-bearing** for two diagnostic callers that render an arbitrary literal (`JintExpression.ToString` for error text, `JintCallStack` for stack-trace arguments), so it could not simply throw; their output is unchanged.

## Performance

Non-computed keys pay nothing — `!resolveComputed` short-circuits before the kind is read. `{ ["foo"]: 1 }` costs one extra `Literal.Kind` read and an inlined 3-way enum compare. Only a computed key spelled as a regex, boolean or `null` now builds and evaluates an expression, which is precisely the work the spec mandates.

## Tests

`Jint.Tests/Runtime/ComputedPropertyKeyTests.cs` — 12 tests, 9 of which fail against unfixed code.

Frees three `staging/` exclusions: `expressions/computed-property-side-effects.js`, `Function/function-name-method.js`, `Function/function-name-property.js`. The latter two were misfiled under "Function source text and inferred names" — each builds a key set ending in `[/a/]` and reads it back, so the computed-key bug broke them long before any inferred-name assertion ran. No NamedEvaluation work was needed.

Refs #3021.
