### PR TITLE
Stop error messages from running user JavaScript

### DIFF
--- a/Jint.Tests.PublicInterface/ReferenceResolverAssignmentTests.cs
+++ b/Jint.Tests.PublicInterface/ReferenceResolverAssignmentTests.cs
@@ -144,7 +144,7 @@ public class ReferenceResolverAssignmentTests
 
         Invoking(() => engine.Execute("'use strict'; o.r = 2;"))
             .Should().Throw<JavaScriptException>()
-            .Which.Message.Should().Be("Cannot assign to read only property 'r' of [object Object]");
+            .Which.Message.Should().Be("Cannot assign to read only property 'r' of Object");
 
         // sloppy mode silently ignores the write
         engine.Execute("o.r = 3;");

--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -132,17 +132,14 @@
     "staging/sm/String/matchAll.js",
     "staging/sm/String/replace-updates-global-lastIndex.js",
 
-    // Set methods (new Set.prototype union/intersection/difference/... ) observe the set-like
-    // argument in a strictly specified order -- GetSetRecord reads size, then has, then keys, and
-    // coerces size exactly once. Jint's order and coercion count differ. Removed by implementing
-    // GetSetRecord to the letter.
-    "staging/sm/Set/difference.js",
+    // Set.prototype.intersection / .isSubsetOf let the *receiver* be mutated while they traverse it
+    // (a set-like's has/keys callback calling this.delete(v) or this.clear()), and the spec models
+    // that with the [[SetData]] tombstone: a deleted entry becomes EMPTY in place rather than being
+    // removed, so the index-based traversal keeps its position and still visits the right elements.
+    // Jint's JsSet compacts on delete, so the traversal skips or repeats entries. Removed by giving
+    // the ordered set a tombstone representation.
     "staging/sm/Set/intersection.js",
-    "staging/sm/Set/is-disjoint-from.js",
     "staging/sm/Set/is-subset-of.js",
-    "staging/sm/Set/is-superset-of.js",
-    "staging/sm/Set/symmetric-difference.js",
-    "staging/sm/Set/union.js",
 
     // Iterator protocol: IteratorClose is not invoked (or not invoked at the right point) on the
     // abrupt paths of Array.from, the Map/Set constructors, for-of and array destructuring, and the
@@ -169,12 +166,11 @@
     "staging/sm/Reflect/has.js",
 
     // Date parsing and clipping: the implementation-defined fallback parser accepts (and rejects)
-    // different strings than SpiderMonkey's, two-digit years map differently, TimeClip does not
-    // reject every out-of-range value, and Symbol.toPrimitive throws a non-object.
+    // different strings than SpiderMonkey's, two-digit years map differently, and TimeClip does not
+    // reject every out-of-range value.
     "staging/sm/Date/non-iso.js",
     "staging/sm/Date/timeclip.js",
     "staging/sm/Date/toISOString.js",
-    "staging/sm/Date/toPrimitive.js",
     "staging/sm/Date/two-digit-years.js",
 
     // String case mapping is done with the BCL's culture-aware tables rather than the Unicode

