### PR TITLE
Recognise the global environment by its type, not by a null outer link

### DIFF
--- a/Jint.Tests/Runtime/ReleasedEnvironmentLookupTests.cs
+++ b/Jint.Tests/Runtime/ReleasedEnvironmentLookupTests.cs
@@ -1,0 +1,78 @@
+using Jint.Native;
+using Jint.Runtime;
+using Jint.Runtime.Environments;
+using Environment = Jint.Runtime.Environments.Environment;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Identifier resolution must recognise the global environment by its type, not by having no outer
+/// environment. Environments are pooled and their outer link is cleared on release, so "no outer" is also
+/// true of any released environment that is still reachable — through a closure, a continuation, or a
+/// generator that resumes after the block it was declared in has been left.
+/// </summary>
+public class ReleasedEnvironmentLookupTests
+{
+    private static DeclarativeEnvironment ReleasedEnvironment(Engine engine, string name, JsValue value)
+    {
+        var env = new DeclarativeEnvironment(engine);
+        env.CreateMutableBindingAndInitialize(name, canBeDeleted: false, value, DisposeHint.Normal);
+
+        // What the pool does on release: JintBlockStatement, JintForInForOfStatement, JintTryStatement,
+        // ScriptFunction and EvalFunction all null the outer link before handing the record back.
+        env._outerEnv = null;
+        return env;
+    }
+
+    [Fact]
+    public void AReleasedEnvironmentIsNotMistakenForTheGlobalOne()
+    {
+        var engine = new Engine();
+        var env = ReleasedEnvironment(engine, "x", 42);
+        var name = new Environment.BindingName("x");
+
+        // The value-returning lookup used to take the "this is the global environment" branch here, cast to
+        // GlobalEnvironment and throw. Its sibling takes the same branch but has no cast, so it answers the
+        // same thing either way while a released environment's outer link stays null — the type test there
+        // is the premise being corrected, not a behaviour change.
+        JintEnvironment.TryGetIdentifierEnvironmentWithBindingValue(env, name, strict: false, out var record, out var value)
+            .Should().BeTrue();
+        record.Should().BeSameAs(env);
+        value.Should().Be((JsValue) 42);
+
+        JintEnvironment.TryGetIdentifierEnvironmentWithBinding(env, name, out var found).Should().BeTrue();
+        found.Should().BeSameAs(env);
+    }
+
+    [Fact]
+    public void AReleasedEnvironmentWithoutTheBindingReportsMissRatherThanThrowing()
+    {
+        var engine = new Engine();
+        var env = ReleasedEnvironment(engine, "x", 42);
+        var name = new Environment.BindingName("somethingElse");
+
+        // The walk ends at the cleared link. A miss is the honest answer — the outer chain this record
+        // used to sit in is gone — and it costs the caller a ReferenceError rather than a CLR exception.
+        JintEnvironment.TryGetIdentifierEnvironmentWithBindingValue(env, name, strict: false, out _, out _)
+            .Should().BeFalse();
+        JintEnvironment.TryGetIdentifierEnvironmentWithBinding(env, name, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TheGlobalEnvironmentIsStillAnsweredDirectly()
+    {
+        var engine = new Engine();
+        engine.Execute("var g = 7;");
+
+        var global = engine.Realm.GlobalEnv;
+        var name = new Environment.BindingName("g");
+
+        JintEnvironment.TryGetIdentifierEnvironmentWithBindingValue(global, name, strict: false, out var record, out var value)
+            .Should().BeTrue();
+        record.Should().BeSameAs(global);
+        value.Should().Be((JsValue) 7);
+
+        JintEnvironment.TryGetIdentifierEnvironmentWithBinding(global, name, out var found).Should().BeTrue();
+        found.Should().BeSameAs(global);
+    }
+}

--- a/Jint/Runtime/Environments/JintEnvironment.cs
+++ b/Jint/Runtime/Environments/JintEnvironment.cs
@@ -15,7 +15,11 @@ internal static class JintEnvironment
     {
         record = env;
 
-        if (env._outerEnv is null)
+        // The type, not the outer link. Jint pools environments and clears _outerEnv on release, so a
+        // released environment still reachable through a closure or a continuation is indistinguishable
+        // from the global one by that link alone. Here that is only a false premise — with no outer link
+        // the walk below reaches the same answer — but the sibling casts on it, and throws.
+        if (env is GlobalEnvironment)
         {
             return env.HasBinding(name);
         }
@@ -55,9 +59,10 @@ internal static class JintEnvironment
         record = env;
         value = default;
 
-        if (env._outerEnv is null)
+        // See the sibling above: a released environment also has a null outer link.
+        if (env is GlobalEnvironment globalEnv)
         {
-            return ((GlobalEnvironment) env).TryGetBinding(name, strict, out value);
+            return globalEnv.TryGetBinding(name, strict, out value);
         }
 
         while (record is not null)


### PR DESCRIPTION
## Summary

Identifier resolution mistakes a released, pooled environment for the global one and throws on the cast.

## Details

Both identifier lookups in `JintEnvironment` short-circuit on "this environment has no outer environment, therefore it is the global one":

```csharp
if (env._outerEnv is null)
{
    return ((GlobalEnvironment) env).TryGetBinding(name, strict, out value);
}
```

That premise is not exclusive. Jint pools environments and **clears the outer link on release** — `JintBlockStatement.cs:160` and `:286`, `JintForInForOfStatement.cs:949`, `JintTryStatement.cs:236`, `ScriptFunction.cs:341`, `EvalFunction.cs:492` all do `env._outerEnv = null` before handing the record back. A released `DeclarativeEnvironment` that is still reachable — through a closure, a continuation, or a generator resuming after its block has been left — is indistinguishable from the global environment by that link alone, takes the branch, and the cast throws:

```
System.InvalidCastException: Unable to cast object of type
'Jint.Runtime.Environments.DeclarativeEnvironment' to type
'Jint.Runtime.Environments.GlobalEnvironment'
   at Jint.Runtime.Environments.JintEnvironment.TryGetIdentifierEnvironmentWithBindingValue(...)
```

The fix is to ask the type instead: `env is GlobalEnvironment`. The global environment still short-circuits exactly as before; anything else falls into the walk below, which ends at the cleared link and reports a miss — a `ReferenceError` for the script rather than a CLR exception through the embedder.

### Reproducible example

The mishandling reproduces directly, and `ReleasedEnvironmentLookupTests` is that repro:

```csharp
var engine = new Engine();

var env = new DeclarativeEnvironment(engine);
env.CreateMutableBindingAndInitialize("x", canBeDeleted: false, 42, DisposeHint.Normal);
env._outerEnv = null;                       // what every release site above does

JintEnvironment.TryGetIdentifierEnvironmentWithBindingValue(
    env, new Environment.BindingName("x"), strict: false, out var record, out var value);
// before: System.InvalidCastException: Unable to cast object of type 'DeclarativeEnvironment'
//         to type 'GlobalEnvironment'
// after:  true, record == env, value == 42
```

Both new tests fail on `main` with that exact exception and pass with the change.

### What this PR does *not* claim to fix

I have **no repro for the escape itself** — for what leaves a released environment reachable in the first place. That is a separate question about the pooling's escape analysis, and I am not proposing an answer to it here. What I can show is that when it does happen, the failure mode is a CLR cast exception escaping into embedder code, and that it need not be. I have seen it three times in production, in a host that runs untrusted page scripts, and never once from a script I could reduce.

That is also why the second lookup changed. `TryGetIdentifierEnvironmentWithBinding` takes the same branch but has no cast, and while a released record's outer link stays null it reaches the same answer either way — so this is not a behaviour fix there. It moves to the type test because the premise is what is wrong, and leaving one of the pair asserting it invites the next cast.

## Linked issue

No existing issue — the symptom is a production stack trace with no script-level reduction, so there was nothing useful to file separately. Happy to open one if you would prefer the PR linked.

## Test plan

- [x] Added or updated unit tests in `Jint.Tests` — `ReleasedEnvironmentLookupTests`: a released environment is not mistaken for the global one, a released environment missing the binding reports a miss rather than throwing, and the global environment is still answered directly. The first two fail on `main` with `InvalidCastException`.
- [x] Ran `dotnet test --configuration Release` locally — `Jint.Tests` 5761/5761 on net10.0 (excluding one pre-existing failure, below), 5677/5677 on net472.
- [x] For ECMAScript spec changes: ran `Jint.Tests.Test262` — 102,326 passed, 342 skipped, **0 failed**, no regressions.
- [ ] For interop changes — n/a.
- [ ] For perf changes — n/a. A type check replaces a null check on the same branch; the global environment still takes it.

Pre-existing failure, unrelated and identical on a clean `main` checkout on this machine: `DateTests.ToLocaleStringOutsideDateTimeRangeDoesNotThrowAClrException` — local ICU renders the year as `−271821` with U+2212 where the assertion expects an ASCII hyphen.

## Breaking change?

No. No public-API change, and no behaviour change for the global environment or for any environment that still has its outer link.
