### PR TITLE
Parse a dynamic function's parameter and body strings as wholes of their own

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -82,15 +82,42 @@
     "staging/sm/Set/intersection.js",
     "staging/sm/Set/is-subset-of.js",
 
-    // Parser early errors that Acornima does not raise, or raises as the wrong error type: an
-    // invalid parameter list, `super()` inside an arrow inside a direct eval in a derived
-    // constructor, a destructuring pattern with a duplicate binding, a legacy octal literal in
-    // strict mode, and a field initializer's TDZ.
-    "staging/sm/Function/invalid-parameter-list.js",
+    // Acornima (the external parser) rejects a SuperCall inside a direct eval. Jint already parses
+    // eval code with AllowSuperOutsideMethod, but that covers SuperProperty only; Acornima 1.7.0 has
+    // no separate switch for a direct `super()`, so `eval("super()")` in a derived constructor fails
+    // to parse with "'super' keyword unexpected here" instead of running. PerformEval only forbids it
+    // when inDerivedConstructor is false (https://tc39.es/ecma262/#sec-performeval), which Jint
+    // already computes. Removed by adams85/acornima#44 (ParserOptions.AllowDirectSuperOutsideMethod,
+    // still a draft) plus a release and wiring the option in EvalFunction. bug1587574 is the same
+    // defect and not a field initializer's TDZ: its `class Q { f = 1; }` exists only to defeat
+    // SpiderMonkey's lazy parsing, and the ReferenceError it expects is the derived constructor's
+    // `this` TDZ, raised because the eval'd `super()` sits inside arrows that are never called.
     "staging/sm/class/derivedConstructorArrowEvalNestedSuperCall.js",
     "staging/sm/class/derivedConstructorArrowEvalSuperCall.js",
-    "staging/sm/destructuring/bug1396261.js",
     "staging/sm/fields/bug1587574.js",
+
+    // Acornima does not re-raise the CoverInitializedName early error when an object literal carrying
+    // a shorthand-with-initializer ends up as the *object of a member expression* inside a
+    // destructuring target. `[{a = 0}] = []` is valid because `{a = 0}` is refined into an
+    // ObjectAssignmentPattern, but in `[{a = 0}.x] = []` the element is the member expression
+    // `{a = 0}.x`, so `{a = 0}` stays an ObjectLiteral and
+    // https://tc39.es/ecma262/#sec-object-initializer-static-semantics-early-errors applies:
+    // "PropertyDefinition : CoverInitializedName - It is a Syntax Error if any source text is matched
+    // by this production." Jint accepts all four such forms. Reported as adams85/acornima#46; the
+    // valid halves of this file already pass.
+    "staging/sm/destructuring/bug1396261.js",
+
+    // Acornima scans the token immediately after an ASI-terminated `"use strict"` directive before it
+    // applies the directive, so a legacy octal literal or a legacy-octal/\8/\9 escape appearing in
+    // exactly that token escapes the strict-mode early errors of
+    // https://tc39.es/ecma262/#sec-numeric-literals-early-errors and
+    // https://tc39.es/ecma262/#sec-string-literals-early-errors. A `"use strict"` line followed by a
+    // line holding just `0755` is accepted, while the same pair with an explicit semicolon after the
+    // directive, or with any statement between the two, is correctly rejected — the strictness itself
+    // is applied either way (`with`, duplicate parameters and `arguments =` are all caught).
+    // Only the sloppy run fails; in the strict run the harness's own prologue makes the tokenizer
+    // strict from the first character. The file's checkPrologue half already passes. Reported as
+    // adams85/acornima#47.
     "staging/sm/strict/deprecated-octal-noctal-tokens.js",
 
     // Argument validation raising no error, or the wrong one: a bad this or a bad index reaching a

