### PR TITLE
Settle a source-phase dynamic import with the module's [[ModuleSource]]

### DIFF
--- a/Jint.Tests.PublicInterface/HostModuleSourcePhaseTests.cs
+++ b/Jint.Tests.PublicInterface/HostModuleSourcePhaseTests.cs
@@ -1,0 +1,146 @@
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Modules;
+
+#nullable enable
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// Source phase imports (<see href="https://tc39.es/proposal-source-phase-imports/">stage 3</see>) let script
+/// reach a module's <c>[[ModuleSource]]</c> without linking or evaluating it. No ECMA-262 module kind has one,
+/// so the slot is filled entirely by the host: a loader overriding <see cref="ModuleLoader.GetModuleSource"/>
+/// is the whole extension point, WebAssembly being the motivating case. These pin both ways script reaches
+/// that object, and what happens for the modules that have none.
+/// </summary>
+public class HostModuleSourcePhaseTests
+{
+    private sealed class SourceProvidingModuleLoader : ModuleLoader
+    {
+        private const string WithSource = "has-source";
+
+        private readonly Dictionary<string, string> _contents = new(StringComparer.Ordinal)
+        {
+            [WithSource] = "export const x = 1;",
+            ["plain"] = "export const y = 2;",
+            ["main"] = "",
+        };
+
+        /// <summary>The object handed back as the <c>[[ModuleSource]]</c>, so a test can assert identity.</summary>
+        internal ObjectInstance? Provided { get; private set; }
+
+        internal void AddModule(string specifier, string contents) => _contents[specifier] = contents;
+
+        public override ResolvedSpecifier Resolve(string? referencingModuleLocation, ModuleRequest moduleRequest)
+            => new ResolvedSpecifier(moduleRequest, moduleRequest.Specifier, Uri: null, SpecifierType.Bare);
+
+        protected override string LoadModuleContents(Engine engine, ResolvedSpecifier resolved)
+            => _contents[resolved.ModuleRequest.Specifier];
+
+        protected override ObjectInstance? GetModuleSource(Engine engine, ResolvedSpecifier resolved)
+        {
+            if (!string.Equals(resolved.ModuleRequest.Specifier, WithSource, StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            var source = new JsObject(engine);
+            source.Set("kind", "host-source");
+            Provided = source;
+            return source;
+        }
+    }
+
+    private static Engine CreateEngine(SourceProvidingModuleLoader loader)
+        => new Engine(options => options.EnableModules(loader));
+
+    [Fact]
+    public void DynamicImportSourceResolvesWithTheHostSuppliedModuleSource()
+    {
+        // ContinueDynamicImport step 3: for the source phase the promise settles with module.[[ModuleSource]]
+        // and the module is never linked or evaluated.
+        var loader = new SourceProvidingModuleLoader();
+        loader.AddModule("main", """
+            globalThis.captured = null;
+            globalThis.settled = null;
+            import.source('has-source').then(
+                s => { globalThis.settled = 'fulfilled'; globalThis.captured = s; },
+                e => { globalThis.settled = 'rejected'; globalThis.captured = e; });
+            """);
+
+        var engine = CreateEngine(loader);
+        engine.Modules.Import("main");
+
+        engine.Evaluate("globalThis.settled").AsString().Should().Be("fulfilled");
+        engine.Evaluate("globalThis.captured.kind").AsString().Should().Be("host-source");
+        engine.Evaluate("globalThis.captured").Should().BeSameAs(loader.Provided);
+    }
+
+    [Fact]
+    public void StaticImportSourceBindsTheHostSuppliedModuleSource()
+    {
+        // InitializeEnvironment step 7.c: `import source x from` binds x to importedModule.[[ModuleSource]].
+        var loader = new SourceProvidingModuleLoader();
+        loader.AddModule("main", """
+            import source x from 'has-source';
+            globalThis.captured = x;
+            """);
+
+        var engine = CreateEngine(loader);
+        engine.Modules.Import("main");
+
+        engine.Evaluate("globalThis.captured.kind").AsString().Should().Be("host-source");
+        engine.Evaluate("globalThis.captured").Should().BeSameAs(loader.Provided);
+    }
+
+    [Fact]
+    public void DynamicImportSourceOfAModuleWithoutASourceRejectsWithSyntaxError()
+    {
+        // ContinueDynamicImport step 3.b: "If moduleSource is empty ... a newly created SyntaxError object".
+        var loader = new SourceProvidingModuleLoader();
+        loader.AddModule("main", """
+            globalThis.errorName = null;
+            import.source('plain').then(
+                () => { globalThis.errorName = 'fulfilled'; },
+                e => { globalThis.errorName = e.constructor.name; });
+            """);
+
+        var engine = CreateEngine(loader);
+        engine.Modules.Import("main");
+
+        engine.Evaluate("globalThis.errorName").AsString().Should().Be("SyntaxError");
+    }
+
+    [Fact]
+    public void StaticImportSourceOfAModuleWithoutASourceThrowsSyntaxError()
+    {
+        // InitializeEnvironment step 7.c.ii: "If moduleSourceObject is empty, throw a SyntaxError exception."
+        var loader = new SourceProvidingModuleLoader();
+        loader.AddModule("main", "import source x from 'plain';");
+
+        var engine = CreateEngine(loader);
+
+        var ex = Assert.Throws<JavaScriptException>(() => engine.Modules.Import("main"));
+        ex.Error.Get("name").AsString().Should().Be("SyntaxError");
+    }
+
+    [Fact]
+    public void SourcePhaseImportDoesNotEvaluateTheModule()
+    {
+        // The source phase stops before Link and Evaluate, so the module body never runs.
+        var loader = new SourceProvidingModuleLoader();
+        loader.AddModule("has-source", "globalThis.evaluated = true; export const x = 1;");
+        loader.AddModule("main", """
+            import source x from 'has-source';
+            globalThis.captured = x;
+            globalThis.wasEvaluated = globalThis.evaluated === true;
+            """);
+
+        var engine = CreateEngine(loader);
+        engine.Modules.Import("main");
+
+        engine.Evaluate("globalThis.wasEvaluated").AsBoolean().Should().BeFalse();
+        engine.Evaluate("globalThis.captured").Should().BeSameAs(loader.Provided);
+    }
+}

--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -141,12 +141,6 @@
     "staging/sm/Symbol/keyFor.js",
     "staging/sm/module/module-export-name-star.js",
 
-    // Source phase imports (stage 3): Jint supports the phase for WebAssembly-shaped sources only,
-    // so `import source` of a JavaScript module is refused outright and the prototype chain of an
-    // AbstractModuleSource is not the one the proposal describes.
-    "staging/source-phase-imports/import-source-source-text-module.js",
-    "staging/source-phase-imports/module-source-prototype-chain.js",
-
     // === PERMANENT EXCLUSIONS ===
     //
     // Everything above this banner is debt: a gap somebody is expected to pay down, each entry saying

--- a/Jint.Tests.Test262/Test262ModuleLoader.cs
+++ b/Jint.Tests.Test262/Test262ModuleLoader.cs
@@ -1,6 +1,5 @@
 #nullable enable
 
-using Jint.Native;
 using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Modules;
@@ -36,18 +35,22 @@ internal sealed class Test262ModuleLoader : ModuleLoader
             return null;
         }
 
-        // $262 (and thus $262.AbstractModuleSource) is installed before any module is imported. The synthetic
-        // [[ModuleSource]] must have %AbstractModuleSource%.prototype on its chain so that the source-phase
-        // binding passes `x instanceof $262.AbstractModuleSource`.
+        // $262 (and thus $262.AbstractModuleSource) is installed before any module is imported.
         if (engine.GetValue("$262") is not ObjectInstance dollar262
             || dollar262.Get("AbstractModuleSource") is not ObjectInstance ctor
-            || ctor.Get("prototype") is not ObjectInstance prototype)
+            || ctor.Get("prototype") is not ObjectInstance abstractModuleSourcePrototype)
         {
             return null;
         }
 
