### PR TITLE
Answer a sloppy function's own arguments instead of throwing

### DIFF
--- a/Jint.Tests/Runtime/FunctionTests.cs
+++ b/Jint.Tests/Runtime/FunctionTests.cs
@@ -1011,4 +1011,46 @@ assertEqual(booleanCount, 1);
         Invoking(() => engine.Invoke(ns.Get("run")))
             .Should().Throw<JavaScriptException>().WithMessage("*read only*");
     }
+
+    [Fact]
+    public void ASloppyFunctionsOwnArgumentsIsReadableRatherThanAThrower()
+    {
+        var engine = new Engine();
+
+        // A library's own-property copier, with its skip-list built from a strict function — which has no
+        // own "arguments" to list, so the name never reaches the skip-list.
+        engine.Execute("""
+            "use strict";
+            var blank = function () { };
+            var skip = Object.getOwnPropertyNames(blank);
+            globalThis.copy = function (fn) {
+                return Object.getOwnPropertyNames(fn).reduce(function (acc, k) {
+                    if (skip.indexOf(k) === -1) acc[k] = fn[k];
+                    return acc;
+                }, {});
+            };
+            """);
+
+        // A separate, non-strict script: this function does carry own "arguments" and "caller", so the
+        // copier above reads both. That read is what used to throw.
+        engine.Execute("var sloppy = function () { }; var copied = copy(sloppy);");
+
+        engine.Evaluate("Object.getOwnPropertyNames(blank).join(',')").AsString()
+            .Should().Be("length,name,prototype");
+        engine.Evaluate("Object.getOwnPropertyNames(sloppy).join(',')").AsString()
+            .Should().Be("length,name,prototype,arguments,caller");
+        engine.Evaluate("copied.arguments").Should().Be(JsValue.Null);
+        // undefined, not null: test262's sentinel for an engine that does not offer the caller extension.
+        engine.Evaluate("copied.caller").Should().Be(JsValue.Undefined);
+    }
+
+    [Fact]
+    public void AStrictFunctionsRestrictedPropertiesStillThrowFromThePrototype()
+    {
+        var engine = new Engine();
+        Invoking(() => engine.Evaluate("(function () { 'use strict'; }).caller"))
+            .Should().Throw<JavaScriptException>().WithMessage("*may not be accessed*");
+        Invoking(() => engine.Evaluate("(function () { 'use strict'; }).arguments"))
+            .Should().Throw<JavaScriptException>().WithMessage("*may not be accessed*");
+    }
 }

--- a/Jint/Native/Function/ScriptFunction.cs
+++ b/Jint/Native/Function/ScriptFunction.cs
@@ -111,13 +111,21 @@ public sealed class ScriptFunction : Function, IConstructor
         }
     }
 
+    // A plain data property holding null, which is what a browser answers for a function that is not
+    // currently executing. %ThrowTypeError% belongs on Function.prototype — where AddRestrictedFunctionProperties
+    // puts it, and where a *strict* function's read still lands; a thrower on the own property is reachable by
+    // a read no browser makes throw. Real code walks it:
+    // Object.getOwnPropertyNames(fn).reduce((acc, k) => (acc[k] = fn[k], acc), {}) is how a Flux-era
+    // library copies a store's statics, and its skip-list is built from a *strict* function, which has no
+    // own "arguments" to list — so the copy reads it off every sloppy one it is given.
     internal PropertyDescriptor MaterializeArgumentsDescriptor()
     {
-        // Same deferred %ThrowTypeError% resolution as the old eager descriptor: the thrower is
-        // looked up from the engine's active realm on the first Get/Set access either way.
-        return _argumentsDescriptor = new GetSetPropertyDescriptor.ThrowerPropertyDescriptor(_engine, PropertyFlag.Configurable);
+        return _argumentsDescriptor = new PropertyDescriptor(Null, PropertyFlag.Configurable);
     }
 
