### PR TITLE
Add hardened untrusted-code profile

### DIFF
--- a/.github/THREAT_MODEL.md
+++ b/.github/THREAT_MODEL.md
@@ -74,6 +74,10 @@ All components above run with the hosting worker's process authority.
 
 Defaults are compatibility choices, not a hardened profile.
 
+`Options.ForUntrustedCode(UntrustedCodeLimits)` is the opt-in hardened profile. It leaves
+the defaults unchanged for compatibility, but closes the static capabilities below and
+requires the host to supply finite request-appropriate resource limits.
+
 | Control | Default | Security effect |
 | --- | --- | --- |
 | CLR namespace access (`Interop.Enabled`) | Disabled | `System`, `importNamespace`, and `clrHelper` are not installed |
@@ -176,6 +180,7 @@ interop, or arbitrary code execution with the worker's identity.
 - `AllowGetType` does not expose the static `System.Type.GetType(string)` family. Its
   `clrHelper` type-widening operations also enforce the namespace type policy.
 - `AllowSystemReflection` gates namespace discovery and wrapping for `System.Reflection`.
+- `ForUntrustedCode` resets all three controls and removes configured assemblies.
 - `ExposeDetailedResolutionErrors` is disabled by default.
 
 **Missing or residual mitigation.**
@@ -214,6 +219,8 @@ exfiltration, or resource-amplification paths.
 - The host chooses every projected value.
 - `TypeResolver.MemberFilter`, wrapper handlers, proxies, and narrow delegates can reduce
   the surface.
+- `ForUntrustedCode` removes registered CLR extension methods as well as disabling CLR
+  namespace access.
 
 **Missing or residual mitigation.**
 
@@ -242,6 +249,7 @@ state regardless of the direct-write option.
 - `ArrayConversionMode.Copy` is the default and disconnects the JavaScript array container
   from later CLR mutations and script writes.
 - Immutable DTOs and Jint-owned record layouts avoid live write-through.
+- `ForUntrustedCode` selects both read-only wrappers and copied CLR arrays.
 
 **Missing or residual mitigation.**
 
@@ -275,6 +283,7 @@ BigInt/string arithmetic, and adversarial algorithms can monopolize a worker.
 - Amortized timeout and cancellation checks are also made after CLR calls return.
 - The untrusted-script configuration report identifies missing limits and sentinel values that
   remove them.
+- `ForUntrustedCode` requires finite time and statement budgets.
 
 **Missing or residual mitigation.**
 
@@ -296,6 +305,7 @@ independent process/container CPU and wall-clock limit.
 
 - Parser stack failures are translated to managed errors.
 - Dynamic string compilation can be disabled.
+- `ForUntrustedCode` disables dynamic string compilation.
 - Function source text retention is disabled by default.
 - `Options.Parsing.MaxSourceLength` bounds UTF-16 parser input across initial execution,
   dynamic compilation, ShadowRealm evaluation, debugger evaluation, and JavaScript or JSON
@@ -358,6 +368,7 @@ most of its time in garbage collection.
   another thread, or a host call made while an async API is outstanding, fails before it can
   reset, disarm, or inspect the in-flight budget.
 - `MaxArraySize` bounds Jint array creation when configured.
+- `ForUntrustedCode` requires finite memory and array limits.
 - Some built-ins reject impossible allocations.
 - Recent-wrapper caching is bounded by default; the unbounded identity map is opt-in.
 - The untrusted-script configuration report identifies missing memory and practical array limits.
@@ -390,6 +401,7 @@ quota.
 - `LimitRecursion` limits JavaScript recursion depth when configured.
 - `Constraints.StackOverflowGuard` probes the remaining native stack on every interpreted
   function entry and converts exhaustion to a catchable `RangeError`.
+- `ForUntrustedCode` requires a finite recursion limit and enables `StackOverflowGuard`.
 - The older `Constraints.MaxExecutionStackCount` lane can move call-expression recursion
   to a fresh thread.
 - The untrusted-script configuration report identifies disabled, saturated, or shadowed stack
@@ -425,6 +437,7 @@ infinite timeout when a worker-like host explicitly opts in with `AgentCanSuspen
 - `AgentCanSuspend` defaults to `false`; `Atomics.wait` throws `TypeError` before registering
   a waiter unless the host opts in.
 - `Atomics.waitAsync` remains available without blocking the engine thread.
+- `ForUntrustedCode` sets `AgentCanSuspend = false`.
 - `MaxAtomicsPauseIterations` caps `Atomics.pause` spin work.
 - Async host and module APIs avoid holding a thread while waiting for I/O.
 
@@ -455,16 +468,23 @@ the host brackets both with one operation deadline.
 
 - Nested re-entry does not reset the outer execution's constraints.
 - `OperationDeadlineConstraint` can span a host-defined multi-entry operation.
+- `ForUntrustedCode` requires a finite operation duration, installs one deadline per engine,
+  and exposes `UntrustedCodeLimits.BeginOperation` to arm it for a scope.
+- The profile rejects overlapping operation scopes on one engine rather than letting an inner
+  scope disarm the outer deadline.
 
 **Missing or residual mitigation.**
 
 - Jint cannot infer which entries form one server request.
 - `OperationDeadlineConstraint` is inert unless the host explicitly brackets the operation.
+- The deadline is cooperative. An idle asynchronous wait may not reach another constraint
+  checkpoint until its separate promise timeout or cancellation token wakes it.
 
 **Required host action.** Arm one `OperationDeadlineConstraint` around all engine work for the
 request, including module import, callbacks, `ConvertResult`, `JsonSerializer`, and bounded error
 rendering. When evaluation and conversion or serialization form one request, they must be inside
-the same `Begin`/`End` pair. Keep per-entry constraints as an additional ceiling.
+the same `UntrustedCodeLimits.BeginOperation` scope. Keep per-entry constraints as an additional
+ceiling.
 
 ### TM-10: Async and promise work outlives the request
 
@@ -616,6 +636,7 @@ from another thread. Use separate engines for mutually distrusting requests.
 
 - Regex execution has a 10-second timeout by default on both supported regex paths.
 - `RegexTimeoutInterval` can lower the timeout.
+- `ForUntrustedCode` requires an explicit finite regex timeout.
 
 **Missing or residual mitigation.**
 
@@ -638,6 +659,8 @@ skips amortized timeout/cancellation checks while paused.
 **Existing mitigations.**
 
 - Debug mode is disabled and `debugger` statements are ignored by default.
+- `ForUntrustedCode` resets debug mode, statement handling, and initial stepping to disabled
+  values if earlier configuration enabled them.
 
 **Missing or residual mitigation.**
 
@@ -1247,56 +1270,54 @@ control plane for anything the scripts on the other side are not allowed to trig
 
 ## Hardened deployment baseline
 
-The numbers below are examples only. Measure normal workloads and choose smaller limits that
-leave acceptable headroom.
+`ForUntrustedCode` configures the in-engine controls in one place and rejects the sentinel
+values that ordinary constraint helpers interpret as unlimited. The numbers below are
+examples only. Measure normal workloads and choose smaller limits that leave acceptable
+headroom.
 
 ```csharp
-var options = new Options()
-    .Strict()
-    .DisableStringCompilation()
-    .TimeoutInterval(TimeSpan.FromSeconds(2))
-    .MaxStatements(50_000)
-    .LimitMemory(16_000_000)
-    .LimitRecursion(64)
-    .MaxArraySize(100_000)
-    .RegexTimeoutInterval(TimeSpan.FromMilliseconds(250))
-    .CancellationToken(requestAborted)
-    .Constraint(static () => new OperationDeadlineConstraint())
-    .AllowClrWrite(false);
+var limits = new UntrustedCodeLimits(
+    timeoutInterval: TimeSpan.FromSeconds(2),
+    maxStatements: 50_000,
+    memoryLimit: 16_000_000,
+    maxRecursionDepth: 64,
+    maxArraySize: 100_000,
+    regexTimeout: TimeSpan.FromMilliseconds(250),
+    promiseTimeout: TimeSpan.FromMilliseconds(500),
+    maxOperationDuration: TimeSpan.FromSeconds(3),
+    maxSourceLength: 100_000,
+    maxNodeCount: 25_000,
+    maxModuleCount: 50,
+    maxTotalModuleSourceBytes: 1_000_000,
+    maxModuleGraphDepth: 10,
+    maxModuleResolutionHops: 200,
+    resultLimits: new ResultLimits(
+        maxDepth: 16,
+        maxPropertyCount: 10_000,
+        maxStringLength: 100_000,
+        maxOutputCharacters: 1_000_000,
+        maxOutputBytes: 2_000_000));
 
-options.Constraints.StackOverflowGuard = true;
-options.Constraints.PromiseTimeout = TimeSpan.FromSeconds(1);
-options.AgentCanSuspend = false;
-options.Interop.ArrayConversion = ArrayConversionMode.Copy;
-options.Parsing.MaxSourceLength = 100_000;
-options.Parsing.MaxNodeCount = 25_000;
-options.ResultLimits = ResultLimits.Conservative;
-options.Interop.ExposeDetailedExceptionMessages = false;
-options.Interop.ExposeDetailedResolutionErrors = false;
-options.Modules.ExposeDetailedLoadErrors = false;
-
-// Do not call AllowClr(). Leave modules and the debugger disabled.
-var report = options.ValidateSecurityConfiguration(SecurityConfigurationPolicy.UntrustedScripts);
-AuditWarnings(report.Diagnostics);
-var engine = new Engine(options.EnsureSecurityConfiguration(SecurityConfigurationPolicy.UntrustedScripts));
-var effectiveReport = engine.Advanced.ValidateSecurityConfiguration(SecurityConfigurationPolicy.UntrustedScripts);
-AuditWarnings(effectiveReport.Diagnostics);
-var deadline = engine.Constraints.Find<OperationDeadlineConstraint>()!;
-
-deadline.Begin(TimeSpan.FromSeconds(3), requestAborted);
-try
+// This declaration is safe to share across concurrent Engine construction.
+var sharedOptions = new Options().Strict().ForUntrustedCode(limits);
+using var engine = new Engine(sharedOptions);
+using (limits.BeginOperation(engine, requestAborted))
 {
-    var value = engine.Evaluate(boundedSource);
-    return engine.Advanced.ConvertResult(value);
-}
-finally
-{
-    deadline.End();
+    try
+    {
+        var value = engine.Evaluate(boundedSource);
+        return new JsonSerializer(engine).Serialize(value).AsString();
+    }
+    catch (JavaScriptException exception)
+    {
+        return exception.GetJavaScriptErrorString(limits.ResultLimits);
+    }
 }
 ```
 
-If untrusted scripts must use modules, replace the modules-disabled baseline with explicit
-limits and an allowlist matched to the loader:
+`ForUntrustedCode` deliberately disables modules. A host that must execute untrusted modules
+cannot use that closed profile unchanged; it needs a separately reviewed, hand-built configuration
+with explicit limits and an allowlist matched to the loader:
 
 ```csharp
 options.EnableModules(moduleRoot);
@@ -1309,11 +1330,20 @@ options.Modules.LoadPolicy = new ModuleAllowlistPolicy
     AllowedSchemes = { "file" },
     AllowedFileRoots = { moduleRoot },
 };
