### PR TITLE
Port fdlibm for acosh, asinh, atanh, cbrt, expm1 and log1p

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -103,16 +103,6 @@
     "staging/sm/class/parenExprToString.js",
     "staging/sm/generators/runtime.js",
 
-    // Math precision. Jint delegates to the BCL, whose acosh/asinh/atanh/cbrt/expm1/log1p differ
-    // from the reference values in the last few ULPs, and expm1/log1p flush 1e-300 to zero. Removed
-    // by implementing these with the spec-grade algorithms rather than the BCL primitives.
-    "staging/sm/Math/acosh-approx.js",
-    "staging/sm/Math/asinh-approx.js",
-    "staging/sm/Math/atanh-approx.js",
-    "staging/sm/Math/cbrt-approx.js",
-    "staging/sm/Math/expm1-approx.js",
-    "staging/sm/Math/log1p-approx.js",
-
     // Number conversion and formatting. toFixed/toPrecision lose the exact mathematical value for
     // extreme magnitudes and subnormals, and ToPrimitive on a Number wrapper consults the wrong
     // method. Removed by exact-value formatting and a spec-order OrdinaryToPrimitive.

--- a/Jint.Tests/Runtime/MathFdlibmTests.cs
+++ b/Jint.Tests/Runtime/MathFdlibmTests.cs
@@ -1,0 +1,682 @@
+﻿using Jint.Native;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Pins Math.acosh / asinh / atanh / cbrt / expm1 / log1p to the fdlibm algorithms ECMA-262 21.3.2
+/// recommends by name, which Jint ports in <c>Jint/Native/Math/Fdlibm.cs</c>.
+/// <para>
+/// These six used to be open-coded from their textbook identities — <c>log(x + sqrt(x*x - 1))</c>,
+/// <c>exp(x) - 1</c>, <c>log(1 + x)</c>, <c>pow(|x|, 1/3)</c> — every one of which loses all
+/// significant digits somewhere in its domain: <c>acosh(1e300)</c> and <c>asinh(1e300)</c> answered
+/// Infinity because <c>x*x</c> overflows, and <c>asinh</c>, <c>atanh</c>, <c>expm1</c> and
+/// <c>log1p</c> all flushed 1e-300 to zero, which is what 21.3.2.14 and 21.3.2.21 forbid in so many
+/// words ("The result is computed in a way that is accurate even when the value of x is close to
+/// 0"). <c>log1p(1e-15)</c> was 11% out and <c>cbrt(1e-300)</c> some 58 ULP out.
+/// </para>
+/// <para>
+/// Expectations are exact bit patterns. Every one of them was checked against the correctly rounded
+/// result computed in 900-digit decimal arithmetic; the port never differs from it by more than
+/// 1 ULP, and each row that is not exactly the correctly rounded double says so in a comment.
+/// The <c>*ReferenceTable</c> sets instead carry test262's own reference values, sampled from
+/// <c>test/staging/sm/Math/*-approx.js</c>, and are asserted with each file's own ULP tolerance.
+/// </para>
+/// </summary>
+public class MathFdlibmTests
+{
+    private readonly Engine _engine = new();
+
+    private double Eval(string source) => _engine.Evaluate(source).AsNumber();
+
+    /// <summary>
+    /// The distance between two doubles in representable values, which is how test262's
+    /// <c>sm/non262-Math-shell.js</c> harness measures "near".
+    /// </summary>
+    private static long UlpDistance(double actual, double expected)
+    {
+        if (double.IsNaN(actual) || double.IsNaN(expected))
+        {
+            return double.IsNaN(actual) && double.IsNaN(expected) ? 0 : long.MaxValue;
+        }
+
+        var a = BitConverter.DoubleToInt64Bits(actual);
+        var b = BitConverter.DoubleToInt64Bits(expected);
+        if (a < 0 != b < 0)
+        {
+            return long.MaxValue;
+        }
+
+        return System.Math.Abs(a - b);
+    }
+
+    private static void ShouldBeExactly(double actual, double expected, string what)
+    {
+        if (double.IsNaN(expected))
+        {
+            double.IsNaN(actual).Should().BeTrue($"{what} should be NaN but was {actual:R}");
+            return;
+        }
+
+        BitConverter.DoubleToInt64Bits(actual).Should().Be(
+            BitConverter.DoubleToInt64Bits(expected),
+            $"{what} should be exactly {expected:R} but was {actual:R}");
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // The eight values from the bug report: every one of them used to be catastrophically wrong.
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void AcoshDoesNotOverflowOnLargeArguments()
+    {
+        // was Infinity, because x*x overflows for x >= ~1.34e154
+        ShouldBeExactly(Eval("Math.acosh(1e300)"), 691.4686750787736, "Math.acosh(1e300)");
+
+        // 1 ULP below the correctly rounded 691.4686750787737, which is the value test262's
+        // acosh-approx.js names (with its own tolerance of 9).
+        UlpDistance(Eval("Math.acosh(1e300)"), 691.4686750787737).Should().BeLessThanOrEqualTo(1);
+    }
+
+    [Fact]
+    public void AsinhDoesNotOverflowOnLargeArguments()
+    {
+        // was Infinity
+        ShouldBeExactly(Eval("Math.asinh(1e300)"), 691.4686750787736, "Math.asinh(1e300)");
+        UlpDistance(Eval("Math.asinh(1e300)"), 691.4686750787737).Should().BeLessThanOrEqualTo(1);
+    }
+
+    [Fact]
+    public void SmallArgumentsAreNotFlushedToZero()
+    {
+        // all four were 0
+        ShouldBeExactly(Eval("Math.asinh(1e-300)"), 1e-300, "Math.asinh(1e-300)");
+        ShouldBeExactly(Eval("Math.atanh(1e-300)"), 1e-300, "Math.atanh(1e-300)");
+        ShouldBeExactly(Eval("Math.expm1(1e-300)"), 1e-300, "Math.expm1(1e-300)");
+        ShouldBeExactly(Eval("Math.log1p(1e-300)"), 1e-300, "Math.log1p(1e-300)");
+    }
+
+    [Fact]
+    public void Log1pIsAccurateNearZero()
+    {
+        // was 1.110223024625156e-15, an 11% error
+        ShouldBeExactly(Eval("Math.log1p(1e-15)"), 9.999999999999995e-16, "Math.log1p(1e-15)");
+    }
+
+    [Fact]
+    public void CbrtIsNotComputedThroughPow()
+    {
+        // was 1.0000000000000128e-100, some 58 ULP out
+        ShouldBeExactly(Eval("Math.cbrt(1e-300)"), 1e-100, "Math.cbrt(1e-300)");
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Ordinary values, domain edges and every special case ECMA-262 21.3.2 fixes.
+    // ---------------------------------------------------------------------------------------
+
+    [Theory]
+    [MemberData(nameof(AcoshValues))]
+    public void Acosh(string argument, double expected)
+        => ShouldBeExactly(Eval($"Math.acosh({argument})"), expected, $"Math.acosh({argument})");
+
+    [Theory]
+    [MemberData(nameof(AsinhValues))]
+    public void Asinh(string argument, double expected)
+        => ShouldBeExactly(Eval($"Math.asinh({argument})"), expected, $"Math.asinh({argument})");
+
+    [Theory]
+    [MemberData(nameof(AtanhValues))]
+    public void Atanh(string argument, double expected)
+        => ShouldBeExactly(Eval($"Math.atanh({argument})"), expected, $"Math.atanh({argument})");
+
+    [Theory]
+    [MemberData(nameof(CbrtValues))]
+    public void Cbrt(string argument, double expected)
+        => ShouldBeExactly(Eval($"Math.cbrt({argument})"), expected, $"Math.cbrt({argument})");
+
+    [Theory]
+    [MemberData(nameof(Expm1Values))]
+    public void Expm1(string argument, double expected)
+        => ShouldBeExactly(Eval($"Math.expm1({argument})"), expected, $"Math.expm1({argument})");
+
+    [Theory]
+    [MemberData(nameof(Log1pValues))]
+    public void Log1p(string argument, double expected)
+        => ShouldBeExactly(Eval($"Math.log1p({argument})"), expected, $"Math.log1p({argument})");
+
+    // ---------------------------------------------------------------------------------------
+    // test262 reference values, sampled from test/staging/sm/Math/*-approx.js. Those files are
+    // excluded from nothing any more; this keeps a representative slice inside the unit suite.
+    // ---------------------------------------------------------------------------------------
+
+    [Theory]
+    [MemberData(nameof(AcoshReferenceTable))]
+    public void AcoshMatchesTest262References(string argument, double expected, int tolerance)
+        => ShouldBeNear("Math.acosh", argument, expected, tolerance);
+
+    [Theory]
+    [MemberData(nameof(AsinhReferenceTable))]
+    public void AsinhMatchesTest262References(string argument, double expected, int tolerance)
+        => ShouldBeNear("Math.asinh", argument, expected, tolerance);
+
+    [Theory]
+    [MemberData(nameof(AtanhReferenceTable))]
+    public void AtanhMatchesTest262References(string argument, double expected, int tolerance)
+        => ShouldBeNear("Math.atanh", argument, expected, tolerance);
+
+    [Theory]
+    [MemberData(nameof(CbrtReferenceTable))]
+    public void CbrtMatchesTest262References(string argument, double expected, int tolerance)
+        => ShouldBeNear("Math.cbrt", argument, expected, tolerance);
+
+    [Theory]
+    [MemberData(nameof(Expm1ReferenceTable))]
+    public void Expm1MatchesTest262References(string argument, double expected, int tolerance)
+        => ShouldBeNear("Math.expm1", argument, expected, tolerance);
+
+    [Theory]
+    [MemberData(nameof(Log1pReferenceTable))]
+    public void Log1pMatchesTest262References(string argument, double expected, int tolerance)
+        => ShouldBeNear("Math.log1p", argument, expected, tolerance);
+
+    private void ShouldBeNear(string function, string argument, double expected, int tolerance)
+    {
+        var actual = Eval($"{function}({argument})");
+        UlpDistance(actual, expected).Should().BeLessThanOrEqualTo(
+            tolerance,
+            $"{function}({argument}) should be within {tolerance} ULP of {expected:R} but was {actual:R}");
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Round trips. Each of these is a loop test262's *-approx.js files also run.
+    // ---------------------------------------------------------------------------------------
+
+    // Tolerances here are a couple of ULP wider than measured, because the inner Math.cosh /
+    // Math.sinh / Math.tanh are still BCL calls and may differ by a ULP between operating systems.
+    // Each range was checked to survive a +-1 ULP perturbation of the inner function; acosh starts
+    // at |x| = 1 because inverting cosh is arbitrarily ill-conditioned as x approaches 0 (cosh(0.2)
+    // is 1.0200667..., where an eight-ULP round trip error is expected and test262 allows nine).
+
+    [Fact]
+    public void AcoshInvertsCosh()
+        => AssertRoundTrip(
+            """
+            (function () {
+                var out = [];
+                for (var i = 0; i <= 100; i++) {
+                    var x = (i - 50) / 5;
+                    if (Math.abs(x) < 1) continue;
+                    out.push(Math.acosh(Math.cosh(x)), Math.abs(x));
+                }
+                for (var i = 1; i < 20; i++) {
+                    out.push(Math.acosh(Math.cosh(i)), i);
+                }
+                return out;
+            })()
+            """,
+            tolerance: 6);
+
+    [Fact]
+    public void AsinhInvertsSinh()
+        => AssertRoundTrip(
+            """
+            (function () {
+                var out = [];
+                for (var i = 0; i <= 80; i++) {
+                    var x = (i - 40) / 4;
+                    out.push(Math.asinh(Math.sinh(x)), x);
+                }
+                for (var i = -20; i < 20; i++) {
+                    out.push(Math.asinh(Math.sinh(i)), i);
+                }
+                return out;
+            })()
+            """,
+            tolerance: 4);
+
+    [Fact]
+    public void AtanhInvertsTanh()
+        => AssertRoundTrip(
+            """
+            (function () {
+                var out = [];
+                for (var i = -1; i < 1; i += 0.05) {
+                    out.push(Math.atanh(Math.tanh(i)), i);
+                }
+                return out;
+            })()
+            """,
+            tolerance: 5);
+
+    [Fact]
+    public void CbrtInvertsCubing()
+        => AssertRoundTrip(
+            """
+            (function () {
+                var out = [];
+                for (var i = -30; i <= 30; i++) {
+                    var x = i / 3;
+                    out.push(Math.cbrt(x * x * x), x);
+                }
+                return out;
+            })()
+            """,
+            tolerance: 2);
+
+    [Fact]
+    public void Expm1AndLog1pInvertEachOther()
+        => AssertRoundTrip(
+            """
+            (function () {
+                var out = [];
+                for (var i = -8; i <= 8; i++) {
+                    var x = i / 8;
+                    out.push(Math.log1p(Math.expm1(x)), x);
+                }
+                for (var i = -7; i <= 40; i++) {
+                    var x = i / 8;
+                    out.push(Math.expm1(Math.log1p(x)), x);
+                }
+                return out;
+            })()
+            """,
+            tolerance: 4);
+
+    private void AssertRoundTrip(string script, int tolerance)
+    {
+        var pairs = _engine.Evaluate(script).AsArray();
+        var length = (int) pairs.Length;
+        length.Should().BeGreaterThan(0);
+
+        for (var i = 0; i < length; i += 2)
+        {
+            var actual = pairs[i].AsNumber();
+            var expected = pairs[i + 1].AsNumber();
+            UlpDistance(actual, expected).Should().BeLessThanOrEqualTo(
+                tolerance,
+                $"round trip #{i / 2} should be within {tolerance} ULP of {expected:R} but was {actual:R}");
+        }
+    }
+
+    public static TheoryData<string, double> AcoshValues =>
+        new()
+        {
+            { "1.0", 0.0 },
+            { "1.0000000000000002", 2.1073424255447017e-08 }, // 1 ULP from correctly rounded 2.1073424255447014e-08
+            { "1.0000000001", 1.4142136208675862e-05 },
+            { "1.0009765625", 0.044190578083110096 },
+            { "1.25", 0.6931471805599453 },
+            { "1.5", 0.9624236501192069 },
+            { "1.9999999999999998", 1.3169578969248166 },
+            { "2.0", 1.3169578969248166 }, // 1 ULP from correctly rounded 1.3169578969248168
+            { "2.0000000000000004", 1.316957896924817 },
+            { "2.0000001", 1.3169579546598416 },
+            { "3.0", 1.7627471740390859 }, // 1 ULP from correctly rounded 1.762747174039086
+            { "4.0", 2.0634370688955608 }, // 1 ULP from correctly rounded 2.0634370688955603
+            { "10.0", 2.993222846126381 },
+            { "100.0", 5.298292365610484 }, // 1 ULP from correctly rounded 5.298292365610485
+            { "12345.678", 10.114208500211527 },
+            { "100000000.0", 19.11382792451231 },
+            { "268435456.0", 20.10126823623841 }, // 1 ULP from correctly rounded 20.101268236238415
+            { "268435456.00000006", 20.10126823623841 }, // 1 ULP from correctly rounded 20.101268236238415
+            { "536870912.0", 20.79441541679836 },
+            { "1000000000000000.0", 35.23192357547063 },
+            { "1e+100", 230.95165647996453 },
+            { "1e+300", 691.4686750787736 }, // 1 ULP from correctly rounded 691.4686750787737
+            { "1.7976931348623157e+308", 710.4758600739439 }, // 1 ULP from correctly rounded 710.475860073944
+            { "Infinity", double.PositiveInfinity },
+            { "NaN", double.NaN },
+            { "0", double.NaN },
+            { "-0", double.NaN },
+            { "-1.0", double.NaN },
+            { "0.9999999999999999", double.NaN },
+            { "5e-324", double.NaN },
+            { "-5e-324", double.NaN },
+            { "-1e+300", double.NaN },
+            { "-Infinity", double.NaN },
+        };
+
+    public static TheoryData<string, double> AsinhValues =>
+        new()
+        {
+            { "0", 0.0 },
+            { "-0", -0.0 },
+            { "5e-324", 5e-324 },
+            { "-5e-324", -5e-324 },
+            { "1e-300", 1e-300 },
+            { "-1e-300", -1e-300 },
+            { "1.862645149230957e-09", 1.862645149230957e-09 },
+            { "3.725290298461914e-09", 3.725290298461914e-09 },
+            { "3.7252902984619136e-09", 3.7252902984619136e-09 },
+            { "1e-10", 1e-10 },
+            { "0.25", 0.24746646154726346 },
+            { "0.5", 0.48121182505960347 },
+            { "1.0", 0.881373587019543 },
+            { "1.5", 1.1947632172871094 }, // 1 ULP from correctly rounded 1.1947632172871092
+            { "1.9999999999999998", 1.4436354751788103 },
+            { "2.0", 1.4436354751788103 },
+            { "2.0000000000000004", 1.4436354751788105 },
+            { "3.0", 1.8184464592320668 },
+            { "10.0", 2.99822295029797 },
+            { "100.0", 5.298342365610589 },
+            { "12345.678", 10.114208503492028 },
+            { "100000000.0", 19.11382792451231 },
+            { "268435456.0", 20.101268236238415 },
+            { "268435456.00000006", 20.101268236238415 },
+            { "536870912.0", 20.79441541679836 },
+            { "1000000000000000.0", 35.23192357547063 },
+            { "1e+100", 230.95165647996453 },
+            { "1e+300", 691.4686750787736 }, // 1 ULP from correctly rounded 691.4686750787737
+            { "1.7976931348623157e+308", 710.4758600739439 }, // 1 ULP from correctly rounded 710.475860073944
+            { "Infinity", double.PositiveInfinity },
+            { "-Infinity", double.NegativeInfinity },
+            { "NaN", double.NaN },
+            { "-0.5", -0.48121182505960347 },
+            { "-1.0", -0.881373587019543 },
+            { "-2.5", -1.6472311463710958 },
+            { "-100.0", -5.298342365610589 },
+            { "-1e+300", -691.4686750787736 }, // 1 ULP from correctly rounded -691.4686750787737
+        };
+
+    public static TheoryData<string, double> AtanhValues =>
+        new()
+        {
+            { "0", 0.0 },
+            { "-0", -0.0 },
+            { "5e-324", 5e-324 },
+            { "-5e-324", -5e-324 },
+            { "1e-300", 1e-300 },
+            { "-1e-300", -1e-300 },
+            { "1.862645149230957e-09", 1.862645149230957e-09 },
+            { "3.725290298461914e-09", 3.725290298461914e-09 },
+            { "3.7252902984619136e-09", 3.7252902984619136e-09 },
+            { "1e-10", 1e-10 },
+            { "0.125", 0.12565721414045303 },
+            { "0.25", 0.25541281188299536 },
+            { "0.49999999999999994", 0.5493061443340548 },
+            { "0.5", 0.5493061443340548 }, // 1 ULP from correctly rounded 0.5493061443340549
+            { "0.5000000000000001", 0.549306144334055 },
+            { "0.75", 0.9729550745276566 },
+            { "0.9", 1.4722194895832204 },
+            { "0.99", 2.6466524123622457 },
+            { "0.999999", 7.254328619247669 },
+            { "0.9999999999999999", 18.714973875118524 },
+            { "1.0", double.PositiveInfinity },
+            { "-1.0", double.NegativeInfinity },
+            { "-0.5", -0.5493061443340548 }, // 1 ULP from correctly rounded -0.5493061443340549
+            { "-0.9999999999999999", -18.714973875118524 },
+            { "-0.25", -0.25541281188299536 },
+            { "1.0000000000000002", double.NaN },
+            { "-1.0000000000000002", double.NaN },
+            { "2.0", double.NaN },
+            { "-2.0", double.NaN },
+            { "1e+300", double.NaN },
+            { "Infinity", double.NaN },
+            { "-Infinity", double.NaN },
+            { "NaN", double.NaN },
+        };
+
+    public static TheoryData<string, double> CbrtValues =>
+        new()
+        {
+            { "0", 0.0 },
+            { "-0", -0.0 },
+            { "5e-324", 1.7031839360032603e-108 },
+            { "-5e-324", -1.7031839360032603e-108 },
+            { "1e-320", 2.1544266950262728e-107 },
+            { "1e-300", 1e-100 },
+            { "-1e-300", -1e-100 },
+            { "2.2250738585072014e-308", 2.812644285236262e-103 },
+            { "2.225073858507201e-308", 2.8126442852362615e-103 },
+            { "1e-100", 4.641588833612779e-34 },
+            { "0.001", 0.1 },
+            { "0.125", 0.5 },
+            { "0.5", 0.7937005259840998 },
+            { "1.0", 1.0 },
+            { "-1.0", -1.0 },
+            { "2.0", 1.2599210498948732 },
+            { "2.718281828459045", 1.3956124250860895 },
+            { "3.141592653589793", 1.4645918875615231 },
+            { "0.6931471805599453", 0.8849970445005177 },
+            { "1.4142135623730951", 1.122462048309373 },
+            { "8.0", 2.0 },
+            { "27.0", 3.0 },
+            { "64.0", 4.0 },
+            { "1000.0", 10.0 },
+            { "1000000.0", 100.0 },
+            { "12345.678", 23.11204184662531 }, // 1 ULP from correctly rounded 23.112041846625313
+            { "1e+100", 2.1544346900318838e+33 },
+            { "1e+300", 1e+100 },
+            { "1.7976931348623157e+308", 5.643803094122362e+102 },
+            { "-1.7976931348623157e+308", -5.643803094122362e+102 },
+            { "Infinity", double.PositiveInfinity },
+            { "-Infinity", double.NegativeInfinity },
+            { "NaN", double.NaN },
+            { "-8.0", -2.0 },
+            { "-27.0", -3.0 },
+            { "-1e+300", -1e+100 },
+        };
+
+    public static TheoryData<string, double> Expm1Values =>
+        new()
+        {
+            { "0", 0.0 },
+            { "-0", -0.0 },
+            { "5e-324", 5e-324 },
+            { "-5e-324", -5e-324 },
+            { "1e-300", 1e-300 },
+            { "-1e-300", -1e-300 },
+            { "2.7755575615628914e-17", 2.7755575615628914e-17 },
+            { "5.551115123125783e-17", 5.551115123125783e-17 },
+            { "5.551115123125782e-17", 5.551115123125782e-17 },
+            { "1e-14", 1.000000000000005e-14 },
+            { "1e-10", 1.00000000005e-10 },
+            { "1e-06", 1.0000005000001665e-06 },
+            { "0.1", 0.10517091807564763 },
+            { "0.25", 0.2840254166877415 },
+            { "0.34657359027997264", 0.41421356237309503 },
+            { "0.3465735902799727", 0.41421356237309515 }, // 1 ULP from correctly rounded 0.4142135623730951
+            { "0.5", 0.6487212707001282 },
+            { "0.75", 1.1170000166126748 }, // 1 ULP from correctly rounded 1.1170000166126746
+            { "1.0", 1.718281828459045 }, // 1 ULP from correctly rounded 1.7182818284590453
+            { "1.0397207708399179", 1.8284271247461898 },
+            { "1.039720770839918", 1.8284271247461905 },
+            { "1.5", 3.481689070338065 },
+            { "2.0", 6.38905609893065 },
+            { "5.0", 147.4131591025766 },
+            { "10.0", 22025.465794806718 },
+            { "100.0", 2.6881171418161356e+43 },
+            { "216.85489905212918", 1.5096839294759838e+94 },
+            { "700.0", 1.0142320547350045e+304 },
+            { "709.0", 8.218407461554972e+307 },
+            { "709.782712893384", 1.7976931348622732e+308 },
+            { "709.7827128933841", double.PositiveInfinity },
+            { "710.0", double.PositiveInfinity },
+            { "1e+300", double.PositiveInfinity },
+            { "Infinity", double.PositiveInfinity },
+            { "-0.1", -0.09516258196404043 },
+            { "-0.25", -0.22119921692859512 },
+            { "-0.5", -0.3934693402873666 },
+            { "-0.6931471805599453", -0.5 },
+            { "-1.0", -0.6321205588285577 },
+            { "-2.0", -0.8646647167633873 },
+            { "-5.0", -0.9932620530009145 },
+            { "-10.0", -0.9999546000702375 },
+            { "-38.81622659593048", -1.0 },
+            { "-38.9", -1.0 },
+            { "-50.0", -1.0 },
+            { "-100.0", -1.0 },
+            { "-745.0", -1.0 },
+            { "-1e+300", -1.0 },
+            { "-Infinity", -1.0 },
+            { "NaN", double.NaN },
+        };
+
+    public static TheoryData<string, double> Log1pValues =>
+        new()
+        {
+            { "0", 0.0 },
+            { "-0", -0.0 },
+            { "5e-324", 5e-324 },
+            { "-5e-324", -5e-324 },
+            { "1e-300", 1e-300 },
+            { "-1e-300", -1e-300 },
+            { "2.7755575615628914e-17", 2.7755575615628914e-17 },
+            { "5.551115123125783e-17", 5.551115123125783e-17 },
+            { "5.551115123125782e-17", 5.551115123125782e-17 },
+            { "9.313225746154785e-10", 9.313225741817976e-10 },
+            { "1.862645149230957e-09", 1.8626451474962336e-09 },
+            { "1.8626451492309568e-09", 1.8626451474962333e-09 },
+            { "1e-15", 9.999999999999995e-16 },
+            { "1e-09", 9.999999995e-10 },
+            { "1e-06", 9.999995000003334e-07 },
+            { "0.1", 0.09531017980432487 },
+            { "0.25", 0.22314355131420976 },
+            { "0.4142135623730951", 0.3465735902799727 },
+            { "0.41421356237309515", 0.3465735902799727 },
+            { "0.5", 0.4054651081081644 },
+            { "1.0", 0.6931471805599453 },
+            { "2.0", 1.0986122886681096 }, // 1 ULP from correctly rounded 1.0986122886681098
+            { "10.0", 2.3978952727983707 },
+            { "1000000.0", 13.815511557963774 },
+            { "10000000000.0", 23.025850930040455 },
+            { "9007199254740992.0", 36.7368005696771 },
+            { "1.8014398509481984e+16", 37.42994775023705 },
+            { "1e+100", 230.25850929940458 },
+            { "1e+300", 690.7755278982137 },
+            { "1.7976931348623157e+308", 709.782712893384 },
+            { "Infinity", double.PositiveInfinity },
+            { "-0.1", -0.10536051565782631 },
+            { "-0.25", -0.2876820724517809 },
+            { "-0.2928932188134524", -0.3465735902799726 },
+            { "-0.29289321881345237", -0.34657359027997253 },
+            { "-0.5", -0.6931471805599453 },
+            { "-0.75", -1.3862943611198906 },
+            { "-0.9", -2.302585092994046 },
+            { "-0.999999", -13.815510557935518 },
+            { "-0.9999999999999999", -36.7368005696771 },
+            { "-1.0", double.NegativeInfinity },
+            { "-1.0000000000000002", double.NaN },
+            { "-1.1", double.NaN },
+            { "-2.0", double.NaN },
+            { "-1e+300", double.NaN },
+            { "-Infinity", double.NaN },
+            { "NaN", double.NaN },
+        };
+
+    public static TheoryData<string, double, int> AcoshReferenceTable =>
+        new()
+        {
+            { "1.0000014305114746", 0.0016914556651292944, 9 },
+            { "1.024169921875", 0.21942279004958354, 9 },
+            { "16.88458251953125", 3.51867003468025, 9 },
+            { "57.119781494140625", 4.73822104001982, 9 },
+            { "86.42214965820312", 5.152357710985635, 9 },
+            { "126.29083251953125", 5.531718947357248, 9 },
+            { "169.22418212890625", 5.824362807770767, 9 },
+            { "199.97052001953125", 5.991310884439669, 9 },
+            { "243.202392578125", 6.187036941752032, 9 },
+            { "284.3428955078125", 6.343324976847916, 9 },
+            { "328.214599609375", 6.486812521370483, 9 },
+            { "363.7503662109375", 6.5896131163651415, 9 },
+            { "396.3114013671875", 6.675345858154136, 9 },
+            { "410.8016357421875", 6.711256159037373, 9 },
+            { "457.9520263671875", 6.819910421197311, 9 },
+            { "479.9122314453125", 6.8667493311188395, 9 },
+            { "5824.533203125", 9.36298131161099, 9 },
+            { "1875817529344", 28.953212876533797, 9 },
+        };
+
+    public static TheoryData<string, double, int> AsinhReferenceTable =>
+        new()
+        {
+            { "-497.181640625", -6.902103625349695, 1 },
+            { "-402.4595947265625", -6.690743430063694, 1 },
+            { "-337.3883056640625", -6.514383886150781, 1 },
+            { "-245.71783447265625", -6.197335184435549, 1 },
+            { "-150.01629638671875", -5.703902219845274, 1 },
+            { "-78.23873901367188", -5.052952927749896, 1 },
+            { "1.6504814008555524e-12", 1.6504814008555524e-12, 1 },
+            { "1.166764889148908e-7", 1.1667648891489053e-07, 1 },
+            { "0.001962467096745968", 0.0019624658370807177, 1 },
+            { "29.58606719970703", 4.080736210902826, 1 },
+            { "116.044677734375", 5.447141014648796, 1 },
+            { "195.23284912109375", 5.967346683696556, 1 },
+            { "257.7401123046875", 6.245102704489327, 1 },
+            { "307.531005859375", 6.421725738171608, 1 },
+            { "378.4306640625", 6.629181796246806, 1 },
+            { "457.5068359375", 6.818940201487998, 1 },
+            { "716.154052734375", 7.2670429692740965, 1 },
+            { "1581915832320", 28.78280496108106, 1 },
+        };
+
+    public static TheoryData<string, double, int> AtanhReferenceTable =>
+        new()
+        {
+            { "-0.9999983310699463", -6.998237084679027, 2 },
+            { "-0.990715742111206", -2.6839646283308363, 2 },
+            { "-0.864722728729248", -1.3117705583444539, 2 },
+            { "-0.7017018795013428", -0.8706453720344796, 2 },
+            { "-0.5654678344726562", -0.6408350116350283, 2 },
+            { "-0.40029656887054443", -0.4240020382545707, 2 },
+            { "-0.2253856658935547", -0.2293228153248168, 2 },
+            { "-0.08401328325271606", -0.08421178632314608, 2 },
+            { "1.6399812063916386e-11", 1.6399812063916386e-11, 2 },
+            { "9.382699772686465e-7", 9.382699772689218e-07, 2 },
+            { "0.008691128343343735", 0.008691347183450786, 2 },
+            { "0.14749455451965332", 0.14857829980464834, 2 },
+            { "0.3271782398223877", 0.3396649461699478, 2 },
+            { "0.48124635219573975", 0.5246050193978663, 2 },
+            { "0.5871362686157227", 0.6732844960442398, 2 },
+            { "0.6437420845031738", 0.7645378650643101, 2 },
+            { "0.8313877582550049", 1.1926138225701433, 2 },
+            { "1e-10", 1e-10, 2 },
+        };
+
+    public static TheoryData<string, double, int> CbrtReferenceTable =>
+        new()
+        {
+            { "Math.E", 1.3956124250860895, 3 },
+            { "Math.PI", 1.4645918875615231, 3 },
+            { "Math.LN2", 0.8849970445005177, 3 },
+            { "Math.SQRT2", 1.1224620483093728, 3 },
+            { "1e-300", 1e-100, 1 },
+            { "-1e-300", -1e-100, 1 },
+        };
+
+    public static TheoryData<string, double, int> Expm1ReferenceTable =>
+        new()
+        {
+            { "-1.875817529344e-70", -1.875817529344e-70, 1 },
+            { "-2.114990849122478e-10", -2.1149908488988187e-10, 1 },
+            { "-0.0000011039855962733358", -1.1039849868814618e-06, 1 },
+            { "-0.000033870281179478836", -3.3869707587981166e-05, 1 },
+            { "-0.005553725496786973", -0.005538332073473123, 1 },
+            { "-0.4721357117742938", -0.3763311320344197, 1 },
+            { "1.875817529344e-70", 1.875817529344e-70, 1 },
+            { "7.09962844069878e-15", 7.099628440698805e-15, 1 },
+            { "2.114990849122478e-10", 2.1149908493461373e-10, 1 },
+            { "0.0000011039855962733358", 1.1039862056656584e-06, 1 },
+            { "0.000033870281179478836", 3.387085478392845e-05, 1 },
+            { "0.005553725496786973", 0.005569176019645543, 1 },
+            { "0.4721357117742938", 0.6034149712523235, 1 },
+            { "3.0693960800487883", 20.528897017773147, 1 },
+            { "7.4227656046482595", 1672.6557833191303, 1 },
+            { "20.11881628179155", 546375092.2355127, 34 },
+            { "46.43974518513109", 1.4740936483807671e+20, 34 },
+            { "216.85489905212918", 1.5096839294759775e+94, 34 },
+        };
+
+    public static TheoryData<string, double, int> Log1pReferenceTable =>
+        new()
+        {
+            { "1.875817529344e-70", 1.875817529344e-70, 1 },
+            { "6.261923313140869e-30", 6.261923313140869e-30, 1 },
+            { "7.09962844069878e-15", 7.099628440698755e-15, 1 },
+            { "1.3671879628418538e-12", 1.3671879628409192e-12, 1 },
+            { "2.114990849122478e-10", 2.1149908488988187e-10, 1 },
+            { "1.6900931765206906e-8", 1.690093162238616e-08, 1 },
+            { "0.0000709962844069878", 7.099376429006658e-05, 1 },
+            { "0.0016793412882520897", 0.00167793277137076, 1 },
+            { "0.011404608812881634", 0.011340066517988035, 1 },
+        };
+}

--- a/Jint/Native/Math/Fdlibm.cs
+++ b/Jint/Native/Math/Fdlibm.cs
@@ -1,0 +1,730 @@
+// ====================================================
+// Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+//
+// Developed at SunSoft/SunPro, a Sun Microsystems, Inc. business.
+// Permission to use, copy, modify, and distribute this
+// software is freely granted, provided that this notice
+// is preserved.
+// ====================================================
+//
+// This file is a C# port of the following files from FreeBSD's libm (msun),
+// taken from https://github.com/freebsd/freebsd-src/tree/main/lib/msun/src at
+// commit aab7bd4d9903b9da0a7474aab47c003c904ef3dd (2026-08-16):
+//
+//   e_acosh.c   0dd5a5603e7a33d976f8e6015620bbc79839c609
+//   s_asinh.c   0dd5a5603e7a33d976f8e6015620bbc79839c609
+//   e_atanh.c   0dd5a5603e7a33d976f8e6015620bbc79839c609
+//   s_cbrt.c    f887d0215fb48e682acccf4cb95f3794974e1a9d  (optimized by Bruce D. Evans)
+//   s_expm1.c   0dd5a5603e7a33d976f8e6015620bbc79839c609
+//   s_log1p.c   0dd5a5603e7a33d976f8e6015620bbc79839c609
+//   e_log.c     0dd5a5603e7a33d976f8e6015620bbc79839c609
+//
+// The structure, the magic constants and the branch thresholds are those of the
+// originals; only the word-access idioms (EXTRACT_WORDS / INSERT_WORDS /
+// SET_HIGH_WORD, which the C sources spell with a union) are rewritten in terms
+// of BitConverter, and the C tricks that exist purely to raise the IEEE inexact
+// flag are dropped because .NET exposes no floating-point status word. Every such
+// deviation is called out at its site and none of them changes a returned value.
+//
+// The only BCL calls left on these paths are Math.Sqrt and Math.Abs. IEEE 754
+// mandates a correctly rounded square root and defines abs as a sign-bit clear, so
+// unlike log/exp/pow neither of them can differ between runtimes: the results below
+// are bit-identical on every target framework and every operating system.
+
+using System.Runtime.CompilerServices;
+
+namespace Jint.Native.Math;
+
+/// <summary>
+/// The transcendental functions ECMA-262 21.3.2 recommends be implemented "using the approximation
+/// algorithms for IEEE 754-2019 arithmetic contained in fdlibm".
+/// <para>
+/// These are not delegated to the BCL. <c>Math.Acosh</c>/<c>Asinh</c>/<c>Atanh</c>/<c>Cbrt</c>
+/// resolve to the platform libm, whose last-place results differ between Windows, Linux and macOS,
+/// and the reference tables Jint is measured against (test262's <c>staging/sm/Math/*-approx.js</c>)
+/// leave no ULP of margin. <c>double.ExpM1</c> and <c>double.LogP1</c> are worse than that: they are
+/// literally <c>Exp(x) - 1</c> and <c>Log(x + 1)</c>, which is exactly the cancellation both
+/// functions exist to avoid. Porting fdlibm makes the answer identical on every target framework and
+/// every operating system, which is what a conformance suite requires.
+/// </para>
+/// </summary>
+internal static class Fdlibm
+{
+    // 0x3FE62E42FEFA39EF
+    private const double Ln2 = 6.93147180559945286227e-01;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int HighWord(double x) => (int) (BitConverter.DoubleToInt64Bits(x) >> 32);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static uint LowWord(double x) => (uint) BitConverter.DoubleToInt64Bits(x);
+
+    /// <summary>Replaces the high 32 bits of <paramref name="x"/>, keeping the low 32.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static double SetHighWord(double x, uint high)
+        => BitConverter.Int64BitsToDouble((long) high << 32 | (uint) BitConverter.DoubleToInt64Bits(x));
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static double FromWords(uint high, uint low)
+        => BitConverter.Int64BitsToDouble((long) high << 32 | low);
+
+    private const double Two54 = 1.80143985094819840000e+16; // 0x4350000000000000
+
+    // The log/log1p minimax polynomial; msun spells these Lg1..Lg7 in e_log.c and Lp1..Lp7 in
+    // s_log1p.c, with identical values.
+    private const double Lg1 = 6.666666666666735130e-01; // 0x3FE5555555555593
+    private const double Lg2 = 3.999999999940941908e-01; // 0x3FD999999997FA04
+    private const double Lg3 = 2.857142874366239149e-01; // 0x3FD2492494229359
+    private const double Lg4 = 2.222219843214978396e-01; // 0x3FCC71C51D8E78AF
+    private const double Lg5 = 1.818357216161805012e-01; // 0x3FC7466496CB03DE
+    private const double Lg6 = 1.531383769920937332e-01; // 0x3FC39A09D078C69F
+    private const double Lg7 = 1.479819860511658591e-01; // 0x3FC2F112DF3E5244
+
+    /// <summary>
+    /// log(x), ported from msun's <c>e_log.c</c>.
+    /// <para>
+    /// This is <b>not</b> what <c>Math.log</c> is implemented with — that stays on the BCL. It
+    /// exists because <see cref="Acosh"/> and <see cref="Asinh"/> reduce their large-argument cases
+    /// to a natural logarithm, and a platform <c>log</c> that is 1 ULP off in the wrong direction
+    /// takes the composed result 2 ULP off its reference value. Measured against the test262
+    /// <c>staging/sm/Math</c> tables, 15 of the 695 acosh/asinh assertions that reach a logarithm
+    /// fail somewhere inside a ±1 ULP envelope around a correctly rounded <c>log</c>, which is
+    /// precisely the latitude a libm has. Keeping the logarithm in-tree is what makes those two
+    /// functions answer identically on every operating system.
+    /// </para>
+    /// </summary>
+    internal static double Log(double x)
+    {
+        var hx = HighWord(x);
+        var lx = LowWord(x);
+
+        var k = 0;
+        if (hx < 0x00100000)
+        {
+            // x < 2**-1022
+            if (((hx & 0x7fffffff) | (int) lx) == 0)
+            {
+                return double.NegativeInfinity; // log(+-0) = -inf
+            }
+
+            if (hx < 0)
+            {
+                return double.NaN; // log(-#) = NaN
+            }
+
+            k -= 54;
+            x *= Two54; // subnormal number, scale up x
+            hx = HighWord(x);
+        }
+
+        if (hx >= 0x7ff00000)
+        {
+            return x + x;
+        }
+
+        k += (hx >> 20) - 1023;
+        hx &= 0x000fffff;
+        var i = (hx + 0x95f64) & 0x100000;
+        x = SetHighWord(x, (uint) (hx | (i ^ 0x3ff00000))); // normalize x or x/2
+        k += i >> 20;
+        var f = x - 1.0;
+
+        double dk;
+        if ((0x000fffff & (2 + hx)) < 3)
+        {
+            // -2**-20 <= f < 2**-20
+            if (f == 0.0)
+            {
+                if (k == 0)
+                {
+                    return 0.0;
+                }
+
+                dk = k;
+                return dk * Ln2Hi + dk * Ln2Lo;
+            }
+
+            var r0 = f * f * (0.5 - 0.33333333333333333 * f);
+            if (k == 0)
+            {
+                return f - r0;
+            }
+
+            dk = k;
+            return dk * Ln2Hi - ((r0 - dk * Ln2Lo) - f);
+        }
+
+        var s = f / (2.0 + f);
+        dk = k;
+        var z = s * s;
+        i = hx - 0x6147a;
+        var w = z * z;
+        var j = 0x6b851 - hx;
+        var t1 = w * (Lg2 + w * (Lg4 + w * Lg6));
+        var t2 = z * (Lg1 + w * (Lg3 + w * (Lg5 + w * Lg7)));
+        i |= j;
+        var r = t2 + t1;
+
+        if (i > 0)
+        {
+            var hfsq = 0.5 * f * f;
+            if (k == 0)
+            {
+                return f - (hfsq - s * (hfsq + r));
+            }
+
+            return dk * Ln2Hi - ((hfsq - (s * (hfsq + r) + dk * Ln2Lo)) - f);
+        }
+
+        if (k == 0)
+        {
+            return f - s * (f - r);
+        }
+
+        return dk * Ln2Hi - ((s * (f - r) - dk * Ln2Lo) - f);
+    }
+
+    /// <summary>
+    /// acosh(x), ported from msun's <c>e_acosh.c</c>.
+    /// <code>
+    ///   acosh(x) := log(x)+ln2,                       if x is large; else
+    ///   acosh(x) := log(2x-1/(sqrt(x*x-1)+x))         if x>2; else
+    ///   acosh(x) := log1p(t+sqrt(2.0*t+t*t))          where t=x-1.
+    /// </code>
+    /// Every ECMA-262 21.3.2.3 special case falls out of the branches below: NaN and x&lt;1 (which
+    /// includes ±0 and every negative) give NaN, +∞ gives +∞, and 1 gives +0.
+    /// </summary>
+    internal static double Acosh(double x)
+    {
+        var hx = HighWord(x);
+        var lx = LowWord(x);
+
+        if (hx < 0x3ff00000)
+        {
+            // x < 1 (a signed comparison, so this also catches every negative and NaN with the
+            // sign bit set). fdlibm computes (x-x)/(x-x) to raise invalid; .NET has no flag to
+            // raise, and the value is NaN either way.
+            return double.NaN;
+        }
+
+        if (hx >= 0x41b00000)
+        {
+            // x > 2**28
+            if (hx >= 0x7ff00000)
+            {
+                return x + x; // x is +inf or NaN
+            }
+
+            return Log(x) + Ln2; // acosh(huge)=log(2x)
+        }
+
+        if (((hx - 0x3ff00000) | (int) lx) == 0)
+        {
+            return 0.0; // acosh(1) = 0
+        }
+
+        if (hx > 0x40000000)
+        {
+            // 2**28 > x > 2
+            var t = x * x;
+            return Log(2.0 * x - 1.0 / (x + System.Math.Sqrt(t - 1.0)));
+        }
+
+        // 1 < x < 2
+        var u = x - 1.0;
+        return Log1p(u + System.Math.Sqrt(2.0 * u + u * u));
+    }
+
+    /// <summary>
+    /// asinh(x), ported from msun's <c>s_asinh.c</c>.
+    /// <code>
+    ///   asinh(x) := x                                              if 1+x*x=1,
+    ///            := sign(x)*(log(x)+ln2)                           for large |x|, else
+    ///            := sign(x)*log(2|x|+1/(|x|+sqrt(x*x+1)))          if |x|>2, else
+    ///            := sign(x)*log1p(|x| + x^2/(1 + sqrt(1+x^2)))
+    /// </code>
+    /// ECMA-262 21.3.2.5 returns x unchanged for NaN, ±∞ and ±0; the first two branches below do
+    /// exactly that.
+    /// </summary>
+    internal static double Asinh(double x)
+    {
+        var hx = HighWord(x);
+        var ix = hx & 0x7fffffff;
+
+        if (ix >= 0x7ff00000)
+        {
+            return x + x; // x is inf or NaN
+        }
+
+        if (ix < 0x3e300000)
+        {
+            // |x| < 2**-28. fdlibm guards this with (huge+x>one), which only exists to raise
+            // inexact; the value returned is x, sign of zero included.
+            return x;
+        }
+
+        double w;
+        if (ix > 0x41b00000)
+        {
+            // |x| > 2**28
+            w = Log(System.Math.Abs(x)) + Ln2;
+        }
+        else if (ix > 0x40000000)
+        {
+            // 2**28 > |x| > 2.0
+            var t = System.Math.Abs(x);
+            w = Log(2.0 * t + 1.0 / (System.Math.Sqrt(x * x + 1.0) + t));
+        }
+        else
+        {
+            // 2.0 > |x| > 2**-28
+            var t = x * x;
+            w = Log1p(System.Math.Abs(x) + t / (1.0 + System.Math.Sqrt(1.0 + t)));
+        }
+
+        return hx > 0 ? w : -w;
+    }
+
+    /// <summary>
+    /// atanh(x), ported from msun's <c>e_atanh.c</c>.
+    /// <code>
+    ///   for x &gt;= 0.5   atanh(x) = 0.5 * log1p(2 * x/(1-x))
+    ///   for x &lt;  0.5   atanh(x) = 0.5 * log1p(2x + 2x*x/(1-x))
+    /// </code>
+    /// ECMA-262 21.3.2.7 wants NaN for NaN and for |x|&gt;1, ±∞ for ±1 and x itself for ±0; the
+    /// three leading branches cover all four.
+    /// </summary>
+    internal static double Atanh(double x)
+    {
+        var hx = HighWord(x);
+        var lx = LowWord(x);
+        var ix = hx & 0x7fffffff;
+
+        // |x| > 1, which also catches NaN. fdlibm writes this as
+        // (ix|((lx|(-lx))>>31)) > 0x3ff00000 to fold the "low word non-zero" test into the
+        // comparison; spelled out, it is the same predicate.
+        if (ix > 0x3ff00000 || (ix == 0x3ff00000 && lx != 0))
+        {
+            return double.NaN;
+        }
+
+        if (ix == 0x3ff00000)
+        {
+            return x / 0.0; // atanh(+-1) = +-inf
+        }
+
+        if (ix < 0x3e300000)
+        {
+            // |x| < 2**-28, again only guarded in C to raise inexact.
+            return x;
+        }
+
+        x = SetHighWord(x, (uint) ix); // x = |x|
+
+        double t;
+        if (ix < 0x3fe00000)
+        {
+            // x < 0.5
+            t = x + x;
+            t = 0.5 * Log1p(t + t * x / (1.0 - x));
+        }
+        else
+        {
+            t = 0.5 * Log1p((x + x) / (1.0 - x));
+        }
+
+        return hx >= 0 ? t : -t;
+    }
+
+    // B1 = (1023-1023/3-0.03306235651)*2**20
+    private const uint CbrtB1 = 715094163;
+
+    // B2 = (1023-1023/3-54/3-0.03306235651)*2**20
+    private const uint CbrtB2 = 696219795;
+
+    // |1/cbrt(x) - p(x)| < 2**-23.5 (~[-7.93e-8, 7.929e-8]).
+    private const double CbrtP0 = 1.87595182427177009643;   // 0x3ffe03e60f61e692
+    private const double CbrtP1 = -1.88497979543377169875;  // 0xbffe28e092f02420
+    private const double CbrtP2 = 1.621429720105354466140;  // 0x3ff9f1604a49d6c2
+    private const double CbrtP3 = -0.758397934778766047437; // 0xbfe844cbbee751d9
+    private const double CbrtP4 = 0.145996192886612446982;  // 0x3fc2b000d4e4edd7
+
+    /// <summary>
+    /// cbrt(x), ported from msun's <c>s_cbrt.c</c>: a 5-bit estimate straight out of the exponent
+    /// bits, a degree-4 polynomial taking it to 23 bits, then one Halley step to 53 bits with an
+    /// error below 0.667 ULP.
+    /// <para>
+    /// ECMA-262 21.3.2.9 returns x unchanged for NaN, ±∞ and ±0, which is what the two leading
+    /// branches do.
+    /// </para>
+    /// </summary>
+    internal static double Cbrt(double x)
+    {
+        var hx = HighWord(x);
+        var low = LowWord(x);
+        var sign = (uint) hx & 0x80000000;
+        hx ^= (int) sign;
+
+        if (hx >= 0x7ff00000)
+        {
+            return x + x; // cbrt(NaN,INF) is itself
+        }
+
+        // Rough cbrt to 5 bits:
+        //    cbrt(2**e*(1+m) ~= 2**(e/3)*(1+(e%3+m)/3)
+        // where e is integral and >= 0, m is real and in [0, 1), and "/" and "%" are integer
+        // division and modulus with rounding towards minus infinity. The RHS is always >= the LHS
+        // and has a maximum relative error of about 1 in 16. Adding a bias of -0.03306235651 to the
+        // (e%3+m)/3 term reduces the error to about 1 in 32. With the IEEE floating point
+        // representation, for finite positive normal values, ordinary integer division of the value
+        // in bits magically gives almost exactly the RHS of the above provided we first subtract the
+        // exponent bias (1023 for doubles) and later add it back. We do the subtraction virtually to
+        // keep e >= 0 so that ordinary integer division rounds towards minus infinity; this is also
+        // efficient.
+        double t;
+        if (hx < 0x00100000)
+        {
+            // zero or subnormal?
+            if ((hx | (int) low) == 0)
+            {
+                return x; // cbrt(0) is itself
+            }
+
+            t = FromWords(0x43500000, 0) * x; // t = 2**54 * x
+            var high = (uint) HighWord(t);
+            t = FromWords(sign | ((high & 0x7fffffff) / 3 + CbrtB2), 0);
+        }
+        else
+        {
+            t = FromWords(sign | ((uint) (hx / 3) + CbrtB1), 0);
+        }
+
+        // New cbrt to 23 bits:
+        //    cbrt(x) = t*cbrt(x/t**3) ~= t*P(t**3/x)
+        // where P(r) is a polynomial of degree 4 that approximates 1/cbrt(r) to within 2**-23.5 when
+        // |r - 1| < 1/10. The rough approximation has produced t such than |t/cbrt(x) - 1| ~< 1/32,
+        // and cubing this gives us bounds for r = t**3/x.
+        var r = t * t * (t / x);
+        t = t * ((CbrtP0 + r * (CbrtP1 + r * CbrtP2)) + ((r * r) * r) * (CbrtP3 + r * CbrtP4));
+
+        // Round t away from zero to 23 bits (sloppily except for ensuring that the result is larger
+        // in magnitude than cbrt(x) but not much more than 2 23-bit ulps larger).
+        t = BitConverter.Int64BitsToDouble(
+            (long) (((ulong) BitConverter.DoubleToInt64Bits(t) + 0x80000000UL) & 0xffffffffc0000000UL));
+
+        // one step Halley iteration to 53 bits with error < 0.667 ulps
+        var s = t * t;    // t*t is exact
+        r = x / s;        // error <= 0.5 ulps; |r| < |t|
+        var w = t + t;    // t+t is exact
+        r = (r - t) / (w + r); // r-t is exact; w+r ~= 3*t
+        t = t + t * r;    // error <= (0.5 + 0.5/3) * ulp
+
+        return t;
+    }
+
+    private const double Expm1OverflowThreshold = 7.09782712893383973096e+02; // 0x40862E42FEFA39EF
+    private const double Ln2Hi = 6.93147180369123816490e-01;                  // 0x3fe62e42fee00000
+    private const double Ln2Lo = 1.90821492927058770002e-10;                  // 0x3dea39ef35793c76
+    private const double InvLn2 = 1.44269504088896338700e+00;                 // 0x3ff71547652b82fe
+
+    // Scaled Q's: Qn_here = 2**n * Qn_above, for R(2*z) where z = hxs = x*x/2:
+    private const double ExpQ1 = -3.33333333333331316428e-02; // 0xBFA11111111110F4
+    private const double ExpQ2 = 1.58730158725481460165e-03;  // 0x3F5A01A019FE5585
+    private const double ExpQ3 = -7.93650757867487942473e-05; // 0xBF14CE199EAADBB7
+    private const double ExpQ4 = 4.00821782732936239552e-06;  // 0x3ED0CFCA86E65239
+    private const double ExpQ5 = -2.01099218183624371326e-07; // 0xBE8AFDB76E09C32D
+
+    /// <summary>
+    /// expm1(x) = exp(x)-1, ported from msun's <c>s_expm1.c</c>. Argument reduction
+    /// x = k*ln2 + r with |r| &lt;= 0.5*ln2, a degree-5 minimax rational in r*r, then a scale back
+    /// by 2^k chosen per k so that the "-1" never cancels the significant digits away. Accurate to
+    /// under 1 ULP, which is what ECMA-262 21.3.2.14's "computed in a way that is accurate even when
+    /// the value of x is close to 0" asks for.
+    /// <para>
+    /// The special cases 21.3.2.14 lists — NaN, ±0 and +∞ returning x, -∞ returning -1 — are all
+    /// produced by the filter at the top.
+    /// </para>
+    /// </summary>
+    internal static double Expm1(double x)
+    {
+        var hx = (uint) HighWord(x);
+        var xsb = hx & 0x80000000; // sign bit of x
+        hx &= 0x7fffffff;          // high word of |x|
+
+        // filter out huge and non-finite argument
+        if (hx >= 0x4043687A)
+        {
+            // |x| >= 56*ln2
+            if (hx >= 0x40862E42)
+            {
+                // |x| >= 709.78...
+                if (hx >= 0x7ff00000)
+                {
+                    var low = LowWord(x);
+                    if (((hx & 0xfffff) | low) != 0)
+                    {
+                        return x + x; // NaN
+                    }
+
+                    return xsb == 0 ? x : -1.0; // expm1(+-inf) = {inf,-1}
+                }
+
+                if (x > Expm1OverflowThreshold)
+                {
+                    return double.PositiveInfinity; // overflow
+                }
+            }
+
+            if (xsb != 0)
+            {
+                // x < -56*ln2; fdlibm returns tiny-one, which is exactly -1.
+                return -1.0;
+            }
+        }
+
+        // argument reduction
+        int k;
+        double c = 0.0;
+        if (hx > 0x3fd62e42)
+        {
+            double hi, lo;
+            if (hx < 0x3FF0A2B2)
+            {
+                // 0.5 ln2 < |x| < 1.5 ln2
+                if (xsb == 0)
+                {
+                    hi = x - Ln2Hi;
+                    lo = Ln2Lo;
+                    k = 1;
+                }
+                else
+                {
+                    hi = x + Ln2Hi;
+                    lo = -Ln2Lo;
+                    k = -1;
+                }
+            }
+            else
+            {
+                k = (int) (InvLn2 * x + (xsb == 0 ? 0.5 : -0.5));
+                double t0 = k;
+                hi = x - t0 * Ln2Hi; // t*ln2_hi is exact here
+                lo = t0 * Ln2Lo;
+            }
+
+            x = hi - lo;
+            c = (hi - x) - lo;
+        }
+        else if (hx < 0x3c900000)
+        {
+            // |x| < 2**-54: fdlibm returns x - (t-(huge+x)), an identity whose only purpose is to
+            // raise inexact. The value is x, sign of zero included.
+            return x;
+        }
+        else
+        {
+            k = 0;
+        }
+
+        // x is now in primary range
+        var hfx = 0.5 * x;
+        var hxs = x * hfx;
+        var r1 = 1.0 + hxs * (ExpQ1 + hxs * (ExpQ2 + hxs * (ExpQ3 + hxs * (ExpQ4 + hxs * ExpQ5))));
+        var t = 3.0 - r1 * hfx;
+        var e = hxs * ((r1 - t) / (6.0 - x * t));
+
+        if (k == 0)
+        {
+            return x - (x * e - hxs); // c is 0
+        }
+
+        var twopk = FromWords((uint) (0x3ff + k) << 20, 0); // 2^k
+        e = x * (e - c) - c;
+        e -= hxs;
+
+        if (k == -1)
+        {
+            return 0.5 * (x - e) - 0.5;
+        }
+
+        if (k == 1)
+        {
+            if (x < -0.25)
+            {
+                return -2.0 * (e - (x + 0.5));
+            }
+
+            return 1.0 + 2.0 * (x - e);
+        }
+
+        double y;
+        if (k <= -2 || k > 56)
+        {
+            // suffice to return exp(x)-1
+            y = 1.0 - (e - x);
+            if (k == 1024)
+            {
+                y = y * 2.0 * 8.98846567431158e+307; // 0x1p1023
+            }
+            else
+            {
+                y = y * twopk;
+            }
+
+            return y - 1.0;
+        }
+
+        t = 1.0;
+        if (k < 20)
+        {
+            t = SetHighWord(t, (uint) (0x3ff00000 - (0x200000 >> k))); // t = 1-2^-k
+            y = t - (e - x);
+            y = y * twopk;
+        }
+        else
+        {
+            t = SetHighWord(t, (uint) ((0x3ff - k) << 20)); // t = 2^-k
+            y = x - (e + t);
+            y += 1.0;
+            y = y * twopk;
+        }
+
+        return y;
+    }
+
+    /// <summary>
+    /// log1p(x) = log(1+x), ported from msun's <c>s_log1p.c</c>. 1+x is formed with an explicit
+    /// correction term c so that the leading digits x carries are not lost, then log is evaluated by
+    /// the usual argument reduction and odd-polynomial approximation. This is what makes
+    /// ECMA-262 21.3.2.21's "accurate even when the value of x is close to 0" true — log1p(1e-300)
+    /// is 1e-300, not 0.
+    /// <para>
+    /// The listed special cases — NaN, ±0 and +∞ returning x, -1 returning -∞, x&lt;-1 returning
+    /// NaN — all come out of the branches below.
+    /// </para>
+    /// </summary>
+    internal static double Log1p(double x)
+    {
+        var hx = HighWord(x);
+        var ax = hx & 0x7fffffff;
+
+        var k = 1;
+        var f = 0.0;
+        var hu = 0;
+        var c = 0.0;
+
+        if (hx < 0x3FDA827A)
+        {
+            // 1+x < sqrt(2)+
+            if (ax >= 0x3ff00000)
+            {
+                // x <= -1.0
+                if (x == -1.0)
+                {
+                    return double.NegativeInfinity; // fdlibm: -two54/vzero
+                }
+
+                return double.NaN; // log1p(x<-1) = NaN
+            }
+
+            if (ax < 0x3e200000)
+            {
+                // |x| < 2**-29
+                if (ax < 0x3c900000)
+                {
+                    // |x| < 2**-54 (the C guard two54+x>zero only raises inexact)
+                    return x;
+                }
+
+                return x - x * x * 0.5;
+            }
+
+            if (hx > 0 || hx <= unchecked((int) 0xbfd2bec4))
+            {
+                // sqrt(2)/2- <= 1+x < sqrt(2)+
+                k = 0;
+                f = x;
+                hu = 1;
+            }
+        }
+
+        if (hx >= 0x7ff00000)
+        {
+            return x + x;
+        }
+
+        if (k != 0)
+        {
+            double u;
+            if (hx < 0x43400000)
+            {
+                u = 1.0 + x;
+                hu = HighWord(u);
+                k = (hu >> 20) - 1023;
+                c = k > 0 ? 1.0 - (u - x) : x - (u - 1.0); // correction term
+                c /= u;
+            }
+            else
+            {
+                u = x;
+                hu = HighWord(u);
+                k = (hu >> 20) - 1023;
+                c = 0;
+            }
+
+            hu &= 0x000fffff;
+
+            // The approximation to sqrt(2) used in thresholds is not critical. However, the ones
+            // used above must give less strict bounds than the one here so that the k==0 case is
+            // never reached from here, since here we have committed to using the correction term but
+            // don't use it if k==0.
+            if (hu < 0x6a09e)
+            {
+                u = SetHighWord(u, (uint) (hu | 0x3ff00000)); // normalize u
+            }
+            else
+            {
+                k += 1;
+                u = SetHighWord(u, (uint) (hu | 0x3fe00000)); // normalize u/2
+                hu = (0x00100000 - hu) >> 2;
+            }
+
+            f = u - 1.0;
+        }
+
+        var hfsq = 0.5 * f * f;
+        if (hu == 0)
+        {
+            // |f| < 2**-20
+            if (f == 0.0)
+            {
+                if (k == 0)
+                {
+                    return 0.0;
+                }
+
+                c += k * Ln2Lo;
+                return k * Ln2Hi + c;
+            }
+
+            var r0 = hfsq * (1.0 - 0.66666666666666666 * f);
+            if (k == 0)
+            {
+                return f - r0;
+            }
+
+            return k * Ln2Hi - ((r0 - (k * Ln2Lo + c)) - f);
+        }
+
+        var s = f / (2.0 + f);
+        var z = s * s;
+        var r = z * (Lg1 + z * (Lg2 + z * (Lg3 + z * (Lg4 + z * (Lg5 + z * (Lg6 + z * Lg7))))));
+
+        if (k == 0)
+        {
+            return f - (hfsq - s * (hfsq + r));
+        }
+
+        return k * Ln2Hi - ((hfsq - (s * (hfsq + r) + (k * Ln2Lo + c))) - f);
+    }
+}

--- a/Jint/Native/Math/MathInstance.cs
+++ b/Jint/Native/Math/MathInstance.cs
@@ -70,16 +70,14 @@ internal sealed partial class MathInstance : BuiltinShapeObject
         return System.Math.Acos(x);
     }
 
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-math.acosh
+    /// </summary>
+    // The whole special-case table (NaN and x < 1 give NaN, 1 gives +0, +inf gives +inf) is
+    // decided inside the fdlibm port, so guarding for it again here would only be a second copy of
+    // the same branches. See Fdlibm.Acosh.
     [JsFunction]
-    private static JsValue Acosh(JsValue thisObject, [ToNumber] double x)
-    {
-        if (double.IsNaN(x) || x < 1)
-        {
-            return JsNumber.DoubleNaN;
-        }
-
-        return System.Math.Log(x + System.Math.Sqrt(x * x - 1.0));
-    }
+    private static JsValue Acosh(JsValue thisObject, [ToNumber] double x) => Fdlibm.Acosh(x);
 
     [JsFunction(FastCall = true, Leaf = true)]
     private static JsValue Asin(JsValue thisObject, [ToNumber] double x)
@@ -96,16 +94,12 @@ internal sealed partial class MathInstance : BuiltinShapeObject
         return System.Math.Asin(x);
     }
 
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-math.asinh
+    /// </summary>
+    // NaN, +-inf and +-0 all return the argument unchanged, which the fdlibm port already does.
     [JsFunction]
-    private static JsValue Asinh(JsValue thisObject, [ToNumber] double x)
-    {
-        if (double.IsInfinity(x) || NumberInstance.IsPositiveZero(x) || NumberInstance.IsNegativeZero(x))
-        {
-            return x;
-        }
-
-        return System.Math.Log(x + System.Math.Sqrt(x * x + 1.0));
-    }
+    private static JsValue Asinh(JsValue thisObject, [ToNumber] double x) => Fdlibm.Asinh(x);
 
     [JsFunction(FastCall = true, Leaf = true)]
     private static JsValue Atan(JsValue thisObject, [ToNumber] double x)
@@ -129,21 +123,16 @@ internal sealed partial class MathInstance : BuiltinShapeObject
 
         return System.Math.Atan(x);
     }
