### PR TITLE
Consult the iterator's done flag before stepping it again

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -145,14 +145,9 @@
     "staging/sm/Set/union.js",
 
     // Iterator protocol: IteratorClose is not invoked (or not invoked at the right point) on the
-    // abrupt paths of Array.from, the Map/Set constructors, for-of and array destructuring, and the
-    // "done" bookkeeping of a destructuring pattern differs from the spec's.
-    "staging/sm/Array/for_of_2.js",
+    // abrupt paths of Array.from, the Map/Set constructors and for-of.
     "staging/sm/Array/from-iterator-close.js",
     "staging/sm/Map/constructor-iterator-close.js",
-    "staging/sm/destructuring/order.js",
-    "staging/sm/destructuring/order-super.js",
-    "staging/sm/expressions/destructuring-array-done.js",
     "staging/sm/statements/for-of-iterator-close.js",
 
     // Array.from applied to an arbitrary constructor: the spec constructs `this` when it is a

--- a/Jint.Tests/Runtime/DestructuringIteratorProtocolTests.cs
+++ b/Jint.Tests/Runtime/DestructuringIteratorProtocolTests.cs
@@ -1,0 +1,267 @@
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// The iterator protocol exactly as array destructuring and %ArrayIteratorPrototype% are specified to
+/// drive it: every element of an array pattern steps only while the iterator record's [[Done]] is
+/// still false (https://tc39.es/ecma262/#sec-runtime-semantics-iteratordestructuringassignmentevaluation),
+/// a nested pattern is fed the stepped <em>value</em> rather than the iterator result object, and
+/// GetIterator (https://tc39.es/ecma262/#sec-getiterator) reads <c>next</c> off whatever the
+/// @@iterator method handed back.
+/// </summary>
+public class DestructuringIteratorProtocolTests
+{
+    /// <summary>
+    /// A logging iterable. Every <c>next()</c> call, every <c>done</c> / <c>value</c> read of the
+    /// result object and every <c>return()</c> close is appended to <c>log</c>. It is deliberately
+    /// not an array, so <c>HandleArrayPattern</c>'s <c>ArrayOperations</c> fast path is bypassed and
+    /// the real iterator protocol runs.
+    /// </summary>
+    private const string Prelude = """
+        var log = [];
+        function iterableOf(values) {
+            var i = 0;
+            return {
+                [Symbol.iterator]() { return this; },
+                next() {
+                    log.push('next');
+                    var has = i < values.length;
+                    var v = has ? values[i++] : undefined;
+                    return {
+                        get done() { log.push('done'); return !has; },
+                        get value() { log.push('value'); return v; }
+                    };
+                },
+                return() { log.push('return'); return {}; }
+            };
+        }
+        """;
+
+    private static string Log(string script)
+    {
+        var engine = new Engine();
+        engine.Execute(Prelude);
+        engine.Execute(script);
+        return engine.Evaluate("log.join(',')").AsString();
+    }
+
+    [Fact]
+    public void AnExhaustedIteratorIsNeverSteppedAgain()
+    {
+        // 13.15.5.5: each element form is guarded by "If iteratorRecord.[[Done]] is false" — once a
+        // step reported done, the remaining elements bind undefined without touching the iterator,
+        // and the pattern does not close it either (IteratorClose only runs while [[Done]] is false).
+        Log("var a, b, c; [a, b, c] = iterableOf([]);")
+            .Should().Be("next,done");
+
+        Log("var a, b, c; [a, b, c] = iterableOf([1]);")
+            .Should().Be("next,done,value,next,done");
+
+        Log("var a, b, c; [a, b, c] = iterableOf([1, 2]);")
+            .Should().Be("next,done,value,next,done,value,next,done");
+
+        // Every element consumed and none left over: three steps, no fourth, no close.
+        Log("var a, b, c; [a, b, c] = iterableOf([1, 2, 3]);")
+            .Should().Be("next,done,value,next,done,value,next,done,value,return");
+    }
+
+    [Fact]
+    public void AnElisionNeverEndsThePattern()
+    {
+        // Elision is its own production and simply discards a step; the elements after it are still
+        // evaluated, so they bind undefined — or run their initializer.
+        var engine = new Engine();
+        engine.Execute(Prelude);
+
+        engine.Evaluate("var a; [, a] = iterableOf([]); String(a)").AsString().Should().Be("undefined");
+        engine.Evaluate("var b; [, b = 5] = iterableOf([]); b").AsNumber().Should().Be(5);
+        engine.Evaluate("var c; [, c = 5] = iterableOf([1]); c").AsNumber().Should().Be(5);
+        engine.Evaluate("var d; [, d] = iterableOf([1, 2]); d").AsNumber().Should().Be(2);
+
+        LogWithTarget("[, t.a] = iterableOf([]);").Should().Be("next,done,set a=undefined");
+    }
+
+    [Fact]
+    public void APatternThatStopsShortClosesTheIterator()
+    {
+        // One step, then the pattern is exhausted while [[Done]] is still false, so IteratorClose runs.
+        Log("var a; [a] = iterableOf([1, 2, 3]);")
+            .Should().Be("next,done,value,return");
+    }
+
+    [Fact]
+    public void ARestElementDoesNotStepAnAlreadyDoneIterator()
+    {
+        // AssignmentRestElement repeats "while iteratorRecord.[[Done]] is false", so an iterator that
+        // the preceding element already drove to done yields an empty rest array with no further step,
+        // and stays unclosed.
+        Log("var a, rest; [a, ...rest] = iterableOf([]);")
+            .Should().Be("next,done");
+
+        Log("var a, rest; [a, ...rest] = iterableOf([1, 2]);")
+            .Should().Be("next,done,value,next,done,value,next,done");
+    }
+
+    [Fact]
+    public void ARestElementCollectsTheSteppedValues()
+    {
+        var engine = new Engine();
+        engine.Execute(Prelude);
+
+        engine.Evaluate("var a, rest; [a, ...rest] = iterableOf([]); a + '|' + rest.join(',') + '|' + rest.length")
+            .AsString().Should().Be("undefined||0");
+
+        engine.Evaluate("var b, more; [b, ...more] = iterableOf([1, 2, 3]); b + '|' + more.join(',')")
+            .AsString().Should().Be("1|2,3");
+    }
+
+    [Fact]
+    public void ANestedPatternReceivesTheSteppedValueNotTheIteratorResult()
+    {
+        // BindingElement : BindingPattern Initializer_opt binds the pattern to the *value* the step
+        // produced. Feeding it the { value, done } result object instead is only invisible while the
+        // right-hand side is a real array (which takes the ArrayOperations fast path), so every case
+        // here iterates a non-array iterable.
+        var engine = new Engine();
+        engine.Execute(Prelude);
+
+        engine.Evaluate("var [[a]] = iterableOf([[7]]); a").AsNumber().Should().Be(7);
+        engine.Evaluate("var [[b, c]] = iterableOf([[7, 8]]); b + ',' + c").AsString().Should().Be("7,8");
+        engine.Evaluate("var [{ p }] = iterableOf([{ p: 9 }]); p").AsNumber().Should().Be(9);
+        engine.Evaluate("var [{ q: { r } }] = iterableOf([{ q: { r: 10 } }]); r").AsNumber().Should().Be(10);
+
+        // Assignment (non-declaration) form of the same shapes.
+        engine.Evaluate("var x; [[x]] = iterableOf([[11]]); x").AsNumber().Should().Be(11);
+        engine.Evaluate("var y; [{ s: y }] = iterableOf([{ s: 12 }]); y").AsNumber().Should().Be(12);
+
+        // A nested pattern also consumes exactly one step, and the done step is the value read the
+        // guard above suppresses.
+        Log("var a; [[a]] = iterableOf([[1]]);").Should().Be("next,done,value,return");
+    }
+
+    [Fact]
+    public void ANestedPatternAgainstAnExhaustedIteratorThrows()
+    {
+        // The element gets undefined, and BindingInitialization of a pattern ToObject's it.
+        var engine = new Engine();
+        engine.Execute(Prelude);
+
+        Invoking(() => engine.Evaluate("var [[a]] = iterableOf([]);"))
+            .Should().Throw<JavaScriptException>();
+    }
+
+    [Fact]
+    public void TheOperationOrderOfAnArrayAssignmentPatternMatchesTheSpec()
+    {
+        // AssignmentElement evaluates its DestructuringAssignmentTarget reference first, then steps,
+        // then PutValue's — and stops stepping the moment [[Done]] is true.
+        LogWithTarget("[t.a, t.b, t.c] = iterableOf([1]);")
+            .Should().Be("next,done,value,set a=1,next,done,set b=undefined,set c=undefined");
+
+        // An elision steps (and reads the value, per IteratorStepValue) but assigns nothing; the
+        // pattern then stops short of the iterator's end, so IteratorClose runs.
+        LogWithTarget("[t.a, , t.b] = iterableOf([1, 2, 3, 4]);")
+            .Should().Be("next,done,value,set a=1,next,done,value,next,done,value,set b=3,return");
+
+        // A rest element drains what is left, and the drained iterator is not closed afterwards.
+        LogWithTarget("[t.a, ...t.rest] = iterableOf([1, 2, 3]);")
+            .Should().Be("next,done,value,set a=1,next,done,value,next,done,value,next,done,set rest=2,3");
+    }
+
+    private static string LogWithTarget(string script)
+    {
+        var engine = new Engine();
+        engine.Execute(Prelude);
+        engine.Execute("""
+            var t = new Proxy({}, {
+                set(target, key, value) {
+                    log.push('set ' + key + '=' + String(value));
+                    target[key] = value;
+                    return true;
+                }
+            });
+            """);
+        engine.Execute(script);
+        return engine.Evaluate("log.join(',')").AsString();
+    }
+
+    [Fact]
+    public void AReplacedArrayIteratorNextKeepsIteratingTheRealObject()
+    {
+        // %ArrayIteratorPrototype%.next replaced by a wrapper that delegates to the original: the
+        // object the array iterator was created for has to survive, so the delegating call still
+        // steps the array rather than the prototype.
+        new Engine().Evaluate("""
+            var proto = Object.getPrototypeOf([][Symbol.iterator]());
+            var original = proto.next;
+            var calls = 0;
+            proto.next = function () { calls++; return original.apply(this, arguments); };
+            var out;
+            try {
+                out = Array.from([1, 2, 3]);
+            } finally {
+                proto.next = original;
+            }
+            out.join(',') + '|' + calls;
+            """).AsString().Should().Be("1,2,3|4");
+
+        // The shape staging/sm/Array/for_of_2.js exercises: the replacement is installed part-way
+        // through, by a getter that runs while the iteration is already in flight.
+        new Engine().Evaluate("""
+            var proto = Object.getPrototypeOf([][Symbol.iterator]());
+            var original = proto.next;
+            var arr = [0, 1, 2];
+            Object.defineProperty(arr, 1, { get: function () { proto.next = replacement; return 1; } });
+            var replacement = function () { return original.apply(this, arguments); };
+            var sum = 0;
+            try {
+                for (var i = 0; i < 10; i++) {
+                    new Set(arr).forEach(function (v) { sum += v; });
+                }
+            } finally {
+                proto.next = original;
+            }
+            sum;
+            """).AsNumber().Should().Be(30);
+    }
+
+    [Fact]
+    public void AnOwnNextOnAnArrayIteratorIsHonoured()
+    {
+        // GetIterator step 3 reads `next` off the object @@iterator returned, so an own `next`
+        // shadowing %ArrayIteratorPrototype%.next is what drives the iteration.
+        new Engine().Evaluate("""
+            var it = [1, 2, 3][Symbol.iterator]();
+            var original = Object.getPrototypeOf(it).next;
+            var calls = 0;
+            it.next = function () { calls++; return original.call(this); };
+            var out = Array.from(it);
+            out.join(',') + '|' + calls;
+            """).AsString().Should().Be("1,2,3|4");
+
+        // Same through spread, which resolves its iterator the same way.
+        new Engine().Evaluate("""
+            var it = [1, 2][Symbol.iterator]();
+            var original = Object.getPrototypeOf(it).next;
+            var calls = 0;
+            it.next = function () { calls++; return original.call(this); };
+            [...it].join(',') + '|' + calls;
+            """).AsString().Should().Be("1,2|3");
+    }
+
+    [Fact]
+    public void APristineArrayIteratorStillIteratesNatively()
+    {
+        // Guard against the wrap above engaging when nothing was replaced.
+        var engine = new Engine();
+        engine.Evaluate("Array.from([1, 2, 3]).join(',')").AsString().Should().Be("1,2,3");
+        engine.Evaluate("[...[1, 2, 3]].join(',')").AsString().Should().Be("1,2,3");
+        engine.Evaluate("Array.from([1, 2, 3][Symbol.iterator]()).join(',')").AsString().Should().Be("1,2,3");
+        engine.Evaluate("Array.from([1, 2, 3].entries()).map(e => e.join(':')).join(',')").AsString().Should().Be("0:1,1:2,2:3");
+        engine.Evaluate("Array.from([1, 2, 3].keys()).join(',')").AsString().Should().Be("0,1,2");
+        engine.Evaluate("var s = 0; for (var v of [1, 2, 3].values()) s += v; s").AsNumber().Should().Be(6);
+        engine.Evaluate("Array.from(new Set([1, 2, 3])).join(',')").AsString().Should().Be("1,2,3");
+        engine.Evaluate("var [a, b] = new Int8Array([4, 5, 6]); a + ',' + b").AsString().Should().Be("4,5");
+    }
+}

