### PR TITLE
Contain CLR type and member resolution

### DIFF
--- a/.github/THREAT_MODEL.md
+++ b/.github/THREAT_MODEL.md
@@ -77,7 +77,8 @@ Defaults are compatibility choices, not a hardened profile.
 | Control | Default | Security effect |
 | --- | --- | --- |
 | CLR namespace access (`Interop.Enabled`) | Disabled | `System`, `importNamespace`, and `clrHelper` are not installed |
-| `AllowGetType`, `AllowSystemReflection` | Disabled | Blocks important reflection and allow-list bypass paths |
+| `AllowGetType`, `AllowSystemReflection` | Disabled | Blocks instance type discovery, type widening, and reflection namespace/object access |
+| `AllowedAssemblies` | Empty until `AllowClr` adds entries | Closed allow-list for `System` / `importNamespace` type discovery, not for what admitted APIs can do |
 | Writes through projected CLR objects | Enabled | A default engine can mutate host objects passed with `SetValue` |
 | CLR array conversion | Live view | Script writes can mutate a projected CLR array |
 | Modules | Disabled | The fail-fast loader rejects imports |
@@ -106,29 +107,49 @@ Defaults are compatibility choices, not a hardened profile.
 
 ### TM-01: CLR access becomes process authority
 
-**Threat.** Enabling CLR interop lets script reach powerful .NET APIs. Core library types
-can be resolved even when `AllowedAssemblies` is empty or narrow, so that collection must
-not be treated as a complete sandbox allow-list. Enabling `AllowGetType` can open further
-type-resolution and reflection paths. The result can be filesystem or environment access,
-network access, process creation, native interop, or arbitrary code execution with the
-worker's identity.
+**Threat.** Enabling CLR interop lets script reach powerful .NET APIs. A type admitted by
+the namespace allow-list, explicitly exported as a `TypeReference`, or returned through a
+projected host object carries the authority of its exposed constructors and members. The
+result can be filesystem or environment access, network access, process creation, native
+interop, or arbitrary code execution with the worker's identity.
 
 **Existing mitigations.**
 
 - CLR namespace access, `AllowGetType`, and `AllowSystemReflection` are disabled by default.
-- `TypeResolver.MemberFilter` can filter projected members.
+- `AllowedAssemblies` is a closed allow-list for namespace discovery, including nested and
+  generic type definitions. Namespace lookup admits only effectively public types: top-level
+  types must be public, and every declaring type in a nested chain must be public. `AllowClr()`
+  without arguments adds only the core assembly that contains `System.Object`; supplying
+  assemblies adds only those assemblies.
+- `TypeResolver.MemberFilter` filters namespace-discovered types, nested types, constructors,
+  and projected members.
+- `AllowGetType` does not expose the static `System.Type.GetType(string)` family. Its
+  `clrHelper` type-widening operations also enforce the namespace type policy.
+- `AllowSystemReflection` gates namespace discovery and wrapping for `System.Reflection`.
 - `ExposeDetailedResolutionErrors` is disabled by default.
 
 **Missing or residual mitigation.**
 
 - Jint cannot reduce the operating-system authority of an enabled CLR API.
-- `AllowedAssemblies` is not a complete capability boundary for core runtime types.
+- `AllowedAssemblies` governs namespace discovery only. Host-projected objects, delegates,
+  and explicitly exported `TypeReference` values are separate capabilities and can expose
+  types from assemblies absent from that list.
+- A type admitted from an allowed assembly may itself load assemblies, resolve or instantiate
+  types by name, or return powerful objects. Assembly membership alone is therefore not a
+  complete capability boundary; a positive member allow-list is still required.
 - A member filter is host code and can be incomplete or become stale as types evolve.
+- Enabling `AllowGetType` still grants runtime type discovery for otherwise admitted objects.
+- Filtering one well-known static type-resolution family is defense in depth, not a general
+  barrier: other admitted APIs may carry equivalent type-resolution or invocation authority.
+- Enabling `AllowSystemReflection`, or explicitly exporting reflection capabilities, restores
+  the authority those APIs carry.
 
-**Required host action.** Never call `AllowClr` for untrusted scripts. Never enable
-`AllowGetType` or `AllowSystemReflection`. If CLR projection is unavoidable, use a dedicated
-allow-listing `TypeResolver`, test it as a security boundary, and still isolate the worker at
-the operating-system level.
+**Required host action.** Prefer leaving CLR namespace access disabled for untrusted scripts.
+If it is unavoidable, pass the minimum explicit assembly set to `AllowClr`, use a dedicated
+allow-listing `TypeResolver`, leave `AllowGetType` and `AllowSystemReflection` disabled, and
+test the complete exported capability surface. Treat every projected object, delegate, and
+explicit `TypeReference` as outside the assembly boundary, and audit every admitted member
+for authority it can return or exercise. Still isolate the worker at the operating-system level.
 
 ### TM-02: Projected host objects and delegates act as ambient capabilities
 