+
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-math.atanh
+    /// </summary>
+    // NaN and +-0 return the argument, +-1 return +-inf and |x| > 1 returns NaN; the fdlibm port
+    // decides all four up front rather than leaving them to fall out of the arithmetic. The
+    // accuracy is what changed: 0.5*Log((1+x)/(1-x)) cancels for small x, so every argument below
+    // 2**-53 came back as zero, and even Math.atanh(0.5) was a ULP out.
     [JsFunction]
-    private static JsValue Atanh(JsValue thisObject, [ToNumber] double x)
-    {
-        if (double.IsNaN(x))
-        {
-            return JsNumber.DoubleNaN;
-        }
-
-        if (NumberInstance.IsPositiveZero(x) || NumberInstance.IsNegativeZero(x))
-        {
-            return x;
-        }
-
-        return 0.5 * System.Math.Log((1.0 + x) / (1.0 - x));
-    }
+    private static JsValue Atanh(JsValue thisObject, [ToNumber] double x) => Fdlibm.Atanh(x);
 
     [JsFunction]
     private static JsValue Atan2(JsValue thisObject, [ToNumber] double y, [ToNumber] double x)
@@ -394,20 +383,14 @@ internal sealed partial class MathInstance : BuiltinShapeObject
         return System.Math.Exp(x);
     }
 
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-math.expm1
+    /// </summary>
+    // "The result is computed in a way that is accurate even when the value of x is close to 0",
+    // which Exp(x) - 1.0 is not: everything below 2**-53 cancelled away to zero. The fdlibm port
+    // also produces the special cases (NaN, +-0 and +inf return x; -inf returns -1).
     [JsFunction]
