### PR TITLE
Give a class its own source text and name the for-in head's anonymous function

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -66,13 +66,6 @@
     // poisoned value's own error instead of the RangeError. Removed by fixing that ordering.
     "staging/sm/TypedArray/constructor-buffer-sequence.js",
 
-    // Function source text and inferred names. Function.prototype.toString does not return the
-    // original source for class expressions and some method forms, and NamedEvaluation does not
-    // reach the for-in head. Removed by carrying the source range and completing NamedEvaluation.
-    "staging/sm/Function/function-name-for.js",
-    "staging/sm/class/parenExprToString.js",
-    "staging/sm/generators/runtime.js",
-
     // Set.prototype.intersection / .isSubsetOf let the *receiver* be mutated while they traverse it
     // (a set-like's has/keys callback calling this.delete(v) or this.clear()), and the spec models
     // that with the [[SetData]] tombstone: a deleted entry becomes EMPTY in place rather than being

--- a/Jint.Tests/Runtime/FunctionTests.cs
+++ b/Jint.Tests/Runtime/FunctionTests.cs
@@ -897,6 +897,74 @@ assertEqual(booleanCount, 1);
     }
 
     [Fact]
+    public void ClassToStringReturnsTheClassSourceTextWhenRetained()
+    {
+        // https://tc39.es/ecma262/#sec-class-definitions-runtime-semantics-evaluation
+        // ClassExpression : class ClassTail -- "Set value.[[SourceText]] to the source text matched by
+        // ClassExpression." A class with no explicit constructor has no function node of its own: the
+        // engine substitutes one synthesized constructor AST that every such class shares, and that node
+        // was parsed apart from the script, so it carries no source text. The text has to come from the
+        // class node itself, which is what the parenthesized cases below also pin -- the parentheses of a
+        // CoverParenthesizedExpression are outside the ClassExpression production and must not be included.
+        var engine = new Engine(options => options.RetainFunctionSourceText());
+
+        engine.Evaluate("(class {}).toString()").AsString().Should().Be("class {}");
+        engine.Evaluate("((class {})).toString()").AsString().Should().Be("class {}");
+        engine.Evaluate("(class Named { m() {} }).toString()").AsString().Should().Be("class Named { m() {} }");
+        engine.Evaluate("(class extends Object {}).toString()").AsString().Should().Be("class extends Object {}");
+        engine.Evaluate("(class { constructor(a) {} }).toString()").AsString().Should().Be("class { constructor(a) {} }");
+    }
+
+    [Fact]
+    public void ClassesWithoutAnExplicitConstructorDoNotShareOneSourceText()
+    {
+        // They all borrow the same synthesized constructor AST, so the interpreter definition that carries
+        // the source-text node must be keyed on the class node and not on that shared function node.
+        var engine = new Engine(options => options.RetainFunctionSourceText());
+
+        engine.Evaluate("class D {} class E {} [D.toString(), E.toString()].join('|')")
+            .AsString().Should().Be("class D {}|class E {}");
+
+        // Derived classes borrow a second shared node (the one forwarding to super).
+        engine.Evaluate("class F extends Object {} class G extends Object {} [F.toString(), G.toString()].join('|')")
+            .AsString().Should().Be("class F extends Object {}|class G extends Object {}");
+    }
+
+    [Fact]
+    public void ClassToStringReturnsNativeCodePlaceholderByDefault()
+    {
+        // Source-text retention stays opt-in for classes exactly as it is for functions.
+        var engine = new Engine();
+
+        engine.Evaluate("(class Named {}).toString()").AsString().Should().Be("function Named() { [native code] }");
+        engine.Evaluate("(class {}).toString()").AsString().Should().Be("function () { [native code] }");
+    }
+
+    [Fact]
+    public void ForInHeadInitializerNamesAnAnonymousFunction()
+    {
+        // https://tc39.es/ecma262/#sec-runtime-semantics-forinofloopevaluation
+        // for ( var BindingIdentifier Initializer in Expression ) Statement:
+        // "If IsAnonymousFunctionDefinition(Initializer) is true, let value be ? NamedEvaluation of
+        // Initializer with argument bindingId."
+        var engine = new Engine();
+
+        engine.Evaluate("for (var a = function () {} in {}) {} a.name").AsString().Should().Be("a");
+        engine.Evaluate("for (var b = () => {} in {}) {} b.name").AsString().Should().Be("b");
+        engine.Evaluate("for (var c = class {} in {}) {} c.name").AsString().Should().Be("c");
+        engine.Evaluate("for (var d = function* () {} in {}) {} d.name").AsString().Should().Be("d");
+        engine.Evaluate("for (var e = async function () {} in {}) {} e.name").AsString().Should().Be("e");
+        engine.Evaluate("for (var h = async () => {} in {}) {} h.name").AsString().Should().Be("h");
+
+        // A definition that carries its own name keeps it.
+        engine.Evaluate("for (var i = function named() {} in {}) {} i.name").AsString().Should().Be("named");
+        engine.Evaluate("for (var j = class named {} in {}) {} j.name").AsString().Should().Be("named");
+
+        // A non-function initializer is unaffected.
+        engine.Evaluate("for (var k = 42 in {}) {} k").AsNumber().Should().Be(42);
+    }
+
+    [Fact]
     public void ClosureInParameterDefaultKeepsItsCapturedEnvironment()
     {
         // The environment-escape analysis must also scan parameter default expressions: a closure created

--- a/Jint.Tests/Runtime/GeneratorTests.cs
+++ b/Jint.Tests/Runtime/GeneratorTests.cs
@@ -870,4 +870,32 @@ public class GeneratorTests
 
         _engine.Evaluate(Script).AsString().Should().Be("[0,0]");
     }
