### PR TITLE
Give the benchmark suite a measurement environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,59 @@ Running everything is slow — filter unless you need the full set.
 
 The cross-engine comparison (`EngineComparisonBenchmark`) has its own notes and published results in [`Jint.Benchmark/README.md`](Jint.Benchmark/README.md). Run it from the `Jint.Benchmark` directory so the `Scripts/*.js` files resolve: `dotnet run -c Release -- --allCategories EngineComparison`.
 
+### The measurement environment
+
+Every benchmark runs under `JintBenchmarkConfig` (`Jint.Benchmark/JintBenchmarkConfig.cs`), applied globally from `Program.cs`. It exists because the suite previously ran on BenchmarkDotNet's bare `DefaultJob` — and almost everything needed here was already in BenchmarkDotNet and merely unused: `LaunchCount`, `WithAffinity`, `WithPowerPlan`, `WithGcConcurrent`, `WithEnvironmentVariable`, `AnalyzeLaunchVariance`, and the `MValue` column. BDN was already computing the multimodality statistic that marks a row as untrustworthy, and this project was throwing it away.
+
+**Keep the two error terms apart.** *Within-run noise* is what `StdDev` describes; BDN resamples it up to 100 iterations and the mean converges. *Between-run offset* — code layout, heap placement, tiered-compilation outcome, starting core — is constant within a process and varies between them, so with `LaunchCount = 1` **none of it reaches the reported error**. That is the shape of an A/B pair that looks decisive and then will not reproduce. More iterations cannot fix an offset; only more launches can.
+
+Three modes, selected by `JINT_BENCH_MODE`:
+
+| Mode | What it adds | Use it for |
+| --- | --- | --- |
+| `stable` (default) | machine-idle check, affinity, fixed-clock plan, blocking GC | day-to-day development |
+| `gate` | the above plus `LaunchCount=3` and launch-variance analysis | **any number quoted in a PR** |
+| `legacy` | nothing — bare `DefaultJob` | measuring the old environment for comparison |
+
+The machine-specific pieces all fail safe. The **affinity mask is derived, never hard-coded** (`BenchmarkTopology`): it picks the last-level-cache domain containing CPU 0 and drops physical core 0, falling back to no pinning on non-Windows, on multi-group machines and on anything too small to pin. On the gating 5950X that is CPU 2–15 — one 32 MB L3 domain, so a thread cannot migrate across the CCD boundary and lose its last-level working set.
+
+**What each control actually costs**, measured one factor at a time against `legacy` on a machine verified idle (medians over six `GuardComparisonBenchmark` rows, three launches each):
+
+| control | cost | variance benefit |
+| --- | --- | --- |
+| blocking GC | +1.1% | none that survives the noise |
+| affinity | +3.2% (+1.6% excluding one bimodal row) | none that survives the noise |
+| **fixed-clock power plan** | **+47%** | **none** |
+
+So pinning and GC mode are kept because they are free and have a principled rationale, not because this experiment proved they help. The **fixed clock is opt-in** and needs *both* `JINT_BENCH_FIXED_CLOCK=1` and `JINT_BENCH_POWERPLAN`: the GUID tends to live in a user-level environment variable forever, and applying it implicitly would silently cost ~47% on every run thereafter. It does buy one thing the numbers support — it removes boost as a free variable (measured 3,375 MHz with peak equal to mean, against 4,744 MHz peak), so absolute figures become comparable across sessions. Create the plan once with `Jint.Benchmark/setup-benchmark-machine.ps1` (elevated).
+
+> **`MachineStateValidator` refuses to start on a busy machine**, naming the offending processes. BDN has no such notion and will happily format a beautiful table from a contaminated run — the failure is otherwise completely silent. `CompatTelRunner.exe` (Microsoft Compatibility Telemetry) is a repeat offender here and starts on its own schedule; it was caught taking 65% of a core. Override with `JINT_BENCH_SKIP_IDLE_CHECK=1` only when the numbers do not need to be gate-quality.
+
+> **After any interrupted run, `./setup-benchmark-machine.ps1 -Restore`.** BDN restores the power plan only on a clean exit. A killed run leaves the fixed-clock plan active *and* can leave an orphaned `Jint.Benchmark` process that re-applies it, so whatever runs next silently runs at nominal frequency.
+
+**Tiered compilation and dynamic PGO stay at production defaults, and nothing works around them.** Turning tiering off does tighten the spread, but it measures code no embedder runs and forfeits PGO's devirtualization — most of the win for a tree-walking interpreter. Two mitigations were built and measured against a verified-idle baseline on `TypeofStringGuard` over ten launches, and **neither shipped**:
+
+| config | StdDev | MValue |
+| --- | --- | --- |
+| production defaults | **0.783 ms** | 2.000 (unimodal) |
+| run to JIT quiescence (`JitInfo.GetCompiledMethodCount`) | 1.224 ms | 2.000 |
+| `DOTNET_TC_QuickJitForLoops=0` + `DOTNET_TC_CallCountingDelayMs=0` | 1.275 ms | 2.795 (and ~13% slower) |
+
+The same row measured StdDev 1.946 ms and looked bimodal on a machine that was quietly busy. **The "bistable slow mode" that looked like a tiering artifact was mostly contention** — which is the strongest argument for the idle check above, and a warning against diagnosing the runtime from numbers taken on a shared machine.
+
+**No machine control reduced the between-process offset**, which is the term that actually breaks reproducibility. Only sampling it helps, which is what `LaunchCount` and the paired comparison below are for.
+
+**Comparing two builds:** BDN runs all of job A then all of job B, so anything that drifts between those two windows becomes a systematic between-arm bias (BDN issue #2004 is that symptom). `Jint.Benchmark/measure-paired.ps1` interleaves the two worktrees round by round, alternating order, and reports the per-round *difference* with a percentile bootstrap CI — the paired ("duet") design, reported in the literature as 2.3–12.5× more accurate than measuring the two separately. **A row is a regression only when its CI excludes zero.**
+
+Validated with an A/A run (the same worktree as both sides, six rounds), which correctly reported *no change* on both rows and calibrates the detection floor:
+
+| row | median Δ | 95% CI |
+| --- | --- | --- |
+| `NullCheckBenchmark.LooseEqualNull` | −0.49% | [−2.37, +0.59] |
+| `NullCheckBenchmark.LooseNotEqualNull` | −0.23% | [−1.03, +0.71] |
+
+So six rounds resolves roughly a 1–2.5% effect on these rows; add rounds rather than reading the median on its own when the interval is too wide to decide. **This is also why the old flat "1% blocks" rule cannot work as stated** — on many rows 1% is below what the measurement can resolve, so it manufactures re-runs rather than catching regressions.
+
 ### Adding a new benchmark
 
 1. Create a class in `Jint.Benchmark/` with `[MemoryDiagnoser]`.

--- a/Jint.Benchmark/BenchmarkTopology.cs
+++ b/Jint.Benchmark/BenchmarkTopology.cs
@@ -1,0 +1,153 @@
+using System.Numerics;
+using System.Runtime.InteropServices;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Derives a processor-affinity mask that keeps a benchmark process inside a single last-level-cache
+/// domain.
+///
+/// <para>It exists because an unpinned process on a chiplet CPU measures the scheduler as much as it
+/// measures the code. On the Ryzen 9 5950X this suite is gated on, the 16 cores are split across two
+/// CCDs with a <em>separate</em> 32 MB L3 each (logical CPUs 0-15 and 16-31), so a thread migrating
+/// across the boundary throws away its whole last-level working set — and per-core boost binning made
+/// the delivered clock range from 3,570 to 4,352 MHz depending on which core a run happened to land
+/// on. Neither effect is visible in BenchmarkDotNet's error bar, because both are constant within a
+/// process and vary between processes.</para>
+///
+/// <para>The mask is <em>derived</em>, never hard-coded: the same source has to run on CI and on
+/// contributors' machines, and a mask that is right here is worse than no mask at all somewhere else.
+/// Detection falls back to <c>null</c> — meaning "let the scheduler decide", exactly as before — on
+/// non-Windows, on machines with more than one processor group, on machines too small to pin safely,
+/// and on any API failure.</para>
+///
+/// <para>Two choices inside the chosen domain are deliberate. The domain containing CPU 0 is preferred
+/// because on Zen the first CCD carries the CPPC preferred cores, and physical core 0 is then removed
+/// from it because Windows lands most DPCs and interrupt work there. The mask stays deliberately wide
+/// (14 logical CPUs here rather than one), so the GC, finalizer and tiered-JIT background threads have
+/// somewhere to run: pinning to a single core starves them and trades one measurement artifact for a
+/// worse one.</para>
+/// </summary>
+internal static partial class BenchmarkTopology
+{
+    private const int RelationProcessorCore = 0;
+    private const int RelationCache = 2;
+
+    // sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION) on x64: ULONG_PTR ProcessorMask (8 bytes), then
+    // LOGICAL_PROCESSOR_RELATIONSHIP (4), then 4 bytes of padding up to the 8-byte alignment the
+    // union requires (it contains a ULONGLONG[2]), then the 16-byte union itself.
+    private const int EntrySize = 32;
+    private const int RelationshipOffset = 8;
+    private const int CacheLevelOffset = 16;
+
+    /// <summary>Smallest domain worth pinning to. Below this the runtime's own threads have nowhere to go.</summary>
+    private const int MinimumDomainWidth = 8;
+
+    /// <summary>Smallest mask left after excluding core 0. Below this, keep core 0 rather than over-constrain.</summary>
+    private const int MinimumMaskWidth = 4;
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool GetLogicalProcessorInformation(IntPtr buffer, ref uint returnLength);
+
+    /// <summary>
+    /// Returns the affinity mask a benchmark process should run under, or <c>null</c> when this machine
+    /// should be left to the scheduler.
+    /// </summary>
+    public static nint? ResolveAffinityMask()
+    {
+        // GetLogicalProcessorInformation only ever describes processor group 0, so a machine large
+        // enough to have several groups would get a mask covering an arbitrary subset of itself.
+        if (!OperatingSystem.IsWindows() || Environment.ProcessorCount > 64)
+        {
+            return null;
+        }
+
+        if (!TryReadTopology(out var lastLevelDomains, out var physicalCores))
+        {
+            return null;
+        }
+
+        // Prefer the domain holding CPU 0 (CCD0 on Zen, which carries the preferred cores), and fall
+        // back to the widest domain on a topology that does not include it.
+        var domain = lastLevelDomains.FirstOrDefault(static m => (m & 1) != 0);
+        if (domain == 0)
+        {
+            domain = lastLevelDomains.OrderByDescending(BitOperations.PopCount).FirstOrDefault();
+        }
+
+        if (domain == 0 || BitOperations.PopCount(domain) < MinimumDomainWidth)
+        {
+            return null;
+        }
+
+        var core0 = physicalCores.FirstOrDefault(static m => (m & 1) != 0);
+        var reduced = domain & ~core0;
+        if (BitOperations.PopCount(reduced) >= MinimumMaskWidth)
+        {
+            domain = reduced;
+        }
+
+        return (nint) domain;
+    }
+
+    /// <summary>Renders a mask the way BenchmarkDotNet reports it, for the banner and the logs.</summary>
+    public static string Describe(nint mask)
+    {
+        var cpus = new List<int>();
+        for (var i = 0; i < 64; i++)
+        {
+            if (((ulong) mask >> i & 1) != 0)
+            {
+                cpus.Add(i);
+            }
+        }
+
+        return cpus.Count == 0 ? "<empty>" : $"CPU {cpus[0]}-{cpus[^1]} ({cpus.Count} logical)";
+    }
+
+    private static bool TryReadTopology(out List<ulong> lastLevelDomains, out List<ulong> physicalCores)
+    {
+        lastLevelDomains = [];
+        physicalCores = [];
+
+        uint length = 0;
+        // The first call is expected to fail with ERROR_INSUFFICIENT_BUFFER and report the size needed.
+        GetLogicalProcessorInformation(IntPtr.Zero, ref length);
+        if (length == 0 || length % EntrySize != 0)
+        {
+            return false;
+        }
+
+        var buffer = Marshal.AllocHGlobal((int) length);
+        try
+        {
+            if (!GetLogicalProcessorInformation(buffer, ref length))
+            {
+                return false;
+            }
+
+            var count = (int) (length / EntrySize);
+            for (var i = 0; i < count; i++)
+            {
+                var entry = IntPtr.Add(buffer, i * EntrySize);
+                var mask = (ulong) Marshal.ReadIntPtr(entry);
+                switch (Marshal.ReadInt32(entry, RelationshipOffset))
+                {
+                    case RelationCache when Marshal.ReadByte(entry, CacheLevelOffset) == 3:
+                        lastLevelDomains.Add(mask);
+                        break;
+                    case RelationProcessorCore:
+                        physicalCores.Add(mask);
+                        break;
+                }
+            }
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(buffer);
+        }
+
+        return lastLevelDomains.Count > 0;
+    }
+}

--- a/Jint.Benchmark/Jint.Benchmark.csproj
+++ b/Jint.Benchmark/Jint.Benchmark.csproj
@@ -17,6 +17,8 @@
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <!-- BenchmarkTopology reads the processor topology through a [LibraryImport] stub. -->
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn);CS8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/Jint.Benchmark/JintBenchmarkConfig.cs
+++ b/Jint.Benchmark/JintBenchmarkConfig.cs
@@ -1,0 +1,214 @@
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using Perfolizer.Horology;
+
+namespace Jint.Benchmark;
+
+/// <summary>Which measurement environment a run uses. Selected by <c>JINT_BENCH_MODE</c>.</summary>
+internal enum BenchmarkEnvironment
+{
+    /// <summary>BenchmarkDotNet's bare <c>DefaultJob</c>, as this suite ran before. Kept so the old
+    /// environment stays measurable and comparable.</summary>
+    Legacy,
+
+    /// <summary>The default: pinned, fixed clock, deterministic GC, machine checked before starting.</summary>
+    Stable,
+
+    /// <summary>What a gating run uses — <see cref="Stable"/> plus the launches needed to see
+    /// between-process variance at all. Roughly three times the wall-clock cost.</summary>
+    Gate,
+}
+
+/// <summary>
+/// The measurement environment every Jint benchmark runs under.
+///
+/// <para>Before this existed, all ~130 benchmark classes ran on BenchmarkDotNet's bare
+/// <c>DefaultJob</c>. That is the root of most of what went wrong, because nearly everything needed
+/// here was already in BenchmarkDotNet and simply unused: <c>LaunchCount</c>, <c>WithAffinity</c>,
+/// <c>WithPowerPlan</c>, <c>WithGcConcurrent</c>, <c>WithEnvironmentVariable</c>,
+/// <c>AnalyzeLaunchVariance</c>, and — the sharpest one — the <c>MValue</c> column and
+/// <c>MultimodalDistributionAnalyzer</c>. BenchmarkDotNet was already computing the multimodality
+/// statistic that flags a row as untrustworthy, and this project was discarding it.</para>
+///
+/// <para><b>The error term that matters.</b> <c>DefaultJob</c> sets <c>LaunchCount = 1</c>, so code
+/// layout, heap placement, tiered-compilation outcome and the starting core are constants
+/// <em>within</em> the measured process and variables <em>between</em> processes. None of them reach
+/// the reported error. That is precisely the shape of an A/B pair that looks decisive and then will
+/// not reproduce: the error bar is honest and is measuring the wrong quantity. More iterations
+/// cannot fix it — they resample within one process. Only more launches can.</para>
+///
+/// <para><b>Tiered compilation and dynamic PGO stay at their production defaults, and nothing here
+/// works around them.</b> That is a measured decision, not an omission. On a machine verified idle,
+/// <c>TypeofStringGuard</c> over ten launches came back at StdDev 0.783 ms with MValue 2.000 —
+/// unimodal — against 1.946 ms on a machine that was quietly busy. The bistable "slow mode" that
+/// looked like a tiering artifact was mostly contention. Two mitigations were built and measured
+/// against that baseline: running the workload to JIT quiescence (StdDev 1.224) and applying
+/// <c>DOTNET_TC_QuickJitForLoops=0</c> + <c>DOTNET_TC_CallCountingDelayMs=0</c> (StdDev 1.275, and
+/// ~13% slower). Neither helped, so neither shipped.</para>
+///
+/// <para><b>The fixed-clock power plan is opt-in for the same reason.</b> Measured one factor at a
+/// time against <c>legacy</c>, blocking GC costs ~1% and pinning ~2-3%, while the fixed clock costs
+/// <b>~47%</b> — and none of the three showed a variance reduction that survived the noise. A
+/// control that expensive has to earn its place, and this one did not, so it applies only when
+/// <c>JINT_BENCH_FIXED_CLOCK=1</c> is set explicitly. It remains useful for one thing the numbers do
+/// support: making absolute figures comparable across sessions, since it removes boost as a free
+/// variable.</para>
+///
+/// <para><b>What actually remains, then, is statistical.</b> No machine control reduced the
+/// between-process offset, which is the term that breaks reproducibility. Only sampling it can:
+/// <c>LaunchCount</c> in gate mode, and the interleaved paired comparison in
+/// <c>measure-paired.ps1</c> for A/B work.</para>
+/// </summary>
+internal static class JintBenchmarkConfig
+{
+    private const string ModeVariable = "JINT_BENCH_MODE";
+    private const string PowerPlanVariable = "JINT_BENCH_POWERPLAN";
+
+    /// <summary>Set to <c>off</c> to skip processor pinning. Present so each control can be ablated alone.</summary>
+    private const string AffinityVariable = "JINT_BENCH_AFFINITY";
+
+    /// <summary>Set to <c>concurrent</c> to keep background GC. Present so each control can be ablated alone.</summary>
+    private const string GcVariable = "JINT_BENCH_GC";
+
+    /// <summary>
+    /// Set to <c>1</c> to apply the fixed-clock plan named by <see cref="PowerPlanVariable"/>.
+    /// Requiring both is deliberate: the plan GUID tends to live in a user-level environment variable
+    /// forever, and applying it implicitly would silently cost ~47% on every run from then on.
+    /// </summary>
+    private const string FixedClockVariable = "JINT_BENCH_FIXED_CLOCK";
+
+    /// <summary>
+    /// Processes a gating run measures. Three is the smallest number that can show a between-process
+    /// offset at all. It triples wall-clock cost, which is why it is not the default.
+    /// </summary>
+    private const int GateLaunchCount = 3;
+
+    /// <summary>
+    /// Iteration time for a row whose operation is long enough that few of them fit in an iteration.
+    /// Deliberately not applied globally: raising it four-fold helps only rows whose operation is a
+    /// large fraction of an iteration, and most of this suite is microsecond-scale rows that converge
+    /// in the minimum 15 iterations either way. A class with a genuinely long, allocation-heavy
+    /// operation should opt in with its own <c>[Config]</c>.
+    /// </summary>
+    public static readonly TimeInterval LongOperationIterationTime = TimeInterval.FromMilliseconds(2000);
+
+    public static IConfig Create()
+    {
+        var mode = ResolveMode();
+        var config = ManualConfig.Create(DefaultConfig.Instance);
+
+        // Surface multimodality on every row. A bimodal row's Mean is not a summary of anything, and
+        // this is the column that says so. It costs nothing and BenchmarkDotNet already computes it.
+        config = config.AddColumn(StatisticColumn.MValue, StatisticColumn.Median);
+
+        if (mode == BenchmarkEnvironment.Legacy)
+        {
+            Announce(mode, affinity: null, powerPlan: null, launchCount: 1, concurrentGc: true);
+            return config;
+        }
+
+        // Check the machine is fit to measure on. BenchmarkDotNet has no such notion; without this the
+        // only symptom of contamination is numbers that quietly disagree with the next run. A gating
+        // run refuses outright; a development run only warns, so nobody's dev loop is blocked by a
+        // sync client waking up.
+        config = config.AddValidator(mode == BenchmarkEnvironment.Gate
+            ? MachineStateValidator.Blocking
+            : MachineStateValidator.Advisory);
+
+        var job = Job.Default;
+
+        var affinityOff = string.Equals(
+            Environment.GetEnvironmentVariable(AffinityVariable), "off", StringComparison.OrdinalIgnoreCase);
+        var affinity = affinityOff ? null : BenchmarkTopology.ResolveAffinityMask();
+        if (affinity is { } mask)
+        {
+            job = job.WithAffinity(mask);
+        }
+
+        // BenchmarkDotNet already forces a power plan for the duration of a run (High performance by
+        // default), which would otherwise overwrite a fixed-clock plan the host had made active.
+        // Handing it the plan's GUID makes it apply that one and restore the previous plan on exit.
+        var powerPlan = ResolvePowerPlan();
+        if (powerPlan is { } plan)
+        {
+            job = job.WithPowerPlan(plan);
+        }
+
+        // Background GC does collection work on its own threads, on whatever core is free and
+        // asynchronously to the iteration boundary. Blocking workstation GC keeps it on the benchmark
+        // thread, inside the affinity mask and inside the iteration being measured.
+        var concurrentGc = string.Equals(
+            Environment.GetEnvironmentVariable(GcVariable), "concurrent", StringComparison.OrdinalIgnoreCase);
+        job = job.WithGcConcurrent(concurrentGc);
+
+        var launchCount = 1;
+        if (mode == BenchmarkEnvironment.Gate)
+        {
+            launchCount = GateLaunchCount;
+            job = job.WithLaunchCount(GateLaunchCount).WithAnalyzeLaunchVariance(true);
+        }
+
+        Announce(mode, affinity, powerPlan, launchCount, concurrentGc);
+        return config.AddJob(job);
+    }
+
+    private static BenchmarkEnvironment ResolveMode()
+    {
+        var raw = Environment.GetEnvironmentVariable(ModeVariable);
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return BenchmarkEnvironment.Stable;
+        }
+
+        if (Enum.TryParse<BenchmarkEnvironment>(raw.Trim(), ignoreCase: true, out var parsed))
+        {
+            return parsed;
+        }
+
+        Console.Error.WriteLine($"// {ModeVariable}='{raw}' is not legacy|stable|gate — using stable.");
+        return BenchmarkEnvironment.Stable;
+    }
+
+    private static Guid? ResolvePowerPlan()
+    {
+        if (Environment.GetEnvironmentVariable(FixedClockVariable) is not ("1" or "true"))
+        {
+            return null;
+        }
+
+        var raw = Environment.GetEnvironmentVariable(PowerPlanVariable);
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            Console.Error.WriteLine(
+                $"// {FixedClockVariable} is set but {PowerPlanVariable} is not — leaving the power plan alone.");
+            return null;
+        }
+
+        if (Guid.TryParse(raw.Trim(), out var guid))
+        {
+            return guid;
+        }
+
+        Console.Error.WriteLine($"// {PowerPlanVariable}='{raw}' is not a GUID — leaving the power plan alone.");
+        return null;
+    }
+
+    private static void Announce(
+        BenchmarkEnvironment mode, nint? affinity, Guid? powerPlan, int launchCount, bool concurrentGc)
+    {
+        Console.WriteLine($"// Jint measurement environment: {mode.ToString().ToLowerInvariant()}");
+        Console.WriteLine($"//   affinity    : {(affinity is { } m ? BenchmarkTopology.Describe(m) : "unpinned (scheduler decides)")}");
+        Console.WriteLine($"//   power plan  : {(powerPlan is { } p ? $"fixed clock {p}" : "BenchmarkDotNet default (High performance)")}");
+        Console.WriteLine($"//   gc          : {(concurrentGc ? "concurrent" : "blocking")} workstation");
+        Console.WriteLine($"//   launches    : {launchCount}");
+        Console.WriteLine("//   tiering     : production defaults (tiered compilation + dynamic PGO)");
+
+        if (mode != BenchmarkEnvironment.Gate)
+        {
+            Console.WriteLine($"//   note        : set {ModeVariable}=gate before quoting a number in a PR.");
+        }
+
+        Console.WriteLine();
+    }
+}

