### PR TITLE
Default CLR array projection to isolated copies

### DIFF
--- a/.github/THREAT_MODEL.md
+++ b/.github/THREAT_MODEL.md
@@ -80,7 +80,7 @@ Defaults are compatibility choices, not a hardened profile.
 | `AllowGetType`, `AllowSystemReflection` | Disabled | Blocks instance type discovery, type widening, and reflection namespace/object access |
 | `AllowedAssemblies` | Empty until `AllowClr` adds entries | Closed allow-list for `System` / `importNamespace` type discovery, not for what admitted APIs can do |
 | Writes through projected CLR objects | Disabled | Fields, properties, indexers, dictionary/list entries, and live array elements require explicit `AllowClrWrite()` opt-in |
-| CLR array conversion | Live view | Script observes the CLR array directly; element writes remain blocked unless CLR writes are enabled |
+| CLR array conversion | Copy | Script receives a detached native JavaScript array snapshot |
 | Modules | Disabled | The fail-fast loader rejects imports |
 | Module graph limits | Unlimited | Count, source bytes, graph depth, and resolution hops are unbounded unless configured |
 | Module load policy | None | A custom loader's resolved targets are unrestricted unless a policy is configured |
@@ -178,19 +178,20 @@ cancellation, and avoid returning powerful objects.
 
 ### TM-03: Script mutates host state
 
-**Threat.** Direct writes through an `ObjectWrapper` are disabled by default, but a host can
-explicitly enable them with `AllowClrWrite()`. Projected CLR arrays are live views by
-default, so enabling writes lets script alter host properties, fields, indexers,
-dictionaries, lists, arrays, or objects reachable from them. Independently of that option,
-calling an exposed instance, static, or extension method can mutate host state and violate
-host invariants.
+**Threat.** Direct writes through an `ObjectWrapper` are disabled by default, and CLR arrays
+cross as detached copies by default. A host can explicitly enable writes with
+`AllowClrWrite()` and independently select `ArrayConversionMode.LiveView`; doing both lets
+script alter host properties, fields, indexers, dictionaries, lists, live arrays, or objects
+reachable from them. Calling an exposed instance, static, or extension method can mutate host
+state regardless of the direct-write option.
 
 **Existing mitigations.**
 
 - Direct writes through CLR wrappers are disabled by default; `AllowClrWrite()` is an
   explicit opt-in.
-- `ArrayConversionMode.Copy`, immutable DTOs, and Jint-owned record layouts avoid live
-  write-through.
+- `ArrayConversionMode.Copy` is the default and disconnects the JavaScript array container
+  from later CLR mutations and script writes.
+- Immutable DTOs and Jint-owned record layouts avoid live write-through.
 
 **Missing or residual mitigation.**
 
@@ -198,12 +199,19 @@ host invariants.
   Jint.
 - Calling exposed methods or extension methods can still mutate state even when direct
   writes are disabled.
+- A copied CLR array is only a shallow projection boundary: reference-type elements can still
+  expose mutable host objects.
+- `ArrayConversionMode.LiveView` restores live reads and avoids the initial O(N) copy and
+  allocation, but does not grant write authority; `AllowClrWrite()` is additionally required
+  for write-through.
+- Wrapper caches can reuse a copied snapshot, preserving script-side mutations and identity
+  across crossings, but they never make later CLR-side array mutations visible through it.
 
-**Required host action.** Leave CLR writes disabled and do not call `AllowClrWrite()` unless
-direct mutation is an intentional capability. Pin `AllowClrWrite(false)` in hardened
-configuration, use copied arrays where a live view is unnecessary, and expose immutable
-snapshots. Do not expose mutating methods unless they are intentional, authorized
-capabilities.
+**Required host action.** Leave CLR writes disabled and keep `ArrayConversionMode.Copy`
+explicitly pinned in hardened configurations. Expose immutable snapshots whose elements are
+also safe to project. Use `LiveView` only when live observation is intentional, and enable CLR
+writes only when shared mutation is a separately authorized capability. Do not expose
+mutating methods unless they are intentional, authorized capabilities.
 
 ### TM-04: Infinite loops and computational denial of service
 
@@ -1201,6 +1209,7 @@ var engine = new Engine(options =>
     options.AgentCanSuspend = false;
     // Pin the safe default explicitly so configuration reviews cannot miss this boundary.
     options.AllowClrWrite(false);
+    // Pin the hardened behavior even though Copy is the compatibility default.
     options.Interop.ArrayConversion = ArrayConversionMode.Copy;
     options.ResultLimits = ResultLimits.Conservative;
     options.Interop.ExposeDetailedExceptionMessages = false;
@@ -1262,6 +1271,8 @@ Before deploying a host that executes untrusted scripts:
 - [ ] CLR namespace access, `AllowGetType`, reflection, debugger, and `Atomics.wait` are off.
 - [ ] Direct CLR writes remain disabled, and projected host objects are immutable or intentionally
   capability-scoped with no unintended mutating instance, static, or extension methods.
+- [ ] CLR arrays use `Copy`; any `LiveView` opt-in is intentional, remains read-only unless
+  write-through is separately authorized, and does not expose mutable element objects accidentally.
 - [ ] Initial source, callback, external serializer, HTTP response, and log limits are enforced
   outside Jint; `ResultLimits` is configured for Jint-owned conversion and JSON output, and all
   four Jint module graph limits are configured when modules are enabled.

--- a/Jint.Benchmark/ClrArrayProjectionBenchmark.cs
+++ b/Jint.Benchmark/ClrArrayProjectionBenchmark.cs
@@ -1,0 +1,56 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Measures the first crossing of a CLR array on an already constructed engine. Each row has its own engine,
+/// and cycles through more source arrays than the recent-wrapper cache can retain, so every invocation measures
+/// projection rather than a cache hit. The host arrays are allocated in setup and stay outside the measurement.
+/// This complements the warm traversal rows in <see cref="InteropWrapperChurnBenchmark"/>: Copy pays O(N) time
+/// and allocation here, while LiveView avoids that upfront work; after crossing, the native Copy snapshot can
+/// traverse as fast as or faster than the wrapper.
+/// </summary>
+[MemoryDiagnoser]
+public class ClrArrayProjectionBenchmark
+{
+    private const int SourceCount = 16;
+
+    private Engine _copyEngine = null!;
+    private Engine _liveViewEngine = null!;
+    private int[][] _copySources = null!;
+    private int[][] _liveViewSources = null!;
+    private int _copyIndex;
+    private int _liveViewIndex;
+
+    [Params(0, 10, 100, 1000)]
+    public int Length { get; set; }
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _copyEngine = new Engine();
+        _liveViewEngine = new Engine(options => options.Interop.ArrayConversion = ArrayConversionMode.LiveView);
+        _copySources = CreateSources();
+        _liveViewSources = CreateSources();
+    }
+
+    [Benchmark(Baseline = true)]
+    public JsValue FirstCrossing_Copy()
+        => JsValue.FromObject(_copyEngine, _copySources[_copyIndex++ & (SourceCount - 1)]);
+
+    [Benchmark]
+    public JsValue FirstCrossing_LiveView()
+        => JsValue.FromObject(_liveViewEngine, _liveViewSources[_liveViewIndex++ & (SourceCount - 1)]);
+
+    private int[][] CreateSources()
+    {
+        var sources = new int[SourceCount][];
+        for (var i = 0; i < sources.Length; i++)
+        {
+            sources[i] = new int[Length];
+        }
+
+        return sources;
+    }
+}

--- a/Jint.Benchmark/InteropWrapperChurnBenchmark.cs
+++ b/Jint.Benchmark/InteropWrapperChurnBenchmark.cs
@@ -51,15 +51,15 @@ public class InteropWrapperChurnBenchmark
     private Engine _engineArrayHoistedDefault = null!;
     private Engine _engineArrayCopy = null!;
     private Engine _engineArrayIdentity = null!;
-    private Engine _engineArrayRecentCache = null!;
+    private Engine _engineArrayLiveView = null!;
 
     [GlobalSetup]
     public void GlobalSetup()
     {
         var holder = new Holder(new Payload { Value = 42 });
 
-        // the out-of-the-box engine: since 4.14 ArrayConversion defaults to LiveView and
-        // CacheRecentObjectWrappers defaults to true (repeated crossings reuse the wrapper)
+        // the out-of-the-box engine: ArrayConversion defaults to Copy and
+        // CacheRecentObjectWrappers defaults to true (repeated crossings reuse the snapshot)
         Engine CreateDefault()
         {
             var engine = new Engine();
@@ -70,7 +70,11 @@ public class InteropWrapperChurnBenchmark
         // opt out of the recent-wrapper cache: every crossing builds a fresh wrapper
         Engine CreateNoCache()
         {
-            var engine = new Engine(cfg => cfg.Interop.CacheRecentObjectWrappers = false);
+            var engine = new Engine(cfg =>
+            {
+                cfg.Interop.ArrayConversion = ArrayConversionMode.LiveView;
+                cfg.Interop.CacheRecentObjectWrappers = false;
+            });
             engine.SetValue("h", holder);
             return engine;
         }
@@ -102,8 +106,15 @@ public class InteropWrapperChurnBenchmark
             return engine;
         }
 
-        // the pre-4.14 default: every array crossing deep-copies into a fresh JsArray snapshot
-        // (the cache opt-out keeps this row measuring the copy itself)
+        Engine CreateLiveView()
+        {
+            var engine = new Engine(cfg => cfg.Interop.ArrayConversion = ArrayConversionMode.LiveView);
+            engine.SetValue("h", holder);
+            return engine;
+        }
+
+        // Every array crossing deep-copies into a fresh JsArray snapshot (the cache opt-out keeps
+        // this row measuring the copy itself).
         Engine CreateCopy()
         {
             var engine = new Engine(cfg =>
@@ -144,8 +155,8 @@ public class InteropWrapperChurnBenchmark
         _engineArrayIdentity = CreateIdentity();
         _engineArrayIdentity.Execute(_arrayTraversal);
 
-        _engineArrayRecentCache = CreateRecentCache();
-        _engineArrayRecentCache.Execute(_arrayTraversal);
+        _engineArrayLiveView = CreateLiveView();
+        _engineArrayLiveView.Execute(_arrayTraversal);
     }
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
@@ -172,14 +183,14 @@ public class InteropWrapperChurnBenchmark
         for (var i = 0; i < OperationsPerInvoke; i++) _engineChurnRecentCache.Execute("h.Payload.Value");
     }
 
-    // A CLR array member read repeatedly inside the loop. Under the default (LiveView) each h.Numbers
-    // read wraps the array in a live fixed-size view without a per-read deep copy; the Copy-mode rows
-    // below deep-copy into a fresh JsArray unless an identity flag reuses the snapshot.
+    // A CLR array member read repeatedly inside the loop. The default Copy mode reuses its first
+    // snapshot through the recent-wrapper cache; the explicit LiveView row avoids a deep copy, and
+    // the uncached Copy row below measures a fresh snapshot on each crossing.
     private static readonly Prepared<Script> _arrayTraversal = Engine.PrepareScript(
         "var s = 0; for (var i = 0; i < 100; i++) { s += h.Numbers[i]; }");
 
     [Benchmark]
-    public void ArrayMemberTraversal_DefaultLiveView()
+    public void ArrayMemberTraversal_DefaultCopy()
     {
         _engineArrayDefault.Execute(_arrayTraversal);
     }
@@ -196,13 +207,13 @@ public class InteropWrapperChurnBenchmark
         "var arr = h.Numbers; var s = 0; for (var pass = 0; pass < 100; pass++) { for (var i = 0; i < 100; i++) { s += arr[i]; } }");
 
     [Benchmark]
