### PR TITLE
A throw from the iterator step must not close the iterator

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -155,12 +155,6 @@
     "staging/sm/Set/intersection.js",
     "staging/sm/Set/is-subset-of.js",
 
-    // Iterator protocol: IteratorClose is not invoked (or not invoked at the right point) on the
-    // abrupt paths of Array.from, the Map/Set constructors and for-of.
-    "staging/sm/Array/from-iterator-close.js",
-    "staging/sm/Map/constructor-iterator-close.js",
-    "staging/sm/statements/for-of-iterator-close.js",
-
     // Proxy trap invariants and the exact trap sequence the array built-ins are specified to
     // perform. Jint's own invariant check on a defineProperty trap also fires where it should not.
     "staging/sm/Array/concat-proxy.js",

--- a/Jint.Tests/Runtime/IteratorCloseTests.cs
+++ b/Jint.Tests/Runtime/IteratorCloseTests.cs
@@ -1,0 +1,220 @@
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Pins who closes an iterator and who does not.
+/// <para>
+/// <a href="https://tc39.es/ecma262/#sec-iteratorstepvalue">IteratorStepValue</a> — and the
+/// IteratorStep/IteratorNext it is built from — sets <c>iteratorRecord.[[Done]]</c> on every abrupt
+/// completion the step itself produces: <c>next()</c> throwing, <c>next()</c> answering a non-object,
+/// and the <c>done</c>/<c>value</c> reads. Callers propagate such a completion with <c>?</c>, so
+/// <a href="https://tc39.es/ecma262/#sec-iteratorclose">IteratorClose</a> is never reached for any of
+/// them. Only the <em>consumer's</em> own abrupt completion — a mapper, an adder, a loop body —
+/// closes. Reaching the end of the iteration closes nothing either.
+/// </para>
+/// <para>
+/// Every consumer below used to wrap the step, the value read and the processing in one
+/// <c>try</c>/<c>catch</c> that closed on anything, so all three step failures wrongly closed; and the
+/// one consumer that did distinguish them (<c>AddEntriesFromIterable</c>, behind <c>Map</c>/
+/// <c>WeakMap</c>) never re-armed that distinction per iteration, so a <c>next()</c> that threw on the
+/// <em>second</em> step closed anyway. for-of additionally closed on normal exhaustion, which
+/// <a href="https://tc39.es/ecma262/#sec-runtime-semantics-forin-div-ofbodyevaluation-lhs-stmt-iterator-lhskind-labelset">ForIn/OfBodyEvaluation</a>
+/// step 8.e ("If done is true, return iterationResult") does not do.
+/// </para>
+/// </summary>
+public class IteratorCloseTests
+{
+    /// <summary>
+    /// The verdict string every consumer must produce: one <c>true</c>/<c>false</c> per mode, in the
+    /// order of <c>MODES</c> below — a step failure never closes, the consumer's own failure always
+    /// does, and running out closes nothing.
+    /// </summary>
+    private const string Expected = "next-throws=false,done-throws=false,value-throws=false,consumer-throws=true,second-next-throws=false,exhausted=false";
+
+    private const string Harness = """
+        // An iterable whose iterator records whether return() was called, and which can be told to
+        // fail at one specific point of the iteration protocol.
+        function makeIterable(mode, values) {
+            const record = { closed: false, closeCount: 0 };
+            let i = 0;
+            record.iterable = {
+                [Symbol.iterator]() {
+                    return {
+                        next() {
+                            i++;
+                            if (mode === 'next-throws') { throw 'from next'; }
+                            if (mode === 'second-next-throws' && i === 2) { throw 'from second next'; }
+                            if (i > values.length) { return { done: true, value: undefined }; }
+                            const value = values[i - 1];
+                            if (mode === 'done-throws') { return { value: value, get done() { throw 'from done'; } }; }
+                            if (mode === 'value-throws') { return { done: false, get value() { throw 'from value'; } }; }
+                            return { done: false, value: value };
+                        },
+                        return() {
+                            record.closed = true;
+                            record.closeCount++;
+                            return {};
+                        }
+                    };
+                }
+            };
+            return record;
+        }
+
+        const MODES = ['next-throws', 'done-throws', 'value-throws', 'consumer-throws', 'second-next-throws', 'exhausted'];
+
+        // Runs the consumer `consumerFor(mode)` over a fresh iterable for every mode and reports the
+        // close verdict of each. 'consumer-throws' gets a perfectly well-behaved iterable — it is the
+        // consumer that fails — and 'exhausted' gets one that simply runs out.
+        function verdicts(consumerFor, values) {
+            return MODES.map(function (mode) {
+                const iterableMode = (mode === 'consumer-throws' || mode === 'exhausted') ? '' : mode;
+                const record = makeIterable(iterableMode, values);
+                try { consumerFor(mode)(record.iterable); } catch (e) { }
+                if (record.closeCount > 1) { throw new Error(mode + ': closed ' + record.closeCount + ' times'); }
+                return mode + '=' + record.closed;
+            }).join(',');
+        }
+
+        const PAIRS = [[{}, {}], [{}, {}]];
+        const OBJECTS = [{}, {}];
+        """;
+
+    private static string Run(string script) => new Engine().Evaluate(Harness + "\n" + script).AsString();
+
+    [Fact]
+    public void ArrayFromClosesOnlyForTheMappersOwnFailure()
+    {
+        Run("""
+            verdicts(function (mode) {
+                if (mode === 'consumer-throws') {
+                    return function (it) { Array.from(it, function () { throw 'from mapper'; }); };
+                }
+                return function (it) { Array.from(it); };
+            }, OBJECTS);
+            """).Should().Be(Expected);
+    }
+
+    /// <summary>
+    /// The same, through the other <c>Array.from</c> branch: a subclass receiver drives the shared
+    /// <c>IteratorProtocol.Execute</c> loop instead of the plain-array builder.
+    /// </summary>
+    [Fact]
+    public void ArraySubclassFromClosesOnlyForTheMappersOwnFailure()
+    {
+        Run("""
+            class MyArray extends Array { }
+            verdicts(function (mode) {
+                if (mode === 'consumer-throws') {
+                    return function (it) { MyArray.from(it, function () { throw 'from mapper'; }); };
+                }
+                return function (it) { MyArray.from(it); };
+            }, OBJECTS);
+            """).Should().Be(Expected);
+    }
+
+    [Fact]
+    public void MapConstructorClosesOnlyForTheAddersOwnFailure()
+    {
+        Run("""
+            class ThrowingMap extends Map { set(k, v) { throw 'from set'; } }
+            verdicts(function (mode) {
+                const ctor = mode === 'consumer-throws' ? ThrowingMap : Map;
+                return function (it) { new ctor(it); };
+            }, PAIRS);
+            """).Should().Be(Expected);
+    }
+
+    [Fact]
+    public void SetConstructorClosesOnlyForTheAddersOwnFailure()
+    {
+        Run("""
+            class ThrowingSet extends Set { add(v) { throw 'from add'; } }
+            verdicts(function (mode) {
+                const ctor = mode === 'consumer-throws' ? ThrowingSet : Set;
+                return function (it) { new ctor(it); };
+            }, OBJECTS);
+            """).Should().Be(Expected);
+    }
+
+    [Fact]
+    public void WeakMapConstructorClosesOnlyForTheAddersOwnFailure()
+    {
+        Run("""
+            class ThrowingWeakMap extends WeakMap { set(k, v) { throw 'from set'; } }
+            verdicts(function (mode) {
+                const ctor = mode === 'consumer-throws' ? ThrowingWeakMap : WeakMap;
+                return function (it) { new ctor(it); };
+            }, PAIRS);
+            """).Should().Be(Expected);
+    }
+
+    [Fact]
+    public void WeakSetConstructorClosesOnlyForTheAddersOwnFailure()
+    {
+        Run("""
+            class ThrowingWeakSet extends WeakSet { add(v) { throw 'from add'; } }
+            verdicts(function (mode) {
+                const ctor = mode === 'consumer-throws' ? ThrowingWeakSet : WeakSet;
+                return function (it) { new ctor(it); };
+            }, OBJECTS);
+            """).Should().Be(Expected);
+    }
+
+    [Fact]
+    public void ForOfClosesOnlyForTheBodysOwnFailure()
+    {
+        Run("""
+            verdicts(function (mode) {
+                if (mode === 'consumer-throws') {
+                    return function (it) { for (const x of it) { throw 'from body'; } };
+                }
+                return function (it) { for (const x of it) { } };
+            }, OBJECTS);
+            """).Should().Be(Expected);
+    }
+
+    /// <summary>
+    /// The control for the entry above: an abrupt completion of the loop <em>statement</em> still
+    /// closes, which is what <c>staging/sm/statements/for-of-iterator-close.js</c> already asserted
+    /// and what must not regress while the exhaustion case is fixed.
+    /// </summary>
+    [Fact]
+    public void ForOfStillClosesOnBreakReturnAndAnAbruptLhs()
+    {
+        Run("""
+            function closedBy(consume) {
+                const record = makeIterable('', OBJECTS);
+                try { consume(record.iterable); } catch (e) { }
+                return record.closed + '/' + record.closeCount;
+            }
+
+            [
+                'break=' + closedBy(function (it) { for (const x of it) { break; } }),
+                'return=' + closedBy(function (it) { (function () { for (const x of it) { return 1; } })(); }),
+                'lhs=' + closedBy(function (it) { function bang() { throw 'from lhs'; } for ((bang().x) of it) { } }),
+                'continue=' + closedBy(function (it) { outer: do { for (const x of it) { continue outer; } } while (false); })
+            ].join(',');
+            """).Should().Be("break=true/1,return=true/1,lhs=true/1,continue=true/1");
+    }
+
+    /// <summary>
+    /// The <c>value</c> read is part of the step for a destructuring for-of too — a throwing getter
+    /// there must not close, while the destructuring itself failing must.
+    /// </summary>
+    [Fact]
+    public void ForOfWithADestructuringTargetSeparatesTheStepFromThePattern()
+    {
+        Run("""
+            function closedBy(mode, values, consume) {
+                const record = makeIterable(mode, values);
+                try { consume(record.iterable); } catch (e) { }
+                return record.closed;
+            }
+
+            [
+                'step=' + closedBy('value-throws', PAIRS, function (it) { for (const [a, b] of it) { } }),
+                'pattern=' + closedBy('', [{ [Symbol.iterator]() { throw 'from pattern'; } }], function (it) { for (const [a] of it) { } })
+            ].join(',');
+            """).Should().Be("step=false,pattern=true");
+    }
+}

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -90,9 +90,9 @@ public sealed partial class ArrayConstructor : Constructor
     /// Iterator branch of Array.from for the plain-array result: accumulates into a pooled
     /// builder and materializes an exact-size dense array instead of per-item
     /// CreateDataPropertyOrThrow writes. The loop structure mirrors
