### PR TITLE
Fix argument validation and evaluation order in five built-ins

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -58,14 +58,6 @@
     "staging/sm/expressions/nullish-coalescing.js",
     "staging/sm/regress/regress-1507322-deep-weakmap.js",
 
-    // Argument-validation order in the TypedArray-from-ArrayBuffer constructor - despite the file's
-    // cross-realm cast, nothing about it is realm-specific and it fails the same way on a buffer from
-    // this realm. InitializeTypedArrayFromArrayBuffer throws the RangeError for a byteOffset that is
-    // not a multiple of the element size (step 3) before it evaluates ToIndex(length) (step 5); Jint
-    // runs them the other way round, so `new Int32Array(buffer, 1, poisonedValue)` reports the
-    // poisoned value's own error instead of the RangeError. Removed by fixing that ordering.
-    "staging/sm/TypedArray/constructor-buffer-sequence.js",
-
     // Acornima (the external parser) rejects a SuperCall inside a direct eval. Jint already parses
     // eval code with AllowSuperOutsideMethod, but that covers SuperProperty only; Acornima 1.7.0 has
     // no separate switch for a direct `super()`, so `eval("super()")` in a derived constructor fails
@@ -103,15 +95,6 @@
     // strict from the first character. The file's checkPrologue half already passes. Reported as
     // adams85/acornima#47.
     "staging/sm/strict/deprecated-octal-noctal-tokens.js",
-
-    // Argument validation raising no error, or the wrong one: a bad this or a bad index reaching a
-    // built-in, a NUL-bearing string reaching one, and the order in which a super reference is
-    // evaluated against its side effects.
-    "staging/sm/TypedArray/constructor-byteoffsets-bounds.js",
-    "staging/sm/TypedArray/iterator-next-with-detached.js",
-    "staging/sm/class/superPropOrdering.js",
-    "staging/sm/extensions/quote-string-for-nul-character.js",
-    "staging/sm/misc/builtin-methods-reject-null-undefined-this.js",
 
     // === PERMANENT EXCLUSIONS ===
     //

--- a/Jint.Tests/Runtime/ArrayIteratorExhaustionTests.cs
+++ b/Jint.Tests/Runtime/ArrayIteratorExhaustionTests.cs
@@ -1,0 +1,91 @@
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// The abstract closure behind <see href="https://tc39.es/ecma262/#sec-createarrayiterator">
+/// CreateArrayIterator</see> is a generator body: once it has run off the end and returned, the generator is
+/// <em>completed</em>, and every later <c>next</c> answers <c>{ value: undefined, done: true }</c> without
+/// executing a single step of it again. So an exhausted iterator observes nothing about the array it came
+/// from — not <c>ValidateTypedArray</c>, which would raise a <c>TypeError</c> for a buffer detached in the
+/// meantime, and not the <c>length</c> read an array-like's step begins with.
+/// <para>
+/// Jint kept stepping the closure. The detached-buffer assertion in particular ran unconditionally, so
+/// detaching a buffer after its typed array had been iterated to the end turned the next <c>next</c> into a
+/// <c>TypeError</c> where the spec requires another <c>{ done: true }</c>. test262 covers it in
+/// <c>staging/sm/TypedArray/iterator-next-with-detached.js</c>.
+/// </para>
+/// </summary>
+public class ArrayIteratorExhaustionTests
+{
+    private readonly Engine _engine = new();
+
+    [Fact]
+    public void AnExhaustedTypedArrayIteratorIgnoresALaterDetach()
+    {
+        const string Script = """
+            var buffer = new ArrayBuffer(2);
+            var array = new Uint8Array(buffer);
+            array[0] = 1;
+            array[1] = 2;
+
+            var iterator = array[Symbol.iterator]();
+            var seen = [iterator.next().value, iterator.next().value];
+            iterator.next().done;
+
+            buffer.transfer();
+            var after = iterator.next();
+            seen.join(',') + ' ' + after.value + ' ' + after.done;
+            """;
+
+        _engine.Evaluate(Script).AsString().Should().Be("1,2 undefined true");
+    }
+
+    /// <summary>
+    /// The control, and the half that was already right: an iterator that has <em>not</em> yet reported
+    /// <c>done</c> still validates the array, so a detach it has not stepped past is a <c>TypeError</c>.
+    /// That includes the all-but-exhausted case, where the elements are gone but the closure has not
+    /// returned yet.
+    /// </summary>
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    public void AnUnfinishedTypedArrayIteratorStillReportsADetach(int stepsBeforeDetaching)
+    {
+        var script = $$"""
+            var buffer = new ArrayBuffer(2);
+            var array = new Uint8Array(buffer);
+            var iterator = array[Symbol.iterator]();
+            for (var i = 0; i < {{stepsBeforeDetaching}}; i++) { iterator.next(); }
+
+            buffer.transfer();
+            try { iterator.next(); return 'did not throw'; }
+            catch (e) { return e.constructor.name; }
+            """;
+
+        _engine.Evaluate($"(function () {{ {script} }})()").AsString().Should().Be("TypeError");
+    }
+
+    /// <summary>
+    /// The same rule for an ordinary array-like: once the closure has returned, nothing re-reads
+    /// <c>length</c>, so a getter that could grow the collection never runs again. The assertion is that the
+    /// count stops moving, not what it reached - how many times the iterator consults <c>length</c> on its
+    /// way to <c>done</c> is a separate question this fix does not touch.
+    /// </summary>
+    [Fact]
+    public void AnExhaustedArrayLikeIteratorDoesNotReReadLength()
+    {
+        const string Script = """
+            var reads = 0;
+            var arrayLike = { 0: 'a', get length() { reads++; return 1; } };
+            var iterator = Array.prototype[Symbol.iterator].call(arrayLike);
+
+            var values = [iterator.next().value, iterator.next().value];
+            var readsWhenDone = reads;
+            iterator.next();
+            iterator.next();
+
+            values.join(',') + ' ' + (reads === readsWhenDone);
+            """;
+
+        _engine.Evaluate(Script).AsString().Should().Be("a, true");
+    }
+}

--- a/Jint.Tests/Runtime/ClassTests.cs
+++ b/Jint.Tests/Runtime/ClassTests.cs
@@ -97,4 +97,100 @@ public class ClassTests
 
         ex.Error.Get("message").AsString().Should().Be(expected);
     }