--- a/Jint.Benchmark/MachineStateValidator.cs
+++ b/Jint.Benchmark/MachineStateValidator.cs
@@ -1,0 +1,203 @@
+using System.Diagnostics;
+using BenchmarkDotNet.Validators;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Refuses to start a measurement on a machine that is not quiet enough to measure on.
+///
+/// <para>BenchmarkDotNet has no notion of whether the host is fit to measure: it will produce a
+/// perfectly formatted table from a run that shared the machine with a build, a sync client or
+/// another benchmark, and nothing in the output says so. That failure is silent and it is not
+/// hypothetical — it invalidated three separate runs while this harness was being built, and in the
+/// worst case a whole arm came back uniformly wrong while looking *more* self-consistent than the
+/// good one, because uniform interference reads as low variance.</para>
+///
+/// <para>So this samples background CPU before the first benchmark and fails the run outright when
+/// it is too high, naming the processes responsible. A refusal costs a minute; a contaminated
+/// twenty-minute arm costs far more, and costs more still if nobody notices and it reaches a PR.</para>
+///
+/// <para>The threshold is expressed against a <em>single core</em> rather than against the whole
+/// machine deliberately. These benchmarks are single-threaded, so what hurts is one competing
+/// runnable thread, and dividing by 32 logical processors would hide exactly that. An otherwise
+/// idle desktop measured ~15% of one core here (shell, compositor, telemetry agents), so the
+/// default leaves room for that and catches genuine contention.</para>
+/// </summary>
+internal sealed class MachineStateValidator : IValidator
+{
+    /// <summary>Background CPU, as a percentage of one core, above which the run is refused.</summary>
+    private const double MaxBackgroundPercentOfOneCore = 40.0;
+
+    private static readonly TimeSpan SampleWindow = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// How long to wait for a busy machine to go quiet before giving up on it.
+    ///
+    /// <para>Waiting rather than failing immediately is the difference between a check that helps and
+    /// one that gets switched off. By far the most common reason the machine is busy at this moment is
+    /// that <em>we</em> just made it busy: the build that produced this executable, or the previous
+    /// benchmark in a sweep, is still winding down. That clears on its own in seconds, and refusing
+    /// the run — or worse, measuring through it — would both be the wrong answer.</para>
+    /// </summary>
+    private static readonly TimeSpan SettleTimeout = TimeSpan.FromSeconds(45);
+
+    /// <summary>
+    /// BenchmarkDotNet invokes validators more than once per run. Sampling costs seconds, so the
+    /// verdict is computed once and reused; the window is short enough that it cannot go stale within
+    /// a single run's validation phase.
+    /// </summary>
+    private static (double Load, string Offenders)? _cached;
+
+    /// <summary>Set <c>JINT_BENCH_SKIP_IDLE_CHECK=1</c> to measure anyway (results are then not gate-quality).</summary>
+    private static bool Skipped =>
+        Environment.GetEnvironmentVariable("JINT_BENCH_SKIP_IDLE_CHECK") is "1" or "true";
+
+    /// <summary>
+    /// Whether a busy machine aborts the run. Gating runs refuse, because their numbers reach a PR
+    /// and a contaminated one is worse than no number at all. Development runs only warn: blocking
+    /// someone's dev loop because a sync client woke up would be disproportionate, and they are not
+    /// quoting those numbers anywhere.
+    /// </summary>
+    private readonly bool _fatal;
+
+    private MachineStateValidator(bool fatal) => _fatal = fatal;
+
+    /// <summary>Warns but lets the run proceed. For development runs.</summary>
+    public static MachineStateValidator Advisory { get; } = new(fatal: false);
+
+    /// <summary>Aborts the run. For gating runs.</summary>
+    public static MachineStateValidator Blocking { get; } = new(fatal: true);
+
+    public bool TreatsWarningsAsErrors => _fatal;
+
+    public IEnumerable<ValidationError> Validate(ValidationParameters validationParameters)
+    {
+        if (Skipped)
+        {
+            Console.WriteLine("// idle check skipped via JINT_BENCH_SKIP_IDLE_CHECK — results are not gate-quality.");
+            yield break;
+        }
+
+        if (Debugger.IsAttached)
+        {
+            yield return new ValidationError(
+                isCritical: _fatal,
+                "A debugger is attached. It disarms the interpreter's tight-loop lane and invalidates every number.",
+                benchmarkCase: null!);
+            yield break;
+        }
+
+        var (load, offenders) = WaitForQuietMachine();
+        Console.WriteLine($"// machine check: background CPU {load:F1}% of one core");
+
+        if (load > MaxBackgroundPercentOfOneCore)
+        {
+            var remedy = _fatal
+                ? "Close them and re-run, or set JINT_BENCH_SKIP_IDLE_CHECK=1 to measure anyway and accept that the numbers are not gate-quality."
+                : "Proceeding, because this is not a gating run — but do not quote these numbers.";
+
+            yield return new ValidationError(
+                isCritical: _fatal,
+                $"Machine is not idle: {load:F1}% of one core is busy (limit {MaxBackgroundPercentOfOneCore:F0}%). " +
+                $"Top consumers: {offenders}. {remedy}",
+                benchmarkCase: null!);
+        }
+    }
+
+    /// <summary>
+    /// Samples until the machine is quiet or <see cref="SettleTimeout"/> expires, returning the last
+    /// reading either way. The verdict is cached for the rest of the validation phase.
+    /// </summary>
+    private static (double Load, string Offenders) WaitForQuietMachine()
+    {
+        if (_cached is { } hit)
+        {
+            return hit;
+        }
+
+        var deadline = Stopwatch.StartNew();
+        var reading = SampleBackgroundLoad();
+        var announced = false;
+
+        while (reading.Load > MaxBackgroundPercentOfOneCore && deadline.Elapsed < SettleTimeout)
+        {
+            if (!announced)
+            {
+                Console.WriteLine(
+                    $"// machine busy ({reading.Load:F0}% of one core: {reading.Offenders}) — " +
+                    $"waiting up to {SettleTimeout.TotalSeconds:F0}s for it to settle");
+                announced = true;
+            }
+
+            reading = SampleBackgroundLoad();
+        }
+
+        _cached = reading;
+        return reading;
+    }
+
+    /// <summary>
+    /// Returns background CPU as a percentage of one core, plus the processes responsible. Our own
+    /// process is excluded: the host is about to hand off to a child and its own cost is not
+    /// contention.
+    /// </summary>
+    private static (double Load, string Offenders) SampleBackgroundLoad()
+    {
+        var self = Environment.ProcessId;
+        var first = Snapshot(self);
+        var clock = Stopwatch.StartNew();
+        Thread.Sleep(SampleWindow);
+        clock.Stop();
+        var second = Snapshot(self);
+
+        var deltas = new List<(string Name, double Percent)>();
+        foreach (var (id, (name, cpu)) in second)
+        {
+            if (!first.TryGetValue(id, out var before))
+            {
+                continue;
+            }
+
+            var percent = 100.0 * (cpu - before.Cpu).TotalSeconds / clock.Elapsed.TotalSeconds;
+            if (percent > 0.5)
+            {
+                deltas.Add((name, percent));
+            }
+        }
+
+        var total = deltas.Sum(d => d.Percent);
+        var offenders = string.Join(", ", deltas
+            .OrderByDescending(d => d.Percent)
+            .Take(4)
+            .Select(d => $"{d.Name} {d.Percent:F0}%"));
+
+        return (total, offenders.Length == 0 ? "none" : offenders);
+    }
+
+    private static Dictionary<int, (string Name, TimeSpan Cpu)> Snapshot(int self)
+    {
+        var map = new Dictionary<int, (string, TimeSpan)>();
+        foreach (var process in Process.GetProcesses())
+        {
+            try
+            {
+                // Protected and exiting processes throw on either access; they are not what we are
+                // looking for, so skipping them is the correct answer rather than a lost sample.
+                if (process.Id != self)
+                {
+                    map[process.Id] = (process.ProcessName, process.TotalProcessorTime);
+                }
+            }
+            catch (Exception)
+            {
+                // ignored by design — see above
+            }
+            finally
+            {
+                process.Dispose();
+            }
+        }
+
+        return map;
+    }
+}

