### PR TITLE
Sanitize host and module failures

### DIFF
--- a/.github/THREAT_MODEL.md
+++ b/.github/THREAT_MODEL.md
@@ -97,6 +97,8 @@ Defaults are compatibility choices, not a hardened profile.
 | `Atomics.wait` suspension | Enabled | Script may block the engine thread, including indefinitely |
 | Debugger | Disabled | Debug callbacks and debugger expressions are inactive |
 | Detailed CLR resolution errors | Disabled | Reduces script-visible CLR surface disclosure |
+| Detailed caught CLR exception messages | Disabled | Replaces host exception text with a generic script-visible error |
+| Detailed module load errors | Disabled | Hides loader messages, canonical paths, URLs, and parse source names from script |
 | Function source retention | Disabled | Submitted function source is not retained solely for `toString()` |
 | Result conversion and JSON output limits | Unlimited | Compatibility default; hostile output is unbounded unless the host opts in |
 
@@ -411,6 +413,9 @@ traces, and `import.meta.url` can disclose paths, hostnames, queries, or credent
 - `IModuleLoadPolicy` can inspect every final resolved target. `ModuleAllowlistPolicy`
   provides composable scheme, exact-host, exact-origin, canonical-file-root, and bare-
   specifier controls.
+- Loader exceptions and module parse locations are redacted from script by default. The
+  original exception remains available to the host through
+  `JintException.TryGetClrException`.
 
 **Missing or residual mitigation.**
 
@@ -426,12 +431,19 @@ traces, and `import.meta.url` can disclose paths, hostnames, queries, or credent
 - File-root policy is lexical and does not resolve symbolic links or Windows reparse points;
   an allowed root containing attacker-controlled links can still escape the lexical root.
 - Base-path checking is not a replacement for filesystem permissions or an OS sandbox.
-- Async loader failures expose the supplied exception message to script.
+- A loader can deliberately bypass automatic redaction with
+  `ModuleLoadCompletion.SetError(string)`, an error decorator, or an explicit
+  `JavaScriptException` message.
+- `Module.Location`, `import.meta`, debugger/source metadata, and successful module values
+  are not anonymized. The host still controls those names and values.
+- `ExposeDetailedErrors()` or `Modules.ExposeDetailedLoadErrors = true` restores detailed
+  loader and source messages for trusted development environments.
 
 **Required host action.** Prefer host-registered modules. Otherwise configure all four graph
 limits and an `IModuleLoadPolicy`; also enforce resolved-IP, redirect, transport-size, and
-timeout policy inside the loader. Use a credential-free module identity, sanitize loader
-errors, and apply restrictive filesystem and network policy to the worker.
+timeout policy inside the loader. Use a credential-free module identity, report failures
+with `SetError(Exception)`, leave detailed load errors disabled, and apply restrictive
+filesystem and network policy to the worker.
 
 ### TM-12: Cross-request state leakage and prototype pollution
 
@@ -542,19 +554,32 @@ very large diagnostics.
 
 **Existing mitigations.**
 
-- Detailed CLR resolution errors and CLR inner-exception chaining are disabled by default.
+- Caught CLR exception messages, CLR method/constructor resolution details, module loader
+  failures, and module parse locations are redacted from script by default.
+- Original CLR and loader exceptions remain available host-side through
+  `JintException.TryGetClrException`; resolution type/member metadata remains available
+  through `TryGetClrType` and `TryGetClrMemberName`.
+- CLR inner-exception chaining is disabled by default.
 - `GetJavaScriptErrorString()` omits a chained CLR exception.
 - CLR exceptions are not catchable by script unless the host opts in.
 - Function source text retention is disabled by default.
 
 **Missing or residual mitigation.**
 
-- Loader error messages and host-provided source/module names can still be script-visible.
+- Explicit messages passed to `JavaScriptException` or
+  `ModuleLoadCompletion.SetError(string)`, decorator-added properties, successful module
+  values, and host-provided source/module names can still be script-visible.
+- `ExposeDetailedErrors()`, `Interop.ExposeDetailedExceptionMessages`,
+  `Interop.ExposeDetailedResolutionErrors`, `Modules.ExposeDetailedLoadErrors`, and
+  `ChainClrExceptions()` are development/diagnostic opt-ins that can expose host details
+  through their documented channels.
 - Host logging and HTTP response formatting are outside Jint.
 
 **Required host action.** Use opaque source and module identifiers, never put credentials in
-URLs, sanitize host errors, cap diagnostic size, encode log fields structurally, and return
-generic server errors while retaining sensitive details only in protected telemetry.
+URLs, leave detailed error options and CLR exception chaining disabled, use exception-based
+module failures rather than explicit strings, cap diagnostic size, encode log fields
+structurally, and return generic server errors while retaining sensitive details only in
+protected telemetry.
 
 ### TM-17: Result conversion and serialization denial of service
 
@@ -1150,6 +1175,9 @@ var engine = new Engine(options =>
     options.AllowClrWrite(false);
     options.Interop.ArrayConversion = ArrayConversionMode.Copy;
     options.ResultLimits = ResultLimits.Conservative;
+    options.Interop.ExposeDetailedExceptionMessages = false;
+    options.Interop.ExposeDetailedResolutionErrors = false;
+    options.Modules.ExposeDetailedLoadErrors = false;
 
     // Do not call AllowClr(). Leave modules and the debugger disabled.
 });

--- a/Jint.Tests.PublicInterface/AsyncModuleLoaderTests.cs
+++ b/Jint.Tests.PublicInterface/AsyncModuleLoaderTests.cs
@@ -271,7 +271,9 @@ public class AsyncModuleLoaderTests
         var engine = CreateEngine(loader);
 
         var ex = await Invoking(() => engine.Modules.ImportAsync("./main.js")).Should().ThrowAsync<PromiseRejectedException>();
-        ex.Which.RejectedValue.Get("message").AsString().Should().Contain("404 ./missing.js");
+        ex.Which.RejectedValue.Get("message").AsString().Should().Be("Could not load module.");
+        JintException.TryGetClrException(ex.Which, out var clrException).Should().BeTrue();
+        clrException.Should().BeOfType<FileNotFoundException>().Which.Message.Should().Contain("404 ./missing.js");
     }
 
     [Fact]
@@ -306,7 +308,7 @@ public class AsyncModuleLoaderTests
         loader.Fail("./gone.js", new HttpRequestExceptionStandIn("connection refused"));
         engine.Advanced.ProcessTasks();
 
-        engine.Evaluate("outcome").AsString().Should().Be("connection refused");
+        engine.Evaluate("outcome").AsString().Should().Be("Could not load module.");
     }
 
     [Fact]
@@ -457,7 +459,7 @@ public class AsyncModuleLoaderTests
 
         import.IsCompleted.Should().BeTrue();
         import.IsFaulted.Should().BeTrue();
-        import.Error!.Get("message").AsString().Should().Be("asset bundle missing");
+        import.Error!.Get("message").AsString().Should().Be("Could not load module.");
         Invoking(() => import.GetResult()).Should().Throw<PromiseRejectedException>();
     }
 
@@ -558,7 +560,10 @@ public class AsyncModuleLoaderTests
 
         import.IsCompleted.Should().BeTrue();
         import.IsFaulted.Should().BeTrue();
-        import.Error!.Get("message").AsString().Should().Be("transport exploded");
+        import.Error!.Get("message").AsString().Should().Be("Could not load module.");
+        var exception = Invoking(() => import.GetResult()).Should().Throw<PromiseRejectedException>().Which;
+        JintException.TryGetClrException(exception, out var clrException).Should().BeTrue();
+        clrException.Should().BeOfType<InvalidOperationException>().Which.Message.Should().Be("transport exploded");
     }
 
     private sealed class ThrowingLoader : IAsyncModuleLoader
@@ -589,10 +594,10 @@ public class AsyncModuleLoaderTests
     }
 
     [Fact]
-    public Task ACanceledFetchRejectsTheImportAsCanceled() => DedicatedThread.RunAsync(() =>
+    public Task ACanceledFetchIsAnOrdinarySanitizedLoadFailure() => DedicatedThread.RunAsync(() =>
     {
-        // Task.IsCanceled is not Task.IsFaulted - there is no exception object to take a message from - so
-        // the base class has to say what happened itself.
+        // This token belongs to the transport, not the engine operation. It is therefore an ordinary load
+        // failure and crosses the same disclosure boundary as every other loader exception.
         var loader = new TokenCapturingLoader();
         var engine = CreateEngine(loader);
 
@@ -609,9 +614,8 @@ public class AsyncModuleLoaderTests
             Thread.Sleep(1);
         }
 
-        import.IsCompleted.Should().BeTrue();
         import.IsFaulted.Should().BeTrue();
-        import.Error!.Get("message").AsString().Should().Be("Loading module './doomed.js' was canceled.");
+        import.Error!.Get("message").AsString().Should().Be("Could not load module.");
     });
 
     [Fact]
@@ -1044,7 +1048,7 @@ public class AsyncModuleLoaderTests
 
         first.IsCompleted.Should().BeTrue("the resolution failure must settle the import rather than strand it");
         first.IsFaulted.Should().BeTrue();
-        first.Error!.Get("message").AsString().Should().Contain("not allowed");
+        first.Error!.Get("message").AsString().Should().Be("Could not load module.");
 
         second.IsCompleted.Should().BeTrue("every waiter attached to the shared load must be finished, not only the first");
         second.IsFaulted.Should().BeTrue();
@@ -1109,7 +1113,7 @@ public class AsyncModuleLoaderTests
 
         import.IsCompleted.Should().BeTrue("the hook failure must settle the import rather than strand it");
         import.IsFaulted.Should().BeTrue();
-        import.Error!.Get("message").AsString().Should().Contain("source hook failed");
+        import.Error!.Get("message").AsString().Should().Be("Could not load module.");
     });
 
     private sealed class ThrowingModuleSourceLoader : AsyncModuleLoader
@@ -1155,10 +1159,14 @@ public class AsyncModuleLoaderTests
         // The failure travels from the queued build to the blocking importer as a promise rejection, which
         // can carry only the error value — but an error UI reads JavaScriptException.Location, and the parse
         // error knows its file, line and column. The original exception must survive the crossing.
-        var engine = new Engine(options => options.EnableModules(new BackgroundDictionaryLoader(new Dictionary<string, string>
+        var engine = new Engine(options =>
         {
-            ["./broken.js"] = "export const ok = 1;\nexport const = broken;",
-        })));
+            options.EnableModules(new BackgroundDictionaryLoader(new Dictionary<string, string>
+            {
+                ["./broken.js"] = "export const ok = 1;\nexport const = broken;",
+            }));
+            options.Modules.ExposeDetailedLoadErrors = true;
+        });
 
         var ex = Invoking(() => engine.Modules.Import("./broken.js"))
             .Should().Throw<JavaScriptException>().Which;
@@ -1168,12 +1176,11 @@ public class AsyncModuleLoaderTests
     }
 
     [Fact]