-    /// <see cref="IteratorProtocol.Execute"/>, including closing the iterator on abrupt
-    /// completion; materialization happens after the loop so a length-related throw does
-    /// not trigger an extra iterator close.
+    /// <see cref="IteratorProtocol.Execute"/>, including closing the iterator on the mapper's
+    /// own abrupt completion (never the step's); materialization happens after the loop so a
+    /// length-related throw does not trigger an extra iterator close.
     /// </summary>
     private JsArray ConstructFromIterator(JsValue items, ICallable usingIterator, ICallable? callable, JsValue thisArg)
     {
@@ -113,12 +113,11 @@ public sealed partial class ArrayConstructor : Constructor
                         _engine.Constraints.Check();
                     }
 
-                    if (!iterator.TryIteratorStep(out var item))
+                    if (!iterator.TryIteratorStepValue(out var jsValue))
                     {
                         break;
                     }
 
-                    var jsValue = item.Get(CommonProperties.Value);
                     index++;
 
                     if (callable is not null)
@@ -131,7 +130,9 @@ public sealed partial class ArrayConstructor : Constructor
             }
             catch
             {
-                iterator.Close(CompletionType.Throw);
+                // Only the mapper is the caller's own abrupt completion; a failure inside the step
+                // has set the record's [[Done]] and must propagate unclosed (IteratorStepValue).
+                iterator.CloseIfNotDone(CompletionType.Throw);
                 throw;
             }
 

