### PR TITLE
Write Annex B's block-function var alias when the declaration is evaluated

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -114,16 +114,6 @@
     "staging/sm/fields/bug1587574.js",
     "staging/sm/strict/deprecated-octal-noctal-tokens.js",
 
-    // Annex B B.3.3 block-scoped function hoisting: the var-scoped alias a sloppy-mode block
-    // function creates is not synthesised the way the spec's FunctionDeclarationInstantiation
-    // amendment describes, so the name is visible with the wrong value (or not at all) in the
-    // enclosing function, inside a direct eval, inside `with`, and after a redeclaration.
-    "staging/sm/lexical-environment/block-scoped-functions-annex-b-arguments.js",
-    "staging/sm/lexical-environment/block-scoped-functions-annex-b-eval.js",
-    "staging/sm/lexical-environment/block-scoped-functions-annex-b-with.js",
-    "staging/sm/lexical-environment/block-scoped-functions-deprecated-redecl.js",
-    "staging/sm/regress/regress-602621.js",
-
     // Argument validation raising no error, or the wrong one: a bad this or a bad index reaching a
     // built-in, a NUL-bearing string reaching one, and the order in which a super reference is
     // evaluated against its side effects.
@@ -226,6 +216,19 @@
     // banner it is the entry most likely to be argued back out, and a PR that argues it is welcome.
     "staging/sm/Date/non-iso.js",
     "staging/sm/Date/two-digit-years.js",
+
+    // === STALE TEST ===
+
+    // Written in 2017 against an edition of FunctionDeclarationInstantiation this test quotes in its
+    // own info block - "22.f. Append \"arguments\" to parameterNames" - and superseded by the
+    // normative change that split paramBindings out of paramNames. Today the Annex B condition reads
+    // "paramNames does not contain funcName", so a block-level `function arguments(){}` IS eligible;
+    // only the creation of a NEW var binding is skipped for that name, while the assignment made when
+    // the declaration is evaluated still runs. V8 and SpiderMonkey both answer "function" where this
+    // test demands the arguments object, and staging/sm/lexical-environment/
+    // block-scoped-functions-annex-b-arguments.js in this very suite asserts the opposite of it.
+    // Reported as tc39/test262#5113; tc39/test262#5112 corrects the file. Removed when that lands.
+    "annexB/language/function-code/block-decl-func-skip-arguments.js",
 
     // === INTL402 EXCLUSIONS ===
     // The following tests require full CLDR locale data support which is not available in the default provider.

