### PR TITLE
Attribute a cross-realm built-in's errors and result arrays to its own realm

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -57,34 +57,6 @@
     "staging/sm/expressions/nullish-coalescing.js",
     "staging/sm/regress/regress-1507322-deep-weakmap.js",
 
-    // Cross-realm identity of a built-in's *products*. $262.createRealm() now hands back a full $262
-    // installed on the new realm's global, so otherGlobal.$262.detachArrayBuffer resolves and the
-    // harness half of these is done; what is left is engine-side, and it is not that error creation
-    // ignores realms in general - most built-ins already raise through their own _realm. It is that
-    // a handful of paths reach for whichever realm happens to be *running* instead of the realm the
-    // called function belongs to, which shows up two ways:
-    //  - the wrong realm's error. `otherGlobal.Iterator.prototype.every.call(...)` and friends throw
-    //    a TypeError (RangeError for toSorted) built from the caller's intrinsics, so the test sees
-    //    "a different error constructor with the same name" and `e instanceof otherGlobal.TypeError`
-    //    is false.
-    //  - the wrong realm's result. A built-in invoked cross-realm allocates its result from the
-    //    active realm, so `otherGlobal.Array.prototype.with.call([1,2,3], 1, 3)` comes back as an
-    //    instance of *this* Array, `g.Array.from(...)` is not an instance of `g.Array`, and
-    //    `otherGlobal.Iterator.from(iter)` hands the iterator straight back instead of wrapping it.
-    // Removed by taking the function's own realm on those paths, for both the throw and the
-    // allocation.
-    "staging/sm/Array/change-array-by-copy-cross-compartment-create.js",
-    "staging/sm/Array/change-array-by-copy-errors-from-correct-realm.js",
-    "staging/sm/Array/from_realms.js",
-    "staging/sm/Iterator/from/wrap-new-global.js",
-    "staging/sm/Iterator/prototype/every/error-from-correct-realm.js",
-    "staging/sm/Iterator/prototype/find/error-from-correct-realm.js",
-    "staging/sm/Iterator/prototype/forEach/error-from-correct-realm.js",
-    "staging/sm/Iterator/prototype/reduce/error-from-correct-realm.js",
-    "staging/sm/Iterator/prototype/some/error-from-correct-realm.js",
-    "staging/sm/Iterator/prototype/toArray/create-in-current-realm.js",
-    "staging/sm/JSON/parse-with-source.js",
-
     // Argument-validation order in the TypedArray-from-ArrayBuffer constructor - despite the file's
     // cross-realm cast, nothing about it is realm-specific and it fails the same way on a buffer from
     // this realm. InitializeTypedArrayFromArrayBuffer throws the RangeError for a byteOffset that is
@@ -185,14 +157,13 @@
     // Parser early errors that Acornima does not raise, or raises as the wrong error type: an
     // invalid parameter list, `super()` inside an arrow inside a direct eval in a derived
     // constructor, a destructuring pattern with a duplicate binding, a legacy octal literal in
-    // strict mode, `yield` as an identifier, and a field initializer's TDZ.
+    // strict mode, and a field initializer's TDZ.
     "staging/sm/Function/invalid-parameter-list.js",
     "staging/sm/class/derivedConstructorArrowEvalNestedSuperCall.js",
     "staging/sm/class/derivedConstructorArrowEvalSuperCall.js",
     "staging/sm/destructuring/bug1396261.js",
     "staging/sm/fields/bug1587574.js",
     "staging/sm/strict/deprecated-octal-noctal-tokens.js",
-    "staging/sm/syntax/yield-as-identifier.js",
 
     // Annex B B.3.3 block-scoped function hoisting: the var-scoped alias a sloppy-mode block
     // function creates is not synthesised the way the spec's FunctionDeclarationInstantiation