-        var source = engine.Realm.Intrinsics.Object.Construct(System.Array.Empty<JsValue>());
-        source.SetPrototypeOf(prototype);
+        // https://tc39.es/proposal-source-phase-imports/#sec-module-source-objects: "A Module Source Object is
+        // an object whose initial [[Prototype]] is an object whose initial [[Prototype]] is
+        // %AbstractModuleSource%.prototype." Two levels, because a real host exposes a concrete module source
+        // *class* (WebAssembly.Module) that subclasses %AbstractModuleSource% and hands out instances of it.
+        // Stand in for that class with a per-module prototype: `x instanceof $262.AbstractModuleSource` still
+        // holds, and Object.getPrototypeOf(Object.getPrototypeOf(x)) is %AbstractModuleSource%.prototype.
+        var sourcePrototype = ObjectInstance.OrdinaryObjectCreate(engine, abstractModuleSourcePrototype);
+        var source = ObjectInstance.OrdinaryObjectCreate(engine, sourcePrototype);
         return source;
     }
 

--- a/Jint.Tests/Runtime/ModuleTests.cs
+++ b/Jint.Tests/Runtime/ModuleTests.cs
@@ -1082,8 +1082,10 @@ export const count = globals.counter;
         _engine.Modules.Import("main");
 
         _engine.Evaluate("globalThis.rejected").AsBoolean().Should().BeTrue();