--- a/Jint/Native/Array/ArrayIteratorPrototype.cs
+++ b/Jint/Native/Array/ArrayIteratorPrototype.cs
@@ -17,7 +17,7 @@ internal sealed partial class ArrayIteratorPrototype : IteratorPrototype
     [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString ArrayIteratorToStringTag = new("Array Iterator");
 
     // Captured by CreateProperties_Generated (via CaptureField below) before any user code can
-    // replace `next`; HasOriginalNext identity-compares against this snapshot to detect overrides.
+    // replace `next`; StepsNatively identity-compares against this snapshot to detect overrides.
     private FunctionInstance _originalNextFunction = null!;
 
     internal ArrayIteratorPrototype(
@@ -36,13 +36,15 @@ internal sealed partial class ArrayIteratorPrototype : IteratorPrototype
     [JsFunction(Name = "next", CaptureField = nameof(_originalNextFunction))]
     private JsValue NextHandler(JsValue thisObject) => Next(thisObject, Arguments.Empty);
 
+    /// <summary>
+    /// CreateArrayIterator (https://tc39.es/ecma262/#sec-createarrayiterator). The object handed back
+    /// is script-visible — it is what <c>[][Symbol.iterator]()</c> evaluates to — so it always
+    /// iterates <paramref name="array"/> with <paramref name="kind"/>, whatever <c>next</c> currently
+    /// resolves to. Whether a *consumer* may then step it natively instead of calling <c>next</c> is
+    /// decided where the iterator record is built, by <see cref="IteratorInstance.HasNativeNext"/>.
+    /// </summary>
     internal IteratorInstance Construct(ObjectInstance array, ArrayIteratorType kind)
     {
-        if (!HasOriginalNext)
-        {
-            return new IteratorInstance.ObjectIterator(this);
-        }
-
         IteratorInstance instance = array is JsArray jsArray
             ? new ArrayIterator(Engine, jsArray, kind) { _prototype = this }
             : new ArrayLikeIterator(Engine, array, kind) { _prototype = this };
@@ -50,8 +52,14 @@ internal sealed partial class ArrayIteratorPrototype : IteratorPrototype
         return instance;
     }
 
-    internal bool HasOriginalNext
-        => ReferenceEquals(Get(CommonProperties.Next), _originalNextFunction);
+    /// <summary>
+    /// One read covers both ways an array iterator's <c>next</c> can stop being the built-in one: an
+    /// own <c>next</c> on the instance shadowing the prototype's, and the prototype's own <c>next</c>
+    /// having been replaced. A prototype swapped out from under the instance fails the type test and
+    /// is treated as replaced too.
+    /// </summary>
+    private bool StepsNatively(ObjectInstance iterator)
+        => ReferenceEquals(iterator.Get(CommonProperties.Next), _originalNextFunction);
 
     private sealed class ArrayIterator : IteratorInstance
     {
@@ -66,6 +74,9 @@ internal sealed partial class ArrayIteratorPrototype : IteratorPrototype
             _array = array;
             _position = 0;
         }
+
+        internal override bool HasNativeNext
+            => _prototype is ArrayIteratorPrototype prototype && prototype.StepsNatively(this);
 
         public override bool TryIteratorStep(out ObjectInstance nextItem)
         {
@@ -136,6 +147,9 @@ internal sealed partial class ArrayIteratorPrototype : IteratorPrototype
 
             _position = 0;
         }
+
+        internal override bool HasNativeNext
+            => _prototype is ArrayIteratorPrototype prototype && prototype.StepsNatively(this);
 
         public override bool TryIteratorStep(out ObjectInstance nextItem)
         {

--- a/Jint/Native/Iterator/IteratorInstance.cs
+++ b/Jint/Native/Iterator/IteratorInstance.cs
@@ -22,6 +22,19 @@ internal abstract class IteratorInstance : ObjectInstance
     public abstract bool TryIteratorStep(out ObjectInstance nextItem);
 
     /// <summary>
+    /// GetIterator (https://tc39.es/ecma262/#sec-getiterator) step 3 reads <c>next</c> off the object
+    /// the @@iterator method handed back, and every step then calls what that read produced. A
+    /// built-in iterator may only be stepped natively — skipping both the read and the call — while
+    /// the read would resolve to the very built-in function its native stepping implements.
+    /// <see cref="JsValue.TryGetIterator"/> asks this before adopting an instance as the iterator
+    /// record; a <see langword="false"/> answer wraps it in an <see cref="ObjectIterator"/>, which
+    /// performs the read and drives the iteration through the replacement.
+    /// The default is <see langword="true"/>: an iterator whose <c>next</c> the engine cannot observe
+    /// being replaced keeps stepping natively.
+    /// </summary>
+    internal virtual bool HasNativeNext => true;
+
+    /// <summary>
     /// Steps the iterator and hands back the value directly, letting concrete iterators skip
     /// the per-step IteratorResult object when nothing user-visible needs it (for-in keys).
     /// The default wraps <see cref="TryIteratorStep"/> with exactly the read the for-in/of

--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -144,7 +144,11 @@ public abstract partial class JsValue : IEquatable<JsValue>
             Throw.TypeError(realm, "Result of the Symbol.iterator method is not an object");
         }
 
-        if (iteratorResult is IteratorInstance i)
+        // GetIterator step 3 reads `next` off what @@iterator returned. A built-in iterator instance
+        // is adopted as the record directly — its native stepping *is* that function's behaviour — but
+        // only while the read would still resolve to it; otherwise the replacement has to drive the
+        // iteration, which is what ObjectIterator does (it performs the read once, as the spec does).
+        if (iteratorResult is IteratorInstance i && i.HasNativeNext)
         {
             iterator = i;
         }

--- a/Jint/Runtime/Interpreter/Expressions/DestructuringPatternAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/DestructuringPatternAssignmentExpression.cs
@@ -45,34 +45,39 @@ internal sealed class DestructuringPatternAssignmentExpression : JintExpression
         return default;
     }
 
-    private static bool ConsumeFromIterator(IteratorInstance it, out JsValue value, out bool done)
+    /// <summary>
+    /// IteratorStepValue (https://tc39.es/ecma262/#sec-iteratorstepvalue) under the
+    /// <c>If iteratorRecord.[[Done]] is false</c> guard that every element form of
+    /// IteratorDestructuringAssignmentEvaluation (https://tc39.es/ecma262/#sec-runtime-semantics-iteratordestructuringassignmentevaluation)
+    /// and IteratorBindingInitialization (https://tc39.es/ecma262/#sec-runtime-semantics-iteratorbindinginitialization)
+    /// is wrapped in: an iterator that has already reported done is never stepped again, and the
+    /// element takes <c>undefined</c> instead. Every abrupt completion — the <c>next</c> call, the
+    /// <c>done</c> read behind <see cref="IteratorInstance.TryIteratorStep"/>, or the <c>value</c>
+    /// read — sets <paramref name="done"/>, so the caller's <c>finally</c> does not close an
+    /// iterator the spec already considers done.
+    /// </summary>
+    private static JsValue StepValue(IteratorInstance it, ref bool done)
     {
-        value = JsValue.Undefined;
-        done = false;
+        if (done)
+        {
+            return JsValue.Undefined;
+        }
 
-        bool stepped;
         try
         {
-            stepped = it.TryIteratorStep(out var d);
-            if (stepped)
+            if (!it.TryIteratorStep(out var result))
             {
-                value = d.Get(CommonProperties.Value);
+                done = true;
+                return JsValue.Undefined;
             }
+
+            return result.Get(CommonProperties.Value);
         }
         catch
         {
-            // Per spec 13.15.5.5 step 2b: If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
             done = true;
             throw;
         }
-
-        if (!stepped)
-        {
-            done = true;
-            return false;
-        }
-
-        return true;
     }
 
     private static JsValue HandleArrayPattern(
@@ -173,10 +178,9 @@ internal sealed class DestructuringPatternAssignmentExpression : JintExpression
                     }
                     else
                     {
-                        if (!ConsumeFromIterator(iterator!, out _, out done))
-                        {
-                            break;
-                        }
+                        // An elision consumes a step and discards it; it never ends the pattern, so
+                        // the elements after it still bind (undefined, or their initializer).
+                        StepValue(iterator!, ref done);
                     }
                     // skip assignment
                     continue;
@@ -191,7 +195,7 @@ internal sealed class DestructuringPatternAssignmentExpression : JintExpression
                     }
                     else
                     {
-                        ConsumeFromIterator(iterator!, out value, out done);
+                        value = StepValue(iterator!, ref done);
                     }
 
                     AssignToIdentifier(engine, identifier.Name, value, environment, checkReference);