--- a/Jint/Native/Iterator/IteratorInstance.cs
+++ b/Jint/Native/Iterator/IteratorInstance.cs
@@ -35,6 +35,66 @@ internal abstract class IteratorInstance : ObjectInstance
     internal virtual bool HasNativeNext => true;
 
     /// <summary>
+    /// The iterator record's [[Done]] field, https://tc39.es/ecma262/#sec-iterator-records.
+    /// <para>
+    /// IteratorNext (steps 3.a and 6.a), IteratorStep (steps 3.a and 5.a) and IteratorStepValue
+    /// (step 4.a) set it for <em>every</em> abrupt completion the step itself produces —
+    /// <c>next()</c> throwing, <c>next()</c> answering a non-object, and the <c>done</c>/<c>value</c>
+    /// reads — plus for the step that reports done. Callers propagate such a completion with
+    /// <c>?</c>, so IteratorClose is never reached for any of them; <see cref="CloseIfNotDone"/> is
+    /// how that reads here. Only the consumer's own abrupt completion closes.
+    /// </para>
+    /// </summary>
+    internal bool Done { get; private set; }
+
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-iteratorstepvalue
+    /// Steps the iterator, produces the step's value and maintains <see cref="Done"/>. Returns
+    /// <c>false</c> for the spec's ~done~ result. Every consumer that loops an iterator and closes it
+    /// on failure should step through this and close through <see cref="CloseIfNotDone"/>, so that
+    /// "abrupt while stepping" and "abrupt while processing" cannot be confused — and so that the
+    /// distinction is re-established on every iteration rather than only on the first.
+    /// </summary>
+    internal bool TryIteratorStepValue([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out JsValue? value)
+    {
+        try
+        {
+            if (!TryStepValue(out value))
+            {
+                // IteratorStep step 5.a: a done result sets [[Done]] as well.
+                Done = true;
+                return false;
+            }
+        }
+        catch
+        {
+            Done = true;
+            throw;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-iteratorclose
+    /// IteratorClose, guarded by the record's [[Done]] — the shape the spec writes as
+    /// "If <c>iteratorRecord</c>.[[Done]] is <c>false</c>, ... IteratorClose". A step that already
+    /// failed (or already reported done) leaves nothing to close.
+    /// </summary>
+    internal void CloseIfNotDone(CompletionType completion)
+    {
+        if (!Done)
+        {
+            Close(completion);
+        }
+    }
+
+    /// <summary>
+    /// Rewinds [[Done]] for an instance that is being reused as a fresh iterator record.
+    /// </summary>
+    private void ResetDone() => Done = false;
+
+    /// <summary>
     /// Steps the iterator and hands back the value directly, letting concrete iterators skip
     /// the per-step IteratorResult object when nothing user-visible needs it (for-in keys).
     /// The default wraps <see cref="TryIteratorStep"/> with exactly the read the for-in/of
@@ -531,6 +591,10 @@ internal abstract class IteratorInstance : ObjectInstance
             // per-level scratch set carried into CompletedLevel — it must not leak across reuses.
             _visited = null;
             _levelAbsent = null;
+            // A pooled instance is a fresh iterator record for the next loop entry, so its [[Done]]
+            // starts over too. For-in steps through TryStepValue rather than TryIteratorStepValue and
+            // so never sets it today; resetting it keeps that an implementation detail of the caller.
+            ResetDone();
             InitializeEnumeration(target);
         }
 

--- a/Jint/Native/Iterator/IteratorProtocol.cs
+++ b/Jint/Native/Iterator/IteratorProtocol.cs
@@ -38,20 +38,20 @@ internal abstract class IteratorProtocol
                     _engine.Constraints.Check();
                 }
 
-                if (!_iterator.TryIteratorStep(out var item))
+                if (!_iterator.TryIteratorStepValue(out var currentValue))
                 {
                     done = true;
                     break;
                 }
-
-                var currentValue = item.Get(CommonProperties.Value);
 
                 ProcessItem(args, currentValue);
             }
         }
         catch
         {
-            IteratorClose(CompletionType.Throw);
+            // Only ProcessItem is the caller's own abrupt completion; a failure inside the step has
+            // set the record's [[Done]] and must propagate unclosed (IteratorStepValue).
+            _iterator.CloseIfNotDone(CompletionType.Throw);
             throw;
         }
         finally