-    public Task AResolutionFailureReachesTheBlockingImportAsTheOriginalException() => DedicatedThread.RunAsync(() =>
+    public Task AResolutionFailureReachesTheBlockingImportThroughTheDisclosurePolicy() => DedicatedThread.RunAsync(() =>
     {
-        // With a synchronous loader, Resolve throwing ModuleResolutionException propagates out of Import as
-        // itself. The asynchronous pipeline reduces it to a rejection on the way through the event loop — the
-        // refusal here happens inside the queued build of './mid.js', two loads deep — and the blocking
-        // importer must still catch what the synchronous stack would have thrown.
+        // The refusal happens inside the queued build of './mid.js', two loads deep. Once it crosses that
+        // asynchronous module boundary, a blocking importer must see the same sanitized error as every other
+        // importer; the original remains available only through the host diagnostic contract.
         var loader = new BackgroundDictionaryLoader(new Dictionary<string, string>
         {
             ["./root.js"] = "import './mid.js';",
@@ -1183,8 +1190,12 @@ public class AsyncModuleLoaderTests
 
         var engine = CreateEngine(loader);
 
-        Invoking(() => engine.Modules.Import("./root.js"))
-            .Should().Throw<ModuleResolutionException>()
+        var exception = Invoking(() => engine.Modules.Import("./root.js"))
+            .Should().Throw<JavaScriptException>().Which;
+
+        exception.Message.Should().Be("Could not load module.");
+        JintException.TryGetClrException(exception, out var original).Should().BeTrue();
+        original.Should().BeOfType<ModuleResolutionException>()
             .Which.Specifier.Should().Be("./forbidden.js");
     });
 
@@ -1268,7 +1279,7 @@ public class AsyncModuleLoaderTests
 
         import.IsCompleted.Should().BeTrue();
         import.IsFaulted.Should().BeTrue();
-        import.Error!.Get("message").AsString().Should().Contain("not allowed");
+        import.Error!.Get("message").AsString().Should().Be("Could not load module.");
     }
 
     [Fact]

--- a/Jint.Tests.PublicInterface/ClrProxyHandlerTests.cs
+++ b/Jint.Tests.PublicInterface/ClrProxyHandlerTests.cs
@@ -673,7 +673,7 @@ public class ClrProxyHandlerTests
         engine.SetValue("p", engine.Advanced.CreateProxy(CreateTarget(engine), handler));
 
         var result = engine.Evaluate("(function () { try { p.x; return 'no-throw'; } catch (e) { return 'caught: ' + e.message; } })()").AsString();
-        result.Should().Be("caught: boom");
+        result.Should().Be("caught: A host operation failed.");
     }
 
     [Fact]

--- a/Jint.Tests.PublicInterface/HostClrExceptionTests.cs
+++ b/Jint.Tests.PublicInterface/HostClrExceptionTests.cs
@@ -341,8 +341,10 @@ public class HostClrExceptionTests
 
         var exception = Invoking(() => engine.Evaluate("parse()")).Should().Throw<JavaScriptException>().Which;
 
-        exception.Message.Should().Be("XML parsing failed");
-        exception.Error.AsObject().Get("message").AsString().Should().Be("XML parsing failed");
+        exception.Message.Should().Be("A host operation failed.");
+        exception.Error.AsObject().Get("message").AsString().Should().Be("A host operation failed.");
+        JintException.TryGetClrException(exception, out var clrException).Should().BeTrue();
+        clrException.Should().BeSameAs(original);
     }
 
     [Fact]
@@ -415,7 +417,7 @@ public class HostClrExceptionTests
         // GetJavaScriptErrorString is what a host shows a script author: the JavaScript error and its
         // JavaScript frames, never the host's .NET stack
         var errorString = exception.GetJavaScriptErrorString();
-        errorString.Should().StartWith("Error: host blew up");
+        errorString.Should().StartWith("Error: A host operation failed.");
         errorString.Should().Contain("at inner", "the JavaScript frames are what this accessor is for");
         errorString.Should().NotContain(nameof(HostFailure));
         errorString.Should().NotContain("root cause");
@@ -475,7 +477,7 @@ public class HostClrExceptionTests
         engine.Evaluate("let caught; try { boom(); } catch (e) { caught = e; }");
 
         engine.Evaluate("caught instanceof Error").AsBoolean().Should().BeTrue();
-        engine.Evaluate("caught.message").AsString().Should().Be("host blew up");
+        engine.Evaluate("caught.message").AsString().Should().Be("A host operation failed.");
         engine.Evaluate("JSON.stringify(caught)").AsString().Should().Be("{}");
     }
 

--- a/Jint.Tests.PublicInterface/HostDelegateTests.cs
+++ b/Jint.Tests.PublicInterface/HostDelegateTests.cs
@@ -275,7 +275,7 @@ public class HostDelegateTests
         engine.SetValue("boom", new Func<int>(() => throw new InvalidOperationException("host failure")));
 
         engine.Evaluate("var m; try { boom(); } catch (e) { m = e.message; } m")
-            .AsString().Should().Be("host failure");
+            .AsString().Should().Be("A host operation failed.");
     }
 
     [Fact]