--- a/Jint.Tests.PublicInterface/ClrTypeResolutionSecurityTests.cs
+++ b/Jint.Tests.PublicInterface/ClrTypeResolutionSecurityTests.cs
@@ -1,0 +1,344 @@
+using System.Reflection;
+using Jint.Runtime.Interop;
+
+namespace Jint.Tests.PublicInterface;
+
+public class ClrTypeResolutionSecurityTests
+{
+    [Fact]
+    public void NarrowAssemblyListDeniesUnlistedRuntimeCapabilities()
+    {
+        var engine = new Engine(options => options.AllowClr(typeof(AllowedClrHost).Assembly));
+
+        engine.Evaluate("System.IO.File").Should().NotBeOfType<TypeReference>();
+        engine.Evaluate("System.Environment").Should().NotBeOfType<TypeReference>();
+        engine.Evaluate("System.Diagnostics.Process").Should().NotBeOfType<TypeReference>();
+        engine.Evaluate("System.Reflection.Assembly").Should().NotBeOfType<TypeReference>();
+    }
+
+    [Fact]
+    public void EmptyComputedAssemblyListFailsClosed()
+    {
+        Assembly[] assemblies = [];
+        var engine = new Engine(options => options.AllowClr(assemblies));
+
+        engine.Evaluate("System.Object").Should().NotBeOfType<TypeReference>();
+    }
+
+    [Fact]
+    public void NarrowAssemblyListRetainsExplicitlyAllowedTypes()
+    {
+        var engine = new Engine(options => options.AllowClr(typeof(AllowedClrHost).Assembly));
+
+        engine.Evaluate(
+                "importNamespace('Jint.Tests.PublicInterface').AllowedClrHost.Value")
+            .Should()
+            .Be(42);
+    }
+
+    [Fact]
+    public void MemberFilterAppliesToNamespaceAndNestedTypeResolution()
+    {
+        var resolver = new TypeResolver
+        {
+            MemberFilter = member => member switch
+            {
+                Type type => type == typeof(AllowedClrHost) || type == typeof(AllowedClrHost.VisibleNested),
+                _ => member.Name == nameof(AllowedClrHost.Value)
+            }
+        };
+        var engine = new Engine(options =>
+        {
+            options.AllowClr(typeof(AllowedClrHost).Assembly);
+            options.SetTypeResolver(resolver);
+        });
+
+        engine.Evaluate("importNamespace('Jint.Tests.PublicInterface').AllowedClrHost")
+            .Should()
+            .BeOfType<TypeReference>();
+        engine.Evaluate("importNamespace('Jint.Tests.PublicInterface').DeniedClrHost")
+            .Should()
+            .NotBeOfType<TypeReference>();
+        engine.Evaluate("importNamespace('Jint.Tests.PublicInterface').AllowedClrHost.VisibleNested")
+            .Should()
+            .BeOfType<TypeReference>();
+        engine.Evaluate("importNamespace('Jint.Tests.PublicInterface').AllowedClrHost.HiddenNested")
+            .Should()
+            .NotBeOfType<TypeReference>();
+        engine.Evaluate("importNamespace('Jint.Tests.PublicInterface').AllowedClrHost.PrivateNested")
+            .Should()
+            .NotBeOfType<TypeReference>();
+        engine.Evaluate("importNamespace('Jint.Tests.PublicInterface').AllowedClrHost.InternalNested")
+            .Should()
+            .NotBeOfType<TypeReference>();
+        engine.Evaluate("importNamespace('Jint.Tests.PublicInterface').InternalClrHost")
+            .Should()
+            .NotBeOfType<TypeReference>();
+        engine.Evaluate("importNamespace('Jint.Tests.PublicInterface')['AllowedClrHost+PrivateNested']")
+            .Should()
+            .NotBeOfType<TypeReference>();
+        engine.Evaluate("importNamespace('Jint.Tests.PublicInterface')['AllowedClrHost+PrivateNested+PublicChild']")
+            .Should()
+            .NotBeOfType<TypeReference>();
+    }
+
+    [Fact]
+    public void ExplicitTypeReferencesRemainCapabilitiesOutsideAssemblyList()
+    {
+        var engine = new Engine(options => options.AllowClr(typeof(AllowedClrHost).Assembly));
+        engine.SetValue("StringType", TypeReference.CreateTypeReference<string>(engine));
+
+        engine.Evaluate("StringType.IsNullOrEmpty('')").Should().BeTrue();
+        engine.Evaluate("System.String").Should().NotBeOfType<TypeReference>();
+    }
+
+    [Fact]
+    public void ExplicitTypeReferenceRoundTripsOutsideAssemblyList()
+    {
+        var engine = new Engine(options =>
+        {
+            options.AllowClr();
+            options.Interop.AllowGetType = true;
+        });
+        engine.SetValue("Explicit", TypeReference.CreateTypeReference<DeniedClrHost>(engine));
+
+        engine.Evaluate("clrHelper.objectToType(clrHelper.typeToObject(Explicit))")
+            .Should()
+            .BeOfType<TypeReference>()
+            .Which.ReferenceType.Should().Be(typeof(DeniedClrHost));
+    }
+
+    [Fact]
+    public void ExplicitTypeCapabilityDoesNotTransferToAnUnrelatedWrapper()
+    {
+        var engine = new Engine(options =>
+        {
+            options.AllowClr();
+            options.Interop.AllowGetType = true;
+        });
+        engine.SetValue("Explicit", TypeReference.CreateTypeReference<DeniedClrHost>(engine));
+        engine.SetValue("types", new ClrTypeHolder());
+        engine.Execute("explicitObject = clrHelper.typeToObject(Explicit)");
+
+        Invoking(() => engine.Evaluate("clrHelper.objectToType(types.HostDenied)"))
+            .Should()
+            .ThrowExactly<InvalidOperationException>()
+            .WithMessage("*not allowed*");
+    }
+
+    [Fact]
+    public void ParameterlessAllowClrIsCoreAssemblyCompatibilityMode()
+    {
+        var engine = new Engine(options => options.AllowClr());
+
+        engine.Evaluate("System.Object").Should().BeOfType<TypeReference>();
+        engine.Evaluate("importNamespace('Jint.Tests.PublicInterface').AllowedClrHost")
+            .Should()
+            .NotBeOfType<TypeReference>();
+    }
+
+    [Fact]
+    public void GenericDefinitionUsesAllowedAssemblyAndExplicitTypeArgument()
+    {
+        var engine = new Engine(options => options.AllowClr(typeof(AllowedClrHost).Assembly));
+        engine.SetValue("StringType", TypeReference.CreateTypeReference<string>(engine));
+
+        engine.Evaluate(
+                """
+                const PublicInterface = importNamespace('Jint.Tests.PublicInterface');
+                const StringBox = PublicInterface.AllowedClrBox(StringType);
+                new StringBox('safe').Value;
+                """)
+            .Should()
+            .Be("safe");
+    }
+
+    [Fact]
+    public void AllowGetTypeDoesNotExposeStaticTypeLookup()
+    {
+        var engine = new Engine(options =>
+        {
+            options.AllowClr();
+            options.Interop.AllowGetType = true;
+        });
+        engine.SetValue("value", new object());
+
+        engine.Evaluate("typeof value.GetType").Should().Be("function");
+        engine.Evaluate("typeof System.Type.GetType").Should().Be("undefined");
+    }
+
+    [Fact]
+    public void ClrHelperCannotWidenOutsideAssemblyPolicy()
+    {
+        var engine = new Engine(options =>
+        {
+            options.AllowClr(typeof(AllowedClrHost).Assembly);
+            options.Interop.AllowGetType = true;
+        });
+        engine.SetValue("types", new ClrTypeHolder());
+
+        engine.Evaluate("clrHelper.objectToType(types.Allowed)")
+            .Should()
+            .BeOfType<TypeReference>()
+            .Which.ReferenceType.Should().Be(typeof(AllowedClrHost));
+
+        Invoking(() => engine.Evaluate("clrHelper.objectToType(types.Denied)"))
+            .Should()
+            .ThrowExactly<InvalidOperationException>()
+            .WithMessage("*not allowed*");
+    }
+
+    [Fact]
+    public void ClrHelperUnwrapCannotRevealUnlistedConcreteType()
+    {
+        var engine = new Engine(options =>
+        {
+            options.AllowClr();
+            options.Interop.AllowGetType = true;
+        });
+        var projected = ObjectWrapper.Create(engine, new ConcreteClrView(), typeof(IClrView));
+        engine.SetValue("projected", projected);
+
+        Invoking(() => engine.Evaluate("clrHelper.unwrap(projected)"))
+            .Should()
+            .ThrowExactly<InvalidOperationException>()
+            .WithMessage("*not allowed*");
+    }
+
+    [Fact]
+    public void ReflectionNamespaceRequiresExplicitOptIn()
+    {
+        var restricted = new Engine(options => options.AllowClr(typeof(object).Assembly));
+        restricted.Evaluate("System.Reflection.Assembly").Should().NotBeOfType<TypeReference>();
+
+        var permissive = new Engine(options =>
+        {
+            options.AllowClr(typeof(object).Assembly);
+            options.Interop.AllowSystemReflection = true;
+        });
+        permissive.Evaluate("System.Reflection.Assembly").Should().BeOfType<TypeReference>();
+    }
+
+    [Fact]
+    public void DeniedMemberErrorsAreSanitizedAcrossColdAndWarmCacheReads()
+    {
+        var resolver = new TypeResolver { MemberFilter = static member => member.Name != nameof(AllowedClrInstance.Secret) };
+        var engine = new Engine(options =>
+        {
+            options.AllowClr(typeof(AllowedClrInstance).Assembly);
+            options.SetTypeResolver(resolver);
+            options.Interop.ThrowOnUnresolvedMember = true;
+        });
+        engine.SetValue("host", new AllowedClrInstance());
+
+        for (var i = 0; i < 2; i++)
+        {
+            Invoking(() => engine.Evaluate("host.Secret"))
+                .Should()
+                .ThrowExactly<MissingMemberException>()
+                .WithMessage("Cannot access the requested CLR member.")
+                .Which.Message.Should().NotContain(nameof(AllowedClrInstance)).And.NotContain(nameof(AllowedClrInstance.Secret));
+        }
+    }
+
+    [Fact]
+    public void DetailedDeniedMemberErrorsRetainCompatibilityMessage()
+    {
+        var resolver = new TypeResolver { MemberFilter = static member => member.Name != nameof(AllowedClrInstance.Secret) };
+        var engine = new Engine(options =>
+        {
+            options.AllowClr(typeof(AllowedClrInstance).Assembly);
+            options.SetTypeResolver(resolver);
+            options.Interop.ThrowOnUnresolvedMember = true;
+            options.Interop.ExposeDetailedResolutionErrors = true;
+        });
+        engine.SetValue("host", new AllowedClrInstance());
+
+        Invoking(() => engine.Evaluate("host.Secret"))
+            .Should()
+            .ThrowExactly<MissingMemberException>()
+            .WithMessage($"*{nameof(AllowedClrInstance.Secret)}*{nameof(AllowedClrInstance)}*");
+    }
+
+    [Fact]
+    public void GenericTypeBindingErrorsFollowResolutionDisclosurePolicy()
+    {
+        static Engine CreateEngine(bool exposeDetails)
+        {
+            var engine = new Engine(options =>
+            {
+                options.AllowClr(typeof(ConstrainedClrBox<>).Assembly);
+                options.Interop.ExposeDetailedResolutionErrors = exposeDetails;
+            });
+            engine.SetValue("StringType", TypeReference.CreateTypeReference<string>(engine));
+            return engine;
+        }
+
+        var sanitized = Invoking(() => CreateEngine(false).Evaluate(
+                "importNamespace('Jint.Tests.PublicInterface').ConstrainedClrBox(StringType)"))
+            .Should()
+            .ThrowExactly<InvalidOperationException>()
+            .Which;
+        sanitized.Message.Should().Be("Could not construct the requested generic CLR type.");
+        sanitized.InnerException.Should().BeNull();
+
+        var detailed = Invoking(() => CreateEngine(true).Evaluate(
+                "importNamespace('Jint.Tests.PublicInterface').ConstrainedClrBox(StringType)"))
+            .Should()
+            .ThrowExactly<InvalidOperationException>()
+            .Which;
+        detailed.Message.Should().Contain(nameof(ConstrainedClrBox<int>));
+        detailed.InnerException.Should().NotBeNull();
+    }
+}
+
+public static class AllowedClrHost
+{
+    public static int Value => 42;
+
+    public sealed class VisibleNested;
+
+    public sealed class HiddenNested;
+
+    private sealed class PrivateNested
+    {
+        public sealed class PublicChild;
+    }
+
+    internal sealed class InternalNested;
+}
+
+public sealed class DeniedClrHost;
+
+internal sealed class InternalClrHost;
+
+public sealed class AllowedClrBox<T>(T value)
+{
+    public T Value { get; } = value;
+}
+
+public sealed class ConstrainedClrBox<T> where T : struct;
+
+public sealed class AllowedClrInstance
+{
+    public string Secret => "secret";
+}
+
+public sealed class ClrTypeHolder
+{
+    public Type Allowed => typeof(AllowedClrHost);
+
+    public Type Denied => typeof(Environment);
+
+    public Type HostDenied => typeof(DeniedClrHost);
+}
+
+public interface IClrView
+{
+    string Name { get; }
+}
+
+public sealed class ConcreteClrView : IClrView
+{
+    public string Name => nameof(ConcreteClrView);
+}

