### PR TITLE
Format toFixed from the double's exact value and read this from [[NumberData]]

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -73,14 +73,6 @@
     "staging/sm/class/parenExprToString.js",
     "staging/sm/generators/runtime.js",
 
-    // Number conversion and formatting. toFixed/toPrecision lose the exact mathematical value for
-    // extreme magnitudes and subnormals, and ToPrimitive on a Number wrapper consults the wrong
-    // method. Removed by exact-value formatting and a spec-order OrdinaryToPrimitive.
-    "staging/sm/Number/20.1.3.3-toFixed.js",
-    "staging/sm/Number/defaultvalue.js",
-    "staging/sm/Number/toFixed-values.js",
-    "staging/sm/Number/toPrecision-values.js",
-
     // Set.prototype.intersection / .isSubsetOf let the *receiver* be mutated while they traverse it
     // (a set-like's has/keys callback calling this.delete(v) or this.clear()), and the spec models
     // that with the [[SetData]] tombstone: a deleted entry becomes EMPTY in place rather than being

--- a/Jint.Tests/Runtime/NumberTests.cs
+++ b/Jint.Tests/Runtime/NumberTests.cs
@@ -1,4 +1,6 @@
-﻿namespace Jint.Tests.Runtime;
+﻿using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
 
 public class NumberTests
 {
@@ -462,5 +464,153 @@ public class NumberTests
         engine.Evaluate("(5n).typ()").AsString().Should().Be("object");
         engine.Execute("BigInt.prototype.styp = function () { 'use strict'; return typeof this; };");
         engine.Evaluate("(5n).styp()").AsString().Should().Be("bigint");
+    }
+
+    // The following tests cover Number.prototype's exact-value formatting and its ThisNumberValue
+    // step. They run on net472 as well as net10.0, which is the point of several of them: the BCL
+    // "F" format specifier carries only 15 significant digits on .NET Framework and refuses a
+    // precision above 99 there, so routing toFixed through it produced a different string per target
+    // framework.
+
+    [Theory]
+    // The double nearest 3.141592653589793 is exactly 3.14159265358979311599796346854418516159057617187500.
+    [InlineData("(3.141592653589793).toFixed(50)", "3.14159265358979311599796346854418516159057617187500")]
+    [InlineData("(3.141592653589793).toFixed(20)", "3.14159265358979311600")]
+    // ... and the one nearest 123456.78 is exactly 123456.77999999999883584678173065185546875.
+    [InlineData("(123456.78).toFixed(50)", "123456.77999999999883584678173065185546875000000000000000")]
+    [InlineData("(-123456.78).toFixed(10)", "-123456.7800000000")]
+    [InlineData("(3.141592653589793).toFixed(100)", "3.1415926535897931159979634685441851615905761718750000000000000000000000000000000000000000000000000000")]
+    public void ToFixedProducesTheExactMathematicalValueOfTheDouble(string source, string expected)
+    {
+        new Engine().Evaluate(source).AsString().Should().Be(expected);
+    }
+
+    [Theory]
+    // Casting through long saturated here: .NET answered long.MaxValue and .NET Framework long.MinValue.
+    [InlineData("(1e20).toFixed(0)", "100000000000000000000")]
+    [InlineData("(1e20).toFixed()", "100000000000000000000")]
+    [InlineData("(1e19).toFixed(0)", "10000000000000000000")]
+    [InlineData("(-1e20).toFixed(0)", "-100000000000000000000")]
+    [InlineData("(1e20).toFixed(1)", "100000000000000000000.0")]
+    // 2^63 is where the exact-integer shortcut has to hand over to the digit generator.
+    [InlineData("(9223372036854775807).toFixed(0)", "9223372036854775808")]
+    [InlineData("(9223372036854775807).toFixed(2)", "9223372036854775808.00")]
+    [InlineData("(9.9e18).toFixed(0)", "9900000000000000000")]
+    // At 10^21 the fixed notation gives way to Number::toString.
+    [InlineData("(1e21).toFixed(2)", "1e+21")]
+    public void ToFixedIsExactPastTheRangeOfLong(string source, string expected)
+    {
+        new Engine().Evaluate(source).AsString().Should().Be(expected);
+    }
+
+    [Theory]
+    // toFixed step 8 works on the real value, for which -0 is not negative, but -Number.MIN_VALUE is.
+    [InlineData("(-0).toFixed(0)", "0")]
+    [InlineData("(-0).toFixed(3)", "0.000")]
+    [InlineData("(-Number.MIN_VALUE).toFixed(0)", "-0")]
+    [InlineData("(-Number.MIN_VALUE).toFixed(3)", "-0.000")]
+    [InlineData("(Number.MIN_VALUE).toFixed(3)", "0.000")]
+    [InlineData("(0.5).toFixed(0)", "1")]
+    [InlineData("(-0.5).toFixed(0)", "-1")]
+    [InlineData("(1.45).toFixed(1)", "1.4")]
+    [InlineData("(-0.4).toFixed(0)", "-0")]
+    [InlineData("(-1e-7).toFixed(0)", "-0")]
+    [InlineData("(-0.000001).toFixed(2)", "-0.00")]
+    // The stored double is a hair above 930.9805, so exact rounding goes up.
+    [InlineData("(930.9805).toFixed(3)", "930.981")]
+    // ... and a hair below 1.005, so exact rounding goes down.
+    [InlineData("(1.005).toFixed(2)", "1.00")]
+    public void ToFixedRoundsTiesToTheLargerIntegerAndKeepsTheSignOfTheValue(string source, string expected)
+    {
+        new Engine().Evaluate(source).AsString().Should().Be(expected);
+    }
+
+    [Theory]
+    // The integrality test behind ToString(double) used to accept anything below ~4.94e-322 as zero.
+    [InlineData("String(Number.MIN_VALUE)", "5e-324")]
+    [InlineData("String(-Number.MIN_VALUE)", "-5e-324")]
+    [InlineData("JSON.stringify(Number.MIN_VALUE)", "5e-324")]
+    [InlineData("(Number.MIN_VALUE).toPrecision()", "5e-324")]
+    [InlineData("(Number.MIN_VALUE).toPrecision(10)", "4.940656458e-324")]
+    [InlineData("`${1e-323}`", "1e-323")]
+    public void SubnormalsKeepTheirValueWhenStringified(string source, string expected)
+    {
+        new Engine().Evaluate(source).AsString().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("(Number.MAX_VALUE).toString()", "1.7976931348623157e+308")]
+    [InlineData("(Number.MAX_VALUE).toString(10)", "1.7976931348623157e+308")]
+    [InlineData("(-Number.MAX_VALUE).toString()", "-1.7976931348623157e+308")]
+    [InlineData("(Number.MAX_VALUE).toString(16).length", "256")]
+    public void TheLargestFiniteDoubleDoesNotReportItselfAsInfinity(string source, string expected)
+    {
+        new Engine().Evaluate(source + ".toString()").AsString().Should().Be(expected);
+    }
+
+    [Theory]
+    // ThisNumberValue reads [[NumberData]] out of the wrapper, so an own valueOf cannot hijack it.
+    [InlineData("var n = new Number(); n.valueOf = function () { return 17; }; n.toString()", "0")]
+    [InlineData("var n = new Number(); n.valueOf = function () { return 17; }; n.toFixed(1)", "0.0")]
+    [InlineData("var n = new Number(); n.valueOf = function () { return 17; }; n.toPrecision(2)", "0.0")]
+    [InlineData("var n = new Number(); n.valueOf = function () { return 17; }; n.toExponential(1)", "0.0e+0")]
+    [InlineData("var n = new Number(); n.valueOf = function () { return 17; }; String(n)", "0")]
+    // ... while ToPrimitive with a string hint still consults the (unmodified) toString first, so an
+    // own valueOf does not decide a property key either.
+    [InlineData("var o = { 0: 17, 8: 42 }; var n = new Number(); n.valueOf = function () { return 8; }; o[n]", "17")]
+    [InlineData("var o = { 0: 17, 9: 42 }; var n = new Number(); n.toString = function () { return 9; }; o[n]", "42")]
+    // ... and the default hint does consult valueOf, which is what makes these two differ.
+    [InlineData("var n = new Number(); n.valueOf = function () { return 8.5; }; n + n", "17")]
+    [InlineData("var n = new Number(); n.toString = function () { return 5; }; n + n", "0")]
+    public void NumberPrototypeMethodsReadTheSlotRatherThanCallingValueOf(string source, string expected)
+    {
+        new Engine().Evaluate(source).ToString().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("Number.prototype.toFixed.call('Hello')")]
+    [InlineData("Number.prototype.toFixed.call({})")]
+    // ThisNumberValue is step 1, so it outranks the fractionDigits range check of step 4.
+    [InlineData("Number.prototype.toFixed.call('Hello', 555)")]
+    [InlineData("Number.prototype.toLocaleString.call('Hello')")]
+    public void NumberPrototypeMethodsRejectANonNumberReceiver(string source)
+    {
+        var engine = new Engine();
+        var exception = Assert.Throws<JavaScriptException>(() => engine.Evaluate(source));
+        exception.Error.Get("constructor").Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Theory]
+    [InlineData("Number.prototype.toFixed.call(NaN, 555)")]
+    [InlineData("Number.prototype.toFixed.call(1, -1)")]
+    [InlineData("Number.prototype.toFixed.call(1, 101)")]
+    [InlineData("Number.prototype.toFixed.call(1, Infinity)")]
+    public void ToFixedRejectsFractionDigitsOutsideZeroToOneHundred(string source)
+    {
+        var engine = new Engine();
+        var exception = Assert.Throws<JavaScriptException>(() => engine.Evaluate(source));
+        exception.Error.Get("constructor").Get("name").AsString().Should().Be("RangeError");
+    }
+
+    [Fact]
+    public void ToStringConvertsItsRadixArgumentExactlyOnce()
+    {
+        var engine = new Engine();
+        engine.Execute("var calls = 0; var radix = { valueOf: function () { calls++; return 16; } };");
+
+        // The negative case used to recurse into toString with the original argument, converting twice.
+        engine.Evaluate("(-255).toString(radix)").AsString().Should().Be("-ff");
+        engine.Evaluate("calls").AsNumber().Should().Be(1d);
+    }
+
+    [Theory]
+    [InlineData("Number.prototype.toFixed.call(NaN)", "NaN")]
+    [InlineData("Number.prototype.toFixed.call(Infinity)", "Infinity")]
+    [InlineData("Number.prototype.toFixed.call(-Infinity)", "-Infinity")]
+    [InlineData("Number.prototype.toExponential.call(new Number(Infinity))", "Infinity")]
+    [InlineData("Number.prototype.toPrecision.call(new Number(-Infinity), 3)", "-Infinity")]
+    public void NonFiniteValuesFormatAsNumberToString(string source, string expected)
+    {
+        new Engine().Evaluate(source).AsString().Should().Be(expected);
     }
 }