-        // SourceTextModules don't have a source representation; rejection type is host-defined.
-        _engine.Evaluate("globalThis.errorName").IsNull().Should().BeFalse();
+        // A SourceTextModule's [[ModuleSource]] is empty, and step 3.b of
+        // https://tc39.es/proposal-source-phase-imports/#sec-ContinueDynamicImport rejects with
+        // "a newly created SyntaxError object" for exactly that case.
+        _engine.Evaluate("globalThis.errorName").AsString().Should().Be("SyntaxError");
     }
 
     [Fact]
@@ -1093,8 +1095,10 @@ export const count = globals.counter;
         _engine.Modules.Add("main", "import source x from 'dep';");
 
         var ex = Invoking(() => _engine.Modules.Import("main")).Should().ThrowExactly<JavaScriptException>().Which;
-        // Must not be SyntaxError per test262 expectations for SourceTextModule source phase.
-        ex.Error.Get("name").AsString().Should().NotBe("SyntaxError");
+        // Step 7.c.ii of
+        // https://tc39.es/proposal-source-phase-imports/#sec-source-text-module-record-initialize-environment:
+        // "If moduleSourceObject is empty, throw a SyntaxError exception."
+        ex.Error.Get("name").AsString().Should().Be("SyntaxError");
     }
 
     [Fact]