--- a/Jint.Tests/Runtime/AnnexBBlockFunctionTests.cs
+++ b/Jint.Tests/Runtime/AnnexBBlockFunctionTests.cs
@@ -1,0 +1,203 @@
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Annex B's "Block-Level Function Declarations Web Legacy Compatibility Semantics" - the Normative
+/// Optional step of https://tc39.es/ecma262/#sec-functiondeclarationinstantiation and its
+/// EvalDeclarationInstantiation / GlobalDeclarationInstantiation siblings. A sloppy-mode function
+/// declared in a Block, CaseClause or DefaultClause also gets a var binding in the enclosing variable
+/// environment, and that binding is <em>assigned when the declaration is evaluated</em>, not when the
+/// block is entered.
+/// </summary>
+public class AnnexBBlockFunctionTests
+{
+    [Fact]
+    public void TheVarAliasIsUndefinedUntilTheDeclarationIsEvaluated()
+    {
+        var engine = new Engine();
+
+        // Jint used to write the alias from BlockDeclarationInstantiation, i.e. at block entry, which
+        // made the name visible one or more statements too early. Inside the block the name resolves to
+        // the block's own binding, so the var alias is observed through a closure made before it.
+        engine.Evaluate("(function(){ var probe = function(){ return typeof f; }; var seen; { seen = probe(); function f(){} } return seen + ',' + probe(); })()")
+            .AsString().Should().Be("undefined,function");
+    }
+
+    [Fact]
+    public void TheVarAliasTakesTheBlockBindingsCurrentValueNotTheDeclarationsOwn()
+    {
+        var engine = new Engine();
+
+        // Both declarations are instantiated at block entry, last one winning, so BOTH evaluations
+        // assign the second function - inside the block and after it.
+        engine.Evaluate("(function(){ { function f(){ return 1; } function f(){ return 2; } } return f(); })()")
+            .AsNumber().Should().Be(2);
+        engine.Evaluate("(function(){ var seen = []; { seen.push(f()); function f(){ return 1; } seen.push(f()); function f(){ return 2; } seen.push(f()); } seen.push(f()); return seen.join(','); })()")
+            .AsString().Should().Be("2,2,2,2");
+    }
+
+    [Fact]
+    public void TheVarAliasIsWrittenToTheVariableEnvironmentNotThroughTheScopeChain()
+    {
+        var engine = new Engine();
+
+        // Inside `with`, the LexicalEnvironment resolves `f` on the with object, but the alias goes to
+        // the running VariableEnvironment, so the with object's property is untouched.
+        engine.Evaluate("var o = { f: 'string-f' }; with (o) { function f(){ return 'fun-f'; } } o.f + ',' + f();")
+            .AsString().Should().Be("string-f,fun-f");
+    }
+
+    [Fact]
+    public void TheGlobalVarAliasExistsBeforeTheDeclarationIsEvaluated()
+    {
+        var engine = new Engine();
+
+        // GlobalDeclarationInstantiation creates it with CreateGlobalVarBinding(F, false).
+        engine.Evaluate("var o = {}; with (o) { var d = Object.getOwnPropertyDescriptor(this, 'f'); function f(){} } String(d.value) + ',' + d.writable + ',' + d.enumerable + ',' + d.configurable;")
+            .AsString().Should().Be("undefined,true,true,false");
+    }
+
+    [Fact]
+    public void ABlockFunctionNamedArgumentsAssignsOverTheArgumentsObject()
+    {
+        var engine = new Engine();
+
+        // The eligibility condition is "paramNames does not contain funcName" - paramNames, not
+        // paramBindings, so the implicit `arguments` binding does not disqualify the name. Only the
+        // creation of a NEW var binding is skipped for it; the assignment still runs.
+        engine.Evaluate("(function(){ var before = typeof arguments; { function arguments(){} } return before + ',' + typeof arguments; })()")
+            .AsString().Should().Be("object,function");
+        engine.Evaluate("(function(x){ { function arguments(){} } return typeof arguments; })()")
+            .AsString().Should().Be("function");
+        engine.Evaluate("(function(..._){ { function arguments(){} } return typeof arguments; })()")
+            .AsString().Should().Be("function");
+    }
+
+    [Fact]
+    public void AFormalParameterNamedArgumentsStillBlocksTheAlias()
+    {
+        var engine = new Engine();
+
+        // The other half of the same condition: here paramNames really does contain the name.
+        engine.Evaluate("(function(arguments){ { function arguments(){} } return typeof arguments; })()")
+            .AsString().Should().Be("undefined");
+        engine.Evaluate("(function(f){ { function f(){} } return f; })(1)").AsNumber().Should().Be(1);
+    }
+
+    [Fact]
+    public void ALabelledBlockFunctionIsScopedToTheBlockAndStillGetsTheAlias()
+    {
+        var engine = new Engine();
+
+        // Annex B.3.1 legalizes `l: function f(){}` in sloppy code and every web implementation gives
+        // it the same treatment as the unlabelled form. Jint used to hoist it to the enclosing var
+        // scope outright, so the block's own binding was missing.
+        engine.Evaluate("(function(){ var seen; { seen = f(); l: function f(){ return 1; } } return seen + ',' + f(); })()")
+            .AsString().Should().Be("1,1");
+        engine.Evaluate("(function(){ { function f(){ return 1; } l0: l: function f(){ return 2; } } return f(); })()")
+            .AsNumber().Should().Be(2);
+    }
+
+    [Fact]
+    public void ALabelledFunctionAtTheTopLevelOfAFunctionBodyStillHoists()
+    {
+        var engine = new Engine();
+
+        // TopLevelVarScopedDeclarations sees through the label, so this one is an ordinary hoisted
+        // function declaration - callable before its own statement.
+        engine.Evaluate("(function(){ var seen = f(); l: function f(){ return 1; } return seen; })()")
+            .AsNumber().Should().Be(1);
+    }
+
+    [Fact]
+    public void ACaseClauseFunctionGetsTheAliasWhenItsClauseIsReached()
+    {
+        var engine = new Engine();
+
+        // As for a Block: the whole CaseBlock's declarations are instantiated on entry, so the alias is
+        // what distinguishes "reached" from "not reached" and is observed through an outside closure.
+        engine.Evaluate("(function(){ var probe = function(){ return typeof f; }; var seen; switch (1) { case 1: seen = probe(); case 2: function f(){} } return seen + ',' + probe(); })()")
+            .AsString().Should().Be("undefined,function");
+        engine.Evaluate("(function(){ var probe = function(){ return typeof f; }; switch (1) { case 1: break; case 2: function f(){} } return probe(); })()")
+            .AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void ALexicalDeclarationOfTheSameNameSuppressesTheAlias()
+    {
+        var engine = new Engine();
+
+        // "replacing the FunctionDeclaration with a VariableStatement ... would not produce any Early
+        // Errors" - a global lexical declaration of the name makes that replacement an early error, so
+        // GlobalDeclarationInstantiation creates no global var binding and nothing is assigned.
+        engine.Evaluate("let f; { function f(){} } typeof Object.getOwnPropertyDescriptor(this, 'f');")
+            .AsString().Should().Be("undefined");
+
+        // control: the same shape without the lexical declaration does create the property
+        new Engine().Evaluate("{ function f(){} } typeof Object.getOwnPropertyDescriptor(this, 'f');")
+            .AsString().Should().Be("object");
+    }
+
+    [Fact]
+    public void AnEvalIntroducedAliasSurvivesADeleteOfTheBindingItCreated()
+    {
+        var engine = new Engine();
+
+        // EvalDeclarationInstantiation settles eligibility once, up front. The var binding it creates
+        // is deletable, so deleting it before the block runs must not turn the alias off - the
+        // assignment recreates it (SetMutableBinding on a missing sloppy binding).
+        engine.Evaluate("(function(){ eval('var seen = (delete q); { function q(){ return 1; } }'); return seen + ',' + q(); })()")
+            .AsString().Should().Be("true,1");
+    }
+
+    [Fact]
+    public void AnEvalAliasTargetsTheVariableEnvironmentThroughAWith()
+    {
+        var engine = new Engine();
+
+        engine.Evaluate(
+            """
+            (function f() {
+              function g() { return 'outer-g'; }
+              var o = { g: function () { return 'with-g'; } };
+              with (o) {
+                eval('{ function g() { return "eval-g"; } }');
+              }
+              return g() + ',' + o.g();
+            })()
+            """).AsString().Should().Be("eval-g,with-g");
+    }
+
+    [Fact]
+    public void ADestructuredCatchParameterSuppressesTheEvalAlias()
+    {
+        var engine = new Engine();
+
+        // B.3.4 exempts only a simple BindingIdentifier catch parameter, so `catch ({ f })` makes the
+        // VariableStatement replacement an early error and the extension is not observed at all.
+        engine.Evaluate("(function(){ eval('try { throw {}; } catch ({ f }) {{ function f(){} }}'); return typeof f; })()")
+            .AsString().Should().Be("undefined");
+
+        // ...while a simple one does not.
+        engine.Evaluate("(function(){ eval('try { throw 1; } catch (f) {{ function f(){} }}'); return typeof f; })()")
+            .AsString().Should().Be("function");
+    }
+
+    [Fact]
+    public void AStrictBlockFunctionGetsNoAlias()
+    {
+        var engine = new Engine();
+
+        engine.Evaluate("(function(){ 'use strict'; { function f(){} } return typeof f; })()")
+            .AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void AGeneratorOrAsyncBlockDeclarationGetsNoAlias()
+    {
+        var engine = new Engine();
+
+        // B.3.2 covers FunctionDeclaration only.
+        engine.Evaluate("(function(){ { function* f(){} } return typeof f; })()").AsString().Should().Be("undefined");
+        engine.Evaluate("(function(){ { async function f(){} } return typeof f; })()").AsString().Should().Be("undefined");
+    }
+}

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -532,6 +532,18 @@ public sealed partial class Engine : IDisposable
     internal int _envBindingInjectionEpoch;
 
     /// <summary>
+    /// The block-level function declarations of the sloppy direct or indirect eval whose body is
+    /// currently running - the Annex B B.3.2 candidates its EvalDeclarationInstantiation considered.
+    /// Null outside an eval body and for a strict one. Set and restored by
+    /// <see cref="Jint.Native.Function.EvalFunction"/>; read by
+    /// <c>JintFunctionDeclarationStatement</c>, which has no other route back to the eval's static
+    /// analysis. Function code answers the same question from its own
+    /// <c>JintFunctionDefinition.State</c> instead, and script/global-eval code from the global
+    /// environment, so this covers only the eval-inside-a-function case.
+    /// </summary>
+    internal List<FunctionDeclaration>? _evalAnnexBFunctions;
+
+    /// <summary>
     /// The realm <c>InitializeHostDefinedRealm</c> created for this engine, as opposed to
     /// <see cref="Realm"/>, which is whichever realm the running execution context names. Assigned once, in
     /// <c>Reset()</c>, and never replaced.

--- a/Jint/HoistingScope.cs
+++ b/Jint/HoistingScope.cs
@@ -211,7 +211,13 @@ internal sealed class HoistingScope
             _module = module;
         }
 
-        public void Visit(Node node, Node? parent, HashSet<string>? enclosingLexicalNames = null)
+        // labelHost / labelHostParent: when `node` is a LabelledStatement, the statement-list container
+        // the label chain sits in and that container's own parent. A LabelledStatement is transparent
+        // for the FunctionDeclaration classification below - TopLevelVarScopedDeclarations sees through
+        // the label (so `l: function f(){}` at the top level of a script or function body hoists like
+        // any other function declaration) while VarScopedDeclarations does not (so inside a Block it is
+        // scoped to that Block).
+        public void Visit(Node node, Node? parent, HashSet<string>? enclosingLexicalNames = null, Node? labelHost = null, Node? labelHostParent = null)
         {
             if (++_depth > MaxDepth)
             {
@@ -220,7 +226,7 @@ internal sealed class HoistingScope
             }
             try
             {
-                VisitCore(node, parent, enclosingLexicalNames);
+                VisitCore(node, parent, enclosingLexicalNames, labelHost, labelHostParent);
             }
             finally
             {
@@ -228,7 +234,7 @@ internal sealed class HoistingScope
             }
         }
 
-        private void VisitCore(Node node, Node? parent, HashSet<string>? enclosingLexicalNames)
+        private void VisitCore(Node node, Node? parent, HashSet<string>? enclosingLexicalNames, Node? labelHost = null, Node? labelHostParent = null)
         {
             // Collect lexical names from this scope level for AnnexB conflict checking.
             // These are let/const/class declarations in non-root scopes (blocks, for headers, etc.)
@@ -327,7 +333,14 @@ internal sealed class HoistingScope
                     // block-level positions (blocks, switch cases, if statement clauses).
                     // Per B.3.2/B.3.3, block-level function declarations in sloppy mode get
                     // special AnnexB hoisting behavior.
-                    if (parent is null || node.Type is not (NodeType.BlockStatement or NodeType.SwitchCase or NodeType.IfStatement))
+                    // A LabelledStatement is transparent here (Annex B.3.1 legalizes the form and
+                    // every web implementation gives it the same treatment as an unlabelled one):
+                    // `l: function f(){}` hoists like any other declaration at the top level of a
+                    // script or function body, and is a block-level declaration when it appears in a
+                    // Block or CaseClause - see the labelHost parameter.
+                    var host = labelHost ?? node;
+                    var hostParent = labelHost is not null ? labelHostParent : parent;
+                    if (hostParent is null || host.Type is not (NodeType.BlockStatement or NodeType.SwitchCase or NodeType.IfStatement))
                     {
                         _functions ??= [];
                         _functions.Add((FunctionDeclaration) childNode);
@@ -391,7 +404,16 @@ internal sealed class HoistingScope
                     && childType != NodeType.StaticBlock
                     && !childNode.ChildNodes.IsEmpty())
                 {
-                    Visit(childNode, node, effectiveLexicalNames);
+                    // Carry this statement list's container into a label chain so the classification
+                    // above can see through it (labels nest, so an already-set host wins).
+                    if (childType == NodeType.LabeledStatement)
+                    {
+                        Visit(childNode, node, effectiveLexicalNames, labelHost ?? node, labelHost is not null ? labelHostParent : parent);
+                    }
+                    else
+                    {
+                        Visit(childNode, node, effectiveLexicalNames);
+                    }
                 }
             }
         }

