### PR TITLE
Array.from honours IsConstructor, and a typed array's length write throws

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -155,12 +155,6 @@
     "staging/sm/expressions/destructuring-array-done.js",
     "staging/sm/statements/for-of-iterator-close.js",
 
-    // Array.from applied to an arbitrary constructor: the spec constructs `this` when it is a
-    // constructor and falls back to ArrayCreate when it is not, and each element goes in through
-    // CreateDataPropertyOrThrow, so a read-only element or a non-extensible target has to throw.
-    "staging/sm/Array/from_constructor.js",
-    "staging/sm/Array/from_errors.js",
-
     // Proxy trap invariants and the exact trap sequence the array built-ins are specified to
     // perform. Jint's own invariant check on a defineProperty trap also fires where it should not.
     "staging/sm/Array/concat-proxy.js",
@@ -213,7 +207,6 @@
     // Argument validation raising no error, or the wrong one, on built-ins called with a bad this
     // or a bad index. Includes SpiderMonkey's own toSource extension, which Jint does not implement
     // at all -- that half is removed by the test moving, not by Jint changing.
-    "staging/sm/Function/bound-non-constructable.js",
     "staging/sm/TypedArray/constructor-byteoffsets-bounds.js",
     "staging/sm/TypedArray/iterator-next-with-detached.js",
     "staging/sm/class/newTargetDVG.js",