--- a/Jint.Tests/Runtime/CrossRealmAttributionTests.cs
+++ b/Jint.Tests/Runtime/CrossRealmAttributionTests.cs
@@ -1,0 +1,184 @@
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// A built-in must attribute what it produces to its own realm, not to whichever realm happens to be
+/// running when it is called. Two shapes are covered here: an error a cross-realm built-in raises has to
+/// be an instance of <em>that</em> realm's error constructor, and a result array a cross-realm built-in
+/// creates has to inherit from <em>that</em> realm's <c>Array.prototype</c>.
+/// <para>
+/// The second realm is built through <c>$262.createRealm()</c>. That object is internal and this project
+/// has <c>InternalsVisibleTo</c>, which is deliberate: a <c>ShadowRealm</c> wraps every function and value
+/// crossing its boundary, so the constructor identities these tests compare would never be observable
+/// through one. This is the same realm plumbing the test262 staging suite exercises.
+/// </para>
+/// </summary>
+public class CrossRealmAttributionTests
+{
+    /// <summary>
+    /// <c>classify</c> answers "&lt;realm&gt; &lt;ErrorName&gt;" so a failure names the realm the error
+    /// actually came from instead of merely reporting <c>false</c>. <c>realmOf</c> does the same for a value.
+    /// </summary>
+    private const string Preamble = """
+        var otherGlobal = $262.createRealm().global;
+
+        function realmOf(v) {
+            if (v instanceof otherGlobal.Array) return 'other';
+            if (v instanceof Array) return 'main';
+            return 'neither';
+        }
+
+        function classify(fn) {
+            try {
+                fn();
+                return 'no throw';
+            } catch (e) {
+                var realm = 'neither';
+                if (e instanceof otherGlobal.Error) realm = 'other';
+                else if (e instanceof Error) realm = 'main';
+                return realm + ' ' + (e && e.constructor ? e.constructor.name : '?');
+            }
+        }
+
+        // 2**32 elements is past MaxArrayLength, so every change-array-by-copy method rejects it.
+        var tooLong = {
+            get "0"() { throw new Error("must not be read"); },
+            length: 2 ** 32
+        };
+        """;
+
+    private static string Evaluate(string source)
+    {
+        var engine = new Engine();
+        Test262Object.Install(engine);
+        engine.Execute(Preamble);
+        return engine.Evaluate(source).AsString();
+    }
+
+    [Theory]
+    // Array.prototype.{toSorted,toReversed,with,toSpliced} all reach ValidateArrayLength.
+    [InlineData("otherGlobal.Array.prototype.toSorted.call(tooLong)", "other RangeError")]
+    [InlineData("otherGlobal.Array.prototype.toReversed.call(tooLong)", "other RangeError")]
+    [InlineData("otherGlobal.Array.prototype.with.call(tooLong, 0, 0)", "other RangeError")]
+    [InlineData("otherGlobal.Array.prototype.toSpliced.call(tooLong, 0, 0)", "other RangeError")]
+    // Controls: these two already used the callee realm before the fix.
+    [InlineData("otherGlobal.Array.prototype.with.call([0, 1, 2], 3, 7)", "other RangeError")]
+    [InlineData("otherGlobal.Array.prototype.toSorted.call([], 5)", "other TypeError")]
+    public void ArrayChangeByCopyErrorsComeFromTheCalleeRealm(string call, string expected)
+    {
+        Evaluate("classify(() => " + call + ")").Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("otherGlobal.Array.prototype.with.call([1, 2, 3], 1, 3)")]
+    [InlineData("otherGlobal.Array.prototype.toSpliced.call([1, 2, 3], 0, 1, 4, 5)")]
+    [InlineData("otherGlobal.Array.prototype.toReversed.call([1, 2, 3])")]
+    [InlineData("otherGlobal.Array.prototype.toSorted.call([1, 2, 3], (x, y) => y > x)")]
+    // The empty-source early returns build a result array too.
+    [InlineData("otherGlobal.Array.prototype.toReversed.call([])")]
+    [InlineData("otherGlobal.Array.prototype.toSorted.call([])")]
+    public void ArrayChangeByCopyResultsUseTheCalleeRealmPrototype(string call)
+    {
+        Evaluate("realmOf(" + call + ")").Should().Be("other");
+    }
+
+    [Theory]
+    // `this` is the other realm's Array constructor, so the result is constructed through it.
+    [InlineData("otherGlobal.Array.from([1, 2, 3])", "other")]
+    // `this` is undefined, so Array.from falls back to ArrayCreate in the *callee's* realm.
+    [InlineData("(0, otherGlobal.Array.from)([1, 2, 3])", "other")]
+    // ...and the reverse still holds: an explicit constructor wins over the callee's realm.
+    [InlineData("otherGlobal.Array.from.call(Array, [1, 2, 3])", "main")]
+    [InlineData("Array.from.call(otherGlobal.Array, [1, 2, 3])", "other")]
+    public void ArrayFromUsesTheCalleeRealm(string call, string expected)
+    {
+        Evaluate("realmOf(" + call + ")").Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("map")]
+    [InlineData("filter")]
+    [InlineData("flatMap")]
+    [InlineData("reduce")]
+    [InlineData("forEach")]
+    [InlineData("some")]
+    [InlineData("every")]
+    [InlineData("find")]
+    public void IteratorHelperArgumentTypeErrorsComeFromTheCalleeRealm(string method)
+    {
+        // Every one of these throws because the callback argument is missing, i.e. not callable.
+        Evaluate("classify(otherGlobal.Iterator.prototype." + method + ".bind([].values()))")
+            .Should().Be("other TypeError");
+    }
+
+    [Fact]
+    public void IteratorHelperArgumentTypeErrorsStillComeFromTheMainRealm()
+    {
+        Evaluate("classify(() => [].values().every())").Should().Be("main TypeError");
+    }
+
+    [Fact]
+    public void IteratorFromComparesAgainstTheCalleeRealmIterator()
+    {
+        // The main realm's array iterator is an instance of the main %Iterator%, so the main
+        // Iterator.from hands it straight back; the other realm's must wrap it instead.
+        var engine = new Engine();
+        Test262Object.Install(engine);
+        engine.Execute(Preamble);
+        engine.Execute("var iter = [1, 2, 3].values();");
+
+        engine.Evaluate("Iterator.from(iter) === iter").AsBoolean()
+            .Should().BeTrue("the main realm's Iterator.from recognises a main-realm iterator");
+        engine.Evaluate("otherGlobal.Iterator.from(iter) === iter").AsBoolean()
+            .Should().BeFalse("the other realm's %Iterator% is a different intrinsic");
+    }
+
+    [Fact]
+    public void IteratorFromWrapperUsesTheCalleeRealmPrototype()
+    {
+        // %WrapForValidIteratorPrototype%'s own [[Prototype]] is that realm's %Iterator.prototype%,
+        // which is the only handle a script has on the wrapper prototype's realm.
+        Evaluate("""
+            (function () {
+                var wrapper = otherGlobal.Iterator.from([1, 2, 3].values());
+                var wrapProto = Object.getPrototypeOf(wrapper);
+                if (Object.getPrototypeOf(wrapProto) === otherGlobal.Iterator.prototype) return 'other';
+                if (Object.getPrototypeOf(wrapProto) === Iterator.prototype) return 'main';
+                return 'neither';
+            })()
+            """).Should().Be("other");
+    }
+
+    [Fact]
+    public void IteratorToArrayCreatesInTheCalleeRealm()
+    {
+        Evaluate("realmOf([1, 2, 3].values().toArray())").Should().Be("main");
+        Evaluate("realmOf(otherGlobal.Iterator.prototype.toArray.call([1, 2, 3].values()))").Should().Be("other");
+    }
+
+    [Theory]
+    [InlineData("otherGlobal.Function('\\'use strict\\'; var yield = 3;')", "other SyntaxError")]
+    [InlineData("otherGlobal.Function('return }')", "other SyntaxError")]
+    [InlineData("Function('return }')", "main SyntaxError")]
+    public void DynamicFunctionSyntaxErrorsComeFromTheCalleeRealm(string call, string expected)
+    {
+        Evaluate("classify(() => " + call + ")").Should().Be(expected);
+    }
+
+    [Fact]
+    public void DynamicFunctionAcceptsYieldAsIdentifierInSloppyMode()
+    {
+        Evaluate("classify(() => otherGlobal.Function('var yield = 3;'))").Should().Be("no throw");
+    }
+
+    [Theory]
+    // ToString(Symbol) throws a realm-less TypeError that the callee has to attribute to itself.
+    [InlineData("otherGlobal.JSON.rawJSON(Symbol('123'))", "other TypeError")]
+    [InlineData("JSON.rawJSON(Symbol('123'))", "main TypeError")]
+    // Controls: rawJSON's own SyntaxErrors already used the callee realm.
+    [InlineData("otherGlobal.JSON.rawJSON('')", "other SyntaxError")]
+    [InlineData("otherGlobal.JSON.rawJSON('\\t123')", "other SyntaxError")]
+    public void JsonRawJsonErrorsComeFromTheCalleeRealm(string call, string expected)
+    {
+        Evaluate("classify(() => " + call + ")").Should().Be(expected);
+    }
+}

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -907,7 +907,7 @@ public sealed partial class ArrayConstructor : Constructor
         }
 
         proto ??= PrototypeObject;