+
+    [Fact]
+    public void GeneratorFunctionConstructorsInheritFromTheFunctionConstructor()
+    {
+        // https://tc39.es/ecma262/#sec-generatorfunction-constructor and
+        // https://tc39.es/ecma262/#sec-asyncgeneratorfunction-constructor: each of these constructors
+        // "has a [[Prototype]] internal slot whose value is %Function%" -- the Function constructor
+        // itself, not its own .prototype object.
+        _engine.Evaluate("Object.getPrototypeOf(Object.getPrototypeOf(function* () {}).constructor) === Function")
+            .AsBoolean().Should().BeTrue();
+        _engine.Evaluate("Object.getPrototypeOf(Object.getPrototypeOf(async function* () {}).constructor) === Function")
+            .AsBoolean().Should().BeTrue();
+
+        // AsyncFunction already had this right; pinned here so the three stay together.
+        _engine.Evaluate("Object.getPrototypeOf(Object.getPrototypeOf(async function () {}).constructor) === Function")
+            .AsBoolean().Should().BeTrue();
+
+        // The prototype objects are unaffected: %GeneratorFunction.prototype%.[[Prototype]] stays
+        // %Function.prototype% (https://tc39.es/ecma262/#sec-properties-of-generatorfunction-prototype).
+        _engine.Evaluate("Object.getPrototypeOf(Object.getPrototypeOf(function* () {})) === Function.prototype")
+            .AsBoolean().Should().BeTrue();
+        _engine.Evaluate("Object.getPrototypeOf(Object.getPrototypeOf(async function* () {})) === Function.prototype")
+            .AsBoolean().Should().BeTrue();
+
+        // And a generator is still an instance of both.
+        _engine.Evaluate("function* g() {} g instanceof Object.getPrototypeOf(g).constructor && g instanceof Function")
+            .AsBoolean().Should().BeTrue();
+    }
 }

--- a/Jint/AstExtensions.cs
+++ b/Jint/AstExtensions.cs
@@ -366,7 +366,14 @@ public static class AstExtensions
     /// <summary>
     /// https://tc39.es/ecma262/#sec-runtime-semantics-definemethod
     /// </summary>