-    public void ArrayHoistedTraversal_DefaultLiveView()
+    public void ArrayHoistedTraversal_DefaultCopy()
     {
         _engineArrayHoistedDefault.Execute(_arrayHoistedTraversal);
     }
 
     [Benchmark]
-    public void ArrayMemberTraversal_CopyMode()
+    public void ArrayMemberTraversal_CopyNoCache()
     {
         _engineArrayCopy.Execute(_arrayTraversal);
     }
@@ -214,8 +225,8 @@ public class InteropWrapperChurnBenchmark
     }
 
     [Benchmark]
-    public void ArrayMemberTraversal_CopyRecentCache()
+    public void ArrayMemberTraversal_LiveView()
     {
-        _engineArrayRecentCache.Execute(_arrayTraversal);
+        _engineArrayLiveView.Execute(_arrayTraversal);
     }
 }

--- a/Jint.Benchmark/README.md
+++ b/Jint.Benchmark/README.md
@@ -296,14 +296,15 @@ What the numbers show:
   Jint +2.6%). Allocation is Jint's on every row: 3.9×–12.4× less than the row's nearest managed
   competitor. (Three ClearScript_FastProxy rows show smaller KB figures, but those count
   interop-bridge overhead only — V8's working memory is on its native heap.)
-* **Collection traversal — last of all engines at 4.13.0 — stays transformed at
-  15,597 → 1,251 µs (12.5×, −99% allocation) with no script changes**: the 4.14.0
-  `ArrayConversionMode.LiveView` default exposes the host array as a live view instead of
+* **Historical 4.14.0 collection traversal result — last of all engines at 4.13.0 — was transformed at
+  15,597 → 1,251 µs (12.5×, −99% allocation) with no script changes**: in that release,
+  `ArrayConversionMode.LiveView` was the default and exposed the host array as a live view instead of
   re-copying it on every read, and a per-descriptor value memo
   ([#2756](https://github.com/sebastienros/jint/pull/2756)) skips re-converting the array on every
   read. NiL.JS took the row back by ~4% in the previous session; here the two are level (0.7%
-  apart, both rank 1) while NiL.JS allocates 12× more. Either way the old hoist-into-a-local
-  workaround is no longer needed.
+  apart, both rank 1) while NiL.JS allocates 12× more. The repeated copies in this historical table predate
+  the current recent-wrapper cache. `Copy` is now the default and normally reuses its first snapshot while
+  cached; explicitly opt into `LiveView` to retain shared mutation and avoid the initial O(N) projection.
 
 | Method                | FileName                     | Mean        | StdDev   | Rank | Allocated   |
 |---------------------- |----------------------------- |------------:|---------:|-----:|------------:|

--- a/Jint.Tests.PublicInterface/ClrWriteConfigurationTests.cs
+++ b/Jint.Tests.PublicInterface/ClrWriteConfigurationTests.cs
@@ -313,6 +313,7 @@ public class ClrWriteConfigurationTests
                 if (allowWrite)
                 {
                     options.AllowClrWrite();
+                    options.Interop.ArrayConversion = ArrayConversionMode.LiveView;
                 }
             })
             .SetValue("host", host)

--- a/Jint.Tests.PublicInterface/HostArrayConversionDiagnosticsTests.cs
+++ b/Jint.Tests.PublicInterface/HostArrayConversionDiagnosticsTests.cs
@@ -1,6 +1,9 @@
 #nullable enable
 
 using System.Collections.Generic;
+using System.Threading;
+using Jint.Constraints;
+using Jint.Runtime;
 using Jint.Runtime.Interop;
 
 namespace Jint.Tests.PublicInterface;
@@ -9,15 +12,19 @@ namespace Jint.Tests.PublicInterface;
 /// Covers <see cref="Engine.AdvancedOperations.GetInteropConversionDiagnostics"/>, the answer to a question a
 /// host cannot otherwise ask: did any CLR array cross into script during this run, and under which semantics?
 /// <para>
-/// <see cref="ArrayConversionMode.LiveView"/> has been the default since 4.14, and the two modes differ in
-/// behavior a script can observe — a live view writes through to the CLR array, a copy does not. A host that
-/// does not own all of its Jint consumers therefore has a real audit to perform and, before these counters, no
-/// way to perform it except by reading every transitive caller. These tests live outside the Jint assembly on
-/// purpose: the project has no internals access, so the audit written here is one a third party can write.
+/// <see cref="ArrayConversionMode.Copy"/> is the default and <see cref="ArrayConversionMode.LiveView"/> remains
+/// an explicit performance opt-in. The modes differ in behavior a script can observe — a live view reads through
+/// to the CLR array and writes through only when CLR writes are separately enabled, while a copy does neither.
+/// A host that does not own all of its Jint consumers therefore has a real audit to perform and, before these
+/// counters, no way to perform it except by reading every transitive caller. These tests live outside the Jint
+/// assembly on purpose: the project has no internals access, so the audit written here is one a third party can
+/// write.
 /// </para>
 /// </summary>
 public class HostArrayConversionDiagnosticsTests
 {
+    public static bool MemoryAccountingAvailable => MemoryLimitConstraint.Accuracy != MemoryLimitAccuracy.Unavailable;
+
     private static Engine CreateEngine(ArrayConversionMode? mode = null) => new(options =>
     {
         options.AllowClr(typeof(HostWithArrays).Assembly);
@@ -41,6 +48,90 @@ public class HostArrayConversionDiagnosticsTests
     }
 
     // ---- the audit ----
+
+    [Fact]
+    public void CopyIsTheDefaultAndLiveViewRemainsAnExplicitOptIn()
+    {
+        new Options().Interop.ArrayConversion.Should().Be(ArrayConversionMode.Copy);
+
+        var copied = new HostWithArrays();
+        var defaultEngine = CreateEngine();
+        defaultEngine.SetValue("host", copied);
+        defaultEngine.Evaluate("Array.isArray(host.Values)").Should().BeTrue();
+        defaultEngine.Execute("host.Values[0] = 99;");
+        copied.Values[0].Should().Be(1);
+
+        var shared = new HostWithArrays();
+        var liveViewEngine = CreateEngine(ArrayConversionMode.LiveView);
+        liveViewEngine.SetValue("host", shared);
+        liveViewEngine.Evaluate("Array.isArray(host.Values)").Should().BeFalse();
+        liveViewEngine.Execute("host.Values[0] = 99;");
+        shared.Values[0].Should().Be(99);
+    }
+
+    [Fact]
+    public void CopyMutationRemainsAllowedWhileLiveViewWriteThroughRequiresBothOptIns()
+    {
+        var copied = new[] { 1, 2 };
+        var copyEngine = new Engine();
+        copyEngine.SetValue("values", copied);
+        copyEngine.Execute("values[0] = 9; values.push(3);");
+        copied.Should().Equal(1, 2);
+        copyEngine.Evaluate("values.join(',')").Should().Be("9,2,3");
+
+        var readOnlyLive = new[] { 1, 2 };
+        var readOnlyEngine = new Engine(options =>
+            options.Interop.ArrayConversion = ArrayConversionMode.LiveView);
+        readOnlyEngine.SetValue("values", readOnlyLive);
+        readOnlyLive[0] = 7;
+        readOnlyEngine.Evaluate("values[0]").Should().Be(7);
+        Invoking(() => readOnlyEngine.Execute("'use strict'; values[0] = 9;"))
+            .Should().Throw<JavaScriptException>();
+        readOnlyLive[0].Should().Be(7);
+
+        var writableLive = new[] { 1, 2 };
+        var writableEngine = new Engine(options =>
+        {
+            options.AllowClrWrite();
+            options.Interop.ArrayConversion = ArrayConversionMode.LiveView;
+        });
+        writableEngine.SetValue("values", writableLive);
+        writableEngine.Execute("values[0] = 9;");
+        writableLive[0].Should().Be(9);
+    }
+
+    [Fact(Skip = "Managed allocation accounting is unavailable on this runtime.", SkipUnless = nameof(MemoryAccountingAvailable))]
+    public void FailedMemoryBoundCopyPublishesNothingAndLaterCopyCanRetry()
+    {
+        var engine = new Engine(options => options.LimitMemory(256_000));
+        var oversized = new object[100_000];
+
+        Invoking(() => engine.SetValue("oversized", oversized))
+            .Should().ThrowExactly<MemoryLimitExceededException>();
+        engine.Advanced.GetInteropConversionDiagnostics().ArrayCopyConversions.Should().Be(0);
+
+        engine.SetValue("small", new[] { 1, 2, 3 });
+        engine.Evaluate("small.join(',')").Should().Be("1,2,3");
+        engine.Advanced.GetInteropConversionDiagnostics().ArrayCopyConversions.Should().Be(1);
+    }
+
+    [Fact]
+    public void FailedDeadlineBoundCopyPublishesNothingAndCanRetryAfterDisarm()
+    {
+        var deadline = new OperationDeadlineConstraint();
+        var engine = new Engine(options => options.Constraint(deadline));
+        deadline.Begin(TimeSpan.FromMilliseconds(1));
+        Thread.Sleep(10);
+
+        Invoking(() => engine.SetValue("timedOut", new object[100_000]))
+            .Should().ThrowExactly<TimeoutException>();
+        engine.Advanced.GetInteropConversionDiagnostics().ArrayCopyConversions.Should().Be(0);
+
+        deadline.End();
+        engine.SetValue("retry", new[] { 1, 2, 3 });
+        engine.Evaluate("retry.join(',')").Should().Be("1,2,3");
+        engine.Advanced.GetInteropConversionDiagnostics().ArrayCopyConversions.Should().Be(1);
+    }
 
     [Fact]
     public void AnAuditOfARunThatCrossesNoArrayAnswersZero()
@@ -126,7 +217,9 @@ public class HostArrayConversionDiagnosticsTests
 
         engine.Execute("for (var i = 0; i < 10; i++) { host.Values[0]; }");
 
-        engine.Advanced.GetInteropConversionDiagnostics().ArrayLiveViewConversions.Should().Be(1);
+        var diagnostics = engine.Advanced.GetInteropConversionDiagnostics();
+        diagnostics.ArrayLiveViewConversions.Should().Be(0);
+        diagnostics.ArrayCopyConversions.Should().Be(1);
     }
 
     [Fact]
@@ -137,7 +230,9 @@ public class HostArrayConversionDiagnosticsTests
 
         engine.Execute("host.Values[0]; host.Others[0];");
 
-        engine.Advanced.GetInteropConversionDiagnostics().ArrayLiveViewConversions.Should().Be(2);
+        var diagnostics = engine.Advanced.GetInteropConversionDiagnostics();
+        diagnostics.ArrayLiveViewConversions.Should().Be(0);
+        diagnostics.ArrayCopyConversions.Should().Be(2);
     }
 
     [Fact]
