### PR TITLE
Perform the internal methods the array built-ins name, not equivalents

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -82,13 +82,6 @@
     "staging/sm/Set/intersection.js",
     "staging/sm/Set/is-subset-of.js",
 
-    // Proxy trap invariants and the exact trap sequence the array built-ins are specified to
-    // perform. Jint's own invariant check on a defineProperty trap also fires where it should not.
-    "staging/sm/Array/concat-proxy.js",
-    "staging/sm/Array/from_proxy.js",
-    "staging/sm/Array/species.js",
-    "staging/sm/Reflect/has.js",
-
     // Parser early errors that Acornima does not raise, or raises as the wrong error type: an
     // invalid parameter list, `super()` inside an arrow inside a direct eval in a derived
     // constructor, a destructuring pattern with a duplicate binding, a legacy octal literal in

--- a/Jint.Tests/Runtime/ArrayBuiltinTrapSequenceTests.cs
+++ b/Jint.Tests/Runtime/ArrayBuiltinTrapSequenceTests.cs
@@ -1,0 +1,190 @@
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// The exact sequence of internal-method calls the array built-ins are specified to perform, observed
+/// through a Proxy, plus the two places Jint substituted a different operation for the one the algorithm
+/// names: <c>Array.prototype.concat</c> defining <c>length</c> instead of setting it, and the array
+/// iterator asking <c>[[HasProperty]]</c> before <c>[[Get]]</c>. A Proxy is the only way a script can see
+/// the difference, which is why these live together.
+/// </summary>
+public class ArrayBuiltinTrapSequenceTests
+{
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-array.prototype.concat step 6 is <c>Set(A, "length", n, true)</c>.
+    /// Defining it instead bypasses the species result's own <c>[[Set]]</c>.
+    /// </summary>
+    [Fact]
+    public void ConcatSetsTheResultLengthRatherThanDefiningIt()
+    {
+        var engine = new Engine();
+        var log = engine.Evaluate("""
+            var log = [];
+            var target = { length: 0 };
+            var p = new Proxy(target, {
+                set(t, k, v) { log.push('set:' + String(k)); t[k] = v; return true; },
+                defineProperty(t, k, d) { log.push('define:' + String(k)); return Reflect.defineProperty(t, k, d); }
+            });
+            var a = [1, 2];
+            a.constructor = { [Symbol.species]: function () { return p; } };
+            a.concat();
+            log.join(',');
+            """).AsString();
+
+        log.Should().Be("define:0,define:1,set:length");
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-array.prototype.slice step 12 is the same <c>Set</c>, and Jint
+    /// performed no length write at all on the generic path.
+    /// </summary>
+    [Fact]
+    public void SliceSetsTheResultLength()
+    {
+        var engine = new Engine();
+        var log = engine.Evaluate("""
+            var log = [];
+            var target = { length: 0 };
+            var p = new Proxy(target, {
+                set(t, k, v) { log.push('set:' + String(k)); t[k] = v; return true; },
+                defineProperty(t, k, d) { log.push('define:' + String(k)); return Reflect.defineProperty(t, k, d); }
+            });
+            var a = [1, 2];
+            a.constructor = { [Symbol.species]: function () { return p; } };
+            a.slice();
+            log.join(',');
+            """).AsString();
+
+        log.Should().Be("define:0,define:1,set:length");
+    }
+
+    /// <summary>
+    /// A <c>FakeArray</c> species whose <c>length</c> is an ordinary configurable data property: defining
+    /// <c>length</c> with the array attributes (writable, non-configurable) on a Proxy over it violates the
+    /// <c>[[DefineOwnProperty]]</c> invariant, so the previous code turned a legal concat into a TypeError.
+    /// </summary>
+    [Fact]
+    public void ConcatIntoAProxyWithAConfigurableLengthDoesNotThrow()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            function FakeArray(n) { this.length = n; }
+            var a = [1, 2, 3];
+            a.constructor = {
+                [Symbol.species]: function (n) {
+                    return new Proxy(new FakeArray(n), {
+                        set() { return true; },
+                        defineProperty() { return true; }
+                    });
+                }
+            };
+            var b = a.concat();
+            b.constructor === FakeArray;
+            """).AsBoolean();
+
+        result.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Step 5.b.iv of concat asks <c>HasProperty</c> per element and skips the <c>CreateDataPropertyOrThrow</c>
+    /// for a hole. The question has to be asked afresh each time: the trap that defines element 0 here deletes
+    /// element 1 of the source.
+    /// </summary>
+    [Fact]
+    public void ConcatRechecksHasPropertyAfterAnEarlierElementIsDeleted()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var a = [1, 2, 3];
+            a.constructor = {
+                [Symbol.species]: function (...args) {
+                    return new Proxy(new Array(...args), {
+                        defineProperty(t, k, d) {
+                            if (k === '0') delete a[1];
+                            return Reflect.defineProperty(t, k, d);
+                        }
+                    });
+                }
+            };
+            var p = a.concat();
+            [0 in p, 1 in p, 2 in p].join(',');
+            """).AsString();
+
+        result.Should().Be("true,false,true");
+    }
+
+    /// <summary>
+    /// A hole in the source is a hole in the result, and it still advances the result index.
+    /// </summary>
+    [Fact]
+    public void ConcatPreservesHolesOnTheGenericPath()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var a = [1, , 3];
+            a.constructor = { [Symbol.species]: Array };
+            var b = a.concat();
+            [b.length, 0 in b, 1 in b, 2 in b].join(',');
+            """).AsString();
+
+        result.Should().Be("3,true,false,true");
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-createarrayiterator steps 10.d.v-vi: a value step is a bare
+    /// <c>Get</c>, and a key step reads no element at all.
+    /// </summary>
+    [Fact]
+    public void ArrayIteratorPerformsOneGetPerElementAndNoHasProperty()
+    {
+        var engine = new Engine();
+        var log = engine.Evaluate("""
+            var log = [];
+            var p = new Proxy([3, 4, 5], {
+                has(t, k) { log.push('has:' + String(k)); return k in t; },
+                get(t, k) { log.push('get:' + String(k)); return t[k]; }
+            });
+            Array.from(p);
+            log.join(',');
+            """).AsString();
+
+        log.Should().Be(
+            "get:Symbol(Symbol.iterator),get:length,get:0,get:length,get:1,get:length,get:2,get:length");
+    }
+
+    [Fact]
+    public void ArrayIteratorKeyKindReadsNoElement()
+    {
+        var engine = new Engine();
+        var log = engine.Evaluate("""
+            var log = [];
+            var p = new Proxy([3, 4, 5], {
+                get(t, k) { log.push('get:' + String(k)); return t[k]; }
+            });
+            for (var k of Array.prototype.keys.call(p)) { }
+            log.join(',');
+            """).AsString();
+
+        log.Should().Be("get:length,get:length,get:length,get:length");
+    }
+
+    /// <summary>
+    /// A hole in an array-like resolves through the prototype chain, because the step is <c>Get</c> and not
+    /// an own-property read.
+    /// </summary>
+    [Fact]
+    public void ArrayLikeIteratorResolvesAHoleThroughThePrototypeChain()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var proto = { 1: 'inherited' };
+            var arrayLike = Object.create(proto);
+            arrayLike[0] = 'a';
+            arrayLike[2] = 'c';
+            arrayLike.length = 3;
+            arrayLike[Symbol.iterator] = Array.prototype[Symbol.iterator];
+            [...arrayLike].join(',');
+            """).AsString();
+
+        result.Should().Be("a,inherited,c");
+    }
+}