@@ -228,7 +232,7 @@ internal sealed class DestructuringPatternAssignmentExpression : JintExpression
                     }
                     else
                     {
-                        ConsumeFromIterator(iterator!, out value, out done);
+                        value = StepValue(iterator!, ref done);
                     }
 
                     AssignToReference(engine, reference, value, environment);
@@ -242,16 +246,9 @@ internal sealed class DestructuringPatternAssignmentExpression : JintExpression
                     }
                     else
                     {
-                        try
-                        {
-                            iterator!.TryIteratorStep(out var temp);
-                            value = temp;
-                        }
-                        catch
-                        {
-                            done = true;
-                            throw;
-                        }
+                        // BindingElement : BindingPattern binds the nested pattern to the value the
+                        // step produced, never to the { value, done } result object the step returned.
+                        value = StepValue(iterator!, ref done);
                     }
                     ProcessPatterns(context, dp, value, environment);
                 }
@@ -299,18 +296,30 @@ internal sealed class DestructuringPatternAssignmentExpression : JintExpression
                     {
                         array = engine.Realm.Intrinsics.Array.ArrayCreate(0);
                         uint index = 0;
-                        done = true;
-                        do
+                        // AssignmentRestElement / BindingRestElement: "Repeat, while
+                        // iteratorRecord.[[Done]] is false". An iterator a preceding element already
+                        // drove to done contributes nothing and is not stepped at all.
+                        while (!done)
                         {
-                            if (!iterator!.TryIteratorStep(out var item))
+                            JsValue value;
+                            try
+                            {
+                                if (!iterator!.TryIteratorStep(out var item))
+                                {
+                                    done = true;
+                                    break;
+                                }
+
+                                value = item.Get(CommonProperties.Value);
+                            }
+                            catch
                             {
                                 done = true;
-                                break;
+                                throw;
                             }
 
-                            var value = item.Get(CommonProperties.Value);
                             array.SetIndexValue(index++, value, updateLength: false);
-                        } while (true);
+                        }
 
                         array.SetLength(index);
                     }
