### PR TITLE
Add opt-in Web API foundation: Options.WebApi, DOMException and console

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,7 @@ Acornima Parser (external) → AST → Interpreter → Runtime → Interop
 - `Jint.Runtime.Interop` — CLR interop: `ObjectWrapper`, `TypeReference`, `ClrFunction`, `DelegateWrapper`, `DefaultTypeConverter`, and `Reflection/` for cached type discovery and method binding.
 - `Jint.Runtime.Environments` — Lexical environments and environment records (Declarative, Function, Global, Object).
 - `Jint.Runtime.Modules` — ES module system: `ModuleLoader` resolution, `CyclicModule` for cyclic dependencies, `ModuleBuilder` for programmatic modules.
+- `Jint.WebApi` — The opt-in WHATWG web platform APIs (`console`, `DOMException`, …), one subfolder and namespace per feature, every file gated `#if NET8_0_OR_GREATER`. See [Web APIs](#web-apis).
 - `Jint.Collections` — High-performance dictionaries (`HybridDictionary`, `StringDictionarySlim`, `DictionarySlim`). `PropertyDictionary` is a global-using alias for `HybridDictionary<PropertyDescriptor>`, which switches between list and hash storage by property count.
 - `Jint.Pooling` — Pools for hot allocations (`ReferencePool`, `ArgumentsInstancePool`, `JsValueArrayPool`, `JsValueListBuilder`).
 
@@ -381,7 +382,7 @@ Performance is a first-class concern; every change must consider its impact.
 - **Partial classes** — Large types are split (`Engine.*.cs`, `Intrinsics.*.cs`, `ObjectInstance.*.cs`). Keep related functionality together when editing.
 - **Type flags** — The `InternalTypes` enum enables fast type checks without casting; many hot paths depend on it.
 - **Property keys** — `KnownKeys` holds pre-computed common property names.
-- **Spec references** — Code cites the section it implements, in a `<summary>` or a comment, and the URL says which document is authoritative: `https://tc39.es/ecma262/#sec-...` for merged language features, `https://tc39.es/ecma402/#sec-...` for i18n, and `https://tc39.es/proposal-<name>/#sec-...` for a feature that is still a proposal. Maintain them when editing, and re-point a proposal's citations when it merges into ECMA-262 — the anchors get renamed on the way in (`sec-iteratorprototype.take` became `sec-iterator.prototype.take`).
+- **Spec references** — Code cites the section it implements, in a `<summary>` or a comment, and the URL says which document is authoritative: `https://tc39.es/ecma262/#sec-...` for merged language features, `https://tc39.es/ecma402/#sec-...` for i18n, and `https://tc39.es/proposal-<name>/#sec-...` for a feature that is still a proposal. Maintain them when editing, and re-point a proposal's citations when it merges into ECMA-262 — the anchors get renamed on the way in (`sec-iteratorprototype.take` became `sec-iterator.prototype.take`). The web APIs under `Jint/WebApi/` are owned by WHATWG living standards instead, each with its own document and anchor vocabulary: `https://console.spec.whatwg.org/#...`, `https://webidl.spec.whatwg.org/#...` (`#idl-*`, `#es-*`, `#dfn-*`), `https://fetch.spec.whatwg.org/#...` (`#dom-*`, `#concept-*`), `https://dom.spec.whatwg.org/#...`, `https://html.spec.whatwg.org/multipage/...`, `https://encoding.spec.whatwg.org/#...` and `https://url.spec.whatwg.org/#...`. Cite the one that actually defines the thing — `fetch` is WHATWG Fetch, `setTimeout` is HTML, `DOMException` is WebIDL — never MDN.
 
 ### Data structures
 
@@ -424,7 +425,21 @@ Follow the specification as closely as practical, support both strict and sloppy
 5. Update `TypeConverter` if new coercion rules apply.
 6. Add a statement/expression handler under `Runtime/Interpreter/` if it is new syntax.
 
-Proposal-stage built-ins are registered unconditionally — there is no per-feature option or ES-version gate. `Options.ExperimentalFeatures` is about CLR interop and has nothing to do with which built-ins exist.
+Proposal-stage **TC39** built-ins are registered unconditionally — there is no per-feature option or ES-version gate for anything ECMAScript defines, however early its stage. `Options.ExperimentalFeatures` is about CLR interop and has nothing to do with which built-ins exist.
+
+**That rule stops at the language.** The WHATWG web APIs under `Jint/WebApi/` are host APIs, not language features, and are deliberately **opt-in**: nothing is installed unless `Options.WebApi.Features` names it, and a default engine is byte-for-byte the engine it was before they existed. Do not "fix" that gating by registering them unconditionally — see [Web APIs](#web-apis) for how it works and why.
+
+### Web APIs
+
+`Jint/WebApi/` holds the opt-in WHATWG surface — `console`, `DOMException`, and the timers/encoding/URL/fetch features still landing — with one subfolder and matching namespace per feature (`Console/`, `DomException/`, …). It is deliberately *not* under `Jint/Native/`, which mirrors ECMAScript; these are host APIs guided by WinterTC's Minimum Common Web Platform API, they use the BCL only (no new package dependencies), and their JS-facing types are `internal sealed` and authored with the source generator exactly like the built-ins.
+
+Three conventions hold across the subtree:
+
+- **Whole-file `#if NET8_0_OR_GREATER`.** Every file in `Jint/WebApi/`, the `Options.WebApi.cs` / `Intrinsics.WebApi.cs` partials, and every test file that touches them is wrapped end to end. No `SUPPORTS_` constant is minted for this — those name absent BCL *types*; this is a uniform floor for the whole feature area. The gate is airtight only if `dotnet build -c Release` is run for the **solution**, since `net462`/`netstandard2.0`/`netstandard2.1` are where a leaked reference shows up. Both test suites also compile `net472` on Windows, which is what the test-file wrapping is for.
+- **Installed from `Options.Apply`, as lazy globals.** `WebApiRegistration.Apply` runs from the one gated block in `Options.Apply` — the sanctioned conditional-install site, the same one `Interop.Enabled` and `Modules.RegisterRequire` use. `[JsIntrinsicReference]` is not usable here: it is unconditional and would leak into every `ShadowRealm`. Each global is a `LazyPropertyDescriptor<Engine>` installed through `GlobalObject.SetProperty`, exactly as `AddLazyGlobal` does and for its reasons — the version bump that keeps inline caches valid, and the unmaterialized state `RestoreGlobalSnapshot` can revert to. The install is **non-clobbering**: the host's `_configurations` run first and any name the global already owns is left alone, checked with a probe so a host's own lazy global is not materialized just by looking.
+- **Only the principal realm.** Nothing outside `Options.Apply` touches a global object, so a `ShadowRealm` never carries these APIs. That diverges from browsers, where they are `[Exposed=*]`; it is a deliberate conservative choice, pinned by a test, and `Host.InitializeShadowRealm` remains the host's door.
+
+Feature flags live in `WebApiFeatures`, whose bit layout is fixed ahead of the implementations so a persisted value keeps its meaning — but a flag is **declared only once the feature behind it exists**, so naming one can never compile into an engine that silently lacks it. `WebApiFeatures.Default` is every non-network feature and will never include fetch.
 
 ## Modules
 

--- a/Jint.Repl/Program.cs
+++ b/Jint.Repl/Program.cs
@@ -70,6 +70,7 @@ for (int i = 0; i < args.Length; i++)
 var engine = new Engine(cfg =>
 {
     cfg.AllowClr();
+    cfg.UseConsole(Console.Out);
     if (timeoutSeconds.HasValue)
     {
         cfg.TimeoutInterval(TimeSpan.FromSeconds(timeoutSeconds.Value));
@@ -85,7 +86,6 @@ var engine = new Engine(cfg =>
 
 engine
     .SetValue("print", new Action<object>(Console.WriteLine))
-    .SetValue("console", new JsConsole())
     .SetValue("load", new Func<string, object>(
         path => engine.Evaluate(File.ReadAllText(path)))
     );
@@ -302,19 +302,4 @@ static void PrintHelp()
     Console.WriteLine("  jint -f script.js -t 10       Execute with 10 second timeout");
     Console.WriteLine("  echo \"1+1\" | jint             Execute from stdin");
     Console.WriteLine("  echo \"1+1\" | jint -t 5        Execute from stdin with timeout");
-}
-
-file sealed class JsConsole
-{
-    public void Log(object value)
-    {
-        Console.WriteLine(value?.ToString() ?? "null");
-    }
-
-    public void Error(object value)
-    {
-        Console.ForegroundColor = ConsoleColor.Red;
-        Console.WriteLine(value?.ToString() ?? "null");
-        Console.ResetColor();
-    }
 }

--- a/Jint.Tests.PublicInterface/WebApiTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiTests.cs
@@ -1,0 +1,172 @@
+#if NET8_0_OR_GREATER
+using Jint;
+using Jint.Native;
+using Jint.WebApi;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// The opt-in web platform APIs seen from outside the assembly: what a host has to write to get them, what it
+/// gets when it writes nothing, and the promises it can build on.
+/// </summary>
+/// <remarks>
+/// This project has no <c>InternalsVisibleTo</c>, so everything here is reachable by a third party. The pin
+/// that matters most is <see cref="ADefaultEngineHasNoWebGlobals"/>: the whole surface is opt-in, and an
+/// engine that did not ask for it must be the engine it was before any of this existed.
+/// </remarks>
+public class WebApiTests
+{
+    private sealed class RecordingSink : ConsoleSink
+    {
+        internal List<(ConsoleLogLevel Level, string Message)> Records { get; } = new();
+
+        public override void Write(ConsoleLogLevel level, string message)
+        {
+            Records.Add((level, message));
+        }
+    }
+
+    [Fact]
+    public void ADefaultEngineHasNoWebGlobals()
+    {
+        var engine = new Engine();
+
+        engine.Evaluate("typeof console").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof DOMException").AsString().Should().Be("undefined");
+        engine.Evaluate("'console' in globalThis").AsBoolean().Should().BeFalse();
+        engine.Evaluate("'DOMException' in globalThis").AsBoolean().Should().BeFalse();
+
+        // Not even an engine that named the group but no feature.
+        var untouched = new Engine(options => options.WebApi.Features = WebApiFeatures.None);
+        untouched.Evaluate("typeof console").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void UseWebApisInstallsTheDefaultSet()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        engine.Evaluate("typeof console").AsString().Should().Be("object");
+        engine.Evaluate("typeof DOMException").AsString().Should().Be("function");
+
+        // The default set never carries a network API, whatever it grows to include.
+        engine.Evaluate("typeof fetch").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void UseConsoleWritesToATextWriter()
+    {
+        var writer = new StringWriter();
+        var engine = new Engine(options => options.UseConsole(writer));
+
+        engine.Execute("console.log('hello %s', 'world'); console.group('g'); console.warn('inner'); console.groupEnd();");
+
+        writer.ToString().Should().Be("hello world" + Environment.NewLine + "g" + Environment.NewLine + "  inner" + Environment.NewLine);
+    }
+
+    [Fact]
+    public void AHostSinkReceivesEveryRecordWithItsLevel()
+    {
+        var sink = new RecordingSink();
+        var engine = new Engine(options => options.UseConsole(sink));
+
+        engine.Execute("console.log('a'); console.error('b'); console.debug('c');");
+
+        sink.Records.Should().HaveCount(3);
+        sink.Records[0].Should().Be((ConsoleLogLevel.Log, "a"));
+        sink.Records[1].Should().Be((ConsoleLogLevel.Error, "b"));
+        sink.Records[2].Should().Be((ConsoleLogLevel.Debug, "c"));
+    }
+
+    [Fact]
+    public void UseConsoleImpliesTheConsoleFeature()
+    {
+        var options = new Options().UseConsole(ConsoleSink.Null);
+
+        options.WebApi.Features.Should().Be(WebApiFeatures.Console);
+        new Engine(options).Evaluate("typeof console").AsString().Should().Be("object");
+    }
+
+    [Fact]
+    public void FeatureCallsAccumulateRatherThanReplace()
+    {
+        var options = new Options()
+            .UseConsole(ConsoleSink.Null)
+            .UseWebApis(WebApiFeatures.None);
+
+        options.WebApi.Features.Should().HaveFlag(WebApiFeatures.Console);
+    }
+
+    [Fact]
+    public void TheDefaultSinkDiscardsEverything()
+    {
+        var options = new Options().UseWebApis();
+
+        // Enabling the feature must never start writing to the process's standard output by itself.
+        options.WebApi.Console.Sink.Should().BeSameAs(ConsoleSink.Null);
+
+        var engine = new Engine(options);
+        engine.Execute("console.log('nothing to see'); console.error('nor this');");
+    }
+
+    [Fact]
+    public void AHostRegisteredGlobalWins()
+    {
+        var marker = new JsString("host's own console");
+
+        var engine = new Engine(options => options
+            .AddLazyGlobal("console", _ => marker)
+            .UseConsole(ConsoleSink.Null));
+
+        // The host's configuration runs first and the install is non-clobbering, so what the host registered
+        // is what the script sees.
+        engine.Evaluate("console").Should().BeSameAs(marker);
+    }
+
+    [Fact]
+    public void OneOptionsInstanceServesSeveralEnginesIndependently()
+    {
+        var sink = new RecordingSink();
+        var options = new Options().UseConsole(sink);
+
+        var first = new Engine(options);
+        var second = new Engine(options);
+
+        first.Execute("console.count('x'); console.group('g'); console.log('deep');");
+        second.Execute("console.count('x'); console.log('flat');");
+
+        // Counters and group depth belong to the engine, never to the shared options.
+        sink.Records.ConvertAll(r => r.Message).Should().Equal("x: 1", "g", "  deep", "x: 1", "flat");
+    }
+
+    [Fact]
+    public void ASwappedSinkTakesEffectOnTheNextRecord()
+    {
+        var first = new RecordingSink();
+        var second = new RecordingSink();
+        var options = new Options().UseConsole(first);
+        var engine = new Engine(options);
+
+        engine.Execute("console.log('one')");
+        options.WebApi.Console.Sink = second;
+        engine.Execute("console.log('two')");
+
+        first.Records.Should().HaveCount(1);
+        second.Records.Should().HaveCount(1);
+        second.Records[0].Message.Should().Be("two");
+    }
+
+    [Fact]
+    public void DomExceptionIsUsableFromScriptAndFromTheHost()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        var exception = engine.Evaluate("new DOMException('gone', 'AbortError')").AsObject();
+
+        exception.Get("name").AsString().Should().Be("AbortError");
+        exception.Get("message").AsString().Should().Be("gone");
+        exception.Get("code").AsNumber().Should().Be(20);
+        engine.Evaluate("new DOMException('gone', 'AbortError') instanceof Error").AsBoolean().Should().BeTrue();
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/ConsoleTests.cs
+++ b/Jint.Tests/Runtime/WebApi/ConsoleTests.cs
@@ -1,0 +1,324 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.WebApi;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// The <c>console</c> object against the Console Standard — https://console.spec.whatwg.org/.
+/// </summary>
+/// <remarks>
+/// Everything is asserted through a recording sink rather than through captured standard output, because
+/// what the engine promises a host is exactly the sequence of
+/// <see cref="ConsoleSink.Write(ConsoleLogLevel, string)"/> calls: one per emitted record, already formatted
+/// and already indented.
+/// </remarks>
+public class ConsoleTests
+{
+    private sealed class RecordingSink : ConsoleSink
+    {
+        internal List<(ConsoleLogLevel Level, string Message)> Records { get; } = new();
+
+        internal List<string> Messages => Records.ConvertAll(r => r.Message);
+
+        public override void Write(ConsoleLogLevel level, string message)
+        {
+            Records.Add((level, message));
+        }
+    }
+
+    private static (Engine Engine, RecordingSink Sink) Recording()
+    {
+        var sink = new RecordingSink();
+        var engine = new Engine(options => options.UseConsole(sink));
+        return (engine, sink);
+    }
+
+    private static List<string> Run(string script)
+    {
+        var (engine, sink) = Recording();
+        engine.Execute(script);
+        return sink.Messages;
+    }
+
+    [Fact]
+    public void SubstitutesTheFormatSpecifiers()
+    {
+        Run("console.log('hello %s', 'world')").Should().Equal("hello world");
+        Run("console.log('%d apples', 3.7)").Should().Equal("3 apples");
+        Run("console.log('%i apples', 3.7)").Should().Equal("3 apples");
+        Run("console.log('%f apples', 3.5)").Should().Equal("3.5 apples");
+        Run("console.log('%o', {a:1})").Should().Equal("{ a: 1 }");
+        Run("console.log('%O', [1,'x'])").Should().Equal("[ 1, 'x' ]");
+    }
+
+    [Fact]
+    public void CoercesAwkwardValuesTheWayTheSpecifierSays()
+    {
+        Run("console.log('%d', Symbol('s'))").Should().Equal("NaN");
+        Run("console.log('%f', Symbol('s'))").Should().Equal("NaN");
+        Run("console.log('%s', Symbol('s'))").Should().Equal("Symbol(s)");
+        Run("console.log('%d', {})").Should().Equal("NaN");
+        Run("console.log('%d', 10n)").Should().Equal("10");
+    }
+
+    [Fact]
+    public void ConsumesPercentCWithoutEmittingStyling()
+    {
+        Run("console.log('%cstyled', 'color: red')").Should().Equal("styled");
+        Run("console.log('%ca%cb', 'x', 'y')").Should().Equal("ab");
+    }
+
+    [Fact]
+    public void CollapsesADoubledPercent()
+    {
+        // Formatter step 1 returns a single argument untouched, so substitution — including %% — only ever
+        // happens when there is something to substitute. This is what a browser does too.
+        Run("console.log('100%% sure')").Should().Equal("100%% sure");
+        Run("console.log('100%% sure of %s', 'it')").Should().Equal("100% sure of it");
+    }
+
+    [Fact]
+    public void LeavesASpecifierWithNoArgumentAlone()
+    {
+        Run("console.log('a %s %s', 'b')").Should().Equal("a b %s");
+    }
+
+    [Fact]
+    public void AppendsExtraArgumentsSeparatedBySpaces()
+    {
+        Run("console.log('a', 'b', 'c')").Should().Equal("a b c");
+        Run("console.log('n=%d', 1, 'and', 2)").Should().Equal("n=1 and 2");
+        Run("console.log(1, 2)").Should().Equal("1 2");
+    }
+
+    [Fact]
+    public void DoesNotTreatANonStringFirstArgumentAsAFormatString()
+    {
+        Run("console.log({a:'%s'}, 'b')").Should().Equal("{ a: '%s' } b");
+    }
+
+    [Fact]
+    public void EmitsNothingWhenThereIsNothingToLog()
+    {
+        // https://console.spec.whatwg.org/#logger step 1.
+        Run("console.log()").Should().BeEmpty();
+        Run("console.warn(); console.error(); console.info(); console.debug()").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void MakesExactlyOneWritePerRecord()
+    {
+        var (engine, sink) = Recording();
+
+        engine.Execute("console.log('a\\nb', {x:1}); console.warn('c')");
+
+        sink.Records.Should().HaveCount(2);
+        sink.Records[0].Message.Should().Be("a\nb { x: 1 }");
+    }
+
+    [Fact]
+    public void MapsEachMethodToItsLevel()
+    {
+        var (engine, sink) = Recording();
+
+        engine.Execute("console.debug('d'); console.log('l'); console.info('i'); console.warn('w'); console.error('e');");
+
+        sink.Records.ConvertAll(r => r.Level).Should().Equal(
+            ConsoleLogLevel.Debug,
+            ConsoleLogLevel.Log,
+            ConsoleLogLevel.Info,
+            ConsoleLogLevel.Warn,
+            ConsoleLogLevel.Error);
+    }
+
+    [Fact]
+    public void IndentsWhatFollowsAGroupLabel()
+    {
+        var messages = Run(@"
+            console.log('before');
+            console.group('outer');
+            console.log('one');
+            console.groupCollapsed('inner');
+            console.log('two');
+            console.groupEnd();
+            console.log('three');
+            console.groupEnd();
+            console.log('after');");
+
+        messages.Should().Equal(
+            "before",
+            "outer",
+            "  one",
+            "  inner",
+            "    two",
+            "  three",
+            "after");
+    }
+
+    [Fact]
+    public void IndentsEveryLineOfAMultiLineRecord()
+    {
+        Run("console.group('g'); console.log('a\\nb')").Should().Equal("g", "  a\n  b");
+    }
+
+    [Fact]
+    public void SurvivesAnUnbalancedGroupEnd()
+    {
+        Run("console.groupEnd(); console.groupEnd(); console.log('flat')").Should().Equal("flat");
+    }
+
+    [Fact]
+    public void CountsPerLabel()
+    {
+        Run("console.count(); console.count(); console.count('a'); console.count()")
+            .Should().Equal("default: 1", "default: 2", "a: 1", "default: 3");
+    }
+
+    [Fact]
+    public void ResetsACounter()
+    {
+        Run("console.count('a'); console.countReset('a'); console.count('a')")
+            .Should().Equal("a: 1", "a: 1");
+    }
+
+    [Fact]
+    public void WarnsWhenResettingACounterThatDoesNotExist()
+    {
+        var (engine, sink) = Recording();
+
+        engine.Execute("console.countReset('nope')");
+
+        sink.Records.Should().HaveCount(1);
+        sink.Records[0].Level.Should().Be(ConsoleLogLevel.Warn);
+        sink.Records[0].Message.Should().Be("Count for 'nope' does not exist");
+    }
+
+    [Fact]
+    public void ReportsTimersByLabelWithADuration()
+    {
+        var (engine, sink) = Recording();
+
+        engine.Execute("console.time(); console.timeLog(); console.timeLog(undefined, 'mid'); console.timeEnd();");
+
+        // Durations are wall-clock, so only the shape is asserted.
+        sink.Records.Should().HaveCount(3);
+        sink.Records[0].Message.Should().MatchRegex(@"^default: [0-9.]+ms$");
+        sink.Records[1].Message.Should().MatchRegex(@"^default: [0-9.]+ms mid$");
+        sink.Records[2].Message.Should().MatchRegex(@"^default: [0-9.]+ms$");
+        sink.Records.TrueForAll(r => r.Level == ConsoleLogLevel.Log).Should().BeTrue();
+    }
+
+    [Fact]
+    public void WarnsAboutADuplicateOrMissingTimer()
+    {
+        var (engine, sink) = Recording();
+
+        engine.Execute("console.time('t'); console.time('t'); console.timeEnd('t'); console.timeEnd('t'); console.timeLog('t');");
+
+        sink.Records[0].Message.Should().Be("Timer 't' already exists");
+        sink.Records[0].Level.Should().Be(ConsoleLogLevel.Warn);
+        sink.Records[1].Message.Should().MatchRegex(@"^t: [0-9.]+ms$");
+        sink.Records[2].Message.Should().Be("Timer 't' does not exist");
+        sink.Records[3].Message.Should().Be("Timer 't' does not exist");
+    }
+
+    [Fact]
+    public void AssertsOnlyOnAFalsyCondition()
+    {
+        var (engine, sink) = Recording();
+
+        engine.Execute("console.assert(true, 'never'); console.assert(1, 'never'); console.assert('x', 'never');");
+        sink.Records.Should().BeEmpty();
+
+        engine.Execute("console.assert(false)");
+        engine.Execute("console.assert(0, 'bad %s', 'thing')");
+        engine.Execute("console.assert(undefined, {a:1})");
+        engine.Execute("console.assert()");
+
+        sink.Records.ConvertAll(r => r.Message).Should().Equal(
+            "Assertion failed",
+            "Assertion failed: bad thing",
+            "Assertion failed { a: 1 }",
+            "Assertion failed");
+        sink.Records.TrueForAll(r => r.Level == ConsoleLogLevel.Error).Should().BeTrue();
+    }
+
+    [Fact]
+    public void TracesTheCallStack()
+    {
+        var (engine, sink) = Recording();
+
+        engine.Execute("function outer() { inner(); } function inner() { console.trace('why'); } outer();");
+
+        sink.Records.Should().HaveCount(1);
+        sink.Records[0].Level.Should().Be(ConsoleLogLevel.Error);
+        sink.Records[0].Message.Should().StartWith("Trace: why");
+        sink.Records[0].Message.Should().Contain("at inner");
+        sink.Records[0].Message.Should().Contain("at outer");
+
+        // The dispatcher's own frame is excluded, exactly as `new Error().stack` excludes the Error constructor.
+        sink.Records[0].Message.Should().NotContain("at trace");
+    }
+
+    [Fact]
+    public void InspectsBoundedAndCycleSafely()
+    {
+        Run("var o = {}; o.self = o; console.log(o)").Should().Equal("{ self: [Circular] }");
+        Run("console.log({a:{b:{c:{d:1}}}})").Should().Equal("{ a: { b: { c: [Object] } } }");
+        Run("console.log([])").Should().Equal("[]");
+        Run("console.log({})").Should().Equal("{}");
+        Run("console.log({ 'not-an-identifier': 1 })").Should().Equal("{ 'not-an-identifier': 1 }");
+
+        // An accessor is named, never invoked: a console must not be a way to run script.
+        Run("console.log({ get x() { throw new Error('nope'); } })").Should().Equal("{ x: [Getter] }");
+
+        // Non-enumerable own properties are skipped, the way Object.keys skips them.
+        Run("var o = {}; Object.defineProperty(o, 'hidden', { value: 1 }); console.log(o)").Should().Equal("{}");
+    }
+
+    [Fact]
+    public void QuotesStringsOnlyBelowTheTopLevel()
+    {
+        Run("console.log('x')").Should().Equal("x");
+        Run("console.log(['x'])").Should().Equal("[ 'x' ]");
+        Run("console.dir('x')").Should().Equal("'x'");
+    }
+
+    [Fact]
+    public void RendersFunctionsSymbolsAndErrors()
+    {
+        Run("console.log(Symbol('s'))").Should().Equal("Symbol(s)");
+        Run("console.log(10n)").Should().Equal("10n");
+        Run("console.log(new TypeError('bad'))").Should().Equal("TypeError: bad");
+        Run("console.log(function foo() {})").Should().Equal("function foo() { [native code] }");
+    }
+
+    [Fact]
+    public void IsIdentityStableAndTagged()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        engine.Evaluate("console === console").AsBoolean().Should().BeTrue();
+        engine.Evaluate("console === globalThis.console").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.prototype.toString.call(console)").AsString().Should().Be("[object console]");
+        engine.Evaluate("console[Symbol.toStringTag]").AsString().Should().Be("console");
+    }
+
+    [Fact]
+    public void CountsAndTimersAreOwnedByTheEngine()
+    {
+        var sink = new RecordingSink();
+        var options = new Options().UseConsole(sink);
+
+        var first = new Engine(options);
+        var second = new Engine(options);
+
+        first.Execute("console.count()");
+        second.Execute("console.count()");
+
+        sink.Messages.Should().Equal("default: 1", "default: 1");
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/DomExceptionTests.cs
+++ b/Jint.Tests/Runtime/WebApi/DomExceptionTests.cs
@@ -1,0 +1,196 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// <c>DOMException</c> as WebIDL specifies it — https://webidl.spec.whatwg.org/#idl-DOMException.
+/// </summary>
+/// <remarks>
+/// It is installed whenever <i>any</i> web API is enabled, because it is how the rest of them report a
+/// failure; <see cref="WebApiFeatures.Console"/> is simply the cheapest way to ask for one here.
+/// </remarks>
+public class DomExceptionTests
+{
+    private static Engine WebEngine() => new(options => options.UseWebApis(WebApiFeatures.Console));
+
+    [Fact]
+    public void DefaultsToTheIdlArguments()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("new DOMException().name").AsString().Should().Be("Error");
+        engine.Evaluate("new DOMException().message").AsString().Should().Be("");
+        engine.Evaluate("new DOMException().code").AsNumber().Should().Be(0);
+
+        // An explicitly passed undefined takes the default too, which is what an optional argument with a
+        // default value means in WebIDL.
+        engine.Evaluate("new DOMException(undefined, undefined).name").AsString().Should().Be("Error");
+    }
+
+    [Fact]
+    public void CarriesTheGivenMessageAndName()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("new DOMException('boom', 'AbortError').message").AsString().Should().Be("boom");
+        engine.Evaluate("new DOMException('boom', 'AbortError').name").AsString().Should().Be("AbortError");
+    }
+
+    [Theory]
+    [InlineData("IndexSizeError", 1)]
+    [InlineData("HierarchyRequestError", 3)]
+    [InlineData("InvalidCharacterError", 5)]
+    [InlineData("NotFoundError", 8)]
+    [InlineData("InvalidStateError", 11)]
+    [InlineData("SyntaxError", 12)]
+    [InlineData("SecurityError", 18)]
+    [InlineData("NetworkError", 19)]
+    [InlineData("AbortError", 20)]
+    [InlineData("QuotaExceededError", 22)]
+    [InlineData("TimeoutError", 23)]
+    [InlineData("DataCloneError", 25)]
+    public void MapsALegacyNameToItsCode(string name, int code)
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate($"new DOMException('', '{name}').code").AsNumber().Should().Be(code);
+    }
+
+    [Theory]
+    [InlineData("NotAllowedError")]
+    [InlineData("EncodingError")]
+    [InlineData("SomethingNobodyStandardized")]
+    [InlineData("")]
+    public void ReportsZeroForANameOutsideTheLegacyTable(string name)
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate($"new DOMException('', '{name}').code").AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void ExposesTheLegacyConstantsOnBothTheInterfaceObjectAndThePrototype()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("DOMException.INDEX_SIZE_ERR").AsNumber().Should().Be(1);
+        engine.Evaluate("DOMException.DATA_CLONE_ERR").AsNumber().Should().Be(25);
+        engine.Evaluate("DOMException.prototype.INDEX_SIZE_ERR").AsNumber().Should().Be(1);
+        engine.Evaluate("DOMException.prototype.DATA_CLONE_ERR").AsNumber().Should().Be(25);
+
+        // All 25 of them, on both objects.
+        engine.Evaluate("Object.getOwnPropertyNames(DOMException).filter(function (n) { return /_ERR$/.test(n); }).length")
+            .AsNumber().Should().Be(25);
+        engine.Evaluate("Object.getOwnPropertyNames(DOMException.prototype).filter(function (n) { return /_ERR$/.test(n); }).length")
+            .AsNumber().Should().Be(25);
+    }
+
+    [Fact]
+    public void GivesTheConstantsTheAttributesWebIdlGivesConstants()
+    {
+        var engine = WebEngine();
+
+        var descriptor = "Object.getOwnPropertyDescriptor(DOMException, 'ABORT_ERR')";
+        engine.Evaluate($"{descriptor}.value").AsNumber().Should().Be(20);
+        engine.Evaluate($"{descriptor}.writable").AsBoolean().Should().BeFalse();
+        engine.Evaluate($"{descriptor}.enumerable").AsBoolean().Should().BeTrue();
+        engine.Evaluate($"{descriptor}.configurable").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void ChainsThroughItsPrototypeToErrorPrototype()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("new DOMException() instanceof DOMException").AsBoolean().Should().BeTrue();
+        engine.Evaluate("new DOMException() instanceof Error").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.getPrototypeOf(DOMException.prototype) === Error.prototype").AsBoolean().Should().BeTrue();
+
+        // The interface object itself is an ordinary function, not a NativeError constructor.
+        engine.Evaluate("Object.getPrototypeOf(DOMException) === Function.prototype").AsBoolean().Should().BeTrue();
+        engine.Evaluate("DOMException.prototype.constructor === DOMException").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void InheritsErrorPrototypeToString()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("String(new DOMException('boom', 'AbortError'))").AsString().Should().Be("AbortError: boom");
+        engine.Evaluate("String(new DOMException())").AsString().Should().Be("Error");
+    }
+
+    [Fact]
+    public void CarriesAStack()
+    {
+        var engine = WebEngine();
+
+        var stack = engine.Evaluate("function make() { return new DOMException('x'); } make().stack").AsString();
+
+        stack.Should().NotBeNullOrEmpty();
+        stack.Should().Contain("at make");
+
+        // Browsers expose it as an own, non-enumerable property of the instance.
+        engine.Evaluate("new DOMException().hasOwnProperty('stack')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.keys(new DOMException()).length").AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void ExposesNameMessageAndCodeAsPrototypeAccessors()
+    {
+        var engine = WebEngine();
+
+        // WebIDL attributes live on the interface prototype object, so the instance owns none of them.
+        engine.Evaluate("new DOMException('m', 'AbortError').hasOwnProperty('name')").AsBoolean().Should().BeFalse();
+        engine.Evaluate("new DOMException('m', 'AbortError').hasOwnProperty('message')").AsBoolean().Should().BeFalse();
+
+        var descriptor = "Object.getOwnPropertyDescriptor(DOMException.prototype, 'name')";
+        engine.Evaluate($"typeof {descriptor}.get").AsString().Should().Be("function");
+        engine.Evaluate($"{descriptor}.set").IsUndefined().Should().BeTrue();
+        engine.Evaluate($"{descriptor}.enumerable").AsBoolean().Should().BeTrue();
+        engine.Evaluate($"{descriptor}.configurable").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void RefusesAnAccessorReceiverThatIsNotADomException()
+    {
+        var engine = WebEngine();
+
+        // DOMException.prototype is an interface prototype object, not an instance of the interface.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("DOMException.prototype.name"))
+            .Message.Should().Contain("DOMException");
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("Object.getOwnPropertyDescriptor(DOMException.prototype, 'code').get.call({})"));
+    }
+
+    [Fact]
+    public void TagsItselfForObjectPrototypeToString()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("Object.prototype.toString.call(new DOMException())").AsString().Should().Be("[object DOMException]");
+        engine.Evaluate("DOMException.prototype[Symbol.toStringTag]").AsString().Should().Be("DOMException");
+    }
+
+    [Fact]
+    public void RequiresNew()
+    {
+        var engine = WebEngine();
+
+        var exception = Assert.Throws<JavaScriptException>(() => engine.Evaluate("DOMException('x')"));
+        exception.Message.Should().Contain("requires 'new'");
+    }
+
+    [Fact]
+    public void HasTheIdlArity()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("DOMException.length").AsNumber().Should().Be(0);
+        engine.Evaluate("DOMException.name").AsString().Should().Be("DOMException");
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/WebApiRegistrationTests.cs
+++ b/Jint.Tests/Runtime/WebApi/WebApiRegistrationTests.cs
@@ -1,0 +1,127 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Native;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Descriptors.Specialized;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// How the opt-in web globals are installed: what they are made of, who does not get them, and what a global
+/// snapshot restore does to them.
+/// </summary>
+public class WebApiRegistrationTests
+{
+    private static Engine WebEngine() => new(options => options.UseWebApis());
+
+    [Fact]
+    public void InstallsUnmaterializedLazyDescriptors()
+    {
+        var engine = WebEngine();
+
+        foreach (var name in new[] { "console", "DOMException" })
+        {
+            var descriptor = engine.Realm.GlobalObject.GetOwnProperty(name);
+
+            descriptor.Should().BeOfType<LazyPropertyDescriptor<Engine>>();
+            // Still flagged CustomJsValue means the factory has not run: enabling a feature nobody uses costs
+            // one descriptor and nothing else.
+            (descriptor._flags & PropertyFlag.CustomJsValue).Should().NotBe(PropertyFlag.None);
+            descriptor._value.Should().BeNull();
+        }
+    }
+
+    [Fact]
+    public void GivesEachGlobalTheAttributesWebIdlAsksFor()
+    {
+        var engine = WebEngine();
+
+        // An interface object is writable and configurable but not enumerable.
+        var domException = engine.Realm.GlobalObject.GetOwnProperty("DOMException");
+        domException.Writable.Should().BeTrue();
+        domException.Configurable.Should().BeTrue();
+        domException.Enumerable.Should().BeFalse();
+
+        // console is an ordinary enumerable data property — a documented simplification of the WebIDL
+        // namespace-object accessor pair.
+        var console = engine.Realm.GlobalObject.GetOwnProperty("console");
+        console.Writable.Should().BeTrue();
+        console.Configurable.Should().BeTrue();
+        console.Enumerable.Should().BeTrue();
+    }
+
+    [Fact]
+    public void InstallsDomExceptionForAnyFeatureButNotForNone()
+    {
+        // DOMException has no flag of its own: it exists whenever any web API does.
+        new Engine(options => options.UseWebApis(WebApiFeatures.Console))
+            .Evaluate("typeof DOMException").AsString().Should().Be("function");
+
+        new Engine(options => options.WebApi.Features = WebApiFeatures.None)
+            .Evaluate("typeof DOMException").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void DoesNotReachIntoAShadowRealm()
+    {
+        var engine = WebEngine();
+
+        // Only the principal realm's global object is touched. This is deliberately more conservative than a
+        // browser, where these APIs are [Exposed=*].
+        engine.Evaluate("new ShadowRealm().evaluate('typeof console')").AsString().Should().Be("undefined");
+        engine.Evaluate("new ShadowRealm().evaluate('typeof DOMException')").AsString().Should().Be("undefined");
+
+        // ... and the outer realm still has them.
+        engine.Evaluate("typeof console").AsString().Should().Be("object");
+    }
+
+    [Fact]
+    public void SurvivesAGlobalSnapshotRestore()
+    {
+        var engine = WebEngine();
+
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+
+        engine.Execute("console.log('first'); var e = new DOMException('x');");
+        engine.Realm.GlobalObject.GetOwnProperty("console")._value.Should().NotBeNull();
+
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        // The descriptor is back to the unmaterialized state it was captured in, so the next read rebuilds
+        // the object rather than serving the previous cycle's.
+        var descriptor = engine.Realm.GlobalObject.GetOwnProperty("console");
+        descriptor.Should().BeOfType<LazyPropertyDescriptor<Engine>>();
+        descriptor._value.Should().BeNull();
+
+        engine.Evaluate("typeof console").AsString().Should().Be("object");
+        engine.Evaluate("new DOMException('y', 'AbortError').code").AsNumber().Should().Be(20);
+        engine.Evaluate("typeof e").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void LeavesAGlobalTheHostAlreadyOwns()
+    {
+        var marker = new JsString("host's own");
+        var engine = new Engine(options => options
+            .Configure(e => e.SetValue("console", marker))
+            .UseWebApis());
+
+        engine.Evaluate("console").Should().BeSameAs(marker);
+    }
+
+    [Fact]
+    public void LeavesAHostLazyGlobalUnmaterialized()
+    {
+        var built = 0;
+        var engine = new Engine(options => options
+            .AddLazyGlobal("console", _ => { built++; return new JsString("host's own"); })
+            .UseWebApis());
+
+        // The non-clobbering check probes rather than reads, so looking does not force the host's factory.
+        built.Should().Be(0);
+        engine.Evaluate("console").AsString().Should().Be("host's own");
+        built.Should().Be(1);
+    }
+}
+#endif

--- a/Jint/Native/Error/ErrorPrototype.cs
+++ b/Jint/Native/Error/ErrorPrototype.cs
@@ -161,10 +161,15 @@ internal sealed partial class ErrorPrototype : ErrorInstance
             Throw.TypeError(_realm, $"Method Error.prototype.toString called on incompatible receiver {thisObject}");
         }
 
-        var nameProp = o.Get("name", this);
+        // Steps 3 and 5 are Get(O, "name") and Get(O, "message"), so the receiver is O — not %Error.prototype%.
+        // It only matters when the property resolves to an accessor somewhere up the chain, which no ordinary
+        // error has but a WebIDL-shaped one (DOMException, whose attributes are prototype accessors that
+        // brand-check their receiver) does: with the prototype as receiver such a getter is handed the wrong
+        // object and rightly refuses.
+        var nameProp = o.Get("name");
         var name = nameProp.IsUndefined() ? "Error" : TypeConverter.ToString(nameProp);
 
-        var msgProp = o.Get("message", this);
+        var msgProp = o.Get("message");
         string msg = msgProp.IsUndefined() ? "" : TypeConverter.ToString(msgProp);
 
         if (name == "")

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -1,0 +1,121 @@
+#if NET8_0_OR_GREATER
+using Jint.WebApi;
+
+namespace Jint;
+
+public partial class Options
+{
+    /// <summary>
+    /// Opt-in WHATWG web platform APIs (<c>console</c>, <c>DOMException</c>, …). Nothing here is installed
+    /// unless <see cref="WebApiOptions.Features"/> names it, so a default engine is byte-for-byte the engine
+    /// it was before these existed.
+    /// <para>
+    /// <b>Requires .NET 8 or higher.</b> The whole surface is compiled only for <c>net8.0</c> and later; on
+    /// <c>net462</c>, <c>netstandard2.0</c> and <c>netstandard2.1</c> the property does not exist at all.
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Reachable through <see cref="WebApiOptionsExtensions.UseWebApis(Options)"/> and friends, which is the
+    /// spelling most hosts want. The group is here for the settings those extensions do not name.
+    /// </para>
+    /// <para>
+    /// Unlike the other option groups this one is allocated on first touch rather than with the
+    /// <see cref="Options"/> instance, so a host that never asks for a web API pays nothing for the group
+    /// existing — <see cref="Apply"/> reads the backing field and never forces it. Touching the property is
+    /// therefore a host-thread act like any other option mutation; an engine build never does it.
+    /// </para>
+    /// </remarks>
+    public WebApiOptions WebApi => _webApi ??= new WebApiOptions();
+
+    private WebApiOptions? _webApi;
+
+    /// <summary>
+    /// Configuration for the opt-in web platform APIs. Requires .NET 8 or higher.
+    /// </summary>
+    /// <remarks>
+    /// Like every other <see cref="Options"/> group this may be shared by any number of engines, including
+    /// concurrent ones: nothing on it is engine-affine. The one obligation that carries is on
+    /// <see cref="ConsoleOptions.Sink"/> — see its documentation.
+    /// </remarks>
+    public class WebApiOptions
+    {
+        /// <summary>
+        /// Which web APIs this engine exposes. Defaults to <see cref="WebApiFeatures.None"/>, which installs
+        /// nothing at all — not even <c>DOMException</c>.
+        /// </summary>
+        public WebApiFeatures Features { get; set; }
+
+        /// <summary>
+        /// Settings for the <c>console</c> object, installed when <see cref="Features"/> contains
+        /// <see cref="WebApiFeatures.Console"/>.
+        /// </summary>
+        public ConsoleOptions Console { get; } = new();
+    }
+
+    /// <summary>
+    /// Settings for the <c>console</c> object. Requires .NET 8 or higher.
+    /// </summary>
+    public class ConsoleOptions
+    {
+        /// <summary>
+        /// Where <c>console</c> output goes. Defaults to <see cref="ConsoleSink.Null"/>, which discards
+        /// everything — enabling the feature never starts writing to the host's standard output by surprise.
+        /// </summary>
+        /// <remarks>
+        /// The sink is read afresh on every emit, so a host may swap it between evaluations. A sink assigned
+        /// to an <see cref="Options"/> instance shared by concurrently running engines is called from each of
+        /// their threads and must be thread-safe; one belonging to a single engine is only ever called on
+        /// that engine's thread. Assigning <see langword="null"/> is read back as
+        /// <see cref="ConsoleSink.Null"/>.
+        /// </remarks>
+        public ConsoleSink Sink { get; set; } = ConsoleSink.Null;
+    }
+}
+
+/// <summary>
+/// The web platform APIs an engine can be asked to expose. Requires .NET 8 or higher.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Unlike TC39 built-ins, which Jint registers unconditionally, WHATWG web APIs are host APIs: an engine
+/// embedded in a workflow runner or a template renderer has no business carrying them, so they are installed
+/// only when named here.
+/// </para>
+/// <para>
+/// The bit layout is fixed ahead of the implementations so that a value persisted by a host keeps its meaning
+/// as the surface grows. The bits reserved for the features still to land are
+/// <c>Timers = 1 &lt;&lt; 1</c>, <c>Encoding = 1 &lt;&lt; 2</c>, <c>Base64 = 1 &lt;&lt; 3</c>,
+/// <c>StructuredClone = 1 &lt;&lt; 4</c>, <c>Crypto = 1 &lt;&lt; 5</c>, <c>Performance = 1 &lt;&lt; 6</c>,
+/// <c>Events = 1 &lt;&lt; 7</c>, <c>Url = 1 &lt;&lt; 8</c>, <c>Files = 1 &lt;&lt; 9</c> and
+/// <c>Fetch = 1 &lt;&lt; 10</c>. A flag is declared here only once the feature behind it actually exists, so
+/// that naming one can never compile into an engine that silently does not have it.
+/// </para>
+/// <para>
+/// <see cref="Default"/> grows as each non-network feature lands, and <b>will never include the fetch
+/// flag</b>: outbound network access from script is a decision a host has to make explicitly, never one it
+/// inherits from asking for "the web APIs".
+/// </para>
+/// </remarks>
+[Flags]
+public enum WebApiFeatures
+{
+    /// <summary>
+    /// No web API is installed. This is the default, and the engine is then indistinguishable from one built
+    /// by a Jint that never had this feature.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// The <c>console</c> object (<c>log</c>, <c>warn</c>, <c>group</c>, <c>count</c>, <c>time</c>, …). Output
+    /// goes to <see cref="Options.ConsoleOptions.Sink"/>, which discards it unless the host sets one.
+    /// </summary>
+    Console = 1 << 0,
+
+    /// <summary>
+    /// The web APIs a host normally wants: everything except outbound network access. Today that is
+    /// <see cref="Console"/>; it grows as further features land, and never comes to include fetch.
+    /// </summary>
+    Default = Console,
+}
+#endif

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -16,7 +16,7 @@ using Jint.Runtime.Modules;
 
 namespace Jint;
 
-public class Options
+public partial class Options
 {
     private static readonly CultureInfo _defaultCulture = CultureInfo.CurrentCulture;
     private static readonly TimeZoneInfo _defaultTimeZone = TimeZoneInfo.Local;
@@ -220,6 +220,18 @@ public class Options
 
 #pragma warning restore IL2026
         }
+
+#if NET8_0_OR_GREATER
+        // Opt-in WHATWG web APIs. Deliberately after the configuration callbacks above, so that a global a
+        // host registered itself is never replaced by one of ours: WebApiRegistration skips every name the
+        // global object already owns. Nothing is installed while Features is None, which is the default.
+        // The backing field rather than the property, so an engine built from options that never mentioned a
+        // web API does not allocate the group just to find out that it is empty.
+        if (_webApi is not null && _webApi.Features != WebApiFeatures.None)
+        {
+            Jint.WebApi.WebApiRegistration.Apply(this, engine);
+        }
+#endif
 
         if (Interop.ExtensionMethodTypes.Count > 0)
         {

--- a/Jint/Runtime/Intrinsics.WebApi.cs
+++ b/Jint/Runtime/Intrinsics.WebApi.cs
@@ -1,0 +1,28 @@
+#if NET8_0_OR_GREATER
+using Jint.WebApi.Console;
+using Jint.WebApi.DomException;
+
+namespace Jint.Runtime;
+
+/// <summary>
+/// The opt-in web platform APIs, lazily created per realm exactly like the ECMAScript intrinsics beside them.
+/// Requires .NET 8 or higher.
+/// </summary>
+/// <remarks>
+/// Reaching one of these fields is what creates it, and nothing but the global installed by
+/// <c>Jint.WebApi.WebApiRegistration</c> reaches them — which is itself a lazy property descriptor. So an
+/// engine that enabled a feature whose global the script never mentions has still built nothing, and a
+/// <c>ShadowRealm</c>'s intrinsics are simply never asked.
+/// </remarks>
+public sealed partial class Intrinsics
+{
+    private DomExceptionConstructor? _domException;
+    private ConsoleInstance? _console;
+
+    internal DomExceptionConstructor DomException =>
+        _domException ??= new DomExceptionConstructor(_engine, _realm, Function.PrototypeObject, Error.PrototypeObject);
+
+    internal ConsoleInstance Console =>
+        _console ??= new ConsoleInstance(_engine, _realm, Object.PrototypeObject);
+}
+#endif

--- a/Jint/WebApi/Console/ConsoleFormatter.cs
+++ b/Jint/WebApi/Console/ConsoleFormatter.cs
@@ -1,0 +1,453 @@
+#if NET8_0_OR_GREATER
+using System.Globalization;
+using System.Text;
+using Jint.Native;
+using Jint.Native.Error;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Console;
+
+/// <summary>
+/// The Console Standard's <i>Formatter</i>, plus the object rendering its <c>%o</c>/<c>%O</c> specifiers and
+/// <c>console.dir</c> leave to the implementation.
+/// <para>
+/// https://console.spec.whatwg.org/#formatter
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// The rendering is deliberately bounded and deterministic rather than clever: depth-capped, entry-capped
+/// and cycle-safe, and it never invokes a script-visible getter — an accessor property is reported as
+/// <c>[Getter]</c> instead of being called. A console that can be made to run arbitrary script, recurse
+/// without bound, or emit a gigabyte because a host object exposed a large collection would be a liability
+/// in exactly the embedding a bounded engine exists for.
+/// </para>
+/// <para>
+/// User code <i>is</i> reached where the specification requires it: <c>%s</c>, <c>%d</c>, <c>%i</c> and
+/// <c>%f</c> are defined in terms of <c>String()</c> and <c>Number()</c>, which coerce through
+/// <c>toString</c>/<c>valueOf</c>.
+/// </para>
+/// </remarks>
+internal static class ConsoleFormatter
+{
+    /// <summary>How deep the object walk goes before collapsing a value to <c>[Object]</c>/<c>[Array]</c>.</summary>
+    private const int MaxDepth = 2;
+
+    /// <summary>How many array elements or object entries are rendered before the rest are summarized.</summary>
+    private const int MaxEntries = 100;
+
+    /// <summary>
+    /// Turns the arguments of a console method into the single string the printer emits.
+    /// </summary>
+    internal static string Format(ReadOnlySpan<JsValue> data)
+    {
+        if (data.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder();
+        var next = 1;
+
+        // Formatter step 1: with a single argument there is no substitution at all, so "50%" stays "50%".
+        if (data.Length > 1 && data[0] is JsString target)
+        {
+            AppendWithSpecifiers(builder, target.ToString(), data, ref next);
+        }
+        else
+        {
+            AppendTopLevel(builder, data[0]);
+        }
+
+        for (var i = next; i < data.Length; i++)
+        {
+            builder.Append(' ');
+            AppendTopLevel(builder, data[i]);
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Renders one value the way <c>%o</c>, <c>%O</c> and <c>console.dir</c> do — strings quoted, objects
+    /// walked.
+    /// </summary>
+    internal static string Inspect(JsValue value)
+    {
+        var builder = new StringBuilder();
+        Inspect(builder, value, depth: 0, seen: null);
+        return builder.ToString();
+    }
+
+    private static void AppendWithSpecifiers(StringBuilder builder, string target, ReadOnlySpan<JsValue> data, ref int next)
+    {
+        for (var i = 0; i < target.Length; i++)
+        {
+            var c = target[i];
+            if (c != '%' || i + 1 >= target.Length)
+            {
+                builder.Append(c);
+                continue;
+            }
+
+            var specifier = target[i + 1];
+            if (specifier == '%')
+            {
+                builder.Append('%');
+                i++;
+                continue;
+            }
+
+            // A specifier with no argument left to consume stays in the output verbatim, which is what every
+            // implementation does and the only behaviour that round-trips a string containing a bare "%s".
+            if (!IsSpecifier(specifier) || next >= data.Length)
+            {
+                builder.Append(c);
+                continue;
+            }
+
+            var current = data[next];
+            next++;
+            i++;
+
+            switch (specifier)
+            {
+                case 's':
+                    AppendAsString(builder, current);
+                    break;
+                case 'd':
+                case 'i':
+                    AppendAsInteger(builder, current);
+                    break;
+                case 'f':
+                    AppendAsNumber(builder, current);
+                    break;
+                case 'o':
+                case 'O':
+                    Inspect(builder, current, depth: 0, seen: null);
+                    break;
+                default:
+                    // '%c' carries CSS. There is no styling to apply to a string, so the argument is
+                    // consumed and produces nothing, exactly as the specification allows.
+                    break;
+            }
+        }
+    }
+
+    private static bool IsSpecifier(char c) => c is 's' or 'd' or 'i' or 'f' or 'o' or 'O' or 'c';
+
+    private static void AppendAsString(StringBuilder builder, JsValue value)
+    {
+        if (value is JsSymbol)
+        {
+            // String(symbol) is the one coercion a symbol survives, and it is what the specification calls for.
+            builder.Append(value.ToString());
+            return;
+        }
+
+        builder.Append(TypeConverter.ToString(value));
+    }
+
+    private static void AppendAsInteger(StringBuilder builder, JsValue value)
+    {
+        if (value is JsSymbol)
+        {
+            builder.Append("NaN");
+            return;
+        }
+
+        if (value is JsBigInt)
+        {
+            builder.Append(TypeConverter.ToString(value));
+            return;
+        }
+
+        var number = TypeConverter.ToNumber(value);
+        if (double.IsNaN(number) || double.IsInfinity(number))
+        {
+            builder.Append(TypeConverter.ToString(JsNumber.Create(number)));
+            return;
+        }
+
+        builder.Append(TypeConverter.ToString(JsNumber.Create(System.Math.Truncate(number))));
+    }
+
+    private static void AppendAsNumber(StringBuilder builder, JsValue value)
+    {
+        if (value is JsSymbol)
+        {
+            builder.Append("NaN");
+            return;
+        }
+
+        if (value is JsBigInt)
+        {
+            builder.Append(TypeConverter.ToString(value));
+            return;
+        }
+
+        builder.Append(TypeConverter.ToString(JsNumber.Create(TypeConverter.ToNumber(value))));
+    }
+
+    /// <summary>
+    /// A top-level argument: a string goes in raw (so <c>console.log("a", "b")</c> is <c>a b</c>, not
+    /// <c>a 'b'</c>), everything else is inspected.
+    /// </summary>
+    private static void AppendTopLevel(StringBuilder builder, JsValue value)
+    {
+        if (value is JsString s)
+        {
+            builder.Append(s.ToString());
+            return;
+        }
+
+        Inspect(builder, value, depth: 0, seen: null);
+    }
+
+    private static void Inspect(StringBuilder builder, JsValue value, int depth, List<ObjectInstance>? seen)
+    {
+        if (value is null || value.IsUndefined())
+        {
+            builder.Append("undefined");
+            return;
+        }
+
+        if (value.IsNull())
+        {
+            builder.Append("null");
+            return;
+        }
+
+        switch (value)
+        {
+            case JsString s:
+                AppendQuoted(builder, s.ToString());
+                return;
+            case JsBoolean:
+            case JsNumber:
+                builder.Append(TypeConverter.ToString(value));
+                return;
+            case JsBigInt:
+                builder.Append(TypeConverter.ToString(value)).Append('n');
+                return;
+            case JsSymbol:
+                builder.Append(value.ToString());
+                return;
+            case ObjectInstance obj:
+                InspectObject(builder, obj, depth, seen);
+                return;
+            default:
+                builder.Append(TypeConverter.ToString(value));
+                return;
+        }
+    }
+
+    private static void InspectObject(StringBuilder builder, ObjectInstance obj, int depth, List<ObjectInstance>? seen)
+    {
+        if (obj is Native.Function.Function function)
+        {
+            builder.Append(function.ToString());
+            return;
+        }
+
+        if (obj is ErrorInstance error)
+        {
+            builder.Append(error.ToString());
+            return;
+        }
+
+        var array = obj as JsArray;
+
+        if (depth > MaxDepth)
+        {
+            builder.Append(array is not null ? "[Array]" : "[Object]");
+            return;
+        }
+
+        if (seen is not null && seen.Contains(obj))
+        {
+            builder.Append("[Circular]");
+            return;
+        }
+
+        seen ??= new List<ObjectInstance>();
+        seen.Add(obj);
+        try
+        {
+            if (array is not null)
+            {
+                InspectArray(builder, array, depth, seen);
+            }
+            else
+            {
+                InspectPlainObject(builder, obj, depth, seen);
+            }
+        }
+        finally
+        {
+            seen.RemoveAt(seen.Count - 1);
+        }
+    }
+
+    private static void InspectArray(StringBuilder builder, JsArray array, int depth, List<ObjectInstance> seen)
+    {
+        var length = array.Length;
+        if (length == 0)
+        {
+            builder.Append("[]");
+            return;
+        }
+
+        builder.Append("[ ");
+        var rendered = System.Math.Min(length, (uint) MaxEntries);
+        for (var i = 0u; i < rendered; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append(", ");
+            }
+
+            AppendDescriptorValue(builder, array.GetOwnProperty(JsString.Create((int) i)), depth + 1, seen);
+        }
+
+        if (length > rendered)
+        {
+            builder.Append(", ... ").Append((length - rendered).ToString(CultureInfo.InvariantCulture)).Append(" more items");
+        }
+
+        builder.Append(" ]");
+    }
+
+    private static void InspectPlainObject(StringBuilder builder, ObjectInstance obj, int depth, List<ObjectInstance> seen)
+    {
+        var keys = obj.GetOwnPropertyKeys(Types.String);
+        var written = 0;
+        var skipped = 0;
+
+        for (var i = 0; i < keys.Count; i++)
+        {
+            var key = keys[i];
+            var descriptor = obj.GetOwnProperty(key);
+            if (ReferenceEquals(descriptor, PropertyDescriptor.Undefined) || !descriptor.Enumerable)
+            {
+                continue;
+            }
+
+            if (written >= MaxEntries)
+            {
+                skipped++;
+                continue;
+            }
+
+            builder.Append(written == 0 ? "{ " : ", ");
+            AppendKey(builder, key.ToString());
+            builder.Append(": ");
+            AppendDescriptorValue(builder, descriptor, depth + 1, seen);
+            written++;
+        }
+
+        if (written == 0)
+        {
+            builder.Append("{}");
+            return;
+        }
+
+        if (skipped > 0)
+        {
+            builder.Append(", ... ").Append(skipped.ToString(CultureInfo.InvariantCulture)).Append(" more properties");
+        }
+
+        builder.Append(" }");
+    }
+
+    /// <summary>
+    /// Renders a property's value without invoking anything: an accessor is named, never called.
+    /// </summary>
+    private static void AppendDescriptorValue(StringBuilder builder, PropertyDescriptor descriptor, int depth, List<ObjectInstance> seen)
+    {
+        if (ReferenceEquals(descriptor, PropertyDescriptor.Undefined))
+        {
+            builder.Append("undefined");
+            return;
+        }
+
+        if (descriptor.IsAccessorDescriptor())
+        {
+            var hasGet = descriptor.Get is not null && !descriptor.Get.IsUndefined();
+            var hasSet = descriptor.Set is not null && !descriptor.Set.IsUndefined();
+            builder.Append(hasGet && hasSet ? "[Getter/Setter]" : hasGet ? "[Getter]" : "[Setter]");
+            return;
+        }
+
+        Inspect(builder, descriptor.Value, depth, seen);
+    }
+
+    private static void AppendKey(StringBuilder builder, string key)
+    {
+        if (IsIdentifierLike(key))
+        {
+            builder.Append(key);
+            return;
+        }
+
+        AppendQuoted(builder, key);
+    }
+
+    private static bool IsIdentifierLike(string key)
+    {
+        if (key.Length == 0)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < key.Length; i++)
+        {
+            var c = key[i];
+            var ok = c is '_' or '$'
+                || (c >= 'a' && c <= 'z')
+                || (c >= 'A' && c <= 'Z')
+                || (i > 0 && c >= '0' && c <= '9');
+
+            if (!ok)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void AppendQuoted(StringBuilder builder, string value)
+    {
+        builder.Append('\'');
+        foreach (var c in value)
+        {
+            switch (c)
+            {
+                case '\'':
+                    builder.Append("\\'");
+                    break;
+                case '\\':
+                    builder.Append("\\\\");
+                    break;
+                case '\n':
+                    builder.Append("\\n");
+                    break;
+                case '\r':
+                    builder.Append("\\r");
+                    break;
+                case '\t':
+                    builder.Append("\\t");
+                    break;
+                default:
+                    builder.Append(c);
+                    break;
+            }
+        }
+
+        builder.Append('\'');
+    }
+}
+#endif

--- a/Jint/WebApi/Console/ConsoleInstance.cs
+++ b/Jint/WebApi/Console/ConsoleInstance.cs
@@ -1,0 +1,409 @@
+#if NET8_0_OR_GREATER
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+using Jint.Native;
+using Jint.Native.Error;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Console;
+
+/// <summary>
+/// The <c>console</c> namespace object.
+/// <para>
+/// https://console.spec.whatwg.org/
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// The engine does all of the specification's <i>Formatter</i> work and the parts of <i>Printer</i> that a
+/// non-interactive console can do — group indentation, counter and timer labels — and hands
+/// <see cref="ConsoleSink"/> one finished string per record. Exactly one
+/// <see cref="ConsoleSink.Write(ConsoleLogLevel, string)"/> call is made per emitted record; a method that
+/// emits nothing (<c>console.log()</c> with no arguments, <c>groupEnd</c>, <c>countReset</c> on an existing
+/// counter, <c>assert</c> on a truthy condition) makes none.
+/// </para>
+/// <para>
+/// Counter, timer and group state is per instance, and the instance is per realm, so <c>console === console</c>
+/// holds and two engines never share a counter.
+/// </para>
+/// <para>
+/// Two documented simplifications against WebIDL. The methods are non-enumerable, where a WebIDL namespace
+/// object's operations are enumerable; and the object is installed as an ordinary enumerable data property
+/// of the global rather than through an accessor pair. Neither is observable except to code inspecting
+/// property attributes.
+/// </para>
+/// <para>
+/// Not implemented: <c>table</c>, <c>dirxml</c>, <c>timeStamp</c>, <c>profile</c> and <c>profileEnd</c>,
+/// none of which has behaviour a string sink can carry.
+/// </para>
+/// </remarks>
+[JsObject]
+internal sealed partial class ConsoleInstance : BuiltinShapeObject
+{
+    private const string DefaultLabel = "default";
+    private const string AssertionFailed = "Assertion failed";
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString ConsoleToStringTag = new("console");
+
+    private readonly Realm _realm;
+
+    /// <summary>The Console Standard's "count map", https://console.spec.whatwg.org/#count-map.</summary>
+    private Dictionary<string, int>? _counts;
+
+    /// <summary>The Console Standard's "timer table", https://console.spec.whatwg.org/#timer-table.</summary>
+    private Dictionary<string, long>? _timers;
+
+    /// <summary>The Console Standard's "group stack" depth, https://console.spec.whatwg.org/#group-stack.</summary>
+    private int _groupDepth;
+
+    /// <summary>
+    /// The <c>trace</c> dispatcher itself, so the stack it renders can leave out its own frame the same way
+    /// <c>new Error().stack</c> leaves out the <c>Error</c> constructor's.
+    /// </summary>
+    private Native.Function.Function _traceFunction = null!;
+
+    internal ConsoleInstance(Engine engine, Realm realm, ObjectPrototype objectPrototype) : base(engine)
+    {
+        _realm = realm;
+        _prototype = objectPrototype;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://console.spec.whatwg.org/#log
+    /// </summary>
+    [JsFunction(Name = "log", Length = 0)]
+    private JsValue Log(JsValue thisObject, [Rest] ReadOnlySpan<JsValue> data)
+    {
+        Logger(ConsoleLogLevel.Log, data);
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://console.spec.whatwg.org/#info
+    /// </summary>
+    [JsFunction(Name = "info", Length = 0)]
+    private JsValue Info(JsValue thisObject, [Rest] ReadOnlySpan<JsValue> data)
+    {
+        Logger(ConsoleLogLevel.Info, data);
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://console.spec.whatwg.org/#warn
+    /// </summary>
+    [JsFunction(Name = "warn", Length = 0)]
+    private JsValue Warn(JsValue thisObject, [Rest] ReadOnlySpan<JsValue> data)
+    {
+        Logger(ConsoleLogLevel.Warn, data);
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://console.spec.whatwg.org/#error
+    /// </summary>
+    [JsFunction(Name = "error", Length = 0)]
+    private JsValue Error(JsValue thisObject, [Rest] ReadOnlySpan<JsValue> data)
+    {
+        Logger(ConsoleLogLevel.Error, data);
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://console.spec.whatwg.org/#debug
+    /// </summary>
+    [JsFunction(Name = "debug", Length = 0)]
+    private JsValue Debug(JsValue thisObject, [Rest] ReadOnlySpan<JsValue> data)
+    {
+        Logger(ConsoleLogLevel.Debug, data);
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://console.spec.whatwg.org/#trace
+    /// </summary>
+    [JsFunction(Name = "trace", Length = 0, CaptureField = nameof(_traceFunction))]
+    private JsValue Trace(JsValue thisObject, [Rest] ReadOnlySpan<JsValue> data)
+    {
+        var header = data.Length == 0 ? "Trace" : "Trace: " + ConsoleFormatter.Format(data);
+
+        // The same machinery Error uses for `stack`, with this dispatcher's own frame excluded so the trace
+        // starts at the call site.
+        var capture = ErrorConstructor.BuildStackTraceCapture(_engine, _traceFunction);
+        var stack = capture?.Render() ?? string.Empty;
+
+        Emit(ConsoleLogLevel.Error, stack.Length == 0 ? header : header + System.Environment.NewLine + stack);
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://console.spec.whatwg.org/#assert
+    /// </summary>
+    [JsFunction(Name = "assert", Length = 0)]
+    private JsValue Assert(JsValue thisObject, JsValue condition, [Rest] ReadOnlySpan<JsValue> data)
+    {
+        if (TypeConverter.ToBoolean(condition))
+        {
+            return Undefined;
+        }
+
+        if (data.Length == 0)
+        {
+            Emit(ConsoleLogLevel.Error, AssertionFailed);
+            return Undefined;
+        }
+
+        if (data[0] is JsString first)
+        {
+            // Step 4: the label is folded into the format string, so its specifiers still substitute.
+            var args = new JsValue[data.Length];
+            data.CopyTo(args);
+            args[0] = JsString.Create(AssertionFailed + ": " + first.ToString());
+            Emit(ConsoleLogLevel.Error, ConsoleFormatter.Format(args));
+            return Undefined;
+        }
+
+        // Step 3: a non-string first argument cannot be a format string, so the label is prepended instead.
+        var prefixed = new JsValue[data.Length + 1];
+        prefixed[0] = JsString.Create(AssertionFailed);
+        data.CopyTo(prefixed.AsSpan(1));
+        Emit(ConsoleLogLevel.Error, ConsoleFormatter.Format(prefixed));
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://console.spec.whatwg.org/#dir
+    /// </summary>
+    [JsFunction(Name = "dir", Length = 0)]
+    private JsValue Dir(JsValue thisObject, JsValue item, JsValue options)
+    {
+        // `options` is part of the IDL signature and has no member a string sink could honour.
+        Emit(ConsoleLogLevel.Log, ConsoleFormatter.Inspect(item));
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://console.spec.whatwg.org/#group
+    /// </summary>
+    [JsFunction(Name = "group", Length = 0)]
+    private JsValue Group(JsValue thisObject, [Rest] ReadOnlySpan<JsValue> data)
+    {
+        return BeginGroup(data);
+    }
+
+    /// <summary>
+    /// https://console.spec.whatwg.org/#groupcollapsed
+    /// <para>
+    /// A string sink cannot collapse anything, so this behaves exactly like <c>group</c> — which is what the
+    /// specification says a non-interactive printer should do.
+    /// </para>
+    /// </summary>
+    [JsFunction(Name = "groupCollapsed", Length = 0)]
+    private JsValue GroupCollapsed(JsValue thisObject, [Rest] ReadOnlySpan<JsValue> data)
+    {
+        return BeginGroup(data);
+    }
+
+    /// <summary>
+    /// https://console.spec.whatwg.org/#groupend
+    /// </summary>
+    [JsFunction(Name = "groupEnd", Length = 0)]
+    private JsValue GroupEnd(JsValue thisObject)
+    {
+        if (_groupDepth > 0)
+        {
+            _groupDepth--;
+        }
+
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://console.spec.whatwg.org/#count
+    /// </summary>
+    [JsFunction(Name = "count", Length = 0)]
+    private JsValue Count(JsValue thisObject, JsValue label)
+    {
+        var key = Label(label);
+        _counts ??= new Dictionary<string, int>(StringComparer.Ordinal);
+        _counts.TryGetValue(key, out var count);
+        count++;
+        _counts[key] = count;
+
+        Emit(ConsoleLogLevel.Log, key + ": " + count.ToString(CultureInfo.InvariantCulture));
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://console.spec.whatwg.org/#countreset
+    /// </summary>
+    [JsFunction(Name = "countReset", Length = 0)]
+    private JsValue CountReset(JsValue thisObject, JsValue label)
+    {
+        var key = Label(label);
+        if (_counts is not null && _counts.ContainsKey(key))
+        {
+            _counts[key] = 0;
+        }
+        else
+        {
+            Emit(ConsoleLogLevel.Warn, "Count for '" + key + "' does not exist");
+        }
+
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://console.spec.whatwg.org/#time
+    /// </summary>
+    [JsFunction(Name = "time", Length = 0)]
+    private JsValue Time(JsValue thisObject, JsValue label)
+    {
+        var key = Label(label);
+        _timers ??= new Dictionary<string, long>(StringComparer.Ordinal);
+        if (_timers.ContainsKey(key))
+        {
+            Emit(ConsoleLogLevel.Warn, "Timer '" + key + "' already exists");
+            return Undefined;
+        }
+
+        _timers[key] = Stopwatch.GetTimestamp();
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://console.spec.whatwg.org/#timelog
+    /// </summary>
+    [JsFunction(Name = "timeLog", Length = 0)]
+    private JsValue TimeLog(JsValue thisObject, JsValue label, [Rest] ReadOnlySpan<JsValue> data)
+    {
+        var key = Label(label);
+        if (_timers is null || !_timers.TryGetValue(key, out var start))
+        {
+            Emit(ConsoleLogLevel.Warn, "Timer '" + key + "' does not exist");
+            return Undefined;
+        }
+
+        var concat = key + ": " + FormatDuration(start);
+        if (data.Length == 0)
+        {
+            Emit(ConsoleLogLevel.Log, concat);
+            return Undefined;
+        }
+
+        var prefixed = new JsValue[data.Length + 1];
+        prefixed[0] = JsString.Create(concat);
+        data.CopyTo(prefixed.AsSpan(1));
+        Emit(ConsoleLogLevel.Log, ConsoleFormatter.Format(prefixed));
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://console.spec.whatwg.org/#timeend
+    /// </summary>
+    [JsFunction(Name = "timeEnd", Length = 0)]
+    private JsValue TimeEnd(JsValue thisObject, JsValue label)
+    {
+        var key = Label(label);
+        if (_timers is null || !_timers.Remove(key, out var start))
+        {
+            Emit(ConsoleLogLevel.Warn, "Timer '" + key + "' does not exist");
+            return Undefined;
+        }
+
+        Emit(ConsoleLogLevel.Log, key + ": " + FormatDuration(start));
+        return Undefined;
+    }
+
+    private JsValue BeginGroup(ReadOnlySpan<JsValue> data)
+    {
+        // The label is printed at the current indentation; only what follows it is indented further.
+        if (data.Length > 0)
+        {
+            Emit(ConsoleLogLevel.Log, ConsoleFormatter.Format(data));
+        }
+
+        _groupDepth++;
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://console.spec.whatwg.org/#logger — including step 1, which is why a console method called with
+    /// no arguments emits nothing at all rather than an empty line.
+    /// </summary>
+    private void Logger(ConsoleLogLevel level, ReadOnlySpan<JsValue> data)
+    {
+        if (data.Length == 0)
+        {
+            return;
+        }
+
+        Emit(level, ConsoleFormatter.Format(data));
+    }
+
+    /// <summary>
+    /// The one place a record reaches the host: applies the group indentation and makes exactly one
+    /// <see cref="ConsoleSink.Write(ConsoleLogLevel, string)"/> call. The sink is read afresh every time, so
+    /// a host may swap it between evaluations.
+    /// </summary>
+    private void Emit(ConsoleLogLevel level, string message)
+    {
+        var sink = _engine.Options.WebApi.Console.Sink ?? ConsoleSink.Null;
+        sink.Write(level, Indent(message));
+    }
+
+    private string Indent(string message)
+    {
+        if (_groupDepth == 0)
+        {
+            return message;
+        }
+
+        var prefix = new string(' ', _groupDepth * 2);
+        if (message.Length == 0)
+        {
+            return prefix;
+        }
+
+        if (message.IndexOf('\n') < 0)
+        {
+            return prefix + message;
+        }
+
+        // A multi-line record (a trace, an inspected object containing newlines) is indented line by line, so
+        // the group's shape survives.
+        var builder = new StringBuilder(message.Length + prefix.Length * 2);
+        builder.Append(prefix);
+        foreach (var c in message)
+        {
+            builder.Append(c);
+            if (c == '\n')
+            {
+                builder.Append(prefix);
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    private static string Label(JsValue label)
+    {
+        return label.IsUndefined() ? DefaultLabel : TypeConverter.ToString(label);
+    }
+
+    private static string FormatDuration(long startTimestamp)
+    {
+        var elapsed = Stopwatch.GetElapsedTime(startTimestamp);
+        return elapsed.TotalMilliseconds.ToString("0.###", CultureInfo.InvariantCulture) + "ms";
+    }
+}
+#endif

--- a/Jint/WebApi/ConsoleSink.cs
+++ b/Jint/WebApi/ConsoleSink.cs
@@ -1,0 +1,107 @@
+#if NET8_0_OR_GREATER
+using Jint.Runtime;
+
+namespace Jint.WebApi;
+
+/// <summary>
+/// Where the engine's <c>console</c> object sends what a script logged. Requires .NET 8 or higher.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The engine does all of the work the <see href="https://console.spec.whatwg.org/">Console Standard</see>
+/// calls <i>Formatter</i> and <i>Printer</i> — format specifiers, group indentation, counter and timer
+/// labels — and hands the sink one finished line per emitted record. A sink therefore never has to parse
+/// anything; it decides only where the string goes and, from the level it is handed, how loud it is.
+/// </para>
+/// <para>
+/// <b>Thread safety.</b> An engine only ever calls its sink from the thread running that engine. A sink
+/// installed on an <see cref="Options"/> instance shared by engines that run concurrently is called from
+/// each of their threads, so such a sink must be thread-safe; <see cref="Null"/> is,
+/// <see cref="FromTextWriter"/>'s is only as far as the writer it wraps is (use
+/// <see cref="System.IO.TextWriter.Synchronized"/> when it is not).
+/// </para>
+/// <para>
+/// This is an abstract class rather than a delegate so that later revisions can add richer overloads —
+/// structured arguments, a timestamp — without breaking hosts that implement it today.
+/// </para>
+/// </remarks>
+public abstract class ConsoleSink
+{
+    /// <summary>
+    /// A sink that discards everything. This is the default, so enabling
+    /// <see cref="WebApiFeatures.Console"/> never starts writing to the host's standard output by surprise.
+    /// </summary>
+    public static ConsoleSink Null { get; } = new NullConsoleSink();
+
+    /// <summary>
+    /// A sink that writes each record to <paramref name="writer"/> as one line, ignoring the level.
+    /// </summary>
+    /// <param name="writer">The destination, e.g. <c>Console.Out</c>.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="writer"/> is <see langword="null"/>.</exception>
+    public static ConsoleSink FromTextWriter(TextWriter writer)
+    {
+        if (writer is null)
+        {
+            Throw.ArgumentNullException(nameof(writer));
+        }
+
+        return new TextWriterConsoleSink(writer);
+    }
+
+    /// <summary>
+    /// Receives one finished console record.
+    /// </summary>
+    /// <param name="level">The severity the console method implies.</param>
+    /// <param name="message">
+    /// The whole record as a single string, already formatted and already carrying any
+    /// <c>console.group</c> indentation. It may contain line breaks and may be empty; it is never
+    /// <see langword="null"/>.
+    /// </param>
+    public abstract void Write(ConsoleLogLevel level, string message);
+
+    private sealed class NullConsoleSink : ConsoleSink
+    {
+        public override void Write(ConsoleLogLevel level, string message)
+        {
+        }
+    }
+
+    private sealed class TextWriterConsoleSink : ConsoleSink
+    {
+        private readonly TextWriter _writer;
+
+        internal TextWriterConsoleSink(TextWriter writer)
+        {
+            _writer = writer;
+        }
+
+        public override void Write(ConsoleLogLevel level, string message)
+        {
+            _writer.WriteLine(message);
+        }
+    }
+}
+
+/// <summary>
+/// The severity a console method implies, mirroring the Console Standard's log levels. Requires .NET 8 or
+/// higher.
+/// </summary>
+public enum ConsoleLogLevel
+{
+    /// <summary><c>console.debug</c>.</summary>
+    Debug,
+
+    /// <summary><c>console.log</c>, and the methods that report state rather than severity — <c>dir</c>,
+    /// <c>group</c>, <c>groupCollapsed</c>, <c>count</c>, <c>time*</c>.</summary>
+    Log,
+
+    /// <summary><c>console.info</c>.</summary>
+    Info,
+
+    /// <summary><c>console.warn</c>, and the Console Standard's warnings about a missing counter or timer.</summary>
+    Warn,
+
+    /// <summary><c>console.error</c>, <c>console.assert</c> on a failed assertion, and <c>console.trace</c>.</summary>
+    Error,
+}
+#endif

--- a/Jint/WebApi/DomException/DomExceptionConstructor.cs
+++ b/Jint/WebApi/DomException/DomExceptionConstructor.cs
@@ -1,0 +1,141 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Error;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.CallStack;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.DomException;
+
+/// <summary>
+/// The <c>DOMException</c> interface object.
+/// <para>
+/// https://webidl.spec.whatwg.org/#idl-DOMException
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>constructor(optional DOMString message = "", optional DOMString name = "Error")</c>. Its
+/// <c>[[Prototype]]</c> is <c>%Function.prototype%</c> — <c>DOMException</c> is a WebIDL interface, not an
+/// ECMAScript <c>NativeError</c>, so the interface object does not inherit from <c>Error</c> even though its
+/// prototype object does. Called without <c>new</c> it raises a <c>TypeError</c>, which is what
+/// <see cref="Constructor"/> already does for every interface object shape.
+/// </para>
+/// <para>
+/// The 25 legacy constants appear here as well as on the prototype, per
+/// https://webidl.spec.whatwg.org/#es-constants.
+/// </para>
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class DomExceptionConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("DOMException");
+    private static readonly JsString _defaultName = new("Error");
+
+    [JsProperty(Name = "INDEX_SIZE_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber IndexSizeErr = JsNumber.Create(1);
+    [JsProperty(Name = "DOMSTRING_SIZE_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber DomStringSizeErr = JsNumber.Create(2);
+    [JsProperty(Name = "HIERARCHY_REQUEST_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber HierarchyRequestErr = JsNumber.Create(3);
+    [JsProperty(Name = "WRONG_DOCUMENT_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber WrongDocumentErr = JsNumber.Create(4);
+    [JsProperty(Name = "INVALID_CHARACTER_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber InvalidCharacterErr = JsNumber.Create(5);
+    [JsProperty(Name = "NO_DATA_ALLOWED_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber NoDataAllowedErr = JsNumber.Create(6);
+    [JsProperty(Name = "NO_MODIFICATION_ALLOWED_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber NoModificationAllowedErr = JsNumber.Create(7);
+    [JsProperty(Name = "NOT_FOUND_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber NotFoundErr = JsNumber.Create(8);
+    [JsProperty(Name = "NOT_SUPPORTED_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber NotSupportedErr = JsNumber.Create(9);
+    [JsProperty(Name = "INUSE_ATTRIBUTE_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber InUseAttributeErr = JsNumber.Create(10);
+    [JsProperty(Name = "INVALID_STATE_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber InvalidStateErr = JsNumber.Create(11);
+    [JsProperty(Name = "SYNTAX_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber SyntaxErr = JsNumber.Create(12);
+    [JsProperty(Name = "INVALID_MODIFICATION_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber InvalidModificationErr = JsNumber.Create(13);
+    [JsProperty(Name = "NAMESPACE_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber NamespaceErr = JsNumber.Create(14);
+    [JsProperty(Name = "INVALID_ACCESS_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber InvalidAccessErr = JsNumber.Create(15);
+    [JsProperty(Name = "VALIDATION_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber ValidationErr = JsNumber.Create(16);
+    [JsProperty(Name = "TYPE_MISMATCH_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber TypeMismatchErr = JsNumber.Create(17);
+    [JsProperty(Name = "SECURITY_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber SecurityErr = JsNumber.Create(18);
+    [JsProperty(Name = "NETWORK_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber NetworkErr = JsNumber.Create(19);
+    [JsProperty(Name = "ABORT_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber AbortErr = JsNumber.Create(20);
+    [JsProperty(Name = "URL_MISMATCH_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber UrlMismatchErr = JsNumber.Create(21);
+    [JsProperty(Name = "QUOTA_EXCEEDED_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber QuotaExceededErr = JsNumber.Create(22);
+    [JsProperty(Name = "TIMEOUT_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber TimeoutErr = JsNumber.Create(23);
+    [JsProperty(Name = "INVALID_NODE_TYPE_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber InvalidNodeTypeErr = JsNumber.Create(24);
+    [JsProperty(Name = "DATA_CLONE_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber DataCloneErr = JsNumber.Create(25);
+
+    internal DomExceptionConstructor(
+        Engine engine,
+        Realm realm,
+        FunctionPrototype functionPrototype,
+        ObjectInstance errorPrototype)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = functionPrototype;
+        PrototypeObject = new DomExceptionPrototype(engine, realm, this, errorPrototype);
+        _length = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal DomExceptionPrototype PrototypeObject { get; }
+
+    protected override void Initialize() => CreateProperties_Generated();
+
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#dom-domexception-domexception
+    /// </summary>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        var messageArgument = arguments.At(0);
+        var nameArgument = arguments.At(1);
+
+        // The IDL defaults are "" and "Error"; an explicitly passed undefined takes the default too, which
+        // is what an optional argument with a default value means in WebIDL.
+        var message = messageArgument.IsUndefined() ? JsString.Empty : TypeConverter.ToJsString(messageArgument);
+        var name = nameArgument.IsUndefined() ? _defaultName : TypeConverter.ToJsString(nameArgument);
+
+        var exception = OrdinaryCreateFromConstructor(
+            newTarget,
+            static intrinsics => intrinsics.DomException.PrototypeObject,
+            static (Engine engine, Realm _, (JsString Name, JsString Message) state) => new JsDomException(engine, state.Name, state.Message),
+            (Name: name, Message: message));
+
+        AttachStack(exception);
+
+        return exception;
+    }
+
+    /// <summary>
+    /// Builds a <c>DOMException</c> from engine code, for the error names the web APIs raise themselves —
+    /// <c>AbortError</c>, <c>TimeoutError</c>, <c>InvalidCharacterError</c> and the rest of
+    /// https://webidl.spec.whatwg.org/#dfn-error-names-table.
+    /// </summary>
+    /// <param name="name">The error name; <see cref="DomExceptionNames"/> holds the ones with a legacy code.</param>
+    /// <param name="message">The message, or the empty string.</param>
+    internal JsDomException CreateException(string name, string message)
+    {
+        var exception = new JsDomException(_engine, JsString.Create(name), JsString.Create(message))
+        {
+            _prototype = PrototypeObject,
+        };
+
+        AttachStack(exception);
+
+        return exception;
+    }
+
+    /// <summary>
+    /// Gives the instance the own <c>stack</c> property browsers put on a <c>DOMException</c>. It is lazy for
+    /// the same reason <c>Error</c>'s is: most exceptions are caught without anyone reading the trace, and
+    /// rendering it costs a string build over the retained frames.
+    /// </summary>
+    private void AttachStack(JsDomException exception)
+    {
+        var capture = ErrorConstructor.BuildStackTraceCapture(_engine, this);
+        if (capture is null)
+        {
+            return;
+        }
+
+        exception.SetProperty(
+            CommonProperties.Stack,
+            PropertyDescriptor.CreateLazy(capture, static c => JsString.Create(c.Render()), PropertyFlag.NonEnumerable));
+    }
+}
+#endif

--- a/Jint/WebApi/DomException/DomExceptionNames.cs
+++ b/Jint/WebApi/DomException/DomExceptionNames.cs
@@ -1,0 +1,73 @@
+#if NET8_0_OR_GREATER
+namespace Jint.WebApi.DomException;
+
+/// <summary>
+/// The error names web APIs raise, and the legacy numeric codes WebIDL still has to expose for them.
+/// <para>
+/// https://webidl.spec.whatwg.org/#dfn-error-names-table
+/// </para>
+/// </summary>
+/// <remarks>
+/// Only the 25 names in the table's "legacy code value" column have a code; every other name — including
+/// every name a script makes up, and the modern additions such as <c>NotAllowedError</c> — reports
+/// <c>0</c>, which is what <c>DOMException.prototype.code</c> is specified to return for them.
+/// </remarks>
+internal static class DomExceptionNames
+{
+    internal const string IndexSize = "IndexSizeError";
+    internal const string HierarchyRequest = "HierarchyRequestError";
+    internal const string WrongDocument = "WrongDocumentError";
+    internal const string InvalidCharacter = "InvalidCharacterError";
+    internal const string NoModificationAllowed = "NoModificationAllowedError";
+    internal const string NotFound = "NotFoundError";
+    internal const string NotSupported = "NotSupportedError";
+    internal const string InUseAttribute = "InUseAttributeError";
+    internal const string InvalidState = "InvalidStateError";
+    internal const string Syntax = "SyntaxError";
+    internal const string InvalidModification = "InvalidModificationError";
+    internal const string Namespace = "NamespaceError";
+    internal const string InvalidAccess = "InvalidAccessError";
+    internal const string TypeMismatch = "TypeMismatchError";
+    internal const string Security = "SecurityError";
+    internal const string Network = "NetworkError";
+    internal const string Abort = "AbortError";
+    internal const string UrlMismatch = "URLMismatchError";
+    internal const string QuotaExceeded = "QuotaExceededError";
+    internal const string Timeout = "TimeoutError";
+    internal const string InvalidNodeType = "InvalidNodeTypeError";
+    internal const string DataClone = "DataCloneError";
+
+    /// <summary>
+    /// The legacy code for an error name, or <c>0</c> when the name has none.
+    /// </summary>
+    internal static ushort CodeFor(string name) => name switch
+    {
+        IndexSize => 1,
+        "DOMStringSizeError" => 2,
+        HierarchyRequest => 3,
+        WrongDocument => 4,
+        InvalidCharacter => 5,
+        "NoDataAllowedError" => 6,
+        NoModificationAllowed => 7,
+        NotFound => 8,
+        NotSupported => 9,
+        InUseAttribute => 10,
+        InvalidState => 11,
+        Syntax => 12,
+        InvalidModification => 13,
+        Namespace => 14,
+        InvalidAccess => 15,
+        "ValidationError" => 16,
+        TypeMismatch => 17,
+        Security => 18,
+        Network => 19,
+        Abort => 20,
+        UrlMismatch => 21,
+        QuotaExceeded => 22,
+        Timeout => 23,
+        InvalidNodeType => 24,
+        DataClone => 25,
+        _ => 0,
+    };
+}
+#endif

--- a/Jint/WebApi/DomException/DomExceptionPrototype.cs
+++ b/Jint/WebApi/DomException/DomExceptionPrototype.cs
@@ -1,0 +1,122 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.DomException;
+
+/// <summary>
+/// <c>DOMException.prototype</c> — the interface prototype object.
+/// <para>
+/// https://webidl.spec.whatwg.org/#idl-DOMException
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// Its <c>[[Prototype]]</c> is <c>%Error.prototype%</c>, which is what makes <c>instanceof Error</c> hold for
+/// an instance and what gives it <c>toString</c>. <c>name</c>, <c>message</c> and <c>code</c> are accessors
+/// here rather than own properties of the instance, as WebIDL specifies attributes; each brand-checks its
+/// receiver and raises a <c>TypeError</c> for anything that is not a <c>DOMException</c> — including
+/// <c>DOMException.prototype</c> itself, which is not one.
+/// </para>
+/// <para>
+/// The 25 legacy constants appear on both this object and the interface object, per
+/// https://webidl.spec.whatwg.org/#es-constants, with the attributes constants are given there:
+/// <c>{ writable: false, enumerable: true, configurable: false }</c>.
+/// </para>
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class DomExceptionPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly DomExceptionConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString DomExceptionToStringTag = new("DOMException");
+
+    [JsProperty(Name = "INDEX_SIZE_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber IndexSizeErr = JsNumber.Create(1);
+    [JsProperty(Name = "DOMSTRING_SIZE_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber DomStringSizeErr = JsNumber.Create(2);
+    [JsProperty(Name = "HIERARCHY_REQUEST_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber HierarchyRequestErr = JsNumber.Create(3);
+    [JsProperty(Name = "WRONG_DOCUMENT_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber WrongDocumentErr = JsNumber.Create(4);
+    [JsProperty(Name = "INVALID_CHARACTER_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber InvalidCharacterErr = JsNumber.Create(5);
+    [JsProperty(Name = "NO_DATA_ALLOWED_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber NoDataAllowedErr = JsNumber.Create(6);
+    [JsProperty(Name = "NO_MODIFICATION_ALLOWED_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber NoModificationAllowedErr = JsNumber.Create(7);
+    [JsProperty(Name = "NOT_FOUND_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber NotFoundErr = JsNumber.Create(8);
+    [JsProperty(Name = "NOT_SUPPORTED_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber NotSupportedErr = JsNumber.Create(9);
+    [JsProperty(Name = "INUSE_ATTRIBUTE_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber InUseAttributeErr = JsNumber.Create(10);
+    [JsProperty(Name = "INVALID_STATE_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber InvalidStateErr = JsNumber.Create(11);
+    [JsProperty(Name = "SYNTAX_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber SyntaxErr = JsNumber.Create(12);
+    [JsProperty(Name = "INVALID_MODIFICATION_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber InvalidModificationErr = JsNumber.Create(13);
+    [JsProperty(Name = "NAMESPACE_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber NamespaceErr = JsNumber.Create(14);
+    [JsProperty(Name = "INVALID_ACCESS_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber InvalidAccessErr = JsNumber.Create(15);
+    [JsProperty(Name = "VALIDATION_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber ValidationErr = JsNumber.Create(16);
+    [JsProperty(Name = "TYPE_MISMATCH_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber TypeMismatchErr = JsNumber.Create(17);
+    [JsProperty(Name = "SECURITY_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber SecurityErr = JsNumber.Create(18);
+    [JsProperty(Name = "NETWORK_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber NetworkErr = JsNumber.Create(19);
+    [JsProperty(Name = "ABORT_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber AbortErr = JsNumber.Create(20);
+    [JsProperty(Name = "URL_MISMATCH_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber UrlMismatchErr = JsNumber.Create(21);
+    [JsProperty(Name = "QUOTA_EXCEEDED_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber QuotaExceededErr = JsNumber.Create(22);
+    [JsProperty(Name = "TIMEOUT_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber TimeoutErr = JsNumber.Create(23);
+    [JsProperty(Name = "INVALID_NODE_TYPE_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber InvalidNodeTypeErr = JsNumber.Create(24);
+    [JsProperty(Name = "DATA_CLONE_ERR", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber DataCloneErr = JsNumber.Create(25);
+
+    internal DomExceptionPrototype(
+        Engine engine,
+        Realm realm,
+        DomExceptionConstructor constructor,
+        ObjectInstance errorPrototype) : base(engine, realm)
+    {
+        _prototype = errorPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#dom-domexception-name
+    /// </summary>
+    [JsAccessor("name", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsString NameGet(JsValue thisObject)
+    {
+        return Brand(thisObject).Name;
+    }
+
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#dom-domexception-message
+    /// </summary>
+    [JsAccessor("message", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsString MessageGet(JsValue thisObject)
+    {
+        return Brand(thisObject).Message;
+    }
+
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#dom-domexception-code
+    /// </summary>
+    [JsAccessor("code", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsNumber CodeGet(JsValue thisObject)
+    {
+        return Brand(thisObject).Code;
+    }
+
+    /// <summary>
+    /// The WebIDL brand check every attribute getter performs: a receiver that is not a platform object
+    /// implementing the interface raises a <c>TypeError</c>.
+    /// </summary>
+    private JsDomException Brand(JsValue thisObject)
+    {
+        if (thisObject is JsDomException exception)
+        {
+            return exception;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a DOMException");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/DomException/JsDomException.cs
+++ b/Jint/WebApi/DomException/JsDomException.cs
@@ -1,0 +1,49 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Error;
+using Jint.Native.Object;
+
+namespace Jint.WebApi.DomException;
+
+/// <summary>
+/// A <c>DOMException</c> instance.
+/// <para>
+/// https://webidl.spec.whatwg.org/#idl-DOMException
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// WebIDL exposes <c>name</c>, <c>message</c> and <c>code</c> as accessors on the interface prototype
+/// object, not as own properties of the instance, so the three values live in CLR fields here and
+/// <see cref="DomExceptionPrototype"/> reads them through a brand check. An instance therefore has no own
+/// property but <c>stack</c>, matching what a browser reports for
+/// <c>Object.getOwnPropertyNames(new DOMException())</c>.
+/// </para>
+/// <para>
+/// It derives from <see cref="ErrorInstance"/> for the <c>[[ErrorData]]</c>-shaped behaviour a host expects
+/// of an error object — notably <see cref="object.ToString"/> rendering as <c>name: message</c>. It is not a
+/// <see cref="JsError"/>, which is sealed, so <c>Error.isError(domException)</c> answers <see langword="false"/>
+/// where a browser answers <see langword="true"/>; the prototype chain, <c>instanceof Error</c> and
+/// <c>stack</c> all behave as they should.
+/// </para>
+/// </remarks>
+internal sealed class JsDomException : ErrorInstance
+{
+    internal JsDomException(Engine engine, JsString name, JsString message)
+        : base(engine, ObjectClass.Error)
+    {
+        Name = name;
+        Message = message;
+        Code = JsNumber.Create(DomExceptionNames.CodeFor(name.ToString()));
+    }
+
+    /// <summary>The <c>[[Name]]</c> of the exception.</summary>
+    internal JsString Name { get; }
+
+    /// <summary>The <c>[[Message]]</c> of the exception.</summary>
+    internal JsString Message { get; }
+
+    /// <summary>The legacy code the name maps to, or <c>0</c>. Computed once, since the name never changes.</summary>
+    internal JsNumber Code { get; }
+}
+#endif

--- a/Jint/WebApi/WebApiOptionsExtensions.cs
+++ b/Jint/WebApi/WebApiOptionsExtensions.cs
@@ -1,0 +1,126 @@
+#if NET8_0_OR_GREATER
+using Jint.Runtime;
+using Jint.WebApi;
+
+// ReSharper disable once CheckNamespace
+namespace Jint;
+
+/// <summary>
+/// Enables the opt-in WHATWG web platform APIs. Requires .NET 8 or higher.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every method here <b>adds</b> to <see cref="Options.WebApiOptions.Features"/> rather than replacing it,
+/// so the calls compose in any order and none of them can silently switch a feature off that an earlier
+/// call switched on. Assign <c>options.WebApi.Features</c> directly to say exactly what the set is.
+/// </para>
+/// <para>
+/// Enabling a feature only makes the engine <i>offer</i> the global: a name the host already registered
+/// itself — through <c>engine.SetValue(...)</c> in an <c>options.Configure(...)</c> callback, or through
+/// <c>options.AddLazyGlobal(...)</c> — is left exactly as the host left it. The host wins.
+/// </para>
+/// </remarks>
+public static class WebApiOptionsExtensions
+{
+    /// <summary>
+    /// Enables <see cref="WebApiFeatures.Default"/>: the web APIs a host normally wants, which is everything
+    /// implemented except outbound network access.
+    /// </summary>
+    /// <param name="options">Options to modify.</param>
+    /// <returns>Options instance for fluent syntax.</returns>
+    public static Options UseWebApis(this Options options)
+    {
+        return UseWebApis(options, WebApiFeatures.Default);
+    }
+
+    /// <summary>
+    /// Enables the named web APIs, in addition to any already enabled.
+    /// </summary>
+    /// <param name="options">Options to modify.</param>
+    /// <param name="features">
+    /// The features to add. <see cref="WebApiFeatures.None"/> adds nothing and, in particular, does not
+    /// disable anything.
+    /// </param>
+    /// <returns>Options instance for fluent syntax.</returns>
+    public static Options UseWebApis(this Options options, WebApiFeatures features)
+    {
+        if (options is null)
+        {
+            Throw.ArgumentNullException(nameof(options));
+        }
+
+        options.WebApi.Features |= features;
+        return options;
+    }
+
+    /// <summary>
+    /// Enables <see cref="WebApiFeatures.Default"/> and then hands the whole web-API options group to
+    /// <paramref name="configure"/>, so a host can adjust the feature set and the per-feature settings in one
+    /// call.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var engine = new Engine(o => o.UseWebApis(w =>
+    /// {
+    ///     w.Console.Sink = ConsoleSink.FromTextWriter(Console.Out);
+    /// }));
+    /// </code>
+    /// </example>
+    /// <param name="options">Options to modify.</param>
+    /// <param name="configure">
+    /// Runs after the default features are enabled, so it observes them and may narrow the set by assigning
+    /// <see cref="Options.WebApiOptions.Features"/> outright.
+    /// </param>
+    /// <returns>Options instance for fluent syntax.</returns>
+    public static Options UseWebApis(this Options options, Action<Options.WebApiOptions> configure)
+    {
+        if (options is null)
+        {
+            Throw.ArgumentNullException(nameof(options));
+        }
+
+        if (configure is null)
+        {
+            Throw.ArgumentNullException(nameof(configure));
+        }
+
+        options.WebApi.Features |= WebApiFeatures.Default;
+        configure(options.WebApi);
+        return options;
+    }
+
+    /// <summary>
+    /// Enables the <c>console</c> object and sends its output to <paramref name="sink"/>.
+    /// </summary>
+    /// <param name="options">Options to modify.</param>
+    /// <param name="sink">Where console output goes. See <see cref="ConsoleSink"/> for the thread-safety obligation.</param>
+    /// <returns>Options instance for fluent syntax.</returns>
+    public static Options UseConsole(this Options options, ConsoleSink sink)
+    {
+        if (options is null)
+        {
+            Throw.ArgumentNullException(nameof(options));
+        }
+
+        if (sink is null)
+        {
+            Throw.ArgumentNullException(nameof(sink));
+        }
+
+        options.WebApi.Features |= WebApiFeatures.Console;
+        options.WebApi.Console.Sink = sink;
+        return options;
+    }
+
+    /// <summary>
+    /// Enables the <c>console</c> object and writes each record to <paramref name="writer"/> as one line.
+    /// </summary>
+    /// <param name="options">Options to modify.</param>
+    /// <param name="writer">The destination, e.g. <c>Console.Out</c>.</param>
+    /// <returns>Options instance for fluent syntax.</returns>
+    public static Options UseConsole(this Options options, TextWriter writer)
+    {
+        return UseConsole(options, ConsoleSink.FromTextWriter(writer));
+    }
+}
+#endif

--- a/Jint/WebApi/WebApiRegistration.cs
+++ b/Jint/WebApi/WebApiRegistration.cs
@@ -1,0 +1,73 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Descriptors.Specialized;
+
+namespace Jint.WebApi;
+
+/// <summary>
+/// Installs the globals for the web APIs an engine opted into. Invoked from <c>Options.Apply</c>, which is
+/// the sanctioned conditional-install site — the same one <c>Interop.Enabled</c> and
+/// <c>Modules.RegisterRequire</c> use.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each global is a <see cref="LazyPropertyDescriptor{T}"/> installed through
+/// <c>GlobalObject.SetProperty</c>, which is what <c>Options.AddLazyGlobal</c> does and for the same two
+/// reasons: <c>SetProperty</c> bumps the own-property version every global-identifier and member-read inline
+/// cache revalidates against, and a lazy descriptor is what
+/// <c>Engine.Advanced.RestoreGlobalSnapshot</c> can return to its unmaterialized state so a pooled engine
+/// rebuilds the object for the next cycle rather than inheriting the previous one's.
+/// </para>
+/// <para>
+/// Nothing here touches anything but the principal realm's global object, so a <c>ShadowRealm</c> never
+/// carries these globals. That is deliberately more conservative than a browser, where the web APIs are
+/// <c>[Exposed=*]</c>; a host that wants them inside a shadow realm has <c>Host.InitializeShadowRealm</c>.
+/// </para>
+/// </remarks>
+internal static class WebApiRegistration
+{
+    internal static void Apply(Options options, Engine engine)
+    {
+        var global = engine.Realm.GlobalObject;
+
+        // DOMException has no feature flag of its own: it is how every other web API reports a failure, so it
+        // exists whenever any of them does. As a WebIDL interface object it is writable and configurable but
+        // NOT enumerable — https://webidl.spec.whatwg.org/#es-interfaces.
+        Install(global, engine, "DOMException", static e => e.Realm.Intrinsics.DomException, PropertyFlag.NonEnumerable);
+
+        if ((options.WebApi.Features & WebApiFeatures.Console) != WebApiFeatures.None)
+        {
+            // A WebIDL namespace object is exposed through an accessor pair; installing it as an ordinary
+            // enumerable data property is a deliberate simplification, documented on ConsoleInstance.
+            Install(global, engine, "console", static e => e.Realm.Intrinsics.Console, PropertyFlag.ConfigurableEnumerableWritable);
+        }
+    }
+
+    /// <summary>
+    /// Installs one global, unless the global object already owns that name.
+    /// </summary>
+    /// <remarks>
+    /// The host's <c>Options</c> configuration callbacks run before this, so a host that registered its own
+    /// <c>console</c> — the thing every embedder that ever wanted logging did — keeps it, and enabling the
+    /// feature can never silently replace it. The check probes rather than reads: a probe answers existence
+    /// and enumerability without materializing a descriptor's value, so a host's own lazy global is not
+    /// forced into existence merely by our looking.
+    /// </remarks>
+    private static void Install(
+        ObjectInstance global,
+        Engine engine,
+        string name,
+        Func<Engine, JsValue> valueFactory,
+        PropertyFlag flags)
+    {
+        if (global.HasOwnProperty(JsString.Create(name)))
+        {
+            return;
+        }
+
+        global.SetProperty(name, new LazyPropertyDescriptor<Engine>(engine, valueFactory, flags));
+    }
+}
+#endif

--- a/README.md
+++ b/README.md
@@ -172,6 +172,66 @@ intermediate tail callers are intentionally absent from `error.stack` and host s
 - Constraints for execution (recursion, memory usage, duration)
 
 
+## Web APIs (opt-in)
+
+Beyond ECMAScript, Jint is growing a WHATWG-faithful set of web platform APIs — the surface a script author
+expects from a browser or from Node: `console`, timers, `TextEncoder`, `fetch` and friends. It follows the
+published standards (`console.spec.whatwg.org`, `webidl.spec.whatwg.org`, `fetch.spec.whatwg.org`, …) rather
+than inventing a Jint-shaped variant, so scripts written against those standards behave the way their authors
+expect.
+
+**Everything here is opt-in and nothing is installed by default.** An engine that does not ask for these APIs
+is byte-for-byte the engine it was before they existed: no extra globals, no extra work at construction, no
+behaviour change. That is deliberate — an engine embedded in a workflow runner or a template renderer has no
+business exposing them, and outbound network access in particular is a decision a host has to make
+explicitly.
+
+**Requires .NET 8 or higher.** The whole surface is compiled only for `net8.0` and later; on `net462`,
+`netstandard2.0` and `netstandard2.1` the options and types simply do not exist.
+
+```csharp
+// Everything except network access.
+var engine = new Engine(options => options.UseWebApis());
+
+// Or exactly what you want, with somewhere for console output to go.
+var engine = new Engine(options => options
+    .UseWebApis(WebApiFeatures.Console)
+    .UseConsole(Console.Out));
+
+engine.Execute("console.log('hello %s', 'world')");
+```
+
+`console` output goes to a `ConsoleSink`, which defaults to `ConsoleSink.Null` and discards everything —
+enabling the feature never starts writing to your process's standard output by surprise. `ConsoleSink.FromTextWriter`
+covers the common case; implement the abstract class to route records to your own logger, where the
+`ConsoleLogLevel` tells you how loud each one is.
+
+A global you registered yourself always wins: the install is non-clobbering, so if your host already exposes
+its own `console` (or any other name in the table below), enabling the feature leaves yours exactly as it is.
+
+| API | Feature flag | Status |
+| --- | --- | --- |
+| `console` (`log`/`warn`/`error`/`group`/`count`/`time`/`assert`/`trace`/`dir`) | `WebApiFeatures.Console` | ✔ shipped |
+| `DOMException` | *(no flag — installed whenever any feature is enabled)* | ✔ shipped |
+| `setTimeout` / `setInterval` / `clearTimeout` / `clearInterval` / `queueMicrotask` | `Timers` | in progress |
+| `TextEncoder` / `TextDecoder` | `Encoding` | in progress |
+| `atob` / `btoa` | `Base64` | in progress |
+| `structuredClone` | `StructuredClone` | in progress |
+| `crypto.getRandomValues` / `crypto.randomUUID` | `Crypto` | in progress |
+| `performance.now` / `performance.timeOrigin` | `Performance` | in progress |
+| `Event` / `EventTarget` / `CustomEvent` / `AbortController` / `AbortSignal` | `Events` | in progress |
+| `URL` / `URLSearchParams` | `Url` | in progress |
+| `Blob` / `File` / `FormData` | `Files` | in progress |
+| `fetch` / `Headers` / `Request` / `Response` | `Fetch` | in progress |
+
+`WebApiFeatures.Default` — what `UseWebApis()` enables — is every non-network feature that has landed. It
+grows as the table fills in, and it will never include `fetch`: network egress is always an explicit choice.
+
+**A `ShadowRealm` does not get these globals.** Only the principal realm's global object is touched, which is
+deliberately more conservative than a browser (where these APIs are `[Exposed=*]`); a host that wants them
+inside a shadow realm can install them through `Host.InitializeShadowRealm`.
+
+
 ## Performance
 
 - Because Jint neither generates any .NET bytecode nor uses the DLR it runs relatively small scripts really fast

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ explicitly.
 var engine = new Engine(options => options.UseWebApis());
 
 // Or exactly what you want, with somewhere for console output to go.
-var engine = new Engine(options => options
+engine = new Engine(options => options
     .UseWebApis(WebApiFeatures.Console)
     .UseConsole(Console.Out));
 


### PR DESCRIPTION
This is the first PR of a planned series that gives Jint an **opt-in, WHATWG-faithful set of web platform APIs** — `console`, timers, `TextEncoder`, `URL`, `AbortController` and ultimately `fetch` — guided by [WinterTC's Minimum Common Web Platform API](https://min-common-api.proposal.wintertc.org/). Users have asked for this since 2017 (#442, discussion #1253), and every embedder that wanted logging or HTTP has had to hand-roll its own shims.

Three ground rules hold for the whole series, and this PR lays them down:

- **BCL only.** No new package dependencies, which is why the surface is uniformly `#if NET8_0_OR_GREATER` (the same shape as the Float16 APIs and the System.Text.Json interop): on `net462`/`netstandard2.x` the options and types simply do not exist.
- **Opt-in, and nothing else changes.** A default engine is byte-for-byte the engine it was before: no globals, no construction cost (the options group itself is allocated on first touch), no behaviour change. `UseWebApis()` enables the non-network set; fetch, when it lands, will always require its own explicit `UseFetch(...)`.
- **The host wins.** Globals are installed as lazy descriptors from `Options.Apply`, after the host's own configuration, and the install is non-clobbering — a `console` the host registered itself is left exactly as the host left it (checked with a probe, so a host's lazy global is not even materialized by the look). Only the principal realm is touched, so a `ShadowRealm` gets none of this.

### What's in this PR

- `Options.WebApi` + `[Flags] WebApiFeatures` + `UseWebApis`/`UseConsole` extensions, and `WebApiRegistration` — the plumbing every later feature rides on. Flags are declared only once the feature behind them exists; the bit layout is reserved up front.
- **`DOMException`** per WebIDL: prototype chained to `%Error.prototype%` (so `instanceof Error` holds and `stack` works), `name`/`message`/`code` as brand-checked prototype accessors, the 25 legacy constants on both the interface object and the prototype. It has no feature flag — it is how every web API reports failure, so it exists whenever any of them does.
- **`console`** per the Console Standard: the log family, `assert`, `trace`, `dir`, `group`, `count` and `time`, with the `%s`/`%d`/`%i`/`%f`/`%o`/`%O`/`%c`/`%%` formatter, group indentation, and a bounded, cycle-safe, getter-free object inspection. Output goes to a host-supplied `ConsoleSink` (one finished line per record); the default sink discards everything, so enabling the feature never surprises a server host with stdout writes.
- **`Jint.Repl`** adopts `UseConsole(Console.Out)` and drops its hand-rolled `JsConsole` — first dogfooding consumer.
- One core fix the work surfaced: **`Error.prototype.toString` passed `%Error.prototype%` as the receiver** for its `name`/`message` reads where spec steps 3 and 5 say `Get(O, …)`. Unobservable for ordinary errors (data properties); wrong for any error whose attributes are prototype accessors that brand-check their receiver, which DOMException's are. Full test262 stays green.
- README gains a "Web APIs (opt-in)" section with the roadmap table; AGENTS.md scopes the unconditional-registration rule to TC39 features and documents the new subtree's conventions.

### Verification

- `dotnet build -c Release` — all five TFMs, 0 errors (the `#if` gate is proven by the downlevel targets compiling).
- `Jint.Tests` and `Jint.Tests.PublicInterface` green on net10.0 and net472, in both the default and the `JINT_HOST_CONTRACT_VERIFICATION=1` configurations.
- Full test262 green (run because a core Error file was touched; the Error-filtered subset was run repeatedly).
- Pins included for: a default engine has no web globals; a host-registered global wins; ShadowRealm gets nothing; a snapshot restore returns the globals to their unmaterialized state.

The next PRs in the series, in dependency order: timers + `queueMicrotask` (the one event-loop change, benchmark-gated), then Event/AbortController, TextEncoder/TextDecoder, atob/btoa, structuredClone, crypto, performance, WHATWG URL, Blob/File/FormData, and finally fetch itself with bounded default policy (scheme allowlist, redirect-hop re-validation, response-size cap, timeout) and a threat-model entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
