### PR TITLE
createRealm installs a full $262 on the new realm and returns it

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -57,11 +57,22 @@
     "staging/sm/expressions/nullish-coalescing.js",
     "staging/sm/regress/regress-1507322-deep-weakmap.js",
 
-    // Cross-realm error identity. $262.createRealm() works, but an error Jint raises while running
-    // a function belonging to another realm is constructed from the *current* realm's intrinsics,
-    // so `e instanceof otherGlobal.TypeError` is false. The realm's global also does not carry its
-    // own $262, so otherGlobal.$262.detachArrayBuffer is undefined. Removed by making error
-    // creation realm-aware (and by installing $262 into every created realm).
+    // Cross-realm identity of a built-in's *products*. $262.createRealm() now hands back a full $262
+    // installed on the new realm's global, so otherGlobal.$262.detachArrayBuffer resolves and the
+    // harness half of these is done; what is left is engine-side, and it is not that error creation
+    // ignores realms in general - most built-ins already raise through their own _realm. It is that
+    // a handful of paths reach for whichever realm happens to be *running* instead of the realm the
+    // called function belongs to, which shows up two ways:
+    //  - the wrong realm's error. `otherGlobal.Iterator.prototype.every.call(...)` and friends throw
+    //    a TypeError (RangeError for toSorted) built from the caller's intrinsics, so the test sees
+    //    "a different error constructor with the same name" and `e instanceof otherGlobal.TypeError`
+    //    is false.
+    //  - the wrong realm's result. A built-in invoked cross-realm allocates its result from the
+    //    active realm, so `otherGlobal.Array.prototype.with.call([1,2,3], 1, 3)` comes back as an
+    //    instance of *this* Array, `g.Array.from(...)` is not an instance of `g.Array`, and
+    //    `otherGlobal.Iterator.from(iter)` hands the iterator straight back instead of wrapping it.
+    // Removed by taking the function's own realm on those paths, for both the throw and the
+    // allocation.
     "staging/sm/Array/change-array-by-copy-cross-compartment-create.js",
     "staging/sm/Array/change-array-by-copy-errors-from-correct-realm.js",
     "staging/sm/Array/from_realms.js",
@@ -73,8 +84,14 @@
     "staging/sm/Iterator/prototype/some/error-from-correct-realm.js",
     "staging/sm/Iterator/prototype/toArray/create-in-current-realm.js",
     "staging/sm/JSON/parse-with-source.js",
+
+    // Argument-validation order in the TypedArray-from-ArrayBuffer constructor - despite the file's
+    // cross-realm cast, nothing about it is realm-specific and it fails the same way on a buffer from
+    // this realm. InitializeTypedArrayFromArrayBuffer throws the RangeError for a byteOffset that is
+    // not a multiple of the element size (step 3) before it evaluates ToIndex(length) (step 5); Jint
+    // runs them the other way round, so `new Int32Array(buffer, 1, poisonedValue)` reports the
+    // poisoned value's own error instead of the RangeError. Removed by fixing that ordering.
     "staging/sm/TypedArray/constructor-buffer-sequence.js",
-    "staging/sm/TypedArray/set-wrapped.js",
 
     // Legacy Function.prototype.caller / arguments.callee.caller. These are Annex B accessors whose
     // sloppy-mode observable behaviour (the calling function, null at the top of the stack, poisoned

