### PR TITLE
Add opt-in structuredClone

### DIFF
--- a/Jint.Tests.PublicInterface/WebApiStructuredCloneTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiStructuredCloneTests.cs
@@ -1,0 +1,152 @@
+#if NET8_0_OR_GREATER
+using Jint;
+using Jint.Native;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// The opt-in <c>structuredClone</c> global seen from outside the assembly: what a host has to write to get
+/// it, what it gets when it writes nothing, and how the algorithm treats the objects a host puts into script.
+/// </summary>
+/// <remarks>
+/// This project has no <c>InternalsVisibleTo</c>, so everything here is reachable by a third party.
+/// </remarks>
+public class WebApiStructuredCloneTests
+{
+    private sealed class HostRecord
+    {
+        public string Name { get; set; } = "host";
+
+        public int Count { get; set; } = 1;
+    }
+
+    [Fact]
+    public void ADefaultEngineHasNoStructuredClone()
+    {
+        var engine = new Engine();
+
+        engine.Evaluate("typeof structuredClone").AsString().Should().Be("undefined");
+        engine.Evaluate("'structuredClone' in globalThis").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void TheFeatureFlagInstallsIt()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.StructuredClone));
+
+        engine.Evaluate("typeof structuredClone").AsString().Should().Be("function");
+        engine.Evaluate("structuredClone({ a: [1, 2] }).a[1]").AsNumber().Should().Be(2);
+
+        // DOMException comes with any web API, because it is how this one reports a refusal.
+        engine.Evaluate("typeof DOMException").AsString().Should().Be("function");
+    }
+
+    [Fact]
+    public void TheDefaultSetIncludesIt()
+    {
+        WebApiFeatures.Default.Should().HaveFlag(WebApiFeatures.StructuredClone);
+
+        new Engine(options => options.UseWebApis()).Evaluate("typeof structuredClone").AsString().Should().Be("function");
+    }
+
+    [Fact]
+    public void AHostRegisteredGlobalWins()
+    {
+        var marker = new JsString("host's own structuredClone");
+
+        var engine = new Engine(options => options
+            .AddLazyGlobal("structuredClone", _ => marker)
+            .UseWebApis(WebApiFeatures.StructuredClone));
+
+        // The host's configuration runs first and the install is non-clobbering.
+        engine.Evaluate("structuredClone").Should().BeSameAs(marker);
+    }
+
+    [Fact]
+    public void HasTheAttributesWebIdlGivesAGlobalOperation()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.StructuredClone));
+
+        engine.Evaluate("var d = Object.getOwnPropertyDescriptor(globalThis, 'structuredClone');");
+        engine.Evaluate("d.writable").AsBoolean().Should().BeTrue();
+        engine.Evaluate("d.enumerable").AsBoolean().Should().BeTrue();
+        engine.Evaluate("d.configurable").AsBoolean().Should().BeTrue();
+        engine.Evaluate("typeof d.get").AsString().Should().Be("undefined");
+
+        engine.Evaluate("structuredClone.length").AsNumber().Should().Be(1);
+        engine.Evaluate("structuredClone.name").AsString().Should().Be("structuredClone");
+    }
+
+    [Fact]
+    public void RefusesAWrappedClrObject()
+    {
+        var engine = new Engine(options => options
+            .AllowClr()
+            .UseWebApis(WebApiFeatures.StructuredClone));
+
+        engine.SetValue("record", new HostRecord());
+
+        // A CLR object projected into script is the engine's equivalent of a platform object that is not
+        // serializable: cloning it would produce a plain object that has quietly lost its identity and its
+        // behaviour, so it is refused instead.
+        var result = engine.Evaluate(@"
+            (function() {
+                try { structuredClone(record); return 'no error'; }
+                catch (e) { return e.name + '/' + (e instanceof DOMException) + '/' + e.code; }
+            })()").AsString();
+
+        result.Should().Be("DataCloneError/true/25");
+    }
+
+    [Fact]
+    public void ClonesAHostSuppliedObjectGraph()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.StructuredClone));
+
+        // What a host builds with the public JsObject factories is an ordinary object, so it clones.
+        var source = JsObject.CreateFromEntries(
+            engine,
+            [
+                new KeyValuePair<string, JsValue>("name", new JsString("host")),
+                new KeyValuePair<string, JsValue>("count", JsNumber.Create(3)),
+            ]);
+
+        engine.SetValue("source", source);
+        engine.Evaluate("var clone = structuredClone(source);");
+
+        engine.Evaluate("clone !== source").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone.name").AsString().Should().Be("host");
+        engine.Evaluate("clone.count").AsNumber().Should().Be(3);
+    }
+
+    [Fact]
+    public void OneOptionsInstanceServesSeveralEngines()
+    {
+        var options = new Options().UseWebApis(WebApiFeatures.StructuredClone);
+
+        var first = new Engine(options);
+        var second = new Engine(options);
+
+        first.Evaluate("structuredClone({ v: 1 }).v").AsNumber().Should().Be(1);
+        second.Evaluate("structuredClone({ v: 2 }).v").AsNumber().Should().Be(2);
+
+        // Each engine has its own function object; nothing about the clone is shared through the options.
+        first.Evaluate("typeof structuredClone").AsString().Should().Be("function");
+        second.Evaluate("typeof structuredClone").AsString().Should().Be("function");
+    }
+
+    [Fact]
+    public void TransfersAnArrayBufferForAHost()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.StructuredClone));
+
+        engine.Execute(@"
+            var buffer = new ArrayBuffer(3);
+            new Uint8Array(buffer).set([7, 8, 9]);
+            var clone = structuredClone(buffer, { transfer: [buffer] });");
+
+        engine.Evaluate("buffer.byteLength").AsNumber().Should().Be(0);
+        engine.Evaluate("Array.from(new Uint8Array(clone)).join(',')").AsString().Should().Be("7,8,9");
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/StructuredCloneTests.cs
+++ b/Jint.Tests/Runtime/WebApi/StructuredCloneTests.cs
@@ -1,0 +1,897 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// <c>structuredClone</c> as the HTML Standard specifies it —
+/// https://html.spec.whatwg.org/multipage/structured-data.html#dom-structuredclone.
+/// </summary>
+public class StructuredCloneTests
+{
+    private static Engine WebEngine()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.StructuredClone));
+
+        // Every "does this throw, and with what?" assertion goes through this, so a DataCloneError is
+        // distinguished from the TypeError the argument conversion raises.
+        engine.Execute("function err(f) { try { f(); return 'no error'; } catch (e) { return e.name; } }");
+        return engine;
+    }
+
+    private static string Err(Engine engine, string body) => engine.Evaluate("err(function() { " + body + " })").AsString();
+
+    // ---------------------------------------------------------------- the function itself
+
+    [Fact]
+    public void IsAWebIdlOperationOnTheGlobal()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("typeof structuredClone").AsString().Should().Be("function");
+        engine.Evaluate("structuredClone.name").AsString().Should().Be("structuredClone");
+        engine.Evaluate("structuredClone.length").AsNumber().Should().Be(1);
+
+        // An operation is not a constructor.
+        Err(engine, "new structuredClone(1)").Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void RequiresTheValueArgument()
+    {
+        var engine = WebEngine();
+
+        Err(engine, "structuredClone()").Should().Be("TypeError");
+
+        // ... but an explicit undefined is a value like any other.
+        engine.Evaluate("structuredClone(undefined) === undefined").AsBoolean().Should().BeTrue();
+    }
+
+    // ---------------------------------------------------------------- primitives
+
+    [Theory]
+    [InlineData("undefined")]
+    [InlineData("null")]
+    [InlineData("true")]
+    [InlineData("42")]
+    [InlineData("'text'")]
+    [InlineData("123456789012345678901234567890n")]
+    public void ReturnsAPrimitiveAsItself(string expression)
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate($"structuredClone({expression}) === {expression} || Object.is(structuredClone({expression}), {expression})")
+            .AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void PreservesNegativeZeroAndNaN()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("Object.is(structuredClone(-0), -0)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Number.isNaN(structuredClone(NaN))").AsBoolean().Should().BeTrue();
+        engine.Evaluate("structuredClone(Infinity)").AsNumber().Should().Be(double.PositiveInfinity);
+    }
+
+    [Fact]
+    public void RefusesASymbol()
+    {
+        var engine = WebEngine();
+
+        Err(engine, "structuredClone(Symbol('x'))").Should().Be("DataCloneError");
+        Err(engine, "structuredClone({ s: Symbol('x') })").Should().Be("DataCloneError");
+    }
+
+    // ---------------------------------------------------------------- ordinary objects
+
+    [Fact]
+    public void ClonesTheOwnEnumerableStringKeyedProperties()
+    {
+        var engine = WebEngine();
+
+        engine.Execute(@"
+            var source = { a: 1, b: 'two', c: { deep: true } };
+            Object.defineProperty(source, 'hidden', { value: 'no', enumerable: false });
+            source[Symbol('key')] = 'no';
+            var clone = structuredClone(source);");
+
+        engine.Evaluate("clone !== source").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone.a").AsNumber().Should().Be(1);
+        engine.Evaluate("clone.b").AsString().Should().Be("two");
+        engine.Evaluate("clone.c.deep").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone.c !== source.c").AsBoolean().Should().BeTrue();
+
+        // Neither a non-enumerable property nor a symbol-keyed one is in EnumerableOwnProperties.
+        engine.Evaluate("'hidden' in clone").AsBoolean().Should().BeFalse();
+        engine.Evaluate("Object.getOwnPropertySymbols(clone).length").AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void RecreatesEveryPropertyAsAPlainDataProperty()
+    {
+        var engine = WebEngine();
+
+        engine.Execute(@"
+            var source = {};
+            Object.defineProperty(source, 'frozen', { value: 1, enumerable: true, writable: false, configurable: false });
+            var descriptor = Object.getOwnPropertyDescriptor(structuredClone(source), 'frozen');");
+
+        // CreateDataProperty, so the clone's attributes are the defaults whatever the source's were.
+        engine.Evaluate("descriptor.value").AsNumber().Should().Be(1);
+        engine.Evaluate("descriptor.writable").AsBoolean().Should().BeTrue();
+        engine.Evaluate("descriptor.enumerable").AsBoolean().Should().BeTrue();
+        engine.Evaluate("descriptor.configurable").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void GivesEveryCloneTheCurrentRealmsObjectPrototype()
+    {
+        var engine = WebEngine();
+
+        // A class instance loses its prototype: the algorithm records properties, never the [[Prototype]].
+        engine.Execute("class Point { constructor() { this.x = 1; } greet() { return 'hi'; } } var clone = structuredClone(new Point());");
+        engine.Evaluate("Object.getPrototypeOf(clone) === Object.prototype").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone instanceof Point").AsBoolean().Should().BeFalse();
+        engine.Evaluate("clone.x").AsNumber().Should().Be(1);
+
+        // And a null-prototype object gains one: deserialization creates "a new Object in targetRealm".
+        engine.Execute("var bare = Object.create(null); bare.a = 1; var bareClone = structuredClone(bare);");
+        engine.Evaluate("Object.getPrototypeOf(bareClone) === Object.prototype").AsBoolean().Should().BeTrue();
+        engine.Evaluate("bareClone.a").AsNumber().Should().Be(1);
+    }
+
+    [Fact]
+    public void InvokesGettersAndClonesWhatTheyReturn()
+    {
+        var engine = WebEngine();
+
+        engine.Execute(@"
+            var calls = 0;
+            var source = { get value() { calls++; return { nested: calls }; } };
+            var clone = structuredClone(source);");
+
+        engine.Evaluate("calls").AsNumber().Should().Be(1);
+        engine.Evaluate("clone.value.nested").AsNumber().Should().Be(1);
+
+        // The clone holds the produced value as data, so reading it again does not re-run the getter.
+        engine.Evaluate("clone.value").AsObject().Should().BeSameAs(engine.Evaluate("clone.value").AsObject());
+        engine.Evaluate("calls").AsNumber().Should().Be(1);
+    }
+
+    [Fact]
+    public void WalksDepthFirstInPropertyOrder()
+    {
+        var engine = WebEngine();
+
+        engine.Execute(@"
+            var order = [];
+            var source = {
+                get a() { order.push('a'); return { get inner() { order.push('inner'); return 1; } }; },
+                get b() { order.push('b'); return 2; }
+            };
+            structuredClone(source);");
+
+        // A value's own graph is finished before its next sibling is read, which is the order the
+        // specification's recursion produces and the only order a getter can tell apart.
+        engine.Evaluate("order.join(',')").AsString().Should().Be("a,inner,b");
+    }
+
+    [Fact]
+    public void SkipsAKeyAnEarlierGetterDeleted()
+    {
+        var engine = WebEngine();
+
+        engine.Execute(@"
+            var source = { get a() { delete this.b; return 1; }, b: 2 };
+            var clone = structuredClone(source);");
+
+        // The key list is snapshot up front, so 'b' is still on it — the HasOwnProperty re-check is what
+        // keeps it out of the clone.
+        engine.Evaluate("clone.a").AsNumber().Should().Be(1);
+        engine.Evaluate("'b' in clone").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void PropagatesWhatAGetterThrows()
+    {
+        var engine = WebEngine();
+
+        Err(engine, "structuredClone({ get boom() { throw new RangeError('nope'); } })").Should().Be("RangeError");
+    }
+
+    // ---------------------------------------------------------------- identity and cycles
+
+    [Fact]
+    public void PreservesCyclesThroughTheMemoryMap()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("var source = { name: 'root' }; source.self = source; var clone = structuredClone(source);");
+
+        engine.Evaluate("clone.self === clone").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone !== source").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void PreservesSharedIdentity()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("var shared = { v: 1 }; var clone = structuredClone({ x: shared, y: shared, z: [shared] });");
+
+        engine.Evaluate("clone.x === clone.y").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone.z[0] === clone.x").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone.x !== shared").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void GivesEachCallItsOwnMemory()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("var source = { a: 1 };");
+        engine.Evaluate("structuredClone(source) !== structuredClone(source)").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ClonesADeeplyNestedGraphWithoutOverflowingTheStack()
+    {
+        var engine = WebEngine();
+
+        // The specification's algorithm recurses once per edge and bounds nothing; a native stack overflow
+        // takes the process down rather than raising something a host can catch, so the walk is iterative and
+        // this depth simply works.
+        engine.Execute(@"
+            var root = {};
+            var cursor = root;
+            for (var i = 0; i < 100000; i++) { cursor.next = {}; cursor = cursor.next; }
+            var clone = structuredClone(root);
+            var depth = 0;
+            for (var node = clone; node.next; node = node.next) { depth++; }");
+
+        engine.Evaluate("depth").AsNumber().Should().Be(100000);
+        engine.Evaluate("clone !== root").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ClonesADeeplyNestedArrayAndMapChainWithoutOverflowingTheStack()
+    {
+        var engine = WebEngine();
+
+        // The array and Map frames are separate from the plain-object one, so they get their own depth pin.
+        engine.Execute(@"
+            var arrayRoot = [];
+            var arrayCursor = arrayRoot;
+            var mapRoot = new Map();
+            var mapCursor = mapRoot;
+            for (var i = 0; i < 100000; i++) {
+                var nextArray = []; arrayCursor.push(nextArray); arrayCursor = nextArray;
+                var nextMap = new Map(); mapCursor.set('next', nextMap); mapCursor = nextMap;
+            }
+            var arrayClone = structuredClone(arrayRoot);
+            var mapClone = structuredClone(mapRoot);
+            var arrayDepth = 0;
+            for (var a = arrayClone; a.length; a = a[0]) { arrayDepth++; }
+            var mapDepth = 0;
+            for (var m = mapClone; m.size; m = m.get('next')) { mapDepth++; }");
+
+        engine.Evaluate("arrayDepth").AsNumber().Should().Be(100000);
+        engine.Evaluate("mapDepth").AsNumber().Should().Be(100000);
+    }
+
+    // ---------------------------------------------------------------- installation
+
+    [Fact]
+    public void IsInstalledOnlyWhenTheFeatureIsNamed()
+    {
+        new Engine().Evaluate("typeof structuredClone").AsString().Should().Be("undefined");
+        new Engine(options => options.UseWebApis(WebApiFeatures.Console)).Evaluate("typeof structuredClone").AsString().Should().Be("undefined");
+        new Engine(options => options.UseWebApis()).Evaluate("typeof structuredClone").AsString().Should().Be("function");
+    }
+
+    [Fact]
+    public void IsAnUnmaterializedLazyGlobalWithTheWebIdlAttributes()
+    {
+        var engine = WebEngine();
+        var descriptor = engine.Realm.GlobalObject.GetOwnProperty("structuredClone");
+
+        descriptor.Should().BeOfType<Jint.Runtime.Descriptors.Specialized.LazyPropertyDescriptor<Engine>>();
+        descriptor._value.Should().BeNull();
+
+        // A WebIDL operation on the global is writable, enumerable and configurable.
+        descriptor.Writable.Should().BeTrue();
+        descriptor.Enumerable.Should().BeTrue();
+        descriptor.Configurable.Should().BeTrue();
+    }
+
+    [Fact]
+    public void DoesNotReachIntoAShadowRealm()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("new ShadowRealm().evaluate('typeof structuredClone')").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof structuredClone").AsString().Should().Be("function");
+    }
+
+    [Fact]
+    public void SurvivesAGlobalSnapshotRestore()
+    {
+        var engine = WebEngine();
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+
+        engine.Execute("var kept = structuredClone({ a: 1 });");
+        engine.Realm.GlobalObject.GetOwnProperty("structuredClone")._value.Should().NotBeNull();
+
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        engine.Realm.GlobalObject.GetOwnProperty("structuredClone")._value.Should().BeNull();
+        engine.Evaluate("structuredClone({ a: 1 }).a").AsNumber().Should().Be(1);
+        engine.Evaluate("typeof kept").AsString().Should().Be("undefined");
+    }
+
+    // ---------------------------------------------------------------- arrays
+
+    [Fact]
+    public void ClonesAnArrayWithItsLengthHolesAndExtraProperties()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("var source = [1, , 3]; source.extra = 'x'; source.length = 5; var clone = structuredClone(source);");
+
+        engine.Evaluate("Array.isArray(clone)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.getPrototypeOf(clone) === Array.prototype").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone.length").AsNumber().Should().Be(5);
+        engine.Evaluate("clone[0]").AsNumber().Should().Be(1);
+        engine.Evaluate("1 in clone").AsBoolean().Should().BeFalse();
+        engine.Evaluate("clone[2]").AsNumber().Should().Be(3);
+        engine.Evaluate("clone.extra").AsString().Should().Be("x");
+    }
+
+    [Fact]
+    public void ClonesNestedArrays()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("var clone = structuredClone([[1, [2, [3]]], { a: [4] }]);");
+
+        engine.Evaluate("clone[0][1][1][0]").AsNumber().Should().Be(3);
+        engine.Evaluate("clone[1].a[0]").AsNumber().Should().Be(4);
+    }
+
+    // ---------------------------------------------------------------- Date, RegExp, boxed primitives
+
+    [Fact]
+    public void ClonesADateByItsTimeValue()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("structuredClone(new Date(1234567890123)).getTime()").AsNumber().Should().Be(1234567890123d);
+        engine.Evaluate("Number.isNaN(structuredClone(new Date(NaN)).getTime())").AsBoolean().Should().BeTrue();
+        engine.Evaluate("structuredClone(new Date(0)) instanceof Date").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ClonesARegExpBySourceAndFlagsButNotLastIndex()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("var source = /a(b+)c/gi; source.lastIndex = 5; var clone = structuredClone(source);");
+
+        engine.Evaluate("clone.source").AsString().Should().Be("a(b+)c");
+        engine.Evaluate("clone.flags").AsString().Should().Be("gi");
+
+        // [[OriginalSource]] and [[OriginalFlags]] serialize; lastIndex does not, so the clone starts at 0.
+        engine.Evaluate("clone.lastIndex").AsNumber().Should().Be(0);
+        engine.Evaluate("clone.exec('xxABBBC')[1]").AsString().Should().Be("BBB");
+        engine.Evaluate("clone instanceof RegExp").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ClonesABoxedPrimitiveByItsDataSlot()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("typeof structuredClone(new Number(3))").AsString().Should().Be("object");
+        engine.Evaluate("structuredClone(new Number(3)).valueOf()").AsNumber().Should().Be(3);
+        engine.Evaluate("structuredClone(new String('hi')).valueOf()").AsString().Should().Be("hi");
+        engine.Evaluate("structuredClone(new Boolean(true)).valueOf()").AsBoolean().Should().BeTrue();
+        engine.Evaluate("structuredClone(Object(7n)).valueOf() === 7n").AsBoolean().Should().BeTrue();
+
+        // The data slot is all that is recorded: a boxed primitive's own properties are not walked.
+        engine.Execute("var boxed = new Number(3); boxed.tag = 'x';");
+        engine.Evaluate("structuredClone(boxed).tag === undefined").AsBoolean().Should().BeTrue();
+    }
+
+    // ---------------------------------------------------------------- Map and Set
+
+    [Fact]
+    public void ClonesAMapWithItsEntriesInOrder()
+    {
+        var engine = WebEngine();
+
+        engine.Execute(@"
+            var key = { id: 1 };
+            var source = new Map([['a', 1], [key, { v: 2 }], [3, 'three']]);
+            var clone = structuredClone(source);");
+
+        engine.Evaluate("clone instanceof Map").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone.size").AsNumber().Should().Be(3);
+        engine.Evaluate("Array.from(clone.keys()).map(function(k) { return typeof k; }).join(',')").AsString()
+            .Should().Be("string,object,number");
+        engine.Evaluate("clone.get('a')").AsNumber().Should().Be(1);
+        engine.Evaluate("clone.has(key)").AsBoolean().Should().BeFalse();
+        engine.Evaluate("Array.from(clone.values())[1].v").AsNumber().Should().Be(2);
+    }
+
+    [Fact]
+    public void ClonesASetWithItsValuesInOrder()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("var clone = structuredClone(new Set(['a', 2, { v: 3 }]));");
+
+        engine.Evaluate("clone instanceof Set").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone.size").AsNumber().Should().Be(3);
+        engine.Evaluate("Array.from(clone)[2].v").AsNumber().Should().Be(3);
+    }
+
+    [Fact]
+    public void LetsACollectionContainItself()
+    {
+        var engine = WebEngine();
+
+        // The container is registered in memory before its contents are walked, which is what makes this
+        // terminate at all.
+        engine.Execute("var map = new Map(); map.set('self', map); var mapClone = structuredClone(map);");
+        engine.Evaluate("mapClone.get('self') === mapClone").AsBoolean().Should().BeTrue();
+
+        engine.Execute("var set = new Set(); set.add(set); var setClone = structuredClone(set);");
+        engine.Evaluate("setClone.has(setClone)").AsBoolean().Should().BeTrue();
+    }
+
+    // ---------------------------------------------------------------- errors
+
+    [Theory]
+    [InlineData("Error")]
+    [InlineData("EvalError")]
+    [InlineData("RangeError")]
+    [InlineData("ReferenceError")]
+    [InlineData("SyntaxError")]
+    [InlineData("TypeError")]
+    [InlineData("URIError")]
+    public void KeepsAWhitelistedErrorName(string name)
+    {
+        var engine = WebEngine();
+
+        engine.Execute($"var clone = structuredClone(new {name}('boom'));");
+
+        engine.Evaluate("clone.name").AsString().Should().Be(name);
+        engine.Evaluate($"clone instanceof {name}").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone.message").AsString().Should().Be("boom");
+    }
+
+    [Fact]
+    public void ReducesAnyOtherErrorNameToError()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("var renamed = new TypeError('x'); renamed.name = 'MyError'; var clone = structuredClone(renamed);");
+        engine.Evaluate("clone.name").AsString().Should().Be("Error");
+        engine.Evaluate("Object.getPrototypeOf(clone) === Error.prototype").AsBoolean().Should().BeTrue();
+
+        // AggregateError is not on the list either, and its `errors` is not carried.
+        engine.Execute("var aggregate = structuredClone(new AggregateError([new Error('inner')], 'outer'));");
+        engine.Evaluate("aggregate.name").AsString().Should().Be("Error");
+        engine.Evaluate("aggregate.message").AsString().Should().Be("outer");
+        engine.Evaluate("aggregate.errors === undefined").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void CarriesOnlyTheErrorsNameMessageAndStack()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("var source = new TypeError('boom'); source.extra = 'dropped'; var clone = structuredClone(source);");
+
+        // An Error's serialization does not set `deep`, so nothing but the three recorded fields survives.
+        engine.Evaluate("clone.extra === undefined").AsBoolean().Should().BeTrue();
+
+        // `message` comes back as a writable, non-enumerable, configurable own property.
+        engine.Evaluate("Object.keys(clone).length").AsNumber().Should().Be(0);
+        engine.Evaluate("Object.getOwnPropertyDescriptor(clone, 'message').enumerable").AsBoolean().Should().BeFalse();
+        engine.Evaluate("Object.getOwnPropertyDescriptor(clone, 'message').writable").AsBoolean().Should().BeTrue();
+
+        // The stack is the "interesting accompanying data" both specifications invite a user agent to carry,
+        // and it is the source's, not the clone site's.
+        engine.Evaluate("clone.stack").AsString().Should().Be(engine.Evaluate("source.stack").AsString());
+    }
+
+    [Fact]
+    public void OmitsAnAbsentOrAccessorMessage()
+    {
+        var engine = WebEngine();
+
+        // An error with no own message inherits Error.prototype.message, and the clone must not turn that
+        // into an own property.
+        engine.Execute("var clone = structuredClone(new Error());");
+        engine.Evaluate("Object.getOwnPropertyDescriptor(clone, 'message') === undefined").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone.message").AsString().Should().Be("");
+
+        // An accessor `message` is read as undefined rather than invoked.
+        engine.Execute(@"
+            var invoked = false;
+            var source = new Error('ignored');
+            Object.defineProperty(source, 'message', { get: function() { invoked = true; return 'from getter'; }, configurable: true });
+            var accessorClone = structuredClone(source);");
+        engine.Evaluate("invoked").AsBoolean().Should().BeFalse();
+        engine.Evaluate("Object.getOwnPropertyDescriptor(accessorClone, 'message') === undefined").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ClonesADomExceptionByNameAndMessage()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("var source = new DOMException('gone', 'AbortError'); var clone = structuredClone(source);");
+
+        // https://webidl.spec.whatwg.org/#idl-DOMException declares the interface [Serializable].
+        engine.Evaluate("clone !== source").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone instanceof DOMException").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone.name").AsString().Should().Be("AbortError");
+        engine.Evaluate("clone.message").AsString().Should().Be("gone");
+        engine.Evaluate("clone.code").AsNumber().Should().Be(20);
+        engine.Evaluate("clone.stack").AsString().Should().Be(engine.Evaluate("source.stack").AsString());
+    }
+
+    // ---------------------------------------------------------------- ArrayBuffer and views
+
+    [Fact]
+    public void CopiesAnArrayBuffersBytes()
+    {
+        var engine = WebEngine();
+
+        engine.Execute(@"
+            var source = new ArrayBuffer(4);
+            new Uint8Array(source).set([1, 2, 3, 4]);
+            var clone = structuredClone(source);
+            new Uint8Array(source)[0] = 99;");
+
+        engine.Evaluate("clone !== source").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone.byteLength").AsNumber().Should().Be(4);
+        engine.Evaluate("Array.from(new Uint8Array(clone)).join(',')").AsString().Should().Be("1,2,3,4");
+    }
+
+    [Fact]
+    public void KeepsAResizableArrayBufferResizable()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("var clone = structuredClone(new ArrayBuffer(4, { maxByteLength: 8 }));");
+
+        engine.Evaluate("clone.resizable").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone.maxByteLength").AsNumber().Should().Be(8);
+        engine.Evaluate("clone.byteLength").AsNumber().Should().Be(4);
+        engine.Execute("clone.resize(8);");
+        engine.Evaluate("clone.byteLength").AsNumber().Should().Be(8);
+    }
+
+    [Fact]
+    public void RefusesADetachedArrayBuffer()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("var buffer = new ArrayBuffer(4); structuredClone(0, { transfer: [buffer] });");
+
+        engine.Evaluate("buffer.byteLength").AsNumber().Should().Be(0);
+        Err(engine, "structuredClone(buffer)").Should().Be("DataCloneError");
+        Err(engine, "structuredClone({ b: buffer })").Should().Be("DataCloneError");
+    }
+
+    [Fact]
+    public void RefusesASharedArrayBuffer()
+    {
+        var engine = WebEngine();
+
+        // Serializable only in a cross-origin-isolated agent cluster, which Jint has no notion of.
+        Err(engine, "structuredClone(new SharedArrayBuffer(4))").Should().Be("DataCloneError");
+    }
+
+    [Fact]
+    public void ClonesTwoViewsOfOneBufferAsTwoViewsOfOneClonedBuffer()
+    {
+        var engine = WebEngine();
+
+        engine.Execute(@"
+            var buffer = new ArrayBuffer(8);
+            new Uint8Array(buffer).set([1, 2, 3, 4, 5, 6, 7, 8]);
+            var clone = structuredClone({ head: new Uint8Array(buffer, 0, 4), tail: new Uint8Array(buffer, 4, 4) });");
+
+        // The memory map is what makes this hold: the buffer is serialized once.
+        engine.Evaluate("clone.head.buffer === clone.tail.buffer").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone.head.buffer !== buffer").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone.head.byteOffset").AsNumber().Should().Be(0);
+        engine.Evaluate("clone.tail.byteOffset").AsNumber().Should().Be(4);
+        engine.Evaluate("Array.from(clone.tail).join(',')").AsString().Should().Be("5,6,7,8");
+
+        // Writing through one view is visible in the other, exactly as in the source.
+        engine.Execute("clone.head[0] = 42;");
+        engine.Evaluate("new Uint8Array(clone.tail.buffer)[0]").AsNumber().Should().Be(42);
+    }
+
+    [Theory]
+    [InlineData("Int8Array")]
+    [InlineData("Uint8Array")]
+    [InlineData("Uint8ClampedArray")]
+    [InlineData("Int16Array")]
+    [InlineData("Uint16Array")]
+    [InlineData("Int32Array")]
+    [InlineData("Uint32Array")]
+    [InlineData("Float32Array")]
+    [InlineData("Float64Array")]
+    public void ClonesEveryNumericTypedArrayKind(string kind)
+    {
+        var engine = WebEngine();
+
+        engine.Execute($"var source = new {kind}([1, 2, 3]); var clone = structuredClone(source);");
+
+        engine.Evaluate($"clone instanceof {kind}").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone.length").AsNumber().Should().Be(3);
+        engine.Evaluate("Array.from(clone).join(',')").AsString().Should().Be("1,2,3");
+        engine.Evaluate("clone.buffer !== source.buffer").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ClonesABigIntTypedArray()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("var clone = structuredClone(new BigInt64Array([1n, -2n]));");
+
+        engine.Evaluate("clone instanceof BigInt64Array").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone[1] === -2n").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ClonesADataViewWithItsOffsetAndLength()
+    {
+        var engine = WebEngine();
+
+        engine.Execute(@"
+            var buffer = new ArrayBuffer(12);
+            var source = new DataView(buffer, 2, 8);
+            source.setInt32(0, 123456);
+            var clone = structuredClone(source);");
+
+        engine.Evaluate("clone instanceof DataView").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone.byteOffset").AsNumber().Should().Be(2);
+        engine.Evaluate("clone.byteLength").AsNumber().Should().Be(8);
+        engine.Evaluate("clone.getInt32(0)").AsNumber().Should().Be(123456);
+        engine.Evaluate("clone.buffer.byteLength").AsNumber().Should().Be(12);
+        engine.Evaluate("clone.buffer !== buffer").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void KeepsALengthTrackingViewTracking()
+    {
+        var engine = WebEngine();
+
+        engine.Execute(@"
+            var buffer = new ArrayBuffer(4, { maxByteLength: 8 });
+            var clone = structuredClone({ array: new Uint8Array(buffer), view: new DataView(buffer) });");
+
+        engine.Evaluate("clone.array.length").AsNumber().Should().Be(4);
+        engine.Evaluate("clone.view.byteLength").AsNumber().Should().Be(4);
+
+        engine.Execute("clone.array.buffer.resize(8);");
+        engine.Evaluate("clone.array.length").AsNumber().Should().Be(8);
+        engine.Evaluate("clone.view.byteLength").AsNumber().Should().Be(8);
+    }
+
+    [Fact]
+    public void RefusesAViewThatItsBufferNoLongerCovers()
+    {
+        var engine = WebEngine();
+
+        engine.Execute(@"
+            var buffer = new ArrayBuffer(8, { maxByteLength: 8 });
+            var array = new Uint8Array(buffer, 4, 4);
+            var view = new DataView(buffer, 4, 4);
+            buffer.resize(2);");
+
+        Err(engine, "structuredClone(array)").Should().Be("DataCloneError");
+        Err(engine, "structuredClone(view)").Should().Be("DataCloneError");
+    }
+
+    // ---------------------------------------------------------------- transfer
+
+    [Fact]
+    public void TransfersAnArrayBufferInsteadOfCopyingIt()
+    {
+        var engine = WebEngine();
+
+        engine.Execute(@"
+            var buffer = new ArrayBuffer(4);
+            new Uint8Array(buffer).set([1, 2, 3, 4]);
+            var clone = structuredClone({ payload: buffer }, { transfer: [buffer] });");
+
+        engine.Evaluate("buffer.byteLength").AsNumber().Should().Be(0);
+        engine.Evaluate("clone.payload.byteLength").AsNumber().Should().Be(4);
+        engine.Evaluate("Array.from(new Uint8Array(clone.payload)).join(',')").AsString().Should().Be("1,2,3,4");
+    }
+
+    [Fact]
+    public void MapsATransferredBufferReachedFromTheValueToTheTransferredResult()
+    {
+        var engine = WebEngine();
+
+        engine.Execute(@"
+            var buffer = new ArrayBuffer(4);
+            new Uint8Array(buffer).set([9, 8, 7, 6]);
+            var clone = structuredClone({ direct: buffer, view: new Uint8Array(buffer) }, { transfer: [buffer] });");
+
+        // One result buffer, reached both directly and through the view.
+        engine.Evaluate("clone.view.buffer === clone.direct").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Array.from(clone.view).join(',')").AsString().Should().Be("9,8,7,6");
+        engine.Evaluate("buffer.byteLength").AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void TransfersABufferTheValueNeverReaches()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("var buffer = new ArrayBuffer(4); var clone = structuredClone('unrelated', { transfer: [buffer] });");
+
+        engine.Evaluate("clone").AsString().Should().Be("unrelated");
+        engine.Evaluate("buffer.byteLength").AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void DetachesOnlyAfterTheWholeGraphHasBeenWalked()
+    {
+        var engine = WebEngine();
+
+        engine.Execute(@"
+            var buffer = new ArrayBuffer(4);
+            var source = {
+                get first() { new Uint8Array(buffer).set([1, 2, 3, 4]); return 'ok'; },
+                second: buffer
+            };
+            var clone = structuredClone(source, { transfer: [buffer] });");
+
+        // A getter reached during the walk can still read and write the buffer, and what it wrote is what
+        // the clone carries — the transfer steps run after serialization.
+        engine.Evaluate("clone.first").AsString().Should().Be("ok");
+        engine.Evaluate("Array.from(new Uint8Array(clone.second)).join(',')").AsString().Should().Be("1,2,3,4");
+        engine.Evaluate("buffer.byteLength").AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void RefusesADuplicateInTheTransferList()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("var buffer = new ArrayBuffer(4);");
+        Err(engine, "structuredClone(0, { transfer: [buffer, buffer] })").Should().Be("DataCloneError");
+
+        // The refusal happens before anything is detached.
+        engine.Evaluate("buffer.byteLength").AsNumber().Should().Be(4);
+    }
+
+    [Fact]
+    public void RefusesANonTransferableEntry()
+    {
+        var engine = WebEngine();
+
+        Err(engine, "structuredClone(0, { transfer: [{}] })").Should().Be("DataCloneError");
+        Err(engine, "structuredClone(0, { transfer: [new Uint8Array(4)] })").Should().Be("DataCloneError");
+        Err(engine, "structuredClone(0, { transfer: [new SharedArrayBuffer(4)] })").Should().Be("DataCloneError");
+    }
+
+    [Fact]
+    public void RefusesAnAlreadyDetachedEntry()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("var buffer = new ArrayBuffer(4); structuredClone(0, { transfer: [buffer] });");
+        Err(engine, "structuredClone(0, { transfer: [buffer] })").Should().Be("DataCloneError");
+    }
+
+    [Fact]
+    public void RefusesABufferAGetterDetachedDuringTheWalk()
+    {
+        var engine = WebEngine();
+
+        engine.Execute(@"
+            var buffer = new ArrayBuffer(4);
+            var source = { get sabotage() { structuredClone(0, { transfer: [buffer] }); return 1; } };");
+
+        // The detached check on the transfer list is step 5.1, after serialization — so this is caught, and
+        // caught as a DataCloneError.
+        Err(engine, "structuredClone(source, { transfer: [buffer] })").Should().Be("DataCloneError");
+    }
+
+    [Fact]
+    public void ValidatesTheOptionsDictionaryBeforeCloningAnything()
+    {
+        var engine = WebEngine();
+
+        // An omitted, undefined or null dictionary is the empty dictionary.
+        engine.Evaluate("structuredClone(1, undefined)").AsNumber().Should().Be(1);
+        engine.Evaluate("structuredClone(1, null)").AsNumber().Should().Be(1);
+        engine.Evaluate("structuredClone(1, {})").AsNumber().Should().Be(1);
+        engine.Evaluate("structuredClone(1, { transfer: undefined })").AsNumber().Should().Be(1);
+        engine.Evaluate("structuredClone(1, { transfer: [] })").AsNumber().Should().Be(1);
+
+        // Anything else is a WebIDL conversion failure, which is a TypeError and not a DataCloneError.
+        Err(engine, "structuredClone(1, 5)").Should().Be("TypeError");
+        Err(engine, "structuredClone(1, 'nope')").Should().Be("TypeError");
+        Err(engine, "structuredClone(1, { transfer: 5 })").Should().Be("TypeError");
+        Err(engine, "structuredClone(1, { transfer: [1] })").Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void TakesTheTransferListThroughTheIteratorProtocol()
+    {
+        var engine = WebEngine();
+
+        engine.Execute(@"
+            var buffer = new ArrayBuffer(4);
+            var clone = structuredClone(buffer, { transfer: new Set([buffer]) });");
+
+        // A WebIDL sequence is built from any iterable, not from an array-like.
+        engine.Evaluate("clone.byteLength").AsNumber().Should().Be(4);
+        engine.Evaluate("buffer.byteLength").AsNumber().Should().Be(0);
+    }
+
+    // ---------------------------------------------------------------- refusals
+
+    [Theory]
+    [InlineData("function() {}")]
+    [InlineData("class Foo {}")]
+    [InlineData("Math.max")]
+    [InlineData("new Proxy({}, {})")]
+    [InlineData("new WeakMap()")]
+    [InlineData("new WeakSet()")]
+    [InlineData("new WeakRef({})")]
+    [InlineData("Promise.resolve(1)")]
+    [InlineData("new Map()[Symbol.iterator]()")]
+    [InlineData("(function* () {})()")]
+    public void RefusesAnUncloneableObject(string expression)
+    {
+        var engine = WebEngine();
+
+        Err(engine, $"structuredClone({expression})").Should().Be("DataCloneError");
+        Err(engine, $"structuredClone({{ nested: {expression} }})").Should().Be("DataCloneError");
+    }
+
+    [Fact]
+    public void RaisesTheRefusalAsADomException()
+    {
+        var engine = WebEngine();
+
+        engine.Execute(@"
+            var caught;
+            try { structuredClone(function() {}); } catch (e) { caught = e; }");
+
+        engine.Evaluate("caught instanceof DOMException").AsBoolean().Should().BeTrue();
+        engine.Evaluate("caught.name").AsString().Should().Be("DataCloneError");
+        engine.Evaluate("caught.code").AsNumber().Should().Be(25);
+        engine.Evaluate("typeof caught.message").AsString().Should().Be("string");
+    }
+
+    [Fact]
+    public void RefusesADomExceptionEvenWhenTheGlobalWasShadowed()
+    {
+        // The algorithm reaches the interface object through the realm's intrinsics, so a script that
+        // replaced the global cannot make the failure unreportable.
+        var engine = WebEngine();
+        engine.Execute("var real = DOMException; DOMException = 1;");
+
+        engine.Execute("var caught; try { structuredClone(Symbol()); } catch (e) { caught = e; }");
+        engine.Evaluate("caught instanceof real").AsBoolean().Should().BeTrue();
+        engine.Evaluate("caught.name").AsString().Should().Be("DataCloneError");
+    }
+}
+#endif

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -135,7 +135,7 @@ public partial class Options
 /// <para>
 /// The bit layout is fixed ahead of the implementations so that a value persisted by a host keeps its meaning
 /// as the surface grows. The bits reserved for the features still to land are
-/// <c>StructuredClone = 1 &lt;&lt; 4</c>, <c>Crypto = 1 &lt;&lt; 5</c>, <c>Performance = 1 &lt;&lt; 6</c>,
+/// <c>Crypto = 1 &lt;&lt; 5</c>, <c>Performance = 1 &lt;&lt; 6</c>,
 /// <c>Events = 1 &lt;&lt; 7</c>, <c>Url = 1 &lt;&lt; 8</c>, <c>Files = 1 &lt;&lt; 9</c> and
 /// <c>Fetch = 1 &lt;&lt; 10</c>. A flag is declared here only once the feature behind it actually exists, so
 /// that naming one can never compile into an engine that silently does not have it.
@@ -181,10 +181,16 @@ public enum WebApiFeatures
     Base64 = 1 << 3,
 
     /// <summary>
-    /// The web APIs a host normally wants: everything except outbound network access. Today that is
-    /// <see cref="Console"/>, <see cref="Timers"/>, <see cref="Encoding"/> and <see cref="Base64"/>; it grows
-    /// as further features land, and never comes to include fetch.
+    /// The global <c>structuredClone</c> function, which deep-clones a value through the HTML Standard's
+    /// structured-clone algorithm and can transfer <c>ArrayBuffer</c>s into the clone.
     /// </summary>
-    Default = Console | Timers | Encoding | Base64,
+    StructuredClone = 1 << 4,
+
+    /// <summary>
+    /// The web APIs a host normally wants: everything except outbound network access. Today that is
+    /// <see cref="Console"/>, <see cref="Timers"/>, <see cref="Encoding"/>, <see cref="Base64"/> and
+    /// <see cref="StructuredClone"/>; it grows as further features land, and never comes to include fetch.
+    /// </summary>
+    Default = Console | Timers | Encoding | Base64 | StructuredClone,
 }
 #endif

--- a/Jint/Runtime/Intrinsics.WebApi.cs
+++ b/Jint/Runtime/Intrinsics.WebApi.cs
@@ -2,8 +2,9 @@
 using Jint.WebApi.Base64;
 using Jint.WebApi.Console;
 using Jint.WebApi.DomException;
-using Jint.WebApi.Timers;
 using Jint.WebApi.Encoding;
+using Jint.WebApi.StructuredClone;
+using Jint.WebApi.Timers;
 
 namespace Jint.Runtime;
 
@@ -26,6 +27,7 @@ public sealed partial class Intrinsics
     private TextDecoderConstructor? _textDecoder;
     private Base64Function? _atob;
     private Base64Function? _btoa;
+    private StructuredCloneFunction? _structuredClone;
 
     internal DomExceptionConstructor DomException =>
         _domException ??= new DomExceptionConstructor(_engine, _realm, Function.PrototypeObject, Error.PrototypeObject);
@@ -50,5 +52,8 @@ public sealed partial class Intrinsics
 
     internal Base64Function Btoa =>
         _btoa ??= new Base64Function(_engine, _realm, Function.PrototypeObject, isAtob: false);
+
+    internal StructuredCloneFunction StructuredClone =>
+        _structuredClone ??= new StructuredCloneFunction(_engine, _realm, Function.PrototypeObject);
 }
 #endif

--- a/Jint/WebApi/StructuredClone/StructuredCloneFunction.cs
+++ b/Jint/WebApi/StructuredClone/StructuredCloneFunction.cs
@@ -1,0 +1,102 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.StructuredClone;
+
+/// <summary>
+/// The global <c>structuredClone(value, options)</c> function.
+/// <para>
+/// https://html.spec.whatwg.org/multipage/structured-data.html#dom-structuredclone
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// Three steps, all of them delegated: convert the options dictionary, run
+/// StructuredSerializeWithTransfer, run StructuredDeserializeWithTransfer in this function's own realm. The
+/// last two are fused into <see cref="StructuredCloner"/>, which documents why that is unobservable here.
+/// </para>
+/// <para>
+/// A fresh <see cref="StructuredCloner"/> per call is the specification's "let memory be an empty map": two
+/// calls share no identity, so <c>structuredClone(x) !== structuredClone(x)</c>, and a getter that re-enters
+/// <c>structuredClone</c> during a clone gets its own memory rather than joining the outer one.
+/// </para>
+/// </remarks>
+internal sealed class StructuredCloneFunction : Jint.Native.Function.Function
+{
+    private static readonly JsString _functionName = new("structuredClone");
+    private static readonly JsString _transfer = new("transfer");
+
+    internal StructuredCloneFunction(Engine engine, Realm realm, FunctionPrototype functionPrototype)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = functionPrototype;
+        _length = new PropertyDescriptor(JsNumber.Create(1), PropertyFlag.Configurable);
+    }
+
+    protected internal override JsValue Call(JsValue thisObject, JsCallArguments arguments)
+    {
+        // `any value` is a required WebIDL argument, so calling with none is a TypeError rather than a clone
+        // of undefined. https://webidl.spec.whatwg.org/#dfn-create-operation-function
+        if (arguments.Length == 0)
+        {
+            Throw.TypeError(_realm, "Failed to execute 'structuredClone': 1 argument required, but only 0 present.");
+        }
+
+        var transferList = ReadTransferList(arguments.At(1));
+        return new StructuredCloner(_engine, _realm).Clone(arguments[0], transferList);
+    }
+
+    /// <summary>
+    /// The <c>StructuredSerializeOptions</c> dictionary — one member, <c>sequence&lt;object&gt; transfer = []</c>.
+    /// <para>
+    /// https://html.spec.whatwg.org/multipage/structured-data.html#dictdef-structuredserializeoptions
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// This runs before any cloning, so a malformed <c>transfer</c> option is a <c>TypeError</c> and nothing
+    /// has been walked, let alone detached. A <c>sequence</c> is converted through the iterator protocol, not
+    /// through <c>length</c>, so any iterable will do; each element must be an object, which is all WebIDL
+    /// checks here — whether it is <i>transferable</i> is a DataCloneError decided later, in the order the
+    /// serialization algorithm specifies.
+    /// </remarks>
+    private List<JsValue>? ReadTransferList(JsValue options)
+    {
+        // An omitted or null dictionary is the empty dictionary.
+        if (options.IsNullOrUndefined())
+        {
+            return null;
+        }
+
+        if (options is not ObjectInstance optionsObject)
+        {
+            Throw.TypeError(_realm, "Failed to execute 'structuredClone': The provided value is not of type 'StructuredSerializeOptions'.");
+            return null;
+        }
+
+        var transfer = optionsObject.Get(_transfer);
+        if (transfer.IsUndefined())
+        {
+            return null;
+        }
+
+        var iterator = transfer.GetIterator(_realm);
+        var list = new List<JsValue>();
+        while (iterator.TryIteratorStepValue(out var item))
+        {
+            if (item is not ObjectInstance)
+            {
+                iterator.Close(CompletionType.Throw);
+                Throw.TypeError(_realm, "Failed to execute 'structuredClone': The provided value is not of type 'object'.");
+            }
+
+            list.Add(item);
+        }
+
+        return list;
+    }
+}
+#endif

--- a/Jint/WebApi/StructuredClone/StructuredCloner.cs
+++ b/Jint/WebApi/StructuredClone/StructuredCloner.cs
@@ -1,0 +1,773 @@
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+using Jint.Native;
+using Jint.Native.Array;
+using Jint.Native.ArrayBuffer;
+using Jint.Native.Error;
+using Jint.Native.Object;
+using Jint.Native.TypedArray;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.DomException;
+
+namespace Jint.WebApi.StructuredClone;
+
+/// <summary>
+/// StructuredSerializeWithTransfer / StructuredDeserializeWithTransfer, fused into a single walk.
+/// <para>
+/// https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// The specification serializes into an intermediate record graph and then deserializes that into the target
+/// realm, because a real user agent has to hand the records to another agent. <c>structuredClone</c> has only
+/// one realm, so this walks the graph once and builds the clone directly, with <see cref="_memory"/> keyed on
+/// the <i>source</i> object rather than on a serialization record. Every observable of the two-phase algorithm
+/// survives that fusion: the traversal order is identical, so getters run in the same order; a throw part-way
+/// through discards a clone nothing can reach; and the transfer steps still run <i>after</i> the whole walk,
+/// which is what lets a getter reached during the walk resize or write into a buffer the caller is
+/// transferring and have the clone see the result (see <see cref="CompleteTransfers"/>).
+/// </para>
+/// <para>
+/// <b>The walk is iterative, not recursive.</b> The specification's algorithm recurses once per graph edge and
+/// bounds nothing, so a hostile <c>{a:{a:{a:…}}}</c> would take the native stack down with it — and a stack
+/// overflow kills the process rather than raising something a host can catch. Container clones therefore push
+/// a <see cref="CloneFrame"/> onto a heap <see cref="Stack{T}"/> and <see cref="Drain"/> runs them to
+/// completion, so the only limit on nesting depth is available memory, and there is no arbitrary cutoff for a
+/// legitimately deep document to trip over. Progress is charged against the engine's execution constraints
+/// every <see cref="Engine.ConstraintCheckInterval"/> values, so a clone of a very large graph stays
+/// interruptible by a timeout or a cancellation the same way a long loop is.
+/// </para>
+/// <para>
+/// Everything the algorithm builds gets the <i>current</i> realm's intrinsic prototypes, per the
+/// specification's "a new … object in targetRealm".
+/// </para>
+/// </remarks>
+internal sealed class StructuredCloner
+{
+    private readonly Engine _engine;
+    private readonly Realm _realm;
+
+    /// <summary>
+    /// The specification's <i>memory</i> map, keyed on object identity: what makes a cycle terminate and what
+    /// makes two references to one object deserialize as two references to one clone.
+    /// </summary>
+    private readonly Dictionary<ObjectInstance, ObjectInstance> _memory = new(ReferenceEqualityComparer.Instance);
+
+    private readonly Stack<CloneFrame> _pending = new();
+
+    private int _visited;
+
+    internal StructuredCloner(Engine engine, Realm realm)
+    {
+        _engine = engine;
+        _realm = realm;
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer
+    /// </summary>
+    /// <param name="value">The value to clone.</param>
+    /// <param name="transferList">
+    /// The already-iterated <c>transfer</c> option, or <see langword="null"/> when the caller passed none.
+    /// Its entries are objects, which is all the WebIDL <c>sequence&lt;object&gt;</c> conversion guarantees;
+    /// deciding whether they are <i>transferable</i> is this algorithm's job.
+    /// </param>
+    internal JsValue Clone(JsValue value, List<JsValue>? transferList)
+    {
+        // Steps 2-4: every transferable is validated and given its (still empty) result buffer BEFORE the
+        // walk, so a transferred buffer reached from `value` resolves to that same result buffer.
+        var transfers = PrepareTransfers(transferList);
+
+        var result = CloneValue(value);
+        Drain();
+
+        // Step 5: only now is anything detached.
+        CompleteTransfers(transfers);
+
+        return result;
+    }
+
+    /// <summary>
+    /// The spine of the walk: runs each pending container frame to exhaustion, depth first, so a value's own
+    /// graph is finished before its next sibling is read — exactly the order the specification's recursion
+    /// produces, which is what a getter observes.
+    /// </summary>
+    private void Drain()
+    {
+        while (_pending.Count > 0)
+        {
+            var frame = _pending.Peek();
+            if (!frame.TryGetNextSource(out var next))
+            {
+                _pending.Pop();
+                continue;
+            }
+
+            frame.Accept(CloneValue(next));
+        }
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal — fused with
+    /// StructuredDeserializeInternal, so what a step "sets serialized to" this method builds outright.
+    /// </summary>
+    private JsValue CloneValue(JsValue value)
+    {
+        // A native walk over a script-controlled graph does not self-throttle through statement counting.
+        if (++_visited % Engine.ConstraintCheckInterval == 0)
+        {
+            _engine.Constraints.Check();
+        }
+
+        if (value is not ObjectInstance source)
+        {
+            // Step 5: a Symbol is the one primitive that is not serializable.
+            if (value.IsSymbol())
+            {
+                ThrowDataCloneError("A Symbol could not be cloned");
+            }
+
+            // Step 4: undefined, null, Boolean, Number, BigInt and String values are their own clone.
+            return value;
+        }
+
+        // Step 2.
+        if (_memory.TryGetValue(source, out var seen))
+        {
+            return seen;
+        }
+
+        ObjectInstance clone;
+        switch (source)
+        {
+            // WebIDL declares DOMException [Serializable]; its serialization steps carry the name and the
+            // message. https://webidl.spec.whatwg.org/#idl-DOMException — checked before the ErrorInstance arm
+            // below, which it derives from.
+            case JsDomException domException:
+                clone = CloneDomException(domException);
+                break;
+
+            // Steps 7-10: the boxed primitives, each identified by its data slot.
+            case Native.Boolean.BooleanInstance boolean:
+                clone = new Native.Boolean.BooleanInstance(_engine, boolean.BooleanData)
+                {
+                    _prototype = _realm.Intrinsics.Boolean.PrototypeObject,
+                };
+                break;
+
+            case Native.Number.NumberInstance number:
+                clone = new Native.Number.NumberInstance(_engine, number.NumberData)
+                {
+                    _prototype = _realm.Intrinsics.Number.PrototypeObject,
+                };
+                break;
+
+            case Native.BigInt.BigIntInstance bigInt:
+                clone = new Native.BigInt.BigIntInstance(_engine, bigInt.BigIntData)
+                {
+                    _prototype = _realm.Intrinsics.BigInt.PrototypeObject,
+                };
+                break;
+
+            case Native.String.StringInstance stringInstance:
+                clone = new Native.String.StringInstance(_engine, stringInstance.StringData)
+                {
+                    _prototype = _realm.Intrinsics.String.PrototypeObject,
+                };
+                break;
+
+            // Step 11: [[DateValue]] and nothing else, so an invalid Date clones to an invalid Date.
+            case JsDate date:
+                clone = new JsDate(_engine, date._dateValue)
+                {
+                    _prototype = _realm.Intrinsics.Date.PrototypeObject,
+                };
+                break;
+
+            // Step 12.
+            case JsRegExp regExp:
+                clone = CloneRegExp(regExp);
+                break;
+
+            // Step 13.
+            case JsArrayBuffer buffer:
+                clone = CloneArrayBuffer(buffer);
+                break;
+
+            // Step 14.
+            case JsTypedArray typedArray:
+                clone = CloneTypedArray(typedArray);
+                break;
+
+            case JsDataView dataView:
+                clone = CloneDataView(dataView);
+                break;
+
+            // Steps 15-16: the container is registered before its contents are walked (step 25 runs before
+            // step 26), which is what lets a Map or Set contain itself.
+            case JsMap map:
+                {
+                    var target = (JsMap) _realm.Intrinsics.Map.Construct(Arguments.Empty, _realm.Intrinsics.Map);
+                    _memory[source] = target;
+                    _pending.Push(new MapFrame(map, target));
+                    return target;
+                }
+
+            case JsSet set:
+                {
+                    var target = (JsSet) _realm.Intrinsics.Set.Construct(Arguments.Empty, _realm.Intrinsics.Set);
+                    _memory[source] = target;
+                    _pending.Push(new SetFrame(set, target));
+                    return target;
+                }
+
+            // Step 17.
+            case ErrorInstance error:
+                clone = CloneError(error);
+                break;
+
+            // Step 18: an Array exotic object. A Proxy whose target is an array is not one — it is a Proxy
+            // exotic object, and falls through to the refusal below, as the specification intends.
+            case ArrayInstance array:
+                {
+                    var target = _realm.Intrinsics.Array.ArrayCreateLazy(array.GetLength());
+                    _memory[source] = target;
+                    _pending.Push(new PropertyFrame(array, target, EnumerableOwnStringKeys(array)));
+                    return target;
+                }
+
+            // Step 24: an ordinary object. Jint recognizes one by construction rather than by asking whether
+            // it has "any internal slot other than [[Prototype]]": JsObject is the type every ordinary object
+            // reaches — object literals, `new Foo()`, Object.create, JSON.parse output, and the host-facing
+            // JsObject.Create / CreateFromEntries factories. See ThrowUncloneable for what that costs.
+            case JsObject plain:
+                {
+                    var target = ObjectInstance.OrdinaryObjectCreate(_engine, _realm.Intrinsics.Object.PrototypeObject);
+                    _memory[source] = target;
+                    _pending.Push(new PropertyFrame(plain, target, EnumerableOwnStringKeys(plain)));
+                    return target;
+                }
+
+            // Steps 20-23.
+            default:
+                ThrowUncloneable(source);
+                return JsValue.Undefined;
+        }
+
+        // Step 25, for everything that has no contents to walk.
+        _memory[source] = clone;
+        return clone;
+    }
+
+    /// <summary>
+    /// EnumerableOwnProperties(value, key) — the own <i>string</i> keys whose property is enumerable, snapshot
+    /// once before any of them is read, per step 26.4.
+    /// </summary>
+    private JsValue[] EnumerableOwnStringKeys(ObjectInstance source)
+    {
+        var ownKeys = source.GetOwnPropertyKeys(Types.String);
+        var keys = new List<JsValue>(ownKeys.Count);
+        for (var i = 0; i < ownKeys.Count; i++)
+        {
+            if (i > 0 && i % Engine.ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
+            var key = ownKeys[i];
+            if (key.IsString() && source.ProbeOwnPropertyChecked(key) == OwnPropertyProbe.Enumerable)
+            {
+                keys.Add(key);
+            }
+        }
+
+        return keys.ToArray();
+    }
+
+    /// <summary>
+    /// Step 12 and its deserialization counterpart: <c>[[OriginalSource]]</c>, <c>[[OriginalFlags]]</c> and
+    /// the compiled <c>[[RegExpMatcher]]</c> carry over, and nothing else does — most visibly
+    /// <c>lastIndex</c>, which a freshly created RegExp object starts at <c>0</c>. The matcher is shared
+    /// rather than recompiled: it is immutable and engine-independent, and re-parsing the source would fail
+    /// outright for a host-supplied .NET <c>Regex</c>, whose <c>Source</c> is not a JavaScript pattern.
+    /// </summary>
+    private JsRegExp CloneRegExp(JsRegExp source)
+    {
+        var clone = new JsRegExp(_engine)
+        {
+            _prototype = _realm.Intrinsics.RegExp.PrototypeObject,
+            Value = source.Value,
+            Source = source.Source,
+            Flags = source.Flags,
+            ParseResult = source.ParseResult,
+            IsHostRegex = source.IsHostRegex,
+        };
+
+        clone.SetOwnProperty(JsRegExp.PropertyLastIndex, new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.OnlyWritable));
+        return clone;
+    }
+
+    /// <summary>
+    /// Step 13. The bytes are copied, and a resizable buffer stays resizable with the same
+    /// <c>[[ArrayBufferMaxByteLength]]</c> (the specification's "ResizableArrayBuffer" serialization type).
+    /// </summary>
+    private JsArrayBuffer CloneArrayBuffer(JsArrayBuffer source)
+    {
+        // Step 13.1: a SharedArrayBuffer is serializable only in a cross-origin-isolated agent cluster.
+        // Jint has no such notion, so it is refused — which is what a browser without cross-origin isolation
+        // does too.
+        if (source.IsSharedArrayBuffer)
+        {
+            ThrowDataCloneError("A SharedArrayBuffer could not be cloned");
+        }
+
+        // Step 13.2.1.
+        if (source.IsDetachedBuffer)
+        {
+            ThrowDataCloneError("A detached ArrayBuffer could not be cloned");
+        }
+
+        var data = source.ArrayBufferData!;
+        var copy = new byte[data.Length];
+        System.Array.Copy(data, copy, data.Length);
+
+        var maxByteLength = source._arrayBufferMaxByteLength;
+        return new JsArrayBuffer(_engine, copy, maxByteLength is null ? null : (uint) maxByteLength.Value)
+        {
+            _prototype = _realm.Intrinsics.ArrayBuffer.PrototypeObject,
+
+            // Not something the HTML Standard knows about yet: the immutable-ArrayBuffer proposal has no
+            // structured-clone integration. Carrying the flag keeps the clone the same kind of buffer the
+            // source was, which is the reading every other slot here follows.
+            _isImmutable = source.IsImmutableBuffer,
+        };
+    }
+
+    /// <summary>
+    /// Step 14, for a typed array. The viewed buffer goes through <see cref="CloneValue"/> and therefore
+    /// through the memory map, which is what makes two views over one buffer come out as two views over one
+    /// cloned buffer — and what makes a view of a <i>transferred</i> buffer land on the transferred result.
+    /// </summary>
+    private JsTypedArray CloneTypedArray(JsTypedArray source)
+    {
+        // Step 14.1: IsArrayBufferViewOutOfBounds, which a detached buffer also fails. This has to come
+        // before the buffer is looked up, because a buffer named in the transfer list is already in the
+        // memory map and would resolve to its result buffer rather than being examined.
+        var record = IntrinsicTypedArrayPrototype.MakeTypedArrayWithBufferWitnessRecord(source, ArrayBufferOrder.SeqCst);
+        if (record.IsTypedArrayOutOfBounds)
+        {
+            ThrowDataCloneError("A TypedArray whose buffer is detached or no longer covers it could not be cloned");
+        }
+
+        var buffer = (JsArrayBuffer) CloneValue(source._viewedArrayBuffer);
+        var constructor = ConstructorFor(source._arrayElementType);
+
+        // A length-tracking view (over a resizable buffer) keeps tracking: the specification carries
+        // [[ArrayLength]] across, and for such a view that value is "auto".
+        var length = source._arrayLength == JsTypedArray.LengthAuto ? (int?) null : (int) source._arrayLength;
+        return constructor.Construct(buffer, source._byteOffset, length);
+    }
+
+    /// <summary>
+    /// Step 14, for a <c>DataView</c> — which records <c>[[ByteLength]]</c> and <c>[[ByteOffset]]</c> but no
+    /// <c>[[ArrayLength]]</c>.
+    /// </summary>
+    private ObjectInstance CloneDataView(JsDataView source)
+    {
+        var sourceBuffer = source._viewedArrayBuffer;
+
+        // Step 14.1 again, spelled out for a DataView: https://tc39.es/ecma262/#sec-isviewoutofbounds. As
+        // above, this has to run before the buffer is looked up in the memory map.
+        if (sourceBuffer is null || sourceBuffer.IsDetachedBuffer || IsOutOfBounds(source, sourceBuffer))
+        {
+            ThrowDataCloneError("A DataView whose buffer is detached or no longer covers it could not be cloned");
+        }
+
+        var buffer = (JsArrayBuffer) CloneValue(sourceBuffer);
+        var constructor = _realm.Intrinsics.DataView;
+
+        JsCallArguments arguments = source._byteLength == JsTypedArray.LengthAuto
+            ? [buffer, JsNumber.Create((int) source._byteOffset)]
+            : [buffer, JsNumber.Create((int) source._byteOffset), JsNumber.Create((int) source._byteLength)];
+
+        return constructor.Construct(arguments, constructor);
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-isviewoutofbounds, for a <c>DataView</c> whose buffer is not detached.
+    /// </summary>
+    private static bool IsOutOfBounds(JsDataView view, JsArrayBuffer buffer)
+    {
+        var bufferByteLength = (long) buffer.ArrayBufferByteLength;
+        var byteOffsetEnd = view._byteLength == JsTypedArray.LengthAuto
+            ? bufferByteLength
+            : view._byteOffset + (long) view._byteLength;
+
+        return view._byteOffset > bufferByteLength || byteOffsetEnd > bufferByteLength;
+    }
+
+    /// <summary>
+    /// Step 17 and its deserialization counterpart. The name is read with <c>Get</c> (so it comes off the
+    /// prototype for <c>new TypeError()</c>) and reduced to the seven names with a matching intrinsic;
+    /// anything else — <c>AggregateError</c>, a subclass, a name the script made up — becomes <c>"Error"</c>.
+    /// The message is read as an own <i>data</i> property only, so an accessor is not invoked.
+    /// </summary>
+    private JsError CloneError(ErrorInstance source)
+    {
+        var prototype = ErrorPrototypeFor(source.Get(CommonProperties.Name));
+
+        var clone = new JsError(_engine)
+        {
+            _prototype = prototype,
+        };
+
+        var messageDescriptor = source.GetOwnProperty(CommonProperties.Message);
+        if (messageDescriptor != PropertyDescriptor.Undefined && !messageDescriptor.IsAccessorDescriptor())
+        {
+            // Deserialization step: writable, non-enumerable, configurable — which is what SetVirtualMessage
+            // gives, without allocating property storage for the overwhelmingly common one-property error.
+            clone.SetVirtualMessage(JsString.Create(TypeConverter.ToString(messageDescriptor.Value)));
+        }
+
+        CopyStack(source, clone);
+        return clone;
+    }
+
+    /// <summary>
+    /// The DOMException serialization/deserialization steps, https://webidl.spec.whatwg.org/#idl-DOMException:
+    /// the clone carries the name and the message, and nothing else. <c>code</c> is derived from the name, as
+    /// it is for any other DOMException.
+    /// </summary>
+    private JsDomException CloneDomException(JsDomException source)
+    {
+        var clone = _realm.Intrinsics.DomException.CreateException(source.Name.ToString(), source.Message.ToString());
+        CopyStack(source, clone);
+        return clone;
+    }
+
+    /// <summary>
+    /// Neither <c>Error</c> nor <c>DOMException</c> has a specified <c>stack</c>; both specifications say only
+    /// that a user agent "should attach a serialized representation of any interesting accompanying data …
+    /// notably the stack property". Browsers carry it, and an error whose trace pointed at the clone site
+    /// rather than at where it was raised would be actively misleading, so it is carried here too — as the
+    /// same kind of property the source had it as.
+    /// </summary>
+    private static void CopyStack(ErrorInstance source, ObjectInstance clone)
+    {
+        if (source.Get(CommonProperties.Stack) is not JsString stack)
+        {
+            return;
+        }
+
+        if (clone is JsError error)
+        {
+            // Jint serves Error.prototype.stack from an internal field through the error-stack accessor
+            // (https://tc39.es/proposal-error-stacks/), so the clone gets no own property and looks exactly
+            // like an error the engine raised itself.
+            error._stack = stack;
+            return;
+        }
+
+        // A DOMException carries stack as an own non-enumerable property, so replace the one CreateException
+        // captured at the clone site.
+        clone.SetProperty(CommonProperties.Stack, new PropertyDescriptor(stack, PropertyFlag.NonEnumerable));
+    }
+
+    private ErrorPrototype ErrorPrototypeFor(JsValue name)
+    {
+        if (name is not JsString jsString)
+        {
+            return _realm.Intrinsics.Error.PrototypeObject;
+        }
+
+        return jsString.ToString() switch
+        {
+            "EvalError" => _realm.Intrinsics.EvalError.PrototypeObject,
+            "RangeError" => _realm.Intrinsics.RangeError.PrototypeObject,
+            "ReferenceError" => _realm.Intrinsics.ReferenceError.PrototypeObject,
+            "SyntaxError" => _realm.Intrinsics.SyntaxError.PrototypeObject,
+            "TypeError" => _realm.Intrinsics.TypeError.PrototypeObject,
+            "URIError" => _realm.Intrinsics.UriError.PrototypeObject,
+            _ => _realm.Intrinsics.Error.PrototypeObject,
+        };
+    }
+
+    private Native.TypedArray.TypedArrayConstructor ConstructorFor(TypedArrayElementType type) => type switch
+    {
+        TypedArrayElementType.Int8 => _realm.Intrinsics.Int8Array,
+        TypedArrayElementType.Uint8 => _realm.Intrinsics.Uint8Array,
+        TypedArrayElementType.Uint8C => _realm.Intrinsics.Uint8ClampedArray,
+        TypedArrayElementType.Int16 => _realm.Intrinsics.Int16Array,
+        TypedArrayElementType.Uint16 => _realm.Intrinsics.Uint16Array,
+        TypedArrayElementType.Int32 => _realm.Intrinsics.Int32Array,
+        TypedArrayElementType.Uint32 => _realm.Intrinsics.Uint32Array,
+        TypedArrayElementType.BigInt64 => _realm.Intrinsics.BigInt64Array,
+        TypedArrayElementType.BigUint64 => _realm.Intrinsics.BigUint64Array,
+        TypedArrayElementType.Float16 => _realm.Intrinsics.Float16Array,
+        TypedArrayElementType.Float32 => _realm.Intrinsics.Float32Array,
+        TypedArrayElementType.Float64 => _realm.Intrinsics.Float64Array,
+        _ => throw new InvalidOperationException("Unknown typed array element type " + type),
+    };
+
+    /// <summary>
+    /// Steps 2-4 of StructuredSerializeWithTransfer: validate the whole transfer list and reserve a result
+    /// buffer for every entry, before a single byte of the graph is looked at.
+    /// </summary>
+    private List<TransferRecord>? PrepareTransfers(List<JsValue>? transferList)
+    {
+        if (transferList is null || transferList.Count == 0)
+        {
+            return null;
+        }
+
+        var records = new List<TransferRecord>(transferList.Count);
+        foreach (var entry in transferList)
+        {
+            // Step 2.1 / 2.2: an ArrayBuffer is the only transferable Jint has. A SharedArrayBuffer is
+            // explicitly not one.
+            if (entry is not JsArrayBuffer buffer || buffer.IsSharedArrayBuffer)
+            {
+                ThrowDataCloneError("Only ArrayBuffer objects can be transferred");
+                return null;
+            }
+
+            // Not in the specification, which predates the immutable-ArrayBuffer proposal: an immutable
+            // buffer cannot hand its storage over, so it is not transferable.
+            if (buffer.IsImmutableBuffer)
+            {
+                ThrowDataCloneError("An immutable ArrayBuffer cannot be transferred");
+            }
+
+            // Step 2.3: a duplicate is a DataCloneError, not a silent second transfer.
+            if (_memory.ContainsKey(buffer))
+            {
+                ThrowDataCloneError("An ArrayBuffer appears more than once in the transfer list");
+            }
+
+            // Step 2.4: the result buffer the walk resolves the source buffer to. It takes the source's data
+            // block straight away rather than waiting for CompleteTransfers, which is what the specification's
+            // uninitialized placeholder would imply, for one reason: a view of this buffer met during the walk
+            // is built over it, and a zero-length stand-in would make that view out of bounds. Sharing the
+            // block is safe because nothing can reach this object until the clone is returned, by which point
+            // the source is detached and this is the only holder — and because a write a getter makes through
+            // the source during the walk is meant to be visible in the clone.
+            var maxByteLength = buffer._arrayBufferMaxByteLength;
+            var target = new JsArrayBuffer(_engine, buffer.ArrayBufferData ?? [], maxByteLength is null ? null : (uint) maxByteLength.Value)
+            {
+                _prototype = _realm.Intrinsics.ArrayBuffer.PrototypeObject,
+            };
+
+            _memory[buffer] = target;
+            records.Add(new TransferRecord(buffer, target));
+        }
+
+        return records;
+    }
+
+    /// <summary>
+    /// Step 5: the detach happens after the walk, so the transferred contents are whatever the source held
+    /// when serialization finished — including anything a getter reached during the walk wrote into it. The
+    /// storage moves rather than being copied, which is the entire point of transferring.
+    /// </summary>
+    private void CompleteTransfers(List<TransferRecord>? transfers)
+    {
+        if (transfers is null)
+        {
+            return;
+        }
+
+        foreach (var record in transfers)
+        {
+            // Step 5.1: a buffer detached during the walk cannot be transferred any more.
+            if (record.Source.IsDetachedBuffer)
+            {
+                ThrowDataCloneError("An ArrayBuffer in the transfer list was detached while it was being cloned");
+            }
+
+            // Re-read rather than trusting what PrepareTransfers took: a getter reached during the walk may
+            // have resized the buffer, which replaces its data block outright.
+            record.Target._arrayBufferData = record.Source.ArrayBufferData;
+            record.Source.DetachArrayBuffer();
+        }
+    }
+
+    [DoesNotReturn]
+    private void ThrowUncloneable(ObjectInstance value)
+    {
+        // Step 21.
+        if (value.IsCallable)
+        {
+            ThrowDataCloneError("A function could not be cloned");
+        }
+
+        // Steps 20, 22 and 23. Jint cannot enumerate an object's internal slots, so the refusal is decided
+        // the other way round: everything the steps above recognize is cloned, and anything else is refused.
+        // That is the conservative direction — it never produces a clone that has silently lost the state its
+        // source carried — but it is stricter than a browser for three shapes with no internal slot of their
+        // own that Jint nevertheless does not build as an ordinary object: a namespace object (Math, JSON,
+        // console), an intrinsic prototype (%Object.prototype%, which step 23 explicitly permits), and an
+        // arguments object. Cloning any of those is refused where a browser would answer with a plain object.
+        var description = value switch
+        {
+            JsProxy => "A Proxy",
+            JsPromise => "A Promise",
+            _ => "An object",
+        };
+
+        ThrowDataCloneError(description + " could not be cloned");
+    }
+
+    [DoesNotReturn]
+    private void ThrowDataCloneError(string message)
+    {
+        throw new JavaScriptException(_realm.Intrinsics.DomException.CreateException(DomExceptionNames.DataClone, message));
+    }
+
+    private readonly record struct TransferRecord(JsArrayBuffer Source, JsArrayBuffer Target);
+
+    /// <summary>
+    /// One container whose contents are still to be cloned. The specification recurses here; this is the heap
+    /// stand-in for the native frame that recursion would have used.
+    /// </summary>
+    private abstract class CloneFrame
+    {
+        /// <summary>
+        /// The next source value this container needs a clone of, or <see langword="false"/> when it is done.
+        /// </summary>
+        internal abstract bool TryGetNextSource(out JsValue source);
+
+        /// <summary>
+        /// Receives the clone of the value the last <see cref="TryGetNextSource"/> handed out.
+        /// </summary>
+        internal abstract void Accept(JsValue clone);
+    }
+
+    /// <summary>
+    /// Step 26.4, for an Array exotic object and for an ordinary object alike: the enumerable own string keys
+    /// snapshot, each read with <c>[[Get]]</c> — so a getter <i>is</i> invoked, and its result is what the
+    /// clone carries, as a plain data property. The <c>HasOwnProperty</c> re-check per key is the
+    /// specification's, and it matters: an earlier getter is allowed to have deleted a later key.
+    /// </summary>
+    private sealed class PropertyFrame : CloneFrame
+    {
+        private readonly ObjectInstance _source;
+        private readonly ObjectInstance _target;
+        private readonly JsValue[] _keys;
+        private int _index;
+        private JsValue _currentKey = JsValue.Undefined;
+
+        internal PropertyFrame(ObjectInstance source, ObjectInstance target, JsValue[] keys)
+        {
+            _source = source;
+            _target = target;
+            _keys = keys;
+        }
+
+        internal override bool TryGetNextSource(out JsValue source)
+        {
+            while (_index < _keys.Length)
+            {
+                var key = _keys[_index++];
+                if (!_source.HasOwnProperty(key))
+                {
+                    continue;
+                }
+
+                _currentKey = key;
+                source = _source.Get(key);
+                return true;
+            }
+
+            source = JsValue.Undefined;
+            return false;
+        }
+
+        internal override void Accept(JsValue clone)
+        {
+            _ = _target.CreateDataProperty(_currentKey, clone);
+        }
+    }
+
+    /// <summary>
+    /// Step 26.1: the entry list is copied before anything is cloned, and each entry's key is serialized
+    /// before its value.
+    /// </summary>
+    private sealed class MapFrame : CloneFrame
+    {
+        private readonly List<KeyValuePair<JsValue, JsValue>> _entries;
+        private readonly JsMap _target;
+        private int _index;
+        private bool _expectingValue;
+        private JsValue _pendingKey = JsValue.Undefined;
+
+        internal MapFrame(JsMap source, JsMap target)
+        {
+            _entries = new List<KeyValuePair<JsValue, JsValue>>(source);
+            _target = target;
+        }
+
+        internal override bool TryGetNextSource(out JsValue source)
+        {
+            if (_index >= _entries.Count)
+            {
+                source = JsValue.Undefined;
+                return false;
+            }
+
+            var entry = _entries[_index];
+            source = _expectingValue ? entry.Value : entry.Key;
+            return true;
+        }
+
+        internal override void Accept(JsValue clone)
+        {
+            if (!_expectingValue)
+            {
+                _pendingKey = clone;
+                _expectingValue = true;
+                return;
+            }
+
+            _target.Set(_pendingKey, clone);
+            _pendingKey = JsValue.Undefined;
+            _expectingValue = false;
+            _index++;
+        }
+    }
+
+    /// <summary>
+    /// Step 26.2, the Set counterpart of <see cref="MapFrame"/>.
+    /// </summary>
+    private sealed class SetFrame : CloneFrame
+    {
+        private readonly List<JsValue> _entries;
+        private readonly JsSet _target;
+        private int _index;
+
+        internal SetFrame(JsSet source, JsSet target)
+        {
+            _entries = new List<JsValue>(source);
+            _target = target;
+        }
+
+        internal override bool TryGetNextSource(out JsValue source)
+        {
+            if (_index >= _entries.Count)
+            {
+                source = JsValue.Undefined;
+                return false;
+            }
+
+            source = _entries[_index++];
+            return true;
+        }
+
+        internal override void Accept(JsValue clone)
+        {
+            _target.Add(clone);
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/WebApiRegistration.cs
+++ b/Jint/WebApi/WebApiRegistration.cs
@@ -78,6 +78,13 @@ internal static class WebApiRegistration
             Install(global, engine, "atob", static e => e.Realm.Intrinsics.Atob, PropertyFlag.ConfigurableEnumerableWritable);
             Install(global, engine, "btoa", static e => e.Realm.Intrinsics.Btoa, PropertyFlag.ConfigurableEnumerableWritable);
         }
+
+        if ((options.WebApi.Features & WebApiFeatures.StructuredClone) != WebApiFeatures.None)
+        {
+            // A WebIDL operation on the global is a writable, enumerable, configurable data property —
+            // https://webidl.spec.whatwg.org/#es-operations.
+            Install(global, engine, "structuredClone", static e => e.Realm.Intrinsics.StructuredClone, PropertyFlag.ConfigurableEnumerableWritable);
+        }
     }
 
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ its own `console` (or any other name in the table below), enabling the feature l
 | `setTimeout` / `setInterval` / `clearTimeout` / `clearInterval` / `queueMicrotask` | `WebApiFeatures.Timers` | ✔ shipped |
 | `TextEncoder` / `TextDecoder` (UTF-8, UTF-16LE, UTF-16BE; `fatal`, `ignoreBOM`, streaming) | `Encoding` | ✔ shipped |
 | `atob` / `btoa` | `Base64` | ✔ shipped |
-| `structuredClone` | `StructuredClone` | in progress |
+| `structuredClone` (incl. `{ transfer }` of `ArrayBuffer`s) | `StructuredClone` | ✔ shipped |
 | `crypto.getRandomValues` / `crypto.randomUUID` | `Crypto` | in progress |
 | `performance.now` / `performance.timeOrigin` | `Performance` | in progress |
 | `Event` / `EventTarget` / `CustomEvent` / `AbortController` / `AbortSignal` | `Events` | in progress |


### PR DESCRIPTION
Part of the opt-in web API series (#3079): `structuredClone(value, { transfer })` behind `WebApiFeatures.StructuredClone` (in `Default`). Usual rules: BCL only, net8+, opt-in, default engine unchanged.

Implements HTML's StructuredSerializeWithTransfer/StructuredDeserializeWithTransfer (https://html.spec.whatwg.org/multipage/structured-data.html) fused into a single walk — `structuredClone` has one realm, so the memory map keys on source-object identity, and the fusion is argued unobservable in the class doc (identical traversal order → identical getter order; a mid-walk throw discards an unreachable clone; transfer still runs strictly after the walk).

Covered: primitives; boxed Boolean/Number/String/BigInt; Date; RegExp (source+flags, `lastIndex` starts 0); ArrayBuffer incl. resizability, detached → `DataCloneError`; TypedArrays/DataView (two views over one buffer deserialize as two views over **one** cloned buffer — the memory map gives it for free); Map/Set; Array with holes preserved; Errors per the spec table (plus `stack` carried, as both HTML and WebIDL say a UA "should"); `DOMException` (it is WebIDL-`[Serializable]`); plain objects via own enumerable string keys read with `Get` (getters run, per spec); circular references. Symbols, functions, proxies and host-wrapped objects throw `DataCloneError` — the recognition is deliberately positive (only object shapes Jint can prove ordinary clone), so nothing ever silently loses data. `transfer` accepts ArrayBuffers, with the spec's duplicate/detached/non-transferable error order pinned.

**The walk is iterative, not recursive — there is no depth limit at all.** The motivation is empirical: the same 100k-deep `{next:{next:…}}` graph run through the engine's recursive `JSON.stringify` kills the process with an uncatchable `0xC00000FD` stack overflow; `structuredClone` of that graph (and equally deep array and Map chains) completes in milliseconds, and progress is charged against the engine's execution constraints so a huge clone stays interruptible by timeout/cancellation.

94 tests including the deep-graph cases, transfer error ordering, realm-correct prototypes, and the public-surface pins. Verified: all-TFM build, both suites × both frameworks × both host-contract-verification configurations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