@@ -76,6 +76,9 @@ internal abstract class IteratorProtocol
 
     protected abstract void ProcessItem(JsValue[] arguments, JsValue currentValue);
 
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-add-entries-from-iterable
+    /// </summary>
     internal static void AddEntriesFromIterable(ObjectInstance target, IteratorInstance iterable, object adder)
     {
         var callable = adder as ICallable;
@@ -86,7 +89,6 @@ internal abstract class IteratorProtocol
 
         var invoker = CallbackInvoker.Rent(target.Engine, callable, 2);
 
-        var skipClose = true;
         var iterations = 0;
         try
         {
@@ -99,14 +101,11 @@ internal abstract class IteratorProtocol
                     target.Engine.Constraints.Check();
                 }
 
-                if (!iterable.TryIteratorStep(out var nextItem))
+                if (!iterable.TryIteratorStepValue(out var temp))
                 {
                     return;
                 }
 
-                var temp = nextItem.Get(CommonProperties.Value);
-
-                skipClose = false;
                 var oi = temp as ObjectInstance;
                 if (oi is null)
                 {
@@ -121,10 +120,9 @@ internal abstract class IteratorProtocol
         }
         catch
         {
-            if (!skipClose)
-            {
-                iterable.Close(CompletionType.Throw);
-            }
+            // Steps 2.c/2.e/2.g/2.i close; step 2.a's own abrupt completion does not, and [[Done]] is
+            // what tells the two apart on every iteration, not just the first.
+            iterable.CloseIfNotDone(CompletionType.Throw);
             throw;
         }
         finally

--- a/Jint/Native/Set/SetConstructor.cs
+++ b/Jint/Native/Set/SetConstructor.cs
@@ -59,19 +59,20 @@ public sealed partial class SetConstructor : Constructor
                         _engine.Constraints.Check();
                     }
 