--- a/Jint.Tests.PublicInterface/HostErrorDisclosureTests.cs
+++ b/Jint.Tests.PublicInterface/HostErrorDisclosureTests.cs
@@ -1,0 +1,510 @@
+using Jint.Native;
+using Jint.Runtime;
+using Jint.Runtime.Interop;
+using Jint.Runtime.Modules;
+using System.Runtime.CompilerServices;
+
+using Module = Jint.Runtime.Modules.Module;
+
+#nullable enable
+
+namespace Jint.Tests.PublicInterface;
+
+public class HostErrorDisclosureTests
+{
+    private const string Secret = "password=correct-horse; /srv/private/app.js; https://user:token@internal.example/module.js";
+
+    private sealed class HostFailure(Exception? inner = null) : Exception(Secret, inner);
+
+    private sealed class SecretApi
+    {
+        public SecretApi(string value)
+        {
+        }
+
+        public void Invoke(string value)
+        {
+        }
+    }
+
+    private sealed class DeferredLoader : IAsyncModuleLoader
+    {
+        public ModuleLoadCompletion? Completion { get; private set; }
+
+        public ResolvedSpecifier Resolve(string? referencingModuleLocation, ModuleRequest moduleRequest)
+            => new(moduleRequest, moduleRequest.Specifier, new Uri("https://user:token@internal.example/module.js"), SpecifierType.RelativeOrAbsolute);
+
+        public Module LoadModule(Engine engine, ResolvedSpecifier resolved)
+            => throw new InvalidOperationException("Synchronous loading is not used.");
+
+        public void LoadModuleAsync(Engine engine, ResolvedSpecifier resolved, ModuleLoadCompletion completion)
+            => Completion = completion;
+    }
+
+    private sealed class FaultedTaskLoader(Exception exception) : AsyncModuleLoader
+    {
+        public override ResolvedSpecifier Resolve(string? referencingModuleLocation, ModuleRequest moduleRequest)
+            => new(moduleRequest, moduleRequest.Specifier, new Uri("https://user:token@internal.example/module.js"), SpecifierType.RelativeOrAbsolute);
+
+        protected override Task<string> LoadModuleContentsAsync(
+            Engine engine,
+            ResolvedSpecifier resolved,
+            CancellationToken cancellationToken)
+            => Task.FromException<string>(exception);
+    }
+
+    private sealed class CanceledTaskLoader : AsyncModuleLoader
+    {
+        private readonly CancellationToken _cancellationToken;
+
+        public CanceledTaskLoader()
+        {
+            using var source = new CancellationTokenSource();
+            source.Cancel();
+            _cancellationToken = source.Token;
+        }
+
+        public override ResolvedSpecifier Resolve(string? referencingModuleLocation, ModuleRequest moduleRequest)
+            => new(moduleRequest, moduleRequest.Specifier, Uri: null, SpecifierType.Bare);
+
+        protected override Task<string> LoadModuleContentsAsync(
+            Engine engine,
+            ResolvedSpecifier resolved,
+            CancellationToken cancellationToken)
+            => Task.FromCanceled<string>(_cancellationToken);
+    }
+
+    private sealed class ThrowingSynchronousLoader(Exception exception) : ModuleLoader
+    {
+        public override ResolvedSpecifier Resolve(string? referencingModuleLocation, ModuleRequest moduleRequest)
+            => new(moduleRequest, moduleRequest.Specifier, new Uri("https://user:token@internal.example/module.js"), SpecifierType.RelativeOrAbsolute);
+
+        protected override string LoadModuleContents(Engine engine, ResolvedSpecifier resolved) => throw exception;
+    }
+
+    private sealed class ReimplementedModuleLoader : ModuleLoader, IModuleLoader
+    {
+        public override ResolvedSpecifier Resolve(string? referencingModuleLocation, ModuleRequest moduleRequest)
+            => new(moduleRequest, moduleRequest.Specifier, Uri: null, SpecifierType.Bare);
+
+        protected override string LoadModuleContents(Engine engine, ResolvedSpecifier resolved)
+            => "export const unused = true;";
+
+        Module IModuleLoader.LoadModule(Engine engine, ResolvedSpecifier resolved)
+            => throw new JavaScriptException(engine.Intrinsics.Error, Secret);
+    }
+
+    private sealed class ThrowingResolveLoader : IAsyncModuleLoader
+    {
+        public ResolvedSpecifier Resolve(string? referencingModuleLocation, ModuleRequest moduleRequest)
+            => throw new JavaScriptException(new JsString(Secret));
+
+        public Module LoadModule(Engine engine, ResolvedSpecifier resolved)
+            => throw new InvalidOperationException("Resolve must fail first.");
+
+        public void LoadModuleAsync(Engine engine, ResolvedSpecifier resolved, ModuleLoadCompletion completion)
+            => throw new InvalidOperationException("Resolve must fail first.");
+    }
+
+    [Fact]
+    public void CaughtHostExceptionsAreGenericToScriptButCompleteToHost()
+    {
+        var original = new HostFailure(new InvalidOperationException("inner-secret"));
+        var engine = new Engine(options => options.CatchClrExceptions());
+        engine.SetValue("fail", new Action(() => throw original));
+
+        engine.Evaluate("try { fail(); } catch (e) { e.message }").AsString()
+            .Should().Be("A host operation failed.");
+
+        var exception = Invoking(() => engine.Evaluate("fail()")).Should().Throw<JavaScriptException>().Which;
+        exception.GetJavaScriptErrorString().Should().NotContain(Secret).And.NotContain("inner-secret");
+        JintException.TryGetClrException(exception, out var clrException).Should().BeTrue();
+        clrException.Should().BeSameAs(original);
+        clrException!.InnerException!.Message.Should().Be("inner-secret");
+    }
+
+    [Fact]
+    public void DetailedDevelopmentOptInRestoresHostExceptionMessages()
+    {
+        var engine = new Engine(options => options.CatchClrExceptions().ExposeDetailedErrors());
+        engine.SetValue("fail", new Action(() => throw new HostFailure()));
+
+        engine.Evaluate("try { fail(); } catch (e) { e.message }").AsString().Should().Be(Secret);
+    }
+
+    [Fact]
+    public void NullJavaScriptExceptionMessageUsesTheSafeDefault()
+    {
+        var original = new HostFailure();
+        var engine = new Engine();
+        engine.SetValue("fail", new Action(() =>
+            throw new JavaScriptException(engine.Intrinsics.Error, message: null, original)));
+
+        var exception = Invoking(() => engine.Evaluate("fail()")).Should().Throw<JavaScriptException>().Which;
+        exception.GetJavaScriptErrorString().Should().NotContain(Secret);
+        JintException.TryGetClrException(exception, out var clrException).Should().BeTrue();
+        clrException.Should().BeSameAs(original);
+    }
+
+    [Fact]
+    public void HostCancellationIsNeverConvertedIntoAScriptError()
+    {
+        var engine = new Engine(options => options.CatchClrExceptions());
+        engine.SetValue("cancel", new Action(() => throw new OperationCanceledException(Secret)));
+
+        Invoking(() => engine.Evaluate("try { cancel(); } catch (e) { 'caught'; }"))
+            .Should().Throw<OperationCanceledException>();
+    }
+
+    [Fact]
+    public void ResolutionFailuresHideTypesAndSignaturesByDefault()
+    {
+        ClrResolutionErrorInfo? resolution = null;
+        var engine = new Engine(options => options.DecorateClrResolutionErrors((_, _, info) => resolution = info));
+        engine.SetValue("api", new SecretApi("value"));
+        engine.SetValue("SecretCtor", TypeReference.CreateTypeReference<SecretApi>(engine));
+
+        var methodError = Invoking(() => engine.Evaluate("api.Invoke(1, 2)"))
+            .Should().Throw<JavaScriptException>().Which;
+        var constructorError = Invoking(() => engine.Evaluate("new SecretCtor(1, 2)"))
+            .Should().Throw<JavaScriptException>().Which;
+
+        methodError.Message.Should().Be("No public methods with the specified arguments were found.");
+        constructorError.Message.Should().Be("Could not resolve a constructor for the specified arguments.");
+        methodError.Message.Should().NotContain(nameof(SecretApi)).And.NotContain("Invoke(String");
+        constructorError.Message.Should().NotContain(nameof(SecretApi)).And.NotContain("SecretApi(String");
+
+        JintException.TryGetClrType(methodError, out var type).Should().BeTrue();
+        type.Should().Be(typeof(SecretApi));
+        resolution.Should().NotBeNull();
+        resolution!.DetailedMessage.Should().Contain(nameof(SecretApi)).And.Contain("SecretApi(String value)");
+    }
+
+    [Fact]
+    public void SetErrorExceptionIsGenericAndRetainsTheOriginal()
+    {
+        var original = new HostFailure(new InvalidOperationException("inner-secret"));
+        var loader = new DeferredLoader();
+        var engine = new Engine(options => options.EnableModules(loader));
+        var import = engine.Modules.StartImport("https://user:token@internal.example/module.js");
+
+        loader.Completion!.SetError(original);
+        engine.Advanced.ProcessTasks();
+
+        import.Error!.Get("message").AsString().Should().Be("Could not load module.");
+        import.Error.Get("message").AsString().Should().NotContain("internal.example").And.NotContain("/srv/private");
+        var rejection = Invoking(() => import.GetResult()).Should().Throw<PromiseRejectedException>().Which;
+        JintException.TryGetClrException(rejection, out var clrException).Should().BeTrue();
+        clrException.Should().BeSameAs(original);
+    }
+
+    [Fact]
+    public void ModuleParseFailuresHideCanonicalUrlsAndPaths()
+    {
+        var loader = new DeferredLoader();
+        var decoratorCalls = 0;
+        var engine = new Engine(options =>
+        {
+            options.EnableModules(loader);
+            options.DecorateClrExceptionErrors((_, _, _) => decoratorCalls++);
+        });
+        var import = engine.Modules.StartImport("https://user:token@internal.example/private/module.js");
+
+        loader.Completion!.SetSource("export const = invalid;");
+        engine.Advanced.ProcessTasks();
+
+        import.Error!.Get("message").AsString().Should().Be("Could not load module.");
+        import.Error.Get("stack").AsString().Should().NotContain("internal.example").And.NotContain("/private/");
+        var rejection = Invoking(() => import.GetResult()).Should().Throw<PromiseRejectedException>().Which;
+        JintException.TryGetClrException(rejection, out var parserException).Should().BeTrue();
+        parserException.Should().NotBeNull();
+        decoratorCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public void ModuleErrorDecoratorReceivesOriginalBeforeCustomizingSafeError()
+    {
+        Exception? decorated = null;
+        var decoratorCalls = 0;
+        var original = new HostFailure();
+        var loader = new DeferredLoader();
+        var engine = new Engine(options =>
+        {
+            options.EnableModules(loader);
+            options.DecorateClrExceptionErrors((_, error, exception) =>
+            {
+                decoratorCalls++;
+                decorated = exception;
+                error.Set("code", "MODULE_LOAD_FAILED");
+            });
+        });
+        var import = engine.Modules.StartImport("./module.js");
+
+        loader.Completion!.SetError(original);
+        engine.Advanced.ProcessTasks();
+
+        decorated.Should().BeSameAs(original);
+        decoratorCalls.Should().Be(1);
+        import.Error!.Get("message").AsString().Should().Be("Could not load module.");
+        import.Error.Get("code").AsString().Should().Be("MODULE_LOAD_FAILED");
+    }
+
+    [Fact]
+    public async Task FaultedTasksAreGenericAndRetainTheOriginal()
+    {
+        var original = new HostFailure();
+        var engine = new Engine(options => options.EnableModules(new FaultedTaskLoader(original)));
+
+        var rejection = await Invoking(() => engine.Modules.ImportAsync("./module.js"))
+            .Should().ThrowAsync<PromiseRejectedException>();
+
+        rejection.Which.RejectedValue.Get("message").AsString().Should().Be("Could not load module.");
+        JintException.TryGetClrException(rejection.Which, out var clrException).Should().BeTrue();
+        clrException.Should().BeSameAs(original);
+    }
+
+    [Fact]
+    public void OrdinaryLoaderCancellationIsSanitizedWhileHostCancellationRemainsControlFlow()
+    {
+        var canceled = new Engine(options => options.EnableModules(new CanceledTaskLoader()));
+
+        var canceledImport = canceled.Modules.StartImport("./module.js");
+        canceled.Advanced.ProcessTasks();
+        canceledImport.Error!.Get("message").AsString().Should().Be("Could not load module.");
+
+        var faultedCancellation = new Engine(options =>
+            options.EnableModules(new FaultedTaskLoader(new OperationCanceledException(Secret))));
+        var faultedImport = faultedCancellation.Modules.StartImport("./module.js");
+        faultedCancellation.Advanced.ProcessTasks();
+        faultedImport.Error!.Get("message").AsString().Should().Be("Could not load module.");
+
+        var loader = new DeferredLoader();
+        var explicitCancellation = new Engine(options => options.EnableModules(loader));
+        var explicitImport = explicitCancellation.Modules.StartImport("./module.js");
+        var transportCancellation = new OperationCanceledException(Secret);
+        loader.Completion!.SetError(transportCancellation);
+        explicitCancellation.Advanced.ProcessTasks();
+        explicitImport.Error!.Get("message").AsString().Should().Be("Could not load module.");
+        var rejection = Invoking(() => explicitImport.GetResult()).Should().Throw<PromiseRejectedException>().Which;
+        JintException.TryGetClrException(rejection, out var original).Should().BeTrue();
+        original.Should().BeSameAs(transportCancellation);
+
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var hostCanceled = new Engine(options =>
+        {
+            options.CancellationToken(cancellation.Token);
+            options.EnableModules(new FaultedTaskLoader(new OperationCanceledException(cancellation.Token)));
+        });
+        Invoking(() => hostCanceled.Modules.StartImport("./module.js"))
+            .Should().Throw<OperationCanceledException>();
+    }
+
+    [Fact]
+    public void SynchronousLoaderFailuresAreGenericToDynamicImportAndOriginalToHostImport()
+    {
+        var original = new HostFailure();
+        var loader = new ThrowingSynchronousLoader(original);
+        var decoratorCalls = 0;
+        var engine = new Engine(options =>
+        {
+            options.EnableModules(loader);
+            options.DecorateClrExceptionErrors((_, _, _) => decoratorCalls++);
+        });
+
+        var operation = engine.Modules.StartImport("https://user:token@internal.example/module.js");
+        engine.Advanced.ProcessTasks();
+
+        operation.Error!.Get("message").AsString().Should().Be("Could not load module.");
+        var rejection = Invoking(() => operation.GetResult()).Should().Throw<PromiseRejectedException>().Which;
+        JintException.TryGetClrException(rejection, out var clrException).Should().BeTrue();
+        clrException.Should().BeSameAs(original);
+        decoratorCalls.Should().Be(1);
+
+        var synchronous = Invoking(() => new Engine(options => options.EnableModules(loader)).Modules.Import("./module.js"))
+            .Should().Throw<JavaScriptException>().Which;
+        synchronous.Message.Should().Be("Could not load module.");
+        JintException.TryGetClrException(synchronous, out var synchronousClrException).Should().BeTrue();
+        synchronousClrException.Should().BeSameAs(original);
+    }
+
+    [Fact]
+    public void ReimplementedModuleLoaderCannotBypassTheDisclosurePolicy()
+    {
+        var engine = new Engine(options => options.EnableModules(new ReimplementedModuleLoader()));
+
+        var import = engine.Modules.StartImport("./module.js");
+        engine.Advanced.ProcessTasks();
+
+        import.Error!.Get("message").AsString().Should().Be("Could not load module.");
+        import.Error.Get("message").AsString().Should().NotContain(Secret);
+    }
+
+    [Fact]
+    public void BlockingImportDoesNotRethrowAnUnprocessedLoaderError()
+    {
+        var decoratorCalls = 0;
+        var engine = new Engine(options =>
+        {
+            options.EnableModules(new ReimplementedModuleLoader());
+            options.DecorateClrExceptionErrors((_, _, _) => decoratorCalls++);
+        });
+
+        var exception = Invoking(() => engine.Modules.Import("./module.js"))
+            .Should().Throw<JavaScriptException>().Which;
+
+        exception.Message.Should().Be("Could not load module.");
+        exception.Message.Should().NotContain(Secret);
+        decoratorCalls.Should().Be(1);
+        JintException.TryGetClrException(exception, out var original).Should().BeTrue();
+        original.Should().BeOfType<JavaScriptException>().Which.Message.Should().Be(Secret);
+    }
+
+    [Fact]
+    public void ModulePolicyProvenanceIsSpecificToTheActiveEngineAndConfiguration()
+    {
+        var trustedLoader = new DeferredLoader();
+        var trusted = new Engine(options =>
+            options.EnableModules(trustedLoader).ExposeDetailedErrors());
+        var trustedImport = trusted.Modules.StartImport("./trusted.js");
+        trustedLoader.Completion!.SetError(new HostFailure());
+        trusted.Advanced.ProcessTasks();
+        trustedImport.Error!.Get("message").AsString().Should().Be(Secret);
+
+        var safeDecoratorCalls = 0;
+        var safeLoader = new DeferredLoader();
+        var safe = new Engine(options =>
+        {
+            options.EnableModules(safeLoader);
+            options.DecorateClrExceptionErrors((_, _, _) => safeDecoratorCalls++);
+        });
+        var safeImport = safe.Modules.StartImport("./safe.js");
+        safeLoader.Completion!.SetError(new JavaScriptException(trustedImport.Error));
+        safe.Advanced.ProcessTasks();
+
+        safeImport.Error!.Get("message").AsString().Should().Be("Could not load module.");
+        safeImport.Error.Get("message").AsString().Should().NotContain(Secret);
+        safeDecoratorCalls.Should().Be(1);
+
+        var changingLoader = new DeferredLoader();
+        var changingOptions = new Options()
+            .EnableModules(changingLoader)
+            .ExposeDetailedErrors();
+        var changing = new Engine(changingOptions);
+        var detailedImport = changing.Modules.StartImport("./detailed.js");
+        changingLoader.Completion!.SetError(new HostFailure());
+        changing.Advanced.ProcessTasks();
+        changingOptions.Modules.ExposeDetailedLoadErrors = false;
+        var redactedImport = changing.Modules.StartImport("./redacted.js");
+        changingLoader.Completion!.SetError(new JavaScriptException(detailedImport.Error!));
+        changing.Advanced.ProcessTasks();
+
+        redactedImport.Error!.Get("message").AsString().Should().Be("Could not load module.");
+        redactedImport.Error.Get("message").AsString().Should().NotContain(Secret);
+    }
+
+    [Fact]
+    public void DebuggerFailureCannotBypassTheDisclosurePolicy()
+    {
+        var decoratorCalls = 0;
+        var loader = new DeferredLoader();
+        var engine = new Engine(options =>
+        {
+            options.EnableModules(loader);
+            options.DecorateClrExceptionErrors((_, _, _) => decoratorCalls++);
+        });
+        engine.Debugger.BeforeEvaluate += (_, _) =>
+            throw new JavaScriptException(engine.Intrinsics.Error, Secret);
+        var import = engine.Modules.StartImport("./module.js");
+
+        loader.Completion!.SetSource("export const value = 1;");
+        engine.Advanced.ProcessTasks();
+
+        import.Error!.Get("message").AsString().Should().Be("Could not load module.");
+        import.Error.Get("message").AsString().Should().NotContain(Secret);
+        decoratorCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public void DetailedResolveFailureStillCrossesTheDecoratorBoundaryOnce()
+    {
+        var decoratorCalls = 0;
+        var engine = new Engine(options =>
+        {
+            options.EnableModules(new ThrowingResolveLoader());
+            options.ExposeDetailedErrors();
+            options.DecorateClrExceptionErrors((_, _, _) => decoratorCalls++);
+        });
+
+        var import = engine.Modules.StartImport("./module.js");
+        engine.Advanced.ProcessTasks();
+
+        import.Error!.Get("message").AsString().Should().Be(Secret);
+        decoratorCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public void DetailedJavaScriptSetErrorStillCrossesTheDecoratorBoundaryOnce()
+    {
+        var decoratorCalls = 0;
+        var loader = new DeferredLoader();
+        var engine = new Engine(options =>
+        {
+            options.EnableModules(loader);
+            options.ExposeDetailedErrors();
+            options.DecorateClrExceptionErrors((_, _, _) => decoratorCalls++);
+        });
+        var import = engine.Modules.StartImport("./module.js");
+
+        loader.Completion!.SetError(new JavaScriptException(engine.Intrinsics.TypeError, Secret));
+        engine.Advanced.ProcessTasks();
+
+        import.Error!.Get("name").AsString().Should().Be("TypeError");
+        import.Error.Get("message").AsString().Should().Be(Secret);
+        decoratorCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public void CanceledCompletionDoesNotRetainItsPendingImportGraph()
+    {
+        var (completion, operation) = CreateCanceledImport();
+
+        for (var i = 0; i < 5 && operation.IsAlive; i++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+        }
+
+        operation.IsAlive.Should().BeFalse();
+        GC.KeepAlive(completion);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static (ModuleLoadCompletion Completion, WeakReference Operation) CreateCanceledImport()
+    {
+        var loader = new DeferredLoader();
+        var engine = new Engine(options => options.EnableModules(loader));
+        var operation = engine.Modules.StartImport("./module.js");
+        var completion = loader.Completion!;
+
+        completion.SetError(new OperationCanceledException("canceled"));
+        engine.Advanced.ProcessTasks();
+        operation.IsCompleted.Should().BeTrue();
+
+        return (completion, new WeakReference(operation));
+    }
+
+    [Fact]
+    public void DetailedDevelopmentOptInRestoresModuleFailureMessages()
+    {
+        var loader = new DeferredLoader();
+        var engine = new Engine(options => options.EnableModules(loader).ExposeDetailedErrors());
+        var import = engine.Modules.StartImport("./module.js");
+
+        loader.Completion!.SetError(new HostFailure());
+        engine.Advanced.ProcessTasks();
+
+        import.Error!.Get("message").AsString().Should().Be(Secret);
+    }
+}

--- a/Jint.Tests.PublicInterface/HostModuleGraphSecurityTests.cs
+++ b/Jint.Tests.PublicInterface/HostModuleGraphSecurityTests.cs
@@ -838,7 +838,7 @@ public sealed class HostModuleGraphSecurityTests
 
         Invoking(() => engine.Modules.Import("cancel"))
             .Should().Throw<JavaScriptException>()
-            .WithMessage("*Could not load module cancel*");
+            .WithMessage("Could not load module.");
     }
 
     [Fact]
@@ -849,7 +849,7 @@ public sealed class HostModuleGraphSecurityTests
 
         Invoking(() => engine.Modules.Import("timeout"))
             .Should().Throw<JavaScriptException>()
-            .WithMessage("*Could not load module timeout*");
+            .WithMessage("Could not load module.");
     }
 
     [Fact]

--- a/Jint.Tests.PublicInterface/HostModuleLoadConstraintTests.cs
+++ b/Jint.Tests.PublicInterface/HostModuleLoadConstraintTests.cs
@@ -107,6 +107,9 @@ public class HostModuleLoadConstraintTests
 
         operation.IsCompleted.Should().BeTrue();
         operation.IsFaulted.Should().BeTrue();
-        operation.Error!.ToString().Should().Contain("the asset pipeline is down");
+        operation.Error!.Get("message").AsString().Should().Be("Could not load module.");
+        var rejection = Invoking(() => operation.GetResult()).Should().Throw<PromiseRejectedException>().Which;
+        JintException.TryGetClrException(rejection, out var clrException).Should().BeTrue();
+        clrException.Should().BeOfType<InvalidOperationException>().Which.Message.Should().Be("the asset pipeline is down");
     }
 }

--- a/Jint.Tests/Runtime/InteropCompiledMemberAccessorTests.cs
+++ b/Jint.Tests/Runtime/InteropCompiledMemberAccessorTests.cs
@@ -862,10 +862,10 @@ public class InteropCompiledMemberAccessorTests
             return true;
         });
 