+
+    /// <summary>
+    /// <see href="https://tc39.es/ecma262/#sec-super-keyword-runtime-semantics-evaluation">
+    /// SuperProperty : super [ Expression ]</see> evaluates Expression (steps 3 and 4) and only then calls
+    /// MakeSuperPropertyReference, whose <c>GetSuperBase</c> reads <c>[[HomeObject]].[[Prototype]]</c>. So an
+    /// Expression that re-points the home object's prototype is observed by the very lookup it is part of.
+    /// Jint resolved the super base first, and the read went to the old prototype. test262 covers it in
+    /// <c>staging/sm/class/superPropOrdering.js</c>.
+    /// </summary>
+    [Fact]
+    public void ComputedSuperPropertyResolvesItsBaseAfterThePropertyExpression()
+    {
+        const string Script = """
+            class Base { constructor() {} }
+            class Derived extends Base {
+                read() { return super[detach()]; }
+            }
+            function detach() { Object.setPrototypeOf(Derived.prototype, null); return 'x'; }
+
+            try { new Derived().read(); return 'did not throw'; }
+            catch (e) { return e.constructor.name; }
+            """;
+
+        new Engine().Evaluate($"(function () {{ {Script} }})()").AsString().Should().Be("TypeError");
+    }
+
+    /// <summary>
+    /// A non-computed <c>super.name</c> has no such expression, so its base is resolved before the argument
+    /// list — the same re-pointing during an argument leaves the already-resolved method alone.
+    /// </summary>
+    [Fact]
+    public void NonComputedSuperPropertyResolvesItsBaseBeforeTheArguments()
+    {
+        const string Script = """
+            class Base { constructor() {} method() { return 'called'; } }
+            class Derived extends Base {
+                call() { return super.method(detach()); }
+            }
+            function detach() { Object.setPrototypeOf(Derived.prototype, null); return 0; }
+
+            new Derived().call();
+            """;
+
+        new Engine().Evaluate(Script).AsString().Should().Be("called");
+    }
+
+    /// <summary>
+    /// Deferring the base must not disturb the ordinary computed cases: the property expression's value is
+    /// still taken before the right-hand side runs, and the reference still writes through the super base's
+    /// [[Set]] onto the receiver.
+    /// </summary>
+    [Fact]
+    public void ComputedSuperPropertyStillReadsAndWritesNormally()
+    {
+        const string Script = """
+            class Base { constructor() {} }
+            Base.prototype.value = 'from base';
+            class Derived extends Base {
+                read(key) { return super[key]; }
+                write() {
+                    let key = 'first';
+                    super[key] = (() => (key = 'second', 42))();
+                    return this.first + ' ' + this.second;
+                }
+            }
+
+            var instance = new Derived();
+            instance.read('value') + ' / ' + instance.write();
+            """;
+
+        new Engine().Evaluate(Script).AsString().Should().Be("from base / 42 undefined");
+    }
+
+    /// <summary>
+    /// And it must survive suspension: <c>super[await key]</c> resumes into the same deferred base rather
+    /// than into whatever evaluating the <c>super</c> keyword on its own would produce.
+    /// </summary>
+    [Fact]
+    public void ComputedSuperPropertySurvivesAnAwaitInThePropertyExpression()
+    {
+        const string Script = """
+            class Base { constructor() {} }
+            Base.prototype.value = 'from base';
+            class Derived extends Base {
+                async read() { return super[await Promise.resolve('value')]; }
+            }
+
+            var result = 'pending';
+            new Derived().read().then(v => result = v);
+            result;
+            """;
+
+        var engine = new Engine();
+        engine.Evaluate(Script);
+        engine.Evaluate("result").AsString().Should().Be("from base");
+    }
 }

--- a/Jint.Tests/Runtime/IntlTests.cs
+++ b/Jint.Tests/Runtime/IntlTests.cs
@@ -1,4 +1,6 @@
-﻿namespace Jint.Tests.Runtime;
+﻿using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
 
 public class IntlTests
 {
@@ -1308,5 +1310,60 @@ public class IntlTests
             .AsString().Should().Be("3/15/2024");
         _engine.Evaluate("new Intl.DateTimeFormat('en-US', { timeZone: 'UTC', dateStyle: 'full' }).format(new Date(Date.UTC(2024, 2, 15)))")
             .AsString().Should().Be("Friday, March 15, 2024");
+    }
+
+    /// <summary>
+    /// <see href="https://tc39.es/ecma402/#sec-resolveoptions">ResolveOptions</see> step 3 reads the
+    /// <c>localeMatcher</c> option through <c>GetOption</c>, which admits only <c>"lookup"</c> and
+    /// <c>"best fit"</c> and raises a <c>RangeError</c> for anything else. <c>Intl.PluralRules</c> left the
+    /// read to <c>ResolveLocale</c>, which takes the raw string and never validates it, so a bad value was
+    /// accepted in silence — the one assertion in
+    /// <c>staging/sm/extensions/quote-string-for-nul-character.js</c> that Jint failed.
+    /// </summary>
+    [Theory]
+    [InlineData("new Intl.PluralRules('en', { localeMatcher: 'lookup\0cookie' })")]
+    [InlineData("new Intl.PluralRules('en', { localeMatcher: 'nonsense' })")]
+    [InlineData("new Intl.PluralRules('en', { localeMatcher: 'Lookup' })")]
+    [InlineData("new Intl.PluralRules('en', { localeMatcher: '' })")]
+    public void PluralRulesRejectsAnInvalidLocaleMatcher(string script)
+    {
+        Invoking(() => _engine.Evaluate(script))
+            .Should().Throw<JavaScriptException>()
+            .WithMessage("Invalid value*for option 'localeMatcher'");
+    }
+
+    /// <summary>
+    /// The control: both accepted values, and the absent option, still construct.
+    /// </summary>
+    [Theory]
+    [InlineData("new Intl.PluralRules('en', { localeMatcher: 'lookup' })")]
+    [InlineData("new Intl.PluralRules('en', { localeMatcher: 'best fit' })")]
+    [InlineData("new Intl.PluralRules('en', { localeMatcher: undefined })")]
+    [InlineData("new Intl.PluralRules('en')")]
+    public void PluralRulesAcceptsAValidLocaleMatcher(string script)
+    {
+        _engine.Evaluate($"typeof {script}").AsString().Should().Be("object");
+    }
+
+    /// <summary>
+    /// The option is read exactly once. It used to be read twice by <c>Intl.Collator</c> — once to validate
+    /// it and once inside <c>ResolveLocale</c> — which a user-supplied getter can see.
+    /// </summary>
+    [Theory]
+    [InlineData("Collator")]
+    [InlineData("PluralRules")]
+    [InlineData("DateTimeFormat")]
+    [InlineData("NumberFormat")]
+    [InlineData("RelativeTimeFormat")]
+    public void TheLocaleMatcherGetterRunsOnce(string constructor)
+    {
+        var script = $$"""
+            var reads = 0;
+            var options = { get localeMatcher() { reads++; return 'lookup'; } };
+            new Intl.{{constructor}}('en', options);
+            reads;
+            """;
+
+        _engine.Evaluate(script).AsNumber().Should().Be(1);
     }
 }