-    internal static Record DefineMethod<T>(this T m, ObjectInstance obj, ObjectInstance? functionPrototype, INode sourceTextNode) where T : IProperty
+    /// <remarks>
+    /// <c>definitionCacheKey</c> is the node the interpreter definition is cached under, defaulting to the
+    /// method's own function node. A class constructor overrides it with the class body: a class without an
+    /// explicit constructor borrows one synthesized constructor AST that every such class shares, so keying on
+    /// the function node would make all of them share one definition — and with it one
+    /// <see cref="JintFunctionDefinition.SourceTextNode"/>, which is whichever class got there first.
+    /// </remarks>
+    internal static Record DefineMethod<T>(this T m, ObjectInstance obj, ObjectInstance? functionPrototype, INode sourceTextNode, Node? definitionCacheKey = null) where T : IProperty
     {
         var engine = obj.Engine;
         var propKey = TypeConverter.ToPropertyKey(m.GetKey(engine));
@@ -386,9 +393,10 @@ public static class AstExtensions
         // re-evaluating the same class (factory functions, re-run prepared scripts) reuses the
         // method's interpreter definition and its warm body handler tree; the closure, home object
         // and environments stay per-evaluation
-        if (!engine.TryGetFunctionDefinition((Node) function, out var definition))
+        var cacheKey = definitionCacheKey ?? (Node) function;
+        if (!engine.TryGetFunctionDefinition(cacheKey, out var definition))
         {
-            engine.CacheFunctionDefinition((Node) function, definition = new JintFunctionDefinition(function, sourceTextNode));
+            engine.CacheFunctionDefinition(cacheKey, definition = new JintFunctionDefinition(function, sourceTextNode));
         }
 
         var closure = intrinsics.Function.OrdinaryFunctionCreate(prototype, definition, definition.ThisMode, env, privateEnv);

--- a/Jint/Engine.Ast.cs
+++ b/Jint/Engine.Ast.cs
@@ -194,6 +194,16 @@ public partial class Engine
                     node.UserData = JintFunctionDefinition.BuildState((IFunction) node, _retainSourceText ? ctx.Input : null);
                     break;
 
+                case NodeType.ClassDeclaration:
+                case NodeType.ClassExpression:
+                    // See Engine.DefaultNodeHandler: a class constructor's source text is the whole class
+                    // production, and a class with no explicit constructor has no function node carrying it.
+                    if (_retainSourceText)
+                    {
+                        node.UserData = ctx.Input;
+                    }
+                    break;
+
                 case NodeType.Program:
                     // A module root is a Program by node type, but nothing reads a module's cached scope —
                     // every reader of it is Script-typed and SourceTextModule walks its own declarations —

--- a/Jint/Engine.Defaults.cs
+++ b/Jint/Engine.Defaults.cs
@@ -70,7 +70,12 @@ public partial class Engine
     /// </summary>
     internal static readonly OnNodeHandler DefaultNodeHandler = static (node, in ctx) =>
     {
-        if (node.Type is NodeType.ArrowFunctionExpression or NodeType.FunctionDeclaration or NodeType.FunctionExpression)
+        // Class nodes are stamped too, because a class constructor's source text is the whole
+        // ClassDeclaration/ClassExpression and a class without an explicit constructor has no function
+        // node of its own to read it from - the engine synthesizes one shared constructor AST for all
+        // of them. https://tc39.es/ecma262/#sec-class-definitions-runtime-semantics-evaluation
+        if (node.Type is NodeType.ArrowFunctionExpression or NodeType.FunctionDeclaration or NodeType.FunctionExpression
+            or NodeType.ClassDeclaration or NodeType.ClassExpression)
         {
             node.UserData = ctx.Input;
         }

--- a/Jint/Native/AsyncGenerator/AsyncGeneratorFunctionConstructor.cs
+++ b/Jint/Native/AsyncGenerator/AsyncGeneratorFunctionConstructor.cs
@@ -16,12 +16,15 @@ internal sealed class AsyncGeneratorFunctionConstructor : Constructor
     internal AsyncGeneratorFunctionConstructor(
         Engine engine,
         Realm realm,
-        FunctionPrototype prototype,
+        FunctionConstructor functionConstructor,
         AsyncIteratorPrototype asyncIteratorPrototype)
         : base(engine, realm, _functionName)
     {
-        PrototypeObject = new AsyncGeneratorFunctionPrototype(engine, this, prototype, asyncIteratorPrototype);
-        _prototype = PrototypeObject;
+        PrototypeObject = new AsyncGeneratorFunctionPrototype(engine, this, functionConstructor.PrototypeObject, asyncIteratorPrototype);
+        // https://tc39.es/ecma262/#sec-asyncgeneratorfunction-constructor
+        // The AsyncGeneratorFunction constructor has a [[Prototype]] internal slot whose value is %Function%,
+        // i.e. the Function constructor itself and not %AsyncGeneratorFunction.prototype%.
+        _prototype = functionConstructor;
         _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
         _length = new PropertyDescriptor(JsNumber.PositiveOne, PropertyFlag.Configurable);
     }

--- a/Jint/Native/Function/ClassDefinition.cs
+++ b/Jint/Native/Function/ClassDefinition.cs
@@ -197,7 +197,12 @@ internal sealed class ClassDefinition
         ScriptFunction F;
         try
         {
-            var constructorInfo = constructor.DefineMethod(proto, constructorParent, sourceTextNode: _class);
+            // The definition is keyed on the class BODY, not on the constructor's function node and not on
+            // the class node. Not the function node, because a class with no explicit constructor borrows a
+            // synthesized one that every such class shares. Not the class node, because a class expression is
+            // also a field initializer's own value node, which the field-initializer cache already keys on
+            // (`B = class {}` would collide). A ClassBody is unique per class and is never a cache key elsewhere.
+            var constructorInfo = constructor.DefineMethod(proto, constructorParent, sourceTextNode: _class, definitionCacheKey: _body);
             F = constructorInfo.Closure;
 
             F.SetFunctionName(_className ?? classBinding ?? "");

--- a/Jint/Native/Function/Function.cs
+++ b/Jint/Native/Function/Function.cs
@@ -614,8 +614,7 @@ public abstract partial class Function : ObjectInstance, ICallable
                 return s;
             }
 
-            var state = _functionDefinition.Initialize();
-            if (state.SourceText.GetValue(sourceTextNode) is { } sourceText)
+            if (_functionDefinition.GetSourceText() is { } sourceText)
             {
                 return sourceText;
             }

--- a/Jint/Native/Function/SourceText.cs
+++ b/Jint/Native/Function/SourceText.cs
@@ -26,22 +26,30 @@ namespace Jint.Native.Function
                 return boxedValue.Value;
             }
 
-            var fullSourceText = (string) _fullSourceTextOrBoxedValue;
-
-            var (start, end) = sourceTextNode.Range;
-
-            // In the case of static class methods, the static keyword is not included.
-            if (sourceTextNode is MethodDefinition { Static: true } m)
-            {
-                start = AstExtensions.GetSecondTokenStartIndex(fullSourceText, start, end);
-            }
-
-            var value = fullSourceText.Substring(start, end - start);
+            var value = Slice(sourceTextNode, (string) _fullSourceTextOrBoxedValue)!;
 
             // Setting this field also releases the reference to the full source text string instance.
             _fullSourceTextOrBoxedValue = new StrongBox<string>(value);
 
             return value;
+        }
+
+        private static string? Slice(Node sourceTextNode, string? fullSourceText)
+        {
+            if (fullSourceText is null)
+            {
+                return null;
+            }
+
+            var (start, end) = sourceTextNode.Range;
+
+            // In the case of static class methods, the static keyword is not included.
+            if (sourceTextNode is MethodDefinition { Static: true })
+            {
+                start = AstExtensions.GetSecondTokenStartIndex(fullSourceText, start, end);
+            }
+
+            return fullSourceText.Substring(start, end - start);
         }
     }
 }