--- a/Jint/Native/JsNumber.cs
+++ b/Jint/Native/JsNumber.cs
@@ -16,9 +16,6 @@ public sealed class JsNumber : JsValue, IEquatable<JsNumber>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     internal readonly double _value;
 
-    // how many decimals to check when determining if double is actually an int
-    internal const double DoubleIsIntegerTolerance = double.Epsilon * 100;
-
     internal static readonly long NegativeZeroBits = BitConverter.DoubleToInt64Bits(-0.0);
 
     // we can cache most common values, doubles are used in indexing too at times so we also cache

--- a/Jint/Native/Number/NumberPrototype.cs
+++ b/Jint/Native/Number/NumberPrototype.cs
@@ -39,18 +39,38 @@ internal sealed partial class NumberPrototype : NumberInstance
     protected override void Initialize() => CreateProperties_Generated();
 
     /// <summary>
+    /// https://tc39.es/ecma262/#sec-thisnumbervalue
+    /// </summary>
+    /// <remarks>
+    /// Deliberately not <c>TypeConverter.ToNumber(thisObject)</c>: [[NumberData]] is read out of the
+    /// wrapper directly, so a <c>valueOf</c> installed on a Number object cannot hijack the built-in
+    /// (<c>new Number()</c> with <c>valueOf = () =&gt; 17</c> still stringifies as "0"), and a receiver
+    /// that is neither a Number nor a Number object is a TypeError rather than a silent NaN.
+    /// </remarks>
+    private double ThisNumberValue(JsValue value, string errorMessage)
+    {
+        if (value is JsNumber number)
+        {
+            return number._value;
+        }
+
+        if (value is NumberInstance instance)
+        {
+            return instance.NumberData._value;
+        }
+
+        Throw.TypeError(_realm, errorMessage);
+        return 0;
+    }
+
+    /// <summary>
     /// https://tc39.es/ecma262/#sec-number.prototype.tolocalestring
     /// https://tc39.es/ecma402/#sup-number.prototype.tolocalestring
     /// </summary>
     [JsFunction]
     private JsValue ToLocaleString(JsValue thisObject, JsCallArguments arguments)
     {
-        if (!thisObject.IsNumber() && thisObject is not NumberInstance)
-        {
-            Throw.TypeError(_realm, "Number.prototype.toLocaleString requires that 'this' be a Number");
-        }
-
-        var x = TypeConverter.ToNumber(thisObject);
+        var x = ThisNumberValue(thisObject, "Number.prototype.toLocaleString requires that 'this' be a Number");
 
         // Use Intl.NumberFormat if available
         var locales = arguments.At(0);
@@ -79,143 +99,159 @@ internal sealed partial class NumberPrototype : NumberInstance
 
     private const double Ten21 = 1e21;
 
-    // FastCall only: the body raises a RangeError for out-of-range digits and coerces the receiver
-    // through ToNumber, so the frame has to stay — matching toExponential/toPrecision.
-    [JsFunction(FastCall = true)]
-    private JsValue ToFixed(JsValue thisObject, [ToInteger] double fAsDouble)
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-number.prototype.tofixed
+    /// </summary>
+    // FastCall only: the body raises TypeError/RangeError and coerces the argument through
+    // ToIntegerOrInfinity, so the frame has to stay — matching toExponential/toPrecision.
+    [JsFunction(Length = 1, FastCall = true)]
+    private JsValue ToFixed(JsValue thisObject, JsValue arg0)
     {
-        var f = (int) fAsDouble;
-        if (f < 0 || f > 100)
+        // Step 1 is ThisNumberValue, so `toFixed.call("Hello")` is a TypeError — and stays one even
+        // when the fractionDigits argument is itself out of range, which the old ordering reported as
+        // a RangeError instead.
+        var x = ThisNumberValue(thisObject, "Number.prototype.toFixed requires that 'this' be a Number");
+
+        // Steps 2-4.
+        var fAsDouble = TypeConverter.ToIntegerOrInfinity(arg0);
+        if (!double.IsFinite(fAsDouble) || fAsDouble < 0 || fAsDouble > 100)
         {
             Throw.RangeError(_realm, "toFixed() digits argument must be between 0 and 100");
         }
 
-        var x = TypeConverter.ToNumber(thisObject);
+        var f = (int) fAsDouble;
 
-        if (double.IsNaN(x))
-        {
-            return "NaN";
-        }
-
-        if (x >= Ten21 || x <= -Ten21)
+        // Step 5, and step 9: at 10^21 and above the fixed form is the ordinary Number::toString.
+        if (!double.IsFinite(x) || x >= Ten21 || x <= -Ten21)
         {
             return ToNumberString(x);
         }
 
-        bool negative = false;
-        if (x < 0)
-        {
-            negative = true;
-            x = -x;
-        }
-
-        if (f == 0)
-        {
-            // Fast path: no fractional digits
-            var rounded = System.Math.Round(x, MidpointRounding.AwayFromZero);
-            var result = negative ? "-" + ((long) rounded).ToString(CultureInfo.InvariantCulture) : ((long) rounded).ToString(CultureInfo.InvariantCulture);
-            return result;
-        }
-
-        // Use .NET formatting for f <= 99 (fast path)
-        if (f <= 99)
-        {
-            // handle non-decimal with greater precision
-            if (System.Math.Abs(x - (long) x) < JsNumber.DoubleIsIntegerTolerance)
-            {
-                var result = ((long) x).ToString("f" + f, CultureInfo.InvariantCulture);
-                return negative ? "-" + result : result;
-            }
-
-            var formatted = x.ToString("f" + f, CultureInfo.InvariantCulture);
-            return negative ? "-" + formatted : formatted;
-        }
-
-        // Use Dtoa infrastructure for f == 100 (avoids .NET format specifier limitation)
-        return ToFixedDtoa(x, f, negative);
+        return ToFixedString(x, f);
     }
 
-    private static string ToFixedDtoa(double x, int fractionDigits, bool negative)
+    /// <summary>
+    /// Steps 8-11 of https://tc39.es/ecma262/#sec-number.prototype.tofixed: the integer n for which
+    /// n / 10^f - x is closest to zero (ties taking the larger n), rendered with the decimal point put
+    /// back in.
+    /// </summary>
+    /// <remarks>
+    /// The digits come from the exact-value bignum generator rather than from a BCL <c>"F"</c> format.
+    /// The spec is written over the *exact* mathematical value of the double, and no target framework
+    /// formats that on request: .NET Framework's <c>"F"</c> carries 15 significant digits and pads the
+    /// rest with zeros (so <c>(3.141592653589793).toFixed(50)</c> lost everything past
+    /// <c>...58979</c>), and caps the precision specifier at 99, which is why <c>f == 100</c> already
+    /// had to detour through here. The old integer shortcut also cast through <c>long</c>, which
+    /// saturates at 2^63: <c>(1e20).toFixed(0)</c> answered "9223372036854775807" on .NET and
+    /// "-9223372036854775808" on .NET Framework.
+    /// </remarks>
+    private static string ToFixedString(double x, int fractionDigits)
     {
-        if (x == 0)
+        // Both shortcuts below need the value to fit a long exactly — 2^63 is the smallest double
+        // above long.MaxValue — so anything larger goes to the digit generator, which is exactly the
+        // guard the old integer shortcut was missing when it answered long.MaxValue for (1e20).toFixed(0).
+        if (x > -9223372036854775808.0 && x < 9223372036854775808.0)
         {
-            var sb = new ValueStringBuilder(stackalloc char[128]);
-            if (negative)
+            // An integral double has no fractional part to round, so n is exactly x * 10^f and the
+            // answer is the integer's own digits followed by f zeros — no digit generation needed.
+            // -0 casts to 0, which is the sign step 8 wants for it.
+            if (x % 1 == 0)
             {
-                sb.Append('-');
+                var integral = ((long) x).ToString(CultureInfo.InvariantCulture);
+                if (fractionDigits == 0)
+                {
+                    return integral;
+                }
+
+                var integralResult = new ValueStringBuilder(stackalloc char[128]);
+                integralResult.Append(integral);
+                integralResult.Append('.');
+                integralResult.Append('0', fractionDigits);
+                return integralResult.ToString();
             }
-            sb.Append("0.");
-            sb.Append('0', fractionDigits);
-            return sb.ToString();
+
+            // Reaching here x has a fractional part, so |x| < 2^52 and rounding cannot leave the
+            // range of long. Round-half-away-from-zero on the magnitude is exactly step 10a's "as
+            // close to zero as possible, ties taking the larger n" applied to the negated value, and
+            // the sign is carried separately so a value rounding to zero still reports "-0".
+            if (fractionDigits == 0)
+            {
+                var rounded = ((long) System.Math.Round(System.Math.Abs(x), MidpointRounding.AwayFromZero)).ToString(CultureInfo.InvariantCulture);
+                return x < 0 ? "-" + rounded : rounded;
+            }
         }
 
-        var dtoaBuilder = new DtoaBuilder(stackalloc char[fractionDigits + 50]);
+        // |x| < 10^21, so the integer part is at most 21 digits (22 if rounding carries out of the
+        // leading digit) and the fraction contributes at most 100.
+        var builder = new DtoaBuilder(stackalloc char[128]);
         DtoaNumberFormatter.DoubleToAscii(
-            ref dtoaBuilder,
+            ref builder,
             x,
             DtoaMode.Fixed,
             fractionDigits,
-            out _,
+            out var negative,
             out var decimalPoint);
 
-        var result2 = new ValueStringBuilder(stackalloc char[fractionDigits + 50]);
+        var result = new ValueStringBuilder(stackalloc char[128]);
         if (negative)
         {
-            result2.Append('-');
+            // Step 8 works on ℝ(x) and takes the sign before rounding, which is why a value that
+            // rounds away to zero still reports one: (-Number.MIN_VALUE).toFixed(0) is "-0".
+            result.Append('-');
         }
 
+        var digits = builder._chars.Slice(0, builder.Length);
         if (decimalPoint <= 0)
         {
-            // 0.000...digits
-            result2.Append("0.");
-            result2.Append('0', -decimalPoint);
-            result2.Append(dtoaBuilder._chars.Slice(0, dtoaBuilder.Length));
-            int remaining = fractionDigits - (-decimalPoint + dtoaBuilder.Length);
-            if (remaining > 0)
-            {
-                result2.Append('0', remaining);
-            }
-        }
-        else if (decimalPoint >= dtoaBuilder.Length)
-        {
-            // Integer part only, pad with zeros
-            result2.Append(dtoaBuilder._chars.Slice(0, dtoaBuilder.Length));
-            result2.Append('0', decimalPoint - dtoaBuilder.Length);
+            // 0.000ddd — the value rounds to something below 1.
+            result.Append('0');
             if (fractionDigits > 0)
             {
-                result2.Append('.');
-                result2.Append('0', fractionDigits);
+                result.Append('.');
+                result.Append('0', -decimalPoint);
+                result.Append(digits);
+                AppendZeros(ref result, fractionDigits + decimalPoint - digits.Length);
+            }
+        }
+        else if (decimalPoint >= digits.Length)
+        {
+            // ddd000.000 — every generated digit belongs to the integer part.
+            result.Append(digits);
+            result.Append('0', decimalPoint - digits.Length);
+            if (fractionDigits > 0)
+            {
+                result.Append('.');
+                result.Append('0', fractionDigits);
             }
         }
         else
         {
-            // digits split across integer and fractional part
-            result2.Append(dtoaBuilder._chars.Slice(0, decimalPoint));
-            result2.Append('.');
-            int fracDigitsFromDtoa = dtoaBuilder.Length - decimalPoint;
-            result2.Append(dtoaBuilder._chars.Slice(decimalPoint, fracDigitsFromDtoa));
-            int remaining = fractionDigits - fracDigitsFromDtoa;
-            if (remaining > 0)
-            {
-                result2.Append('0', remaining);
-            }
+            // dd.ddd — the digits straddle the point.
+            result.Append(digits.Slice(0, decimalPoint));
+            result.Append('.');
+            result.Append(digits.Slice(decimalPoint));
+            AppendZeros(ref result, fractionDigits - (digits.Length - decimalPoint));
         }
 
-        return result2.ToString();
+        return result.ToString();
+    }
+
+    private static void AppendZeros(ref ValueStringBuilder builder, int count)
+    {
+        // The generator never hands back more digits than the requested fraction can hold, so a
+        // negative count would mean a broken generator rather than a reachable input.
+        Debug.Assert(count >= 0);
+        builder.Append('0', System.Math.Max(0, count));
     }
 
     /// <summary>
-    /// https://www.ecma-international.org/ecma-262/6.0/#sec-number.prototype.toexponential
+    /// https://tc39.es/ecma262/#sec-number.prototype.toexponential
     /// </summary>
     [JsFunction(Length = 1, FastCall = true)]
     private JsValue ToExponential(JsValue thisObject, JsValue arg0)
     {
-        if (!thisObject.IsNumber() && ReferenceEquals(thisObject.TryCast<NumberInstance>(), null))
-        {
-            Throw.TypeError(_realm, "Number.prototype.toExponential requires that 'this' be a Number");
-        }
+        var x = ThisNumberValue(thisObject, "Number.prototype.toExponential requires that 'this' be a Number");
 
-        var x = TypeConverter.ToNumber(thisObject);
         var fractionDigits = arg0;
         if (fractionDigits.IsUndefined())
         {
@@ -224,14 +260,9 @@ internal sealed partial class NumberPrototype : NumberInstance
 
         var f = (int) TypeConverter.ToInteger(fractionDigits);
 
-        if (double.IsNaN(x))
+        if (!double.IsFinite(x))
         {
-            return "NaN";
-        }
-
-        if (double.IsInfinity(x))
-        {
-            return thisObject.ToString();
+            return ToNumberString(x);
         }
 
         if (f < 0 || f > 100)
@@ -284,15 +315,14 @@ internal sealed partial class NumberPrototype : NumberInstance
         return result;
     }
 
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-number.prototype.toprecision
+    /// </summary>
     [JsFunction(Length = 1, FastCall = true)]
     private JsValue ToPrecision(JsValue thisObject, JsValue arg0)
     {
-        if (!thisObject.IsNumber() && ReferenceEquals(thisObject.TryCast<NumberInstance>(), null))
-        {
-            Throw.TypeError(_realm, "Number.prototype.toPrecision requires that 'this' be a Number");
-        }
+        var x = ThisNumberValue(thisObject, "Number.prototype.toPrecision requires that 'this' be a Number");
 
-        var x = TypeConverter.ToNumber(thisObject);
         var precisionArgument = arg0;
 
         if (precisionArgument.IsUndefined())
@@ -302,14 +332,9 @@ internal sealed partial class NumberPrototype : NumberInstance
 
         var p = (int) TypeConverter.ToInteger(precisionArgument);
 
-        if (double.IsNaN(x))
+        if (!double.IsFinite(x))
         {
-            return "NaN";
-        }
-
-        if (double.IsInfinity(x))
-        {
-            return thisObject.ToString();
+            return ToNumberString(x);
         }
 
         if (p < 1 || p > 100)
@@ -405,13 +430,16 @@ internal sealed partial class NumberPrototype : NumberInstance
         return sb.ToString();
     }
 
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-number.prototype.tostring
+    /// </summary>
     [JsFunction(Length = 1, Name = "toString", FastCall = true)]
     private JsValue ToNumberString(JsValue thisObject, JsValue arg0)
     {
-        if (!thisObject.IsNumber() && (ReferenceEquals(thisObject.TryCast<NumberInstance>(), null)))
-        {
-            Throw.TypeError(_realm, "Number.prototype.toString requires that 'this' be a Number");
-        }
+        // Step 1 is ThisNumberValue, and steps 2-3 convert the radix exactly once — the negative case
+        // used to recurse into this method with the original argument and so ran a user-supplied
+        // `valueOf` on it a second time.
+        var x = ThisNumberValue(thisObject, "Number.prototype.toString requires that 'this' be a Number");
 
         var radix = arg0.IsUndefined()
             ? 10
@@ -422,8 +450,20 @@ internal sealed partial class NumberPrototype : NumberInstance
             Throw.RangeError(_realm, "toString() radix argument must be between 2 and 36");
         }
 
-        var x = TypeConverter.ToNumber(thisObject);
+        if (radix == 10)
+        {
+            return ToNumberString(x);
+        }
 
+        return ToRadixString(x, radix);
+    }
+
+    /// <summary>
+    /// Number::toString(x, radix) for a radix other than 10.
+    /// https://tc39.es/ecma262/#sec-numeric-types-number-tostring
+    /// </summary>
+    private static string ToRadixString(double x, int radix)
+    {
         if (double.IsNaN(x))
         {
             return "NaN";
@@ -431,22 +471,20 @@ internal sealed partial class NumberPrototype : NumberInstance
 
         if (x == 0)
         {
-            return JsString.NumberZeroString;
+            return "0";
         }
 
-        if (double.IsPositiveInfinity(x) || x >= double.MaxValue)
+        if (double.IsInfinity(x))
         {
-            return "Infinity";
+            // The guard here used to be `x >= double.MaxValue`, which made the largest finite double
+            // report itself as Infinity: (Number.MAX_VALUE).toString() answered "Infinity" and
+            // (Number.MAX_VALUE).toString(16) answered "Infinity" instead of 257 hex digits.
+            return double.IsNegativeInfinity(x) ? "-Infinity" : "Infinity";
         }
 
         if (x < 0)
         {
-            return "-" + ToNumberString(-x, arg0);
-        }
-
-        if (radix == 10)
-        {
-            return ToNumberString(x);
+            return "-" + ToRadixString(-x, radix);
         }
 
         var truncated = System.Math.Truncate(x);

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -13,9 +13,6 @@ namespace Jint.Runtime;
 
 public static class TypeConverter
 {
-    // how many decimals to check when determining if double is actually an int
-    private const double DoubleIsIntegerTolerance = double.Epsilon * 100;
-
     private static readonly string[] intToString = new string[1024];
     private static readonly string[] charToString = new string[256];
 
@@ -920,7 +917,12 @@ public static class TypeConverter
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static bool CanBeStringifiedAsLong(double d)
     {
-        return d > long.MinValue && d < long.MaxValue && Math.Abs(d % 1) <= DoubleIsIntegerTolerance;
+        // `d % 1` is exact for every finite double, so comparing it against zero *is* the integrality
+        // test — there is no rounding error for a tolerance to absorb. Comparing against one
+        // (double.Epsilon * 100, i.e. ~4.94e-322) instead classified every subnormal below it as the
+        // integer zero, so String(Number.MIN_VALUE) answered "0" while (5e-324).toString(), which does
+        // not come through here, answered "5e-324". JSON.stringify had the same hole.
+        return d > long.MinValue && d < long.MaxValue && d % 1 == 0;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Frees the four `staging/sm/Number/` files that #3021 lists under "Number conversion and formatting".

## The exclusion comment was mostly wrong

It read:

> toFixed/toPrecision lose the exact mathematical value for extreme magnitudes and subnormals, and ToPrimitive on a Number wrapper consults the wrong method. Removed by exact-value formatting and a spec-order OrdinaryToPrimitive.

Running the two value tables shows `toFixed` already reproduced 104 of its 108 rows and `toPrecision` 88 of its 90 — including `(3.141592653589793).toFixed(100)` and `Number.MAX_VALUE.toPrecision(100)`, which are exactly the exact-expansion cases the comment says were lost. And `TypeConverter.OrdinaryToPrimitive` is spec-exact: it consults `toString` before `valueOf` for a string hint, as it should. Nothing in this PR touches it.

The four real causes:

**1. `toFixed` cast the value through `long`.** `(1e20).toFixed(0)` answered `"9223372036854775807"` — the fast path did `(long) System.Math.Round(x)`, and an out-of-range double-to-integer conversion saturates to `long.MaxValue` on .NET and yields `long.MinValue` on .NET Framework, so the same source produced two different wrong answers depending on the target framework. `ToIntegerOrInfinity` already carries a comment about this exact hazard.

**2. `Number.prototype.toString` and friends implemented `ThisNumberValue` as `TypeConverter.ToNumber(this)`.** For a Number *object* that runs `ToPrimitive` with a number hint, so an own `valueOf` hijacks the built-in: `var n = new Number(); n.valueOf = () => 17; String(n)` gave `"17"` where the spec reads `[[NumberData]]` and gives `"0"`. That is what `defaultvalue.js` is testing — through a property key, because `obj[n]` runs `ToPropertyKey` → `ToPrimitive(n, string)` → `toString` → `Number.prototype.toString`, which is where the hijack landed. `toFixed` had no receiver check at all, so `Number.prototype.toFixed.call("Hello")` returned `"NaN"` instead of throwing a `TypeError` (`20.1.3.3-toFixed.js`).

**3. `TypeConverter.CanBeStringifiedAsLong` used a tolerance to decide integrality.** `Math.Abs(d % 1) <= double.Epsilon * 100` classifies every subnormal below ~4.94e-322 as the integer zero, so `String(Number.MIN_VALUE)` and `JSON.stringify(Number.MIN_VALUE)` answered `"0"` while `(5e-324).toString()`, which does not come through that helper, answered `"5e-324"`. `toPrecision()` with no argument is `ToString(x)`, which is how `toPrecision-values.js` caught it. `d % 1` is exact for every finite double, so there is no rounding error for a tolerance to absorb and the comparison is simply `d % 1 == 0`.

**4. `toFixed` formatted through the BCL `"F"` specifier**, which the spec's exact-value phrasing (§21.1.3.3 step 10a is over ℝ(x)) cannot be expressed in. On .NET Framework `(3.141592653589793).ToString("F50")` is `3.14159265358979000000…` — 15 significant digits and zeros — and `"F100"` is not even a valid precision there, which is why `f == 100` already had to detour through the bignum generator. Not caught by the test262 run, which is net10.0 only, but caught by the new unit tests, which run on net472 too.

Spec read: <https://tc39.es/ecma262/#sec-number.prototype.tofixed>, <https://tc39.es/ecma262/#sec-number.prototype.tostring>, <https://tc39.es/ecma262/#sec-thisnumbervalue>.

## What changed

`Jint/Native/Number/NumberPrototype.cs`

- New private `ThisNumberValue(value, errorMessage)` implementing §21.1.3.7.1: a `JsNumber` is its own value, a `NumberInstance` yields `[[NumberData]]`, anything else is a `TypeError`. `toString`, `toFixed`, `toExponential`, `toPrecision` and `toLocaleString` all use it, replacing the `IsNumber() || NumberInstance` guard followed by `ToNumber(this)`.
- `toFixed` now follows the spec's step order — `ThisNumberValue`, then `ToIntegerOrInfinity`, then the range check — so `toFixed.call("Hello", 555)` is a `TypeError` rather than a `RangeError`. Its parameter became a plain `JsValue` (the generated `Length`, fast-call shape and dispatch are unchanged).
- The formatting itself moved into `ToFixedString`, which reaches the existing exact-value `DtoaMode.Fixed` bignum generator for anything the two exact shortcuts above it do not cover: a double that is already an integer within `long`'s range (its expansion is the integer's digits plus f zeros — no rounding), and `f == 0`, where round-half-away-from-zero on the magnitude *is* step 10a and the sign is carried separately so `(-0.4).toFixed(0)` still reports `"-0"`. Both shortcuts are guarded on 2^63, which is the guard the old one was missing.
- `Number::toString(x, radix)` for a non-decimal radix moved into `ToRadixString`. Two incidental defects went with it, both in lines this PR had to rewrite anyway: the infinity guard was `x >= double.MaxValue`, so `(Number.MAX_VALUE).toString()` answered `"Infinity"`; and the negative case recursed into the built-in with the original radix argument, running a user `valueOf` on it twice.

`Jint/Runtime/TypeConverter.cs` — `CanBeStringifiedAsLong` tests `d % 1 == 0`.

`Jint/Native/JsNumber.cs` — drops `DoubleIsIntegerTolerance`, now unused and a repeat of the same mistake waiting to happen.

`Jint.Tests/Runtime/NumberTests.cs` — 46 new cases across eight facts. On unmodified sources 24 of them fail on net10.0 and 28 on net472; the extra four are the exact-expansion rows, which only .NET Framework gets wrong.

## Performance

`TypeConverter.ToPrimitive` is untouched, so the hottest path in the engine is unchanged; the receiver work moved *out* of it, since a Number built-in called on a wrapper no longer runs `ToPrimitive` at all. `CanBeStringifiedAsLong`, which is on `ToString(double)`, loses a `Math.Abs` and compares against zero instead of a constant.

`toFixed` itself is the only method whose cost profile moves. The two shortcuts keep integral values and `f == 0` off the generator, so what newly reaches it is a fractional value with `f > 0` — which now allocates the four `Bignum` instances (~2 KB) that `toFixed(100)`, `toExponential`, `toPrecision` and the shortest-`toString` fallback have always paid, in exchange for a string the BCL cannot produce on three of the five target frameworks. I have deliberately not quoted numbers: several agents were running on this machine throughout, and the `toString()` control row moved 380–680 ns between runs, which is wider than anything worth reporting.

## Files freed

- `staging/sm/Number/20.1.3.3-toFixed.js`
- `staging/sm/Number/defaultvalue.js`
- `staging/sm/Number/toFixed-values.js`
- `staging/sm/Number/toPrecision-values.js`

Refs #3021.

## Verification

- `staging/sm` (whole directory, with the four re-enabled): 2492 passed, 0 failed.
- `built-ins/Number` 680, `built-ins/JSON` 330, `built-ins/String` 2679, `built-ins/Math` 654, `built-ins/BigInt` 154, `built-ins/Date` 1236, `built-ins/Array` 6609, `built-ins/parseInt` 110, `built-ins/parseFloat` 108, `language/expressions` — all passing.
- `Jint.Tests` 6341 net10.0 / 6256 net472, `Jint.Tests.PublicInterface` 1488 / 1487, `Jint.Tests.CommonScripts` 28 / 28.

## Out of scope, noted while here

`(5e-324).toString(2)` returns 52 characters: `ToFractionBase` walks the fraction by repeated multiplication and stops at an arbitrary 50 digits, so a non-decimal radix truncates. No test262 file in the current set covers it, and it is a separate defect from anything above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