-        engine.Evaluate("try { host.ThrowingIntGetter; 'no throw' } catch (e) { e.message }").Should().Be("int getter boom");
-        engine.Evaluate("try { host.ThrowingDecimalGetter; 'no throw' } catch (e) { e.message }").Should().Be("decimal getter boom");
-        engine.Evaluate("try { host.ThrowingIntSetter = 1; 'no throw' } catch (e) { e.message }").Should().Be("int setter boom");
-        engine.Evaluate("try { host.ThrowingDecimalSetter = 1; 'no throw' } catch (e) { e.message }").Should().Be("decimal setter boom");
+        engine.Evaluate("try { host.ThrowingIntGetter; 'no throw' } catch (e) { e.message }").Should().Be("A host operation failed.");
+        engine.Evaluate("try { host.ThrowingDecimalGetter; 'no throw' } catch (e) { e.message }").Should().Be("A host operation failed.");
+        engine.Evaluate("try { host.ThrowingIntSetter = 1; 'no throw' } catch (e) { e.message }").Should().Be("A host operation failed.");
+        engine.Evaluate("try { host.ThrowingDecimalSetter = 1; 'no throw' } catch (e) { e.message }").Should().Be("A host operation failed.");
 
         seen.Should().AllSatisfy(e => e.Should().BeOfType<InvalidOperationException>());
         seen.Should().HaveCount(4);

--- a/Jint.Tests/Runtime/InteropTests.ErrorMessages.cs
+++ b/Jint.Tests/Runtime/InteropTests.ErrorMessages.cs
@@ -109,8 +109,8 @@ public partial class InteropTests
 
         var ex = Invoking(() => engine.Evaluate("new CtorFails(1, 2)")).Should().ThrowExactly<JavaScriptException>().Which;
 
-        // historical terse text (names the type, as it always has) but none of the added detail
-        ex.Message.Should().Be("Could not resolve a constructor for type Jint.Tests.Runtime.CtorFails for given arguments");
+        ex.Message.Should().Be("Could not resolve a constructor for the specified arguments.");
+        ex.Message.Should().NotContain(nameof(CtorFails));
         ex.Message.Should().NotContain("provided arguments");
         ex.Message.Should().NotContain("candidate signatures");
     }