-        var instance = new JsArray(Engine, (uint) length, (uint) length)
+        var instance = new JsArray(this, (uint) length, (uint) length)
         {
             _prototype = proto
         };
@@ -929,7 +929,7 @@ public sealed partial class ArrayConstructor : Constructor
         }
 
         proto ??= PrototypeObject;
-        var instance = new JsArray(Engine, capacity: 0, length: (uint) length)
+        var instance = new JsArray(this, capacity: 0, length: (uint) length)
         {
             _prototype = proto
         };
@@ -970,14 +970,14 @@ public sealed partial class ArrayConstructor : Constructor
     {
         var array = new JsValue[contents.Length];
         System.Array.Copy(contents, array, contents.Length);
-        return new JsArray(_engine, array);
+        return new JsArray(this, array);
     }
 
     internal JsArray ConstructFast(List<JsValue> contents)
     {
         var array = new JsValue[contents.Count];
         contents.CopyTo(array);
-        return new JsArray(_engine, array);
+        return new JsArray(this, array);
     }
 
     /// <summary>
@@ -998,7 +998,7 @@ public sealed partial class ArrayConstructor : Constructor
 
         if (length < ArrayInstance.MaxDenseArrayLengthInternal)
         {
-            return new JsArray(_engine, builder.ToArray());
+            return new JsArray(this, builder.ToArray());
         }
 
         // The incremental write path would have converted an array this large to sparse

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -71,9 +71,9 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
         _dense = [];
     }
 