--- a/Jint.Tests/Runtime/InteropExplicitTypeTests.cs
+++ b/Jint.Tests/Runtime/InteropExplicitTypeTests.cs
@@ -221,8 +221,27 @@ public class InteropExplicitTypeTests
     [Fact]
     public void ClrHelperUnwrap()
     {
-        _engine.Evaluate("holder.I1.Name").Should().NotBe(holder.CI1.Name);
-        _engine.Evaluate("clrHelper.unwrap(holder.I1).Name").Should().Be(holder.CI1.Name);
+        var engine = new Engine(options =>
+        {
+            options.AllowClr(typeof(CI1).Assembly);
+            options.Interop.AllowGetType = true;
+        }).SetValue("holder", holder);
+
+        engine.Evaluate("holder.I1.Name").Should().NotBe(holder.CI1.Name);
+        engine.Evaluate("clrHelper.unwrap(holder.I1).Name").Should().Be(holder.CI1.Name);
+    }
+
+    [Fact]
+    public void ClrHelperUnwrapRequiresAllowGetType()
+    {
+        var engine = new Engine(options => options.AllowClr(typeof(CI1).Assembly))
+            .SetValue("holder", holder);
+
+        var ex = Invoking(() => engine.Evaluate("clrHelper.unwrap(holder.I1)"))
+            .Should()
+            .ThrowExactly<InvalidOperationException>()
+            .Which;
+        ex.Message.Should().Be("Invalid when Engine.Options.Interop.AllowGetType == false");
     }
 
     [Fact]
@@ -316,7 +335,7 @@ public class InteropExplicitTypeTests
 
         runner.Invoke(new Engine(cfg =>
         {
-            cfg.AllowClr();
+            cfg.AllowClr(typeof(TypeHolder).Assembly);
             cfg.Interop.AllowGetType = true;
         }));
 

--- a/Jint.Tests/Runtime/InteropStaticMemberCacheTests.cs
+++ b/Jint.Tests/Runtime/InteropStaticMemberCacheTests.cs
@@ -3,10 +3,10 @@ using Jint.Runtime.Interop;
 namespace Jint.Tests.Runtime;
 
 /// <summary>
-/// The accessors backing static member access on a type reference live in a cache shared by the whole
-/// process and keyed only by (declaring type, member name). Entries must therefore capture nothing that
+/// The accessors backing static member access on a type reference live in the configured
+/// <see cref="TypeResolver"/> and are partitioned by the resolution profile. Entries must capture nothing that
 /// belongs to a single engine. A nested type is the exception: it resolves to an accessor holding a
-/// <see cref="TypeReference"/>, which is an object owned by the engine that created it.
+/// <see cref="TypeReference"/>, which is an object owned by the engine that created it and is not cached.
 /// </summary>
 public class InteropStaticMemberCacheTests
 {
@@ -34,35 +34,63 @@ public class InteropStaticMemberCacheTests
     [Fact]
     public void OrdinaryStaticMemberResolutionIsStillCached()
     {
-        // The cache is keyed by (type, member name) alone, so an engine that finds an entry never runs its
-        // own resolution. A second engine performing no member name lookups at all is therefore proof that
-        // the entry the first one produced was reused, and that excluding nested types did not quietly turn
-        // the cache off for everything else.
-
         var firstLookups = 0;
         var secondLookups = 0;
+        Action onLookup = () => firstLookups++;
+        var resolver = new TypeResolver
+        {
+            MemberNameCreator = member =>
+            {
+                onLookup();
+                return new[] { member.Name };
+            }
+        };
 
-        ReadStaticMember(() => firstLookups++).Should().Be(42);
-        ReadStaticMember(() => secondLookups++).Should().Be(42);
+        ReadStaticMember(resolver).Should().Be(42);
+        onLookup = () => secondLookups++;
+        ReadStaticMember(resolver).Should().Be(42);
 
         firstLookups.Should().BeGreaterThan(0, "the first engine has to resolve the member itself.");
         secondLookups.Should().Be(0, "the second engine must be served from the shared accessor cache.");
 
-        static double ReadStaticMember(Action onLookup)
+        static double ReadStaticMember(TypeResolver resolver)
         {
-            var resolver = new TypeResolver
-            {
-                MemberNameCreator = member =>
-                {
-                    onLookup();
-                    return new[] { member.Name };
-                }
-            };
-
             var engine = new Engine(options => options.SetTypeResolver(resolver));
             engine.SetValue("Holder", TypeReference.CreateTypeReference<CachedMemberHolder>(engine));
             return engine.Evaluate("Holder.Value").AsNumber();
         }
+    }
+
+    [Fact]
+    public void StaticAllowGetTypePolicyPartitionsTheCache()
+    {
+        var resolver = new TypeResolver();
+        var restricted = new Engine(options => options.SetTypeResolver(resolver));
+        restricted.SetValue("Holder", TypeReference.CreateTypeReference<StaticGetTypeHost>(restricted));
+        var permissive = new Engine(options =>
+        {
+            options.SetTypeResolver(resolver);
+            options.Interop.AllowGetType = true;
+        });
+        permissive.SetValue("Holder", TypeReference.CreateTypeReference<StaticGetTypeHost>(permissive));
+
+        restricted.Evaluate("typeof Holder.GetType").Should().Be("undefined");
+        permissive.Evaluate("typeof Holder.GetType").Should().Be("function");
+        restricted.Evaluate("typeof Holder.GetType").Should().Be("undefined");
+    }
+
+    [Fact]
+    public void ConstructorCacheBelongsToTheResolver()
+    {
+        var denied = new TypeResolver { MemberFilter = static _ => false };
+        var deniedEngine = new Engine(options => options.SetTypeResolver(denied));
+        deniedEngine.SetValue("Host", TypeReference.CreateTypeReference<ConstructorHost>(deniedEngine));
+        Invoking(() => deniedEngine.Evaluate("new Host()")).Should().Throw<Jint.Runtime.JavaScriptException>();
+
+        var allowed = new TypeResolver();
+        var allowedEngine = new Engine(options => options.SetTypeResolver(allowed));
+        allowedEngine.SetValue("Host", TypeReference.CreateTypeReference<ConstructorHost>(allowedEngine));
+        allowedEngine.Evaluate("new Host().Value").Should().Be(42);
     }
 
     /// <summary>
@@ -80,5 +108,15 @@ public class InteropStaticMemberCacheTests
     private sealed class CachedMemberHolder
     {
         public static int Value => 42;
+    }
+
+    private sealed class StaticGetTypeHost
+    {
+        public static new Type GetType() => typeof(StaticGetTypeHost);
+    }
+
+    private sealed class ConstructorHost
+    {
+        public int Value => 42;
     }
 }

