### PR TITLE
Disable projected CLR writes by default

### DIFF
--- a/.github/THREAT_MODEL.md
+++ b/.github/THREAT_MODEL.md
@@ -79,8 +79,8 @@ Defaults are compatibility choices, not a hardened profile.
 | CLR namespace access (`Interop.Enabled`) | Disabled | `System`, `importNamespace`, and `clrHelper` are not installed |
 | `AllowGetType`, `AllowSystemReflection` | Disabled | Blocks instance type discovery, type widening, and reflection namespace/object access |
 | `AllowedAssemblies` | Empty until `AllowClr` adds entries | Closed allow-list for `System` / `importNamespace` type discovery, not for what admitted APIs can do |
-| Writes through projected CLR objects | Enabled | A default engine can mutate host objects passed with `SetValue` |
-| CLR array conversion | Live view | Script writes can mutate a projected CLR array |
+| Writes through projected CLR objects | Disabled | Fields, properties, indexers, dictionary/list entries, and live array elements require explicit `AllowClrWrite()` opt-in |
+| CLR array conversion | Live view | Script observes the CLR array directly; element writes remain blocked unless CLR writes are enabled |
 | Modules | Disabled | The fail-fast loader rejects imports |
 | Module graph limits | Unlimited | Count, source bytes, graph depth, and resolution hops are unbounded unless configured |
 | Module load policy | None | A custom loader's resolved targets are unrestricted unless a policy is configured |
@@ -178,14 +178,17 @@ cancellation, and avoid returning powerful objects.
 
 ### TM-03: Script mutates host state
 
-**Threat.** Writes through an `ObjectWrapper` are enabled by default. Projected CLR arrays
-are live views by default. A script used only for "read-only" rules or templates can
-therefore alter host properties, fields, collections, arrays, or objects reachable from
-them, potentially violating host invariants.
+**Threat.** Direct writes through an `ObjectWrapper` are disabled by default, but a host can
+explicitly enable them with `AllowClrWrite()`. Projected CLR arrays are live views by
+default, so enabling writes lets script alter host properties, fields, indexers,
+dictionaries, lists, arrays, or objects reachable from them. Independently of that option,
+calling an exposed instance, static, or extension method can mutate host state and violate
+host invariants.
 
 **Existing mitigations.**
 
-- `AllowClrWrite(false)` blocks writes through CLR wrappers.
+- Direct writes through CLR wrappers are disabled by default; `AllowClrWrite()` is an
+  explicit opt-in.
 - `ArrayConversionMode.Copy`, immutable DTOs, and Jint-owned record layouts avoid live
   write-through.
 
@@ -193,9 +196,12 @@ them, potentially violating host invariants.
 
 - Read-only wrapper configuration does not make a mutable object graph immutable outside
   Jint.
-- Calling exposed methods can still mutate state even when property writes are disabled.
+- Calling exposed methods or extension methods can still mutate state even when direct
+  writes are disabled.
 
-**Required host action.** Set `AllowClrWrite(false)`, use copied arrays, and expose immutable
+**Required host action.** Leave CLR writes disabled and do not call `AllowClrWrite()` unless
+direct mutation is an intentional capability. Pin `AllowClrWrite(false)` in hardened
+configuration, use copied arrays where a live view is unnecessary, and expose immutable
 snapshots. Do not expose mutating methods unless they are intentional, authorized
 capabilities.
 