--- a/Jint.Tests/Runtime/ArrayFromConstructorTests.cs
+++ b/Jint.Tests/Runtime/ArrayFromConstructorTests.cs
@@ -1,0 +1,289 @@
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// <c>Array.from</c> / <c>Array.fromAsync</c> branch on the spec's IsConstructor
+/// (https://tc39.es/ecma262/#sec-isconstructor), which is a question about the object's [[Construct]] slot and
+/// not about which CLR interface its implementing type happens to declare. Arrow functions, generators, async
+/// functions, concise methods and a bound function whose target is not constructable are all callable objects
+/// with no [[Construct]], so §23.1.2.1 steps 5.a / 6.b make each of them fall back to ArrayCreate.
+/// <para>
+/// The other half of the same algorithm is the trailing <c>Perform ? Set(A, "length", len, true)</c> (steps
+/// 5.b.iii.7 and 6.g): <c>%TypedArray%.prototype.length</c> is a getter-only accessor, so a typed array as the
+/// receiver has to make that write throw a TypeError rather than silently do nothing.
+/// </para>
+/// </summary>
+public class ArrayFromConstructorTests
+{
+    private const string ArrowFunction = "(() => ({}))";
+    private const string GeneratorFunction = "(function* () {})";
+    private const string AsyncFunction = "(async function () {})";
+    private const string ConciseMethod = "({ m() {} }).m";
+    private const string BoundNonConstructor = "Math.sin.bind(null)";
+
+    [Theory]
+    [InlineData(ArrowFunction)]
+    [InlineData(GeneratorFunction)]
+    [InlineData(AsyncFunction)]
+    [InlineData(ConciseMethod)]
+    [InlineData(BoundNonConstructor)]
+    public void ArrayFromFallsBackToArrayCreateForANonConstructorThisOnTheIteratorPath(string nonConstructor)
+    {
+        var engine = new Engine();
+
+        var result = engine.Evaluate($$"""
+            var out = Array.from.call({{nonConstructor}}, [1, 2]);
+            JSON.stringify([Array.isArray(out), out.length, out[0], out[1]]);
+            """).AsString();
+
+        result.Should().Be("[true,2,1,2]");
+    }
+
+    [Theory]
+    [InlineData(ArrowFunction)]
+    [InlineData(GeneratorFunction)]
+    [InlineData(AsyncFunction)]
+    [InlineData(ConciseMethod)]
+    [InlineData(BoundNonConstructor)]
+    public void ArrayFromFallsBackToArrayCreateForANonConstructorThisOnTheArrayLikePath(string nonConstructor)
+    {
+        var engine = new Engine();
+
+        // No @@iterator, so this is the ConstructArrayFromArrayLike branch (step 6) rather than step 5.
+        var result = engine.Evaluate($$"""
+            var out = Array.from.call({{nonConstructor}}, { length: 2, 0: 1, 1: 2 });
+            JSON.stringify([Array.isArray(out), out.length, out[0], out[1]]);
+            """).AsString();
+
+        result.Should().Be("[true,2,1,2]");
+    }
+
+    [Theory]
+    [InlineData(ArrowFunction)]
+    [InlineData(GeneratorFunction)]
+    [InlineData(AsyncFunction)]
+    [InlineData(ConciseMethod)]
+    [InlineData(BoundNonConstructor)]
+    public void ArrayFromAsyncFallsBackToArrayCreateForANonConstructorThis(string nonConstructor)
+    {
+        var engine = new Engine();
+
+        var result = engine.Evaluate($$"""
+            Array.fromAsync.call({{nonConstructor}}, [1, 2]).then(function (out) {
+                return JSON.stringify([Array.isArray(out), out.length, out[0], out[1]]);
+            });
+            """).UnwrapIfPromise(TimeSpan.FromSeconds(5)).AsString();
+
+        result.Should().Be("[true,2,1,2]");
+    }
+
+    [Theory]
+    [InlineData(ArrowFunction)]
+    [InlineData(GeneratorFunction)]
+    [InlineData(AsyncFunction)]
+    [InlineData(ConciseMethod)]
+    [InlineData(BoundNonConstructor)]
+    public void ArrayFromAsyncFallsBackToArrayCreateForANonConstructorThisOnTheArrayLikePath(string nonConstructor)
+    {
+        var engine = new Engine();
+
+        var result = engine.Evaluate($$"""
+            Array.fromAsync.call({{nonConstructor}}, { length: 2, 0: 1, 1: 2 }).then(function (out) {
+                return JSON.stringify([Array.isArray(out), out.length, out[0], out[1]]);
+            });
+            """).UnwrapIfPromise(TimeSpan.FromSeconds(5)).AsString();
+
+        result.Should().Be("[true,2,1,2]");
+    }
+
+    [Fact]
+    public void ArrayOfFallsBackToArrayCreateForANonConstructorThis()
+    {
+        // Array.of already asked the right question; pinned here so the two stay in step.
+        var engine = new Engine();
+
+        var result = engine.Evaluate($$"""
+            var out = Array.of.call({{BoundNonConstructor}}, 1, 2, 3);
+            JSON.stringify([Array.isArray(out), out.length, out[0], out[2]]);
+            """).AsString();
+
+        result.Should().Be("[true,3,1,3]");
+    }
+
+    [Fact]
+    public void ABoundNonConstructorIsStillCallableAndStillNotConstructable()
+    {
+        var engine = new Engine();
+
+        engine.Evaluate($"typeof ({BoundNonConstructor})(0)").AsString().Should().Be("number");
+        engine.Evaluate($$"""
+            try { new ({{BoundNonConstructor}}); 'no throw'; } catch (e) { e.constructor.name; }
+            """).AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void ArrayFromStillConstructsAGenuineConstructorThis()
+    {
+        var engine = new Engine();
+
+        var result = engine.Evaluate("""
+            function C() { this.constructed = true; }
+            var out = Array.from.call(C, [1, 2]);
+            JSON.stringify([Array.isArray(out), out instanceof C, out.constructed, out.length, out[0], out[1]]);
+            """).AsString();
+
+        result.Should().Be("[false,true,true,2,1,2]");
+    }
+
+    [Fact]
+    public void ArrayFromPassesTheLengthToAGenuineConstructorOnTheArrayLikePath()
+    {
+        var engine = new Engine();
+
+        // Step 6.b: Construct(C, « 𝔽(len) »).
+        var result = engine.Evaluate("""
+            function C(n) { this.argCount = arguments.length; this.arg = n; }
+            var out = Array.from.call(C, { length: 2, 0: 'a', 1: 'b' });
+            JSON.stringify([out instanceof C, out.argCount, out.arg, out.length, out[0], out[1]]);
+            """).AsString();
+
+        result.Should().Be("[true,1,2,2,\"a\",\"b\"]");
+    }
+
+    [Fact]
+    public void ArrayFromConstructsAClassAndABoundConstructor()
+    {
+        var engine = new Engine();
+
+        engine.Evaluate("""
+            class C {}
+            var out = Array.from.call(C, [1]);
+            JSON.stringify([out instanceof C, out.length, out[0]]);
+            """).AsString().Should().Be("[true,1,1]");
+
+        engine.Evaluate("""
+            function D() {}
+            var Bound = D.bind(null);
+            var out = Array.from.call(Bound, [1]);
+            JSON.stringify([out instanceof D, out.length, out[0]]);
+            """).AsString().Should().Be("[true,1,1]");
+    }
+
+    [Fact]
+    public void TypedArrayFromIsUnaffected()
+    {
+        var engine = new Engine();
+
+        // %TypedArray%.from is its own algorithm and never performs the Set(A, "length", ...).
+        engine.Evaluate("""
+            var out = Uint8Array.from([]);
+            JSON.stringify([out instanceof Uint8Array, out.length]);
+            """).AsString().Should().Be("[true,0]");
+
+        engine.Evaluate("""
+            var out = Uint8Array.from([1, 2, 3]);
+            JSON.stringify([out instanceof Uint8Array, out.length, out[0], out[2]]);
+            """).AsString().Should().Be("[true,3,1,3]");
+    }
+
+    [Fact]
+    public void ArrayFromWithATypedArrayConstructorThrowsOnTheUnwritableLength()
+    {
+        var engine = new Engine();
+
+        // Iterator path (step 5.b.iii.7).
+        engine.Evaluate("""
+            try { Array.from.call(Uint8Array, []); 'no throw'; } catch (e) { e.constructor.name; }
+            """).AsString().Should().Be("TypeError");
+
+        // Array-like path (step 6.g).
+        engine.Evaluate("""
+            try { Array.from.call(Uint8Array, { length: 0 }); 'no throw'; } catch (e) { e.constructor.name; }
+            """).AsString().Should().Be("TypeError");
+
+        // The exact shape staging/sm/Array/from_errors.js uses.
+        engine.Evaluate("""
+            Uint8Array.from = Array.from;
+            try { Uint8Array.from([]); 'no throw'; } catch (e) { e.constructor.name; }
+            """).AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void ArrayFromThrowsWhenTheConstructedObjectHasAnUnwritableLength()
+    {
+        var engine = new Engine();
+
+        // Same Set(A, "length", ...) obligation reached through an ordinary object; the typed-array lane
+        // above is only a second way to own a length that refuses to be written.
+        engine.Evaluate("""
+            function C() { Object.defineProperty(this, 'length', { configurable: true, writable: false, value: 4 }); }
+            try { Array.from.call(C, []); 'no throw'; } catch (e) { e.constructor.name; }
+            """).AsString().Should().Be("TypeError");
+
+        engine.Evaluate("""
+            function C() { Object.defineProperty(this, 'length', { configurable: true, get: function () { return 4; } }); }
+            try { Array.from.call(C, [0, 10]); 'no throw'; } catch (e) { e.constructor.name; }
+            """).AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void ArrayPrototypeGenericsThrowOnATypedArraysUnwritableLength()
+    {
+        var engine = new Engine();
+
+        // Every one of these is specified to Set(O, "length", ...) with throw = true on the receiver.
+        foreach (var script in new[]
+                 {
+                     "Array.prototype.push.call(new Uint8Array(3))",
+                     "Array.prototype.pop.call(new Uint8Array(0))",
+                     "Array.prototype.shift.call(new Uint8Array(0))",
+                     "Array.prototype.unshift.call(new Uint8Array(3))",
+                     "Array.prototype.splice.call(new Uint8Array(3), 0, 0)",
+                 })
+        {
+            engine.Evaluate($$"""
+                try { {{script}}; 'no throw'; } catch (e) { e.constructor.name; }
+                """).AsString().Should().Be("TypeError", because: script);
+        }
+    }
+
+    [Fact]
+    public void FilterDoesNotWriteALengthTheSpecNeverWrites()
+    {
+        var engine = new Engine();
+
+        // Array.prototype.filter has no Set(A, "length", ...) step at all, so a typed-array species must come
+        // back untouched rather than tripping over the length accessor the trailing bookkeeping write used to
+        // aim at.
+        var result = engine.Evaluate("""
+            var a = [1, 2, 3];
+            a.constructor = { [Symbol.species]: Uint8Array };
+            var out = a.filter(function () { return false; });
+            JSON.stringify([out instanceof Uint8Array, out.length]);
+            """).AsString();
+
+        result.Should().Be("[true,0]");
+    }
+
+    [Fact]
+    public void FilterStillFixesUpTheLengthOfARealArrayResult()
+    {
+        var engine = new Engine();
+
+        engine.Evaluate("""
+            var a = [1, 2, 3, 4];
+            a.constructor = Array;
+            var out = a.filter(function (x) { return x % 2 === 0; });
+            JSON.stringify([Array.isArray(out), out.length, out[0], out[1]]);
+            """).AsString().Should().Be("[true,2,2,4]");
+
+        engine.Evaluate("""
+            class MyArray extends Array {}
+            var a = new MyArray();
+            a.push(1, 2, 3, 4, 5);
+            var out = a.filter(function (x) { return x > 3; });
+            JSON.stringify([out instanceof MyArray, out.length, out[0], out[1]]);
+            """).AsString().Should().Be("[true,2,4,5]");
+    }
+}

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -61,9 +61,13 @@ public sealed partial class ArrayConstructor : Constructor
         var usingIterator = GetMethod(_realm, items, GlobalSymbolRegistry.Iterator);
         if (usingIterator is not null)
         {
-            if (!ReferenceEquals(this, thisObject) && thisObject is IConstructor constructor)
+            // Step 5.a: IsConstructor(C), which is a question about the [[Construct]] slot, not about the CLR
+            // interface the implementing type declares -- an arrow function, a generator, an async function, a
+            // method with a [[HomeObject]] and a bound function over a non-constructor all implement
+            // IConstructor and are all rejected by IsConstructor. Fall back to ArrayCreate for those.
+            if (!ReferenceEquals(this, thisObject) && thisObject.IsConstructor)
             {
-                var instance = constructor.Construct([], thisObject);
+                var instance = ((IConstructor) thisObject).Construct([], thisObject);
                 var iterator = items.GetIterator(_realm, method: usingIterator);
                 var protocol = new ArrayProtocol(_engine, thisArg, instance, iterator, callable);
                 protocol.Execute();
@@ -247,9 +251,9 @@ public sealed partial class ArrayConstructor : Constructor
         // ii. Let iteratorRecord be ? GetIterator(asyncItems, async).
         // We'll handle both async and sync iterators
         ObjectInstance instance;
-        if (!ReferenceEquals(this, c) && c is IConstructor constructor)
+        if (!ReferenceEquals(this, c) && c.IsConstructor)
         {
-            instance = constructor.Construct([], c);
+            instance = ((IConstructor) c).Construct([], c);
         }
         else
         {
@@ -498,9 +502,9 @@ public sealed partial class ArrayConstructor : Constructor
             // v. Else,
             //     1. Let A be ? ArrayCreate(len).
             ObjectInstance a;
-            if (!ReferenceEquals(c, this) && c is IConstructor constructor)
+            if (!ReferenceEquals(c, this) && c.IsConstructor)
             {
-                a = constructor.Construct([(JsNumber) longLen], c);
+                a = ((IConstructor) c).Construct([(JsNumber) longLen], c);
             }
             else
             {
@@ -650,10 +654,11 @@ public sealed partial class ArrayConstructor : Constructor
         var length = source.GetLength();
 
         ObjectInstance a;
-        if (!ReferenceEquals(thisObj, this) && thisObj is IConstructor constructor)
+        // Step 6.b: IsConstructor(C) -- see the note on the iterator branch above.
+        if (!ReferenceEquals(thisObj, this) && thisObj.IsConstructor)
         {
             var argumentsList = new JsValue[] { length };
-            a = Construct(constructor, argumentsList);
+            a = Construct((IConstructor) thisObj, argumentsList);
         }
         else
         {

--- a/Jint/Native/Array/ArrayOperations.cs
+++ b/Jint/Native/Array/ArrayOperations.cs
@@ -385,9 +385,12 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
 
         public override ulong GetLongLength() => GetLength();
 
+        // Every caller of this is a spec step spelled "Perform ? Set(O, "length", len, true)" -- Array.from,
+        // Array.fromAsync and the Array.prototype generics that a typed array can be the receiver of. A typed
+        // array's "length" is a getter-only accessor on %TypedArray%.prototype, so that Set fails and, being a
+        // throwing one, raises a TypeError. Doing nothing here silently swallowed all of them.
         public override void SetLength(ulong length)
-        {
-        }
+            => _target.Set(CommonProperties.Length, length, true);
 
         public override void EnsureCapacity(ulong capacity)
         {

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -583,7 +583,17 @@ public sealed partial class ArrayPrototype : ArrayInstance
             }
         }
 
-        operations.SetLength(to);
+        // https://tc39.es/ecma262/#sec-array.prototype.filter has no Set(A, "length", ...) step at all: A is
+        // created with length 0 and each accepted element arrives through CreateDataPropertyOrThrow, which is
+        // what grows an array's length. The write below is Jint's own bookkeeping, needed because the fast
+        // JsArray lane stores elements with updateLength: false. Anything that is not an array -- a typed array
+        // species, a plain object, a Proxy -- must be left alone, or the algorithm performs a Set it does not
+        // have; on a typed array that Set now correctly throws, which would turn a legal filter into a TypeError.
+        if (a is JsArray)
+        {
+            operations.SetLength(to);
+        }
+
         invoker.Return();
 
         return a;


### PR DESCRIPTION
Two independent defects in `Array.from` / `Array.fromAsync`.

## 1. `is IConstructor` is a CLR type test, not `IsConstructor`

`ArrayConstructor` asked `thisObject is IConstructor constructor` in four places. But `ScriptFunction` implements the interface **unconditionally** and puts the real predicate in an override that correctly rejects arrow functions, generators, async functions and methods with a `[[HomeObject]]`; `BindFunction` and `JsProxy` do the same and gate at runtime.

So the type test admitted objects that [IsConstructor](https://tc39.es/ecma262/#sec-isconstructor) rejects, and [23.1.2.1](https://tc39.es/ecma262/#sec-array.from) steps 5.a / 6.b require falling back to `ArrayCreate`:

```js
Array.from.call(() => ({}), [1, 2]);          // took the construct branch
Array.from.call(Math.sin.bind(null), [1,2]);  // threw "is not a constructor"
```

`Array.fromAsync.call(async function(){}, {length: 2})` was worse than mis-constructing — it rejected with `Cannot read properties of undefined (reading 'length')`, i.e. the wrong branch produced an internally inconsistent result.

Fixed by using the `IsConstructor` virtual, as `Array.of` already does.

Every other `is IConstructor` / `as IConstructor` site was reviewed. `Function.cs`'s is the definition itself; `JintNewExpression`'s and `JsProxy`'s are preceded by the authoritative check and so are tautological; `PromiseConstructor`'s two are the wrong predicate but strictly more permissive and reach the same `TypeError` via `NewPromiseCapability`. `BindFunction.Construct`'s is the same confusion but is now unreachable in a wrong state, since `Array.from` was the one caller that skipped the gate. Left alone, noted as a latent trap.

## 2. `JsTypedArrayOperations.SetLength` was an empty method

```csharp
public override void SetLength(ulong length) { }
```

`%TypedArray%.prototype.length` is a getter-only accessor, so every spec step spelled `Perform ? Set(O, "length", len, true)` must throw when the receiver is a typed array. Nine of them were silently swallowed — `Array.from`, `Array.fromAsync`, and `push`/`pop`/`shift`/`unshift`/`splice` applied to a typed array, all of which throw in V8 and SpiderMonkey.

**One caller had to be excluded, and it is the interesting part.** `Array.prototype.filter` has **no** length-write step at all ([23.1.3.8](https://tc39.es/ecma262/#sec-array.prototype.filter): `A` is created empty and grows through `CreateDataPropertyOrThrow`). Jint's call there is its own bookkeeping, needed only because the fast `JsArray` lane writes elements with `updateLength: false`. Making `SetLength` throw without guarding it would have broken legal code:

```js
var a = [1,2,3];
a.constructor = { [Symbol.species]: Uint8Array };
a.filter(() => false);   // must give Uint8Array(0)
```

The bookkeeping write is now confined to `a is JsArray`, which is also strictly more spec-correct for a plain-object or Proxy species — those used to receive a `set` the algorithm never performs.

## Tests

`Jint.Tests/Runtime/ArrayFromConstructorTests.cs` — 31 cases, 22 failing against unfixed code, covering all five non-constructor shapes on both the iterator and array-like paths for `from` and `fromAsync`, the typed-array length throw, the generics, and both filter regressions.

Frees three `staging/` exclusions: `Array/from_constructor.js`, `Array/from_errors.js`, `Function/bound-non-constructable.js`.

Refs #3021.