--- a/Jint.Tests/Runtime/NumberTests.cs
+++ b/Jint.Tests/Runtime/NumberTests.cs
@@ -613,4 +613,68 @@ public class NumberTests
     {
         new Engine().Evaluate(source).AsString().Should().Be(expected);
     }
+
+    /// <summary>
+    /// <see href="https://tc39.es/ecma262/#sec-number.prototype.tofixed">Number.prototype.toFixed</see> opens
+    /// with <c>ThisNumberValue(this value)</c>, which is a <c>TypeError</c> for any receiver that is neither a
+    /// Number nor a Number object. Jint coerced the receiver with <c>ToNumber</c> instead, so a null receiver
+    /// silently formatted 0 and an undefined one formatted NaN. test262 covers the whole family in
+    /// <c>staging/sm/misc/builtin-methods-reject-null-undefined-this.js</c>, where <c>toFixed</c> was the only
+    /// entry in a table of roughly a hundred built-ins that Jint got wrong.
+    /// </summary>
+    [Theory]
+    [InlineData("Number.prototype.toFixed.call(null)")]
+    [InlineData("Number.prototype.toFixed.call(undefined)")]
+    [InlineData("Number.prototype.toFixed.apply(null)")]
+    [InlineData("Number.prototype.toFixed.call(null, 2)")]
+    [InlineData("Number.prototype.toFixed.call('1')")]
+    [InlineData("Number.prototype.toFixed.call({})")]
+    [InlineData("Number.prototype.toFixed.call(Symbol())")]
+    [InlineData("Number.prototype.toFixed.call(1n)")]
+    [InlineData("(0, Number.prototype.toFixed)()")]
+    public void ToFixedRequiresANumberReceiver(string script)
+    {
+        Invoking(() => new Engine().Evaluate(script))
+            .Should().Throw<JavaScriptException>()
+            .WithMessage("Number.prototype.toFixed requires that 'this' be a Number");
+    }
+
+    /// <summary>
+    /// The receiver check is step 1 and the argument coercion is step 2, so a bad receiver is reported even
+    /// when the argument would also have thrown.
+    /// </summary>
+    [Fact]
+    public void ToFixedChecksItsReceiverBeforeCoercingItsArgument()
+    {
+        const string Script = """
+            var argumentWasCoerced = false;
+            var poisoned = { valueOf: function () { argumentWasCoerced = true; throw new Error('argument'); } };
+            var message;
+            try { Number.prototype.toFixed.call(null, poisoned); message = 'did not throw'; }
+            catch (e) { message = e.constructor.name; }
+            message + ' ' + argumentWasCoerced;
+            """;
+
+        new Engine().Evaluate(Script).AsString().Should().Be("TypeError false");
+    }
+
+    /// <summary>
+    /// The control: every receiver that is a Number still formats, and the digit range is still the one the
+    /// spec's steps 4 and 5 describe.
+    /// </summary>
+    [Fact]
+    public void ToFixedStillFormatsEveryNumberReceiver()
+    {
+        var engine = new Engine();
+
+        engine.Evaluate("(3).toFixed(2)").AsString().Should().Be("3.00");
+        engine.Evaluate("new Number(3).toFixed(2)").AsString().Should().Be("3.00");
+        engine.Evaluate("Number.prototype.toFixed()").AsString().Should().Be("0");
+        engine.Evaluate("(3).toFixed(-0)").AsString().Should().Be("3");
+        engine.Evaluate("(3).toFixed(100).length").AsNumber().Should().Be(102);
+
+        Invoking(() => engine.Evaluate("(3).toFixed(-1)")).Should().Throw<JavaScriptException>();
+        Invoking(() => engine.Evaluate("(3).toFixed(101)")).Should().Throw<JavaScriptException>();
+        Invoking(() => engine.Evaluate("(3).toFixed(Infinity)")).Should().Throw<JavaScriptException>();
+    }
 }