--- a/Jint/Options.Extensions.cs
+++ b/Jint/Options.Extensions.cs
@@ -303,8 +303,22 @@ public static class OptionsExtensions
     }
 
     /// <summary>
-    /// Allows scripts to call CLR types directly like <example>System.IO.File</example>
+    /// Allows scripts to resolve CLR types from the core assembly containing <see cref="object"/> through
+    /// <c>System</c> and <c>importNamespace</c>.
     /// </summary>
+    public static Options AllowClr(this Options options)
+    {
+        return options.AllowClr(typeof(object).Assembly);
+    }
+
+    /// <summary>
+    /// Allows scripts to resolve CLR types from the supplied assemblies through <c>System</c> and
+    /// <c>importNamespace</c>.
+    /// </summary>
+    /// <remarks>
+    /// The supplied assemblies are a closed namespace-resolution allow-list. They do not restrict CLR objects,
+    /// delegates, or <see cref="TypeReference"/> values explicitly exported by the host.
+    /// </remarks>
     public static Options AllowClr(this Options options, params Assembly[] assemblies)
     {
         options.Interop.Enabled = true;

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -251,16 +251,20 @@ public partial class Options
         if (Interop.Enabled)
         {
 #pragma warning disable IL2026
+            var typeResolutionPolicy = new ClrTypeResolutionPolicy(Interop);
 
-            engine.Realm.GlobalObject.SetProperty("System", new PropertyDescriptor(new NamespaceReference(engine, "System"), PropertyFlag.AllForbidden));
+            engine.Realm.GlobalObject.SetProperty("System", new PropertyDescriptor(new NamespaceReference(engine, "System", typeResolutionPolicy), PropertyFlag.AllForbidden));
 
             engine.Realm.GlobalObject.SetProperty("importNamespace", new PropertyDescriptor(new ClrFunction(
                     engine,
                     "importNamespace",
-                    (_, arguments) => new NamespaceReference(engine, arguments.At(0).IsNullOrUndefined() ? null : TypeConverter.ToString(arguments.At(0)))),
+                    (_, arguments) => new NamespaceReference(
+                        engine,
+                        arguments.At(0).IsNullOrUndefined() ? null : TypeConverter.ToString(arguments.At(0)),
+                        typeResolutionPolicy)),
                 PropertyFlag.AllForbidden));
 
-            engine.Realm.GlobalObject.SetProperty("clrHelper", new PropertyDescriptor(ObjectWrapper.Create(engine, new ClrHelper(Interop)), PropertyFlag.AllForbidden));
+            engine.Realm.GlobalObject.SetProperty("clrHelper", new PropertyDescriptor(ObjectWrapper.Create(engine, new ClrHelper(Interop, typeResolutionPolicy)), PropertyFlag.AllForbidden));
 
 #pragma warning restore IL2026
         }
@@ -425,20 +429,34 @@ public partial class Options
         public bool Enabled { get; set; }
 
         /// <summary>
-        /// Whether to expose <see cref="object.GetType"></see> which can allow bypassing allow lists and open a way to reflection.
-        /// Defaults to false.
+        /// Whether to expose instance <see cref="object.GetType"/> members and the type-widening operations
+        /// <c>clrHelper.unwrap</c>, <c>typeOf</c>, <c>typeToObject</c>, and <c>objectToType</c>. Defaults to false.
         /// </summary>
         /// <remarks>
+        /// Jint filters the static <see cref="Type.GetType(string)"/> family from ordinary member resolution.
+        /// This is not a general type-resolution or reflection sandbox: other APIs admitted by the host can
+        /// carry equivalent authority. Type-widening <c>clrHelper</c> operations additionally
+        /// require the resulting type to satisfy the namespace-resolution assembly, reflection, and
+        /// <see cref="TypeResolver.MemberFilter"/> policy. A <see cref="Jint.Runtime.Interop.TypeReference"/> converted
+        /// to a <see cref="Type"/> object and back preserves that already-explicit capability.
+        /// <para>
         /// Read once, while the engine is being constructed. Changing it afterwards has no effect on an
         /// engine that already exists: resolved members are cached under the value captured then, so a later
-        /// change could only be honoured by some reads and not others.
+        /// change could only be honoured by some reads and not others. Enabling it grants powerful reflection
+        /// capabilities and is not recommended for untrusted scripts.
+        /// </para>
         /// </remarks>
         public bool AllowGetType { get; set; }
 
         /// <summary>
-        /// Whether Jint should allow wrapping objects from System.Reflection namespace.
-        /// Defaults to false.
+        /// Whether Jint should allow resolving or wrapping types from the <c>System.Reflection</c> namespace.
+        /// Defaults to false. A <see cref="TypeReference"/> explicitly exported by the host remains an explicit
+        /// capability and is not subject to namespace-resolution policy.
         /// </summary>
+        /// <remarks>
+        /// Namespace resolution reads this once when the engine installs its CLR globals. Configure it before
+        /// constructing the engine.
+        /// </remarks>
         public bool AllowSystemReflection { get; set; }
 
         /// <summary>
@@ -611,8 +629,19 @@ public partial class Options
         public ClrResolutionErrorDecoratorDelegate? ClrResolutionErrorDecorator { get; set; }
 
         /// <summary>
-        /// Assemblies to allow scripts to call CLR types directly like <example>System.IO.File</example>.
+        /// Assemblies from which <see cref="Jint.Runtime.Interop.NamespaceReference"/> may resolve CLR types.
         /// </summary>
+        /// <remarks>
+        /// This is a closed allow-list: no calling, executing, or core runtime assembly is searched implicitly.
+        /// <see cref="OptionsExtensions.AllowClr(Options)"/> adds the assembly containing <see cref="object"/>
+        /// for compatibility with core CLR type access. Passing an empty array to
+        /// <see cref="OptionsExtensions.AllowClr(Options, Assembly[])"/> adds no assemblies.
+        /// The list is snapshotted when the engine installs its CLR globals. It does not restrict ordinary CLR
+        /// objects, delegates, or <see cref="TypeReference"/> values explicitly exported by the host; those are
+        /// capabilities in their own right. Namespace lookup admits only public top-level types and nested
+        /// types whose complete declaring-type chain is public. Resolved types must also satisfy
+        /// <see cref="TypeResolver.MemberFilter"/> and <see cref="AllowSystemReflection"/>.
+        /// </remarks>
         public List<Assembly> AllowedAssemblies { get; set; } = new();
 
         /// <summary>

--- a/Jint/Runtime/Interop/ClrHelper.cs
+++ b/Jint/Runtime/Interop/ClrHelper.cs
@@ -1,4 +1,5 @@
-﻿using Jint.Native;
+﻿using System.Runtime.CompilerServices;
+using Jint.Native;
 
 namespace Jint.Runtime.Interop;
 
@@ -11,10 +12,13 @@ internal sealed class ClrHelper
     // not a supported pattern - member resolution could not honour a later change either, since the accessor
     // cache is partitioned by the value captured at construction.
     private readonly bool _allowGetType;
+    private readonly ClrTypeResolutionPolicy _typeResolutionPolicy;
+    private readonly ConditionalWeakTable<ObjectWrapper, TypeReference> _explicitTypeCapabilities = new();
 
