### PR TITLE
Walk an array truncation downwards, and report the writes the generics fail

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -171,15 +171,6 @@
     "staging/sm/extensions/quote-string-for-nul-character.js",
     "staging/sm/misc/builtin-methods-reject-null-undefined-this.js",
 
-    // Array exotic [[DefineOwnProperty]] and the generics' element ordering: truncating length past
-    // a non-configurable sparse element stops at the wrong index, sort/unshift observe the wrong
-    // element sequence, and the strict-mode generics do not report failure to write.
-    "staging/sm/Array/length-truncate-nonconfigurable-sparse.js",
-    "staging/sm/Array/sort-typedarray-with-own-length.js",
-    "staging/sm/Array/unshift-with-enumeration.js",
-    "staging/sm/strict/15.4.4.9.js",
-    "staging/sm/strict/15.4.4.12.js",
-
     // Remaining one-offs, each its own gap: Iterator.from's next() result validation, the Map
     // constructor's per-entry type check, Symbol.keyFor over a cross-realm registry, and a module
     // namespace re-exported under a string name.

--- a/Jint.Tests/Runtime/ArrayExoticOrderingTests.cs
+++ b/Jint.Tests/Runtime/ArrayExoticOrderingTests.cs
@@ -1,0 +1,158 @@
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Order-sensitive corners of the array exotic object and of the generics that write through it: the
+/// downward walk <c>ArraySetLength</c> performs when it truncates, the throwing <c>Set</c> that
+/// <c>shift</c> and <c>splice</c> use to relocate an element, and <c>LengthOfArrayLike</c> being a real
+/// <c>Get</c> when the receiver of an <c>Array.prototype</c> generic is a typed array.
+/// </summary>
+public class ArrayExoticOrderingTests
+{
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-arraysetlength step 17 walks downwards from <c>oldLen - 1</c> and stops
+    /// at the first index whose <c>[[Delete]]</c> fails, reporting that index + 1 as the length. Everything
+    /// below the survivor is shielded by it. Jint deleted the concrete elements in ascending order, so the
+    /// low ones were gone by the time the non-configurable one refused.
+    /// </summary>
+    [Fact]
+    public void TruncatingLengthStopsAtTheHighestNonConfigurableElement()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var arr = [];
+            arr[10] = 'a';
+            arr[20] = 'b';
+            Object.defineProperty(arr, 30, { value: 'keep', configurable: false, writable: true, enumerable: true });
+            arr[40] = 'c';
+            arr.length = 1;
+            [arr.length, 10 in arr, 20 in arr, 30 in arr, 40 in arr].join(',');
+            """).AsString();
+
+        result.Should().Be("31,true,true,true,false");
+    }
+
+    [Fact]
+    public void TruncatingADenseArrayStopsAtTheHighestNonConfigurableElement()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var arr = [0, 1, 2, 3, 4];
+            Object.defineProperty(arr, 2, { value: 2, configurable: false, writable: true, enumerable: true });
+            arr.length = 0;
+            [arr.length, 0 in arr, 1 in arr, 2 in arr, 3 in arr, 4 in arr].join(',');
+            """).AsString();
+
+        result.Should().Be("3,true,true,true,false,false");
+    }
+
+    /// <summary>
+    /// Truncation in strict mode reports the same length and the same surviving set, but the failed
+    /// <c>[[DefineOwnProperty]]</c> becomes a TypeError.
+    /// </summary>
+    [Fact]
+    public void TruncatingPastANonConfigurableElementThrowsInStrictMode()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            'use strict';
+            var arr = [];
+            arr[10] = 'a';
+            Object.defineProperty(arr, 30, { value: 'keep', configurable: false, writable: true, enumerable: true });
+            arr[40] = 'c';
+            var threw = false;
+            try { arr.length = 1; } catch (e) { threw = e instanceof TypeError; }
+            [threw, arr.length, 10 in arr, 30 in arr, 40 in arr].join(',');
+            """).AsString();
+
+        result.Should().Be("true,31,true,true,false");
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-array.prototype.shift step 6.d.ii is <c>Set(O, to, fromValue, true)</c>:
+    /// a non-writable destination is a TypeError in sloppy mode too.
+    /// </summary>
+    [Theory]
+    [InlineData("var a = [10, 20, 30]; Object.defineProperty(a, 0, { writable: false }); a.shift();")]
+    [InlineData("var o = { 0: 10, 1: 20, 2: 30, length: 3 }; Object.defineProperty(o, 0, { writable: false }); Array.prototype.shift.call(o);")]
+    [InlineData("var a = [1, 2, 3]; Object.defineProperty(a, 0, { writable: false }); a.splice(0, 1);")]
+    [InlineData("var o = { 0: 1, 1: 2, 2: 3, length: 3 }; Object.defineProperty(o, 0, { writable: false }); Array.prototype.splice.call(o, 0, 1);")]
+    public void RelocatingOverANonWritableElementThrows(string source)
+    {
+        foreach (var prefix in new[] { "", "'use strict';\n" })
+        {
+            var engine = new Engine();
+            var act = () => engine.Evaluate(prefix + source);
+            act.Should().Throw<JavaScriptException>().Which.Error.ToString().Should().Contain("read only");
+        }
+    }
+
+    /// <summary>
+    /// A hole in the source means <c>DeletePropertyOrThrow</c> on the destination, which a
+    /// non-configurable element refuses.
+    /// </summary>
+    [Theory]
+    [InlineData("var a = [1, 2, , 4]; Object.defineProperty(a, 1, { configurable: false }); a.shift();")]
+    [InlineData("var a = [1, 2, , 4]; Object.defineProperty(a, 1, { configurable: false }); a.splice(0, 1);")]
+    public void DeletingANonConfigurableDestinationThrows(string source)
+    {
+        foreach (var prefix in new[] { "", "'use strict';\n" })
+        {
+            var engine = new Engine();
+            var act = () => engine.Evaluate(prefix + source);
+            act.Should().Throw<JavaScriptException>();
+        }
+    }
+
+    /// <summary>
+    /// An <c>Array.prototype</c> generic takes its length from <c>LengthOfArrayLike</c>, which is
+    /// <c>ToLength(? Get(O, "length"))</c> — so an own <c>"length"</c> on a typed array shadows the
+    /// <c>%TypedArray%.prototype</c> accessor and narrows what the generic touches.
+    /// </summary>
+    [Fact]
+    public void ArrayGenericOnATypedArrayHonoursAnOwnLength()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var ta = new Int8Array([3, 2, 1]);
+            Object.defineProperty(ta, 'length', { value: 2 });
+            Array.prototype.sort.call(ta, function (a, b) { return a - b; });
+            ta.toString();
+            """).AsString();
+
+        result.Should().Be("2,3,1");
+    }
+
+    /// <summary>
+    /// The typed array's <em>own</em> sort is specified on <c>TypedArrayLength</c>
+    /// (https://tc39.es/ecma262/#sec-%typedarray%.prototype.sort step 4), so the same shadowing property
+    /// must not narrow it.
+    /// </summary>
+    [Fact]
+    public void TypedArraySortIgnoresAnOwnLength()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var ta = new Int8Array([3, 2, 1]);
+            Object.defineProperty(ta, 'length', { value: 2 });
+            ta.sort(function (a, b) { return a - b; });
+            ta.toString();
+            """).AsString();
+
+        result.Should().Be("1,2,3");
+    }
+
+    [Fact]
+    public void ArrayGenericOnATypedArrayWithoutAnOwnLengthIsUnchanged()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var ta = new Int8Array([3, 2, 1]);
+            Array.prototype.sort.call(ta, function (a, b) { return a - b; });
+            ta.toString();
+            """).AsString();
+
+        result.Should().Be("1,2,3");
+    }
+}