--- a/Jint.Benchmark/Program.cs
+++ b/Jint.Benchmark/Program.cs
@@ -113,6 +113,6 @@ if (args.Length > 0 && args[0] is "--disasm" or "--disasm-hw")
 
 BenchmarkSwitcher
     .FromAssembly(typeof(ArrayBenchmark).GetTypeInfo().Assembly)
-    .Run(args);
+    .Run(args, JintBenchmarkConfig.Create());
 
 return 0;

--- a/Jint.Benchmark/measure-paired.ps1
+++ b/Jint.Benchmark/measure-paired.ps1
@@ -1,0 +1,158 @@
+<#
+.SYNOPSIS
+    Interleaved paired A/B measurement. The gating protocol for comparing two Jint builds.
+
+.DESCRIPTION
+    The problem this solves is not noise inside a run - BenchmarkDotNet already averages that away.
+    It is the offset BETWEEN processes, which with LaunchCount=1 never reaches the reported error at
+    all. Measured on the gating machine, that offset is ~3% at the median and ~10% at p90 even with
+    the process pinned and the clock fixed, and it is dominated by a bistable ~1.9x slow mode that
+    tiered compilation produces per process (TieredCompilation=0 collapses it from StdDev 1.95 to
+    0.37 - at the cost of measuring code that never ships).
+
+    Rather than disabling the runtime features that cause it, this measures around them. Each round
+    runs BOTH builds once, and the order alternates every round so that whatever penalises the
+    second run in a pair - thermal state, machine drift, run order - lands on each build equally
+    often. The statistic is then the per-round DIFFERENCE, not two independently estimated means.
+
+    This is the "duet"/paired design from the benchmarking literature (Bulej et al., Duet
+    Benchmarking, arXiv:2001.05811), which reports 2.3-12.5x accuracy improvements on JVM workloads
+    over measuring the two variants separately. It is adapted to interleave in time rather than run
+    concurrently, because on a dedicated machine concurrency would introduce contention instead of
+    cancelling it.
+
+    Every runtime feature stays production-default: tiered compilation on, dynamic PGO on. The
+    per-process lottery is sampled rather than suppressed.
+
+.PARAMETER Baseline
+    Path to the baseline worktree (the branch being compared against).
+
+.PARAMETER Candidate
+    Path to the candidate worktree (the change under test).
+
+.PARAMETER Filter
+    BenchmarkDotNet filter(s), e.g. '*SunSpiderBenchmark*'.
+
+.PARAMETER Rounds
+    Number of A/B pairs. 8 is a reasonable floor; the paired CI narrows roughly as 1/sqrt(Rounds).
+
+.EXAMPLE
+    ./measure-paired.ps1 -Baseline D:\Work\jint -Candidate D:\Work\jint.myfix -Filter '*ForOfArrayBenchmark*'
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)] [string]   $Baseline,
+    [Parameter(Mandatory)] [string]   $Candidate,
+    [Parameter(Mandatory)] [string[]] $Filter,
+    [int]    $Rounds = 8,
+    [string] $OutputRoot = (Join-Path ([IO.Path]::GetTempPath()) "jint-paired-$(Get-Date -Format yyyyMMdd-HHmmss)")
+)
+
+$ErrorActionPreference = 'Stop'
+New-Item -ItemType Directory -Force -Path $OutputRoot | Out-Null
+
+$env:JINT_BENCH_MODE      = 'stable'   # pinned + fixed clock; LaunchCount stays 1 per round
+$env:JINT_BENCH_POWERPLAN = [Environment]::GetEnvironmentVariable('JINT_BENCH_POWERPLAN', 'User')
+
+function Invoke-Side([string] $root, [string] $tag, [int] $round) {
+    $proj = Join-Path $root 'Jint.Benchmark'
+    $art  = Join-Path $OutputRoot "$tag-r$round"
+    Push-Location $proj
+    try {
+        $a = @('run','-c','Release','--project','.','--','--filter') + $Filter +
+             @('--artifacts', $art, '--launchCount','1')
+        & dotnet @a *> (Join-Path $OutputRoot "$tag-r$round.log")
+    } finally { Pop-Location }
+    $art
+}
+
+# Parse every *-report.csv BenchmarkDotNet wrote, keyed by "Class.Method[params]".
+function Read-Means([string] $artifactDir) {
+    $rows = @{}
+    Get-ChildItem (Join-Path $artifactDir 'results') -Filter '*-report.csv' -EA SilentlyContinue | ForEach-Object {
+        $cls = ($_.BaseName -replace '-report$','') -replace '^Jint\.Benchmark\.',''
+        Import-Csv $_.FullName | ForEach-Object {
+            $r = $_
+            $paramCols = $r.PSObject.Properties.Name | Where-Object {
+                $_ -notin 'Method','Job','Mean','Error','StdDev','Median','Min','Max','Gen0','Gen1','Gen2','Allocated','Rank','StdErr','MValue' -and
+                $r.$_ -and $r.$_ -ne 'Default'
+            }
+            $suffix = if ($paramCols) { '[' + (($paramCols | ForEach-Object { $r.$_ }) -join ',') + ']' } else { '' }
+            $key = "$cls.$($r.Method)$suffix"
+
+            # "20.68 ms" / "1.234 us" / "987.6 ns" -> nanoseconds
+            if ($r.Mean -match '^\s*([\d.,]+)\s*(ns|us|ms|s)\s*$') {
+                $v = [double]($Matches[1] -replace ',','')
+                $ns = switch ($Matches[2]) { 'ns' {$v} 'us' {$v*1e3} 'ms' {$v*1e6} 's' {$v*1e9} }
+                $rows[$key] = $ns
+            }
+        }
+    }
+    $rows
+}
+
+$paired = @{}   # key -> list of percentage differences, one per round
+
+for ($r = 1; $r -le $Rounds; $r++) {
+    # Alternate which side runs first so run-order penalty is shared equally.
+    $baseFirst = ($r % 2) -eq 1
+    Write-Host "round $r/$Rounds ($(if($baseFirst){'base,cand'}else{'cand,base'}))"
+
+    if ($baseFirst) {
+        $b = Read-Means (Invoke-Side $Baseline  'base' $r)
+        $c = Read-Means (Invoke-Side $Candidate 'cand' $r)
+    } else {
+        $c = Read-Means (Invoke-Side $Candidate 'cand' $r)
+        $b = Read-Means (Invoke-Side $Baseline  'base' $r)
+    }
+
+    foreach ($k in $b.Keys) {
+        if (-not $c.ContainsKey($k)) { continue }
+        if (-not $paired.ContainsKey($k)) { $paired[$k] = @() }
+        $paired[$k] += 100.0 * ($c[$k] - $b[$k]) / $b[$k]
+    }
+}
+
+# --- paired statistics ---------------------------------------------------------------------
+# The per-round difference is the unit of observation. Reporting its median plus a percentile
+# bootstrap CI avoids assuming normality, which a bimodal per-process distribution violates.
+
+function Get-Median([double[]] $v) {
+    $s = $v | Sort-Object; $n = $s.Count
+    if ($n % 2) { $s[[int](($n-1)/2)] } else { ($s[$n/2-1] + $s[$n/2]) / 2 }
+}
+
+function Get-BootstrapCi([double[]] $v, [int] $iter = 5000) {
+    $rng = [Random]::new(20260816)   # fixed seed: the report must be reproducible from the same data
+    $meds = for ($i = 0; $i -lt $iter; $i++) {
+        $s = for ($j = 0; $j -lt $v.Count; $j++) { $v[$rng.Next($v.Count)] }
+        Get-Median ([double[]] $s)
+    }
+    $sorted = $meds | Sort-Object
+    @($sorted[[int](0.025 * $iter)], $sorted[[int](0.975 * $iter)])
+}
+
+Write-Host ''
+'{0,-52} {1,9} {2,20} {3,8} {4}' -f 'row', 'median %', '95% CI', 'sign', 'verdict'
+'-' * 108
+
+$report = foreach ($k in ($paired.Keys | Sort-Object)) {
+    $d = [double[]] $paired[$k]
+    if ($d.Count -lt 3) { continue }
+    $med = Get-Median $d
+    $ci  = Get-BootstrapCi $d
+    $pos = ($d | Where-Object { $_ -gt 0 }).Count
+
+    # A result counts only when the whole interval sits on one side of zero.
+    $verdict = if ($ci[0] -gt 0) { 'SLOWER' } elseif ($ci[1] -lt 0) { 'FASTER' } else { 'no change' }
+
+    '{0,-52} {1,9:+0.00;-0.00} {2,20} {3,8} {4}' -f
+        $k.Substring(0, [Math]::Min(52, $k.Length)), $med,
+        ("[{0:+0.00;-0.00}, {1:+0.00;-0.00}]" -f $ci[0], $ci[1]), "$pos/$($d.Count)", $verdict
+}
+$report
+
+Write-Host ''
+"rounds: $Rounds   raw data: $OutputRoot"
+'A row is only a regression when its 95% CI excludes zero. A wide CI means the measurement was'
+'not precise enough to decide - add rounds rather than reading the median on its own.'