--- a/Jint.Tests/Runtime/TypedArrayConstructorBoundsTests.cs
+++ b/Jint.Tests/Runtime/TypedArrayConstructorBoundsTests.cs
@@ -1,0 +1,139 @@
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// <see href="https://tc39.es/ecma262/#sec-initializetypedarrayfromarraybuffer">
+/// InitializeTypedArrayFromArrayBuffer</see> treats <c>byteOffset</c> and <c>length</c> as mathematical
+/// integers anywhere in <c>ToIndex</c>'s range (0 to 2^53-1) and lets three comparisons decide whether the
+/// request fits the buffer. Jint narrowed both to <c>int</c> before those comparisons, so a value past
+/// <c>2^31</c> wrapped into something small enough to pass them: <c>new Int32Array(new ArrayBuffer(0),
+/// 2**31 + 4)</c> built a typed array with byte offset <c>-2147483644</c> and length <c>536870911</c>
+/// instead of raising a <c>RangeError</c>.
+/// <para>
+/// The same algorithm also fixes the order of its two observable coercions. <c>ToIndex(byteOffset)</c> is
+/// step 2, the offset-must-be-a-multiple-of-the-element-size <c>RangeError</c> is step 3, and
+/// <c>ToIndex(length)</c> only arrives at step 5 — so a misaligned offset is reported even when the length
+/// argument would itself have thrown. Jint ran both coercions up front and reported the length's error.
+/// </para>
+/// <para>
+/// test262's own coverage of all of this is <c>staging/sm/TypedArray/constructor-byteoffsets-bounds.js</c>
+/// and <c>staging/sm/TypedArray/constructor-buffer-sequence.js</c>; these pin it outside the generated
+/// projection so a future rearrangement cannot trade one half for the other.
+/// </para>
+/// </summary>
+public class TypedArrayConstructorBoundsTests
+{
+    private readonly Engine _engine = new();
+
+    /// <summary>
+    /// The constructor name of whatever <paramref name="source"/> throws, or <c>did not throw</c>. Written in
+    /// script rather than with <c>Assert.Throws</c> so that a CLR exception leaking out of the engine fails
+    /// the test as an escaping exception instead of being caught and reported as a JavaScript error.
+    /// </summary>
+    private string ThrownErrorName(string source) => _engine
+        .Evaluate($"(function () {{ try {{ {source}; return 'did not throw'; }} catch (e) {{ return e.constructor.name; }} }})()")
+        .AsString();
+
+    /// <summary>
+    /// 2147483648 and 2147483652 are where narrowing to a signed 32-bit integer produced a negative offset;
+    /// 4294967292 and 4294967296 are where it wrapped back to a small non-negative one. 2147483647 and
+    /// 4294967295 are the odd values on either side, which happened to be rejected already because they are
+    /// not multiples of the element size — they are here so the alignment check cannot start standing in for
+    /// the range check.
+    /// </summary>
+    [Theory]
+    [InlineData("2147483644")]
+    [InlineData("2147483647")]
+    [InlineData("2147483648")]
+    [InlineData("2147483649")]
+    [InlineData("2147483652")]
+    [InlineData("4294967292")]
+    [InlineData("4294967295")]
+    [InlineData("4294967296")]
+    [InlineData("4294967297")]
+    [InlineData("4294967300")]
+    [InlineData("9007199254740991")]
+    public void ByteOffsetPastTheBufferIsARangeError(string byteOffset)
+    {
+        ThrownErrorName($"new Int32Array(new ArrayBuffer(0), {byteOffset})").Should().Be("RangeError");
+    }
+
+    /// <summary>
+    /// The same for the length argument, whose product with the element size is what used to overflow.
+    /// </summary>
+    [Theory]
+    [InlineData("2147483647")]
+    [InlineData("2147483648")]
+    [InlineData("2147483649")]
+    [InlineData("4294967295")]
+    [InlineData("4294967296")]
+    [InlineData("4294967297")]
+    [InlineData("9007199254740991")]
+    public void LengthPastTheBufferIsARangeError(string length)
+    {
+        ThrownErrorName($"new Int32Array(new ArrayBuffer(0), 0, {length})").Should().Be("RangeError");
+    }
+
+    /// <summary>
+    /// The control: offsets and lengths the buffer really can hold still build the array they always did.
+    /// </summary>
+    [Fact]
+    public void OffsetsAndLengthsWithinTheBufferStillWork()
+    {
+        _engine.Evaluate("new Int32Array(new ArrayBuffer(16), 4).length").AsNumber().Should().Be(3);
+        _engine.Evaluate("new Int32Array(new ArrayBuffer(16), 4).byteOffset").AsNumber().Should().Be(4);
+        _engine.Evaluate("new Int32Array(new ArrayBuffer(16), 8, 2).length").AsNumber().Should().Be(2);
+        _engine.Evaluate("new Int32Array(new ArrayBuffer(16)).length").AsNumber().Should().Be(4);
+    }
+
+    /// <summary>
+    /// Step 3 precedes step 5: the misaligned offset is reported, not whatever evaluating the length would
+    /// have raised.
+    /// </summary>
+    [Fact]
+    public void MisalignedByteOffsetIsReportedBeforeTheLengthIsCoerced()
+    {
+        const string Script = """
+            var lengthWasCoerced = false;
+            var poisoned = { valueOf: function () { lengthWasCoerced = true; throw new Error('length'); } };
+            var name;
+            try { new Int32Array(new ArrayBuffer(8), 1, poisoned); name = 'did not throw'; }
+            catch (e) { name = e.constructor.name; }
+            name + ' ' + lengthWasCoerced;
+            """;
+
+        _engine.Evaluate(Script).AsString().Should().Be("RangeError false");
+    }
+
+    /// <summary>
+    /// And step 2 precedes step 3: an offset that throws while being coerced does so before anything can
+    /// decide it is misaligned.
+    /// </summary>
+    [Fact]
+    public void ByteOffsetIsCoercedBeforeItIsCheckedForAlignment()
+    {
+        const string Script = """
+            var poisoned = { valueOf: function () { throw new RangeError('offset'); } };
+            try { new Int32Array(new ArrayBuffer(8), poisoned, 0); return 'did not throw'; }
+            catch (e) { return e.message; }
+            """;
+
+        _engine.Evaluate($"(function () {{ {Script} }})()").AsString().Should().Be("offset");
+    }
+
+    /// <summary>
+    /// Step 6 (the detached-buffer <c>TypeError</c>) comes after both coercions, so a buffer detached from
+    /// inside the length's <c>valueOf</c> is still seen.
+    /// </summary>
+    [Fact]
+    public void ADetachedBufferIsNoticedAfterBothArgumentsAreCoerced()
+    {
+        const string Script = """
+            var buffer = new ArrayBuffer(8);
+            var detaching = { valueOf: function () { buffer.transfer(); return 0; } };
+            try { new Int32Array(buffer, 0, detaching); return 'did not throw'; }
+            catch (e) { return e.constructor.name; }
+            """;
+
+        _engine.Evaluate($"(function () {{ {Script} }})()").AsString().Should().Be("TypeError");
+    }
+}