--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -2753,7 +2753,11 @@ public partial class InteropTests : IDisposable
     {
         var exceptionMessage = "myExceptionMessage";
 
-        var engine = new Engine(o => o.CatchClrExceptions())
+        var engine = new Engine(o =>
+            {
+                o.CatchClrExceptions();
+                o.Interop.ExposeDetailedExceptionMessages = true;
+            })
             .SetValue("throwMyException", new Action(() => { throw new Exception(exceptionMessage); }))
             .SetValue("Thrower", typeof(Thrower))
             .Execute(@"
@@ -2785,7 +2789,11 @@ public partial class InteropTests : IDisposable
     [Fact]
     public void CaughtClrExceptionShouldExposeJavaScriptLocation()
     {
-        var engine = new Engine(o => o.CatchClrExceptions())
+        var engine = new Engine(o =>
+            {
+                o.CatchClrExceptions();
+                o.Interop.ExposeDetailedExceptionMessages = true;
+            })
             .SetValue("Thrower", typeof(Thrower));
 
         const string script = @"// line 1
@@ -2938,7 +2946,11 @@ new Thrower().ThrowExceptionWithMessage('boom');";
     {
         var exceptionMessage = "myExceptionMessage";
 
-        var engine = new Engine(o => o.CatchClrExceptions(e => e is NotSupportedException))
+        var engine = new Engine(o =>
+            {
+                o.CatchClrExceptions(e => e is NotSupportedException);
+                o.Interop.ExposeDetailedExceptionMessages = true;
+            })
             .SetValue("throwMyException1", new Action(() => { throw new NotSupportedException(exceptionMessage); }))
             .SetValue("throwMyException2", new Action(() => { throw new ArgumentNullException(); }))
             .SetValue("Thrower", typeof(Thrower))
@@ -3035,7 +3047,7 @@ new Thrower().ThrowExceptionWithMessage('boom');";
         var errorObject = result.AsObject();
         errorObject.Get("customProperty").AsString().Should().Be("decorated");
         errorObject.Get("clrType").AsString().Should().Be("System.InvalidOperationException");
-        errorObject.Get("message").AsString().Should().Be($"[Decorated] {exceptionMessage}");
+        errorObject.Get("message").AsString().Should().Be("[Decorated] A host operation failed.");
     }
 
     [Fact]
@@ -4084,7 +4096,11 @@ new Thrower().ThrowExceptionWithMessage('boom');";
     [Fact]
     public void ShouldBeJavaScriptException()
     {
-        var engine = new Engine(cfg => cfg.AllowClr().AllowOperatorOverloading().CatchClrExceptions());
+        var engine = new Engine(cfg =>
+        {
+            cfg.AllowClr().AllowOperatorOverloading().CatchClrExceptions();
+            cfg.Interop.ExposeDetailedExceptionMessages = true;
+        });
         engine.SetValue("Dimensional", typeof(Dimensional));
 
         engine.Execute(@"	
@@ -4211,7 +4227,11 @@ wrap();
     [Fact]
     public void ShouldConvertClrExceptionsToErrors()
     {
-        var engine = new Engine(opts => opts.CatchClrExceptions(exc => exc is InvalidOperationException));
+        var engine = new Engine(opts =>
+        {
+            opts.CatchClrExceptions(exc => exc is InvalidOperationException);
+            opts.Interop.ExposeDetailedExceptionMessages = true;
+        });
         engine.SetValue("fn", new ClrFunction(engine, "fn", (_, _) => throw new InvalidOperationException("This is a C# error")));
         const string Source = @"
 function wrap() {
@@ -4227,7 +4247,11 @@ wrap();
     [Fact]
     public void ShouldAllowCatchingConvertedClrExceptions()
     {
-        var engine = new Engine(opts => opts.CatchClrExceptions(exc => exc is InvalidOperationException));
+        var engine = new Engine(opts =>
+        {
+            opts.CatchClrExceptions(exc => exc is InvalidOperationException);
+            opts.Interop.ExposeDetailedExceptionMessages = true;
+        });
         engine.SetValue("fn", new ClrFunction(engine, "fn", (_, _) => throw new InvalidOperationException("This is a C# error")));
         const string Source = @"
 try {

--- a/Jint.Tests/Runtime/ModuleTests.cs
+++ b/Jint.Tests/Runtime/ModuleTests.cs
@@ -222,6 +222,7 @@ public class ModuleTests
     [Fact]
     public void ShouldPropagateParseError()
     {
+        _engine.Options.Modules.ExposeDetailedLoadErrors = true;
         _engine.Modules.Add("imported", "export const invalid;");
         _engine.Modules.Add("my-module", "import { invalid } from 'imported';");
 
@@ -233,6 +234,7 @@ public class ModuleTests
     [Fact]
     public void ShouldPropagateLinkError()
     {
+        _engine.Options.Modules.ExposeDetailedLoadErrors = true;
         _engine.Modules.Add("imported", "export invalid;");
         _engine.Modules.Add("my-module", "import { value } from 'imported';");
 

--- a/Jint/Engine.Modules.cs
+++ b/Jint/Engine.Modules.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using Jint.Native;
+using Jint.Native.Error;
 using Jint.Native.Object;
 using Jint.Native.Promise;
 using Jint.Runtime;
@@ -112,6 +113,11 @@ public partial class Engine
         /// </summary>
         private JsValue? _lastLoadFailureError;
         private ExceptionDispatchInfo? _lastLoadFailure;
+
+        private object _moduleErrorPolicyToken = new();
+        private bool _moduleErrorPolicyInitialized;
+        private bool _moduleErrorPolicyExposeDetails;
+        private Options.ClrExceptionErrorDecoratorDelegate? _moduleErrorPolicyDecorator;
 
         // --- Module graph limit accounting ---
 
@@ -327,7 +333,10 @@ public partial class Engine
             }
             catch (JavaScriptException ex)
             {
-                Finish(module: null, ex.Error, ex);
+                var error = HasModuleErrorPolicyApplied(ex.Error)
+                    ? ex.Error
+                    : CreateLoadError(ex);
+                Finish(module: null, error, ex);
                 return;
             }
             catch (Exception ex) when (_engine._eventLoop.IsRunningJob
@@ -340,7 +349,7 @@ public partial class Engine
                 // left: escaping would erupt out of ProcessTasks with the graph state's pending count never
                 // decremented, stranding the import promise forever. The refusal becomes the load's failure,
                 // and the original exception travels along for the blocking importer to rethrow.
-                Finish(module: null, _engine.Realm.Intrinsics.Error.Construct(ex.Message), ex);
+                Finish(module: null, CreateLoadError(ex), ex);
                 return;
             }
 
@@ -378,12 +387,14 @@ public partial class Engine
                 }
                 catch (JavaScriptException ex) when (_engine._eventLoop.IsRunningJob)
                 {
-                    builderError = ex.Error;
+                    builderError = HasModuleErrorPolicyApplied(ex.Error)
+                        ? ex.Error
+                        : CreateLoadError(ex);
                     builderException = ex;
                 }
                 catch (Exception ex) when (_engine._eventLoop.IsRunningJob && !ModuleLoadCompletion.MustPropagate(ex))
                 {
-                    builderError = _engine.Realm.Intrinsics.Error.Construct(ex.Message);
+                    builderError = CreateLoadError(ex);
                     builderException = ex;
                 }
 
@@ -440,7 +451,9 @@ public partial class Engine
             }
             catch (JavaScriptException ex)
             {
-                loadError = ex.Error;
+                loadError = HasModuleErrorPolicyApplied(ex.Error)
+                    ? ex.Error
+                    : CreateLoadError(ex);
                 loadException = ex;
             }
 
@@ -451,7 +464,10 @@ public partial class Engine
 
             void Finish(Module? module, JsValue? error, Exception? exception = null)
             {
-                if (error is not null && exception is not null)
+                if (error is not null
+                    && exception is JavaScriptException javaScriptException
+                    && ReferenceEquals(javaScriptException.Error, error)
+                    && HasModuleErrorPolicyApplied(error))
                 {
                     RememberLoadFailure(error, exception);
                 }
@@ -531,6 +547,35 @@ public partial class Engine
             _lastLoadFailureError = error;
             _lastLoadFailure = ExceptionDispatchInfo.Capture(exception);
         }
+
+        private ObjectInstance CreateLoadError(Exception exception)
+        {
+            var message = _engine.Options.Modules.ExposeDetailedLoadErrors
+                ? exception.Message
+                : "Could not load module.";
+            return Throw.CreateClrError(_engine, exception, message, moduleErrorPolicyApplied: true);
+        }
+
+        internal object GetModuleErrorPolicyToken()
+        {
+            var exposeDetails = _engine.Options.Modules.ExposeDetailedLoadErrors;
+            var decorator = _engine.Options.Interop.ClrExceptionErrorDecorator;
+            if (!_moduleErrorPolicyInitialized
+                || exposeDetails != _moduleErrorPolicyExposeDetails
+                || !ReferenceEquals(decorator, _moduleErrorPolicyDecorator))
+            {
+                _moduleErrorPolicyToken = new object();
+                _moduleErrorPolicyExposeDetails = exposeDetails;
+                _moduleErrorPolicyDecorator = decorator;
+                _moduleErrorPolicyInitialized = true;
+            }
+
+            return _moduleErrorPolicyToken;
+        }
+
+        internal bool HasModuleErrorPolicyApplied(JsValue error)
+            => error is ErrorInstance errorInstance
+               && errorInstance.HasModuleErrorPolicyToken(GetModuleErrorPolicyToken());
 
         /// <summary>
         /// Rethrows the original exception <paramref name="error"/> was reduced from, stack intact, when it
@@ -954,7 +999,9 @@ public partial class Engine
             }
             catch (JavaScriptException ex)
             {
-                capability.Reject(ex.Error);
+                capability.Reject(HasModuleErrorPolicyApplied(ex.Error)
+                    ? ex.Error
+                    : CreateLoadError(ex));
             }
             catch (Exception ex) when (!ModuleLoadCompletion.MustPropagateLoaderException(_engine, ex))
             {
@@ -963,7 +1010,7 @@ public partial class Engine
                 // operation's Error. One failure must not have two delivery channels depending on where it
                 // happened, and host code written to the poll-then-GetResult pattern must not crash at the
                 // start call.
-                capability.Reject(_engine.Realm.Intrinsics.Error.Construct(ex.Message));
+                capability.Reject(CreateLoadError(ex));
             }
             var operation = new ModuleImportOperation(_engine, capability.PromiseInstance);
 

--- a/Jint/Extensions/AcornimaExtensions.cs
+++ b/Jint/Extensions/AcornimaExtensions.cs
@@ -60,12 +60,27 @@ internal static class AcornimaExtensions
         }
         catch (ParseErrorException ex)
         {
-            Throw.SyntaxError(engine.Realm, $"Error while loading module: error in module '{source}': {ex.Error}", ToLocation(ex, source));
+            var exposeDetails = engine.Options.Modules.ExposeDetailedLoadErrors;
+            var message = exposeDetails
+                ? $"Error while loading module: error in module '{source}': {ex.Error}"
+                : "Could not load module.";
+            var error = Throw.CreateClrError(
+                engine,
+                ex,
+                message,
+                engine.Realm.Intrinsics.SyntaxError,
+                moduleErrorPolicyApplied: true);
+            var location = ToLocation(ex, exposeDetails ? source : null);
+            Throw.JavaScriptException(engine, error, in location);
             return default;
         }
-        catch (Exception ex) when (ex is not ParsingLimitException)
+        catch (Exception ex) when (!Runtime.Modules.ModuleLoadCompletion.MustPropagate(ex))
         {
-            Throw.JavaScriptException(engine, $"Could not load module {source}", in AstExtensions.DefaultLocation);
+            var message = engine.Options.Modules.ExposeDetailedLoadErrors
+                ? $"Could not load module {source}: {ex.Message}"
+                : "Could not load module.";
+            var error = Throw.CreateClrError(engine, ex, message, moduleErrorPolicyApplied: true);
+            Throw.JavaScriptException(engine, error, in AstExtensions.DefaultLocation);
             return default;
         }
     }

--- a/Jint/Native/Error/ErrorInstance.cs
+++ b/Jint/Native/Error/ErrorInstance.cs
@@ -8,7 +8,11 @@ namespace Jint.Native.Error;
 /// rather than as one field per fact. Errors that came out of CLR interop are a small minority of the errors
 /// an engine builds, so a field per fact would have every error object carrying the ones it never fills.
 /// </summary>
-internal sealed record ClrErrorContext(Type? ResolutionType, string? ResolutionMemberName, Exception? ClrException);
+internal sealed record ClrErrorContext(
+    Type? ResolutionType,
+    string? ResolutionMemberName,
+    Exception? ClrException,
+    object? ModuleErrorPolicyToken);
 
 /// <summary>
 /// Marks an object that carries the specification's <c>[[ErrorData]]</c> internal slot, which is the brand
@@ -61,6 +65,9 @@ public class ErrorInstance : ObjectInstance
     /// </summary>
     internal Exception? ClrException => _clrContext?.ClrException;
 
+    internal bool HasModuleErrorPolicyToken(object token)
+        => ReferenceEquals(_clrContext?.ModuleErrorPolicyToken, token);
+
     /// <summary>
     /// Records where a failed CLR resolution came from, keeping any exception already recorded.
     /// </summary>
@@ -73,7 +80,11 @@ public class ErrorInstance : ObjectInstance
     /// </remarks>
     internal void SetClrResolutionInfo(Type clrType, string? memberName)
     {
-        _clrContext = new ClrErrorContext(clrType, memberName, _clrContext?.ClrException);
+        _clrContext = new ClrErrorContext(
+            clrType,
+            memberName,
+            _clrContext?.ClrException,
+            _clrContext?.ModuleErrorPolicyToken);
     }
 
     /// <summary>
@@ -83,7 +94,21 @@ public class ErrorInstance : ObjectInstance
     internal void SetClrException(Exception clrException)
     {
         var existing = _clrContext;
-        _clrContext = new ClrErrorContext(existing?.ResolutionType, existing?.ResolutionMemberName, clrException);
+        _clrContext = new ClrErrorContext(
+            existing?.ResolutionType,
+            existing?.ResolutionMemberName,
+            clrException,
+            existing?.ModuleErrorPolicyToken);
+    }
+
+    internal void SetModuleErrorPolicyToken(object token)
+    {
+        var existing = _clrContext;
+        _clrContext = new ClrErrorContext(
+            existing?.ResolutionType,
+            existing?.ResolutionMemberName,
+            existing?.ClrException,
+            token);
     }
 
     /// <summary>

--- a/Jint/Options.Extensions.cs
+++ b/Jint/Options.Extensions.cs
@@ -360,9 +360,29 @@ public static class OptionsExtensions
     }
 
     /// <summary>
+    /// Exposes detailed CLR exception, CLR resolution and module loading messages to script code.
+    /// Off by default because those messages can contain host types, signatures, paths, URLs and inner-system
+    /// details. Intended for trusted development environments only.
+    /// </summary>
+    /// <remarks>
+    /// This does not control host-side diagnostics. Original CLR and module exceptions remain available through
+    /// <see cref="JintException.TryGetClrException"/>, and CLR resolution metadata through
+    /// <see cref="JintException.TryGetClrType"/> and <see cref="JintException.TryGetClrMemberName"/>, whether
+    /// detailed messages are exposed or not.
+    /// </remarks>
+    public static Options ExposeDetailedErrors(this Options options, bool expose = true)
+    {
+        options.Interop.ExposeDetailedExceptionMessages = expose;
+        options.Interop.ExposeDetailedResolutionErrors = expose;
+        options.Modules.ExposeDetailedLoadErrors = expose;
+        return options;
+    }
+
+    /// <summary>
     /// Sets a decorator function that is called after a JavaScript error object is created from a CLR exception.
     /// The decorator can add custom properties, modify the error message, or enrich the error with additional context.
-    /// This is only called when <see cref="CatchClrExceptions(Options)"/> is enabled and the exception is caught.
+    /// It is called when <see cref="CatchClrExceptions(Options)"/> converts a host exception and when a module
+    /// loader exception becomes an import error.
     /// </summary>
     /// <param name="options">The engine options.</param>
     /// <param name="decorator">A function that receives the engine, the created error object, and the original CLR exception.</param>

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -582,7 +582,20 @@ public partial class Options
         public bool ChainClrExceptionAsInnerException { get; set; }
 
         /// <summary>
-        /// Called after a JavaScript error object is created from a CLR exception (when <see cref="ExceptionHandler"/> returns true).
+        /// When <c>true</c>, JavaScript errors created from CLR exceptions expose the original exception
+        /// message to script code. Defaults to <c>false</c>, so exception messages, paths, URLs and other host
+        /// details are not disclosed to untrusted scripts.
+        /// </summary>
+        /// <remarks>
+        /// The original exception is retained either way and can be read host-side through
+        /// <see cref="JintException.TryGetClrException"/>. This setting only changes the script-visible
+        /// message. Treat it as a development option.
+        /// </remarks>
+        public bool ExposeDetailedExceptionMessages { get; set; }
+
+        /// <summary>
+        /// Called after a JavaScript error object is created from a CLR exception, either because
+        /// <see cref="ExceptionHandler"/> returned true or because a module loader exception became an import error.
         /// Allows decorating the error object with additional properties or modifying its state.
         /// The decorator receives the engine instance, the created error object, and the original CLR exception.
         /// </summary>
@@ -969,6 +982,14 @@ public partial class Options
         /// <c>null</c> means no policy (the default — everything the loader resolves is allowed).
         /// </summary>
         public IModuleLoadPolicy? LoadPolicy { get; set; }
+
+        /// <summary>
+        /// When <c>true</c>, module loading failures expose the original exception message to script code.
+        /// Defaults to <c>false</c>, so paths, URLs, transport details and other host information are replaced
+        /// with a generic message. The original exception remains available to the host through
+        /// <see cref="JintException.TryGetClrException"/>.
+        /// </summary>
+        public bool ExposeDetailedLoadErrors { get; set; }
     }
 
     /// <summary>

--- a/Jint/Runtime/Interop/TypeReference.cs
+++ b/Jint/Runtime/Interop/TypeReference.cs
@@ -201,7 +201,7 @@ public sealed class TypeReference : Constructor, IObjectWrapper
             {
                 var message = engine.Options.Interop.ExposeDetailedResolutionErrors
                     ? InteropErrorHelper.CreateNoMatchingConstructorMessage(referenceType, arguments, constructors)
-                    : $"Could not resolve a constructor for type {referenceType} for given arguments";
+                    : "Could not resolve a constructor for the specified arguments.";
                 Throw.InteropResolutionError(realm, message, referenceType, memberName: null, arguments, constructors);
             }
 

--- a/Jint/Runtime/JavaScriptException.cs
+++ b/Jint/Runtime/JavaScriptException.cs
@@ -50,7 +50,8 @@ public class JavaScriptException : JintException
     /// Throw this from host code — a <see cref="Jint.Runtime.Interop.ClrFunction"/> delegate, a module export —
     /// to raise an error the script can catch while the originating CLR exception still reaches the host, read
     /// there with <see cref="JintException.TryGetClrException"/>. A null <paramref name="message"/> takes the
-    /// exception's own message.
+    /// generic host-error message by default; enable
+    /// <see cref="Options.InteropOptions.ExposeDetailedExceptionMessages"/> to use the exception's own message.
     /// <para>
     /// Prefer this over projecting the exception into the script
     /// (<c>new JavaScriptException(JsValue.FromObject(engine, ex))</c>). That value is not an <c>Error</c> — it
@@ -59,7 +60,7 @@ public class JavaScriptException : JintException
     /// </para>
     /// </summary>
     public JavaScriptException(ErrorConstructor errorConstructor, string? message, Exception clrException)
-        : this(errorConstructor, ResolveClrMessage(message, clrException))
+        : this(errorConstructor, ResolveClrMessage(errorConstructor, message, clrException))
     {
         if (Error is ErrorInstance errorInstance)
         {
@@ -67,14 +68,17 @@ public class JavaScriptException : JintException
         }
     }
 
-    private static string? ResolveClrMessage(string? message, Exception clrException)
+    private static string? ResolveClrMessage(ErrorConstructor errorConstructor, string? message, Exception clrException)
     {
         if (clrException is null)
         {
             Throw.ArgumentNullException(nameof(clrException));
         }
 
-        return message ?? clrException.Message;
+        return message
+               ?? (errorConstructor.Engine.Options.Interop.ExposeDetailedExceptionMessages
+                   ? clrException.Message
+                   : Throw.GenericHostErrorMessage);
     }
 
     public JavaScriptException(JsValue error)

--- a/Jint/Runtime/Modules/AsyncModuleLoader.cs
+++ b/Jint/Runtime/Modules/AsyncModuleLoader.cs
@@ -65,9 +65,10 @@ public abstract class AsyncModuleLoader : ModuleLoader, IAsyncModuleLoader
     /// thread, at any time.
     /// </summary>
     /// <remarks>
-    /// A faulted task fails the load, rejecting every importer waiting on it with the exception's message —
-    /// which is the behaviour a host wants for an HTTP 404 or a cancelled fetch. It is not a way to abort the
-    /// engine: to bound execution, register a constraint on <see cref="Options"/>.
+    /// A faulted task fails the load. Its exception is retained for host-side diagnostics while the
+    /// script-visible message is generic unless detailed load errors are explicitly enabled. Cancellation
+    /// exceptions remain control flow and abort the engine operation rather than becoming a catchable import
+    /// rejection.
     /// </remarks>
     protected abstract Task<string> LoadModuleContentsAsync(Engine engine, ResolvedSpecifier resolved, CancellationToken cancellationToken);
 
@@ -98,7 +99,8 @@ public abstract class AsyncModuleLoader : ModuleLoader, IAsyncModuleLoader
     {
         if (task is null)
         {
-            completion.SetError($"'{nameof(LoadModuleContentsAsync)}' returned null for '{completion.Resolved.ModuleRequest.Specifier}'.");
+            completion.SetError(new InvalidOperationException(
+                $"'{nameof(LoadModuleContentsAsync)}' returned null for '{completion.Resolved.ModuleRequest.Specifier}'."));
             return;
         }
 
@@ -123,7 +125,8 @@ public abstract class AsyncModuleLoader : ModuleLoader, IAsyncModuleLoader
     {
         if (task is null)
         {
-            completion.SetError($"'{nameof(LoadModuleContentsAsBytesAsync)}' returned null for '{completion.Resolved.ModuleRequest.Specifier}'.");
+            completion.SetError(new InvalidOperationException(
+                $"'{nameof(LoadModuleContentsAsBytesAsync)}' returned null for '{completion.Resolved.ModuleRequest.Specifier}'."));
             return;
         }
 
@@ -183,7 +186,7 @@ public abstract class AsyncModuleLoader : ModuleLoader, IAsyncModuleLoader
             }
             else
             {
-                completion.SetError($"Loading module '{completion.Resolved.ModuleRequest.Specifier}' was canceled.");
+                completion.SetError(new TaskCanceledException(task));
             }
             return true;
         }

--- a/Jint/Runtime/Modules/IAsyncModuleLoader.cs
+++ b/Jint/Runtime/Modules/IAsyncModuleLoader.cs
@@ -50,9 +50,10 @@ public interface IAsyncModuleLoader : IModuleLoader
     /// failed import no longer bounds anything. Note what that means for a host cancelling its own fetch:
     /// <see cref="OperationCanceledException"/> (and so <see cref="System.Threading.Tasks.TaskCanceledException"/>)
     /// thrown from here is read as the engine aborting, not as a failed load, and on a queued event-loop turn
-    /// it escapes with the importers of that specifier left pending. Report a cancelled fetch through
-    /// <see cref="ModuleLoadCompletion.SetError(Exception)"/> or a faulted task instead — which is what
-    /// <see cref="AsyncModuleLoader"/> does for you.
+    /// it escapes with the importers of that specifier left pending. The same rule applies to
+    /// <see cref="ModuleLoadCompletion.SetError(Exception)"/>, faulted tasks and canceled tasks. A host that
+    /// deliberately wants cancellation to be an ordinary failed import must report an explicit script-facing
+    /// message through <see cref="ModuleLoadCompletion.SetError(string)"/> instead.
     /// </para>
     /// </remarks>
     void LoadModuleAsync(Engine engine, ResolvedSpecifier resolved, ModuleLoadCompletion completion);

--- a/Jint/Runtime/Modules/ModuleBuilder.cs
+++ b/Jint/Runtime/Modules/ModuleBuilder.cs
@@ -212,9 +212,21 @@ public sealed class ModuleBuilder
         }
         catch (ParseErrorException ex)
         {
-            // The diagnostic names the module the way the host knows it, which is the registration name.
-            var errorLocation = SourceLocation.From(Position.From(ex.LineNumber, ex.Column), Position.From(ex.LineNumber, ex.Column), _specifier);
-            Throw.SyntaxError(_engine.Realm, $"Error while loading module: error in module '{_specifier}': {ex.Error}", in errorLocation);
+            var exposeDetails = _engine.Options.Modules.ExposeDetailedLoadErrors;
+            var errorLocation = SourceLocation.From(
+                Position.From(ex.LineNumber, ex.Column),
+                Position.From(ex.LineNumber, ex.Column),
+                exposeDetails ? _specifier : null);
+            var message = exposeDetails
+                ? $"Error while loading module: error in module '{_specifier}': {ex.Error}"
+                : "Could not load module.";
+            var error = Throw.CreateClrError(
+                _engine,
+                ex,
+                message,
+                _engine.Realm.Intrinsics.SyntaxError,
+                moduleErrorPolicyApplied: true);
+            Throw.JavaScriptException(_engine, error, in errorLocation);
             return default;
         }
     }

--- a/Jint/Runtime/Modules/ModuleFactory.cs
+++ b/Jint/Runtime/Modules/ModuleFactory.cs
@@ -138,9 +138,18 @@ public static class ModuleFactory
         {
             module = new JsonParser(engine).Parse(jsonString);
         }
-        catch (Exception)
+        catch (Exception ex) when (!ModuleLoadCompletion.MustPropagate(ex))
         {
-            Throw.SyntaxError(engine.Realm, $"Could not load module {source}");
+            var message = engine.Options.Modules.ExposeDetailedLoadErrors
+                ? $"Could not load module {source}: {ex.Message}"
+                : "Could not load module.";
+            var error = Throw.CreateClrError(
+                engine,
+                ex,
+                message,
+                engine.Realm.Intrinsics.SyntaxError,
+                moduleErrorPolicyApplied: true);
+            Throw.JavaScriptException(engine, error, in AstExtensions.DefaultLocation);
             module = null;
         }
 

--- a/Jint/Runtime/Modules/ModuleLoadCompletion.cs
+++ b/Jint/Runtime/Modules/ModuleLoadCompletion.cs
@@ -2,6 +2,7 @@ using System.Runtime.ExceptionServices;
 using System.Threading;
 using Jint.Constraints;
 using Jint.Native;
+using Jint.Native.Error;
 
 namespace Jint.Runtime.Modules;
 
@@ -163,8 +164,10 @@ public sealed class ModuleLoadCompletion
 
     /// <summary>
     /// Fails the load. Every importer waiting on it — the promise from a dynamic <c>import()</c>, the load
-    /// phase of a static import graph — is rejected with an <c>Error</c> carrying
-    /// <paramref name="exception"/>'s message. Engine resource-limit and cancellation exceptions propagate
+    /// phase of a static import graph — is rejected with an <c>Error</c>. By default the script-visible message
+    /// is generic; <see cref="Options.ModuleOptions.ExposeDetailedLoadErrors"/> restores the exception message
+    /// for trusted development environments. The original exception remains available host-side through
+    /// <see cref="JintException.TryGetClrException"/>. Engine resource-limit and cancellation exceptions propagate
     /// instead, because turning them into a script-catchable rejection would defeat the bound.
     /// </summary>
     public void SetError(Exception exception)
@@ -180,15 +183,17 @@ public sealed class ModuleLoadCompletion
             return;
         }
 