--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -3007,7 +3007,7 @@ x.test = {
         var engine = new Engine();
         const string source = "'use strict'; var x = () => { delete Boolean.prototype; }; x();";
         var ex = Invoking(() => engine.Evaluate(source)).Should().ThrowExactly<JavaScriptException>().Which;
-        ex.Message.Should().Be("Cannot delete property 'prototype' of function Boolean() { [native code] }");
+        ex.Message.Should().Be("Cannot delete property 'prototype' of Object");
 
         const string source2 = "'use strict'; delete foobar;";
         ex = Invoking(() => engine.Evaluate(source2)).Should().ThrowExactly<JavaScriptException>().Which;

--- a/Jint.Tests/Runtime/ErrorMessageSideEffectTests.cs
+++ b/Jint.Tests/Runtime/ErrorMessageSideEffectTests.cs
@@ -1,0 +1,307 @@
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Building an error message must never run user JavaScript. <c>ObjectInstance.ToString()</c> is the full
+/// JavaScript ToString algorithm (<c>ToPrimitive</c> → <c>Get(@@toPrimitive)</c> → <c>Get("toString")</c> →
+/// <b>call it</b> → <c>Get(@@toStringTag)</c>), so interpolating a <see cref="Jint.Native.JsValue"/> into a
+/// <c>Throw.*</c> message is observable twice over: the extra <c>[[Get]]</c> operations show up in a Proxy
+/// log, and a user <c>toString</c> that throws replaces the intended TypeError with whatever it threw.
+/// These tests pin that error messages are built from side-effect-free renderings only.
+/// </summary>
+public class ErrorMessageSideEffectTests
+{
+    [Fact]
+    public void SetLikeWithNonCallableHasDoesNotRunUserCodeWhileBuildingTheError()
+    {
+        var engine = new Engine();
+
+        engine.Execute("""
+            var log = [];
+            var target = {
+                size: 0,
+                has: {},
+                keys: function () { throw new Error('keys must not be reached'); }
+            };
+            var setLike = new Proxy(target, {
+                get: function (t, pk, r) {
+                    log.push(typeof pk === 'symbol' ? 'symbol:' + String(pk.description) : pk);
+                    return Reflect.get(t, pk, r);
+                }
+            });
+            var threw = null;
+            try { new Set().union(setLike); } catch (e) { threw = e; }
+            """);
+
+        engine.Evaluate("threw instanceof TypeError").AsBoolean().Should().BeTrue();
+
+        // GetSetRecord reads exactly size, has, keys and then stops: the failure is that `has` is not
+        // callable, and rendering the receiver into that message must add nothing to the log.
+        engine.Evaluate("log.join(',')").AsString().Should().Be("size,has");
+    }
+
+    [Fact]
+    public void SetLikeWithNonCallableKeysDoesNotRunUserCodeWhileBuildingTheError()
+    {
+        var engine = new Engine();
+
+        engine.Execute("""
+            var log = [];
+            var target = { size: 0, has: function () {}, keys: {} };
+            var setLike = new Proxy(target, {
+                get: function (t, pk, r) {
+                    log.push(typeof pk === 'symbol' ? 'symbol:' + String(pk.description) : pk);
+                    return Reflect.get(t, pk, r);
+                }
+            });
+            var threw = null;
+            try { new Set().union(setLike); } catch (e) { threw = e; }
+            """);
+
+        engine.Evaluate("threw instanceof TypeError").AsBoolean().Should().BeTrue();
+        engine.Evaluate("log.join(',')").AsString().Should().Be("size,has,keys");
+    }
+
+    [Fact]
+    public void SetLikeWhoseToStringThrowsStillReportsTheTypeError()
+    {
+        var engine = new Engine();
+
+        // A user toString that throws must not be able to replace the TypeError with its own exception.
+        var value = engine.Evaluate("""
+            var setLike = {
+                size: 0,
+                has: {},
+                keys: function () {},
+                toString: function () { throw new Error('boom'); }
+            };
+            try { new Set().union(setLike); return 'no throw'; }
+            catch (e) { return e.constructor.name + ':' + e.message; }
+            """);
+
+        value.AsString().Should().StartWith("TypeError:");
+    }
+
+    [Fact]
+    public void DateToPrimitiveWithAThrowingToStringHintReportsTypeError()
+    {
+        var engine = new Engine();
+
+        var value = engine.Evaluate("""
+            var hint = { toString: function () { throw new Error('boom'); } };
+            try { Date.prototype[Symbol.toPrimitive].call(new Date(), hint); return 'no throw'; }
+            catch (e) { return e.constructor.name + ':' + e.message; }
+            """);
+
+        value.AsString().Should().StartWith("TypeError:");
+    }
+
+    [Fact]
+    public void DateToPrimitiveWithANonStringHintDoesNotCoerceIt()
+    {
+        var engine = new Engine();
+
+        // An array hint is not a string, so it is rejected; coercing it for the message would call
+        // Array.prototype.join and hide the fact that the argument was never a valid hint.
+        var value = engine.Evaluate("""
+            var log = [];
+            var hint = { toString: function () { log.push('toString'); return 'number'; } };
+            try { Date.prototype[Symbol.toPrimitive].call(new Date(), hint); } catch (e) { }
+            return log.length;
+            """);
+
+        value.AsNumber().Should().Be(0);
+    }
+
+    /// <summary>
+    /// The same hazard reached far past the two sites that first exposed it. Every row here threw the
+    /// user's own <c>Error</c> instead of the engine's <c>TypeError</c> before the sweep.
+    /// </summary>
+    [Theory]
+    [InlineData("(function () { return victim; })()();", "callee that is not a reference")]
+    [InlineData("[1].flatMap(victim);", "Array.prototype.flatMap mapper")]
+    [InlineData("Symbol.keyFor(victim);", "Symbol.keyFor argument")]
+    [InlineData("var a = [1]; a.constructor = {}; a.constructor[Symbol.species] = victim; a.filter(function () { return true; });", "ArraySpeciesCreate")]
+    [InlineData("Reflect.construct(victim, []);", "Reflect.construct target")]
+    [InlineData("Reflect.construct(function () {}, [], victim);", "Reflect.construct newTarget")]
+    [InlineData("var t = new Int8Array(4); t.constructor = {}; t.constructor[Symbol.species] = victim; t.slice(0, 1);", "TypedArray species")]
+    [InlineData("Object.getOwnPropertyDescriptor(Map.prototype, 'size').get.call(victim);", "Map.prototype.size brand check")]
+    [InlineData("Object.getOwnPropertyDescriptor(Set.prototype, 'size').get.call(victim);", "Set.prototype.size brand check")]
+    [InlineData("Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, 'byteLength').get.call(victim);", "ArrayBuffer.prototype.byteLength brand check")]
+    [InlineData("ArrayBuffer.prototype.slice.call(victim);", "ArrayBuffer.prototype.slice brand check")]
+    [InlineData("Object.getOwnPropertyDescriptor(DataView.prototype, 'buffer').get.call(victim);", "DataView.prototype.buffer brand check")]
+    [InlineData("DataView.prototype.getInt8.call(victim, 0);", "DataView.prototype.getInt8 brand check")]
+    [InlineData("Object.getOwnPropertyDescriptor(Int8Array.prototype.__proto__, 'byteLength').get.call(victim);", "TypedArray.prototype.byteLength brand check")]
+    [InlineData("RegExp.prototype.exec.call(victim, 'x');", "RegExp.prototype.exec brand check")]
+    [InlineData("new ShadowRealm().evaluate(victim);", "ShadowRealm.prototype.evaluate source text")]
+    [InlineData("Object.defineProperty({}, 'p', { get: victim });", "property descriptor getter")]
+    [InlineData("Object.defineProperty({}, 'p', { set: victim });", "property descriptor setter")]
+    [InlineData("new Promise(victim);", "Promise resolver")]
+    [InlineData("var it = {}; it[Symbol.iterator] = function () { return { next: function () { return Object.assign(Object.create(victim), { value: {}, done: false }); } }; }; Math.sumPrecise(it);", "Math.sumPrecise iterator result")]
+    [InlineData("victim in 1;", "'in' operator left operand")]
+    public void BuildingTheErrorNeverRunsAUserToString(string script, string _)
+    {
+        var engine = new Engine();
+
+        var result = engine.Evaluate($$"""
+            var victim = { toString: function () { throw new Error('BOOM'); } };
+            try { {{script}} return 'no throw'; }
+            catch (e) { return (e && e.constructor ? e.constructor.name : typeof e) + ':' + (e && e.message); }
+            """);
+
+        // Any engine-raised error type is fine; what must never happen is the user's own Error escaping.
+        result.AsString().Should().NotBe("Error:BOOM");
+    }
+
+    /// <summary>
+    /// The strict-mode rows live outside the theory above because <c>'use strict'</c> is only a directive
+    /// prologue at the top of a script or function body — inside the theory's <c>try</c> block it is an
+    /// ordinary expression statement, the write is silently ignored in sloppy mode and the test would
+    /// pass without ever reaching the message.
+    /// </summary>
+    [Theory]
+    [InlineData("Object.defineProperty(victim, 'p', { value: 1, writable: false }); victim.p = 2;")]
+    [InlineData("Object.defineProperty(victim, 'p', { value: 1, configurable: false }); delete victim.p;")]
+    public void AStrictModeRefusalDoesNotRenderTheBaseObject(string script)
+    {
+        var engine = new Engine();
+
+        var result = engine.Evaluate($$"""
+            'use strict';
+            var victim = { toString: function () { throw new Error('BOOM'); } };
+            var outcome;
+            try { {{script}} outcome = 'no throw'; }
+            catch (e) { outcome = (e && e.constructor ? e.constructor.name : typeof e) + ':' + (e && e.message); }
+            outcome;
+            """);
+
+        result.AsString().Should().NotBe("Error:BOOM");
+    }
+
+    [Fact]
+    public void AFailedStrictAssignmentCoercesTheComputedKeyExactlyOnce()
+    {
+        var engine = new Engine();
+
+        // The message used to quote the pre-coercion referenced name, so ToPropertyKey ran once for
+        // the assignment and the interpolation ran the user toString a second time.
+        var value = engine.Evaluate("""
+            'use strict';
+            var count = 0;
+            var key = { toString: function () { count++; return 'p'; } };
+            var frozen = Object.freeze({ p: 1 });
+            try { frozen[key] = 2; } catch (e) { }
+            count;
+            """);
+
+        value.AsNumber().Should().Be(1);
+    }
+
+    /// <summary>
+    /// A forward guard rather than a regression test: today <c>Object.defineProperty</c> routes the new
+    /// descriptor into ordinary property storage and leaves <c>Function._nameDescriptor</c> holding the
+    /// original <see cref="Jint.Native.JsString"/>, so the message never reached the tampered value and
+    /// this passes both before and after the fix. It is kept because the message now reads the field
+    /// directly, and nothing else would notice if a future change let a tampered <c>name</c> land there.
+    /// </summary>
+    [Fact]
+    public void ConstructorRequiresNewDoesNotCoerceATamperedNameProperty()
+    {
+        var engine = new Engine();
+
+        // `name` is configurable on every built-in constructor, so a script may replace it with an
+        // object whose toString throws.
+        var value = engine.Evaluate("""
+            Object.defineProperty(Map, 'name', { value: { toString: function () { throw new Error('BOOM'); } } });
+            try { Map(); return 'no throw'; }
+            catch (e) { return (e && e.constructor ? e.constructor.name : typeof e) + ':' + (e && e.message); }
+            """);
+
+        value.AsString().Should().StartWith("TypeError:");
+    }
+
+    [Fact]
+    public void InstanceOfWithASymbolPrototypeReportsTheIntendedError()
+    {
+        var engine = new Engine();
+
+        // The prototype is proven non-object here, but TypeConverter.ToString throws for a Symbol,
+        // which used to replace the intended message with "Cannot convert a Symbol value to a string".
+        var value = engine.Evaluate("""
+            function f() {}
+            f.prototype = Symbol('tag');
+            try { ({}) instanceof f; return 'no throw'; } catch (e) { return e.message; }
+            """);
+
+        value.AsString().Should().Contain("non-object prototype");
+    }
+
+    /// <summary>
+    /// A guard against over-correcting this bug class. The base of a nullish read is proven
+    /// <c>undefined</c> or <c>null</c> by the caller, so interpolating it runs nothing — and the wording
+    /// it produces is the single most recognizable error message in JavaScript. Rendering the value's
+    /// <c>Type</c> instead would silently turn it into "... of Undefined" for every embedder.
+    /// </summary>
+    [Theory]
+    [InlineData("var u; typeof u.x;", "Cannot read property 'x' of undefined")]
+    [InlineData("var n = null; typeof n.x;", "Cannot read property 'x' of null")]
+    public void ANullishReadKeepsTheLowercaseLiteralWording(string script, string expected)
+    {
+        var engine = new Engine();
+
+        var value = engine.Evaluate($$"""
+            try { {{script}} return 'no throw'; } catch (e) { return e.message; }
+            """);
+
+        value.AsString().Should().Be(expected);
+    }
+
+    /// <summary>
+    /// Safety must not cost the diagnostic. Where the offending <i>value</i> is what the reader needs,
+    /// the message names it — rendering its type instead would leave "search for 'String' in ...".
+    /// </summary>
+    [Theory]
+    [InlineData("'foo' in 1;", "Cannot use 'in' operator to search for 'foo' in 1")]
+    [InlineData("Symbol('s') in 1;", "Cannot use 'in' operator to search for 'Symbol(s)' in 1")]
+    [InlineData("Symbol.keyFor(5);", "5 is not a symbol")]
+    [InlineData("(function () { return 5; })()();", "5 is not a function")]
+    public void ASafeMessageStillNamesTheOffendingValue(string script, string expected)
+    {
+        var engine = new Engine();
+
+        var value = engine.Evaluate($$"""
+            try { {{script}} return 'no throw'; } catch (e) { return e.message; }
+            """);
+
+        value.AsString().Should().Be(expected);
+    }
+
+    [Fact]
+    public void ASymbolKeyOnANullishBaseReportsTheReadError()
+    {
+        var engine = new Engine();
+
+        // A Symbol *is* primitive, so the "only render a primitive key" guard let it through to
+        // TypeConverter.ToString, which throws for symbols — replacing this TypeError with
+        // "Cannot convert a Symbol value to a string".
+        var value = engine.Evaluate("""
+            var u;
+            try { u[Symbol.iterator]; return 'no throw'; } catch (e) { return e.message; }
+            """);
+
+        value.AsString().Should().Be("Cannot read properties of undefined (reading 'Symbol(Symbol.iterator)')");
+    }
+
+    [Fact]
+    public void DateToPrimitiveStillNamesAnInvalidStringHint()
+    {
+        var engine = new Engine();
+
+        // A hint that *is* a string is provably primitive, so it stays in the message verbatim.
+        var value = engine.Evaluate("""
+            try { Date.prototype[Symbol.toPrimitive].call(new Date(), 'boolean'); return 'no throw'; }
+            catch (e) { return e.message; }
+            """);
+
+        value.AsString().Should().Contain("boolean");
+    }
+}

--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -4359,13 +4359,13 @@ try {
         engineNoWrite.SetValue("data", dictionary);
 
         var ex1 = Invoking(() => engineNoWrite.Evaluate("data['a'] = 42")).Should().ThrowExactly<JavaScriptException>().Which;
-        ex1.Message.Should().Be("Cannot assign to read only property 'a' of System.Collections.Generic.Dictionary`2[System.String,System.Int32]");
+        ex1.Message.Should().Be("Cannot assign to read only property 'a' of Object");
 
         // no changes
         engineNoWrite.Evaluate("data['a'] === 1").AsBoolean().Should().BeTrue();
 
         var ex2 = Invoking(() => engineNoWrite.Execute("delete data['a'];")).Should().ThrowExactly<JavaScriptException>().Which;
-        ex2.Message.Should().Be("Cannot delete property 'a' of System.Collections.Generic.Dictionary`2[System.String,System.Int32]");
+        ex2.Message.Should().Be("Cannot delete property 'a' of Object");
     }
 
     public record RecordTestClass(object Value = null);

--- a/Jint.Tests/Runtime/MapSetSizeAccessorTests.cs
+++ b/Jint.Tests/Runtime/MapSetSizeAccessorTests.cs
@@ -58,7 +58,7 @@ public class MapSetSizeAccessorTests
         {
             Invoking(() => engine.Evaluate($"get.call({receiver});"))
                 .Should().ThrowExactly<JavaScriptException>(receiver)
-                .WithMessage($"Method {kind}.prototype.get size called on incompatible receiver *");
+                .WithMessage($"Method {kind}.prototype.get size called on incompatible receiver");
         }
     }
 