@@ -197,8 +292,8 @@ public class HostArrayConversionDiagnosticsTests
         first.Execute("host.Values[0]; host.Others[0];");
         second.Execute("host.Values[0];");
 
-        first.Advanced.GetInteropConversionDiagnostics().ArrayLiveViewConversions.Should().Be(2);
-        second.Advanced.GetInteropConversionDiagnostics().ArrayLiveViewConversions.Should().Be(1);
+        first.Advanced.GetInteropConversionDiagnostics().ArrayCopyConversions.Should().Be(2);
+        second.Advanced.GetInteropConversionDiagnostics().ArrayCopyConversions.Should().Be(1);
     }
 
     [Fact]
@@ -215,8 +310,8 @@ public class HostArrayConversionDiagnosticsTests
         engine.Execute("host.Values[0];");
         var afterSecond = engine.Advanced.GetInteropConversionDiagnostics();
 
-        afterFirst.ArrayLiveViewConversions.Should().Be(1);
-        afterSecond.ArrayLiveViewConversions.Should().Be(2);
+        afterFirst.ArrayCopyConversions.Should().Be(1);
+        afterSecond.ArrayCopyConversions.Should().Be(2);
     }
 
     [Fact]
@@ -231,8 +326,8 @@ public class HostArrayConversionDiagnosticsTests
         engine.Execute("host.Values[0];");
         var after = engine.Advanced.GetInteropConversionDiagnostics();
 
-        before.ArrayLiveViewConversions.Should().Be(0);
-        after.ArrayLiveViewConversions.Should().Be(1);
+        before.ArrayCopyConversions.Should().Be(0);
+        after.ArrayCopyConversions.Should().Be(1);
         before.Should().NotBe(after);
         engine.Advanced.GetInteropConversionDiagnostics().Should().Be(after);
     }

--- a/Jint.Tests/Runtime/ExtensionMethods/ExtensionMethodShadowingTests.cs
+++ b/Jint.Tests/Runtime/ExtensionMethods/ExtensionMethodShadowingTests.cs
@@ -121,9 +121,13 @@ public class ExtensionMethodShadowingTests
     }
 
     [Fact]
-    public void LinqChainWorksUnderLiveViewDefault()
+    public void LinqChainWorksUnderExplicitLiveView()
     {
-        var engine = new Engine(options => options.AddExtensionMethods(typeof(Enumerable)));
+        var engine = new Engine(options =>
+        {
+            options.AddExtensionMethods(typeof(Enumerable));
+            options.Interop.ArrayConversion = ArrayConversionMode.LiveView;
+        });
         engine.SetValue("stringList", new List<string> { "working", "linq" });
 
         // the ToArray() result is a live array wrapper whose pure-extension 'Enumerable.Join'

--- a/Jint.Tests/Runtime/ExtensionMethods/ExtensionMethodsTest.cs
+++ b/Jint.Tests/Runtime/ExtensionMethods/ExtensionMethodsTest.cs
@@ -65,8 +65,8 @@ public class ExtensionMethodsTest
         {
             opts.AddExtensionMethods(typeof(CustomStringExtensions));
             // this exercises extension-method dispatch producing a CLR array (string[]) that the test
-            // reads back as a JS array; pin Copy so the result is a native JsArray (the LiveView default
-            // would expose it as a live wrapper that AsArray() does not accept)
+            // reads back as a JS array; pin Copy so the test remains independent of the configured default
+            // and the result is a native JsArray that AsArray() accepts
             opts.Interop.ArrayConversion = ArrayConversionMode.Copy;
         });
 
@@ -153,7 +153,7 @@ public class ExtensionMethodsTest
     [Fact]
     public void LinqExtensionMethodWithMultipleGenericParameters()
     {
-        // Copy produces a native JsArray whose 'join' is the prototype method. The LiveView default
+        // Copy produces a native JsArray whose 'join' is the prototype method. Explicit LiveView
         // works too since #2976: the wrapper's pure-extension 'Enumerable.Join' candidate defers to
         // native 'Array.prototype.join' - ExtensionMethodShadowingTests covers that flavor.
         var engine = GetLinqEngine(opts => opts.Interop.ArrayConversion = ArrayConversionMode.Copy);
@@ -325,7 +325,7 @@ public class ExtensionMethodsTest
             // prevent ExpandoObject wrapping
             options.Interop.CreateClrObject = null;
             // '.ToArray()' results are read back as JS arrays via AsArray(); pin Copy so they are native
-            // JsArrays rather than the LiveView default's live wrapper views
+            // JsArrays independent of the configured array-conversion default
             options.Interop.ArrayConversion = ArrayConversionMode.Copy;
         });
         engine.Execute("var a = [ 2, 4 ];");

--- a/Jint.Tests/Runtime/InteropIntegerCoercionBoxingTests.cs
+++ b/Jint.Tests/Runtime/InteropIntegerCoercionBoxingTests.cs
@@ -186,7 +186,12 @@ public class InteropIntegerCoercionBoxingTests
     public void CanAssignIntegerToLongArrayElement()
     {
         var host = new CollectionHost();
-        var engine = CreateEngine().SetValue("host", host);
+        var engine = new Engine(options =>
+            {
+                options.AllowClrWrite();
+                options.Interop.ArrayConversion = ArrayConversionMode.LiveView;
+            })
+            .SetValue("host", host);
 
         engine.Execute("host.LongArray[0] = 42;");
         host.LongArray[0].Should().Be(42L);

--- a/Jint.Tests/Runtime/InteropTests.ArrayIdentityCache.cs
+++ b/Jint.Tests/Runtime/InteropTests.ArrayIdentityCache.cs
@@ -10,13 +10,12 @@ public partial class InteropTests
     }
 
     [Fact]