-    private static JsNumber Expm1(JsValue thisObject, [ToNumber] double x)
-    {
-        if (double.IsNaN(x) || NumberInstance.IsPositiveZero(x) || NumberInstance.IsNegativeZero(x) || double.IsPositiveInfinity(x))
-        {
-            return JsNumber.Create(x);
-        }
-        if (double.IsNegativeInfinity(x))
-        {
-            return JsNumber.DoubleNegativeOne;
-        }
-
-        return JsNumber.Create(System.Math.Exp(x) - 1.0);
-    }
+    private static JsNumber Expm1(JsValue thisObject, [ToNumber] double x) => JsNumber.Create(Fdlibm.Expm1(x));
 
     [JsFunction(FastCall = true, Leaf = true)]
     private static JsValue Floor(JsValue thisObject, [ToNumber] double x)
@@ -463,31 +446,14 @@ internal sealed partial class MathInstance : BuiltinShapeObject
         return System.Math.Log(x);
     }
 
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-math.log1p
+    /// </summary>
+    // Same normative "accurate even when the value of x is close to 0" as expm1, and Log(1 + x) was
+    // just as far from honouring it: 1 + 1e-300 is 1, and 1 + 1e-15 loses a tenth of its digits.
+    // NaN, +-0 and +inf return x, -1 returns -inf, x < -1 returns NaN, all inside the port.
     [JsFunction(FastCall = true, Leaf = true)]