+options.EnsureSecurityConfiguration(SecurityConfigurationPolicy.UntrustedScripts);
 ```
 
 A network loader must additionally enforce redirect targets/count, DNS and resolved-IP
 policy, response bytes, and timeout/cancellation inside the loader. Jint cannot observe
 those transport steps.
+
+The operation scope is required: only the host knows which engine entries make up one request.
+It carries a cumulative deadline, cancellation token, and managed-allocation budget across
+evaluation/import and bounded output handling; statement limits keep their documented per-entry
+reset. It cannot preempt a host callback that does not return or bound retained/native memory and
+operating-system resources, so the outer worker deadline remains the hard stop. Prepared scripts
+and modules must use matching parsing limits. Property writes are blocked, but deliberately
+projected methods and delegates remain host capabilities.
 
 This configuration is incomplete without host controls:
 
@@ -1346,7 +1376,9 @@ Before deploying a host that executes untrusted scripts:
   are explicitly configured and tested with adversarial inputs.
 - [ ] Every explicit parsing option and script/module preparation option is validated with the
   timeout that will actually be used.
-- [ ] Async API cancellation is paired with an engine cancellation constraint.
+- [ ] Every multi-entry request is enclosed in `UntrustedCodeLimits.BeginOperation`.
+- [ ] Every operation scope receives the request's cancellable token, and async work is awaited
+  before the scope is disposed or the engine is returned to a pool.
 - [ ] No engine, mutable host object, `JsValue`, module, or request context crosses trust
   domains.
 - [ ] An `IModuleLoadPolicy` restricts final resolved targets, and custom module loaders

--- a/Jint.Benchmark/EngineConstructionBenchmark.cs
+++ b/Jint.Benchmark/EngineConstructionBenchmark.cs
@@ -3,11 +3,16 @@ using Jint.Native;
 
 namespace Jint.Benchmark;
 
+/// <summary>
+/// Measures cold construction, including the complete construction cost for the hardened-profile row.
+/// Engine construction is the operation under test; no engine is warmed or reused between invocations.
+/// </summary>
 [MemoryDiagnoser]
 public class EngineConstructionBenchmark
 {
     private Prepared<Script> _program;
     private Prepared<Script> _simple;
+    private Options _untrustedOptions;
 
     [GlobalSetup]
     public void GlobalSetup()
@@ -15,7 +20,19 @@ public class EngineConstructionBenchmark
         _program = Engine.PrepareScript("([].length + ''.length)");
         _simple = Engine.PrepareScript("1");
         new Engine().Evaluate(_program);
+        _untrustedOptions = new Options().ForUntrustedCode(new UntrustedCodeLimits(
+            timeoutInterval: TimeSpan.FromSeconds(1),
+            maxStatements: 100_000,
+            memoryLimit: 16_000_000,
+            maxRecursionDepth: 64,
+            maxArraySize: 10_000,
+            regexTimeout: TimeSpan.FromMilliseconds(250),
+            promiseTimeout: TimeSpan.FromMilliseconds(500),
+            maxOperationDuration: TimeSpan.FromSeconds(2)));
     }
+
+    [Benchmark]
+    public Engine BuildUntrustedEngine() => new(_untrustedOptions);
 
     [Benchmark]
     public Engine BuildEngine()

--- a/Jint.Tests.PublicInterface/SecurityConfigurationTests.cs
+++ b/Jint.Tests.PublicInterface/SecurityConfigurationTests.cs
@@ -84,7 +84,11 @@ public class SecurityConfigurationTests
             (SecurityDiagnosticCodes.ClrPolicyUnrestricted, () => CreateSafeOptions().AllowClr(Array.Empty<System.Reflection.Assembly>())),
             (SecurityDiagnosticCodes.LiveClrArrayWritesEnabled, () => Change(CreateSafeOptions().AllowClrWrite(), x => x.Interop.ArrayConversion = ArrayConversionMode.LiveView)),
             (SecurityDiagnosticCodes.ModuleAllowlistInsufficient, CreateSchemeOnlyModuleOptions),
-            (SecurityDiagnosticCodes.ClrExtensionMethodsConfigured, () => CreateSafeOptions().AddExtensionMethods(typeof(SecurityConfigurationUnsafeExtensions)))
+            (SecurityDiagnosticCodes.ClrExtensionMethodsConfigured, () => CreateSafeOptions().AddExtensionMethods(typeof(SecurityConfigurationUnsafeExtensions))),
+            (SecurityDiagnosticCodes.ClrOperatorOverloadingEnabled, () => Change(CreateSafeOptions(), x => x.Interop.AllowOperatorOverloading = true)),
+            (SecurityDiagnosticCodes.NonPublicClrMembersEnabled, () => Change(
+                CreateSafeOptions(),
+                x => x.Interop.ObjectWrapperReportedPropertyBindingFlags = System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic))
         };
 
         foreach (var (code, createOptions) in cases)
@@ -101,6 +105,7 @@ public class SecurityConfigurationTests
             {
                 Invoking(() => options.EnsureSecurityConfiguration()).Should().ThrowExactly<SecurityConfigurationException>();
             }
+
             else
             {
                 if (!options.ValidateSecurityConfiguration().HasErrors)
@@ -109,6 +114,21 @@ public class SecurityConfigurationTests
                 }
             }
         }
+    }
+
+    [Fact]
+    public void EngineReportUsesCapturedClrBindingFlags()
+    {
+        var options = CreateSafeOptions();
+        options.Interop.ObjectWrapperReportedPropertyBindingFlags =
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic;
+        var engine = new Engine(options);
+
+        options.Interop.ObjectWrapperReportedPropertyBindingFlags =
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public;
+
+        engine.Advanced.ValidateSecurityConfiguration().Diagnostics.Should().ContainSingle(
+            diagnostic => diagnostic.Code == SecurityDiagnosticCodes.NonPublicClrMembersEnabled);
     }
 
     [Fact]

--- a/Jint.Tests.PublicInterface/UntrustedCodeProfileTests.cs
+++ b/Jint.Tests.PublicInterface/UntrustedCodeProfileTests.cs
@@ -1,0 +1,616 @@
+#nullable enable
+
+using Jint.Constraints;
+using Jint.Native.Json;
+using Jint.Runtime;
+using Jint.Runtime.Debugger;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// Pins the complete untrusted-code profile from the same public surface available to an embedder.
+/// </summary>
+public class UntrustedCodeProfileTests
+{
+    [Fact]
+    public void ProfileOverridesPreviouslyEnabledStaticCapabilities()
+    {
+        var limits = CreateLimits();
+        var options = new Options()
+            .AllowClr(typeof(UntrustedCodeProfileTests).Assembly)
+            .AllowClrWrite()
+            .AddExtensionMethods(typeof(UntrustedCodeProfileStringExtensions))
+            .DebugMode()
+            .DebuggerStatementHandling(DebuggerStatementHandling.Clr)
+            .InitialStepMode(StepMode.Into)
+            .EnableModules(Environment.CurrentDirectory)
+            .DisableStringCompilation(disable: false);
+
+        options.AgentCanSuspend = true;
+        options.Interop.AllowGetType = true;
+        options.Interop.AllowSystemReflection = true;
+        options.Interop.AllowOperatorOverloading = true;
+        options.Interop.ArrayConversion = ArrayConversionMode.LiveView;
+        options.Interop.ExposeDetailedExceptionMessages = true;
+        options.Interop.ExposeDetailedResolutionErrors = true;
+        options.Interop.ChainClrExceptionAsInnerException = true;
+        options.Interop.ObjectWrapperReportedFieldBindingFlags = BindingFlags.Instance | BindingFlags.NonPublic;
+        options.Interop.ObjectWrapperReportedPropertyBindingFlags = BindingFlags.Instance | BindingFlags.NonPublic;
+        options.Interop.ObjectWrapperReportedMethodBindingFlags = BindingFlags.Instance | BindingFlags.NonPublic;
+        options.Modules.ExposeDetailedLoadErrors = true;
+        options.Constraints.MaxExecutionStackCount = 1;
+        options.Constraints.StackOverflowGuard = false;
+
+        options.ForUntrustedCode(limits);
+
+        var engine = new Engine(options);
+
+        // Declaring the profile never mutates the shared source options.
+        options.Interop.AllowWrite.Should().BeTrue();
+        options.Interop.AllowOperatorOverloading.Should().BeTrue();
+        options.Modules.ExposeDetailedLoadErrors.Should().BeTrue();
+        engine.Constraints.Find<MaxStatementsConstraint>()!.MaxStatements.Should().Be(limits.MaxStatements);
+        engine.Constraints.Find<MemoryLimitConstraint>().Should().NotBeNull();
+        engine.Constraints.Find<OperationDeadlineConstraint>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ProfileIsReappliedAfterEarlierDeferredConfiguration()
+    {
+        var limits = CreateLimits();
+        var options = new Options();
+        options.Configure(engine =>
+        {
+            options.AllowClr(typeof(UntrustedCodeProfileTests).Assembly);
+            options.Interop.AllowGetType = true;
+            options.Interop.AllowSystemReflection = true;
+            options.Interop.AllowWrite = true;
+            options.Interop.AllowOperatorOverloading = true;
+            options.Interop.ArrayConversion = ArrayConversionMode.LiveView;
+            options.Interop.ExposeDetailedExceptionMessages = true;
+            options.Interop.ExposeDetailedResolutionErrors = true;
+            options.Interop.ChainClrExceptionAsInnerException = true;
+            options.AddExtensionMethods(typeof(UntrustedCodeProfileStringExtensions));
+            options.Modules.RegisterRequire = true;
+            options.Modules.ExposeDetailedLoadErrors = true;
+            options.Debugger.StatementHandling = DebuggerStatementHandling.Clr;
+            options.Debugger.InitialStepMode = StepMode.Into;
+            options.AgentCanSuspend = true;
+            options.Host.StringCompilationAllowed = true;
+            options.Constraints.MaxExecutionStackCount = 1;
+            options.Constraints.StackOverflowGuard = false;
+            options.Constraints.MaxRecursionDepth = int.MaxValue;
+            options.Constraints.MaxArraySize = uint.MaxValue;
+            options.Constraints.RegexTimeout = TimeSpan.MaxValue;
+            options.Constraints.PromiseTimeout = TimeSpan.MaxValue;
+            engine.Constraints.Find<MaxStatementsConstraint>()!.MaxStatements = int.MaxValue;
+            engine.Constraints.Find<OperationDeadlineConstraint>()!.Begin(TimeSpan.MaxValue);
+            engine.Constraints.Find<MemoryLimitConstraint>()!.Begin();
+            engine.Modules.Add("configured", "export const reachable = true;");
+        });
+        options.ForUntrustedCode(limits);
+
+        var engine = new Engine(options);
+
+        engine.Constraints.Find<MaxStatementsConstraint>()!.MaxStatements.Should().Be(limits.MaxStatements);
+        Invoking(engine.Constraints.Check).Should().NotThrow();
+        engine.Constraints.Find<MemoryLimitConstraint>()!.IsOperationActive.Should().BeFalse();
+        Invoking(() => engine.Modules.Import("configured"))
+            .Should().Throw<InvalidOperationException>().WithMessage("*disabled*");
+    }
+
+    [Fact]
+    public void SharedOptionsGiveEachEngineItsOwnOperationDeadline()
+    {
+        var options = new Options().ForUntrustedCode(CreateLimits());
+        var first = new Engine(options);
+        var second = new Engine(options);
+
+        first.Constraints.Find<OperationDeadlineConstraint>().Should().NotBeSameAs(
+            second.Constraints.Find<OperationDeadlineConstraint>());
+    }
+
+    [Fact]
+    public async Task ConcurrentConstructionNeverMutatesSharedOptionsOrReopensAnExistingEngine()
+    {
+        var limits = CreateLimits();
+        using var secondCallbackEntered = new ManualResetEventSlim(false);
+        using var releaseSecondCallback = new ManualResetEventSlim(false);
+        var callbackCount = 0;
+        var options = new Options().AllowClrWrite();
+        options.Configure(_ =>
+        {
+            if (Interlocked.Increment(ref callbackCount) == 2)
+            {
+                secondCallbackEntered.Set();
+                releaseSecondCallback.Wait();
+            }
+        });
+        options.ForUntrustedCode(limits);
+
+        var first = new Engine(options).SetValue("host", new WritableHost());
+        var secondTask = Task.Run(() => new Engine(options));
+        secondCallbackEntered.Wait();
+
+        options.Interop.AllowWrite.Should().BeTrue();
+        Invoking(() => first.Execute("'use strict'; host.Value = 42;"))
+            .Should().Throw<JavaScriptException>();
+
+        releaseSecondCallback.Set();
+        var second = await secondTask;
+        second.SetValue("host", new WritableHost());
+        Invoking(() => second.Execute("'use strict'; host.Value = 42;"))
+            .Should().Throw<JavaScriptException>();
+    }
+
+    [Fact]
+    public void ProfileSettingsAreObservedByScriptAndProjectedObjects()
+    {
+        var host = new WritableHost();
+        var array = new[] { 1, 2, 3 };
+        var engine = new Engine(options => options.ForUntrustedCode(CreateLimits()))
+            .SetValue("host", host)
+            .SetValue("array", array);
+
+        engine.Evaluate("typeof System").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof ''.UnsafeCapability").AsString().Should().Be("undefined");
+        Invoking(() => engine.Modules.Import("blocked"))
+            .Should().Throw<InvalidOperationException>().WithMessage("*disabled*");
+
+        Invoking(() => engine.Execute("'use strict'; host.Value = 42;"))
+            .Should().Throw<JavaScriptException>();
+        host.Value.Should().Be(1);
+
+        engine.Execute("array[0] = 42;");
+        array[0].Should().Be(1);
+        engine.Evaluate("Array.isArray(array)").AsBoolean().Should().BeTrue();
+
+        Invoking(() => engine.Evaluate("eval('1 + 1')"))
+            .Should().ThrowExactly<JavaScriptException>()
+            .WithMessage("String compilation has been disabled in engine options");
+        Invoking(() => engine.Evaluate("new Function('return 1')"))
+            .Should().ThrowExactly<JavaScriptException>()
+            .WithMessage("String compilation has been disabled in engine options");
+
+        Invoking(() => engine.Evaluate(
+                "Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 0)"))
+            .Should().ThrowExactly<JavaScriptException>()
+            .WithMessage("Atomics.wait cannot be used in this agent");
+    }
+
+    [Fact]
+    public void ProfileClearsHostFactoryAndOperatorCapabilities()
+    {
+        var factoryInvoked = false;
+        OperatorHost.InvocationCount = 0;
+        var options = new Options()
+            .UseHostFactory(_ =>
+            {
+                factoryInvoked = true;
+                return new Host();
+            });
+        options.Interop.AllowOperatorOverloading = true;
+        options.ForUntrustedCode(CreateLimits());
+        var engine = new Engine(options).SetValue("host", new OperatorHost());
+
+        engine.Evaluate("host + host");
+
+        factoryInvoked.Should().BeFalse();
+        OperatorHost.InvocationCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void ProfileDoesNotExposeNonPublicClrMembers()
+    {
+        var options = new Options();
+        options.Interop.ObjectWrapperReportedFieldBindingFlags = BindingFlags.Instance | BindingFlags.NonPublic;
+        options.Interop.ObjectWrapperReportedPropertyBindingFlags = BindingFlags.Instance | BindingFlags.NonPublic;
+        options.Interop.ObjectWrapperReportedMethodBindingFlags = BindingFlags.Instance | BindingFlags.NonPublic;
+        options.ForUntrustedCode(CreateLimits());
+        var engine = new Engine(options).SetValue("host", new PrivateHost());
+
+        engine.Evaluate("host.Secret").IsUndefined().Should().BeTrue();
+        engine.Advanced.ValidateSecurityConfiguration().Diagnostics.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CopiedClrArraysRespectTheProfileArrayLimit()
+    {
+        var engine = new Engine(options => options.ForUntrustedCode(CreateLimits(maxArraySize: 2)));
+
+        Invoking(() => engine.SetValue("array", new[] { 1, 2, 3 }))
+            .Should().Throw<MemoryLimitExceededException>()
+            .WithMessage("*larger than maximum allowed*2*");
+    }
+
+    [Fact]
+    public void PerEntryTimeoutIsEnforced()
+    {
+        var limits = CreateLimits(timeoutInterval: TimeSpan.FromMilliseconds(1));
+        var engine = new Engine(options => options.ForUntrustedCode(limits))
+            .SetValue("pause", new Action(() => Thread.Sleep(TimeSpan.FromMilliseconds(25))));
+
+        Invoking(() => engine.Evaluate("pause(); 1;")).Should().Throw<TimeoutException>();
+    }
+
+    [Fact]
+    public void OperationScopeEnforcesAndThenDisarmsTheMultiEntryDeadline()
+    {
+        var limits = CreateLimits(maxOperationDuration: TimeSpan.FromMilliseconds(1));
+        var engine = new Engine(options => options.ForUntrustedCode(limits));
+
+        using var cancellation = new CancellationTokenSource();
+        using (limits.BeginOperation(engine, cancellation.Token))
+        {
+            engine.Constraints.Find<MemoryLimitConstraint>()!.IsOperationActive.Should().BeTrue();
+            Thread.Sleep(TimeSpan.FromMilliseconds(25));
+            Invoking(engine.Constraints.Check).Should().Throw<TimeoutException>();
+        }
+
+        Invoking(engine.Constraints.Check).Should().NotThrow();
+        engine.Constraints.Find<MemoryLimitConstraint>()!.IsOperationActive.Should().BeFalse();
+    }
+
+    [Fact]
+    public void NestedOperationScopeIsRejectedWithoutDisarmingTheOuterScope()
+    {
+        var limits = CreateLimits(maxOperationDuration: TimeSpan.FromMilliseconds(1));
+        var engine = new Engine(options => options.ForUntrustedCode(limits));
+
+        using var cancellation = new CancellationTokenSource();
+        using (limits.BeginOperation(engine, cancellation.Token))
+        {
+            Invoking(() => limits.BeginOperation(engine, cancellation.Token))
+                .Should().Throw<InvalidOperationException>()
+                .WithMessage("*already active*");
+
+            Thread.Sleep(TimeSpan.FromMilliseconds(25));
+            Invoking(engine.Constraints.Check).Should().Throw<TimeoutException>();
+        }
+
+        Invoking(engine.Constraints.Check).Should().NotThrow();
+    }
+
+    [Fact]
+    public async Task ConcurrentOperationScopesCannotBothAcquireTheDeadline()
+    {
+        var limits = CreateLimits();
+        var engine = new Engine(options => options.ForUntrustedCode(limits));
+        using var cancellation = new CancellationTokenSource();
+        using var start = new Barrier(2);
+        using var attempted = new CountdownEvent(2);
+        using var release = new ManualResetEventSlim(false);
+        var acquired = 0;
+        var rejected = 0;
+
+        Task Attempt()
+        {
+            return Task.Run(() =>
+            {
+                start.SignalAndWait();
+                IDisposable? scope = null;
+                try
+                {
+                    scope = limits.BeginOperation(engine, cancellation.Token);
+                    Interlocked.Increment(ref acquired);
+                }
+                catch (InvalidOperationException)
+                {
+                    Interlocked.Increment(ref rejected);
+                }
+                finally
+                {
+                    attempted.Signal();
+                    if (scope is not null)
+                    {
+                        release.Wait();
+                        scope.Dispose();
+                    }
+                }
+            });
+        }
+
+        var first = Attempt();
+        var second = Attempt();
+        attempted.Wait();
+        release.Set();
+        await Task.WhenAll(first, second);
+
+        acquired.Should().Be(1);
+        rejected.Should().Be(1);
+        Invoking(engine.Constraints.Check).Should().NotThrow();
+    }
+
+    [Fact]
+    public async Task OperationScopeCannotEndWhileAsyncWorkOwnsTheEngine()
+    {
+        var limits = CreateLimits();
+        using var cancellation = new CancellationTokenSource();
+        // TaskCompletionSource<bool> rather than the non-generic one, which only exists from .NET 5 and
+        // this project also compiles for net472.
+        var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var engine = new Engine(options => options.ForUntrustedCode(limits))
+            .SetValue("gate", new Func<Task>(() => gate.Task));
+        var scope = limits.BeginOperation(engine, cancellation.Token);
+        var pending = engine.EvaluateAsync("(async () => { await gate(); return 42; })()");
+
+        Invoking(scope.Dispose)
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("*asynchronous operation in progress*");
+
+        gate.SetResult(true);
+        (await pending).AsNumber().Should().Be(42);
+        Invoking(scope.Dispose).Should().NotThrow();
+        engine.Constraints.Find<MemoryLimitConstraint>()!.IsOperationActive.Should().BeFalse();
+    }
+
+    [Fact]
+    public void OperationScopeFailsClosedWhenTheProfileWasNotInstalled()
+    {
+        var limits = CreateLimits();
+
+        using var cancellation = new CancellationTokenSource();
+        Invoking(() => limits.BeginOperation(new Engine(), cancellation.Token))
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("*ForUntrustedCode*");
+    }
+
+    [Fact]
+    public void OperationScopeRejectsAGeneralPurposeDeadlineWithoutTheProfile()
+    {
+        var limits = CreateLimits();
+        var engine = new Engine(options =>
+            options.Constraint(static () => new OperationDeadlineConstraint()));
+
+        using var cancellation = new CancellationTokenSource();
+        Invoking(() => limits.BeginOperation(engine, cancellation.Token))
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("*ForUntrustedCode*");
+    }
+
+    [Fact]
+    public void OperationScopeRejectsADifferentLimitsInstance()
+    {
+        var configuredLimits = CreateLimits();
+        var otherLimits = CreateLimits();
+        var engine = new Engine(options => options.ForUntrustedCode(configuredLimits));
+
+        using var cancellation = new CancellationTokenSource();
+        Invoking(() => otherLimits.BeginOperation(engine, cancellation.Token))
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("*this UntrustedCodeLimits instance*");
+    }
+
+    [Fact]
+    public void RejectsNonPositiveLimits()
+    {
+        AssertInvalid(() => CreateLimits(timeoutInterval: TimeSpan.Zero), "timeoutInterval");
+        AssertInvalid(() => CreateLimits(maxStatements: 0), "maxStatements");
+        AssertInvalid(() => CreateLimits(memoryLimit: 0), "memoryLimit");
+        AssertInvalid(() => CreateLimits(maxRecursionDepth: -1), "maxRecursionDepth");
+        AssertInvalid(() => CreateLimits(maxArraySize: 0), "maxArraySize");
+        AssertInvalid(() => CreateLimits(regexTimeout: TimeSpan.Zero), "regexTimeout");
+        AssertInvalid(() => CreateLimits(promiseTimeout: TimeSpan.Zero), "promiseTimeout");
+        AssertInvalid(() => CreateLimits(maxOperationDuration: TimeSpan.Zero), "maxOperationDuration");
+    }
+
+    [Fact]
+    public void RejectsSaturatedUnlimitedLimits()
+    {
+        AssertInvalid(() => CreateLimits(timeoutInterval: TimeSpan.MaxValue), "timeoutInterval");
+        AssertInvalid(() => CreateLimits(maxStatements: int.MaxValue), "maxStatements");
+        AssertInvalid(() => CreateLimits(memoryLimit: long.MaxValue), "memoryLimit");
+        AssertInvalid(() => CreateLimits(maxRecursionDepth: int.MaxValue), "maxRecursionDepth");
+        AssertInvalid(() => CreateLimits(maxArraySize: uint.MaxValue), "maxArraySize");
+        AssertInvalid(() => CreateLimits(regexTimeout: TimeSpan.MaxValue), "regexTimeout");
+        AssertInvalid(() => CreateLimits(promiseTimeout: TimeSpan.MaxValue), "promiseTimeout");
+        AssertInvalid(() => CreateLimits(maxOperationDuration: TimeSpan.MaxValue), "maxOperationDuration");
+    }
+
+    [Fact]
+    public void ProfileRequiresLimits()
+    {
+        Action act = () => new Options().ForUntrustedCode(null!);
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("limits");
+    }
+
+    [Fact]
+    public void RejectsUnboundedResultLimits()
+    {
+        Invoking(() => new UntrustedCodeLimits(
+                TimeSpan.FromSeconds(1),
+                1_000,
+                1_000_000,
+                16,
+                1_000,
+                TimeSpan.FromMilliseconds(100),
+                TimeSpan.FromMilliseconds(100),
+                TimeSpan.FromSeconds(2),
+                resultLimits: ResultLimits.Unlimited))
+            .Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName("resultLimits");
+    }
+
+    [Fact]
+    public void EffectiveDiagnosticsDoNotRetainProfileState()
+    {
+        var (limits, options, engine, report) = CreateCollectibleProfileReport();
+
+        ForceCollection();
+
+        limits.IsAlive.Should().BeFalse();
+        options.IsAlive.Should().BeFalse();
+        engine.IsAlive.Should().BeFalse();
+        report.Diagnostics.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void OperationScopeRequiresACancellableToken()
+    {
+        var limits = CreateLimits();
+        var engine = new Engine(options => options.ForUntrustedCode(limits));
+
+        Invoking(() => limits.BeginOperation(engine, CancellationToken.None))
+            .Should().Throw<ArgumentException>()
+            .WithParameterName("cancellationToken");
+    }
+
+    [Fact]
+    public void OperationScopeSpansEvaluationConversionSerializationAndErrorRendering()
+    {
+        var limits = CreateLimits();
+        using var cancellation = new CancellationTokenSource();
+        var engine = new Engine(options => options.ForUntrustedCode(limits));
+
+        using (limits.BeginOperation(engine, cancellation.Token))
+        {
+            var value = engine.Evaluate("({ answer: 42 })");
+            engine.Advanced.ConvertResult(value).Should().NotBeNull();
+            new JsonSerializer(engine).Serialize(value).AsString().Should().Be("""{"answer":42}""");
+
+            var exception = Invoking(() => engine.Evaluate("throw new Error('safe')"))
+                .Should().ThrowExactly<JavaScriptException>().Which;
+            exception.GetJavaScriptErrorString(limits.ResultLimits).Should().Contain("safe");
+        }
+    }
+
+    [Fact]
+    public void OperationScopeCancellationIsHostVisibleAndCleansUp()
+    {
+        var limits = CreateLimits();
+        using var cancellation = new CancellationTokenSource();
+        var engine = new Engine(options => options.ForUntrustedCode(limits));
+
+        using (limits.BeginOperation(engine, cancellation.Token))
+        {
+            cancellation.Cancel();
+            Invoking(engine.Constraints.Check)
+                .Should().Throw<OperationCanceledException>()
+                .Which.CancellationToken.Should().Be(cancellation.Token);
+        }
+
+        engine.Constraints.Find<MemoryLimitConstraint>()!.IsOperationActive.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ProfileDiagnosticsAreExactAndUserCallbacksRemainVisible()
+    {
+        var cleanOptions = new Options().ForUntrustedCode(CreateLimits());
+        cleanOptions.ValidateSecurityConfiguration().Diagnostics.Should().BeEmpty();
+        new Engine(cleanOptions).Advanced.ValidateSecurityConfiguration().Diagnostics.Should().BeEmpty();
+
+        var callbackOptions = new Options();
+        callbackOptions.Configure(static _ => { });
+        callbackOptions.ForUntrustedCode(CreateLimits());
+        var report = new Engine(callbackOptions).Advanced.ValidateSecurityConfiguration();
+
+        report.Diagnostics.Select(static diagnostic => diagnostic.Code)
+            .Should().Equal(SecurityDiagnosticCodes.EngineConstructionCallback);
+    }
+
+    [Fact]
+    public void ProfileBoundsParserAndResults()
+    {
+        var limits = new UntrustedCodeLimits(
+            TimeSpan.FromSeconds(5),
+            100_000,
+            16_000_000,
+            64,
+            10_000,
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromSeconds(10),
+            maxSourceLength: 30,
+            maxNodeCount: 100,
+            resultLimits: new ResultLimits(
+                maxDepth: 2,
+                maxPropertyCount: 1,
+                maxStringLength: 5,
+                maxOutputCharacters: 10,
+                maxOutputBytes: 10));
+        var engine = new Engine(options => options.ForUntrustedCode(limits));
+
+        Invoking(() => engine.Evaluate($"'{new string('1', 31)}'"))
+            .Should().Throw<ParsingLimitException>();
+        var value = engine.Evaluate("({ a: 1, b: 2 })");
+        Invoking(() => engine.Advanced.ConvertResult(value))
+            .Should().Throw<ResultLimitExceededException>();
+    }
+
+    private static UntrustedCodeLimits CreateLimits(
+        TimeSpan? timeoutInterval = null,
+        int? maxStatements = null,
+        long? memoryLimit = null,
+        int? maxRecursionDepth = null,
+        uint? maxArraySize = null,
+        TimeSpan? regexTimeout = null,
+        TimeSpan? promiseTimeout = null,
+        TimeSpan? maxOperationDuration = null)
+    {
+        return new UntrustedCodeLimits(
+            timeoutInterval ?? TimeSpan.FromSeconds(5),
+            maxStatements ?? 100_000,
+            memoryLimit ?? 16_000_000,
+            maxRecursionDepth ?? 64,
+            maxArraySize ?? 10_000,
+            regexTimeout ?? TimeSpan.FromMilliseconds(100),
+            promiseTimeout ?? TimeSpan.FromMilliseconds(100),
+            maxOperationDuration ?? TimeSpan.FromSeconds(10));
+    }
+
+    private static void AssertInvalid(Func<UntrustedCodeLimits> create, string parameterName)
+    {
+        create.Should().Throw<ArgumentOutOfRangeException>().WithParameterName(parameterName);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static (WeakReference Limits, WeakReference Options, WeakReference Engine, SecurityConfigurationReport Report)
+        CreateCollectibleProfileReport()
+    {
+        var limits = CreateLimits();
+        var options = new Options().ForUntrustedCode(limits);
+        var engine = new Engine(options);
+        var report = engine.Advanced.ValidateSecurityConfiguration();
+        return (new WeakReference(limits), new WeakReference(options), new WeakReference(engine), report);
+    }
+
+    private static void ForceCollection()
+    {
+        for (var i = 0; i < 3; i++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+        }
+    }
+
+    private sealed class WritableHost
+    {
+        public int Value { get; set; } = 1;
+    }
+
+    private sealed class OperatorHost
+    {
+        public static int InvocationCount { get; set; }
+
+        public static OperatorHost operator +(OperatorHost left, OperatorHost right)
+        {
+            InvocationCount++;
+            return left;
+        }
+
+    }
+
+    private sealed class PrivateHost
+    {
+        private string Secret => "secret";
+    }
+}
+
+internal static class UntrustedCodeProfileStringExtensions
+{
+    public static string UnsafeCapability(this string value) => value;
+}

--- a/Jint/Constraints/OperationDeadlineConstraint.cs
+++ b/Jint/Constraints/OperationDeadlineConstraint.cs
@@ -64,6 +64,8 @@ namespace Jint.Constraints;
 /// </remarks>
 public sealed class OperationDeadlineConstraint : Constraint
 {
+    private static readonly object _endingScope = new();
+
     // No operation is in flight, so the deadline half of Check never fails. Mirrors TimeConstraint's
     // not-started sentinel, and is also what a non-positive budget arms.
     private const long Disarmed = 0;
@@ -72,6 +74,7 @@ public sealed class OperationDeadlineConstraint : Constraint
     private long _deadline;
 
     private CancellationToken _cancellationToken;
+    private object? _scopeOwner;
 
     /// <summary>
     /// A deadline and a cancellation token are both external state that <see cref="Check"/> only reads and
@@ -135,6 +138,26 @@ public sealed class OperationDeadlineConstraint : Constraint
     {
         _deadline = Disarmed;
         _cancellationToken = default;
+    }
+
+    internal bool TryBeginScope(object owner, TimeSpan budget, CancellationToken cancellationToken)
+    {
+        if (Interlocked.CompareExchange(ref _scopeOwner, owner, null) is not null)
+        {
+            return false;
+        }
+
+        Begin(budget, cancellationToken);
+        return true;
+    }
+
+    internal void EndScope(object owner)
+    {
+        if (ReferenceEquals(Interlocked.CompareExchange(ref _scopeOwner, _endingScope, owner), owner))
+        {
+            End();
+            Volatile.Write(ref _scopeOwner, null);
+        }
     }
 
     /// <summary>

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -806,6 +806,7 @@ public sealed partial class Engine : IDisposable
 
     internal readonly bool _isDebugMode;
     internal readonly bool _isStrict;
+    internal readonly UntrustedCodeLimits? _untrustedCodeLimits;
 
     // Whether the reference resolver is consulted at all, plus the per-situation subscription flags
     // derived from Options.ReferenceResolverInterests. Splitting them is what lets a resolver that only
@@ -956,10 +957,12 @@ public sealed partial class Engine : IDisposable
 
         _executionContexts = new ExecutionContextStack(2);
 
-        // we can use default options if there's no action to modify it
-        Options = options ?? (configure is not null ? new Options() : _defaultEngineOptions);
-
-        configure?.Invoke(this, Options);
+        // A hardened profile is applied to an engine-local snapshot. Options is documented as shareable
+        // between concurrently constructed engines, so deferred rehardening must never mutate its source.
+        var sourceOptions = options ?? (configure is not null ? new Options() : _defaultEngineOptions);
+        configure?.Invoke(this, sourceOptions);
+        Options = sourceOptions.CreateEngineOptions();
+        _untrustedCodeLimits = Options.UntrustedCodeLimits;
 
         _extensionMethods = ExtensionMethodCache.Build(Options.Interop.ExtensionMethodTypes);
 

--- a/Jint/Options.Extensions.cs
+++ b/Jint/Options.Extensions.cs
@@ -1,8 +1,10 @@
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using Jint.Constraints;
 using Jint.Native;
 using Jint.Runtime;
+using Jint.Runtime.CallStack;
 using Jint.Runtime.Debugger;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Descriptors.Specialized;
@@ -16,6 +18,134 @@ namespace Jint;
 /// </summary>
 public static class OptionsExtensions
 {
+    /// <summary>
+    /// Configures the engine to run untrusted JavaScript with a hardened static surface and explicit,
+    /// request-appropriate resource limits.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The profile disables CLR namespace and reflection access, registered extension methods, module loading,
+    /// debugger handling, agent suspension, writes through projected CLR objects, live CLR array views and
+    /// dynamic string compilation. It also enables the native stack-overflow guard.
+    /// </para>
+    /// <para>
+    /// Every resource limit is required through <paramref name="limits"/>; there are no universal defaults
+    /// suitable for every workload. Per-entry limits are enforced automatically. A host operation made from
+    /// several entries must additionally be enclosed in
+    /// <see cref="UntrustedCodeLimits.BeginOperation(Engine, System.Threading.CancellationToken)"/>.
+    /// </para>
+    /// <para>
+    /// The profile declaration is immutable engine input: each engine receives a private effective options
+    /// snapshot, applies the profile before construction, and reapplies it after user construction callbacks.
+    /// The source <see cref="Options"/> remains unchanged and can be shared by concurrently constructed engines.
+    /// User callbacks remain visible to security diagnostics but cannot reopen profile-controlled settings.
+    /// </para>
+    /// </remarks>
+    /// <param name="options">Options to harden.</param>
+    /// <param name="limits">Finite limits chosen for the host request and workload.</param>
+    /// <returns>The options instance for fluent configuration.</returns>
+    public static Options ForUntrustedCode(this Options options, UntrustedCodeLimits limits)
+    {
+        if (limits is null)
+        {
+            Throw.ArgumentNullException(nameof(limits));
+        }
+
+        options.UntrustedCodeLimits = limits;
+        return options;
+    }
+
+    internal static void ApplyUntrustedCodeOptions(Options options, UntrustedCodeLimits limits)
+    {
+        options.UntrustedCodeLimits = limits;
+        options.Constraints.Constraints.Clear();
+        options.Constraints.ConstraintFactories.Clear();
+        options.Constraints.RequestedMaxStatements = null;
+        options.Constraints.RequestedMemoryLimit = null;
+        options.Constraints.RequestedTimeoutInterval = null;
+        options.Constraints.CancellationConstraintRequested = false;
+        options.Constraints.OperationDeadlineConstraintRequested = false;
+
+        options.Interop.Enabled = false;
+        options.Interop.AllowedAssemblies = [];
+        options.Interop.AllowGetType = false;
+        options.Interop.AllowSystemReflection = false;
+        options.Interop.AllowWrite = false;
+        options.Interop.AllowOperatorOverloading = false;
+        options.Interop.ArrayConversion = ArrayConversionMode.Copy;
+        options.Interop.ExtensionMethodTypes.Clear();
+        options.Interop.ObjectConverters.Clear();
+        options.Interop.ImmutableCrossingTypes.Clear();
+        options.Interop.WrapObjectHandler = Options.InteropOptions._defaultWrapObjectHandler;
+        options.Interop.MemberAccessor = Options.InteropOptions._defaultMemberAccessor;
+        options.Interop.ExceptionHandler = Options.InteropOptions._defaultExceptionHandler;
+        options.Interop.BuildCallStackHandler = null;
+        options.Interop.SerializeToJson = null;
+        options.Interop.CreateClrObject = Options.InteropOptions._defaultCreateClrObject;
+        options.Interop.CreateTypeReferenceObject = Options.InteropOptions._defaultCreateTypeReferenceObject;
+        options.Interop.ObjectWrapperReportedPropertyKeys = Options.InteropOptions._defaultReportedPropertyKeys;
+        options.Interop.ExposeDetailedExceptionMessages = false;
+        options.Interop.ExposeDetailedResolutionErrors = false;
+        options.Interop.ChainClrExceptionAsInnerException = false;
+        options.Interop.ClrExceptionErrorDecorator = null;
+        options.Interop.ClrResolutionErrorDecorator = null;
+        options.Interop.ObjectWrapperReportedFieldBindingFlags = BindingFlags.Instance | BindingFlags.Public;
+        options.Interop.ObjectWrapperReportedPropertyBindingFlags = BindingFlags.Instance | BindingFlags.Public;
+        options.Interop.ObjectWrapperReportedMethodBindingFlags =
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.Static;
+
+        options.Modules.ModuleLoader = FailFastModuleLoader.Instance;
+        options.Modules.RegisterRequire = false;
+        options.Modules.MaxModuleCount = limits.MaxModuleCount;
+        options.Modules.MaxTotalModuleSourceBytes = limits.MaxTotalModuleSourceBytes;
+        options.Modules.MaxModuleGraphDepth = limits.MaxModuleGraphDepth;
+        options.Modules.MaxModuleResolutionHops = limits.MaxModuleResolutionHops;
+        options.Modules.LoadPolicy = null;
+        options.Modules.ExposeDetailedLoadErrors = false;
+
+        options.Debugger.Enabled = false;
+        options.Debugger.StatementHandling = Runtime.Debugger.DebuggerStatementHandling.Ignore;
+        options.Debugger.InitialStepMode = StepMode.None;
+
+        options.AgentCanSuspend = false;
+        options.ExperimentalFeatures = ExperimentalFeature.None;
+        options.RetainFunctionSourceText = false;
+        options.Host.StringCompilationAllowed = false;
+        options.Host.Factory = Options.HostOptions._defaultFactory;
+        options.Host.FunctionToStringHandler = Options.HostOptions._defaultFunctionToStringHandler;
+        options.ReferenceResolver = DefaultReferenceResolver.Instance;
+        options.ReferenceResolverInterests = ReferenceResolverInterests.None;
+        options.Constraints.MaxExecutionStackCount = StackGuard.Disabled;
+        options.Constraints.StackOverflowGuard = true;
+        options.Constraints.CancellationConstraintRequested = true;
+        options.Parsing.MaxSourceLength = limits.MaxSourceLength;
+        options.Parsing.MaxNodeCount = limits.MaxNodeCount;
+        options.ResultLimits = limits.ResultLimits;
+
+        options.LimitRecursion(limits.MaxRecursionDepth);
+        options.MaxArraySize(limits.MaxArraySize);
+        options.RegexTimeoutInterval(limits.RegexTimeout);
+        options.Constraints.PromiseTimeout = limits.PromiseTimeout;
+
+        options.TimeoutInterval(limits.TimeoutInterval);
+        options.MaxStatements(limits.MaxStatements);
+        options.LimitMemory(limits.MemoryLimit);
+        options.Constraint(static () => new OperationDeadlineConstraint());
+    }
+
+    internal static void ReapplyUntrustedCodeOptions(
+        Options options,
+        Engine engine,
+        UntrustedCodeLimits limits)
+    {
+        ApplyUntrustedCodeOptions(options, limits);
+        engine.TypeConverter = new DefaultTypeConverter(engine);
+        engine.Constraints.Find<MaxStatementsConstraint>()!.MaxStatements = limits.MaxStatements;
+        engine.Constraints.Find<MemoryLimitConstraint>()!.End();
+        engine.Constraints.Find<OperationDeadlineConstraint>()!.End();
+        engine.Modules = new Engine.ModuleOperations(engine, FailFastModuleLoader.Instance);
+    }
+
     /// <summary>
     /// Run the script in strict mode.
     /// </summary>

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -23,11 +23,12 @@ public partial class Options
     private static readonly TimeZoneInfo _defaultTimeZone = TimeZoneInfo.Local;
 
     private ITimeSystem? _timeSystem;
-    internal List<EngineConfiguration> _configurations { get; } = new();
+    internal List<EngineConfiguration> _configurations { get; private set; } = new();
     internal bool HasUserHostFactory { get; set; }
     internal bool HasUserEngineConstructionCallback =>
         HasUserHostFactory
         || _configurations.Exists(static configuration => configuration.Provenance == EngineConfigurationProvenance.User);
+    internal UntrustedCodeLimits? UntrustedCodeLimits { get; set; }
 
     public delegate JsValue? MemberAccessorDelegate(Engine engine, object target, string member);
 
@@ -48,22 +49,22 @@ public partial class Options
     /// <summary>
     /// Execution constraints for the engine.
     /// </summary>
-    public ConstraintOptions Constraints { get; } = new();
+    public ConstraintOptions Constraints { get; private set; } = new();
 
     /// <summary>
     /// Resource limits applied while parsing scripts and modules.
     /// </summary>
-    public ParsingOptions Parsing { get; } = new();
+    public ParsingOptions Parsing { get; private set; } = new();
 
     /// <summary>
     /// CLR interop related options.
     /// </summary>
-    public InteropOptions Interop { get; } = new();
+    public InteropOptions Interop { get; private set; } = new();
 
     /// <summary>
     /// Debugger configuration.
     /// </summary>
-    public DebuggerOptions Debugger { get; } = new();
+    public DebuggerOptions Debugger { get; private set; } = new();
 
     /// <summary>
     /// Script code coverage configuration. Off by default.
@@ -73,12 +74,12 @@ public partial class Options
     /// <summary>
     /// Host options.
     /// </summary>
-    public HostOptions Host { get; } = new();
+    public HostOptions Host { get; private set; } = new();
 
     /// <summary>
     /// Module options
     /// </summary>
-    public ModuleOptions Modules { get; } = new();
+    public ModuleOptions Modules { get; private set; } = new();
 
     /// <summary>
     /// Internationalization (Intl) options.
@@ -252,6 +253,11 @@ public partial class Options
             configuration.Apply(engine);
         }
 
+        if (UntrustedCodeLimits is { } limits)
+        {
+            OptionsExtensions.ReapplyUntrustedCodeOptions(this, engine, limits);
+        }
+
         // add missing bits if needed
         if (Interop.Enabled)
         {
@@ -306,6 +312,26 @@ public partial class Options
                     }),
                 PropertyFlag.AllForbidden));
         }
+    }
+
+    internal Options CreateEngineOptions()
+    {
+        if (UntrustedCodeLimits is null)
+        {
+            return this;
+        }
+
+        var clone = (Options) MemberwiseClone();
+        clone._configurations = new List<EngineConfiguration>(_configurations);
+        clone.Constraints = Constraints.Clone();
+        clone.Parsing = Parsing.Clone();
+        clone.Interop = Interop.Clone();
+        clone.Debugger = Debugger.Clone();
+        clone.Host = Host.Clone();
+        clone.Modules = Modules.Clone();
+        clone.Json = new JsonOptions { MaxParseDepth = Json.MaxParseDepth };
+        OptionsExtensions.ApplyUntrustedCodeOptions(clone, UntrustedCodeLimits);
+        return clone;
     }
 
     private static void AttachExtensionMethodsToPrototypes(Engine engine)
@@ -394,6 +420,8 @@ public partial class Options
         /// Configures the step mode used when entering the script.
         /// </summary>
         public StepMode InitialStepMode { get; set; } = StepMode.None;
+
+        internal DebuggerOptions Clone() => (DebuggerOptions) MemberwiseClone();
     }
 
     /// <summary>
@@ -489,12 +517,12 @@ public partial class Options
         /// <summary>
         /// Types holding extension methods that should be considered when resolving methods.
         /// </summary>
-        public List<Type> ExtensionMethodTypes { get; } = new();
+        public List<Type> ExtensionMethodTypes { get; private set; } = new();
 
         /// <summary>
         /// Object converters to try when build-in conversions.
         /// </summary>
-        public List<IObjectConverter> ObjectConverters { get; } = new();
+        public List<IObjectConverter> ObjectConverters { get; private set; } = new();
 
         /// <summary>
         /// CLR types whose instances the host promises are immutable while they are exposed to the engine —
@@ -510,7 +538,7 @@ public partial class Options
         /// <see cref="TrackObjectWrapperIdentity"/> and a shared <see cref="TypeResolver"/> already describe,
         /// and owned by the host in exactly the same way. Read once, while the engine is being constructed.
         /// </remarks>
-        public List<Type> ImmutableCrossingTypes { get; } = new();
+        public List<Type> ImmutableCrossingTypes { get; private set; } = new();
 
         /// <summary>
         /// Whether identity map is persisted for object wrappers in order to maintain object identity. This can cause
@@ -789,6 +817,16 @@ public partial class Options
         internal static readonly ReportedPropertyKeysDelegate _defaultReportedPropertyKeys = static (_, _) => null;
 
         public ReportedPropertyKeysDelegate ObjectWrapperReportedPropertyKeys { get; set; } = _defaultReportedPropertyKeys;
+
+        internal InteropOptions Clone()
+        {
+            var clone = (InteropOptions) MemberwiseClone();
+            clone.ExtensionMethodTypes = new List<Type>(ExtensionMethodTypes);
+            clone.ObjectConverters = new List<IObjectConverter>(ObjectConverters);
+            clone.ImmutableCrossingTypes = new List<Type>(ImmutableCrossingTypes);
+            clone.AllowedAssemblies = new List<Assembly>(AllowedAssemblies);
+            return clone;
+        }
     }
 
     public class ConstraintOptions
@@ -804,14 +842,14 @@ public partial class Options
         /// (<see cref="OptionsExtensions.Constraint(Options, Func{Constraint})"/>) so each engine gets
         /// its own instance; the built-in constraint extension methods already do that.
         /// </remarks>
-        public List<Constraint> Constraints { get; } = new();
+        public List<Constraint> Constraints { get; private set; } = new();
 
         /// <summary>
         /// Registered constraint factories. Each engine built from these options invokes every factory
         /// exactly once while constructing, so the constraints — and the per-execution state they carry —
         /// belong to that engine alone.
         /// </summary>
-        internal List<Func<Constraint>> ConstraintFactories { get; } = new();
+        internal List<Func<Constraint>> ConstraintFactories { get; private set; } = new();
 
         internal int? RequestedMaxStatements { get; set; }
 
@@ -925,6 +963,14 @@ public partial class Options
         /// How many iterations is Atomics.pause allowed to instruct to wait using <see cref="System.Threading.Thread.SpinWait"/>, defaults to 10 000.
         /// </summary>
         public int MaxAtomicsPauseIterations { get; set; } = 10_000;
+
+        internal ConstraintOptions Clone()
+        {
+            var clone = (ConstraintOptions) MemberwiseClone();
+            clone.Constraints = new List<Constraint>(Constraints);
+            clone.ConstraintFactories = new List<Func<Constraint>>(ConstraintFactories);
+            return clone;
+        }
     }
 
     /// <summary>
@@ -948,6 +994,8 @@ public partial class Options
         /// <see langword="null"/> (the default) means no limit.
         /// </summary>
         public int? MaxNodeCount { get; set; }
+
+        internal ParsingOptions Clone() => (ParsingOptions) MemberwiseClone();
     }
 
     /// <summary>
@@ -955,7 +1003,9 @@ public partial class Options
     /// </summary>
     public class HostOptions
     {
-        internal Func<Engine, Host> Factory { get; set; } = _ => new Host();
+        internal static readonly Func<Engine, Host> _defaultFactory = static _ => new Host();
+
+        internal Func<Engine, Host> Factory { get; set; } = _defaultFactory;
 
         /// <summary>
         /// Whether calling 'eval' with custom code and function constructors taking function code as string is allowed.
@@ -983,6 +1033,8 @@ public partial class Options
         internal static readonly Func<Function, Node, string?> _defaultFunctionToStringHandler = static (_, _) => null;
 
         public Func<Function, Node, string?> FunctionToStringHandler { get; set; } = _defaultFunctionToStringHandler;
+
+        internal HostOptions Clone() => (HostOptions) MemberwiseClone();
     }
 
     /// <summary>
@@ -1055,6 +1107,8 @@ public partial class Options
         /// <see cref="JintException.TryGetClrException"/>.
         /// </summary>
         public bool ExposeDetailedLoadErrors { get; set; }
+
+        internal ModuleOptions Clone() => (ModuleOptions) MemberwiseClone();
     }
 
     /// <summary>

--- a/Jint/Runtime/Interop/DefaultObjectConverter.cs
+++ b/Jint/Runtime/Interop/DefaultObjectConverter.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Jint.Native;
+using Jint.Native.Array;
 using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Interop;
@@ -434,6 +435,12 @@ internal static class DefaultObjectConverter
     private static JsArray CreateArraySnapshot(Engine engine, Array source)
     {
         var length = (uint) source.Length;
+        if (engine._untrustedCodeLimits is not null
+            && length > engine.Options.Constraints.MaxArraySize)
+        {
+            ArrayInstance.ThrowMaximumArraySizeReachedException(engine, length);
+        }
+
         return new JsArray(engine, new JsValue[length]);
     }
 

--- a/Jint/SecurityConfiguration.cs
+++ b/Jint/SecurityConfiguration.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Reflection;
 using System.Text;
 using Jint.Constraints;
 using Jint.Runtime;
@@ -34,7 +35,10 @@ internal readonly record struct EngineSecurityConfigurationSnapshot(
     int MaxExecutionStackCount,
     bool ClrCompatibilityMode,
     bool ClrPolicyUnrestricted,
-    bool ExtensionMethodsConfigured)
+    bool ExtensionMethodsConfigured,
+    bool OperatorOverloadingAllowed,
+    bool NonPublicBindingFlags,
+    bool UntrustedProfileApplied)
 {
     internal static EngineSecurityConfigurationSnapshot Capture(Engine engine)
     {
@@ -56,7 +60,12 @@ internal readonly record struct EngineSecurityConfigurationSnapshot(
             interop.Enabled && ReferenceEquals(interop.TypeResolver, TypeResolver.Default),
             !ReferenceEquals(
                 engine._extensionMethods,
-                Runtime.Interop.Reflection.ExtensionMethodCache.Empty));
+                Runtime.Interop.Reflection.ExtensionMethodCache.Empty),
+            engine._operatorOverloadingAllowed,
+            (interop.ObjectWrapperReportedFieldBindingFlags & BindingFlags.NonPublic) != BindingFlags.Default
+                || (interop.ObjectWrapperReportedPropertyBindingFlags & BindingFlags.NonPublic) != BindingFlags.Default
+                || (interop.ObjectWrapperReportedMethodBindingFlags & BindingFlags.NonPublic) != BindingFlags.Default,
+            engine._untrustedCodeLimits is not null);
     }
 }
 
@@ -134,6 +143,8 @@ public static class SecurityDiagnosticCodes
     public const string LiveClrArrayWritesEnabled = "JINTSEC055";
     public const string ModuleAllowlistInsufficient = "JINTSEC056";
     public const string ClrExtensionMethodsConfigured = "JINTSEC057";
+    public const string ClrOperatorOverloadingEnabled = "JINTSEC058";
+    public const string NonPublicClrMembersEnabled = "JINTSEC059";
 }
 
 /// <summary>
@@ -225,7 +236,7 @@ public static class OptionsSecurityExtensions
         SecurityConfigurationPolicy policy = SecurityConfigurationPolicy.UntrustedScripts)
     {
         ArgumentNull(options, nameof(options));
-        return CreateReport(CreateOptionsDiagnostics(options!, policy));
+        return CreateReport(CreateOptionsDiagnostics(options!.CreateEngineOptions(), policy));
     }
 
     /// <summary>
@@ -239,8 +250,9 @@ public static class OptionsSecurityExtensions
         ArgumentNull(options, nameof(options));
         ArgumentNull(parsingOptions, nameof(parsingOptions));
 
+        var effectiveOptions = options!.CreateEngineOptions();
         var diagnostics = CreateOptionsDiagnostics(
-            options!,
+            effectiveOptions,
             policy,
             includeParsing: false,
             includeEngineRegex: !parsingOptions!.RegexTimeout.HasValue);
@@ -251,8 +263,8 @@ public static class OptionsSecurityExtensions
 
         var limits = parsingOptions as IParsingLimitOptions;
         AddParsing(
-            Minimum(options.Parsing.MaxSourceLength, limits?.MaxSourceLength),
-            Minimum(options.Parsing.MaxNodeCount, limits?.MaxNodeCount),
+            Minimum(effectiveOptions.Parsing.MaxSourceLength, limits?.MaxSourceLength),
+            Minimum(effectiveOptions.Parsing.MaxNodeCount, limits?.MaxNodeCount),
             parsingOptions.RetainFunctionSourceText,
             diagnostics);
         return CreateReport(diagnostics);
@@ -319,7 +331,10 @@ public static class OptionsSecurityExtensions
             engineSnapshot: engine._securityConfigurationSnapshot,
             effectiveModuleLoader: engine.Modules.ModuleLoader);
         diagnostics.RemoveAll(static diagnostic => IsConstraintCode(diagnostic.Code));
-        AddEffectiveConstraints(engine.ActiveConstraintsForSecurityDiagnostics, diagnostics);
+        AddEffectiveConstraints(
+            engine.ActiveConstraintsForSecurityDiagnostics,
+            engine._securityConfigurationSnapshot.UntrustedProfileApplied,
+            diagnostics);
         return CreateReport(diagnostics);
     }
 
@@ -454,6 +469,7 @@ public static class OptionsSecurityExtensions
 
     private static void AddEffectiveConstraints(
         Constraint[] constraints,
+        bool untrustedProfileApplied,
         List<SecurityDiagnostic> diagnostics)
     {
         var hasStatements = false;
@@ -491,7 +507,7 @@ public static class OptionsSecurityExtensions
                 "Register a positive finite TimeConstraint.");
         }
 
-        if (!hasCancellation)
+        if (!hasCancellation && !untrustedProfileApplied)
         {
             Error(diagnostics, SecurityDiagnosticCodes.CancellationMissing,
                 "The constructed engine has no cancellation constraint.",
@@ -677,6 +693,20 @@ public static class OptionsSecurityExtensions
                 "Remove extension methods from untrusted engines or audit every exposed method as a host capability.");
         }
 
+        if (engineSnapshot?.OperatorOverloadingAllowed ?? interop.AllowOperatorOverloading)
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.ClrOperatorOverloadingEnabled,
+                "CLR operator overloads can execute host methods.",
+                "Disable Interop.AllowOperatorOverloading for untrusted engines.");
+        }
+
+        if (engineSnapshot?.NonPublicBindingFlags ?? HasNonPublicBindingFlags(interop))
+        {
+            Error(diagnostics, SecurityDiagnosticCodes.NonPublicClrMembersEnabled,
+                "CLR member binding flags include non-public members.",
+                "Use public instance fields/properties and public instance/static methods only.");
+        }
+
         if (engineSnapshot?.ClrCompatibilityMode
             ?? (interop.Enabled && interop.ClrAccessConfiguration == ClrAccessConfiguration.Compatibility))
         {
@@ -716,6 +746,11 @@ public static class OptionsSecurityExtensions
                 "Disable debug mode, debugger statements, and initial stepping.");
         }
     }
+
+    private static bool HasNonPublicBindingFlags(Options.InteropOptions interop)
+        => (interop.ObjectWrapperReportedFieldBindingFlags & BindingFlags.NonPublic) != BindingFlags.Default
+            || (interop.ObjectWrapperReportedPropertyBindingFlags & BindingFlags.NonPublic) != BindingFlags.Default
+            || (interop.ObjectWrapperReportedMethodBindingFlags & BindingFlags.NonPublic) != BindingFlags.Default;
 
     private static void AddModules(
         Options options,

--- a/Jint/UntrustedCodeLimits.cs
+++ b/Jint/UntrustedCodeLimits.cs
@@ -1,0 +1,323 @@
+using System.Threading;
+using Jint.Constraints;
+using Jint.Runtime;
+
+namespace Jint;
+
+/// <summary>
+/// Explicit resource limits for an engine configured with
+/// <see cref="OptionsExtensions.ForUntrustedCode"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This type deliberately has no defaults. Limits for untrusted code depend on the request and workload,
+/// so the host must choose every value. Values that the ordinary constraint helpers interpret as
+/// "unlimited" are rejected instead of silently disabling a protection.
+/// </para>
+/// <para>
+/// <see cref="TimeoutInterval"/>, <see cref="MaxStatements"/> and <see cref="MemoryLimit"/> apply to one
+/// top-level engine entry. <see cref="MaxOperationDuration"/> spans a host operation containing several
+/// entries, but only while the host brackets that operation with <see cref="BeginOperation"/>.
+/// </para>
+/// </remarks>
+public sealed class UntrustedCodeLimits
+{
+    /// <summary>
+    /// Creates a complete set of finite limits for untrusted code.
+    /// </summary>
+    /// <param name="timeoutInterval">Maximum wall-clock time for one engine entry.</param>
+    /// <param name="maxStatements">Maximum statements executed by one engine entry.</param>
+    /// <param name="memoryLimit">Maximum bytes allocated by one engine entry.</param>
+    /// <param name="maxRecursionDepth">
+    /// Maximum recursion depth. Zero forbids recursion; unlike <see cref="OptionsExtensions.LimitRecursion"/>,
+    /// negative and saturated values are rejected rather than treated as unlimited or effectively unlimited.
+    /// </param>
+    /// <param name="maxArraySize">Maximum JavaScript array size.</param>
+    /// <param name="regexTimeout">
+    /// Maximum time one regular expression operation may run. A prepared script or module carries the timeout
+    /// from its own parsing options, so prepare untrusted code with the same value.
+    /// </param>
+    /// <param name="promiseTimeout">Maximum time the engine may wait for a promise to settle.</param>
+    /// <param name="maxOperationDuration">
+    /// Maximum wall-clock time for a host operation containing one or more engine entries. The host must
+    /// activate this limit with <see cref="BeginOperation"/> around each operation.
+    /// </param>
+    /// <param name="maxSourceLength">Maximum UTF-16 source length for every engine-owned parse.</param>
+    /// <param name="maxNodeCount">Maximum AST nodes for every engine-owned parse.</param>
+    /// <param name="maxModuleCount">Maximum distinct module records registered by one engine.</param>
+    /// <param name="maxTotalModuleSourceBytes">Maximum aggregate module source bytes registered by one engine.</param>
+    /// <param name="maxModuleGraphDepth">Maximum graph depth for one top-level module load.</param>
+    /// <param name="maxModuleResolutionHops">Maximum resolver calls for one top-level module load.</param>
+    /// <param name="resultLimits">Bounds conversion, JSON serialization, and error rendering.</param>
+    public UntrustedCodeLimits(
+        TimeSpan timeoutInterval,
+        int maxStatements,
+        long memoryLimit,
+        int maxRecursionDepth,
+        uint maxArraySize,
+        TimeSpan regexTimeout,
+        TimeSpan promiseTimeout,
+        TimeSpan maxOperationDuration,
+        int maxSourceLength = 1_000_000,
+        int maxNodeCount = 250_000,
+        int maxModuleCount = 100,
+        long maxTotalModuleSourceBytes = 10_000_000,
+        int maxModuleGraphDepth = 32,
+        int maxModuleResolutionHops = 1_000,
+        ResultLimits? resultLimits = null)
+    {
+        ValidateFiniteTimeout(timeoutInterval, nameof(timeoutInterval));
+        ValidateRange(maxStatements, nameof(maxStatements));
+        ValidateRange(memoryLimit, nameof(memoryLimit));
+
+        if (maxRecursionDepth < 0 || maxRecursionDepth == int.MaxValue)
+        {
+            Throw.ArgumentOutOfRangeException(
+                nameof(maxRecursionDepth),
+                "The recursion depth must be between zero and Int32.MaxValue - 1.");
+        }
+
+        if (maxArraySize == 0 || maxArraySize == uint.MaxValue)
+        {
+            Throw.ArgumentOutOfRangeException(
+                nameof(maxArraySize),
+                "The array size must be between one and UInt32.MaxValue - 1.");
+        }
+
+        ValidateFiniteTimeout(regexTimeout, nameof(regexTimeout));
+        ValidateFiniteTimeout(promiseTimeout, nameof(promiseTimeout));
+        ValidateFiniteTimeout(maxOperationDuration, nameof(maxOperationDuration));
+        ValidateRange(maxSourceLength, nameof(maxSourceLength));
+        ValidateRange(maxNodeCount, nameof(maxNodeCount));
+        ValidateRange(maxModuleCount, nameof(maxModuleCount));
+        ValidateRange(maxTotalModuleSourceBytes, nameof(maxTotalModuleSourceBytes));
+        ValidateRange(maxModuleGraphDepth, nameof(maxModuleGraphDepth));
+        ValidateRange(maxModuleResolutionHops, nameof(maxModuleResolutionHops));
+        resultLimits ??= ResultLimits.Conservative;
+        ValidateResultLimits(resultLimits, nameof(resultLimits));
+
+        TimeoutInterval = timeoutInterval;
+        MaxStatements = maxStatements;
+        MemoryLimit = memoryLimit;
+        MaxRecursionDepth = maxRecursionDepth;
+        MaxArraySize = maxArraySize;
+        RegexTimeout = regexTimeout;
+        PromiseTimeout = promiseTimeout;
+        MaxOperationDuration = maxOperationDuration;
+        MaxSourceLength = maxSourceLength;
+        MaxNodeCount = maxNodeCount;
+        MaxModuleCount = maxModuleCount;
+        MaxTotalModuleSourceBytes = maxTotalModuleSourceBytes;
+        MaxModuleGraphDepth = maxModuleGraphDepth;
+        MaxModuleResolutionHops = maxModuleResolutionHops;
+        ResultLimits = resultLimits;
+    }
+
+    /// <summary>
+    /// Maximum wall-clock time for one engine entry.
+    /// </summary>
+    public TimeSpan TimeoutInterval { get; }
+
+    /// <summary>
+    /// Maximum statements executed by one engine entry.
+    /// </summary>
+    public int MaxStatements { get; }
+
+    /// <summary>
+    /// Maximum bytes allocated by one engine entry.
+    /// </summary>
+    public long MemoryLimit { get; }
+
+    /// <summary>
+    /// Maximum recursion depth. Zero forbids recursion.
+    /// </summary>
+    public int MaxRecursionDepth { get; }
+
+    /// <summary>
+    /// Maximum JavaScript array size.
+    /// </summary>
+    public uint MaxArraySize { get; }
+
+    /// <summary>
+    /// Maximum time one regular expression operation may run.
+    /// </summary>
+    /// <remarks>
+    /// A prepared script or module carries the timeout selected when it was prepared; set its parsing options
+    /// to this value as well.
+    /// </remarks>
+    public TimeSpan RegexTimeout { get; }
+
+    /// <summary>
+    /// Maximum time the engine may wait for a promise to settle.
+    /// </summary>
+    public TimeSpan PromiseTimeout { get; }
+
+    /// <summary>
+    /// Maximum wall-clock time for a host operation containing one or more engine entries.
+    /// </summary>
+    public TimeSpan MaxOperationDuration { get; }
+
+    /// <summary>Maximum UTF-16 source length for every engine-owned parse.</summary>
+    public int MaxSourceLength { get; }
+
+    /// <summary>Maximum AST nodes for every engine-owned parse.</summary>
+    public int MaxNodeCount { get; }
+
+    /// <summary>Maximum distinct module records registered by one engine.</summary>
+    public int MaxModuleCount { get; }
+
+    /// <summary>Maximum aggregate module source bytes registered by one engine.</summary>
+    public long MaxTotalModuleSourceBytes { get; }
+
+    /// <summary>Maximum conservative graph depth for one top-level module load.</summary>
+    public int MaxModuleGraphDepth { get; }
+
+    /// <summary>Maximum resolver calls for one top-level module load.</summary>
+    public int MaxModuleResolutionHops { get; }
+
+    /// <summary>Bounds result conversion, JSON serialization, and error rendering.</summary>
+    public ResultLimits ResultLimits { get; }
+
+    /// <summary>
+    /// Arms the multi-entry operation deadline installed by
+    /// <see cref="OptionsExtensions.ForUntrustedCode"/> and returns a scope that disarms it.
+    /// </summary>
+    /// <param name="engine">The engine that will execute the operation.</param>
+    /// <param name="cancellationToken">A cancellable token tied to the same host operation.</param>
+    /// <returns>
+    /// A scope that must enclose every engine entry belonging to the operation. Disposing it ends the
+    /// operation deadline.
+    /// </returns>
+    /// <remarks>
+    /// The deadline is a cooperative engine constraint. A host callback that does not return cannot be
+    /// preempted, and an idle asynchronous wait may observe its separate <see cref="PromiseTimeout"/> before
+    /// the engine reaches another constraint checkpoint. Keep the outer worker/request deadline as the hard
+    /// stop. Operation scopes cannot overlap on one engine; a nested or concurrent scope is rejected rather
+    /// than allowed to disarm the still-active outer deadline.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// The engine was not configured with this limits instance through
+    /// <see cref="OptionsExtensions.ForUntrustedCode"/>, or an operation scope is already active.
+    /// </exception>
+    public IDisposable BeginOperation(Engine engine, CancellationToken cancellationToken)
+    {
+        if (engine is null)
+        {
+            Throw.ArgumentNullException(nameof(engine));
+        }
+
+        if (!cancellationToken.CanBeCanceled)
+        {
+            Throw.ArgumentException(
+                "A cancellable host-operation token is required.",
+                nameof(cancellationToken));
+        }
+
+        using var ownership = engine!.EnterHostCall();
+        if (!ReferenceEquals(engine._untrustedCodeLimits, this))
+        {
+            Throw.InvalidOperationException(
+                "The engine was not configured with this UntrustedCodeLimits instance through Options.ForUntrustedCode.");
+        }
+
+        var deadline = engine.Constraints.Find<OperationDeadlineConstraint>();
+        var memory = engine.Constraints.Find<MemoryLimitConstraint>();
+        if (deadline is null || memory is null)
+        {
+            Throw.InvalidOperationException(
+                "The engine does not contain the complete untrusted-code operation constraints.");
+        }
+
+        var scope = new OperationScope(engine, deadline!, memory!);
+        if (!deadline.TryBeginScope(scope, MaxOperationDuration, cancellationToken))
+        {
+            Throw.InvalidOperationException(
+                "An untrusted-code operation scope is already active for this engine.");
+        }
+
+        try
+        {
+            memory.Begin();
+        }
+        catch
+        {
+            deadline.EndScope(scope);
+            throw;
+        }
+
+        return scope;
+    }
+
+    private static void ValidateFiniteTimeout(TimeSpan value, string paramName)
+    {
+        if (value <= TimeSpan.Zero || value == TimeSpan.MaxValue)
+        {
+            Throw.ArgumentOutOfRangeException(
+                paramName,
+                "The timeout must be greater than zero and less than TimeSpan.MaxValue.");
+        }
+    }
+
+    private static void ValidateRange(int value, string paramName)
+    {
+        if (value <= 0 || value == int.MaxValue)
+        {
+            Throw.ArgumentOutOfRangeException(
+                paramName,
+                "The limit must be between one and Int32.MaxValue - 1.");
+        }
+    }
+
+    private static void ValidateRange(long value, string paramName)
+    {
+        if (value <= 0 || value == long.MaxValue)
+        {
+            Throw.ArgumentOutOfRangeException(
+                paramName,
+                "The limit must be between one and Int64.MaxValue - 1.");
+        }
+    }
+
+    private static void ValidateResultLimits(ResultLimits limits, string paramName)
+    {
+        if (limits.MaxDepth == int.MaxValue
+            || limits.MaxPropertyCount == long.MaxValue
+            || limits.MaxStringLength == int.MaxValue
+            || limits.MaxOutputCharacters == long.MaxValue
+            || limits.MaxOutputBytes == long.MaxValue)
+        {
+            Throw.ArgumentOutOfRangeException(
+                paramName,
+                "Every result limit must be finite for untrusted code.");
+        }
+    }
+
+    private sealed class OperationScope(
+        Engine engine,
+        OperationDeadlineConstraint deadline,
+        MemoryLimitConstraint memory) : IDisposable
+    {
+        private int _state;
+
+        public void Dispose()
+        {
+            if (Interlocked.CompareExchange(ref _state, 1, 0) != 0)
+            {
+                return;
+            }
+
+            try
+            {
+                using var ownership = engine.EnterHostCall();
+                memory.End();
+                deadline.EndScope(this);
+                Volatile.Write(ref _state, 2);
+            }
+            catch
+            {
+                Volatile.Write(ref _state, 0);
+                throw;
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -2426,6 +2426,90 @@ astronomical, Chinese/Dangi at extreme dates) is on the roadmap; until then non-
 calendars use `System.Globalization.Calendar` subclasses, which constrains some date
 ranges (see [`Jint/Native/Temporal/NonIsoCalendars.cs`](Jint/Native/Temporal/NonIsoCalendars.cs)).
 
+## Running untrusted code
+
+`ForUntrustedCode` applies Jint's opt-in hardened profile. It disables CLR namespace and reflection access,
+registered extension methods, module loading, debugger handling, blocking `Atomics.wait`, writes through
+projected CLR objects, live views over CLR arrays, and `eval`/function constructors that compile strings. It
+also enables the native stack-overflow guard.
+
+Core execution limits are required rather than guessed: a useful budget depends on the request and workload,
+and a security API must not silently turn saturated sentinels into "unlimited." Parser, module-graph, and
+result limits have conservative finite defaults that should still be tuned for the host:
+
+```c#
+var limits = new UntrustedCodeLimits(
+    timeoutInterval: TimeSpan.FromSeconds(1),       // one Engine entry
+    maxStatements: 100_000,                        // one Engine entry
+    memoryLimit: 16_000_000,                       // one Engine entry
+    maxRecursionDepth: 64,
+    maxArraySize: 10_000,
+    regexTimeout: TimeSpan.FromMilliseconds(250),
+    promiseTimeout: TimeSpan.FromSeconds(1),
+    maxOperationDuration: TimeSpan.FromSeconds(2),
+    maxSourceLength: 100_000,
+    maxNodeCount: 25_000,
+    maxModuleCount: 50,
+    maxTotalModuleSourceBytes: 1_000_000,
+    maxModuleGraphDepth: 10,
+    maxModuleResolutionHops: 200,
+    resultLimits: new ResultLimits(
+        maxDepth: 16,
+        maxPropertyCount: 10_000,
+        maxStringLength: 100_000,
+        maxOutputCharacters: 1_000_000,
+        maxOutputBytes: 2_000_000));
+
+// Build once and share concurrently. ForUntrustedCode records an immutable profile declaration;
+// every Engine gets a private effective snapshot and construction never mutates sharedOptions.
+var sharedOptions = new Options().Strict().ForUntrustedCode(limits);
+using var engine = new Engine(sharedOptions);
+
+using (limits.BeginOperation(engine, cancellationToken))
+{
+    try
+    {
+        var value = engine.Evaluate(source);
+        var json = new JsonSerializer(engine).Serialize(value).AsString();
+        return Encoding.UTF8.GetBytes(json); // keep the transport's own response-byte cap too
+    }
+    catch (JavaScriptException exception)
+    {
+        return Encoding.UTF8.GetBytes(exception.GetJavaScriptErrorString(limits.ResultLimits));
+    }
+}
+```
+
+`TimeoutInterval` and statement count reset around each top-level engine entry. `BeginOperation` requires a
+cancellable host token and spans one cumulative wall-clock deadline and managed-allocation budget across
+evaluation/import, callbacks, `ConvertResult`, `JsonSerializer`, and bounded error rendering. Ordinary
+statement limits intentionally remain per-entry. Like Jint's other constraints, these are cooperative: they
+cannot preempt a host callback that does not return. Keep an outer worker/request deadline as the hard stop.
+Scopes cannot overlap, cannot end while async work still owns the engine, and failed disposal remains
+retryable after that work completes.
+
+Prepared scripts and modules carry the regex timeout selected when they were prepared. When preparing
+untrusted code for reuse, pass the same limit explicitly:
+
+```c#
+var prepared = Engine.PrepareScript(source, new ScriptPreparationOptions
+{
+    ParsingOptions = new ScriptParsingOptions { RegexTimeout = limits.RegexTimeout }
+});
+```
+
+Configuration order cannot reopen profile-controlled settings. The profile is applied to the private engine
+snapshot before construction and reapplied after user `Configure` callbacks; registered extension methods,
+custom converters/factories, detailed errors, unsafe CLR policies, loaders, and programmatic modules are
+removed. User callbacks remain an honestly reported `JINTSEC031` host capability. Mutating the shared source
+`Options` after engines are being constructed is still unsupported; finish configuration before sharing it.
+The compatibility tradeoffs are intentional: projected CLR arrays become snapshots, projected CLR members
+are read-only, registered extension methods are removed, dynamic string compilation and module imports fail,
+and `Atomics.wait` raises a JavaScript `TypeError`. Projected methods/delegates and callbacks deliberately
+exposed by the host remain capabilities. The profile is defense in depth, not process isolation; mutually
+distrusting scripts should still use separate engines in disposable least-privileged workers with OS CPU,
+memory, filesystem, network, and lifetime controls.
+
 ## Execution Constraints 
 
 Execution constraints are used during script execution to ensure that requirements around resource consumption are met, for example:


### PR DESCRIPTION
## Summary

Adds the final hardened `ForUntrustedCode` profile and exact-profile operation scope on top of the complete security stack.

- records an immutable `UntrustedCodeLimits` declaration on shared `Options`, then constructs a private effective options snapshot per Engine without mutating shared state
- applies the complete profile before construction and reapplies it after user `Configure` callbacks, while preserving first-party provenance and reporting genuine host callbacks as `JINTSEC031`
- disables CLR namespace/reflection/GetType/write/operator/non-public-member access, extension methods, converters/factories, detailed error channels, live CLR arrays, debugger behavior, string compilation, programmatic/custom modules, blocking Atomics, and unsafe stack behavior
- composes finite parser, module graph, result, regex, promise, statement, recursion, array, memory, per-entry timeout, and cumulative operation controls
- makes `BeginOperation` exact-profile and ownership-safe, rejects overlap, requires a cancellable token, and spans cumulative deadline plus memory accounting across evaluation/import and bounded output handling; statement limits retain their existing per-entry reset contract
- preserves async ownership transfer and rejects scope disposal while async work still owns the Engine
- documents the profile as defense in depth, not an OS sandbox, with a shared-options server example and residual host/worker responsibilities

## Stack

This is the final/top PR in the stack:

#3059 -> #3058 -> #3057 -> #3056 -> #3054 -> #3052 -> #3051 -> #3046 -> #3045 -> #3037 -> #3036 -> #3035 -> #3030

Base: `sebros/security-configuration-diagnostics-79b` (`5c54305b8c0fc1debb2965f4770cd58213de0384`).

## Review

A max-scope security/API/concurrency review traced the complete composed branch. Confirmed findings fixed:

- shared `Options` mutation during concurrent Engine construction
- false first-party `JINTSEC031` provenance
- CLR operator and non-public binding-flag escape paths
- detailed CLR/module error disclosure left enabled
- non-atomic operation acquisition/disposal and cumulative-memory coordination
- profile-triggered constraint factory probing during diagnostics/construction
- effective diagnostics reading mutable binding flags instead of the Engine snapshot

The final follow-up review reported no confirmed security findings.

A correctly profiled Engine now has an empty expected security report. Genuine user construction callbacks remain the sole `JINTSEC031` finding and cannot reopen profile-controlled effective settings.

## Validation

- Release multi-target `Jint` build: passed (`net462`, `netstandard2.0`, `netstandard2.1`, `net8.0`, `net10.0`)
- `Jint.Tests.PublicInterface`: 1,785 passed, 9 expected verification-only skips
- `JINT_HOST_CONTRACT_VERIFICATION=1` PublicInterface: 1,789 passed, 5 expected non-verifying skips
- full `Jint.Tests` under UTC: 5,801 passed, 4 pre-existing skips
- combined 13-layer security selection: 380 passed
- concurrency/scope/async stress: 10 runs x 44 tests, all passed
- focused GC retention: 2 passed
- benchmark project build: passed
- `git diff --check`: clean

The mandated proxy does not currently contain `Meziantou.Analyzer` 3.0.156, so validation temporarily used proxy-available 3.0.141 and restored the repository pin before commit. `Test262Harness.Console` 1.1.2 is also unavailable from `https://packagefeedproxy.microsoft.io/nuget/v3/index.json`, so Test262 generation/conformance could not be run; no workaround is committed.

## Benchmarks

Default BenchmarkDotNet jobs (not `--job short`):

- fresh Engine: 518.0 ns, 8.5 KB
- hardened-profile Engine: 1,091.6 ns, 12.23 KB
- guarded execution control: 10.88 ms unconstrained; 11.12 ms statement-only; 11.90 ms timeout-only; 12.12 ms timeout+statement; exact memory accounting rows 28.96-30.41 ms; all rows allocated 960 B

The private effective snapshot adds about 0.57 microseconds and 3.73 KB per hardened Engine, with no shared `Options` mutation. Guard overhead remains consistent with the existing constraint cost model.