@@ -168,7 +168,7 @@ public class MapSetSizeAccessorTests
         // reached the getter and answered 3 instead.
         Invoking(() => new Engine().Evaluate($"new Proxy({create}, {{}}).size;"))
             .Should().ThrowExactly<JavaScriptException>()
-            .WithMessage($"Method {kind}.prototype.get size called on incompatible receiver *");
+            .WithMessage($"Method {kind}.prototype.get size called on incompatible receiver");
     }
 
     [Theory]

--- a/Jint.Tests/Runtime/ProxyTests.cs
+++ b/Jint.Tests/Runtime/ProxyTests.cs
@@ -459,7 +459,7 @@ public class ProxyTests
             let p = new Proxy(o, handler);
         """);
         var ex = Invoking(() => _engine.Evaluate("p.value")).Should().ThrowExactly<JavaScriptException>().Which;
-        AssertJsTypeError(_engine, ex, "'get' on proxy: property 'value' is a read-only and non-configurable data property on the proxy target but the proxy did not return its actual value (expected '42' but got '32')");
+        AssertJsTypeError(_engine, ex, "'get' on proxy: property 'value' is a read-only and non-configurable data property on the proxy target but the proxy did not return its actual value");
     }
 
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/get#invariants
@@ -483,7 +483,7 @@ public class ProxyTests
             let p = new Proxy(o, handler);
         """);
         var ex = Invoking(() => _engine.Evaluate("p.value")).Should().ThrowExactly<JavaScriptException>().Which;
-        AssertJsTypeError(_engine, ex, "'get' on proxy: property 'value' is a non-configurable accessor property on the proxy target and does not have a getter function, but the trap did not return 'undefined' (got '32')");
+        AssertJsTypeError(_engine, ex, "'get' on proxy: property 'value' is a non-configurable accessor property on the proxy target and does not have a getter function, but the trap did not return 'undefined'");
     }
 
     private const string ScriptProxyHandlerSetInvariantsDataPropertyImmutable = """
@@ -556,7 +556,7 @@ public class ProxyTests
             p.value = 42;
         """)).Should().ThrowExactly<JavaScriptException>().Which;
         // V8: "'set' on proxy: trap returned falsish for property 'value'",
-        AssertJsTypeError(_engine, ex, "Cannot assign to read only property 'value' of [object Object]");
+        AssertJsTypeError(_engine, ex, "Cannot assign to read only property 'value' of Object");
     }
 
     [Fact]

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1481,25 +1481,12 @@ public sealed partial class Engine : IDisposable
 
     private void ThrowPropertyNotFound(JsValue property, JsValue baseValue)
     {
-        // Avoid calling ToString() on the property as it may have a custom toString that throws
-        string propertyName;
-        if (property.IsSymbol())
-        {
-            propertyName = "[Symbol]";
-        }
-        else if (property.IsString())
-        {
-            propertyName = property.ToString();
-        }
-        else if (property.IsNumber())
-        {
-            propertyName = Runtime.TypeConverter.ToString(property);
-        }
-        else
-        {
-            propertyName = "unknown";
-        }
-        Throw.TypeError(Realm, $"Cannot read property '{propertyName}' of {baseValue}");
+        // The property may carry a custom toString that throws, so it goes through the safe renderer.
+        // baseValue does not: the only caller guards this with baseValue.IsNullOrUndefined(), so it is
+        // always JsUndefined or JsNull, whose ToString() is a constant. Interpolating it keeps the
+        // message the one every JavaScript developer recognizes -- "... of undefined", not "... of
+        // Undefined", which is what rendering the type would produce.
+        Throw.TypeError(Realm, $"Cannot read property '{Throw.SafeToDisplayString(property)}' of {baseValue}");
     }
 
     private bool TryHandleStringValue(JsValue property, JsString s, ref ObjectInstance? o, out JsValue jsValue)
@@ -1576,7 +1563,10 @@ public sealed partial class Engine : IDisposable
             var succeeded = baseObject.Set(reference.ReferencedName, value, reference.ThisValue);
             if (!succeeded && reference.Strict)
             {
-                Throw.TypeError(Realm, $"Cannot assign to read only property '{property}' of {baseObject}");
+                // reference.ReferencedName is the already-coerced key; the `property` local still holds the
+                // pre-coercion value, so quoting it would run a user toString a second time. The base is
+                // rendered as its type because rendering the object itself would run one too.
+                Throw.TypeError(Realm, $"Cannot assign to read only property '{reference.ReferencedName}' of {baseObject.Type}");
             }
         }
         else