-    private static JsValue Log1p(JsValue thisObject, [ToNumber] double x)
-    {
-        if (double.IsNaN(x))
-        {
-            return JsNumber.DoubleNaN;
-        }
-
-        if (x < -1)
-        {
-            return JsNumber.DoubleNaN;
-        }
-
-        if (x == -1)
-        {
-            return JsNumber.DoubleNegativeInfinity;
-        }
-
-        if (x == 0 || double.IsPositiveInfinity(x))
-        {
-            return JsNumber.Create(x);
-        }
-
-        return System.Math.Log(1 + x);
-    }
+    private static JsValue Log1p(JsValue thisObject, [ToNumber] double x) => Fdlibm.Log1p(x);
 
     [JsFunction(FastCall = true, Leaf = true)]
     private static JsValue Log2(JsValue thisObject, [ToNumber] double x)
@@ -959,33 +925,14 @@ internal sealed partial class MathInstance : BuiltinShapeObject
         return System.Math.Sign(x);
     }
 
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-math.cbrt
+    /// </summary>
+    // Pow(|x|, 1.0/3.0) is not a cube root: 1/3 is not representable, so the exponent is already
+    // wrong before Pow starts, and Math.cbrt(1e-300) came out ~58 ULP high. NaN, +-inf and +-0
+    // return the argument, which the fdlibm port does itself.
     [JsFunction(FastCall = true, Leaf = true)]