-    private protected ArrayInstance(Engine engine, uint capacity = 0, uint length = 0) : base(engine, type: InternalTypes.Object | InternalTypes.Array)
+    private protected ArrayInstance(Engine engine, uint capacity = 0, uint length = 0, ArrayConstructor? constructor = null) : base(engine, type: InternalTypes.Object | InternalTypes.Array)
     {
-        InitializePrototypeAndValidateCapacity(engine, System.Math.Max(capacity, length));
+        InitializePrototypeAndValidateCapacity(engine, System.Math.Max(capacity, length), constructor);
 
         if (capacity < MaxDenseArrayLength)
         {
@@ -87,9 +87,9 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
         _lengthValue = JsNumber.Create(length);
     }
 
-    private protected ArrayInstance(Engine engine, JsValue[] items) : base(engine, type: InternalTypes.Object | InternalTypes.Array)
+    private protected ArrayInstance(Engine engine, JsValue[] items, ArrayConstructor? constructor = null) : base(engine, type: InternalTypes.Object | InternalTypes.Array)
     {
-        InitializePrototypeAndValidateCapacity(engine, capacity: 0);
+        InitializePrototypeAndValidateCapacity(engine, capacity: 0, constructor);
 
         // _dense must be an exact JsValue[] so the dense element-write fast paths can store any JsValue
         // without paying a per-write CLR array-covariance check (see WriteDenseUnchecked). Array covariance
@@ -111,9 +111,15 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
         _lengthValue = JsNumber.Create(items.Length);
     }
 
-    private void InitializePrototypeAndValidateCapacity(Engine engine, uint capacity)
+    /// <summary>
+    /// A <paramref name="constructor"/> of <c>null</c> means "whichever realm is running", which is what
+    /// the public <see cref="JsArray"/> constructors have always done and must keep doing. Every in-box
+    /// built-in that creates a result array names its own <c>%Array%</c> instead, so a cross-realm call
+    /// produces an array inheriting from the callee's <c>Array.prototype</c> rather than the caller's.
+    /// </summary>
+    private void InitializePrototypeAndValidateCapacity(Engine engine, uint capacity, ArrayConstructor? constructor)
     {
-        _constructor = engine.Realm.Intrinsics.Array;
+        _constructor = constructor ?? engine.Realm.Intrinsics.Array;
         _prototype = _constructor.PrototypeObject;
 
         // Validates against the larger of the physical backing capacity and the declared length:
@@ -1661,7 +1667,9 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
 
         var len = GetLength();
 
-        var callable = GetCallable(callbackfn);
+        // `this` is the receiver, not the built-in that owns the algorithm (ArrayPrototype delegates
+        // here), so no callee realm is reachable and the running one is the best available answer.
+        var callable = callbackfn.GetCallable(_engine.Realm);
         var a = _engine.Realm.Intrinsics.Array.ArrayCreate(len);
         var invoker = CallbackInvoker.Rent(_engine, callable, 3, this);
         for (uint k = 0; k < len; k++)
@@ -1691,7 +1699,9 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
 
         var len = GetLength();
 
-        var callable = GetCallable(callbackfn);
+        // `this` is the receiver, not the built-in that owns the algorithm (ArrayPrototype delegates
+        // here), so no callee realm is reachable and the running one is the best available answer.
+        var callable = callbackfn.GetCallable(_engine.Realm);
 
         // Output size is unknown (only bounded by len); accumulate into a pooled buffer and
         // materialize an exact-size result instead of growing the result's dense backing by
@@ -1738,7 +1748,9 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
         bool visitUnassigned,
         bool fromEnd = false)
     {
-        var callable = GetCallable(callbackfn);
+        // `this` is the receiver, not the built-in that owns the algorithm (ArrayPrototype delegates
+        // here), so no callee realm is reachable and the running one is the best available answer.
+        var callable = callbackfn.GetCallable(_engine.Realm);
 
         var len = GetLength();
         if (len == 0)

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -49,6 +49,13 @@ public sealed partial class ArrayPrototype : ArrayInstance
         _joinStack = new(engine);
     }
 
+    /// <summary>
+    /// Coerces a built-in's callback argument, raising the TypeError from this prototype's own realm.
+    /// <see cref="ArrayPrototype"/> descends from <see cref="ArrayInstance"/> rather than from
+    /// <see cref="Prototype"/>, so it needs its own copy of the helper the latter declares.
+    /// </summary>
+    private ICallable GetCallable(JsValue source) => source.GetCallable(_realm);
+
     protected override void Initialize()
     {
         CreateProperties_Generated();
@@ -156,7 +163,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
             {
                 System.Array.Copy(dense, a, count);
                 a[actualIndex] = value;
-                return new JsArray(_engine, a);
+                return new JsArray(_constructor, a);
             }
         }
 
@@ -172,7 +179,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
                 _engine.Constraints.Check();
             }
         }