-                    if (!iterable.TryIteratorStep(out var next))
+                    if (!iterable.TryIteratorStepValue(out var nextValue))
                     {
                         return set;
                     }
 
-                    var nextValue = next.Get(CommonProperties.Value);
                     args[0] = nextValue;
                     adder.Call(set, args);
                 } while (true);
             }
             catch
             {
-                iterable.Close(CompletionType.Throw);
+                // Step 8.d closes for the adder's own abrupt completion (step 8.c); step 8.a's does
+                // not, and [[Done]] is what tells the two apart on every iteration, not just the first.
+                iterable.CloseIfNotDone(CompletionType.Throw);
                 throw;
             }
         }

--- a/Jint/Native/WeakSet/WeakSetConstructor.cs
+++ b/Jint/Native/WeakSet/WeakSetConstructor.cs
@@ -24,6 +24,9 @@ internal sealed class WeakSetConstructor : Constructor
 
     private WeakSetPrototype PrototypeObject { get; }
 
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-weakset-iterable
+    /// </summary>
     public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
     {
         if (newTarget.IsUndefined())
@@ -79,19 +82,20 @@ internal sealed class WeakSetConstructor : Constructor
                         _engine.Constraints.Check();
                     }
 
-                    if (!iterable.TryIteratorStep(out var next))
+                    if (!iterable.TryIteratorStepValue(out var nextValue))
                     {
                         return set;
                     }
 
-                    var nextValue = next.Get(CommonProperties.Value);
                     args[0] = nextValue;
                     adder.Call(set, args);
                 } while (true);
             }
             catch
             {
-                iterable.Close(CompletionType.Throw);
+                // Step 8.d closes for the adder's own abrupt completion (step 8.c); step 8.a's does
+                // not, and [[Done]] is what tells the two apart on every iteration, not just the first.
+                iterable.CloseIfNotDone(CompletionType.Throw);
                 throw;
             }
         }