--- a/Jint.Tests/Runtime/DynamicFunctionSourceTests.cs
+++ b/Jint.Tests/Runtime/DynamicFunctionSourceTests.cs
@@ -1,0 +1,98 @@
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// CreateDynamicFunction assembles <c>function anonymous(&lt;params&gt;\n) {\n&lt;body&gt;\n}</c> and then
+/// parses the parameter string and the body string on their own before parsing that assembly, "to
+/// ensure that each is valid alone" (https://tc39.es/ecma262/#sec-createdynamicfunction, steps 17-24).
+/// Jint used to parse the assembled source only, so an argument string that reached across the
+/// boundaries the assembly inserted — an unterminated comment or template swallowing the closing
+/// parenthesis, a parameter string closing the list itself, a body string closing the function and
+/// continuing with statements of its own — produced a function instead of a SyntaxError.
+/// </summary>
+public class DynamicFunctionSourceTests
+{
+    // The five cases from test262's staging/sm/Function/invalid-parameter-list.js. Each pair is
+    // otherwise syntactically valid: assembled without the line feed the spec inserts after the
+    // parameters, every one of them parses.
+    [Theory]
+    [InlineData("/*", "*/) {")]
+    [InlineData("//", ") {")]
+    [InlineData("a = `", "` ) {")]
+    [InlineData(") { var x = function (", "} ")]
+    [InlineData("x = function (", "}) {")]
+    public void ParameterStringMayNotReachPastTheParameterList(string parameters, string body)
+    {
+        var engine = new Engine();
+        engine.SetValue("p", parameters);
+        engine.SetValue("b", body);
+
+        Invoking(() => engine.Evaluate("new Function(p, b)")).Should().ThrowExactly<JavaScriptException>()
+            .Which.Error.Get("name").AsString().Should().Be("SyntaxError");
+    }
+
+    [Theory]
+    [InlineData("} function g() {")]
+    [InlineData("} ; {")]
+    [InlineData("} , {")]
+    public void BodyStringMayNotCloseTheFunctionAndContinue(string body)
+    {
+        var engine = new Engine();
+        engine.SetValue("b", body);
+
+        Invoking(() => engine.Evaluate("new Function('a', b)")).Should().ThrowExactly<JavaScriptException>()
+            .Which.Error.Get("name").AsString().Should().Be("SyntaxError");
+    }
+
+    [Fact]
+    public void RejectionSurvivesTheCompilationCache()
+    {
+        // The compilation cache promotes a source on its second sighting, so a rejected source must
+        // stay rejected rather than being answered from a poisoned entry.
+        var engine = new Engine();
+        for (var i = 0; i < 3; i++)
+        {
+            Invoking(() => engine.Evaluate("new Function('/*', '*/) {')")).Should().ThrowExactly<JavaScriptException>();
+        }
+    }
+
+    [Theory]
+    // Parameter strings that legitimately contain the characters the check keys on: a comment, a
+    // nested parenthesis, a nested function body, a template, a destructuring pattern, a trailing
+    // comma and an embedded line feed. Every one of them must still compile to a working function.
+    [InlineData("a /* comment */, b", "return a + b", "1, 2")]
+    [InlineData("a = (1 + 2)", "return a", "")]
+    [InlineData("a = function () { return 3; }", "return a()", "")]
+    [InlineData("a = `x${22}`", "return a.length", "")]
+    [InlineData("{ a, b }", "return a + b", "{ a: 1, b: 2 }")]
+    [InlineData("a,", "return a", "3")]
+    [InlineData("a\n, b", "return a + b", "1, 2")]
+    [InlineData("...a", "return a.length", "0, 0, 0")]
+    public void ValidArgumentStringsStillCompile(string parameters, string body, string callArguments)
+    {
+        var engine = new Engine();
+        engine.SetValue("p", parameters);
+        engine.SetValue("b", body);
+
+        engine.Evaluate($"new Function(p, b)({callArguments})").AsNumber().Should().Be(3);
+    }
+
+    [Theory]
+    [InlineData("Object.getPrototypeOf(function* () {}).constructor", "yield a")]
+    [InlineData("Object.getPrototypeOf(async function () {}).constructor", "return a")]
+    [InlineData("Object.getPrototypeOf(async function* () {}).constructor", "yield a")]
+    public void TheCheckAccountsForEachFunctionKindsPrefix(string constructorExpression, string body)
+    {
+        var engine = new Engine();
+        engine.SetValue("b", body);
+
+        // A valid parameter string is accepted for every kind: the expected body offset is derived
+        // from that kind's own source prefix, which is longer than "function anonymous(".
+        engine.Evaluate($"typeof new ({constructorExpression})('a', b)").AsString().Should().Be("function");
+
+        Invoking(() => engine.Evaluate($"new ({constructorExpression})('/*', '*/) {{')"))
+            .Should().ThrowExactly<JavaScriptException>()
+            .Which.Error.Get("name").AsString().Should().Be("SyntaxError");
+    }
+}

