### PR TITLE
Bound result conversion, JSON serialization, and error rendering

### DIFF
--- a/.github/THREAT_MODEL.md
+++ b/.github/THREAT_MODEL.md
@@ -98,6 +98,7 @@ Defaults are compatibility choices, not a hardened profile.
 | Debugger | Disabled | Debug callbacks and debugger expressions are inactive |
 | Detailed CLR resolution errors | Disabled | Reduces script-visible CLR surface disclosure |
 | Function source retention | Disabled | Submitted function source is not retained solely for `toString()` |
+| Result conversion and JSON output limits | Unlimited | Compatibility default; hostile output is unbounded unless the host opts in |
 
 ## Threat inventory
 
@@ -341,9 +342,13 @@ when the outer deadline expires.
 
 ### TM-09: A sequence of engine entries escapes a per-entry budget
 
-**Threat.** `Execute`, `Evaluate`, `Invoke`, and `Call` are separate top-level runs. Built-in
+**Threat.** `Execute`, `Evaluate`, `Invoke`, `Call`, `Advanced.ConvertResult`, public
+`JsonSerializer.Serialize` calls, and bounded
+`JavaScriptException.GetJavaScriptErrorString` are separate top-level runs. Built-in
 constraints reset around each one, so a host loop that invokes a script once per record
-grants a fresh timeout, statement budget, and allocation baseline to every call.
+grants a fresh timeout, statement budget, and allocation baseline to every call. Evaluating
+a result and then converting or serializing it also grants each phase a fresh budget unless
+the host brackets both with one operation deadline.
 
 **Existing mitigations.**
 
@@ -355,9 +360,10 @@ grants a fresh timeout, statement budget, and allocation baseline to every call.
 - Jint cannot infer which entries form one server request.
 - `OperationDeadlineConstraint` is inert unless the host explicitly brackets the operation.
 
-**Required host action.** Arm one operation deadline around all engine work for the request,
-including module import, callbacks, and result handling. Keep per-entry constraints as an
-additional ceiling.
+**Required host action.** Arm one `OperationDeadlineConstraint` around all engine work for the
+request, including module import, callbacks, `ConvertResult`, `JsonSerializer`, and bounded error
+rendering. When evaluation and conversion or serialization form one request, they must be inside
+the same `Begin`/`End` pair. Keep per-entry constraints as an additional ceiling.
 
 ### TM-10: Async and promise work outlives the request
 
@@ -560,16 +566,39 @@ run additional code and consume CPU or memory outside the intended execution bud
 
 - The host controls whether and how values cross out of the engine.
 - `JSON.parse` has a configurable maximum parse depth.
+- `ResultLimits` can bound conversion/serialization depth, cumulative properties or elements,
+  individual strings, aggregate characters, and UTF-8 or binary bytes.
+- `Advanced.ConvertResult` copies Jint-owned arrays, typed arrays, maps, sets, and enumerable
+  object properties to a detached CLR graph, rejects cycles, and enforces the selected limits
+  before known-size output allocations and before property getters are read.
+- Jint's JSON serializer enforces the same limits while walking, counts escaped characters
+  before appending, and checks exact UTF-8 bytes before touching a writer.
+- Conversion, JSON serialization, and bounded JavaScript error rendering run under execution
+  constraints because getters, proxy traps, `toJSON`, replacers, and `stack` accessors can run
+  script.
 
 **Missing or residual mitigation.**
 
-- Jint does not impose a universal response byte, object depth, property count, or host
-  serializer limit.
+- Result limits are unlimited by default.
+- Shared references that are not cycles are converted once per occurrence and can amplify the
+  detached CLR graph. `MaxPropertyCount` is the structural-work and container-allocation bound;
+  string, character, and binary-byte limits do not substitute for it.
+- Proxy `ownKeys` and host property-key hooks can allocate their key list before Jint receives
+  and counts it; memory constraints and process isolation remain the backstop.
+- Observable coercion hooks on boxed strings and numbers must run before Jint knows the
+  resulting primitive's size; they can allocate before the result limiter can inspect it.
+- A CLR wrapper target is already host-owned and is returned without walking its object graph.
+- `System.Text.Json`, Newtonsoft.Json, configured `Interop.SerializeToJson` delegates, custom
+  converters, logging formatters, standard `Exception.ToString()`, and debugger frontends run
+  outside Jint's bounded walker. Jint can cap a delegate's returned text before copying it, but
+  cannot undo work already performed inside the delegate.
 - Returning an engine-owned `JsValue` extends the engine and realm lifetime.
 
-**Required host action.** Define a small result schema, copy only approved primitive fields,
-cap depth/property count/bytes, serialize under the outer request budget, reject cycles, and
-discard engine-owned values with the engine.
+**Required host action.** Define a small result schema, configure and tune `ResultLimits` (the
+`Conservative` preset is only a starting point), and return `Advanced.ConvertResult` output or
+bounded `JsonSerializer` output. Keep time, statement, cancellation, memory, stack, worker, and
+response-server byte limits around the whole operation. Independently configure every external
+serializer and log sink, and discard engine-owned values with the engine.
 
 ### TM-18: Retention and cache-based memory growth
 
@@ -1120,6 +1149,7 @@ var engine = new Engine(options =>
     options.AgentCanSuspend = false;
     options.AllowClrWrite(false);
     options.Interop.ArrayConversion = ArrayConversionMode.Copy;
+    options.ResultLimits = ResultLimits.Conservative;
 
     // Do not call AllowClr(). Leave modules and the debugger disabled.
 });
@@ -1127,7 +1157,8 @@ var engine = new Engine(options =>
 deadline.Begin(TimeSpan.FromSeconds(3), requestAborted);
 try
 {
-    return engine.Evaluate(boundedSource).ToObject();
+    var value = engine.Evaluate(boundedSource);
+    return engine.Advanced.ConvertResult(value);
 }
 finally
 {
@@ -1163,8 +1194,8 @@ This configuration is incomplete without host controls:
 3. Deny filesystem and outbound network access unless explicitly required.
 4. Expose only narrow, authorized, cancellation-aware host functions.
 5. Use a fresh engine for mutually distrusting requests.
-6. Cap module graphs, callback work, returned object shape, serialized bytes, logs, and
-   total request time.
+6. Tune `ResultLimits`, and separately cap module graphs, callback work, external serializers,
+   HTTP response bytes, logs, and total request time.
 7. Discard the worker if it misses the outer deadline; do not wait indefinitely for
    in-process cleanup.
 
@@ -1174,8 +1205,9 @@ Before deploying a host that executes untrusted scripts:
 
 - [ ] CLR namespace access, `AllowGetType`, reflection, debugger, and `Atomics.wait` are off.
 - [ ] Projected host objects are immutable or intentionally capability-scoped and read-only.
-- [ ] Initial source, callback, result, and log limits are enforced outside Jint; all four
-  Jint module graph limits are configured when modules are enabled.
+- [ ] Initial source, callback, external serializer, HTTP response, and log limits are enforced
+  outside Jint; `ResultLimits` is configured for Jint-owned conversion and JSON output, and all
+  four Jint module graph limits are configured when modules are enabled.
 - [ ] Time, statement, memory, recursion, stack, array, regex, promise, and operation limits
   are explicitly configured and tested with adversarial inputs.
 - [ ] Async API cancellation is paired with an engine cancellation constraint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,6 +210,7 @@ Jint is not only an engine to work on, it is an engine that gets **embedded**. I
 | `ReferencedGlobals` + `Prepared<T>.ReferencedGlobals` + `{Script,Module}PreparationOptions.CollectReferencedGlobals` | `Jint/ReferencedGlobals.cs`, `Jint/Prepared.cs`, `Jint/PreparationOptions.cs` |
 | `{Script,Module}PreparationOptions.StaticAnalysis` — the opt-out from the prepare-time analysis pass, plus the promise that the parse-only tree it returns is *still* safe to share across engines | `Jint/PreparationOptions.cs` |
 | `GlobalSnapshot` + `Engine.Advanced.CaptureGlobalSnapshot` / `RestoreGlobalSnapshot` / `WithRestoredGlobals` | `Jint/Engine.GlobalSnapshot.cs` |
+| `ResultLimits` + `ResultLimit` + `ResultLimitExceededException` + `Engine.Advanced.ConvertResult` + bounded `JsonSerializer` / `JavaScriptException.GetJavaScriptErrorString` overloads | `Jint/ResultLimits.cs`, `Jint/Runtime/ResultLimitExceededException.cs`, `Jint/Engine.Advanced.cs`, `Jint/Native/Json/JsonSerializer.cs`, `Jint/Runtime/JavaScriptException.cs` |
 | `IModuleLoader` — and the promise that a loader which only implements *it* is still driven synchronously | `Jint/Runtime/Modules/IModuleLoader.cs` |
 | `Module.Location` — the name a module knows itself by, never null, and the `referencingModuleLocation` its own imports resolve against | `Jint/Runtime/Modules/Module.cs` |
 | `ModuleFactory.LocationOf` — public **static**, the rule deriving that name from a `ResolvedSpecifier`, which a host naming a module itself has to match exactly | `Jint/Runtime/Modules/ModuleFactory.cs` |

--- a/Jint.Tests.PublicInterface/AsyncModuleLoaderTests.cs
+++ b/Jint.Tests.PublicInterface/AsyncModuleLoaderTests.cs
@@ -124,6 +124,41 @@ public class AsyncModuleLoaderTests
         }
     }
 
+    private sealed class ResultFailureLoader(Exception failure, bool settle) : IAsyncModuleLoader
+    {
+        public ResolvedSpecifier Resolve(string? referencingModuleLocation, ModuleRequest moduleRequest)
+            => new(moduleRequest, moduleRequest.Specifier, Uri: null, SpecifierType.Bare);
+
+        public Module LoadModule(Engine engine, ResolvedSpecifier resolved)
+            => throw new InvalidOperationException("The asynchronous path is required.");
+
+        public void LoadModuleAsync(Engine engine, ResolvedSpecifier resolved, ModuleLoadCompletion completion)
+        {
+            if (settle)
+            {
+                completion.SetError(failure);
+                return;
+            }
+
+            throw failure;
+        }
+    }
+
+    private sealed class FaultedResultFailureLoader(Exception failure) : AsyncModuleLoader
+    {
+        public override ResolvedSpecifier Resolve(string? referencingModuleLocation, ModuleRequest moduleRequest)
+            => new(moduleRequest, moduleRequest.Specifier, Uri: null, SpecifierType.Bare);
+
+        protected override async Task<string> LoadModuleContentsAsync(
+            Engine engine,
+            ResolvedSpecifier resolved,
+            CancellationToken cancellationToken)
+        {
+            await Task.Yield();
+            throw failure;
+        }
+    }
+
     [Fact]
     public async Task CanImportAModuleWhoseSourceArrivesAsynchronously()
     {
@@ -139,6 +174,48 @@ public class AsyncModuleLoaderTests
 
         ns.Get("result").AsNumber().Should().Be(42);
         loader.Loads.Should().Be(2);
+    }
+
+    [Fact]
+    public void DirectResultLimitFromLoaderRemainsFatal()
+    {
+        var failure = CreateResultLimitFailure();
+        var engine = new Engine(options => options.EnableModules(new ResultFailureLoader(failure, settle: false)));
+
+        Invoking(() => engine.Modules.Import("module"))
+            .Should().ThrowExactly<ResultLimitExceededException>();
+        engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
+    }
+
+    [Fact]
+    public void SettledResultLimitFromLoaderRemainsFatal()
+    {
+        var failure = CreateResultLimitFailure();
+        var engine = new Engine(options => options.EnableModules(new ResultFailureLoader(failure, settle: true)));
+
+        Invoking(() => engine.Modules.Import("module"))
+            .Should().ThrowExactly<ResultLimitExceededException>();
+        engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task FaultedResultLimitFromLoaderRemainsFatal()
+    {
+        var failure = CreateResultLimitFailure();
+        var engine = new Engine(options => options.EnableModules(new FaultedResultFailureLoader(failure)));
+
+        await Awaiting(() => engine.Modules.ImportAsync("module"))
+            .Should().ThrowExactlyAsync<ResultLimitExceededException>();
+        engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
+    }
+
+    private static ResultLimitExceededException CreateResultLimitFailure()
+    {
+        using var engine = new Engine();
+        return Invoking(() => engine.Advanced.ConvertResult(
+                engine.Evaluate("[1, 2]"),
+                new ResultLimits(maxPropertyCount: 1)))
+            .Should().ThrowExactly<ResultLimitExceededException>().Which;
     }
 
     [Fact]

--- a/Jint.Tests.PublicInterface/ClrProxyHandlerTests.cs
+++ b/Jint.Tests.PublicInterface/ClrProxyHandlerTests.cs
@@ -700,6 +700,26 @@ public class ClrProxyHandlerTests
     }
 
     [Fact]