--- a/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
@@ -439,6 +439,14 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
         {
             while (true)
             {
+                // Steps 8.a-8.f (next(), the await, the non-object check, the "done" read and the
+                // "value" read) all propagate with ?, and step 8.e returns iterationResult when done
+                // — none of them reaches IteratorClose. So the loop enters every iteration with
+                // nothing to close, and only a completed step (below) arms it. Re-arming per
+                // iteration is what keeps a next() that throws on the SECOND step from closing on
+                // the strength of the first step's success.
+                close = false;
+
                 engine.ExecutionContext.ClearCompletedAwaitsIfNotResuming();
 
                 DeclarativeEnvironment? iterationEnv = null;
@@ -524,7 +532,7 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                             var doneVal = nextResult.Get(CommonProperties.Done);
                             if (!doneVal.IsUndefined() && TypeConverter.ToBoolean(doneVal))
                             {
-                                close = true;
+                                // step 8.e: "If done is true, return iterationResult" — no close
                                 suspendable?.Data.Clear(this);
                                 return new Completion(CompletionType.Normal, v, _statement!);
                             }
@@ -575,7 +583,7 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                             var doneVal = nextResult.Get(CommonProperties.Done);
                             if (!doneVal.IsUndefined() && TypeConverter.ToBoolean(doneVal))
                             {
-                                close = true;
+                                // step 8.e: "If done is true, return iterationResult" — no close
                                 suspendable?.Data.Clear(this);
                                 return new Completion(CompletionType.Normal, v, _statement!);
                             }
@@ -591,7 +599,9 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                     // Get(value) sequence for everything else.
                     if (!iteratorRecord.TryStepValue(out var steppedValue))
                     {
-                        close = true;
+                        // step 8.e: "If done is true, return iterationResult" — no close. An
+                        // iterator that runs out is not closed; only an abrupt completion of the
+                        // binding or the body (below) reaches IteratorClose.
                         // Clean up suspend data on normal completion
                         suspendable?.Data.Clear(this);
                         return new Completion(CompletionType.Normal, v, _statement!);
@@ -600,6 +610,8 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                     nextValue = steppedValue;
                 }
 
+                // The step produced a value, so from here on an abrupt completion is the loop's own
+                // (steps 8.i and 8.m) and does reach IteratorClose.
                 close = true;
 
                 var valueForResume = nextValue;


### PR DESCRIPTION
[§7.4.9 IteratorStepValue](https://tc39.es/ecma262/#sec-iteratorstepvalue) sets the iterator record's `[[Done]]` on **any** abrupt completion produced by the step itself — `next()` throwing, `next()` answering a non-object, or the `done`/`value` reads throwing — and [§7.4.11 IteratorClose](https://tc39.es/ecma262/#sec-iteratorclose) is then never reached, because callers propagate those with `?`. Only the **consumer's own** abrupt completion (a mapper, an adder, `CreateDataPropertyOrThrow`) closes the iterator.

Jint wrapped step, value-read and processing in a single `try` at four sites, so all three step failures closed. `AddEntriesFromIterable` was the one site that already got it right — which is exactly why the `Map`/`WeakMap` rows of `staging/sm/Map/constructor-iterator-close.js` passed while the `Set`/`WeakSet` rows failed. A second defect at the same sites: the "skip close" flag was never re-armed per iteration, so a `next()` that threw on the **second** step closed on the strength of the first step's success.

Separately, for-of closed the iterator on **normal exhaustion**. [§14.7.5.7](https://tc39.es/ecma262/#sec-runtime-semantics-forin-div-ofbodyevaluation) step 7.d is `If done is true, return NormalCompletion(V)` — no `IteratorClose`. **for-await-of had the identical defect**, since step 8.e is written once for both iterator kinds.

Measured before/after, `true` = `return()` was called (expected: `false,false,false,true,false,false`):

```
                    next  done  value  consumer  2nd-next  exhausted
Array.from   before  true  true   true     true      true      false
new Map      before false false  false     true      true      false
new Set      before  true  true   true     true      true      false
for-of       before false false  false     true      true      TRUE
             after  false false  false     true     false      false   (all rows)
```

## The fix

`IteratorInstance` gains `[[Done]]`, plus `TryIteratorStepValue` (one `try` that classifies every way a step can fail) and `CloseIfNotDone` (the spec's `If iteratorRecord.[[Done]] is false, … IteratorClose`). All five sites now step through the former and close through the latter, so the per-iteration re-arm bug cannot recur — there is no per-iteration flag left to forget; `skipClose` is deleted, not generalised. A pooled instance resets `[[Done]]` on reuse.

for-of deliberately does **not** route through `TryIteratorStepValue`: that would put a `try`/`catch` region around the hottest step in the interpreter. It gets `close = false` at loop top instead, which also fixes its own second-step bug.

## Performance

for-of pays one extra store of a `bool` local per iteration; `IteratorInstance` grows one `bool` field, once per loop entry. The five protocol sites get **faster** — they now call `TryStepValue` rather than `TryIteratorStep` + `Get("value")`, so `Array.from(array)`, `[...array]`, `new Set(array)` and `new Map(entries)` skip a per-element `IteratorResult` allocation and property read when the source is a value-kind array iterator. The added `try` costs nothing when nothing throws, and all five sites already sat inside one.

## Tests

`Jint.Tests/Runtime/IteratorCloseTests.cs` — 9 tests, 7 failing against unfixed code, covering the six cases above across `Array.from`, `new Map`/`Set`/`WeakMap`/`WeakSet` and for-of. No existing test depended on the old for-of behaviour; the four candidates all use non-terminating iterators and exit abruptly.

test262: **102,332 passed, 0 failed** (+6 over baseline; three files × two modes).

Note this reaches array spread, function-parameter array patterns and `groupBy`, which share `IteratorProtocol.Execute` — each spec-correct in the same direction.

Frees `Array/from-iterator-close.js`, `Map/constructor-iterator-close.js`, `statements/for-of-iterator-close.js`.

Refs #3021.