-        return new JsArray(_engine, a);
+        return new JsArray(_constructor, a);
     }
 
     [JsFunction]
@@ -2244,7 +2251,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
 
         if (len == 0)
         {
-            return new JsArray(_engine);
+            return new JsArray(_constructor);
         }
 
         var a = CreateBackingArray(len);
@@ -2266,7 +2273,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
             {
                 System.Array.Copy(dense, a, count);
                 a.AsSpan(0, count).Reverse();
-                return new JsArray(_engine, a);
+                return new JsArray(_constructor, a);
             }
         }
 
@@ -2282,7 +2289,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
                 _engine.Constraints.Check();
             }
         }
-        return new JsArray(_engine, a);
+        return new JsArray(_constructor, a);
     }
 
     [JsFunction(Length = 1, FastCall = true)]
@@ -2296,14 +2303,14 @@ public sealed partial class ArrayPrototype : ArrayInstance
 
         if (len == 0)
         {
-            return new JsArray(_engine);
+            return new JsArray(_constructor);
         }
 
         var array = o.GetAll(skipHoles: true);
 
         array = SortArray(array, compareFn);
 
-        return new JsArray(_engine, array);
+        return new JsArray(_constructor, array);
     }
 
     [JsFunction(Length = 2)]
@@ -2366,7 +2373,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
         ValidateArrayLength(newLen);
 
         var r = actualStart + actualDeleteCount;