-        // A JavaScriptException already carries the error value the host wants raised — and travels along so
-        // a blocking importer can rethrow it with its location and stack intact; anything else is a CLR
-        // failure whose message is the only part meaningful to script.
-        var javaScriptException = exception as JavaScriptException;
-        Settle(() => Fail(javaScriptException, javaScriptException?.Error, exception.Message));
+        var error = exception is JavaScriptException { Error: ErrorInstance markedError }
+                    && _modules.HasModuleErrorPolicyApplied(markedError)
+            ? markedError
+            : null;
+        Settle(() => Fail(exception, error, exception.Message));
     }
 
     /// <summary>
-    /// Fails the load with an <c>Error</c> carrying <paramref name="message"/>.
+    /// Fails the load with an <c>Error</c> carrying <paramref name="message"/>. This overload is an explicit
+    /// script-facing message and is not redacted; use <see cref="SetError(Exception)"/> to preserve diagnostic
+    /// details for the host while applying the configured disclosure policy to script.
     /// </summary>
     public void SetError(string message)
     {
@@ -275,9 +280,10 @@ public sealed class ModuleLoadCompletion
             }
             catch (JavaScriptException ex)
             {
-                // Parsing the source the host handed over is engine work, so a syntax error in it belongs to
-                // the importer as a rejection rather than to whichever turn of the event loop ran the build.
-                Fail(ex, ex.Error, ex.Message);
+                var error = _modules.HasModuleErrorPolicyApplied(ex.Error)
+                    ? ex.Error
+                    : null;
+                Fail(ex, error, ex.Message);
                 return;
             }
             catch (Exception ex) when (Engine.EventLoop.IsRunningJob && !MustPropagate(ex))