--- a/Jint/Native/Generator/GeneratorFunctionConstructor.cs
+++ b/Jint/Native/Generator/GeneratorFunctionConstructor.cs
@@ -16,12 +16,15 @@ internal sealed class GeneratorFunctionConstructor : Constructor
     internal GeneratorFunctionConstructor(
         Engine engine,
         Realm realm,
-        FunctionPrototype prototype,
+        FunctionConstructor functionConstructor,
         IteratorPrototype iteratorPrototype)
         : base(engine, realm, _functionName)
     {
-        PrototypeObject = new GeneratorFunctionPrototype(engine, this, prototype, iteratorPrototype);
-        _prototype = PrototypeObject;
+        PrototypeObject = new GeneratorFunctionPrototype(engine, this, functionConstructor.PrototypeObject, iteratorPrototype);
+        // https://tc39.es/ecma262/#sec-generatorfunction-constructor
+        // The GeneratorFunction constructor has a [[Prototype]] internal slot whose value is %Function%,
+        // i.e. the Function constructor itself and not %GeneratorFunction.prototype%.
+        _prototype = functionConstructor;
         _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
         _length = new PropertyDescriptor(JsNumber.PositiveOne, PropertyFlag.Configurable);
     }

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -44,16 +44,39 @@ internal sealed class JintFunctionDefinition
     // (This might be different from the Function node, e.g., in the case of class methods.)
     public readonly INode SourceTextNode;
 
