### PR TITLE
Honor the receiver in an arguments object's [[Set]] and rebind a body var over a parameter

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -157,11 +157,6 @@
     "staging/sm/lexical-environment/block-scoped-functions-deprecated-redecl.js",
     "staging/sm/regress/regress-602621.js",
 
-    // Mapped arguments: the exotic object's link to the formal parameters (and what an object
-    // created *from* it inherits) does not match the spec's mapping.
-    "staging/sm/Function/arguments-parameter-shadowing.js",
-    "staging/sm/regress/regress-552432.js",
-
     // Argument validation raising no error, or the wrong one: a bad this or a bad index reaching a
     // built-in, a NUL-bearing string reaching one, and the order in which a super reference is
     // evaluated against its side effects.

--- a/Jint.Tests/Runtime/ArgumentsCacheBehaviorTests.cs
+++ b/Jint.Tests/Runtime/ArgumentsCacheBehaviorTests.cs
@@ -261,4 +261,38 @@ public class ArgumentsCacheBehaviorTests
             JsValue.Undefined,
         ]);
     }
+
+    [Fact]
+    public void MappedArgumentWriteThroughAnotherReceiverDoesNotReachTheParameter()
+    {
+        // https://tc39.es/ecma262/#sec-arguments-exotic-objects-set-p-v-receiver step 1: the
+        // parameter map is consulted only when the receiver IS the arguments object. Writing "0" on
+        // an object that merely INHERITS from arguments must create an own property on that object
+        // and leave the formal parameter alone; Jint used to write straight through to the binding.
+        var engine = new Engine();
+
+        engine.Evaluate("(function(y){ var x = Object.create(arguments); x[0] = 3; return x[0] + ',' + y + ',' + arguments[0]; })(1)")
+            .AsString().Should().Be("3,1,1");
+    }
+
+    [Fact]
+    public void MappedArgumentWriteThroughAReflectSetReceiverDoesNotReachTheParameter()
+    {
+        // Same rule reached without a prototype chain: Reflect.set names the receiver directly.
+        var engine = new Engine();
+
+        engine.Evaluate("(function(y){ var t = {}; Reflect.set(arguments, 0, 5, t); return t[0] + ',' + y; })(1)")
+            .AsString().Should().Be("5,1");
+    }
+
+    [Fact]
+    public void MappedArgumentWriteOnTheArgumentsObjectItselfStillReachesTheParameter()
+    {
+        // The other half of the same step: with the arguments object as its own receiver the write
+        // does go through the map, so the formal parameter sees it.
+        var engine = new Engine();
+
+        engine.Evaluate("(function(y){ arguments[0] = 7; return y; })(1)").AsNumber().Should().Be(7);
+    }
 }
+

--- a/Jint.Tests/Runtime/DeclarationScopeTests.cs
+++ b/Jint.Tests/Runtime/DeclarationScopeTests.cs
@@ -145,4 +145,47 @@ public class DeclarationScopeTests
         moduleWalk._lexicalDeclarations.Should().NotBeNull().And.HaveCount(3);
         programWalk._lexicalDeclarations.Should().NotBeNull().And.HaveCount(3);
     }
+
+    // https://tc39.es/ecma262/#sec-functiondeclarationinstantiation step 28: when the parameter list
+    // contains expressions the body's vars live in a variableEnv of their own, and a var whose name
+    // is also a parameter binding gets a binding *there*, seeded with the parameter's value. Jint
+    // skipped those names entirely, so the var resolved to the parameter environment's binding and a
+    // write to it was visible to a closure created in the parameter list.
+
+    [Fact]
+    public void AVarNamedLikeAParameterIsReboundInTheBodyWhenParametersHaveExpressions()
+    {
+        var engine = new Engine();
+
+        engine.Evaluate("function f(a = 1, g = () => a) { var a = 2; return g() + ',' + a; } f();")
+            .AsString().Should().Be("1,2");
+    }
+
+    [Fact]
+    public void AVarNamedArgumentsIsReboundInTheBodyWhenParametersHaveExpressions()
+    {
+        var engine = new Engine();
+
+        // `var arguments;` with no initializer still creates the body binding, seeded with the
+        // parameter environment's arguments object, so the two start out identical...
+        engine.Evaluate("function f(h = () => arguments) { var arguments; return arguments === h(); } f();")
+            .AsBoolean().Should().BeTrue();
+
+        // ...and diverge as soon as the body writes to its own binding.
+        engine.Evaluate("function f(h = () => arguments) { var arguments; arguments = 0; return arguments === h(); } f();")
+            .AsBoolean().Should().BeFalse();
+        engine.Evaluate("function f(h = () => arguments) { var arguments = 0; return arguments === h(); } f();")
+            .AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void AVarNamedLikeAParameterIsNotReboundWhenTheParameterListIsSimple()
+    {
+        var engine = new Engine();
+
+        // The other arm of the same step: without parameter expressions there is a single
+        // environment, so `var a` is the parameter and keeps its value.
+        engine.Evaluate("function f(a) { var a; return a; } f(1);").AsNumber().Should().Be(1);
+    }
 }
+