@@ -314,7 +320,18 @@ public sealed class ModuleLoadCompletion
         try
         {
             _modules.RemovePendingLoad(_cacheKey);
-            FinishWaiters(module: null, error ?? CreateError(message), exception);
+            var loadError = error;
+            if (loadError is null)
+            {
+                loadError = exception is null
+                    ? CreateError(message)
+                    : Throw.CreateClrError(
+                        Engine,
+                        exception,
+                        Engine.Options.Modules.ExposeDetailedLoadErrors ? message : GenericLoadErrorMessage,
+                        moduleErrorPolicyApplied: true);
+            }
+            FinishWaiters(module: null, loadError, exception);
         }
 
         finally
@@ -332,7 +349,10 @@ public sealed class ModuleLoadCompletion
 
     private void FinishWaiters(Module? module, JsValue? error, Exception? exception)
     {
-        if (error is not null && exception is not null)
+        if (error is not null
+            && exception is JavaScriptException javaScriptException
+            && ReferenceEquals(javaScriptException.Error, error)
+            && _modules.HasModuleErrorPolicyApplied(error))
         {
             // Keeps the original exception reachable for the blocking import paths, which otherwise can only
             // rebuild a JavaScriptException from the error value — losing its location, stack and Data.
@@ -425,6 +445,15 @@ public sealed class ModuleLoadCompletion
         }
 
         return exception is TimeoutException && Throw.IsEngineAbortException(exception);
+    }
+
+    private const string GenericLoadErrorMessage = "Could not load module.";
+
+    private void Abort(Exception exception)
+    {
+        _modules.RemovePendingLoad(_cacheKey);
+        _waiters.Clear();
+        ExceptionDispatchInfo.Capture(exception).Throw();
     }
 
     private Native.Object.ObjectInstance CreateError(string message) => Engine.Realm.Intrinsics.Error.Construct(message);

--- a/Jint/Runtime/Modules/ModuleLoader.cs
+++ b/Jint/Runtime/Modules/ModuleLoader.cs
@@ -23,7 +23,7 @@ public abstract class ModuleLoader : IModuleLoader
             catch (Exception ex) when (ex is not NotSupportedException
                                        && !ModuleLoadCompletion.MustPropagateLoaderException(engine, ex))
             {
-                Throw.JavaScriptException(engine, $"Could not load module {resolved.ModuleRequest.Specifier}", in AstExtensions.DefaultLocation);
+                ThrowLoadError(engine, resolved, ex);
                 return default!;
             }
 
@@ -42,7 +42,7 @@ public abstract class ModuleLoader : IModuleLoader
             catch (Exception ex) when (ex is not NotSupportedException
                                        && !ModuleLoadCompletion.MustPropagateLoaderException(engine, ex))
             {
-                Throw.JavaScriptException(engine, $"Could not load module {resolved.ModuleRequest.Specifier}", in AstExtensions.DefaultLocation);
+                ThrowLoadError(engine, resolved, ex);
                 return default!;
             }
 
@@ -65,9 +65,25 @@ public abstract class ModuleLoader : IModuleLoader
 
         // Attach the host-defined [[ModuleSource]] (used by source-phase imports). Returns null for
         // ordinary modules, leaving behaviour unchanged.
-        moduleRecord.ModuleSource = GetModuleSource(engine, resolved);
+        try
+        {
+            moduleRecord.ModuleSource = GetModuleSource(engine, resolved);
+        }
+        catch (Exception ex) when (!ModuleLoadCompletion.MustPropagate(ex))
+        {
+            ThrowLoadError(engine, resolved, ex);
+        }
 
         return moduleRecord;
+    }
+
+    private static void ThrowLoadError(Engine engine, ResolvedSpecifier resolved, Exception exception)
+    {
+        var message = engine.Options.Modules.ExposeDetailedLoadErrors
+            ? $"Could not load module {resolved.ModuleRequest.Specifier}: {exception.Message}"
+            : "Could not load module.";
+        var error = Throw.CreateClrError(engine, exception, message, moduleErrorPolicyApplied: true);
+        Throw.JavaScriptException(engine, error, in AstExtensions.DefaultLocation);
     }
 
     /// <summary>
@@ -75,13 +91,23 @@ public abstract class ModuleLoader : IModuleLoader
     /// outside this class and must still attach the same host-defined <c>[[ModuleSource]]</c>.
     /// </summary>
     internal Jint.Native.Object.ObjectInstance? GetModuleSourceForAsyncLoad(Engine engine, ResolvedSpecifier resolved)
-        => GetModuleSource(engine, resolved);
+    {
+        try
+        {
+            return GetModuleSource(engine, resolved);
+        }
+        catch (Exception ex) when (!ModuleLoadCompletion.MustPropagate(ex))
+        {
+            ThrowLoadError(engine, resolved, ex);
+            return null;
+        }
+    }
 
     /// <summary>