--- a/Jint/Native/Function/FunctionInstance.Dynamic.cs
+++ b/Jint/Native/Function/FunctionInstance.Dynamic.cs
@@ -94,54 +94,30 @@ public partial class Function
         JintFunctionDefinition? definition = null;
         try
         {
-            string? functionExpression = null;
-            if (argCount == 0)
+            string? prefix = null;
+            switch (kind)
             {
-                switch (kind)
-                {
-                    case FunctionKind.Normal:
-                        functionExpression = "function anonymous(\n) {\n\n}";
-                        break;
-                    case FunctionKind.Generator:
-                        functionExpression = "function* anonymous(\n) {\n\n}";
-                        break;
-                    case FunctionKind.Async:
-                        functionExpression = "async function anonymous(\n) {\n\n}";
-                        break;
-                    case FunctionKind.AsyncGenerator:
-                        functionExpression = "async function* anonymous(\n) {\n\n}";
-                        break;
-                    default:
-                        Throw.ArgumentOutOfRangeException(nameof(kind), kind.ToString());
-                        break;
-                }
+                case FunctionKind.Normal:
+                    prefix = "function anonymous(";
+                    break;
+                case FunctionKind.Async:
+                    prefix = "async function anonymous(";
+                    break;
+                case FunctionKind.Generator:
+                    prefix = "function* anonymous(";
+                    break;
+                case FunctionKind.AsyncGenerator:
+                    prefix = "async function* anonymous(";
+                    break;
+                default:
+                    Throw.ArgumentOutOfRangeException(nameof(kind), kind.ToString());
+                    break;
             }
-            else
-            {
-                switch (kind)
-                {
-                    case FunctionKind.Normal:
-                        functionExpression = "function anonymous(";
-                        break;
-                    case FunctionKind.Async:
-                        functionExpression = "async function anonymous(";
-                        break;
-                    case FunctionKind.Generator:
-                        functionExpression = "function* anonymous(";
-                        break;
-                    case FunctionKind.AsyncGenerator:
-                        functionExpression = "async function* anonymous(";
-                        break;
-                    default:
-                        Throw.ArgumentOutOfRangeException(nameof(kind), kind.ToString());
-                        break;
-                }
 
-                // Per spec (CreateDynamicFunction step 29), a line feed follows the parameters,
-                // and the body is wrapped with line feeds (step 16). This ensures HTML-like
-                // comments (<!-- and -->) are correctly handled as line comments.
-                functionExpression += p + "\n) {\n" + body + "\n}";
-            }
+            // Per spec (CreateDynamicFunction step 15), a line feed follows the parameters, and the
+            // body is wrapped with line feeds (step 14). This ensures HTML-like comments (<!-- and -->)
+            // are correctly handled as line comments.
+            var functionExpression = prefix + p + "\n) {\n" + body + "\n}";
 
             var parserOptions = _engine.GetActiveParserOptions();
             if (!parserOptions.AllowReturnOutsideFunction)
@@ -152,7 +128,7 @@ public partial class Function
             // Compilation cache for repeated new Function(...) with identical sources: the parsed
             // function definition is shared (like closures sharing one definition); the resulting
             // Function object below is always a fresh instance. Parse failures are never cached.
-            var cacheable = functionExpression!.Length <= DynamicFunctionCacheMaxSourceLength;
+            var cacheable = functionExpression.Length <= DynamicFunctionCacheMaxSourceLength;
             var cacheKey = new DynamicFunctionCacheKey(functionExpression, _engine._isStrict);
             var cache = _realm._dynamicFunctionCache;
             if (cacheable
@@ -165,11 +141,12 @@ public partial class Function
             else
             {
                 Parser parser = new(parserOptions);
-                // CreateDynamicFunction step 21 throws its SyntaxError in the current realm, and the
+                // CreateDynamicFunction step 24 throws its SyntaxError in the current realm, and the
                 // current realm while a built-in runs is the built-in's own [[Realm]] — not the caller's.
                 // Jint does not push an execution context for a built-in call, so _engine.ExecutionContext
                 // still describes the caller here and only _realm names the callee.
-                var function = (IFunction) parser.ParseScriptGuarded(_realm, functionExpression, strict: _engine._isStrict).Body[0];
+                var script = parser.ParseScriptGuarded(_realm, functionExpression, strict: _engine._isStrict);
+                var function = ValidateDynamicFunctionShape(script, prefix!.Length, p.Length);
                 definition = new JintFunctionDefinition(function)
                 {
                     IsDynamic = true,
@@ -223,6 +200,52 @@ public partial class Function
         }
 
         return F;
+    }
+
+    /// <summary>
+    /// Enforces CreateDynamicFunction steps 17-24 for a source assembled by
+    /// <see cref="CreateDynamicFunction"/>: the spec parses <c>paramString</c> and
+    /// <c>bodyParseString</c> on their own (steps 17-20) before parsing the assembled source as a
+    /// single function expression (steps 23-24), "to ensure that each is valid alone. For example,
+    /// new Function("/*", "*/ ) {") does not evaluate to a function."
+    /// https://tc39.es/ecma262/#sec-createdynamicfunction
+    /// </summary>
+    /// <remarks>
+    /// Reparsing both halves would cost two extra parses on every <c>new Function(...)</c> that misses
+    /// the compilation cache, so the single parse is checked against the two source positions the
+    /// assembled text fixed in advance — which is exactly as strict, because the assembly interleaves
+    /// nothing else with the two argument strings.
+    /// <list type="bullet">
+    /// <item>The body's <c>{</c> can only sit at <c>prefixLength + parameterLength + 3</c> when the
+    /// <c>)</c> the spec inserted after the parameters is the one that closed the parameter list, so
+    /// the text the parser accepted as parameters is exactly the parameter string. A smaller offset
+    /// means the parameter string closed the list itself; a larger one means it swallowed the inserted
+    /// <c>)</c> inside an unterminated comment, template or nested parenthesis.</item>
+    /// <item>A parse yielding more than one statement is a body string that closed the function early
+    /// and continued with statements of its own, which a standalone <c>FunctionBody</c> parse rejects
+    /// and which step 23's single <c>FunctionExpression</c> goal rejects as well.</item>
+    /// </list>
+    /// </remarks>
+    private IFunction ValidateDynamicFunctionShape(Script script, int prefixLength, int parameterLength)
+    {
+        var parsed = script.Body.Count == 1 ? script.Body[0] as IFunction : null;
+        if (parsed is null)
+        {
+            Throw.SyntaxError(_realm, "Function body string is not a complete function body");
+        }
+
+        // prefixLength + parameterLength addresses the line feed the assembly inserted after the
+        // parameters; the ')' and the space follow it, so the body's '{' is three characters further on.
+        var expectedBodyStart = prefixLength + parameterLength + 3;
+        var actualBodyStart = parsed.Body.Start;
+        if (actualBodyStart != expectedBodyStart)
+        {
+            Throw.SyntaxError(_realm, actualBodyStart < expectedBodyStart
+                ? "Function parameter string terminates the parameter list early"
+                : "Function parameter string is not a complete parameter list");
+        }
+
+        return parsed;
     }
 
     /// <summary>


### PR DESCRIPTION
Part of #3021 (wave 2). This workstream owned six `staging/` exclusions filed under one comment
saying "Parser early errors that Acornima does not raise, or raises as the wrong error type".

That diagnosis was wrong in both directions, so the triage came first. One file is Jint's and is
fixed here; the other five are defects in Acornima, the external parser, and stay excluded with
prose that names the actual defect and what would remove it.

## The one that was Jint's — `staging/sm/Function/invalid-parameter-list.js`

Not a parser problem at all. [CreateDynamicFunction](https://tc39.es/ecma262/#sec-createdynamicfunction)
assembles `function anonymous(<params>\n) {\n<body>\n}` (steps 14-15) and then parses `paramString`
and `bodyParseString` **on their own** (steps 17-20) before parsing that assembly as a single
function expression (steps 23-24). The spec's own note names the case:

> The parameters and body are parsed separately to ensure that each is valid alone. For example,
> `new Function("/*", "*/ ) {")` does not evaluate to a function.

Jint parsed the assembly only, and took `Body[0]` from the resulting script. So an argument string
that reached across a boundary the assembly inserted produced a working function. Before this change:

```
new Function("/*", "*/) {")                  -> a function (should be SyntaxError)
new Function("a = `", "` ) {")               -> a function
new Function(") { var x = function (", "} ") -> a function
new Function("x = function (", "}) {")       -> a function
new Function("a", "} function g() {")        -> a function, silently discarding `function g`
```

Four of the test's five cases plus the trailing-statement case; the fifth (`"//"`, `") {"`) already
failed because the assembly itself does not parse. V8 rejects all of them.

### What changed

`Jint/Native/Function/FunctionInstance.Dynamic.cs` — reparsing both halves would cost two extra
parses on every `new Function(...)` that misses the compilation cache, so the existing single parse
is checked against the two source positions the assembly fixed in advance
(`ValidateDynamicFunctionShape`, with the reasoning in its doc comment):

- the body's `{` can only sit at `prefixLength + parameterLength + 3` when the `)` the spec inserted
  after the parameters is the one that closed the parameter list, so the text the parser accepted as
  parameters is exactly the parameter string;
- the parse can only yield one statement when the body string did not close the function early and
  continue with statements of its own.

The two per-kind switches collapsed into one that yields just the source prefix — the zero-argument
branch built a string character-identical to what the general branch builds, and one construction
site means one place the expected offset is derived from. The stale spec step numbers in the two
comments there are updated to the current edition's.

### Evidence

Pre-fix, with the file un-excluded:

```
Failed Sm_Function("staging/sm/Function/invalid-parameter-list.js",True)
Failed Sm_Function("staging/sm/Function/invalid-parameter-list.js",False)
  Jint.Runtime.JavaScriptException: Expected a SyntaxError to be thrown but no exception was thrown at all
```

Post-fix: `Passed! - Failed: 0, Passed: 2` for that file, and
`Failed: 0, Passed: 1115, Skipped: 5` across `built-ins/Function`, `built-ins/GeneratorFunction`,
`built-ins/AsyncFunction`, `built-ins/AsyncGeneratorFunction` and `staging/sm/Function`;
`Failed: 0, Passed: 2255` across `language/eval-code`, `language/expressions/function`,
`language/statements/function` and `language/directive-prologue`. `Jint.Tests` and
`Jint.Tests.PublicInterface` are green on both target frameworks.

`Jint.Tests/Runtime/DynamicFunctionSourceTests.cs` adds 20 cases (10 of which fail against the
unfixed engine with "Expected Jint.Runtime.JavaScriptException, but no exception was thrown"),
covering the five test262 pairs, body strings that continue past the function, the rejection
surviving the compilation cache's second-sighting promotion, each function kind's own source prefix,
and parameter strings that legitimately contain comments, parentheses, nested function bodies,
templates, patterns, trailing commas, rest elements and line feeds.

## The five that are Acornima's

None of these can be fixed in this repository; the exclusion comments are rewritten to say so
precisely. Each was reproduced against Acornima 1.7.0 (the pinned version) and cross-checked against
V8, which accepts or rejects each one as the spec requires.

**`class/derivedConstructorArrowEvalSuperCall.js`, `class/derivedConstructorArrowEvalNestedSuperCall.js`,
`fields/bug1587574.js`** — a `SuperCall` inside a direct eval. Jint already parses eval code with
`AllowSuperOutsideMethod`, but that covers `SuperProperty` only; Acornima 1.7.0 exposes no separate
switch for a direct `super()`, so `eval("super()")` in a derived constructor fails to parse with
`'super' keyword unexpected here`. [PerformEval](https://tc39.es/ecma262/#sec-performeval) forbids it
only when `inDerivedConstructor` is false, which Jint already computes in `EvalFunction`. The
non-eval halves of those files (`(()=>super())()`, `(()=>(()=>super())())()`) already pass.
adams85/acornima#44 adds `ParserOptions.AllowDirectSuperOutsideMethod` and is still a draft — once
it lands and ships, this is a package bump plus one line in `EvalFunction`.

`fields/bug1587574.js` is the same defect, not "a field initializer's TDZ" as the old comment said:
its `class Q { f = 1; }` exists only to defeat SpiderMonkey's lazy parsing, and the `ReferenceError`
it expects is the derived constructor's `this` TDZ, raised because the eval'd `super()` sits inside
arrows that are never called.

**`destructuring/bug1396261.js`** — not "a destructuring pattern with a duplicate binding". Acornima
does not re-raise the `CoverInitializedName` early error when an object literal carrying a
shorthand-with-initializer ends up as the *object of a member expression* inside a destructuring
target. `[{a = 0}] = []` is valid because `{a = 0}` is refined into an `ObjectAssignmentPattern`, but
in `[{a = 0}.x] = []` the element is the member expression `{a = 0}.x`, so `{a = 0}` stays an
`ObjectLiteral` and [13.2.5.1](https://tc39.es/ecma262/#sec-object-initializer-static-semantics-early-errors)
applies: "`PropertyDefinition : CoverInitializedName` — It is a Syntax Error if any source text is
matched by this production." Jint accepts all four such forms; the file's valid half already passes.

**`strict/deprecated-octal-noctal-tokens.js`** — Jint does not raise "the wrong error type" here; the
first half of the file already passes with the right one. What fails is the second half: Acornima
scans the token immediately after an ASI-terminated `"use strict"` directive *before* it applies the
directive, so a legacy octal literal or a legacy-octal/`\8`/`\9` escape appearing in exactly that one
token escapes the strict-mode early errors of
[12.9.3.1](https://tc39.es/ecma262/#sec-numeric-literals-early-errors) and
[12.9.4.1](https://tc39.es/ecma262/#sec-string-literals-early-errors). The strictness itself is
applied correctly — `with`, duplicate parameters and `arguments =` are all caught — and moving the
literal one statement further on, or terminating the directive with an explicit semicolon, restores
the error. Only the sloppy run fails; in the strict run the harness's own prologue makes the
tokenizer strict from the first character. Not yet reported upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