--- a/Jint.Benchmark/setup-benchmark-machine.ps1
+++ b/Jint.Benchmark/setup-benchmark-machine.ps1
@@ -1,0 +1,139 @@
+<#
+.SYNOPSIS
+    Prepares a Windows machine to produce reproducible BenchmarkDotNet numbers for Jint.
+
+.DESCRIPTION
+    Creates (once) a dedicated "Jint Benchmark (fixed clock)" power plan and records its GUID in the
+    user environment variable JINT_BENCH_POWERPLAN, which JintBenchmarkConfig reads. BenchmarkDotNet
+    then applies that plan for the duration of a run and restores the previous one afterwards, so the
+    machine is never left in benchmark mode.
+
+    Why a fixed clock. On the Ryzen 9 5950X this suite is gated on, the stock High performance plan
+    leaves PERFBOOSTMODE at Aggressive, and the delivered frequency then depends on package
+    temperature, on what the other 15 cores are doing, and on per-core silicon binning. Measured under
+    a single-threaded load: High performance peaks at 4,607 MHz and averages 3,810 MHz across cores,
+    while this plan holds every core at 3,375 MHz with peak equal to mean. Absolute numbers drop
+    11-27%; run-to-run comparability is what is bought with that.
+
+    -Check runs the verification only and changes nothing.
+
+    -Restore puts the machine back on High performance and kills any orphaned benchmark process. Run
+    it after any interrupted run: BenchmarkDotNet restores the previous power plan when it exits
+    normally, but a run killed part-way through leaves the fixed-clock plan active, and the next thing
+    to use the machine — including an unrelated benchmark — then silently runs at nominal frequency.
+
+.EXAMPLE
+    ./setup-benchmark-machine.ps1              # create or update the plan (needs an elevated shell)
+
+.EXAMPLE
+    ./setup-benchmark-machine.ps1 -Check       # report the current state, change nothing
+
+.EXAMPLE
+    ./setup-benchmark-machine.ps1 -Restore     # after an interrupted run
+#>
+[CmdletBinding()]
+param(
+    [switch] $Check,
+    [switch] $Restore
+)
+
+$ErrorActionPreference = 'Stop'
+
+$PlanName        = 'Jint Benchmark (fixed clock)'
+$HighPerformance = '8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c'
+$PerfBoostMode   = 'be337238-0d82-4146-a960-4f3749d470c7'   # hidden by default
+$IdleDisable     = '5d76a2ca-e8c0-402f-a133-2158492d58ad'   # hidden by default
+
+function Test-Elevated {
+    $id = [Security.Principal.WindowsIdentity]::GetCurrent()
+    (New-Object Security.Principal.WindowsPrincipal($id)).IsInRole(
+        [Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Get-JintPlanGuid {
+    $line = powercfg /L | Select-String -SimpleMatch $PlanName | Select-Object -First 1
+    if (-not $line) { return $null }
+    [regex]::Match($line.ToString(), '[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}').Value
+}
+
+function Show-PlanSettings([string] $guid) {
+    $dump = powercfg /q $guid SUB_PROCESSOR | Out-String
+    foreach ($alias in 'PERFBOOSTMODE', 'PROCTHROTTLEMIN', 'PROCTHROTTLEMAX', 'CPMINCORES', 'IDLEDISABLE') {
+        $m = [regex]::Match($dump, "GUID Alias: $alias[\s\S]*?Current AC Power Setting Index: (0x[0-9a-f]+)")
+        $value = if ($m.Success) { [Convert]::ToInt32($m.Groups[1].Value, 16) } else { '?' }
+        '{0,-16} = {1}' -f $alias, $value
+    }
+}
+
+# --- restore after an interrupted run -----------------------------------------------------------
+
+if ($Restore) {
+    $stray = Get-Process -Name 'Jint.Benchmark' -ErrorAction SilentlyContinue
+    if ($stray) {
+        # Kill first: a live host process re-applies its own plan and would undo the restore below.
+        $stray | Stop-Process -Force
+        Start-Sleep -Milliseconds 500
+        "Killed $($stray.Count) orphaned benchmark process(es)."
+    }
+
+    powercfg /setactive $HighPerformance
+    "Active scheme: $((powercfg /getactivescheme))"
+    exit 0
+}
+
+# --- report-only ------------------------------------------------------------------------------
+
+if ($Check) {
+    $guid = Get-JintPlanGuid
+    if (-not $guid) {
+        Write-Warning "Plan '$PlanName' does not exist. Run this script elevated, without -Check."
+        exit 1
+    }
+
+    "Plan GUID          : $guid"
+    "JINT_BENCH_POWERPLAN : $([Environment]::GetEnvironmentVariable('JINT_BENCH_POWERPLAN', 'User'))"
+    ''
+    Show-PlanSettings $guid
+    exit 0
+}
+
+# --- create or update -------------------------------------------------------------------------
+
+if (-not (Test-Elevated)) {
+    throw 'This script must run in an elevated shell (powercfg needs administrator rights to create a scheme).'
+}
+
+$guid = Get-JintPlanGuid
+if ($guid) {
+    "Reusing existing plan $guid"
+} else {
+    $out  = powercfg -duplicatescheme $HighPerformance | Out-String
+    $guid = [regex]::Match($out, '[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}').Value
+    if (-not $guid) { throw "Could not duplicate the High performance scheme: $out" }
+    powercfg -changename $guid $PlanName 'Fixed-frequency plan for reproducible BenchmarkDotNet runs.'
+    "Created plan $guid"
+}
+
+# PERFBOOSTMODE and IDLEDISABLE are hidden attributes; powercfg refuses to set them until unhidden.
+powercfg -attributes SUB_PROCESSOR $PerfBoostMode -ATTRIB_HIDE
+powercfg -attributes SUB_PROCESSOR $IdleDisable   -ATTRIB_HIDE
+
+powercfg -setacvalueindex $guid SUB_PROCESSOR PERFBOOSTMODE   0     # no opportunistic boost
+powercfg -setacvalueindex $guid SUB_PROCESSOR PROCTHROTTLEMIN 100   # every core at nominal
+powercfg -setacvalueindex $guid SUB_PROCESSOR PROCTHROTTLEMAX 100
+powercfg -setacvalueindex $guid SUB_PROCESSOR CPMINCORES      100   # no core parking
+powercfg -setacvalueindex $guid SUB_PROCESSOR IDLEDISABLE     1     # no C-state entry
+powercfg -setacvalueindex $guid SUB_PROCESSOR PERFEPP         0     # favour performance over efficiency
+
+[Environment]::SetEnvironmentVariable('JINT_BENCH_POWERPLAN', $guid, 'User')
+$env:JINT_BENCH_POWERPLAN = $guid
+
+''
+"Plan GUID            : $guid"
+'JINT_BENCH_POWERPLAN : set for the current user (restart open shells to pick it up)'
+''
+Show-PlanSettings $guid
+''
+'Next: run a gating measurement with'
+'  $env:JINT_BENCH_MODE = "gate"'
+'  dotnet run -c Release --project Jint.Benchmark -- --filter "*YourBenchmark*"'


### PR DESCRIPTION
All ~130 benchmark classes ran on BenchmarkDotNet's bare `DefaultJob`. Most of what was needed was **already in BenchmarkDotNet and simply unused** — `LaunchCount`, `WithAffinity`, `WithPowerPlan`, `WithGcConcurrent`, `AnalyzeLaunchVariance`, and `MValue`. BDN was already computing the multimodality statistic that says a row's Mean isn't a summary of anything, and we were throwing it away. `MValue` and `Median` are now on every row.

## The error term that matters

`DefaultJob` sets `LaunchCount = 1`, so code layout, heap placement, tiered-compilation outcome and the starting core are constants *within* the measured process and variables *between* processes — none of them reach the reported error. That is exactly the A/B pair that looks decisive and then won't reproduce. **More iterations cannot fix it**; they resample within one process. `JINT_BENCH_MODE=gate` raises `LaunchCount` so the offset is sampled rather than hidden.

## What BDN genuinely lacks

No notion of whether the host is fit to measure on. It will produce a beautiful table from a run that shared the machine with a build, and nothing in the output says so. `MachineStateValidator` uses `IValidator` — BDN's own pre-run hook — waits for the machine to go quiet, then warns (`stable`) or refuses (`gate`), naming the offenders. It immediately caught `CompatTelRunner.exe` (Microsoft Compatibility Telemetry) taking 65% of a core on a machine that looked idle, and caught a sweep script whose cases were starting while the previous case wound down. It *waits* rather than failing outright because the usual reason the machine is busy at that moment is that we just made it busy.

## Measured, one factor at a time, on a verified-idle machine

Medians over six `GuardComparisonBenchmark` rows, three launches each, vs `legacy`:

| control | cost | variance benefit | outcome |
| --- | --- | --- | --- |
| blocking GC | +1.1% | none surviving noise | kept (free) |
| affinity (one L3 domain) | +3.2% | none surviving noise | kept (free) |
| fixed-clock power plan | **+47%** | **none** | **now opt-in** |

The fixed clock previously applied whenever `JINT_BENCH_POWERPLAN` was set; since that GUID tends to live in a user environment variable forever, that silently cost ~47% on every run. It now also requires `JINT_BENCH_FIXED_CLOCK=1`. It still earns its place for one thing: removing boost as a free variable so absolute figures compare across sessions.

## Tiering stays at production defaults

Two mitigations were built and measured on `TypeofStringGuard`, ten launches — **neither shipped**:

| config | StdDev | MValue |
| --- | --- | --- |
| production defaults | **0.783 ms** | 2.000 (unimodal) |
| run to JIT quiescence | 1.224 ms | 2.000 |
| `QuickJitForLoops=0` + `CallCountingDelayMs=0` | 1.275 ms | 2.795 (~13% slower) |

The same row reads 1.946 ms and looks bimodal on a quietly-busy machine. **The "bistable slow mode" that looked like a tiering artifact was mostly contention** — the strongest argument for the idle check, and a warning against diagnosing the runtime from numbers taken on a shared machine.

## What's left is statistical

No machine control reduced the between-process offset. `measure-paired.ps1` interleaves two worktrees round by round, alternating order so run-order penalty falls on each side equally, and reports the per-round *difference* with a percentile bootstrap CI — the paired design from [Bulej et al., *Duet Benchmarking*](https://arxiv.org/abs/2001.05811). An A/A run (same worktree both sides, six rounds) correctly reports **no change** on every row:

| row | median Δ | 95% CI |
| --- | --- | --- |
| `LooseEqualNull` | −0.49% | [−2.37, +0.59] |
| `LooseNotEqualNull` | −0.23% | [−1.03, +0.71] |

That puts the detection floor at roughly **1–2.5% over six rounds**, which is also why a flat "1% blocks" gate cannot work as stated — on many rows 1% is below what the measurement resolves.

## Safety

Everything machine-specific fails safe. The affinity mask is **derived from L3 topology, never hard-coded**, and falls back to no pinning on non-Windows, multi-group machines, and anything too small to pin. The power plan is opt-in twice over. With no environment variables set, `stable` adds only the idle check and the two free controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)