@@ -370,7 +379,7 @@ internal sealed class DestructuringPatternAssignmentExpression : JintExpression
                     }
                     else
                     {
-                        ConsumeFromIterator(iterator!, out value, out done);
+                        value = StepValue(iterator!, ref done);
                     }
 
                     // Only an initializer the engine actually ran can be the subject of


### PR DESCRIPTION
Four defects in array destructuring and the array iterator.

## 1. `done` was tracked but never consulted before stepping again

`DestructuringPatternAssignmentExpression` maintained a `done` flag and correctly suppressed the close when it was set, but nothing guarded the *next* step. Per [§13.15.5.5](https://tc39.es/ecma262/#sec-runtime-semantics-iteratordestructuringassignmentevaluation) each element only steps `If iteratorRecord.[[Done]] is false`. Six call sites were unguarded — elision, Identifier, MemberExpression, nested pattern, rest element, AssignmentPattern — and one of them set `done = true` unconditionally before re-stepping.

```js
[a, b, c] = iterableOf([]);   // "next,done,next,done,next,done" -> "next,done"
```

## 2. An elision terminated the whole pattern

The elision site did `if (!ConsumeFromIterator(...)) break;`, so **every element after an elision was skipped** once the iterator ran out:

```js
var b; [, b = 5] = nonArrayIterable;   // b was undefined, must be 5
```

This one was not in the issue's description of the group at all.

## 3. A nested pattern received the iterator *result object*, not `result.value`

The nested-pattern branch assigned `temp` (the `{value, done}` object) where its three sibling branches all read `CommonProperties.Value`. This is a shipping bug beyond test262 — `let [[a]] = someNonArrayIterable` was broken, masked whenever the RHS is a real array because that takes an `ArrayOperations` fast path.

## 4. A replaced `%ArrayIteratorPrototype%.next` lost the iterated object

`ArrayIteratorPrototype.Construct` dropped its `array` and `kind` arguments and returned an iterator over **the prototype** when `next` was not pristine, so a replacement that delegates to the original got `TypeError`.

Now `Construct` always returns the real array iterator (that object is script-visible — it is what `[][Symbol.iterator]()` returns), and `JsValue.TryGetIterator` wraps it when `next` is not native. The check reads `next` **off the instance**, which also closes a related gap: [§7.4.4 GetIterator](https://tc39.es/ecma262/#sec-getiterator) step 3 reads `next` unconditionally, so an **own** `next` on an array-iterator instance was previously ignored.

## Performance

Destructuring pays one perfectly-predicted branch per element on the iterator path, and it is *saved* work when taken; the real-array fast path is untouched. The `Get(next)` did not appear — it **moved**: `Construct` used to perform it on every call and no longer does, `HasNativeNext` performs it instead, so it is the same one read per iterator record. `arr.values()` called straight from script now performs **zero** reads where it used to perform one. Other iterator kinds pay one virtual call returning a constant, once per loop entry.

All 20 `GetIterator` call sites were checked; none casts to a concrete iterator type, and every other `IteratorInstance` subclass keeps the default.

## Tests

`Jint.Tests/Runtime/DestructuringIteratorProtocolTests.cs` — 10 tests, 6 failing against unfixed code, asserting spec-exact `next` counts for 0/1/2/3-element iterables and full operation logs.

test262: **102,334 passed, 0 failed** (+8; four files × two modes, verified in both sloppy and strict).

Frees `Array/for_of_2.js`, `destructuring/order.js`, `destructuring/order-super.js`, `expressions/destructuring-array-done.js`.

Two pre-existing gaps left alone and noted: for-of bypasses `GetIterator` when its RHS is already an `IteratorInstance`, and the array destructuring/spread fast paths identity-check `@@iterator` only, so a replaced `%ArrayIteratorPrototype%.next` is still skipped for a real array.

Refs #3021.