-    public void ArrayConversionCreatesFreshCopyInCopyMode()
+    public void ArrayConversionCreatesFreshCopyByDefaultWithoutCache()
     {
-        // Copy is no longer the default (LiveView since 4.14) and the recent-wrapper cache would
-        // reuse the first snapshot; opt out of both to lock the fresh-snapshot-per-crossing contract
+        // The recent-wrapper cache would reuse the first default Copy snapshot; opt out to lock the
+        // fresh-snapshot-per-crossing contract.
         var engine = new Engine(options =>
         {
-            options.Interop.ArrayConversion = ArrayConversionMode.Copy;
             options.Interop.CacheRecentObjectWrappers = false;
         });
         engine.SetValue("host", new ArrayConversionHost());
@@ -33,7 +32,6 @@ public partial class InteropTests
         var host = new ArrayConversionHost();
         var engine = new Engine(options =>
         {
-            options.Interop.ArrayConversion = ArrayConversionMode.Copy;
             options.Interop.TrackObjectWrapperIdentity = true;
         });
         engine.SetValue("host", host);
@@ -51,11 +49,7 @@ public partial class InteropTests
     [Fact]
     public void ArrayConversionReusesSnapshotWithRecentObjectWrapperCache()
     {
-        var engine = new Engine(options =>
-        {
-            options.Interop.ArrayConversion = ArrayConversionMode.Copy;
-            options.Interop.CacheRecentObjectWrappers = true;
-        });
+        var engine = new Engine();
         engine.SetValue("host", new ArrayConversionHost());
 
         engine.Evaluate("host.Numbers === host.Numbers").AsBoolean().Should().BeTrue();
@@ -68,6 +62,7 @@ public partial class InteropTests
         // a type-guard miss must replace the entry (last view wins), not throw on Add
         var engine = new Engine(options =>
         {
+            options.Interop.ArrayConversion = ArrayConversionMode.LiveView;
             options.Interop.TrackObjectWrapperIdentity = true;
             options.Interop.WrapObjectHandler = static (e, target, type) =>
                 ObjectWrapper.Create(e, target, target is int[] ? typeof(System.Collections.IList) : type);

--- a/Jint.Tests/Runtime/InteropTests.ClrArrayLiveView.cs
+++ b/Jint.Tests/Runtime/InteropTests.ClrArrayLiveView.cs
@@ -1,5 +1,7 @@
-﻿using Jint.Native;
+﻿using Jint.Constraints;
+using Jint.Native;
 using Jint.Runtime;
+using Jint.Runtime.Interop;
 
 namespace Jint.Tests.Runtime;
 
@@ -21,22 +23,30 @@ public partial class InteropTests
     }
 
     [Fact]
-    public void ArrayConversionDefaultsToLiveView()
+    public void ArrayConversionDefaultsToCopy()
     {
-        new Options().Interop.ArrayConversion.Should().Be(ArrayConversionMode.LiveView);
+        new Options().Interop.ArrayConversion.Should().Be(ArrayConversionMode.Copy);
 
-        // LiveView mode (the default since 4.14): a CLR array crosses as a live wrapper view, not a
-        // native JS array snapshot, so it is not an Array and repeated crossings share wrapper identity
+        var holder = new ArrayHolder();
         var engine = new Engine();
-        engine.SetValue("h", new ArrayHolder());
-        engine.Evaluate("Array.isArray(h.Numbers)").AsBoolean().Should().BeFalse();
+        engine.SetValue("h", holder);
+
+        // Copy produces a native JsArray snapshot. The default recent-wrapper cache preserves the
+        // snapshot's identity and script-side mutations, but the CLR array stays disconnected.
+        engine.Evaluate("Array.isArray(h.Numbers)").AsBoolean().Should().BeTrue();
         engine.Evaluate("h.Numbers === h.Numbers").AsBoolean().Should().BeTrue();
+        engine.Execute("h.Numbers[0] = 42;");
+        holder.Numbers[0].Should().Be(10);
+        engine.Evaluate("h.Numbers[0]").AsNumber().Should().Be(42);
+
+        holder.Numbers[1] = 99;
+        engine.Evaluate("h.Numbers[1]").AsNumber().Should().Be(20);
     }
 
     [Fact]
     public void LiveViewElementReadsConvertPrimitiveItemTypes()
     {
-        var engine = new Engine();
+        var engine = CreateLiveViewEngine();
         engine.SetValue("ints", new[] { 1, int.MaxValue, -1 });
         engine.SetValue("doubles", new[] { 0.5, double.MaxValue, -0.0 });
         engine.SetValue("longs", new[] { 1L, long.MaxValue });
@@ -75,7 +85,7 @@ public partial class InteropTests
     [Fact]
     public void LiveViewHonorsNonArrayDeclaredType()
     {
-        var engine = new Engine();
+        var engine = CreateLiveViewEngine();
         var host = new ReadOnlyDeclaredArrayHolder();
         engine.SetValue("h", host);
 
@@ -106,7 +116,7 @@ public partial class InteropTests
         // the static type-mapper memoization must not register the array lane under a non-array
         // declared type: a later non-array value of the same declared type would hit an
         // InvalidCastException — and poison every engine in the process
-        var engine = new Engine();
+        var engine = CreateLiveViewEngine();
         engine.SetValue("a", new EnumerableHolder { Data = [1] });
         engine.Evaluate("a.Data[0]").AsNumber().Should().Be(1);
 
@@ -122,7 +132,7 @@ public partial class InteropTests
     [Fact]
     public void InOperatorMatchesJsArraySemantics()
     {
-        var engine = new Engine();
+        var engine = CreateLiveViewEngine();
         engine.SetValue("a", new[] { 1, 2, 3 });
         engine.SetValue("l", new List<int> { 1, 2, 3 });
 
@@ -143,7 +153,7 @@ public partial class InteropTests
     [Fact]
     public void KeyEnumerationYieldsIndexKeys()
     {
-        var engine = new Engine();
+        var engine = CreateLiveViewEngine();
         engine.SetValue("a", new[] { 1, 2, 3 });
         engine.SetValue("l", new List<string> { "x", "y" });
 
@@ -169,8 +179,7 @@ public partial class InteropTests
     [Fact]
     public void CopyModeArrayIsJsArraySnapshot()
     {
-        // full pre-4.14 behavior needs Copy plus opting out of the recent-wrapper cache: each
-        // crossing then produces an independent JsArray snapshot
+        // Opting out of the recent-wrapper cache makes each crossing produce an independent snapshot.
         var engine = CreateCopyEngine(options => options.Interop.CacheRecentObjectWrappers = false);
         engine.SetValue("h", new ArrayHolder());
         engine.Evaluate("Array.isArray(h.Numbers)").AsBoolean().Should().BeTrue();
@@ -193,6 +202,297 @@ public partial class InteropTests
         engine.Execute("arr[1] = 42;");
 
         numbers[1].Should().Be(2);
+    }
+
+    [Fact]
+    public void CopyModeKeepsClrSnapshotsOutsideTheJsArraySizeConstraint()
+    {
+        var engine = CreateCopyEngine(options => options.MaxArraySize(2));
+
+        engine.SetValue("arr", new[] { 1, 2, 3 });
+
+        engine.Evaluate("arr.length").AsNumber().Should().Be(3);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CopyModePreservesSelfReferentialArrays(bool cacheRecentWrappers)
+    {
+        var engine = CreateCopyEngine(options => options.Interop.CacheRecentObjectWrappers = cacheRecentWrappers);
+        var source = new object[1];
+        source[0] = source;
+
+        engine.SetValue("arr", source);
+
+        engine.Evaluate("Array.isArray(arr) && arr[0] === arr").AsBoolean().Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CopyModePreservesMutuallyReferentialArrays(bool cacheRecentWrappers)
+    {
+        var engine = CreateCopyEngine(options => options.Interop.CacheRecentObjectWrappers = cacheRecentWrappers);
+        var first = new object[1];
+        var second = new object[1];
+        first[0] = second;
+        second[0] = first;
+
+        engine.SetValue("arr", first);
+
+        engine.Evaluate("Array.isArray(arr[0]) && arr[0][0] === arr").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void CopyModeDoesNotSpliceACachedDescendantFromAnOlderCyclicGraph()
+    {
+        var first = new object[1];
+        var second = new object[1];
+        first[0] = second;
+        second[0] = first;
+
+        var engine = CreateCopyEngine();
+        engine.SetValue("oldSecond", second);
+        for (var i = 0; i < 7; i++)
+        {
+            engine.SetValue($"filler{i}", new ArrayHolder());
+        }
+
+        engine.SetValue("newFirst", first);
+
+        engine.Evaluate("newFirst !== oldSecond[0] && newFirst[0][0] === newFirst")
+            .AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReentrantCopyDoesNotSpliceACachedDescendantFromAnOlderCyclicGraph()
+    {
+        var first = new object[1];
+        var second = new object[1];
+        first[0] = second;
+        second[0] = first;
+
+        var engine = CreateCopyEngine(options =>
+            options.AddObjectConverter(new ReentrantArrayConverter(second)));
+        engine.SetValue("oldSecond", second);
+        for (var i = 0; i < 7; i++)
+        {
+            engine.SetValue($"filler{i}", new ArrayHolder());
+        }
+
+        first[0] = new ReentrantArrayProbe();
+        engine.SetValue("newFirst", first);
+
+        engine.Evaluate("newFirst !== oldSecond[0] && newFirst[0][0] === newFirst")
+            .AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ConverterDependencyDoesNotSpliceACachedDescendantFromAnOlderCyclicGraph()
+    {
+        var root = new object[1];
+        var child = new object[1];
+        root[0] = child;
+        child[0] = new ConverterCycleProbe();
+
+        var engine = CreateCopyEngine(options =>
+            options.AddObjectConverter(new ConverterCycleConverter(root)));
+        engine.SetValue("oldChild", child);
+        for (var i = 0; i < 7; i++)
+        {
+            engine.SetValue($"filler{i}", new ArrayHolder());
+        }
+
+        engine.SetValue("newRoot", root);
+
+        engine.Evaluate("newRoot !== oldChild[0] && newRoot[0][0] === newRoot")
+            .AsBoolean().Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CopyModeReusesCachedAcyclicDescendants(bool trackIdentity)
+    {
+        var child = new object[] { 1 };
+        var parent = new object[] { child };
+        var engine = CreateCopyEngine(options =>
+            options.Interop.TrackObjectWrapperIdentity = trackIdentity);
+        engine.SetValue("child", child);
+        engine.SetValue("parent", parent);
+
+        engine.Evaluate("child === parent[0]").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void CachedDescendantProvenanceHandlesMultidimensionalArrays()
+    {
+        var child = new object[] { new int[2, 2] };
+        var engine = CreateCopyEngine(options =>
+            options.AddObjectConverter(new MultidimensionalArrayConverter()));
+        engine.SetValue("child", child);
+        engine.SetValue("parent", new object[] { child });
+
+        engine.Evaluate("child === parent[0]").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void FailedIdentityTrackedCopyDoesNotPublishSnapshot()
+    {
+        var deadline = new OperationDeadlineConstraint();
+        var converter = new OneTimeSlowConverter();
+        var engine = CreateCopyEngine(options =>
+        {
+            options.Interop.TrackObjectWrapperIdentity = true;
+            options.Constraint(deadline);
+            options.AddObjectConverter(converter);
+        });
+        var source = new object[] { new SlowCopyProbe() };
+
+        deadline.Begin(TimeSpan.FromMilliseconds(10));
+        Invoking(() => engine.SetValue("failed", source))
+            .Should().ThrowExactly<TimeoutException>();
+        engine.Advanced.GetInteropConversionDiagnostics().ArrayCopyConversions.Should().Be(0);
+        deadline.End();
+
+        engine.SetValue("retry", source);
+        engine.Evaluate("retry.length === 1 && retry[0] === 1").AsBoolean().Should().BeTrue();
+        engine.Advanced.GetInteropConversionDiagnostics().ArrayCopyConversions.Should().Be(1);
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(false, false)]
+    public void CopyModeAppliesCacheIdentityWithinOneArrayGraph(bool cacheRecentWrappers, bool expectedSame)
+    {
+        var engine = CreateCopyEngine(options => options.Interop.CacheRecentObjectWrappers = cacheRecentWrappers);
+        var child = new object[1];
+        var source = new object[] { child, child };
+
+        engine.SetValue("arr", source);
+
+        engine.Evaluate("arr[0] === arr[1]").AsBoolean().Should().Be(expectedSame);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CopyModePreservesBoundedRecentCacheSemanticsWithinOneArrayGraph(bool trackIdentity)
+    {
+        var child = new object[1];
+        var source = new object[10];
+        source[0] = child;
+        for (var i = 1; i <= 8; i++)
+        {
+            source[i] = new object[1];
+        }
+        source[9] = child;
+
+        var engine = CreateCopyEngine(options => options.Interop.TrackObjectWrapperIdentity = trackIdentity);
+        engine.SetValue("arr", source);
+
+        engine.Evaluate("arr[0] === arr[9]").AsBoolean().Should().Be(trackIdentity);
+    }
+
+    [Fact]
+    public void CopyModeSharesRecentCacheEvictionWithNonArrayWrappersWithinOneGraph()
+    {
+        var child = new object[1];
+        var source = new object[10];
+        source[0] = child;
+        for (var i = 1; i <= 8; i++)
+        {
+            source[i] = new ArrayHolder();
+        }
+        source[9] = child;
+
+        var engine = CreateCopyEngine();
+        engine.SetValue("arr", source);
+
+        engine.Evaluate("arr[0] === arr[9]").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void FailedCyclicCopyDoesNotPublishPartialSnapshotsToTheRecentCache()
+    {
+        var engine = CreateCopyEngine();
+        var first = new object[2];
+        var second = new object[1];
+        first[0] = second;
+        first[1] = new int[2, 2];
+        second[0] = first;
+
+        Invoking(() => engine.SetValue("first", first)).Should().ThrowExactly<ArgumentException>();
+        engine.Advanced.GetInteropConversionDiagnostics().ArrayCopyConversions.Should().Be(0);
+
+        // If the nested snapshot escaped from the failed conversion, this would return that partial
+        // graph instead of reaching the still-unsupported multidimensional element and throwing again.
+        Invoking(() => engine.SetValue("second", second)).Should().ThrowExactly<ArgumentException>();
+        engine.Advanced.GetInteropConversionDiagnostics().ArrayCopyConversions.Should().Be(0);
+    }
+
+    [Fact]
+    public void FailedCopyRestoresThePreviousRecentCacheTimeline()
+    {
+        var cached = new object[1];
+        var failed = new object[10];
+        for (var i = 0; i < failed.Length - 1; i++)
+        {
+            failed[i] = new ArrayHolder();
+        }
+        failed[^1] = new int[2, 2];
+
+        var engine = CreateCopyEngine();
+        engine.SetValue("before", cached);
+        Invoking(() => engine.SetValue("failed", failed)).Should().ThrowExactly<ArgumentException>();
+        engine.SetValue("after", cached);
+
+        engine.Evaluate("before === after").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void CaughtReentrantCopyFailureRollsBackItsStagedCachesAndDiagnostics()
+    {
+        var failedRoot = new object[2];
+        var failedChild = new object[1];
+        failedRoot[0] = failedChild;
+        failedRoot[1] = new int[2, 2];
+        failedChild[0] = failedRoot;
+
+        var engine = CreateCopyEngine(options =>
+            options.AddObjectConverter(new CaughtArrayFailureConverter(failedRoot)));
+        engine.SetValue("outer", new object[] { new ReentrantCopyProbe() });
+
+        engine.Evaluate("outer[0]").AsNumber().Should().Be(1);
+        engine.Advanced.GetInteropConversionDiagnostics().ArrayCopyConversions.Should().Be(1);
+
+        Invoking(() => engine.SetValue("failed", failedRoot)).Should().ThrowExactly<ArgumentException>();
+        engine.Advanced.GetInteropConversionDiagnostics().ArrayCopyConversions.Should().Be(1);
+    }
+
+    [Fact]
+    public void CopyModeConvertsDeepAcyclicArrayGraphsWithoutUsingTheClrStack()
+    {
+        const int Depth = 10_000;
+        object value = 42;
+        for (var i = 0; i < Depth; i++)
+        {
+            value = new object[] { value };
+        }
+
+        var engine = CreateCopyEngine();
+        engine.SetValue("value", value);
+
+        engine.Evaluate(
+            """
+            var depth = 0;
+            while (Array.isArray(value)) {
+                depth++;
+                value = value[0];
+            }
+            depth + ':' + value
+            """).AsString().Should().Be($"{Depth}:42");
     }
 
     [Fact]
@@ -375,13 +675,25 @@ public partial class InteropTests
     [Fact]
     public void MultiRankArraysKeepCopyModeFailureUnderBothModes()
     {
-        // multi-dimensional arrays have never been convertible (Array.GetValue with a single
-        // flat index throws) and LiveView must not change that failure mode
+        // Non-empty multidimensional arrays are not convertible (Array.GetValue with a single
+        // flat index throws), and LiveView must not change that failure mode.
         var copyEngine = new Engine();
         Invoking(() => copyEngine.SetValue("md", new int[2, 2])).Should().ThrowExactly<ArgumentException>();
 
         var liveViewEngine = CreateLiveViewEngine();
         Invoking(() => liveViewEngine.SetValue("md", new int[2, 2])).Should().ThrowExactly<ArgumentException>();
+    }
+
+    [Fact]
+    public void ZeroLengthMultiRankArraysKeepCopyFallbackUnderBothModes()
+    {
+        var copyEngine = new Engine();
+        copyEngine.SetValue("md", new int[0, 2]);
+        copyEngine.Evaluate("Array.isArray(md) && md.length === 0").AsBoolean().Should().BeTrue();
+
+        var liveViewEngine = CreateLiveViewEngine();
+        liveViewEngine.SetValue("md", new int[0, 2]);
+        liveViewEngine.Evaluate("Array.isArray(md) && md.length === 0").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -395,5 +707,113 @@ public partial class InteropTests
 
         list.Should().HaveCount(4);
         list[3].Should().Be(4);
+    }
+
+    private sealed class ReentrantCopyProbe
+    {
+    }
+
+    private sealed class ReentrantArrayProbe
+    {
+    }
+
+    private sealed class ReentrantArrayConverter(Array source) : IObjectConverter
+    {
+        public bool TryConvert(Engine engine, object value, out JsValue result)
+        {
+            if (value is not ReentrantArrayProbe)
+            {
+                result = null;
+                return false;
+            }
+
+            result = JsValue.FromObject(engine, source);
+            return true;
+        }
+    }
+
+    private sealed class MultidimensionalArrayConverter : IObjectConverter
+    {
+        public bool TryConvert(Engine engine, object value, out JsValue result)
+        {
+            if (value is not Array { Rank: > 1 })
+            {
+                result = null;
+                return false;
+            }
+
+            result = JsString.Create("multidimensional");
+            return true;
+        }
+    }
+
+    private sealed class ConverterCycleProbe
+    {
+    }
+
+    private sealed class ConverterCycleConverter(Array source) : IObjectConverter
+    {
+        public bool TryConvert(Engine engine, object value, out JsValue result)
+        {
+            if (value is not ConverterCycleProbe)
+            {
+                result = null;
+                return false;
+            }
+
+            result = JsValue.FromObject(engine, source);
+            return true;
+        }
+    }
+
+    private sealed class SlowCopyProbe
+    {
+    }
+
+    private sealed class OneTimeSlowConverter : IObjectConverter
+    {
+        private bool _delayed;
+
+        public bool TryConvert(Engine engine, object value, out JsValue result)
+        {
+            if (value is not SlowCopyProbe)
+            {
+                result = null;
+                return false;
+            }
+
+            if (!_delayed)
+            {
+                _delayed = true;
+                Thread.Sleep(30);
+            }
+
+            result = JsNumber.Create(1);
+            return true;
+        }
+    }
+
+    private sealed class CaughtArrayFailureConverter(object[] failedRoot) : IObjectConverter
+    {
+        public bool TryConvert(Engine engine, object value, out JsValue result)
+        {
+            if (value is not ReentrantCopyProbe)
+            {
+                result = null;
+                return false;
+            }
+
+            try
+            {
+                JsValue.FromObject(engine, failedRoot);
+            }
+            catch (ArgumentException)
+            {
+                result = JsNumber.Create(1);
+                return true;
+            }
+
+            throw new InvalidOperationException("The nested array conversion should fail.");
+        }
     }
 }

--- a/Jint.Tests/Runtime/InteropTests.PropertyValueMemo.cs
+++ b/Jint.Tests/Runtime/InteropTests.PropertyValueMemo.cs
@@ -54,16 +54,16 @@ public partial class InteropTests
     }
 
     [Fact]
-    public void PropertyValueMemoDoesNotHideInPlaceMutation()
+    public void PropertyValueMemoDoesNotHideInPlaceMutationForLiveView()
     {
         var host = new PropertyMemoHost();
-        var engine = new Engine();
+        var engine = new Engine(options => options.Interop.ArrayConversion = ArrayConversionMode.LiveView);
         engine.SetValue("host", host);
 
         engine.Evaluate("host.stable[0]").AsNumber().Should().Be(10);
 
-        // a CLR-side in-place mutation of the same array instance must remain visible: the memo caches
-        // the wrapper, not element values, and the default wrapper is a live view
+        // A CLR-side in-place mutation of the same array instance must remain visible: the memo caches
+        // the explicitly selected live wrapper, not element values.
         host.stable[0] = 99;
         engine.Evaluate("host.stable[0]").AsNumber().Should().Be(99);
     }

--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -893,7 +893,6 @@ public partial class InteropTests : IDisposable
         // an element must throw a TypeError in strict mode. Regression: it previously neither threw nor
         // assigned (the dense-write fast path bypassed the writability check).
         // This scenario is about a copied JS array's per-element descriptors, so it pins Copy mode
-        // (the LiveView default exposes a live wrapper whose element writability is handled differently).
         var engine = new Engine(x =>
         {
             x.Strict();

--- a/Jint/Engine.Advanced.cs
+++ b/Jint/Engine.Advanced.cs
@@ -371,12 +371,12 @@ public partial class Engine
         /// for audits, assertions and regression tests, never for production branching.
         /// </para>
         /// <para>
-        /// The motivating case: <see cref="ArrayConversionMode.LiveView"/> has been the default since 4.14, and
-        /// the two modes differ in behavior a script can observe — a live view writes through to the CLR array
-        /// and tracks its contents, a copy does neither. A host that does not own all of its Jint consumers has
-        /// no way to find out whether any CLR array crosses into script at all, let alone under which
-        /// semantics, short of auditing every transitive caller by hand. Reading the counters around a run
-        /// answers it directly.
+        /// The motivating case: <see cref="ArrayConversionMode.Copy"/> is the default, while
+        /// <see cref="ArrayConversionMode.LiveView"/> is an explicit performance opt-in, and the two modes differ
+        /// in behavior a script can observe — a live view writes through to the CLR array and tracks its contents,
+        /// while a copy does neither. A host that does not own all of its Jint consumers has no way to find out
+        /// whether any CLR array crosses into script at all, let alone under which semantics, short of auditing
+        /// every transitive caller by hand. Reading the counters around a run answers it directly.
         /// </para>
         /// <para>
         /// Scope, stated honestly. What is counted is a conversion that actually went through the

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -882,6 +882,9 @@ public sealed partial class Engine : IDisposable
     // cache for already wrapped CLR objects to keep object identity
     internal ConditionalWeakTable<object, ObjectInstance>? _objectWrapperCache;
 
+    // Reused while CLR array snapshots are built so cyclic graphs can point back to an in-progress JsArray.
+    internal ArrayCopyContext? _arrayCopyContext;
+
     // per-object private-element storage ([[PrivateElements]]). Kept off ObjectInstance in a weak table
     // (keyed by the owning object) so the 8-byte reference doesn't bloat every object on the heap — only
     // instances of JS classes that declare #private members ever allocate an entry here.
@@ -2133,6 +2136,27 @@ public sealed partial class Engine : IDisposable
         foreach (var constraint in _amortizedConstraints)
         {
             constraint.Check();
+        }
+    }
+
+    internal void CheckInteropProjectionConstraints()
+    {
+        _memoryLimitConstraint?.Check();
+
+        if (_executionContexts.Count > 1)
+        {
+            CheckAmortizedConstraints();
+            return;
+        }
+
+        // Host-side projection is not an execution entry, so an ordinary timeout has no active
+        // budget to enforce. Cancellation and a host-armed operation deadline do span entries.
+        foreach (var constraint in _amortizedConstraints)
+        {
+            if (constraint is CancellationConstraint or OperationDeadlineConstraint)
+            {
+                constraint.Check();
+            }
         }
     }
 

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -508,10 +508,10 @@ public partial class Options
         /// <summary>
         /// Whether identity map is persisted for object wrappers in order to maintain object identity. This can cause
         /// memory usage to grow when targeting large set and freeing of memory can be delayed due to ConditionalWeakTable semantics.
-        /// Also covers CLR arrays: repeated conversions of the same array instance return the same result — the live
-        /// wrapper view under <see cref="ArrayConversionMode.LiveView"/> (the default), or the same JsArray snapshot
-        /// under <see cref="ArrayConversionMode.Copy"/> (script-side mutations persist across reads; CLR-side mutations
-        /// after the first conversion are not re-copied) — instead of re-converting on every read.
+        /// Also covers CLR arrays: repeated conversions of the same array instance return the same result — the same
+        /// JsArray snapshot under the default <see cref="ArrayConversionMode.Copy"/> mode (script-side mutations persist
+        /// across reads; CLR-side mutations after the first conversion are not re-copied), or the live wrapper view
+        /// under <see cref="ArrayConversionMode.LiveView"/> — instead of re-converting on every read.
         /// Defaults to false.
         /// </summary>
         public bool TrackObjectWrapperIdentity { get; set; }
@@ -532,14 +532,16 @@ public partial class Options
         public bool CacheRecentObjectWrappers { get; set; } = true;
 
         /// <summary>
-        /// How CLR arrays (<c>T[]</c>) are exposed to script code, defaults to <see cref="Jint.ArrayConversionMode.LiveView"/>
-        /// (changed from <see cref="Jint.ArrayConversionMode.Copy"/> in 4.14), which exposes single-rank arrays as live,
-        /// fixed-size wrapper views over the underlying array — the same way wrapped <see cref="System.Collections.Generic.List{T}"/>
-        /// already behaves. <see cref="Jint.ArrayConversionMode.Copy"/> instead copies the array contents into a new
-        /// JavaScript array on each conversion; select it to preserve the pre-4.14 behavior. See the enum members for
-        /// the exact semantic differences (write-through, identity, <c>Array.isArray</c>, resizing).
+        /// How CLR arrays (<c>T[]</c>) are exposed to script code. Defaults to
+        /// <see cref="Jint.ArrayConversionMode.Copy"/>, which snapshots the contents into a native JavaScript array.
+        /// <see cref="Jint.ArrayConversionMode.LiveView"/> remains available as an explicit opt-in for a fixed-size
+        /// view that avoids the copy and its allocation, and whose element reads stay connected to the CLR array.
+        /// Writes reach the CLR array only when <see cref="AllowWrite"/> is also enabled.
+        /// This default is a breaking change for hosts that relied on the live-view default introduced in 4.14.
+        /// See the enum members for the exact semantic differences (write-through, identity, wrapper caches,
+        /// <c>Array.isArray</c>, resizing and multidimensional arrays).
         /// </summary>
-        public ArrayConversionMode ArrayConversion { get; set; } = ArrayConversionMode.LiveView;
+        public ArrayConversionMode ArrayConversion { get; set; } = ArrayConversionMode.Copy;
 
         /// <summary>
         /// How a CLR sequence that is <em>only</em> an <see cref="System.Collections.Generic.IEnumerable{T}"/> — a LINQ
@@ -1168,22 +1170,31 @@ public enum EnumConversionMode
 public enum ArrayConversionMode
 {
     /// <summary>
-    /// Each conversion copies the array contents into a new JavaScript array (<c>Array.isArray</c> returns <c>true</c>).
-    /// Script-side mutations affect only the copy and CLR-side mutations after the conversion are not visible
-    /// through it. Each crossing produces a new independent snapshot unless
+    /// The default. Each conversion copies the array contents into a native JavaScript array
+    /// (<c>Array.isArray</c> returns <c>true</c>) that script can mutate and resize normally. Script-side mutations
+    /// affect only the copy, and CLR-side mutations after the conversion are not visible through it. Each crossing
+    /// produces a new independent snapshot unless
     /// <see cref="Options.InteropOptions.TrackObjectWrapperIdentity"/> or
-    /// <see cref="Options.InteropOptions.CacheRecentObjectWrappers"/> reuses the earlier one.
+    /// <see cref="Options.InteropOptions.CacheRecentObjectWrappers"/> reuses the earlier one; when reused, script-side
+    /// mutations and object identity persist for that cached snapshot, but CLR-side changes are still not re-copied.
+    /// Self- and mutually referential CLR arrays preserve those cycles in the JavaScript snapshot.
+    /// Multidimensional and non-zero-based CLR arrays are unsupported: non-empty instances throw during
+    /// conversion, while zero-length instances currently produce an empty snapshot.
     /// </summary>
     Copy,
 
     /// <summary>
-    /// Single-rank arrays are exposed as live wrapper views over the underlying CLR array, the same way wrapped
+    /// The explicit opt-in. Single-rank arrays are exposed as live wrapper views over the underlying CLR array,
+    /// avoiding the copy and its allocation, the same way wrapped
     /// <see cref="System.Collections.Generic.List{T}"/> instances already behave: element reads and writes go
-    /// straight to the array in both directions, and wrapper identity across repeated crossings follows the same
-    /// caches as other wrapped objects (<see cref="Options.InteropOptions.TrackObjectWrapperIdentity"/> /
-    /// <see cref="Options.InteropOptions.CacheRecentObjectWrappers"/>). An array crossing under a non-array
-    /// declared type keeps honoring that contract (for example a member typed <c>IReadOnlyList&lt;T&gt;</c>
-    /// produces a read-only view).
+    /// straight to the array in both directions when <see cref="Options.InteropOptions.AllowWrite"/> is enabled.
+    /// With writes disabled, reads remain live but mutations that would reach the backing array are denied. Repeated
+    /// views over the same CLR array compare strictly equal by wrapped-target identity even when caches are disabled;
+    /// whether the same wrapper instance is returned follows
+    /// the same caches as other wrapped objects (<see cref="Options.InteropOptions.TrackObjectWrapperIdentity"/> /
+    /// <see cref="Options.InteropOptions.CacheRecentObjectWrappers"/>). An array crossing under a non-array declared
+    /// type keeps honoring that contract (for example a member typed <c>IReadOnlyList&lt;T&gt;</c> produces a read-only
+    /// view).
     /// <para>
     /// The view is array-like — iteration, <c>Array.prototype</c> methods, index-key enumeration
     /// (<c>Object.keys</c> / <c>for-in</c>), out-of-range reads yielding <c>undefined</c> and JSON
@@ -1192,7 +1203,9 @@ public enum ArrayConversionMode
     /// CLR arrays are fixed-size the view behaves like an integer-indexed exotic object: resizing attempts
     /// (growing writes, <c>push</c>/<c>pop</c>, <c>length</c> writes) throw a <c>TypeError</c>, and like for
     /// typed arrays, <c>shift</c>/<c>splice</c> may move elements before their length change throws.
-    /// Multi-dimensional arrays are not supported by the view and behave as under <see cref="Copy"/>.
+    /// Multidimensional and non-zero-based CLR arrays are unsupported in both modes. They fall back to the
+    /// <see cref="Copy"/> path, where non-empty instances throw during conversion and zero-length instances
+    /// currently produce an empty snapshot.
     /// </para>
     /// </summary>
     LiveView,

--- a/Jint/Runtime/Interop/DefaultObjectConverter.cs
+++ b/Jint/Runtime/Interop/DefaultObjectConverter.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using Jint.Native;
 using Jint.Native.Object;
@@ -262,50 +263,253 @@ internal static class DefaultObjectConverter
         // static cross-engine memoization, so per-engine option state can never be baked into the
         // memoized mapper.
         var arrayType = v.GetType();
-        if (e._objectWrapperCache?.TryGetValue(v, out var cached) == true
-            && (cached is not ObjectWrapper cachedWrapper || cachedWrapper.ClrType == arrayType))
+        var copyContext = e._arrayCopyContext;
+        if (copyContext?.TryGetGraphCopy(v, out var inProgress) == true)
         {
+            copyContext.ObserveDependency(inProgress);
+            return inProgress;
+        }
+
+        if (e._objectWrapperCache?.TryGetValue(v, out var cached) == true
+            && (cached is not ObjectWrapper cachedWrapper || cachedWrapper.ClrType == arrayType)
+            && (copyContext is null || copyContext.CanReuseCachedArray((Array) v, cached)))
+        {
+            copyContext?.ObserveDependency(cached);
             return cached;
         }
 
-        if (e._recentObjectWrapperCache?.TryGet(v, arrayType) is { } recentlyConverted)
+        if (e._recentObjectWrapperCache?.TryGet(v, arrayType) is { } recentlyConverted
+            && (copyContext is null || copyContext.CanReuseCachedArray((Array) v, recentlyConverted)))
         {
+            copyContext?.ObserveDependency(recentlyConverted);
             return recentlyConverted;
         }
 
         if (e.Options.Interop.ArrayConversion == ArrayConversionMode.LiveView
             && TryConvertArrayLiveView(e, v, arrayType, out var liveView))
         {
+            if (liveView is ObjectInstance liveViewObject)
+            {
+                copyContext?.ObserveDependency(liveViewObject);
+            }
+
             return liveView;
         }
 
-        var array = (Array) v;
-        var arrayLength = (uint) array.Length;
-
-        var values = new JsValue[arrayLength];
-        for (uint i = 0; i < arrayLength; ++i)
-        {
-            values[i] = JsValue.FromObject(e, array.GetValue(i));
-        }
-
-        var result = new JsArray(e, values);
-        e._arrayCopyConversions++;
-
-        if (e.Options.Interop.TrackObjectWrapperIdentity)
-        {
-            e._objectWrapperCache ??= new ConditionalWeakTable<object, ObjectInstance>();
-            // the table may hold a wrapper for a different exposed view of the same
-            // object (the type-guarded lookup above missed it) — last view wins
-            e._objectWrapperCache.Remove(v);
-            e._objectWrapperCache.Add(v, result);
-        }
-        else if (e.Options.Interop.CacheRecentObjectWrappers)
-        {
-            e._recentObjectWrapperCache ??= new RecentObjectWrapperCache();
-            e._recentObjectWrapperCache.Add(v, result);
-        }
-
+        copyContext ??= e._arrayCopyContext = new ArrayCopyContext();
+        var result = copyContext.IsActive
+            ? CopyArrayGraph(e, (Array) v, copyContext)
+            : e.ExecuteWithMemoryAccounting(() => CopyArrayGraph(e, (Array) v, copyContext));
+        copyContext.ObserveDependency(result);
         return result;
+    }
+
+    private static JsArray CopyArrayGraph(Engine engine, Array source, ArrayCopyContext copyContext)
+    {
+        engine.CheckInteropProjectionConstraints();
+        var result = CreateArraySnapshot(engine, source);
+        engine.CheckInteropProjectionConstraints();
+        var isRootCopy = !copyContext.IsActive;
+        var savepoint = copyContext.CreateSavepoint(engine);
+        var stack = new List<ArrayCopyFrame>(capacity: 4);
+        var workUntilConstraintCheck = Engine.ConstraintCheckInterval;
+        var succeeded = false;
+        copyContext.Begin(source, result);
+        stack.Add(new ArrayCopyFrame(source, result, Index: 0));
+        try
+        {
+            while (stack.Count > 0)
+            {
+                var frameIndex = stack.Count - 1;
+                var frame = stack[frameIndex];
+                if (frame.Index >= frame.Result.Length)
+                {
+                    copyContext.Complete(
+                        engine,
+                        frame.Source,
+                        frame.Result,
+                        engine.Options.Interop.TrackObjectWrapperIdentity,
+                        engine.Options.Interop.CacheRecentObjectWrappers);
+                    copyContext.End(frame.Source);
+                    stack.RemoveAt(frameIndex);
+                    continue;
+                }
+
+                var index = frame.Index;
+                stack[frameIndex] = frame with { Index = index + 1 };
+                if (--workUntilConstraintCheck == 0)
+                {
+                    engine.CheckInteropProjectionConstraints();
+                    workUntilConstraintCheck = Engine.ConstraintCheckInterval;
+                }
+
+                var element = frame.Source.GetValue(index);
+                JsValue converted;
+                if (element is Array child)
+                {
+                    if (!TryConvertNestedArrayObserved(
+                            engine,
+                            child,
+                            copyContext,
+                            frame.Result,
+                            out var nestedConverted))
+                    {
+                        if (child.Length >= Engine.ConstraintCheckInterval)
+                        {
+                            engine.CheckInteropProjectionConstraints();
+                        }
+
+                        var childResult = CreateArraySnapshot(engine, child);
+                        if (child.Length >= Engine.ConstraintCheckInterval)
+                        {
+                            engine.CheckInteropProjectionConstraints();
+                        }
+
+                        copyContext.Begin(child, childResult);
+                        copyContext.RecordDependency(frame.Result, childResult);
+                        frame.Result.SetIndexValue(index, childResult, updateLength: false);
+                        stack.Add(new ArrayCopyFrame(child, childResult, Index: 0));
+                        continue;
+                    }
+
+                    converted = nestedConverted;
+                }
+                else
+                {
+                    if (engine._objectConverters is null)
+                    {
+                        converted = JsValue.FromObject(engine, element);
+                    }
+                    else
+                    {
+                        var observation = copyContext.BeginDependencyObservation();
+                        try
+                        {
+                            converted = JsValue.FromObject(engine, element);
+                        }
+                        finally
+                        {
+                            copyContext.EndDependencyObservation(frame.Result, observation);
+                        }
+                    }
+                }
+
+                copyContext.RecordDependency(frame.Result, converted);
+                frame.Result.SetIndexValue(index, converted, updateLength: false);
+            }
+
+            if (isRootCopy)
+            {
+                copyContext.Publish(engine);
+                engine.CheckInteropProjectionConstraints();
+                copyContext.CommitDiagnostics(engine);
+            }
+
+            succeeded = true;
+            return result;
+        }
+        finally
+        {
+            for (var i = stack.Count - 1; i >= 0; i--)
+            {
+                copyContext.End(stack[i].Source);
+            }
+
+            if (!succeeded)
+            {
+                copyContext.Rollback(engine, in savepoint);
+            }
+            else
+            {
+                ArrayCopyContext.Commit(in savepoint);
+            }
+
+            if (isRootCopy)
+            {
+                copyContext.DiscardCompleted();
+            }
+        }
+    }
+
+    private static JsArray CreateArraySnapshot(Engine engine, Array source)
+    {
+        var length = (uint) source.Length;
+        return new JsArray(engine, new JsValue[length]);
+    }
+
+    private static bool TryConvertNestedArray(
+        Engine engine,
+        Array array,
+        ArrayCopyContext copyContext,
+        [NotNullWhen(true)] out JsValue? result)
+    {
+        if (engine._objectConverters is not null)
+        {
+            foreach (var converter in engine._objectConverters)
+            {
+                if (converter.TryConvert(engine, array, out result))
+                {
+                    return true;
+                }
+            }
+        }
+
+        var arrayType = array.GetType();
+        // A nested array may reuse a snapshot from an older graph unless its CLR graph reaches an
+        // array currently being copied. In that case the older snapshot points back to an older
+        // root and would splice two generations of a cycle together.
+        if (engine._objectWrapperCache?.TryGetValue(array, out var cached) == true
+            && (cached is not ObjectWrapper cachedWrapper || cachedWrapper.ClrType == arrayType)
+            && copyContext.CanReuseCachedArray(array, cached))
+        {
+            result = cached;
+            return true;
+        }
+
+        if (engine._recentObjectWrapperCache?.TryGet(array, arrayType) is { } recentlyConverted
+            && copyContext.CanReuseCachedArray(array, recentlyConverted))
+        {
+            result = recentlyConverted;
+            return true;
+        }
+
+        if (copyContext.TryGetGraphCopy(array, out var graphCopy))
+        {
+            result = graphCopy;
+            return true;
+        }
+
+        if (engine.Options.Interop.ArrayConversion == ArrayConversionMode.LiveView
+            && TryConvertArrayLiveView(engine, array, arrayType, out result))
+        {
+            return true;
+        }
+
+        result = null;
+        return false;
+    }
+
+    private static bool TryConvertNestedArrayObserved(
+        Engine engine,
+        Array array,
+        ArrayCopyContext copyContext,
+        ObjectInstance parent,
+        [NotNullWhen(true)] out JsValue? result)
+    {
+        if (engine._objectConverters is null)
+        {
+            return TryConvertNestedArray(engine, array, copyContext, out result);
+        }
+
+        var observation = copyContext.BeginDependencyObservation();
+        try
+        {
+            return TryConvertNestedArray(engine, array, copyContext, out result);
+        }
+        finally
+        {
+            copyContext.EndDependencyObservation(parent, observation);
+        }
     }
 
     /// <summary>
@@ -351,7 +555,363 @@ internal static class DefaultObjectConverter
         result = wrapped;
         return true;
     }
+
+    [StructLayout(LayoutKind.Auto)]
+    private readonly record struct ArrayCopyFrame(Array Source, JsArray Result, uint Index);
 }
+
+internal sealed class ArrayCopyContext
+{
+    private const int MaximumRetainedBookkeepingCapacity = 1024;
+
+    private readonly ConditionalWeakTable<object, ObjectInstance> _inProgress = new();
+    private readonly ConditionalWeakTable<object, ObjectInstance> _completedIdentityCopies = new();
+    private readonly ConditionalWeakTable<object, ArrayToken> _arrayTokens = new();
+    private readonly ConditionalWeakTable<ObjectInstance, ArrayToken> _snapshotTokens = new();
+    private readonly ConditionalWeakTable<ObjectInstance, ArrayDependencies> _arrayDependencies = new();
+    private readonly HashSet<ArrayToken> _inProgressTokens = [];
+    private readonly List<CompletedArrayCopy> _completed = [];
+    private readonly List<PublishedIdentityCopy> _publishedIdentityCopies = [];
+    private readonly List<List<ObjectInstance>?> _dependencyObservations = [];
+    private int _depth;
+
+    public bool IsActive => _depth > 0;
+
+    public bool TryGetGraphCopy(object target, [NotNullWhen(true)] out ObjectInstance? result)
+        => _inProgress.TryGetValue(target, out result)
+            || _completedIdentityCopies.TryGetValue(target, out result);
+
+    public ArrayCopySavepoint CreateSavepoint(Engine engine)
+    {
+        if (!engine.Options.Interop.TrackObjectWrapperIdentity
+            && engine.Options.Interop.CacheRecentObjectWrappers)
+        {
+            var createdRecentCache = engine._recentObjectWrapperCache is null;
+            engine._recentObjectWrapperCache ??= new RecentObjectWrapperCache();
+            return new(
+                _completed.Count,
+                _publishedIdentityCopies.Count,
+                engine._recentObjectWrapperCache,
+                engine._recentObjectWrapperCache.BeginTransaction(),
+                createdRecentCache);
+        }
+
+        return new(
+            _completed.Count,
+            _publishedIdentityCopies.Count,
+            RecentCache: null,
+            RecentTransaction: null,
+            CreatedRecentCache: false);
+    }
+
+    public void Begin(object target, ObjectInstance result)
+    {
+        if (!_arrayTokens.TryGetValue(target, out var token))
+        {
+            token = new ArrayToken();
+            _arrayTokens.Add(target, token);
+        }
+
+        _inProgress.Add(target, result);
+        _snapshotTokens.Add(result, token);
+        _inProgressTokens.Add(token);
+        _depth++;
+    }
+
+    public void Complete(
+        Engine engine,
+        object target,
+        ObjectInstance result,
+        bool trackIdentity,
+        bool cacheRecent)
+    {
+        _completed.Add(new CompletedArrayCopy(target, result, trackIdentity));
+        if (trackIdentity)
+        {
+            // Defer publication to the engine caches until the root copy succeeds, but preserve the
+            // same reuse semantics for repeated references within the graph being converted.
+            _completedIdentityCopies.Add(target, result);
+        }
+        else if (cacheRecent)
+        {
+            // Add to the real bounded ring so array and non-array conversions share one eviction timeline.
+            // Its active transaction restores the previous state if the graph later fails.
+            engine._recentObjectWrapperCache ??= new RecentObjectWrapperCache();
+            engine._recentObjectWrapperCache.Add(target, result);
+        }
+    }
+
+    public void End(object target)
+    {
+        if (_arrayTokens.TryGetValue(target, out var token))
+        {
+            _inProgressTokens.Remove(token);
+        }
+
+        _inProgress.Remove(target);
+        _depth--;
+    }
+
+    public void RecordDependency(ObjectInstance parent, JsValue value)
+    {
+        if (value is not ObjectInstance child
+            || !_snapshotTokens.TryGetValue(child, out var token))
+        {
+            return;
+        }
+
+        if (!_arrayDependencies.TryGetValue(parent, out var dependencies))
+        {
+            dependencies = new ArrayDependencies();
+            _arrayDependencies.Add(parent, dependencies);
+        }
+
+        dependencies.Add(token, child);
+    }
+
+    public DependencyObservation BeginDependencyObservation()
+    {
+        var observation = new DependencyObservation(_dependencyObservations.Count);
+        _dependencyObservations.Add(null);
+        return observation;
+    }
+
+    public void ObserveDependency(ObjectInstance snapshot)
+    {
+        if (!_snapshotTokens.TryGetValue(snapshot, out _))
+        {
+            return;
+        }
+
+        for (var i = 0; i < _dependencyObservations.Count; i++)
+        {
+            var items = _dependencyObservations[i] ??= [];
+            if (!items.Contains(snapshot))
+            {
+                items.Add(snapshot);
+            }
+        }
+    }
+
+    public void EndDependencyObservation(ObjectInstance parent, DependencyObservation observation)
+    {
+        var last = _dependencyObservations.Count - 1;
+        if (last != observation.Depth)
+        {
+            Throw.InvalidOperationException("Array dependency observations must end in stack order.");
+        }
+
+        var items = _dependencyObservations[last];
+        _dependencyObservations.RemoveAt(last);
+        if (items is null)
+        {
+            return;
+        }
+
+        foreach (var snapshot in items)
+        {
+            RecordDependency(parent, snapshot);
+        }
+    }
+
+    public bool IsCompletedByCurrentGraph(object target, ObjectInstance result)
+    {
+        for (var i = _completed.Count - 1; i >= 0; i--)
+        {
+            var copy = _completed[i];
+            if (ReferenceEquals(copy.Target, target) && ReferenceEquals(copy.Result, result))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public bool CanReuseCachedArray(Array source, ObjectInstance result)
+    {
+        if (!IsActive
+            || IsCompletedByCurrentGraph(source, result))
+        {
+            return true;
+        }
+
+        if (!_arrayDependencies.TryGetValue(result, out _))
+        {
+            return true;
+        }
+
+        var pending = new List<ObjectInstance>(capacity: 4) { result };
+        var visited = new HashSet<ObjectInstance> { result };
+        while (pending.Count > 0)
+        {
+            var last = pending.Count - 1;
+            var current = pending[last];
+            pending.RemoveAt(last);
+            if (!_arrayDependencies.TryGetValue(current, out var dependencies))
+            {
+                continue;
+            }
+
+            foreach (var dependency in dependencies.Items)
+            {
+                if (_inProgressTokens.Contains(dependency.Token))
+                {
+                    return false;
+                }
+
+                if (dependency.Snapshot.TryGetTarget(out var snapshot)
+                    && visited.Add(snapshot))
+                {
+                    pending.Add(snapshot);
+                }
+            }
+        }
+
+        return true;
+    }
+
+    public void Publish(Engine engine)
+    {
+        foreach (var copy in _completed)
+        {
+            if (copy.TrackIdentity)
+            {
+                engine._objectWrapperCache ??= new ConditionalWeakTable<object, ObjectInstance>();
+                engine._objectWrapperCache.TryGetValue(copy.Target, out var previous);
+                _publishedIdentityCopies.Add(new PublishedIdentityCopy(copy.Target, previous));
+                // The table may hold a wrapper for a different exposed view of the same object.
+                engine._objectWrapperCache.Remove(copy.Target);
+                engine._objectWrapperCache.Add(copy.Target, copy.Result);
+            }
+        }
+
+    }
+
+    public void CommitDiagnostics(Engine engine)
+    {
+        engine._arrayCopyConversions += _completed.Count;
+    }
+
+    public void DiscardCompleted()
+    {
+        foreach (var copy in _completed)
+        {
+            if (copy.TrackIdentity)
+            {
+                _completedIdentityCopies.Remove(copy.Target);
+            }
+        }
+
+        _completed.Clear();
+        _publishedIdentityCopies.Clear();
+        if (_completed.Capacity > MaximumRetainedBookkeepingCapacity)
+        {
+            _completed.Capacity = 0;
+        }
+
+        if (_publishedIdentityCopies.Capacity > MaximumRetainedBookkeepingCapacity)
+        {
+            _publishedIdentityCopies.Capacity = 0;
+        }
+
+    }
+
+    public static void Commit(in ArrayCopySavepoint savepoint)
+    {
+        if (savepoint.RecentCache is { } recentCache
+            && savepoint.RecentTransaction is { } recentTransaction)
+        {
+            recentCache.Commit(in recentTransaction);
+        }
+    }
+
+    public void Rollback(Engine engine, in ArrayCopySavepoint savepoint)
+    {
+        for (var i = _publishedIdentityCopies.Count - 1; i >= savepoint.PublishedIdentityCount; i--)
+        {
+            var publication = _publishedIdentityCopies[i];
+            engine._objectWrapperCache!.Remove(publication.Target);
+            if (publication.Previous is not null)
+            {
+                engine._objectWrapperCache.Add(publication.Target, publication.Previous);
+            }
+        }
+
+        _publishedIdentityCopies.RemoveRange(
+            savepoint.PublishedIdentityCount,
+            _publishedIdentityCopies.Count - savepoint.PublishedIdentityCount);
+
+        for (var i = _completed.Count - 1; i >= savepoint.CompletedCount; i--)
+        {
+            var copy = _completed[i];
+            if (copy.TrackIdentity)
+            {
+                _completedIdentityCopies.Remove(copy.Target);
+            }
+        }
+
+        if (savepoint.RecentCache is { } recentCache
+            && savepoint.RecentTransaction is { } recentTransaction)
+        {
+            recentCache.Rollback(in recentTransaction);
+            if (savepoint.CreatedRecentCache)
+            {
+                engine._recentObjectWrapperCache = null;
+            }
+        }
+
+        _completed.RemoveRange(savepoint.CompletedCount, _completed.Count - savepoint.CompletedCount);
+    }
+
+    [StructLayout(LayoutKind.Auto)]
+    private readonly record struct CompletedArrayCopy(
+        object Target,
+        ObjectInstance Result,
+        bool TrackIdentity);
+
+    [StructLayout(LayoutKind.Auto)]
+    private readonly record struct PublishedIdentityCopy(object Target, ObjectInstance? Previous);
+
+    private sealed class ArrayToken;
+
+    private sealed class ArrayDependencies
+    {
+        private readonly List<ArrayDependency> _items = [];
+
+        public IReadOnlyList<ArrayDependency> Items => _items;
+
+        public void Add(ArrayToken token, ObjectInstance snapshot)
+        {
+            for (var i = 0; i < _items.Count; i++)
+            {
+                if (_items[i].Snapshot.TryGetTarget(out var existing)
+                    && ReferenceEquals(existing, snapshot))
+                {
+                    return;
+                }
+            }
+
+            _items.Add(new ArrayDependency(token, new WeakReference<ObjectInstance>(snapshot)));
+        }
+    }
+
+    [StructLayout(LayoutKind.Auto)]
+    private readonly record struct ArrayDependency(
+        ArrayToken Token,
+        WeakReference<ObjectInstance> Snapshot);
+
+    [StructLayout(LayoutKind.Auto)]
+    internal readonly record struct DependencyObservation(int Depth);
+}
+
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct ArrayCopySavepoint(
+    int CompletedCount,
+    int PublishedIdentityCount,
+    RecentObjectWrapperCache? RecentCache,
+    RecentObjectWrapperCache.Transaction? RecentTransaction,
+    bool CreatedRecentCache);
 
 /// <summary>
 /// Bounded ring of most recently wrapped CLR objects, looked up by reference identity.
@@ -364,7 +924,9 @@ internal sealed class RecentObjectWrapperCache
 
     private readonly object?[] _targets = new object?[Capacity];
     private readonly ObjectInstance[] _wrappers = new ObjectInstance[Capacity];
+    private List<Mutation>? _mutations;
     private int _next;
+    private int _transactionDepth;
 
     public ObjectInstance? TryGet(object target, Type clrType)
     {
@@ -391,6 +953,12 @@ internal sealed class RecentObjectWrapperCache
     public void Add(object target, ObjectInstance wrapper)
     {
         var index = _next;
+        if (_transactionDepth > 0)
+        {
+            _mutations ??= [];
+            _mutations.Add(new Mutation(index, _targets[index], _wrappers[index]));
+        }
+
         _targets[index] = target;
         _wrappers[index] = wrapper;
         _next = (index + 1) & (Capacity - 1);
@@ -402,4 +970,64 @@ internal sealed class RecentObjectWrapperCache
         Array.Clear(_wrappers, 0, _wrappers.Length);
         _next = 0;
     }
+
+    public Transaction BeginTransaction()
+    {
+        _transactionDepth++;
+        return new(_mutations?.Count ?? 0, _next);
+    }
+
+    public void Commit(in Transaction transaction)
+    {
+        _transactionDepth--;
+        if (_transactionDepth == 0)
+        {
+            ReleaseMutationsIfOversized();
+        }
+    }
+
+    public void Rollback(in Transaction transaction)
+    {
+        if (_mutations is { } mutations)
+        {
+            for (var i = mutations.Count - 1; i >= transaction.MutationCount; i--)
+            {
+                var mutation = mutations[i];
+                _targets[mutation.Index] = mutation.Target;
+                _wrappers[mutation.Index] = mutation.Wrapper!;
+            }
+
+            mutations.RemoveRange(transaction.MutationCount, mutations.Count - transaction.MutationCount);
+        }
+
+        _next = transaction.Next;
+        _transactionDepth--;
+        if (_transactionDepth == 0)
+        {
+            ReleaseMutationsIfOversized();
+        }
+    }
+
+    private void ReleaseMutationsIfOversized()
+    {
+        if (_mutations is not { } mutations)
+        {
+            return;
+        }
+
+        if (mutations.Capacity > 1024)
+        {
+            _mutations = null;
+        }
+        else
+        {
+            mutations.Clear();
+        }
+    }
+
+    [StructLayout(LayoutKind.Auto)]
+    private readonly record struct Mutation(int Index, object? Target, ObjectInstance? Wrapper);
+
+    [StructLayout(LayoutKind.Auto)]
+    internal readonly record struct Transaction(int MutationCount, int Next);
 }

--- a/README.md
+++ b/README.md
@@ -1821,6 +1821,33 @@ You can check out [the engine comparison results](Jint.Benchmark), bear in mind 
 Notes for hosts that project their own objects into script, pool engines, or bound execution. Each of these
 is a cost model rather than a rule; the XML documentation on the named APIs has the detail.
 
+**Migrating CLR array projections.** CLR arrays now default to `ArrayConversionMode.Copy`. This is a breaking
+compatibility change from the live-view default introduced in 4.14: the safer default gives script a native,
+independent `JsArray` snapshot (`Array.isArray` is `true`) that it can mutate and resize without changing the
+host's array, and later CLR-side mutations are not visible through that snapshot. The default recent-wrapper
+cache means repeated crossings of the same CLR array reuse that first snapshot while it remains cached, so
+JavaScript identity and script-side mutations persist across those reads; `TrackObjectWrapperIdentity` extends
+that identity for the wrapper-map lifetime, while disabling both caches restores a fresh snapshot per crossing.
+
+Hosts that intentionally need shared mutable state can preserve the previous behavior explicitly:
+
+```c#
+var engine = new Engine(options =>
+    options.Interop.ArrayConversion = ArrayConversionMode.LiveView);
+```
+
+`LiveView` avoids the copy and its allocation, and exposes a fixed-size array-like wrapper. Reads stay connected
+to the CLR array, but selecting `LiveView` does not grant write authority: script mutations that would reach the
+backing array remain denied unless `AllowClrWrite()` is separately enabled. With both opt-ins, element writes
+change the CLR array. Repeated wrappers over the same CLR array compare equal by target identity even with caches
+disabled; the wrapper caches determine whether the same wrapper instance is reused. It is not a native JavaScript
+array (`Array.isArray` is `false`), and resizing operations throw. Multidimensional and non-zero-based CLR arrays
+remain unsupported in either mode: non-empty instances fail during conversion, while zero-length instances
+currently fall through as empty snapshots. Choose `Copy` for isolation and JavaScript-array compatibility; opt
+into `LiveView` when live observation and avoiding the initial O(N) copy and allocation are required, and
+authorize writes separately. Once a snapshot is cached, its native JavaScript-array element access can be as
+fast as or faster than traversing the live wrapper.
+
 **Projecting host data.** Subclassing `ObjectInstance` is the most expensive way to expose data. Such a
 receiver gets no own-property inline caching — every own read reaches your `GetOwnProperty` and allocates the
 `PropertyDescriptor` it returns. Cheaper options, in order of preference:


### PR DESCRIPTION
## Summary
- make `ArrayConversionMode.Copy` the breaking security default while retaining explicit `LiveView` compatibility
- keep copied arrays as mutable engine-owned JS snapshots while requiring separate `AllowClrWrite()` authority for LiveView write-through
- preserve cyclic/deep graph identity with transactional cache publication, rollback, resource accounting, and weak converter-aware provenance
- document the migration and add public/core coverage plus a trustworthy cold-projection benchmark

## Security stack
#3054 -> #3052 -> #3051 -> #3046 -> #3045 -> #3037 -> #3036 -> #3035 -> #3030

## Validation
- Release Jint multi-target build (`net462`, `netstandard2.0`, `netstandard2.1`, `net8.0`, `net10.0`)
- PublicInterface: 1,745 tests default; 1,745 with host-contract verification
- Core under UTC: 5,800 tests
- Focused host-verification interop/memory/result/GC/concurrency: 439 tests
- Benchmark project Release build and `git diff --check`
- clean specialist follow-up review

## Benchmark
Default BenchmarkDotNet job, `ClrArrayProjectionBenchmark` (cold first crossing):

| Length | Copy | LiveView | Copy allocated | LiveView allocated |
| ---: | ---: | ---: | ---: | ---: |
| 0 | 445.98 ns | 53.29 ns | 458 B | 192 B |
| 10 | 574.63 ns | 53.50 ns | 774 B | 192 B |
| 100 | 2.104 us | 52.60 ns | 3,661 B | 192 B |
| 1,000 | 16.764 us | 53.58 ns | 32,465 B | 192 B |