--- a/Jint/Native/JsArguments.cs
+++ b/Jint/Native/JsArguments.cs
@@ -323,9 +323,9 @@ public sealed class JsArguments : ObjectInstance
         return desc.Enumerable ? OwnPropertyProbe.Enumerable : OwnPropertyProbe.NonEnumerable;
     }
 
-    /// Implementation from ObjectInstance official specs as the one
-    /// in ObjectInstance is optimized for the general case and wouldn't work
-    /// for arrays
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-arguments-exotic-objects-set-p-v-receiver
+    /// </summary>
     public override bool Set(JsValue property, JsValue value, JsValue receiver)
     {
         // Mapped-index writes go straight to the parameter binding (matching the
@@ -349,37 +349,21 @@ public sealed class JsArguments : ObjectInstance
 
         EnsureInitialized();
 
-        if (!CanPut(property))
+        // Steps 1-3: the parameter map is consulted only when the receiver IS this arguments object.
+        // A write that reaches here through a *different* receiver - `var x = Object.create(arguments);
+        // x[0] = 3` - must not write through to the formal parameter; OrdinarySet installs an own
+        // property on the receiver instead.
+        if (ReferenceEquals(this, receiver) && ParameterMap is { } map && map.HasOwnProperty(property))
         {
-            return false;
+            // a mapped formal parameter is always writable, so this cannot fail
+            map.Set(property, value, throwOnError: false);
         }
 
-        var ownDesc = GetOwnProperty(property);
-
-        if (ownDesc.IsDataDescriptor())
-        {
-            var valueDesc = new PropertyDescriptor(value, PropertyFlag.None);
-            return DefineOwnProperty(property, valueDesc);
-        }
-
-        // property is an accessor or inherited
-        var desc = GetOwnProperty(property);
-
-        if (desc.IsAccessorDescriptor())
-        {
-            if (desc.Set is not ICallable setter)
-            {
-                return false;
-            }
-            setter.Call(receiver, value);
-        }
-        else
-        {
-            var newDesc = new PropertyDescriptor(value, PropertyFlag.ConfigurableEnumerableWritable);
-            return DefineOwnProperty(property, newDesc);
-        }
-
-        return true;
+        // Step 4: OrdinarySet(args, P, V, Receiver). ObjectInstance.Set is
+        // OrdinarySetWithOwnDescriptor and honors the receiver; this type's GetOwnProperty overlays
+        // the (already updated) mapped value, and its DefineOwnProperty keeps the map in sync for
+        // the receiver-is-this case.
+        return base.Set(property, value, receiver);
     }
 
     public override bool DefineOwnProperty(JsValue property, PropertyDescriptor desc)

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -691,37 +691,36 @@ internal sealed class JintFunctionDefinition
         }
         else
         {
-            var instantiatedVarNames = state.VarNames != null
-                ? new HashSet<Key>(state.ParameterBindings)
-                : null;
+            // https://tc39.es/ecma262/#sec-functiondeclarationinstantiation step 28: with parameter
+            // expressions the body's vars live in a variableEnv of their own, and
+            // instantiatedVariableNames starts out as a *new empty List* - not as a copy of
+            // paramBindings, which is what the hasParamExprs=false arm above uses. So a var whose
+            // name is also a parameter (or "arguments") still gets its own binding in variableEnv,
+            // seeded with the parameter's already-initialized value. Seeding this set with
+            // paramBindings instead left `var arguments` resolving straight to the parameter
+            // environment's binding, so a later write to it was visible to a closure created in the
+            // parameter list.
+            var instantiatedVarNames = new HashSet<Key>();
 
             // Add function names first (they take precedence over var declarations with same name)
             foreach (var fn in state.FunctionNames)
             {
-                if (instantiatedVarNames?.Add(fn) != false)
+                if (instantiatedVarNames.Add(fn))
                 {
-                    instantiatedVarNames ??= new HashSet<Key>();
-                    instantiatedVarNames.Add(fn);
-                    JsValue? initialValue = null;
-                    if (!state.ParameterBindings.Contains(fn))
-                    {
-                        initialValue = JsValue.Undefined;
-                    }
-                    varsToInitialize.Add(new State.VariableValuePair(Name: fn, InitialValue: initialValue));
+                    // step 28.f.iv: funcNames contains the name, so the initial value is undefined
+                    varsToInitialize.Add(new State.VariableValuePair(Name: fn, InitialValue: JsValue.Undefined));
                 }
             }
 
             for (var i = 0; i < state.VarNames?.Count; i++)
             {
                 var n = state.VarNames[i];
-                if (instantiatedVarNames!.Add(n))
+                if (instantiatedVarNames.Add(n))
                 {
-                    JsValue? initialValue = null;
-                    if (!state.ParameterBindings.Contains(n) || state.FunctionNames.Contains(n))
-                    {
-                        initialValue = JsValue.Undefined;
-                    }
-
+                    // step 28.f.iv/v: undefined unless the name is also a parameter binding, in
+                    // which case the var starts out with that parameter's value (a null InitialValue
+                    // tells FunctionDeclarationInstantiation to read it out of the parameter env)
+                    var initialValue = state.ParameterBindings.Contains(n) ? null : JsValue.Undefined;
                     varsToInitialize.Add(new State.VariableValuePair(Name: n, InitialValue: initialValue));
                 }
             }


### PR DESCRIPTION
Two of the `staging/` exclusions in #3021 sat under this banner:

```
// Mapped arguments: the exotic object's link to the formal parameters (and what an object
// created *from* it inherits) does not match the spec's mapping.
"staging/sm/Function/arguments-parameter-shadowing.js",
"staging/sm/regress/regress-552432.js",
```

The comment is half right. One file is about the parameter map. The other has nothing to do with the map at all — it is about which environment a `var` lands in when the parameter list contains expressions. They are separate defects and both are fixed here.

### `regress-552432.js` — the parameter map is receiver-sensitive

```js
(function (y) {
    arguments.y = 2;
    var x = Object.create(arguments);
    x[0] = 3;
    assert.sameValue(x[0], 3);
    assert.sameValue(y, 1);      // was 3
})(1);
```

[10.4.4.4 `[[Set]] ( propertyKey, value, receiver )`](https://tc39.es/ecma262/#sec-arguments-exotic-objects-set-p-v-receiver) begins:

> 1. If SameValue(*args*, *receiver*) is **false**, then
>    a. Let *isMapped* be **false**.
> 2. Else, … *isMapped* be ! HasOwnProperty(*map*, *propertyKey*).
> 3. If *isMapped* is **true**, … Perform ! Set(*map*, *propertyKey*, *value*, **false**).
> 4. Return ? OrdinarySet(*args*, *propertyKey*, *value*, *receiver*).

`JsArguments.Set` never looked at `receiver` on its materialized path — it went straight to `GetOwnProperty` + `DefineOwnProperty` on `this`, which syncs the map. So a write reaching the arguments object *through* another receiver (an `Object.create(arguments)` prototype chain, or a `Reflect.set` with an explicit receiver) wrote through to the formal parameter and never created the own property on the receiver at all.

The method's tail was also still an ES5-era `[[Put]]` (`CanPut`, then a data/accessor split). It is now literally the algorithm above: the receiver-guarded map write, then `base.Set`, which is `ObjectInstance`'s `OrdinarySetWithOwnDescriptor` and already honors the receiver. The virtual-read fast path above it was already receiver-guarded and is unchanged.

### `arguments-parameter-shadowing.js` — a body `var` over a parameter binding

```js
function g9(h = () => arguments) {
  var arguments;
  assert.sameValue(h(), arguments);          // same object to begin with
  arguments = 0;
  assert.sameValue(arguments === h(), false); // ...and diverging after a write
}
```

[FunctionDeclarationInstantiation step 28](https://tc39.es/ecma262/#sec-functiondeclarationinstantiation) — the `hasParamExprs` arm — reads:

> Let *instantiatedVariableNames* be **a new empty List**.
> For each element *name* of *variableNames*, do … Perform ! *variableEnv*.CreateMutableBinding(*name*, false).
> If *paramBindings* does not contain *name* or *funcNames* contains *name*, let *initialValue* be **undefined**.
> Else, let *initialValue* be ! *envRecord*.GetBindingValue(*name*, false).

The empty list is the point: with parameter expressions the body's vars live in a `variableEnv` of their own, so a var whose name is *also* a parameter binding still gets a binding **there**, seeded with the parameter's already-initialized value. Jint seeded that set with `paramBindings` instead (which is what the `hasParamExprs is false` arm above it correctly does), so those names were skipped entirely and the var resolved straight to the parameter environment's binding — making a later write visible to a closure created in the parameter list. `arguments` is in `paramBindings`, which is why the test finds it there, but the same bug applies to any parameter name:

```js
function f(a = 1, g = () => a) { var a = 2; return g(); }   // 1 per spec, was 2
```

### Changes

- `Jint/Native/JsArguments.cs` — `Set` rewritten as 10.4.4.4; XML doc now cites the section.
- `Jint/Runtime/Interpreter/JintFunctionDefinition.cs` — the `HasParameterExpressions` arm of the var-initialization plan starts from an empty set and derives `InitialValue` per step 28.

Both are outside every fast path: the `Set` change only affects the materialized arguments object, and the instantiation change only the `hasParamExprs` arm, which already forfeits the fixed-slot environment.

### Verification

- The two files pass in both modes; their exclusion entries are removed.
- New coverage in `Jint.Tests` (`ArgumentsCacheBehaviorTests`, `DeclarationScopeTests`), each including the control case that already passed. Against the unfixed engine the four new assertions fail, e.g. `Expected … .AsBoolean() to be False, but found True.`
- test262 `arguments-object`, `built-ins/Function`, `language/{expressions,statements}/function`, `arrow-function`, `class`, `annexB`, `eval-code`, `global-code`, `block-scope`, `statements/for`, `sm/Function` — 27,083 passed, 0 failed.
- Full `Jint.Tests` (net10.0 + net472), `Jint.Tests.PublicInterface`, `Jint.Tests.CommonScripts` — all green.

The remaining five files under the Annex B B.3.3 banner in #3021 are a separate fix and get their own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