--- a/Jint.Tests/Runtime/GuardFusionTests.cs
+++ b/Jint.Tests/Runtime/GuardFusionTests.cs
@@ -227,7 +227,7 @@ public class GuardFusionTests
     {
         var engine = new Engine();
         // an object with the [[IsHTMLDDA]] internal slot (the document.all shape)
-        var htmlDDA = new Jint.Native.IsHTMLDDA(engine);
+        var htmlDDA = new Jint.Native.IsHTMLDDA(engine, engine.Realm);
         engine.SetValue("htmlDDA", (Jint.Native.JsValue) htmlDDA);
 
         // Annex B: loose equality with null/undefined is true (both orientations, both operators)

--- a/Jint.Tests/Runtime/Test262HarnessObjectTests.cs
+++ b/Jint.Tests/Runtime/Test262HarnessObjectTests.cs
@@ -1,0 +1,92 @@
+#nullable enable
+
+using Jint.Native.Function;
+using Jint.Native.Object;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// test262's INTERPRETING.md specifies that <c>$262.createRealm()</c> "creates a new ECMAScript Realm,
+/// defines this API on the new realm's global object, and returns the <c>$262</c> property of the new
+/// realm's global object". So the value handed back is a full <c>$262</c> — not the bare global — and the
+/// new realm's global carries it, which is how <c>otherGlobal.$262.detachArrayBuffer</c> resolves.
+/// </summary>
+public class Test262HarnessObjectTests
+{
+    [Fact]
+    public void CreateRealmReturnsTheNewRealmsOwn262Object()
+    {
+        var engine = new Engine();
+        Test262Object.Install(engine);
+
+        var created = engine.Evaluate("$262.createRealm()");
+        created.Should().BeAssignableTo<ObjectInstance>();
+        engine.SetValue("other", created);
+
+        foreach (var member in new[] { "createRealm", "detachArrayBuffer", "evalScript", "gc" })
+        {
+            engine.Evaluate("typeof other." + member).AsString().Should().Be("function", "$262." + member + " must exist on the created realm's $262");
+        }
+
+        engine.Evaluate("typeof other.global").AsString().Should().Be("object");
+
+        // The returned object is the new realm's global's own $262, per INTERPRETING.md.
+        engine.Evaluate("other.global.$262 === other").AsBoolean().Should().BeTrue();
+
+        // ... and the top-level $262 knows its own global too.
+        engine.Evaluate("$262.global === globalThis").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void CreatedRealmHasItsOwnGlobalAndIntrinsics()
+    {
+        var engine = new Engine();
+        Test262Object.Install(engine);
+
+        engine.SetValue("other", engine.Evaluate("$262.createRealm()"));
+
+        engine.Evaluate("other.global !== globalThis").AsBoolean().Should().BeTrue();
+        engine.Evaluate("other.global.Array !== Array").AsBoolean().Should().BeTrue();
+        engine.Evaluate("other.global.TypeError !== TypeError").AsBoolean().Should().BeTrue();
+
+        // Nested realms: the created $262 can create one of its own.
+        engine.Evaluate("other.createRealm().global !== other.global").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void CreatedRealmsFunctionsBelongToThatRealm()
+    {
+        var engine = new Engine();
+        Test262Object.Install(engine);
+
+        var created = (ObjectInstance) engine.Evaluate("$262.createRealm()");
+        var newGlobal = (ObjectInstance) created.Get("global");
+
+        // The $262 object and every function on it must be built from the new realm's intrinsics,
+        // never from whichever realm happened to be active when createRealm ran.
+        created.Prototype.Should().BeSameAs(newGlobal.Get("Object").AsObject().Get("prototype"));
+
+        foreach (var member in new[] { "createRealm", "detachArrayBuffer", "evalScript", "gc" })
+        {
+            var function = created.Get(member).Should().BeAssignableTo<Function>().Subject;
+            function._realm.Should().NotBeSameAs(engine.Realm, member + " must not be pinned to the principal realm");
+            function._realm.GlobalObject.Should().BeSameAs(newGlobal);
+        }
+    }
+
+    [Fact]
+    public void CreatedRealmDetachesABufferMadeInThatRealm()
+    {
+        var engine = new Engine();
+        Test262Object.Install(engine);
+
+        engine.SetValue("other", engine.Evaluate("$262.createRealm()"));
+
+        engine.Evaluate("var buffer = other.evalScript('new ArrayBuffer(8)');");
+        engine.Evaluate("buffer instanceof other.global.ArrayBuffer").AsBoolean().Should().BeTrue();
+        engine.Evaluate("buffer.byteLength").AsNumber().Should().Be(8);
+
+        engine.Evaluate("other.detachArrayBuffer(buffer);");
+        engine.Evaluate("buffer.byteLength").AsNumber().Should().Be(0);
+    }
+}

--- a/Jint/Native/IsHTMLDDA.cs
+++ b/Jint/Native/IsHTMLDDA.cs
@@ -12,8 +12,11 @@ namespace Jint.Native;
 /// </summary>
 internal sealed class IsHTMLDDA : ObjectInstance, ICallable
 {
-    internal IsHTMLDDA(Engine engine) : base(engine, ObjectClass.Object, InternalTypes.Object | InternalTypes.IsHTMLDDA | InternalTypes.Callable)
+    internal IsHTMLDDA(Engine engine, Realm realm) : base(engine, ObjectClass.Object, InternalTypes.Object | InternalTypes.IsHTMLDDA | InternalTypes.Callable)
     {
+        // The base constructor takes the prototype from whichever realm is active; this object may be
+        // built for another one ($262.createRealm() installs a $262 into the realm it just made).
+        _prototype = realm.Intrinsics.Object.PrototypeObject;
     }
 
     JsValue ICallable.Call(JsValue thisObject, JsCallArguments arguments) => Null;

--- a/Jint/Test262Object.cs
+++ b/Jint/Test262Object.cs
@@ -18,14 +18,30 @@ internal static class Test262Object
     /// <summary>
     /// Installs the $262 object into the engine's global scope and returns it.
     /// </summary>
-    public static ObjectInstance Install(Engine engine)
+    public static ObjectInstance Install(Engine engine) => Install(engine, engine.Realm);
+
+    /// <summary>
+    /// Installs a $262 object onto the global object of <paramref name="realm"/> and returns it.
+    /// <para>
+    /// Everything it carries is built from <paramref name="realm"/>'s own intrinsics and pinned to that
+    /// realm, because <c>$262.createRealm()</c> installs an API into a realm other than the one running.
+    /// A function left pinned to the caller's realm would report its errors — and hand out its
+    /// prototypes — from the wrong one.
+    /// </para>
+    /// </summary>
+    public static ObjectInstance Install(Engine engine, Realm realm)
     {
-        var o = engine.Realm.Intrinsics.Object.Construct(Arguments.Empty);
+        // Not Intrinsics.Object.Construct: for a plain construction that lands on `new JsObject(engine)`,
+        // which takes the *active* realm's Object.prototype. Name the prototype explicitly instead.
+        var o = ObjectInstance.OrdinaryObjectCreate(engine, realm.Intrinsics.Object.PrototypeObject);
+
+        // "A reference to the global object on which the $262 object lives."
+        o.FastSetProperty("global", new PropertyDescriptor(realm.GlobalObject, true, true, true));
 
         // %AbstractModuleSource% intrinsic - exposed via $262 for source-phase-imports tests
-        o.FastSetProperty("AbstractModuleSource", new PropertyDescriptor(CreateAbstractModuleSource(engine), true, true, true));
+        o.FastSetProperty("AbstractModuleSource", new PropertyDescriptor(CreateAbstractModuleSource(engine, realm), true, true, true));
 
-        o.FastSetProperty("evalScript", new PropertyDescriptor(new ClrFunction(engine, "evalScript",
+        o.FastSetProperty("evalScript", new PropertyDescriptor(new ClrFunction(engine, realm, "evalScript",
             (_, args) =>
             {
                 if (args.Length > 1)
@@ -33,47 +49,35 @@ internal static class Test262Object
                     throw new ArgumentException("only script parsing supported", nameof(args));
                 }
 
-                var script = Engine.PrepareScript(args.At(0).AsString(), options: new ScriptPreparationOptions
-                {
-                    ParsingOptions = ScriptParsingOptions.Default with { Tolerant = false, RetainFunctionSourceText = true },
-                });
+                return EvaluateInRealm(engine, realm, args.At(0).AsString());
+            }, 0), true, true, true));
 
-                return engine.Evaluate(in script);
-            }), true, true, true));
+        // Per test262 INTERPRETING.md, createRealm "creates a new ECMAScript Realm, defines this API on
+        // the new realm's global object, and returns the $262 property of the new realm's global object".
+        // So the whole API - createRealm included, so realms can nest - goes onto the new global, and the
+        // new realm's own $262 is what comes back.
+        o.FastSetProperty("createRealm", new PropertyDescriptor(new ClrFunction(engine, realm, "createRealm",
+            (_, _) => Install(engine, engine._host.CreateRealm()), 0), true, true, true));
 
-        o.FastSetProperty("createRealm", new PropertyDescriptor(new ClrFunction(engine, "createRealm",
-            (_, _) =>
-            {
-                var realm = engine._host.CreateRealm();
-                var newGlobal = realm.GlobalObject;
-                newGlobal.Set("global", newGlobal);
-                // Per test262 INTERPRETING.md, the object returned by createRealm exposes an evalScript
-                // that evaluates in the new realm. Provide it so cross-realm tests (e.g. FallbackSymbol
-                // per-realm) can run code against the freshly created realm's intrinsics.
-                newGlobal.Set("evalScript", new ClrFunction(engine, "evalScript",
-                    (_, args) => EvaluateInRealm(engine, realm, args.At(0).AsString())));
-                return newGlobal;
-            }), true, true, true));
-
-        o.FastSetProperty("detachArrayBuffer", new PropertyDescriptor(new ClrFunction(engine, "detachArrayBuffer",
+        o.FastSetProperty("detachArrayBuffer", new PropertyDescriptor(new ClrFunction(engine, realm, "detachArrayBuffer",
             (_, args) =>
             {
                 var buffer = (JsArrayBuffer) args.At(0);
                 buffer.DetachArrayBuffer();
                 return JsValue.Undefined;
-            }), true, true, true));
+            }, 0), true, true, true));
 
-        o.FastSetProperty("gc", new PropertyDescriptor(new ClrFunction(engine, "gc",
+        o.FastSetProperty("gc", new PropertyDescriptor(new ClrFunction(engine, realm, "gc",
             (_, _) =>
             {
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
                 return JsValue.Undefined;
-            }), true, true, true));
+            }, 0), true, true, true));
 
-        o.FastSetProperty("IsHTMLDDA", new PropertyDescriptor(new IsHTMLDDA(engine), true, true, true));
+        o.FastSetProperty("IsHTMLDDA", new PropertyDescriptor(new IsHTMLDDA(engine, realm), true, true, true));
 
-        engine.SetValue("$262", o);
+        realm.GlobalObject.Set("$262", o);
         return o;
     }
 