+    // Source text for a definition whose text does not live on its function node. That is the shape of a
+    // class with no explicit constructor: the engine borrows one synthesized constructor AST that every
+    // such class shares, and with it one State, so the text has to come from the class node and be
+    // memoized here — where the definition is per class — instead of in that shared State.
+    private SourceText _ownSourceText;
+
     public JintFunctionDefinition(IFunction function, INode sourceTextNode)
     {
         Function = function;
         Name = !string.IsNullOrEmpty(function.Id?.Name) ? function.Id!.Name : null;
         JsName = Name is not null ? new JsString(Name) : null;
         SourceTextNode = sourceTextNode;
+
+        if (!ReferenceEquals(sourceTextNode, function))
+        {
+            // Only a class node ever carries retained input of its own; for a method definition this is null
+            // and the function node's own State answers, exactly as it did before.
+            _ownSourceText = new SourceText(((Node) sourceTextNode).UserData as string);
+        }
     }
 
     public JintFunctionDefinition(IFunction function)
         : this(function, function) { }
+
+    /// <summary>
+    /// The source text matched by the production this function was defined by, or <see langword="null"/>
+    /// when the parse did not retain it. https://tc39.es/ecma262/#sec-function.prototype.tostring
+    /// </summary>
+    internal string? GetSourceText()
+    {
+        var sourceTextNode = (Node) SourceTextNode;
+        return Initialize().SourceText.GetValue(sourceTextNode) ?? _ownSourceText.GetValue(sourceTextNode);
+    }
 
     public bool Strict => Function.IsStrict();
 

--- a/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using Jint.Native;
 using Jint.Native.AsyncFunction;
 using Jint.Native.Disposable;
+using Jint.Native.Function;
 using Jint.Native.Iterator;
 using Jint.Native.Object;
 using Jint.Native.Promise;
@@ -302,7 +303,26 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
         if (_forInVarInitializer is not null)
         {
             var lhs = engine.ResolveBinding(_forInVarName!);
-            var value = _forInVarInitializer.GetValue(context);
+
+            // The head is one of NamedEvaluation's positions: "If IsAnonymousFunctionDefinition(Initializer)
+            // is true, let value be ? NamedEvaluation of Initializer with argument bindingId."
+            // https://tc39.es/ecma262/#sec-runtime-semantics-forinofloopevaluation
+            JsValue value;
+            if (_forInVarInitializer is JintClassExpression classExpression
+                && _forInVarInitializer._expression.IsAnonymousFunctionDefinition())
+            {
+                value = classExpression.EvaluateWithName(context, _forInVarName!);
+            }
+            else
+            {
+                value = _forInVarInitializer.GetValue(context);
+                if (_forInVarInitializer._expression.IsFunctionDefinition())
+                {
+                    // A no-op when the definition already carries its own name.
+                    ((Function) value).SetFunctionName(_forInVarName!);
+                }
+            }
+
             engine.PutValue(lhs, value);
         }
 

