### PR TITLE
Derive String.prototype case conversion from Jint's own Unicode tables

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -97,12 +97,6 @@
     "staging/sm/Array/species.js",
     "staging/sm/Reflect/has.js",
 
-    // String case mapping is done with the BCL's culture-aware tables rather than the Unicode
-    // Default Case Conversion the spec requires, so a handful of code points (dotless i, the
-    // supplementary planes) map differently. Removed by using the Unicode data directly.
-    "staging/sm/String/string-code-point-upper-lower-mapping.js",
-    "staging/sm/String/string-upper-lower-mapping.js",
-
     // Parser early errors that Acornima does not raise, or raises as the wrong error type: an
     // invalid parameter list, `super()` inside an arrow inside a direct eval in a derived
     // constructor, a destructuring pattern with a duplicate binding, a legacy octal literal in

--- a/Jint.Tests/Runtime/StringTests.cs
+++ b/Jint.Tests/Runtime/StringTests.cs
@@ -525,6 +525,56 @@ var big = (s + '|tail').split('|');       // [s, 'tail']: first segment is ~the 
     }
 
     /// <summary>
+    /// toUpperCase and toLowerCase are defined over the Unicode Default Case Conversion algorithm
+    /// (https://tc39.es/ecma262/#sec-string.prototype.tolowercase), which the framework's
+    /// ToUpperInvariant/ToLowerInvariant do not implement: they keep U+0131 unchanged by design,
+    /// supply only the simple mappings, and carry whichever Unicode version the host's ICU — or
+    /// Windows NLS, on .NET Framework — happens to ship, so a script added in a recent version
+    /// maps differently from machine to machine. Both sides are evaluated so the supplementary
+    /// expectations stay readable; String.fromCodePoint is independent of case conversion.
+    /// </summary>
+    [Theory]
+    // U+0131 LATIN SMALL LETTER DOTLESS I. ToUpperInvariant deliberately maps it to itself.
+    [InlineData("'\\u0131'.toUpperCase()", "'I'")]
+    // The locale entry points must agree with the language-insensitive ones when no locale tailors casing.
+    [InlineData("'\\u0131'.toLocaleUpperCase()", "'I'")]
+    [InlineData("'\\u0131'.toLocaleUpperCase('en')", "'I'")]
+    // GARAY, added in Unicode 16.0 — newer than the ICU most hosts carry.
+    [InlineData("String.fromCodePoint(0x10D70).toUpperCase()", "String.fromCodePoint(0x10D50)")]
+    [InlineData("String.fromCodePoint(0x10D50).toLowerCase()", "String.fromCodePoint(0x10D70)")]
+    // VITHKUQI, added in Unicode 14.0.
+    [InlineData("String.fromCodePoint(0x10597).toUpperCase()", "String.fromCodePoint(0x10570)")]
+    // A supplementary code point in a string that also needs a SpecialCasing expansion: the
+    // expansion path used to pass every surrogate pair through unmapped.
+    [InlineData("('\\u00DF' + String.fromCodePoint(0x10428)).toUpperCase()", "'SS' + String.fromCodePoint(0x10400)")]
+    [InlineData("('\\u0130' + String.fromCodePoint(0x10400)).toLowerCase()", "'i\\u0307' + String.fromCodePoint(0x10428)")]
+    public void CaseConversionUsesTheUnicodeDefaultCaseConversionAlgorithm(string actual, string expected)
+    {
+        var actualValue = _engine.Evaluate(actual).AsString();
+        var expectedValue = _engine.Evaluate(expected).AsString();
+        actualValue.Should().Be(expectedValue);
+    }
+
+    /// <summary>
+    /// Turkish, Azeri and Lithuanian are the languages the Unicode Character Database tailors case
+    /// mapping for, and ECMA-402's toLocale{Upper,Lower}Case must keep honouring them even though
+    /// every other locale now goes through the language-insensitive tables.
+    /// https://tc39.es/ecma402/#sup-string.prototype.tolocaleuppercase
+    /// </summary>
+    [Theory]
+    [InlineData("'i'.toLocaleUpperCase('tr')", "İ")]
+    [InlineData("'i'.toLocaleUpperCase('tr-TR')", "İ")]
+    [InlineData("'i'.toLocaleUpperCase('az')", "İ")]
+    [InlineData("'I'.toLocaleLowerCase('tr')", "ı")]
+    [InlineData("'I'.toLocaleLowerCase('az')", "ı")]
+    [InlineData("'İ'.toLocaleLowerCase('tr')", "i")]
+    [InlineData("'İ'.toLocaleLowerCase('und')", "i̇")]
+    public void LocaleTailoredCasingIsPreserved(string expression, string expected)
+    {
+        _engine.Evaluate(expression).AsString().Should().Be(expected);
+    }
+
+    /// <summary>
     /// lastIndexOf's position argument bounds where a match may <em>start</em>, not where the search
     /// begins, which is easy to get off by one. Every expectation here was verified against V8.
     /// </summary>

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -14,6 +14,9 @@ using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Descriptors.Specialized;
 using FunctionInstance = Jint.Native.Function.Function;