-    internal ClrHelper(Options.InteropOptions interopOptions)
+    internal ClrHelper(Options.InteropOptions interopOptions, ClrTypeResolutionPolicy typeResolutionPolicy)
     {
         _allowGetType = interopOptions.AllowGetType;
+        _typeResolutionPolicy = typeResolutionPolicy;
     }
 
     /// <summary>
@@ -34,6 +38,8 @@ internal sealed class ClrHelper
     public JsValue Unwrap(ObjectWrapper obj)
 #pragma warning restore CA1822
     {
+        MustAllowGetType();
+        MustAllowType(obj.Target.GetType());
         return ObjectWrapper.Create(obj.Engine, obj.Target);
     }
 
@@ -57,6 +63,7 @@ internal sealed class ClrHelper
     public JsValue TypeOf(ObjectWrapper obj)
     {
         MustAllowGetType();
+        MustAllowType(obj.ClrType);
         return TypeReference.CreateTypeReference(obj.Engine, obj.ClrType);
     }
 
@@ -67,7 +74,13 @@ internal sealed class ClrHelper
     {
         MustAllowGetType();
         var engine = type.Engine;
-        return engine.Options.Interop.WrapObjectHandler.Invoke(engine, type.ReferenceType, null) ?? JsValue.Undefined;
+        var wrapped = engine.Options.Interop.WrapObjectHandler.Invoke(engine, type.ReferenceType, null);
+        if (wrapped is ObjectWrapper objectWrapper)
+        {
+            _explicitTypeCapabilities.Remove(objectWrapper);
+            _explicitTypeCapabilities.Add(objectWrapper, type);
+        }
+        return wrapped ?? JsValue.Undefined;
     }
 
     /// <summary>
@@ -78,6 +91,13 @@ internal sealed class ClrHelper
         MustAllowGetType();
         if (obj.Target is Type t)
         {
+            if (_explicitTypeCapabilities.TryGetValue(obj, out var explicitType)
+                && ReferenceEquals(explicitType.ReferenceType, t))
+            {
+                return explicitType;
+            }
+
+            MustAllowType(t);
             return TypeReference.CreateTypeReference(obj.Engine, t);
         }
 
@@ -90,6 +110,14 @@ internal sealed class ClrHelper
         if (!_allowGetType)
         {
             Throw.InvalidOperationException("Invalid when Engine.Options.Interop.AllowGetType == false");
+        }
+    }
+
+    private void MustAllowType(Type type)
+    {
+        if (!_typeResolutionPolicy.Allows(type))
+        {
+            Throw.InvalidOperationException("The CLR type is not allowed by the engine's namespace resolution policy");
         }
     }
 }

--- a/Jint/Runtime/Interop/NamespaceReference.cs
+++ b/Jint/Runtime/Interop/NamespaceReference.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Jint.Native;
 using Jint.Native.Object;
 using Jint.Runtime.Descriptors;
@@ -18,9 +19,17 @@ namespace Jint.Runtime.Interop;
 [RequiresUnreferencedCode("Dynamic loading")]
 public class NamespaceReference : ObjectInstance, ICallable
 {
-    private readonly string? _path;
+    private static readonly ConditionalWeakTable<Assembly, Dictionary<string, Type>> _typesByAssembly = new();
 
-    public NamespaceReference(Engine engine, string? path) : base(engine)
+    private readonly string? _path;
+    private readonly ClrTypeResolutionPolicy _policy;
+
+    public NamespaceReference(Engine engine, string? path)
+        : this(engine, path, new ClrTypeResolutionPolicy(engine.Options.Interop))
+    {
+    }
+
+    internal NamespaceReference(Engine engine, string? path, ClrTypeResolutionPolicy policy) : base(engine)
     {
         // Member access resolves namespace/type segments, not ordinary property lookup, so the
         // prototype-method inline cache must skip this receiver. See InternalTypes.ExoticGet.
@@ -28,6 +37,7 @@ public class NamespaceReference : ObjectInstance, ICallable
         // ICallable to bind a generic type, so call sites must see this as callable.
         _type |= InternalTypes.ExoticGet | InternalTypes.Callable;
         _path = path;
+        _policy = policy;
     }
 
     public override bool DefineOwnProperty(JsValue property, PropertyDescriptor desc)
@@ -51,7 +61,10 @@ public class NamespaceReference : ObjectInstance, ICallable
                 || !genericTypeReference.IsObject()
                 || genericTypeReference.AsObject() is not TypeReference tr)
             {
-                Throw.TypeError(_engine.Realm, "Invalid generic type parameter on " + _path + ", if this is not a generic type / method, are you missing a lookup assembly?");
+                var message = _policy.ExposeDetailedResolutionErrors
+                    ? "Invalid generic type parameter on " + _path + ", if this is not a generic type / method, are you missing a lookup assembly?"
+                    : "Invalid generic CLR type parameter.";
+                Throw.TypeError(_engine.Realm, message);
                 return default;
             }
 
@@ -71,9 +84,14 @@ public class NamespaceReference : ObjectInstance, ICallable
 
             return TypeReference.CreateTypeReference(Engine, genericType);
         }
-        catch (Exception e)
+        catch (Exception e) when (!Throw.MustPropagateHostException(e))
         {
-            Throw.InvalidOperationException($"Invalid generic type parameter on {_path}, if this is not a generic type / method, are you missing a lookup assembly?", e);
+            if (_policy.ExposeDetailedResolutionErrors)
+            {
+                Throw.InvalidOperationException($"Invalid generic type parameter on {_path}, if this is not a generic type / method, are you missing a lookup assembly?", e);
+            }
+
+            Throw.InvalidOperationException("Could not construct the requested generic CLR type.");
             return null;
         }
     }
@@ -92,113 +110,60 @@ public class NamespaceReference : ObjectInstance, ICallable
     {
         if (_engine.TypeCache.TryGetValue(path, out var type))
         {
-            if (type == null)
+            if (type == null || !_policy.Allows(type))
             {
-                return new NamespaceReference(_engine, path);
+                return new NamespaceReference(_engine, path, _policy);
             }
 
             return TypeReference.CreateTypeReference(_engine, type);
         }
 
-        // in CoreCLR, for example, classes that used to be in
-        // mscorlib were moved away, and only stubs remained, because
-        // of that, we do the search on the lookup assemblies first,
-        // and only then in mscorlib. Probelm usage: System.IO.File.CreateText
-
-        // search in loaded assemblies
-        var lookupAssemblies = new[] { Assembly.GetCallingAssembly(), Assembly.GetExecutingAssembly() };
-
-        foreach (var assembly in lookupAssemblies)
-        {
-            type = assembly.GetType(path);
-            if (type != null)
-            {
-                _engine.TypeCache.Add(path, type);
-                return TypeReference.CreateTypeReference(_engine, type);
-            }
-        }
-
-        // search in lookup assemblies
+        // Search only the host's closed allow-list. Explicit TypeReference values are separate capabilities.
         var comparedPath = path.Replace('+', '.');
-        foreach (var assembly in _engine.Options.Interop.AllowedAssemblies)
+        foreach (var assembly in _policy.AllowedAssemblies)
         {
             type = assembly.GetType(path);
-            if (type != null)
+            if (type is null)
+            {
+                type = GetTypeByNormalizedName(assembly, comparedPath);
+            }
+
+            if (type is not null)
             {
                 _engine.TypeCache.Add(path, type);
-                return TypeReference.CreateTypeReference(_engine, type);
+                return _policy.Allows(type)
+                    ? TypeReference.CreateTypeReference(_engine, type)
+                    : new NamespaceReference(_engine, path, _policy);
             }
-
-            var lastPeriodPos = path.LastIndexOf('.');
-            if (lastPeriodPos != -1)
-            {
-                var trimPath = path.Substring(0, lastPeriodPos);
-                type = GetType(assembly, trimPath);
-            }
-            if (type != null)
-            {
-                foreach (Type nType in GetAllNestedTypes(type))
-                {
-                    if (nType.FullName != null && nType.FullName.Replace('+', '.').Equals(comparedPath, StringComparison.Ordinal))
-                    {
-                        _engine.TypeCache.Add(comparedPath, nType);
-                        return TypeReference.CreateTypeReference(_engine, nType);
-                    }
-                }
-            }
-        }
-
-        // search for type in mscorlib
-        type = System.Type.GetType(path);
-        if (type != null)
-        {
-            _engine.TypeCache.Add(path, type);
-            return TypeReference.CreateTypeReference(_engine, type);
         }
 
         // the new path doesn't represent a known class, thus return a new namespace instance
 
         _engine.TypeCache.Add(path, null);
-        return new NamespaceReference(_engine, path);
+        return new NamespaceReference(_engine, path, _policy);
     }
 
