### PR TITLE
Stop ClassBenchmark rebuilding its engine per iteration

### DIFF
--- a/Jint.Benchmark/ClassBenchmark.cs
+++ b/Jint.Benchmark/ClassBenchmark.cs
@@ -1,64 +1,60 @@
-﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Attributes;
 
 namespace Jint.Benchmark;
 
+/// <summary>
+/// Class construction and member access on a six-deep inheritance chain.
+///
+/// <para>Each row gets its own engine, built in <c>[GlobalSetup]</c> and warmed with that row's own
+/// script and nothing else (<see cref="IsolatedScript"/>). The class declarations are a fixture every
+/// row needs, so they are evaluated on each row's engine — a shared fixture is fine, a shared
+/// <em>engine</em> is not.</para>
+///
+/// <para>This class previously used <c>[IterationSetup]</c> to rebuild the engine, which is the one
+/// thing the benchmarking rules here forbid: it forces <c>InvocationCount=1</c> and <c>UnrollFactor=1</c>,
+/// which leaks tiered-JIT warm-up into the measured iterations and made identical code report 2.489 ms
+/// and 9.811 ms in different runs. Nothing needed it — every row's script is idempotent with respect to
+/// engine state (the constructions allocate garbage, <c>GetSet</c> rewrites the same property, and the
+/// class-declaration row runs inside an IIFE), so one engine per row serves all iterations. Engine
+/// construction and warm-up stay out of the measurement as a result.</para>
+/// </summary>
 [MemoryDiagnoser]
 public class ClassBenchmark
 {
-    private Engine _engine;
+    private const string ClassFixture = """
+                                        class A { x = 1; };
+                                        class B extends A { y = 2; };
+                                        class C extends B { z = 3; };
+                                        class D extends C { x2 = 1; };
+                                        class E extends D { x3 = 1; };
+                                        class F extends E { x4 = 1; }
+                                        """;
 
-    [IterationSetup]
+    private IsolatedScript _constructSimple;
+    private IsolatedScript _constructDeepInheritance;
+    private IsolatedScript _getSet;
+    private IsolatedScript _reEvaluateClassDeclarations;
+
+    private static Engine CreateEngine()
+    {
+        var engine = new Engine();
+        engine.Execute(ClassFixture);
+        engine.Execute("const target = new F();");
+        return engine;
+    }
+
+    [GlobalSetup]
     public void Setup()
     {
-        _engine = new Engine();
-        _engine.Execute("""
-                        class A { x = 1; }; 
-                        class B extends A { y = 2; };
-                        class C extends B { z = 3; }; 
-                        class D extends C { x2 = 1; };
-                        class E extends D { x3 = 1; };
-                        class F extends E { x4 = 1; }
-                        """);
-        _engine.Execute("const target = new F();");
-    }
+        _constructSimple = IsolatedScript.Warm("new A();", CreateEngine);
+        _constructDeepInheritance = IsolatedScript.Warm("new F();", CreateEngine);
+        _getSet = IsolatedScript.Warm("target.x4 = 42; target.x4;", CreateEngine);
 
-    [Benchmark]
-    public void ConstructSimple()
-    {
-        var script = Engine.PrepareScript("new A();");
-        for (var i = 0; i < 400_000; ++i)
-        {
-            _engine.Evaluate(script);
-        }
-    }
-
-    [Benchmark]
-    public void ConstructDeepInheritance()
-    {
-        var script = Engine.PrepareScript("new F();");
-        for (var i = 0; i < 80_000; ++i)
-        {
-            _engine.Evaluate(script);
-        }
-    }
-
-    [Benchmark]
-    public void GetSet()
-    {
-        var script = Engine.PrepareScript("target.x4 = 42; target.x4;");
-        for (var i = 0; i < 500_000; ++i)
-        {
-            _engine.Evaluate(script);
-        }
-    }
-
-    [Benchmark]
-    public void ReEvaluateClassDeclarations()
-    {
         // the dom.js / class-factory shape: one engine re-evaluates the same prepared script that
         // declares classes; member definitions come from the per-engine cache while class
         // identities, prototypes, private state and static-block effects stay per-evaluation
-        var script = Engine.PrepareScript("""
+        _reEvaluateClassDeclarations = IsolatedScript.Warm(
+            """
             (function () {
                 class Node {
                     #tag = 'node';
@@ -79,10 +75,43 @@ public class ClassBenchmark
                 e.alias = 'main';
                 return e.describe() + '/' + e.childCount + '/' + Element.VERSION;
             })();
-            """);
+            """,
+            CreateEngine);
+    }
+
+    [Benchmark]
+    public void ConstructSimple()
+    {
+        for (var i = 0; i < 400_000; ++i)
+        {
+            _constructSimple.Run();
+        }
+    }
+
+    [Benchmark]
+    public void ConstructDeepInheritance()
+    {
+        for (var i = 0; i < 80_000; ++i)
+        {
+            _constructDeepInheritance.Run();
+        }
+    }
+
+    [Benchmark]
+    public void GetSet()
+    {
+        for (var i = 0; i < 500_000; ++i)
+        {
+            _getSet.Run();
+        }
+    }
+
+    [Benchmark]
+    public void ReEvaluateClassDeclarations()
+    {
         for (var i = 0; i < 40_000; ++i)
         {
-            _engine.Evaluate(script);
+            _reEvaluateClassDeclarations.Run();
         }
     }
 }


### PR DESCRIPTION
`ClassBenchmark` used `[IterationSetup]`, which `AGENTS.md` explicitly forbids: it forces `InvocationCount=1` and `UnrollFactor=1`, leaking tiered-JIT warm-up into the measured iterations. The repo's own note records this making identical code report **2.489 ms and 9.811 ms** in different runs.

Every other benchmark class already follows the rule — this one was missed.

### Why nothing needed it

Each row's script is idempotent with respect to engine state, so one engine per row serves all iterations:

| row | why re-creating the engine was unnecessary |
| --- | --- |
| `ConstructSimple` / `ConstructDeepInheritance` | allocate garbage only |
| `GetSet` | rewrites the same property |
| `ReEvaluateClassDeclarations` | runs inside an IIFE |

It now follows the documented `IsolatedScript` pattern — each row gets its own engine, built in `[GlobalSetup]` and warmed with that row's own script and nothing else — so engine construction and warm-up stay outside the measurement while the rows keep their warm-dispatch character.

The prepared scripts also move into `[GlobalSetup]`; they were being parsed inside the benchmark method, putting `Engine.PrepareScript` on the measured path.

Numbers from this class are not comparable to any published before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)