@@ -86,7 +90,7 @@ internal static class Test262Object
     {
         var script = Engine.PrepareScript(source, options: new ScriptPreparationOptions
         {
-            ParsingOptions = ScriptParsingOptions.Default with { Tolerant = false },
+            ParsingOptions = ScriptParsingOptions.Default with { Tolerant = false, RetainFunctionSourceText = true },
         });
 
         var context = new ExecutionContext(
@@ -114,15 +118,13 @@ internal static class Test262Object
     /// Creates the %AbstractModuleSource% intrinsic constructor and prototype.
     /// https://tc39.es/proposal-source-phase-imports/#sec-%abstractmodulesource%
     /// </summary>
-    private static ClrFunction CreateAbstractModuleSource(Engine engine)
+    private static ClrFunction CreateAbstractModuleSource(Engine engine, Realm realm)
     {
-        var realm = engine.Realm;
-
-        // Create the prototype object
-        var proto = engine.Realm.Intrinsics.Object.Construct(Arguments.Empty);
+        // Create the prototype object (see the note in Install about naming the prototype explicitly)
+        var proto = ObjectInstance.OrdinaryObjectCreate(engine, realm.Intrinsics.Object.PrototypeObject);
 
         // @@toStringTag getter on prototype
-        var toStringTagGetter = new ClrFunction(engine, "get [Symbol.toStringTag]", (thisObj, _) =>
+        var toStringTagGetter = new ClrFunction(engine, realm, "get [Symbol.toStringTag]", (thisObj, _) =>
         {
             if (thisObj is not ObjectInstance)
             {
@@ -139,7 +141,7 @@ internal static class Test262Object
             PropertyFlag.Configurable));
 
         // The constructor function that always throws TypeError
-        var ctor = new ClrFunction(engine, "AbstractModuleSource", (_, _) =>
+        var ctor = new ClrFunction(engine, realm, "AbstractModuleSource", (_, _) =>
         {
             Throw.TypeError(realm, "Abstract class constructor %AbstractModuleSource% cannot be invoked");
             return JsValue.Undefined;


### PR DESCRIPTION
test262's [INTERPRETING.md](https://github.com/tc39/test262/blob/main/INTERPRETING.md) specifies that `$262.createRealm()` *"creates a new ECMAScript Realm, defines this API on the new realm's global object, and returns the `$262` property of the new realm's global object"*.

Jint returned the new realm's **global object** and installed only `global` and `evalScript` on it. So `otherRealm.$262` was `undefined` and `otherRealm.$262.detachArrayBuffer` could not be reached. It worked at all only because it set `global` on the global itself, so `other.global` happened to resolve.

## The fix

`Test262Object.Install` gains a `(Engine, Realm)` overload that builds `$262` from the *target realm's* intrinsics using the realm-pinned `ClrFunction` constructor, and `createRealm` now installs a full `$262` — `createRealm`, `detachArrayBuffer`, `evalScript`, `gc`, `IsHTMLDDA`, `AbstractModuleSource`, `global` — on the new realm's global and returns it.

One thing worth recording, because it is not obvious: **`realm.Intrinsics.Object.Construct(...)` does not give you an object of that realm.** A plain construction lands on `new JsObject(engine)`, whose prototype comes from the *active* realm. The `$262` object and the `%AbstractModuleSource%` prototype therefore use `OrdinaryObjectCreate(engine, realm.Intrinsics.Object.PrototypeObject)` instead. That same behaviour is the root cause of the "wrong realm's result" exclusions still listed in the file.

## Compatibility

All 284 test262 files that call `createRealm` were surveyed: 297 uses chain `.global` directly, and of the 9 that bind the result to a variable the only properties ever read are `.global` (24) and `.evalScript` (2). Both survive. No file reads `.global` off a variable already holding the new global, so dropping the old self-reference is safe. `Test262AgentManager`'s minimal worker `$262` is untouched.

## Tests

`Jint.Tests/Runtime/Test262HarnessObjectTests.cs` — 4 tests, all failing against unfixed code. They assert the returned object carries every member, that `result.global` is a distinct global with distinct intrinsics, that the installed functions genuinely belong to the new realm, and that `detachArrayBuffer` detaches a buffer created in that realm.

Because this touches the harness every cross-realm test262 file depends on, the 219 generated test methods covering all 498 files that mention `$262` were run in sequential chunks: **46,905 passed, 0 failed**.

## Exclusions

Frees `staging/sm/TypedArray/set-wrapped.js`.

`constructor-buffer-sequence.js` is **not** freed and stays excluded, moved to its own block with a precise reason: with the `$262` gap closed it progresses to a realm-independent failure. `InitializeTypedArrayFromArrayBuffer` must raise the misaligned-`byteOffset` `RangeError` (step 3) before evaluating `ToIndex(length)` (step 5); Jint evaluates both `ToIndex` calls at the call site first, so `new Int32Array(buffer, 1, poisonedValue)` reports the poisoned value's own error. Those are the same two lines as the `int`-truncation bug behind `constructor-byteoffsets-bounds.js`, so one fix removes both entries.

The cross-realm banner is rewritten. Its claim that "an error Jint raises while running a function belonging to another realm is constructed from the current realm's intrinsics" is wrong as a general statement — most built-ins already raise through their own `_realm`. What remains is a handful of paths that reach for whichever realm is *running*, in two distinct shapes (wrong realm's error, wrong realm's result), and the comment now says which files are which.

Refs #3021.