@@ -2614,7 +2604,7 @@ public sealed partial class Engine : IDisposable
         {
             if (!callable.IsCallable)
             {
-                Throw.ArgumentException(callable + " is not callable");
+                Throw.ArgumentException($"{callable.Type} is not callable");
             }
 
             return Call((ICallable) callable, thisObject, arguments, null);
@@ -2658,7 +2648,7 @@ public sealed partial class Engine : IDisposable
         {
             if (!constructor.IsConstructor)
             {
-                Throw.ArgumentException(constructor + " is not a constructor");
+                Throw.ArgumentException($"{constructor.Type} is not a constructor");
             }
 
             return Construct(constructor, arguments, constructor, null);

--- a/Jint/JsValueExtensions.cs
+++ b/Jint/JsValueExtensions.cs
@@ -678,7 +678,10 @@ public static class JsValueExtensions
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static JsValue ThrowNotObject(JsValue value)
     {
-        Throw.ArgumentException(value + " is not object");
+        // Every caller reaches here from a failed `value is ObjectInstance`, so value is a primitive and
+        // rendering it runs nothing; the safe renderer states that rather than relying on the reader to
+        // re-derive it. Which value it was is the whole point of a host-facing ArgumentException.
+        Throw.ArgumentException($"{Throw.SafeToDisplayString(value)} is not object");
         return null;
     }
 

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -199,7 +199,7 @@ public sealed partial class ArrayConstructor : Constructor
         {
             if (mapfn is not ICallable mapCallable)
             {
-                Throw.TypeError(_realm, $"{mapfn} is not a function");
+                Throw.TypeError(_realm, "mapfn is not a function");
                 return;
             }
             callable = mapCallable;
@@ -1058,7 +1058,9 @@ public sealed partial class ArrayConstructor : Constructor
 
         if (!c.IsConstructor)
         {
-            Throw.TypeError(_realm, $"{c} is not a constructor");
+            // Not interpolating c: rendering a JsValue runs the full JavaScript ToString algorithm,
+            // so a user toString would be called (and could throw) while the error is being built.
+            Throw.TypeError(_realm, "The constructor's [Symbol.species] property is not a constructor");
         }
 
         return ((IConstructor) c).Construct([JsNumber.Create(length)], c);

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -688,7 +688,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
 
         if (!mapperFunction.IsCallable)
         {
-            Throw.TypeError(_realm, $"{mapperFunction} is not a function");
+            Throw.TypeError(_realm, "mapperFunction is not a function");
         }
 
         if (thisObject is JsArray { CanUseFastAccess: true } jsArray

--- a/Jint/Native/ArrayBuffer/ArrayBufferConstructor.cs
+++ b/Jint/Native/ArrayBuffer/ArrayBufferConstructor.cs
@@ -54,7 +54,7 @@ public sealed partial class ArrayBufferConstructor : Constructor
     {
         if (newTarget.IsUndefined())
         {
-            Throw.TypeError(_realm, $"Constructor {_nameDescriptor?.Value} requires 'new'");
+            Throw.TypeError(_realm, $"Constructor {GetOwnFunctionNameForMessage()} requires 'new'");
         }
 
         var length = arguments.At(0);

--- a/Jint/Native/ArrayBuffer/ArrayBufferPrototype.cs
+++ b/Jint/Native/ArrayBuffer/ArrayBufferPrototype.cs
@@ -38,7 +38,7 @@ internal sealed partial class ArrayBufferPrototype : Prototype
         var o = thisObject as JsArrayBuffer;
         if (o is null || o.IsSharedArrayBuffer)
         {
-            Throw.TypeError(_realm, "Method ArrayBuffer.prototype.detached called on incompatible receiver " + thisObject);
+            Throw.TypeError(_realm, "Method ArrayBuffer.prototype.detached called on incompatible receiver");
         }
 
         return o.IsDetachedBuffer;
@@ -53,7 +53,7 @@ internal sealed partial class ArrayBufferPrototype : Prototype
         var o = thisObject as JsArrayBuffer;
         if (o is null || o.IsSharedArrayBuffer)
         {
-            Throw.TypeError(_realm, "Method ArrayBuffer.prototype.immutable called on incompatible receiver " + thisObject);
+            Throw.TypeError(_realm, "Method ArrayBuffer.prototype.immutable called on incompatible receiver");
         }
 
         return o.IsImmutableBuffer;
@@ -68,7 +68,7 @@ internal sealed partial class ArrayBufferPrototype : Prototype
         var o = thisObject as JsArrayBuffer;
         if (o is null || o.IsSharedArrayBuffer)
         {
-            Throw.TypeError(_realm, "Method ArrayBuffer.prototype.maxByteLength called on incompatible receiver " + thisObject);
+            Throw.TypeError(_realm, "Method ArrayBuffer.prototype.maxByteLength called on incompatible receiver");
         }
 
         if (o.IsDetachedBuffer)
@@ -92,7 +92,7 @@ internal sealed partial class ArrayBufferPrototype : Prototype
         var o = thisObject as JsArrayBuffer;
         if (o is null || o.IsSharedArrayBuffer)
         {
-            Throw.TypeError(_realm, "Method ArrayBuffer.prototype.resizable called on incompatible receiver " + thisObject);
+            Throw.TypeError(_realm, "Method ArrayBuffer.prototype.resizable called on incompatible receiver");
         }
 
         return !o.IsFixedLengthArrayBuffer;
@@ -108,7 +108,7 @@ internal sealed partial class ArrayBufferPrototype : Prototype
         var o = thisObject as JsArrayBuffer;
         if (o is null || o.IsSharedArrayBuffer)
         {
-            Throw.TypeError(_realm, "Method ArrayBuffer.prototype.resize called on incompatible receiver " + thisObject);
+            Throw.TypeError(_realm, "Method ArrayBuffer.prototype.resize called on incompatible receiver");
         }
 
         // Step 2: Perform ? RequireInternalSlot(O, [[ArrayBufferMaxByteLength]]).
@@ -136,7 +136,7 @@ internal sealed partial class ArrayBufferPrototype : Prototype
         var o = thisObject as JsArrayBuffer;
         if (o is null || o.IsSharedArrayBuffer)
         {
-            Throw.TypeError(_realm, "Method ArrayBuffer.prototype.byteLength called on incompatible receiver " + thisObject);
+            Throw.TypeError(_realm, "Method ArrayBuffer.prototype.byteLength called on incompatible receiver");
         }
 
         if (o.IsDetachedBuffer)
@@ -156,7 +156,7 @@ internal sealed partial class ArrayBufferPrototype : Prototype
         var o = thisObject as JsArrayBuffer;
         if (o is null || o.IsSharedArrayBuffer)
         {
-            Throw.TypeError(_realm, "Method ArrayBuffer.prototype.slice called on incompatible receiver " + thisObject);
+            Throw.TypeError(_realm, "Method ArrayBuffer.prototype.slice called on incompatible receiver");
         }
 
         o.AssertNotDetached();
@@ -277,7 +277,7 @@ internal sealed partial class ArrayBufferPrototype : Prototype
         var o = thisObject as JsArrayBuffer;
         if (o is null || o.IsSharedArrayBuffer)
         {
-            Throw.TypeError(_realm, "Method ArrayBuffer.prototype.sliceToImmutable called on incompatible receiver " + thisObject);
+            Throw.TypeError(_realm, "Method ArrayBuffer.prototype.sliceToImmutable called on incompatible receiver");
         }
 
         // 4. If IsDetachedBuffer(O) is true, throw a TypeError exception.
@@ -335,7 +335,7 @@ internal sealed partial class ArrayBufferPrototype : Prototype
     {
         if (o is not JsArrayBuffer arrayBuffer || arrayBuffer.IsSharedArrayBuffer)
         {
-            Throw.TypeError(_realm, "Method ArrayBuffer.prototype.ArrayBufferCopyAndDetach called on incompatible receiver " + o);
+            Throw.TypeError(_realm, "Method ArrayBuffer.prototype.ArrayBufferCopyAndDetach called on incompatible receiver");
             return Undefined;
         }
 

--- a/Jint/Native/Constructor.cs
+++ b/Jint/Native/Constructor.cs
@@ -15,7 +15,7 @@ public abstract class Constructor : Function.Function, IConstructor
 
     protected internal override JsValue Call(JsValue thisObject, JsCallArguments arguments)
     {
-        Throw.TypeError(_realm, $"Constructor {_nameDescriptor?.Value} requires 'new'");
+        Throw.TypeError(_realm, $"Constructor {GetOwnFunctionNameForMessage()} requires 'new'");
         return null;
     }
 

--- a/Jint/Native/DataView/DataViewConstructor.cs
+++ b/Jint/Native/DataView/DataViewConstructor.cs
@@ -31,7 +31,7 @@ internal sealed class DataViewConstructor : Constructor
     {
         if (newTarget.IsUndefined())
         {
-            Throw.TypeError(_realm, $"Constructor {_nameDescriptor?.Value} requires 'new'");
+            Throw.TypeError(_realm, $"Constructor {GetOwnFunctionNameForMessage()} requires 'new'");
         }
 
         var buffer = arguments.At(0) as JsArrayBuffer;

--- a/Jint/Native/DataView/DataViewPrototype.cs
+++ b/Jint/Native/DataView/DataViewPrototype.cs
@@ -43,7 +43,7 @@ internal sealed partial class DataViewPrototype : Prototype
         var o = thisObject as JsDataView;
         if (o is null)
         {
-            Throw.TypeError(_realm, "Method get DataView.prototype.buffer called on incompatible receiver " + thisObject);
+            Throw.TypeError(_realm, "Method get DataView.prototype.buffer called on incompatible receiver");
         }
 
         return o._viewedArrayBuffer!;
@@ -58,7 +58,7 @@ internal sealed partial class DataViewPrototype : Prototype
         var o = thisObject as JsDataView;
         if (o is null)
         {
-            Throw.TypeError(_realm, "Method get DataView.prototype.byteLength called on incompatible receiver " + thisObject);
+            Throw.TypeError(_realm, "Method get DataView.prototype.byteLength called on incompatible receiver");
         }
 
         var viewRecord = MakeDataViewWithBufferWitnessRecord(o, ArrayBufferOrder.SeqCst);
@@ -82,7 +82,7 @@ internal sealed partial class DataViewPrototype : Prototype
         var o = thisObject as JsDataView;
         if (o is null)
         {
-            Throw.TypeError(_realm, "Method get DataView.prototype.byteOffset called on incompatible receiver " + thisObject);
+            Throw.TypeError(_realm, "Method get DataView.prototype.byteOffset called on incompatible receiver");
         }
 
         var viewRecord = MakeDataViewWithBufferWitnessRecord(o, ArrayBufferOrder.SeqCst);
@@ -241,7 +241,7 @@ internal sealed partial class DataViewPrototype : Prototype
     {
         if (view is not JsDataView dataView)
         {
-            Throw.TypeError(_realm, "Method called on incompatible receiver " + view);
+            Throw.TypeError(_realm, "Method called on incompatible receiver");
             return Undefined;
         }
 
@@ -364,7 +364,7 @@ internal sealed partial class DataViewPrototype : Prototype
         var dataView = view as JsDataView;
         if (dataView is null)
         {
-            Throw.TypeError(_realm, "Method called on incompatible receiver " + view);
+            Throw.TypeError(_realm, "Method called on incompatible receiver");
         }
 
         var buffer = dataView._viewedArrayBuffer!;

--- a/Jint/Native/Date/DatePrototype.cs
+++ b/Jint/Native/Date/DatePrototype.cs
@@ -67,7 +67,10 @@ internal sealed partial class DatePrototype : Prototype
         var hint = arguments.At(0);
         if (!hint.IsString())
         {
-            Throw.TypeError(_realm, $"Invalid hint: {hint}");
+            // Render the type rather than the value: hint is not a string here, so interpolating it
+            // would run the full JavaScript ToString algorithm on it (a user toString would be called,
+            // and one that throws would replace this TypeError with its own exception).
+            Throw.TypeError(_realm, $"Invalid hint: {hint.Type}");
         }
 
         var hintString = hint.ToString();
@@ -82,7 +85,10 @@ internal sealed partial class DatePrototype : Prototype
         }
         else
         {
-            Throw.TypeError(_realm, $"Invalid hint: {hint}");
+            // hintString, not hint: the guard above proves hint is a JsString, but interpolating the
+            // JsValue would leave a ToString() call on a JsValue-typed expression for a later reader
+            // to have to re-prove safe. The rendering is identical.
+            Throw.TypeError(_realm, $"Invalid hint: {hintString}");
         }
 
         return TypeConverter.OrdinaryToPrimitive(oi, tryFirst);

--- a/Jint/Native/Disposable/AsyncDisposableStackConstructor.cs
+++ b/Jint/Native/Disposable/AsyncDisposableStackConstructor.cs
@@ -21,7 +21,7 @@ internal sealed class AsyncDisposableStackConstructor : Constructor
     {
         if (newTarget.IsUndefined())
         {
-            Throw.TypeError(_realm, $"Constructor {_nameDescriptor?.Value} requires 'new'");
+            Throw.TypeError(_realm, $"Constructor {GetOwnFunctionNameForMessage()} requires 'new'");
         }
 
         var stack = OrdinaryCreateFromConstructor(

--- a/Jint/Native/Disposable/DisposableStackConstructor.cs
+++ b/Jint/Native/Disposable/DisposableStackConstructor.cs
@@ -21,7 +21,7 @@ internal sealed class DisposableStackConstructor : Constructor
     {
         if (newTarget.IsUndefined())
         {
-            Throw.TypeError(_realm, $"Constructor {_nameDescriptor?.Value} requires 'new'");
+            Throw.TypeError(_realm, $"Constructor {GetOwnFunctionNameForMessage()} requires 'new'");
         }
 
         var stack = OrdinaryCreateFromConstructor(

--- a/Jint/Native/FinalizationRegistry/FinalizationRegistryConstructor.cs
+++ b/Jint/Native/FinalizationRegistry/FinalizationRegistryConstructor.cs
@@ -35,7 +35,7 @@ internal sealed class FinalizationRegistryConstructor : Constructor
     {
         if (newTarget.IsUndefined())
         {
-            Throw.TypeError(_realm, $"Constructor {_nameDescriptor?.Value} requires 'new'");
+            Throw.TypeError(_realm, $"Constructor {GetOwnFunctionNameForMessage()} requires 'new'");
         }
 
         var cleanupCallback = arguments.At(0);

--- a/Jint/Native/Function/BindFunction.cs
+++ b/Jint/Native/Function/BindFunction.cs
@@ -67,7 +67,7 @@ public sealed class BindFunction : ObjectInstance, IConstructor, ICallable
         var target = BoundTargetFunction as IConstructor;
         if (target is null)
         {
-            Throw.TypeError(_realm, $"{BoundTargetFunction} is not a constructor");
+            Throw.TypeError(_realm, "The bound target function is not a constructor");
         }
 
         var args = CreateArguments(arguments);

--- a/Jint/Native/Function/Function.cs
+++ b/Jint/Native/Function/Function.cs
@@ -651,6 +651,22 @@ public abstract partial class Function : ObjectInstance, ICallable
     }
 
     /// <summary>
+    /// The function's own <c>name</c> for an error message, rendered without ever running script.
+    /// <para>
+    /// <c>name</c> is configurable on every built-in, so a script can replace it with an object whose
+    /// <c>toString</c> throws. <see cref="GetOwnFunctionName"/> coerces through <c>TypeConverter.ToString</c>
+    /// and would let that object hijack the error being built — an extra observable call, and a thrown
+    /// value replacing the <c>TypeError</c> the caller meant to raise. So only an actual string is quoted
+    /// here; anything else falls back to the CLR type's name, which no script can influence. Reading
+    /// <see cref="PropertyDescriptor.Value"/> touches the raw field and never invokes an accessor.
+    /// </para>
+    /// </summary>
+    internal string GetOwnFunctionNameForMessage()
+    {
+        return _nameDescriptor?.Value is JsString name ? name.ToString() : GetType().Name;
+    }
+
+    /// <summary>
     /// A constructor's lazily created <c>prototype</c> object, which serves <c>constructor</c> from a field
     /// instead of the property bag. It goes through the internal constructor rather than the protected one so
     /// its type flags are stated rather than derived per type: it does not override

--- a/Jint/Native/JsProxy.cs
+++ b/Jint/Native/JsProxy.cs
@@ -118,7 +118,7 @@ internal sealed class JsProxy : ObjectInstance, IConstructor, ICallable
         var callable = target as ICallable;
         if (callable is null)
         {
-            Throw.TypeError(_engine.Realm, target + " is not a function");
+            Throw.TypeError(_engine.Realm, "Proxy target is not a function");
         }
 
         return callable.Call(thisObject, arguments);
@@ -238,7 +238,7 @@ internal sealed class JsProxy : ObjectInstance, IConstructor, ICallable
                 var targetValue = targetDesc.Value;
                 if (!targetDesc.Configurable && !targetDesc.Writable && !SameValue(result, targetValue))
                 {
-                    Throw.TypeError(_engine.Realm, $"'get' on proxy: property '{property}' is a read-only and non-configurable data property on the proxy target but the proxy did not return its actual value (expected '{targetValue}' but got '{result}')");
+                    Throw.TypeError(_engine.Realm, $"'get' on proxy: property '{property}' is a read-only and non-configurable data property on the proxy target but the proxy did not return its actual value");
                 }
             }
 
@@ -246,7 +246,7 @@ internal sealed class JsProxy : ObjectInstance, IConstructor, ICallable
             {
                 if (!targetDesc.Configurable && (targetDesc.Get ?? Undefined).IsUndefined() && !result.IsUndefined())
                 {
-                    Throw.TypeError(_engine.Realm, $"'get' on proxy: property '{property}' is a non-configurable accessor property on the proxy target and does not have a getter function, but the trap did not return 'undefined' (got '{result}')");
+                    Throw.TypeError(_engine.Realm, $"'get' on proxy: property '{property}' is a non-configurable accessor property on the proxy target and does not have a getter function, but the trap did not return 'undefined'");
                 }
             }
         }

--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -537,7 +537,9 @@ public abstract partial class JsValue : IEquatable<JsValue>
         var p = Get(CommonProperties.Prototype);
         if (p is not ObjectInstance)
         {
-            Throw.TypeError(o.Engine.Realm, $"Function has non-object prototype '{TypeConverter.ToString(p)}' in instanceof check");
+            // p is proven not to be an object, so its own ToString() runs no script -- and unlike
+            // TypeConverter.ToString it does not throw for a Symbol, which would replace this message.
+            Throw.TypeError(o.Engine.Realm, $"Function has non-object prototype '{p}' in instanceof check");
         }
 
         while (true)
@@ -621,7 +623,7 @@ public abstract partial class JsValue : IEquatable<JsValue>
     {
         if (!c.IsConstructor)
         {
-            Throw.TypeError(engine.Realm, c + " is not a constructor");
+            Throw.TypeError(engine.Realm, $"{c.Type} is not a constructor");
         }
 
         return (IConstructor) c;

--- a/Jint/Native/Map/MapConstructor.cs
+++ b/Jint/Native/Map/MapConstructor.cs
@@ -58,7 +58,7 @@ public sealed partial class MapConstructor : Constructor
     {
         if (newTarget.IsUndefined())
         {
-            Throw.TypeError(_realm, $"Constructor {_nameDescriptor?.Value} requires 'new'");
+            Throw.TypeError(_realm, $"Constructor {GetOwnFunctionNameForMessage()} requires 'new'");
         }
 
         if (ReferenceEquals(newTarget, this))

--- a/Jint/Native/Map/MapPrototype.cs
+++ b/Jint/Native/Map/MapPrototype.cs
@@ -190,7 +190,7 @@ internal sealed partial class MapPrototype : Prototype
             return map;
         }
 
-        Throw.TypeError(_realm, $"Method Map.prototype.{MapMethodName(methodName)} called on incompatible receiver {thisObject}");
+        Throw.TypeError(_realm, $"Method Map.prototype.{MapMethodName(methodName)} called on incompatible receiver");
         return default;
     }
 

--- a/Jint/Native/Math/MathInstance.cs
+++ b/Jint/Native/Math/MathInstance.cs
@@ -1060,7 +1060,7 @@ internal sealed partial class MathInstance : BuiltinShapeObject
 
                 if (value is not JsNumber jsNumber)
                 {
-                    Throw.TypeError(_realm, "Input is not a number: " + next);
+                    Throw.TypeError(_realm, "Input is not a number");
                     return default;
                 }
 

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -181,7 +181,7 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
             return (IConstructor) s;
         }
 
-        Throw.TypeError(o._engine.Realm, $"{s} is not a constructor");
+        Throw.TypeError(o._engine.Realm, "The [Symbol.species] property is not a constructor");
         return null;
     }
 
@@ -2991,7 +2991,7 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
         var func = v.GetV(_engine.Realm, p);
         if (func is not ICallable callable)
         {
-            Throw.TypeError(_engine.Realm, $"{v}.{p} is not a function");
+            Throw.TypeError(_engine.Realm, $"Property '{p}' of object is not a function");
             return default;
         }
 

--- a/Jint/Native/Promise/PromiseConstructor.cs
+++ b/Jint/Native/Promise/PromiseConstructor.cs
@@ -48,7 +48,7 @@ internal sealed partial class PromiseConstructor : Constructor
 
         if (arguments.At(0) is not ICallable executor)
         {
-            Throw.TypeError(_realm, $"Promise resolver {(arguments.At(0))} is not a function");
+            Throw.TypeError(_realm, "Promise resolver is not a function");
             return null;
         }
 
@@ -356,7 +356,7 @@ internal sealed partial class PromiseConstructor : Constructor
                 var then = nextPromise.GetV(_realm, "then");
                 if (then is not ICallable thenFunc)
                 {
-                    Throw.TypeError(_realm, $"{then} is not a function");
+                    Throw.TypeError(_realm, "then is not a function");
                     return;
                 }
 
@@ -388,7 +388,7 @@ internal sealed partial class PromiseConstructor : Constructor
                 var then = nextPromise.GetV(_realm, "then");
                 if (then is not ICallable thenFunc)
                 {
-                    Throw.TypeError(_realm, $"{then} is not a function");
+                    Throw.TypeError(_realm, "then is not a function");
                     return;
                 }
 
@@ -843,7 +843,7 @@ internal sealed partial class PromiseConstructor : Constructor
                 var then = nextPromise.GetV(_realm, "then");
                 if (then is not ICallable thenFunc)
                 {
-                    Throw.TypeError(_realm, $"{then} is not a function");
+                    Throw.TypeError(_realm, "then is not a function");
                     return capability.PromiseInstance;
                 }
 

--- a/Jint/Native/Proxy/ProxyConstructor.cs
+++ b/Jint/Native/Proxy/ProxyConstructor.cs
@@ -31,7 +31,7 @@ internal sealed partial class ProxyConstructor : Constructor
     {
         if (newTarget.IsUndefined())
         {
-            Throw.TypeError(_realm, $"Constructor {_nameDescriptor?.Value} requires 'new'");
+            Throw.TypeError(_realm, $"Constructor {GetOwnFunctionNameForMessage()} requires 'new'");
         }
 
         return Construct(arguments.At(0), arguments.At(1));

--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -1285,7 +1285,7 @@ internal sealed partial class RegExpPrototype : Prototype
             var result = callable.Call(r, s);
             if (!result.IsNull() && !result.IsObject())
             {
-                Throw.TypeError(r.Engine.Realm, $"Method RegExp.prototype.exec called on incompatible receiver {r}");
+                Throw.TypeError(r.Engine.Realm, "Method RegExp.prototype.exec called on incompatible receiver");
             }
 
             return result;
@@ -1293,7 +1293,7 @@ internal sealed partial class RegExpPrototype : Prototype
 
         if (ri is null)
         {
-            Throw.TypeError(r.Engine.Realm, $"Method RegExp.prototype.exec called on incompatible receiver {r}");
+            Throw.TypeError(r.Engine.Realm, "Method RegExp.prototype.exec called on incompatible receiver");
         }
 
         return RegExpBuiltinExec(ri, s);
@@ -1927,7 +1927,7 @@ internal sealed partial class RegExpPrototype : Prototype
         var r = thisObject as JsRegExp;
         if (r is null)
         {
-            Throw.TypeError(_engine.Realm, $"Method RegExp.prototype.exec called on incompatible receiver {thisObject}");
+            Throw.TypeError(_engine.Realm, "Method RegExp.prototype.exec called on incompatible receiver");
         }
 
         var s = TypeConverter.ToString(arguments.At(0));

--- a/Jint/Native/Set/SetConstructor.cs
+++ b/Jint/Native/Set/SetConstructor.cs
@@ -83,7 +83,7 @@ public sealed partial class SetConstructor : Constructor
     {
         if (newTarget.IsUndefined())
         {
-            Throw.TypeError(_engine.Realm, $"Constructor {_nameDescriptor?.Value} requires 'new'");
+            Throw.TypeError(_engine.Realm, $"Constructor {GetOwnFunctionNameForMessage()} requires 'new'");
         }
 
         if (ReferenceEquals(newTarget, this))

--- a/Jint/Native/Set/SetPrototype.cs
+++ b/Jint/Native/Set/SetPrototype.cs
@@ -487,13 +487,17 @@ internal sealed partial class SetPrototype : Prototype
         var has = obj.Get(CommonProperties.Has);
         if (!has.IsCallable)
         {
-            Throw.TypeError(_realm, $"{obj}.has is not a function");
+            // Deliberately not interpolating obj: ObjectInstance.ToString() is the full JavaScript
+            // ToString algorithm, so rendering the receiver here would run user code while the error
+            // is being built (observable as extra [[Get]]s, and a throwing toString would replace
+            // this TypeError with its own exception).
+            Throw.TypeError(_realm, "The .has property of the object is not a function");
         }
 
         var keys = obj.Get(CommonProperties.Keys);
         if (!keys.IsCallable)
         {
-            Throw.TypeError(_realm, $"{obj}.keys is not a function");
+            Throw.TypeError(_realm, "The .keys property of the object is not a function");
         }
 
         return new SetRecord(Set: obj, Size: intSize, Has: (ICallable) has, Keys: (ICallable) keys);
@@ -513,7 +517,7 @@ internal sealed partial class SetPrototype : Prototype
             return set;
         }
 
-        Throw.TypeError(_realm, $"Method Set.prototype.{SetMethodName(methodName)} called on incompatible receiver {thisObject}");
+        Throw.TypeError(_realm, $"Method Set.prototype.{SetMethodName(methodName)} called on incompatible receiver");
         return default;
     }
 

--- a/Jint/Native/ShadowRealm/ShadowRealmConstructor.cs
+++ b/Jint/Native/ShadowRealm/ShadowRealmConstructor.cs
@@ -71,7 +71,7 @@ public sealed class ShadowRealmConstructor : Constructor
     {
         if (newTarget.IsUndefined())
         {
-            Throw.TypeError(_realm, $"Constructor {_nameDescriptor?.Value} requires 'new'");
+            Throw.TypeError(_realm, $"Constructor {GetOwnFunctionNameForMessage()} requires 'new'");
         }
 
         return Construct(newTarget);

--- a/Jint/Native/ShadowRealm/ShadowRealmPrototype.cs
+++ b/Jint/Native/ShadowRealm/ShadowRealmPrototype.cs
@@ -41,7 +41,7 @@ internal sealed partial class ShadowRealmPrototype : Prototype
 
         if (!sourceText.IsString())
         {
-            Throw.TypeError(_realm, "Invalid source text " + sourceText);
+            Throw.TypeError(_realm, "Invalid source text");
         }
 
         var parserOptions = _engine.GetActiveParserOptions();

--- a/Jint/Native/SharedArrayBuffer/SharedArrayBufferConstructor.cs
+++ b/Jint/Native/SharedArrayBuffer/SharedArrayBufferConstructor.cs
@@ -62,7 +62,7 @@ internal sealed partial class SharedArrayBufferConstructor : Constructor
     {
         if (newTarget.IsUndefined())
         {
-            Throw.TypeError(_realm, $"Constructor {_nameDescriptor?.Value} requires 'new'");
+            Throw.TypeError(_realm, $"Constructor {GetOwnFunctionNameForMessage()} requires 'new'");
         }
 
         var length = arguments.At(0);

--- a/Jint/Native/SharedArrayBuffer/SharedArrayBufferPrototype.cs
+++ b/Jint/Native/SharedArrayBuffer/SharedArrayBufferPrototype.cs
@@ -39,7 +39,7 @@ internal sealed partial class SharedArrayBufferPrototype : Prototype
         var o = thisObject as JsSharedArrayBuffer;
         if (o is null || !o.IsSharedArrayBuffer)
         {
-            Throw.TypeError(_realm, "Method prototype.byteLength called on incompatible receiver " + thisObject);
+            Throw.TypeError(_realm, "Method prototype.byteLength called on incompatible receiver");
         }
 
         return JsNumber.Create(o.ArrayBufferByteLength);
@@ -54,7 +54,7 @@ internal sealed partial class SharedArrayBufferPrototype : Prototype
         var o = thisObject as JsSharedArrayBuffer;
         if (o is null || !o.IsSharedArrayBuffer)
         {
-            Throw.TypeError(_realm, "Method prototype.slice called on incompatible receiver " + thisObject);
+            Throw.TypeError(_realm, "Method prototype.slice called on incompatible receiver");
         }
 
         o.AssertNotDetached();
@@ -136,7 +136,7 @@ internal sealed partial class SharedArrayBufferPrototype : Prototype
         var o = thisObject as JsSharedArrayBuffer;
         if (o is null || !o.IsSharedArrayBuffer)
         {
-            Throw.TypeError(_realm, "Method SharedArrayBuffer.prototype.growable called on incompatible receiver " + thisObject);
+            Throw.TypeError(_realm, "Method SharedArrayBuffer.prototype.growable called on incompatible receiver");
         }
 
         return !o.IsFixedLengthArrayBuffer;
@@ -151,7 +151,7 @@ internal sealed partial class SharedArrayBufferPrototype : Prototype
         var o = thisObject as JsSharedArrayBuffer;
         if (o is null || !o.IsSharedArrayBuffer)
         {
-            Throw.TypeError(_realm, "Method SharedArrayBuffer.prototype.grow called on incompatible receiver " + thisObject);
+            Throw.TypeError(_realm, "Method SharedArrayBuffer.prototype.grow called on incompatible receiver");
         }
 
         var newByteLength = TypeConverter.ToIndex(_realm, newLength);
@@ -172,7 +172,7 @@ internal sealed partial class SharedArrayBufferPrototype : Prototype
         var o = thisObject as JsSharedArrayBuffer;
         if (o is null || !o.IsSharedArrayBuffer)
         {
-            Throw.TypeError(_realm, "Method SharedArrayBuffer.prototype.maxByteLength called on incompatible receiver " + thisObject);
+            Throw.TypeError(_realm, "Method SharedArrayBuffer.prototype.maxByteLength called on incompatible receiver");
         }
 
         if (o.IsDetachedBuffer)

--- a/Jint/Native/Symbol/SymbolConstructor.cs
+++ b/Jint/Native/Symbol/SymbolConstructor.cs
@@ -93,7 +93,10 @@ internal sealed partial class SymbolConstructor : Constructor
         var symbol = sym as JsSymbol;
         if (symbol is null)
         {
-            Throw.TypeError(_realm, $"{sym} is not a symbol");
+            // sym is provably not a JsSymbol here, so it may be an object carrying a user toString.
+            // Which value was passed is what the caller needs, so render it safely rather than naming
+            // its type -- matching what other engines report for Symbol.keyFor(5).
+            Throw.TypeError(_realm, $"{Throw.SafeToDisplayString(sym)} is not a symbol");
         }
 
         if (_engine.GlobalSymbolRegistry.TryGetSymbol(symbol._value, out var e))

--- a/Jint/Native/TypedArray/IntrinsicTypedArrayPrototype.cs
+++ b/Jint/Native/TypedArray/IntrinsicTypedArrayPrototype.cs
@@ -63,7 +63,7 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
         var o = thisObject as JsTypedArray;
         if (o is null)
         {
-            Throw.TypeError(_realm, $"Method get TypedArray.prototype.buffer called on incompatible receiver {thisObject}");
+            Throw.TypeError(_realm, "Method get TypedArray.prototype.buffer called on incompatible receiver");
         }
 
         return o._viewedArrayBuffer;
@@ -78,7 +78,7 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
         var o = thisObject as JsTypedArray;
         if (o is null)
         {
-            Throw.TypeError(_realm, $"Method get TypedArray.prototype.byteLength called on incompatible receiver {thisObject}");
+            Throw.TypeError(_realm, "Method get TypedArray.prototype.byteLength called on incompatible receiver");
         }
 
         var taRecord = MakeTypedArrayWithBufferWitnessRecord(o, ArrayBufferOrder.SeqCst);
@@ -94,7 +94,7 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
         var o = thisObject as JsTypedArray;
         if (o is null)
         {
-            Throw.TypeError(_realm, $"Method get TypedArray.prototype.byteOffset called on incompatible receiver {thisObject}");
+            Throw.TypeError(_realm, "Method get TypedArray.prototype.byteOffset called on incompatible receiver");
         }
 
         var taRecord = MakeTypedArrayWithBufferWitnessRecord(o, ArrayBufferOrder.SeqCst);
@@ -115,7 +115,7 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
         var o = thisObject as JsTypedArray;
         if (o is null)
         {
-            Throw.TypeError(_realm, $"Method get TypedArray.prototype.length called on incompatible receiver {thisObject}");
+            Throw.TypeError(_realm, "Method get TypedArray.prototype.length called on incompatible receiver");
         }
 
         var taRecord = MakeTypedArrayWithBufferWitnessRecord(o, ArrayBufferOrder.SeqCst);
@@ -1051,7 +1051,7 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
         var target = thisObject as JsTypedArray;
         if (target is null)
         {
-            Throw.TypeError(_realm, $"Method TypedArray.prototype.set called on incompatible receiver {thisObject}");
+            Throw.TypeError(_realm, "Method TypedArray.prototype.set called on incompatible receiver");
         }
 
         // https://tc39.es/proposal-immutable-arraybuffer/ — set must reject an immutable target before
@@ -1433,7 +1433,7 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
         var o = thisObject as JsTypedArray;
         if (o is null)
         {
-            Throw.TypeError(_realm, $"Method TypedArray.prototype.subarray called on incompatible receiver {thisObject}");
+            Throw.TypeError(_realm, "Method TypedArray.prototype.subarray called on incompatible receiver");
         }
 
         var buffer = o._viewedArrayBuffer;

--- a/Jint/Native/TypedArray/TypedArrayConstructor.cs
+++ b/Jint/Native/TypedArray/TypedArrayConstructor.cs
@@ -54,7 +54,7 @@ public abstract partial class TypedArrayConstructor : Constructor
     {
         if (newTarget.IsUndefined())
         {
-            Throw.TypeError(_realm, $"Constructor {_nameDescriptor?.Value} requires 'new'");
+            Throw.TypeError(_realm, $"Constructor {GetOwnFunctionNameForMessage()} requires 'new'");
         }
 
         var numberOfArgs = arguments.Length;

--- a/Jint/Native/WeakMap/WeakMapConstructor.cs
+++ b/Jint/Native/WeakMap/WeakMapConstructor.cs
@@ -29,7 +29,7 @@ internal sealed class WeakMapConstructor : Constructor
     {
         if (newTarget.IsUndefined())
         {
-            Throw.TypeError(_realm, $"Constructor {_nameDescriptor?.Value} requires 'new'");
+            Throw.TypeError(_realm, $"Constructor {GetOwnFunctionNameForMessage()} requires 'new'");
         }
 
         var map = OrdinaryCreateFromConstructor(

--- a/Jint/Native/WeakRef/WeakRefConstructor.cs
+++ b/Jint/Native/WeakRef/WeakRefConstructor.cs
@@ -31,7 +31,7 @@ internal sealed class WeakRefConstructor : Constructor
     {
         if (newTarget.IsUndefined())
         {
-            Throw.TypeError(_realm, $"Constructor {_nameDescriptor?.Value} requires 'new'");
+            Throw.TypeError(_realm, $"Constructor {GetOwnFunctionNameForMessage()} requires 'new'");
         }
 
         var target = arguments.At(0);

--- a/Jint/Native/WeakSet/WeakSetConstructor.cs
+++ b/Jint/Native/WeakSet/WeakSetConstructor.cs
@@ -28,7 +28,7 @@ internal sealed class WeakSetConstructor : Constructor
     {
         if (newTarget.IsUndefined())
         {
-            Throw.TypeError(_realm, $"Constructor {_nameDescriptor?.Value} requires 'new'");
+            Throw.TypeError(_realm, $"Constructor {GetOwnFunctionNameForMessage()} requires 'new'");
         }
 
         var set = OrdinaryCreateFromConstructor(

--- a/Jint/Runtime/Descriptors/PropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/PropertyDescriptor.cs
@@ -468,7 +468,7 @@ public class PropertyDescriptor
         {
             if (!get!.IsUndefined() && get!.TryCast<ICallable>() == null)
             {
-                Throw.TypeError(realm, $"Getter must be a function: {get}");
+                Throw.TypeError(realm, "Getter must be a function");
             }
 
             ((GetSetPropertyDescriptor) desc).SetGet(get!);
@@ -478,7 +478,7 @@ public class PropertyDescriptor
         {
             if (!set!.IsUndefined() && set!.TryCast<ICallable>() is null)
             {
-                Throw.TypeError(realm, $"Setter must be a function: {set}");
+                Throw.TypeError(realm, "Setter must be a function");
             }
 
             ((GetSetPropertyDescriptor) desc).SetSet(set!);

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -2340,7 +2340,10 @@ internal abstract class JintBinaryExpression : JintExpression
             var oi = right as ObjectInstance;
             if (oi is null)
             {
-                Throw.TypeError(context.Engine.Realm, $"Cannot use 'in' operator to search for '{left}' in {right}");
+                // left is the property name the reader needs and is not coerced before this check, so it
+                // may be an arbitrary object -- hence the safe renderer. right is interpolated directly:
+                // this throw fires precisely because right is not an object, so its ToString() is its own.
+                Throw.TypeError(context.Engine.Realm, $"Cannot use 'in' operator to search for '{Throw.SafeToDisplayString(left)}' in {right}");
             }
 
             if (left.IsPrivateName())

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -727,7 +727,7 @@ internal sealed class JintCallExpression : JintExpression
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void ThrowReferenceNotFunction(Reference? referenceRecord1, object reference, Engine engine)
     {
-        var message = $"{referenceRecord1?.ReferencedName ?? reference} is not a function";
+        var message = $"{DescribeCallee(referenceRecord1, reference)} is not a function";
         Throw.TypeError(engine.Realm, message);
     }
 
@@ -736,9 +736,26 @@ internal sealed class JintCallExpression : JintExpression
     private static void ThrowMemberIsNotFunction(Reference? referenceRecord1, object reference, Engine engine)
     {
         var message = referenceRecord1 == null
-            ? reference + " is not a function"
+            ? $"{DescribeCallee(referenceRecord1, reference)} is not a function"
             : $"Property '{referenceRecord1.ReferencedName}' of object is not a function";
         Throw.TypeError(engine.Realm, message);
+    }
+
+    /// <summary>
+    /// A description of the callee for an error message, built without running user JavaScript — see
+    /// <see cref="Throw.SafeToDisplayString"/> for why interpolating an evaluated <see cref="JsValue"/>
+    /// directly is a bug. A named callee is quoted by name; an unnamed one (the result of a call, an
+    /// index, a parenthesized expression) is quoted by value as far as that is safe.
+    /// </summary>
+    private static string DescribeCallee(Reference? referenceRecord, object reference)
+    {
+        if (referenceRecord is not null)
+        {
+            // A referenced name is a property key, i.e. a String or a Symbol; both render from own state.
+            return Throw.SafeToDisplayString(referenceRecord.ReferencedName);
+        }
+
+        return reference is JsValue value ? Throw.SafeToDisplayString(value) : "expression";
     }
 
     private JsValue HandleEval(EvaluationContext context, JsValue func, Engine engine, Reference referenceRecord)

--- a/Jint/Runtime/Interpreter/Expressions/JintImportExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintImportExpression.cs
@@ -74,7 +74,7 @@ internal sealed class JintImportExpression : JintExpression
 
                         if (!value.IsString())
                         {
-                            Throw.TypeError(context.Engine.Realm, "Invalid option value " + value);
+                            Throw.TypeError(context.Engine.Realm, "Invalid option value");
                             return JsValue.Undefined;
                         }
 

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -402,7 +402,7 @@ internal sealed class JintMemberExpression : JintExpression
                     return CompleteReadFromReference(context, engine, nullishBaseReference);
                 }
 
-                TypeConverter.CheckObjectCoercible(engine, baseValue, _memberExpression.Property, determinedProperty.ToString());
+                TypeConverter.CheckObjectCoercible(engine, baseValue, _memberExpression.Property, Throw.SafeToDisplayString(determinedProperty));
             }
 
             context.LastSyntaxElement = _expression;
@@ -629,9 +629,12 @@ internal sealed class JintMemberExpression : JintExpression
         if (reference.Base.IsNullOrUndefined() && !engine._nullishPropagatesInline)
         {
             var property = reference.ReferencedName;
-            // Only use property for error message if it's already a primitive (won't trigger ToPropertyKey)
+            // Only use property for error message if it's already a primitive (won't trigger ToPropertyKey).
+            // The rendering goes through the safe helper because a Symbol *is* primitive and
+            // TypeConverter.ToString throws for one, which replaced this TypeError with
+            // "Cannot convert a Symbol value to a string" for every `nullishBase[someSymbol]` read.
             var referenceName = property.IsPrimitive()
-                ? TypeConverter.ToString(property)
+                ? Throw.SafeToDisplayString(property)
                 : null;
 
             TypeConverter.CheckObjectCoercible(engine, reference.Base, _memberExpression.Property, referenceName);

--- a/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
@@ -270,12 +270,12 @@ internal sealed class JintUnaryExpression : JintExpression
                     {
                         if (r.Strict)
                         {
-                            Throw.TypeError(engine.Realm, $"Cannot delete property '{r.ReferencedName}' of {o}");
+                            Throw.TypeError(engine.Realm, $"Cannot delete property '{r.ReferencedName}' of {o.Type}");
                         }
 
                         if (engine.ExecutionContext.Strict && !r.Base.AsObject().GetOwnProperty(r.ReferencedName).Configurable)
                         {
-                            Throw.TypeError(engine.Realm, $"Cannot delete property '{r.ReferencedName}' of {o}");
+                            Throw.TypeError(engine.Realm, $"Cannot delete property '{r.ReferencedName}' of {o.Type}");
                         }
                     }
 

--- a/Jint/Runtime/Throw.cs
+++ b/Jint/Runtime/Throw.cs
@@ -17,6 +17,37 @@ internal sealed record ErrorDispatchInfo(ErrorConstructor ErrorConstructor, stri
 
 internal static class Throw
 {
+    /// <summary>
+    /// Renders <paramref name="value"/> for an error message without ever running user JavaScript.
+    /// <para>
+    /// This is the sanctioned way to put a <see cref="JsValue"/> into a <c>Throw.*</c> message. Writing
+    /// <c>$"{value} is not a function"</c> instead is a bug: the message argument is evaluated eagerly, and
+    /// <see cref="Native.Object.ObjectInstance.ToString"/> is <see cref="TypeConverter.ToString(JsValue)"/>
+    /// — the full JavaScript ToString algorithm, which reads <c>@@toPrimitive</c>, reads <c>toString</c>,
+    /// <b>calls it</b>, and reads <c>@@toStringTag</c>. That makes building the error observable (the extra
+    /// <c>[[Get]]</c>s show up in a Proxy log) and lets a user <c>toString</c> that throws replace the error
+    /// with its own exception.
+    /// </para>
+    /// <para>
+    /// Every non-object <see cref="JsValue"/> renders from its own state and is therefore safe:
+    /// <see cref="JsString"/> (and its concatenated/sliced forms) hands back its characters,
+    /// <see cref="JsNumber"/>, <see cref="JsBigInt"/>, <see cref="JsBoolean"/>, <see cref="JsNull"/> and
+    /// <see cref="JsUndefined"/> are pure conversions, and <see cref="JsSymbol"/> renders
+    /// SymbolDescriptiveString over an own field, so a symbol keeps its description. An object has no safe
+    /// value rendering at all, so it is reported as its shape rather than its contents.
+    /// </para>
+    /// <para>
+    /// Prefer this wherever the offending <i>value</i> is what the reader needs. Where the reader needs the
+    /// <i>kind</i> of thing that was passed rather than which one, <c>value.Type</c> is the better answer and
+    /// is equally safe; and where a guard already proves the value is a primitive, interpolating it directly
+    /// is fine — say so in a comment, because the next sweep for this bug class will look at that line again.
+    /// </para>
+    /// </summary>
+    public static string SafeToDisplayString(JsValue value)
+    {
+        return value.IsObject() ? "[object]" : value.ToString();
+    }
+
     [DoesNotReturn]
     public static void SyntaxError(Realm realm, string? message = null)
     {


### PR DESCRIPTION
`Throw.TypeError(Realm, string?)` takes an **eagerly evaluated** `string`. A number of call sites interpolated a `JsValue` into that string — and `ObjectInstance.ToString()` is `TypeConverter.ToString(this)`, the full JavaScript ToString algorithm: `ToPrimitive` -> `Get(@@toPrimitive)` -> `Get("toString")` -> **call it** -> `Get(@@toStringTag)`.

So building an error message could run arbitrary user JavaScript. Two observable consequences:

```js
// 1. extra property reads while the error is constructed
new Set().union({ size: 1, has: 0, keys(){} });
//   spec-visible operations: size, has
//   Jint also performed: @@toPrimitive, toString, @@toStringTag

// 2. a throwing toString replaces the intended error
Date.prototype[Symbol.toPrimitive].call(new Date(), { toString() { throw new Error("boom") } });
//   threw Error "boom" instead of TypeError
```

Plain concatenation (`target + " is not a function"`) has the same defect and is missed by an interpolation-only search; 6 such sites were dangerous.

## The fix

A single helper, `Throw.SafeToDisplayString(JsValue)`:

```csharp
return value.IsObject() ? "[object]" : value.ToString();
```

That is correct structurally, not by enumeration: every non-object `JsValue` renders from its own state — `JsNumber.ToString()` **is** `TypeConverter.ToString`, `JsSymbol.ToString()` is SymbolDescriptiveString over an own field — and only `ObjectInstance` routes through the user-visible path. Symbols therefore keep their descriptions for free.

48 sites reviewed. Where the value is provably primitive at that point, the interpolation is left alone (with the guard named in a comment). Where the *type* is genuinely what the reader needs, `.Type` is used. Otherwise the helper. Messages generally improved rather than degraded:

| | before | after |
|---|---|---|
| `'foo' in 1` | `search for 'String' in 1` | `search for 'foo' in 1` |
| `Symbol.keyFor(5)` | `Number is not a symbol` | `5 is not a symbol` |
| `undefinedBase[Symbol.iterator]` | `Cannot convert a Symbol value to a string` | `Cannot read properties of undefined (reading 'Symbol(Symbol.iterator)')` |

## Three latent bugs found in passing

- **A computed key was coerced twice.** A failed strict-mode assignment quoted the *pre*-coercion referenced name, so `frozen[key] = 2` ran the key's `toString` a second time.
- **Two sites guarded on `IsPrimitive()` and forgot symbols.** A Symbol *is* primitive, and `TypeConverter.ToString` throws for one, so `undefinedBase[Symbol.iterator]` and `f.prototype = Symbol()` reported "Cannot convert a Symbol value to a string" instead of the intended error.
- **`Math.sumPrecise` rendered the iterator result object** rather than the offending element.

## Tests

25 new assertions; 23 fail against unfixed code (the other 2 are deliberate guards). Nine existing assertions that pinned old message text were updated — text only, no behaviour change.

Frees six `staging/` exclusions: five of the seven `Set/*.js` files and `Date/toPrimitive.js`. The Set exclusion comment blamed `GetSetRecord` ordering; `GetSetRecord` is in fact already spec-exact, and the operation-log mismatch was entirely this bug. `Set/intersection.js` and `Set/is-subset-of.js` remain — they need the `[[SetData]]` tombstone model, and the banner is reworded to say so.

Refs #3021.