--- a/Jint/Native/Function/EvalFunction.cs
+++ b/Jint/Native/Function/EvalFunction.cs
@@ -330,6 +330,16 @@ public sealed class EvalFunction : Function
 
         Engine.EnterExecutionContext(lexEnv, varEnv, evalRealm, privateEnv, strictEval);
 
+        // Annex B's var-scope alias for a block-level function declaration is written when the
+        // declaration is evaluated, but whether it may be written at all is settled here, by
+        // EvalDeclarationInstantiation. Which declarations qualify is a static property of this eval's
+        // body (chiefly "replacing it with a VariableStatement would not produce any Early Errors"),
+        // and a block statement has no other way back to it - see
+        // JintFunctionDeclarationStatement.IsAliasEligible. Saved and restored around the body so a
+        // nested eval, and the caller, keep their own.
+        var outerAnnexBFunctions = _engine._evalAnnexBFunctions;
+        _engine._evalAnnexBFunctions = strictEval ? null : cached.HoistingScope._annexBFunctionDeclarations;
+
         try
         {
             Engine.EvalDeclarationInstantiation(script, cached.HoistingScope, varEnv, lexEnv, privateEnv, strictEval, bindingsPreInitialized: useSlots);
@@ -355,6 +365,7 @@ public sealed class EvalFunction : Function
         }
         finally
         {
+            _engine._evalAnnexBFunctions = outerAnnexBFunctions;
             Engine.LeaveExecutionContext();
         }
     }