-        var a = new JsArray(_engine, (uint) newLen);
+        var a = new JsArray(_constructor, (uint) newLen);
         uint i = 0;
 
         while (i < actualStart)
@@ -2572,7 +2579,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
     {
         if (length > ArrayOperations.MaxArrayLength)
         {
-            Throw.RangeError(_engine.Realm, "Invalid array length " + length);
+            Throw.RangeError(_realm, "Invalid array length " + length);
         }
     }
 

--- a/Jint/Native/Function/Function.cs
+++ b/Jint/Native/Function/Function.cs
@@ -58,6 +58,13 @@ public abstract partial class Function : ObjectInstance, ICallable
     internal PrivateEnvironment? _privateEnvironment;
     internal readonly IScriptOrModule? _scriptOrModule;
 
+    /// <summary>
+    /// Coerces a built-in's callback argument, raising the TypeError from this function's own
+    /// <c>[[Realm]]</c> rather than from whichever realm is running. See the same helper on
+    /// <see cref="Prototype"/> for why it is not declared on <see cref="ObjectInstance"/>.
+    /// </summary>
+    private protected ICallable GetCallable(JsValue source) => source.GetCallable(_realm);
+
     protected Function(
         Engine engine,
         Realm realm,

--- a/Jint/Native/Function/FunctionInstance.Dynamic.cs
+++ b/Jint/Native/Function/FunctionInstance.Dynamic.cs
@@ -165,7 +165,11 @@ public partial class Function
             else
             {
                 Parser parser = new(parserOptions);
-                var function = (IFunction) parser.ParseScriptGuarded(callerRealm, functionExpression, strict: _engine._isStrict).Body[0];
+                // CreateDynamicFunction step 21 throws its SyntaxError in the current realm, and the
+                // current realm while a built-in runs is the built-in's own [[Realm]] — not the caller's.
+                // Jint does not push an execution context for a built-in call, so _engine.ExecutionContext
+                // still describes the caller here and only _realm names the callee.
+                var function = (IFunction) parser.ParseScriptGuarded(_realm, functionExpression, strict: _engine._isStrict).Body[0];
                 definition = new JintFunctionDefinition(function)
                 {
                     IsDynamic = true,
@@ -192,7 +196,7 @@ public partial class Function
         }
         catch (ParseErrorException ex)
         {
-            Throw.SyntaxError(_engine.ExecutionContext.Realm, ex.Message);
+            Throw.SyntaxError(_realm, ex.Message);
         }
 
         var proto = GetPrototypeFromConstructor(newTarget, fallbackProto);

--- a/Jint/Native/Iterator/IteratorConstructor.cs
+++ b/Jint/Native/Iterator/IteratorConstructor.cs
@@ -90,7 +90,7 @@ internal sealed partial class IteratorConstructor : Constructor
         var iteratorRecord = GetIteratorFlattenable(o, StringHandlingType.IterateStrings, out var underlyingIterator);
 
         // 3. Let hasInstance be ? OrdinaryHasInstance(%Iterator%, iteratorRecord.[[Iterator]]).
-        var hasInstance = _engine.Intrinsics.Iterator.OrdinaryHasInstance(underlyingIterator);
+        var hasInstance = _realm.Intrinsics.Iterator.OrdinaryHasInstance(underlyingIterator);
 
         // 4. If hasInstance is true, return iteratorRecord.[[Iterator]].
         if (TypeConverter.ToBoolean(hasInstance))
@@ -101,7 +101,7 @@ internal sealed partial class IteratorConstructor : Constructor
         // 5. Let wrapper be OrdinaryObjectCreate(%WrapForValidIteratorPrototype%, « [[Iterated]] »).
         // 6. Set wrapper.[[Iterated]] to iteratorRecord.
         // 7. Return wrapper.
-        var wrapper = new WrapForValidIterator(_engine, iteratorRecord);
+        var wrapper = new WrapForValidIterator(_engine, _realm, iteratorRecord);
         return wrapper;
     }
 

--- a/Jint/Native/Iterator/IteratorPrototype.cs
+++ b/Jint/Native/Iterator/IteratorPrototype.cs
@@ -587,7 +587,7 @@ internal partial class IteratorPrototype : Prototype
                 }
             }
 