--- a/Jint.Tests/Runtime/ForInEnumerationTests.cs
+++ b/Jint.Tests/Runtime/ForInEnumerationTests.cs
@@ -612,4 +612,72 @@ public class ForInEnumerationTests
 
         result.Should().Be(0);
     }
+
+    /// <summary>
+    /// <a href="https://tc39.es/ecma262/#sec-enumerate-object-properties">EnumerateObjectProperties</a> is
+    /// specified over the key set the enumeration started with: a key deleted before its turn is ignored,
+    /// and a key that did not exist then is not part of the enumeration. Filling a hole below the starting
+    /// bound is exactly that second case — an <c>unshift</c> from inside the loop body shifts the elements
+    /// down over the hole, so index 1 becomes present and index 2 becomes the hole. Only "0" was ever in
+    /// the key set.
+    /// </summary>
+    [Theory]
+    [InlineData("Array.prototype.unshift", "[0]")]
+    [InlineData("Array.prototype.splice", "[0, 0, 0]")]
+    public void FillingAHoleDuringEnumerationDoesNotAddItToTheEnumeration(string method, string args)
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate($$"""
+            var array = [1, /* hole */, 3];
+            var called = false;
+            var keys = [];
+            for (var key in array) {
+                keys.push(key);
+                if (!called) {
+                    called = true;
+                    Reflect.apply({{method}}, array, {{args}});
+                }
+            }
+            keys.join(',');
+            """).AsString();
+
+        result.Should().Be("0");
+    }
+
+    /// <summary>
+    /// The hole-free case the index fast path still serves: every index below the bound was present at head
+    /// evaluation, so an index that goes missing mid-loop was "deleted before it is processed" and skipping
+    /// it is what the specification requires.
+    /// </summary>
+    [Fact]
+    public void ShiftingDuringEnumerationOfADenseArraySkipsTheVanishedTail()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var array = [1, 2, 3];
+            var called = false;
+            var keys = [];
+            for (var key in array) {
+                keys.push(key);
+                if (!called) { called = true; array.shift(); }
+            }
+            keys.join(',');
+            """).AsString();
+
+        result.Should().Be("0,1");
+    }
+
+    [Fact]
+    public void HolesAreSkippedWhenNothingMutatesTheArray()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var array = [1, , 3, , 5];
+            var keys = [];
+            for (var key in array) { keys.push(key); }
+            keys.join(',');
+            """).AsString();
+
+        result.Should().Be("0,2,4");
+    }
 }

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -239,33 +239,38 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
             return false;
         }
 
