### PR TITLE
Date.prototype.setTime must store the clipped time value

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -168,12 +168,10 @@
     "staging/sm/Array/species.js",
     "staging/sm/Reflect/has.js",
 
-    // Date parsing and clipping: the implementation-defined fallback parser accepts (and rejects)
-    // different strings than SpiderMonkey's, two-digit years map differently, and TimeClip does not
-    // reject every out-of-range value.
+    // Date parsing: the implementation-defined fallback parser accepts (and rejects) different strings
+    // than SpiderMonkey's, and two-digit years map differently. Both are implementation-defined
+    // territory the spec leaves open, so these two stay.
     "staging/sm/Date/non-iso.js",
-    "staging/sm/Date/timeclip.js",
-    "staging/sm/Date/toISOString.js",
     "staging/sm/Date/two-digit-years.js",
 
     // String case mapping is done with the BCL's culture-aware tables rather than the Unicode

--- a/Jint.Tests/Runtime/DateTests.cs
+++ b/Jint.Tests/Runtime/DateTests.cs
@@ -653,4 +653,129 @@ public class DateTests
         result2.Should().Contain("GMT+1200");
         result2.Should().Contain("Sep 28 2025 00:00:00");
     }
+
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-date.prototype.settime sets [[DateValue]] to the clipped value v,
+    /// and setTime stored the raw argument instead — the one setter in the file that did.
+    /// The returned value was always right, so the object and its own return value disagreed. It
+    /// surfaces because an infinite argument becomes a DatePresentation flagged Infinity whose Value
+    /// is 0, so getTime read the stored infinity back as the epoch rather than as NaN.
+    /// </summary>
+    [Theory]
+    [InlineData("Infinity")]
+    [InlineData("-Infinity")]
+    [InlineData("NaN")]
+    [InlineData("8.64e15 + 1")]
+    [InlineData("-8.64e15 - 1")]
+    [InlineData("Number.MAX_VALUE")]
+    [InlineData("-Number.MAX_VALUE")]
+    public void SetTimeStoresTheClippedTimeValue(string argument)
+    {
+        _engine.Execute($"var d = new Date(); var returned = d.setTime({argument});");
+
+        double.IsNaN(_engine.Evaluate("returned").AsNumber()).Should().BeTrue("setTime returns the clipped value");
+        double.IsNaN(_engine.Evaluate("d.getTime()").AsNumber()).Should().BeTrue("getTime reports the clipped value");
+        double.IsNaN(_engine.Evaluate("d.valueOf()").AsNumber()).Should().BeTrue("valueOf reports the clipped value");
+
+        // Numeric coercion of a Date has its own fast path in TypeConverter.ToNumeric, which reads
+        // [[DateValue]] directly rather than going through valueOf, so it has to agree as well.
+        double.IsNaN(_engine.Evaluate("+d").AsNumber()).Should().BeTrue("unary + reports the clipped value");
+    }
+
+    /// <summary>
+    /// The extremes https://tc39.es/ecma262/#sec-timeclip admits are legal time values and must survive
+    /// the round trip untouched — clipping one millisecond too eagerly would be the opposite defect.
+    /// </summary>
+    [Theory]
+    [InlineData("8.64e15", 8640000000000000d)]
+    [InlineData("-8.64e15", -8640000000000000d)]
+    [InlineData("0", 0d)]
+    [InlineData("-1", -1d)]
+    public void SetTimeAtTheClipBoundaryRoundTrips(string argument, double expected)
+    {
+        _engine.Execute($"var d = new Date(); var returned = d.setTime({argument});");
+
+        _engine.Evaluate("returned").AsNumber().Should().Be(expected);
+        _engine.Evaluate("d.getTime()").AsNumber().Should().Be(expected);
+        _engine.Evaluate("d.valueOf()").AsNumber().Should().Be(expected);
+        _engine.Evaluate("+d").AsNumber().Should().Be(expected);
+    }
+
+    [Fact]
+    public void SetTimeAtTheUpperClipBoundaryStillFormats()
+    {
+        _engine.Execute("var d = new Date(); d.setTime(8.64e15);");
+        _engine.Evaluate("d.toISOString()").AsString().Should().Be("+275760-09-13T00:00:00.000Z");
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-date.prototype.toisostring throws a RangeError when [[DateValue]] is
+    /// NaN, which in the spec's value domain is every non-finite time value there is. Jint's
+    /// DatePresentation is wider — an infinity is flags plus a Value of 0 — so the IsNaN guard let one
+    /// through to the formatter, which produced the epoch string for it.
+    /// </summary>
+    [Theory]
+    [InlineData("Infinity")]
+    [InlineData("-Infinity")]
+    [InlineData("NaN")]
+    [InlineData("Number.MAX_VALUE")]
+    [InlineData("8.64e15 + 1")]
+    public void ToIsoStringThrowsRangeErrorForANonFiniteTimeValue(string argument)
+    {
+        _engine.Execute($"var d = new Date(); d.setTime({argument});");
+
+        _engine.Evaluate("(function () { try { return d.toISOString(); } catch (e) { return e.constructor.name; } })()")
+            .AsString().Should().Be("RangeError");
+    }
+
+    [Fact]
+    public void ToIsoStringThrowsRangeErrorForADateConstructedFromNaN()
+    {
+        _engine.Evaluate("(function () { try { return new Date(NaN).toISOString(); } catch (e) { return e.constructor.name; } })()")
+            .AsString().Should().Be("RangeError");
+    }
+
+    /// <summary>
+    /// The invariant behind both of the above, stated once: whatever setTime hands back is what the
+    /// object then reports. Object.is rather than === so the NaN rows say something.
+    /// </summary>
+    [Theory]
+    [InlineData("0")]
+    [InlineData("1")]
+    [InlineData("-1")]
+    [InlineData("1.5")]
+    [InlineData("8.64e15")]
+    [InlineData("-8.64e15")]
+    [InlineData("8.64e15 + 1")]
+    [InlineData("Infinity")]
+    [InlineData("-Infinity")]
+    [InlineData("NaN")]
+    [InlineData("Number.MAX_VALUE")]
+    public void SetTimeReturnsWhatGetTimeSubsequentlyReports(string argument)
+    {
+        _engine.Evaluate($"var d = new Date(); var returned = d.setTime({argument}); Object.is(returned, d.getTime()) && Object.is(returned, d.valueOf());")
+            .AsBoolean().Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The class of defect rather than the instance: DatePresentation stores an infinity as flags plus a
+    /// Value of 0, so any reader testing IsNaN alone reads it back as the epoch. ToJsValue is the single
+    /// place every such read funnels through, so answering NaN for anything that is not a finite in-range
+    /// time value closes it for the next caller too.
+    /// </summary>
+    [Fact]
+    public void AnInfinityFlaggedDatePresentationReadsBackAsNaN()
+    {
+        DatePresentation positive = double.PositiveInfinity;
+        positive.IsInfinity.Should().BeTrue();
+        double.IsNaN(positive.ToJsValue().AsNumber()).Should().BeTrue();
+
+        DatePresentation negative = double.NegativeInfinity;
+        negative.IsInfinity.Should().BeTrue();
+        double.IsNaN(negative.ToJsValue().AsNumber()).Should().BeTrue();
+
+        // The DateTime sentinels are finite, in-range time values and must keep reading back as numbers.
+        DatePresentation.MinValue.ToJsValue().AsNumber().Should().Be(JsDate.Min);
+        DatePresentation.MaxValue.ToJsValue().AsNumber().Should().Be(JsDate.Max);
+    }
 }

--- a/Jint/Native/Date/DatePrototype.cs
+++ b/Jint/Native/Date/DatePrototype.cs
@@ -629,7 +629,10 @@ internal sealed partial class DatePrototype : Prototype
         var t = TypeConverter.ToNumber(arguments.At(0));
         var v = t.TimeClip();
 
-        ((JsDate) thisObject)._dateValue = t;
+        // "Set dateObj.[[DateValue]] to v" - the clipped value, not the argument. Storing t instead let
+        // an out-of-range or infinite argument survive in the object while setTime returned NaN, so the
+        // Date and setTime's own return value disagreed from that point on.
+        ((JsDate) thisObject)._dateValue = v;
         return v.ToJsValue();
     }
 