-    /// <summary>   Gets a type. </summary>
-    ///<remarks>Nested type separators are converted to '.' instead of '+' </remarks>
-    /// <param name="assembly"> The assembly. </param>
-    /// <param name="typeName"> Name of the type. </param>
-    ///
-    /// <returns>   The type. </returns>
     [RequiresUnreferencedCode("Assembly type loading")]
-    private static Type? GetType(Assembly assembly, string typeName)
+    private static Type? GetTypeByNormalizedName(Assembly assembly, string typeName)
     {
-        var compared = typeName.Replace('+', '.');
-        foreach (Type t in assembly.GetTypes())
+        var types = _typesByAssembly.GetValue(assembly, static a =>
         {
-            if (string.Equals(t.FullName?.Replace('+', '.'), compared, StringComparison.Ordinal))
+            var result = new Dictionary<string, Type>(StringComparer.Ordinal);
+            foreach (var type in a.GetTypes())
             {
-                return t;
+                if (!ClrTypeResolutionPolicy.IsPubliclyAccessibleType(type))
+                {
+                    continue;
+                }
+
+                if (type.FullName?.Replace('+', '.') is { } name && !result.ContainsKey(name))
+                {
+                    result.Add(name, type);
+                }
             }
-        }
-
-        return null;
-    }
-
-    private static Type[] GetAllNestedTypes(Type type)
-    {
-        var types = new List<Type>();
-        AddNestedTypesRecursively(types, type);
-        return types.ToArray();
-    }
-
-    private static void AddNestedTypesRecursively(
-        List<Type> types,
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicNestedTypes)] Type type)
-    {
-        foreach (var nestedType in type.GetNestedTypes(BindingFlags.Public))
-        {
-            types.Add(nestedType);
-            AddNestedTypesRecursively(types, nestedType);
-        }
+            return result;
+        });
+        return types.TryGetValue(typeName, out var type) ? type : null;
     }
 
     public override PropertyDescriptor GetOwnProperty(JsValue property)
@@ -209,5 +174,52 @@ public class NamespaceReference : ObjectInstance, ICallable
     public override string ToString()
     {
         return "[CLR namespace: " + _path + "]";
+    }
+}
+
+internal sealed class ClrTypeResolutionPolicy
+{
+    private readonly bool _allowSystemReflection;
+    private readonly TypeResolver _typeResolver;
+
+    internal ClrTypeResolutionPolicy(Options.InteropOptions options)
+    {
+        AllowedAssemblies = new HashSet<Assembly>(options.AllowedAssemblies);
+        _allowSystemReflection = options.AllowSystemReflection;
+        ExposeDetailedResolutionErrors = options.ExposeDetailedResolutionErrors;
+        _typeResolver = options.TypeResolver;
+    }
+
+    internal HashSet<Assembly> AllowedAssemblies { get; }
+
+    internal bool ExposeDetailedResolutionErrors { get; }
+
+    internal bool Allows(Type type)
+    {
+        return AllowedAssemblies.Contains(type.Assembly)
+               && IsPubliclyAccessibleType(type)
+               && (_allowSystemReflection
+                   || type.Namespace?.StartsWith("System.Reflection", StringComparison.Ordinal) != true)
+               && _typeResolver.FilterType(type);
+    }
+
+    internal static bool IsPubliclyAccessibleType(Type type)
+    {
+        if (!type.IsNested)
+        {
+            return type.IsPublic;
+        }
+
+        while (type.IsNested)
+        {
+            if (!type.IsNestedPublic)
+            {
+                return false;
+            }
+
+            type = type.DeclaringType!;
+        }
+
+        return type.IsPublic;
     }
 }

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -353,7 +353,7 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
 
                     if (_engine.Options.Interop.ThrowOnUnresolvedMember)
                     {
-                        throw new MissingMemberException($"Cannot access property '{member}' on type '{ClrType.FullName}");
+                        throw TypeResolver.CreateMissingMemberException(_engine, ClrType, member);
                     }
 
                     // there's no such property, but we can allow extending by calling base
@@ -674,7 +674,7 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
             && !_typeDescriptor.IsDictionary
             && _engine.Options.Interop.ThrowOnUnresolvedMember)
         {
-            throw new MissingMemberException($"Cannot access property '{property}' on type '{ClrType.FullName}");
+            throw TypeResolver.CreateMissingMemberException(_engine, ClrType, property.ToString());
         }
 
         return protoResult;

--- a/Jint/Runtime/Interop/TypeReference.cs
+++ b/Jint/Runtime/Interop/TypeReference.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Concurrent;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Jint.Native;
 using Jint.Native.Object;
@@ -11,14 +10,18 @@ using Jint.Runtime.Interop.Reflection;
 
 namespace Jint.Runtime.Interop;
 
+/// <summary>
+/// An explicit host-granted capability for constructing a CLR type and accessing its static members.
+/// </summary>
+/// <remarks>
+/// An explicitly exported reference is not restricted by <see cref="Options.InteropOptions.AllowedAssemblies"/>,
+/// which governs namespace discovery. Its constructors, static members, and nested types still pass through
+/// <see cref="TypeResolver.MemberFilter"/>, <see cref="Options.InteropOptions.AllowGetType"/>, and the other
+/// member-resolution safeguards.
+/// </remarks>
 public sealed class TypeReference : Constructor, IObjectWrapper
 {
     private static readonly JsString _name = new("typereference");
-    private static readonly ConcurrentDictionary<Type, MethodDescriptor[]> _constructorCache = new();
-    private static readonly ConcurrentDictionary<MemberAccessorKey, ReflectionAccessor> _memberAccessors = new();
-
-    private readonly record struct MemberAccessorKey(Type Type, string PropertyName);
-
     private TypeReference(
         Engine engine,
         [DynamicallyAccessedMembers(InteropHelper.DefaultDynamicallyAccessedMemberTypes)] Type type)
@@ -79,14 +82,7 @@ public sealed class TypeReference : Constructor, IObjectWrapper
             }
             else
             {
-                constructors = _constructorCache.GetOrAdd(
-                    referenceType,
-                    t =>
-                    {
-                        List<ConstructorInfo> constructors = [.. t.GetConstructors(BindingFlags.Public | BindingFlags.Instance)];
-                        constructors.RemoveAll(x => !engine.Options.Interop.TypeResolver.MemberFilter(x));
-                        return MethodDescriptor.Build(constructors);
-                    });
+                constructors = engine.Options.Interop.TypeResolver.GetConstructors(engine, referenceType);
 
                 Func<MethodDescriptor, MethodResolverState, JsCallArguments> argumentProvider = static (method, state) =>
                 {
@@ -319,25 +315,7 @@ public sealed class TypeReference : Constructor, IObjectWrapper
                 .CreatePropertyDescriptor(_engine, ReferenceType, name, enumerable: true);
         }
 
-        var key = new MemberAccessorKey(ReferenceType, name);
-        if (!_memberAccessors.TryGetValue(key, out var accessor))
-        {
-            accessor = ResolveMemberAccessor(_engine, key.Type, key.PropertyName);
-
-            // The cache is process-wide, so an accessor may only enter it when it captures nothing bound to
-            // a single engine. Everything this path can produce is derived from the reflected type alone — a
-            // PropertyInfo or FieldInfo and the delegates compiled from it, a MethodDescriptor set, or a
-            // ConstantValueAccessor over a primitive enum value — and the engine-affine parts are built per
-            // call in CreatePropertyDescriptor below. The one exception is a nested type: it resolves to an
-            // accessor holding a TypeReference, an object owned by this engine, so caching it would keep the
-            // engine, its realm and all of its intrinsics alive for the lifetime of the process and hand this
-            // engine's object to any other engine that later asks for the same member. Those are re-resolved.
-            if (accessor is not NestedTypeAccessor)
-            {
-                // racy, we don't care: both racers resolved the same member the same way
-                _memberAccessors.TryAdd(key, accessor);
-            }
-        }
+        var accessor = _engine.Options.Interop.TypeResolver.GetStaticAccessor(_engine, ReferenceType, name);
 
         return accessor.CreatePropertyDescriptor(_engine, ReferenceType, name, enumerable: true);
     }