--- a/Jint.Tests/Runtime/StringObjectIndexKeyTests.cs
+++ b/Jint.Tests/Runtime/StringObjectIndexKeyTests.cs
@@ -1,0 +1,76 @@
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// A String exotic object owns an index only for the <em>canonical</em> numeric string of that index —
+/// StringGetOwnProperty steps 3-6, https://tc39.es/ecma262/#sec-stringgetownproperty. Jint parsed the key
+/// with a plain <c>ToNumber</c>, so <c>"01"</c>, <c>"+1"</c>, <c>"1.0"</c>, <c>" 1"</c> and <c>"-0"</c> all
+/// resolved to a character that the spec says is not there.
+/// </summary>
+public class StringObjectIndexKeyTests
+{
+    [Theory]
+    [InlineData("-0")]
+    [InlineData("01")]
+    [InlineData("+1")]
+    [InlineData("1.0")]
+    [InlineData(" 1")]
+    [InlineData("1e0")]
+    [InlineData("0x1")]
+    public void ANonCanonicalNumericKeyIsNotAnOwnIndex(string key)
+    {
+        var engine = new Engine();
+        engine.SetValue("key", key);
+
+        engine.Evaluate("var s = new String('hello');");
+
+        engine.Evaluate("key in s").AsBoolean().Should().BeFalse();
+        engine.Evaluate("Reflect.has(s, key)").AsBoolean().Should().BeFalse();
+        engine.Evaluate("s.hasOwnProperty(key)").AsBoolean().Should().BeFalse();
+        engine.Evaluate("s[key]").IsUndefined().Should().BeTrue();
+        engine.Evaluate("Object.getOwnPropertyDescriptor(s, key)").IsUndefined().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ACanonicalNumericKeyStillResolves()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var s = new String('hello');
+            ['0' in s, '4' in s, '5' in s, s[1], s['3']].join(',');
+            """).AsString();
+
+        result.Should().Be("true,true,false,e,l");
+    }
+
+    /// <summary>
+    /// A numeric key is turned into a property key by ToPropertyKey before any internal method sees it, and
+    /// <c>ToString(-0)</c> is <c>"0"</c> — so <c>str[-0]</c> is index 0 even though <c>str["-0"]</c> is nothing.
+    /// </summary>
+    [Fact]
+    public void NegativeZeroAsANumberIsIndexZero()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var s = new String('hello');
+            [Reflect.has(s, -0), Reflect.has(s, '-0'), s[-0]].join(',');
+            """).AsString();
+
+        result.Should().Be("true,false,h");
+    }
+
+    /// <summary>
+    /// A non-canonical key is an ordinary property name, so it can be defined and read back like any other.
+    /// </summary>
+    [Fact]
+    public void ANonCanonicalNumericKeyCanBeAnOrdinaryOwnProperty()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var s = new String('hello');
+            s['01'] = 'x';
+            ['01' in s, s['01'], s[1]].join(',');
+            """).AsString();
+
+        result.Should().Be("true,x,e");
+    }
+}

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -1686,17 +1686,21 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
         }
     }
 
-    internal JsArray Map(JsCallArguments arguments)
+    /// <param name="calleeRealm">
+    /// The realm of the <c>Array.prototype.map</c> that delegated here -- <c>this</c> is only the receiver,
+    /// so it cannot supply it. Both the callback's TypeError and the result array belong to the called
+    /// built-in's [[Realm]], which for a cross-realm call is not the running one.
+    /// </param>
+    /// <param name="arguments">The <c>map</c> arguments: the callback and its <c>thisArg</c>.</param>
+    internal JsArray Map(Realm calleeRealm, JsCallArguments arguments)
     {
         var callbackfn = arguments.At(0);
         var thisArg = arguments.At(1);
 
         var len = GetLength();
 
-        // `this` is the receiver, not the built-in that owns the algorithm (ArrayPrototype delegates
-        // here), so no callee realm is reachable and the running one is the best available answer.
-        var callable = callbackfn.GetCallable(_engine.Realm);
-        var a = _engine.Realm.Intrinsics.Array.ArrayCreate(len);
+        var callable = callbackfn.GetCallable(calleeRealm);
+        var a = calleeRealm.Intrinsics.Array.ArrayCreate(len);
         var invoker = CallbackInvoker.Rent(_engine, callable, 3, this);
         for (uint k = 0; k < len; k++)
         {
@@ -1718,16 +1722,18 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
         return a;
     }
 
-    internal JsArray Filter(JsCallArguments arguments)
+    /// <param name="calleeRealm">
+    /// The realm of the <c>Array.prototype.filter</c> that delegated here; see <see cref="Map"/>.
+    /// </param>
+    /// <param name="arguments">The <c>filter</c> arguments: the callback and its <c>thisArg</c>.</param>
+    internal JsArray Filter(Realm calleeRealm, JsCallArguments arguments)
     {
         var callbackfn = arguments.At(0);
         var thisArg = arguments.At(1);
 
         var len = GetLength();
 
-        // `this` is the receiver, not the built-in that owns the algorithm (ArrayPrototype delegates
-        // here), so no callee realm is reachable and the running one is the best available answer.
-        var callable = callbackfn.GetCallable(_engine.Realm);
+        var callable = callbackfn.GetCallable(calleeRealm);
 
         // Output size is unknown (only bounded by len); accumulate into a pooled buffer and
         // materialize an exact-size result instead of growing the result's dense backing by
@@ -1756,7 +1762,7 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
                 }
             }
 
-            return _engine.Realm.Intrinsics.Array.ConstructFromBuilder(ref builder);
+            return calleeRealm.Intrinsics.Array.ConstructFromBuilder(ref builder);
         }
         finally
         {

--- a/Jint/Native/Array/ArrayIteratorPrototype.cs
+++ b/Jint/Native/Array/ArrayIteratorPrototype.cs
@@ -1,4 +1,4 @@
-using Jint.Native.ArrayBuffer;
+﻿using Jint.Native.ArrayBuffer;
 using Jint.Native.Iterator;
 using Jint.Native.Object;
 using Jint.Native.TypedArray;
@@ -182,12 +182,14 @@ internal sealed partial class ArrayIteratorPrototype : IteratorPrototype
                 }
                 else
                 {
-                    _operations!.TryGetValue(_position, out var value);
+                    // Steps 10.d.v-vi of CreateArrayIterator: a key-kind step reads no element at all, and a
+                    // value/entry step is a bare Get -- never a HasProperty first, which on a Proxy or an
+                    // array-like host object is an extra observable trap the algorithm does not perform.
                     nextItem = _kind switch
                     {
                         ArrayIteratorType.Key => IteratorResult.CreateValueIteratorPosition(_engine, JsNumber.Create(_position)),
-                        ArrayIteratorType.Value => IteratorResult.CreateValueIteratorPosition(_engine, value),
-                        _ => IteratorResult.CreateKeyValueIteratorPosition(_engine, JsNumber.Create(_position), value)
+                        ArrayIteratorType.Value => IteratorResult.CreateValueIteratorPosition(_engine, _operations!.Get(_position)),
+                        _ => IteratorResult.CreateKeyValueIteratorPosition(_engine, JsNumber.Create(_position), _operations!.Get(_position))
                     };
                 }
 
@@ -202,9 +204,9 @@ internal sealed partial class ArrayIteratorPrototype : IteratorPrototype
 
         // Value-kind for-of over a non-typed-array array-like only needs the element, so skip the
         // per-step IteratorResult TryIteratorStep allocates. Mirrors the non-typed-array branch of
-        // that method exactly (live length each step, same done/closed transition, TryGetValue
-        // leaves holes as undefined). Typed arrays keep their detach/out-of-bounds guarded path,
-        // and Key/Entry kinds keep the wrapping path, both via base.
+        // that method exactly (live length each step, same done/closed transition, the same single
+        // Get per step). Typed arrays keep their detach/out-of-bounds guarded path, and Key/Entry
+        // kinds keep the wrapping path, both via base.
         internal override bool TryStepValue([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out JsValue? value)
         {
             if (_kind == ArrayIteratorType.Value && _typedArray is null)
@@ -212,7 +214,7 @@ internal sealed partial class ArrayIteratorPrototype : IteratorPrototype
                 var len = _operations!.GetLength();
                 if (!_closed && _position < len)
                 {
-                    _operations!.TryGetValue(_position, out var stepped);
+                    var stepped = _operations!.Get(_position);
                     _position++;
                     value = stepped;
                     return true;

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -556,7 +556,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
         if (thisObject is JsArray { CanUseFastAccess: true } arrayInstance
             && !arrayInstance.HasOwnProperty(CommonProperties.Constructor))
         {
-            return arrayInstance.Filter(arguments);
+            return arrayInstance.Filter(_realm, arguments);
         }
 
         var callbackfn = arguments.At(0);
@@ -615,7 +615,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
         if (thisObject is JsArray { CanUseFastAccess: true } arrayInstance
             && !arrayInstance.HasOwnProperty(CommonProperties.Constructor))
         {
-            return arrayInstance.Map(arguments);
+            return arrayInstance.Map(_realm, arguments);
         }
 
         var o = ArrayOperations.For(_realm, thisObject, forWrite: false);
@@ -1677,7 +1677,8 @@ public sealed partial class ArrayPrototype : ArrayInstance
         {
             // slower path
             var operations = ArrayOperations.For(a, forWrite: true);
-            for (uint n = 0; k < final; k++, n++)
+            uint n = 0;
+            for (; k < final; k++, n++)
             {
                 if (n > 0 && n % ConstraintCheckInterval == 0)
                 {
@@ -1689,6 +1690,11 @@ public sealed partial class ArrayPrototype : ArrayInstance
                     operations.CreateDataPropertyOrThrow(n, kValue);
                 }
             }
+
+            // Step 12: Perform ? Set(A, "length", n, true). Only CreateDataPropertyOrThrow grows an
+            // array's length, so a trailing hole -- and any species result that is not an array at all --
+            // is left with the wrong length without this.
+            operations.SetLength(n);
         }
         return a;
     }
@@ -2011,8 +2017,15 @@ public sealed partial class ArrayPrototype : ArrayInstance
                             _engine.Constraints.Check();
                         }
 
-                        operations.TryGetValue(k, out var subElement);
-                        aOperations.CreateDataPropertyOrThrow(n, subElement);
+                        // Step 5.b.iv.2-3: a hole contributes no property to A, it only advances n. The
+                        // existence question is asked afresh per element because the CreateDataPropertyOrThrow
+                        // of an earlier one can have deleted a later one (a Proxy defineProperty trap, an
+                        // array with a setter species).
+                        if (operations.TryGetValue(k, out var subElement))
+                        {
+                            aOperations.CreateDataPropertyOrThrow(n, subElement);
+                        }
+
                         n++;
                     }
                 }
@@ -2024,9 +2037,10 @@ public sealed partial class ArrayPrototype : ArrayInstance
             }
         }
 
-        // this is not in the specs, but is necessary in case the last element of the last
-        // array doesn't exist, and thus the length would not be incremented
-        a.DefineOwnProperty(CommonProperties.Length, new PropertyDescriptor(n, PropertyFlag.OnlyWritable));
+        // Step 6: Perform ? Set(A, "length", n, true). A plain [[DefineOwnProperty]] with the array
+        // length attributes is not the same operation: it bypasses a species result's own [[Set]] and,
+        // on a Proxy whose target has a configurable "length", trips the defineProperty invariant.
+        aOperations.SetLength(n);
 
         return a;
     }

--- a/Jint/Native/String/StringInstance.cs
+++ b/Jint/Native/String/StringInstance.cs
@@ -1,3 +1,4 @@
+using Jint.Native.Array;
 using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
@@ -21,15 +22,24 @@ internal class StringInstance : ObjectInstance, IJsPrimitive
 
     public JsString StringData { get; }
 
-    private static bool IsInt32(double d, out int intValue)
+    /// <summary>
+    /// StringGetOwnProperty steps 3-6 (https://tc39.es/ecma262/#sec-stringgetownproperty): a String
+    /// exotic object owns an index only when the key is the <em>canonical</em> numeric string for an
+    /// integral, non-negative index. So <c>"01"</c>, <c>"+1"</c>, <c>"1.0"</c> and <c>" 1"</c> denote no
+    /// element -- their CanonicalNumericIndexString is undefined -- and neither does <c>"-0"</c>, which
+    /// step 6 rejects outright. <see cref="ArrayInstance.IsArrayIndex"/> is exactly that test: it accepts
+    /// a numeric key by value (a JsNumber key stands in for the string ToPropertyKey would have produced,
+    /// which is why <c>str[-0]</c> still resolves to index 0) and a string key only in canonical form.
+    /// </summary>
+    private static bool TryGetStringIndex(JsValue property, int length, out int index)
     {
-        if (d >= int.MinValue && d <= int.MaxValue)
+        if (ArrayInstance.IsArrayIndex(property, out var arrayIndex) && arrayIndex < (uint) length)
         {
-            intValue = (int) d;
-            return intValue == d;
+            index = (int) arrayIndex;
+            return true;
         }
 
-        intValue = 0;
+        index = 0;
         return false;
     }
 
@@ -56,14 +66,12 @@ internal class StringInstance : ObjectInstance, IJsPrimitive
             return PropertyDescriptor.Undefined;
         }
 
-        var str = StringData.ToString();
-        var number = TypeConverter.ToNumber(property);
-        if (!IsInt32(number, out var index) || index < 0 || index >= str.Length)
+        if (!TryGetStringIndex(property, StringData.Length, out var index))
         {
             return PropertyDescriptor.Undefined;
         }
 
-        return new PropertyDescriptor(str[index], PropertyFlag.OnlyEnumerable);
+        return new PropertyDescriptor(StringData.ToString()[index], PropertyFlag.OnlyEnumerable);
     }
 
     /// <summary>
@@ -112,8 +120,7 @@ internal class StringInstance : ObjectInstance, IJsPrimitive
             return OwnPropertyProbe.Missing;
         }
 
-        var number = TypeConverter.ToNumber(property);
-        if (!IsInt32(number, out var index) || index < 0 || index >= StringData.Length)
+        if (!TryGetStringIndex(property, StringData.Length, out _))
         {
             return OwnPropertyProbe.Missing;
         }


### PR DESCRIPTION
Four of the `staging/sm` exclusions in issue #3021 were grouped under "Proxy trap invariants … Jint's own invariant check on a defineProperty trap also fires where it should not". That diagnosis is wrong twice over: the invariant check in `JsProxy` is correct and was reporting a real violation, and one of the four files has nothing to do with `Proxy`.

Re-derived, they are five separate defects.

**`concat` and `slice` do not perform the `Set` their algorithm names.** [`Array.prototype.concat`](https://tc39.es/ecma262/#sec-array.prototype.concat) step 6 is `Perform ? Set(A, "length", 𝔽(n), true)`. Jint ended with a raw `[[DefineOwnProperty]]` of `"length"` carrying the array attributes — writable, non-enumerable, non-configurable. That bypasses a species result's own `[[Set]]`, and on a `Proxy` whose target has an ordinary configurable `"length"` it *is* a `[[DefineOwnProperty]]` invariant violation, so the check that fired was right and the operation reaching it was wrong. [`Array.prototype.slice`](https://tc39.es/ecma262/#sec-array.prototype.slice) step 12 is the same `Set`, and Jint performed no length write at all on its generic path, so a species result that is not an array came back with the wrong length.

**`concat` ignored the per-element `HasProperty`.** Step 5.b.iv.2–3 asks `HasProperty(E, P)` and only then does `Get` + `CreateDataPropertyOrThrow`; `n` advances either way. Jint called the equivalent of both and discarded the existence answer, so a hole in the source became an own `undefined` in the result. The question also has to be asked afresh on each iteration, because an earlier element's `CreateDataPropertyOrThrow` can delete a later one — which is exactly what `concat-proxy.js` does from a `defineProperty` trap.

**The array iterator asked `HasProperty` before `Get`.** [`CreateArrayIterator`](https://tc39.es/ecma262/#sec-createarrayiterator) steps 10.d.v–vi are a bare `Get`; a key-kind step reads no element at all. Jint's array-like iterator did a `HasProperty`-then-`Get` for every kind, which on a `Proxy` or an array-like host object is an extra observable trap the algorithm does not perform. As a side effect a hole in an array-like now resolves through the prototype chain, which is what `Get` does and what `TryGetValue` did not.

**`filter` and `map` built their result in the running realm.** Both delegate a dense receiver to `ArrayInstance.Filter`/`Map`, which had no callee realm available and used `_engine.Realm` — the comment there said as much. `g.a.filter(...)` therefore returned a main-realm array where the spec wants a `g`-realm one. They now take the calling built-in's realm as a parameter. This is the same class of defect #3049 fixed elsewhere; these two paths were left behind precisely because the receiver cannot supply the realm.

**`Reflect/has.js` is not a Proxy test.** A String exotic object owns an index only for the *canonical* numeric string of that index — [`StringGetOwnProperty`](https://tc39.es/ecma262/#sec-stringgetownproperty) steps 3–6, via [`CanonicalNumericIndexString`](https://tc39.es/ecma262/#sec-canonicalnumericindexstring). Jint parsed the key with a plain `ToNumber`, so `new String("hello")` answered `true` for `"01"`, `"+1"`, `"1.0"`, `" 1"`, `"1e0"` and `"-0"`, and handed back a character for each. `ArrayInstance.IsArrayIndex` is exactly that canonical test, and it is cheaper than the `ToNumber` it replaces (no double parse, no `int` round-trip), so `GetOwnProperty` and `ProbeOwnProperty` both get slightly faster as well as correct. A numeric key is still accepted by value, because `ToPropertyKey` has already turned it into its canonical string before any internal method sees it — which is why `str[-0]` is index 0 while `str["-0"]` is nothing.

## Performance

Nothing here touches the dense fast lanes. `concat`'s two `JsArray` fast paths and `slice`'s `CopyValues` path are untouched; the changed code is the generic species path. The extra work on that path is one existing `TryGetValue` return value that used to be discarded, and one `SetLength` at the end. `StringInstance`'s index test gets cheaper. `Filter`/`Map` gain one parameter.

## Verified

The four files pass in both modes. `built-ins/Array`, `built-ins/String`, `built-ins/Proxy`, `built-ins/Reflect` (10,203 tests), `built-ins/TypedArray`, `built-ins/Object`, `language/statements/for-of`, `language/statements/for-in` (12,840 tests) all pass, as do `Jint.Tests` (6,299 + 6,214) and `Jint.Tests.PublicInterface`.

New coverage in `Jint.Tests/Runtime/ArrayBuiltinTrapSequenceTests.cs` and `Jint.Tests/Runtime/StringObjectIndexKeyTests.cs`; 15 of their 18 cases fail against the unfixed engine.

Frees `staging/sm/Array/concat-proxy.js`, `staging/sm/Array/from_proxy.js`, `staging/sm/Array/species.js` and `staging/sm/Reflect/has.js`. Refs #3021.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
