### PR TITLE
Add opt-in Blob, File and FormData

### DIFF
--- a/Jint.Tests.PublicInterface/WebApiFilesTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiFilesTests.cs
@@ -1,0 +1,160 @@
+#if NET8_0_OR_GREATER
+using Jint;
+using Jint.Native;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// <c>Blob</c>, <c>File</c> and <c>FormData</c> seen from outside the assembly: what a host has to write to
+/// get them, what it gets when it writes nothing, and the attributes the globals carry.
+/// </summary>
+/// <remarks>
+/// This project has no <c>InternalsVisibleTo</c>, so everything here is reachable by a third party. The pin
+/// that matters most is <see cref="ADefaultEngineHasNoFileGlobals"/>: the surface is opt-in, and an engine
+/// that did not ask for it must be the engine it was before any of this existed.
+/// </remarks>
+public class WebApiFilesTests
+{
+    [Fact]
+    public void ADefaultEngineHasNoFileGlobals()
+    {
+        var engine = new Engine();
+
+        engine.Evaluate("typeof Blob").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof File").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof FormData").AsString().Should().Be("undefined");
+        engine.Evaluate("'Blob' in globalThis").AsBoolean().Should().BeFalse();
+
+        // Not even an engine that named the group but no feature.
+        new Engine(options => options.WebApi.Features = WebApiFeatures.None)
+            .Evaluate("typeof Blob").AsString().Should().Be("undefined");
+
+        // ... nor one that asked for a different feature.
+        new Engine(options => options.UseWebApis(WebApiFeatures.Console))
+            .Evaluate("typeof Blob").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void TheFilesFlagInstallsAllThreeInterfaces()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Files));
+
+        engine.Evaluate("typeof Blob").AsString().Should().Be("function");
+        engine.Evaluate("typeof File").AsString().Should().Be("function");
+        engine.Evaluate("typeof FormData").AsString().Should().Be("function");
+
+        // DOMException comes with any feature, because it is how the web APIs report a failure.
+        engine.Evaluate("typeof DOMException").AsString().Should().Be("function");
+    }
+
+    [Fact]
+    public void TheDefaultSetIncludesFiles()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        engine.Evaluate("typeof Blob").AsString().Should().Be("function");
+        WebApiFeatures.Default.Should().HaveFlag(WebApiFeatures.Files);
+    }
+
+    [Fact]
+    public void TheGlobalsCarryTheAttributesWebIdlAsksFor()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Files));
+
+        // An interface object is writable and configurable but NOT enumerable —
+        // https://webidl.spec.whatwg.org/#es-interfaces.
+        foreach (var name in new[] { "Blob", "File", "FormData" })
+        {
+            var descriptor = engine.Evaluate($"Object.getOwnPropertyDescriptor(globalThis, '{name}')").AsObject();
+
+            descriptor.Get("writable").AsBoolean().Should().BeTrue();
+            descriptor.Get("configurable").AsBoolean().Should().BeTrue();
+            descriptor.Get("enumerable").AsBoolean().Should().BeFalse();
+        }
+    }
+
+    [Fact]
+    public void AHostRegisteredGlobalWins()
+    {
+        var marker = new JsString("host's own Blob");
+
+        var engine = new Engine(options => options
+            .AddLazyGlobal("Blob", _ => marker)
+            .UseWebApis(WebApiFeatures.Files));
+
+        // The host's configuration runs first and the install is non-clobbering.
+        engine.Evaluate("Blob").Should().BeSameAs(marker);
+
+        // The names it did not claim are still installed.
+        engine.Evaluate("typeof FormData").AsString().Should().Be("function");
+    }
+
+    [Fact]
+    public void AShadowRealmDoesNotGetThem()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Files));
+
+        // Only the principal realm's global object is touched — deliberately more conservative than a
+        // browser, where these are [Exposed=*].
+        engine.Evaluate("new ShadowRealm().evaluate('typeof Blob')").AsString().Should().Be("undefined");
+        engine.Evaluate("new ShadowRealm().evaluate('typeof FormData')").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof Blob").AsString().Should().Be("function");
+    }
+
+    [Fact]
+    public void SurvivesAGlobalSnapshotRestore()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Files));
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+
+        engine.Execute("var b = new Blob(['x']);");
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        engine.Evaluate("typeof b").AsString().Should().Be("undefined");
+        engine.Evaluate("new Blob(['abc']).size").AsNumber().Should().Be(3);
+    }
+
+    [Fact]
+    public void TheWholeRoundTripWorksFromAHostsPointOfView()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Files));
+
+        var formData = engine.Evaluate("""
+            (function () {
+                const form = new FormData();
+                form.append('greeting', new File(['hello'], 'greeting.txt', { type: 'text/plain' }));
+                form.append('who', 'world');
+                return form;
+            })()
+            """);
+
+        // A host gets a real JsValue back and can hand it to the next evaluation.
+        formData.IsObject().Should().BeTrue();
+        engine.SetValue("fd", formData);
+
+        engine.Evaluate("fd.get('greeting').name").AsString().Should().Be("greeting.txt");
+        engine.Evaluate("fd.get('greeting').type").AsString().Should().Be("text/plain");
+        engine.Evaluate("fd.get('greeting').text()").UnwrapIfPromise().AsString().Should().Be("hello");
+        engine.Evaluate("fd.get('who')").AsString().Should().Be("world");
+    }
+
+    [Fact]
+    public void OneOptionsInstanceServesSeveralEnginesIndependently()
+    {
+        var options = new Options().UseWebApis(WebApiFeatures.Files);
+
+        var first = new Engine(options);
+        var second = new Engine(options);
+
+        first.Execute("var b = new Blob(['first']);");
+        second.Execute("var b = new Blob(['second-one']);");
+
+        first.Evaluate("b.size").AsNumber().Should().Be(5);
+        second.Evaluate("b.size").AsNumber().Should().Be(10);
+
+        // Nothing is shared between the two: each realm builds its own interface objects.
+        first.Evaluate("b instanceof Blob").AsBoolean().Should().BeTrue();
+        second.Evaluate("b instanceof Blob").AsBoolean().Should().BeTrue();
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/BlobTests.cs
+++ b/Jint.Tests/Runtime/WebApi/BlobTests.cs
@@ -1,0 +1,359 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// <c>Blob</c> as the File API specifies it — https://w3c.github.io/FileAPI/.
+/// </summary>
+public class BlobTests
+{
+    private static Engine WebEngine() => new(options => options.UseWebApis(WebApiFeatures.Files));
+
+    private static JsValue Eval(string source) => WebEngine().Evaluate(source);
+
+    [Fact]
+    public void ConstructsAnEmptyBlobFromNoArguments()
+    {
+        // https://w3c.github.io/FileAPI/#constructorBlob step 1.
+        Eval("new Blob().size").AsNumber().Should().Be(0);
+        Eval("new Blob().type").AsString().Should().Be("");
+
+        // A missing sequence is still a missing sequence when the options are given.
+        Eval("new Blob(undefined, { type: 'x/y' }).size").AsNumber().Should().Be(0);
+        Eval("new Blob(undefined, { type: 'x/y' }).type").AsString().Should().Be("x/y");
+    }
+
+    [Fact]
+    public void ConcatenatesThePartsInOrder()
+    {
+        // https://w3c.github.io/FileAPI/#process-blob-parts
+        Eval("new Blob(['a', 'bc', 'd']).size").AsNumber().Should().Be(4);
+        Eval("new Blob(['a', 'bc']).text()").UnwrapIfPromise().AsString().Should().Be("abc");
+    }
+
+    [Fact]
+    public void EncodesStringPartsAsUtf8()
+    {
+        // "Append the result of UTF-8 encoding s to bytes" — so size counts bytes, not code units.
+        Eval("new Blob(['é']).size").AsNumber().Should().Be(2);
+        Eval("new Blob(['𝌆']).size").AsNumber().Should().Be(4);
+
+        // A USVString substitutes U+FFFD for an unpaired surrogate, which is three bytes.
+        Eval("new Blob(['\\uD800']).size").AsNumber().Should().Be(3);
+        Eval("new Blob(['\\uD800']).text()").UnwrapIfPromise().AsString().Should().Be("\uFFFD");
+    }
+
+    [Fact]
+    public void StringifiesAPartThatIsNeitherABufferSourceNorABlob()
+    {
+        Eval("new Blob([123]).text()").UnwrapIfPromise().AsString().Should().Be("123");
+        Eval("new Blob([null]).text()").UnwrapIfPromise().AsString().Should().Be("null");
+        Eval("new Blob([{ toString() { return 'hi'; } }]).text()").UnwrapIfPromise().AsString().Should().Be("hi");
+    }
+
+    [Fact]
+    public void CopiesTheBytesOfEveryBufferSourceShape()
+    {
+        // "If element is a BufferSource, get a copy of the bytes held by the buffer source".
+        Eval("new Blob([new Uint8Array([1, 2, 3])]).size").AsNumber().Should().Be(3);
+        Eval("new Blob([new Uint8Array([1, 2, 3, 4]).subarray(1, 3)]).size").AsNumber().Should().Be(2);
+        Eval("new Blob([new Uint32Array([1, 2])]).size").AsNumber().Should().Be(8);
+        Eval("new Blob([new Uint8Array([1, 2, 3, 4]).buffer]).size").AsNumber().Should().Be(4);
+        Eval("new Blob([new DataView(new Uint8Array([1, 2, 3, 4]).buffer, 2)]).size").AsNumber().Should().Be(2);
+    }
+
+    [Fact]
+    public void CopiesRatherThanAliasesABufferSource()
+    {
+        var engine = WebEngine();
+        engine.Execute("var a = new Uint8Array([65]); var b = new Blob([a]); a[0] = 66;");
+
+        // The blob is immutable, so a later write through the view cannot reach it.
+        engine.Evaluate("b.text()").UnwrapIfPromise().AsString().Should().Be("A");
+    }
+
+    [Fact]
+    public void AppendsTheBytesOfANestedBlob()
+    {
+        Eval("new Blob([new Blob(['ab']), 'c']).text()").UnwrapIfPromise().AsString().Should().Be("abc");
+    }
+
+    [Fact]
+    public void TreatsADetachedBufferAsNoBytes()
+    {
+        // A detached buffer holds nothing to copy. It is not an error: WebIDL admits the value, and the
+        // byte sequence it contributes is empty.
+        Eval("(function () { var b = new ArrayBuffer(8); b.transfer(); return new Blob([b]).size; })()")
+            .AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void TreatsAViewThatHasGoneOutOfBoundsAsNoBytes()
+    {
+        // A resizable buffer can shrink out from under a view, leaving both its offset and its length past
+        // the end of the block. There are no bytes left to copy, and reaching for them must not fault.
+        Eval("""
+            (function () {
+                const buffer = new ArrayBuffer(8, { maxByteLength: 8 });
+                const view = new Uint8Array(buffer, 4);
+                buffer.resize(2);
+                return new Blob([view]).size;
+            })()
+            """).AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void ReadsBackAnEmptyBlob()
+    {
+        Eval("new Blob().text()").UnwrapIfPromise().AsString().Should().Be("");
+        Eval("new Blob().arrayBuffer()").UnwrapIfPromise().AsObject().Get("byteLength").AsNumber().Should().Be(0);
+        Eval("new Blob().bytes()").UnwrapIfPromise().AsObject().Get("length").AsNumber().Should().Be(0);
+        Eval("new Blob().slice(0, 0).size").AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void RejectsAnythingThatIsNotASequence()
+    {
+        // WebIDL sequence conversion: a bare string is not an object and is not iterated character by
+        // character, which is the mistake `new Blob('abc')` usually is.
+        Assert.Throws<JavaScriptException>(() => Eval("new Blob('abc')"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+
+        Assert.Throws<JavaScriptException>(() => Eval("new Blob(null)"));
+        Assert.Throws<JavaScriptException>(() => Eval("new Blob({})"));
+        Assert.Throws<JavaScriptException>(() => Eval("new Blob(5)"));
+    }
+
+    [Fact]
+    public void AcceptsAnyIterable()
+    {
+        Eval("new Blob(new Set(['a', 'b'])).size").AsNumber().Should().Be(2);
+        Eval("new Blob(function* () { yield 'a'; yield 'bc'; }()).size").AsNumber().Should().Be(3);
+    }
+
+    [Theory]
+    [InlineData("text/plain", "text/plain")]
+    [InlineData("TEXT/PLAIN", "text/plain")]
+    [InlineData("Text/Plain; Charset=UTF-8", "text/plain; charset=utf-8")]
+    // A code point outside U+0020..U+007E replaces the whole type with the empty string.
+    [InlineData("a\u00FFb", "")]
+    [InlineData("a\tb", "")]
+    [InlineData("a\nb", "")]
+    public void NormalizesTheMediaType(string given, string expected)
+    {
+        // https://w3c.github.io/FileAPI/#constructorBlob step 3.
+        WebEngine().SetValue("given", given).Evaluate("new Blob([], { type: given }).type").AsString().Should().Be(expected);
+    }
+
+    [Fact]
+    public void TakesTheOptionsBagTheWayWebIdlDoes()
+    {
+        // null and undefined mean "every member defaulted"; anything else that is not an object is a
+        // TypeError — https://webidl.spec.whatwg.org/#es-dictionary.
+        Eval("new Blob([], null).type").AsString().Should().Be("");
+        Eval("new Blob([], undefined).type").AsString().Should().Be("");
+        Eval("new Blob([], { type: undefined }).type").AsString().Should().Be("");
+        Assert.Throws<JavaScriptException>(() => Eval("new Blob([], 5)"));
+    }
+
+    [Fact]
+    public void ReadsDictionaryMembersInLexicographicalOrder()
+    {
+        var engine = WebEngine();
+
+        // Members are converted in lexicographical order of their identifiers, so `endings` is observed
+        // before `type`. The parts are drained before either, being an earlier argument.
+        engine.Execute("""
+            var seen = [];
+            new Blob(
+                (function* () { seen.push('parts'); yield 'x'; })(),
+                { get endings() { seen.push('endings'); return 'transparent'; },
+                  get type() { seen.push('type'); return 'a/b'; } });
+            """);
+
+        engine.Evaluate("seen.join(',')").AsString().Should().Be("parts,endings,type");
+    }
+
+    [Fact]
+    public void ValidatesTheEndingsEnumerationButTreatsNativeAsTransparent()
+    {
+        Eval("new Blob(['a'], { endings: 'transparent' }).size").AsNumber().Should().Be(1);
+
+        // "native" is accepted, and deliberately does nothing: rewriting line endings would make a blob's
+        // bytes depend on the host operating system.
+        Eval("new Blob(['a\\nb'], { endings: 'native' }).size").AsNumber().Should().Be(3);
+
+        // An unknown enumeration value is still a TypeError, as a WebIDL enum conversion is.
+        Assert.Throws<JavaScriptException>(() => Eval("new Blob([], { endings: 'bogus' })"));
+    }
+
+    [Fact]
+    public void ExposesSizeAndTypeAsPrototypeAccessors()
+    {
+        var engine = WebEngine();
+
+        // WebIDL attributes live on the interface prototype object, so the instance has no own property.
+        engine.Evaluate("Object.getOwnPropertyNames(new Blob(['a'])).length").AsNumber().Should().Be(0);
+
+        engine.Evaluate("var d = Object.getOwnPropertyDescriptor(Blob.prototype, 'size'); typeof d.get").AsString().Should().Be("function");
+        engine.Evaluate("d.set").IsUndefined().Should().BeTrue();
+        engine.Evaluate("d.enumerable").AsBoolean().Should().BeTrue();
+        engine.Evaluate("d.configurable").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void BrandChecksEveryMember()
+    {
+        var engine = WebEngine();
+
+        // Blob.prototype is not itself a Blob.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("Blob.prototype.size"));
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("Blob.prototype.type"));
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("Blob.prototype.slice.call({})"));
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("Blob.prototype.text.call({})"));
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("Blob.prototype.arrayBuffer.call([])"));
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("Blob.prototype.bytes.call('')"));
+    }
+
+    [Fact]
+    public void HasTheToStringTagAndConstructorWebIdlAsksFor()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("Object.prototype.toString.call(new Blob())").AsString().Should().Be("[object Blob]");
+        engine.Evaluate("new Blob().constructor === Blob").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.getPrototypeOf(Blob.prototype) === Object.prototype").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Blob.length").AsNumber().Should().Be(0);
+        engine.Evaluate("Blob.name").AsString().Should().Be("Blob");
+    }
+
+    [Fact]
+    public void RequiresNew()
+    {
+        Assert.Throws<JavaScriptException>(() => Eval("Blob()"));
+    }
+
+    [Fact]
+    public void SupportsSubclassing()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("class MyBlob extends Blob { constructor(p) { super(p); this.tag = 'mine'; } }");
+        engine.Evaluate("new MyBlob(['abc']).size").AsNumber().Should().Be(3);
+        engine.Evaluate("new MyBlob(['abc']) instanceof MyBlob").AsBoolean().Should().BeTrue();
+        engine.Evaluate("new MyBlob(['abc']).tag").AsString().Should().Be("mine");
+    }
+
+    [Theory]
+    // https://w3c.github.io/FileAPI/#slice-blob — relativeStart/relativeEnd normalization.
+    [InlineData("blob.slice()", "abcdef")]
+    [InlineData("blob.slice(2)", "cdef")]
+    [InlineData("blob.slice(2, 4)", "cd")]
+    [InlineData("blob.slice(-2)", "ef")]
+    [InlineData("blob.slice(-100)", "abcdef")]
+    [InlineData("blob.slice(0, -2)", "abcd")]
+    [InlineData("blob.slice(0, -100)", "")]
+    [InlineData("blob.slice(4, 2)", "")]
+    [InlineData("blob.slice(100)", "")]
+    [InlineData("blob.slice(0, 100)", "abcdef")]
+    // An optional argument with no default value is missing when undefined is passed explicitly.
+    [InlineData("blob.slice(undefined, undefined)", "abcdef")]
+    [InlineData("blob.slice(2, undefined)", "cdef")]
+    // [Clamp] rounds to nearest, ties to even, and NaN becomes zero.
+    [InlineData("blob.slice(1.5, 4.5)", "cd")]
+    [InlineData("blob.slice(2.4)", "cdef")]
+    [InlineData("blob.slice(NaN, 2)", "ab")]
+    [InlineData("blob.slice(-Infinity, Infinity)", "abcdef")]
+    public void SlicesByByteOrderPosition(string expression, string expected)
+    {
+        var engine = WebEngine();
+        engine.Execute("var blob = new Blob(['abcdef']);");
+
+        engine.Evaluate(expression + ".text()").UnwrapIfPromise().AsString().Should().Be(expected);
+    }
+
+    [Fact]
+    public void GivesTheSliceOnlyTheContentTypeItWasAskedFor()
+    {
+        var engine = WebEngine();
+        engine.Execute("var blob = new Blob(['abcdef'], { type: 'text/plain' });");
+
+        // The type is never inherited: a slice with no contentType has the empty type.
+        engine.Evaluate("blob.slice(0, 2).type").AsString().Should().Be("");
+        engine.Evaluate("blob.slice(0, 2, undefined).type").AsString().Should().Be("");
+        engine.Evaluate("blob.slice(0, 2, 'TEXT/HTML').type").AsString().Should().Be("text/html");
+        engine.Evaluate("blob.slice(0, 2, 'a\u00FFb').type").AsString().Should().Be("");
+
+        // And the result is a Blob, never a File.
+        engine.Evaluate("blob.slice(0, 2) instanceof Blob").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReadsBackAsTextArrayBufferAndBytes()
+    {
+        var engine = WebEngine();
+        engine.Execute("var blob = new Blob(['hi']);");
+
+        engine.Evaluate("blob.text()").UnwrapIfPromise().AsString().Should().Be("hi");
+        engine.Evaluate("blob.arrayBuffer()").UnwrapIfPromise().AsObject().Get("byteLength").AsNumber().Should().Be(2);
+        engine.Evaluate("blob.bytes()").UnwrapIfPromise().AsObject().Get("length").AsNumber().Should().Be(2);
+
+        engine.Evaluate("blob.arrayBuffer().then(a => a instanceof ArrayBuffer)").UnwrapIfPromise().AsBoolean().Should().BeTrue();
+        engine.Evaluate("blob.bytes().then(b => b instanceof Uint8Array && b[0] === 104 && b[1] === 105)")
+            .UnwrapIfPromise().AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void TheReadMethodsAnswerRealPromises()
+    {
+        var engine = WebEngine();
+
+        // Already resolved, but promises all the same — awaiting one is a microtask turn, not a stall.
+        engine.Evaluate("new Blob(['x']).text() instanceof Promise").AsBoolean().Should().BeTrue();
+        engine.Evaluate("(async () => (await new Blob(['x']).text()) + '!')()").UnwrapIfPromise().AsString().Should().Be("x!");
+
+        // A read never hands out a view over the blob's own storage: writing to what came back must not
+        // change what the next read produces.
+        engine.Execute("var blob = new Blob(['AB']); var first; blob.bytes().then(b => { first = b; b[0] = 67; });");
+        engine.Evaluate("blob.text()").UnwrapIfPromise().AsString().Should().Be("AB");
+    }
+
+    [Fact]
+    public void TextIsALenientBomStrippingUtf8Decode()
+    {
+        // https://encoding.spec.whatwg.org/#utf-8-decode strips one leading BOM ...
+        Eval("new Blob([new Uint8Array([0xEF, 0xBB, 0xBF, 0x61])]).text()").UnwrapIfPromise().AsString().Should().Be("a");
+
+        // ... and substitutes U+FFFD for an ill-formed sequence rather than rejecting.
+        Eval("new Blob([new Uint8Array([0xFF])]).text()").UnwrapIfPromise().AsString().Should().Be("\uFFFD");
+
+        // The BOM is only stripped once, and only at the start.
+        Eval("new Blob([new Uint8Array([0xEF, 0xBB, 0xBF, 0xEF, 0xBB, 0xBF])]).text()").UnwrapIfPromise().AsString().Should().Be("\uFEFF");
+    }
+
+    [Fact]
+    public void HasNoStreamMethod()
+    {
+        // Absent rather than throwing: Jint has no streams yet, and feature detection is written against
+        // absence.
+        Eval("typeof Blob.prototype.stream").AsString().Should().Be("undefined");
+        Eval("'stream' in Blob.prototype").AsBoolean().Should().BeFalse();
+        Eval("typeof Blob.prototype.textStream").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void DeclaresTheArityTheIdlDoes()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("Blob.prototype.slice.length").AsNumber().Should().Be(0);
+        engine.Evaluate("Blob.prototype.text.length").AsNumber().Should().Be(0);
+        engine.Evaluate("Blob.prototype.arrayBuffer.length").AsNumber().Should().Be(0);
+        engine.Evaluate("Blob.prototype.bytes.length").AsNumber().Should().Be(0);
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/FileTests.cs
+++ b/Jint.Tests/Runtime/WebApi/FileTests.cs
@@ -1,0 +1,171 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// <c>File</c> as the File API specifies it — https://w3c.github.io/FileAPI/#file-section.
+/// </summary>
+public class FileTests
+{
+    private static Engine WebEngine() => new(options => options.UseWebApis(WebApiFeatures.Files));
+
+    private static JsValue Eval(string source) => WebEngine().Evaluate(source);
+
+    [Fact]
+    public void CarriesTheBitsTheNameAndTheOptions()
+    {
+        var engine = WebEngine();
+        engine.Execute("var f = new File(['ab', 'c'], 'note.txt', { type: 'TEXT/Plain', lastModified: 42 });");
+
+        engine.Evaluate("f.size").AsNumber().Should().Be(3);
+        engine.Evaluate("f.name").AsString().Should().Be("note.txt");
+        engine.Evaluate("f.type").AsString().Should().Be("text/plain");
+        engine.Evaluate("f.lastModified").AsNumber().Should().Be(42);
+        engine.Evaluate("f.text()").UnwrapIfPromise().AsString().Should().Be("abc");
+    }
+
+    [Fact]
+    public void InheritsBlob()
+    {
+        var engine = WebEngine();
+
+        // The interface prototype object's [[Prototype]] is the inherited interface prototype object, and
+        // the interface object's is the inherited interface object —
+        // https://webidl.spec.whatwg.org/#interface-object.
+        engine.Evaluate("Object.getPrototypeOf(File.prototype) === Blob.prototype").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.getPrototypeOf(File) === Blob").AsBoolean().Should().BeTrue();
+
+        engine.Evaluate("new File([], 'a') instanceof Blob").AsBoolean().Should().BeTrue();
+        engine.Evaluate("new File(['abc'], 'a').slice(1).size").AsNumber().Should().Be(2);
+        engine.Evaluate("Object.prototype.toString.call(new File([], 'a'))").AsString().Should().Be("[object File]");
+    }
+
+    [Fact]
+    public void SlicingAFileProducesAPlainBlob()
+    {
+        // "Return a new Blob object S" — a slice has no name to carry.
+        var engine = WebEngine();
+        engine.Execute("var s = new File(['abc'], 'a.txt').slice(1);");
+
+        engine.Evaluate("s instanceof Blob").AsBoolean().Should().BeTrue();
+        engine.Evaluate("s instanceof File").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void RequiresBothOfItsRequiredArguments()
+    {
+        Assert.Throws<JavaScriptException>(() => Eval("new File()"));
+        Assert.Throws<JavaScriptException>(() => Eval("new File(['a'])"));
+        Assert.Throws<JavaScriptException>(() => Eval("File(['a'], 'b')"));
+
+        // fileBits is a required sequence, so undefined is not a stand-in for an empty one.
+        Assert.Throws<JavaScriptException>(() => Eval("new File(undefined, 'a')"));
+    }
+
+    [Fact]
+    public void ConvertsTheNameToAScalarValueString()
+    {
+        // USVString: an unpaired surrogate becomes U+FFFD.
+        Eval("new File([], 'a\\uD800b').name").AsString().Should().Be("a�b");
+
+        // A well-formed pair survives.
+        Eval("new File([], 'a\\uD83D\\uDE00b').name").AsString().Should().Be("a😀b");
+
+        // And the name is a plain string conversion otherwise.
+        Eval("new File([], 5).name").AsString().Should().Be("5");
+    }
+
+    [Fact]
+    public void DefaultsLastModifiedToTheEngineClock()
+    {
+        var engine = WebEngine();
+
+        // The default is "the current date and time ... the equivalent of Date.now()", captured once at
+        // construction and never moving afterwards.
+        engine.Execute("var before = Date.now(); var f = new File([], 'a'); var after = Date.now();");
+
+        engine.Evaluate("f.lastModified >= before && f.lastModified <= after").AsBoolean().Should().BeTrue();
+        engine.Evaluate("f.lastModified === f.lastModified").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReadsLastModifiedAsAWebIdlLongLong()
+    {
+        // long long truncates towards zero, and every non-finite value is zero.
+        Eval("new File([], 'a', { lastModified: 1.9 }).lastModified").AsNumber().Should().Be(1);
+        Eval("new File([], 'a', { lastModified: -1.9 }).lastModified").AsNumber().Should().Be(-1);
+        Eval("new File([], 'a', { lastModified: NaN }).lastModified").AsNumber().Should().Be(0);
+        Eval("new File([], 'a', { lastModified: Infinity }).lastModified").AsNumber().Should().Be(0);
+        Eval("new File([], 'a', { lastModified: '7' }).lastModified").AsNumber().Should().Be(7);
+        Eval("new File([], 'a', { lastModified: 0 }).lastModified").AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void ReadsTheInheritedDictionaryMembersFirst()
+    {
+        var engine = WebEngine();
+
+        // Inherited members come first, then the derived dictionary's own — so endings, type, lastModified.
+        engine.Execute("""
+            var seen = [];
+            new File([], 'a', {
+                get endings() { seen.push('endings'); return 'transparent'; },
+                get lastModified() { seen.push('lastModified'); return 0; },
+                get type() { seen.push('type'); return ''; } });
+            """);
+
+        engine.Evaluate("seen.join(',')").AsString().Should().Be("endings,type,lastModified");
+    }
+
+    [Fact]
+    public void BrandChecksNameAndLastModified()
+    {
+        var engine = WebEngine();
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("File.prototype.name"));
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("File.prototype.lastModified"));
+
+        // A plain blob is not a file, even though it passes Blob's own brand check.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("Object.getOwnPropertyDescriptor(File.prototype, 'name').get.call(new Blob())"));
+    }
+
+    [Fact]
+    public void ExposesNameAndLastModifiedAsAccessorsOnItsOwnPrototype()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("Object.getOwnPropertyNames(new File([], 'a')).length").AsNumber().Should().Be(0);
+        engine.Evaluate("Object.getOwnPropertyNames(File.prototype).sort().join(',')").AsString()
+            .Should().Be("constructor,lastModified,name");
+
+        engine.Evaluate("var d = Object.getOwnPropertyDescriptor(File.prototype, 'name'); d.enumerable").AsBoolean().Should().BeTrue();
+        engine.Evaluate("d.configurable").AsBoolean().Should().BeTrue();
+        engine.Evaluate("d.set").IsUndefined().Should().BeTrue();
+    }
+
+    [Fact]
+    public void DeclaresTheArityTheIdlDoes()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("File.length").AsNumber().Should().Be(2);
+        engine.Evaluate("File.name").AsString().Should().Be("File");
+        engine.Evaluate("new File([], 'a').constructor === File").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void SupportsSubclassing()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("class MyFile extends File {}");
+        engine.Evaluate("new MyFile(['ab'], 'n').name").AsString().Should().Be("n");
+        engine.Evaluate("new MyFile(['ab'], 'n').size").AsNumber().Should().Be(2);
+        engine.Evaluate("new MyFile(['ab'], 'n') instanceof Blob").AsBoolean().Should().BeTrue();
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/FormDataTests.cs
+++ b/Jint.Tests/Runtime/WebApi/FormDataTests.cs
@@ -1,0 +1,312 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// <c>FormData</c> as the XMLHttpRequest Standard specifies it —
+/// https://xhr.spec.whatwg.org/#interface-formdata.
+/// </summary>
+public class FormDataTests
+{
+    private static Engine WebEngine() => new(options => options.UseWebApis(WebApiFeatures.Files));
+
+    private static JsValue Eval(string source) => WebEngine().Evaluate(source);
+
+    private static Engine WithEntries()
+    {
+        var engine = WebEngine();
+        engine.Execute("var fd = new FormData(); fd.append('a', '1'); fd.append('b', '2'); fd.append('a', '3');");
+        return engine;
+    }
+
+    [Fact]
+    public void StartsEmptyAndTakesNoForm()
+    {
+        Eval("[...new FormData()].length").AsNumber().Should().Be(0);
+
+        // There is no DOM, so there is no form to scrape — and a passed argument is refused rather than
+        // silently ignored.
+        Assert.Throws<JavaScriptException>(() => Eval("new FormData(null)"));
+        Assert.Throws<JavaScriptException>(() => Eval("new FormData({})"));
+        Assert.Throws<JavaScriptException>(() => Eval("new FormData(1)"));
+
+        // An explicitly passed undefined is a missing optional argument, so it is fine.
+        Eval("[...new FormData(undefined)].length").AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void RequiresNew()
+    {
+        Assert.Throws<JavaScriptException>(() => Eval("FormData()"));
+    }
+
+    [Fact]
+    public void AppendsInOrderAndKeepsDuplicates()
+    {
+        var engine = WithEntries();
+
+        // https://xhr.spec.whatwg.org/#dom-formdata-append — the entry list is ordered and admits
+        // duplicate names.
+        engine.Evaluate("JSON.stringify([...fd])").AsString().Should().Be("""[["a","1"],["b","2"],["a","3"]]""");
+    }
+
+    [Fact]
+    public void GetAnswersTheFirstMatchAndNullOtherwise()
+    {
+        var engine = WithEntries();
+
+        engine.Evaluate("fd.get('a')").AsString().Should().Be("1");
+        engine.Evaluate("fd.get('missing')").IsNull().Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetAllAnswersEveryMatchInOrder()
+    {
+        var engine = WithEntries();
+
+        engine.Evaluate("fd.getAll('a').join(',')").AsString().Should().Be("1,3");
+        engine.Evaluate("Array.isArray(fd.getAll('missing')) && fd.getAll('missing').length === 0").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasAnswersWhetherAnyEntryCarriesTheName()
+    {
+        var engine = WithEntries();
+
+        engine.Evaluate("fd.has('a')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("fd.has('missing')").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void DeleteRemovesEveryEntryWithTheName()
+    {
+        var engine = WithEntries();
+        engine.Execute("fd.delete('a');");
+
+        engine.Evaluate("JSON.stringify([...fd])").AsString().Should().Be("""[["b","2"]]""");
+
+        // Deleting a name that is not there is not an error.
+        engine.Execute("fd.delete('missing');");
+        engine.Evaluate("[...fd].length").AsNumber().Should().Be(1);
+    }
+
+    [Fact]
+    public void SetReplacesTheFirstMatchInPlaceAndRemovesTheRest()
+    {
+        var engine = WithEntries();
+        engine.Execute("fd.set('a', '9');");
+
+        // The replacement keeps the first match's position — 'a' stays ahead of 'b'.
+        engine.Evaluate("JSON.stringify([...fd])").AsString().Should().Be("""[["a","9"],["b","2"]]""");
+    }
+
+    [Fact]
+    public void SetAppendsWhenTheNameIsAbsent()
+    {
+        var engine = WithEntries();
+        engine.Execute("fd.set('c', '4');");
+
+        engine.Evaluate("JSON.stringify([...fd])").AsString().Should().Be("""[["a","1"],["b","2"],["a","3"],["c","4"]]""");
+    }
+
+    [Fact]
+    public void ConvertsNamesAndStringValuesToScalarValueStrings()
+    {
+        var engine = WebEngine();
+        engine.Execute("var fd = new FormData(); fd.append(1, 2); fd.append('s\\uD800', 'v\\uDFFF');");
+
+        engine.Evaluate("fd.get('1')").AsString().Should().Be("2");
+        engine.Evaluate("fd.get('s\\uFFFD')").AsString().Should().Be("v�");
+    }
+
+    [Fact]
+    public void WrapsABlobValueIntoAFileNamedBlob()
+    {
+        var engine = WebEngine();
+        engine.Execute("var fd = new FormData(); fd.append('f', new Blob(['zz'], { type: 'text/x' }));");
+
+        // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#create-an-entry
+        engine.Evaluate("fd.get('f') instanceof File").AsBoolean().Should().BeTrue();
+        engine.Evaluate("fd.get('f').name").AsString().Should().Be("blob");
+        engine.Evaluate("fd.get('f').size").AsNumber().Should().Be(2);
+
+        // "representing the same bytes" — the media type is carried over.
+        engine.Evaluate("fd.get('f').type").AsString().Should().Be("text/x");
+    }
+
+    [Fact]
+    public void UsesTheFilenameWheneverOneIsGiven()
+    {
+        var engine = WebEngine();
+        engine.Execute("""
+            var fd = new FormData();
+            fd.append('a', new Blob(['x']), 'named.txt');
+            fd.append('b', new File(['x'], 'own.txt'));
+            fd.append('c', new File(['x'], 'own.txt'), 'override.txt');
+            """);
+
+        engine.Evaluate("fd.get('a').name").AsString().Should().Be("named.txt");
+
+        // A file with no filename argument keeps its own name.
+        engine.Evaluate("fd.get('b').name").AsString().Should().Be("own.txt");
+        engine.Evaluate("fd.get('c').name").AsString().Should().Be("override.txt");
+    }
+
+    [Fact]
+    public void AlwaysStoresAFreshFileRatherThanTheValueItWasGiven()
+    {
+        var engine = WebEngine();
+        engine.Execute("var f = new File(['x'], 'a.txt', { lastModified: 7 }); var fd = new FormData(); fd.append('k', f);");
+
+        // The algorithm creates a new File even from a File, so the entry never aliases the object the
+        // script still holds ...
+        engine.Evaluate("fd.get('k') === f").AsBoolean().Should().BeFalse();
+
+        // ... while representing the same bytes, name and modification time.
+        engine.Evaluate("fd.get('k').name").AsString().Should().Be("a.txt");
+        engine.Evaluate("fd.get('k').lastModified").AsNumber().Should().Be(7);
+        engine.Evaluate("fd.get('k').text()").UnwrapIfPromise().AsString().Should().Be("x");
+    }
+
+    [Fact]
+    public void ResolvesTheOverloadOnTheValueNotTheFilename()
+    {
+        var engine = WebEngine();
+        engine.Execute("var fd = new FormData();");
+
+        // With three arguments only the Blob signature exists, so a string value is a TypeError — which is
+        // what a browser answers too.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("fd.append('a', 'b', 'c')"));
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("fd.set('a', 'b', 'c')"));
+
+        // A trailing undefined for an optional argument with no default value means it was not passed.
+        engine.Execute("fd.append('a', 'b', undefined);");
+        engine.Evaluate("fd.get('a')").AsString().Should().Be("b");
+
+        // Overload resolution precedes every conversion, so the name is not stringified on the way to the
+        // failure.
+        engine.Execute("var touched = false; var probe = { toString() { touched = true; return 'n'; } };");
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("fd.append(probe, 'b', 'c')"));
+        engine.Evaluate("touched").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void StringifiesANonBlobValue()
+    {
+        var engine = WebEngine();
+        engine.Execute("var fd = new FormData(); fd.append('n', 5); fd.append('o', { toString() { return 'z'; } }); fd.append('u', undefined);");
+
+        engine.Evaluate("fd.get('n')").AsString().Should().Be("5");
+        engine.Evaluate("fd.get('o')").AsString().Should().Be("z");
+        engine.Evaluate("fd.get('u')").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void IteratesEntriesKeysAndValues()
+    {
+        var engine = WithEntries();
+
+        engine.Evaluate("JSON.stringify([...fd.entries()])").AsString().Should().Be("""[["a","1"],["b","2"],["a","3"]]""");
+        engine.Evaluate("[...fd.keys()].join(',')").AsString().Should().Be("a,b,a");
+        engine.Evaluate("[...fd.values()].join(',')").AsString().Should().Be("1,2,3");
+    }
+
+    [Fact]
+    public void ItsDefaultIteratorIsEntriesItself()
+    {
+        var engine = WebEngine();
+
+        // https://webidl.spec.whatwg.org/#es-iterable — @@iterator is the very same function object.
+        engine.Evaluate("FormData.prototype[Symbol.iterator] === FormData.prototype.entries").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.prototype.toString.call(new FormData().entries())").AsString().Should().Be("[object FormData Iterator]");
+
+        // Its prototype chain reaches %IteratorPrototype%, so the iterator helpers work on it.
+        engine.Evaluate("Object.getPrototypeOf(Object.getPrototypeOf(new FormData().keys())) === Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()))")
+            .AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void IteratesTheLiveEntryList()
+    {
+        var engine = WebEngine();
+        engine.Execute("""
+            var fd = new FormData();
+            fd.append('a', '1');
+            var seen = [];
+            for (const [k, v] of fd) {
+                seen.push(k + v);
+                if (seen.length === 1) { fd.append('b', '2'); }
+            }
+            """);
+
+        // An entry appended during iteration is reached: the iterator indexes the live list.
+        engine.Evaluate("seen.join(',')").AsString().Should().Be("a1,b2");
+    }
+
+    [Fact]
+    public void ForEachVisitsValueKeyAndTheFormData()
+    {
+        var engine = WithEntries();
+        engine.Execute("var seen = []; fd.forEach(function (v, k, o) { seen.push(k + '=' + v + (o === fd)); });");
+
+        engine.Evaluate("seen.join(',')").AsString().Should().Be("a=1true,b=2true,a=3true");
+    }
+
+    [Fact]
+    public void ForEachHonoursItsThisArgAndRejectsANonCallable()
+    {
+        var engine = WithEntries();
+
+        engine.Execute("var marker = {}; var got; fd.forEach(function () { got = this; }, marker);");
+        engine.Evaluate("got === marker").AsBoolean().Should().BeTrue();
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("fd.forEach(5)"));
+    }
+
+    [Fact]
+    public void BrandChecksEveryMember()
+    {
+        var engine = WebEngine();
+
+        foreach (var member in new[] { "append", "delete", "get", "getAll", "has", "set", "forEach", "entries", "keys", "values" })
+        {
+            Assert.Throws<JavaScriptException>(() => engine.Evaluate($"FormData.prototype.{member}.call({{}}, 'a', 'b')"));
+        }
+    }
+
+    [Fact]
+    public void HasTheShapeWebIdlAsksFor()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("Object.prototype.toString.call(new FormData())").AsString().Should().Be("[object FormData]");
+        engine.Evaluate("new FormData().constructor === FormData").AsBoolean().Should().BeTrue();
+        engine.Evaluate("FormData.length").AsNumber().Should().Be(0);
+        engine.Evaluate("FormData.name").AsString().Should().Be("FormData");
+
+        engine.Evaluate("FormData.prototype.append.length").AsNumber().Should().Be(2);
+        engine.Evaluate("FormData.prototype.set.length").AsNumber().Should().Be(2);
+        engine.Evaluate("FormData.prototype.delete.length").AsNumber().Should().Be(1);
+        engine.Evaluate("FormData.prototype.get.length").AsNumber().Should().Be(1);
+        engine.Evaluate("FormData.prototype.getAll.length").AsNumber().Should().Be(1);
+        engine.Evaluate("FormData.prototype.has.length").AsNumber().Should().Be(1);
+        engine.Evaluate("FormData.prototype.forEach.length").AsNumber().Should().Be(1);
+        engine.Evaluate("FormData.prototype.entries.length").AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void SupportsSubclassing()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("class MyForm extends FormData {}");
+        engine.Evaluate("new MyForm() instanceof FormData").AsBoolean().Should().BeTrue();
+        engine.Execute("var m = new MyForm(); m.append('a', 'b');");
+        engine.Evaluate("m.get('a')").AsString().Should().Be("b");
+    }
+}
+#endif

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -136,7 +136,7 @@ public partial class Options
 /// The bit layout is fixed ahead of the implementations so that a value persisted by a host keeps its meaning
 /// as the surface grows. The bits reserved for the features still to land are
 /// <c>Crypto = 1 &lt;&lt; 5</c>, <c>Performance = 1 &lt;&lt; 6</c>,
-/// <c>Events = 1 &lt;&lt; 7</c>, <c>Url = 1 &lt;&lt; 8</c>, <c>Files = 1 &lt;&lt; 9</c> and
+/// <c>Events = 1 &lt;&lt; 7</c>, <c>Url = 1 &lt;&lt; 8</c> and
 /// <c>Fetch = 1 &lt;&lt; 10</c>. A flag is declared here only once the feature behind it actually exists, so
 /// that naming one can never compile into an engine that silently does not have it.
 /// </para>
@@ -187,10 +187,18 @@ public enum WebApiFeatures
     StructuredClone = 1 << 4,
 
     /// <summary>
-    /// The web APIs a host normally wants: everything except outbound network access. Today that is
-    /// <see cref="Console"/>, <see cref="Timers"/>, <see cref="Encoding"/>, <see cref="Base64"/> and
-    /// <see cref="StructuredClone"/>; it grows as further features land, and never comes to include fetch.
+    /// <c>Blob</c>, <c>File</c> and <c>FormData</c> — in-memory byte sequences and the ordered entry list a
+    /// form submission is made of. No streaming (<c>Blob.stream()</c> is absent) and no
+    /// <c>multipart/form-data</c> serialization, which arrives with fetch.
     /// </summary>
-    Default = Console | Timers | Encoding | Base64 | StructuredClone,
+    Files = 1 << 9,
+
+    /// <summary>
+    /// The web APIs a host normally wants: everything except outbound network access. Today that is
+    /// <see cref="Console"/>, <see cref="Timers"/>, <see cref="Encoding"/>, <see cref="Base64"/>,
+    /// <see cref="StructuredClone"/> and <see cref="Files"/>; it grows as further features land, and never
+    /// comes to include fetch.
+    /// </summary>
+    Default = Console | Timers | Encoding | Base64 | StructuredClone | Files,
 }
 #endif

--- a/Jint/Runtime/Intrinsics.WebApi.cs
+++ b/Jint/Runtime/Intrinsics.WebApi.cs
@@ -5,6 +5,7 @@ using Jint.WebApi.DomException;
 using Jint.WebApi.Encoding;
 using Jint.WebApi.StructuredClone;
 using Jint.WebApi.Timers;
+using Jint.WebApi.Files;
 
 namespace Jint.Runtime;
 
@@ -55,5 +56,21 @@ public sealed partial class Intrinsics
 
     internal StructuredCloneFunction StructuredClone =>
         _structuredClone ??= new StructuredCloneFunction(_engine, _realm, Function.PrototypeObject);
+    private BlobConstructor? _blob;
+    private FileConstructor? _file;
+    private FormDataConstructor? _formData;
+    private FormDataIteratorPrototype? _formDataIteratorPrototype;
+
+    internal BlobConstructor Blob =>
+        _blob ??= new BlobConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
+
+    internal FileConstructor File =>
+        _file ??= new FileConstructor(_engine, _realm, Blob);
+
+    internal FormDataConstructor FormData =>
+        _formData ??= new FormDataConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
+
+    internal FormDataIteratorPrototype FormDataIteratorPrototype =>
+        _formDataIteratorPrototype ??= new FormDataIteratorPrototype(_engine, _realm, IteratorPrototype);
 }
 #endif

--- a/Jint/WebApi/Files/BlobConstructor.cs
+++ b/Jint/WebApi/Files/BlobConstructor.cs
@@ -1,0 +1,67 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Files;
+
+/// <summary>
+/// The <c>Blob</c> interface object.
+/// <para>
+/// https://w3c.github.io/FileAPI/#dfn-Blob
+/// </para>
+/// </summary>
+/// <remarks>
+/// <c>constructor(optional sequence&lt;BlobPart&gt; blobParts, optional BlobPropertyBag options = {})</c>.
+/// Called without <c>new</c> it raises a <c>TypeError</c>, which is what <see cref="Constructor"/> already
+/// does for every interface object shape.
+/// </remarks>
+internal sealed class BlobConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("Blob");
+
+    internal BlobConstructor(
+        Engine engine,
+        Realm realm,
+        FunctionPrototype functionPrototype,
+        ObjectPrototype objectPrototype)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = functionPrototype;
+        PrototypeObject = new BlobPrototype(engine, realm, this, objectPrototype);
+        _length = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal BlobPrototype PrototypeObject { get; }
+
+    /// <summary>
+    /// https://w3c.github.io/FileAPI/#constructorBlob
+    /// </summary>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        if (newTarget.IsUndefined())
+        {
+            Throw.TypeError(_realm, $"Constructor {GetOwnFunctionNameForMessage()} requires 'new'");
+        }
+
+        // blobParts is optional with no default value, so an explicitly passed `undefined` means the
+        // argument is missing rather than something to convert — https://webidl.spec.whatwg.org/#es-overloads.
+        // The options are still read, which is why this is not the whole of step 1.
+        var blobParts = arguments.At(0);
+
+        // Arguments are converted left to right, so the sequence is drained — and every element that is
+        // neither a buffer source nor a blob stringified — before the options dictionary is read.
+        var bytes = blobParts.IsUndefined() ? [] : FileApi.ProcessBlobParts(_realm, blobParts);
+        var type = FileApi.ReadBlobPropertyBag(_realm, arguments.At(1));
+
+        return OrdinaryCreateFromConstructor(
+            newTarget,
+            static intrinsics => intrinsics.Blob.PrototypeObject,
+            static (Engine engine, Realm _, (byte[] Bytes, string Type) state) => new JsBlob(engine, state.Bytes, state.Type),
+            (Bytes: bytes, Type: type));
+    }
+}
+#endif

--- a/Jint/WebApi/Files/BlobPrototype.cs
+++ b/Jint/WebApi/Files/BlobPrototype.cs
@@ -1,0 +1,214 @@
+#if NET8_0_OR_GREATER
+using SystemEncoding = System.Text.Encoding;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Native.Promise;
+using Jint.Native.TypedArray;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Files;
+
+/// <summary>
+/// <c>Blob.prototype</c> — the interface prototype object.
+/// <para>
+/// https://w3c.github.io/FileAPI/#dfn-Blob
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>size</c> and <c>type</c> are accessors here rather than own properties of the instance, as WebIDL
+/// specifies attributes; each brand-checks its receiver and raises a <c>TypeError</c> for anything that is
+/// not a <c>Blob</c> — including <c>Blob.prototype</c> itself, which is not one.
+/// </para>
+/// <para>
+/// <c>stream()</c> and <c>textStream()</c> are <b>absent</b>, not throwing: Jint has no streams yet, and an
+/// absent method is what feature detection is written against. <c>text()</c>, <c>arrayBuffer()</c> and
+/// <c>bytes()</c> are the whole of the read surface, and each answers an already-resolved promise — the
+/// bytes are in memory, so there is nothing for an event-loop turn to wait for. They are still real
+/// promises: <c>await blob.text()</c> works exactly as it does in a browser, and the value arrives on the
+/// microtask turn a <c>then</c> would give it.
+/// </para>
+/// <para>
+/// One documented simplification against WebIDL: the operations are non-enumerable, where a WebIDL
+/// interface prototype object's operations are enumerable. That is how every built-in Jint has ever shipped
+/// declares its prototype methods, and it is observable only to code inspecting property attributes.
+/// </para>
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class BlobPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly BlobConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString BlobToStringTag = new("Blob");
+
+    internal BlobPrototype(
+        Engine engine,
+        Realm realm,
+        BlobConstructor constructor,
+        ObjectInstance objectPrototype) : base(engine, realm)
+    {
+        _prototype = objectPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/FileAPI/#dfn-size
+    /// </summary>
+    [JsAccessor("size", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsNumber SizeGet(JsValue thisObject)
+    {
+        return JsNumber.Create(Brand(thisObject).Data.Length);
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/FileAPI/#dfn-type
+    /// </summary>
+    [JsAccessor("type", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsString TypeGet(JsValue thisObject)
+    {
+        return JsString.Create(Brand(thisObject).MediaType);
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/FileAPI/#slice-method-algo, which delegates to the slice blob algorithm,
+    /// https://w3c.github.io/FileAPI/#slice-blob.
+    /// </summary>
+    /// <remarks>
+    /// The result is always a <c>Blob</c>, never a <c>File</c>: the algorithm says "a new Blob object",
+    /// and a slice of a file has no name to carry. The bytes are shared with the receiver rather than
+    /// copied, which a blob's immutability makes safe.
+    /// </remarks>
+    [JsFunction(Name = "slice", Length = 0)]
+    private JsBlob Slice(JsValue thisObject, JsValue start, JsValue end, JsValue contentType)
+    {
+        var blob = Brand(thisObject);
+        var originalSize = blob.Data.Length;
+
+        // Every optional argument here has no default value, so an explicitly passed `undefined` means the
+        // argument is missing — `blob.slice(0, undefined)` slices to the end, it does not slice to zero.
+        var relativeStart = start.IsUndefined()
+            ? 0
+            : Relative(FileApi.ToClampedLongLong(start), originalSize);
+
+        var relativeEnd = end.IsUndefined()
+            ? originalSize
+            : Relative(FileApi.ToClampedLongLong(end), originalSize);
+
+        var relativeContentType = contentType.IsUndefined()
+            ? string.Empty
+            : FileApi.NormalizeMediaType(TypeConverter.ToString(contentType));
+
+        var span = System.Math.Max(relativeEnd - relativeStart, 0);
+
+        return new JsBlob(_engine, blob.Data.Slice(relativeStart, span), relativeContentType)
+        {
+            _prototype = _realm.Intrinsics.Blob.PrototypeObject,
+        };
+    }
+
+    /// <summary>
+    /// The normalization both the start and the end parameter get: a negative value counts back from the
+    /// end, and either direction clamps into <c>[0, originalSize]</c>.
+    /// </summary>
+    private static int Relative(long value, int originalSize)
+    {
+        if (value < 0)
+        {
+            return (int) System.Math.Max(originalSize + value, 0);
+        }
+
+        return (int) System.Math.Min(value, originalSize);
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/FileAPI/#text-method-algo
+    /// </summary>
+    /// <remarks>
+    /// The fulfillment value is the UTF-8 decode of the bytes, which is BOM-stripping and lenient: an
+    /// ill-formed sequence becomes U+FFFD rather than rejecting — https://encoding.spec.whatwg.org/#utf-8-decode.
+    /// </remarks>
+    [JsFunction(Name = "text", Length = 0)]
+    private JsValue Text(JsValue thisObject)
+    {
+        var data = Brand(thisObject).Data.Span;
+
+        // UTF-8 decode: strip one leading BOM, then decode without it.
+        if (data.Length >= 3 && data[0] == 0xEF && data[1] == 0xBB && data[2] == 0xBF)
+        {
+            data = data.Slice(3);
+        }
+
+        return Resolved(JsString.Create(SystemEncoding.UTF8.GetString(data)));
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/FileAPI/#arraybuffer-method-algo
+    /// </summary>
+    [JsFunction(Name = "arrayBuffer", Length = 0)]
+    private JsValue ArrayBuffer(JsValue thisObject)
+    {
+        return Resolved(NewArrayBuffer(Brand(thisObject)));
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/FileAPI/#bytes-method-algo
+    /// </summary>
+    [JsFunction(Name = "bytes", Length = 0)]
+    private JsValue Bytes(JsValue thisObject)
+    {
+        var blob = Brand(thisObject);
+        var uint8Array = _realm.Intrinsics.Uint8Array;
+        var array = uint8Array.AllocateTypedArray(uint8Array, (uint) blob.Data.Length);
+        TypedArrayConstructor.FillTypedArrayInstance(array, blob.Data.Span);
+        return Resolved(array);
+    }
+
+    /// <summary>
+    /// A blob's bytes always cross into script through a fresh <c>ArrayBuffer</c>: script may write to what
+    /// it is handed, and a blob is immutable.
+    /// </summary>
+    private JsArrayBuffer NewArrayBuffer(JsBlob blob)
+    {
+        return new JsArrayBuffer(_engine, blob.Data.ToArray())
+        {
+            _prototype = _realm.Intrinsics.ArrayBuffer.PrototypeObject,
+        };
+    }
+
+    /// <summary>
+    /// A promise that is already fulfilled with <paramref name="value"/>. Every read method returns one:
+    /// the data is in memory, so nothing is waiting on the event loop, but the method still has to answer
+    /// a real promise a script can <c>await</c> or chain.
+    /// </summary>
+    private JsValue Resolved(JsValue value)
+    {
+        var capability = PromiseConstructor.NewPromiseCapability(_engine, _realm.Intrinsics.Promise);
+        capability.Resolve(value);
+        return capability.PromiseInstance;
+    }
+
+    /// <summary>
+    /// The WebIDL brand check every member performs: a receiver that is not a platform object implementing
+    /// the interface raises a <c>TypeError</c>.
+    /// </summary>
+    private JsBlob Brand(JsValue thisObject)
+    {
+        if (thisObject is JsBlob blob)
+        {
+            return blob;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a Blob");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Files/FileApi.cs
+++ b/Jint/WebApi/Files/FileApi.cs
@@ -1,0 +1,393 @@
+#if NET8_0_OR_GREATER
+using System.Buffers;
+using SystemEncoding = System.Text.Encoding;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Native.TypedArray;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Files;
+
+/// <summary>
+/// The pieces of the File API that several of its interfaces share: the byte-sequence builder behind the
+/// <c>Blob</c> and <c>File</c> constructors, the media-type normalization both of them and
+/// <c>Blob.slice</c> perform, and the WebIDL scalar conversions their arguments declare.
+/// <para>
+/// https://w3c.github.io/FileAPI/
+/// </para>
+/// </summary>
+internal static class FileApi
+{
+    /// <summary>
+    /// The name a bare <c>Blob</c> is given when <c>FormData</c> wraps it into a <c>File</c>.
+    /// <para>
+    /// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#create-an-entry
+    /// </para>
+    /// </summary>
+    internal const string DefaultBlobFileName = "blob";
+
+    private const string EndingsTransparent = "transparent";
+    private const string EndingsNative = "native";
+
+    /// <summary>
+    /// Processing blob parts, https://w3c.github.io/FileAPI/#process-blob-parts, fused with the WebIDL
+    /// conversion of the <c>sequence&lt;BlobPart&gt;</c> argument that feeds it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The two are fused because the conversion is what makes each element a <c>BufferSource</c>, a
+    /// <c>Blob</c> or a <c>USVString</c>, and that is observable: an element that is none of the first two
+    /// reaches <c>toString</c>, and it does so while the sequence is being drained — before the options
+    /// dictionary's members are read. Doing it in one pass keeps that order without materializing the
+    /// intermediate sequence.
+    /// </para>
+    /// <para>
+    /// A <c>SharedArrayBuffer</c> is deliberately not a <c>BufferSource</c> — the typedef covers
+    /// <c>ArrayBuffer</c> and the views, and sharing is only admitted where <c>[AllowShared]</c> says so,
+    /// which <c>BlobPart</c> does not. It therefore falls through to the <c>USVString</c> arm and is
+    /// stringified, exactly as in a browser.
+    /// </para>
+    /// </remarks>
+    internal static byte[] ProcessBlobParts(Realm realm, JsValue parts)
+    {
+        // WebIDL sequence conversion: anything that is not an object cannot be one, and that includes a
+        // bare string — `new Blob("abc")` is a TypeError, not a one-character-per-element blob.
+        if (parts is not ObjectInstance)
+        {
+            Throw.TypeError(realm, "The provided value cannot be converted to a sequence");
+        }
+
+        var writer = new ArrayBufferWriter<byte>();
+        var iterator = parts.GetIterator(realm);
+        while (iterator.TryIteratorStepValue(out var element))
+        {
+            AppendBlobPart(writer, element);
+        }
+
+        return writer.WrittenSpan.ToArray();
+    }
+
+    private static void AppendBlobPart(ArrayBufferWriter<byte> writer, JsValue element)
+    {
+        switch (element)
+        {
+            // A detached buffer holds no bytes to copy, so it contributes none. Nothing here can observe
+            // the difference between that and an empty buffer.
+            case JsArrayBuffer { IsSharedArrayBuffer: false } buffer:
+                Append(writer, buffer.ArrayBufferData.AsSpan());
+                return;
+
+            case JsTypedArray typedArray:
+                Append(writer, ViewBytes(typedArray));
+                return;
+
+            case JsDataView dataView:
+                Append(writer, ViewBytes(dataView));
+                return;
+
+            case JsBlob blob:
+                Append(writer, blob.Data.Span);
+                return;
+
+            default:
+                AppendUtf8(writer, TypeConverter.ToString(element));
+                return;
+        }
+    }
+
+    private static ReadOnlySpan<byte> ViewBytes(JsTypedArray typedArray)
+    {
+        var data = typedArray._viewedArrayBuffer.ArrayBufferData;
+        if (data is null)
+        {
+            return default;
+        }
+
+        // Length answers 0 for a view that has gone out of bounds over a resizable buffer, but the offset
+        // it was created with can still be past the end of the shrunken block, so clamp both.
+        var offset = System.Math.Min(typedArray._byteOffset, data.Length);
+        var byteLength = System.Math.Min((int) typedArray.Length * typedArray._arrayElementType.GetElementSize(), data.Length - offset);
+        return data.AsSpan(offset, byteLength);
+    }
+
+    private static ReadOnlySpan<byte> ViewBytes(JsDataView dataView)
+    {
+        var buffer = dataView._viewedArrayBuffer;
+        var data = buffer?.ArrayBufferData;
+        if (data is null)
+        {
+            return default;
+        }
+
+        // A resizable buffer may have shrunk under the view since it was created; clamp rather than
+        // trusting the recorded extent.
+        var offset = (int) System.Math.Min(dataView._byteOffset, (uint) data.Length);
+        var length = (int) System.Math.Min(dataView._byteLength, (uint) (data.Length - offset));
+        return data.AsSpan(offset, length);
+    }
+
+    private static void Append(ArrayBufferWriter<byte> writer, ReadOnlySpan<byte> bytes)
+    {
+        if (!bytes.IsEmpty)
+        {
+            writer.Write(bytes);
+        }
+    }
+
+    /// <summary>
+    /// UTF-8 encoding of a USVString. <see cref="System.Text.Encoding.UTF8"/> substitutes U+FFFD for an unpaired
+    /// surrogate, which is exactly the scalar-value-string conversion the argument's USVString type asks
+    /// for, so no separate pass is needed here.
+    /// </summary>
+    private static void AppendUtf8(ArrayBufferWriter<byte> writer, string value)
+    {
+        if (value.Length == 0)
+        {
+            return;
+        }
+
+        var byteCount = SystemEncoding.UTF8.GetByteCount(value);
+        var destination = writer.GetSpan(byteCount);
+        var written = SystemEncoding.UTF8.GetBytes(value.AsSpan(), destination);
+        writer.Advance(written);
+    }
+
+    /// <summary>
+    /// Reads a <c>BlobPropertyBag</c> and answers the normalized <c>type</c> it carries.
+    /// <para>
+    /// https://w3c.github.io/FileAPI/#dfn-BlobPropertyBag
+    /// </para>
+    /// </summary>
+    internal static string ReadBlobPropertyBag(Realm realm, JsValue options)
+    {
+        var dictionary = ToDictionary(realm, options);
+        if (dictionary is null)
+        {
+            return string.Empty;
+        }
+
+        // Dictionary members are converted in lexicographical order of their identifiers, so a bag whose
+        // members are getters observes `endings` before `type`.
+        ReadEndings(realm, dictionary);
+        return ReadType(dictionary);
+    }
+
+    /// <summary>
+    /// Reads a <c>FilePropertyBag</c>: the inherited <c>BlobPropertyBag</c> members and then
+    /// <c>lastModified</c>, which is absent rather than defaulted when the member is not given.
+    /// <para>
+    /// https://w3c.github.io/FileAPI/#dfn-FilePropertyBag
+    /// </para>
+    /// </summary>
+    internal static string ReadFilePropertyBag(Realm realm, JsValue options, out long? lastModified)
+    {
+        lastModified = null;
+
+        var dictionary = ToDictionary(realm, options);
+        if (dictionary is null)
+        {
+            return string.Empty;
+        }
+
+        // Inherited members come first, then the derived dictionary's own — so `endings`, `type`,
+        // `lastModified`.
+        ReadEndings(realm, dictionary);
+        var type = ReadType(dictionary);
+
+        var value = dictionary.Get("lastModified");
+        if (!value.IsUndefined())
+        {
+            lastModified = ToLongLong(value);
+        }
+
+        return type;
+    }
+
+    /// <summary>
+    /// WebIDL dictionary conversion: <see langword="null"/> and <c>undefined</c> mean "every member
+    /// defaulted", and anything that is not an object is a <c>TypeError</c>.
+    /// <para>
+    /// https://webidl.spec.whatwg.org/#es-dictionary
+    /// </para>
+    /// </summary>
+    private static ObjectInstance? ToDictionary(Realm realm, JsValue options)
+    {
+        if (options.IsUndefined() || options.IsNull())
+        {
+            return null;
+        }
+
+        if (options is not ObjectInstance dictionary)
+        {
+            Throw.TypeError(realm, "The provided value is not of type 'BlobPropertyBag'");
+            return null;
+        }
+
+        return dictionary;
+    }
+
+    /// <summary>
+    /// Validates the <c>EndingType</c> enumeration member and then discards it.
+    /// </summary>
+    /// <remarks>
+    /// An unknown string is a <c>TypeError</c>, which is what a WebIDL enumeration conversion does; but
+    /// <c>"native"</c> is honoured as a synonym for <c>"transparent"</c> rather than rewriting line
+    /// endings. Jint is embedded, not run on a desktop: the "underlying platform's conventions" a browser
+    /// appeals to would here be the conventions of whatever machine happens to host the embedder, so
+    /// honouring it would make the bytes of a blob — and therefore a hash, a signature, a request body —
+    /// depend on the host operating system. A script that wants CRLF can write it.
+    /// </remarks>
+    private static void ReadEndings(Realm realm, ObjectInstance dictionary)
+    {
+        var value = dictionary.Get("endings");
+        if (value.IsUndefined())
+        {
+            return;
+        }
+
+        var endings = TypeConverter.ToString(value);
+        if (!string.Equals(endings, EndingsTransparent, StringComparison.Ordinal)
+            && !string.Equals(endings, EndingsNative, StringComparison.Ordinal))
+        {
+            Throw.TypeError(realm, "The provided value '" + endings + "' is not a valid enum value of type EndingType");
+        }
+    }
+
+    private static string ReadType(ObjectInstance dictionary)
+    {
+        var value = dictionary.Get("type");
+        return value.IsUndefined() ? string.Empty : NormalizeMediaType(TypeConverter.ToString(value));
+    }
+
+    /// <summary>
+    /// The media-type normalization the <c>Blob</c> constructor and <c>slice</c> both perform: a type
+    /// carrying anything outside U+0020 to U+007E is replaced by the empty string, and what survives is
+    /// ASCII-lowercased.
+    /// <para>
+    /// https://w3c.github.io/FileAPI/#constructorBlob
+    /// </para>
+    /// </summary>
+    internal static string NormalizeMediaType(string type)
+    {
+        foreach (var c in type)
+        {
+            if (c is < ' ' or > '~')
+            {
+                return string.Empty;
+            }
+        }
+
+        // Every code point is ASCII by the loop above, so the invariant lowercase is the ASCII lowercase
+        // the specification asks for.
+        return type.ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// The WebIDL scalar value string conversion — every unpaired surrogate becomes U+FFFD.
+    /// <para>
+    /// https://webidl.spec.whatwg.org/#idl-USVString
+    /// </para>
+    /// </summary>
+    internal static string ToScalarValueString(string value)
+    {
+        var index = IndexOfSurrogate(value, 0);
+        if (index < 0)
+        {
+            return value;
+        }
+
+        var buffer = value.ToCharArray();
+        while (index >= 0)
+        {
+            var c = buffer[index];
+            if (char.IsHighSurrogate(c) && index + 1 < buffer.Length && char.IsLowSurrogate(buffer[index + 1]))
+            {
+                // A well-formed pair is one scalar value; skip past both halves.
+                index = IndexOfSurrogate(buffer, index + 2);
+                continue;
+            }
+
+            buffer[index] = '\uFFFD';
+            index = IndexOfSurrogate(buffer, index + 1);
+        }
+
+        return new string(buffer);
+    }
+
+    private static int IndexOfSurrogate(ReadOnlySpan<char> value, int start)
+    {
+        for (var i = start; i < value.Length; i++)
+        {
+            if (char.IsSurrogate(value[i]))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// The WebIDL <c>long long</c> conversion: truncate towards zero and wrap modulo 2^64 into the signed
+    /// range, with every non-finite value becoming zero.
+    /// <para>
+    /// https://webidl.spec.whatwg.org/#idl-long-long
+    /// </para>
+    /// </summary>
+    internal static long ToLongLong(JsValue value)
+    {
+        const double TwoPow64 = 18446744073709551616.0;
+        const double TwoPow63 = 9223372036854775808.0;
+
+        var number = TypeConverter.ToNumber(value);
+        if (!double.IsFinite(number))
+        {
+            return 0;
+        }
+
+        // The remainder is exact, and so is each of the two corrections: at those magnitudes both operands
+        // are multiples of the same power of two, and the result is smaller than either. Folding the
+        // negative half through [0, 2^64) instead would not be — 2^64 − 1 is not a representable double, so
+        // −1 would come back as 0.
+        number = System.Math.Truncate(number) % TwoPow64;
+        if (number >= TwoPow63)
+        {
+            number -= TwoPow64;
+        }
+        else if (number < -TwoPow63)
+        {
+            number += TwoPow64;
+        }
+
+        return (long) number;
+    }
+
+    /// <summary>
+    /// The WebIDL <c>[Clamp] long long</c> conversion: NaN is zero, an out-of-range value saturates
+    /// rather than wrapping, and a fractional value rounds to even.
+    /// <para>
+    /// https://webidl.spec.whatwg.org/#Clamp
+    /// </para>
+    /// </summary>
+    internal static long ToClampedLongLong(JsValue value)
+    {
+        var number = TypeConverter.ToNumber(value);
+        if (double.IsNaN(number))
+        {
+            return 0;
+        }
+
+        if (number <= long.MinValue)
+        {
+            return long.MinValue;
+        }
+
+        if (number >= long.MaxValue)
+        {
+            return long.MaxValue;
+        }
+
+        return (long) System.Math.Round(number, MidpointRounding.ToEven);
+    }
+}
+#endif

--- a/Jint/WebApi/Files/FileConstructor.cs
+++ b/Jint/WebApi/Files/FileConstructor.cs
@@ -1,0 +1,79 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Files;
+
+/// <summary>
+/// The <c>File</c> interface object.
+/// <para>
+/// https://w3c.github.io/FileAPI/#file-constructor
+/// </para>
+/// </summary>
+/// <remarks>
+/// <c>constructor(sequence&lt;BlobPart&gt; fileBits, USVString fileName, optional FilePropertyBag options = {})</c>.
+/// The first two arguments are required, so fewer than two is a <c>TypeError</c> before anything is read.
+/// <c>File</c> inherits <c>Blob</c>, so this interface object's <c>[[Prototype]]</c> is the <c>Blob</c>
+/// interface object and <c>File.prototype</c>'s is <c>Blob.prototype</c> —
+/// https://webidl.spec.whatwg.org/#interface-object.
+/// </remarks>
+internal sealed class FileConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("File");
+
+    internal FileConstructor(
+        Engine engine,
+        Realm realm,
+        BlobConstructor blobConstructor)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = blobConstructor;
+        PrototypeObject = new FilePrototype(engine, realm, this, blobConstructor.PrototypeObject);
+        _length = new PropertyDescriptor(JsNumber.Create(2), PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal FilePrototype PrototypeObject { get; }
+
+    /// <summary>
+    /// https://w3c.github.io/FileAPI/#file-constructor
+    /// </summary>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        if (newTarget.IsUndefined())
+        {
+            Throw.TypeError(_realm, $"Constructor {GetOwnFunctionNameForMessage()} requires 'new'");
+        }
+
+        if (arguments.Length < 2)
+        {
+            Throw.TypeError(_realm, "File constructor: At least 2 arguments required, but only " + arguments.Length + " passed");
+        }
+
+        var bytes = FileApi.ProcessBlobParts(_realm, arguments.At(0));
+        var name = FileApi.ToScalarValueString(TypeConverter.ToString(arguments.At(1)));
+        var type = FileApi.ReadFilePropertyBag(_realm, arguments.At(2), out var lastModified);
+
+        return OrdinaryCreateFromConstructor(
+            newTarget,
+            static intrinsics => intrinsics.File.PrototypeObject,
+            static (Engine engine, Realm _, (byte[] Bytes, string Type, string Name, long LastModified) state)
+                => new JsFile(engine, state.Bytes, state.Type, state.Name, state.LastModified),
+            (Bytes: bytes, Type: type, Name: name, LastModified: lastModified ?? Now(_engine)));
+    }
+
+    /// <summary>
+    /// The <c>lastModified</c> default: "the current date and time represented as the number of
+    /// milliseconds since the Unix Epoch (which is the equivalent of <c>Date.now()</c>)". It is read from
+    /// the engine's own <c>ITimeSystem</c>, so it is the same clock <c>Date.now()</c> answers from and a
+    /// host that supplied a fixed one gets a fixed value here.
+    /// </summary>
+    internal static long Now(Engine engine)
+    {
+        var ticks = engine.Options.TimeSystem.GetUtcNow().UtcTicks - DateTime.UnixEpoch.Ticks;
+        return ticks / TimeSpan.TicksPerMillisecond;
+    }
+}
+#endif

--- a/Jint/WebApi/Files/FilePrototype.cs
+++ b/Jint/WebApi/Files/FilePrototype.cs
@@ -1,0 +1,74 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Files;
+
+/// <summary>
+/// <c>File.prototype</c> — the interface prototype object.
+/// <para>
+/// https://w3c.github.io/FileAPI/#file-section
+/// </para>
+/// </summary>
+/// <remarks>
+/// Its <c>[[Prototype]]</c> is <c>Blob.prototype</c>, which is what makes <c>file instanceof Blob</c> hold
+/// and what gives a file <c>size</c>, <c>type</c>, <c>slice</c> and the read methods. Only <c>name</c> and
+/// <c>lastModified</c> are declared here, both brand-checked against <c>File</c> rather than <c>Blob</c>:
+/// a plain blob has no name.
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class FilePrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly FileConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString FileToStringTag = new("File");
+
+    internal FilePrototype(
+        Engine engine,
+        Realm realm,
+        FileConstructor constructor,
+        BlobPrototype blobPrototype) : base(engine, realm)
+    {
+        _prototype = blobPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/FileAPI/#dfn-name
+    /// </summary>
+    [JsAccessor("name", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsString NameGet(JsValue thisObject)
+    {
+        return JsString.Create(Brand(thisObject).Name);
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/FileAPI/#dfn-lastModified
+    /// </summary>
+    [JsAccessor("lastModified", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsNumber LastModifiedGet(JsValue thisObject)
+    {
+        return JsNumber.Create(Brand(thisObject).LastModified);
+    }
+
+    private JsFile Brand(JsValue thisObject)
+    {
+        if (thisObject is JsFile file)
+        {
+            return file;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a File");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Files/FormDataConstructor.cs
+++ b/Jint/WebApi/Files/FormDataConstructor.cs
@@ -1,0 +1,64 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Files;
+
+/// <summary>
+/// The <c>FormData</c> interface object.
+/// <para>
+/// https://xhr.spec.whatwg.org/#interface-formdata
+/// </para>
+/// </summary>
+/// <remarks>
+/// The IDL constructor is <c>constructor(optional HTMLFormElement form, optional HTMLElement? submitter = null)</c>,
+/// and neither argument can mean anything here: there is no DOM, so there is no form to scrape an entry
+/// list from. Rather than ignore an argument a script passed in earnest — which would hand back a silently
+/// empty <c>FormData</c> — a non-<c>undefined</c> first argument raises a <c>TypeError</c>. That is the
+/// shape WinterTC's Minimum Common Web Platform API describes for a runtime without a DOM.
+/// </remarks>
+internal sealed class FormDataConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("FormData");
+
+    internal FormDataConstructor(
+        Engine engine,
+        Realm realm,
+        FunctionPrototype functionPrototype,
+        ObjectPrototype objectPrototype)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = functionPrototype;
+        PrototypeObject = new FormDataPrototype(engine, realm, this, objectPrototype);
+        _length = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal FormDataPrototype PrototypeObject { get; }
+
+    /// <summary>
+    /// https://xhr.spec.whatwg.org/#dom-formdata
+    /// </summary>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        if (newTarget.IsUndefined())
+        {
+            Throw.TypeError(_realm, $"Constructor {GetOwnFunctionNameForMessage()} requires 'new'");
+        }
+
+        if (!arguments.At(0).IsUndefined())
+        {
+            Throw.TypeError(_realm, "FormData constructor: the form argument is not supported, there is no DOM");
+        }
+
+        return OrdinaryCreateFromConstructor(
+            newTarget,
+            static intrinsics => intrinsics.FormData.PrototypeObject,
+            static (Engine engine, Realm _, object? _) => new JsFormData(engine),
+            state: null);
+    }
+}
+#endif

--- a/Jint/WebApi/Files/FormDataIteratorPrototype.cs
+++ b/Jint/WebApi/Files/FormDataIteratorPrototype.cs
@@ -1,0 +1,111 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Iterator;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Files;
+
+/// <summary>
+/// <c>%FormDataIteratorPrototype%</c> — the default iterator object prototype a WebIDL
+/// <c>iterable&lt;&gt;</c> declaration produces.
+/// <para>
+/// https://webidl.spec.whatwg.org/#es-iterator-prototype-object
+/// </para>
+/// </summary>
+/// <remarks>
+/// Its <c>[[Prototype]]</c> is <c>%IteratorPrototype%</c> and its <c>@@toStringTag</c> is the interface's
+/// name followed by <c>" Iterator"</c>, both as the specification prescribes. It is not reachable from any
+/// global: the only way to obtain one is to call <c>entries</c>, <c>keys</c> or <c>values</c>.
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class FormDataIteratorPrototype : IteratorPrototype
+{
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString FormDataIteratorToStringTag = new("FormData Iterator");
+
+    internal FormDataIteratorPrototype(
+        Engine engine,
+        Realm realm,
+        IteratorPrototype iteratorPrototype) : base(engine, realm, iteratorPrototype)
+    {
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    [JsFunction(Name = "next")]
+    private JsValue NextHandler(JsValue thisObject) => Next(thisObject, Arguments.Empty);
+
+    internal FormDataIterator ConstructEntryIterator(JsFormData formData)
+        => Construct(formData, FormDataIteratorKind.KeyAndValue);
+
+    internal FormDataIterator ConstructKeyIterator(JsFormData formData)
+        => Construct(formData, FormDataIteratorKind.Key);
+
+    internal FormDataIterator ConstructValueIterator(JsFormData formData)
+        => Construct(formData, FormDataIteratorKind.Value);
+
+    private FormDataIterator Construct(JsFormData formData, FormDataIteratorKind kind)
+    {
+        return new FormDataIterator(Engine, formData, kind)
+        {
+            _prototype = this,
+        };
+    }
+}
+
+internal enum FormDataIteratorKind
+{
+    Key,
+    Value,
+    KeyAndValue,
+}
+
+/// <summary>
+/// The default iterator object's stepping: an index into the <b>live</b> entry list, re-read on every step.
+/// That is what the specification describes — the list of value pairs to iterate over is evaluated per step
+/// — so an entry appended during iteration is reached, and one removed before its turn is not.
+/// <para>
+/// https://webidl.spec.whatwg.org/#es-iterator-prototype-object
+/// </para>
+/// </summary>
+internal sealed class FormDataIterator : IteratorInstance
+{
+    private readonly JsFormData _formData;
+    private readonly FormDataIteratorKind _kind;
+    private int _position;
+
+    internal FormDataIterator(Engine engine, JsFormData formData, FormDataIteratorKind kind) : base(engine)
+    {
+        _formData = formData;
+        _kind = kind;
+    }
+
+    public override bool TryIteratorStep(out ObjectInstance nextItem)
+    {
+        var entries = _formData.Entries;
+        if (_position >= entries.Count)
+        {
+            nextItem = IteratorResult.CreateKeyValueIteratorPosition(_engine);
+            return false;
+        }
+
+        var entry = entries[_position];
+        _position++;
+
+        nextItem = _kind switch
+        {
+            FormDataIteratorKind.Key => IteratorResult.CreateValueIteratorPosition(_engine, JsString.Create(entry.Name)),
+            FormDataIteratorKind.Value => IteratorResult.CreateValueIteratorPosition(_engine, entry.Value),
+            _ => IteratorResult.CreateKeyValueIteratorPosition(_engine, JsString.Create(entry.Name), entry.Value),
+        };
+
+        return true;
+    }
+}
+#endif

--- a/Jint/WebApi/Files/FormDataPrototype.cs
+++ b/Jint/WebApi/Files/FormDataPrototype.cs
@@ -1,0 +1,281 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Array;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Files;
+
+/// <summary>
+/// <c>FormData.prototype</c> — the interface prototype object.
+/// <para>
+/// https://xhr.spec.whatwg.org/#interface-formdata
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// The IDL declares <c>iterable&lt;USVString, FormDataEntryValue&gt;</c>, which is what gives the interface
+/// <c>entries</c>, <c>keys</c>, <c>values</c>, <c>forEach</c> and an <c>@@iterator</c> that is the very same
+/// function object as <c>entries</c> — https://webidl.spec.whatwg.org/#es-iterable.
+/// </para>
+/// <para>
+/// <c>append</c> and <c>set</c> are overloaded on their second argument: a <c>Blob</c> takes the
+/// three-argument form, anything else the two-argument string form. Passing a filename therefore <i>is</i>
+/// choosing the blob overload, so <c>fd.append('a', 'b', 'c')</c> is a <c>TypeError</c> — exactly as in a
+/// browser — while <c>fd.append('a', 'b', undefined)</c> is not, because a trailing <c>undefined</c> for an
+/// optional argument with no default value means the argument was not passed.
+/// </para>
+/// </remarks>
+[JsSymbolAlias("Iterator", "entries")]
+[JsObject(UseShape = true)]
+internal sealed partial class FormDataPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly FormDataConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString FormDataToStringTag = new("FormData");
+
+    internal FormDataPrototype(
+        Engine engine,
+        Realm realm,
+        FormDataConstructor constructor,
+        ObjectInstance objectPrototype) : base(engine, realm)
+    {
+        _prototype = objectPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://xhr.spec.whatwg.org/#dom-formdata-append
+    /// </summary>
+    [JsFunction(Name = "append", Length = 2)]
+    private JsValue Append(JsValue thisObject, JsValue name, JsValue value, JsValue filename)
+    {
+        var formData = Brand(thisObject);
+        formData.Entries.Add(CreateEntry(name, value, filename));
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://xhr.spec.whatwg.org/#dom-formdata-delete
+    /// </summary>
+    [JsFunction(Name = "delete", Length = 1)]
+    private JsValue Delete(JsValue thisObject, JsValue name)
+    {
+        var formData = Brand(thisObject);
+        var key = Name(name);
+
+        var entries = formData.Entries;
+        for (var i = entries.Count - 1; i >= 0; i--)
+        {
+            if (string.Equals(entries[i].Name, key, StringComparison.Ordinal))
+            {
+                entries.RemoveAt(i);
+            }
+        }
+
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://xhr.spec.whatwg.org/#dom-formdata-get
+    /// </summary>
+    [JsFunction(Name = "get", Length = 1)]
+    private JsValue GetEntry(JsValue thisObject, JsValue name)
+    {
+        var formData = Brand(thisObject);
+        var index = formData.IndexOf(Name(name));
+        return index < 0 ? Null : formData.Entries[index].Value;
+    }
+
+    /// <summary>
+    /// https://xhr.spec.whatwg.org/#dom-formdata-getall
+    /// </summary>
+    [JsFunction(Name = "getAll", Length = 1)]
+    private JsArray GetAll(JsValue thisObject, JsValue name)
+    {
+        var formData = Brand(thisObject);
+        var key = Name(name);
+
+        var values = new List<JsValue>();
+        foreach (var entry in formData.Entries)
+        {
+            if (string.Equals(entry.Name, key, StringComparison.Ordinal))
+            {
+                values.Add(entry.Value);
+            }
+        }
+
+        return _realm.Intrinsics.Array.ConstructFast(values);
+    }
+
+    /// <summary>
+    /// https://xhr.spec.whatwg.org/#dom-formdata-has
+    /// </summary>
+    [JsFunction(Name = "has", Length = 1)]
+    private JsBoolean Has(JsValue thisObject, JsValue name)
+    {
+        var formData = Brand(thisObject);
+        return JsBoolean.Create(formData.IndexOf(Name(name)) >= 0);
+    }
+
+    /// <summary>
+    /// https://xhr.spec.whatwg.org/#dom-formdata-set
+    /// </summary>
+    /// <remarks>
+    /// The replacement keeps the first match's position and drops every later one, so <c>set</c> on an
+    /// existing name never moves the entry to the end.
+    /// </remarks>
+    [JsFunction(Name = "set", Length = 2)]
+    private JsValue Set(JsValue thisObject, JsValue name, JsValue value, JsValue filename)
+    {
+        var formData = Brand(thisObject);
+        var entry = CreateEntry(name, value, filename);
+
+        var entries = formData.Entries;
+        var first = formData.IndexOf(entry.Name);
+        if (first < 0)
+        {
+            entries.Add(entry);
+            return Undefined;
+        }
+
+        entries[first] = entry;
+
+        for (var i = entries.Count - 1; i > first; i--)
+        {
+            if (string.Equals(entries[i].Name, entry.Name, StringComparison.Ordinal))
+            {
+                entries.RemoveAt(i);
+            }
+        }
+
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#es-forEach
+    /// </summary>
+    /// <remarks>
+    /// The index is re-read against the live list on every step, which is what lets a callback that appends
+    /// see what it appended and one that deletes shorten the walk.
+    /// </remarks>
+    [JsFunction(Name = "forEach", Length = 1)]
+    private JsValue ForEach(JsValue thisObject, JsValue callbackfn, JsValue thisArg)
+    {
+        var formData = Brand(thisObject);
+        var callable = GetCallable(callbackfn);
+
+        for (var i = 0; i < formData.Entries.Count; i++)
+        {
+            var entry = formData.Entries[i];
+            callable.Call(thisArg, [entry.Value, JsString.Create(entry.Name), thisObject]);
+        }
+
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#es-iterable
+    /// </summary>
+    [JsFunction(Name = "entries", Length = 0)]
+    private FormDataIterator Entries(JsValue thisObject)
+    {
+        return _realm.Intrinsics.FormDataIteratorPrototype.ConstructEntryIterator(Brand(thisObject));
+    }
+
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#es-iterable
+    /// </summary>
+    [JsFunction(Name = "keys", Length = 0)]
+    private FormDataIterator Keys(JsValue thisObject)
+    {
+        return _realm.Intrinsics.FormDataIteratorPrototype.ConstructKeyIterator(Brand(thisObject));
+    }
+
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#es-iterable
+    /// </summary>
+    [JsFunction(Name = "values", Length = 0)]
+    private FormDataIterator Values(JsValue thisObject)
+    {
+        return _realm.Intrinsics.FormDataIteratorPrototype.ConstructValueIterator(Brand(thisObject));
+    }
+
+    /// <summary>
+    /// Creating an entry,
+    /// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#create-an-entry, fused with
+    /// the overload resolution that decides which of <c>append</c>/<c>set</c>'s two signatures was called.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A blob value always becomes a <i>new</i> <c>File</c>, even when it already was one: the algorithm
+    /// says so, and it is what keeps an entry from aliasing a file object the script goes on to hold. The
+    /// name is <c>"blob"</c> for a bare blob, the file's own name when no filename is given, and the
+    /// filename whenever one is. The specification says only "representing the same bytes"; the media type
+    /// and, for a file, the modification time are carried over, which is what every implementation does and
+    /// the only reading under which a round trip through <c>FormData</c> preserves a file.
+    /// </para>
+    /// <para>
+    /// Overload resolution happens first, and it is observable: with three arguments only the blob
+    /// signature exists, so a string value there is a <c>TypeError</c> rather than a silently ignored
+    /// filename.
+    /// </para>
+    /// </remarks>
+    private FormDataEntry CreateEntry(JsValue name, JsValue value, JsValue filename)
+    {
+        var blob = value as JsBlob;
+
+        // Overload resolution precedes every argument conversion, so a value that cannot satisfy the only
+        // three-argument signature fails before the name's toString is ever reached.
+        if (blob is null && !filename.IsUndefined())
+        {
+            Throw.TypeError(_realm, "FormData: parameter 2 is not of type 'Blob', which the three-argument overload requires");
+        }
+
+        // Arguments are then converted left to right.
+        var entryName = Name(name);
+
+        if (blob is null)
+        {
+            return new FormDataEntry(entryName, JsString.Create(FileApi.ToScalarValueString(TypeConverter.ToString(value))));
+        }
+
+        var file = value as JsFile;
+        var entryFileName = filename.IsUndefined()
+            ? file?.Name ?? FileApi.DefaultBlobFileName
+            : FileApi.ToScalarValueString(TypeConverter.ToString(filename));
+
+        var wrapped = new JsFile(_engine, blob.Data, blob.MediaType, entryFileName, file?.LastModified ?? FileConstructor.Now(_engine))
+        {
+            _prototype = _realm.Intrinsics.File.PrototypeObject,
+        };
+
+        return new FormDataEntry(entryName, wrapped);
+    }
+
+    private static string Name(JsValue name) => FileApi.ToScalarValueString(TypeConverter.ToString(name));
+
+    /// <summary>
+    /// The WebIDL brand check every member performs.
+    /// </summary>
+    private JsFormData Brand(JsValue thisObject)
+    {
+        if (thisObject is JsFormData formData)
+        {
+            return formData;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a FormData");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Files/JsBlob.cs
+++ b/Jint/WebApi/Files/JsBlob.cs
@@ -1,0 +1,39 @@
+#if NET8_0_OR_GREATER
+using Jint.Native.Object;
+
+namespace Jint.WebApi.Files;
+
+/// <summary>
+/// A <c>Blob</c> instance: an immutable byte sequence plus the media type it claims to be.
+/// <para>
+/// https://w3c.github.io/FileAPI/#dfn-Blob
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>size</c> and <c>type</c> are WebIDL attributes, so they live in CLR state here and
+/// <see cref="BlobPrototype"/> reads them through a brand check rather than being own properties of the
+/// instance — <c>Object.getOwnPropertyNames(new Blob())</c> is empty, as in a browser.
+/// </para>
+/// <para>
+/// The bytes are held as a <see cref="ReadOnlyMemory{T}"/> and never handed out by reference: a blob is
+/// immutable by specification, so <c>slice</c> takes a window over the very same array instead of copying,
+/// while <c>arrayBuffer</c> and <c>bytes</c> — which hand the bytes to script, where they are mutable —
+/// always copy.
+/// </para>
+/// </remarks>
+internal class JsBlob : ObjectInstance
+{
+    internal JsBlob(Engine engine, ReadOnlyMemory<byte> data, string type) : base(engine, ObjectClass.Object)
+    {
+        Data = data;
+        MediaType = type;
+    }
+
+    /// <summary>The blob's associated byte sequence, https://w3c.github.io/FileAPI/#byte-sequence.</summary>
+    internal ReadOnlyMemory<byte> Data { get; }
+
+    /// <summary>The normalized media type, or the empty string.</summary>
+    internal string MediaType { get; }
+}
+#endif

--- a/Jint/WebApi/Files/JsFile.cs
+++ b/Jint/WebApi/Files/JsFile.cs
@@ -1,0 +1,37 @@
+#if NET8_0_OR_GREATER
+namespace Jint.WebApi.Files;
+
+/// <summary>
+/// A <c>File</c> instance: a <see cref="JsBlob"/> that also knows a name and a modification time.
+/// <para>
+/// https://w3c.github.io/FileAPI/#file-section
+/// </para>
+/// </summary>
+/// <remarks>
+/// <c>File</c> inherits <c>Blob</c> in the IDL, so it inherits it here too: <c>size</c>, <c>type</c>,
+/// <c>slice</c> and the read methods all resolve on <c>Blob.prototype</c> and their brand check passes on a
+/// file. Only <c>name</c> and <c>lastModified</c> are its own.
+/// </remarks>
+internal sealed class JsFile : JsBlob
+{
+    internal JsFile(Engine engine, ReadOnlyMemory<byte> data, string type, string name, long lastModified)
+        : base(engine, data, type)
+    {
+        Name = name;
+        LastModified = lastModified;
+    }
+
+    /// <summary>The file's name, https://w3c.github.io/FileAPI/#dfn-name.</summary>
+    internal string Name { get; }
+
+    /// <summary>
+    /// Milliseconds since the Unix epoch, https://w3c.github.io/FileAPI/#dfn-lastModified.
+    /// </summary>
+    /// <remarks>
+    /// When the constructor was not given one it is <b>captured at construction</b> from the engine's
+    /// <c>ITimeSystem</c> — the same clock <c>Date.now()</c> reads, so a host that installed a fixed clock
+    /// gets a deterministic value here too. It never moves afterwards.
+    /// </remarks>
+    internal long LastModified { get; }
+}
+#endif

--- a/Jint/WebApi/Files/JsFormData.cs
+++ b/Jint/WebApi/Files/JsFormData.cs
@@ -1,0 +1,61 @@
+#if NET8_0_OR_GREATER
+using System.Runtime.InteropServices;
+using Jint.Native;
+using Jint.Native.Object;
+
+namespace Jint.WebApi.Files;
+
+/// <summary>
+/// A <c>FormData</c> instance: an ordered list of (name, value) entries, where a value is either a string
+/// or a <c>File</c>.
+/// <para>
+/// https://xhr.spec.whatwg.org/#interface-formdata
+/// </para>
+/// </summary>
+/// <remarks>
+/// The list is ordered and admits duplicate names, so it is a <see cref="List{T}"/> and not a dictionary:
+/// <c>getAll</c>, the iteration order and <c>set</c>'s "replace the first, remove the rest" all depend on
+/// position. Nothing here serializes: turning an entry list into a <c>multipart/form-data</c> body is the
+/// business of a request body, and arrives with <c>fetch</c>.
+/// </remarks>
+internal sealed class JsFormData : ObjectInstance
+{
+    internal JsFormData(Engine engine) : base(engine, ObjectClass.Object)
+    {
+    }
+
+    /// <summary>
+    /// The entry list, https://xhr.spec.whatwg.org/#concept-formdata-entry-list. Mutated in place by
+    /// <c>append</c>, <c>delete</c> and <c>set</c>, and read live by the iterators.
+    /// </summary>
+    internal List<FormDataEntry> Entries { get; } = [];
+
+    /// <summary>
+    /// The index of the first entry named <paramref name="name"/>, or <c>-1</c>.
+    /// </summary>
+    internal int IndexOf(string name)
+    {
+        var entries = Entries;
+        for (var i = 0; i < entries.Count; i++)
+        {
+            if (string.Equals(entries[i].Name, name, StringComparison.Ordinal))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+}
+
+/// <summary>
+/// One entry of a <c>FormData</c>'s entry list.
+/// <para>
+/// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#entry
+/// </para>
+/// </summary>
+/// <param name="Name">The entry's name, already a scalar value string.</param>
+/// <param name="Value">The entry's value: a <see cref="JsString"/> or a <see cref="JsFile"/>, never a bare blob.</param>
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct FormDataEntry(string Name, JsValue Value);
+#endif

--- a/Jint/WebApi/WebApiRegistration.cs
+++ b/Jint/WebApi/WebApiRegistration.cs
@@ -85,6 +85,13 @@ internal static class WebApiRegistration
             // https://webidl.spec.whatwg.org/#es-operations.
             Install(global, engine, "structuredClone", static e => e.Realm.Intrinsics.StructuredClone, PropertyFlag.ConfigurableEnumerableWritable);
         }
+
+        if ((options.WebApi.Features & WebApiFeatures.Files) != WebApiFeatures.None)
+        {
+            Install(global, engine, "Blob", static e => e.Realm.Intrinsics.Blob, PropertyFlag.NonEnumerable);
+            Install(global, engine, "File", static e => e.Realm.Intrinsics.File, PropertyFlag.NonEnumerable);
+            Install(global, engine, "FormData", static e => e.Realm.Intrinsics.FormData, PropertyFlag.NonEnumerable);
+        }
     }
 
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ its own `console` (or any other name in the table below), enabling the feature l
 | `performance.now` / `performance.timeOrigin` | `Performance` | in progress |
 | `Event` / `EventTarget` / `CustomEvent` / `AbortController` / `AbortSignal` | `Events` | in progress |
 | `URL` / `URLSearchParams` | `Url` | in progress |
-| `Blob` / `File` / `FormData` | `Files` | in progress |
+| `Blob` / `File` / `FormData` | `Files` | ✔ shipped |
 | `fetch` / `Headers` / `Request` / `Response` | `Fetch` | in progress |
 
 `WebApiFeatures.Default` — what `UseWebApis()` enables — is every non-network feature that has landed. It


### PR DESCRIPTION
Part of the opt-in web API series (#3079): `Blob`, `File` and `FormData` behind `WebApiFeatures.Files` (in `Default`). These are prerequisites for fetch's body model. Usual rules: BCL only, net8+, opt-in, default engine unchanged.

- **Blob** (https://w3c.github.io/FileAPI/): byte[]-backed and immutable; the constructor's blob-parts processing is fused with the WebIDL sequence conversion so element coercion order stays observable; media-type normalization per spec; `slice` with negative-index clamping; `text()`/`arrayBuffer()`/`bytes()` return real (already-resolved) promises. `endings: "native"` is accepted but behaves as `"transparent"` — honouring it would make a blob's bytes (and any hash or request body over them) depend on the host OS; unknown enum values still throw `TypeError` per WebIDL. `stream()` is absent (not throwing) until the streams campaign (#3082).
- **File extends Blob**: `name`, `lastModified` — defaulting from the engine's `ITimeSystem` rather than `DateTime.UtcNow`, so it agrees with `Date.now()` and is deterministic under a host-installed clock.
- **FormData** (https://xhr.spec.whatwg.org/#interface-formdata): ordered entry list of string/`File`; `append`/`set` overload resolution on the *value* with three-argument string forms a `TypeError` (matches Chrome; resolution runs before argument conversion, pinned); a bare `Blob` value is wrapped into a `File` named `"blob"` per create-an-entry; `set` replaces in place; full iteration surface (`entries`/`keys`/`values`/`@@iterator`/`forEach`). The constructor takes no arguments here — a non-undefined argument is a `TypeError`, per the WinterTC caveat for runtimes without HTML forms. Multipart serialization deliberately lands with fetch, not here.

Two defects were caught by writing the failing test first (quoted pre-fix in the test comments): `new File(undefined, 'a')` silently building an empty file, and the WebIDL `long long` wrap folding `lastModified: -1` to `0`.

143 WebApi tests run on net10 (the net472 leg compiles none of this, proving the gate). Verified: all-TFM build, both suites × both frameworks × both host-contract-verification configurations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