+    // Deliberately undefined rather than the null a browser answers: undefined is test262's sentinel for
+    // "this implementation does not offer the caller extension" (language/arguments-object/10.6-13-a-2 and
+    // -3), and the alternative is a value the suite then requires to be callable.
     internal PropertyDescriptor MaterializeCallerDescriptor()
     {
         return _callerDescriptor = new PropertyDescriptor(Undefined, PropertyFlag.Configurable);


### PR DESCRIPTION
## Summary

A non-strict function's own `arguments` throws when read, where browsers answer `null`.

## Details

`ScriptFunction` gives a non-strict, non-arrow, non-generator, non-async function its own `arguments` and `caller` — correct, that is the legacy extension browsers implement. But `arguments` is materialized as a `%ThrowTypeError%` accessor, so an ordinary read of the own property throws:

```js
function sloppy() { }
Object.getOwnPropertyNames(sloppy);  // ["length","name","prototype","arguments","caller"]
sloppy.caller;                       // undefined
sloppy.arguments;                    // TypeError: 'caller', 'callee', and 'arguments' properties
                                     // may not be accessed on strict mode functions ...
```

`%ThrowTypeError%` belongs on `Function.prototype`, which is where [`AddRestrictedFunctionProperties`](https://tc39.es/ecma262/#sec-addrestrictedfunctionproperties) installs it and where a **strict** function's read lands — that part is already right here and stays right. The own property on a sloppy function is a legacy extension, and V8, SpiderMonkey and JSC all implement it as a data property valued `null`. The asymmetry in the current code is itself the tell: `caller` is already a plain data property, only `arguments` is a thrower.

**This is not an exotic read.** The shape that walks into it is a generic own-property copier:

```js
Object.getOwnPropertyNames(fn).reduce((acc, k) => (acc[k] = fn[k], acc), {})
```

with a skip-list built from a *strict* function. A strict function has no own `arguments` to list (correctly — §17 Forbidden Extensions forbids it), so the skip-list does not carry the name, so the copier reads it off every sloppy function it is given. That is verbatim `getInternalMethods` in [alt 0.18.5](https://cdnjs.cloudflare.com/ajax/libs/alt/0.18.5/alt.min.js), and the throw takes down the store it was constructing. I hit it rendering a real page's bundle.

### Reproducible example

```csharp
var engine = new Engine();

// A library's own-property copier, with its skip-list built from a strict function — which has no
// own "arguments" to list, so the name never reaches the skip-list.
engine.Execute("""
    "use strict";
    var blank = function () { };
    var skip = Object.getOwnPropertyNames(blank);   // ["length","name","prototype"]
    globalThis.copy = function (fn) {
        return Object.getOwnPropertyNames(fn).reduce(function (acc, k) {
            if (skip.indexOf(k) === -1) acc[k] = fn[k];
            return acc;
        }, {});
    };
    """);

// A separate, non-strict script: this function does carry own "arguments" and "caller".
engine.Execute("var sloppy = function () { }; var copied = copy(sloppy);");
// before: Jint.Runtime.JavaScriptException: 'caller', 'callee', and 'arguments' properties
//         may not be accessed on strict mode functions or the arguments objects for calls to them
// after:  copied.arguments === null, copied.caller === undefined
```

The two `Execute` calls matter: the copier has to be defined in strict code and applied to a function declared in sloppy code, which is exactly how it lands on a page (a strict UMD module, a non-strict bundle around it).

Shorter, if that is easier to run:

```js
function sloppy() { }
try { sloppy.arguments; "no throw"; } catch (e) { "threw: " + e.message; }
```

### `caller` deliberately stays `undefined`

Browsers answer `null` for both, but the pair cannot be made symmetric here. test262's `language/arguments-object/10.6-13-a-2.js` and `-3.js` (flagged `noStrict`, feature `caller`) read `undefined` as "this implementation does not offer the caller extension" and take an escape hatch; any other value they require to be **callable**:

```js
function test2() {
    if (arguments.callee.caller === undefined) {
        called = true;      // Extension not supported - fake it
    } else {
        arguments.callee.caller(true);
    }
}
```

Changing `caller` to `null` fails both. I tried it first, so the comment on `MaterializeCallerDescriptor` now records why not — it is the obvious next "cleanup" otherwise.

## Linked issue

No existing issue — found while running a page's own bundle, and reported here with the repro above rather than opened separately. Happy to file one if you would prefer the PR linked.

## Test plan

- [x] Added or updated unit tests in `Jint.Tests` — `FunctionTests.ASloppyFunctionsOwnArgumentsIsReadableRatherThanAThrower` is the repro above, and pins the own-property names on both function kinds plus both values; `AStrictFunctionsRestrictedPropertiesStillThrowFromThePrototype` pins that a strict function's read still throws, from the prototype.
- [x] Ran `dotnet test --configuration Release` locally — `Jint.Tests` 5760/5760 on net10.0, 5676/5676 on net472. One pre-existing failure on this machine, `DateTests.ToLocaleStringOutsideDateTimeRangeDoesNotThrowAClrException`, fails identically on a clean `main` checkout here: local ICU renders the year as `−271821` with U+2212 where the assertion expects an ASCII hyphen. Unrelated to this change.
- [x] For ECMAScript spec changes: ran `Jint.Tests.Test262` — 102,326 passed, 342 skipped, **0 failed**, no regressions.
- [ ] For interop changes — n/a.
- [ ] For perf changes — n/a. `MaterializeArgumentsDescriptor` allocates a `PropertyDescriptor` instead of a `ThrowerPropertyDescriptor` on the same lazy path; the field-backed fast path and the pending sentinel are untouched.

## Breaking change?

No public-API change. Behavioural: `sloppyFn.arguments` returns `null` instead of throwing, and the property is now a data descriptor rather than an accessor — `Object.getOwnPropertyDescriptor(sloppyFn, "arguments")` reports `value`/`writable` where it previously reported `get`/`set`. Both move toward browser behaviour. Strict functions are unaffected, and `Function.prototype.arguments`/`caller` keep their throwers.