--- a/Jint/Native/Array/ArrayIteratorPrototype.cs
+++ b/Jint/Native/Array/ArrayIteratorPrototype.cs
@@ -153,12 +153,23 @@ internal sealed partial class ArrayIteratorPrototype : IteratorPrototype
 
         public override bool TryIteratorStep(out ObjectInstance nextItem)
         {
+            // https://tc39.es/ecma262/#sec-createarrayiterator - the abstract closure is a generator
+            // body, so once it has returned the generator is completed and a further `next` answers
+            // { value: undefined, done: true } without running a single step again. Nothing here may
+            // observe the array after that: no ValidateTypedArray (which would raise a TypeError for a
+            // buffer detached in the meantime) and no `length` read on an array-like.
+            if (_closed)
+            {
+                nextItem = IteratorResult.CreateKeyValueIteratorPosition(_engine);
+                return false;
+            }
+
             uint len;
             if (_typedArray is not null)
             {
                 _typedArray._viewedArrayBuffer.AssertNotDetached();
                 var taRecord = IntrinsicTypedArrayPrototype.MakeTypedArrayWithBufferWitnessRecord(_typedArray, ArrayBufferOrder.SeqCst);
-                if (!_closed && taRecord.IsTypedArrayOutOfBounds)
+                if (taRecord.IsTypedArrayOutOfBounds)
                 {
                     Throw.TypeError(_typedArray.Engine.Realm, "TypedArray is out of bounds");
                 }
@@ -169,7 +180,7 @@ internal sealed partial class ArrayIteratorPrototype : IteratorPrototype
                 len = _operations!.GetLength();
             }
 
-            if (!_closed && _position < len)
+            if (_position < len)
             {
                 if (_typedArray is not null)
                 {
@@ -211,8 +222,14 @@ internal sealed partial class ArrayIteratorPrototype : IteratorPrototype
         {
             if (_kind == ArrayIteratorType.Value && _typedArray is null)
             {
+                if (_closed)
+                {
+                    value = null;
+                    return false;
+                }
+
                 var len = _operations!.GetLength();
-                if (!_closed && _position < len)
+                if (_position < len)
                 {
                     var stepped = _operations!.Get(_position);
                     _position++;

--- a/Jint/Native/Intl/CollatorConstructor.cs
+++ b/Jint/Native/Intl/CollatorConstructor.cs
@@ -174,13 +174,15 @@ internal sealed partial class CollatorConstructor : Constructor
         // Get options object
         var optionsObj = IntlUtilities.CoerceOptionsToObject(_engine, options);
 
-        // Validate localeMatcher option first (must be done before other processing)
-        GetStringOption(optionsObj, "localeMatcher", in LocaleMatcherValues, "best fit");
+        // Validate localeMatcher option first (must be done before other processing). The resolved
+        // value is threaded through rather than re-read inside ResolveLocale: the spec reads the
+        // option exactly once, so a second Get would run a user-supplied getter a second time.
+        var localeMatcher = GetStringOption(optionsObj, "localeMatcher", in LocaleMatcherValues, "best fit");
 
         // Resolve locale
         var requestedLocales = IntlUtilities.CanonicalizeLocaleList(_engine, locales);
         var availableLocales = IntlUtilities.GetAvailableLocales();
-        var resolvedLocale = ResolveCollatorLocale(_engine, availableLocales, requestedLocales, optionsObj);
+        var resolvedLocale = ResolveCollatorLocale(_engine, availableLocales, requestedLocales, localeMatcher);
 
         // Parse Unicode extensions from the first requested locale (if any) since resolved locale may strip them
         string? uCollation = null;
@@ -532,9 +534,9 @@ internal sealed partial class CollatorConstructor : Constructor
         return options;
     }
 
-    private static string ResolveCollatorLocale(Engine engine, HashSet<string> availableLocales, List<string> requestedLocales, ObjectInstance options)
+    private static string ResolveCollatorLocale(Engine engine, HashSet<string> availableLocales, List<string> requestedLocales, string localeMatcher)
     {
-        var resolved = IntlUtilities.ResolveLocale(engine, availableLocales, requestedLocales, options, []);
+        var resolved = IntlUtilities.ResolveLocale(engine, availableLocales, requestedLocales, localeMatcher, []);
         return resolved.Locale;
     }
 

--- a/Jint/Native/Intl/IntlUtilities.cs
+++ b/Jint/Native/Intl/IntlUtilities.cs
@@ -1534,22 +1534,8 @@ internal static class IntlUtilities
 
     /// <summary>
     /// https://tc39.es/ecma402/#sec-resolvelocale
-    /// </summary>
-    internal static ResolvedLocale ResolveLocale(
-        Engine engine,
-        HashSet<string> availableLocales,
-        List<string> requestedLocales,
-        JsValue options,
-        string[] relevantExtensionKeys)
-    {
-        // 1. Let matcher be options.[[localeMatcher]].
-        var matcher = options.IsObject() ? options.Get("localeMatcher").ToString() : "best fit";
-        return ResolveLocaleCore(engine, availableLocales, requestedLocales, matcher, relevantExtensionKeys);
-    }
-
-    /// <summary>
-    /// https://tc39.es/ecma402/#sec-resolvelocale
-    /// Overload that accepts pre-read localeMatcher to avoid reading the option twice.
+    /// The localeMatcher is passed in already read and validated: step 1 takes it from the internal
+    /// [[localeMatcher]] slot the caller filled in, never from the options object a second time.
     /// </summary>
     internal static ResolvedLocale ResolveLocale(
         Engine engine,

--- a/Jint/Native/Intl/PluralRulesConstructor.cs
+++ b/Jint/Native/Intl/PluralRulesConstructor.cs
@@ -60,12 +60,16 @@ internal sealed partial class PluralRulesConstructor : Constructor
         // Get options object
         var optionsObj = IntlUtilities.CoerceOptionsToObject(_engine, options);
 
-        // Note: localeMatcher is read by ResolveLocale, so we don't read it here
+        // https://tc39.es/ecma402/#sec-resolveoptions step 3: the localeMatcher option is read - and
+        // validated against « "lookup", "best fit" » - before any of the options below it. Reading it
+        // through ResolveLocale instead skipped the validation entirely, so a bad value was silently
+        // accepted rather than raising a RangeError.
+        var localeMatcher = GetStringOption(optionsObj, "localeMatcher", in LocaleMatcherValues, "best fit");
 
         // Resolve locale
         var requestedLocales = IntlUtilities.CanonicalizeLocaleList(_engine, locales);
         var availableLocales = IntlUtilities.GetAvailableLocales();
-        var resolvedLocale = ResolvePluralRulesLocale(_engine, availableLocales, requestedLocales, optionsObj);
+        var resolvedLocale = ResolvePluralRulesLocale(_engine, availableLocales, requestedLocales, localeMatcher);
 
         // Get type option
         var type = GetStringOption(optionsObj, "type", in TypeValues, "cardinal");
@@ -194,9 +198,9 @@ internal sealed partial class PluralRulesConstructor : Constructor
         return intValue;
     }
 
-    private static string ResolvePluralRulesLocale(Engine engine, HashSet<string> availableLocales, List<string> requestedLocales, ObjectInstance options)
+    private static string ResolvePluralRulesLocale(Engine engine, HashSet<string> availableLocales, List<string> requestedLocales, string localeMatcher)
     {
-        var resolved = IntlUtilities.ResolveLocale(engine, availableLocales, requestedLocales, options, []);
+        var resolved = IntlUtilities.ResolveLocale(engine, availableLocales, requestedLocales, localeMatcher, []);
         return resolved.Locale;
     }
 

--- a/Jint/Native/TypedArray/TypedArrayConstructor.cs
+++ b/Jint/Native/TypedArray/TypedArrayConstructor.cs
@@ -46,7 +46,9 @@ public abstract partial class TypedArrayConstructor : Constructor
     public JsTypedArray Construct(JsArrayBuffer buffer, int? byteOffset = null, int? length = null)
     {
         var o = AllocateTypedArray(this);
-        InitializeTypedArrayFromArrayBuffer(o, buffer, byteOffset, length);
+        var offset = byteOffset ?? 0;
+        ValidateByteOffsetAlignment(offset, o);
+        InitializeTypedArrayFromArrayBuffer(o, buffer, offset, length);
         return o;
     }
 
@@ -73,9 +75,7 @@ public abstract partial class TypedArrayConstructor : Constructor
             }
             else if (firstArgument is JsArrayBuffer arrayBuffer)
             {
-                int? byteOffset = !arguments.At(1).IsUndefined() ? (int) TypeConverter.ToIndex(_realm, arguments[1]) : null;
-                int? length = !arguments.At(2).IsUndefined() ? (int) TypeConverter.ToIndex(_realm, arguments[2]) : null;
-                InitializeTypedArrayFromArrayBuffer(o, arrayBuffer, byteOffset, length);
+                InitializeTypedArrayFromArrayBuffer(o, arrayBuffer, arguments.At(1), arguments.At(2));
             }
             else
             {
@@ -94,8 +94,16 @@ public abstract partial class TypedArrayConstructor : Constructor
             return o;
         }
 
-        var elementLength = TypeConverter.ToIndex(_realm, firstArgument);
-        return AllocateTypedArray(newTarget, elementLength);
+        var elementLength = TypeConverter.ToIndexLong(_realm, firstArgument);
+        if (elementLength > uint.MaxValue)
+        {
+            // AllocateTypedArrayBuffer would ask for elementLength * elementSize bytes, which cannot be
+            // allocated; CreateByteDataBlock reports that as a RangeError, so report it here too rather
+            // than truncating the length into something that happens to fit.
+            Throw.RangeError(_realm, "Invalid typed array length");
+        }
+
+        return AllocateTypedArray(newTarget, (uint) elementLength);
     }
 
     /// <summary>
@@ -171,30 +179,72 @@ public abstract partial class TypedArrayConstructor : Constructor
     }
 
     /// <summary>
+    /// Step 3 of https://tc39.es/ecma262/#sec-initializetypedarrayfromarraybuffer, split out because it
+    /// sits between the two ToIndex coercions and therefore cannot live with the rest of the algorithm.
+    /// </summary>
+    private void ValidateByteOffsetAlignment(long offset, JsTypedArray o)
+    {
+        if (offset % o._arrayElementType.GetElementSize() != 0)
+        {
+            Throw.RangeError(_realm, "Invalid offset");
+        }
+    }
+
+    /// <summary>
     /// https://tc39.es/ecma262/#sec-initializetypedarrayfromarraybuffer
+    /// </summary>
+    /// <remarks>
+    /// The two coercions and the alignment check between them are observable and their order is
+    /// normative: ToIndex(byteOffset) is step 2, the offset-modulo-elementSize RangeError is step 3, and
+    /// ToIndex(length) only comes at step 5. Running both coercions up front made a call such as
+    /// new Int32Array(buffer, 1, poisonedValue) report the poisoned value's own error where the spec
+    /// requires the RangeError.
+    /// </remarks>
+    private void InitializeTypedArrayFromArrayBuffer(
+        JsTypedArray o,
+        JsArrayBuffer buffer,
+        JsValue byteOffset,
+        JsValue length)
+    {
+        // 2. Let offset be ? ToIndex(byteOffset).
+        var offset = TypeConverter.ToIndexLong(_realm, byteOffset);
+
+        // 3. If offset modulo elementSize is not 0, throw a RangeError exception.
+        ValidateByteOffsetAlignment(offset, o);
+
+        // 5. If length is not undefined, let newLength be ? ToIndex(length).
+        long? newLength = length.IsUndefined() ? null : TypeConverter.ToIndexLong(_realm, length);
+
+        InitializeTypedArrayFromArrayBuffer(o, buffer, offset, newLength);
+    }
+
+    /// <summary>
+    /// Steps 4 and 6 onwards of https://tc39.es/ecma262/#sec-initializetypedarrayfromarraybuffer, for a
+    /// byteOffset and length that are already coerced and whose alignment has already been checked.
     /// </summary>
     private void InitializeTypedArrayFromArrayBuffer(
         JsTypedArray o,
         JsArrayBuffer buffer,
-        int? byteOffset,
-        int? length)
+        long offset,
+        long? length)
     {
+        // The arithmetic below stays in 64 bits. ToIndex admits anything up to 2^53-1, and narrowing an
+        // offset or a length to Int32 first wrapped it into a value that then passed the bounds checks:
+        // a byteOffset of 2^31+4 on an empty buffer produced a typed array with a negative byte offset
+        // and a length of 536870911.
         var elementSize = o._arrayElementType.GetElementSize();
-        var offset = byteOffset ?? 0;
-        if (offset % elementSize != 0)
-        {
-            Throw.RangeError(_realm, "Invalid offset");
-        }
 
-        int newByteLength;
-        var newLength = length ?? 0;
-
+        // 4. Let bufferIsFixedLength be IsFixedLengthArrayBuffer(buffer).
         var bufferIsFixedLength = buffer.IsFixedLengthArrayBuffer;
 
+        // 6. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
         buffer.AssertNotDetached();
 
-        var bufferByteLength = IntrinsicTypedArrayPrototype.ArrayBufferByteLength(buffer, ArrayBufferOrder.SeqCst);
-        if (length == null && !bufferIsFixedLength)
+        // 7. Let bufferByteLength be ArrayBufferByteLength(buffer, seq-cst).
+        long bufferByteLength = IntrinsicTypedArrayPrototype.ArrayBufferByteLength(buffer, ArrayBufferOrder.SeqCst);
+
+        // 8. If length is undefined and bufferIsFixedLength is false, then
+        if (length is null && !bufferIsFixedLength)
         {
             if (offset > bufferByteLength)
             {
@@ -206,7 +256,8 @@ public abstract partial class TypedArrayConstructor : Constructor
         }
         else
         {
-            if (length == null)
+            long newByteLength;
+            if (length is null)
             {
                 if (bufferByteLength % elementSize != 0)
                 {
@@ -221,7 +272,7 @@ public abstract partial class TypedArrayConstructor : Constructor
             }
             else
             {
-                newByteLength = newLength * elementSize;
+                newByteLength = length.Value * elementSize;
                 if (offset + newByteLength > bufferByteLength)
                 {
                     Throw.RangeError(_realm, "Invalid buffer byte length");
@@ -233,7 +284,7 @@ public abstract partial class TypedArrayConstructor : Constructor
         }
 
         o._viewedArrayBuffer = buffer;
-        o._byteOffset = offset;
+        o._byteOffset = (int) offset;
     }
 
     private static void InitializeTypedArrayFromList(JsTypedArray o, List<JsValue> values)

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -243,12 +243,20 @@ internal sealed class JintMemberExpression : JintExpression
         object? baseReferenceName = null;
         JsValue? baseValue = null;
 
+        // Non-null only for `super[expr]`, whose super base must not be resolved until after `expr`
+        // has been evaluated - see the comment on the super branch below.
+        FunctionEnvironment? deferredSuperEnvironment = null;
+
         var engine = context.Engine;
         ref readonly var executionContext = ref engine.ExecutionContext;
         var strict = executionContext.Strict;
         var suspendable = executionContext.Suspendable;
 
+        // A super base is derived from the running execution context, not from evaluating the object
+        // side, so a resume re-derives it rather than reading it back - which is also what keeps the
+        // deferral below intact across `super[await x]`.
         if (suspendable is { IsResuming: true }
+            && _objectExpression is not JintSuperExpression
             && suspendable.Data.TryGet(this, out MemberExpressionSuspendData? suspendData))
         {
             // Resume: reuse the previously-resolved object state so a side-effectful
@@ -289,12 +297,25 @@ internal sealed class JintMemberExpression : JintExpression
             }
             else if (_objectExpression is JintSuperExpression)
             {
+                // https://tc39.es/ecma262/#sec-super-keyword-runtime-semantics-evaluation
+                // `super [ Expression ]` evaluates Expression (steps 3-4) and only then calls
+                // MakeSuperPropertyReference, whose GetSuperBase reads [[HomeObject]].[[Prototype]].
+                // So a side effect in Expression that re-points the home object's prototype - the
+                // whole point of staging/sm/class/superPropOrdering.js - is observed by the lookup.
+                // `super . IdentifierName` has no such expression and resolves its base immediately.
                 var env = (FunctionEnvironment) engine.ExecutionContext.GetThisEnvironment();
                 actualThis = env.GetThisBinding();
-                baseValue = env.GetSuperBase();
+                if (_propertyExpression is null)
+                {
+                    baseValue = env.GetSuperBase();
+                }
+                else
+                {
+                    deferredSuperEnvironment = env;
+                }
             }
 
-            if (baseValue is null)
+            if (baseValue is null && deferredSuperEnvironment is null)
             {
                 // fast checks failed
                 var baseReference = _objectExpression.Evaluate(context);
@@ -327,8 +348,10 @@ internal sealed class JintMemberExpression : JintExpression
 
             // Only this link's own `?.` short-circuits. An object expression that merely *contains* one
             // (`({})?.a` in `({})?.a['b']`) has already decided not to short-circuit and produced a
-            // genuine undefined, so this access must run against it and throw.
-            if (_memberExpression.Optional && baseValue.IsNullOrUndefined())
+            // genuine undefined, so this access must run against it and throw. A deferred super base
+            // leaves baseValue null here but cannot reach this test: bare `super` is not a
+            // MemberExpression, so `super?.x` is a SyntaxError and Optional is always false for one.
+            if (_memberExpression.Optional && baseValue!.IsNullOrUndefined())
             {
                 return ShortCircuit();
             }
@@ -336,11 +359,21 @@ internal sealed class JintMemberExpression : JintExpression
 
         var property = _determinedProperty ?? _propertyExpression!.GetValue(context);
 
+        // Unconditional, suspension included: GetSuperBase reads [[HomeObject]].[[Prototype]], and a
+        // [[HomeObject]] is always an ordinary object, so this is a field read with nothing observable
+        // about when it happens - only about what it happens *after*. A suspended pass still needs a
+        // base for the Reference it hands back, and the resumed pass re-derives it after re-evaluating
+        // the property expression, which is where the ordering guarantee actually has to hold.
+        if (deferredSuperEnvironment is not null)
+        {
+            baseValue = deferredSuperEnvironment.GetSuperBase();
+        }
+
         if (context.IsSuspended())
         {
             // Property-side suspended. Save the resolved object state so resume
             // doesn't re-evaluate the (potentially side-effectful) object side.
-            if (suspendable is not null)
+            if (suspendable is not null && _objectExpression is not JintSuperExpression)
             {
                 var data = suspendable.Data.GetOrCreate<MemberExpressionSuspendData>(this);
                 data.BaseValue = baseValue!;

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -833,6 +833,23 @@ public static class TypeConverter
     /// </summary>
     public static uint ToIndex(Realm realm, JsValue value)
     {
+        // Clamped rather than range-checked: every caller of this overload goes on to reject anything
+        // larger than the buffer or view it indexes, so a saturated value produces the same RangeError
+        // the real one would. A caller that instead computes with the result - the TypedArray-from-
+        // ArrayBuffer constructor does - must call ToIndexLong, or the saturation silently becomes a
+        // different, in-range offset.
+        return (uint) Math.Min(uint.MaxValue, ToIndexLong(realm, value));
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-toindex
+    /// </summary>
+    /// <remarks>
+    /// Returns the whole spec range, 0 to 2^53-1. Callers storing the result in a narrower field are
+    /// responsible for rejecting what does not fit.
+    /// </remarks>
+    internal static long ToIndexLong(Realm realm, JsValue value)
+    {
         if (value.IsUndefined())
         {
             return 0;
@@ -850,7 +867,7 @@ public static class TypeConverter
             Throw.RangeError(realm, "Invalid index");
         }
 
-        return (uint) Math.Min(uint.MaxValue, index);
+        return (long) index;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Part of the #3021 campaign. Six `staging/` exclusions, in two blocks, all about a built-in either validating an argument in the wrong order or not validating it at all. Every diagnosis below was re-derived from the test and from Jint's source; where the exclusion comment was wrong, that is called out.

## `staging/sm/TypedArray/constructor-buffer-sequence.js`

The exclusion comment was **right**. [InitializeTypedArrayFromArrayBuffer](https://tc39.es/ecma262/#sec-initializetypedarrayfromarraybuffer) takes `ToIndex(byteOffset)` at step 2, raises the offset-modulo-elementSize `RangeError` at step 3, and only reaches `ToIndex(length)` at step 5. `TypedArrayConstructor.Construct` ran both coercions before calling the initializer, so `new Int32Array(buffer, 1, poisonedValue)` reported the poisoned value's own error:

```
Jint.Runtime.JavaScriptException: Expected a RangeError but got a Error
```

The algorithm is now written in spec order, with the alignment check split into `ValidateByteOffsetAlignment` precisely because it sits between the two coercions. The public `Construct(JsArrayBuffer, int?, int?)` overload keeps its shape and calls the same check.

## `staging/sm/TypedArray/constructor-byteoffsets-bounds.js`

The catch-all comment called this "a bad index reaching a built-in", which understates it. `byteOffset` and `length` were narrowed to `int` before the bounds comparisons, so any value past `2^31` wrapped into one that passed them:

```
Jint.Runtime.JavaScriptException: Expected a RangeError to be thrown but no exception was thrown at all
```

`new Int32Array(new ArrayBuffer(0), 2**31 + 4)` produced a typed array with `byteOffset === -2147483644` and `length === 536870911`, and reading through one of those raised a raw CLR `IndexOutOfRangeException`. `new Int32Array(ab, 0, 2**32)` produced a silently truncated length. This is the same defect `DataViewBoundsTests` was written for, one algorithm over.

The arithmetic now stays in 64 bits. `TypeConverter.ToIndex` was itself part of the problem: it clamps its result at `uint.MaxValue`, which is harmless for every caller that goes on to reject anything larger than the buffer it indexes, but not for one that computes with the value. The spec-range operation is now `ToIndexLong` (0 to 2^53-1) and `ToIndex` is the clamping convenience expressed in terms of it, with a comment saying which callers may use which. No other call site changes behaviour.

## `staging/sm/TypedArray/iterator-next-with-detached.js`

Not "a bad index" either. The abstract closure in [CreateArrayIterator](https://tc39.es/ecma262/#sec-createarrayiterator) is a generator body, so once it has returned the generator is *completed* and every later `next` answers `{ value: undefined, done: true }` without running a step. Jint kept stepping it, and the detached-buffer assertion ran unconditionally:

```
Jint.Runtime.JavaScriptException: ArrayBuffer has been detached
   at call (staging/sm/TypedArray/iterator-next-with-detached.js:59:31)
```

That line is the `next` *after* the iterator had already reported `done`. `ArrayLikeIterator.TryIteratorStep` now returns the done result immediately when it is closed, which also stops it re-reading `length` on an array-like.

## `staging/sm/class/superPropOrdering.js`

Interpreter-side, and the comment's "the order in which a super reference is evaluated against its side effects" is right as far as it goes. [`SuperProperty : super [ Expression ]`](https://tc39.es/ecma262/#sec-super-keyword-runtime-semantics-evaluation) evaluates Expression at steps 3-4 and only then calls MakeSuperPropertyReference, whose `GetSuperBase` reads `[[HomeObject]].[[Prototype]]`. So an Expression that re-points the home object's prototype is observed by the lookup it is part of. Jint resolved the base first:

```
Jint.Runtime.JavaScriptException: Expected a TypeError to be thrown but no exception was thrown at all
```

`JintMemberExpression` now defers `GetSuperBase` past the property expression for the computed form only — `super.name` has no such expression and keeps resolving its base immediately, which is what makes `super.method(sideEffect())` still find the method. `GetSuperBase` reads an ordinary object's prototype field and is not observable, so it is also resolved on a suspended pass, and a resume re-derives it from the execution context rather than reading back suspend data (`super[await x]` has a test).

The other six orderings the file checks — the property value being captured before the right-hand side, the setter being looked up at `PutValue` time rather than at reference creation, the compound-assignment getter/setter pair — were already correct and are unchanged.

## `staging/sm/extensions/quote-string-for-nul-character.js`

The original triage note claimed this was about SpiderMonkey's `toSource`/`uneval` and would be "removed by the test moving, not by Jint changing". **That is wrong** — the file as it exists at the pinned SHA contains no `toSource` at all. It is a NUL-in-a-string test, and exactly one of its ~40 assertions failed:

```
Jint.Runtime.JavaScriptException: cookie Expected a RangeError to be thrown but no exception was thrown at all
```

`new Intl.PluralRules("en", { localeMatcher: "lookup\0cookie" })` was accepted. [ResolveOptions](https://tc39.es/ecma402/#sec-resolveoptions) step 3 reads `localeMatcher` through `GetOption`, which admits only `"lookup"` and `"best fit"`. `Intl.PluralRules` left the read to `ResolveLocale`, which takes the raw string and validates nothing — the `// Note: localeMatcher is read by ResolveLocale, so we don't read it here` comment was true and was the bug. Every other Intl constructor already validated it explicitly. `Intl.PluralRules` now does too, and the NUL handling this file is nominally about needed no change: Jint already reports a NUL-bearing option value without truncating it.

While there, `Intl.Collator` was the last user of the `ResolveLocale` overload that re-reads the option off the options object, so it validated `localeMatcher` and then read it a second time — visible to a user-supplied getter. It now threads the validated value through like everyone else, and that overload is gone.

## `staging/sm/misc/builtin-methods-reject-null-undefined-this.js`

This is the sweep the workstream was built around: roughly a hundred built-ins called with `null` and `undefined` as `this`, each of which must throw `TypeError`. Jint failed exactly one of them.

```
Jint.Runtime.JavaScriptException: wrong error for Number.prototype.toFixed.call(null) Expected a TypeError to be thrown but no exception was thrown at all
```

`Number.prototype.toFixed` coerced its receiver with `ToNumber` rather than [ThisNumberValue](https://tc39.es/ecma262/#sec-number.prototype.tofixed), so `toFixed.call(null)` formatted `0` and `toFixed.call(undefined)` formatted `NaN`. `toString`, `valueOf`, `toExponential` and `toPrecision` all had the check; `toFixed` alone did not. Since the check is step 1 and the argument coercion is step 2, the coercion also had to move off the parameter — the source generator emits an `[ToInteger]` parameter's conversion at the call site, i.e. before the body is entered — so `toFixed` now takes a `JsValue` like its siblings and keeps `Length = 1`.

I re-ran the file's whole table by hand to be sure nothing else in it was merely masked by the first failure. Nothing was.

## Verification

Pre-fix, with the two blocks removed: `Failed: 12, Passed: 0` (six files, strict and sloppy). Post-fix: `Passed! - Failed: 0, Passed: 12`.

Neighbouring suites, all green:

- `built-ins/{TypedArray,ArrayBuffer,DataView,Number,Atomics,BigInt}` — 7500 passed
- `built-ins/Array`, `built-ins/Iterator`, `language/expressions/{super,class,object}`, `language/statements/class` — 27046 passed
- `intl402/{Collator,PluralRules,NumberFormat,DateTimeFormat,RelativeTimeFormat,ListFormat,Segmenter,DisplayNames,DurationFormat}` — 2002 passed, 34 skipped
- `staging/` — 2644 passed, 135 skipped
- `Jint.Tests` — 6335 (net10.0) / 6250 (net472) passed
- `Jint.Tests.PublicInterface` — 1488 / 1487 passed

New coverage in `Jint.Tests`, each of which was run against the unfixed engine first (27 of 58 failed):

- `TypedArrayConstructorBoundsTests` — the bounds at both boundaries for offset and length, plus the three coercion-order cases
- `ArrayIteratorExhaustionTests` — exhausted vs. all-but-exhausted vs. unfinished across a detach, and the array-like `length` re-read
- `ClassTests` — computed and non-computed `super`, the ordinary read/write cases, and `super[await x]`
- `NumberTests` — the `toFixed` receiver, its order against the argument, and a control that every Number receiver still formats
- `IntlTests` — the `localeMatcher` rejection and acceptance sets, and a getter-runs-once check across five constructors

Files freed: `staging/sm/TypedArray/constructor-buffer-sequence.js`, `staging/sm/TypedArray/constructor-byteoffsets-bounds.js`, `staging/sm/TypedArray/iterator-next-with-detached.js`, `staging/sm/class/superPropOrdering.js`, `staging/sm/extensions/quote-string-for-nul-character.js`, `staging/sm/misc/builtin-methods-reject-null-undefined-this.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
