### PR TITLE
Add security configuration diagnostics

### DIFF
--- a/.github/THREAT_MODEL.md
+++ b/.github/THREAT_MODEL.md
@@ -103,6 +103,56 @@ Defaults are compatibility choices, not a hardened profile.
 | Function source retention | Disabled | Submitted function source is not retained solely for `toString()` |
 | Result conversion and JSON output limits | Unlimited | Compatibility default; hostile output is unbounded unless the host opts in |
 
+## Configuration diagnostics
+
+`Options.ValidateSecurityConfiguration(SecurityConfigurationPolicy.UntrustedScripts)` inspects the
+configured `Options` without invoking deferred callbacks or constraint factories. It returns an immutable report whose diagnostics
+have stable `JINTSECnnn` codes, an error or warning severity, a description, and remediation
+guidance. Results are sorted by code so deployment logs and policy tests are deterministic.
+`EnsureSecurityConfiguration` performs the same validation and throws
+`SecurityConfigurationException` when the report contains an error; ordinary engine construction
+does not validate or change defaults automatically.
+
+The untrusted-script policy reports:
+
+- missing per-entry and cumulative operation deadlines, statement, memory, cancellation, recursion,
+  native-stack, parser, result, and array limits;
+- non-positive and saturated statement, memory, and timeout values that remove a limit;
+- blocking `Atomics.wait`, dynamic string compilation, CLR access, reflection, `GetType`, CLR
+  writes, and live CLR array views;
+- module loaders, aggregate count/byte limits, per-load depth/hop limits, destination policies,
+  `require`, debugger behavior, and detailed CLR/module errors that require host review;
+- unbounded or long regex and synchronous promise waits; and
+- directly registered `Constraint` instances whose mutable state would be shared by engines built
+  from one `Options` object; and
+- host callbacks and converters, CLR compatibility access, live array/write combinations, decorators,
+  retained source, and callbacks registered to run during engine construction.
+
+Explicit parsing options and prepared programs are separate configuration surfaces:
+`ValidateSecurityConfiguration(options, parsingOptions)` checks an override together with the
+engine options, while `ValidateSecurityConfiguration` / `EnsureSecurityConfiguration` on
+`ScriptPreparationOptions` and `ModulePreparationOptions` check the regex timeout that will be
+embedded in prepared code. The actual source-length, AST-node, source-retention, and regex settings
+are validated together; the default preparation options therefore report unbounded parser limits and
+the 10-second regex warning.
+
+After construction, `engine.Advanced.ValidateSecurityConfiguration()` reads the effective options and
+the constraint instances the engine already created. It does not replay a callback or factory. Public
+`Configure`, `SetTypeConverter`, and `UseHostFactory` callbacks continue to produce `JINTSEC031`;
+Jint-owned configuration has separate internal provenance so a future first-party hardened profile can
+compose without suppressing user callbacks or relying on delegate names.
+
+This is a configuration check, not a capability proof or hardened-profile implementation.
+In particular, it cannot inspect the behavior of a projected delegate or object, prove that a
+custom `TypeResolver` is a complete allow-list, determine whether a module loader blocks SSRF or
+path traversal, infer whether a cancellation token has an outer deadline, or enforce process,
+transport redirects, callback behavior, external serialization, response, or log limits. A warning is
+not an approval: it means the setting can be legitimate only after the host verifies and tests the
+corresponding external policy. A clean report still requires the worker isolation and host controls
+in this document. Treat the validated `Options` as immutable and pass it directly to
+`Engine(Options)` and inspect the effective engine report when deferred configuration exists. Zero
+findings do not prove sandbox safety.
+
 ## Threat inventory
 
 ### TM-01: CLR access becomes process authority
@@ -223,6 +273,8 @@ BigInt/string arithmetic, and adversarial algorithms can monopolize a worker.
 - `TimeoutInterval`, `MaxStatements`, and `CancellationToken` constraints.
 - Long-running built-ins periodically call the constraint set.
 - Amortized timeout and cancellation checks are also made after CLR calls return.
+- The untrusted-script configuration report identifies missing limits and sentinel values that
+  remove them.
 
 **Missing or residual mitigation.**
 
@@ -308,6 +360,7 @@ most of its time in garbage collection.
 - `MaxArraySize` bounds Jint array creation when configured.
 - Some built-ins reject impossible allocations.
 - Recent-wrapper caching is bounded by default; the unbounded identity map is opt-in.
+- The untrusted-script configuration report identifies missing memory and practical array limits.
 
 **Missing or residual mitigation.**
 
@@ -339,6 +392,8 @@ quota.
   function entry and converts exhaustion to a catchable `RangeError`.
 - The older `Constraints.MaxExecutionStackCount` lane can move call-expression recursion
   to a fresh thread.
+- The untrusted-script configuration report identifies disabled, saturated, or shadowed stack
+  protections.
 
 **Missing or residual mitigation.**
 
@@ -567,9 +622,12 @@ from another thread. Use separate engines for mutually distrusting requests.
 - Ten seconds per regex is usually too high for a server request.
 - Repeated regex operations can consume the entire request budget.
 - A regex timeout does not replace the overall execution deadline.
+- Explicit parsing and preparation options override the engine timeout; prepared programs retain
+  that timeout when shared across engines.
 
 **Required host action.** Set a short, workload-tested regex timeout and retain the overall
-time, statement, and process CPU limits.
+time, statement, and process CPU limits. Validate every explicit parsing/preparation configuration
+and set the nested preparation `ParsingOptions.RegexTimeout` for untrusted source.
 
 ### TM-15: Debugger features bypass production assumptions
 