--- a/Jint/Runtime/Intrinsics.cs
+++ b/Jint/Runtime/Intrinsics.cs
@@ -320,10 +320,10 @@ public sealed partial class Intrinsics
         _shadowRealm ??= new ShadowRealmConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
 
     internal GeneratorFunctionConstructor GeneratorFunction =>
-        _generatorFunction ??= new GeneratorFunctionConstructor(_engine, _realm, Function.PrototypeObject, IteratorPrototype);
+        _generatorFunction ??= new GeneratorFunctionConstructor(_engine, _realm, Function, IteratorPrototype);
 
     internal AsyncGeneratorFunctionConstructor AsyncGeneratorFunction =>
-        _asyncGeneratorFunction ??= new AsyncGeneratorFunctionConstructor(_engine, _realm, Function.PrototypeObject, AsyncIteratorPrototype);
+        _asyncGeneratorFunction ??= new AsyncGeneratorFunctionConstructor(_engine, _realm, Function, AsyncIteratorPrototype);
 
     public EvalFunction Eval =>
         _eval ??= new EvalFunction(_engine, _realm, Function.PrototypeObject);


### PR DESCRIPTION
Part of the #3021 campaign to shrink the `staging/` exclusion list. Frees three files.

## What the exclusion comment claimed

> Function source text and inferred names. `Function.prototype.toString` does not return the original source for class expressions and some method forms, and NamedEvaluation does not reach the for-in head. Removed by carrying the source range and completing NamedEvaluation.

It was right about one third of that. There are three unrelated defects here, and the group's name fits only one of them.

## What the causes actually are

