### PR TITLE
Keep the outer link on a parked Function-constructor environment

### DIFF
--- a/Jint.Tests/Runtime/DynamicFunctionEnvironmentReuseTests.cs
+++ b/Jint.Tests/Runtime/DynamicFunctionEnvironmentReuseTests.cs
@@ -1,0 +1,68 @@
+#nullable enable
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// A Function-constructor instance's call environment is parked on its definition when the call returns,
+/// so the next instance built from the same source rents it instead of allocating. Escape analysis lets a
+/// closure the call handed out survive that park — <c>EnvironmentMayEscape</c> only asks whether a closure
+/// reads one of the environment's own bindings — and such a closure still resolves everything else
+/// <em>through</em> that record, so the park must leave its outer link attached.
+/// </summary>
+public class DynamicFunctionEnvironmentReuseTests
+{
+    private const string Make =
+        "var make = new Function('a', 'var b = a; return function () { return answer; };');";
+
+    [Fact]
+    public void AClosureReturnedByADynamicFunctionStillReachesTheGlobalScope()
+    {
+        var engine = new Engine();
+        engine.Execute("var answer = 42;");
+        engine.Execute(Make);
+
+        // The closure reads no binding of the call it came from, which is what makes that call's
+        // environment poolable; its scope chain runs through the parked record all the same.
+        engine.Evaluate("make(1)()").Should().Be(42);
+    }
+
+    [Fact]
+    public void TheClosureKeepsAnsweringAfterTheParkedEnvironmentIsRented()
+    {
+        var engine = new Engine();
+        engine.Execute("var answer = 42;");
+        engine.Execute(Make);
+
+        engine.Execute("var first = make(1);");
+
+        // The second call rents what the first parked, and re-binds it to that call. The first
+        // closure reads nothing from it, so both keep answering.
+        engine.Execute("var second = make(2);");
+        engine.Evaluate("first()").Should().Be(42);
+        engine.Evaluate("second()").Should().Be(42);
+    }
+
+    [Fact]
+    public void AClosureThatDoesReadTheCallKeepsItsOwnValues()
+    {
+        var engine = new Engine();
+        engine.Execute("var make = new Function('a', 'var b = a * 10; return function () { return b; };');");
+
+        // Reading a slot is what the escape analysis looks for, so this call's environment is not
+        // pooled at all — the other half of the same rule, and the reason the shape above is the
+        // one that could break.
+        engine.Execute("var first = make(1); var second = make(2);");
+        engine.Evaluate("first()").Should().Be(10);
+        engine.Evaluate("second()").Should().Be(20);
+    }
+
+    [Fact]
+    public void AnObjectTheDynamicCallReturnedResolvesGlobalsThroughIt()
+    {
+        var engine = new Engine();
+        engine.Execute("var answer = 7;");
+        engine.Execute("var make = new Function('a', 'var b = a; return { read: function () { return answer; } };');");
+
+        engine.Evaluate("make(1).read()").Should().Be(7);
+    }
+}

--- a/Jint/Native/Function/ScriptFunction.cs
+++ b/Jint/Native/Function/ScriptFunction.cs
@@ -1,4 +1,4 @@
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using System.Threading;
 using Jint.Native.Object;
 using Jint.Pooling;
@@ -338,7 +338,15 @@ public sealed class ScriptFunction : Function, IConstructor
                 // `new Function(...)`), so an instance-level cache never warms. Park the env
                 // on the per-realm definition instead — env identity then stays stable across
                 // instances, keeping the shared statement tree's per-node slot caches valid.
-                funcEnv._outerEnv = null;
+                //
+                // The outer link stays attached, unlike the block/catch/loop parks. Those pool only
+                // environments no closure can reach at all; EnvironmentMayEscape is weaker — it lets a
+                // closure that reads none of the slots escape this one — and such a closure still
+                // resolves its free identifiers *through* this record. Detaching left such a closure
+                // starting its lookup at a record with no outer link, which identifier resolution reads
+                // as "this is the global environment" — so a plain global read threw InvalidCastException.
+                // Keeping the link roots nothing: a dynamic function closes over the realm's global
+                // environment (CreateDynamicFunction), which the realm holds for its own lifetime.
                 Interlocked.Exchange(ref state._dynamicCachedEnv, funcEnv);
             }
             else


### PR DESCRIPTION
## Summary

A parked Function-constructor environment kept its outer link, so a closure it returned still resolves globals.

## Details

`ScriptFunction.ReturnEnvironment` parks a Function-constructor instance's call environment on its definition (`State._dynamicCachedEnv`) so the next one-shot instance rents it, and it detached the outer link first.

Every other park that detaches one pools an environment no closure can reach at all. This gate is weaker: `EnvironmentMayEscape` asks whether a closure reads one of the environment's *own* bindings, so a closure that reads none of them is allowed to escape the call. Such a closure still resolves its free identifiers **through** the record, and detaching left it starting its lookup at a record with no outer link — which `JintEnvironment` reads as "this is the global environment":

```js
var answer = 42;
var make = new Function('a', 'var b = a; return function () { return answer; };');
make(1)();
```

on `main`:

```
System.InvalidCastException: Unable to cast object of type 'Jint.Runtime.Environments.FunctionEnvironment'
to type 'Jint.Runtime.Environments.GlobalEnvironment'
```

The `var b = a;` matters: it is what gives the call fixed slots, so the slot-aware escape analysis runs and lets the closure — which names neither `a` nor `b` — escape a poolable environment. A closure that *does* read one of the slots (`return b;`) keeps the environment out of the pool, and that shape has always worked.

The fix is to leave the link attached. It roots nothing: `CreateDynamicFunction` closes a dynamic function over the realm's global environment, which the realm holds for its own lifetime anyway — and on rent, `Reset(f, newTarget, f._environment)` writes the same environment back. Reuse itself is unchanged; the park is one field write shorter.

Found with a temporary instrumented build that reports any park detaching the outer link of an environment a closure can still reach. Under it, test262, the repository's suites and a 75-site live-page render corpus flagged no other site — the block, catch, loop and eval parks are all guarded by their conservative analyses.

## Linked issue

None — found by instrumentation rather than reported. It reaches ordinary page code through anything that builds a function with `new Function` and hands back a closure (bundler loaders, templating).

## Test plan

- [x] Added or updated unit tests in `Jint.Tests` — `Jint.Tests/Runtime/DynamicFunctionEnvironmentReuseTests.cs`: the escaping closure before and after the parked environment is rented, an object the call returned, and the other half of the rule. Three of the four fail on `main` with the `InvalidCastException` above.
- [x] Ran `dotnet test --configuration Release` locally — `Jint.Tests` 5762 passed / net472 5678 passed, `Jint.Tests.CommonScripts` 28, `Jint.Tests.PublicInterface` 1488 (+1487 net472); also with `JINT_HOST_CONTRACT_VERIFICATION=1`. The one failure, `DateTests.ToLocaleStringOutsideDateTimeRangeDoesNotThrowAClrException`, fails the same way on unmodified `main` on this machine (ICU data), so it is not from this change.
- [x] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no regressions — 102,326 passed, 0 failed.
- [ ] For interop changes: covered in `Jint.Tests/Runtime/Interop` — n/a.
- [ ] For perf changes: included before/after numbers from `Jint.Benchmark` — n/a. Not a perf change: the pooling behaviour is identical, with one field write removed from the park.

## Breaking change?

No. Behaviour only moves toward the spec — code that threw `InvalidCastException` now evaluates.