-            return _engine.Realm.Intrinsics.Array.ConstructFromBuilder(ref builder);
+            return _realm.Intrinsics.Array.ConstructFromBuilder(ref builder);
         }
         finally
         {

--- a/Jint/Native/Iterator/WrapForValidIteratorPrototype.cs
+++ b/Jint/Native/Iterator/WrapForValidIteratorPrototype.cs
@@ -79,9 +79,11 @@ internal sealed class WrapForValidIterator : ObjectInstance
 {
     internal readonly IteratorInstance.ObjectIterator Iterated;
 
-    public WrapForValidIterator(Engine engine, IteratorInstance.ObjectIterator iterated) : base(engine)
+    public WrapForValidIterator(Engine engine, Realm realm, IteratorInstance.ObjectIterator iterated) : base(engine)
     {
         Iterated = iterated;
-        _prototype = engine.Realm.Intrinsics.WrapForValidIteratorPrototype;
+        // The realm is the one Iterator.from itself belongs to, not whichever realm is running:
+        // step 5 creates the wrapper from the callee's %WrapForValidIteratorPrototype%.
+        _prototype = realm.Intrinsics.WrapForValidIteratorPrototype;
     }
 }

--- a/Jint/Native/JsArray.cs
+++ b/Jint/Native/JsArray.cs
@@ -25,6 +25,21 @@ public sealed class JsArray : ArrayInstance
     {
     }
 
+    /// <summary>
+    /// Creates an array belonging to <paramref name="constructor"/>'s realm rather than to whichever
+    /// realm happens to be running. Built-ins that create a result array use this so a cross-realm call
+    /// returns an array inheriting from the callee's <c>Array.prototype</c>.
+    /// </summary>
+    internal JsArray(ArrayConstructor constructor, uint capacity = 0, uint length = 0)
+        : base(constructor.Engine, capacity, length, constructor)
+    {
+    }
+
+    /// <inheritdoc cref="JsArray(ArrayConstructor, uint, uint)"/>
+    internal JsArray(ArrayConstructor constructor, JsValue[] items) : base(constructor.Engine, items, constructor)
+    {
+    }
+
     public uint Length => GetLength();
 
     private sealed class JsArrayDebugView

--- a/Jint/Native/Json/JsonInstance.cs
+++ b/Jint/Native/Json/JsonInstance.cs
@@ -45,7 +45,19 @@ internal sealed partial class JsonInstance : BuiltinShapeObject
     private JsValue RawJSON(JsValue thisObject, JsValue text)
     {
         // 1. Let jsonString be ? ToString(text).
-        var jsonString = TypeConverter.ToString(text);
+        // ToString has no realm to raise from — a Symbol argument produces the engine-less TypeError that
+        // the statement list would otherwise attribute to whichever realm is running. Re-raise it here so
+        // a cross-realm `otherGlobal.JSON.rawJSON(Symbol())` throws that realm's TypeError.
+        string jsonString;
+        try
+        {
+            jsonString = TypeConverter.ToString(text);
+        }
+        catch (TypeErrorException ex)
+        {
+            Throw.TypeError(_realm, ex.Message);
+            return Undefined;
+        }
 
         // 2. Throw a SyntaxError exception if jsonString is the empty String,
         //    or if either the first or last code unit of jsonString is a

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -2468,7 +2468,9 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
             return false;
         }
 
-        var callable = GetCallable(callbackfn);
+        // `this` is the receiver the generic was applied to, not the built-in that owns the algorithm,
+        // so no callee realm is reachable here and the running one is the best available answer.
+        var callable = callbackfn.GetCallable(_engine.Realm);
 
         var invoker = CallbackInvoker.Rent(_engine, callable, 3, this);
 
@@ -2529,8 +2531,6 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
         value = Undefined;
         return false;
     }
-
-    internal ICallable GetCallable(JsValue source) => source.GetCallable(_engine.Realm);
 
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     internal bool IsConcatSpreadable

--- a/Jint/Native/Prototype.cs
+++ b/Jint/Native/Prototype.cs
@@ -11,4 +11,13 @@ public abstract class Prototype : ObjectInstance
     {
         _realm = realm;
     }