+        // ArraySetLength step 17 walks the range downwards from oldLen - 1 and stops at the first index
+        // whose [[Delete]] fails, leaving everything below it in place and reporting that index + 1 as the
+        // length (https://tc39.es/ecma262/#sec-arraysetlength). Both branches below skip the indices that
+        // provably hold nothing -- deleting an absent index always succeeds, so that is unobservable -- but
+        // the *order* is not an optimization detail: an ascending walk deletes elements that a
+        // non-configurable one above them should have shielded.
         var count = _dense?.Length ?? _sparse!.Count;
         if (count < oldLen - newLen)
         {
-            if (_dense != null)
+            var dense = _dense;
+            if (dense != null)
             {
-                for (uint keyIndex = 0; keyIndex < _dense.Length; ++keyIndex)
+                var highest = (uint) System.Math.Min((ulong) dense.Length, oldLen);
+                for (var keyIndex = highest; keyIndex > newLen;)
                 {
-                    if (_dense[keyIndex] is null)
+                    keyIndex--;
+                    if (dense[keyIndex] is null)
                     {
                         continue;
                     }
 
-                    // is it the index of the array
-                    if (keyIndex >= newLen && keyIndex < oldLen)
+                    var deleteSucceeded = Delete(keyIndex);
+                    if (!deleteSucceeded)
                     {
-                        var deleteSucceeded = Delete(keyIndex);
-                        if (!deleteSucceeded)
+                        newLenDesc.Value = keyIndex + 1;
+                        if (!newWritable)
                         {
-                            newLenDesc.Value = keyIndex + 1;
-                            if (!newWritable)
-                            {
-                                newLenDesc.Writable = false;
-                            }
-
-                            base.DefineOwnProperty(CommonProperties.Length, newLenDesc);
-                            return false;
+                            newLenDesc.Writable = false;
                         }
+
+                        base.DefineOwnProperty(CommonProperties.Length, newLenDesc);
+                        return false;
                     }
                 }
             }
@@ -273,27 +278,31 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
             {
                 // in the case of sparse arrays, treat each concrete element instead of
                 // iterating over all indexes
-                var keys = new List<uint>(_sparse!.Keys);
-                var keysCount = keys.Count;
-                for (var i = 0; i < keysCount; i++)
+                var keys = new List<uint>();
+                foreach (var key in _sparse!.Keys)
+                {
+                    // is it the index of the array
+                    if (key >= newLen && key < oldLen)
+                    {
+                        keys.Add(key);
+                    }
+                }
+
+                keys.Sort();
+                for (var i = keys.Count - 1; i >= 0; i--)
                 {
                     var keyIndex = keys[i];
-
-                    // is it the index of the array
-                    if (keyIndex >= newLen && keyIndex < oldLen)
+                    var deleteSucceeded = Delete(TypeConverter.ToString(keyIndex));
+                    if (!deleteSucceeded)
                     {
-                        var deleteSucceeded = Delete(TypeConverter.ToString(keyIndex));
-                        if (!deleteSucceeded)
+                        newLenDesc.Value = JsNumber.Create(keyIndex + 1);
+                        if (!newWritable)
                         {
-                            newLenDesc.Value = JsNumber.Create(keyIndex + 1);
-                            if (!newWritable)
-                            {
-                                newLenDesc.Writable = false;
-                            }
-
-                            base.DefineOwnProperty(CommonProperties.Length, newLenDesc);
-                            return false;
+                            newLenDesc.Writable = false;
                         }
+
+                        base.DefineOwnProperty(CommonProperties.Length, newLenDesc);
+                        return false;
                     }
                 }
             }
@@ -566,6 +575,17 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
     /// per-index descriptors and no named own string properties has exactly its present indices
     /// (plus non-enumerable length) as own string keys, in ascending order. <paramref name="bound"/>
     /// is the index stepping limit — everything at or beyond it is provably a hole.
+    /// <para>
+    /// The range has to be <em>hole-free</em>, which is what makes stepping it live equivalent to the
+    /// snapshot the exact path takes. With every index below the bound present at head evaluation, the
+    /// snapshot is exactly [0, bound), so an index that has gone missing by the time its turn comes is a
+    /// property "deleted before it is processed", which
+    /// <a href="https://tc39.es/ecma262/#sec-enumerate-object-properties">EnumerateObjectProperties</a>
+    /// requires be ignored — precisely what skipping it does. A hole below the bound breaks that: it is
+    /// absent from the snapshot, so filling it mid-loop (an <c>unshift</c> or a <c>splice</c> from inside
+    /// the body, which shifts the elements down over it) would hand out a key the snapshot never held.
+    /// Such an array takes the exact path instead.
+    /// </para>
     /// </summary>
     internal bool TryStartForInIndexMode(out uint bound)
     {
@@ -577,6 +597,12 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
         }
 
         bound = (uint) System.Math.Min((ulong) dense.Length, GetLongLength());
+        if (System.Array.IndexOf(dense, null, 0, (int) bound) >= 0)
+        {
+            bound = 0;
+            return false;
+        }
+
         return true;
     }
 