@@ -1193,41 +1251,37 @@ The numbers below are examples only. Measure normal workloads and choose smaller
 leave acceptable headroom.
 
 ```csharp
-var deadline = new OperationDeadlineConstraint();
+var options = new Options()
+    .Strict()
+    .DisableStringCompilation()
+    .TimeoutInterval(TimeSpan.FromSeconds(2))
+    .MaxStatements(50_000)
+    .LimitMemory(16_000_000)
+    .LimitRecursion(64)
+    .MaxArraySize(100_000)
+    .RegexTimeoutInterval(TimeSpan.FromMilliseconds(250))
+    .CancellationToken(requestAborted)
+    .Constraint(static () => new OperationDeadlineConstraint())
+    .AllowClrWrite(false);
 
-var engine = new Engine(options =>
-{
-    options.Strict();
-    options.DisableStringCompilation();
+options.Constraints.StackOverflowGuard = true;
+options.Constraints.PromiseTimeout = TimeSpan.FromSeconds(1);
+options.AgentCanSuspend = false;
+options.Interop.ArrayConversion = ArrayConversionMode.Copy;
+options.Parsing.MaxSourceLength = 100_000;
+options.Parsing.MaxNodeCount = 25_000;
+options.ResultLimits = ResultLimits.Conservative;
+options.Interop.ExposeDetailedExceptionMessages = false;
+options.Interop.ExposeDetailedResolutionErrors = false;
+options.Modules.ExposeDetailedLoadErrors = false;
 
-    options.TimeoutInterval(TimeSpan.FromSeconds(2));
-    options.MaxStatements(50_000);
-    options.LimitMemory(16_000_000);
-    options.LimitRecursion(64);
-    options.MaxArraySize(100_000);
-    options.RegexTimeoutInterval(TimeSpan.FromMilliseconds(250));
-    options.CancellationToken(requestAborted);
-    options.Constraint(deadline);
-
-    options.Parsing.MaxSourceLength = 100_000;
-    options.Parsing.MaxNodeCount = 25_000;
-
-    // Enabled by default; keep it explicit in the hardened profile.
-    options.Constraints.StackOverflowGuard = true;
-    options.Constraints.PromiseTimeout = TimeSpan.FromSeconds(2);
-
-    options.AgentCanSuspend = false;
-    // Pin the safe default explicitly so configuration reviews cannot miss this boundary.
-    options.AllowClrWrite(false);
-    // Pin the hardened behavior even though Copy is the compatibility default.
-    options.Interop.ArrayConversion = ArrayConversionMode.Copy;
-    options.ResultLimits = ResultLimits.Conservative;
-    options.Interop.ExposeDetailedExceptionMessages = false;
-    options.Interop.ExposeDetailedResolutionErrors = false;
-    options.Modules.ExposeDetailedLoadErrors = false;
-
-    // Do not call AllowClr(). Leave modules and the debugger disabled.
-});
+// Do not call AllowClr(). Leave modules and the debugger disabled.
+var report = options.ValidateSecurityConfiguration(SecurityConfigurationPolicy.UntrustedScripts);
+AuditWarnings(report.Diagnostics);
+var engine = new Engine(options.EnsureSecurityConfiguration(SecurityConfigurationPolicy.UntrustedScripts));
+var effectiveReport = engine.Advanced.ValidateSecurityConfiguration(SecurityConfigurationPolicy.UntrustedScripts);
+AuditWarnings(effectiveReport.Diagnostics);
+var deadline = engine.Constraints.Find<OperationDeadlineConstraint>()!;
 
 deadline.Begin(TimeSpan.FromSeconds(3), requestAborted);
 try
@@ -1278,6 +1332,8 @@ This configuration is incomplete without host controls:
 
 Before deploying a host that executes untrusted scripts:
 
+- [ ] The fully configured `Options` object is validated before engine construction; every
+  reported warning is explicitly reviewed and the report is regression-tested by stable code.
 - [ ] CLR namespace access, `AllowGetType`, reflection, debugger, and `Atomics.wait` are off.
 - [ ] Direct CLR writes remain disabled, and projected host objects are immutable or intentionally
   capability-scoped with no unintended mutating instance, static, or extension methods.
@@ -1288,6 +1344,8 @@ Before deploying a host that executes untrusted scripts:
   four Jint module graph limits are configured when modules are enabled.
 - [ ] Time, statement, memory, recursion, stack, array, regex, promise, and operation limits
   are explicitly configured and tested with adversarial inputs.
+- [ ] Every explicit parsing option and script/module preparation option is validated with the
+  timeout that will actually be used.
 - [ ] Async API cancellation is paired with an engine cancellation constraint.
 - [ ] No engine, mutable host object, `JsValue`, module, or request context crosses trust
   domains.

--- a/Jint.Tests.PublicInterface/SecurityConfigurationTests.cs
+++ b/Jint.Tests.PublicInterface/SecurityConfigurationTests.cs
@@ -1,0 +1,640 @@
+#nullable enable
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using Jint.Constraints;
+using Jint.Runtime;
+using Jint.Runtime.Interop;
+using Jint.Runtime.Modules;
+
+namespace Jint.Tests.PublicInterface;
+
+public class SecurityConfigurationTests
+{
+    [Fact]
+    public void CleanHandBuiltOptionsHaveNoDiagnostics()
+    {
+        var options = CreateSafeOptions();
+
+        var report = options.ValidateSecurityConfiguration(SecurityConfigurationPolicy.UntrustedScripts);
+
+        report.Diagnostics.Should().BeEmpty();
+        report.HasErrors.Should().BeFalse();
+        report.HasWarnings.Should().BeFalse();
+        options.EnsureSecurityConfiguration().Should().BeSameAs(options);
+
+        Invoking(() => new Engine(options.EnsureSecurityConfiguration())).Should().NotThrow();
+    }
+
+    [Fact]
+    public void EverySecurityConditionHasAStableDiagnostic()
+    {
+        var cases = new (string Code, Func<Options> CreateOptions)[]
+        {
+            (SecurityDiagnosticCodes.StatementLimitMissing, CreateWithoutStatementLimit),
+            (SecurityDiagnosticCodes.StatementLimitNonPositive, () => CreateSafeOptions().MaxStatements(0)),
+            (SecurityDiagnosticCodes.StatementLimitSaturated, () => CreateSafeOptions().MaxStatements(int.MaxValue)),
+            (SecurityDiagnosticCodes.MemoryLimitMissing, CreateWithoutMemoryLimit),
+            (SecurityDiagnosticCodes.MemoryLimitNonPositive, () => CreateSafeOptions().LimitMemory(0)),
+            (SecurityDiagnosticCodes.MemoryLimitSaturated, () => CreateSafeOptions().LimitMemory(long.MaxValue)),
+            (SecurityDiagnosticCodes.TimeoutMissing, CreateWithoutTimeout),
+            (SecurityDiagnosticCodes.TimeoutNonPositive, () => CreateSafeOptions().TimeoutInterval(TimeSpan.Zero)),
+            (SecurityDiagnosticCodes.TimeoutSaturated, () => CreateSafeOptions().TimeoutInterval(TimeSpan.MaxValue)),
+            (SecurityDiagnosticCodes.RecursionLimitDisabled, () => Change(CreateSafeOptions(), x => x.Constraints.MaxRecursionDepth = -1)),
+            (SecurityDiagnosticCodes.RecursionLimitSaturated, () => Change(CreateSafeOptions(), x => x.Constraints.MaxRecursionDepth = int.MaxValue)),
+            (SecurityDiagnosticCodes.StackOverflowGuardDisabled, () => Change(CreateSafeOptions(), x => x.Constraints.StackOverflowGuard = false)),
+            (SecurityDiagnosticCodes.StackOverflowGuardShadowed, () => Change(CreateSafeOptions(), x => x.Constraints.MaxExecutionStackCount = 100)),
+            (SecurityDiagnosticCodes.AgentSuspensionEnabled, () => Change(CreateSafeOptions(), x => x.AgentCanSuspend = true)),
+            (SecurityDiagnosticCodes.ClrAccessEnabled, CreateWithRestrictiveClr),
+            (SecurityDiagnosticCodes.GetTypeEnabled, () => Change(CreateSafeOptions(), x => x.Interop.AllowGetType = true)),
+            (SecurityDiagnosticCodes.SystemReflectionEnabled, () => Change(CreateSafeOptions(), x => x.Interop.AllowSystemReflection = true)),
+            (SecurityDiagnosticCodes.ClrWriteEnabled, () => CreateSafeOptions().AllowClrWrite()),
+            (SecurityDiagnosticCodes.LiveClrArraysEnabled, () => Change(CreateSafeOptions(), x => x.Interop.ArrayConversion = ArrayConversionMode.LiveView)),
+            (SecurityDiagnosticCodes.StringCompilationEnabled, () => Change(CreateSafeOptions(), x => x.Host.StringCompilationAllowed = true)),
+            (SecurityDiagnosticCodes.ModuleLoadingEnabled, () => CreateSafeOptions().EnableModules(new EmptyModuleLoader())),
+            (SecurityDiagnosticCodes.RequireWithoutModuleLoader, () => Change(CreateSafeOptions(), x => x.Modules.RegisterRequire = true)),
+            (SecurityDiagnosticCodes.DebuggerEnabled, () => CreateSafeOptions().DebugMode()),
+            (SecurityDiagnosticCodes.ArraySizeUnlimited, () => CreateSafeOptions().MaxArraySize(uint.MaxValue)),
+            (SecurityDiagnosticCodes.RegexTimeoutUnbounded, () => CreateSafeOptions().RegexTimeoutInterval(TimeSpan.Zero)),
+            (SecurityDiagnosticCodes.RegexTimeoutLong, () => CreateSafeOptions().RegexTimeoutInterval(TimeSpan.FromSeconds(2))),
+            (SecurityDiagnosticCodes.PromiseTimeoutUnbounded, () => Change(CreateSafeOptions(), x => x.Constraints.PromiseTimeout = TimeSpan.Zero)),
+            (SecurityDiagnosticCodes.PromiseTimeoutLong, () => Change(CreateSafeOptions(), x => x.Constraints.PromiseTimeout = TimeSpan.FromSeconds(2))),
+            (SecurityDiagnosticCodes.SharedConstraintInstance, () => CreateSafeOptions().Constraint(new NoOpConstraint())),
+            (SecurityDiagnosticCodes.DetailedClrErrorsEnabled, () => Change(CreateSafeOptions(), x => x.Interop.ExposeDetailedResolutionErrors = true)),
+            (SecurityDiagnosticCodes.EngineConstructionCallback, () => CreateSafeOptions().Configure(static _ => { })),
+            (SecurityDiagnosticCodes.RegexTimeoutExcessive, () => CreateSafeOptions().RegexTimeoutInterval(TimeSpan.MaxValue)),
+            (SecurityDiagnosticCodes.CancellationMissing, CreateWithoutCancellation),
+            (SecurityDiagnosticCodes.OperationDeadlineMissing, CreateWithoutOperationDeadline),
+            (SecurityDiagnosticCodes.ParserSourceLengthUnlimited, () => Change(CreateSafeOptions(), x => x.Parsing.MaxSourceLength = null)),
+            (SecurityDiagnosticCodes.ParserNodeCountUnlimited, () => Change(CreateSafeOptions(), x => x.Parsing.MaxNodeCount = null)),
+            (SecurityDiagnosticCodes.FunctionSourceRetentionEnabled, () => Change(CreateSafeOptions(), x => x.RetainFunctionSourceText = true)),
+            (SecurityDiagnosticCodes.ModuleCountUnlimited, () => Change(CreateSafeModuleOptions(), x => x.Modules.MaxModuleCount = int.MaxValue)),
+            (SecurityDiagnosticCodes.ModuleSourceBytesUnlimited, () => Change(CreateSafeModuleOptions(), x => x.Modules.MaxTotalModuleSourceBytes = long.MaxValue)),
+            (SecurityDiagnosticCodes.ModuleGraphDepthUnlimited, () => Change(CreateSafeModuleOptions(), x => x.Modules.MaxModuleGraphDepth = int.MaxValue)),
+            (SecurityDiagnosticCodes.ModuleResolutionHopsUnlimited, () => Change(CreateSafeModuleOptions(), x => x.Modules.MaxModuleResolutionHops = int.MaxValue)),
+            (SecurityDiagnosticCodes.ModuleDestinationPolicyMissing, () => Change(CreateSafeModuleOptions(), x => x.Modules.LoadPolicy = null)),
+            (SecurityDiagnosticCodes.ModulePerLoadLimitsReset, CreateSafeModuleOptions),
+            (SecurityDiagnosticCodes.ResultLimitsUnlimited, () => Change(CreateSafeOptions(), x => x.ResultLimits = ResultLimits.Unlimited)),
+            (SecurityDiagnosticCodes.DetailedClrExceptionMessagesEnabled, () => Change(CreateSafeOptions(), x => x.Interop.ExposeDetailedExceptionMessages = true)),
+            (SecurityDiagnosticCodes.ClrExceptionChainingEnabled, () => Change(CreateSafeOptions(), x => x.Interop.ChainClrExceptionAsInnerException = true)),
+            (SecurityDiagnosticCodes.DetailedModuleErrorsEnabled, () => Change(CreateSafeModuleOptions(), x => x.Modules.ExposeDetailedLoadErrors = true)),
+            (SecurityDiagnosticCodes.ClrErrorDecoratorConfigured, () => Change(CreateSafeOptions(), x => x.Interop.ClrExceptionErrorDecorator = static (_, _, _) => { })),
+            (SecurityDiagnosticCodes.ClrCallbackConfigured, () => Change(CreateSafeOptions(), x => x.Interop.ExceptionHandler = static _ => false)),
+            (SecurityDiagnosticCodes.ClrCompatibilityModeEnabled, () => CreateSafeOptions().AllowClr()),
+            (SecurityDiagnosticCodes.ClrPolicyUnrestricted, () => CreateSafeOptions().AllowClr(Array.Empty<System.Reflection.Assembly>())),
+            (SecurityDiagnosticCodes.LiveClrArrayWritesEnabled, () => Change(CreateSafeOptions().AllowClrWrite(), x => x.Interop.ArrayConversion = ArrayConversionMode.LiveView)),
+            (SecurityDiagnosticCodes.ModuleAllowlistInsufficient, CreateSchemeOnlyModuleOptions),
+            (SecurityDiagnosticCodes.ClrExtensionMethodsConfigured, () => CreateSafeOptions().AddExtensionMethods(typeof(SecurityConfigurationUnsafeExtensions)))
+        };
+
+        foreach (var (code, createOptions) in cases)
+        {
+            var options = createOptions();
+            var diagnostic = options.ValidateSecurityConfiguration().Diagnostics
+                .Should().ContainSingle(candidate => candidate.Code == code).Which;
+            diagnostic.Code.Should().Be(code);
+            diagnostic.Severity.Should().Be(ExpectedSeverity(code));
+            diagnostic.Message.Should().NotBeNullOrWhiteSpace();
+            diagnostic.Guidance.Should().NotBeNullOrWhiteSpace();
+
+            if (diagnostic.Severity == SecurityDiagnosticSeverity.Error)
+            {
+                Invoking(() => options.EnsureSecurityConfiguration()).Should().ThrowExactly<SecurityConfigurationException>();
+            }
+            else
+            {
+                if (!options.ValidateSecurityConfiguration().HasErrors)
+                {
+                    Invoking(() => options.EnsureSecurityConfiguration()).Should().NotThrow();
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void DiagnosticsAreOrderedByStableCode()
+    {
+        var report = new Options().ValidateSecurityConfiguration();
+
+        report.Diagnostics.Select(static diagnostic => diagnostic.Code)
+            .Should().BeInAscendingOrder(StringComparer.Ordinal);
+        report.Diagnostics.Select(static diagnostic => diagnostic.Code)
+            .Should().Equal(new Options().ValidateSecurityConfiguration().Diagnostics.Select(static diagnostic => diagnostic.Code));
+    }
+
+    [Fact]
+    public void EnsureThrowsBeforeEngineConstructionAndCarriesTheReport()
+    {
+        var options = new Options();
+
+        var exception = Invoking(() => options.EnsureSecurityConfiguration())
+            .Should().ThrowExactly<SecurityConfigurationException>().Which;
+
+        exception.Report.HasErrors.Should().BeTrue();
+        exception.Report.Diagnostics.Should().Contain(static diagnostic =>
+            diagnostic.Code == SecurityDiagnosticCodes.StatementLimitMissing
+            && diagnostic.Severity == SecurityDiagnosticSeverity.Error);
+        exception.Message.Should().Contain(SecurityDiagnosticCodes.StatementLimitMissing);
+    }
+
+    [Fact]
+    public void WarningsRemainVisibleWithoutFailingExplicitValidation()
+    {
+        var options = CreateSafeModuleOptions();
+
+        var report = options.ValidateSecurityConfiguration();
+
+        report.HasErrors.Should().BeFalse();
+        report.HasWarnings.Should().BeTrue();
+        report.Diagnostics.Should().OnlyContain(
+            static diagnostic => diagnostic.Severity == SecurityDiagnosticSeverity.Warning);
+        options.EnsureSecurityConfiguration().Should().BeSameAs(options);
+    }
+
+    [Fact]
+    public void RemovingABuiltInConstraintUpdatesTheReport()
+    {
+        var options = CreateSafeOptions()
+            .WithoutConstraint(static constraint => constraint is MaxStatementsConstraint);
+
+        options.ValidateSecurityConfiguration().Diagnostics.Should().ContainSingle().Which.Code
+            .Should().Be(SecurityDiagnosticCodes.StatementLimitMissing);
+    }
+
+    [Fact]
+    public void SideEffectFreeConstraintFactoriesRemainSupported()
+    {
+        var options = CreateSafeOptions().Constraint(static () => new NoOpConstraint());
+
+        options.ValidateSecurityConfiguration().Diagnostics.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ExplicitParsingTimeoutIsValidatedWithEngineOptions()
+    {
+        var options = CreateSafeOptions();
+
+        options.ValidateSecurityConfiguration(ScriptParsingOptions.Default).Diagnostics.Should().BeEmpty();
+
+        var longTimeout = ScriptParsingOptions.Default with { RegexTimeout = TimeSpan.FromSeconds(2) };
+        var longDiagnostic = options.ValidateSecurityConfiguration(longTimeout).Diagnostics.Should().ContainSingle().Which;
+        longDiagnostic.Code.Should().Be(SecurityDiagnosticCodes.RegexTimeoutOverrideLong);
+        longDiagnostic.Severity.Should().Be(SecurityDiagnosticSeverity.Warning);
+        options.EnsureSecurityConfiguration(longTimeout).Should().BeSameAs(options);
+
+        var unbounded = ScriptParsingOptions.Default with { RegexTimeout = TimeSpan.Zero };
+        var unboundedDiagnostic = options.ValidateSecurityConfiguration(unbounded).Diagnostics.Should().ContainSingle().Which;
+        unboundedDiagnostic.Code.Should().Be(SecurityDiagnosticCodes.RegexTimeoutOverrideUnbounded);
+        unboundedDiagnostic.Severity.Should().Be(SecurityDiagnosticSeverity.Error);
+        Invoking(() => options.EnsureSecurityConfiguration(unbounded))
+            .Should().ThrowExactly<SecurityConfigurationException>();
+    }
+
+    [Fact]
+    public void PreparationTimeoutIsValidatedIndependentlyOfEngineOptions()
+    {
+        var scriptDefault = ScriptPreparationOptions.Default.ValidateSecurityConfiguration()
+            .Diagnostics.Should().ContainSingle(
+                diagnostic => diagnostic.Code == SecurityDiagnosticCodes.RegexTimeoutOverrideLong).Which;
+        scriptDefault.Code.Should().Be(SecurityDiagnosticCodes.RegexTimeoutOverrideLong);
+        scriptDefault.Severity.Should().Be(SecurityDiagnosticSeverity.Warning);
+
+        var moduleDefault = ModulePreparationOptions.Default.ValidateSecurityConfiguration()
+            .Diagnostics.Should().ContainSingle(
+                diagnostic => diagnostic.Code == SecurityDiagnosticCodes.RegexTimeoutOverrideLong).Which;
+        moduleDefault.Code.Should().Be(SecurityDiagnosticCodes.RegexTimeoutOverrideLong);
+
+        var safeScript = ScriptPreparationOptions.Default with
+        {
+            ParsingOptions = ScriptParsingOptions.Default with
+            {
+                RegexTimeout = TimeSpan.FromSeconds(1),
+                MaxSourceLength = 100_000,
+                MaxNodeCount = 25_000
+            }
+        };
+        safeScript.ValidateSecurityConfiguration().Diagnostics.Should().BeEmpty();
+        safeScript.EnsureSecurityConfiguration().Should().BeSameAs(safeScript);
+
+        var excessiveModule = ModulePreparationOptions.Default with
+        {
+            ParsingOptions = ModuleParsingOptions.Default with
+            {
+                RegexTimeout = TimeSpan.MaxValue,
+                MaxSourceLength = 100_000,
+                MaxNodeCount = 25_000
+            }
+        };
+        var excessiveDiagnostic = excessiveModule.ValidateSecurityConfiguration()
+            .Diagnostics.Should().ContainSingle(
+                diagnostic => diagnostic.Code == SecurityDiagnosticCodes.RegexTimeoutOverrideExcessive).Which;
+        excessiveDiagnostic.Code.Should().Be(SecurityDiagnosticCodes.RegexTimeoutOverrideExcessive);
+        excessiveDiagnostic.Severity.Should().Be(SecurityDiagnosticSeverity.Error);
+        Invoking(() => excessiveModule.EnsureSecurityConfiguration())
+            .Should().ThrowExactly<SecurityConfigurationException>();
+    }
+
+    [Fact]
+    public void EveryEngineConstructionCallbackIsRejected()
+    {
+        var options = new[]
+        {
+            CreateSafeOptions().Configure(static _ => { }),
+            CreateSafeOptions().SetTypeConverter(static _ => new PassThroughTypeConverter()),
+            CreateSafeOptions().UseHostFactory(static _ => new Host())
+        };
+
+        foreach (var configured in options)
+        {
+            configured.ValidateSecurityConfiguration().Diagnostics.Should().ContainSingle().Which.Code
+                .Should().Be(SecurityDiagnosticCodes.EngineConstructionCallback);
+        }
+    }
+
+    [Fact]
+    public void EffectiveEngineReportRunsDeferredCallbacksOnceAndObservesFinalState()
+    {
+        var callbackCount = 0;
+        var options = CreateSafeOptions();
+        options.Configure(_ =>
+        {
+            callbackCount++;
+            options.AgentCanSuspend = true;
+        });
+
+        var engine = new Engine(options);
+        var report = engine.Advanced.ValidateSecurityConfiguration();
+
+        callbackCount.Should().Be(1);
+        report.Diagnostics.Should().ContainSingle(
+            diagnostic => diagnostic.Code == SecurityDiagnosticCodes.EngineConstructionCallback);
+        report.Diagnostics.Should().ContainSingle(
+            diagnostic => diagnostic.Code == SecurityDiagnosticCodes.AgentSuspensionEnabled);
+    }
+
+    [Fact]
+    public void EffectiveEngineReportUsesEngineSnapshotsTakenBeforeDeferredCallbacks()
+    {
+        var options = CreateSafeOptions();
+        options.Debugger.Enabled = true;
+        options.Configure(_ => options.Debugger.Enabled = false);
+
+        var report = new Engine(options).Advanced.ValidateSecurityConfiguration();
+
+        report.Diagnostics.Should().ContainSingle(
+            diagnostic => diagnostic.Code == SecurityDiagnosticCodes.DebuggerEnabled);
+    }
+
+    [Fact]
+    public void EffectiveEngineReportCannotBeCleanedByMutatingFixedOptionsAfterConstruction()
+    {
+        var options = CreateSafeOptions().AllowClr();
+        options.Interop.ExposeDetailedResolutionErrors = true;
+        var engine = new Engine(options);
+
+        options.Interop.Enabled = false;
+        options.Interop.AllowGetType = false;
+        options.Interop.AllowSystemReflection = false;
+        options.Interop.ExposeDetailedResolutionErrors = false;
+        options.Interop.TypeResolver = new TypeResolver { MemberFilter = static _ => false };
+
+        var report = engine.Advanced.ValidateSecurityConfiguration();
+
+        report.Diagnostics.Should().ContainSingle(
+            diagnostic => diagnostic.Code == SecurityDiagnosticCodes.ClrAccessEnabled);
+        report.Diagnostics.Should().ContainSingle(
+            diagnostic => diagnostic.Code == SecurityDiagnosticCodes.ClrCompatibilityModeEnabled);
+        report.Diagnostics.Should().ContainSingle(
+            diagnostic => diagnostic.Code == SecurityDiagnosticCodes.ClrPolicyUnrestricted);
+        report.Diagnostics.Should().ContainSingle(
+            diagnostic => diagnostic.Code == SecurityDiagnosticCodes.DetailedClrErrorsEnabled);
+    }
+
+    [Fact]
+    public void EffectiveEngineReportUsesTheLoaderActuallyInstalled()
+    {
+        var options = CreateSafeModuleOptions();
+        var engine = new Engine(options);
+        options.Modules.ModuleLoader = new Options().Modules.ModuleLoader;
+
+        engine.Advanced.ValidateSecurityConfiguration().Diagnostics.Should().ContainSingle(
+            diagnostic => diagnostic.Code == SecurityDiagnosticCodes.ModuleLoadingEnabled);
+    }
+
+    [Fact]
+    public void EffectiveEngineReportPreservesParserAndStackConstructionSettings()
+    {
+        var options = CreateSafeOptions();
+        options.Parsing.MaxSourceLength = null;
+        options.Parsing.MaxNodeCount = null;
+        options.RetainFunctionSourceText = true;
+        options.Constraints.RegexTimeout = TimeSpan.FromSeconds(2);
+        options.Constraints.MaxRecursionDepth = -1;
+        options.Constraints.StackOverflowGuard = false;
+        var engine = new Engine(options);
+
+        options.Parsing.MaxSourceLength = 100_000;
+        options.Parsing.MaxNodeCount = 25_000;
+        options.RetainFunctionSourceText = false;
+        options.Constraints.RegexTimeout = TimeSpan.FromSeconds(1);
+        options.Constraints.MaxRecursionDepth = 64;
+        options.Constraints.StackOverflowGuard = true;
+
+        var codes = engine.Advanced.ValidateSecurityConfiguration().Diagnostics
+            .Select(static diagnostic => diagnostic.Code);
+        codes.Should().Contain(SecurityDiagnosticCodes.ParserSourceLengthUnlimited);
+        codes.Should().Contain(SecurityDiagnosticCodes.ParserNodeCountUnlimited);
+        codes.Should().Contain(SecurityDiagnosticCodes.FunctionSourceRetentionEnabled);
+        codes.Should().Contain(SecurityDiagnosticCodes.RegexTimeoutLong);
+        codes.Should().Contain(SecurityDiagnosticCodes.RecursionLimitDisabled);
+        codes.Should().Contain(SecurityDiagnosticCodes.StackOverflowGuardDisabled);
+    }
+
+    [Fact]
+    public void EffectiveEngineReportUsesInstalledExtensionMethodCache()
+    {
+        var options = CreateSafeOptions().AddExtensionMethods(typeof(SecurityConfigurationUnsafeExtensions));
+        options.Configure(_ => options.Interop.ExtensionMethodTypes.Clear());
+
+        var report = new Engine(options).Advanced.ValidateSecurityConfiguration();
+
+        report.Diagnostics.Should().ContainSingle(
+            diagnostic => diagnostic.Code == SecurityDiagnosticCodes.ClrExtensionMethodsConfigured);
+    }
+
+    [Fact]
+    public void UserCallbackCannotSpoofFirstPartyProvenance()
+    {
+        var options = CreateSafeOptions().Configure(ConfigureFirstParty);
+
+        options.ValidateSecurityConfiguration().Diagnostics.Should().ContainSingle(
+            diagnostic => diagnostic.Code == SecurityDiagnosticCodes.EngineConstructionCallback);
+
+        static void ConfigureFirstParty(Engine _)
+        {
+        }
+    }
+
+    [Fact]
+    public void ConstraintFactoriesAreNotInvokedByDiagnostics()
+    {
+        var calls = 0;
+        var options = CreateSafeOptions().Constraint(() =>
+        {
+            calls++;
+            return new NoOpConstraint();
+        });
+
+        options.ValidateSecurityConfiguration();
+        calls.Should().Be(0);
+
+        var engine = new Engine(options);
+        engine.Advanced.ValidateSecurityConfiguration();
+        calls.Should().Be(1);
+    }
+
+    [Fact]
+    public void SharedOptionsProduceDeterministicReportsAcrossConcurrentEngines()
+    {
+        var options = CreateSafeOptions();
+        var reports = new string[16];
+
+        Parallel.For(0, reports.Length, index =>
+        {
+            var engine = new Engine(options);
+            reports[index] = string.Join(",", engine.Advanced.ValidateSecurityConfiguration()
+                .Diagnostics.Select(static diagnostic => diagnostic.Code));
+        });
+
+        reports.Should().OnlyContain(static report => report.Length == 0);
+    }
+
+    [Fact]
+    public void ReportsDoNotRetainOptionsEnginesCallbacksOrHostState()
+    {
+        var references = CreateCollectibleReport();
+
+        ForceCollection();
+
+        references.Options.IsAlive.Should().BeFalse();
+        references.Engine.IsAlive.Should().BeFalse();
+        references.HostState.IsAlive.Should().BeFalse();
+        references.Report.Diagnostics.Should().ContainSingle(
+            diagnostic => diagnostic.Code == SecurityDiagnosticCodes.EngineConstructionCallback);
+    }
+
+    [Fact]
+    public void DiagnosticTextDoesNotEchoSensitiveConfigurationValues()
+    {
+        const string secret = "/private/customer/acme-token";
+        var options = CreateSafeModuleOptions();
+        var policy = new ModuleAllowlistPolicy();
+        policy.AllowedFileRoots.Add(secret);
+        options.Modules.LoadPolicy = policy;
+        options.Interop.ClrExceptionErrorDecorator = static (_, _, _) => { };
+
+        var rendered = string.Join(
+            "\n",
+            options.ValidateSecurityConfiguration().Diagnostics.Select(
+                static diagnostic => diagnostic.Message + "\n" + diagnostic.Guidance));
+
+        rendered.Should().NotContain(secret);
+        rendered.Should().NotContain(nameof(SecretHostState));
+    }
+
+    private static Options CreateSafeOptions()
+    {
+        var options = CreateBaseOptions();
+        options.MaxStatements(100_000);
+        options.LimitMemory(4_000_000);
+        options.TimeoutInterval(TimeSpan.FromSeconds(2));
+        return options;
+    }
+
+    private static Options CreateWithoutStatementLimit()
+    {
+        var options = CreateBaseOptions();
+        options.LimitMemory(4_000_000);
+        options.TimeoutInterval(TimeSpan.FromSeconds(2));
+        return options;
+    }
+
+    private static Options CreateWithoutMemoryLimit()
+    {
+        var options = CreateBaseOptions();
+        options.MaxStatements(100_000);
+        options.TimeoutInterval(TimeSpan.FromSeconds(2));
+        return options;
+    }
+
+    private static Options CreateWithoutTimeout()
+    {
+        var options = CreateBaseOptions();
+        options.MaxStatements(100_000);
+        options.LimitMemory(4_000_000);
+        return options;
+    }
+
+    private static Options CreateBaseOptions()
+    {
+        var options = new Options
+        {
+            AgentCanSuspend = false
+        };
+
+        options.Constraints.MaxRecursionDepth = 64;
+        options.Constraints.StackOverflowGuard = true;
+        options.Constraints.MaxArraySize = 100_000;
+        options.Constraints.RegexTimeout = TimeSpan.FromSeconds(1);
+        options.Constraints.PromiseTimeout = TimeSpan.FromSeconds(1);
+        options.Parsing.MaxSourceLength = 100_000;
+        options.Parsing.MaxNodeCount = 25_000;
+        options.Interop.AllowWrite = false;
+        options.Interop.ArrayConversion = ArrayConversionMode.Copy;
+        options.Host.StringCompilationAllowed = false;
+        options.ResultLimits = ResultLimits.Conservative;
+        options.CancellationToken(new CancellationTokenSource().Token);
+        options.Constraint(static () => new OperationDeadlineConstraint());
+        return options;
+    }
+
+    private static Options CreateWithoutCancellation()
+    {
+        var options = CreateSafeOptions();
+        options.WithoutConstraint(static constraint => constraint is CancellationConstraint);
+        return options;
+    }
+
+    private static Options CreateWithoutOperationDeadline()
+    {
+        var options = CreateSafeOptions();
+        options.WithoutConstraint(static constraint => constraint is OperationDeadlineConstraint);
+        return options;
+    }
+
+    private static Options CreateSafeModuleOptions()
+    {
+        var options = CreateSafeOptions().EnableModules(new EmptyModuleLoader());
+        options.Modules.MaxModuleCount = 100;
+        options.Modules.MaxTotalModuleSourceBytes = 1_000_000;
+        options.Modules.MaxModuleGraphDepth = 20;
+        options.Modules.MaxModuleResolutionHops = 100;
+        var policy = new ModuleAllowlistPolicy();
+        policy.AllowedSchemes.Add("https");
+        policy.AllowedHosts.Add("modules.example.invalid");
+        options.Modules.LoadPolicy = policy;
+        return options;
+    }
+
+    private static Options CreateWithRestrictiveClr()
+    {
+        var options = CreateSafeOptions().AllowClr(Array.Empty<System.Reflection.Assembly>());
+        options.Interop.TypeResolver = new TypeResolver
+        {
+            MemberFilter = static _ => false
+        };
+        return options;
+    }
+
+    private static Options CreateSchemeOnlyModuleOptions()
+    {
+        var options = CreateSafeModuleOptions();
+        var policy = new ModuleAllowlistPolicy();
+        policy.AllowedSchemes.Add("file");
+        options.Modules.LoadPolicy = policy;
+        return options;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static CollectibleReport CreateCollectibleReport()
+    {
+        var state = new SecretHostState();
+        var options = CreateSafeOptions().Configure(_ => GC.KeepAlive(state));
+        var engine = new Engine(options);
+        var report = engine.Advanced.ValidateSecurityConfiguration();
+        return new CollectibleReport(
+            new WeakReference(options),
+            new WeakReference(engine),
+            new WeakReference(state),
+            report);
+    }
+
+    private static void ForceCollection()
+    {
+        for (var i = 0; i < 3; i++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+        }
+    }
+
+    private static Options Change(Options options, Action<Options> change)
+    {
+        change(options);
+        return options;
+    }
+
+    private static SecurityDiagnosticSeverity ExpectedSeverity(string code) => code switch
+    {
+        SecurityDiagnosticCodes.ModuleLoadingEnabled
+            or SecurityDiagnosticCodes.RequireWithoutModuleLoader
+            or SecurityDiagnosticCodes.RegexTimeoutLong
+            or SecurityDiagnosticCodes.PromiseTimeoutLong
+            or SecurityDiagnosticCodes.SharedConstraintInstance
+            or SecurityDiagnosticCodes.DetailedClrErrorsEnabled
+            or SecurityDiagnosticCodes.FunctionSourceRetentionEnabled
+            or SecurityDiagnosticCodes.ModulePerLoadLimitsReset
+            or SecurityDiagnosticCodes.ClrExceptionChainingEnabled
+            or SecurityDiagnosticCodes.ClrErrorDecoratorConfigured
+            or SecurityDiagnosticCodes.ClrCallbackConfigured => SecurityDiagnosticSeverity.Warning,
+        _ => SecurityDiagnosticSeverity.Error
+    };
+
+    private sealed class NoOpConstraint : Constraint
+    {
+        public override void Check()
+        {
+        }
+
+        public override void Reset()
+        {
+        }
+    }
+
+    private sealed class EmptyModuleLoader : ModuleLoader
+    {
+        public override ResolvedSpecifier Resolve(string? referencingModuleLocation, ModuleRequest moduleRequest)
+            => new(moduleRequest, moduleRequest.Specifier, Uri: null, SpecifierType.Bare);
+
+        protected override string LoadModuleContents(Engine engine, ResolvedSpecifier resolved) => string.Empty;
+    }
+
+    private sealed class PassThroughTypeConverter : ITypeConverter
+    {
+        public object? Convert(object? value, Type type, IFormatProvider formatProvider) => value;
+
+        public bool TryConvert(
+            object? value,
+            Type type,
+            IFormatProvider formatProvider,
+            [NotNullWhen(true)] out object? converted)
+        {
+            converted = value;
+            return converted is not null;
+        }
+    }
+
+    private sealed class SecretHostState;
+
+    private sealed record CollectibleReport(
+        WeakReference Options,
+        WeakReference Engine,
+        WeakReference HostState,
+        SecurityConfigurationReport Report);
+}
+
+internal static class SecurityConfigurationUnsafeExtensions
+{
+    public static string ReadSecret(this string value) => value;
+}

--- a/Jint.Tests/Runtime/SecurityConfigurationInternalsTests.cs
+++ b/Jint.Tests/Runtime/SecurityConfigurationInternalsTests.cs
@@ -1,0 +1,45 @@
+using Jint.Constraints;
+
+namespace Jint.Tests.Runtime;
+
+public class SecurityConfigurationInternalsTests
+{
+    [Fact]
+    public void FirstPartyConfigurationHasUnspoofableDiagnosticProvenance()
+    {
+        var callbackCount = 0;
+        var options = CreateSafeOptions().ConfigureFirstParty(engine =>
+        {
+            callbackCount++;
+            engine.Options.Strict = true;
+        });
+
+        options.ValidateSecurityConfiguration().Diagnostics.Should().BeEmpty();
+
+        var engine = new Engine(options);
+
+        callbackCount.Should().Be(1);
+        engine.Advanced.ValidateSecurityConfiguration().Diagnostics.Should().BeEmpty();
+    }
+
+    private static Options CreateSafeOptions()
+    {
+        var options = new Options()
+            .MaxStatements(100_000)
+            .LimitMemory(4_000_000)
+            .TimeoutInterval(TimeSpan.FromSeconds(2))
+            .CancellationToken(new CancellationTokenSource().Token)
+            .Constraint(static () => new OperationDeadlineConstraint())
+            .LimitRecursion(64)
+            .MaxArraySize(100_000)
+            .RegexTimeoutInterval(TimeSpan.FromSeconds(1))
+            .DisableStringCompilation()
+            .AllowClrWrite(false);
+
+        options.Constraints.PromiseTimeout = TimeSpan.FromSeconds(1);
+        options.Parsing.MaxSourceLength = 100_000;
+        options.Parsing.MaxNodeCount = 25_000;
+        options.ResultLimits = ResultLimits.Conservative;
+        return options;
+    }
+}

--- a/Jint/Constraints/ConstraintsOptionsExtensions.cs
+++ b/Jint/Constraints/ConstraintsOptionsExtensions.cs
@@ -47,6 +47,7 @@ public static class ConstraintsOptionsExtensions
     public static Options MaxStatements(this Options options, int maxStatements = 0)
     {
         options.WithoutConstraint(x => x is MaxStatementsConstraint);
+        options.Constraints.RequestedMaxStatements = maxStatements;
 
         if (maxStatements > 0 && maxStatements < int.MaxValue)
         {
@@ -72,6 +73,7 @@ public static class ConstraintsOptionsExtensions
     public static Options LimitMemory(this Options options, long memoryLimit)
     {
         options.WithoutConstraint(x => x is MemoryLimitConstraint);
+        options.Constraints.RequestedMemoryLimit = memoryLimit;
 
         if (memoryLimit > 0 && memoryLimit < long.MaxValue)
         {
@@ -95,6 +97,7 @@ public static class ConstraintsOptionsExtensions
     public static Options TimeoutInterval(this Options options, TimeSpan timeoutInterval)
     {
         options.WithoutConstraint(x => x is TimeConstraint);
+        options.Constraints.RequestedTimeoutInterval = timeoutInterval;
 
         if (timeoutInterval > TimeSpan.Zero && timeoutInterval < TimeSpan.MaxValue)
         {
@@ -116,6 +119,7 @@ public static class ConstraintsOptionsExtensions
     public static Options CancellationToken(this Options options, CancellationToken cancellationToken)
     {
         options.WithoutConstraint(x => x is CancellationConstraint);
+        options.Constraints.CancellationConstraintRequested = cancellationToken != default;
 
         if (cancellationToken != default)
         {

--- a/Jint/Engine.Advanced.cs
+++ b/Jint/Engine.Advanced.cs
@@ -99,6 +99,20 @@ public partial class Engine
         }
 
         /// <summary>
+        /// Inspects the effective security configuration after engine-construction callbacks have run.
+        /// </summary>
+        /// <remarks>
+        /// The callbacks are not replayed. Constraint factories are inspected through the instances this engine
+        /// already created, so the report neither invokes user code nor changes runtime policy.
+        /// </remarks>
+        public SecurityConfigurationReport ValidateSecurityConfiguration(
+            SecurityConfigurationPolicy policy = SecurityConfigurationPolicy.UntrustedScripts)
+        {
+            using var ownership = _engine.EnterHostCall();
+            return OptionsSecurityExtensions.CreateEngineReport(_engine, policy);
+        }
+
+        /// <summary>
         /// EXPERIMENTAL! Subject to change.
         ///
         /// Registers a promise within the currently running EventLoop (has to be called within "ExecuteWithEventLoop" call).

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -843,6 +843,9 @@ public sealed partial class Engine : IDisposable
     // track depth at all from the same value (see the JintCallStack construction below).
     internal readonly int _maxRecursionDepth;
 
+    internal Constraint[] ActiveConstraintsForSecurityDiagnostics => _constraints;
+    internal readonly EngineSecurityConfigurationSnapshot _securityConfigurationSnapshot;
+
     // Snapshot of Options.Interop.AllowOperatorOverloading, consulted by the arithmetic, comparison,
     // update and assignment expressions to decide whether an operand may have a CLR operator behind
     // it. Like _maxRecursionDepth it is read after Options.Apply, so a Configure callback can still
@@ -1059,6 +1062,7 @@ public sealed partial class Engine : IDisposable
         _parsingConstraints = ParsingConstraints.From(Options.Parsing);
         _defaultParserOptions = scriptParsingDefaults.GetParserOptions(Options);
         _defaultParser = JintParser.Create(_defaultParserOptions, in _parsingConstraints);
+        _securityConfigurationSnapshot = EngineSecurityConfigurationSnapshot.Capture(this);
     }
 
     private static void ValidateModuleOptions(Options.ModuleOptions modules)

--- a/Jint/Options.Extensions.cs
+++ b/Jint/Options.Extensions.cs
@@ -282,7 +282,9 @@ public static class OptionsExtensions
     /// </summary>
     public static Options SetTypeConverter(this Options options, Func<Engine, ITypeConverter> typeConverterFactory)
     {
-        options._configurations.Add(engine => engine.TypeConverter = typeConverterFactory(engine));
+        options._configurations.Add(new EngineConfiguration(
+            engine => engine.TypeConverter = typeConverterFactory(engine),
+            EngineConfigurationProvenance.User));
         return options;
     }
 
@@ -308,7 +310,11 @@ public static class OptionsExtensions
     /// </summary>
     public static Options AllowClr(this Options options)
     {
-        return options.AllowClr(typeof(object).Assembly);
+        options.Interop.Enabled = true;
+        options.Interop.ClrAccessConfiguration = ClrAccessConfiguration.Compatibility;
+        options.Interop.AllowedAssemblies.Add(typeof(object).Assembly);
+        options.Interop.AllowedAssemblies = options.Interop.AllowedAssemblies.Distinct().ToList();
+        return options;
     }
 
     /// <summary>
@@ -322,6 +328,7 @@ public static class OptionsExtensions
     public static Options AllowClr(this Options options, params Assembly[] assemblies)
     {
         options.Interop.Enabled = true;
+        options.Interop.ClrAccessConfiguration = ClrAccessConfiguration.Explicit;
         options.Interop.AllowedAssemblies.AddRange(assemblies);
         options.Interop.AllowedAssemblies = options.Interop.AllowedAssemblies.Distinct().ToList();
         return options;
@@ -443,6 +450,7 @@ public static class OptionsExtensions
         if (constraint != null)
         {
             options.Constraints.Constraints.Add(constraint);
+            options.Constraints.OperationDeadlineConstraintRequested |= constraint is Constraints.OperationDeadlineConstraint;
         }
 
         return options;
@@ -473,6 +481,22 @@ public static class OptionsExtensions
     }
 
     /// <summary>
+    /// Registers a typed constraint factory while preserving the declared constraint kind for configuration
+    /// diagnostics. The factory is still invoked exactly once per engine and is never invoked by diagnostics.
+    /// </summary>
+    public static Options Constraint<TConstraint>(this Options options, Func<TConstraint> constraintFactory)
+        where TConstraint : Constraint
+    {
+        if (constraintFactory is not null)
+        {
+            options.Constraints.ConstraintFactories.Add(() => constraintFactory());
+            options.Constraints.OperationDeadlineConstraintRequested |= typeof(TConstraint) == typeof(Constraints.OperationDeadlineConstraint);
+        }
+
+        return options;
+    }
+
+    /// <summary>
     /// Removes every registered constraint matching <paramref name="predicate"/>.
     /// </summary>
     /// <remarks>
@@ -486,12 +510,68 @@ public static class OptionsExtensions
     /// </remarks>
     public static Options WithoutConstraint(this Options options, Predicate<Constraint> predicate)
     {
-        options.Constraints.Constraints.RemoveAll(predicate);
+        var removedMaxStatements = false;
+        var removedMemoryLimit = false;
+        var removedTimeout = false;
+        var removedCancellation = false;
+        var removedOperationDeadline = false;
+
+        void RecordRemoval(Constraint constraint)
+        {
+            removedMaxStatements |= constraint is Constraints.MaxStatementsConstraint;
+            removedMemoryLimit |= constraint is Constraints.MemoryLimitConstraint;
+            removedTimeout |= constraint is Constraints.TimeConstraint;
+            removedCancellation |= constraint is Constraints.CancellationConstraint;
+            removedOperationDeadline |= constraint is Constraints.OperationDeadlineConstraint;
+        }
+
+        options.Constraints.Constraints.RemoveAll(constraint =>
+        {
+            if (!predicate(constraint))
+            {
+                return false;
+            }
+
+            RecordRemoval(constraint);
+            return true;
+        });
         options.Constraints.ConstraintFactories.RemoveAll(factory =>
         {
             var probe = factory();
-            return probe is not null && predicate(probe);
+            if (probe is null || !predicate(probe))
+            {
+                return false;
+            }
+
+            RecordRemoval(probe);
+            return true;
         });
+
+        if (removedMaxStatements)
+        {
+            options.Constraints.RequestedMaxStatements = null;
+        }
+
+        if (removedMemoryLimit)
+        {
+            options.Constraints.RequestedMemoryLimit = null;
+        }
+
+        if (removedTimeout)
+        {
+            options.Constraints.RequestedTimeoutInterval = null;
+        }
+
+        if (removedCancellation)
+        {
+            options.Constraints.CancellationConstraintRequested = false;
+        }
+
+        if (removedOperationDeadline)
+        {
+            options.Constraints.OperationDeadlineConstraintRequested = false;
+        }
+
         return options;
     }
 
@@ -667,9 +747,11 @@ public static class OptionsExtensions
             Throw.ArgumentNullException(nameof(valueFactory));
         }
 
-        options._configurations.Add(engine => engine.Realm.GlobalObject.SetProperty(
-            name,
-            new LazyPropertyDescriptor<Engine>(engine, valueFactory, flags)));
+        options._configurations.Add(new EngineConfiguration(
+            engine => engine.Realm.GlobalObject.SetProperty(
+                name,
+                new LazyPropertyDescriptor<Engine>(engine, valueFactory, flags)),
+            EngineConfigurationProvenance.FirstParty));
 
         return options;
     }
@@ -682,7 +764,13 @@ public static class OptionsExtensions
     /// <param name="configuration">The action to register.</param>
     public static Options Configure(this Options options, Action<Engine> configuration)
     {
-        options._configurations.Add(configuration);
+        options._configurations.Add(new EngineConfiguration(configuration, EngineConfigurationProvenance.User));
+        return options;
+    }
+
+    internal static Options ConfigureFirstParty(this Options options, Action<Engine> configuration)
+    {
+        options._configurations.Add(new EngineConfiguration(configuration, EngineConfigurationProvenance.FirstParty));
         return options;
     }
 
@@ -694,6 +782,7 @@ public static class OptionsExtensions
     /// </remarks>
     public static Options UseHostFactory<T>(this Options options, Func<Engine, T> factory) where T : Host
     {
+        options.HasUserHostFactory = true;
         options.Host.Factory = factory;
         return options;
     }

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -23,7 +23,11 @@ public partial class Options
     private static readonly TimeZoneInfo _defaultTimeZone = TimeZoneInfo.Local;
 
     private ITimeSystem? _timeSystem;
-    internal List<Action<Engine>> _configurations { get; } = new();
+    internal List<EngineConfiguration> _configurations { get; } = new();
+    internal bool HasUserHostFactory { get; set; }
+    internal bool HasUserEngineConstructionCallback =>
+        HasUserHostFactory
+        || _configurations.Exists(static configuration => configuration.Provenance == EngineConfigurationProvenance.User);
 
     public delegate JsValue? MemberAccessorDelegate(Engine engine, object target, string member);
 
@@ -245,7 +249,7 @@ public partial class Options
 
         foreach (var configuration in _configurations)
         {
-            configuration(engine);
+            configuration.Apply(engine);
         }
 
         // add missing bits if needed
@@ -429,6 +433,8 @@ public partial class Options
         /// </summary>
         public bool Enabled { get; set; }
 
+        internal ClrAccessConfiguration ClrAccessConfiguration { get; set; }
+
         /// <summary>
         /// Whether to expose instance <see cref="object.GetType"/> members and the type-widening operations
         /// <c>clrHelper.unwrap</c>, <c>typeOf</c>, <c>typeToObject</c>, and <c>objectToType</c>. Defaults to false.
@@ -559,7 +565,10 @@ public partial class Options
         /// ObjectInstance using class ObjectWrapper. This function can be used to
         /// change the behavior.
         /// </summary>
-        public WrapObjectDelegate WrapObjectHandler { get; set; } = static (engine, target, type) => ObjectWrapper.Create(engine, target, type);
+        internal static readonly WrapObjectDelegate _defaultWrapObjectHandler =
+            static (engine, target, type) => ObjectWrapper.Create(engine, target, type);
+
+        public WrapObjectDelegate WrapObjectHandler { get; set; } = _defaultWrapObjectHandler;
 
         /// <summary>
         /// The handler used to build stack traces. Changing this enables mapping
@@ -678,13 +687,19 @@ public partial class Options
         /// <summary>
         /// Strategy to create a CLR object to hold converted <see cref="ObjectInstance"/>.
         /// </summary>
-        public Func<ObjectInstance, IDictionary<string, object?>>? CreateClrObject { get; set; } = _ => new ExpandoObject();
+        internal static readonly Func<ObjectInstance, IDictionary<string, object?>> _defaultCreateClrObject =
+            static _ => new ExpandoObject();
+
+        public Func<ObjectInstance, IDictionary<string, object?>>? CreateClrObject { get; set; } = _defaultCreateClrObject;
 
         /// <summary>
         /// Strategy to create a CLR object from TypeReference.
         /// Defaults to retuning null which makes TypeReference attempt to find suitable constructor.
         /// </summary>
-        public Func<Engine, Type, JsValue[], object?> CreateTypeReferenceObject { get; set; } = (_, _, _) => null;
+        internal static readonly Func<Engine, Type, JsValue[], object?> _defaultCreateTypeReferenceObject =
+            static (_, _, _) => null;
+
+        public Func<Engine, Type, JsValue[], object?> CreateTypeReferenceObject { get; set; } = _defaultCreateTypeReferenceObject;
 
         internal static readonly ExceptionHandlerDelegate _defaultExceptionHandler = static exception => false;
 
@@ -771,7 +786,9 @@ public partial class Options
         /// resolvable through the wrapper's normal member/indexer access for their values to be readable.
         /// Defaults to returning <c>null</c>.
         /// </summary>
-        public ReportedPropertyKeysDelegate ObjectWrapperReportedPropertyKeys { get; set; } = static (_, _) => null;
+        internal static readonly ReportedPropertyKeysDelegate _defaultReportedPropertyKeys = static (_, _) => null;
+
+        public ReportedPropertyKeysDelegate ObjectWrapperReportedPropertyKeys { get; set; } = _defaultReportedPropertyKeys;
     }
 
     public class ConstraintOptions
@@ -795,6 +812,16 @@ public partial class Options
         /// belong to that engine alone.
         /// </summary>
         internal List<Func<Constraint>> ConstraintFactories { get; } = new();
+
+        internal int? RequestedMaxStatements { get; set; }
+
+        internal long? RequestedMemoryLimit { get; set; }
+
+        internal TimeSpan? RequestedTimeoutInterval { get; set; }
+
+        internal bool CancellationConstraintRequested { get; set; }
+
+        internal bool OperationDeadlineConstraintRequested { get; set; }
 
         /// <summary>
         /// Maximum recursion depth allowed, defaults to -1 (no checks).
@@ -953,7 +980,9 @@ public partial class Options
         /// - For object methods and getters/setters, a node of type <see cref="ObjectProperty"/> is passed
         ///   since <c>toString()</c> should include the <c>get</c> or <c>set</c> tokens for getters/setters and the member name as per specification.
         /// </remarks>
-        public Func<Function, Node, string?> FunctionToStringHandler { get; set; } = (_, _) => null;
+        internal static readonly Func<Function, Node, string?> _defaultFunctionToStringHandler = static (_, _) => null;
+
+        public Func<Function, Node, string?> FunctionToStringHandler { get; set; } = _defaultFunctionToStringHandler;
     }
 
     /// <summary>
@@ -1162,6 +1191,24 @@ public enum EnumConversionMode
     /// a value that has no name. Values converted back to the CLR keep accepting both the name and the number.
     /// </summary>
     String,
+}
+
+[System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
+internal readonly record struct EngineConfiguration(
+    Action<Engine> Apply,
+    EngineConfigurationProvenance Provenance);
+
+internal enum EngineConfigurationProvenance
+{
+    FirstParty,
+    User
+}
+
+internal enum ClrAccessConfiguration
+{
+    None,
+    Compatibility,
+    Explicit
 }
 
 /// <summary>

--- a/Jint/Runtime/Modules/DefaultModuleLoader.cs
+++ b/Jint/Runtime/Modules/DefaultModuleLoader.cs
@@ -5,6 +5,8 @@ public class DefaultModuleLoader : ModuleLoader
     private readonly Uri _basePath;
     private readonly bool _restrictToBasePath;
 
+    internal bool RestrictsToBasePath => _restrictToBasePath;
+
     public DefaultModuleLoader(string basePath, bool restrictToBasePath = true)
     {
         if (string.IsNullOrWhiteSpace(basePath))

--- a/Jint/Runtime/Modules/ModuleAllowlistPolicy.cs
+++ b/Jint/Runtime/Modules/ModuleAllowlistPolicy.cs
@@ -68,9 +68,14 @@ public sealed class ModuleAllowlistPolicy : IModuleLoadPolicy
     /// </summary>
     public bool AllowBareSpecifiers { get; set; }
 
-    private bool HasAnyRestriction =>
+    internal bool HasAnyRestriction =>
         AllowedSchemes.Count > 0
         || AllowedHosts.Count > 0
+        || AllowedOrigins.Count > 0
+        || AllowedFileRoots.Count > 0;
+
+    internal bool HasDestinationBoundary =>
+        AllowedHosts.Count > 0
         || AllowedOrigins.Count > 0
         || AllowedFileRoots.Count > 0;
 

--- a/Jint/SecurityConfiguration.cs
+++ b/Jint/SecurityConfiguration.cs
@@ -1,0 +1,960 @@
+using System.Collections.ObjectModel;
+using System.Text;
+using Jint.Constraints;
+using Jint.Runtime;
+using Jint.Runtime.CallStack;
+using Jint.Runtime.Debugger;
+using Jint.Runtime.Interop;
+using Jint.Runtime.Modules;
+
+namespace Jint;
+
+/// <summary>
+/// A security policy evaluated against Jint configuration.
+/// </summary>
+public enum SecurityConfigurationPolicy
+{
+    /// <summary>Checks controls relevant to untrusted script source.</summary>
+    UntrustedScripts = 0
+}
+
+[System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
+internal readonly record struct EngineSecurityConfigurationSnapshot(
+    bool DebuggerEnabled,
+    bool ClrEnabled,
+    bool AllowGetType,
+    bool AllowSystemReflection,
+    bool DetailedClrResolutionErrors,
+    int? MaxSourceLength,
+    int? MaxNodeCount,
+    bool RetainFunctionSourceText,
+    TimeSpan RegexTimeout,
+    int MaxRecursionDepth,
+    bool StackOverflowGuard,
+    int MaxExecutionStackCount,
+    bool ClrCompatibilityMode,
+    bool ClrPolicyUnrestricted,
+    bool ExtensionMethodsConfigured)
+{
+    internal static EngineSecurityConfigurationSnapshot Capture(Engine engine)
+    {
+        var interop = engine.Options.Interop;
+        return new EngineSecurityConfigurationSnapshot(
+            engine._isDebugMode,
+            interop.Enabled,
+            interop.AllowGetType,
+            interop.AllowSystemReflection,
+            interop.ExposeDetailedResolutionErrors,
+            engine.Options.Parsing.MaxSourceLength,
+            engine.Options.Parsing.MaxNodeCount,
+            engine.Options.RetainFunctionSourceText,
+            engine.Options.Constraints.RegexTimeout,
+            engine._maxRecursionDepth,
+            engine.Options.Constraints.StackOverflowGuard,
+            engine.Options.Constraints.MaxExecutionStackCount,
+            interop.Enabled && interop.ClrAccessConfiguration == ClrAccessConfiguration.Compatibility,
+            interop.Enabled && ReferenceEquals(interop.TypeResolver, TypeResolver.Default),
+            !ReferenceEquals(
+                engine._extensionMethods,
+                Runtime.Interop.Reflection.ExtensionMethodCache.Empty));
+    }
+}
+
+/// <summary>
+/// The severity of a <see cref="SecurityDiagnostic"/>.
+/// </summary>
+public enum SecurityDiagnosticSeverity
+{
+    /// <summary>The host must review or compensate for the setting.</summary>
+    Warning = 0,
+
+    /// <summary>A required control is absent or an unsafe capability is enabled.</summary>
+    Error = 1
+}
+
+/// <summary>
+/// Stable machine-readable security diagnostic codes.
+/// </summary>
+public static class SecurityDiagnosticCodes
+{
+    public const string StatementLimitMissing = "JINTSEC001";
+    public const string StatementLimitNonPositive = "JINTSEC002";
+    public const string StatementLimitSaturated = "JINTSEC003";
+    public const string MemoryLimitMissing = "JINTSEC004";
+    public const string MemoryLimitNonPositive = "JINTSEC005";
+    public const string MemoryLimitSaturated = "JINTSEC006";
+    public const string TimeoutMissing = "JINTSEC007";
+    public const string TimeoutNonPositive = "JINTSEC008";
+    public const string TimeoutSaturated = "JINTSEC009";
+    public const string RecursionLimitDisabled = "JINTSEC010";
+    public const string RecursionLimitSaturated = "JINTSEC011";
+    public const string StackOverflowGuardDisabled = "JINTSEC012";
+    public const string StackOverflowGuardShadowed = "JINTSEC013";
+    public const string AgentSuspensionEnabled = "JINTSEC014";
+    public const string ClrAccessEnabled = "JINTSEC015";
+    public const string GetTypeEnabled = "JINTSEC016";
+    public const string SystemReflectionEnabled = "JINTSEC017";
+    public const string ClrWriteEnabled = "JINTSEC018";
+    public const string LiveClrArraysEnabled = "JINTSEC019";
+    public const string StringCompilationEnabled = "JINTSEC020";
+    public const string ModuleLoadingEnabled = "JINTSEC021";
+    public const string RequireWithoutModuleLoader = "JINTSEC022";
+    public const string DebuggerEnabled = "JINTSEC023";
+    public const string ArraySizeUnlimited = "JINTSEC024";
+    public const string RegexTimeoutUnbounded = "JINTSEC025";
+    public const string RegexTimeoutLong = "JINTSEC026";
+    public const string PromiseTimeoutUnbounded = "JINTSEC027";
+    public const string PromiseTimeoutLong = "JINTSEC028";
+    public const string SharedConstraintInstance = "JINTSEC029";
+    public const string DetailedClrErrorsEnabled = "JINTSEC030";
+    public const string EngineConstructionCallback = "JINTSEC031";
+    public const string RegexTimeoutExcessive = "JINTSEC032";
+    public const string RegexTimeoutOverrideUnbounded = "JINTSEC033";
+    public const string RegexTimeoutOverrideLong = "JINTSEC034";
+    public const string RegexTimeoutOverrideExcessive = "JINTSEC035";
+    public const string CancellationMissing = "JINTSEC036";
+    public const string OperationDeadlineMissing = "JINTSEC037";
+    public const string ParserSourceLengthUnlimited = "JINTSEC038";
+    public const string ParserNodeCountUnlimited = "JINTSEC039";
+    public const string FunctionSourceRetentionEnabled = "JINTSEC040";
+    public const string ModuleCountUnlimited = "JINTSEC041";
+    public const string ModuleSourceBytesUnlimited = "JINTSEC042";
+    public const string ModuleGraphDepthUnlimited = "JINTSEC043";
+    public const string ModuleResolutionHopsUnlimited = "JINTSEC044";
+    public const string ModuleDestinationPolicyMissing = "JINTSEC045";
+    public const string ModulePerLoadLimitsReset = "JINTSEC046";
+    public const string ResultLimitsUnlimited = "JINTSEC047";
+    public const string DetailedClrExceptionMessagesEnabled = "JINTSEC048";
+    public const string ClrExceptionChainingEnabled = "JINTSEC049";
+    public const string DetailedModuleErrorsEnabled = "JINTSEC050";
+    public const string ClrErrorDecoratorConfigured = "JINTSEC051";
+    public const string ClrCallbackConfigured = "JINTSEC052";
+    public const string ClrCompatibilityModeEnabled = "JINTSEC053";
+    public const string ClrPolicyUnrestricted = "JINTSEC054";
+    public const string LiveClrArrayWritesEnabled = "JINTSEC055";
+    public const string ModuleAllowlistInsufficient = "JINTSEC056";
+    public const string ClrExtensionMethodsConfigured = "JINTSEC057";
+}
+
+/// <summary>
+/// One security-relevant observation.
+/// </summary>
+public sealed class SecurityDiagnostic
+{
+    internal SecurityDiagnostic(string code, SecurityDiagnosticSeverity severity, string message, string guidance)
+    {
+        Code = code;
+        Severity = severity;
+        Message = message;
+        Guidance = guidance;
+    }
+
+    public string Code { get; }
+
+    public SecurityDiagnosticSeverity Severity { get; }
+
+    /// <remarks>Use <see cref="Code"/>, not this text, for policy decisions.</remarks>
+    public string Message { get; }
+
+    /// <remarks>Use <see cref="Code"/>, not this text, for policy decisions.</remarks>
+    public string Guidance { get; }
+
+    public override string ToString() => $"{Code} {Severity}: {Message}";
+}
+
+/// <summary>
+/// An immutable, deterministically ordered security validation result.
+/// </summary>
+public sealed class SecurityConfigurationReport
+{
+    internal SecurityConfigurationReport(List<SecurityDiagnostic> diagnostics)
+    {
+        Diagnostics = new ReadOnlyCollection<SecurityDiagnostic>(diagnostics);
+        HasErrors = diagnostics.Exists(static diagnostic => diagnostic.Severity == SecurityDiagnosticSeverity.Error);
+        HasWarnings = diagnostics.Exists(static diagnostic => diagnostic.Severity == SecurityDiagnosticSeverity.Warning);
+    }
+
+    public IReadOnlyList<SecurityDiagnostic> Diagnostics { get; }
+
+    public bool HasErrors { get; }
+
+    public bool HasWarnings { get; }
+}
+
+/// <summary>
+/// Thrown when security configuration validation finds an error.
+/// </summary>
+public sealed class SecurityConfigurationException : InvalidOperationException
+{
+    internal SecurityConfigurationException(SecurityConfigurationReport report)
+        : base(CreateMessage(report))
+    {
+        Report = report;
+    }
+
+    public SecurityConfigurationReport Report { get; }
+
+    private static string CreateMessage(SecurityConfigurationReport report)
+    {
+        var builder = new StringBuilder("The Jint options do not satisfy the requested security policy:");
+        foreach (var diagnostic in report.Diagnostics)
+        {
+            if (diagnostic.Severity == SecurityDiagnosticSeverity.Error)
+            {
+                builder.Append(' ').Append(diagnostic.Code).Append('.');
+            }
+        }
+
+        return builder.ToString();
+    }
+}
+
+/// <summary>
+/// Security diagnostics for Jint configuration.
+/// </summary>
+public static class OptionsSecurityExtensions
+{
+    private static readonly TimeSpan MaximumRecommendedWait = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan MaximumAllowedRegexTimeout = TimeSpan.FromDays(365);
+
+    /// <summary>
+    /// Inspects configured options without constructing an engine or invoking callbacks or factories.
+    /// </summary>
+    public static SecurityConfigurationReport ValidateSecurityConfiguration(
+        this Options options,
+        SecurityConfigurationPolicy policy = SecurityConfigurationPolicy.UntrustedScripts)
+    {
+        ArgumentNull(options, nameof(options));
+        return CreateReport(CreateOptionsDiagnostics(options!, policy));
+    }
+
+    /// <summary>
+    /// Inspects engine options together with explicit parsing options that override parser defaults.
+    /// </summary>
+    public static SecurityConfigurationReport ValidateSecurityConfiguration(
+        this Options options,
+        IParsingOptions parsingOptions,
+        SecurityConfigurationPolicy policy = SecurityConfigurationPolicy.UntrustedScripts)
+    {
+        ArgumentNull(options, nameof(options));
+        ArgumentNull(parsingOptions, nameof(parsingOptions));
+
+        var diagnostics = CreateOptionsDiagnostics(
+            options!,
+            policy,
+            includeParsing: false,
+            includeEngineRegex: !parsingOptions!.RegexTimeout.HasValue);
+        if (parsingOptions.RegexTimeout.HasValue)
+        {
+            AddRegexOverride(parsingOptions.RegexTimeout.Value, diagnostics);
+        }
+
+        var limits = parsingOptions as IParsingLimitOptions;
+        AddParsing(
+            Minimum(options.Parsing.MaxSourceLength, limits?.MaxSourceLength),
+            Minimum(options.Parsing.MaxNodeCount, limits?.MaxNodeCount),
+            parsingOptions.RetainFunctionSourceText,
+            diagnostics);
+        return CreateReport(diagnostics);
+    }
+
+    /// <summary>Inspects script preparation options.</summary>
+    public static SecurityConfigurationReport ValidateSecurityConfiguration(
+        this ScriptPreparationOptions options,
+        SecurityConfigurationPolicy policy = SecurityConfigurationPolicy.UntrustedScripts)
+    {
+        ArgumentNull(options, nameof(options));
+        return CreatePreparationReport(options!.ParsingOptions, policy);
+    }
+
+    /// <summary>Inspects module preparation options.</summary>
+    public static SecurityConfigurationReport ValidateSecurityConfiguration(
+        this ModulePreparationOptions options,
+        SecurityConfigurationPolicy policy = SecurityConfigurationPolicy.UntrustedScripts)
+    {
+        ArgumentNull(options, nameof(options));
+        return CreatePreparationReport(options!.ParsingOptions, policy);
+    }
+
+    public static Options EnsureSecurityConfiguration(
+        this Options options,
+        SecurityConfigurationPolicy policy = SecurityConfigurationPolicy.UntrustedScripts)
+    {
+        ThrowIfErrors(options.ValidateSecurityConfiguration(policy));
+        return options;
+    }
+
+    public static Options EnsureSecurityConfiguration(
+        this Options options,
+        IParsingOptions parsingOptions,
+        SecurityConfigurationPolicy policy = SecurityConfigurationPolicy.UntrustedScripts)
+    {
+        ThrowIfErrors(options.ValidateSecurityConfiguration(parsingOptions, policy));
+        return options;
+    }
+
+    public static ScriptPreparationOptions EnsureSecurityConfiguration(
+        this ScriptPreparationOptions options,
+        SecurityConfigurationPolicy policy = SecurityConfigurationPolicy.UntrustedScripts)
+    {
+        ThrowIfErrors(options.ValidateSecurityConfiguration(policy));
+        return options;
+    }
+
+    public static ModulePreparationOptions EnsureSecurityConfiguration(
+        this ModulePreparationOptions options,
+        SecurityConfigurationPolicy policy = SecurityConfigurationPolicy.UntrustedScripts)
+    {
+        ThrowIfErrors(options.ValidateSecurityConfiguration(policy));
+        return options;
+    }
+
+    internal static SecurityConfigurationReport CreateEngineReport(
+        Engine engine,
+        SecurityConfigurationPolicy policy)
+    {
+        var diagnostics = CreateOptionsDiagnostics(
+            engine.Options,
+            policy,
+            engineSnapshot: engine._securityConfigurationSnapshot,
+            effectiveModuleLoader: engine.Modules.ModuleLoader);
+        diagnostics.RemoveAll(static diagnostic => IsConstraintCode(diagnostic.Code));
+        AddEffectiveConstraints(engine.ActiveConstraintsForSecurityDiagnostics, diagnostics);
+        return CreateReport(diagnostics);
+    }
+
+    private static List<SecurityDiagnostic> CreateOptionsDiagnostics(
+        Options options,
+        SecurityConfigurationPolicy policy,
+        bool includeParsing = true,
+        bool includeEngineRegex = true,
+        EngineSecurityConfigurationSnapshot? engineSnapshot = null,
+        IModuleLoader? effectiveModuleLoader = null)
+    {
+        ValidatePolicy(policy);
+        var diagnostics = new List<SecurityDiagnostic>();
+        AddLimits(options, diagnostics);
+        if (includeParsing)
+        {
+            AddParsing(
+                engineSnapshot.HasValue ? engineSnapshot.Value.MaxSourceLength : options.Parsing.MaxSourceLength,
+                engineSnapshot.HasValue ? engineSnapshot.Value.MaxNodeCount : options.Parsing.MaxNodeCount,
+                engineSnapshot?.RetainFunctionSourceText ?? options.RetainFunctionSourceText,
+                diagnostics);
+        }
+
+        AddStack(options, engineSnapshot, diagnostics);
+        AddCapabilities(options, engineSnapshot, diagnostics);
+        AddModules(options, effectiveModuleLoader, diagnostics);
+        AddResources(options, includeEngineRegex, engineSnapshot, diagnostics);
+        AddResultLimits(options.ResultLimits, diagnostics);
+        AddConstraintRegistration(options, diagnostics);
+        return diagnostics;
+    }
+
+    private static SecurityConfigurationReport CreatePreparationReport(
+        IParsingOptions parsingOptions,
+        SecurityConfigurationPolicy policy)
+    {
+        ValidatePolicy(policy);
+        var diagnostics = new List<SecurityDiagnostic>();
+        AddRegexOverride(parsingOptions.RegexTimeout ?? Engine.DefaultRegexTimeout, diagnostics);
+        var limits = parsingOptions as IParsingLimitOptions;
+        AddParsing(
+            limits?.MaxSourceLength,
+            limits?.MaxNodeCount,
+            parsingOptions.RetainFunctionSourceText,
+            diagnostics);
+        return CreateReport(diagnostics);
+    }
+
+    private static void AddLimits(Options options, List<SecurityDiagnostic> diagnostics)
+    {
+        var constraints = options.Constraints;
+        AddRequestedLimit(
+            constraints.RequestedMaxStatements,
+            int.MaxValue,
+            SecurityDiagnosticCodes.StatementLimitMissing,
+            SecurityDiagnosticCodes.StatementLimitNonPositive,
+            SecurityDiagnosticCodes.StatementLimitSaturated,
+            "statement-count",
+            diagnostics);
+        AddRequestedLimit(
+            constraints.RequestedMemoryLimit,
+            long.MaxValue,
+            SecurityDiagnosticCodes.MemoryLimitMissing,
+            SecurityDiagnosticCodes.MemoryLimitNonPositive,
+            SecurityDiagnosticCodes.MemoryLimitSaturated,
+            "managed-allocation",
+            diagnostics);
+
+        if (!constraints.RequestedTimeoutInterval.HasValue)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.TimeoutMissing,
+                "No per-entry execution timeout was configured.",
+                "Call TimeoutInterval with a positive finite interval.");
+        }
+        else if (constraints.RequestedTimeoutInterval <= TimeSpan.Zero)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.TimeoutNonPositive,
+                "The requested execution timeout is non-positive and removes the timeout.",
+                "Use a positive execution timeout.");
+        }
+        else if (constraints.RequestedTimeoutInterval == TimeSpan.MaxValue)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.TimeoutSaturated,
+                "The saturated execution timeout removes the timeout.",
+                "Use a finite interval below TimeSpan.MaxValue.");
+        }
+
+        if (!constraints.CancellationConstraintRequested)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.CancellationMissing,
+                "No cancellation constraint was configured.",
+                "Register a cancellable token tied to the host request.");
+        }
+
+        if (!constraints.OperationDeadlineConstraintRequested)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.OperationDeadlineMissing,
+                "No cumulative operation deadline was configured.",
+                "Register OperationDeadlineConstraint and bracket each complete host operation.");
+        }
+    }
+
+    private static void AddRequestedLimit<T>(
+        T? value,
+        T saturated,
+        string missingCode,
+        string nonPositiveCode,
+        string saturatedCode,
+        string name,
+        List<SecurityDiagnostic> diagnostics)
+        where T : struct, IComparable<T>
+    {
+        if (!value.HasValue)
+        {
+            Error(diagnostics, missingCode,
+                $"No {name} limit was configured.",
+                "Configure a positive finite budget.");
+        }
+        else if (value.Value.CompareTo(default) <= 0)
+        {
+            Error(diagnostics, nonPositiveCode,
+                $"The requested {name} limit is non-positive and removes the limit.",
+                "Use a positive budget.");
+        }
+        else if (value.Value.CompareTo(saturated) == 0)
+        {
+            Error(diagnostics, saturatedCode,
+                $"The saturated {name} value removes the limit.",
+                "Use a finite value below the numeric maximum.");
+        }
+    }
+
+    private static void AddEffectiveConstraints(
+        Constraint[] constraints,
+        List<SecurityDiagnostic> diagnostics)
+    {
+        var hasStatements = false;
+        var hasMemory = false;
+        var hasTimeout = false;
+        var hasCancellation = false;
+        var hasOperationDeadline = false;
+        foreach (var constraint in constraints)
+        {
+            hasStatements |= constraint is MaxStatementsConstraint;
+            hasMemory |= constraint is MemoryLimitConstraint;
+            hasTimeout |= constraint is TimeConstraint;
+            hasCancellation |= constraint is CancellationConstraint;
+            hasOperationDeadline |= constraint is OperationDeadlineConstraint;
+        }
+
+        if (!hasStatements)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.StatementLimitMissing,
+                "The constructed engine has no statement-count limit.",
+                "Register a positive finite MaxStatements constraint.");
+        }
+
+        if (!hasMemory)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.MemoryLimitMissing,
+                "The constructed engine has no managed-allocation limit.",
+                "Register a positive finite MemoryLimitConstraint.");
+        }
+
+        if (!hasTimeout)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.TimeoutMissing,
+                "The constructed engine has no per-entry timeout.",
+                "Register a positive finite TimeConstraint.");
+        }
+
+        if (!hasCancellation)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.CancellationMissing,
+                "The constructed engine has no cancellation constraint.",
+                "Register a cancellable token tied to the host request.");
+        }
+
+        if (!hasOperationDeadline)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.OperationDeadlineMissing,
+                "The constructed engine has no cumulative operation deadline.",
+                "Register OperationDeadlineConstraint and bracket each complete host operation.");
+        }
+    }
+
+    private static void AddParsing(
+        int? maxSourceLength,
+        int? maxNodeCount,
+        bool retainSource,
+        List<SecurityDiagnostic> diagnostics)
+    {
+        if (!maxSourceLength.HasValue)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.ParserSourceLengthUnlimited,
+                "The effective parser source-length limit is unbounded.",
+                "Set MaxSourceLength on engine and explicit parsing or preparation options.");
+        }
+
+        if (!maxNodeCount.HasValue)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.ParserNodeCountUnlimited,
+                "The effective parser AST-node limit is unbounded.",
+                "Set MaxNodeCount on engine and explicit parsing or preparation options.");
+        }
+
+        if (retainSource)
+        {
+            Warning(diagnostics, SecurityDiagnosticCodes.FunctionSourceRetentionEnabled,
+                "Parsed function source text is retained.",
+                "Disable source retention unless its bounded memory lifetime is required.");
+        }
+    }
+
+    private static void AddStack(
+        Options options,
+        EngineSecurityConfigurationSnapshot? engineSnapshot,
+        List<SecurityDiagnostic> diagnostics)
+    {
+        var constraints = options.Constraints;
+        var maxRecursionDepth = engineSnapshot?.MaxRecursionDepth ?? constraints.MaxRecursionDepth;
+        var stackOverflowGuard = engineSnapshot?.StackOverflowGuard ?? constraints.StackOverflowGuard;
+        var maxExecutionStackCount = engineSnapshot?.MaxExecutionStackCount ?? constraints.MaxExecutionStackCount;
+        if (maxRecursionDepth < 0)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.RecursionLimitDisabled,
+                "The per-function recursion limit is disabled.",
+                "Set MaxRecursionDepth to a finite non-negative value.");
+        }
+        else if (maxRecursionDepth == int.MaxValue)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.RecursionLimitSaturated,
+                "The recursion limit is effectively unreachable.",
+                "Use a finite host-appropriate recursion depth.");
+        }
+
+        if (!stackOverflowGuard)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.StackOverflowGuardDisabled,
+                "The native stack-overflow guard is disabled.",
+                "Set Constraints.StackOverflowGuard to true.");
+        }
+        else if (maxExecutionStackCount != StackGuard.Disabled)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.StackOverflowGuardShadowed,
+                "MaxExecutionStackCount shadows the broader native stack guard.",
+                "Leave MaxExecutionStackCount disabled when using StackOverflowGuard.");
+        }
+    }
+
+    private static void AddCapabilities(
+        Options options,
+        EngineSecurityConfigurationSnapshot? engineSnapshot,
+        List<SecurityDiagnostic> diagnostics)
+    {
+        if (options.AgentCanSuspend)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.AgentSuspensionEnabled,
+                "Atomics.wait can block the engine thread.",
+                "Set AgentCanSuspend to false.");
+        }
+
+        var interop = options.Interop;
+        if (engineSnapshot?.ClrEnabled ?? interop.Enabled)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.ClrAccessEnabled,
+                "Scripts can resolve CLR namespaces and types.",
+                "Keep CLR access disabled or enforce an explicit least-authority policy.");
+        }
+
+        if (engineSnapshot?.AllowGetType ?? interop.AllowGetType)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.GetTypeEnabled,
+                "Wrapped CLR objects expose type discovery and widening operations.",
+                "Set Interop.AllowGetType to false.");
+        }
+
+        if (engineSnapshot?.AllowSystemReflection ?? interop.AllowSystemReflection)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.SystemReflectionEnabled,
+                "System.Reflection values can cross into script.",
+                "Set Interop.AllowSystemReflection to false.");
+        }
+
+        if (interop.AllowWrite)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.ClrWriteEnabled,
+                "Scripts can write through wrapped CLR objects.",
+                "Disable CLR writes and expose immutable capability-scoped facades.");
+        }
+
+        if (interop.ArrayConversion == ArrayConversionMode.LiveView)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.LiveClrArraysEnabled,
+                "CLR arrays cross into script as live views.",
+                "Use ArrayConversionMode.Copy.");
+        }
+
+        if (interop.AllowWrite && interop.ArrayConversion == ArrayConversionMode.LiveView)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.LiveClrArrayWritesEnabled,
+                "Live CLR arrays and CLR writes combine into direct array write-through.",
+                "Use copied arrays or disable CLR writes.");
+        }
+
+        if (engineSnapshot?.DetailedClrResolutionErrors ?? interop.ExposeDetailedResolutionErrors)
+        {
+            Warning(diagnostics, SecurityDiagnosticCodes.DetailedClrErrorsEnabled,
+                "Detailed CLR resolution failures disclose host surface information.",
+                "Disable detailed resolution errors for untrusted output.");
+        }
+
+        if (interop.ExposeDetailedExceptionMessages)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.DetailedClrExceptionMessagesEnabled,
+                "CLR exception messages are exposed to script.",
+                "Use generic script-visible errors and bounded host-only diagnostics.");
+        }
+
+        if (interop.ChainClrExceptionAsInnerException)
+        {
+            Warning(diagnostics, SecurityDiagnosticCodes.ClrExceptionChainingEnabled,
+                "CLR exceptions are chained into host-rendered exceptions.",
+                "Keep chained exceptions away from untrusted responses and bounded logs.");
+        }
+
+        if (interop.ClrExceptionErrorDecorator is not null || interop.ClrResolutionErrorDecorator is not null)
+        {
+            Warning(diagnostics, SecurityDiagnosticCodes.ClrErrorDecoratorConfigured,
+                "A CLR error decorator can publish host-derived data to script.",
+                "Emit only bounded non-sensitive constants.");
+        }
+
+        if (!ReferenceEquals(interop.ExceptionHandler, Options.InteropOptions._defaultExceptionHandler)
+            || !ReferenceEquals(interop.WrapObjectHandler, Options.InteropOptions._defaultWrapObjectHandler)
+            || !ReferenceEquals(interop.MemberAccessor, Options.InteropOptions._defaultMemberAccessor)
+            || interop.BuildCallStackHandler is not null
+            || interop.ObjectConverters.Count > 0
+            || interop.SerializeToJson is not null
+            || !ReferenceEquals(interop.CreateClrObject, Options.InteropOptions._defaultCreateClrObject)
+            || !ReferenceEquals(interop.CreateTypeReferenceObject, Options.InteropOptions._defaultCreateTypeReferenceObject)
+            || !ReferenceEquals(interop.ObjectWrapperReportedPropertyKeys, Options.InteropOptions._defaultReportedPropertyKeys)
+            || !ReferenceEquals(options.Host.FunctionToStringHandler, Options.HostOptions._defaultFunctionToStringHandler)
+            || !ReferenceEquals(options.ReferenceResolver, DefaultReferenceResolver.Instance))
+        {
+            Warning(diagnostics, SecurityDiagnosticCodes.ClrCallbackConfigured,
+                "Custom CLR callbacks or converters can execute host code or expose values.",
+                "Audit authority, cancellation, reentrancy, exceptions, and output bounds.");
+        }
+
+        if (engineSnapshot?.ExtensionMethodsConfigured ?? interop.ExtensionMethodTypes.Count > 0)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.ClrExtensionMethodsConfigured,
+                "CLR extension methods are installed on JavaScript prototypes.",
+                "Remove extension methods from untrusted engines or audit every exposed method as a host capability.");
+        }
+
+        if (engineSnapshot?.ClrCompatibilityMode
+            ?? (interop.Enabled && interop.ClrAccessConfiguration == ClrAccessConfiguration.Compatibility))
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.ClrCompatibilityModeEnabled,
+                "Parameterless AllowClr enabled compatibility-mode core CLR access.",
+                "Use explicit assemblies with a positive member allowlist, or leave CLR access disabled.");
+        }
+
+        if (engineSnapshot?.ClrPolicyUnrestricted
+            ?? (interop.Enabled && ReferenceEquals(interop.TypeResolver, TypeResolver.Default)))
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.ClrPolicyUnrestricted,
+                "CLR access uses the permissive default member-resolution policy.",
+                "Use a dedicated TypeResolver with a positive member filter.");
+        }
+
+        if (options.Host.StringCompilationAllowed)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.StringCompilationEnabled,
+                "Dynamic string compilation is enabled.",
+                "Call DisableStringCompilation and keep parser limits for all remaining compilation paths.");
+        }
+
+        if (options.HasUserEngineConstructionCallback)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.EngineConstructionCallback,
+                "A user callback runs during engine construction.",
+                "Review the effective engine report after construction; do not replay the callback.");
+        }
+
+        if ((engineSnapshot?.DebuggerEnabled ?? options.Debugger.Enabled)
+            || options.Debugger.StatementHandling != DebuggerStatementHandling.Ignore
+            || options.Debugger.InitialStepMode != StepMode.None)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.DebuggerEnabled,
+                "Debugger behavior is enabled.",
+                "Disable debug mode, debugger statements, and initial stepping.");
+        }
+    }
+
+    private static void AddModules(
+        Options options,
+        IModuleLoader? effectiveModuleLoader,
+        List<SecurityDiagnostic> diagnostics)
+    {
+        var modules = options.Modules;
+        var moduleLoader = effectiveModuleLoader ?? modules.ModuleLoader;
+        if (ReferenceEquals(moduleLoader, FailFastModuleLoader.Instance))
+        {
+            if (modules.RegisterRequire)
+            {
+                Warning(diagnostics, SecurityDiagnosticCodes.RequireWithoutModuleLoader,
+                    "require is enabled with the fail-fast module loader.",
+                    "Disable require or configure and secure a loader.");
+            }
+
+            return;
+        }
+
+        Warning(diagnostics, SecurityDiagnosticCodes.ModuleLoadingEnabled,
+            "A module loader resolves script-controlled specifiers and executes host loader code.",
+            "Bound loader I/O and use an explicit destination policy.");
+
+        if (modules.MaxModuleCount == int.MaxValue)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.ModuleCountUnlimited,
+                "The aggregate module-count limit is unbounded.",
+                "Set a finite positive engine-lifetime module count.");
+        }
+
+        if (modules.MaxTotalModuleSourceBytes == long.MaxValue)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.ModuleSourceBytesUnlimited,
+                "The aggregate module-source-byte limit is unbounded.",
+                "Set a finite positive engine-lifetime source-byte budget.");
+        }
+
+        if (modules.MaxModuleGraphDepth == int.MaxValue)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.ModuleGraphDepthUnlimited,
+                "The per-load module graph-depth limit is unbounded.",
+                "Set a finite positive graph-depth budget.");
+        }
+
+        if (modules.MaxModuleResolutionHops == int.MaxValue)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.ModuleResolutionHopsUnlimited,
+                "The per-load module resolution-hop limit is unbounded.",
+                "Set a finite positive resolution-hop budget.");
+        }
+
+        var loaderRestricts = moduleLoader is DefaultModuleLoader { RestrictsToBasePath: true };
+        if (!loaderRestricts && modules.LoadPolicy is null)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.ModuleDestinationPolicyMissing,
+                "The enabled module loader has no destination policy.",
+                "Use a restricted default loader or an explicit scheme, origin, host, or root allowlist.");
+        }
+        else if (modules.LoadPolicy is ModuleAllowlistPolicy { HasDestinationBoundary: false })
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.ModuleAllowlistInsufficient,
+                "The assigned module allowlist has no host, origin, or filesystem-root boundary.",
+                "Configure a host or origin for network modules, or a filesystem root for file modules.");
+        }
+
+        if (modules.MaxModuleGraphDepth != int.MaxValue || modules.MaxModuleResolutionHops != int.MaxValue)
+        {
+            Warning(diagnostics, SecurityDiagnosticCodes.ModulePerLoadLimitsReset,
+                "Depth and hop budgets reset per top-level load; count and bytes remain aggregate.",
+                "Combine all four limits and bound top-level loads at the operation boundary.");
+        }
+
+        if (modules.ExposeDetailedLoadErrors)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.DetailedModuleErrorsEnabled,
+                "Module failures expose detailed messages to script.",
+                "Use generic script-visible errors and bounded host-only diagnostics.");
+        }
+    }
+
+    private static void AddResources(
+        Options options,
+        bool includeEngineRegex,
+        EngineSecurityConfigurationSnapshot? engineSnapshot,
+        List<SecurityDiagnostic> diagnostics)
+    {
+        var constraints = options.Constraints;
+        if (constraints.MaxArraySize == uint.MaxValue)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.ArraySizeUnlimited,
+                "JavaScript arrays can grow to the implementation maximum.",
+                "Set a finite host-appropriate MaxArraySize.");
+        }
+
+        if (includeEngineRegex)
+        {
+            AddRegex(
+                engineSnapshot?.RegexTimeout ?? constraints.RegexTimeout,
+                SecurityDiagnosticCodes.RegexTimeoutUnbounded,
+                SecurityDiagnosticCodes.RegexTimeoutLong,
+                SecurityDiagnosticCodes.RegexTimeoutExcessive,
+                "engine",
+                diagnostics);
+        }
+
+        if (constraints.PromiseTimeout <= TimeSpan.Zero)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.PromiseTimeoutUnbounded,
+                "Synchronous promise unwrapping can wait indefinitely.",
+                "Set a positive finite PromiseTimeout.");
+        }
+        else if (constraints.PromiseTimeout > MaximumRecommendedWait)
+        {
+            Warning(diagnostics, SecurityDiagnosticCodes.PromiseTimeoutLong,
+                "The synchronous promise wait exceeds one second.",
+                "Use one second or less, or prefer asynchronous host entry points.");
+        }
+    }
+
+    private static void AddRegexOverride(TimeSpan timeout, List<SecurityDiagnostic> diagnostics)
+        => AddRegex(
+            timeout,
+            SecurityDiagnosticCodes.RegexTimeoutOverrideUnbounded,
+            SecurityDiagnosticCodes.RegexTimeoutOverrideLong,
+            SecurityDiagnosticCodes.RegexTimeoutOverrideExcessive,
+            "parsing or preparation",
+            diagnostics);
+
+    private static void AddRegex(
+        TimeSpan timeout,
+        string unboundedCode,
+        string longCode,
+        string excessiveCode,
+        string surface,
+        List<SecurityDiagnostic> diagnostics)
+    {
+        if (timeout <= TimeSpan.Zero)
+        {
+            Error(diagnostics, unboundedCode,
+                $"The {surface} regex timeout is not positive.",
+                "Use a positive finite regex timeout.");
+        }
+        else if (timeout >= MaximumAllowedRegexTimeout)
+        {
+            Error(diagnostics, excessiveCode,
+                $"The {surface} regex timeout exceeds the fixed upper bound.",
+                "Use less than one year; one second or less is recommended.");
+        }
+        else if (timeout > MaximumRecommendedWait)
+        {
+            Warning(diagnostics, longCode,
+                $"The {surface} regex timeout exceeds one second.",
+                "Use one second or less unless a measured workload requires more.");
+        }
+    }
+
+    private static void AddResultLimits(ResultLimits limits, List<SecurityDiagnostic> diagnostics)
+    {
+        if (limits.MaxDepth == int.MaxValue
+            || limits.MaxPropertyCount == long.MaxValue
+            || limits.MaxStringLength == int.MaxValue
+            || limits.MaxOutputCharacters == long.MaxValue
+            || limits.MaxOutputBytes == long.MaxValue)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.ResultLimitsUnlimited,
+                "One or more result conversion or JSON serialization limits are unbounded.",
+                "Bound every ResultLimits dimension and external serializers, responses, and logs.");
+        }
+    }
+
+    private static void AddConstraintRegistration(Options options, List<SecurityDiagnostic> diagnostics)
+    {
+        if (options.Constraints.Constraints.Count > 0)
+        {
+            Warning(diagnostics, SecurityDiagnosticCodes.SharedConstraintInstance,
+                "A mutable Constraint instance is shared by engines built from these options.",
+                "Register a factory when options can build more than one engine.");
+        }
+    }
+
+    private static bool IsConstraintCode(string code)
+        => code is
+            SecurityDiagnosticCodes.StatementLimitMissing
+            or SecurityDiagnosticCodes.StatementLimitNonPositive
+            or SecurityDiagnosticCodes.StatementLimitSaturated
+            or SecurityDiagnosticCodes.MemoryLimitMissing
+            or SecurityDiagnosticCodes.MemoryLimitNonPositive
+            or SecurityDiagnosticCodes.MemoryLimitSaturated
+            or SecurityDiagnosticCodes.TimeoutMissing
+            or SecurityDiagnosticCodes.TimeoutNonPositive
+            or SecurityDiagnosticCodes.TimeoutSaturated
+            or SecurityDiagnosticCodes.CancellationMissing
+            or SecurityDiagnosticCodes.OperationDeadlineMissing;
+
+    private static int? Minimum(int? left, int? right)
+        => !left.HasValue ? right : !right.HasValue ? left : Math.Min(left.Value, right.Value);
+
+    private static SecurityConfigurationReport CreateReport(List<SecurityDiagnostic> diagnostics)
+    {
+        diagnostics.Sort(static (left, right) => StringComparer.Ordinal.Compare(left.Code, right.Code));
+        return new SecurityConfigurationReport(diagnostics);
+    }
+
+    private static void ValidatePolicy(SecurityConfigurationPolicy policy)
+    {
+        if (policy != SecurityConfigurationPolicy.UntrustedScripts)
+        {
+            Throw.ArgumentOutOfRangeException(nameof(policy), "Unknown security configuration policy.");
+        }
+    }
+
+    private static void ThrowIfErrors(SecurityConfigurationReport report)
+    {
+        if (report.HasErrors)
+        {
+            throw new SecurityConfigurationException(report);
+        }
+    }
+
+    private static void ArgumentNull(object? value, string paramName)
+    {
+        if (value is null)
+        {
+            Throw.ArgumentNullException(paramName);
+        }
+    }
+
+    private static void Error(
+        List<SecurityDiagnostic> diagnostics,
+        string code,
+        string message,
+        string guidance)
+        => diagnostics.Add(new SecurityDiagnostic(code, SecurityDiagnosticSeverity.Error, message, guidance));
+
+    private static void Warning(
+        List<SecurityDiagnostic> diagnostics,
+        string code,
+        string message,
+        string guidance)
+        => diagnostics.Add(new SecurityDiagnostic(code, SecurityDiagnosticSeverity.Warning, message, guidance));
+}

--- a/README.md
+++ b/README.md
@@ -2433,6 +2433,88 @@ Execution constraints are used during script execution to ensure that requiremen
 * Scripts should not use more than X memory.
 * Scripts should only run for a maximum amount of time.
 
+### Validating options for untrusted scripts
+
+Jint does not change its general-purpose defaults when a host runs untrusted source. A host can inspect its
+fully configured `Options` before constructing an engine and enforce the built-in untrusted-script policy
+explicitly:
+
+```c#
+var options = new Options()
+    .MaxStatements(100_000)
+    .LimitMemory(4_000_000)
+    .TimeoutInterval(TimeSpan.FromSeconds(2))
+    .CancellationToken(requestAborted)
+    .Constraint(static () => new OperationDeadlineConstraint())
+    .LimitRecursion(64)
+    .DisableStringCompilation()
+    .AllowClrWrite(false)
+    .MaxArraySize(100_000)
+    .RegexTimeoutInterval(TimeSpan.FromSeconds(1));
+
+options.AgentCanSuspend = false;
+options.Constraints.StackOverflowGuard = true;
+options.Constraints.PromiseTimeout = TimeSpan.FromSeconds(1);
+options.Interop.ArrayConversion = ArrayConversionMode.Copy;
+options.Parsing.MaxSourceLength = 100_000;
+options.Parsing.MaxNodeCount = 25_000;
+options.ResultLimits = ResultLimits.Conservative;
+
+var report = options.ValidateSecurityConfiguration(SecurityConfigurationPolicy.UntrustedScripts);
+foreach (var diagnostic in report.Diagnostics)
+{
+    logger.LogWarning(
+        "{Code} {Severity}: {Message} {Guidance}",
+        diagnostic.Code,
+        diagnostic.Severity,
+        diagnostic.Message,
+        diagnostic.Guidance);
+}
+
+// Throws SecurityConfigurationException if the report contains an error.
+var engine = new Engine(options.EnsureSecurityConfiguration(SecurityConfigurationPolicy.UntrustedScripts));
+var effectiveReport = engine.Advanced.ValidateSecurityConfiguration(SecurityConfigurationPolicy.UntrustedScripts);
+```
+
+Validation is read-only: it does not apply a hardened profile or change normal engine defaults, so it also
+works for `Options` assembled by direct property assignment or by application-specific helpers. Diagnostic
+codes are stable and results are ordered by code for deterministic logging. Warnings identify settings that
+need host-specific review (for example a custom module loader); they remain in the report but do not make
+`EnsureSecurityConfiguration` throw. Treat a validated `Options` as immutable and pass it directly to
+`Engine(Options)`. Public engine-construction callbacks registered by `Configure`, `SetTypeConverter`, or
+`UseHostFactory` produce `JINTSEC031`; inspect `engine.Advanced.ValidateSecurityConfiguration()` after
+construction to validate their final effects without replaying them. Custom constraint factories remain
+supported under their existing contract and are invoked only by engine construction, never by diagnostics.
+
+| Codes | Coverage |
+| --- | --- |
+| `JINTSEC001`-`009`, `036`-`037` | Statement, memory, per-entry timeout, cancellation, and cumulative operation deadline |
+| `JINTSEC010`-`014` | Recursion, native stack guard, legacy stack lane, and `Atomics.wait` suspension |
+| `JINTSEC015`-`020`, `030`, `048`-`055`, `057` | CLR access policy, `GetType`/unwrap, reflection, writes, array crossing, extension methods, error disclosure, callbacks, and compatibility mode |
+| `JINTSEC021`-`022`, `041`-`046`, `050`, `056` | Module loader trust, count/bytes/depth/hops, destination policy, per-load reset semantics, and detailed errors |
+| `JINTSEC023`-`029`, `032` | Debugger, arrays, regex, promise waits, and shared constraint instances |
+| `JINTSEC031` | User-provided deferred engine configuration |
+| `JINTSEC033`-`035`, `038`-`040` | Actual parsing/preparation regex settings, source and AST limits, and source retention |
+| `JINTSEC047` | Result conversion and Jint JSON serialization limits; external serializers, responses, and logs remain host responsibilities |
+
+A report with no findings is not proof of sandboxing. Jint remains in-process; worker isolation, least
+privilege, request/response limits, callback authorization, and correct operation bracketing are host
+architecture responsibilities.
+
+Explicit `ScriptParsingOptions` / `ModuleParsingOptions` can override the engine regex timeout, and
+prepared programs embed their preparation-time timeout instead of consulting the engine. Validate
+the actual pair before direct parsing, and validate every preparation configuration before preparing:
+
+```c#
+options.EnsureSecurityConfiguration(scriptParsingOptions);
+scriptPreparationOptions.EnsureSecurityConfiguration();
+modulePreparationOptions.EnsureSecurityConfiguration();
+```
+
+The default preparation options use Jint's 10-second regex timeout and unbounded parser size limits.
+Set `RegexTimeout`, `MaxSourceLength`, and `MaxNodeCount` on the actual nested parsing options used
+for untrusted source.
+
 You can configure them via the options:
 
 ```c#