-    private static JsValue Cbrt(JsValue thisObject, [ToNumber] double x)
-    {
-        if (double.IsNaN(x))
-        {
-            return JsNumber.DoubleNaN;
-        }
-        else if (NumberInstance.IsPositiveZero(x) || NumberInstance.IsNegativeZero(x))
-        {
-            return x;
-        }
-        else if (double.IsPositiveInfinity(x))
-        {
-            return JsNumber.DoublePositiveInfinity;
-        }
-        else if (double.IsNegativeInfinity(x))
-        {
-            return JsNumber.DoubleNegativeInfinity;
-        }
-
-        if (System.Math.Sign(x) >= 0)
-        {
-            return System.Math.Pow(x, 1.0 / 3.0);
-        }
-
-        return -1 * System.Math.Pow(System.Math.Abs(x), 1.0 / 3.0);
-    }
+    private static JsValue Cbrt(JsValue thisObject, [ToNumber] double x) => Fdlibm.Cbrt(x);
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-math.hypot


### PR DESCRIPTION
The exclusion comment for these six said "Jint delegates to the BCL, whose acosh/asinh/atanh/cbrt/expm1/log1p differ from the reference values in the last few ULPs". **Jint calls the BCL for none of them.** It open-coded the naive identities, and they do not lose a few ULPs — they lose everything:

```js
Math.acosh(1e300)   // Infinity                 correct: 691.4686750787736   (x*x overflows)
Math.asinh(1e300)   // Infinity                 correct: 691.4686750787736
Math.asinh(1e-300)  // 0                        correct: 1e-300
Math.atanh(1e-300)  // 0                        correct: 1e-300
Math.expm1(1e-300)  // 0                        correct: 1e-300
Math.log1p(1e-300)  // 0                        correct: 1e-300
Math.log1p(1e-15)   // 1.110223024625156e-15    correct: 9.999999999999995e-16   (11% out)
Math.cbrt(1e-300)   // 1.0000000000000128e-100  correct: 1e-100                  (~58 ULP)
```

`Infinity` is not an approximation of 691.47, and zero significant digits is not within the "implementation-approximated" latitude of [21.3.2](https://tc39.es/ecma262/#sec-math-object). Two are against **normative prose**: [`Math.expm1`](https://tc39.es/ecma262/#sec-math.expm1) and [`Math.log1p`](https://tc39.es/ecma262/#sec-math.log1p) both require the result to be "accurate even when the value of x is close to 0".

## The fix

A C# port of FreeBSD msun's `e_acosh.c`, `s_asinh.c`, `e_atanh.c`, `s_cbrt.c`, `s_expm1.c`, `s_log1p.c` — which 21.3.2 recommends **by name** — in a new internal `Jint/Native/Math/Fdlibm.cs`. The Sun/SunPro notice is preserved verbatim and each source file's upstream revision is recorded. Only the word-access idioms are rewritten (`BitConverter` in place of a C union); the C tricks that exist solely to raise the IEEE inexact flag are dropped, since .NET exposes no status word, and every such deviation is annotated at its site. No `#if`, no `unsafe`, no allocation — one implementation for all five target frameworks.

### Why seven files, not six

`e_log.c` is included, and this is load-bearing rather than gold-plating. `acosh` and `asinh` reduce their large-argument cases to a natural logarithm, so leaving `System.Math.Log` on the path reintroduces exactly the platform dependence the port exists to remove. Perturbing `log` by ±1 ULP — the latitude any libm is entitled to — makes **15 of the 695** acosh/asinh assertions fail; `asinh(1e300)` lands 2 ULP from its reference against a tolerance of 1. `Fdlibm.Log` is internal and used only by those two; `Math.log` itself is untouched. The only BCL calls left are `Math.Sqrt` and `Math.Abs`, both bit-exact by IEEE mandate.

This is also why the BCL route was rejected wholesale: `System.Math.Acosh/Asinh/Atanh/Cbrt` resolve to the platform libm, the `asinh` table has **zero** ULP of margin across 407 assertions, and CI runs four operating systems. (`double.ExpM1` and `double.LogP1` are literally `Exp(x)-1` and `Log(x+1)`, so the BCL offers nothing for those two anyway.)

## Verification

- **389,914 inputs** — uniform random 64-bit patterns across every exponent, sign, subnormal and out-of-domain value, plus dense sampling of each branch threshold — run through both a `net10.0` and a `net472` build: **byte-for-byte identical**.
- **2,905** sampled results checked against 900-digit decimal references: never more than **1 ULP** from correctly rounded, zero spec-case mismatches.
- fdlibm decides every special case itself, so the guards in `MathInstance` were removed rather than kept as a second copy; all six `staging/sm/Math/*-exact.js` files (the spec tables) run clean.
- `Cbrt` and `Log1p` keep `FastCall`/`Leaf` — the port is pure arithmetic and cannot raise a JS error or re-enter the interpreter.

## Tests

`Jint.Tests/Runtime/MathFdlibmTests.cs` — 333 exact-bit-pattern assertions, **126 failing** against unfixed code, drawn from the test262 tables plus every spec special case and round-trip. Passing on both TFMs, which is a second independent equality proof through the real engine.

test262: **102,338 passed, 0 failed** (+12; six files × two modes).

One correction to the issue text: `Math.acosh(1e300)` is now `691.4686750787736`, not `691.4686750787737`. That is fdlibm's answer — 1 ULP below correctly rounded, well inside the test's own tolerance of 9 — and it is what V8 and SpiderMonkey return, since they ship this same code.

Frees all six `staging/sm/Math/*-approx.js`; the block and its banner are deleted.

Refs #3021.