--- a/Jint/Runtime/Host.cs
+++ b/Jint/Runtime/Host.cs
@@ -205,11 +205,22 @@ public class Host
     /// </remarks>
     internal virtual void ContinueDynamicImport(Module module, ModuleRequest moduleRequest, PromiseCapability payload)
     {
-        // Source phase: SourceTextModules don't support source phase imports.
+        // Step 3 of https://tc39.es/proposal-source-phase-imports/#sec-ContinueDynamicImport: a source-phase
+        // import settles here and goes no further — the module is never linked or evaluated. It resolves with
+        // the module's [[ModuleSource]], and rejects with a SyntaxError only when that slot is empty, which is
+        // the case for every ECMA-262 module record (a JavaScript module has no source representation).
         if (moduleRequest.Phase == ModuleImportPhase.Source)
         {
-            var error = Engine.Realm.Intrinsics.SyntaxError.Construct("Source phase import is not supported for JavaScript modules");
-            payload.Reject(error);
+            var moduleSource = module.ModuleSource;
+            if (moduleSource is null)
+            {
+                payload.Reject(Engine.Realm.Intrinsics.SyntaxError.Construct("Source phase import is not supported for this module"));
+            }
+            else
+            {
+                payload.Resolve(moduleSource);
+            }
+
             return;
         }
 

--- a/Jint/Runtime/Modules/SourceTextModule.cs
+++ b/Jint/Runtime/Modules/SourceTextModule.cs
@@ -230,10 +230,11 @@ internal class SourceTextModule : CyclicModule
                     var source = importedModule.ModuleSource;
                     if (source is null)
                     {
-                        // The module has no [[ModuleSource]] (e.g. an ordinary JavaScript module). Throw a
-                        // TypeError rather than SyntaxError — test262 `import-source.js` expects a
-                        // host-defined non-SyntaxError rejection for this case.
-                        Throw.TypeError(_realm, "Source phase import is not supported for this module");
+                        // Step 7.c.ii of
+                        // https://tc39.es/proposal-source-phase-imports/#sec-source-text-module-record-initialize-environment:
+                        // "If moduleSourceObject is empty, throw a SyntaxError exception." Empty is the case for
+                        // every ECMA-262 module record, an ordinary JavaScript module included.
+                        Throw.SyntaxError(_realm, "Source phase import is not supported for this module");
                     }
 
                     env.CreateImmutableBinding(ie.LocalName, strict: true);


### PR DESCRIPTION
Frees the last two `staging/` exclusions for source phase imports, from the group indexed by #3021.

## What the exclusion comment claimed

> Source phase imports (stage 3): Jint supports the phase for WebAssembly-shaped sources only, so `import source` of a JavaScript module is refused outright and the prototype chain of an AbstractModuleSource is not the one the proposal describes.

Both halves are wrong, in different directions.

**"`import source` of a JavaScript module is refused outright"** describes the *required* behaviour, not a defect. No ECMA-262 module record has a source representation, and both tests here assert that the refusal happens — they only disagree with Jint about the error type. `staging/source-phase-imports/import-source-source-text-module.js` is titled "GetModuleSource of SourceTextModule throws a SyntaxError", and Jint's dynamic path already got that right. The static path did not:

```
Test262Error: Promise should be rejected with SyntaxError in indirect import source
Expected a SyntaxError to be thrown asynchronously but got a TypeError
```

**"Jint supports the phase for WebAssembly-shaped sources only"** overstates what worked. `Host.ContinueDynamicImport` rejected *every* source-phase dynamic import with a SyntaxError before it ever looked at the module, so a host that did supply a `[[ModuleSource]]` through the public `ModuleLoader.GetModuleSource` hook could reach it only through the static `import source x from` form — `import.source()` was dead for everyone:

```
staging/source-phase-imports/module-source-prototype-chain.js
System.Exception: SyntaxError: Source phase import is not supported for JavaScript modules
```

That test never gets as far as inspecting a prototype chain, so the comment's second claim was a guess. The chain *was* also wrong, but the object in question is built by Jint's own test262 host glue rather than by the engine.

## The spec

[Stage 3 draft, 25 March 2026](https://tc39.es/proposal-source-phase-imports/).

[ContinueDynamicImport](https://tc39.es/proposal-source-phase-imports/#sec-ContinueDynamicImport) step 3 — a source-phase import settles there and is never linked or evaluated:

> 3. If _phase_ is ~source~, then
>    a. Let _moduleSource_ be _module_.[[ModuleSource]].
>    b. If _moduleSource_ is ~empty~, then Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « a newly created *SyntaxError* object »).
>    c. Else, Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, « _moduleSource_ »).
>    d. Return ~unused~.

[InitializeEnvironment](https://tc39.es/proposal-source-phase-imports/#sec-source-text-module-record-initialize-environment) step 7.c:

> c. Else if _in_.[[ImportName]] is ~source~, then
>    i. Let _moduleSourceObject_ be _importedModule_.[[ModuleSource]].
>    ii. If _moduleSourceObject_ is ~empty~, throw a *SyntaxError* exception.

[Module Source Objects](https://tc39.es/proposal-source-phase-imports/#sec-module-source-objects):

> A Module Source Object is an object whose initial [[Prototype]] is an object whose initial [[Prototype]] is %AbstractModuleSource%.prototype.

Two levels, because a host exposes a concrete module source *class* (`WebAssembly.Module`) that subclasses `%AbstractModuleSource%` and hands out instances of it.

## What changed

- `Jint/Runtime/Host.cs` — `ContinueDynamicImport` now performs step 3 as written: resolve with `module.ModuleSource`, reject with a `SyntaxError` only when the slot is empty. The module has already been loaded when this runs (`DynamicImportPayload.Continue` hands it over), so this is exactly the spec's `moduleCompletion`.
- `Jint/Runtime/Modules/SourceTextModule.cs` — `InitializeEnvironment`'s empty-slot case throws a `SyntaxError` rather than a `TypeError`. The comment it replaces cited `language/module-code/source-phase-import/import-source.js` as requiring a non-`SyntaxError`; that test's fixtures import from `'<do not resolve>'` and fail during *loading*, so they never reach this step. It still passes.
- `Jint.Tests.Test262/Test262ModuleLoader.cs` — the stand-in `[[ModuleSource]]` for test262's `<module source>` specifier gets the two-level prototype chain the proposal defines. `x instanceof $262.AbstractModuleSource` still holds.
- `Jint.Tests/Runtime/ModuleTests.cs` — two existing tests pinned the old behaviour, one of them asserting `NotBe("SyntaxError")` for precisely the case the spec says is a `SyntaxError`. Both now assert the spec's error type.
- `Jint.Tests.PublicInterface/HostModuleSourcePhaseTests.cs` (new) — five tests over a third-party `ModuleLoader` overriding `GetModuleSource`, covering both directions of both forms plus the promise that the source phase does not evaluate the module. Two of them fail on `main` (`"rejected"` vs `"fulfilled"`, and `"TypeError"` vs `"SyntaxError"`).

## Files this frees

- `staging/source-phase-imports/import-source-source-text-module.js`
- `staging/source-phase-imports/module-source-prototype-chain.js`

## Verification

| filter | result |
| --- | --- |
| `~staging/source-phase-imports` | 4/4 (was 0/4) |
| `~source-phase` | 8/8 |
| `~built-ins/AbstractModuleSource` | 8/8 |
| `~language/module-code` | 601/601 |
| `~language/expressions/dynamic-import` | 1900/1900 |
| `~language/import` | 135/135 |
| `Jint.Tests` | 6281 net10.0 / 6196 net472 |
| `Jint.Tests.PublicInterface` | 1493 net10.0 / 1492 net472 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