+
+    /// <summary>
+    /// Coerces a built-in's callback argument, raising the TypeError from this prototype's own realm.
+    /// Deliberately declared here rather than on <see cref="ObjectInstance"/>: the callee realm is what
+    /// the spec attributes such an error to, and only a type that knows its realm can supply it. A
+    /// built-in whose receiver is an arbitrary object has no callee realm to reach for and must say
+    /// <c>_engine.Realm</c> at the call site instead, so that the gap stays visible.
+    /// </summary>
+    private protected ICallable GetCallable(JsValue source) => source.GetCallable(_realm);
 }


### PR DESCRIPTION
When a built-in belonging to one realm is called from another, the error it raises and the array it returns must come from **its own** realm, not from whichever realm happens to be running.

The existing exclusion comment said Jint builds errors from the current realm in general. That is not so — 913 of 1332 `Throw.*Error(...)` call sites already pass the built-in's own `_realm`, and script functions push the callee realm properly. What existed was a handful of specific leaks:

| Leak | Site |
|---|---|
| `ValidateArrayLength` used the running realm — the one line in `ArrayPrototype` not using `_realm` | `toSorted`, `toReversed`, `with`, `toSpliced` |
| `ObjectInstance.GetCallable` used the running realm (46 call sites) | the five `Iterator.prototype` predicates |
| A result array adopted the running realm's `Array.prototype` | `with`/`toReversed`/`toSorted`/`toSpliced`, `Array.from`, `Iterator.prototype.toArray` |
| `Iterator.from` compared against the running realm's `%Iterator%` | `Iterator.from` |
| A realm-less coercion `TypeError` | `JSON.rawJSON(Symbol())` |
| `CreateDynamicFunction` parsed in the caller's realm | `new Function` with a syntax error |

## `GetCallable`

`ObjectInstance.GetCallable` is **deleted** and re-declared as `private protected` on `Prototype`, `Function` and `ArrayPrototype`, using `_realm`.

An `internal virtual OwnRealm` on `ObjectInstance` was considered and rejected: it conflates "the realm of the object this was invoked on" with "the callee realm", and those coincide only when `this` **is** the built-in. Four of the 46 sites run with `this` = the *receiver*, so `Array.prototype.map.call(someFunction, notCallable)` would have started throwing in the receiver function's realm — a new, differently-wrong answer. Moving the method instead makes the **compiler** find those four: they no longer compile, and now spell `_engine.Realm` explicitly with a comment saying no callee realm is reachable there. That gap is real, pre-existing and unchanged, but it is now visible rather than silently wrong.

## Result arrays, without touching public API

`ArrayInstance`'s two `private protected` constructors gained a trailing optional `ArrayConstructor?`; the **public `JsArray(Engine, …)` constructors are unchanged in signature and behaviour** (they pass nothing). Two new `internal JsArray(ArrayConstructor, …)` constructors supply one, and `ArrayCreate`, `ArrayCreateLazy` and both `ConstructFast` overloads route through it, so `_constructor` and `_prototype` can no longer disagree about realm.

## Performance

Every changed site trades `_engine.Realm` — two field loads plus an execution-context stack peek — for a `_realm` field load, so all of it is neutral-to-cheaper. The one addition is a null test per array construction, replacing a two-hop `engine.Realm.Intrinsics.Array` walk whenever a constructor is supplied.

Deliberately **not** done: making built-in calls push an `ExecutionContext`. That is the spec-shaped fix, but it costs a push/pop per built-in call on the leaf lane engineered to have none, and it would change `Engine.Intrinsics`/`Engine.Global` — public surface — for a host `ClrFunction` invoked cross-realm.

## Tests

`Jint.Tests/Runtime/CrossRealmAttributionTests.cs` — 36 tests via `ShadowRealm` (public API; `$262` is internal), 26 failing against unfixed code, asserting both shapes: an error is `instanceof` the callee realm's constructor, and a result array is `instanceof` the callee realm's `Array`.

test262: **102,350 passed, 0 failed** (+24; twelve files × two modes).

Two corrections to the issue's grouping: `syntax/yield-as-identifier.js` is a realm bug, not a parser one, and is moved out of the parser block. `TypedArray/set-wrapped.js` and `constructor-buffer-sequence.js` stay — both fail on `$262` missing from created realms, which #3044 addresses, so expect a conflict with that PR in this block.

Refs #3021.