### PR DESCRIPTION
## Summary

- add immutable, deterministic `JINTSEC001`-`JINTSEC057` diagnostics for untrusted server execution across constraints, parsing, modules, result bounds, CLR containment and errors, array/write policy, stack protection, and Atomics suspension
- add pre-construction `Options` validation plus post-construction effective-engine validation that never replays callbacks or constraint factories
- add unspoofable internal provenance for future first-party hardened-profile composition while preserving `JINTSEC031` for user `Configure`, converter, and host-factory callbacks
- document diagnostic guidance and host responsibilities in README and the threat model

## Security review

Specialist review completed clean after fixing:
- scheme-only module allowlists being treated as destination boundaries
- CLR extension methods missing from capability diagnostics
- effective reports reading mutable options instead of construction snapshots
- detailed CLR resolution and installed extension-method state not being snapshotted

## Validation

- Jint Release multi-target build: passed (`net462`, `netstandard2.0`, `netstandard2.1`, `net8.0`, `net10.0`)
- PublicInterface default: 1,758 passed, 9 skipped
- PublicInterface host-contract verification: 1,762 passed, 5 skipped
- core under UTC: 5,801 passed, 4 skipped
- focused core security/parsing/module/result/CLR/array/stack/Atomics/concurrency/GC: 1,550 passed, 1 skipped
- focused PublicInterface coverage: 662 passed, 2 skipped
- `git diff --check`: passed

The solution-level Test262 project build is blocked under the mandated NuGet proxy because it does not currently carry `test262harness.console` 1.1.2; all other solution projects built in Release, and the temporary proxy-compatible analyzer version used for local validation was restored.

## Stack

#3058 -> #3057 -> #3056 -> #3054 -> #3052 -> #3051 -> #3046 -> #3045 -> #3037 -> #3036 -> #3035 -> #3030