@@ -390,10 +368,7 @@ public sealed class TypeReference : Constructor, IObjectWrapper
             return ConstantValueAccessor.NullAccessor;
         }
 
-        const BindingFlags BindingFlags = BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy;
-        return typeResolver.TryFindMemberAccessor(engine, type, name, BindingFlags, indexerToTry: null, out var accessor)
-            ? accessor
-            : ConstantValueAccessor.NullAccessor;
+        return typeResolver.GetStaticAccessor(engine, type, name);
     }
 
     public object Target => ReferenceType;

--- a/Jint/Runtime/Interop/TypeResolver.cs
+++ b/Jint/Runtime/Interop/TypeResolver.cs
@@ -29,20 +29,22 @@ public sealed class TypeResolver
     public static readonly TypeResolver Default = new();
 
     private readonly ConcurrentDictionary<AccessorCacheKey, ReflectionAccessor> _reflectionAccessors = new();
+    private readonly ConcurrentDictionary<StaticAccessorCacheKey, ReflectionAccessor> _staticAccessors = new();
+    private readonly ConcurrentDictionary<Type, MethodDescriptor[]> _constructors = new();
 
     /// <summary>
     /// How many accessors this resolver currently holds. The cache never evicts, so this is the retention
     /// the resolver commits to: it must stay bounded by the distinct members the engines using it resolve,
     /// and must not grow with the number of engines constructed.
     /// </summary>
-    internal int ResolvedAccessorCount => _reflectionAccessors.Count;
+    internal int ResolvedAccessorCount => _reflectionAccessors.Count + _staticAccessors.Count;
 
     private Predicate<MemberInfo> _memberFilter = static _ => true;
     private Func<MemberInfo, IEnumerable<string>> _memberNameCreator = NameCreator;
     private StringComparer _memberNameComparer = DefaultMemberNameComparer.Instance;
 
     /// <summary>
-    /// Registers a filter that determines whether given member is wrapped to interop or returned as undefined.
+    /// Registers a filter that determines whether a type or member is exposed to interop or returned as undefined.
     /// By default allows all but will also be limited by <see cref="Options.InteropOptions.AllowGetType"/> configuration.
     /// </summary>
     /// <remarks>
@@ -50,6 +52,11 @@ public sealed class TypeResolver
     /// accessor was produced under the previous filter, and a member it exposed (or hid) would otherwise keep
     /// being served from the cache to engines that ask afterwards, in this engine and in every other one
     /// sharing the resolver. Assigning the same instance back costs nothing.
+    /// <para>
+    /// <see cref="NamespaceReference"/> consults the filter for each top-level or nested type it discovers.
+    /// A root <see cref="TypeReference"/> explicitly exported by the host is already a capability and bypasses
+    /// that type check, but its constructors, static members, and nested types still use this filter.
+    /// </para>
     /// </remarks>
     /// <seealso cref="Options.InteropOptions.AllowGetType"/>
     public Predicate<MemberInfo> MemberFilter
@@ -75,7 +82,12 @@ public sealed class TypeResolver
     /// have had to reason about anyway. Mutate the settings before handing the resolver to an engine when
     /// that matters.
     /// </remarks>
-    private void InvalidateResolvedAccessors() => _reflectionAccessors.Clear();
+    private void InvalidateResolvedAccessors()
+    {
+        _reflectionAccessors.Clear();
+        _staticAccessors.Clear();
+        _constructors.Clear();
+    }
 
     internal bool Filter(Engine engine, Type targetType, MemberInfo m)
     {
@@ -101,8 +113,21 @@ public sealed class TypeResolver
             }
         }
 
+        if (m is MethodInfo { IsStatic: true, DeclaringType: not null } method
+            && method.DeclaringType == typeof(Type)
+            && string.Equals(method.Name, nameof(Type.GetType), StringComparison.Ordinal))
+        {
+            return false;
+        }
+
         return (AllowGetType(engine) || !string.Equals(m.Name, nameof(GetType), StringComparison.Ordinal)) && _memberFilter(m);
     }
+
+    /// <summary>
+    /// Whether a type discovered through a namespace is part of the host's type allow-list. Explicitly exported
+    /// <see cref="TypeReference"/> values do not use this check.
+    /// </summary>
+    internal bool FilterType(Type type) => _memberFilter(type);
 
     /// <summary>
     /// Gives the exposed names for a member. Allows to expose C# convention following member like IsSelected
@@ -227,7 +252,7 @@ public sealed class TypeResolver
                 && ReferenceEquals(accessor, ConstantValueAccessor.NullAccessor)
                 && engine.Options.Interop.ThrowOnUnresolvedMember)
             {
-                throw new MissingMemberException($"Cannot access property '{member}' on type '{type.FullName}");
+                throw CreateMissingMemberException(engine, type, member);
             }
             return accessor;
         }
@@ -247,6 +272,59 @@ public sealed class TypeResolver
         }
 
         return accessor;
+    }
+
+    internal ReflectionAccessor GetStaticAccessor(
+        Engine engine,
+        [DynamicallyAccessedMembers(InteropHelper.DefaultDynamicallyAccessedMemberTypes | DynamicallyAccessedMemberTypes.PublicNestedTypes | DynamicallyAccessedMemberTypes.Interfaces)]
+        Type type,
+        string member)
+    {
+        var profile = engine._interopResolutionProfile;
+        if (!profile.IsCaptured)
+        {
+            return ResolveStaticAccessor(engine, type, member);
+        }
+
+        var key = new StaticAccessorCacheKey(type, member, profile);
+        if (_staticAccessors.TryGetValue(key, out var accessor))
+        {
+            return accessor;
+        }
+
+        accessor = ResolveStaticAccessor(engine, type, member);
+        if (IsShareable(engine, accessor))
+        {
+            _staticAccessors.TryAdd(key, accessor);
+        }
+
+        return accessor;
+    }
+
+    internal MethodDescriptor[] GetConstructors(
+        Engine engine,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
+    {
+        return _constructors.GetOrAdd(
+            type,
+            t =>
+            {
+                List<ConstructorInfo> constructors = [.. t.GetConstructors(BindingFlags.Public | BindingFlags.Instance)];
+                constructors.RemoveAll(x => !Filter(engine, t, x));
+                return MethodDescriptor.Build(constructors);
+            });
+    }
+
+    private ReflectionAccessor ResolveStaticAccessor(
+        Engine engine,
+        [DynamicallyAccessedMembers(InteropHelper.DefaultDynamicallyAccessedMemberTypes | DynamicallyAccessedMemberTypes.PublicNestedTypes | DynamicallyAccessedMemberTypes.Interfaces)]
+        Type type,
+        string member)
+    {
+        const BindingFlags BindingFlags = BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy;
+        return TryFindMemberAccessor(engine, type, member, BindingFlags, indexerToTry: null, out var accessor)
+            ? accessor
+            : ConstantValueAccessor.NullAccessor;
     }
 
     /// <summary>
@@ -434,10 +512,18 @@ public sealed class TypeResolver
 
         if (throwOnError && engine.Options.Interop.ThrowOnUnresolvedMember)
         {
-            throw new MissingMemberException($"Cannot access property '{memberName}' on type '{type.FullName}");
+            throw CreateMissingMemberException(engine, type, memberName);
         }
 
         return ConstantValueAccessor.NullAccessor;
+    }
+
+    internal static MissingMemberException CreateMissingMemberException(Engine engine, Type type, string member)
+    {
+        var message = engine.Options.Interop.ExposeDetailedResolutionErrors
+            ? $"Cannot access property '{member}' on type '{type.FullName}"
+            : "Cannot access the requested CLR member.";
+        return new MissingMemberException(message);
     }
 
     private static bool ContainsMethodWithSameSignature(List<MethodInfo>? methods, MethodInfo method)