--- a/Jint/Runtime/Interpreter/DeclarationCache.cs
+++ b/Jint/Runtime/Interpreter/DeclarationCache.cs
@@ -37,6 +37,17 @@ internal static class DeclarationCacheBuilder
         ref readonly var statementListItems = ref statement.Body;
         foreach (var node in statementListItems.AsSpan())
         {
+            if (node.Type == NodeType.LabeledStatement)
+            {
+                var labelled = UnwrapLabelledFunctionDeclaration((LabeledStatement) node);
+                if (labelled is not null)
+                {
+                    Collect(boundNames, labelled, ref allLexical, declarations);
+                }
+
+                continue;
+            }
+
             if (node.Type != NodeType.VariableDeclaration && node.Type != NodeType.FunctionDeclaration && node.Type != NodeType.ClassDeclaration)
             {
                 continue;
@@ -53,6 +64,24 @@ internal static class DeclarationCacheBuilder
         return new DeclarationCache(declarations, allLexical);
     }
 
+    /// <summary>
+    /// LexicallyScopedDeclarations of a <c>LabelledStatement</c> is the FunctionDeclaration it labels -
+    /// Annex B.3.1 makes <c>l: function f() {}</c> legal in sloppy code, and inside a Block or CaseClause
+    /// that declaration is scoped to the block just like an unlabelled one. Labels nest, so unwrap all of
+    /// them. Every other labelled item contributes nothing.
+    /// https://tc39.es/ecma262/#sec-static-semantics-lexicallyscopeddeclarations
+    /// </summary>
+    private static FunctionDeclaration? UnwrapLabelledFunctionDeclaration(LabeledStatement statement)
+    {
+        var body = statement.Body;
+        while (body.Type == NodeType.LabeledStatement)
+        {
+            body = ((LabeledStatement) body).Body;
+        }
+
+        return body as FunctionDeclaration;
+    }
+
     public static DeclarationCache Build(SwitchCase statement)
     {
         var allLexical = true;
@@ -62,6 +91,17 @@ internal static class DeclarationCacheBuilder
         ref readonly var statementListItems = ref statement.Consequent;
         foreach (var node in statementListItems.AsSpan())
         {
+            if (node.Type == NodeType.LabeledStatement)
+            {
+                var labelled = UnwrapLabelledFunctionDeclaration((LabeledStatement) node);
+                if (labelled is not null)
+                {
+                    Collect(boundNames, labelled, ref allLexical, declarations);
+                }
+
+                continue;
+            }
+
             if (node.Type == NodeType.FunctionDeclaration || node.Type == NodeType.ClassDeclaration)
             {
                 Collect(boundNames, node, ref allLexical, declarations);

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -728,7 +728,11 @@ internal sealed class JintFunctionDefinition
 
         state.VarsToInitialize = varsToInitialize;
 
-        // B.3.3.1: AnnexB block-level function declarations need var bindings
+        // https://tc39.es/ecma262/#sec-functiondeclarationinstantiation, the Normative Optional
+        // "Block-Level Function Declarations Web Legacy Compatibility Semantics" step: a sloppy-mode
+        // block-level function declaration also gets a var binding in the function's variable
+        // environment, initialized to undefined. The value is written when the declaration is
+        // evaluated - see JintFunctionDeclarationStatement.
         var annexBFunctions = hoistingScope._annexBFunctionDeclarations;
         if (annexBFunctions != null)
         {
@@ -743,12 +747,17 @@ internal sealed class JintFunctionDefinition
                 var f = annexBFunctions[i];
                 Key fn = f.Id!.Name;
 
-                // Skip if name conflicts with parameter or lexical declaration
-                if (state.ParameterBindings!.Contains(fn))
+                // "...and paramNames does not contain funcName". paramNames, not paramBindings: the
+                // implicit "arguments" binding does NOT disqualify a block function called
+                // `arguments`, it only means no *new* var binding is created for it (below). Testing
+                // ParameterBindings here made `{ function arguments() {} }` a no-op.
+                if (System.Array.IndexOf(state.ParameterNames, fn) >= 0)
                 {
                     continue;
                 }
 
+                // Skip if the name conflicts with a lexical declaration - "replacing the
+                // FunctionDeclaration with a VariableStatement ... would not produce any Early Errors"
                 if (lexicalNames?.Contains(fn) == true)
                 {
                     continue;
@@ -760,7 +769,10 @@ internal sealed class JintFunctionDefinition
                 state.AnnexBFunctionDeclarations ??= [];
                 state.AnnexBFunctionDeclarations.Add(f);
 
-                if (instantiatedVarNames.Add(fn))
+                // "If instantiatedVariableNames does not contain funcName and funcName is not
+                // 'arguments'": the arguments binding already exists and must not be re-created here,
+                // but the declaration's evaluation still assigns over it.
+                if (fn != KnownKeys.Arguments && instantiatedVarNames.Add(fn))
                 {
                     varsToInitialize.Add(new State.VariableValuePair(Name: fn, InitialValue: JsValue.Undefined));
                 }

--- a/Jint/Runtime/Interpreter/JintStatementList.cs
+++ b/Jint/Runtime/Interpreter/JintStatementList.cs
@@ -50,7 +50,14 @@ internal sealed class JintStatementList
     {
     }
 
-    public JintStatementList(Statement? statement, in NodeList<Statement> statements, CompletionValueObservability? observability = null)
+    // blockLevel: true for the StatementList of a Block, a CaseClause or a DefaultClause - the
+    // syntactic position Annex B B.3.2 gives a function declaration its var-scope alias in. See
+    // JintFunctionDeclarationStatement.
+    public JintStatementList(
+        Statement? statement,
+        in NodeList<Statement> statements,
+        CompletionValueObservability? observability = null,
+        bool blockLevel = false)
     {
         _statement = statement;
         _observability = observability
@@ -63,7 +70,9 @@ internal sealed class JintStatementList
         for (var i = 0; i < jintStatements.Length; i++)
         {
             var esprimaStatement = statements[i];
-            var stmt = JintStatement.Build(esprimaStatement);
+            var stmt = blockLevel
+                ? JintStatement.BuildBlockLevel(esprimaStatement)
+                : JintStatement.Build(esprimaStatement);
             // FastResolve pre-evaluates literal return values.
             // Debug mode check moved to Execute loop to preserve stepping behavior.
             var value = JintStatement.FastResolve(esprimaStatement);
@@ -381,43 +390,9 @@ internal sealed class JintStatementList
                 var fo = env._engine.Realm.Intrinsics.Function.InstantiateFunctionObject(definition, env, privateEnv);
                 env.InitializeBinding(fn, fo, DisposeHint.Normal);
 
-                // B.3.2/B.3.3/B.3.3.1: Copy block-level function declaration to var scope in sloppy mode
-                // Only regular function declarations get AnnexB treatment (not generators, async, or async generators)
-                if (!functionDeclaration.Generator && !functionDeclaration.Async && !env._engine.ExecutionContext.Strict)
-                {
-                    var engine = env._engine;
-                    var executionContext = engine.ExecutionContext;
-                    var varEnv = executionContext.VariableEnvironment;
-                    if (!ReferenceEquals(varEnv, env))
-                    {
-                        var shouldCopy = false;
-                        if (executionContext.Function is { _functionDefinition: { } funcDef })
-                        {
-                            // Function scope: check AnnexBFunctionDeclarations from B.3.3.1
-                            // Must check the specific declaration, not just the name, because
-                            // nested blocks can have same-named declarations with different eligibility.
-                            shouldCopy = funcDef.Initialize().AnnexBFunctionDeclarations?.Contains(functionDeclaration) == true;
-                        }
-                        else if (varEnv is GlobalEnvironment globalEnv)
-                        {
-                            // Global/eval scope: copy if not a lexical declaration
-                            shouldCopy = !globalEnv.HasLexicalDeclaration(fn) && globalEnv.HasOwnBinding(fn);
-                        }
-                        else
-                        {
-                            // Eval in function scope: copy if var binding exists
-                            shouldCopy = varEnv.HasBinding(fn);
-                        }
-
-                        if (shouldCopy)
-                        {
-                            // this may CREATE a binding in the pre-existing var env (sloppy
-                            // set-on-missing) — invalidate pinned nested-global chain memos
-                            engine._envBindingInjectionEpoch++;
-                            varEnv.SetMutableBinding(fn, fo, strict: false);
-                        }
-                    }
-                }
+                // NOTE: Annex B's var-scope alias for a sloppy-mode block-level function declaration is
+                // written when the declaration is EVALUATED, not here - see
+                // JintFunctionDeclarationStatement.ExecuteAnnexBVarScopeAssignment.
             }
         }
 

--- a/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
@@ -34,11 +34,13 @@ internal sealed class JintBlockStatement : JintStatement<NestedBlockStatement>
 
         if (blockStatement.Body.Count == 1)
         {
-            _singleStatement = Build(blockStatement.Body[0]);
+            // BuildBlockLevel: a Block's own StatementList is the position Annex B B.3.2 gives a
+            // function declaration its var-scope alias in - see JintFunctionDeclarationStatement.
+            _singleStatement = BuildBlockLevel(blockStatement.Body[0]);
         }
         else
         {
-            _statementList = new JintStatementList(blockStatement, blockStatement.Body);
+            _statementList = new JintStatementList(blockStatement, blockStatement.Body, blockLevel: true);
         }
     }
 

--- a/Jint/Runtime/Interpreter/Statements/JintFunctionDeclarationStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintFunctionDeclarationStatement.cs
@@ -1,15 +1,151 @@
 using Jint.Native;
+using Jint.Runtime.Environments;
+using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Runtime.Interpreter.Statements;
 
 internal sealed class JintFunctionDeclarationStatement : JintStatement<FunctionDeclaration>
 {
-    public JintFunctionDeclarationStatement(FunctionDeclaration statement) : base(statement)
+    /// <summary>
+    /// True when this declaration is <em>directly</em> contained in the StatementList of a Block, a
+    /// CaseClause or a DefaultClause and could therefore carry Annex B's var-scope alias. Decided at
+    /// build time from the containing statement list - a top-level declaration, or one reached through
+    /// a LabelledStatement, never enters <see cref="ExecuteAnnexBVarScopeAssignment"/> at all.
+    /// </summary>
+    private readonly bool _blockLevel;
+
+    private readonly Key _name;
+
+    public JintFunctionDeclarationStatement(FunctionDeclaration statement, bool blockLevel = false) : base(statement)
     {
+        _name = statement.Id?.Name ?? "";
+
+        // B.3.2 covers FunctionDeclaration only - a GeneratorDeclaration, AsyncFunctionDeclaration or
+        // AsyncGeneratorDeclaration in a block stays purely block-scoped.
+        _blockLevel = blockLevel && statement.Id is not null && !statement.Generator && !statement.Async;
     }
 
     protected override Completion ExecuteInternal(EvaluationContext context)
     {
+        if (_blockLevel)
+        {
+            ExecuteAnnexBVarScopeAssignment(context);
+        }
+
         return new Completion(CompletionType.Normal, JsEmpty.Instance, ((JintStatement) this)._statement);
+    }
+
+    /// <summary>
+    /// The "Block-Level Function Declarations Web Legacy Compatibility Semantics" step of
+    /// <see href="https://tc39.es/ecma262/#sec-functiondeclarationinstantiation">FunctionDeclarationInstantiation</see>
+    /// and of its
+    /// <see href="https://tc39.es/ecma262/#sec-evaldeclarationinstantiation">EvalDeclarationInstantiation</see> /
+    /// <see href="https://tc39.es/ecma262/#sec-globaldeclarationinstantiation">GlobalDeclarationInstantiation</see>
+    /// siblings:
+    /// <code>
+    /// Let funcEnv be the running execution context's VariableEnvironment.
+    /// Let blockEnv be the running execution context's LexicalEnvironment.
+    /// Let funcObj be ! blockEnv.GetBindingValue(funcName, false).
+    /// Perform ! funcEnv.SetMutableBinding(funcName, funcObj, false).
+    /// </code>
+    /// This runs <em>in place of</em> the ordinary FunctionDeclaration Evaluation, i.e. when the
+    /// declaration statement is reached, not when the block is entered. The distinction is observable:
+    /// the var-scoped alias is <c>undefined</c> until then, and the value taken is the block binding's
+    /// current one - which a later same-named declaration in the same block has already overwritten.
+    /// </summary>
+    private void ExecuteAnnexBVarScopeAssignment(EvaluationContext context)
+    {
+        var engine = context.Engine;
+        var executionContext = engine.ExecutionContext;
+        if (executionContext.Strict)
+        {
+            return;
+        }
+
+        var varEnv = executionContext.VariableEnvironment;
+        var blockEnv = executionContext.LexicalEnvironment;
+        if (ReferenceEquals(varEnv, blockEnv) || !IsAliasEligible(engine, in executionContext, varEnv, blockEnv))
+        {
+            return;
+        }
+
+        var funcObj = blockEnv.GetBindingValue(_name, strict: false);
+
+        // this may CREATE a binding in the pre-existing var env (sloppy set-on-missing) —
+        // invalidate pinned nested-global chain memos
+        engine._envBindingInjectionEpoch++;
+        varEnv.SetMutableBinding(_name, funcObj, strict: false);
+    }
+
+    /// <summary>
+    /// Whether the instantiation that preceded this evaluation decided the alias was creatable. The
+    /// three arms mirror the three amendments: function code, script/global-eval code, and a sloppy
+    /// direct eval inside a function.
+    /// </summary>
+    private bool IsAliasEligible(Engine engine, in ExecutionContext executionContext, Environment varEnv, Environment blockEnv)
+    {
+        if (executionContext.Function is { _functionDefinition: { } funcDef })
+        {
+            // FunctionDeclarationInstantiation settled this once per declaration node. Keying on the
+            // node rather than the name matters: same-named declarations at different block levels
+            // are not interchangeable.
+            return funcDef.Initialize().AnnexBFunctionDeclarations?.Contains(_statement) == true;
+        }
+
+        if (varEnv is GlobalEnvironment globalEnv)
+        {
+            // Script or global-scope eval: Global/EvalDeclarationInstantiation created the global var
+            // binding exactly when the name was definable and not lexically declared.
+            return !globalEnv.HasLexicalDeclaration(_name) && globalEnv.HasOwnBinding(_name);
+        }
+
+        // Sloppy direct eval inside a function. Two conditions, and only the engine has both.
+        //
+        // The static one - "replacing the FunctionDeclaration with a VariableStatement ... would not
+        // produce any Early Errors for body" - is what excludes, say, a declaration under a
+        // DESTRUCTURED catch parameter of the same name, which B.3.4's exemption does not cover. It is
+        // decided once for the eval body by HoistingScope, and reaches here through the engine because
+        // a block statement has no other route back to the eval that is running it.
+        var candidates = engine._evalAnnexBFunctions;
+        if (candidates is null)
+        {
+            return false;
+        }
+
+        var eligible = false;
+        for (var i = 0; i < candidates.Count; i++)
+        {
+            if (ReferenceEquals(candidates[i], _statement))
+            {
+                eligible = true;
+                break;
+            }
+        }
+
+        if (!eligible)
+        {
+            return false;
+        }
+
+        // The dynamic one is EvalDeclarationInstantiation's bindingExists walk: an environment between
+        // the eval's own and the variable environment that already binds the name blocks the alias.
+        // Object environment records (a `with` scope) and catch environments are skipped, per the same
+        // amendment and B.3.4. Note this is deliberately NOT a test for the binding EDI may itself have
+        // created in varEnv: eval-introduced var bindings are deletable, and `delete f` before the
+        // block runs must not turn the alias off.
+        for (var env = blockEnv._outerEnv; env is not null && !ReferenceEquals(env, varEnv); env = env._outerEnv)
+        {
+            if (env is ObjectEnvironment or DeclarativeEnvironment { _catchEnvironment: true })
+            {
+                continue;
+            }
+
+            if (env.HasBinding(_name))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintLabeledStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintLabeledStatement.cs
@@ -5,9 +5,11 @@ internal sealed class JintLabeledStatement : JintStatement<LabeledStatement>
     private readonly JintStatement _body;
     private readonly string? _labelName;
 
-    public JintLabeledStatement(LabeledStatement statement) : base(statement)
+    public JintLabeledStatement(LabeledStatement statement, bool blockLevel = false) : base(statement)
     {
-        _body = Build(statement.Body);
+        // A label chain sitting in a Block / CaseClause StatementList keeps its item block-level, so a
+        // labelled function declaration still writes Annex B's var-scope alias when it is evaluated.
+        _body = blockLevel ? BuildBlockLevel(statement.Body) : Build(statement.Body);
         _labelName = statement.Label.Name;
     }
 

--- a/Jint/Runtime/Interpreter/Statements/JintStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintStatement.cs
@@ -61,6 +61,23 @@ internal abstract class JintStatement
 
     public ref readonly SourceLocation Location => ref _statement.LocationRef;
 
+    /// <summary>
+    /// Builds a statement that sits directly in the StatementList of a Block, a CaseClause or a
+    /// DefaultClause - the position Annex B B.3.2 gives a sloppy-mode function declaration its
+    /// var-scope alias in. A LabelledStatement is transparent for that purpose: <c>l: function f(){}</c>
+    /// there is treated exactly as the unlabelled form, which is what every web implementation does and
+    /// what B.3.1 legalizes the form for.
+    /// </summary>
+    protected internal static JintStatement BuildBlockLevel(Statement statement)
+    {
+        return statement.Type switch
+        {
+            NodeType.FunctionDeclaration => new JintFunctionDeclarationStatement((FunctionDeclaration) statement, blockLevel: true),
+            NodeType.LabeledStatement => new JintLabeledStatement((LabeledStatement) statement, blockLevel: true),
+            _ => Build(statement)
+        };
+    }
+
     protected internal static JintStatement Build(Statement statement)
     {
         // INVARIANT: statement handlers may carry per-engine mutable state (JintBlockStatement._cachedEnv,

--- a/Jint/Runtime/Interpreter/Statements/JintSwitchBlock.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintSwitchBlock.cs
@@ -216,7 +216,9 @@ start:
 
         public JintSwitchCase(SwitchCase switchCase)
         {
-            Consequent = new JintStatementList(statement: null, switchCase.Consequent, CompletionValueObservability.Inherit);
+            // blockLevel: a CaseClause / DefaultClause StatementList carries Annex B B.3.2's
+            // var-scope alias exactly as a Block's does.
+            Consequent = new JintStatementList(statement: null, switchCase.Consequent, CompletionValueObservability.Inherit, blockLevel: true);
             LexicalDeclarations = DeclarationCacheBuilder.Build(switchCase);
             Range = switchCase.Range;
             TestRange = switchCase.Test?.Range;


### PR DESCRIPTION
Five of the `staging/` exclusions in #3021 sat under this banner:

```
// Annex B B.3.3 block-scoped function hoisting: the var-scoped alias a sloppy-mode block
// function creates is not synthesised the way the spec's FunctionDeclarationInstantiation
// amendment describes, so the name is visible with the wrong value (or not at all) in the
// enclosing function, inside a direct eval, inside `with`, and after a redeclaration.
```

The comment names the right area but not the defect. Jint does synthesise the alias — the problem is **when**, plus three narrower bugs that only that timing change exposes.

## The timing

The amendment is a Normative Optional step of [FunctionDeclarationInstantiation](https://tc39.es/ecma262/#sec-functiondeclarationinstantiation) (and of its [EvalDeclarationInstantiation](https://tc39.es/ecma262/#sec-evaldeclarationinstantiation) / [GlobalDeclarationInstantiation](https://tc39.es/ecma262/#sec-globaldeclarationinstantiation) siblings). Instantiation creates the var binding, initialized to **undefined**, and then:

> **When the FunctionDeclaration *funcDecl* is evaluated**, perform the following steps *in place of* the FunctionDeclaration Evaluation algorithm provided in 15.2.6:
> 1. Let *funcEnv* be the running execution context's VariableEnvironment.
> 2. Let *blockEnv* be the running execution context's LexicalEnvironment.
> 3. Let *funcObj* be ! *blockEnv*.GetBindingValue(*funcName*, **false**).
> 4. Perform ! *funcEnv*.SetMutableBinding(*funcName*, *funcObj*, **false**).

Jint did this from `BlockDeclarationInstantiation` — at block **entry** — and assigned the function object it had just constructed rather than reading the block binding. Three things follow, and each is one of the excluded files:

- The alias is visible before the declaration statement has run. `block-scoped-functions-annex-b-with.js` catches this at global scope, where the var binding is a global property: `Object.getOwnPropertyDescriptor(this, "f").value` must still be `undefined` at a statement preceding the declaration. Jint reported the function.
- The value taken is the block binding's *current* one. Two same-named declarations in one sloppy block are legal (B.3.2's early-error relaxation) and BlockDeclarationInstantiation initializes the binding twice, last one winning — so **both** evaluations assign the second function. `block-scoped-functions-deprecated-redecl.js`.
- `funcEnv` is the VariableEnvironment, not whatever the scope chain resolves. That part Jint already had right, and it stays right.

The assignment now lives in `JintFunctionDeclarationStatement`, gated on a `_blockLevel` flag the statement handler receives when it is built from a Block's, CaseClause's or DefaultClause's StatementList.

## `function arguments() {}` is eligible

The condition is

> If replacing the FunctionDeclaration *funcDecl* with a VariableStatement that has *funcName* as a BindingIdentifier would not produce any Early Errors for *func* and **paramNames** does not contain *funcName*, then
>   - If *instantiatedVariableNames* does not contain *funcName* **and *funcName* is not `"arguments"`**, then … create the binding …
>   - When the FunctionDeclaration *funcDecl* is evaluated, … *(a sibling of the step above, not nested in it)*

`paramNames`, not `paramBindings` — the implicit `arguments` binding does not disqualify the name; only the creation of a *new* var binding is skipped for it, while the assignment still runs. Jint tested `ParameterBindings`, which carries `"arguments"`, so `{ function arguments() {} }` was a no-op. `block-scoped-functions-annex-b-arguments.js` and `regress-602621.js`.

## Labelled function declarations

`l: function f(){}` inside a Block is a *lexically scoped declaration of that Block* — `LexicallyScopedDeclarations` of a LabelledStatement is the FunctionDeclaration it labels. Jint's `HoistingScope` walker saw the LabelledStatement as the container and hoisted the function to the enclosing var scope outright, so the block had no binding of its own for it. At the top level of a script or function body it still hoists, because `TopLevelVarScopedDeclarations` *does* see through the label; the walker now carries the label chain's real container so both cases come out right.

Annex B applies to the labelled form too. A literal reading of "directly contained in the StatementList" would say otherwise, but B.3.1 exists precisely because "most browser-hosted implementations supported that extension", V8 and SpiderMonkey both give it the var alias, and `staging/sm/lexical-environment/block-scoped-functions-annex-b-label.js` — already in the suite and passing — requires it (`{ f1(); l: function f1() { return 42; } } assert.sameValue(f1(), 42);`). That file is what caught the first draft of this change.

## Eligibility inside a direct eval

`block-scoped-functions-annex-b-eval.js` contains

```js
function h() {
  eval(`
    log += (delete q);          // true  - eval-introduced var bindings are configurable
    { function q() { log += "q"; }
      log += (delete q); }      // false - the block's lexical binding is not
  `);
  return q;                     // the function
}
```

Jint decided eligibility at block-entry time by asking whether the var binding existed — which the `delete` had just removed, so `q` was never rebound and `return q` threw. The spec settles eligibility once, in EvalDeclarationInstantiation, and the evaluation-time assignment is unconditional afterwards (`SetMutableBinding` on a missing sloppy binding creates it).

The verdict has a static half that no environment inspection can recover: "replacing the FunctionDeclaration with a VariableStatement would not produce any Early Errors", which is what excludes a declaration under a **destructured** catch parameter of the same name (B.3.4's exemption covers a simple BindingIdentifier only). So `EvalFunction` now hands the eval body's Annex B candidate list to the engine for the duration of the body, saved and restored around it, and the statement checks it alongside the spec's `bindingExists` walk over the environments between the block and the variable environment. Without the static half, `annexB/language/eval-code/direct/func-*-eval-func-skip-early-err-try.js` regress.

## One test262 file excluded as stale

`annexB/language/function-code/block-decl-func-skip-arguments.js` (V8, April 2017) asserts the opposite of the staging file above: that `arguments` is *still* the arguments object after `{ function arguments() {} }`. Its own `info` block quotes the algorithm it was written against —

```
22. If argumentsObjectNeeded is true, then
  f. Append "arguments" to parameterNames.
```

— i.e. the edition before `paramBindings` was split out of `paramNames`. Under today's text the name is eligible. Both shipping engines agree with today's text and with the staging file:

```
$ node -e "console.log((function(){ { function arguments(){} } return typeof arguments; })())"
function
```

and the same for the named-parameter and rest-parameter shapes the test exercises. It is excluded under a new `=== STALE TEST ===` banner naming what removes it (an upstream fix). **Note for whoever lands the #3021 branches:** this is an *addition* to `ExcludedFiles`, not one of the removals, so the usual "take the union of removals" conflict resolution needs to keep it.

## Cost

Nothing new runs on a hot path.

- The per-block-entry copy is **gone** from `BlockDeclarationInstantiation`.
- The replacement is one branch on a `readonly bool` in `JintFunctionDeclarationStatement.ExecuteInternal`, decided when the handler is built. A top-level function declaration statement — the common case — reaches nothing else.
- `HoistingScope`, `DeclarationCacheBuilder` and the statement-list constructor each gain a comparison or two, all at prepare time.
- `EvalFunction` gains two field writes per eval; `Engine` one reference field.
- Nothing engine-affine is published to AST `UserData`: the flag lives on the per-engine handler, and the extra `ScopedDeclaration` a labelled function contributes to a `BlockState` is a `Key[]` plus a node reference.

## Verification

- The five files pass in both modes; their exclusion entries are removed.
- New coverage in `Jint.Tests/Runtime/AnnexBBlockFunctionTests.cs` (15 tests), including the controls that already passed — strict mode, generator/async declarations, a formal parameter actually named `arguments`, a simple catch parameter. Against the unfixed engine 7 of them fail, e.g. `"function,function"` where `"undefined,function"` is expected, and `"function f() { [native code] },true,true,false"` for the global descriptor.
- test262 `annexB` + all of `language` + all of `staging` — 48,546 passed, 0 failed. `built-ins/{Function,eval,global,Proxy,Reflect}` — 1,896 passed, 0 failed.
- Full `Jint.Tests` (net10.0 + net472), `Jint.Tests.PublicInterface`, `Jint.Tests.CommonScripts` — all green.

The two files under the "Mapped arguments" banner in #3021 turned out to be an unrelated fix and are in #3067.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
