### PR TITLE
Choose the regex engine per subject, and stop RegExp replace from rewriting lastIndex

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -97,17 +97,6 @@
     "staging/sm/Number/toFixed-values.js",
     "staging/sm/Number/toPrecision-values.js",
 
-    // RegExp semantics: case-insensitive matching across the Latin-1 boundary, and lastIndex
-    // bookkeeping in the Symbol.match / Symbol.replace / matchAll paths (including -0 and the
-    // ToLength recomputation the spec performs per iteration).
-    "staging/sm/RegExp/ignoreCase-non-latin1-to-latin1.js",
-    "staging/sm/RegExp/lastIndex-match-or-replace.js",
-    "staging/sm/RegExp/replace-local-tolength-lastindex.js",
-    "staging/sm/RegExp/replace-local-tolength-recompilation.js",
-    "staging/sm/RegExp/unicode-ignoreCase-ascii.js",
-    "staging/sm/String/matchAll.js",
-    "staging/sm/String/replace-updates-global-lastIndex.js",
-
     // Set.prototype.intersection / .isSubsetOf let the *receiver* be mutated while they traverse it
     // (a set-like's has/keys callback calling this.delete(v) or this.clear()), and the spec models
     // that with the [[SetData]] tombstone: a deleted entry becomes EMPTY in place rather than being

--- a/Jint.Tests/Runtime/RegExpTests.cs
+++ b/Jint.Tests/Runtime/RegExpTests.cs
@@ -655,4 +655,195 @@ public class RegExpTests
 
         result.AsString().Should().Be("[true,5]");
     }