@@ -1193,6 +1199,7 @@ var engine = new Engine(options =>
     options.Constraints.PromiseTimeout = TimeSpan.FromSeconds(2);
 
     options.AgentCanSuspend = false;
+    // Pin the safe default explicitly so configuration reviews cannot miss this boundary.
     options.AllowClrWrite(false);
     options.Interop.ArrayConversion = ArrayConversionMode.Copy;
     options.ResultLimits = ResultLimits.Conservative;
@@ -1253,7 +1260,8 @@ This configuration is incomplete without host controls:
 Before deploying a host that executes untrusted scripts:
 
 - [ ] CLR namespace access, `AllowGetType`, reflection, debugger, and `Atomics.wait` are off.
-- [ ] Projected host objects are immutable or intentionally capability-scoped and read-only.
+- [ ] Direct CLR writes remain disabled, and projected host objects are immutable or intentionally
+  capability-scoped with no unintended mutating instance, static, or extension methods.
 - [ ] Initial source, callback, external serializer, HTTP response, and log limits are enforced
   outside Jint; `ResultLimits` is configured for Jint-owned conversion and JSON output, and all
   four Jint module graph limits are configured when modules are enabled.

--- a/Jint.Tests.PublicInterface/ClrProxyHandlerTests.cs
+++ b/Jint.Tests.PublicInterface/ClrProxyHandlerTests.cs
@@ -360,7 +360,7 @@ public class ClrProxyHandlerTests
     [Fact]
     public void GetAndSetTrapsWorkAgainstObjectWrapperTarget()
     {
-        var engine = new Engine();
+        var engine = new Engine(options => options.AllowClrWrite());
         var person = new Person { Name = "Jane" };
         var blockedWrites = new List<string>();
         var handler = new DelegatingProxyHandler

--- a/Jint.Tests.PublicInterface/ClrWriteConfigurationTests.cs
+++ b/Jint.Tests.PublicInterface/ClrWriteConfigurationTests.cs
@@ -1,0 +1,331 @@
+using System.Dynamic;
+using Jint.Runtime;
+using Jint.Runtime.Interop;
+using Newtonsoft.Json.Linq;
+
+namespace Jint.Tests.PublicInterface;
+
+public class ClrWriteConfigurationTests
+{
+    internal sealed class Host
+    {
+        private readonly Dictionary<string, int> _indexed = new(StringComparer.Ordinal)
+        {
+            ["item"] = 3
+        };
+
+        public int Field = 1;
+
+        public static int StaticField = 1;
+
+        public int Property { get; set; } = 2;
+
+        public int SetterCalls { get; private set; }
+
+        public int SetterTracked
+        {
+            get => 4;
+            set => SetterCalls++;
+        }
+
+        public int this[string key]
+        {
+            get => _indexed[key];
+            set => _indexed[key] = value;
+        }
+
+        public void Mutate(int value)
+        {
+            Field = value;
+        }
+    }
+
+    [Fact]
+    public void DirectClrWritesAreDisabledByDefault()
+    {
+        new Options().Interop.AllowWrite.Should().BeFalse();
+
+        var host = new Host();
+        var dictionary = new Dictionary<string, int>(StringComparer.Ordinal) { ["item"] = 5 };
+        var list = new List<int> { 6 };
+        var array = new[] { 7 };
+        var engine = CreateEngine(host, dictionary, list, array);
+
+        engine.Execute(
+            """
+            host.Field = 11;
+            host.Property = 12;
+            host.SetterTracked = 13;
+            host.item = 14;
+            dictionary.item = 15;
+            list[0] = 16;
+            array[0] = 17;
+            """);
+
+        host.Field.Should().Be(1);
+        host.Property.Should().Be(2);
+        host.SetterCalls.Should().Be(0);
+        host["item"].Should().Be(3);
+        dictionary["item"].Should().Be(5);
+        list.Should().Equal(6);
+        array.Should().Equal(7);
+    }
+
+    [Fact]
+    public void ExplicitOptInEnablesDirectClrWrites()
+    {
+        var host = new Host();
+        var dictionary = new Dictionary<string, int>(StringComparer.Ordinal) { ["item"] = 5 };
+        var list = new List<int> { 6 };
+        var array = new[] { 7 };
+        var engine = CreateEngine(host, dictionary, list, array, allowWrite: true);
+
+        engine.Execute(
+            """
+            host.Field = 11;
+            host.Property = 12;
+            host.SetterTracked = 13;
+            host.item = 14;
+            dictionary.item = 15;
+            list[0] = 16;
+            array[0] = 17;
+            """);
+
+        host.Field.Should().Be(11);
+        host.Property.Should().Be(12);
+        host.SetterCalls.Should().Be(1);
+        host["item"].Should().Be(14);
+        dictionary["item"].Should().Be(15);
+        list.Should().Equal(16);
+        array.Should().Equal(17);
+    }
+
+    [Fact]
+    public void StrictModeSurfacesBlockedWritesAsTypeErrors()
+    {
+        var host = new Host();
+        var engine = new Engine().SetValue("host", host);
+
+        var exception = Invoking(() => engine.Execute("'use strict'; host.Property = 12;"))
+            .Should().Throw<JavaScriptException>().Which;
+
+        exception.Error.Get("name").AsString().Should().Be("TypeError");
+        host.Property.Should().Be(2);
+    }
+
+    [Fact]
+    public void AllowClrDoesNotImplicitlyEnableDirectWrites()
+    {
+        var host = new Host();
+        var options = new Options().AllowClr();
+        var engine = new Engine(options).SetValue("host", host);
+
+        options.Interop.AllowWrite.Should().BeFalse();
+        engine.Execute("host.Property = 12;");
+
+        host.Property.Should().Be(2);
+    }
+
+    [Fact]
+    public void CachedAccessorsDoNotShareWriteAuthorityAcrossEngines()
+    {
+        var writableHost = new Host();
+        var writableEngine = new Engine(options => options.AllowClrWrite()).SetValue("host", writableHost);
+        writableEngine.Execute("host.Property = 12;");
+        writableHost.Property.Should().Be(12);
+
+        var readOnlyHost = new Host();
+        var readOnlyEngine = new Engine().SetValue("host", readOnlyHost);
+        var exception = Invoking(() => readOnlyEngine.Execute("'use strict'; host.Property = 13;"))
+            .Should().Throw<JavaScriptException>().Which;
+
+        exception.Error.Get("name").AsString().Should().Be("TypeError");
+        readOnlyHost.Property.Should().Be(2);
+    }
+
+    [Fact]
+    public void AlternateClrMutationRoutesAreBlockedByDefault()
+    {
+        Host.StaticField = 1;
+        IDictionary<string, object> expando = new ExpandoObject();
+        expando["Value"] = 3;
+        var host = new Host();
+        var engine = new Engine()
+            .SetValue("host", host)
+            .SetValue("expando", expando);
+        engine.SetValue("Host", TypeReference.CreateTypeReference(engine, typeof(Host)));
+
+        engine.Execute(
+            """
+            host.Field++;
+            host.Property += 10;
+            const proxy = new Proxy(host, {});
+            proxy.Property = 20;
+            Host.StaticField = 30;
+            expando.Value = 40;
+            """);
+
+        host.Field.Should().Be(1);
+        host.Property.Should().Be(2);
+        Host.StaticField.Should().Be(1);
+        expando["Value"].Should().Be(3);
+        engine.Evaluate("Reflect.set(host, 'Property', 50)").Should().BeFalse();
+        engine.Evaluate("Reflect.deleteProperty(host, 'Property')").Should().BeFalse();
+        Invoking(() => engine.Execute("Object.defineProperty(host, 'Property', { value: 60 })"))
+            .Should().Throw<JavaScriptException>();
+    }
+
+    [Fact]
+    public void OrdinaryJavaScriptObjectWritesRemainEnabled()
+    {
+        var engine = new Engine();
+
+        engine.Evaluate(
+            """
+            const value = { count: 1 };
+            value.count++;
+            value.extra = 3;
+            Object.defineProperty(value, 'defined', { value: 4 });
+            value.count + value.extra + value.defined;
+            """).Should().Be(9);
+    }
+
+    [Fact]
+    public void ClrWriteOptInDoesNotBypassJavaScriptObjectExtensibility()
+    {
+        var engine = new Engine(options => options.AllowClrWrite());
+
+        var exception = Invoking(() => engine.Execute("const value = [0, , 2]; Object.preventExtensions(value); value.fill(9);"))
+            .Should().Throw<JavaScriptException>().Which;
+
+        exception.Error.Get("name").AsString().Should().Be("TypeError");
+        engine.Evaluate("1 in value").Should().BeFalse();
+
+        exception = Invoking(() => engine.Execute(
+                """
+                const result = [0, , 2];
+                Object.preventExtensions(result);
+                const source = [3, 4];
+                source.constructor = { [Symbol.species]: function () { return result; } };
+                source.filter(() => true);
+                """))
+            .Should().Throw<JavaScriptException>().Which;
+
+        exception.Error.Get("name").AsString().Should().Be("TypeError");
+        engine.Evaluate("1 in result").Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("Array.prototype.push.call(list, 9)")]
+    [InlineData("Array.prototype.unshift.call(list, 9)")]
+    [InlineData("Array.prototype.splice.call(list, 0, 1)")]
+    [InlineData("Array.prototype.fill.call(list, 9)")]
+    [InlineData("const source = [3, 4]; source.constructor = { [Symbol.species]: function () { return list; } }; source.filter(() => true)")]
+    public void ArrayGenericsCannotMutateClrListsByDefault(string script)
+    {
+        var list = new List<int> { 1, 2 };
+        var engine = new Engine().SetValue("list", list);
+
+        var exception = Invoking(() => engine.Execute(script))
+            .Should().Throw<JavaScriptException>().Which;
+
+        exception.Error.Get("name").AsString().Should().Be("TypeError");
+        list.Should().Equal(1, 2);
+    }
+
+    [Theory]
+    [InlineData("Array.prototype.fill.call(list, 9)")]
+    [InlineData("Array.prototype.push.call(list, 9)")]
+    [InlineData("Array.prototype.pop.call(list)")]
+    [InlineData("Array.prototype.shift.call(list)")]
+    [InlineData("Array.prototype.splice.call(list, 0, 1)")]
+    [InlineData("list['0'] = 9")]
+    [InlineData("Reflect.set(list, '0', 9)")]
+    [InlineData("Object.assign(list, { 0: 9 })")]
+    [InlineData("Object.getOwnPropertyDescriptor(list, '0').set.call(list, 9)")]
+    public void ArrayGenericsCannotMutateFrozenClrListsWhenWritesAreEnabled(string script)
+    {
+        var list = new List<int> { 1, 2 };
+        var engine = new Engine(options => options.AllowClrWrite()).SetValue("list", list);
+        engine.Execute("Object.freeze(list);");
+
+        var exception = Invoking(() => engine.Execute(script))
+            .Should().Throw<JavaScriptException>().Which;
+
+        exception.Error.Get("name").AsString().Should().Be("TypeError");
+        list.Should().Equal(1, 2);
+    }
+
+    [Fact]
+    public void AbsentPropertiesCanBeDeletedFromReadOnlyClrWrappers()
+    {
+        var engine = new Engine().SetValue("list", new List<int> { 1, 2 });
+
+        engine.Evaluate("Reflect.deleteProperty(list, 'missing')").Should().BeTrue();
+        engine.Evaluate("Reflect.deleteProperty(list, '99')").Should().BeTrue();
+        engine.Evaluate("'use strict'; delete list.missing").Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReadOnlyDictionaryShapedWrappersUseKeyMembershipForDeletion()
+    {
+        var value = new JObject
+        {
+            ["5"] = 1,
+            ["other"] = 2
+        };
+        var engine = new Engine().SetValue("value", value);
+
+        engine.Evaluate("Reflect.deleteProperty(value, '5')").Should().BeFalse();
+        engine.Evaluate("Reflect.deleteProperty(value, '0')").Should().BeTrue();
+        value["5"]!.Value<int>().Should().Be(1);
+    }
+
+    [Fact]
+    public void MethodsAndExtensionMethodsCanStillMutateHostState()
+    {
+        var host = new Host();
+        var list = new List<int> { 1 };
+        var engine = new Engine(options => options.AddExtensionMethods(typeof(ClrWriteHostExtensions)))
+            .SetValue("host", host)
+            .SetValue("list", list);
+
+        engine.Execute(
+            """
+            host.Mutate(20);
+            host.MutateThroughExtension(21);
+            list.Add(2);
+            """);
+
+        host.Field.Should().Be(21);
+        list.Should().Equal(1, 2);
+    }
+
+    private static Engine CreateEngine(
+        Host host,
+        Dictionary<string, int> dictionary,
+        List<int> list,
+        int[] array,
+        bool allowWrite = false)
+    {
+        return new Engine(options =>
+            {
+                if (allowWrite)
+                {
+                    options.AllowClrWrite();
+                }
+            })
+            .SetValue("host", host)
+            .SetValue("dictionary", dictionary)
+            .SetValue("list", list)
+            .SetValue("array", array);
+    }
+}
+
+internal static class ClrWriteHostExtensions
+{
+    public static void MutateThroughExtension(this ClrWriteConfigurationTests.Host value, int newValue)
+    {
+        value.Mutate(newValue);
+    }
+}

--- a/Jint.Tests.PublicInterface/EnumConversionModeTests.cs
+++ b/Jint.Tests.PublicInterface/EnumConversionModeTests.cs
@@ -55,6 +55,7 @@ public class EnumConversionModeTests
     {
         var engine = new Engine(options =>
         {
+            options.AllowClrWrite();
             if (mode is not null)
             {
                 options.Interop.EnumConversion = mode.Value;

--- a/Jint.Tests.PublicInterface/GlobalSnapshotTests.cs
+++ b/Jint.Tests.PublicInterface/GlobalSnapshotTests.cs
@@ -868,7 +868,7 @@ public class GlobalSnapshotTests
     public void HostClrStateChangedThroughInteropSurvivesRestore()
     {
         var config = new Config();
-        var engine = new Engine(o => o.AllowClr());
+        var engine = new Engine(o => o.AllowClr().AllowClrWrite());
         engine.SetValue("config", config);
 
         var snapshot = engine.Advanced.CaptureGlobalSnapshot();

--- a/Jint.Tests.PublicInterface/HostArrayConversionDiagnosticsTests.cs
+++ b/Jint.Tests.PublicInterface/HostArrayConversionDiagnosticsTests.cs
@@ -21,6 +21,7 @@ public class HostArrayConversionDiagnosticsTests
     private static Engine CreateEngine(ArrayConversionMode? mode = null) => new(options =>
     {
         options.AllowClr(typeof(HostWithArrays).Assembly);
+        options.AllowClrWrite();
         if (mode is not null)
         {
             options.Interop.ArrayConversion = mode.Value;

--- a/Jint.Tests.PublicInterface/HostDictionaryEnumerationTests.cs
+++ b/Jint.Tests.PublicInterface/HostDictionaryEnumerationTests.cs
@@ -25,9 +25,15 @@ public class HostDictionaryEnumerationTests
         ["nested"] = new Dictionary<string, object>(System.StringComparer.Ordinal) { ["deep"] = 1d },
     };
 
-    private static Engine CreateEngine(object host)
+    private static Engine CreateEngine(object host, bool allowWrite = false)
     {
-        var engine = new Engine();
+        var engine = new Engine(options =>
+        {
+            if (allowWrite)
+            {
+                options.AllowClrWrite();
+            }
+        });
         engine.SetValue("doc", host);
         return engine;
     }
@@ -121,7 +127,7 @@ public class HostDictionaryEnumerationTests
     [Fact]
     public void ADefinedDescriptorOutranksTheDictionary()
     {
-        var engine = CreateEngine(Document());
+        var engine = CreateEngine(Document(), allowWrite: true);
 
         engine.Execute("Object.defineProperty(doc, 'name', { value: 'redefined', enumerable: false, configurable: true });");
 

--- a/Jint.Tests.PublicInterface/HostImmutableCrossingTests.cs
+++ b/Jint.Tests.PublicInterface/HostImmutableCrossingTests.cs
@@ -119,7 +119,9 @@ public class HostImmutableCrossingTests
     public void AWriteThroughTheWrapperEvictsThatKeysMemo()
     {
         var inner = new Dictionary<string, object>(StringComparer.Ordinal) { ["country"] = "FI" };
-        var engine = new Engine(options => options.AddImmutableCrossing(typeof(Dictionary<string, object>)));
+        var engine = new Engine(options => options
+            .AllowClrWrite()
+            .AddImmutableCrossing(typeof(Dictionary<string, object>)));
         engine.SetValue("record", inner);
 
         engine.Evaluate("record.country").AsString().Should().Be("FI");

--- a/Jint.Tests.PublicInterface/HostKeyedMemberAccessTests.cs
+++ b/Jint.Tests.PublicInterface/HostKeyedMemberAccessTests.cs
@@ -21,7 +21,7 @@ public class HostKeyedMemberAccessTests
 {
     private static Engine CreateEngine(object host)
     {
-        var engine = new Engine();
+        var engine = new Engine(options => options.AllowClrWrite());
         engine.SetValue("host", host);
         return engine;
     }

--- a/Jint.Tests.PublicInterface/HostStaticMemberAccessTests.cs
+++ b/Jint.Tests.PublicInterface/HostStaticMemberAccessTests.cs
@@ -21,7 +21,11 @@ public class HostStaticMemberAccessTests
 {
     private static Engine CreateEngine(Action<Options>? configure = null)
     {
-        var engine = configure is null ? new Engine() : new Engine(configure);
+        var engine = new Engine(options =>
+        {
+            options.AllowClrWrite();
+            configure?.Invoke(options);
+        });
         engine.SetValue("Host", TypeReference.CreateTypeReference(engine, typeof(StaticHost)));
         return engine;
     }

--- a/Jint.Tests.PublicInterface/InteropTests.Dynamic.cs
+++ b/Jint.Tests.PublicInterface/InteropTests.Dynamic.cs
@@ -96,7 +96,7 @@ public partial class InteropTests
     public void CanAccessDynamicObject()
     {
         var test = new DynamicClass();
-        var engine = new Engine();
+        var engine = new Engine(options => options.AllowClrWrite());
 
         engine.SetValue("test", test);
 

--- a/Jint.Tests.PublicInterface/InteropTests.NewtonsoftJson.cs
+++ b/Jint.Tests.PublicInterface/InteropTests.NewtonsoftJson.cs
@@ -119,7 +119,7 @@ public partial class InteropTests
     [Fact]
     public void ShouldBeAbleToChangePropertyWithNameValue()
     {
-        var engine = new Engine();
+        var engine = new Engine(options => options.AllowClrWrite());
 
         var input = Newtonsoft.Json.JsonConvert.DeserializeObject(@"{ ""value"": ""ORIGINAL"" }");
         var result = engine

--- a/Jint.Tests.PublicInterface/InteropTests.SystemTextJson.cs
+++ b/Jint.Tests.PublicInterface/InteropTests.SystemTextJson.cs
@@ -168,6 +168,7 @@ public partial class InteropTests
     {
         var engine = new Engine(options =>
         {
+            options.AllowClrWrite();
 #if !NET8_0_OR_GREATER
             // Jint doesn't know about the types statically as they are not part of the out-of-the-box experience
             options.AddObjectConverter(SystemTextJsonValueConverter.Instance);

--- a/Jint.Tests.PublicInterface/InteropTests.cs
+++ b/Jint.Tests.PublicInterface/InteropTests.cs
@@ -8,9 +8,11 @@ public partial class InteropTests : IDisposable
 
     public InteropTests()
     {
-        _engine = new Engine(cfg => cfg.AllowClr(
+        _engine = new Engine(cfg => cfg
+                .AllowClr(
                     typeof(Console).GetTypeInfo().Assembly,
-                    typeof(File).GetTypeInfo().Assembly))
+                    typeof(File).GetTypeInfo().Assembly)
+                .AllowClrWrite())
                 .SetValue("log", new Action<object>(Console.WriteLine))
                 .SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()))
                 .SetValue("equal", new Action<object, object>(static (expected, actual) =>

--- a/Jint.Tests.PublicInterface/ObjectConverterRegistrationTests.cs
+++ b/Jint.Tests.PublicInterface/ObjectConverterRegistrationTests.cs
@@ -411,7 +411,9 @@ public class ObjectConverterRegistrationTests
     public void DeclaredConverterDoesNotAffectWrites()
     {
         var host = new Host();
-        var engine = CreateEngine(host, options => options.AddObjectConverter(new MeddlingConverter(), typeof(Guid)));
+        var engine = CreateEngine(host, options => options
+            .AllowClrWrite()
+            .AddObjectConverter(new MeddlingConverter(), typeof(Guid)));
 
         engine.Evaluate("host.Flag = false; host.Number = 7; host.Text = 'written';");
 

--- a/Jint.Tests.PublicInterface/ReadOnlyClrMemberWriteTests.cs
+++ b/Jint.Tests.PublicInterface/ReadOnlyClrMemberWriteTests.cs
@@ -57,7 +57,7 @@ public class ReadOnlyClrMemberWriteTests
         public const string Constant = Initial;
     }
 
-    private static Engine CreateEngine(object host) => new Engine().SetValue("host", host);
+    private static Engine CreateEngine(object host) => new Engine(options => options.AllowClrWrite()).SetValue("host", host);
 
     private static void AssertTypeError(Engine engine, string script, string memberName)
     {
@@ -366,10 +366,10 @@ public class ReadOnlyClrMemberWriteTests
     }
 
     [Fact]
-    public void DisallowingClrWritesStillRefusesWritableMembers()
+    public void DefaultConfigurationRefusesWritableMembers()
     {
         var host = new Host();
-        var engine = new Engine(options => options.AllowClrWrite(false)).SetValue("host", host);
+        var engine = new Engine().SetValue("host", host);
 
         engine.Evaluate("host.Writable = 'written';");
         host.Writable.Should().Be(Initial);

--- a/Jint.Tests.PublicInterface/ReferenceResolverAssignmentTests.cs
+++ b/Jint.Tests.PublicInterface/ReferenceResolverAssignmentTests.cs
@@ -63,9 +63,14 @@ public class ReferenceResolverAssignmentTests
         public int ReadOnly => 7;
     }
 
-    private static Engine CreateEngine(bool withResolver) => withResolver
-        ? new Engine(options => options.SetReferencesResolver(new PassThroughResolver()))
-        : new Engine();
+    private static Engine CreateEngine(bool withResolver) => new(options =>
+    {
+        options.AllowClrWrite();
+        if (withResolver)
+        {
+            options.SetReferencesResolver(new PassThroughResolver());
+        }
+    });
 
     [Theory]
     [InlineData(true)]

--- a/Jint.Tests/Runtime/ArrayTests.cs
+++ b/Jint.Tests/Runtime/ArrayTests.cs
@@ -1207,7 +1207,7 @@ return get + '' === ""length,0,1,2,3"";";
     [Fact]
     public void PopWrappedGenericList()
     {
-        var engine = new Engine();
+        var engine = new Engine(options => options.AllowClrWrite());
         var list = new List<int> { 1, 2, 3 };
         engine.SetValue("list", list);
         var result = engine.Evaluate("list.pop()").AsNumber();

--- a/Jint.Tests/Runtime/DefaultTypeConverterTests.cs
+++ b/Jint.Tests/Runtime/DefaultTypeConverterTests.cs
@@ -84,7 +84,8 @@ public class DefaultTypeConverterTests
     {
         var engine = new Engine(options => options
             .SetTypeConverter(e => new PointTypeConverter(e))
-            .CatchClrExceptions());
+            .CatchClrExceptions()
+            .AllowClrWrite());
 
         engine.SetValue("a", new Person());
 

--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -2845,7 +2845,7 @@ function output(x) {
     public void ShouldParseAnonymousToTypeObject()
     {
         var obj = new Wrapper();
-        var engine = new Engine()
+        var engine = new Engine(options => options.AllowClrWrite())
             .SetValue("x", obj);
         var js = @"
 x.test = {

--- a/Jint.Tests/Runtime/ExecutionConstraintTests.cs
+++ b/Jint.Tests/Runtime/ExecutionConstraintTests.cs
@@ -999,7 +999,9 @@ myarr[0](0);
     private static void AssertCancelledDuringThirdHostCall(Func<CancellationTokenSource, Engine, Func<int>> setup, string script)
     {
         using var cts = new CancellationTokenSource();
-        var engine = new Engine(cfg => cfg.CancellationToken(cts.Token));
+        var engine = new Engine(cfg => cfg
+            .CancellationToken(cts.Token)
+            .AllowClrWrite());
         var hostCallCount = setup(cts, engine);
 
         Invoking(() => engine.Execute(script)).Should().ThrowExactly<ExecutionCanceledException>();

--- a/Jint.Tests/Runtime/ExtensionMethods/EnumerableSnapshotTests.cs
+++ b/Jint.Tests/Runtime/ExtensionMethods/EnumerableSnapshotTests.cs
@@ -14,6 +14,7 @@ public class EnumerableSnapshotTests
     {
         return new Engine(options =>
         {
+            options.AllowClrWrite();
             if (withExtensions)
             {
                 options.AddExtensionMethods(typeof(ShadowingMapExtensions));

--- a/Jint.Tests/Runtime/ExtensionMethods/ExtensionMethodShadowingTests.cs
+++ b/Jint.Tests/Runtime/ExtensionMethods/ExtensionMethodShadowingTests.cs
@@ -113,6 +113,7 @@ public class ExtensionMethodShadowingTests
         {
             options.AddExtensionMethods(typeof(Enumerable));
             options.Interop.PreferJsPrototypeMethods = true;
+            options.AllowClrWrite();
         });
         engine.SetValue("list", new List<int> { 1, 2, 3 });
 

--- a/Jint.Tests/Runtime/InteropAccessorCacheSharingTests.cs
+++ b/Jint.Tests/Runtime/InteropAccessorCacheSharingTests.cs
@@ -79,6 +79,7 @@ public class InteropAccessorCacheSharingTests
     {
         var engine = new Engine(options =>
         {
+            options.AllowClrWrite();
             options.Interop.TypeResolver = resolver;
             configure?.Invoke(options);
         });

--- a/Jint.Tests/Runtime/InteropCompiledMemberAccessorTests.cs
+++ b/Jint.Tests/Runtime/InteropCompiledMemberAccessorTests.cs
@@ -169,7 +169,11 @@ public class InteropCompiledMemberAccessorTests
 
     private static Engine CreateEngine(object host, Action<Options>? configure = null)
     {
-        var engine = configure is null ? new Engine() : new Engine(configure);
+        var engine = new Engine(options =>
+        {
+            options.AllowClrWrite();
+            configure?.Invoke(options);
+        });
         engine.SetValue("host", host);
         return engine;
     }
@@ -339,7 +343,7 @@ public class InteropCompiledMemberAccessorTests
         // converter - which cannot turn the resulting System.String back into a JsString. The fast
         // lane must not "fix" that, or the write would start succeeding where it used to throw.
         var host = new JsSubtypeHost();
-        var engine = new Engine();
+        var engine = new Engine(options => options.AllowClrWrite());
         engine.SetValue("host", host);
 
         Invoking(() => engine.Execute("host.JsStringProp = 'abc';"))
@@ -952,7 +956,7 @@ public class InteropCompiledMemberAccessorTests
     public void IndexerIsResolvedBeforeTheMember()
     {
         var host = new IndexerHost();
-        var engine = new Engine();
+        var engine = new Engine(options => options.AllowClrWrite());
         engine.SetValue("host", host);
 
         // the indexer is probed first and answers for "Value", shadowing the int property
@@ -966,7 +970,7 @@ public class InteropCompiledMemberAccessorTests
     [Fact]
     public void StructHostStillWorks()
     {
-        var engine = new Engine();
+        var engine = new Engine(options => options.AllowClrWrite());
         engine.SetValue("host", new StructHost(3));
 
         engine.Evaluate("host.IntProp").Should().Be(3);
@@ -981,7 +985,7 @@ public class InteropCompiledMemberAccessorTests
     public void ReadOnlyFieldAndPropertyWritesFail()
     {
         var host = new ReadOnlyHost();
-        var engine = new Engine();
+        var engine = new Engine(options => options.AllowClrWrite());
         engine.SetValue("host", host);
 
         engine.Evaluate("host.ReadOnlyIntProp").Should().Be(11);
@@ -1007,7 +1011,7 @@ public class InteropCompiledMemberAccessorTests
         StaticHost.StaticIntProp = 3;
         StaticHost.StaticStringField = "s";
 
-        var engine = new Engine();
+        var engine = new Engine(options => options.AllowClrWrite());
         engine.SetValue("Statics", TypeReference.CreateTypeReference(engine, typeof(StaticHost)));
 
         engine.Evaluate("Statics.StaticIntProp").Should().Be(3);
@@ -1022,7 +1026,7 @@ public class InteropCompiledMemberAccessorTests
     public void InterfaceDeclaredPropertyWorksThroughTheInterface()
     {
         var owner = new HolderOwner();
-        var engine = new Engine();
+        var engine = new Engine(options => options.AllowClrWrite());
         engine.SetValue("owner", owner);
 
         engine.Execute("owner.Holder.Value = 5; owner.Holder.Name = 'n';");
@@ -1100,7 +1104,7 @@ public class InteropCompiledMemberAccessorTests
     public void PropertyWithNonPublicGetter()
     {
         var host = new NonPublicGetterHost();
-        var engine = new Engine();
+        var engine = new Engine(options => options.AllowClrWrite());
         engine.SetValue("host", host);
 
         engine.Execute("host.HalfHidden = 9;");

--- a/Jint.Tests/Runtime/InteropDictionaryValueAccessTests.cs
+++ b/Jint.Tests/Runtime/InteropDictionaryValueAccessTests.cs
@@ -14,7 +14,7 @@ public class InteropDictionaryValueAccessTests
 {
     private static Engine CreateEngine(object host)
     {
-        var engine = new Engine();
+        var engine = new Engine(options => options.AllowClrWrite());
         engine.SetValue("d", host);
         return engine;
     }

--- a/Jint.Tests/Runtime/InteropExplicitTypeTests.cs
+++ b/Jint.Tests/Runtime/InteropExplicitTypeTests.cs
@@ -88,10 +88,12 @@ public class InteropExplicitTypeTests
     public InteropExplicitTypeTests()
     {
         holder = new InterfaceHolder();
-        _engine = new Engine(cfg => cfg.AllowClr(
+        _engine = new Engine(cfg => cfg
+                .AllowClr(
                     typeof(CI1).Assembly,
                     typeof(Console).Assembly,
-                    typeof(File).Assembly))
+                    typeof(File).Assembly)
+                .AllowClrWrite())
                 .SetValue("log", new Action<object>(Console.WriteLine))
                 .SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()))
                 .SetValue("equal", new Action<object, object>(static (expected, actual) =>
@@ -179,7 +181,11 @@ public class InteropExplicitTypeTests
     [Fact]
     public void DerivedRuntimePropertyFromBaseDeclaredProperty()
     {
-        var engine = new Engine(options => options.Interop.ThrowOnUnresolvedMember = true);
+        var engine = new Engine(options =>
+        {
+            options.AllowClrWrite();
+            options.Interop.ThrowOnUnresolvedMember = true;
+        });
         var holder = new BaseValueHolder();
         engine.SetValue("holder", holder);
 

--- a/Jint.Tests/Runtime/InteropIntegerCoercionBoxingTests.cs
+++ b/Jint.Tests/Runtime/InteropIntegerCoercionBoxingTests.cs
@@ -15,6 +15,8 @@ namespace Jint.Tests.Runtime;
 /// </summary>
 public class InteropIntegerCoercionBoxingTests
 {
+    private static Engine CreateEngine() => new(options => options.AllowClrWrite());
+
     #region hosts
 
     public sealed class Host
@@ -87,7 +89,7 @@ public class InteropIntegerCoercionBoxingTests
     public void CanAssignIntegerToLongField()
     {
         var host = new Host();
-        var engine = new Engine().SetValue("host", host);
+        var engine = CreateEngine().SetValue("host", host);
 
         engine.Execute("host.LongField = 42;");
         host.LongField.Should().Be(42L);
@@ -100,7 +102,7 @@ public class InteropIntegerCoercionBoxingTests
     public void CanAssignIntegerToLongProperty()
     {
         var host = new Host();
-        var engine = new Engine().SetValue("host", host);
+        var engine = CreateEngine().SetValue("host", host);
 
         engine.Execute("host.LongProperty = 42;");
         host.LongProperty.Should().Be(42L);
@@ -113,7 +115,7 @@ public class InteropIntegerCoercionBoxingTests
     public void CanPassIntegerToLongParameter()
     {
         var host = new Host();
-        var engine = new Engine().SetValue("host", host);
+        var engine = CreateEngine().SetValue("host", host);
 
         engine.Execute("host.TakeLong(42);");
         host.LastParameterType.Should().Be(typeof(long));
@@ -126,7 +128,7 @@ public class InteropIntegerCoercionBoxingTests
     public void CanPassIntegerToLongDelegateParameter()
     {
         Type? observed = null;
-        var engine = new Engine()
+        var engine = CreateEngine()
             .SetValue("takeLong", new LongCallback(value => observed = ((object) value).GetType()))
             .SetValue("takeInt", new IntCallback(value => observed = ((object) value).GetType()));
 
@@ -141,7 +143,7 @@ public class InteropIntegerCoercionBoxingTests
     public void CanAssignIntegerToGenericListOfLongElement()
     {
         var host = new CollectionHost();
-        var engine = new Engine().SetValue("host", host);
+        var engine = CreateEngine().SetValue("host", host);
 
         engine.Execute("host.Longs[0] = 42;");
         host.Longs[0].Should().Be(42L);
@@ -154,7 +156,7 @@ public class InteropIntegerCoercionBoxingTests
     public void CanAppendIntegerToGenericListOfLong()
     {
         var host = new CollectionHost();
-        var engine = new Engine().SetValue("host", host);
+        var engine = CreateEngine().SetValue("host", host);
 
         engine.Execute("host.Longs.push(42);");
         host.Longs[2].Should().Be(42L);
@@ -171,7 +173,7 @@ public class InteropIntegerCoercionBoxingTests
     public void CanFillGenericListOfLong()
     {
         var host = new CollectionHost();
-        var engine = new Engine().SetValue("host", host);
+        var engine = CreateEngine().SetValue("host", host);
 
         engine.Execute("host.Longs.fill(42);");
         host.Longs.Should().Equal(42L, 42L);
@@ -184,7 +186,7 @@ public class InteropIntegerCoercionBoxingTests
     public void CanAssignIntegerToLongArrayElement()
     {
         var host = new CollectionHost();
-        var engine = new Engine().SetValue("host", host);
+        var engine = CreateEngine().SetValue("host", host);
 
         engine.Execute("host.LongArray[0] = 42;");
         host.LongArray[0].Should().Be(42L);
@@ -202,7 +204,11 @@ public class InteropIntegerCoercionBoxingTests
     public void CanAssignIntegerToLongMemberWithCustomTypeConverter()
     {
         var host = new Host();
-        var engine = new Engine(options => options.SetTypeConverter(e => new CustomTypeConverter(e)))
+        var engine = new Engine(options =>
+            {
+                options.AllowClrWrite();
+                options.SetTypeConverter(e => new CustomTypeConverter(e));
+            })
             .SetValue("host", host);
 
         engine.Execute("host.LongField = 42; host.LongProperty = 43; host.IntField = 44; host.IntProperty = 45;");

--- a/Jint.Tests/Runtime/InteropTests.ClrArrayLiveView.cs
+++ b/Jint.Tests/Runtime/InteropTests.ClrArrayLiveView.cs
@@ -14,6 +14,7 @@ public partial class InteropTests
     {
         return new Engine(options =>
         {
+            options.AllowClrWrite();
             options.Interop.ArrayConversion = ArrayConversionMode.LiveView;
             additionalConfiguration?.Invoke(options);
         });

--- a/Jint.Tests/Runtime/InteropTests.ImmutableCrossing.cs
+++ b/Jint.Tests/Runtime/InteropTests.ImmutableCrossing.cs
@@ -75,7 +75,9 @@ public partial class InteropTests
 
     private static Engine ImmutableCrossingEngine(params Type[] types)
     {
-        return new Engine(options => options.AddImmutableCrossing(types));
+        return new Engine(options => options
+            .AllowClrWrite()
+            .AddImmutableCrossing(types));
     }
 
     [Fact]

--- a/Jint.Tests/Runtime/InteropTests.MemberAccess.cs
+++ b/Jint.Tests/Runtime/InteropTests.MemberAccess.cs
@@ -167,6 +167,7 @@ public partial class InteropTests
         var engine = new Engine(options =>
         {
             options.AllowClr();
+            options.AllowClrWrite();
         });
 
         var dc = new CustomDictionary<float>();
@@ -192,6 +193,7 @@ public partial class InteropTests
         var engine = new Engine(options =>
         {
             options.AllowClr();
+            options.AllowClrWrite();
         });
 
         engine.SetValue("B", TypeReference.CreateTypeReference(engine, typeof(InheritingFromClassWithStatics)));
@@ -270,7 +272,7 @@ public partial class InteropTests
     [Fact]
     public void NewTypedObjectFromUntypedInitializerShouldBeMapped()
     {
-        var engine = new Engine();
+        var engine = new Engine(options => options.AllowClrWrite());
 
         engine.SetValue("obj", new ClassWithData());
         engine.Execute("obj.Data = { Value: '123' };");

--- a/Jint.Tests/Runtime/InteropTests.PropertyValueMemo.cs
+++ b/Jint.Tests/Runtime/InteropTests.PropertyValueMemo.cs
@@ -118,7 +118,7 @@ public partial class InteropTests
     public void PropertyValueMemoWorksForObjectProperty()
     {
         var host = new PropertyMemoHost();
-        var engine = new Engine();
+        var engine = new Engine(options => options.AllowClrWrite());
         engine.SetValue("host", host);
 
         engine.Evaluate("host.child.x").AsNumber().Should().Be(7);

--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -21,10 +21,12 @@ public partial class InteropTests : IDisposable
 
     public InteropTests()
     {
-        _engine = new Engine(cfg => cfg.AllowClr(
+        _engine = new Engine(cfg => cfg
+                .AllowClr(
                     typeof(Shape).GetTypeInfo().Assembly,
                     typeof(Console).GetTypeInfo().Assembly,
-                    typeof(File).GetTypeInfo().Assembly))
+                    typeof(File).GetTypeInfo().Assembly)
+                .AllowClrWrite())
                 .SetValue("log", new Action<object>(Console.WriteLine))
                 .SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()))
                 .SetValue("equal", new Action<object, object>(static (expected, actual) =>
@@ -995,7 +997,7 @@ public partial class InteropTests : IDisposable
         // A frozen IList<T> wrapper must reject element assignment in strict mode rather than letting the
         // base SetSlow path silently "succeed". Wrappers don't track per-element writability, so the
         // non-extensible (frozen) state is what blocks the write.
-        var engine = new Engine(x => x.Strict());
+        var engine = new Engine(x => x.Strict().AllowClrWrite());
         var list = new List<object> { "a", "b" };
         engine.SetValue("list", list);
         engine.Execute("Object.freeze(list);");
@@ -1008,7 +1010,7 @@ public partial class InteropTests : IDisposable
     [Fact]
     public void FrozenListWrapper_SilentlyIgnoresIndexWrite_NonStrict()
     {
-        var engine = new Engine();
+        var engine = new Engine(options => options.AllowClrWrite());
         var list = new List<object> { "a", "b" };
         engine.SetValue("list", list);
         engine.Execute("Object.freeze(list);");
@@ -1021,7 +1023,7 @@ public partial class InteropTests : IDisposable
     public void WritableListWrapper_AllowsIndexWrite()
     {
         // The frozen guard must not regress ordinary writable element assignment through the wrapper.
-        var engine = new Engine(x => x.Strict());
+        var engine = new Engine(x => x.Strict().AllowClrWrite());
         var list = new List<object> { "a", "b" };
         engine.SetValue("list", list);
 
@@ -1561,7 +1563,7 @@ public partial class InteropTests : IDisposable
     [Fact]
     public void CanSetIsConcatSpreadableForArrays()
     {
-        var engine = new Engine();
+        var engine = new Engine(options => options.AllowClrWrite());
 
         engine
             .SetValue("list1", new List<string> { "A", "B", "C" })
@@ -1669,7 +1671,11 @@ public partial class InteropTests : IDisposable
     [Fact]
     public void ShouldAllowBooleanCoercion()
     {
-        var engine = new Engine(options => { options.Interop.ValueCoercion = ValueCoercionType.Boolean; });
+        var engine = new Engine(options =>
+        {
+            options.AllowClrWrite();
+            options.Interop.ValueCoercion = ValueCoercionType.Boolean;
+        });
 
         engine.SetValue("o", new TestClass());
         engine.Evaluate("o.Bool = 1; return o.Bool;").AsBoolean().Should().BeTrue();
@@ -1699,7 +1705,11 @@ public partial class InteropTests : IDisposable
     [Fact]
     public void ShouldAllowNumberCoercion()
     {
-        var engine = new Engine(options => { options.Interop.ValueCoercion = ValueCoercionType.Number; });
+        var engine = new Engine(options =>
+        {
+            options.AllowClrWrite();
+            options.Interop.ValueCoercion = ValueCoercionType.Number;
+        });
 
         engine.SetValue("o", new TestClass());
         engine.Evaluate("o.Int = true; return o.Int;").AsNumber().Should().Be(1);
@@ -1728,7 +1738,11 @@ public partial class InteropTests : IDisposable
     [Fact]
     public void ShouldAllowStringCoercion()
     {
-        var engine = new Engine(options => { options.Interop.ValueCoercion = ValueCoercionType.String; });
+        var engine = new Engine(options =>
+        {
+            options.AllowClrWrite();
+            options.Interop.ValueCoercion = ValueCoercionType.String;
+        });
 
         // basic premise, booleans in JS are lower-case, so should the the toString under interop
         engine.Evaluate("'' + true").AsString().Should().Be("true");
@@ -3210,7 +3224,7 @@ new Thrower().ThrowExceptionWithMessage('boom');";
     public void ShouldBeAbleToPlusAssignStringProperty()
     {
         var p = new Person();
-        var engine = new Engine();
+        var engine = new Engine(options => options.AllowClrWrite());
         engine.SetValue("P", p);
         engine.Evaluate("P.Name = 'b';");
         engine.Evaluate("P.Name += 'c';");
@@ -3295,7 +3309,7 @@ new Thrower().ThrowExceptionWithMessage('boom');";
     [Fact]
     public void ShouldNotChangeFunctionArgumentsWhenFunctionStoredInDictionary()
     {
-        var engine = new Engine();
+        var engine = new Engine(options => options.AllowClrWrite());
         engine.SetValue("globalScope", new Dictionary<string, object>());
 
         engine.Execute("""
@@ -3404,7 +3418,9 @@ new Thrower().ThrowExceptionWithMessage('boom');";
     [Fact]
     public void SettingValueViaIntegerIndexer()
     {
-        var engine = new Engine(cfg => cfg.AllowClr(typeof(FloatIndexer).GetTypeInfo().Assembly));
+        var engine = new Engine(cfg => cfg
+            .AllowClr(typeof(FloatIndexer).GetTypeInfo().Assembly)
+            .AllowClrWrite());
         engine.SetValue("log", new Action<object>(Console.WriteLine));
         engine.Execute(@"
                 var domain = importNamespace('Jint.Tests.Runtime.Domain');
@@ -3810,6 +3826,7 @@ new Thrower().ThrowExceptionWithMessage('boom');";
 
         var engine = new Engine(options =>
         {
+            options.AllowClrWrite();
             options.SetTypeResolver(customTypeResolver);
             options.AddExtensionMethods(typeof(CustomNamedExtensions));
         });
@@ -3844,7 +3861,7 @@ new Thrower().ThrowExceptionWithMessage('boom');";
     [Fact]
     public void ShouldBeAbleToHandleInvalidClrConversionViaCatchClrExceptions()
     {
-        var engine = new Engine(cfg => cfg.CatchClrExceptions());
+        var engine = new Engine(cfg => cfg.CatchClrExceptions().AllowClrWrite());
         engine.SetValue("a", new Person());
         var ex = Invoking(() => engine.Execute("a.age = 'It will not work, but it is normal'")).Should().ThrowExactly<JavaScriptException>().Which;
         ex.Message.Should().ContainEquivalentOf("input string ");
@@ -3966,7 +3983,7 @@ new Thrower().ThrowExceptionWithMessage('boom');";
     [Fact]
     public void ArrayPrototypePushWithInteropList()
     {
-        var engine = new Jint.Engine();
+        var engine = new Jint.Engine(options => options.AllowClrWrite());
 
         var list = new List<string> { "A", "B", "C" };
 
@@ -3981,7 +3998,7 @@ new Thrower().ThrowExceptionWithMessage('boom');";
     [Fact]
     public void ArrayPrototypePopWithInteropList()
     {
-        var engine = new Jint.Engine();
+        var engine = new Jint.Engine(options => options.AllowClrWrite());
 
         var list = new List<string> { "A", "B", "C" };
         engine.SetValue("list", list);
@@ -4010,7 +4027,7 @@ new Thrower().ThrowExceptionWithMessage('boom');";
     [Fact]
     public void PreferJsPrototypeMethodsMakesArrayReverseWin()
     {
-        var engine = new Jint.Engine(cfg => cfg.PreferJsPrototypeMethods());
+        var engine = new Jint.Engine(cfg => cfg.PreferJsPrototypeMethods().AllowClrWrite());
         var list = new List<int> { 1, 2, 3 };
         engine.SetValue("list", list);
 
@@ -4024,7 +4041,7 @@ new Thrower().ThrowExceptionWithMessage('boom');";
         // Without the flag List<int>.Sort gives ascending int sort and returns void.
         // With the flag, Array.prototype.sort returns the array and uses JS string-compare semantics
         // ([10, 2, 1] -> [1, 10, 2] because "10" < "2" lexicographically).
-        var engine = new Jint.Engine(cfg => cfg.PreferJsPrototypeMethods());
+        var engine = new Jint.Engine(cfg => cfg.PreferJsPrototypeMethods().AllowClrWrite());
         var list = new List<int> { 10, 2, 1 };
         engine.SetValue("list", list);
 
@@ -4072,19 +4089,23 @@ new Thrower().ThrowExceptionWithMessage('boom');";
     public void ListReverseCanBeFixedTodayWithMemberFilter()
     {
         // Documents the workaround that works without the new flag, on existing Jint versions.
-        var engine = new Jint.Engine(options => options.SetTypeResolver(new TypeResolver
+        var engine = new Jint.Engine(options =>
         {
-            MemberFilter = m =>
+            options.AllowClrWrite();
+            options.SetTypeResolver(new TypeResolver
             {
-                if (m is System.Reflection.MethodInfo mi
-                    && mi.DeclaringType is { } dt
-                    && typeof(System.Collections.IList).IsAssignableFrom(dt))
+                MemberFilter = m =>
                 {
-                    return mi.Name is not ("Reverse" or "Sort");
+                    if (m is System.Reflection.MethodInfo mi
+                        && mi.DeclaringType is { } dt
+                        && typeof(System.Collections.IList).IsAssignableFrom(dt))
+                    {
+                        return mi.Name is not ("Reverse" or "Sort");
+                    }
+                    return true;
                 }
-                return true;
-            }
-        }));
+            });
+        });
 
         var list = new List<int> { 1, 2, 3 };
         engine.SetValue("list", list);
@@ -4347,7 +4368,7 @@ try {
     [Fact]
     public void ShouldBeAbleToDeleteDictionaryEntries()
     {
-        var engine = new Engine(options => options.Strict());
+        var engine = new Engine(options => options.Strict().AllowClrWrite());
 
         var dictionary = new Dictionary<string, int>
         {

--- a/Jint.Tests/Runtime/InteropWrapperMemberCacheTests.cs
+++ b/Jint.Tests/Runtime/InteropWrapperMemberCacheTests.cs
@@ -9,6 +9,8 @@
 /// </summary>
 public class InteropWrapperMemberCacheTests
 {
+    private static Engine CreateEngine() => new(options => options.AllowClrWrite());
+
     public class CountingHost
     {
         private int _value;
@@ -44,7 +46,7 @@ public class InteropWrapperMemberCacheTests
     public void PropertyReadsAndWritesInLoopStayLive()
     {
         var host = new CountingHost();
-        var engine = new Engine().SetValue("host", host);
+        var engine = CreateEngine().SetValue("host", host);
 
         var sum = engine.Evaluate("""
             var sum = 0;
@@ -66,7 +68,7 @@ public class InteropWrapperMemberCacheTests
     public void ClrSideMutationsBetweenIterationsAreVisible()
     {
         var host = new CountingHost();
-        var engine = new Engine()
+        var engine = CreateEngine()
             .SetValue("host", host)
             .SetValue("mutate", new Action<int>(host.SetBackingField));
 
@@ -86,7 +88,7 @@ public class InteropWrapperMemberCacheTests
     [Fact]
     public void DefinePropertyOnWrapperMidLoopInvalidatesReadCache()
     {
-        var engine = new Engine().SetValue("host", new CountingHost());
+        var engine = CreateEngine().SetValue("host", new CountingHost());
 
         var result = engine.Evaluate("""
             Object.defineProperty(host, 'extra', { value: 'first', writable: true, configurable: true });
@@ -106,7 +108,7 @@ public class InteropWrapperMemberCacheTests
     [Fact]
     public void DefinePropertyOnWrapperMidLoopInvalidatesMethodCallCache()
     {
-        var engine = new Engine().SetValue("host", new CountingHost());
+        var engine = CreateEngine().SetValue("host", new CountingHost());
 
         var result = engine.Evaluate("""
             var r = [];
@@ -130,7 +132,7 @@ public class InteropWrapperMemberCacheTests
         first.SetBackingField(1);
         second.SetBackingField(2);
 
-        var engine = new Engine()
+        var engine = CreateEngine()
             .SetValue("first", first)
             .SetValue("second", second);
 
@@ -156,7 +158,7 @@ public class InteropWrapperMemberCacheTests
     {
         var host = new CountingHost();
         host.SetBackingField(7);
-        var engine = new Engine().SetValue("host", host);
+        var engine = CreateEngine().SetValue("host", host);
 
         var result = engine.Evaluate("""
             function read(o) { return o.value; }
@@ -175,7 +177,7 @@ public class InteropWrapperMemberCacheTests
     public void DictionaryBackedWrapperMembersStayDynamic()
     {
         var dictionary = new Dictionary<string, object>();
-        var engine = new Engine()
+        var engine = CreateEngine()
             .SetValue("dict", dictionary)
             .SetValue("clrSet", new Action(() => dictionary["key"] = "clr"))
             .SetValue("clrRemove", new Action(() => dictionary.Remove("key")));
@@ -200,7 +202,7 @@ public class InteropWrapperMemberCacheTests
     [Fact]
     public void ReadOnlyClrPropertyWriteIsIgnoredInSloppyMode()
     {
-        var engine = new Engine().SetValue("host", new ReadOnlyHost());
+        var engine = CreateEngine().SetValue("host", new ReadOnlyHost());
 
         var result = engine.Evaluate("""
             var r = [];
@@ -218,7 +220,7 @@ public class InteropWrapperMemberCacheTests
     [Fact]
     public void ReadOnlyClrPropertyWriteThrowsTypeErrorInStrictMode()
     {
-        var engine = new Engine().SetValue("host", new ReadOnlyHost());
+        var engine = CreateEngine().SetValue("host", new ReadOnlyHost());
 
         var result = engine.Evaluate("""
             var r = [];
@@ -245,7 +247,7 @@ public class InteropWrapperMemberCacheTests
     public void FastLaneAgreesWithForcedSlowLaneAcrossMutations()
     {
         var host = new CountingHost();
-        var engine = new Engine()
+        var engine = CreateEngine()
             .SetValue("host", host)
             .SetValue("mutate", new Action<int>(host.SetBackingField));
 

--- a/Jint.Tests/Runtime/OwnPropertyProbeTests.cs
+++ b/Jint.Tests/Runtime/OwnPropertyProbeTests.cs
@@ -267,7 +267,7 @@ public class OwnPropertyProbeTests
     [Fact]
     public void WrappedDictionaryProbeAgreesWhenAScriptHasRedefinedAKey()
     {
-        var engine = new Engine();
+        var engine = new Engine(options => options.AllowClrWrite());
         engine.SetValue("doc", new Dictionary<string, object>(StringComparer.Ordinal) { ["a"] = 1d, ["b"] = 2d });
         engine.Execute("Object.defineProperty(doc, 'a', { value: 9, enumerable: false, configurable: true });");
 

--- a/Jint.Tests/Runtime/PropertyDescriptorTests.cs
+++ b/Jint.Tests/Runtime/PropertyDescriptorTests.cs
@@ -37,10 +37,12 @@ public class PropertyDescriptorTests
 
     public PropertyDescriptorTests()
     {
-        _engine = new Engine(cfg => cfg.AllowClr(
+        _engine = new Engine(cfg => cfg
+                .AllowClr(
                     typeof(TestClass).Assembly,
                     typeof(Console).Assembly,
-                    typeof(File).Assembly))
+                    typeof(File).Assembly)
+                .AllowClrWrite())
                 .SetValue("log", new Action<object>(Console.WriteLine))
                 .SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()))
                 .SetValue("equal", new Action<object, object>(static (expected, actual) =>

--- a/Jint/Native/Array/ArrayOperations.cs
+++ b/Jint/Native/Array/ArrayOperations.cs
@@ -341,7 +341,15 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
             => _target.DeletePropertyOrThrow((uint) index);
 
         public override void CreateDataPropertyOrThrow(ulong index, JsValue value)
-            => _target.SetIndexValue((uint) index, value, updateLength: false);
+        {
+            if (!_target.Extensible && !_target.HasOwnIndexProperty(index))
+            {
+                _target.CreateDataPropertyOrThrow(JsString.Create(index), value);
+                return;
+            }
+
+            _target.SetIndexValue((uint) index, value, updateLength: false);
+        }
 
         public override void Set(ulong index, JsValue value, bool updateLength = false, bool throwOnError = true)
         {
@@ -613,6 +621,12 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
 
         public override void SetLength(ulong length)
         {
+            if (!_target.Engine.Options.Interop.AllowWrite || !_target.Extensible)
+            {
+                _target.Set(CommonProperties.Length, length, true);
+                return;
+            }
+
             if (_list == null)
             {
                 throw new NotSupportedException();
@@ -672,7 +686,7 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
                 SetLength(index + 1);
             }
 
-            _target[(int) index] = value;
+            _target.Set(JsString.Create(index), value, throwOnError);
         }
 
         public override void DeletePropertyOrThrow(ulong index)
@@ -762,24 +776,14 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
 
         public override ulong GetLongLength() => GetLength();
 
-        public override void SetLength(ulong length)
-        {
-            while (_target.Length > (int) length)
-            {
-                // shrink list to fit
-                _target.RemoveAt(_target.Length - 1);
-            }
-
-            while (_target.Length < (int) length)
-            {
-                // expand list to fit
-                _target.AddDefault();
-            }
-        }
+        public override void SetLength(ulong length) => _target.Set(CommonProperties.Length, length, true);
 
         public override void EnsureCapacity(ulong capacity)
         {
-            _target.EnsureCapacity((int) capacity);
+            if (capacity > (ulong) _target.Length)
+            {
+                SetLength(capacity);
+            }
         }
 
         public override JsValue Get(ulong index) => index < (ulong) _target.Length ? ReadValue((int) index) : JsValue.Undefined;
@@ -809,7 +813,14 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
 
         public override void Set(ulong index, JsValue value, bool updateLength = false, bool throwOnError = true)
         {
-            _target.SetAt((int) index, value);
+            if (_target.Engine.Options.Interop.AllowWrite && _target.Extensible)
+            {
+                _target.SetAt((int) index, value);
+            }
+            else
+            {
+                _target.Set(JsNumber.Create(index), value, throwOnError);
+            }
         }
 
         public override void DeletePropertyOrThrow(ulong index)

--- a/Jint/Options.Extensions.cs
+++ b/Jint/Options.Extensions.cs
@@ -327,6 +327,14 @@ public static class OptionsExtensions
         return options;
     }
 
+    /// <summary>
+    /// Configures whether scripts can write directly through projected CLR objects. Direct CLR writes are
+    /// disabled by default.
+    /// </summary>
+    /// <remarks>
+    /// This controls writes to fields, properties, indexers, and collection entries. It does not prevent
+    /// scripts from calling CLR methods or extension methods whose implementations mutate host state.
+    /// </remarks>
     public static Options AllowClrWrite(this Options options, bool allow = true)
     {
         options.Interop.AllowWrite = allow;

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -460,9 +460,14 @@ public partial class Options
         public bool AllowSystemReflection { get; set; }
 
         /// <summary>
-        /// Whether writing to CLR objects is allowed (set properties), defaults to true.
+        /// Whether direct writes through projected CLR objects are allowed, including fields, properties,
+        /// indexers, and collection entries. Defaults to false.
         /// </summary>
-        public bool AllowWrite { get; set; } = true;
+        /// <remarks>
+        /// This option controls the wrapper's write operations. It does not prevent scripts from calling CLR
+        /// methods or extension methods whose implementations mutate host state.
+        /// </remarks>
+        public bool AllowWrite { get; set; }
 
         /// <summary>
         /// Whether operator overloading resolution is allowed, defaults to false.

--- a/Jint/Runtime/Descriptors/Specialized/ReflectionDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/ReflectionDescriptor.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Jint.Native;
+using Jint.Native.Object;
 using Jint.Runtime.Interop;
 using Jint.Runtime.Interop.Reflection;
 
@@ -11,6 +12,7 @@ internal sealed class ReflectionDescriptor : PropertyDescriptor
     private readonly ReflectionAccessor _reflectionAccessor;
     private readonly object _target;
     private readonly string _propertyName;
+    private ObjectInstance? _owner;
 
     private JsValue? _get;
     private JsValue? _set;
@@ -81,6 +83,8 @@ internal sealed class ReflectionDescriptor : PropertyDescriptor
         set => DoSet(thisObj: null, value);
     }
 
+    internal void AttachOwner(ObjectInstance owner) => _owner = owner;
+
     private JsValue DoGet(JsValue? thisObj)
     {
         // Immutability promise (Options.Interop.ImmutableCrossingTypes): the member has already been read
@@ -148,6 +152,11 @@ internal sealed class ReflectionDescriptor : PropertyDescriptor
 
     private void DoSet(JsValue? thisObj, JsValue? v)
     {
+        if (!_engine.Options.Interop.AllowWrite || _owner is { Extensible: false })
+        {
+            Throw.TypeError(_engine.Realm, $"Cannot assign to read only property '{_propertyName}' of object '#<Object>'");
+        }
+
         // A write invalidates the memo whether or not the target was declared immutable: without this a
         // declared-immutable member would keep serving the pre-write value to the very script that wrote it.
         // Insurance for a host whose promise was wrong, on a path that is about to run a CLR write anyway.

--- a/Jint/Runtime/Interop/ObjectWrapper.Specialized.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.Specialized.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 using Jint.Extensions;
 using Jint.Native;
 using Jint.Native.Array;
+using Jint.Native.Object;
 
 namespace Jint.Runtime.Interop;
 
@@ -166,9 +167,43 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
 
     public sealed override bool Delete(JsValue property)
     {
-        if (!_engine.Options.Interop.AllowWrite)
+        if (!_engine.Options.Interop.AllowWrite || !Extensible)
         {
-            return false;
+            if (property is JsString dictionaryKey
+                && _typeDescriptor.IsStringKeyedGenericDictionary
+                && _typeDescriptor.CanTestDictionaryKey)
+            {
+                var contains = _typeDescriptor.ContainsDictionaryKey(Target, dictionaryKey.ToString());
+                _engine.CheckAmortizedConstraintsAtHostBoundary();
+                if (contains)
+                {
+                    return false;
+                }
+
+                if (ArrayInstance.ParseArrayIndex(dictionaryKey.ToString()) != uint.MaxValue)
+                {
+                    return true;
+                }
+            }
+
+            if (!_typeDescriptor.IsDictionary && property.IsNumber())
+            {
+                var value = ((JsNumber) property)._value;
+                if (TypeConverter.IsIntegralNumber(value))
+                {
+                    return value < 0 || value >= Length;
+                }
+            }
+            else if (!_typeDescriptor.IsDictionary && property is JsString jsString)
+            {
+                var index = ArrayInstance.ParseArrayIndex(jsString.ToString());
+                if (index != uint.MaxValue)
+                {
+                    return index >= (uint) Length;
+                }
+            }
+
+            return ProbeOwnPropertyChecked(property) == OwnPropertyProbe.Missing;
         }
 
         if (property.IsNumber())
@@ -287,7 +322,7 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
 
         if (ReferenceEquals(receiver, this) && CommonProperties.Length.Equals(property))
         {
-            if (!CanWrite)
+            if (!CanWrite || !Extensible)
             {
                 return false;
             }
@@ -325,15 +360,16 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
 
         if (ReferenceEquals(receiver, this) && property.IsNumber())
         {
-            // An in-range element write to a read-only or non-extensible (frozen) wrapper must be refused:
+            // An element write to a read-only or non-extensible (frozen) wrapper must be refused:
             // base.SetSlow would otherwise materialize a throwaway descriptor and return true, silently
-            // "succeeding" (#2541). Everything else — writable in-range writes, growth, out-of-range,
-            // negative and non-integral indices — defers to base.Set, which writes through and already
+            // "succeeding" (#2541), or reach an indexer with an out-of-range growth write. Everything else —
+            // writable in-range writes, growth, negative and non-integral indices — defers to base.Set, which
+            // writes through and already
             // rejects runtime read-only collections (e.g. ReadOnlyCollection<T>) cleanly. Wrappers don't
             // track per-element writability, so a non-extensible wrapper blocks existing-element writes too
             // — a deliberate, contained interop divergence from the spec.
             var numValue = ((JsNumber) property)._value;
-            if (TypeConverter.IsIntegralNumber(numValue) && numValue >= 0 && numValue < Length
+            if (TypeConverter.IsIntegralNumber(numValue) && numValue >= 0
                 && (!CanWrite || !Extensible))
             {
                 return false;

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -9,6 +9,7 @@ using Jint.Native.Iterator;
 using Jint.Native.Object;
 using Jint.Native.Symbol;
 using Jint.Runtime.Descriptors;
+using Jint.Runtime.Descriptors.Specialized;
 using Jint.Runtime.Interop.Reflection;
 
 #pragma warning disable IL2067
@@ -1008,6 +1009,10 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
         }
 
         var descriptor = accessor.CreatePropertyDescriptor(_engine, Target, member, enumerable: !isDictionary);
+        if (descriptor is ReflectionDescriptor reflectionDescriptor)
+        {
+            reflectionDescriptor.AttachOwner(this);
+        }
         if (!isDictionary
             && !ReferenceEquals(descriptor, PropertyDescriptor.Undefined)
             && requirement.IsSatisfiedBy(accessor))

--- a/README.md
+++ b/README.md
@@ -2189,18 +2189,33 @@ var square = new Engine()
     .ToObject(); // converts the value to .NET
 ```
 
-You can also directly pass POCOs or anonymous objects and use them from JavaScript. In this example for instance a new `Person` instance is manipulated from JavaScript. 
+You can also directly pass POCOs or anonymous objects and use them from JavaScript. Direct writes through
+projected CLR objects are disabled by default. Opt in with `AllowClrWrite()` when scripts should be able to
+change CLR fields, properties, indexers, dictionaries, lists, or arrays:
+
 ```c#
 var p = new Person {
     Name = "Mickey Mouse"
 };
 
-var engine = new Engine()
+var engine = new Engine(options => options.AllowClrWrite())
     .SetValue("p", p)
     .Execute("p.Name = 'Minnie'");
 
 Assert.AreEqual("Minnie", p.Name);
 ```
+
+This is a breaking default change. Applications upgrading from a version where CLR writes were enabled by
+default must add `AllowClrWrite()` to preserve that behavior. The option only controls direct writes through
+Jint's projected-object wrappers; it does not make a projected object immutable. CLR methods and registered
+extension methods remain callable and can mutate host state:
+
+```c#
+var engine = new Engine(options => options.AddExtensionMethods(typeof(MyExtensions)));
+```
+
+Do not expose mutating methods to untrusted scripts when method side effects are outside the intended
+capability set.
 
 You can invoke JavaScript function reference
 ```c#
@@ -2896,6 +2911,11 @@ var engine = new Engine(options =>
   - Function -> Delegate
 - Extensions methods
 
+Direct writes through projected CLR objects are disabled by default. Assignments to CLR fields, properties,
+indexers, dictionary/list entries, and live array elements require `AllowClrWrite()`. In sloppy JavaScript a
+blocked assignment is ignored; in strict JavaScript it throws a `TypeError`. Calls are outside this option's
+scope: instance, static, and extension methods can still mutate CLR state.
+
 ## Error handling
 
 ### A CLR exception thrown by host code
@@ -3063,6 +3083,8 @@ a hardened deployment baseline.
 
 - Define memory limits, to prevent allocations from depleting the memory.
 - Enable/disable usage of BCL to prevent scripts from invoking .NET code.
+- Direct writes through projected CLR objects are disabled by default; enable them only with
+  `AllowClrWrite()`. This does not block side effects from callable CLR methods.
 - Limit number of statements to prevent infinite loops.
 - Limit depth of calls to prevent deep recursion calls.
 - Define a timeout, to prevent scripts from taking too long to finish.


### PR DESCRIPTION
## Summary

- disable direct writes through projected CLR objects by default
- add explicit `AllowClrWrite()` opt-in without making parameterless `AllowClr()` grant write authority
- preserve method and extension-method side effects as a separate documented capability boundary
- enforce write authority across fields, properties, statics, indexers, arrays, lists, dictionaries, dynamic objects, proxies, cached accessors, and borrowed/species array operations
- preserve ordinary JavaScript object semantics and write-enabled interop compatibility
- document the breaking default, migration, and residual risks in README and the threat model

## Security review

Specialist review found and this branch fixes:

- optimized borrowed/species array operations resizing CLR lists without write authority
- cached/detached setter and string-key routes bypassing frozen CLR wrappers
- frozen wrapper element deletion and partial `pop`/`shift`/`splice` mutation
- ordinary JavaScript non-extensibility bypasses in array `Set` and `CreateDataPropertyOrThrow` fast paths
- denied-delete semantics for absent array-like properties and numeric dictionary-shaped keys
- write-enabled `JsonArray` growth compatibility and .NET Framework base compatibility

A clean follow-up review reported no significant issues.

## Validation

- Release multi-target `Jint/Jint.csproj` build: net462, netstandard2.0, netstandard2.1, net8.0, net10.0
- PublicInterface default: 1,732 passed, 9 skipped
- PublicInterface host-contract verification: 1,736 passed, 5 skipped
- core default: 5,774 passed, 4 skipped
- core host-contract verification: 5,774 passed, 4 skipped
- `git diff --check`

Validation used the mandated NuGet proxy with the analyzer-only local workaround restored before publishing.

## Stack

#3052 -> #3051 -> #3046 -> #3045 -> #3037 -> #3036 -> #3035 -> #3030

Base: `sebros/stack-clr-containment-medium`