@@ -979,7 +982,13 @@ internal sealed partial class DatePrototype : Prototype
     {
         var thisTime = ThisTimeValue(thisObject);
         var t = thisTime;
-        if (t.IsNaN)
+
+        // Step 4 is "If tv is NaN, throw a RangeError exception", and in the spec that is the whole of
+        // "not a finite time value": a [[DateValue]] is either NaN or an integral Number inside the
+        // TimeClip range. DatePresentation is wider than that domain - it can carry an Infinity flag
+        // with a Value of 0 - so IsNaN alone let such a value reach the formatter, which rendered the
+        // epoch for it. Testing IsFinite is the same step expressed over the representation we have.
+        if (!t.IsFinite)
         {
             Throw.RangeError(_realm, "Invalid time value");
         }

--- a/Jint/Native/DatePresentation.cs
+++ b/Jint/Native/DatePresentation.cs
@@ -81,7 +81,10 @@ internal readonly record struct DatePresentation(long Value, DateFlags Flags)
 
     internal JsNumber ToJsValue()
     {
-        if (IsNaN || Value is < -8640000000000000 or > 8640000000000000)
+        // A non-finite presentation keeps its state in the flags and leaves Value at 0, so a reader
+        // testing IsNaN alone reads an infinity back as the epoch. Only a finite value inside the range
+        // https://tc39.es/ecma262/#sec-timeclip admits is a time value; everything else is NaN.
+        if (!IsFinite || Value is < -8640000000000000 or > 8640000000000000)
         {
             return JsNumber.DoubleNaN;
         }


### PR DESCRIPTION
`Date.prototype.setTime` stored the **unclipped** argument:

```csharp
var v = t.TimeClip();
((JsDate) thisObject)._dateValue = t;   // spec stores v
return v.ToJsValue();
```

[21.4.4.27](https://tc39.es/ecma262/#sec-date.prototype.settime) step 5 sets `[[DateValue]]` to `v`. All 15 sibling setters already do this correctly — `setTime` was the sole outlier.

The effect is larger than "an infinity survives". `DatePresentation`'s conversion turns `±Infinity` into a flagged presentation with `Value = 0`, and `ToJsValue()` tested only `IsNaN`, so an infinity read back as the **epoch**:

```js
var d = new Date(); d.setTime(Infinity); d.getTime();   // 0, should be NaN
d.setTime(8.64e15 + 1); d.getTime();                    // NaN, but...
d.toISOString();                                        // "+275760-09-13T00:00:00.001Z"
d.setTime(Number.MAX_VALUE); d.toISOString();           // "+292278994-08-17T07:12:56.807Z"
```

The last two are finite-but-out-of-range, so they are not fixed by a `toISOString` guard alone — only storing `v` fixes them. (`Number.MAX_VALUE` produced year 292278994 because the `double`->`long` cast saturates.)

## The fix

Three lines:

1. `setTime` stores `v`.
2. `toISOString` guards on "not finite" rather than "is NaN".
3. `DatePresentation.ToJsValue()` answers `NaN` for any non-finite presentation, not just a NaN one.

On (2): [21.4.4.36](https://tc39.es/ecma262/#sec-date.prototype.toisostring) step 4 literally says *"If tv is NaN, throw a RangeError"*, and in the spec that **is** the whole of "not a finite time value" — a `[[DateValue]]` is by construction either NaN or a finite in-range integral Number. `DatePresentation` is wider than that domain, so `IsFinite` is the same step expressed over the representation Jint actually has. The code comment says exactly this rather than misquoting the spec.

(3) closes the class rather than the instance. Every `ToJsValue` consumer was checked; the only behavioural delta is `IsInfinity` reading back as `NaN` instead of `0`. In particular the `DateTimeMinValue`/`DateTimeMaxValue` flags are *not* in the finite mask but their values sit well inside the TimeClip range, so they still read back as numbers — pinned by a test.

## Tests

`Jint.Tests/Runtime/DateTests.cs` — 30 cases, 9 failing against unfixed code, covering `setTime` with `±Infinity`/`NaN`/`8.64e15 + 1`/`Number.MAX_VALUE`, the exact `8.64e15` boundary, `toISOString` raising `RangeError`, and `setTime` agreeing with the subsequent `getTime`/`valueOf`. No existing expectation changed.

Frees two `staging/` exclusions: `Date/timeclip.js` and `Date/toISOString.js`.

Refs #3021.