+    public void ResultLimitFromAnyTrapRemainsFatal()
+    {
+        var engine = new Engine(options => options.CatchClrExceptions());
+        var value = engine.Evaluate("[1, 2]");
+        var handler = new DelegatingProxyHandler
+        {
+            OnGet = (_, _, _) =>
+            {
+                engine.Advanced.ConvertResult(value, new ResultLimits(maxPropertyCount: 1));
+                return null;
+            }
+        };
+        engine.SetValue("p", engine.Advanced.CreateProxy(CreateTarget(engine), handler));
+
+        Invoking(() => engine.Evaluate("try { p.x; } catch { globalThis.caught = true; }"))
+            .Should().ThrowExactly<ResultLimitExceededException>();
+        engine.GetValue("caught").Should().BeUndefined();
+    }
+
+    [Fact]
     public void FactoriesValidateArguments()
     {
         var engine = new Engine();

--- a/Jint.Tests.PublicInterface/HostResultLimitsTests.cs
+++ b/Jint.Tests.PublicInterface/HostResultLimitsTests.cs
@@ -1,0 +1,507 @@
+using Jint.Constraints;
+using Jint.Native;
+using Jint.Native.Json;
+using Jint.Runtime;
+using Jint.Runtime.Interop;
+
+namespace Jint.Tests.PublicInterface;
+
+public class HostResultLimitsTests
+{
+    private const string ConcurrentUseMessage = "*already in use by another thread or has an asynchronous operation in progress*";
+
+    [Fact]
+    public void DefaultConversionRemainsUnlimitedAndCompatible()
+    {
+        var options = new Options();
+        using var engine = new Engine(options);
+        var value = engine.Evaluate("({ name: 'jint', nested: [1, true, null] })");
+
+        var result = engine.Advanced.ConvertResult(value)
+            .Should().BeAssignableTo<IDictionary<string, object>>().Which;
+
+        result["name"].Should().Be("jint");
+        result["nested"].Should().BeEquivalentTo(new object[] { 1d, true, null });
+        options.ResultLimits.Should().BeSameAs(ResultLimits.Unlimited);
+    }
+
+    [Fact]
+    public void DepthBoundaryIsInclusive()
+    {
+        using var engine = new Engine();
+        var value = engine.Evaluate("({ child: { value: 1 } })");
+
+        engine.Advanced.ConvertResult(value, Limits(maxDepth: 2)).Should().NotBeNull();
+        AssertLimit(
+            () => engine.Advanced.ConvertResult(value, Limits(maxDepth: 1)),
+            ResultLimit.Depth,
+            maximum: 1,
+            observed: 2);
+    }
+
+    [Fact]
+    public void LeafObjectsDoNotConsumeContainerDepth()
+    {
+        using var engine = new Engine();
+        var value = engine.Evaluate("({ date: new Date(0), boxed: new Number(1), regexp: /x/ })");
+
+        engine.Advanced.ConvertResult(value, Limits(maxDepth: 1)).Should().NotBeNull();
+    }
+
+    [Fact]
+    public void PropertyBoundaryIsCheckedBeforeGettersRun()
+    {
+        using var engine = new Engine();
+        var value = engine.Evaluate("""
+            globalThis.reads = 0;
+            ({ get a() { reads++; return 1; }, get b() { reads++; return 2; }, get c() { reads++; return 3; } })
+            """);
+
+        engine.Advanced.ConvertResult(value, Limits(maxPropertyCount: 3)).Should().NotBeNull();
+        engine.GetValue("reads").AsNumber().Should().Be(3);
+
+        engine.SetValue("reads", 0);
+        AssertLimit(
+            () => engine.Advanced.ConvertResult(value, Limits(maxPropertyCount: 2)),
+            ResultLimit.PropertyCount,
+            maximum: 2,
+            observed: 3);
+        engine.GetValue("reads").AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void StringAndAggregateCharacterLimitsAreIndependent()
+    {
+        using var engine = new Engine();
+        var value = engine.Evaluate("({ a: '1234', b: '5678' })");
+
+        AssertLimit(
+            () => engine.Advanced.ConvertResult(value, Limits(maxStringLength: 3)),
+            ResultLimit.StringLength,
+            maximum: 3,
+            observed: 4);
+        AssertLimit(
+            () => engine.Advanced.ConvertResult(value, Limits(maxOutputCharacters: 9)),
+            ResultLimit.OutputCharacters,
+            maximum: 9,
+            observed: 10);
+    }
+
+    [Fact]
+    public void ArraysAndTypedArraysAreRejectedBeforeOutputAllocation()
+    {
+        using var engine = new Engine();
+
+        AssertLimit(
+            () => engine.Advanced.ConvertResult(
+                engine.Evaluate("[1, 2, 3]"),
+                Limits(maxPropertyCount: 2)),
+            ResultLimit.PropertyCount,
+            maximum: 2,
+            observed: 3);
+
+        AssertLimit(
+            () => engine.Advanced.ConvertResult(
+                engine.Evaluate("new Uint32Array(3)"),
+                Limits(maxOutputBytes: 11)),
+            ResultLimit.OutputBytes,
+            maximum: 11,
+            observed: 12);
+    }
+
+    [Fact]
+    public void BinaryByteLimitIsCumulativeAndArrayBuffersAreCopied()
+    {
+        using var engine = new Engine();
+        var value = engine.Evaluate("""
+            globalThis.buffer = new Uint8Array([1, 2, 3]).buffer;
+            ({ first: buffer, second: new Uint8Array([4, 5, 6]).buffer })
+            """);
+
+        AssertLimit(
+            () => engine.Advanced.ConvertResult(value, Limits(maxOutputBytes: 5)),
+            ResultLimit.OutputBytes,
+            maximum: 5,
+            observed: 6);
+
+        var bytes = (byte[]) engine.Advanced.ConvertResult(engine.GetValue("buffer"));
+        bytes[0] = 99;
+        engine.Evaluate("new Uint8Array(buffer)[0]").AsNumber().Should().Be(1);
+    }
+
+    [Fact]
+    public void FunctionsAndSymbolsAreNotExportedAsEngineAffineValues()
+    {
+        using var engine = new Engine();
+
+        Invoking(() => engine.Advanced.ConvertResult(engine.Evaluate("(function () {})")))
+            .Should().ThrowExactly<NotSupportedException>();
+        Invoking(() => engine.Advanced.ConvertResult(engine.Evaluate("Symbol('x')")))
+            .Should().ThrowExactly<NotSupportedException>();
+    }
+
+    [Fact]
+    public void MapsAndSetsConvertToDetachedClrCollections()
+    {
+        using var engine = new Engine();
+        var value = engine.Evaluate("""
+            ({
+                map: new Map([['a', 1], ['b', { value: 2 }]]),
+                set: new Set(['x', 'y'])
+            })
+            """);
+
+        var result = (Dictionary<string, object>) engine.Advanced.ConvertResult(value, Limits(maxPropertyCount: 10));
+        var map = result["map"].Should()
+            .BeAssignableTo<List<KeyValuePair<object, object>>>().Which;
+        var set = result["set"].Should().BeAssignableTo<object[]>().Which;
+
+        map.Should().HaveCount(2);
+        map[0].Key.Should().Be("a");
+        map[1].Value.Should().BeAssignableTo<IDictionary<string, object>>();
+        set.Should().Equal("x", "y");
+    }
+
+    [Fact]
+    public void CyclesAreRejected()
+    {
+        using var engine = new Engine();
+        var value = engine.Evaluate("var value = {}; value.self = value; value");
+
+        Invoking(() => engine.Advanced.ConvertResult(value, ResultLimits.Conservative))
+            .Should().ThrowExactly<JavaScriptException>()
+            .WithMessage("*Cyclic reference detected*");
+    }
+
+    [Fact]
+    public void ProxyKeysAreCountedBeforeProxyGetsRun()
+    {
+        using var engine = new Engine();
+        var value = engine.Evaluate("""
+            globalThis.gets = 0;
+            new Proxy({ a: 1, b: 2, c: 3 }, {
+                get(target, key, receiver) {
+                    gets++;
+                    return Reflect.get(target, key, receiver);
+                }
+            })
+            """);
+
+        AssertLimit(
+            () => engine.Advanced.ConvertResult(value, Limits(maxPropertyCount: 2)),
+            ResultLimit.PropertyCount,
+            maximum: 2,
+            observed: 3);
+        engine.GetValue("gets").AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void ProxiedArraysPreserveArrayOutputAndRunGetTraps()
+    {
+        using var engine = new Engine();
+        var value = engine.Evaluate("""
+            globalThis.gets = 0;
+            new Proxy([1, 2], {
+                get(target, key, receiver) {
+                    gets++;
+                    return Reflect.get(target, key, receiver);
+                }
+            })
+            """);
+
+        engine.Advanced.ConvertResult(value, Limits(maxDepth: 1, maxPropertyCount: 2))
+            .Should().BeEquivalentTo(new object[] { 1d, 2d });
+        engine.GetValue("gets").AsNumber().Should().Be(3, "length and both elements are read through the proxy");
+    }
+
+    [Fact]
+    public void GetterExecutionUsesEngineConstraints()
+    {
+        using var engine = new Engine(options => options.MaxStatements(100));
+        var value = engine.Evaluate("({ get value() { while (true) {} } })");
+
+        Invoking(() => engine.Advanced.ConvertResult(value, ResultLimits.Conservative))
+            .Should().ThrowExactly<StatementsCountOverflowException>();
+    }
+
+    [Fact]
+    public void ConstraintCadenceSpansManySmallContainers()
+    {
+        var constraint = new ArmedConstraint();
+        using var engine = new Engine(new Options().Constraint(constraint));
+        var value = engine.Evaluate("""
+            var node = { value: 0 };
+            for (var i = 0; i < 14; i++) {
+                node = { left: node, right: node };
+            }
+            node;
+            """);
+        constraint.Armed = true;
+
+        Invoking(() => engine.Advanced.ConvertResult(
+                value,
+                Limits(maxDepth: 20, maxPropertyCount: 100_000)))
+            .Should().ThrowExactly<InvalidOperationException>()
+            .WithMessage("conversion constraint checked");
+    }
+
+    [Fact]
+    public void PropertyCountBoundsRepeatedSharedReferences()
+    {
+        using var engine = new Engine();
+        var value = engine.Evaluate("""
+            var leaf = { value: 1 };
+            ({ first: leaf, second: leaf });
+            """);
+
+        AssertLimit(
+            () => engine.Advanced.ConvertResult(value, Limits(maxPropertyCount: 3)),
+            ResultLimit.PropertyCount,
+            maximum: 3,
+            observed: 4);
+    }
+
+    [Fact]
+    public void HostWrappersReturnTheirExistingTargetWithoutWalkingIt()
+    {
+        using var engine = new Engine();
+        var target = new HostPayload { Value = "unbounded host-owned value" };
+        var wrapper = ObjectWrapper.Create(engine, target);
+
+        engine.Advanced.ConvertResult(wrapper, new ResultLimits(maxDepth: 0, maxPropertyCount: 0))
+            .Should().BeSameAs(target);
+    }
+
+    [Fact]
+    public void JavaScriptErrorRenderingCanBeBounded()
+    {
+        using var engine = new Engine();
+        var exception = Invoking(() => engine.Evaluate("throw new Error('1234')"))
+            .Should().ThrowExactly<JavaScriptException>().Which;
+
+        AssertLimit(
+            () => exception.GetJavaScriptErrorString(Limits(maxStringLength: 3)),
+            ResultLimit.StringLength,
+            maximum: 3,
+            observed: 4);
+    }
+
+    [Fact]
+    public void JavaScriptErrorStackAccessUsesEngineConstraints()
+    {
+        using var engine = new Engine(options => options.MaxStatements(100));
+        var error = engine.Evaluate("""
+            var error = new Error("x");
+            Object.defineProperty(error, "stack", { get() { while (true) {} } });
+            error;
+            """);
+        var exception = new JavaScriptException(error);
+
+        Invoking(() => exception.GetJavaScriptErrorString(ResultLimits.Conservative))
+            .Should().ThrowExactly<StatementsCountOverflowException>();
+    }
+
+    [Fact]
+    public async Task PublicResultBoundariesRejectConcurrentUseAndRecover()
+    {
+        using var entered = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        using var engine = new Engine();
+        var value = engine.Evaluate("({ value: 42 })");
+        var serializer = new JsonSerializer(engine);
+        var exception = new JavaScriptException(engine.Evaluate("new Error('failure')"));
+        engine.SetValue("block", new Action(() =>
+        {
+            entered.Set();
+            release.Wait();
+        }));
+        var running = Task.Run(() => engine.Execute("block()"));
+
+        entered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+        try
+        {
+            Invoking(() => engine.Advanced.ConvertResult(value))
+                .Should().Throw<InvalidOperationException>()
+                .WithMessage(ConcurrentUseMessage);
+            Invoking(() => serializer.Serialize(value))
+                .Should().Throw<InvalidOperationException>()
+                .WithMessage(ConcurrentUseMessage);
+            Invoking(() => exception.GetJavaScriptErrorString(ResultLimits.Conservative))
+                .Should().Throw<InvalidOperationException>()
+                .WithMessage(ConcurrentUseMessage);
+        }
+        finally
+        {
+            release.Set();
+        }
+
+        await running;
+        engine.Advanced.ConvertResult(value).Should().NotBeNull();
+        serializer.Serialize(value).AsString().Should().Be("""{"value":42}""");
+    }
+
+    [Fact]
+    public void ConversionAndSerializationAllowSameOwnerCallbackReentry()
+    {
+        using var engine = new Engine();
+        engine.SetValue("reenter", new Func<int>(() => (int) engine.Evaluate("40 + 2").AsNumber()));
+        var value = engine.Evaluate("""
+            new Proxy({}, {
+                ownKeys() { return ["value"]; },
+                getOwnPropertyDescriptor() { return { enumerable: true, configurable: true }; },
+                get() { return reenter(); }
+            })
+            """);
+
+        var converted = (Dictionary<string, object>) engine.Advanced.ConvertResult(value);
+        converted["value"].Should().Be(42d);
+        new JsonSerializer(engine).Serialize(value).AsString().Should().Be("""{"value":42}""");
+    }
+
+    [Fact]
+    public void OperationDeadlineSpansEvaluationAndConversion()
+    {
+        var deadline = new OperationDeadlineConstraint();
+        using var engine = new Engine(options => options.Constraint(deadline));
+        engine.SetValue("pause", new Action(() => Thread.Sleep(250)));
+        engine.SetValue("noop", new Action(() => { }));
+
+        // Warm parsing, the interop call path and ConvertResult before the clock starts. The budget
+        // leaves only 150ms of headroom over the first pause, and on .NET Framework a cold first
+        // evaluation costs more than that often enough to make the Evaluate below throw the
+        // TimeoutException this test means to observe from the conversion instead.
+        engine.Advanced.ConvertResult(engine.Evaluate("noop(); ({ get value() { noop(); return 42; } })"));
+
+        deadline.Begin(TimeSpan.FromMilliseconds(400));
+        try
+        {
+            var value = engine.Evaluate("pause(); ({ get value() { pause(); return 42; } })");
+
+            Invoking(() => engine.Advanced.ConvertResult(value))
+                .Should().ThrowExactly<TimeoutException>();
+        }
+        finally
+        {
+            deadline.End();
+        }
+
+        engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
+    }
+
+    [Fact]
+    public void ExplicitMemoryOperationSpansEvaluationAndConversion()
+    {
+        const int allocationSize = 2_000_000;
+        var allocations = new List<byte[]>();
+        using var engine = new Engine(options => options.LimitMemory(3_500_000));
+        engine.SetValue("allocate", new Action(() => allocations.Add(new byte[allocationSize])));
+        var memory = engine.Constraints.Find<MemoryLimitConstraint>()!;
+
+        memory.Begin();
+        try
+        {
+            var value = engine.Evaluate("allocate(); ({ get value() { allocate(); return 42; } })");
+
+            Invoking(() => engine.Advanced.ConvertResult(value))
+                .Should().ThrowExactly<MemoryLimitExceededException>();
+        }
+        finally
+        {
+            memory.End();
+        }
+
+        engine.Advanced.ConvertResult(engine.Evaluate("({ value: 42 })")).Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ModuleNamespaceCanBeConvertedUnderResultLimits()
+    {
+        using var engine = new Engine();
+        engine.Modules.Add("result", "export const answer = 42; export const nested = { ok: true };");
+
+        var module = engine.Modules.Import("result");
+        var converted = (Dictionary<string, object>) engine.Advanced.ConvertResult(
+            module,
+            Limits(maxDepth: 2, maxPropertyCount: 4));
+
+        converted["answer"].Should().Be(42d);
+        converted["nested"].Should().BeAssignableTo<IDictionary<string, object>>();
+    }
+
+    [Fact]
+    public void FailedConversionReleasesStateForRetry()
+    {
+        using var engine = new Engine();
+        var value = engine.Evaluate("({ a: 1, b: 2 })");
+
+        AssertLimit(
+            () => engine.Advanced.ConvertResult(value, Limits(maxPropertyCount: 1)),
+            ResultLimit.PropertyCount,
+            maximum: 1,
+            observed: 2);
+
+        engine.Advanced.ConvertResult(value, Limits(maxPropertyCount: 2)).Should().NotBeNull();
+        engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
+    }
+
+    [Fact]
+    public void ResultLimitFromClrCallbackRemainsFatalWhenClrExceptionsAreCatchable()
+    {
+        using var engine = new Engine(options => options.CatchClrExceptions());
+        var value = engine.Evaluate("[1, 2]");
+        engine.SetValue("convert", new Action(() =>
+            engine.Advanced.ConvertResult(value, Limits(maxPropertyCount: 1))));
+
+        Invoking(() => engine.Evaluate("""
+            try {
+                convert();
+            } catch {
+                globalThis.caught = true;
+            }
+            """))
+            .Should().ThrowExactly<ResultLimitExceededException>();
+        engine.GetValue("caught").Should().BeUndefined();
+    }
+
+    private static ResultLimits Limits(
+        int maxDepth = int.MaxValue,
+        long maxPropertyCount = long.MaxValue,
+        int maxStringLength = int.MaxValue,
+        long maxOutputCharacters = long.MaxValue,
+        long maxOutputBytes = long.MaxValue)
+        => new(maxDepth, maxPropertyCount, maxStringLength, maxOutputCharacters, maxOutputBytes);
+
+    private static void AssertLimit(
+        Action action,
+        ResultLimit limit,
+        long maximum,
+        long observed)
+    {
+        var exception = Invoking(action).Should().ThrowExactly<ResultLimitExceededException>().Which;
+        exception.Limit.Should().Be(limit);
+        exception.Maximum.Should().Be(maximum);
+        exception.Observed.Should().Be(observed);
+    }
+
+    private sealed class HostPayload
+    {
+        public string Value { get; set; } = "";
+    }
+
+    private sealed class ArmedConstraint : Constraint
+    {
+        public bool Armed { get; set; }
+
+        public override void Check()
+        {
+            if (Armed)
+            {
+                throw new InvalidOperationException("conversion constraint checked");
+            }
+        }
+
+        public override void Reset()
+        {
+        }
+    }
+}

--- a/Jint.Tests/Runtime/JsonSerializerTests.cs
+++ b/Jint.Tests/Runtime/JsonSerializerTests.cs
@@ -1,10 +1,186 @@
 ﻿using Jint.Native;
 using Jint.Native.Json;
+using Jint.Runtime;
+using System.Buffers;
 
 namespace Jint.Tests.Runtime;
 
 public class JsonSerializerTests
 {
+    [Fact]
+    public void ResultLimitsAreInclusiveAndDefaultsRemainCompatible()
+    {
+        using var engine = new Engine();
+        var value = engine.Evaluate("({ a: [1, 2], b: 'text' })");
+        var expected = "{\"a\":[1,2],\"b\":\"text\"}";
+
+        new JsonSerializer(engine).Serialize(value).AsString().Should().Be(expected);
+        new JsonSerializer(engine).SerializeWithLimits(
+            value,
+            new ResultLimits(
+                maxDepth: 2,
+                maxPropertyCount: 4,
+                maxStringLength: 4,
+                maxOutputCharacters: expected.Length)).AsString().Should().Be(expected);
+    }
+
+    [Fact]
+    public void ReentrantUseOfTheSameInstanceCannotReplaceOuterLimits()
+    {
+        var engine = new Engine();
+        var serializer = new JsonSerializer(engine);
+        var nestedWasRejected = false;
+        engine.SetValue("reenter", new Func<string>(() =>
+        {
+            try
+            {
+                serializer.SerializeWithLimits(new JsString("unbounded"), ResultLimits.Unlimited);
+            }
+            catch (InvalidOperationException)
+            {
+                nestedWasRejected = true;
+            }
+
+            return "1234";
+        }));
+        var value = engine.Evaluate("({ toJSON() { return reenter(); } })");
+
+        Invoking(() => serializer.SerializeWithLimits(value, new ResultLimits(maxStringLength: 3)))
+            .Should().ThrowExactly<ResultLimitExceededException>();
+        nestedWasRejected.Should().BeTrue();
+        serializer.Serialize(new JsString("ok")).AsString().Should().Be("\"ok\"");
+    }
+
+    [Fact]
+    public void JsonLimitsDepthPropertiesStringsAndCharacters()
+    {
+        using var engine = new Engine();
+        var serializer = new JsonSerializer(engine);
+
+        AssertLimit(
+            () => serializer.SerializeWithLimits(engine.Evaluate("({ a: { b: 1 } })"), new ResultLimits(maxDepth: 1)),
+            ResultLimit.Depth);
+        AssertLimit(
+            () => serializer.SerializeWithLimits(engine.Evaluate("[1, 2, 3]"), new ResultLimits(maxPropertyCount: 2)),
+            ResultLimit.PropertyCount);
+        AssertLimit(
+            () => serializer.SerializeWithLimits(new JsString("1234"), new ResultLimits(maxStringLength: 3)),
+            ResultLimit.StringLength);
+        AssertLimit(
+            () => serializer.SerializeWithLimits(new JsString("1234"), new ResultLimits(maxOutputCharacters: 5)),
+            ResultLimit.OutputCharacters);
+    }
+
+    [Fact]
+    public void EscapingIsCountedBeforeTheQuotedStringIsAppended()
+    {
+        using var engine = new Engine();
+        var value = new JsString(new string('\0', 20));
+
+        AssertLimit(
+            () => new JsonSerializer(engine).SerializeWithLimits(
+                value,
+                new ResultLimits(maxOutputCharacters: 100)),
+            ResultLimit.OutputCharacters);
+    }
+
+    [Fact]
+    public void StringLengthIsCheckedBeforeAConcatenatedStringIsFlattened()
+    {
+        using var engine = new Engine();
+        var value = (JsString.ConcatenatedString) engine.Evaluate("""
+            var values = ["a"];
+            values[0] += "b";
+            values[0] += "c";
+            values[0];
+            """);
+        value._value.Should().Be("ab");
+
+        AssertLimit(
+            () => new JsonSerializer(engine).SerializeWithLimits(
+                value,
+                new ResultLimits(maxStringLength: 2)),
+            ResultLimit.StringLength);
+        value._value.Should().Be("ab");
+    }
+
+    [Fact]
+    public void BoxedStringsUseObservableStringCoercion()
+    {
+        using var engine = new Engine();
+
+        engine.Evaluate("""
+            var value = new String("original");
+            value.toString = function () { return "overridden"; };
+            JSON.stringify(value);
+            """).AsString().Should().Be("\"overridden\"");
+
+        engine.Evaluate("""
+            var key = new String("a");
+            key.toString = function () { return "selected"; };
+            JSON.stringify({ a: 1, selected: 2 }, [key]);
+            """).AsString().Should().Be("{\"selected\":2}");
+    }
+
+    [Fact]
+    public void PropertyLimitFiresBeforeJsonGetter()
+    {
+        using var engine = new Engine();
+        var value = engine.Evaluate("""
+            globalThis.reads = 0;
+            ({ get a() { reads++; return 1; }, get b() { reads++; return 2; } })
+            """);
+
+        AssertLimit(
+            () => new JsonSerializer(engine).SerializeWithLimits(value, new ResultLimits(maxPropertyCount: 1)),
+            ResultLimit.PropertyCount);
+        engine.GetValue("reads").AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void Utf8LimitIsExactAndWriterIsUntouchedOnFailure()
+    {
+        using var engine = new Engine();
+        var serializer = new JsonSerializer(engine);
+        var value = new JsString("é");
+        var writer = new CountingBufferWriter();
+
+        serializer.Serialize(value, writer, new ResultLimits(maxOutputBytes: 4)).Should().BeTrue();
+        writer.WrittenCount.Should().Be(4);
+
+        writer = new CountingBufferWriter();
+        AssertLimit(
+            () => serializer.Serialize(value, writer, new ResultLimits(maxOutputBytes: 3)),
+            ResultLimit.OutputBytes);
+        writer.WrittenCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void ConfiguredLimitsAlsoBoundScriptStringify()
+    {
+        using var engine = new Engine(options =>
+            options.ResultLimits = new ResultLimits(maxOutputCharacters: 5));
+
+        Invoking(() => engine.Evaluate("try { JSON.stringify([1, 2, 3]); } catch { 'caught'; }"))
+            .Should().ThrowExactly<ResultLimitExceededException>();
+    }
+
+    [Fact]
+    public void ToJsonExecutionUsesEngineConstraints()
+    {
+        using var engine = new Engine(options => options.MaxStatements(100));
+        var value = engine.Evaluate("({ toJSON() { while (true) {} } })");
+
+        Invoking(() => new JsonSerializer(engine).SerializeWithLimits(value, ResultLimits.Conservative))
+            .Should().ThrowExactly<StatementsCountOverflowException>();
+    }
+
+    private static void AssertLimit(Action action, ResultLimit limit)
+    {
+        Invoking(action).Should().ThrowExactly<ResultLimitExceededException>()
+            .Which.Limit.Should().Be(limit);
+    }
+
     [Fact]
     public void CanStringifyBasicTypes()
     {
@@ -279,5 +455,42 @@ public class JsonSerializerTests
             """).AsBoolean();
 
         ok.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A minimal <see cref="IBufferWriter{T}"/> for the byte-writing overloads. Hand-written rather than
+    /// <c>ArrayBufferWriter&lt;byte&gt;</c> because that type is internal in the <c>System.Memory</c> package
+    /// this project compiles against on .NET Framework, and the API under test takes the interface anyway.
+    /// </summary>
+    private sealed class CountingBufferWriter : IBufferWriter<byte>
+    {
+        private byte[] _buffer = new byte[256];
+
+        public int WrittenCount { get; private set; }
+
+        public void Advance(int count) => WrittenCount += count;
+
+        public Memory<byte> GetMemory(int sizeHint = 0)
+        {
+            Grow(sizeHint);
+            return _buffer.AsMemory(WrittenCount);
+        }
+
+        public Span<byte> GetSpan(int sizeHint = 0)
+        {
+            Grow(sizeHint);
+            return _buffer.AsSpan(WrittenCount);
+        }
+
+        private void Grow(int sizeHint)
+        {
+            var needed = WrittenCount + Math.Max(sizeHint, 1);
+            if (needed <= _buffer.Length)
+            {
+                return;
+            }
+
+            Array.Resize(ref _buffer, Math.Max(needed, _buffer.Length * 2));
+        }
     }
 }

--- a/Jint/Engine.Advanced.cs
+++ b/Jint/Engine.Advanced.cs
@@ -71,6 +71,34 @@ public partial class Engine
         }
 
         /// <summary>
+        /// Converts a script result to a detached CLR graph while enforcing depth, size, and output limits.
+        /// </summary>
+        /// <remarks>
+        /// Arrays, typed arrays, array buffers, maps, sets, and enumerable own object properties are copied.
+        /// Cycles are rejected, as are functions and symbols that cannot form a detached data result. CLR
+        /// wrappers return their existing host-owned target without walking it. Property access may invoke
+        /// getters and proxy traps, so the conversion runs under the engine's execution constraints; those
+        /// constraints and an outer request deadline remain required for untrusted code.
+        /// </remarks>
+        public object? ConvertResult(JsValue value, ResultLimits? limits = null)
+        {
+            if (value is null)
+            {
+                Throw.ArgumentNullException(nameof(value));
+            }
+
+            if (value is ObjectInstance instance && !ReferenceEquals(instance.Engine, _engine))
+            {
+                Throw.ArgumentException("The value belongs to a different engine.", nameof(value));
+            }
+
+            var effectiveLimits = limits ?? _engine.Options.ResultLimits;
+            return _engine.ExecuteWithConstraints(
+                _engine.Options.Strict,
+                () => ResultConverter.Convert(_engine, value, effectiveLimits));
+        }
+
+        /// <summary>
         /// EXPERIMENTAL! Subject to change.
         ///
         /// Registers a promise within the currently running EventLoop (has to be called within "ExecuteWithEventLoop" call).

--- a/Jint/Native/JsProxy.cs
+++ b/Jint/Native/JsProxy.cs
@@ -1096,7 +1096,7 @@ internal sealed class JsProxy : ObjectInstance, IConstructor, ICallable
         {
             return clrHandler.Get(target, property, receiver);
         }
-        catch (Exception e) when (e is not JavaScriptException and not ParsingLimitException && !_bubbleExceptions)
+        catch (Exception e) when (e is not JavaScriptException && !_bubbleExceptions)
         {
             RethrowClrTrapException(e);
             return null;
@@ -1262,7 +1262,7 @@ internal sealed class JsProxy : ObjectInstance, IConstructor, ICallable
     [DoesNotReturn]
     private void RethrowClrTrapException(Exception exception)
     {
-        if (exception is ParsingLimitException)
+        if (Throw.MustPropagateHostException(exception))
         {
             ExceptionDispatchInfo.Capture(exception).Throw();
         }

--- a/Jint/Native/Json/JsonSerializer.cs
+++ b/Jint/Native/Json/JsonSerializer.cs
@@ -27,9 +27,9 @@ namespace Jint.Native.Json;
 /// across calls — every field the per-call prologue only conditionally assigns (the replacer function, the
 /// replacer-array property list, the indentation and the cycle-detection stack) is reset at the start of
 /// each <c>Serialize</c> call, so a previous call cannot leak state into the next, including a call that
-/// threw part-way through on a circular structure. It is not thread-safe: that per-call state is instance
-/// state, so two concurrent calls on one instance corrupt each other's output. Hold one per engine (and
-/// serialize access to the engine anyway, which is itself single-threaded), or construct one per call as
+/// threw part-way through on a circular structure. The same instance cannot be re-entered from a
+/// <c>toJSON</c>, replacer, or host callback because its per-call state is instance state. Hold one per engine
+/// (and serialize access to the engine anyway, which is itself single-threaded), or construct one per call as
 /// <c>JSON.stringify</c> does.
 /// </para>
 /// <para>
@@ -44,9 +44,9 @@ namespace Jint.Native.Json;
 /// <b>Document length.</b> The <see cref="JsValue"/>-returning overloads produce a JavaScript string and
 /// are bounded by the same maximum length as every other way of building one: a document that would
 /// exceed it raises <c>RangeError: Invalid string length</c>, which a script can catch, and raises it
-/// while the document is being built rather than after it has been paid for. The
-/// <see cref="IBufferWriter{T}"/> overloads produce bytes the host consumes and never a string, so the
-/// language's limit does not apply to them; they remain bounded only by what a CLR array can hold.
+/// while the document is being built rather than after it has been paid for. Configured
+/// <see cref="ResultLimits"/> additionally bound both overload families, including exact UTF-8 bytes before
+/// an <see cref="IBufferWriter{T}"/> is touched. The compatibility default is unlimited.
 /// </para>
 /// <para>
 /// <b>BigInt.</b> A <c>BigInt</c> that reaches the output throws a
@@ -70,6 +70,12 @@ public sealed class JsonSerializer
     private string _gap = string.Empty;
     private List<JsValue>? _propertyList;
     private bool _hasReplacerFunction;
+    private ResultLimits _limits = ResultLimits.Unlimited;
+    private long _propertyCount;
+    private int _depth;
+    private long _maxOutputBytes;
+    private ResultLimit? _documentLengthResultLimit;
+    private bool _active;
 
     // The largest document this call is allowed to build. JsString.MaxLength for the overloads whose
     // result is a JavaScript string, so JSON.stringify can no longer hand back a string the engine's
@@ -107,7 +113,15 @@ public sealed class JsonSerializer
     /// </returns>
     public JsValue Serialize(JsValue value)
     {
-        return Serialize(value, JsValue.Undefined, JsValue.Undefined);
+        return Serialize(value, JsValue.Undefined, JsValue.Undefined, _engine.Options.ResultLimits);
+    }
+
+    /// <summary>
+    /// Serializes <paramref name="value"/> using explicit host output limits.
+    /// </summary>
+    public JsValue SerializeWithLimits(JsValue value, ResultLimits limits)
+    {
+        return Serialize(value, JsValue.Undefined, JsValue.Undefined, limits);
     }
 
     /// <summary>
@@ -128,31 +142,55 @@ public sealed class JsonSerializer
     /// </returns>
     public JsValue Serialize(JsValue value, JsValue replacer, JsValue space)
     {
-        if (!TryCreateHolder(value, replacer, space, JsString.MaxLength, out var wrapper))
-        {
-            return JsValue.Undefined;
-        }
+        return Serialize(value, replacer, space, _engine.Options.ResultLimits);
+    }
 
-        var json = new ValueStringBuilder();
+    /// <summary>
+    /// Serializes <paramref name="value"/> with the JSON replacer and spacing rules while enforcing explicit
+    /// host output limits.
+    /// </summary>
+    public JsValue Serialize(JsValue value, JsValue replacer, JsValue space, ResultLimits limits)
+    {
+        return _engine.ExecuteWithConstraints(
+            _engine.Options.Strict,
+            () => SerializeEntry(value, replacer, space, limits));
+    }
+
+    private JsValue SerializeEntry(JsValue value, JsValue replacer, JsValue space, ResultLimits limits)
+    {
+        Enter();
         try
         {
-            if (SerializeJSONProperty(JsString.Empty, wrapper, ref json) == SerializeResult.Undefined)
+            if (!TryCreateHolder(value, replacer, space, JsString.MaxLength, utf8: false, limits, out var wrapper))
             {
                 return JsValue.Undefined;
             }
 
-            // The walk refuses an over-long document while it is being built; this catches the one
-            // thing a single append can still overshoot by — the expansion of a quoted string's
-            // escapes — before the document is turned into a JsString.
-            ThrowIfDocumentLengthExceeded(json.Length);
-            return new JsString(json.ToString());
+            var json = new ValueStringBuilder();
+            try
+            {
+                if (SerializeJSONProperty(JsString.Empty, wrapper, ref json) == SerializeResult.Undefined)
+                {
+                    return JsValue.Undefined;
+                }
+
+                // The walk refuses an over-long document while it is being built; this catches the one
+                // thing a single append can still overshoot by — the expansion of a quoted string's
+                // escapes — before the document is turned into a JsString.
+                ThrowIfDocumentLengthExceeded(json.Length);
+                return new JsString(json.ToString());
+            }
+            finally
+            {
+                // Dispose rather than the ToString() this used to end in: on the throwing path that
+                // materialized the whole partial document, which is up to half a billion characters the
+                // caller never sees. ToString() disposes on the way out, so this is a no-op after it.
+                json.Dispose();
+            }
         }
         finally
         {
-            // Dispose rather than the ToString() this used to end in: on the throwing path that
-            // materialized the whole partial document, which is up to half a billion characters the
-            // caller never sees. ToString() disposes on the way out, so this is a no-op after it.
-            json.Dispose();
+            _active = false;
         }
     }
 
@@ -168,7 +206,15 @@ public sealed class JsonSerializer
     /// </returns>
     public bool Serialize(JsValue value, IBufferWriter<byte> writer)
     {
-        return Serialize(value, JsValue.Undefined, JsValue.Undefined, writer);
+        return Serialize(value, JsValue.Undefined, JsValue.Undefined, writer, _engine.Options.ResultLimits);
+    }
+
+    /// <summary>
+    /// Serializes <paramref name="value"/> as UTF-8 using explicit host output limits.
+    /// </summary>
+    public bool Serialize(JsValue value, IBufferWriter<byte> writer, ResultLimits limits)
+    {
+        return Serialize(value, JsValue.Undefined, JsValue.Undefined, writer, limits);
     }
 
     /// <summary>
@@ -192,31 +238,81 @@ public sealed class JsonSerializer
     /// </remarks>
     public bool Serialize(JsValue value, JsValue replacer, JsValue space, IBufferWriter<byte> writer)
     {
+        return Serialize(value, replacer, space, writer, _engine.Options.ResultLimits);
+    }
+
+    /// <summary>
+    /// Serializes <paramref name="value"/> as UTF-8 with the JSON replacer and spacing rules while enforcing
+    /// explicit host output limits.
+    /// </summary>
+    public bool Serialize(
+        JsValue value,
+        JsValue replacer,
+        JsValue space,
+        IBufferWriter<byte> writer,
+        ResultLimits limits)
+    {
         if (writer is null)
         {
             Throw.ArgumentNullException(nameof(writer));
         }
 
-        if (!TryCreateHolder(value, replacer, space, ClrLimits.MaxArrayLength, out var wrapper))
-        {
-            return false;
-        }
+        return _engine.ExecuteWithConstraints(
+            _engine.Options.Strict,
+            () => SerializeEntry(value, replacer, space, writer, limits));
+    }
 
-        var json = new ValueStringBuilder();
+    private bool SerializeEntry(
+        JsValue value,
+        JsValue replacer,
+        JsValue space,
+        IBufferWriter<byte> writer,
+        ResultLimits limits)
+    {
+        Enter();
         try
         {
-            if (SerializeJSONProperty(JsString.Empty, wrapper, ref json) == SerializeResult.Undefined)
+            if (!TryCreateHolder(value, replacer, space, ClrLimits.MaxArrayLength, utf8: true, limits, out var wrapper))
             {
                 return false;
             }
 
-            WriteUtf8(json.AsSpan(), writer);
-            return true;
+            var json = new ValueStringBuilder();
+            try
+            {
+                if (SerializeJSONProperty(JsString.Empty, wrapper, ref json) == SerializeResult.Undefined)
+                {
+                    return false;
+                }
+
+                var byteCount = GetUtf8ByteCount(json.AsSpan());
+                if (byteCount > _maxOutputBytes)
+                {
+                    ThrowResultLimit(ResultLimit.OutputBytes, _maxOutputBytes, byteCount);
+                }
+
+                WriteUtf8(json.AsSpan(), writer);
+                return true;
+            }
+            finally
+            {
+                json.Dispose();
+            }
         }
         finally
         {
-            json.Dispose();
+            _active = false;
         }
+    }
+
+    private void Enter()
+    {
+        if (_active)
+        {
+            Throw.InvalidOperationException("The JsonSerializer instance is already serializing a value.");
+        }
+
+        _active = true;
     }
 
     /// <summary>
@@ -224,10 +320,40 @@ public sealed class JsonSerializer
     /// gap, and builds the wrapper object the value is serialized out of. Returns <see langword="false"/>
     /// for the inputs that produce no output at all.
     /// </summary>
-    private bool TryCreateHolder(JsValue value, JsValue replacer, JsValue space, long maxDocumentLength, out ObjectInstance wrapper)
+    private bool TryCreateHolder(
+        JsValue value,
+        JsValue replacer,
+        JsValue space,
+        long maxDocumentLength,
+        bool utf8,
+        ResultLimits limits,
+        out ObjectInstance wrapper)
     {
+        if (limits is null)
+        {
+            Throw.ArgumentNullException(nameof(limits));
+        }
+
         _stack = new ObjectTraverseStack(_engine);
-        _maxDocumentLength = maxDocumentLength;
+        _limits = limits;
+        var resultLength = limits.MaxOutputCharacters;
+        _documentLengthResultLimit = ResultLimit.OutputCharacters;
+        if (utf8 && limits.MaxOutputBytes < resultLength)
+        {
+            // Every UTF-16 code unit contributes at least one UTF-8 byte, so this is a conservative
+            // pre-allocation bound. The finished document is counted exactly before the writer is touched.
+            resultLength = limits.MaxOutputBytes;
+            _documentLengthResultLimit = ResultLimit.OutputBytes;
+        }
+
+        _maxDocumentLength = System.Math.Min(maxDocumentLength, resultLength);
+        _maxOutputBytes = limits.MaxOutputBytes;
+        if (maxDocumentLength < resultLength)
+        {
+            _documentLengthResultLimit = null;
+        }
+        _propertyCount = 0;
+        _depth = 0;
 
         // JSON.stringify allocates a serializer per call, but the type is public and a host may hold an
         // instance across calls: every field the prologue only conditionally assigns has to be cleared
@@ -280,8 +406,77 @@ public sealed class JsonSerializer
     {
         if (length > _maxDocumentLength)
         {
+            if (_documentLengthResultLimit is { } resultLimit)
+            {
+                ThrowResultLimit(resultLimit, _maxDocumentLength, length);
+            }
+
             Throw.RangeError(_engine.Realm, "Invalid string length");
         }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void ThrowIfStringLengthExceeded(int length)
+    {
+        if (length > _limits.MaxStringLength)
+        {
+            ThrowResultLimit(ResultLimit.StringLength, _limits.MaxStringLength, length);
+        }
+    }
+
+    private void CountProperties(long count)
+    {
+        var observed = checked(_propertyCount + count);
+        if (observed > _limits.MaxPropertyCount)
+        {
+            ThrowResultLimit(ResultLimit.PropertyCount, _limits.MaxPropertyCount, observed);
+        }
+
+        _propertyCount = observed;
+    }
+
+    private void EnterContainer(ObjectInstance value)
+    {
+        var observed = _depth + 1;
+        if (observed > _limits.MaxDepth)
+        {
+            ThrowResultLimit(ResultLimit.Depth, _limits.MaxDepth, observed);
+        }
+
+        _stack.Enter(value);
+        _depth = observed;
+    }
+
+    private void ExitContainer()
+    {
+        _stack.Exit();
+        _depth--;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ThrowResultLimit(ResultLimit limit, long maximum, long observed)
+    {
+        throw new ResultLimitExceededException(limit, maximum, observed);
+    }
+
+    private static long GetUtf8ByteCount(ReadOnlySpan<char> chars)
+    {
+        const int CharChunkLength = 1024;
+        const int ByteChunkLength = 4096;
+
+        var encoder = Encoding.UTF8.GetEncoder();
+        Span<byte> destination = stackalloc byte[ByteChunkLength];
+        long total = 0;
+        while (!chars.IsEmpty)
+        {
+            var chunk = chars.Length <= CharChunkLength ? chars : chars.Slice(0, CharChunkLength);
+            var flush = chunk.Length == chars.Length;
+            encoder.Convert(chunk, destination, flush, out var charsUsed, out var bytesUsed, out _);
+            total += bytesUsed;
+            chars = chars.Slice(charsUsed);
+        }
+
+        return total;
     }
 
     /// <summary>
@@ -347,6 +542,7 @@ public sealed class JsonSerializer
             {
                 _propertyList = new List<JsValue>();
                 var len = oi.GetLength();
+                CountProperties(len);
                 var k = 0;
                 while (k < len)
                 {
@@ -374,9 +570,13 @@ public sealed class JsonSerializer
                         }
                     }
 
-                    if (!item.IsUndefined() && !_propertyList.Contains(item))
+                    if (!item.IsUndefined())
                     {
-                        _propertyList.Add(item);
+                        ThrowIfStringLengthExceeded(((JsString) item).Length);
+                        if (!_propertyList.Contains(item))
+                        {
+                            _propertyList.Add(item);
+                        }
                     }
 
                     k++;
@@ -385,7 +585,7 @@ public sealed class JsonSerializer
         }
     }
 
-    private static string BuildSpacingGap(JsValue space)
+    private string BuildSpacingGap(JsValue space)
     {
         if (space.IsObject())
         {
@@ -414,6 +614,7 @@ public sealed class JsonSerializer
 
         if (space.IsString())
         {
+            ThrowIfStringLengthExceeded(((JsString) space).Length);
             var stringSpace = space.ToString();
             return stringSpace.Length <= 10 ? stringSpace : stringSpace.Substring(0, 10);
         }
@@ -450,13 +651,10 @@ public sealed class JsonSerializer
 
         if (value.IsString())
         {
+            ThrowIfStringLengthExceeded(((JsString) value).Length);
             var stringValue = value.ToString();
 
-            // Quoting adds the two quotes and can only expand what is between them, so the unquoted
-            // length is a lower bound on what this append costs. Checking here refuses a string that
-            // cannot fit before it is copied into the document — including the case where the string
-            // is the whole document.
-            ThrowIfDocumentLengthExceeded(json.Length + 2L + stringValue.Length);
+            ThrowIfQuotedStringLengthExceeded(json.Length, stringValue);
 
             QuoteJSONString(stringValue, ref json);
             return SerializeResult.NotUndefined;
@@ -499,6 +697,7 @@ public sealed class JsonSerializer
             // Handle RawJSON objects - output rawJSON property directly
             if (objectInstance is JsRawJson rawJson)
             {
+                ThrowIfStringLengthExceeded(rawJson.RawJson.Length);
                 // Raw JSON text and the host hook below are copied through verbatim, so what they
                 // add is exactly their length: both are single appends large enough to be worth
                 // refusing before the copy.
@@ -521,6 +720,7 @@ public sealed class JsonSerializer
                 var hostJson = serialize(wrapper.Target, _gap, _indent);
                 if (hostJson is { Length: > 0 })
                 {
+                    ThrowIfStringLengthExceeded(hostJson.Length);
                     ThrowIfDocumentLengthExceeded(json.Length + (long) hostJson.Length);
                     json.Append(hostJson);
                 }
@@ -677,6 +877,36 @@ public sealed class JsonSerializer
         json.Append('"');
     }
 
+    private void ThrowIfQuotedStringLengthExceeded(long currentLength, string value)
+    {
+        if (_documentLengthResultLimit is null)
+        {
+            ThrowIfDocumentLengthExceeded(currentLength + 2L + value.Length);
+            return;
+        }
+
+        long quotedLength = 2;
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+            if (char.IsSurrogatePair(value, i))
+            {
+                quotedLength += 2;
+                i++;
+            }
+            else if (c is '\"' or '\\' or '\b' or '\f' or '\n' or '\r' or '\t')
+            {
+                quotedLength += 2;
+            }
+            else
+            {
+                quotedLength += c < 0x20 || char.IsSurrogate(c) ? 6 : 1;
+            }
+
+            ThrowIfDocumentLengthExceeded(currentLength + quotedLength);
+        }
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void AppendJsonStringCharacter(string value, ref int index, ref ValueStringBuilder json)
     {
@@ -735,13 +965,16 @@ public sealed class JsonSerializer
     private void SerializeJSONArray(ObjectInstance value, ref ValueStringBuilder json)
     {
         var len = TypeConverter.ToUint32(value.Get(CommonProperties.Length));
+        CountProperties(len);
         if (len == 0)
         {
+            EnterContainer(value);
+            ExitContainer();
             json.Append("[]");
             return;
         }
 
-        _stack.Enter(value);
+        EnterContainer(value);
         var stepback = _indent;
         if (_gap.Length > 0)
         {
@@ -792,7 +1025,7 @@ public sealed class JsonSerializer
 
         if (!hasPrevious)
         {
-            _stack.Exit();
+            ExitContainer();
             _indent = stepback;
             json.Append("[]");
             return;
@@ -805,7 +1038,7 @@ public sealed class JsonSerializer
         }
         json.Append(']');
 
-        _stack.Exit();
+        ExitContainer();
         _indent = stepback;
     }
 
@@ -824,16 +1057,29 @@ public sealed class JsonSerializer
             return;
         }
 
-        var enumeration = _propertyList is null
-            ? PropertyEnumeration.FromObjectInstance(value)
-            : PropertyEnumeration.FromList(_propertyList);
+        PropertyEnumeration enumeration;
+        if (_propertyList is null)
+        {
+            var keys = value.GetOwnPropertyKeys(Types.String);
+            CountProperties(keys.Count);
+            RemoveUnserializableProperties(value, keys);
+            enumeration = PropertyEnumeration.FromList(keys);
+        }
+        else
+        {
+            CountProperties(_propertyList.Count);
+            enumeration = PropertyEnumeration.FromList(_propertyList);
+        }
+
         if (enumeration.IsEmpty)
         {
+            EnterContainer(value);
+            ExitContainer();
             json.Append("{}");
             return;
         }
 
-        _stack.Enter(value);
+        EnterContainer(value);
         var stepback = _indent;
         if (_gap.Length > 0)
         {
@@ -871,7 +1117,10 @@ public sealed class JsonSerializer
                 json.Append(_indent);
             }
 
-            QuoteJSONString(p.ToString(), ref json);
+            ThrowIfStringLengthExceeded(((JsString) p).Length);
+            var propertyName = p.ToString();
+            ThrowIfQuotedStringLengthExceeded(json.Length, propertyName);
+            QuoteJSONString(propertyName, ref json);
             json.Append(':');
             if (_gap.Length > 0)
             {
@@ -890,7 +1139,7 @@ public sealed class JsonSerializer
 
         if (!hasPrevious)
         {
-            _stack.Exit();
+            ExitContainer();
             _indent = stepback;
             json.Append("{}");
             return;
@@ -903,7 +1152,7 @@ public sealed class JsonSerializer
         }
         json.Append('}');
 
-        _stack.Exit();
+        ExitContainer();
         _indent = stepback;
     }
 
@@ -934,11 +1183,14 @@ public sealed class JsonSerializer
 
         if (keys.Length == 0)
         {
+            EnterContainer(value);
+            ExitContainer();
             json.Append("{}");
             return true;
         }
 
-        _stack.Enter(value);
+        CountProperties(keys.Length);
+        EnterContainer(value);
         var stepback = _indent;
         if (_gap.Length > 0)
         {
@@ -975,6 +1227,8 @@ public sealed class JsonSerializer
                 json.Append(_indent);
             }
 
+            ThrowIfStringLengthExceeded(keys[i].Name.Length);
+            ThrowIfQuotedStringLengthExceeded(json.Length, keys[i].Name);
             QuoteJSONString(keys[i].Name, ref json);
             json.Append(':');
             if (_gap.Length > 0)
@@ -1015,7 +1269,7 @@ public sealed class JsonSerializer
 
         if (!hasPrevious)
         {
-            _stack.Exit();
+            ExitContainer();
             _indent = stepback;
             json.Append("{}");
             return true;
@@ -1028,7 +1282,7 @@ public sealed class JsonSerializer
         }
         json.Append('}');
 
-        _stack.Exit();
+        ExitContainer();
         _indent = stepback;
         return true;
     }
@@ -1050,27 +1304,25 @@ public sealed class JsonSerializer
         public static PropertyEnumeration FromList(List<JsValue> keys)
             => new PropertyEnumeration(keys, keys.Count == 0);
 
-        public static PropertyEnumeration FromObjectInstance(ObjectInstance instance)
-        {
-            var allKeys = instance.GetOwnPropertyKeys(Types.String);
-            RemoveUnserializableProperties(instance, allKeys);
-            return new PropertyEnumeration(allKeys, allKeys.Count == 0);
-        }
-
-        private static void RemoveUnserializableProperties(ObjectInstance instance, List<JsValue> keys)
-        {
-            for (var i = 0; i < keys.Count; i++)
-            {
-                var key = keys[i];
-                if (instance.ProbeOwnPropertyChecked(key) != OwnPropertyProbe.Enumerable)
-                {
-                    keys.RemoveAt(i);
-                    i--;
-                }
-            }
-        }
-
         public readonly List<JsValue> Keys;
         public readonly bool IsEmpty;
+    }
+
+    private void RemoveUnserializableProperties(ObjectInstance instance, List<JsValue> keys)
+    {
+        for (var i = 0; i < keys.Count; i++)
+        {
+            if (i > 0 && i % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
+            var key = keys[i];
+            if (instance.ProbeOwnPropertyChecked(key) != OwnPropertyProbe.Enumerable)
+            {
+                keys.RemoveAt(i);
+                i--;
+            }
+        }
     }
 }

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -185,6 +185,31 @@ public partial class Options
     public JsonOptions Json { get; set; } = new();
 
     /// <summary>
+    /// Limits applied by host-side result conversion and JSON serialization. Defaults to
+    /// <see cref="ResultLimits.Unlimited"/> for compatibility.
+    /// </summary>
+    /// <remarks>
+    /// Setting this also bounds script-visible <c>JSON.stringify</c>. Use per-call limits on
+    /// <see cref="Engine.AdvancedOperations.ConvertResult"/> or <see cref="Native.Json.JsonSerializer"/> when
+    /// different requests sharing one options object need different policies.
+    /// </remarks>
+    public ResultLimits ResultLimits
+    {
+        get => _resultLimits;
+        set
+        {
+            if (value is null)
+            {
+                Throw.ArgumentNullException(nameof(value));
+            }
+
+            _resultLimits = value;
+        }
+    }
+
+    private ResultLimits _resultLimits = ResultLimits.Unlimited;
+
+    /// <summary>
     /// What experimental features are allowed, functionality may lacking or even plain wrong. Defaults to having none.
     /// </summary>
     public ExperimentalFeature ExperimentalFeatures { get; set; }
@@ -549,7 +574,7 @@ public partial class Options
         /// with <see cref="JintException.TryGetClrException"/>, and a running script sees neither.
         /// </para>
         /// <para>
-        /// <see cref="JavaScriptException.GetJavaScriptErrorString"/> is exempt and renders the same string
+        /// <see cref="JavaScriptException.GetJavaScriptErrorString()"/> is exempt and renders the same string
         /// either way. It is the accessor a host uses to show a <em>script author</em> what went wrong, so the
         /// chain would put the host's .NET frames in front of the JavaScript ones there.
         /// </para>

--- a/Jint/ResultLimits.cs
+++ b/Jint/ResultLimits.cs
@@ -1,0 +1,103 @@
+namespace Jint;
+
+/// <summary>
+/// Bounds host-side conversion and serialization of values produced by script.
+/// </summary>
+/// <remarks>
+/// These limits do not replace execution constraints. Property access during conversion and JSON serialization
+/// can invoke getters, proxy traps, <c>toJSON</c>, and replacer functions, so untrusted code also needs time,
+/// statement, cancellation, memory, and stack limits.
+/// </remarks>
+public sealed class ResultLimits
+{
+    /// <summary>
+    /// No result-specific limits. This is the compatibility default.
+    /// </summary>
+    public static ResultLimits Unlimited { get; } = new();
+
+    /// <summary>
+    /// A conservative starting point for untrusted results. Hosts should tune these values for their schema and
+    /// still enforce an outer response and process budget.
+    /// </summary>
+    public static ResultLimits Conservative { get; } = new(
+        maxDepth: 32,
+        maxPropertyCount: 10_000,
+        maxStringLength: 1_000_000,
+        maxOutputCharacters: 2_000_000,
+        maxOutputBytes: 4_000_000);
+
+    public ResultLimits(
+        int maxDepth = int.MaxValue,
+        long maxPropertyCount = long.MaxValue,
+        int maxStringLength = int.MaxValue,
+        long maxOutputCharacters = long.MaxValue,
+        long maxOutputBytes = long.MaxValue)
+    {
+        ValidateNonNegative(maxDepth, nameof(maxDepth));
+        ValidateNonNegative(maxPropertyCount, nameof(maxPropertyCount));
+        ValidateNonNegative(maxStringLength, nameof(maxStringLength));
+        ValidateNonNegative(maxOutputCharacters, nameof(maxOutputCharacters));
+        ValidateNonNegative(maxOutputBytes, nameof(maxOutputBytes));
+
+        MaxDepth = maxDepth;
+        MaxPropertyCount = maxPropertyCount;
+        MaxStringLength = maxStringLength;
+        MaxOutputCharacters = maxOutputCharacters;
+        MaxOutputBytes = maxOutputBytes;
+    }
+
+    private static void ValidateNonNegative(long value, string paramName)
+    {
+        if (value < 0)
+        {
+            Runtime.Throw.ArgumentOutOfRangeException(paramName, "Result limits cannot be negative.");
+        }
+    }
+
+    /// <summary>
+    /// Maximum number of nested containers. A primitive has depth zero and the root container has depth one.
+    /// </summary>
+    public int MaxDepth { get; }
+
+    /// <summary>
+    /// Maximum cumulative number of object properties, array elements, map entries, or set elements visited.
+    /// </summary>
+    /// <remarks>
+    /// This is the structural-work and container-allocation bound for
+    /// <see cref="Engine.AdvancedOperations.ConvertResult"/>. Shared, non-cyclic references are converted once
+    /// per occurrence, so hosts processing untrusted graphs must set this limit even when string and binary
+    /// limits are configured.
+    /// </remarks>
+    public long MaxPropertyCount { get; }
+
+    /// <summary>
+    /// Maximum UTF-16 length of any individual string value or property name.
+    /// </summary>
+    public int MaxStringLength { get; }
+
+    /// <summary>
+    /// Maximum cumulative UTF-16 characters copied into a CLR result, or characters in a JSON document.
+    /// </summary>
+    public long MaxOutputCharacters { get; }
+
+    /// <summary>
+    /// Maximum bytes in a JSON UTF-8 document or cumulatively across binary values in a CLR result.
+    /// </summary>
+    /// <remarks>
+    /// For CLR conversion this counts binary payloads only. It does not estimate dictionary, array, map, or set
+    /// allocation; <see cref="MaxPropertyCount"/> bounds that structural output.
+    /// </remarks>
+    public long MaxOutputBytes { get; }
+}
+
+/// <summary>
+/// Identifies the result boundary exceeded by a conversion or serialization operation.
+/// </summary>
+public enum ResultLimit
+{
+    Depth,
+    PropertyCount,
+    StringLength,
+    OutputCharacters,
+    OutputBytes
+}

--- a/Jint/Runtime/ConstraintFailure.cs
+++ b/Jint/Runtime/ConstraintFailure.cs
@@ -1,5 +1,3 @@
-using Jint.Runtime.Modules;
-
 namespace Jint.Runtime;
 
 /// <summary>
@@ -18,24 +16,17 @@ internal static class ConstraintFailure
     /// Whether <paramref name="exception"/> must escape the job it was raised in.
     /// </summary>
     /// <remarks>
-    /// <see cref="RecursionDepthOverflowException"/> belongs here for the same reason as the rest, and reaches
-    /// these paths whenever host code re-enters the engine — a module resolve hook or a virtual file system
-    /// written in script, which is a shape hosts really do use.
-    /// <see cref="PlatformNotSupportedException"/> is on the list for the same reason but arrives by a
-    /// different route: <see cref="Jint.Constraints.MemoryLimitConstraint"/> raises it when the runtime does
-    /// not expose <c>GC.GetAllocatedBytesForCurrentThread</c>, so a configured allocation budget cannot be
-    /// enforced at all. That is a bound failing closed, and a job that turned it into a rejection would go on
-    /// running unbounded.
+    /// A job boundary is the host boundary plus two: <see cref="Throw.MustPropagateHostException"/> is the
+    /// list a CLR call is not allowed to swallow, and this is that list with
+    /// <see cref="TimeoutException"/> and <see cref="OperationCanceledException"/> added. The two are apart
+    /// on purpose — a host method may raise either of those as its own ordinary failure, so an interop
+    /// boundary cannot read them as a bound, while for a queued turn they are Jint's own timeout and
+    /// cancellation and nothing else. Defining this one over the other is what stops them drifting.
+    /// <see cref="RecursionDepthOverflowException"/> reaches <i>these</i> paths whenever host code re-enters
+    /// the engine — a module resolve hook or a virtual file system written in script, which is a shape hosts
+    /// really do use.
     /// </remarks>
-    internal static bool MustPropagate(Exception exception) => exception
-        is ExecutionCanceledException
-        or ParsingLimitException
-        or MemoryLimitExceededException
-        or StatementsCountOverflowException
-        or RecursionDepthOverflowException
-        or ModuleGraphLimitException
-        or TimeoutException
-        or OperationCanceledException
-        or PlatformNotSupportedException
-        or OutOfMemoryException;
+    internal static bool MustPropagate(Exception exception)
+        => Throw.MustPropagateHostException(exception)
+           || exception is TimeoutException or OperationCanceledException;
 }

--- a/Jint/Runtime/Debugger/DebugHandler.cs
+++ b/Jint/Runtime/Debugger/DebugHandler.cs
@@ -145,7 +145,7 @@ public class DebugHandler
         {
             result = list.Execute(context);
         }
-        catch (Exception ex) when (ex is not ParsingLimitException)
+        catch (Exception ex) when (!Throw.MustPropagateHostException(ex))
         {
             // An error in the evaluation may return a Throw Completion, or it may throw an exception:
             throw new DebugEvaluationException("An error occurred during debugger evaluation", ex);

--- a/Jint/Runtime/Interop/ClrFunction.cs
+++ b/Jint/Runtime/Interop/ClrFunction.cs
@@ -70,7 +70,7 @@ public sealed class ClrFunction : Function, IEquatable<ClrFunction>
         {
             return _func(thisObject, arguments);
         }
-        catch (Exception e) when (e is not JavaScriptException and not ParsingLimitException)
+        catch (Exception e) when (e is not JavaScriptException && !Throw.MustPropagateHostException(e))
         {
             if (_engine.Options.Interop.ExceptionHandler(e))
             {

--- a/Jint/Runtime/Interop/DefaultTypeConverter.cs
+++ b/Jint/Runtime/Interop/DefaultTypeConverter.cs
@@ -368,7 +368,7 @@ public class DefaultTypeConverter : ITypeConverter
         }
         catch (Exception e)
         {
-            if (e is ParsingLimitException)
+            if (Throw.MustPropagateHostException(e))
             {
                 throw;
             }

--- a/Jint/Runtime/Interop/ResultConverter.cs
+++ b/Jint/Runtime/Interop/ResultConverter.cs
@@ -1,0 +1,364 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using Jint.Native;
+using Jint.Native.BigInt;
+using Jint.Native.Boolean;
+using Jint.Native.Number;
+using Jint.Native.Object;
+using Jint.Native.Promise;
+using Jint.Native.String;
+using Jint.Native.TypedArray;
+
+namespace Jint.Runtime.Interop;
+
+internal static class ResultConverter
+{
+    public static object? Convert(Engine engine, JsValue value, ResultLimits limits)
+    {
+        var context = new ConversionContext(engine, limits);
+        return context.Convert(value);
+    }
+
+    private sealed class ConversionContext
+    {
+        private readonly Engine _engine;
+        private readonly ResultLimits _limits;
+        private readonly HashSet<ObjectInstance> _path = new(ReferenceComparer.Instance);
+        private long _propertyCount;
+        private long _outputCharacters;
+        private long _outputBytes;
+        private int _depth;
+        private int _workUntilConstraintCheck = Engine.ConstraintCheckInterval;
+
+        public ConversionContext(Engine engine, ResultLimits limits)
+        {
+            _engine = engine;
+            _limits = limits;
+        }
+
+        public object? Convert(JsValue value)
+        {
+            if (value is not ObjectInstance instance)
+            {
+                return ConvertPrimitive(value);
+            }
+
+            if (instance is IObjectWrapper wrapper)
+            {
+                // The target already belongs to the host. Jint neither copies nor walks that CLR graph.
+                return wrapper.Target;
+            }
+
+            if (instance.IsArray())
+            {
+                return ConvertArray(instance);
+            }
+
+            return ConvertObject(instance);
+        }
+
+        private object? ConvertPrimitive(JsValue value)
+        {
+            if (value.IsString())
+            {
+                CountStringLength(((JsString) value).Length);
+                var text = value.ToString();
+                CountOutputCharacters(text.Length);
+                return text;
+            }
+
+            if (value.IsSymbol())
+            {
+                Throw.NotSupportedException("Symbol values cannot be converted to a host result.");
+            }
+
+            return value.ToObject();
+        }
+
+        private object ConvertObject(ObjectInstance instance)
+        {
+            switch (instance)
+            {
+                case StringInstance stringInstance:
+                    CountStringLength(stringInstance.StringData.Length);
+                    var text = stringInstance.StringData.ToString();
+                    CountOutputCharacters(text.Length);
+                    return text;
+                case JsDate date:
+                    return date.ToDateTime();
+                case BooleanInstance booleanInstance:
+                    return booleanInstance.BooleanData._value ? JsBoolean.BoxedTrue : JsBoolean.BoxedFalse;
+                case ICallable when instance.Class == ObjectClass.Function:
+                    Throw.NotSupportedException("Function values cannot be converted to a host result.");
+                    return null!;
+                case NumberInstance numberInstance:
+                    return numberInstance.NumberData._value;
+                case JsRegExp regexp:
+                    return regexp.Value;
+                case BigIntInstance bigIntInstance:
+                    return bigIntInstance.BigIntData._value;
+                case JsPromise promise
+                    when (_engine.Options.ExperimentalFeatures & ExperimentalFeature.TaskInterop) != ExperimentalFeature.None:
+                    return Convert(promise.UnwrapIfPromise(_engine.Options.Constraints.PromiseTimeout))!;
+                case JsTypedArray typedArray:
+                    return ConvertTypedArray(typedArray);
+                case JsArrayBuffer arrayBuffer:
+                    arrayBuffer.AssertNotDetached();
+                    var arrayBufferData = arrayBuffer.ArrayBufferData!;
+                    CountBytes(arrayBufferData.LongLength);
+                    return arrayBufferData.AsSpan().ToArray();
+                case JsDataView dataView:
+                    dataView._viewedArrayBuffer!.AssertNotDetached();
+                    CountBytes(dataView._byteLength);
+                    var bytes = new byte[dataView._byteLength];
+                    System.Array.Copy(
+                        dataView._viewedArrayBuffer._arrayBufferData!,
+                        dataView._byteOffset,
+                        bytes,
+                        0,
+                        dataView._byteLength);
+                    return bytes;
+                case JsMap map:
+                    return ConvertMap(map);
+                case JsSet set:
+                    return ConvertSet(set);
+                default:
+                    return ConvertProperties(instance);
+            }
+        }
+
+        private object?[] ConvertArray(ObjectInstance array)
+        {
+            Enter(array);
+            try
+            {
+                var length = array.GetLength();
+                CountProperties(length);
+                if (length > ClrLimits.MaxArrayLength)
+                {
+                    ThrowLimit(ResultLimit.PropertyCount, ClrLimits.MaxArrayLength, length);
+                }
+
+                var result = new object?[length];
+                for (uint i = 0; i < length; i++)
+                {
+                    CheckConstraints();
+                    var value = array[i];
+                    result[i] = value.IsUndefined() ? null : Convert(value);
+                }
+
+                return result;
+            }
+            finally
+            {
+                Exit(array);
+            }
+        }
+
+        private object ConvertTypedArray(JsTypedArray array)
+        {
+            Enter(array);
+            try
+            {
+                var length = array.GetLength();
+                CountProperties(length);
+                if (length > ClrLimits.MaxArrayLength)
+                {
+                    ThrowLimit(ResultLimit.PropertyCount, ClrLimits.MaxArrayLength, length);
+                }
+
+                CountBytes((long) length * array._arrayElementType.GetElementSize());
+
+                return array._arrayElementType switch
+                {
+                    TypedArrayElementType.Int8 => array.ToNativeArray<sbyte>(),
+                    TypedArrayElementType.Int16 => array.ToNativeArray<short>(),
+                    TypedArrayElementType.Int32 => array.ToNativeArray<int>(),
+                    TypedArrayElementType.BigInt64 => array.ToNativeArray<long>(),
+#if SUPPORTS_HALF
+                    TypedArrayElementType.Float16 => array.ToNativeArray<Half>(),
+#endif
+                    TypedArrayElementType.Float32 => array.ToNativeArray<float>(),
+                    TypedArrayElementType.Float64 => array.ToNativeArray<double>(),
+                    TypedArrayElementType.Uint8 => array.ToNativeArray<byte>(),
+                    TypedArrayElementType.Uint8C => array.ToNativeArray<byte>(),
+                    TypedArrayElementType.Uint16 => array.ToNativeArray<ushort>(),
+                    TypedArrayElementType.Uint32 => array.ToNativeArray<uint>(),
+                    TypedArrayElementType.BigUint64 => array.ToNativeArray<ulong>(),
+                    _ => throw new NotSupportedException("Cannot handle typed array element type.")
+                };
+            }
+            finally
+            {
+                Exit(array);
+            }
+        }
+
+        private List<KeyValuePair<object?, object?>> ConvertMap(JsMap map)
+        {
+            Enter(map);
+            try
+            {
+                CountProperties(map.Size);
+                var result = new List<KeyValuePair<object?, object?>>(map.Size);
+                foreach (var pair in map)
+                {
+                    CheckConstraints();
+                    result.Add(new KeyValuePair<object?, object?>(Convert(pair.Key), Convert(pair.Value)));
+                }
+
+                return result;
+            }
+            finally
+            {
+                Exit(map);
+            }
+        }
+
+        private object?[] ConvertSet(JsSet set)
+        {
+            Enter(set);
+            try
+            {
+                CountProperties(set.Size);
+                var result = new object?[set.Size];
+                var index = 0;
+                foreach (var value in set)
+                {
+                    CheckConstraints();
+                    result[index++] = Convert(value);
+                }
+
+                return result;
+            }
+            finally
+            {
+                Exit(set);
+            }
+        }
+
+        private Dictionary<string, object?> ConvertProperties(ObjectInstance instance)
+        {
+            Enter(instance);
+            try
+            {
+                var keys = instance.GetOwnPropertyKeys(Types.String);
+                CountProperties(keys.Count);
+                var enumerableKeys = new List<JsValue>(keys.Count);
+                for (var i = 0; i < keys.Count; i++)
+                {
+                    CheckConstraints();
+                    if (instance.ProbeOwnPropertyChecked(keys[i]) == OwnPropertyProbe.Enumerable)
+                    {
+                        enumerableKeys.Add(keys[i]);
+                    }
+                }
+
+                var result = new Dictionary<string, object?>(enumerableKeys.Count, StringComparer.Ordinal);
+                for (var i = 0; i < enumerableKeys.Count; i++)
+                {
+                    CheckConstraints();
+                    var key = enumerableKeys[i].ToString();
+                    CountStringLength(((JsString) enumerableKeys[i]).Length);
+                    CountOutputCharacters(key.Length);
+                    result.Add(key, Convert(instance.Get(enumerableKeys[i])));
+                }
+
+                return result;
+            }
+            finally
+            {
+                Exit(instance);
+            }
+        }
+
+        private void Enter(ObjectInstance value)
+        {
+            var nextDepth = _depth + 1;
+            if (nextDepth > _limits.MaxDepth)
+            {
+                ThrowLimit(ResultLimit.Depth, _limits.MaxDepth, nextDepth);
+            }
+
+            if (!_path.Add(value))
+            {
+                Throw.TypeError(_engine.Realm, "Cyclic reference detected.");
+            }
+
+            _depth = nextDepth;
+        }
+
+        private void Exit(ObjectInstance value)
+        {
+            _path.Remove(value);
+            _depth--;
+        }
+
+        private void CountProperties(long count)
+        {
+            var observed = checked(_propertyCount + count);
+            if (observed > _limits.MaxPropertyCount)
+            {
+                ThrowLimit(ResultLimit.PropertyCount, _limits.MaxPropertyCount, observed);
+            }
+
+            _propertyCount = observed;
+        }
+
+        private void CountStringLength(int length)
+        {
+            if (length > _limits.MaxStringLength)
+            {
+                ThrowLimit(ResultLimit.StringLength, _limits.MaxStringLength, length);
+            }
+        }
+
+        private void CountOutputCharacters(int length)
+        {
+            var observed = checked(_outputCharacters + length);
+            if (observed > _limits.MaxOutputCharacters)
+            {
+                ThrowLimit(ResultLimit.OutputCharacters, _limits.MaxOutputCharacters, observed);
+            }
+
+            _outputCharacters = observed;
+        }
+
+        private void CountBytes(long count)
+        {
+            var observed = checked(_outputBytes + count);
+            if (observed > _limits.MaxOutputBytes)
+            {
+                ThrowLimit(ResultLimit.OutputBytes, _limits.MaxOutputBytes, observed);
+            }
+
+            _outputBytes = observed;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void CheckConstraints()
+        {
+            if (--_workUntilConstraintCheck == 0)
+            {
+                _engine.Constraints.Check();
+                _workUntilConstraintCheck = Engine.ConstraintCheckInterval;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowLimit(ResultLimit limit, long maximum, long observed)
+        {
+            throw new ResultLimitExceededException(limit, maximum, observed);
+        }
+    }
+
+    private sealed class ReferenceComparer : IEqualityComparer<ObjectInstance>
+    {
+        public static ReferenceComparer Instance { get; } = new();
+
+        public bool Equals(ObjectInstance? x, ObjectInstance? y) => ReferenceEquals(x, y);
+
+        public int GetHashCode(ObjectInstance obj) => RuntimeHelpers.GetHashCode(obj);
+    }
+}

--- a/Jint/Runtime/JavaScriptException.cs
+++ b/Jint/Runtime/JavaScriptException.cs
@@ -112,6 +112,30 @@ public class JavaScriptException : JintException
     public string GetJavaScriptErrorString() => _jsErrorException.Render(includeChainedClrException: false);
 
     /// <summary>
+    /// Returns the JavaScript error and stack while enforcing host output limits.
+    /// </summary>
+    /// <remarks>
+    /// Reading a script-defined <c>stack</c> accessor can execute JavaScript, so this overload runs under the
+    /// originating engine's execution constraints when the thrown value is an object.
+    /// </remarks>
+    public string GetJavaScriptErrorString(ResultLimits limits)
+    {
+        if (limits is null)
+        {
+            Throw.ArgumentNullException(nameof(limits));
+        }
+
+        if (Error is ObjectInstance objectInstance)
+        {
+            return objectInstance.Engine.ExecuteWithConstraints(
+                objectInstance.Engine.Options.Strict,
+                () => _jsErrorException.Render(includeChainedClrException: false, limits));
+        }
+
+        return _jsErrorException.Render(includeChainedClrException: false, limits);
+    }
+
+    /// <summary>
     /// Returns this exception as the base exception.
     /// The inner exception is a private implementation detail and should not be exposed.
     /// </summary>
@@ -210,40 +234,79 @@ public class JavaScriptException : JintException
 
         /// <summary>
         /// <paramref name="includeChainedClrException"/> is false for
-        /// <see cref="JavaScriptException.GetJavaScriptErrorString"/>, which promises the JavaScript error and
+        /// <see cref="JavaScriptException.GetJavaScriptErrorString()"/>, which promises the JavaScript error and
         /// nothing else; the string form of the exception itself keeps the chain.
         /// </summary>
-        internal string Render(bool includeChainedClrException)
+        internal string Render(bool includeChainedClrException, ResultLimits? limits = null)
         {
             var sb = new ValueStringBuilder();
-
-            sb.Append("Error");
-            var message = Message;
-            if (!string.IsNullOrEmpty(message))
+            try
             {
-                sb.Append(": ");
-                sb.Append(message);
+                AppendBounded(ref sb, "Error", limits, checkIndividualString: false);
+                var message = Message;
+                if (!string.IsNullOrEmpty(message))
+                {
+                    AppendBounded(ref sb, ": ", limits, checkIndividualString: false);
+                    AppendBounded(ref sb, message, limits, checkIndividualString: true);
+                }
+
+                // Exception.ToString() renders an inner exception between the message and the frames. This override
+                // replaces that rendering wholesale, so a chained CLR exception has to be spelled out here or it
+                // would be reachable through InnerException and yet invisible in every log line.
+                if (includeChainedClrException && InnerException is { } innerException)
+                {
+                    AppendBounded(ref sb, " ---> ", limits, checkIndividualString: false);
+                    AppendBounded(ref sb, innerException.ToString(), limits, checkIndividualString: true);
+                    AppendBounded(ref sb, Environment.NewLine, limits, checkIndividualString: false);
+                    AppendBounded(
+                        ref sb,
+                        "   --- End of inner exception stack trace ---",
+                        limits,
+                        checkIndividualString: false);
+                }
+
+                var stackTrace = StackTrace;
+                if (stackTrace != null)
+                {
+                    AppendBounded(ref sb, Environment.NewLine, limits, checkIndividualString: false);
+                    AppendBounded(ref sb, stackTrace, limits, checkIndividualString: true);
+                }
+
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
+
+        private static void AppendBounded(
+            ref ValueStringBuilder builder,
+            string value,
+            ResultLimits? limits,
+            bool checkIndividualString)
+        {
+            if (limits is not null)
+            {
+                if (checkIndividualString && value.Length > limits.MaxStringLength)
+                {
+                    throw new ResultLimitExceededException(
+                        ResultLimit.StringLength,
+                        limits.MaxStringLength,
+                        value.Length);
+                }
+
+                var observed = (long) builder.Length + value.Length;
+                if (observed > limits.MaxOutputCharacters)
+                {
+                    throw new ResultLimitExceededException(
+                        ResultLimit.OutputCharacters,
+                        limits.MaxOutputCharacters,
+                        observed);
+                }
             }
 
-            // Exception.ToString() renders an inner exception between the message and the frames. This override
-            // replaces that rendering wholesale, so a chained CLR exception has to be spelled out here or it
-            // would be reachable through InnerException and yet invisible in every log line.
-            if (includeChainedClrException && InnerException is { } innerException)
-            {
-                sb.Append(" ---> ");
-                sb.Append(innerException.ToString());
-                sb.Append(Environment.NewLine);
-                sb.Append("   --- End of inner exception stack trace ---");
-            }
-
-            var stackTrace = StackTrace;
-            if (stackTrace != null)
-            {
-                sb.Append(Environment.NewLine);
-                sb.Append(stackTrace);
-            }
-
-            return sb.ToString();
+            builder.Append(value);
         }
     }
 }

--- a/Jint/Runtime/Modules/IAsyncModuleLoader.cs
+++ b/Jint/Runtime/Modules/IAsyncModuleLoader.cs
@@ -43,7 +43,8 @@ public interface IAsyncModuleLoader : IModuleLoader
     /// <para>
     /// One class of exception is exempt from that catch, and a host has to know which: the ones that exist to
     /// bound or abort execution — <see cref="ExecutionCanceledException"/>,
-    /// <see cref="MemoryLimitExceededException"/>, <see cref="StatementsCountOverflowException"/>,
+    /// <see cref="MemoryLimitExceededException"/>, <see cref="ResultLimitExceededException"/>,
+    /// <see cref="StatementsCountOverflowException"/>,
     /// <see cref="TimeoutException"/>, <see cref="OperationCanceledException"/> and
     /// <see cref="OutOfMemoryException"/> — keep propagating, because a constraint that becomes an ordinary
     /// failed import no longer bounds anything. Note what that means for a host cancelling its own fetch:

--- a/Jint/Runtime/Modules/ModuleLoadCompletion.cs
+++ b/Jint/Runtime/Modules/ModuleLoadCompletion.cs
@@ -413,14 +413,7 @@ public sealed class ModuleLoadCompletion
 
     private static bool MustPropagateLoaderException(Exception exception, CancellationToken cancellationToken)
     {
-        if (exception is ExecutionCanceledException
-            or ParsingLimitException
-            or MemoryLimitExceededException
-            or StatementsCountOverflowException
-            or RecursionDepthOverflowException
-            or ModuleGraphLimitException
-            or System.Text.RegularExpressions.RegexMatchTimeoutException
-            or OutOfMemoryException)
+        if (Throw.MustPropagateHostException(exception))
         {
             return true;
         }

--- a/Jint/Runtime/ResultLimitExceededException.cs
+++ b/Jint/Runtime/ResultLimitExceededException.cs
@@ -1,0 +1,21 @@
+namespace Jint.Runtime;
+
+/// <summary>
+/// Thrown when host-side conversion or serialization exceeds a configured <see cref="ResultLimits"/> boundary.
+/// </summary>
+public sealed class ResultLimitExceededException : JintException
+{
+    internal ResultLimitExceededException(ResultLimit limit, long maximum, long observed)
+        : base($"Result {limit} limit of {maximum} was exceeded (observed {observed}).")
+    {
+        Limit = limit;
+        Maximum = maximum;
+        Observed = observed;
+    }
+
+    public ResultLimit Limit { get; }
+
+    public long Maximum { get; }
+
+    public long Observed { get; }
+}

--- a/Jint/Runtime/Throw.cs
+++ b/Jint/Runtime/Throw.cs
@@ -52,6 +52,19 @@ internal static class Throw
     internal static bool IsEngineAbortException(Exception exception)
         => EngineAbortRegistry.Exceptions.TryGetValue(exception, out _);
 
+    internal static bool MustPropagateHostException(Exception exception) => exception
+        is global::Jint.Runtime.ExecutionCanceledException
+        or global::Jint.ParsingLimitException
+        or global::Jint.Runtime.MemoryLimitExceededException
+        or global::Jint.Runtime.ResultLimitExceededException
+        or global::Jint.Runtime.StatementsCountOverflowException
+        or global::Jint.Runtime.RecursionDepthOverflowException
+        or global::Jint.Runtime.Modules.ModuleGraphLimitException
+        or System.Text.RegularExpressions.RegexMatchTimeoutException
+        or System.PlatformNotSupportedException
+        or System.OutOfMemoryException
+        || IsEngineAbortException(exception);
+
     private static void MarkEngineAbort(Exception exception)
         => EngineAbortRegistry.Exceptions.Add(exception, EngineAbortRegistry.Marker);
 
@@ -338,7 +351,7 @@ internal static class Throw
     public static void MeaningfulException(Engine engine, TargetInvocationException exception)
     {
         var meaningfulException = exception.InnerException ?? exception;
-        if (meaningfulException is ParsingLimitException)
+        if (MustPropagateHostException(meaningfulException))
         {
             ExceptionDispatchInfo.Capture(meaningfulException).Throw();
         }

--- a/README.md
+++ b/README.md
@@ -1989,7 +1989,50 @@ charge unrelated allocations while an async operation is suspended.
 **Values do not cross engines.** A `JsValue` that is an `ObjectInstance` holds a hard reference to the engine
 and realm that created it, and passing one to a different engine is not supported — it is neither validated
 nor made safe. `Prepared<Script>` / `Prepared<Module>` and `ModuleBuilder` are the supported ways to share
-work between engines; convert to CLR values (`ToObject()`) to move data.
+work between engines. For a script result, prefer
+`engine.Advanced.ConvertResult(value, limits)`: it copies arrays, typed arrays, array buffers, maps, sets and
+enumerable own properties into a detached CLR data graph while incrementally enforcing depth, cumulative
+property/element count, individual string length, aggregate characters and binary bytes. Cycles, functions and
+symbols are rejected. A CLR wrapper is already host-owned, so conversion returns its target without walking or
+limiting that target's graph.
+
+**Bound untrusted output.** `Options.ResultLimits` defaults to `ResultLimits.Unlimited` for compatibility.
+`ResultLimits.Conservative` is an opt-in starting point, not a complete sandbox profile:
+
+```csharp
+var engine = new Engine(options =>
+{
+    options.ResultLimits = ResultLimits.Conservative;
+    options.TimeoutInterval(TimeSpan.FromSeconds(2));
+    options.MaxStatements(50_000);
+    options.LimitMemory(16_000_000);
+});
+
+var value = engine.Evaluate(source);
+var result = engine.Advanced.ConvertResult(value);
+```
+
+The same option bounds Jint's `JsonSerializer` and script-visible `JSON.stringify`; per-call overloads can use
+a tighter policy. JSON output counts escaped UTF-16 characters before appending and exact UTF-8 bytes before
+touching an `IBufferWriter<byte>`. Conversion and serialization run under execution constraints because getters,
+proxy traps, `toJSON`, replacers and error `stack` accessors can execute script. Limits do not make host code
+interruptible: pair them with time, statement, cancellation, memory and stack constraints plus an outer worker
+deadline.
+
+`Evaluate`, `ConvertResult`, `JsonSerializer`, and bounded error rendering are separate top-level entries. If
+evaluation plus result handling is one request, bracket every phase with the same `OperationDeadlineConstraint`
+`Begin`/`End` pair; otherwise each phase receives a fresh ordinary per-entry budget.
+
+For CLR conversion, `MaxPropertyCount` is the structural-work and container-allocation bound. Shared references
+that are not cycles are copied once per occurrence, so a graph can amplify as it is detached; string, character
+and binary-byte limits do not bound that shape by themselves.
+
+Jint cannot impose these limits inside external serializers. `System.Text.Json`, Newtonsoft.Json, a configured
+`Interop.SerializeToJson` delegate, custom logging/diagnostic formatters, and serialization of a returned CLR
+wrapper target remain the host's responsibility. The delegate's returned JSON text is capped before Jint copies
+it, but any work or allocation the delegate performed to produce that string has already happened. Standard
+`Exception.ToString()` and debugger frontends are external sinks too; use
+`JavaScriptException.GetJavaScriptErrorString(limits)` for bounded script-error text.
 
 ## Profiling scripts (opt-in)
 


### PR DESCRIPTION
## Summary

- add `ResultLimits` and detached `Advanced.ConvertResult` handling for arrays, typed/binary values, maps, sets, and enumerable object graphs
- bound Jint JSON serialization and JavaScript error rendering by depth, structural work, strings, output characters, and bytes
- preserve one DAG-wide constraint cadence and count repeated shared references through `MaxPropertyCount`
- integrate result boundaries with Engine ownership and explicit deadline/memory operations spanning evaluation or import plus result handling
- keep result/resource failures fatal through CLR callbacks, proxy traps, reflection/conversion, debugger evaluation, and every async loader settlement path
- reject same-instance `JsonSerializer` reentry before nested callbacks can replace outer traversal state or limits
- document the cumulative untrusted-script deployment model in README and `.github/THREAT_MODEL.md`

## Stack

1. #3030 `initial-threat-model`
2. #3035 `sebros/reject-concurrent-engine-use`
3. #3036 `sebros/improve-memory-accounting`
4. #3037 `sebros/parser-source-ast-limits`
5. #3045 `sebros/stack-module-graph-limits`
6. this PR

## Validation

- Release multi-target `Jint/Jint.csproj` build
- full `Jint.Tests.PublicInterface` default and host-contract-verification runs
- full `Jint.Tests` default and host-contract-verification runs under UTC
- targeted result-limit, JSON, concurrency, memory, parser/module, proxy, and async-loader tests
- clean specialist security follow-up review
- `git diff --check`