-    /// Loads the module's source text. An ordinary loader or transport failure is reported to script as
-    /// <c>Could not load module {specifier}</c>. Engine constraint failures and host-requested cancellation
-    /// propagate instead, because reducing either to a catchable import rejection would defeat the bound.
-    /// One further exception:
+    /// Loads the module's source text. Anything this throws is a failed load, reported to script with a generic
+    /// message unless <see cref="Options.ModuleOptions.ExposeDetailedLoadErrors"/> is enabled. Engine constraint
+    /// failures and host-requested cancellation propagate instead, because reducing either to a catchable import
+    /// rejection would defeat the bound. One further exception:
     /// <see cref="NotSupportedException"/> propagates as itself, reserved for telling a host that it reached
     /// this loader the wrong way rather than that a module is missing.
     /// <see cref="AsyncModuleLoader.LoadModuleContents"/> is the in-box use of it.

--- a/Jint/Runtime/Throw.cs
+++ b/Jint/Runtime/Throw.cs
@@ -5,6 +5,7 @@ using System.Runtime.ExceptionServices;
 using System.Threading;
 using Jint.Native;
 using Jint.Native.Error;
+using Jint.Native.Object;
 using Jint.Runtime.CallStack;
 using Jint.Runtime.Interop;
 using Jint.Runtime.Modules;
@@ -49,6 +50,8 @@ internal static class Throw
         return value.IsObject() ? "[object]" : value.ToString();
     }
 
+    internal const string GenericHostErrorMessage = "A host operation failed.";
+
     internal static bool IsEngineAbortException(Exception exception)
         => EngineAbortRegistry.Exceptions.TryGetValue(exception, out _);
 
@@ -73,7 +76,6 @@ internal static class Throw
         internal static readonly ConditionalWeakTable<Exception, object> Exceptions = new();
         internal static readonly object Marker = new();
     }
-
     [DoesNotReturn]
     public static void SyntaxError(Realm realm, string? message = null)
     {
@@ -306,17 +308,15 @@ internal static class Throw
     [DoesNotReturn]
     public static void FromClrException(Engine engine, Exception clrException)
     {
-        var error = engine.Realm.Intrinsics.Error.Construct(clrException.Message);
-
-        // The error value survives the interpreter's throw-completion reconstruction (the .NET exception
-        // instance does not), so the only place the originating exception can be recorded and still reach
-        // the host is the error object itself. Attached before the decorator runs, so a decorator can read it.
-        if (error is ErrorInstance errorInstance)
+        if (ModuleLoadCompletion.MustPropagate(clrException))
         {
-            errorInstance.SetClrException(clrException);
+            ExceptionDispatchInfo.Capture(clrException).Throw();
         }
 
-        engine.Options.Interop.ClrExceptionErrorDecorator?.Invoke(engine, error, clrException);
+        var message = engine.Options.Interop.ExposeDetailedExceptionMessages
+            ? clrException.Message
+            : GenericHostErrorMessage;
+        var error = CreateClrError(engine, clrException, message);
 
         var jsException = new JavaScriptException(error);
         var location = engine._lastSyntaxElement?.Location ?? default;
@@ -326,7 +326,71 @@ internal static class Throw
             // (e.g. copying clrException.StackTrace onto the JS Error).
             jsException.SetJavaScriptCallstack(engine, in location, overwriteExisting: false);
         }
+
         throw jsException;
+    }
+
+    internal static ObjectInstance CreateClrError(
+        Engine engine,
+        Exception clrException,
+        string message,
+        ErrorConstructor? errorConstructor = null,
+        bool moduleErrorPolicyApplied = false)
+    {
+        var diagnosticException = JintException.TryGetClrException(clrException, out var originatingException)
+            ? originatingException
+            : clrException;
+        errorConstructor ??= clrException is JavaScriptException { Error: ObjectInstance javaScriptError }
+            ? GetErrorConstructor(engine, javaScriptError)
+            : engine.Realm.Intrinsics.Error;
+        var error = errorConstructor.Construct(message);
+
+        // The error value survives the interpreter's throw-completion reconstruction (the .NET exception
+        // instance does not), so the only place the originating exception can be recorded and still reach
+        // the host is the error object itself. Attached before the decorator runs, so a decorator can read it.
+        if (error is ErrorInstance errorInstance)
+        {
+            errorInstance.SetClrException(diagnosticException);
+            if (moduleErrorPolicyApplied)
+            {
+                errorInstance.SetModuleErrorPolicyToken(engine.Modules.GetModuleErrorPolicyToken());
+            }
+        }
+
+        engine.Options.Interop.ClrExceptionErrorDecorator?.Invoke(engine, error, diagnosticException);
+        return error;
+    }
+
+    private static ErrorConstructor GetErrorConstructor(Engine engine, ObjectInstance error)
+    {
+        var intrinsics = engine.Realm.Intrinsics;
+        var prototype = error.Prototype;
+        if (ReferenceEquals(prototype, intrinsics.SyntaxError.PrototypeObject))
+        {
+            return intrinsics.SyntaxError;
+        }
+        if (ReferenceEquals(prototype, intrinsics.TypeError.PrototypeObject))
+        {
+            return intrinsics.TypeError;
+        }
+        if (ReferenceEquals(prototype, intrinsics.RangeError.PrototypeObject))
+        {
+            return intrinsics.RangeError;
+        }
+        if (ReferenceEquals(prototype, intrinsics.ReferenceError.PrototypeObject))
+        {
+            return intrinsics.ReferenceError;
+        }
+        if (ReferenceEquals(prototype, intrinsics.EvalError.PrototypeObject))
+        {
+            return intrinsics.EvalError;
+        }
+        if (ReferenceEquals(prototype, intrinsics.UriError.PrototypeObject))
+        {
+            return intrinsics.UriError;
+        }
+
+        return intrinsics.Error;
     }
 
     [DoesNotReturn]

--- a/README.md
+++ b/README.md
@@ -2819,9 +2819,11 @@ engine.SetValue("parse", new Action<string>(s => new XmlDocument().LoadXml(s)));
 engine.Evaluate("parse('<not xml')");
 ```
 
-`CatchClrExceptions` changes that: the exception becomes a JavaScript `Error` carrying its message, which the
-script can `try`/`catch` like any other. The predicate overload decides per exception, so you can let the
-script handle what it should handle and keep the rest fatal.
+`CatchClrExceptions` changes that: the exception becomes a JavaScript `Error` which the script can
+`try`/`catch` like any other. Its message is `A host operation failed.` by default; the original message,
+stack trace and inner exceptions remain host-only. The predicate overload decides per exception, so you can
+let the script handle what it should handle and keep the rest fatal. Cancellation, timeout, memory, statement
+and recursion-limit exceptions always remain control flow and are never converted into script errors.
 
 ```c#
 var engine = new Engine(options => options.CatchClrExceptions(e => e is not OperationCanceledException));
@@ -2870,6 +2872,28 @@ Two related accessors work the same way: `JintException.TryGetJavaScriptLocation
 exception, and `TryGetClrType`/`TryGetClrMemberName` report the type and member behind a failed interop
 resolution. To shape what the *script* sees — rewrite the message, attach an error code —
 use `DecorateClrExceptionErrors`.
+
+### Detailed development errors
+
+Host exception messages, module loader failures, and CLR method/constructor resolution details are redacted by
+default because they commonly contain secrets, filesystem paths, URLs, CLR type names and candidate signatures.
+`ExposeDetailedErrors` restores the previous development-friendly messages across all three surfaces:
+
+```c#
+var engine = new Engine(options => options
+    .CatchClrExceptions()
+    .EnableModules(loader)
+    .ExposeDetailedErrors());
+```
+
+Use it only when scripts and their error output are trusted. For narrower opt-ins, set
+`options.Interop.ExposeDetailedExceptionMessages`, `options.Interop.ExposeDetailedResolutionErrors`, or
+`options.Modules.ExposeDetailedLoadErrors` individually. These settings affect only script-visible messages;
+`TryGetClrException`, `TryGetClrType`, `TryGetClrMemberName`, and the CLR error decorators retain full host-side
+diagnostics under the safe defaults. `ModuleLoadCompletion.SetError(string)` remains an explicit script-facing
+message; use `SetError(Exception)` when the detail must be retained for the host and redacted from script.
+`DecorateClrExceptionErrors` also runs once for a module loader exception's final script-visible error, so the
+same host-side decorator can attach a safe error code to interop and module failures.
 
 ### Raising an error from host code
 


### PR DESCRIPTION
## Summary

- redact caught CLR exception messages, CLR resolution details, and module load failures by default while retaining explicit detailed-development opt-ins
- apply CLR error decorators exactly once across synchronous and asynchronous module boundaries, including parse, resolve, build, debugger, and custom-loader failures
- keep every resource/control failure fatal while treating ordinary loader transport timeout/cancellation as sanitized load failures
- scope module-policy provenance to the active engine and disclosure/decorator configuration, and preserve bounded host-only diagnostics through `TryGetClrException`

## Security integration

This PR is stacked on #3046 and preserves the ownership, memory, parser, module graph, result-limit, fatal-cleanup, and bounded-rendering layers below it. Module policy provenance uses an opaque active-policy token, so foreign/stale errors cannot bypass redaction or decoration. Blocking imports rethrow an original exception only when it carries the exact approved error; otherwise they throw the sanitized/decorated error and retain the original through the host-only diagnostic contract.

Stack: #3046 -> #3045 -> #3037 -> #3036 -> #3035 -> #3030.

## Conflict resolution

The reviewed redaction commits were transplanted from `330224cfc` onto `c7dac6a31`. Conflicts in `Engine.Modules`, `ModuleLoadCompletion`, `ModuleLoader`, `AsyncModuleLoader`, `AcornimaExtensions`, `Throw`, and `Options` retained the newer ownership, parsing, module-graph, result-limit, and engine timeout/cancellation classifications while layering sanitized disclosure and exactly-once decoration. `.github/THREAT_MODEL.md` preserves both graph-policy guidance and the sanitized-default/detailed-opt-in trust boundary.

## Review

A specialist security review found two issues: reusable boolean provenance across engines/configurations, and blocking imports rethrowing raw undecorated exceptions. Both were fixed with active-policy tokens and exact approved-error memoization. A fresh follow-up security review reported no high-confidence findings.

## Validation

- Release multi-target `Jint/Jint.csproj` build: 5 target frameworks, 0 warnings/errors
- full `Jint.Tests.PublicInterface`: 1691 passed, 9 skipped
- full `Jint.Tests.PublicInterface` with `JINT_HOST_CONTRACT_VERIFICATION=1`: 1695 passed, 5 skipped
- full UTC `Jint.Tests`: 5771 passed, 4 skipped
- focused disclosure/module policy: 127 passed
- focused result/parser/ownership/retention: 98 passed
- focused GC/debugger/interop: 518 passed, 1 skipped
- `git diff --check`

Validation used only `https://packagefeedproxy.microsoft.io/nuget/v3/index.json`. Because that proxy currently exposes Meziantou.Analyzer 3.0.141 rather than the pinned 3.0.156, the analyzer version was temporarily lowered only for local validation and restored exactly before commit; dependency manifests are unchanged.