--- a/Jint/Native/Array/ArrayOperations.cs
+++ b/Jint/Native/Array/ArrayOperations.cs
@@ -35,6 +35,17 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
         return For(TypeConverter.ToObject(realm, value), forWrite);
     }
 
+    /// <summary>
+    /// A typed array viewed through its <em>intrinsic</em> length rather than through
+    /// <c>LengthOfArrayLike</c>. <c>%TypedArray%.prototype.sort</c> and <c>toSorted</c> are specified on
+    /// <c>TypedArrayLength(taRecord)</c> (https://tc39.es/ecma262/#sec-%typedarray%.prototype.sort step 4),
+    /// so an own <c>"length"</c> shadowing the prototype accessor must not narrow what they sort -- unlike
+    /// the array-like algorithms <see cref="For(ObjectInstance, bool)"/> serves, which all say
+    /// <c>LengthOfArrayLike</c>.
+    /// </summary>
+    public static ArrayOperations ForIntrinsicLength(JsTypedArray instance)
+        => new JsTypedArrayOperations(instance, useIntrinsicLength: true);
+
     public static ArrayOperations For(ObjectInstance instance, bool forWrite)
     {
         if (instance is JsArray { CanUseFastAccess: true } arrayInstance)
@@ -282,8 +293,8 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
         public override void EnsureCapacity(ulong capacity)
             => _target.EnsureCapacity((uint) capacity);
 
+        // array max size is uint
         public override bool TryGetValue(ulong index, out JsValue value)
-            // array max size is uint
             => _target.TryGetValue((uint) index, out value);
 
         public override JsValue Get(ulong index) => _target.Get((uint) index);
@@ -357,19 +368,31 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
     private sealed class JsTypedArrayOperations : ArrayOperations
     {
         private readonly JsTypedArray _target;
+        private readonly bool _useIntrinsicLength;
 
-        public JsTypedArrayOperations(JsTypedArray target)
+        public JsTypedArrayOperations(JsTypedArray target, bool useIntrinsicLength = false)
         {
             _target = target;
+            _useIntrinsicLength = useIntrinsicLength;
         }
 
         public override ObjectInstance Target => _target;
 
         public override ulong GetSmallestIndex(ulong length) => 0;
 
+        // This lane serves the *array-like* algorithms -- the Array.prototype generics a typed array can be
+        // the receiver of, Array.from, apply-spreading -- and every one of them says
+        // "Let len be ? LengthOfArrayLike(O)", which is ToLength(? Get(O, "length"))
+        // (https://tc39.es/ecma262/#sec-lengthofarraylike). Usually that resolves to the accessor on
+        // %TypedArray%.prototype and agrees with the intrinsic length, but not when the object carries an
+        // own "length" of its own: "length" is not a canonical numeric index string, so
+        // Object.defineProperty(ta, "length", ...) installs an ordinary own property that shadows the
+        // accessor, and Array.prototype.sort.call(ta) must then sort only that many elements.
+        // %TypedArray%.prototype's own methods do not come through here -- they read the intrinsic length
+        // directly -- so nothing that must ignore an own "length" is affected.
         public override uint GetLength()
         {
-            if (!_target.IsConcatSpreadable)
+            if (_useIntrinsicLength)
             {
                 return _target.GetLength();
             }
@@ -377,7 +400,13 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
             var descValue = _target.Get(CommonProperties.Length);
             if (descValue is not null)
             {
-                return (uint) TypeConverter.ToInteger(descValue);
+                var length = TypeConverter.ToInteger(descValue);
+                if (length <= 0)
+                {
+                    return 0;
+                }
+
+                return (uint) System.Math.Min(length, MaxArrayLength);
             }
 
             return 0;

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -1345,7 +1345,9 @@ public sealed partial class ArrayPrototype : ArrayInstance
                 if (o.HasProperty(from))
                 {
                     var fromValue = o.Get(from);
-                    o.Set(to, fromValue, throwOnError: false);
+                    // https://tc39.es/ecma262/#sec-array.prototype.splice step 15.b.iv is the throwing
+                    // Set, exactly as the growing branch below already performs.
+                    o.Set(to, fromValue, throwOnError: true);
                 }
                 else
                 {
@@ -1724,7 +1726,10 @@ public sealed partial class ArrayPrototype : ArrayInstance
             var to = k - 1;
             if (o.TryGetValue(k, out var fromVal))
             {
-                o.Set(to, fromVal, throwOnError: false);
+                // https://tc39.es/ecma262/#sec-array.prototype.shift step 6.d.ii is
+                // Perform ? Set(O, to, fromValue, true) -- a non-writable element, or a Proxy set trap
+                // answering false, has to surface as a TypeError in both modes rather than be dropped.
+                o.Set(to, fromVal, throwOnError: true);
             }
             else
             {

--- a/Jint/Native/TypedArray/IntrinsicTypedArrayPrototype.cs
+++ b/Jint/Native/TypedArray/IntrinsicTypedArrayPrototype.cs
@@ -1807,7 +1807,7 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
     private static JsValue[] SortArray(JsArrayBuffer buffer, ICallable? compareFn, JsTypedArray obj)
     {
         var comparer = TypedArrayComparer.WithFunction(buffer, compareFn);
-        var operations = ArrayOperations.For(obj, forWrite: false);
+        var operations = ArrayOperations.ForIntrinsicLength(obj);
         try
         {
             // StableOrder, not a BCL sort: the sort must be stable (spec, since ES2019) and must


### PR DESCRIPTION
Five `staging/sm` exclusions from issue #3021 were grouped as "array exotic `[[DefineOwnProperty]]` and the generics' element ordering". The grouping holds; the individual diagnoses only partly. These are four independent defects, and the one the banner attributes to `sort` is really about `LengthOfArrayLike`.

**A truncating `length` write walked the wrong way.** [`ArraySetLength`](https://tc39.es/ecma262/#sec-arraysetlength) step 17 walks the range downwards from `oldLen - 1` and stops at the first index whose `[[Delete]]` fails, so everything below the survivor is shielded by it and the reported length is that index + 1. Jint's concrete-elements branch — the one taken when the array holds far fewer elements than the range being removed — iterated the elements in *ascending* order, so the low ones were already gone by the time the non-configurable one refused. `arr.length = 1` on `length-truncate-nonconfigurable-sparse.js`'s array left 6 own properties where the spec leaves 10, while correctly reporting `length === 27182819`. Both branches now walk downwards; the sparse one filters the in-range keys and sorts them first. Skipping indices that provably hold nothing is still fine — deleting an absent index always succeeds — it was only the order that was observable.

**`shift` and `splice` dropped a failed write.** [`Array.prototype.shift`](https://tc39.es/ecma262/#sec-array.prototype.shift) step 6.d.ii and [`Array.prototype.splice`](https://tc39.es/ecma262/#sec-array.prototype.splice) step 15.b.iv are `Perform ? Set(O, to, fromValue, true)`. Jint passed `throwOnError: false` on both, so relocating an element over a non-writable one silently did nothing instead of raising a `TypeError` — in strict *and* sloppy mode, since the flag is part of the algorithm rather than of the caller's mode. `splice`'s growing branch already used the throwing form; only the shrinking one did not.

**`Array.prototype.sort.call(typedArray)` ignored an own `"length"`.** Every array-like algorithm says `Let len be ? LengthOfArrayLike(O)`, which is [`ToLength(? Get(O, "length"))`](https://tc39.es/ecma262/#sec-lengthofarraylike). Jint's typed-array lane returned the intrinsic length instead, so an own `"length"` installed with `Object.defineProperty` — legal, because `"length"` is not a canonical numeric index string and so falls through to `OrdinaryDefineOwnProperty` — did not narrow what the generic touched. That lane now performs the `Get`. `%TypedArray%.prototype.sort` and `toSorted` are specified on `TypedArrayLength(taRecord)` instead, so they take a new intrinsic-length view (`ArrayOperations.ForIntrinsicLength`) and keep ignoring such a property; a test pins both directions. The same change removes an unrelated observable: the lane used to read `@@isConcatSpreadable` on every length read of a typed array, a `Get` no algorithm performs there.

**`for-in` over a holey array yielded a key the enumeration never held.** [`EnumerateObjectProperties`](https://tc39.es/ecma262/#sec-enumerate-object-properties) is specified over the key set the enumeration started with — a key deleted before its turn is ignored, and a key that did not exist then is not part of it. Jint's exact path implements that: it snapshots the keys and re-probes each at its turn. The index fast path stepped the range *live* instead, which is equivalent only while every index below the bound was present at head evaluation. A hole that gets filled mid-loop — an `unshift` or `splice` from inside the body shifts the elements down over it — then produces a key the snapshot never contained.

The decisive point is that the two lanes disagreed on the same array, and a single named own property was enough to select between them:

```js
function run(array) {
  var called = false, keys = [];
  for (var key in array) {
    keys.push(key);
    if (!called) { called = true; array.unshift(0); }
  }
  return keys.join(',');
}
run([1, , 3]);                        // before: "0,1"   (index fast lane)
var b = [1, , 3]; b.tag = 'x'; run(b) // before: "0,tag" (exact lane, index 1 never yielded)
```

So this is an optimization changing observable behaviour, not a choice between two readings of the spec. The fast path now requires the range to be hole-free, which is exactly the condition under which stepping it live and replaying the snapshot cannot differ.

## Performance

Two rows are affected and **neither has been measured** — several agents were working in parallel, so no benchmark run would have been trustworthy. Both deserve a serial check against `ForInGuardBenchmark`'s `ForInDenseArray` and `ForInHoleyArray` rows before this lands:

- **Hole-free array**: one extra `Array.IndexOf(dense, null, 0, bound)` at head evaluation, over exactly the range the enumeration is about to walk. It is the same null test the loop already does per element, paid once more up front, and `Array.IndexOf` for a `null` value is a tight reference-compare loop. Expected to be small against the per-key work (key creation, iterator step, loop-variable binding, body) but it is a real O(n) addition.
- **Holey array**: loses the index lane entirely and takes the exact snapshot path — the same path every non-array object and every array with a named own property already takes.

`ArraySetLength`'s sparse branch now allocates a filtered key list and sorts it instead of copying the whole key set; that path only runs when a `length` write truncates a sparse array. `shift`/`splice`/`sort` are otherwise untouched, and none of the dense fast paths in `ArrayPrototype` changed.

## Verified

The five files pass in both modes (the truncation test is `noStrict`, so 21 cases in total). `built-ins/Array`, `built-ins/TypedArray`, `built-ins/Object` (17,741), `built-ins/Proxy`, `built-ins/Reflect`, `built-ins/Function`, `language/statements/for-in`, `language/statements/for-of`, `annexB` (4,833 + 12,512 across two runs) all pass, as do `Jint.Tests` (6,297 + 6,212) and `Jint.Tests.PublicInterface`.

New coverage in `Jint.Tests/Runtime/ArrayExoticOrderingTests.cs` and three cases added to `ForInEnumerationTests.cs`; 9 of the 51 cases in those two files fail against the unfixed engine, the rest being regression guards for the neighbouring behaviour each fix had to leave alone.

Frees `staging/sm/Array/length-truncate-nonconfigurable-sparse.js`, `staging/sm/Array/sort-typedarray-with-own-length.js`, `staging/sm/Array/unshift-with-enumeration.js`, `staging/sm/strict/15.4.4.9.js` and `staging/sm/strict/15.4.4.12.js`. Refs #3021.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