+    // ---- RegExp.prototype[Symbol.replace] lastIndex handling
+    // (https://tc39.es/ecma262/#sec-regexp.prototype-@@replace) ----
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("i")]
+    [InlineData("u")]
+    [InlineData("iu")]
+    public void ReplaceLeavesLastIndexAloneOnNonGlobalRegExp(string flags)
+    {
+        // Only step 9 writes lastIndex, and only when the regexp is global. A non-global one is left
+        // exactly as the script set it - including a -0 that a write of +0 would quietly normalize.
+        var engine = new Engine();
+        var result = engine.Evaluate($$"""
+            var re = /a/{{flags}};
+            re.lastIndex = -0;
+            re[Symbol.replace]('a', 'b');
+            var kept = /a/{{flags}};
+            kept.lastIndex = 7;
+            kept[Symbol.replace]('a', 'b');
+            JSON.stringify([Object.is(re.lastIndex, -0), kept.lastIndex])
+            """);
+
+        result.AsString().Should().Be("[true,7]");
+    }
+
+    [Fact]
+    public void ReplaceLeavesLastIndexWhereAReplacerFunctionPutIt()
+    {
+        // The exec loop of steps 11-12 runs to exhaustion before the first replacer call, so by then
+        // lastIndex is back to +0 and nothing may overwrite what the replacer assigns afterwards.
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var re = /x/g;
+            re.lastIndex = 3;
+            var seen = [];
+            '0x2x4x6x8'.replace(re, function () { seen.push(re.lastIndex++); return 'y'; });
+            JSON.stringify([seen, re.lastIndex])
+            """);
+
+        result.AsString().Should().Be("[[0,1,2,3],4]");
+    }
+
+    [Theory]
+    [InlineData("", true)]
+    [InlineData("y", true)]
+    [InlineData("g", false)]
+    [InlineData("gy", false)]
+    public void ReplaceCoercesLastIndexOnNonGlobalRegExp(string flags, bool expectedCoercion)
+    {
+        // RegExpBuiltinExec step 2 coerces lastIndex whatever the flags say, and only a global regexp
+        // has had that value replaced by the +0 of step 9 before the coercion could run.
+        var engine = new Engine();
+        var result = engine.Evaluate($$"""
+            var re = new RegExp('a', '{{flags}}');
+            var called = false;
+            re.lastIndex = { valueOf: function () { called = true; return 0; } };
+            re[Symbol.replace]('', '');
+            called
+            """);
+
+        result.AsBoolean().Should().Be(expectedCoercion);
+    }
+
+    [Fact]
+    public void ReplaceHonoursARecompileFromTheLastIndexCoercion()
+    {
+        // Step 2 runs before step 3 reads the flags and step 8 reads the matcher, so a compile() from
+        // inside the coercion decides which pattern the very same exec goes on to match with.
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var re = new RegExp('a', '');
+            re.lastIndex = { valueOf: function () { re.compile('b'); return 0; } };
+            var replaced = re[Symbol.replace]('b', 'pass');
+
+            var toGlobal = new RegExp('a', '');
+            toGlobal.lastIndex = { valueOf: function () { toGlobal.compile('a', 'g'); return 0; } };
+            toGlobal[Symbol.replace]('a', '');
+
+            var fromSticky = new RegExp('a', 'y');
+            fromSticky.lastIndex = { valueOf: function () { fromSticky.compile('a', ''); fromSticky.lastIndex = 9000; return 0; } };
+            fromSticky[Symbol.replace]('a', '');
+
+            JSON.stringify([replaced, toGlobal.lastIndex, fromSticky.lastIndex])
+            """);
+
+        result.AsString().Should().Be("""["pass",1,9000]""");
+    }
+
+    [Fact]
+    public void ReplaceStartsAStickyRegExpAtItsLastIndex()
+    {
+        // A sticky match is anchored at lastIndex and writes the end position back. The non-ASCII
+        // pattern is what routes this through the custom engine, whose fast path used to scan from
+        // the start of the subject regardless.
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var re = /µ/iy;
+            re.lastIndex = 1;
+            JSON.stringify([re[Symbol.replace]('Xµ', 'Z'), re.lastIndex])
+            """);
+
+        result.AsString().Should().Be("""["XZ",2]""");
+    }
+
+    // ---- RegExp.prototype.exec replaced by an accessor (https://tc39.es/ecma262/#sec-regexpexec) ----
+
+    [Fact]
+    public void ReplacingExecWithAnAccessorDoesNotInvokeItOnThePrototype()
+    {
+        // Deciding whether exec is still the built-in must not perform an ordinary [[Get]]: that calls
+        // a script-installed getter an extra time, with RegExp.prototype as the receiver rather than
+        // the regexp being matched.
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var builtinExec = RegExp.prototype.exec;
+            var receivers = [];
+            Object.defineProperty(RegExp.prototype, 'exec', {
+                configurable: true,
+                get: function () { receivers.push(this); return builtinExec; }
+            });
+            var re = /a+/g;
+            var matched = 'aabbaa'.match(re);
+            Object.defineProperty(RegExp.prototype, 'exec', {
+                value: builtinExec, writable: true, enumerable: false, configurable: true
+            });
+            JSON.stringify([matched, receivers.length, receivers.every(function (r) { return r === re; })])
+            """);
+
+        result.AsString().Should().Be("""[["aa","aa"],3,true]""");
+    }
+
+    // ---- Case-insensitive matching across the ASCII/non-ASCII boundary
+    // (https://tc39.es/ecma262/#sec-runtime-semantics-canonicalize-ch) ----
+
+    [Theory]
+    // Canonicalize is toUpperCase in non-Unicode mode, so U+00B5 MICRO SIGN and U+039C GREEK CAPITAL
+    // MU share a canonical value and match either way round.
+    [InlineData(@"/\xB5/i", 0x039C, true)]
+    [InlineData(@"/Μ/i", 0x00B5, true)]
+    // The Latin-1 pair whose uppercase stays non-ASCII matches too.
+    [InlineData(@"/\xFF/i", 0x0178, true)]
+    // ... but step 9 keeps a character at or above U+0080 whose uppercase is ASCII to itself, so these
+    // pairs stay distinct however alike .NET's IgnoreCase considers them.
+    [InlineData(@"/\x6B/i", 0x212A, false)]
+    [InlineData("/k/i", 0x212A, false)]
+    [InlineData("/K/i", 0x212A, false)]
+    [InlineData("/[a-z]/i", 0x212A, false)]
+    [InlineData("/[j-l]/i", 0x212A, false)]
+    // ... and the word-character set contains them, so it carries the same hazard.
+    [InlineData(@"/\w/i", 0x212A, false)]
+    [InlineData(@"/\x73/i", 0x017F, false)]
+    [InlineData(@"/\xDF/i", 0x1E9E, false)]
+    [InlineData(@"/\xE5/i", 0x212B, false)]
+    public void CaseInsensitiveMatchingUsesCanonicalizeNotDotNetCaseFolding(string pattern, int subject, bool expected)
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate($"{pattern}.test(String.fromCharCode({subject}))");
+
+        result.AsBoolean().Should().Be(expected);
+    }
+
+    [Theory]
+    // In Unicode mode Canonicalize is Simple Case Folding, and the two non-ASCII characters that fold
+    // into ASCII must be found even though the first-character scan searches for ASCII code units.
+    [InlineData("/s/iu", 0x017F, 1)]
+    [InlineData("/S/iu", 0x017F, 1)]
+    [InlineData("/k/iu", 0x212A, 1)]
+    [InlineData("/K/iu", 0x212A, 1)]
+    [InlineData("/s+/iu", 0x017F, 2)]
+    public void UnicodeCaseFoldingFindsTheNonAsciiFoldingPartners(string pattern, int subject, int repeat)
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate(
+            $"{pattern}.exec(String.fromCharCode({subject}).repeat({repeat}))[0].length");
+
+        result.AsNumber().Should().Be(repeat);
+    }
+
+    [Fact]
+    public void UnicodeCaseFoldingFindsAFoldingPartnerInsideALiteralPrefix()
+    {
+        // The multi-code-unit scan path searches for the whole literal with OrdinalIgnoreCase, which
+        // knows nothing about the folding partners either.
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            JSON.stringify([/as/iu.exec('xxaſ')[0], /sa/iu.exec('xxſa')[0]])
+            """);
+
+        result.AsString().Should().Be("[\"aſ\",\"ſa\"]");
+    }
 }

--- a/Jint.Tests/Runtime/RegExpTests.cs
+++ b/Jint.Tests/Runtime/RegExpTests.cs
@@ -846,4 +846,109 @@ public class RegExpTests
 
         result.AsString().Should().Be("[\"aſ\",\"ſa\"]");
     }
+    [Theory]
+    // The word-boundary assertions classify their neighbours with .NET's own word-character set,
+    // which under IgnoreCase takes in U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE. The spec's
+    // WordCharacters gains nothing in non-Unicode mode, so U+0130 is a boundary on both sides.
+    [InlineData(@"/a\b/i", "aİ", true)]
+    [InlineData(@"/a\B/i", "aİ", false)]
+    [InlineData(@"/\bk/i", "İk", true)]
+    [InlineData(@"/\Bk/i", "İk", false)]
+    public void WordBoundariesTreatTheDottedCapitalIAsANonWordCharacter(string pattern, string subject, bool expected)
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate($"{pattern}.test({ToJsLiteral(subject)})");
+
+        result.AsBoolean().Should().Be(expected);
+    }
+
+    [Theory]
+    // \W is the one construct the .NET adaptation expands into a positive class spanning the whole
+    // BMP while excluding the ASCII word characters. Closing that class under IgnoreCase pulls the
+    // partners of its non-ASCII members back in, so /\W/i matched 'k' on .NET 7+ and 'I' on .NET
+    // Framework - a divergence a pure-ASCII subject already shows.
+    [InlineData(@"/\W/i", "k", false)]
+    [InlineData(@"/\W/i", "K", false)]
+    [InlineData(@"/\W/i", "i", false)]
+    [InlineData(@"/\W/i", "I", false)]
+    [InlineData(@"/[\W]/i", "k", false)]
+    [InlineData(@"/\W/i", "-", true)]
+    public void NegatedWordClassDoesNotTakeInItsMembersCasePartners(string pattern, string subject, bool expected)
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate($"{pattern}.test({ToJsLiteral(subject)})");
+
+        result.AsBoolean().Should().Be(expected);
+    }
+
+    [Fact]
+    public void OneRegExpAlternatesBetweenEnginesAcrossSubjects()
+    {
+        // The engine is chosen per subject, so the same instance has to answer correctly whichever
+        // subject it sees next - including after a compile() drops what it had determined.
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var kelvin = String.fromCharCode(0x212A);
+            var re = /[a-z]/i;
+            var answers = [re.test('Q'), re.test(kelvin), re.test('Q'), re.test(kelvin), re.test('4')];
+            re.compile('[0-9]', 'i');
+            answers.push(re.test(kelvin), re.test('4'), re.test('Q'));
+            JSON.stringify(answers)
+            """);
+
+        result.AsString().Should().Be("[true,false,true,false,false,false,true,false]");
+    }
+
+    [Fact]
+    public void GlobalMatchOverASubjectCarryingATriggerStaysCorrectForEveryMatch()
+    {
+        // The per-subject probe is memoized by string instance so a match loop scans the subject once;
+        // the memo must not let the first answer stand for a different subject.
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var kelvin = String.fromCharCode(0x212A);
+            var re = /[a-z]+/gi;
+            var withTrigger = 'ab' + kelvin + 'cd';
+            var first = withTrigger.match(re);
+            var second = 'abcd'.match(re);
+            var third = withTrigger.match(re);
+            JSON.stringify([first, second, third])
+            """);
+
+        result.AsString().Should().Be("""[["ab","cd"],["abcd"],["ab","cd"]]""");
+    }
+
+    [Theory]
+    // Routing pin. A case-insensitive pattern that merely mentions 'k', covers it with a range, or
+    // uses \w keeps the .NET engine and is diverted per subject; only the verdict that holds for
+    // every subject takes a pattern away from it. Losing this would put the most common
+    // case-insensitive patterns in real scripts on the bytecode interpreter for every match.
+    [InlineData("[a-z0-9]+", "i", false)]
+    [InlineData(@"\w+", "i", false)]
+    [InlineData("k", "i", false)]
+    [InlineData("check", "i", false)]
+    [InlineData(@"\bfoo\b", "i", false)]
+    [InlineData(@"\x6B", "i", false)]
+    // ... while non-ASCII pattern content and \W do, on every subject.
+    [InlineData(@"\xB5", "i", true)]
+    [InlineData(@"Μ", "i", true)]
+    [InlineData(@"\W", "i", true)]
+    [InlineData("[a-z]", "u", true)]
+    public void CaseInsensitivePatternsKeepTheDotNetEngineUnlessTheyDivergeOnEverySubject(
+        string pattern, string flags, bool needsCustomEngine)
+    {
+        Jint.Native.RegExp.RegExpConstructor.NeedCustomEngine(pattern, flags).Should().Be(needsCustomEngine);
+    }
+
+    private static string ToJsLiteral(string value)
+    {
+        var builder = new System.Text.StringBuilder(value.Length * 6 + 2);
+        builder.Append('\'');
+        foreach (var c in value)
+        {
+            builder.Append("\\u").Append(((int) c).ToString("x4", System.Globalization.CultureInfo.InvariantCulture));
+        }
+
+        return builder.Append('\'').ToString();
+    }
 }

--- a/Jint/Extensions/Polyfills.cs
+++ b/Jint/Extensions/Polyfills.cs
@@ -177,6 +177,19 @@ internal static class Polyfills
     internal static bool ContainsAnyExceptInRange(this ReadOnlySpan<char> span, char lowInclusive, char highInclusive)
         => span.IndexOfAnyExceptInRange(lowInclusive, highInclusive) >= 0;
 
+    internal static bool ContainsAny(this ReadOnlySpan<char> span, SearchValues<char> values)
+    {
+        for (var i = 0; i < span.Length; i++)
+        {
+            if (values.Contains(span[i]))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     internal static int IndexOfAnyExcept(this ReadOnlySpan<char> span, SearchValues<char> values)
     {
         for (var i = 0; i < span.Length; i++)

--- a/Jint/Native/JsRegExp.cs
+++ b/Jint/Native/JsRegExp.cs
@@ -1,3 +1,4 @@
+﻿using System.Buffers;
 using System.Text.RegularExpressions;
 using Jint.Native.Object;
 using Jint.Native.RegExp;
@@ -15,6 +16,30 @@ public sealed class JsRegExp : ObjectInstance
     private string _flags = null!;
 
     private PropertyDescriptor _prototypeDescriptor = null!;
+
+    // 0 = not determined yet, 1 = no hazard, 2 = hazard. Determined lazily on the first match rather
+    // than at construction: a regexp literal caches its adaptation on the AST node and skips
+    // RegExpConstructor entirely on every evaluation after the first, so there is no construction-time
+    // hook that all of them pass through.
+    private byte _caseFoldingHazard;
+    private JintRegExpEngine? _caseFoldingFallbackEngine;
+
+    // One-entry memo of the last subject probed for a trigger, so a match loop over one string
+    // (`while (re.exec(s))`, @@match, @@replace) scans it once instead of once per match.
+    private string? _lastProbedSubject;
+    private bool _lastProbedSubjectHasTrigger;
+
+    /// <summary>
+    /// The non-ASCII code points that a case relation can connect to an ASCII one, and therefore the
+    /// only subject characters over which .NET's IgnoreCase matching of an all-ASCII pattern can
+    /// disagree with the specification's Canonicalize: U+0130 and U+0131 (dotted and dotless I),
+    /// U+017F LATIN SMALL LETTER LONG S, and U+212A KELVIN SIGN. Which of the four any given target
+    /// framework actually pairs with ASCII differs - .NET 7 and later pair U+212A with <c>k</c> and
+    /// .NET Framework pairs none of them - so all four are listed and the set is a property of Unicode
+    /// rather than of a framework version.
+    /// </summary>
+    internal static readonly SearchValues<char> CaseFoldingTriggers =
+        SearchValues.Create("\u0130\u0131\u017F\u212A");
 
     public JsRegExp(Engine engine)
         : base(engine, ObjectClass.RegExp)
@@ -37,6 +62,13 @@ public sealed class JsRegExp : ObjectInstance
         set
         {
             _flags = value;
+
+            // Every construction and every compile() assigns Flags last, so this is the one place that
+            // has to drop the lazily determined case-folding state along with the flags themselves.
+            _caseFoldingHazard = 0;
+            _caseFoldingFallbackEngine = null;
+            _lastProbedSubject = null;
+
             // Reset all flags before parsing (needed for RegExp.prototype.compile re-initialization)
             DotAll = false;
             Global = false;
@@ -106,6 +138,52 @@ public sealed class JsRegExp : ObjectInstance
     public bool UnicodeSets { get; private set; }
 
     internal bool HasDefaultRegExpExec => Properties == null && Prototype is RegExpPrototype { HasDefaultExec: true };
+
+    /// <summary>
+    /// Whether this match has to leave the .NET engine for the custom one because the pattern is
+    /// case-insensitive in a way .NET resolves differently from the specification's Canonicalize, and
+    /// this particular subject carries one of the <see cref="CaseFoldingTriggers"/> that makes the
+    /// difference observable. Everything else stays on .NET: the scan is the only cost a pattern with
+    /// the hazard pays on a subject without a trigger, and it is memoized per subject instance so a
+    /// match loop over one string pays it once.
+    /// <para>
+    /// A host-supplied <see cref="Regex"/> is exempt - it is the host's own .NET pattern, not one
+    /// adapted from JavaScript, so its casing rules are the host's to decide. So is a Unicode-mode
+    /// pattern, which never reaches the .NET engine at all.
+    /// </para>
+    /// </summary>
+    internal bool NeedsCaseFoldingFallback(string subject)
+    {
+        if (_caseFoldingHazard == 0)
+        {
+            _caseFoldingHazard = (byte) (IgnoreCase && !IsHostRegex && !FullUnicode
+                && RegExp.RegExpConstructor.HasSubjectDependentCaseFoldingHazard(Source, _flags)
+                ? 2
+                : 1);
+        }
+
+        if (_caseFoldingHazard == 1)
+        {
+            return false;
+        }
+
+        if (!ReferenceEquals(subject, _lastProbedSubject))
+        {
+            _lastProbedSubject = subject;
+            _lastProbedSubjectHasTrigger = subject.AsSpan().ContainsAny(CaseFoldingTriggers);
+        }
+
+        return _lastProbedSubjectHasTrigger;
+    }
+
+    /// <summary>
+    /// The custom-engine compilation of this pattern, built on the first subject that needs it and
+    /// reused afterwards. Never reached unless <see cref="NeedsCaseFoldingFallback"/> said so, so a
+    /// pattern whose subjects never carry a trigger never pays the compilation.
+    /// </summary>
+    internal JintRegExpEngine GetCaseFoldingFallbackEngine(TimeSpan timeout)
+        => _caseFoldingFallbackEngine ??=
+            RegExp.RegExpConstructor.TryCompileWithCustomEngine(Engine.Realm, Source, _flags, timeout);
 
     /// <summary>Whether this regex uses the .NET Regex engine (not the custom engine).</summary>
     internal bool UsesDotNetEngine => IsHostRegex || ParseResult.ConversionResult is Regex;

--- a/Jint/Native/RegExp/RegExpConstructor.cs
+++ b/Jint/Native/RegExp/RegExpConstructor.cs
@@ -617,9 +617,10 @@ public sealed partial class RegExpConstructor : Constructor
 
         // Case-insensitive matching that reaches across the ASCII boundary: .NET IgnoreCase groups
         // characters that the spec's Canonicalize keeps apart in non-unicode mode, where it is
-        // toUpperCase with a hard barrier rather than Unicode case folding. See HasCaseFoldingHazard
-        // for exactly which pattern content that covers.
-        if (flags.Contains('i') && HasCaseFoldingHazard(pattern))
+        // toUpperCase with a hard barrier rather than Unicode case folding. Only the verdict that holds
+        // for every subject takes the pattern away from .NET here; the subject-dependent one keeps the
+        // .NET engine and is resolved per match, see JsRegExp.NeedsCaseFoldingFallback.
+        if (flags.Contains('i') && GetCaseFoldingHazard(pattern) == CaseFoldingHazard.Always)
         {
             return true;
         }
@@ -1083,41 +1084,66 @@ public sealed partial class RegExpConstructor : Constructor
     }
 
     /// <summary>
-    /// Detect pattern content whose case-insensitive matching .NET resolves differently from
+    /// How far .NET's case-insensitive matching of a pattern can drift from
     /// <see href="https://tc39.es/ecma262/#sec-runtime-semantics-canonicalize-ch">Canonicalize</see>
-    /// in non-Unicode mode, which is what routes such a pattern to the custom engine. Two kinds:
+    /// in non-Unicode mode. Ordered by severity: a scan keeps the most severe verdict it finds.
+    /// </summary>
+    internal enum CaseFoldingHazard : byte
+    {
+        /// <summary>The two agree on every subject, so the pattern keeps the .NET engine unconditionally.</summary>
+        None,
+
+        /// <summary>
+        /// They agree on every subject free of <see cref="JsRegExp.CaseFoldingTriggers"/>. The pattern keeps
+        /// the .NET engine and only the rare subject that carries a trigger is diverted per match.
+        /// </summary>
+        SubjectDependent,
+
+        /// <summary>They can disagree on any subject at all, so the custom engine takes the pattern outright.</summary>
+        Always,
+    }
+
+    /// <summary>
+    /// Classify pattern content whose case-insensitive matching .NET resolves differently from
+    /// <see href="https://tc39.es/ecma262/#sec-runtime-semantics-canonicalize-ch">Canonicalize</see>
+    /// in non-Unicode mode, where Canonicalize is toUpperCase plus a hard barrier: a character at or
+    /// above U+0080 whose uppercase is a single code unit below U+0080 canonicalizes to itself (step 9).
+    /// .NET instead closes every character set in the pattern under its own case-equivalence relation.
     /// <list type="bullet">
     /// <item><description>
-    /// Any non-ASCII code point, whether written literally or as a <c>\uXXXX</c>, <c>\u{XXXX}</c> or
-    /// <c>\xNN</c> escape. Canonicalize is toUpperCase plus a hard barrier — a character at or above
-    /// U+0080 whose uppercase is a single code unit below U+0080 canonicalizes to itself (step 9) — so
-    /// U+00DF and U+1E9E, or U+00E5 and U+212B, are distinct to the spec while .NET groups them.
+    /// <see cref="CaseFoldingHazard.Always"/> for any non-ASCII code point, written literally or as a
+    /// <c>\uXXXX</c>, <c>\u{XXXX}</c> or <c>\xNN</c> escape: there the barrier keeps U+00DF and U+1E9E,
+    /// or U+00E5 and U+212B, distinct while .NET groups them. Also for a decimal escape, which is either
+    /// a backreference or an Annex B legacy octal escape denoting any code point up to U+00FF (telling
+    /// the two apart needs the capture-group count). And for <c>\W</c>, which is the one construct the
+    /// adapter expands into a *positive* class spanning the whole BMP while excluding the ASCII word
+    /// characters, so closing it pulls those characters back in and <c>/\W/i</c> matches <c>k</c> on
+    /// .NET 7+ and <c>I</c> on .NET Framework - a divergence an all-ASCII subject already shows, which
+    /// no check on the subject could catch.
     /// </description></item>
     /// <item><description>
-    /// The letters <c>K</c> and <c>k</c>, which .NET 7 and later group with U+212A KELVIN SIGN while the
-    /// barrier keeps the spec from doing so. They are the only ASCII code points .NET pairs with a
-    /// non-ASCII one under <c>RegexOptions.ECMAScript | IgnoreCase | CultureInvariant</c>, so no other
-    /// ASCII character needs the custom engine on account of a subject character it never mentions.
-    /// A range inside a character class counts when it covers one of them.
+    /// <see cref="CaseFoldingHazard.SubjectDependent"/> for an all-ASCII pattern that can match <c>K</c>
+    /// or <c>k</c> - as a literal, through a class range covering one, or through <c>\w</c> - and for the
+    /// word-boundary assertions. Closing an all-ASCII set can only ever add a
+    /// <see cref="JsRegExp.CaseFoldingTriggers">trigger</see> to it, and the barrier keeps the spec from
+    /// mapping any non-ASCII subject character onto an ASCII one, so the two engines provably agree on
+    /// every subject that carries no trigger.
     /// </description></item>
     /// </list>
-    /// A decimal escape is hazardous outright: it is either a backreference, whose matched text is not
-    /// known here and is compared through that same Canonicalize, or an Annex B legacy octal escape that
-    /// can denote any code point up to U+00FF — and telling the two apart needs the capture-group count.
-    /// So is <c>\w</c> / <c>\W</c>, whose set contains <c>k</c> and <c>K</c>.
     /// <para>
     /// Only consulted for a pattern that already carries the <c>i</c> flag and neither <c>u</c> nor
     /// <c>v</c> (those go to the custom engine regardless), so a pattern without <c>i</c> never pays for
     /// this scan and never loses the .NET engine over a character that only matters when folding.
     /// </para>
     /// </summary>
-    private static bool HasCaseFoldingHazard(string pattern)
+    private static CaseFoldingHazard GetCaseFoldingHazard(string pattern)
     {
         // Kelvin sign folding partners: the only ASCII characters .NET puts in a case-equivalence class
         // with a non-ASCII one.
         const int KelvinPartnerUpper = 'K';
         const int KelvinPartnerLower = 'k';
 
+        var worst = CaseFoldingHazard.None;
         var inClass = false;
 
         // Code point a following '-' would open a class range from, or -1 when the preceding element
@@ -1132,11 +1158,16 @@ public sealed partial class RegExpConstructor : Constructor
 
             if (ch == '\\')
             {
-                if (!TryDecodeEscape(pattern, ref i, out codePoint))
+                if (!TryDecodeEscape(pattern, ref i, out codePoint, out var escapeHazard))
                 {
-                    if (codePoint < 0)
+                    if (escapeHazard == CaseFoldingHazard.Always)
                     {
-                        return true;
+                        return CaseFoldingHazard.Always;
+                    }
+
+                    if (escapeHazard > worst)
+                    {
+                        worst = escapeHazard;
                     }
 
                     // A class escape (\d, \w, ...) stands for a set, so it cannot be a range bound.
@@ -1169,14 +1200,18 @@ public sealed partial class RegExpConstructor : Constructor
                 codePoint = ch;
             }
 
+            if (codePoint > 0x7F)
+            {
+                return CaseFoldingHazard.Always;
+            }
+
             if (inRange)
             {
                 // An inverted range is a SyntaxError the parser rejects, so it needs no special care here.
-                if (codePoint > 0x7F
-                    || (rangeStart <= KelvinPartnerUpper && KelvinPartnerUpper <= codePoint)
+                if ((rangeStart <= KelvinPartnerUpper && KelvinPartnerUpper <= codePoint)
                     || (rangeStart <= KelvinPartnerLower && KelvinPartnerLower <= codePoint))
                 {
-                    return true;
+                    worst = CaseFoldingHazard.SubjectDependent;
                 }
 
                 rangeStart = -1;
@@ -1184,27 +1219,39 @@ public sealed partial class RegExpConstructor : Constructor
                 continue;
             }
 
-            if (codePoint > 0x7F || codePoint == KelvinPartnerUpper || codePoint == KelvinPartnerLower)
+            if (codePoint == KelvinPartnerUpper || codePoint == KelvinPartnerLower)
             {
-                return true;
+                worst = CaseFoldingHazard.SubjectDependent;
             }
 
             rangeStart = codePoint;
         }
 
-        return false;
+        return worst;
     }
+
+    /// <summary>
+    /// Whether a case-insensitive pattern keeps the .NET engine but has to be diverted to the custom one
+    /// for a subject carrying a <see cref="JsRegExp.CaseFoldingTriggers">trigger</see>.
+    /// </summary>
+    internal static bool HasSubjectDependentCaseFoldingHazard(string pattern, string flags)
+        => flags.Contains('i')
+           && !flags.Contains('u')
+           && !flags.Contains('v')
+           && GetCaseFoldingHazard(pattern) == CaseFoldingHazard.SubjectDependent;
 
     /// <summary>
     /// Decode the escape sequence starting at the backslash <paramref name="i"/> points at, leaving
     /// <paramref name="i"/> on its last character. Returns <see langword="true"/> with the single code
-    /// point the escape denotes. Returns <see langword="false"/> with <paramref name="codePoint"/> set to
-    /// -1 for an escape that is hazardous on its own (a decimal escape — backreference or legacy octal —
-    /// or a named backreference), and to 0 for one that denotes a set of characters rather than one
-    /// (<c>\d</c>, <c>\w</c>, <c>\s</c>, <c>\p{…}</c>, the assertions).
+    /// point the escape denotes and <paramref name="hazard"/> set to <see cref="CaseFoldingHazard.None"/>,
+    /// leaving the caller to judge that code point. Returns <see langword="false"/> for an escape that
+    /// denotes no single character, with <paramref name="hazard"/> carrying its own verdict.
     /// </summary>
-    private static bool TryDecodeEscape(string pattern, ref int i, out int codePoint)
+    private static bool TryDecodeEscape(string pattern, ref int i, out int codePoint, out CaseFoldingHazard hazard)
     {
+        hazard = CaseFoldingHazard.None;
+        codePoint = 0;
+
         if (i + 1 >= pattern.Length)
         {
             // Trailing backslash: not a valid pattern, and the parser has the final say on that.
@@ -1218,19 +1265,28 @@ public sealed partial class RegExpConstructor : Constructor
         switch (ch)
         {
             case >= '0' and <= '9':
-                codePoint = -1;
+                hazard = CaseFoldingHazard.Always;
+                return false;
+
+            case 'W':
+                hazard = CaseFoldingHazard.Always;
+                return false;
+
+            case 'w':
+                // The word-character set contains 'k' and 'K'.
+                hazard = CaseFoldingHazard.SubjectDependent;
+                return false;
+
+            case 'b' or 'B':
+                // The word-boundary assertions classify their neighbours with .NET's own word-character
+                // set, which under IgnoreCase takes in U+0130 on every target framework.
+                hazard = CaseFoldingHazard.SubjectDependent;
                 return false;
 
             case 'k':
-                // Either a named backreference or, under Annex B, an IdentityEscape for 'k' — and 'k' is
-                // itself a hazard, so the two readings agree.
-                codePoint = -1;
-                return false;
-
-            case 'w' or 'W':
-                // The word-character set contains 'k' and 'K', so it carries the hazard the same way an
-                // explicit class covering them does: /\w/i matches U+212A on .NET where the spec does not.
-                codePoint = -1;
+                // Either a named backreference or, under Annex B, an IdentityEscape for 'k'. Both carry
+                // the same hazard as a literal 'k', so the two readings agree.
+                hazard = CaseFoldingHazard.SubjectDependent;
                 return false;
 
             case 'u' when i + 1 < pattern.Length && pattern[i + 1] == '{':
@@ -1255,11 +1311,9 @@ public sealed partial class RegExpConstructor : Constructor
             case 'c' when i + 1 < pattern.Length && char.IsAsciiLetter(pattern[i + 1]):
                 // ControlLetter: always below U+0020.
                 i++;
-                codePoint = 0;
                 return false;
 
-            case 'd' or 'D' or 's' or 'S' or 'b' or 'B' or 'p' or 'P':
-                codePoint = 0;
+            case 'd' or 'D' or 's' or 'S' or 'p' or 'P':
                 return false;
 
             default:

--- a/Jint/Native/RegExp/RegExpConstructor.cs
+++ b/Jint/Native/RegExp/RegExpConstructor.cs
@@ -615,12 +615,11 @@ public sealed partial class RegExpConstructor : Constructor
             return true;
         }
 
-        // Case-insensitive with non-ASCII characters: .NET IgnoreCase applies broader
-        // Unicode case folding than ES spec (e.g. U+212A KELVIN SIGN matches 'K',
-        // U+017F LONG S matches 's'). In non-unicode mode, ES spec Canonicalize uses
-        // toUpperCase only, not Unicode case folding. This applies to both literal
-        // non-ASCII characters and \uXXXX escape sequences for non-ASCII code points.
-        if (flags.Contains('i') && HasNonAsciiContent(pattern))
+        // Case-insensitive matching that reaches across the ASCII boundary: .NET IgnoreCase groups
+        // characters that the spec's Canonicalize keeps apart in non-unicode mode, where it is
+        // toUpperCase with a hard barrier rather than Unicode case folding. See HasCaseFoldingHazard
+        // for exactly which pattern content that covers.
+        if (flags.Contains('i') && HasCaseFoldingHazard(pattern))
         {
             return true;
         }
@@ -1084,77 +1083,222 @@ public sealed partial class RegExpConstructor : Constructor
     }
 
     /// <summary>
-    /// Detect non-ASCII content in the pattern: either literal non-ASCII characters or
-    /// \uXXXX / \u{XXXX} hex escapes for non-ASCII code points (&gt;0x7F).
-    /// .NET IgnoreCase applies broader Unicode case folding than ES spec for these characters.
-    /// ASCII-range escapes like \u0041 work correctly in .NET and don't need the custom engine.
+    /// Detect pattern content whose case-insensitive matching .NET resolves differently from
+    /// <see href="https://tc39.es/ecma262/#sec-runtime-semantics-canonicalize-ch">Canonicalize</see>
+    /// in non-Unicode mode, which is what routes such a pattern to the custom engine. Two kinds:
+    /// <list type="bullet">
+    /// <item><description>
+    /// Any non-ASCII code point, whether written literally or as a <c>\uXXXX</c>, <c>\u{XXXX}</c> or
+    /// <c>\xNN</c> escape. Canonicalize is toUpperCase plus a hard barrier — a character at or above
+    /// U+0080 whose uppercase is a single code unit below U+0080 canonicalizes to itself (step 9) — so
+    /// U+00DF and U+1E9E, or U+00E5 and U+212B, are distinct to the spec while .NET groups them.
+    /// </description></item>
+    /// <item><description>
+    /// The letters <c>K</c> and <c>k</c>, which .NET 7 and later group with U+212A KELVIN SIGN while the
+    /// barrier keeps the spec from doing so. They are the only ASCII code points .NET pairs with a
+    /// non-ASCII one under <c>RegexOptions.ECMAScript | IgnoreCase | CultureInvariant</c>, so no other
+    /// ASCII character needs the custom engine on account of a subject character it never mentions.
+    /// A range inside a character class counts when it covers one of them.
+    /// </description></item>
+    /// </list>
+    /// A decimal escape is hazardous outright: it is either a backreference, whose matched text is not
+    /// known here and is compared through that same Canonicalize, or an Annex B legacy octal escape that
+    /// can denote any code point up to U+00FF — and telling the two apart needs the capture-group count.
+    /// So is <c>\w</c> / <c>\W</c>, whose set contains <c>k</c> and <c>K</c>.
+    /// <para>
+    /// Only consulted for a pattern that already carries the <c>i</c> flag and neither <c>u</c> nor
+    /// <c>v</c> (those go to the custom engine regardless), so a pattern without <c>i</c> never pays for
+    /// this scan and never loses the .NET engine over a character that only matters when folding.
+    /// </para>
     /// </summary>
-    private static bool HasNonAsciiContent(string pattern)
+    private static bool HasCaseFoldingHazard(string pattern)
     {
-        for (int i = 0; i < pattern.Length; i++)
+        // Kelvin sign folding partners: the only ASCII characters .NET puts in a case-equivalence class
+        // with a non-ASCII one.
+        const int KelvinPartnerUpper = 'K';
+        const int KelvinPartnerLower = 'k';
+
+        var inClass = false;
+
+        // Code point a following '-' would open a class range from, or -1 when the preceding element
+        // cannot be a range bound (a class escape, or a range that just closed).
+        var rangeStart = -1;
+        var inRange = false;
+
+        for (var i = 0; i < pattern.Length; i++)
         {
-            char ch = pattern[i];
+            var ch = pattern[i];
+            int codePoint;
 
-            if (ch == '\\' && i + 1 < pattern.Length)
+            if (ch == '\\')
             {
-                if (pattern[i + 1] == 'u' && i + 2 < pattern.Length)
+                if (!TryDecodeEscape(pattern, ref i, out codePoint))
                 {
-                    if (pattern[i + 2] == '{')
+                    if (codePoint < 0)
                     {
-                        // \u{XXXX} syntax — parse hex value
-                        int value = 0;
-                        int j = i + 3;
-                        while (j < pattern.Length && pattern[j] != '}')
-                        {
-                            int digit = HexDigitValue(pattern[j]);
-                            if (digit < 0) break;
-                            value = (value << 4) | digit;
-                            j++;
-                        }
-
-                        if (j < pattern.Length && pattern[j] == '}' && value > 0x7F)
-                        {
-                            return true;
-                        }
-
-                        i = j; // skip past parsed escape
+                        return true;
                     }
-                    else if (i + 5 < pattern.Length)
-                    {
-                        // \uXXXX syntax — parse 4 hex digits
-                        int d0 = HexDigitValue(pattern[i + 2]);
-                        int d1 = HexDigitValue(pattern[i + 3]);
-                        int d2 = HexDigitValue(pattern[i + 4]);
-                        int d3 = HexDigitValue(pattern[i + 5]);
-                        if (d0 >= 0 && d1 >= 0 && d2 >= 0 && d3 >= 0)
-                        {
-                            int value = (d0 << 12) | (d1 << 8) | (d2 << 4) | d3;
-                            if (value > 0x7F)
-                            {
-                                return true;
-                            }
-                        }
 
-                        i += 5; // skip past \uXXXX
-                    }
-                    else
-                    {
-                        i++; // skip escaped char
-                    }
-                }
-                else
-                {
-                    i++; // skip escaped char
+                    // A class escape (\d, \w, ...) stands for a set, so it cannot be a range bound.
+                    rangeStart = -1;
+                    inRange = false;
+                    continue;
                 }
             }
-            else if (ch > 0x7F)
+            else if (!inClass && ch == '[')
             {
-                // Literal non-ASCII character in the pattern
+                inClass = true;
+                rangeStart = -1;
+                inRange = false;
+                continue;
+            }
+            else if (inClass && ch == ']')
+            {
+                inClass = false;
+                rangeStart = -1;
+                inRange = false;
+                continue;
+            }
+            else if (inClass && ch == '-' && rangeStart >= 0)
+            {
+                inRange = true;
+                continue;
+            }
+            else
+            {
+                codePoint = ch;
+            }
+
+            if (inRange)
+            {
+                // An inverted range is a SyntaxError the parser rejects, so it needs no special care here.
+                if (codePoint > 0x7F
+                    || (rangeStart <= KelvinPartnerUpper && KelvinPartnerUpper <= codePoint)
+                    || (rangeStart <= KelvinPartnerLower && KelvinPartnerLower <= codePoint))
+                {
+                    return true;
+                }
+
+                rangeStart = -1;
+                inRange = false;
+                continue;
+            }
+
+            if (codePoint > 0x7F || codePoint == KelvinPartnerUpper || codePoint == KelvinPartnerLower)
+            {
                 return true;
             }
+
+            rangeStart = codePoint;
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Decode the escape sequence starting at the backslash <paramref name="i"/> points at, leaving
+    /// <paramref name="i"/> on its last character. Returns <see langword="true"/> with the single code
+    /// point the escape denotes. Returns <see langword="false"/> with <paramref name="codePoint"/> set to
+    /// -1 for an escape that is hazardous on its own (a decimal escape — backreference or legacy octal —
+    /// or a named backreference), and to 0 for one that denotes a set of characters rather than one
+    /// (<c>\d</c>, <c>\w</c>, <c>\s</c>, <c>\p{…}</c>, the assertions).
+    /// </summary>
+    private static bool TryDecodeEscape(string pattern, ref int i, out int codePoint)
+    {
+        if (i + 1 >= pattern.Length)
+        {
+            // Trailing backslash: not a valid pattern, and the parser has the final say on that.
+            codePoint = '\\';
+            return true;
+        }
+
+        var ch = pattern[i + 1];
+        i++;
+
+        switch (ch)
+        {
+            case >= '0' and <= '9':
+                codePoint = -1;
+                return false;
+
+            case 'k':
+                // Either a named backreference or, under Annex B, an IdentityEscape for 'k' — and 'k' is
+                // itself a hazard, so the two readings agree.
+                codePoint = -1;
+                return false;
+
+            case 'w' or 'W':
+                // The word-character set contains 'k' and 'K', so it carries the hazard the same way an
+                // explicit class covering them does: /\w/i matches U+212A on .NET where the spec does not.
+                codePoint = -1;
+                return false;
+
+            case 'u' when i + 1 < pattern.Length && pattern[i + 1] == '{':
+                return TryDecodeBracedUnicodeEscape(pattern, ref i, out codePoint);
+
+            case 'u' when i + 4 < pattern.Length
+                          && HexDigitValue(pattern[i + 1]) >= 0 && HexDigitValue(pattern[i + 2]) >= 0
+                          && HexDigitValue(pattern[i + 3]) >= 0 && HexDigitValue(pattern[i + 4]) >= 0:
+                codePoint = (HexDigitValue(pattern[i + 1]) << 12)
+                            | (HexDigitValue(pattern[i + 2]) << 8)
+                            | (HexDigitValue(pattern[i + 3]) << 4)
+                            | HexDigitValue(pattern[i + 4]);
+                i += 4;
+                return true;
+
+            case 'x' when i + 2 < pattern.Length
+                          && HexDigitValue(pattern[i + 1]) >= 0 && HexDigitValue(pattern[i + 2]) >= 0:
+                codePoint = (HexDigitValue(pattern[i + 1]) << 4) | HexDigitValue(pattern[i + 2]);
+                i += 2;
+                return true;
+
+            case 'c' when i + 1 < pattern.Length && char.IsAsciiLetter(pattern[i + 1]):
+                // ControlLetter: always below U+0020.
+                i++;
+                codePoint = 0;
+                return false;
+
+            case 'd' or 'D' or 's' or 'S' or 'b' or 'B' or 'p' or 'P':
+                codePoint = 0;
+                return false;
+
+            default:
+                // IdentityEscape (including a malformed \u, \x or \c): the escape denotes the character.
+                codePoint = ch;
+                return true;
+        }
+    }
+
+    /// <summary>
+    /// Decode a braced unicode escape whose opening brace sits at <paramref name="i"/> + 1, leaving
+    /// <paramref name="i"/> on the closing brace. A sequence that is not well formed is an IdentityEscape
+    /// for <c>u</c> in a non-unicode pattern, which is what the parser makes of it too.
+    /// </summary>
+    private static bool TryDecodeBracedUnicodeEscape(string pattern, ref int i, out int codePoint)
+    {
+        var value = 0;
+        var j = i + 2;
+        while (j < pattern.Length && pattern[j] != '}')
+        {
+            var digit = HexDigitValue(pattern[j]);
+            if (digit < 0)
+            {
+                break;
+            }
+
+            value = (value << 4) | digit;
+            j++;
+        }
+
+        if (j < pattern.Length && pattern[j] == '}')
+        {
+            codePoint = value;
+            i = j;
+            return true;
+        }
+
+        codePoint = 'u';
+        return true;
     }
 
     private static int HexDigitValue(char c)

--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -203,8 +203,30 @@ internal sealed partial class RegExpPrototype : Prototype
             rx.Set(JsRegExp.PropertyLastIndex, 0, true);
         }
 
+        // Step 9 above is the only lastIndex write this algorithm performs of its own accord; everything
+        // else is left to RegExpBuiltinExec. In particular there is no write *after* the matching is
+        // done: for a global regexp the exec that ends the loop has already reset lastIndex to +0, and a
+        // non-global one is not supposed to have its lastIndex touched at all (so a -0 stays -0, and a
+        // replacer function that assigns lastIndex keeps what it assigned).
+
+        // The two fused fast paths below collapse the whole RegExpExec loop (steps 11-12) into a single
+        // engine-level scan, so they may only run where that substitution is unobservable. Two things
+        // make it observable, both of them inside RegExpBuiltinExec:
+        //   - step 2 reads and coerces lastIndex *before* step 3 reads the flags and step 8 reads the
+        //     matcher, so a lastIndex holding an object runs user code from inside the match, and that
+        //     code may replace the very pattern being matched (RegExp.prototype.compile);
+        //   - a sticky regexp starts matching at lastIndex (step 12.b) and writes the result back.
+        // Neither is reproducible in a fused scan, so both send the call down the generic path below.
+        // Reading lastIndex here is free of side effects in turn: it is a non-configurable data property
+        // of every RegExp instance, so it can never have become an accessor.
+        // https://tc39.es/ecma262/#sec-regexpbuiltinexec
+        var canFuseExecLoop = rx is JsRegExp fusable
+                              && !fusable.Sticky
+                              && (global || fusable.Get(JsRegExp.PropertyLastIndex) is JsNumber);
+
         // Custom engine fast path for simple string replacement (no $-substitutions, no function)
-        if (!functionalReplace
+        if (canFuseExecLoop
+            && !functionalReplace
             && !mayHaveNamedCaptures
             && rx is JsRegExp { HasDefaultRegExpExec: true, UsesDotNetEngine: false } customRei)
         {
@@ -241,15 +263,13 @@ internal sealed partial class RegExpPrototype : Prototype
             }
 
             sb.Append(s.AsSpan(lastPos));
-            rx.Set(JsRegExp.PropertyLastIndex, JsNumber.PositiveZero);
             return sb.ToString();
         }
 
         // check if we can access fast path (only for .NET Regex engine)
-        // Derive sticky from already-read flags string to avoid extra observable property access
-        if (!fullUnicode
+        if (canFuseExecLoop
+            && !fullUnicode
             && !mayHaveNamedCaptures
-            && !flags.Contains('y')
             && rx is JsRegExp { HasDefaultRegExpExec: true, UsesDotNetEngine: true } rei)
         {
             var count = global ? int.MaxValue : 1;
@@ -311,7 +331,6 @@ internal sealed partial class RegExpPrototype : Prototype
                 result = rei.Value.Replace(s, TypeConverter.ToString(replaceValue), count);
             }
 
-            rx.Set(JsRegExp.PropertyLastIndex, JsNumber.PositiveZero);
             return result;
         }
 
@@ -1299,7 +1318,27 @@ internal sealed partial class RegExpPrototype : Prototype
         return RegExpBuiltinExec(ri, s);
     }
 
-    internal bool HasDefaultExec => Get(PropertyExec) is ClrFunction functionInstance && functionInstance._func == _defaultExec;
+    /// <summary>
+    /// Whether <c>RegExp.prototype.exec</c> is still this realm's built-in implementation, which is what
+    /// lets <see cref="RegExpExec"/> and the fast paths skip the <c>Get(R, "exec")</c> of
+    /// <see href="https://tc39.es/ecma262/#sec-regexpexec">RegExpExec</see> step 1.
+    /// <para>
+    /// The check reads the own descriptor rather than performing an ordinary <c>[[Get]]</c>: a script may
+    /// have replaced <c>exec</c> with an accessor, and a <c>[[Get]]</c> here would call that accessor an
+    /// extra time — with <c>RegExp.prototype</c> itself as the receiver rather than the regexp being
+    /// matched, which is observable and simply wrong.
+    /// </para>
+    /// </summary>
+    internal bool HasDefaultExec
+    {
+        get
+        {
+            var descriptor = GetOwnProperty(PropertyExec);
+            return !descriptor.IsAccessorDescriptor()
+                   && UnwrapJsValue(descriptor) is ClrFunction functionInstance
+                   && functionInstance._func == _defaultExec;
+        }
+    }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-regexpbuiltinexec

--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -1,4 +1,4 @@
-#pragma warning disable CA1859 // Use concrete types when possible for improved performance -- most of prototype methods return JsValue
+﻿#pragma warning disable CA1859 // Use concrete types when possible for improved performance -- most of prototype methods return JsValue
 
 using System.Diagnostics;
 using System.Text;
@@ -270,7 +270,8 @@ internal sealed partial class RegExpPrototype : Prototype
         if (canFuseExecLoop
             && !fullUnicode
             && !mayHaveNamedCaptures
-            && rx is JsRegExp { HasDefaultRegExpExec: true, UsesDotNetEngine: true } rei)
+            && rx is JsRegExp { HasDefaultRegExpExec: true, UsesDotNetEngine: true } rei
+            && !rei.NeedsCaseFoldingFallback(s))
         {
             var count = global ? int.MaxValue : 1;
 
@@ -740,7 +741,8 @@ internal sealed partial class RegExpPrototype : Prototype
             return a;
         }
 
-        if (!unicodeMatching && splitter is JsRegExp R && R.HasDefaultRegExpExec && R.UsesDotNetEngine)
+        if (!unicodeMatching && splitter is JsRegExp R && R.HasDefaultRegExpExec && R.UsesDotNetEngine
+            && !R.NeedsCaseFoldingFallback(s))
         {
             // we can take faster path
 
@@ -993,7 +995,7 @@ internal sealed partial class RegExpPrototype : Prototype
             }
 
             // Fast path for .NET Regex engine
-            if (!R.FullUnicode)
+            if (!R.FullUnicode && !R.NeedsCaseFoldingFallback(s))
             {
                 if (!R.Sticky && !R.Global)
                 {
@@ -1150,7 +1152,8 @@ internal sealed partial class RegExpPrototype : Prototype
         }
 
         if (!fullUnicode
-            && rx is JsRegExp { HasDefaultRegExpExec: true, UsesDotNetEngine: true } dotnetRei)
+            && rx is JsRegExp { HasDefaultRegExpExec: true, UsesDotNetEngine: true } dotnetRei
+            && !dotnetRei.NeedsCaseFoldingFallback(s))
         {
             // fast path (only for .NET Regex engine)
             var a = _realm.Intrinsics.Array.ArrayCreate(0);
@@ -1373,7 +1376,14 @@ internal sealed partial class RegExpPrototype : Prototype
         // Use custom engine when .NET Regex cannot handle the pattern
         if (!R.UsesDotNetEngine)
         {
-            return CustomEngineBuiltinExec(R, s, lastIndex, global, sticky);
+            return CustomEngineBuiltinExec(R, R.CustomEngine!, s, lastIndex, global, sticky);
+        }
+
+        // ... or when it can, but this particular subject is one of the rare ones on which its
+        // case-insensitive matching would disagree with Canonicalize. See JsRegExp.CaseFoldingTriggers.
+        if (R.NeedsCaseFoldingFallback(s))
+        {
+            return CustomEngineBuiltinExec(R, GetCaseFoldingFallbackEngine(R), s, lastIndex, global, sticky);
         }
 
         var matcher = R.Value;
@@ -1452,9 +1462,8 @@ internal sealed partial class RegExpPrototype : Prototype
     /// <summary>
     /// RegExpBuiltinExec implementation for the custom regex engine.
     /// </summary>
-    private static JsValue CustomEngineBuiltinExec(JsRegExp R, string s, ulong lastIndex, bool global, bool sticky)
+    private static JsValue CustomEngineBuiltinExec(JsRegExp R, JintRegExpEngine customEngine, string s, ulong lastIndex, bool global, bool sticky)
     {
-        var customEngine = R.CustomEngine!;
         var hasIndices = R.Indices;
         var length = (ulong) s.Length;
 
@@ -1495,6 +1504,14 @@ internal sealed partial class RegExpPrototype : Prototype
     /// carried via <see cref="RegExpParseResult.AdditionalData"/>; falls back to the engine's
     /// configured constraint for runtime-built regexes (where the same value was used at compile time).
     /// </summary>
+    /// <summary>
+    /// The custom-engine compilation that stands in for the .NET one on a subject carrying a
+    /// <see cref="JsRegExp.CaseFoldingTriggers">fold trigger</see>. Compiled on first need, under the
+    /// same timeout the pattern would have been compiled with in the first place.
+    /// </summary>
+    private static JintRegExpEngine GetCaseFoldingFallbackEngine(JsRegExp R)
+        => R.GetCaseFoldingFallbackEngine(GetCustomEngineTimeout(R));
+
     private static TimeSpan GetCustomEngineTimeout(JsRegExp R) =>
         (R.ParseResult.AdditionalData as Engine.RegexConversionOptions)?.Timeout
         ?? R.Engine.Options.Constraints.RegexTimeout;

--- a/Jint/Runtime/RegExp/RegExpInterpreter.cs
+++ b/Jint/Runtime/RegExp/RegExpInterpreter.cs
@@ -81,7 +81,8 @@ internal static class RegExpInterpreter
     {
         int bytecodeLen = BinaryPrimitives.ReadInt32LittleEndian(bytecode.Slice(RegExpHeader.OffsetBytecodeLen));
         var bc = bytecode.Slice(RegExpHeader.Length, bytecodeLen);
-        return TryDetectScanLoop(bc);
+        var flags = GetFlags(bytecode);
+        return TryDetectScanLoop(bc, (flags & (RegExpFlags.Unicode | RegExpFlags.UnicodeSets)) != RegExpFlags.None);
     }
 
     /// <summary>
@@ -707,7 +708,7 @@ internal static class RegExpInterpreter
     /// The scan loop is: SplitGotoFirst(5) + Any(1) + Goto(5) = 11 bytes, followed by SaveStart 0.
     /// Returns scan info for Char, CharI, Range, or LineStart (anchored) first opcodes.
     /// </summary>
-    private static ScanLoopInfo TryDetectScanLoop(ReadOnlySpan<byte> bc)
+    private static ScanLoopInfo TryDetectScanLoop(ReadOnlySpan<byte> bc, bool isUnicode)
     {
         // Need at least: 11 (scan loop) + 2 (SaveStart 0) + 1 (opcode) = 14 bytes
         if (bc.Length < 14)
@@ -788,7 +789,7 @@ internal static class RegExpInterpreter
         if (firstOp == (byte) RegExpOpcode.CharI && bc.Length >= 16)
         {
             char val = (char) ReadU16(bc, 14);
-            if (val < 128)
+            if (val < 128 && !FoldsAcrossAsciiBoundary(val, isUnicode))
             {
                 char alt = char.IsLower(val) ? char.ToUpperInvariant(val) : char.ToLowerInvariant(val);
 
@@ -805,7 +806,7 @@ internal static class RegExpInterpreter
                         && bc[nextOp] == (byte) RegExpOpcode.CharI)
                     {
                         char c = (char) ReadU16(bc, nextOp + 1);
-                        if (c >= 128)
+                        if (c >= 128 || FoldsAcrossAsciiBoundary(c, isUnicode))
                         {
                             break;
                         }
@@ -848,6 +849,23 @@ internal static class RegExpInterpreter
 
         return default;
     }
+
+    /// <summary>
+    /// Whether an ASCII canonical value is also what a non-ASCII character canonicalizes to, which
+    /// makes the two-code-unit ASCII scan set below (and the OrdinalIgnoreCase literal search) an
+    /// incomplete prefilter: the scan would skip the very position where the match starts.
+    /// <para>
+    /// In Unicode mode Canonicalize is Simple Case Folding, and exactly two non-ASCII characters fold
+    /// into ASCII — U+017F LATIN SMALL LETTER LONG S to <c>s</c> and U+212A KELVIN SIGN to <c>k</c>.
+    /// In non-Unicode mode it is toUpperCase with the barrier of
+    /// <see href="https://tc39.es/ecma262/#sec-runtime-semantics-canonicalize-ch">step 9</see>, which
+    /// makes a character at or above U+0080 canonicalize to itself whenever its uppercase drops below
+    /// it — so there the ASCII scan set is complete and the prefilter stays on.
+    /// </para>
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool FoldsAcrossAsciiBoundary(char canonical, bool isUnicode)
+        => isUnicode && (canonical == 's' || canonical == 'k');
 
     /// <summary>
     /// Find the next position of the scan character(s) in the input string.
@@ -917,7 +935,7 @@ internal static class RegExpInterpreter
         // First-character scan optimization: replace the bytecode scan loop
         // (SplitGotoFirst/Any/Goto) with SIMD-accelerated string.IndexOf/IndexOfAny.
         // Use pre-computed scan info when available, fall back to runtime detection.
-        var effectiveScanInfo = scanInfo.HasFastScan ? scanInfo : TryDetectScanLoop(bc);
+        var effectiveScanInfo = scanInfo.HasFastScan ? scanInfo : TryDetectScanLoop(bc, isUnicode);
         bool hasFastScan = effectiveScanInfo.HasFastScan;
         int lastScanStart = cindex;
 


### PR DESCRIPTION
Part of #3021 (wave 2). Frees seven `staging/` exclusions.

## What the exclusion comment claimed

> RegExp semantics: case-insensitive matching across the Latin-1 boundary, and lastIndex bookkeeping in the `Symbol.match` / `Symbol.replace` / `matchAll` paths (including -0 and the `ToLength` recomputation the spec performs per iteration).

Half right. `RegExp.prototype[Symbol.match]` and `%RegExpStringIteratorPrototype%.next` keep `lastIndex` exactly as the spec asks and needed no change at all; the `matchAll` failure is not about `lastIndex` in any way. And the Unicode case-conversion tables are correct — the case-folding failures come from the predicate that decides which engine runs a pattern, plus a prefilter inside the custom engine.

## The four causes

**1. `Symbol.replace` wrote `lastIndex` after matching.** Both fused fast paths ended with `rx.Set(lastIndex, +0)`. [The algorithm](https://tc39.es/ecma262/#sec-regexp.prototype-@@replace) has no such step: step 9 resets a global regexp *before* the loop, and after the loop `lastIndex` is whatever `RegExpBuiltinExec` or a replacer function left there. So a `-0` was quietly normalized to `+0`, and `'0x2x4x6x8'.replace(/x/g, fn)` where `fn` assigns `lastIndex` reported `0` instead of `4`.

**2. Those fast paths ran where they are observable.** They collapse the whole `RegExpExec` loop into one engine-level scan, which only works when the exec they stand in for could neither run user code nor consult `lastIndex`. [`RegExpBuiltinExec`](https://tc39.es/ecma262/#sec-regexpbuiltinexec) step 2 coerces `lastIndex` *before* step 3 reads the flags and step 8 reads the matcher, so a `lastIndex` holding an object runs `valueOf` from inside the match and can `compile()` the very pattern being matched. And a sticky regexp starts at `lastIndex` and writes the end position back — which the custom-engine path ignored outright, always scanning from the start of the subject, so `/µ/iy` with `lastIndex = 1` failed to replace at position 1. Both cases now take the generic path; the guard is a `lastIndex` that is already a number, and a non-sticky regexp.

**3. `HasDefaultExec` performed an ordinary `[[Get]]`.** Deciding whether `RegExp.prototype.exec` is still the built-in called a script-installed accessor an extra time, with `RegExp.prototype` as the receiver rather than the regexp being matched. A `String.prototype.matchAll` iterator therefore reported `source === "(?:)"`, `flags === ""` and `lastIndex === undefined` — those are `RegExp.prototype`'s own answers. It reads the own descriptor now, which is also one fewer prototype walk on every `exec`, `match` and `replace`.

**4. Case folding: the routing predicate, not the tables.** Non-Unicode `Canonicalize` is `toUpperCase` plus the barrier of [step 9](https://tc39.es/ecma262/#sec-runtime-semantics-canonicalize-ch) — a character at or above U+0080 whose uppercase is a single code unit below U+0080 canonicalizes to itself. .NET's `IgnoreCase` does not work that way, which is why `NeedCustomEngine` diverts a case-insensitive pattern with non-ASCII content. Two gaps:

- The scan recognised `\uXXXX` and `\u{XXXX}` but **not `\xNN`**, so `/\xB5/i` went to .NET and failed to match U+039C, while `/\xDF/i` and `/\xE5/i` matched U+1E9E and U+212B where the spec says they must not.
- An **all-ASCII** pattern can diverge too: `/k/i`, `/[a-z]/i` and `/\w/i` all matched U+212A KELVIN SIGN.

### The engine is chosen per subject, not per pattern

Diverting every case-insensitive pattern that mentions `k` or `K` — which a class range covering them and `\w` both do — would move `/[a-z0-9]+/i` and `/\w+/i` onto the bytecode interpreter for every match. An exhaustive differential shows that is unnecessary: 57 patterns compiled with **both** engines and compared over all 65,536 BMP code units in 17 subject shapes each.

For an all-ASCII pattern, .NET closes each character set under its own case-equivalence relation, and the only relation reaching across the boundary is `K`/`k` ↔ U+212A on .NET 7+ (none at all on .NET Framework). Step 9 meanwhile stops the spec mapping any non-ASCII subject character onto an ASCII one. So on a subject carrying none of the four code points a case relation can connect to ASCII — U+0130, U+0131, U+017F, U+212A — the two provably agree.

The verdict therefore splits. Non-ASCII pattern content still takes the custom engine outright; a pattern that merely mentions `k`/`K` keeps the .NET engine and is diverted **per match**, only when the subject actually carries a trigger. The check is a vectorized `ContainsAny` over a string the match is about to scan anyway, memoized by subject instance so a match loop scans it once rather than once per match, and the custom engine is compiled only if a trigger ever shows up.

Two things the differential turned up that this reasoning does not cover:

- **`\W` has to stay unconditional.** It is the one construct the adaptation expands into a *positive* class spanning the whole BMP while excluding the ASCII word characters, so closing that class pulls the partners of its non-ASCII members back in: `/\W/i` matched `k` on .NET 7+ and `I` on .NET Framework. That shows on a **pure-ASCII** subject, where no check on the input could catch it. The equivalent `[^\w]` is fine — a negated class is closed on the excluded set and then negated, so its divergence is at U+212A only.
- **`\b` / `\B` classify their neighbours with .NET's own word-character set**, which under IgnoreCase takes in U+0130 on every target framework. That is why the trigger set is the four code points rather than U+212A alone.

**...and then the custom engine had a hole of its own.** Its first-character scan turns the bytecode scan loop into a SIMD `IndexOfAny` over the canonical value and its ASCII case flip. In Unicode mode `Canonicalize` is Simple Case Folding, and exactly two non-ASCII characters fold into ASCII (U+017F → `s`, U+212A → `k`), so the two-code-unit ASCII scan set skipped the position where the match starts and `/s/iu` never found U+017F. The prefilter (and the `OrdinalIgnoreCase` literal-prefix search behind it) stands down for those two canonical values. In non-Unicode mode step 9's barrier guarantees no non-ASCII character canonicalizes into ASCII, so the prefilter stays on.

## Changed

- `Jint/Native/RegExp/RegExpPrototype.cs` — `Replace` gains a `canFuseExecLoop` guard on both fast paths and drops the two trailing `lastIndex` writes; `HasDefaultExec` reads the own descriptor; `RegExpBuiltinExec` and the .NET fast paths in `Test`, `Match`, `Replace` and `Split` consult the per-subject verdict.
- `Jint/Native/RegExp/RegExpConstructor.cs` — `HasNonAsciiContent` becomes `GetCaseFoldingHazard`, returning `None` / `SubjectDependent` / `Always`, with a proper escape decoder (`\xNN`, `\uXXXX`, `\u{XXXX}`, identity escapes) and class-range tracking.
- `Jint/Native/JsRegExp.cs` — the trigger set, the lazily determined hazard, the per-subject memo and the lazily compiled fallback engine; all three are dropped by the `Flags` setter, which every construction and every `compile()` passes through last.
- `Jint/Runtime/RegExp/RegExpInterpreter.cs` — `TryDetectScanLoop` takes the Unicode flag and refuses the `CharI` prefilter for the two folding partners.
- `Jint/Extensions/Polyfills.cs` — `ContainsAny(ReadOnlySpan<char>, SearchValues<char>)` downlevel, beside the existing `IndexOfAnyExcept`.
- `Jint.Tests/Runtime/RegExpTests.cs` — 46 new cases, including a routing pin asserting that `/[a-z0-9]+/i`, `/\w+/i`, `/check/i` and `/\bfoo\b/i` keep the .NET engine.

## Frees

```
staging/sm/RegExp/ignoreCase-non-latin1-to-latin1.js
staging/sm/RegExp/lastIndex-match-or-replace.js
staging/sm/RegExp/replace-local-tolength-lastindex.js
staging/sm/RegExp/replace-local-tolength-recompilation.js
staging/sm/RegExp/unicode-ignoreCase-ascii.js
staging/sm/String/matchAll.js
staging/sm/String/replace-updates-global-lastIndex.js
```

## Verification

All 14 (7 files × strict/sloppy) failed before and pass after. No regression in `built-ins/RegExp` (3,922), `built-ins/String` (2,679), `annexB` (1,377), `language/literals` (1,053) or the rest of `staging/sm/RegExp` + `staging/sm/String` (266). `Jint.Tests` 6,333, `Jint.Tests.PublicInterface` 1,488 and `Jint.Tests.CommonScripts` 28 all green on net10.0 and net472.

Every new test was run against the unfixed engine first and failed there — 23 of the first batch on net10.0 and 16 on net472, then 11 and 8 of the routing batch. The `K`/`k` rows already pass on .NET Framework, which has no cross-boundary case equivalence at all; that asymmetry is itself evidence for the diagnosis.

No benchmarks were run — other agents were building concurrently and the numbers would have been noise. The design is what removes the need for one: the patterns that would have been affected keep the engine they already had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