@@ -678,14 +764,23 @@ public sealed class TypeResolver
             }
         }
 
-        foreach (var m in type.GetMethods(bindingFlags ?? MethodBindingFlags(engine)))
+        var methodBindingFlags = bindingFlags ?? MethodBindingFlags(engine);
+
+        foreach (var m in type.GetMethods(methodBindingFlags))
         {
             AddMethod(m);
         }
 
         foreach (var iface in type.GetInterfaces())
         {
-            foreach (var m in iface.GetMethods())
+            // Reflect the interface with the lane's own flags. A parameterless GetMethods() reports
+            // public instance *and* static members whatever the caller asked for, so the static-only
+            // lookup behind a TypeReference used to pick up instance interface methods. On .NET
+            // Framework that is how System.Type's COM mirrors — _Type and _MemberInfo, which declare
+            // an instance GetType(), InvokeMember(), GetMethod() and the rest — reached script as
+            // static members of System.Type, past the static Type.GetType guard in Filter, which
+            // never matched them because they are not static.
+            foreach (var m in iface.GetMethods(methodBindingFlags))
             {
                 AddMethod(m, skipIfSignatureAlreadyPresent: true);
             }
@@ -717,7 +812,7 @@ public sealed class TypeResolver
 
         // look for nested type
         var nestedType = type.GetNestedType(memberName, bindingFlags ?? BindingFlags.Instance | BindingFlags.Public | BindingFlags.Static);
-        if (nestedType != null)
+        if (nestedType != null && Filter(engine, type, nestedType))
         {
             var typeReference = TypeReference.CreateTypeReference(engine, nestedType);
             accessor = new NestedTypeAccessor(typeReference);
@@ -790,6 +885,12 @@ internal readonly record struct AccessorCacheKey(
     Type Type,
     Key PropertyName,
     MemberResolutionRequirement Requirement,
+    InteropResolutionProfile Profile);
+
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct StaticAccessorCacheKey(
+    Type Type,
+    string PropertyName,
     InteropResolutionProfile Profile);
 
 /// <summary>

--- a/README.md
+++ b/README.md
@@ -2217,7 +2217,7 @@ engine.Invoke("add", 1, 2); // -> 3
 ```
 ## Accessing .NET assemblies and classes
 
-You can allow an engine to access any .NET class by configuring the engine instance like this:
+You can allow an engine to access types from the core assembly that contains `System.Object` by configuring the engine instance like this:
 ```c#
 var engine = new Engine(cfg => cfg.AllowClr());
 ```
@@ -2235,12 +2235,49 @@ jint> log('Hello World !');
 => "Hello World !"
 ```
 
-When allowing the CLR, you can optionally pass custom assemblies to load types from. 
+When allowing the CLR, you can instead pass the exact assemblies from which namespace lookup may resolve types.
 ```c#
 var engine = new Engine(cfg => cfg
     .AllowClr(typeof(Bar).Assembly)
 );
 ```
+
+`AllowedAssemblies` is a closed namespace-discovery allow-list. Namespace lookup admits only effectively
+public types: a top-level type must be public, and every declaring type in a nested chain must be public.
+Supplying an assembly does not implicitly add the core runtime, Jint, the calling assembly, or the executing
+assembly. Add every assembly whose public types must be discoverable:
+
+```c#
+var engine = new Engine(cfg => cfg.AllowClr(
+    typeof(object).Assembly,
+    typeof(Bar).Assembly));
+```
+
+This is a security-relevant compatibility change. Earlier releases could resolve core runtime and Jint types
+outside a narrow `AllowedAssemblies` list. Hosts that intentionally relied on that fallback must now list the
+required assemblies. `AllowClr()` without arguments continues to add the assembly containing `System.Object`.
+Passing an explicitly empty assembly array adds nothing, so a dynamically computed allow-list fails closed.
+
+This list is not a complete sandbox for everything a discovered type can do. An admitted API may itself load
+assemblies, resolve types, access files, start processes, or return powerful objects. For untrusted scripts,
+prefer leaving CLR access disabled; otherwise combine the minimum assembly set with a positive
+`TypeResolver.MemberFilter`, purpose-built projected capabilities, and process isolation.
+
+The boundary applies to `System` and `importNamespace`, including nested and generic type definitions.
+`TypeResolver.MemberFilter` is also consulted for each discovered type and for nested types. Generic type
+arguments must already be `TypeReference` values; passing one does not make its assembly discoverable.
+An explicitly exported `TypeReference`, such as the example below, remains a host-granted capability even
+when its assembly is absent from `AllowedAssemblies`, while its constructors, static members, and nested
+types still obey `MemberFilter`. Converting that explicit reference to a `System.Type` object and back through
+`clrHelper` preserves the same capability; an unrelated `System.Type` object must satisfy the namespace policy.
+
+`AllowGetType` exposes instance `object.GetType` and the type-widening `clrHelper.unwrap`, `typeOf`,
+`typeToObject`, and `objectToType` operations. This means `clrHelper.unwrap` now throws unless
+`AllowGetType` is enabled. The helper operations cannot widen to a type rejected by the namespace policy.
+Jint filters the static `System.Type.GetType(string)` family from ordinary member resolution, but
+`AllowGetType` is not a general type-resolution or reflection sandbox: other APIs admitted by the host can
+carry equivalent authority. `AllowSystemReflection` must be enabled before namespace lookup may resolve
+`System.Reflection` types; leave both options disabled for untrusted scripts.
 
 and then to assign local namespaces the same way `System` does it for you, use `importNamespace`
 ```javascript


### PR DESCRIPTION
## Summary

- close CLR namespace discovery over an explicit assembly allow-list and effectively public types
- apply member policy to top-level, nested, static, constructor, generic, and wrapper resolution paths
- require `AllowGetType` for widening helpers while preserving wrapper-specific explicit `TypeReference` provenance
- keep normalized nested-type lookup process-cached through a collectible-safe `ConditionalWeakTable`
- align denied member/generic errors with the sanitized-by-default disclosure policy and preserve fatal exception propagation

## Stack

Base: #3051 (`sebros/stack-host-error-redaction`)

#3051 -> #3046 -> #3045 -> #3037 -> #3036 -> #3035 -> #3030

## Integration and review

The two previously reviewed containment commits were transplanted unchanged onto live base `aa5a91b8ea2c31c8c357df4516534920061ae8c9`; they applied without manual conflicts. Integration then sanitized unresolved-member and generic-binding failures, prevented raw generic exceptions under default policy, and preserved fatal resource/control exceptions.

Fresh specialist review found two `Assembly.GetType` visibility bypasses: CLR `+` names could reach non-public nested types, and internal top-level types remained resolvable. Both were fixed with an effective-public check across the complete declaring-type chain. The final follow-up security review was clean.

## Validation

- Release multi-target `Jint/Jint.csproj` build
- `Jint.Tests`: 5,774 passed, 4 skipped (default and host-contract verification)
- `Jint.Tests.PublicInterface`: 1,707 passed / 9 skipped default; 1,711 passed / 5 skipped with host-contract verification
- focused CLR containment, explicit `TypeReference`, nested-type, cache, GC, reflection, debugger, module, result, and security coverage included in the full suites
- `git diff --check`

NuGet validation used only `https://packagefeedproxy.microsoft.io/nuget/v3/index.json`; the proxy-compatible analyzer downgrade was local-only and the manifest is restored exactly.

## Performance

Default BenchmarkDotNet job, fresh-engine probe:

| Scenario | Mean | Ratio | Allocated |
| --- | ---: | ---: | ---: |
| Compatibility fresh engine | 1.181 us | 1.00 | 11,499 B |
| Restrictive fresh engine | 1.170 us | 0.99 | 11,499 B |
| Restrictive + cached nested resolution | 2.695 us | 2.28 | 17,766 B |
| Same workload with former per-engine scan simulated | 12.455 us | 10.55 | 58,705 B |

Restrictive construction is allocation-neutral and within noise of compatibility mode; the process cache avoids about 9.76 us and 40.9 KB per fresh-engine nested lookup versus the former scan shape.