+// Aliased because Acornima, whose namespace is a global using, has an inaccessible type of the
+// same name, so the unqualified name resolves to that one and fails to compile.
+using JintUnicode = Jint.Runtime.RegExp.Unicode.UnicodeProperties;
 
 namespace Jint.Native.String;
 
@@ -213,6 +216,13 @@ internal sealed partial class StringPrototype : StringInstance
             culture = IntlUtilities.GetCultureInfo(requestedLocales[0]) ?? CultureInfo.InvariantCulture;
         }
 
+        // Every locale outside the tailored set maps exactly as the language-insensitive default
+        // does, so it goes through the same Unicode tables rather than the framework's.
+        if (!HasTailoredCasing(culture))
+        {
+            return new JsString(ToUpperCaseDefault(s));
+        }
+
         if (string.Equals("lt", culture.Name, StringComparison.OrdinalIgnoreCase))
         {
             s = StringInlHelper.LithuanianStringProcessor(s);
@@ -233,7 +243,21 @@ internal sealed partial class StringPrototype : StringInstance
     private JsValue ToUpperCase(JsValue thisObject)
     {
         var s = TypeConverter.ToString(thisObject);
-        return new JsString(ToUpperCaseWithSpecialCasing(s, CultureInfo.InvariantCulture));
+        return new JsString(ToUpperCaseDefault(s));
+    }
+
+    /// <summary>
+    /// The only languages for which the Unicode Character Database tailors case mapping away from
+    /// the language-insensitive default: Turkish and Azeri (dotted and dotless i) and Lithuanian
+    /// (the retained dot above). Everything else — including the framework's own culture-aware
+    /// conversion, which only ever special-cases Turkish — agrees with the default algorithm.
+    /// </summary>
+    private static bool HasTailoredCasing(CultureInfo culture)
+    {
+        var language = culture.TwoLetterISOLanguageName;
+        return string.Equals(language, "tr", StringComparison.Ordinal)
+               || string.Equals(language, "az", StringComparison.Ordinal)
+               || string.Equals(language, "lt", StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -438,6 +462,13 @@ internal sealed partial class StringPrototype : StringInstance
             culture = IntlUtilities.GetCultureInfo(requestedLocales[0]) ?? CultureInfo.InvariantCulture;
         }
 
+        // Every locale outside the tailored set maps exactly as the language-insensitive default
+        // does, so it goes through the same Unicode tables rather than the framework's.
+        if (!HasTailoredCasing(culture))
+        {
+            return new JsString(ToLowerCaseDefault(s));
+        }
+
         return ToLowerCaseWithSpecialCasing(s, culture);
     }
 
@@ -446,7 +477,122 @@ internal sealed partial class StringPrototype : StringInstance
     private JsValue ToLowerCase(JsValue thisObject)
     {
         var s = TypeConverter.ToString(thisObject);
-        return ToLowerCaseWithSpecialCasing(s, CultureInfo.InvariantCulture);
+        return new JsString(ToLowerCaseDefault(s));
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-string.prototype.touppercase — the Unicode Default Case
+    /// Conversion toUppercase algorithm, applied to the string's code points.
+    /// </summary>
+    private string ToUpperCaseDefault(string s)
+    {
+        // Fast path: an all-ASCII string maps within ASCII, where the Unicode mapping is exactly
+        // a-z -> A-Z. Both the scan and the framework's invariant conversion are vectorized, so
+        // this costs the same two passes the SpecialCasing pre-scan used to.
+        if (!s.AsSpan().ContainsAnyExceptInRange('\0', '\u007F'))
+        {
+            return s.ToUpperInvariant();
+        }
+
+        return ConvertCaseDefault(s, toLower: false);
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-string.prototype.tolowercase — the Unicode Default Case
+    /// Conversion toLowercase algorithm, applied to the string's code points.
+    /// </summary>
+    private string ToLowerCaseDefault(string s)
+    {
+        if (!s.AsSpan().ContainsAnyExceptInRange('\0', '\u007F'))
+        {
+            return s.ToLowerInvariant();
+        }
+
+        return ConvertCaseDefault(s, toLower: true);
+    }
+
+    /// <summary>
+    /// Walks the string by code point and applies the full case mapping from Jint's own Unicode
+    /// tables (UnicodeData.txt plus the unconditional entries of SpecialCasing.txt, so a mapping
+    /// may produce up to three code points and change the string's length).
+    /// <para>
+    /// The framework's <c>ToUpperInvariant</c>/<c>ToLowerInvariant</c> cannot serve here: they
+    /// supply the <em>simple</em> mappings only, they deviate from the Unicode default for a few
+    /// code points on purpose (U+0131 dotless i upper-cases to itself), and their Unicode version
+    /// is whatever ICU — or, on .NET Framework, Windows NLS — happens to ship, so newer scripts
+    /// such as Garay or Vithkuqi map differently from host to host and from target framework to
+    /// target framework. Reading the tables directly makes the answer the same everywhere.
+    /// </para>
+    /// </summary>
+    private string ConvertCaseDefault(string s, bool toLower)
+    {
+        // Stack buffer covers most strings; ValueStringBuilder rents from ArrayPool if it grows beyond.
+        Span<char> stackBuffer = stackalloc char[128];
+        var sb = new ValueStringBuilder(stackBuffer);
+        Span<uint> mapped = stackalloc uint[JintUnicode.MaxCaseConversionLength];
+
+        for (var i = 0; i < s.Length; i++)
+        {
+            if (i > 0 && i % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
+            var c = s[i];
+            if (c < 0x80)
+            {
+                // ASCII neither expands nor leaves ASCII, so the whole table lookup is one range test.
+                if (toLower)
+                {
+                    sb.Append((uint) (c - 'A') <= 'Z' - 'A' ? (char) (c + 0x20) : c);
+                }
+                else
+                {
+                    sb.Append((uint) (c - 'a') <= 'z' - 'a' ? (char) (c - 0x20) : c);
+                }
+                continue;
+            }
+
+            // Final_Sigma is the one conditional mapping SpecialCasing.txt declares
+            // language-insensitive, so it belongs to the default algorithm and needs the
+            // surrounding text the per-code-point table cannot see.
+            if (toLower && c == '\u03A3')
+            {
+                sb.Append(IsFinalSigmaContext(s, i) ? '\u03C2' : '\u03C3');
+                continue;
+            }
+
+            int codePoint = c;
+            if (char.IsHighSurrogate(c) && i + 1 < s.Length && char.IsLowSurrogate(s[i + 1]))
+            {
+                codePoint = char.ConvertToUtf32(c, s[i + 1]);
+                i++;
+            }
+
+            var count = toLower
+                ? JintUnicode.ToLowerCase(mapped, (uint) codePoint)
+                : JintUnicode.ToUpperCase(mapped, (uint) codePoint);
+
+            for (var k = 0; k < count; k++)
+            {
+                AppendCodePoint(ref sb, mapped[k]);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static void AppendCodePoint(ref ValueStringBuilder sb, uint codePoint)
+    {
+        if (codePoint <= 0xFFFF)
+        {
+            sb.Append((char) codePoint);
+            return;
+        }
+
+        codePoint -= 0x10000;
+        sb.Append((char) (0xD800 + (codePoint >> 10)));
+        sb.Append((char) (0xDC00 + (codePoint & 0x3FF)));
     }
 
     /// <summary>

--- a/Jint/Runtime/RegExp/Unicode/UnicodeProperties.cs
+++ b/Jint/Runtime/RegExp/Unicode/UnicodeProperties.cs
@@ -190,6 +190,25 @@ internal static class UnicodeProperties
         Span<uint> r = stackalloc uint[MaxCaseConvLen]; CaseConv(r, c, ct); return r[0];
     }
 
+    /// <summary>Maximum number of code points a single full case mapping can produce.</summary>
+    public const int MaxCaseConversionLength = MaxCaseConvLen;
+
+    /// <summary>
+    /// Full uppercase mapping of a single code point per the Unicode Default Case Conversion
+    /// algorithm, i.e. UnicodeData.txt plus the unconditional, language-insensitive expansions of
+    /// SpecialCasing.txt (U+00DF -> "SS", U+FB03 -> "FFI", the Greek ypogegrammeni forms).
+    /// <paramref name="res"/> must hold <see cref="MaxCaseConversionLength"/> code points; the
+    /// return value says how many were written.
+    /// </summary>
+    public static int ToUpperCase(Span<uint> res, uint c) => CaseConv(res, c, 0);
+
+    /// <summary>
+    /// Full lowercase mapping of a single code point per the Unicode Default Case Conversion
+    /// algorithm. The context-dependent Final_Sigma rule is not applied here — it needs the
+    /// surrounding text — so U+03A3 maps to the medial form and the caller decides.
+    /// </summary>
+    public static int ToLowerCase(Span<uint> res, uint c) => CaseConv(res, c, 1);
+
     /// <summary>Case-convert code point. convType: 0=upper, 1=lower, 2=casefold.</summary>
     public static int CaseConv(Span<uint> res, uint c, int convType)
     {


### PR DESCRIPTION
Part of #3021.

## What the exclusion comment claimed

> String case mapping is done with the BCL's culture-aware tables rather than the Unicode
> Default Case Conversion the spec requires, so a handful of code points (dotless i, the
> supplementary planes) map differently.

That one is essentially right, and the wave-1 note that no new Unicode table is needed holds:
`Jint/Runtime/RegExp/Unicode/UnicodeData.cs` already ships Unicode 17 full case-conversion data
for the regex engine (`UnicodeProperties.CaseConv`, ported from QuickJS), covering the
supplementary planes and the multi-code-point expansions of SpecialCasing.txt. It was simply not
wired to `String.prototype`.

## What the cause actually is

`String.prototype.toLowerCase` (<https://tc39.es/ecma262/#sec-string.prototype.tolowercase>) and
`toUpperCase` (<https://tc39.es/ecma262/#sec-string.prototype.touppercase>) are defined over the
code points of the string and the Unicode Default Case Conversion algorithm — explicitly
locale-insensitive, and explicitly including SpecialCasing.txt. `StringPrototype` implemented that
as `string.ToUpper(CultureInfo.InvariantCulture)` plus a hand-written table of the SpecialCasing
expansions. Three things go wrong with that:

* **The framework's invariant casing is not the Unicode default.** `ToUpperInvariant` maps U+0131
  LATIN SMALL LETTER DOTLESS I to itself by design, where the Unicode default maps it to `I`.
  (Amusingly, the *culture-aware* path does map it: before this change `'ı'.toUpperCase()` and
  `'ı'.toLocaleUpperCase()` answered `'ı'` while `'ı'.toLocaleUpperCase('en')` answered `'I'`.)
* **Its Unicode version is the host's, not Jint's.** ICU on .NET Core, Windows NLS on .NET
  Framework. Scripts added recently — Garay (Unicode 16), Vithkuqi (Unicode 14) — map differently
  from machine to machine and from target framework to target framework. The first failing
  assertion in the supplementary-plane test is Garay, not Deseret.
* **The expansion path dropped supplementary mappings entirely.** Once a string contained any
  character with a SpecialCasing expansion, the per-character loop it fell into passed every
  surrogate pair through unmapped, with the comment "No supplementary-plane special-cased
  uppercase mappings — pass through". So `('ß' + '𐐨').toUpperCase()` produced `'SS𐐨'` instead of
  `'SS𐐀'`.

## What changed

`Jint/Native/String/StringPrototype.cs`

* `ToUpperCaseDefault` / `ToLowerCaseDefault` are the new entry points for `toUpperCase` and
  `toLowerCase`. Each keeps an all-ASCII fast path, then walks the string by code point in
  `ConvertCaseDefault` and applies the full mapping from the Unicode tables, appending one to
  three code points per input code point — so a conversion may change the string's length
  (ß → SS, ﬀ → FF, İ → i + U+0307), and surrogate pairs are mapped as code points.
* Final_Sigma stays where it was: it is the one conditional mapping SpecialCasing.txt declares
  language-insensitive, and it needs surrounding context the per-code-point table cannot see, so
  U+03A3 is still resolved by `IsFinalSigmaContext` before the table is consulted.
* `toLocaleUpperCase` / `toLocaleLowerCase` route to the same tables for every locale that does
  not tailor case mapping. Turkish, Azeri and Lithuanian keep the existing culture-aware handling
  (`HasTailoredCasing`); the framework's own culture-aware conversion only ever special-cases
  Turkish, so nothing else changes behaviour, and the previously observable disagreement between
  `toUpperCase()` and `toLocaleUpperCase()` is gone.

`Jint/Runtime/RegExp/Unicode/UnicodeProperties.cs`

* `ToUpperCase` / `ToLowerCase` / `MaxCaseConversionLength` — named wrappers over the existing
  `CaseConv(res, c, convType)` so the call sites do not pass a bare `0` or `1`. No table or
  algorithm change.

`Jint.Tests/Runtime/StringTests.cs`

* `CaseConversionUsesTheUnicodeDefaultCaseConversionAlgorithm` covers dotless i, Garay, Vithkuqi
  and a supplementary code point inside a string that also needs an expansion. Six of its eight
  rows fail against the code before this change.
* `LocaleTailoredCasingIsPreserved` pins the Turkish/Azeri behaviour that must *not* move; it
  passes both before and after, which is the point.

## Performance

The ASCII path — the overwhelmingly common input — is unchanged in shape and cost: one vectorized
range scan (a `ContainsAnyExceptInRange` over U+0000..U+007F, replacing the old special-casing
pre-scan, which was also a single vectorized pass) followed by the framework's vectorized
`ToUpperInvariant`/`ToLowerInvariant`, which is exactly the Unicode default for ASCII. No
per-character table lookup is added there.

Non-ASCII input does get slower: where a string without a SpecialCasing character previously took
one batched ICU call, it now costs a binary search over the 378-entry range table per code point
(~9 comparisons over a ~1.5 KB array). That is the price of an answer that does not depend on the
host's ICU version, and it is the same lookup the regex engine already performs per character for
`/i`. Happy to have a measured run scheduled if that figure is wanted.

## Files this frees

* `staging/sm/String/string-code-point-upper-lower-mapping.js`
* `staging/sm/String/string-upper-lower-mapping.js`

## Verification

* Both files pass in strict and sloppy mode (4/4). Before the change they failed with
  `Expected SameValue(«68976», «68944») to be true` (U+10D70 GARAY SMALL LETTER A not
  upper-casing to U+10D50) and `Expected SameValue(«"ı"», «"I"») to be true`.
* `built-ins/String`, `built-ins/RegExp`, `staging/sm/String` — 6691 passed, 0 failed.
* `built-ins/String/prototype/{toUpperCase,toLowerCase,toLocaleUpperCase,toLocaleLowerCase}` —
  220 passed, 0 failed.
* Full `Jint.Tests` green on net10.0 and net472, as are `Jint.Tests.PublicInterface` and
  `Jint.Tests.CommonScripts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