**`staging/sm/class/parenExprToString.js` — not about parentheses, and not about methods.** Jint's range handling is correct: `(class A { constructor() {} }).toString()` already returned exactly `class A { constructor() {} }`, parens excluded, and every method form (`m() {}`, `get x() {}`, `static s() {}`) was already right. What returned the `function () { [native code] }` placeholder was a class with *no explicit constructor* — including the test's `(class {})`. Such a class has no function node of its own: `ClassDefinition` substitutes one of two synthesized constructor ASTs (`class temp { constructor() {} }` / the `super(...args)` forwarder), parsed once in a static constructor and shared by every class in the process, so that node carries no retained input and `[[SourceText]]` came out empty. The spec asks for "the source text matched by" the *class* production ([ClassExpression evaluation](https://tc39.es/ecma262/#sec-class-definitions-runtime-semantics-evaluation)), so the text has to come from the class node.

**`staging/sm/generators/runtime.js` — not a source-text test at all.** It is a broad generator-runtime file (a V8 `generators-runtime.js` port), and its failure was:

> `Expected SameValue(«function Function() { [native code] }», «[object GeneratorFunction]») to be true`

i.e. `Object.getPrototypeOf(GeneratorFunction) !== Function`. [§27.3.2](https://tc39.es/ecma262/#sec-generatorfunction-constructor) says the GeneratorFunction constructor "has a `[[Prototype]]` internal slot whose value is %Function%" — the Function *constructor*. Jint set it to `%GeneratorFunction.prototype%`. Same bug in [`AsyncGeneratorFunctionConstructor`](https://tc39.es/ecma262/#sec-asyncgeneratorfunction-constructor); `AsyncFunctionConstructor` already had it right, which is what made the discrepancy easy to miss. There is no test in the stable `built-ins/GeneratorFunction/` directory for the constructor's own `[[Prototype]]`, so nothing else caught it.

**`staging/sm/Function/function-name-for.js` — the comment was right.** The AnnexB for-in head is one of NamedEvaluation's positions ([ForIn/OfLoopEvaluation](https://tc39.es/ecma262/#sec-runtime-semantics-forinofloopevaluation): "If IsAnonymousFunctionDefinition(*Initializer*) is true, let *value* be ? NamedEvaluation of *Initializer* with argument *bindingId*"), and Jint just evaluated the initializer. `for (var forInHead = function () {} in {})` left `forInHead.name` as `""`.

## Pre-fix failures

```
Failed Sm_class("staging/sm/class/parenExprToString.js",False)
  Expected SameValue(«"function () { [native code] }"», «"class {}"») to be true
Failed Sm_generators("staging/sm/generators/runtime.js",False)
  Expected SameValue(«function Function() { [native code] }», «[object GeneratorFunction]») to be true
Failed Sm_Function("staging/sm/Function/function-name-for.js",False)
  Expected SameValue(«""», «"forInHead"») to be true
Failed!  - Failed: 5, Passed: 0, Total: 5
```

## What changed

- `Engine.Defaults.cs` / `Engine.Ast.cs` — the two source-text retention handlers now stamp `ClassDeclaration`/`ClassExpression` nodes with the parse input, as they already do for function nodes. Only when `RetainFunctionSourceText` is on; nothing new is allocated, the same string instance is already held by the parse's function nodes.
- `AstExtensions.DefineMethod` — takes an optional `definitionCacheKey`, and `ClassDefinition` passes the class **body**. Keying the constructor's `JintFunctionDefinition` on the function node made every default-constructor class in an engine share one definition, and therefore one `SourceTextNode` — whichever class got there first. The class node itself is not usable as the key: it is also a field initializer's own value node, which `ClassFieldDefinition` already keys on, so `B = class {}` collides (caught by `language/expressions/class/elements/private-*-on-nested-class.js`). A `ClassBody` is unique per class and is not a cache key anywhere else.
- `JintFunctionDefinition` — gains `GetSourceText()` and a `_ownSourceText` for a definition whose text does not live on its function node, memoized there because the definition is per class while the synthesized constructor's `State` is shared. `SourceText.GetValue` is otherwise unchanged; its slicing moved into a private helper.
- `GeneratorFunctionConstructor` / `AsyncGeneratorFunctionConstructor` — `[[Prototype]]` is the `Function` constructor. They now take the `FunctionConstructor` rather than its prototype object, which is how `AsyncFunctionConstructor` was already written.
- `JintForInForOfStatement` — the AnnexB initializer path performs NamedEvaluation, routing a class expression through `EvaluateWithName` as the `var`/assignment paths do.

## Tests

`Jint.Tests/Runtime/FunctionTests.cs` gains four tests (class source text incl. the parenthesized forms, two default-constructor classes not sharing one text, the native-code placeholder staying the default, the for-in head naming); `GeneratorTests.cs` gains one for the three function-constructor prototypes. All but the placeholder test fail on the unfixed engine.

## Verification

- The three files: `Failed: 0, Passed: 5` (strict and sloppy).
- `built-ins/Function`, `built-ins/{,Async}GeneratorFunction`, `built-ins/AsyncFunction`, `language/{statements,expressions}/class`, `annexB`, `staging/sm/{class,Function,generators}` — `Failed: 0, Passed: 19398, Skipped: 14`.
- `language/statements/for-in`, `language/statements/for-of`, `language/expressions/assignment` — `Failed: 0, Passed: 4502`.
- `Jint.Tests` — `Failed: 0, Passed: 6286` (net10.0) / `6201` (net472).
- `Jint.Tests.PublicInterface` — `Failed: 0, Passed: 1488` / `1487`.

## Files this frees

```
staging/sm/Function/function-name-for.js
staging/sm/class/parenExprToString.js
staging/sm/generators/runtime.js
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
