### PR TITLE
Add opt-in crypto.getRandomValues, crypto.randomUUID and performance.now

### DIFF
--- a/Jint.Tests.PublicInterface/WebApiCryptoTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiCryptoTests.cs
@@ -1,0 +1,153 @@
+#if NET8_0_OR_GREATER
+using Jint;
+using Jint.Native;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// The <c>crypto</c> object seen from outside the assembly: what a host has to write to get it, what it gets
+/// when it writes nothing, and the promises it can build on.
+/// </summary>
+/// <remarks>
+/// This project has no <c>InternalsVisibleTo</c>, so everything here is reachable by a third party and every
+/// assertion goes through script or the public options surface, exactly as an embedder's would.
+/// </remarks>
+public class WebApiCryptoTests
+{
+    [Fact]
+    public void ADefaultEngineHasNoCrypto()
+    {
+        var engine = new Engine();
+
+        engine.Evaluate("typeof crypto").AsString().Should().Be("undefined");
+        engine.Evaluate("'crypto' in globalThis").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void UseWebApisInstallsCrypto()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        engine.Evaluate("typeof crypto").AsString().Should().Be("object");
+        engine.Evaluate("typeof crypto.getRandomValues").AsString().Should().Be("function");
+        engine.Evaluate("typeof crypto.randomUUID").AsString().Should().Be("function");
+
+        // The default set is what UseWebApis() means, and it now names crypto.
+        new Options().UseWebApis().WebApi.Features.Should().HaveFlag(WebApiFeatures.Crypto);
+    }
+
+    [Fact]
+    public void AskingForConsoleAloneDoesNotBringCrypto()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Console));
+
+        engine.Evaluate("typeof console").AsString().Should().Be("object");
+        engine.Evaluate("typeof crypto").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void FillsAHostSuppliedTypedArrayWithRandomBytes()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Crypto));
+
+        // Sixteen bytes coming back all zero would be a 2^-128 event, so this is a fair test that the host's
+        // array really was filled and that the same object came back.
+        engine.Evaluate("""
+            (() => {
+                const array = new Uint8Array(16);
+                const returned = crypto.getRandomValues(array);
+                return returned === array && array.some(b => b !== 0);
+            })()
+            """).AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ProducesRandomUuidsAHostCanParse()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Crypto));
+
+        var first = engine.Evaluate("crypto.randomUUID()").AsString();
+        var second = engine.Evaluate("crypto.randomUUID()").AsString();
+
+        first.Should().NotBe(second);
+        Guid.TryParseExact(first, "D", out var parsed).Should().BeTrue();
+        parsed.ToString("D").Should().Be(first, "the string is already the lowercase hyphenated form");
+
+        // Version 4 and the RFC 4122 variant, which is what the algorithm's bit-setting steps produce.
+        first[14].Should().Be('4');
+        "89ab".Contains(first[19]).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReportsItsFailuresAsTheStandardExceptions()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Crypto));
+
+        // A DOMException a script can catch and branch on, not a CLR exception erupting through the host.
+        engine.Evaluate("""
+            (() => {
+                const seen = [];
+                try { crypto.getRandomValues(new Float64Array(4)); } catch (e) { seen.push(e.name); }
+                try { crypto.getRandomValues(new Uint8Array(65537)); } catch (e) { seen.push(e.name); }
+                try { crypto.getRandomValues([1, 2, 3]); } catch (e) { seen.push(e.constructor.name); }
+                return seen.join(',');
+            })()
+            """).AsString().Should().Be("TypeMismatchError,QuotaExceededError,TypeError");
+    }
+
+    [Fact]
+    public void HasNoSubtleCryptoForFeatureDetectionToFind()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        engine.Evaluate("typeof crypto.subtle").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void AHostRegisteredCryptoGlobalWins()
+    {
+        var marker = new JsString("the host's own crypto");
+
+        var engine = new Engine(options => options
+            .AddLazyGlobal("crypto", _ => marker)
+            .UseWebApis());
+
+        // The host's configuration runs first and the install is non-clobbering.
+        engine.Evaluate("crypto").Should().BeSameAs(marker);
+    }
+
+    [Fact]
+    public void IsAnEnumerableDataPropertyOfTheGlobal()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Crypto));
+
+        // A documented simplification of the WebIDL [Replaceable] accessor pair, and the same shape console
+        // is installed with.
+        var descriptor = engine.Evaluate("Object.getOwnPropertyDescriptor(globalThis, 'crypto')").AsObject();
+        descriptor.Get("writable").AsBoolean().Should().BeTrue();
+        descriptor.Get("enumerable").AsBoolean().Should().BeTrue();
+        descriptor.Get("configurable").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void DoesNotReachIntoAShadowRealm()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        engine.Evaluate("new ShadowRealm().evaluate('typeof crypto')").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof crypto").AsString().Should().Be("object");
+    }
+
+    [Fact]
+    public void OneOptionsInstanceServesSeveralEngines()
+    {
+        var options = new Options().UseWebApis(WebApiFeatures.Crypto);
+
+        var first = new Engine(options);
+        var second = new Engine(options);
+
+        first.Evaluate("crypto === crypto").AsBoolean().Should().BeTrue();
+        first.Evaluate("crypto.randomUUID()").AsString().Should().NotBe(second.Evaluate("crypto.randomUUID()").AsString());
+    }
+}
+#endif

--- a/Jint.Tests.PublicInterface/WebApiPerformanceTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiPerformanceTests.cs
@@ -1,0 +1,189 @@
+#if NET8_0_OR_GREATER
+using Jint;
+using Jint.Native;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// The <c>performance</c> object seen from outside the assembly: what a host has to write to get it, what it
+/// gets when it writes nothing, and the promises it can build on.
+/// </summary>
+/// <remarks>
+/// This project has no <c>InternalsVisibleTo</c>, so nothing here can reach the engine's time origin
+/// directly. What a host <i>can</i> do is supply the clock, which is what most of these do — the same
+/// <see cref="TimeProvider"/> the timers are scheduled against, so one fake drives both.
+/// </remarks>
+public class WebApiPerformanceTests
+{
+    /// <summary>
+    /// A host-supplied clock. <see cref="TimeProvider.GetTimestamp"/> answers <c>now()</c> and
+    /// <see cref="TimeProvider.GetUtcNow"/> is read exactly once, for the time origin.
+    /// </summary>
+    private sealed class ManualClock : TimeProvider
+    {
+        private long _timestamp;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp() => _timestamp;
+
+        public override DateTimeOffset GetUtcNow() => DateTimeOffset.UnixEpoch.AddTicks(_timestamp);
+
+        internal void Advance(int milliseconds) => _timestamp += milliseconds * TimeSpan.TicksPerMillisecond;
+    }
+
+    [Fact]
+    public void ADefaultEngineHasNoPerformance()
+    {
+        var engine = new Engine();
+
+        engine.Evaluate("typeof performance").AsString().Should().Be("undefined");
+        engine.Evaluate("'performance' in globalThis").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void UseWebApisInstallsPerformance()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        engine.Evaluate("typeof performance").AsString().Should().Be("object");
+        engine.Evaluate("typeof performance.now").AsString().Should().Be("function");
+        engine.Evaluate("typeof performance.timeOrigin").AsString().Should().Be("number");
+
+        new Options().UseWebApis().WebApi.Features.Should().HaveFlag(WebApiFeatures.Performance);
+    }
+
+    [Fact]
+    public void AskingForConsoleAloneDoesNotBringPerformance()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Console));
+
+        engine.Evaluate("typeof console").AsString().Should().Be("object");
+        engine.Evaluate("typeof performance").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void MeasuresElapsedTimeAgainstTheHostsClock()
+    {
+        var clock = new ManualClock();
+        var engine = new Engine(options => options.UseWebApis(webApi =>
+        {
+            webApi.Features = WebApiFeatures.Performance;
+            webApi.Timers.TimeProvider = clock;
+        }));
+
+        engine.Evaluate("performance.now()").AsNumber().Should().Be(0);
+
+        clock.Advance(1500);
+
+        engine.Evaluate("performance.now()").AsNumber().Should().Be(1500);
+        engine.Evaluate("performance.timeOrigin + performance.now()").AsNumber().Should().Be(1500);
+    }
+
+    [Fact]
+    public void OneHostClockDrivesTheTimersAndTheReadingsTogether()
+    {
+        var clock = new ManualClock();
+        var engine = new Engine(options => options.UseWebApis(webApi => webApi.Timers.TimeProvider = clock));
+
+        engine.Execute("var firedAt = -1; setTimeout(() => { firedAt = performance.now(); }, 200);");
+        engine.Evaluate("firedAt").AsNumber().Should().Be(-1);
+
+        clock.Advance(200);
+        engine.Advanced.ProcessTasks();
+
+        // The whole point of the two features sharing Options.WebApi.Timers.TimeProvider: a host that fakes
+        // the clock gets a deterministic answer from both, not a timer that fires against a reading that has
+        // not moved.
+        engine.Evaluate("firedAt").AsNumber().Should().Be(200);
+    }
+
+    [Fact]
+    public void WorksOnAnEngineThatEnabledNoTimers()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Performance));
+
+        engine.Evaluate("typeof setTimeout").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof performance.now()").AsString().Should().Be("number");
+    }
+
+    [Fact]
+    public void TimeOriginNamesTheMomentTheEngineWasBuilt()
+    {
+        var before = (DateTimeOffset.UtcNow - DateTimeOffset.UnixEpoch).TotalMilliseconds;
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Performance));
+        var after = (DateTimeOffset.UtcNow - DateTimeOffset.UnixEpoch).TotalMilliseconds;
+
+        var origin = engine.Evaluate("performance.timeOrigin").AsNumber();
+
+        // Unix epoch milliseconds, so a host can turn a reading into a wall-clock instant:
+        // DateTimeOffset.FromUnixTimeMilliseconds((long) (timeOrigin + now)).
+        origin.Should().BeGreaterThanOrEqualTo(before).And.BeLessThanOrEqualTo(after);
+    }
+
+    [Fact]
+    public void ReadingsAreMonotonicOnTheDefaultClock()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Performance));
+
+        var first = engine.Evaluate("performance.now()").AsNumber();
+        var second = engine.Evaluate("performance.now()").AsNumber();
+
+        second.Should().BeGreaterThanOrEqualTo(first);
+        first.Should().BeGreaterThanOrEqualTo(0);
+    }
+
+    [Fact]
+    public void AHostRegisteredPerformanceGlobalWins()
+    {
+        var marker = new JsString("the host's own performance");
+
+        var engine = new Engine(options => options
+            .AddLazyGlobal("performance", _ => marker)
+            .UseWebApis());
+
+        engine.Evaluate("performance").Should().BeSameAs(marker);
+    }
+
+    [Fact]
+    public void IsAnEnumerableDataPropertyOfTheGlobal()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Performance));
+
+        var descriptor = engine.Evaluate("Object.getOwnPropertyDescriptor(globalThis, 'performance')").AsObject();
+        descriptor.Get("writable").AsBoolean().Should().BeTrue();
+        descriptor.Get("enumerable").AsBoolean().Should().BeTrue();
+        descriptor.Get("configurable").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void DoesNotReachIntoAShadowRealm()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        engine.Evaluate("new ShadowRealm().evaluate('typeof performance')").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof performance").AsString().Should().Be("object");
+    }
+
+    [Fact]
+    public void OneOptionsInstanceGivesEachEngineItsOwnTimeOrigin()
+    {
+        var clock = new ManualClock();
+        var options = new Options().UseWebApis(webApi =>
+        {
+            webApi.Features = WebApiFeatures.Performance;
+            webApi.Timers.TimeProvider = clock;
+        });
+
+        var first = new Engine(options);
+        clock.Advance(3000);
+        var second = new Engine(options);
+
+        // The origin belongs to the engine, never to the shared Options: the engine built three seconds later
+        // reads zero where the first reads three thousand.
+        first.Evaluate("performance.now()").AsNumber().Should().Be(3000);
+        second.Evaluate("performance.now()").AsNumber().Should().Be(0);
+        second.Evaluate("performance.timeOrigin").AsNumber().Should().Be(3000);
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/CryptoTests.cs
+++ b/Jint.Tests/Runtime/WebApi/CryptoTests.cs
@@ -1,0 +1,332 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// The <c>crypto</c> object against the Web Cryptography API — https://w3c.github.io/webcrypto/#crypto-interface.
+/// </summary>
+/// <remarks>
+/// Randomness makes an exact assertion impossible, so the shape of every "it filled the array" test is that
+/// enough bytes were written for all of them being zero to be impossible in practice: a 32-byte array is
+/// 2^-256 to come back untouched. What <i>is</i> asserted exactly is everything around the randomness —
+/// which views are accepted, which failure each rejection is, the quota boundary, the bytes outside a view's
+/// own slice, and the UUID's shape.
+/// </remarks>
+public class CryptoTests
+{
+    private static Engine WebEngine() => new(options => options.UseWebApis(WebApiFeatures.Crypto));
+
+    [Theory]
+    [InlineData("Int8Array")]
+    [InlineData("Uint8Array")]
+    [InlineData("Uint8ClampedArray")]
+    [InlineData("Int16Array")]
+    [InlineData("Uint16Array")]
+    [InlineData("Int32Array")]
+    [InlineData("Uint32Array")]
+    [InlineData("BigInt64Array")]
+    [InlineData("BigUint64Array")]
+    public void FillsEveryIntegerViewTypeTheAlgorithmAccepts(string type)
+    {
+        var engine = WebEngine();
+
+        // Step 1's list, verbatim: "an Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array,
+        // Int32Array, Uint32Array, BigInt64Array, or BigUint64Array".
+        engine.Evaluate($$"""
+            (() => {
+                const array = new {{type}}(32);
+                const returned = crypto.getRandomValues(array);
+                const zero = typeof array[0] === 'bigint' ? 0n : 0;
+                return returned === array && array.some(v => v !== zero);
+            })()
+            """).AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReturnsTheVeryArrayItWasGiven()
+    {
+        var engine = WebEngine();
+
+        // Step 7: "Return array" — the same object, never a copy.
+        engine.Evaluate("(() => { const a = new Uint8Array(8); return crypto.getRandomValues(a) === a; })()")
+            .AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void WritesOnlyIntoTheViewsOwnSlice()
+    {
+        var engine = WebEngine();
+
+        // A view with a byte offset must have exactly its own window filled: the bytes on either side of it
+        // in the same buffer belong to nobody here and must be left alone.
+        engine.Evaluate("""
+            (() => {
+                const buffer = new ArrayBuffer(16);
+                crypto.getRandomValues(new Uint8Array(buffer, 4, 8));
+                const all = new Uint8Array(buffer);
+                const outsideUntouched = all.slice(0, 4).every(v => v === 0) && all.slice(12).every(v => v === 0);
+                const insideWritten = all.slice(4, 12).some(v => v !== 0);
+                return outsideUntouched && insideWritten;
+            })()
+            """).AsBoolean().Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("new Float16Array(4)")]
+    [InlineData("new Float32Array(4)")]
+    [InlineData("new Float64Array(4)")]
+    [InlineData("new DataView(new ArrayBuffer(8))")]
+    public void RejectsAViewThatIsNotAnIntegerArrayWithATypeMismatchError(string expression)
+    {
+        var engine = WebEngine();
+
+        // Step 1: a float array and a DataView are both ArrayBufferViews, so they pass WebIDL's conversion
+        // and fail the method's own first step — a DOMException, not a TypeError.
+        engine.Evaluate($$"""
+            (() => {
+                try { crypto.getRandomValues({{expression}}); }
+                catch (e) { return [e instanceof DOMException, e.name, e.code].join('|'); }
+                return 'no error';
+            })()
+            """).AsString().Should().Be("true|TypeMismatchError|17");
+    }
+
+    [Theory]
+    [InlineData("[1, 2, 3]")]
+    [InlineData("{}")]
+    [InlineData("42")]
+    [InlineData("null")]
+    [InlineData("undefined")]
+    [InlineData("'not a view'")]
+    [InlineData("new ArrayBuffer(8)")]
+    public void RejectsSomethingThatIsNotAViewAtAllWithATypeError(string expression)
+    {
+        var engine = WebEngine();
+
+        // The IDL is getRandomValues(ArrayBufferView array): anything that is not a view fails WebIDL's own
+        // conversion, which is a TypeError and never a DOMException. An ArrayBuffer is not a view.
+        var thrown = Assert.Throws<JavaScriptException>(() => engine.Evaluate($"crypto.getRandomValues({expression})"));
+        thrown.Error.Get("name").AsString().Should().Be("TypeError");
+        thrown.Message.Should().Contain("ArrayBufferView");
+    }
+
+    [Fact]
+    public void RejectsAViewOntoASharedArrayBufferWithATypeError()
+    {
+        var engine = WebEngine();
+
+        // https://webidl.spec.whatwg.org/#es-arraybufferview — a shared view is accepted only where the
+        // operation declares [AllowShared], and the Crypto IDL does not.
+        var thrown = Assert.Throws<JavaScriptException>(
+            () => engine.Evaluate("crypto.getRandomValues(new Uint8Array(new SharedArrayBuffer(8)))"));
+
+        thrown.Error.Get("name").AsString().Should().Be("TypeError");
+        thrown.Message.Should().Contain("SharedArrayBuffer");
+    }
+
+    [Fact]
+    public void AcceptsExactlyTheQuotaAndRefusesOneByteMore()
+    {
+        var engine = WebEngine();
+
+        // Step 3: "If byteLength is greater than 65536, throw a QuotaExceededError" — so 65536 itself is fine.
+        engine.Evaluate("crypto.getRandomValues(new Uint8Array(65536)).byteLength").AsNumber().Should().Be(65536);
+
+        engine.Evaluate("""
+            (() => {
+                try { crypto.getRandomValues(new Uint8Array(65537)); }
+                catch (e) { return [e instanceof DOMException, e.name, e.code].join('|'); }
+                return 'no error';
+            })()
+            """).AsString().Should().Be("true|QuotaExceededError|22");
+    }
+
+    [Fact]
+    public void CountsTheQuotaInBytesRatherThanInElements()
+    {
+        var engine = WebEngine();
+
+        // 32768 Uint16 elements are 65536 bytes and fit; one more element is 65538 bytes and does not.
+        engine.Evaluate("crypto.getRandomValues(new Uint16Array(32768)).length").AsNumber().Should().Be(32768);
+
+        engine.Evaluate("""
+            (() => {
+                try { crypto.getRandomValues(new Uint16Array(32769)); }
+                catch (e) { return e.name; }
+                return 'no error';
+            })()
+            """).AsString().Should().Be("QuotaExceededError");
+    }
+
+    [Fact]
+    public void AnEmptyViewIsReturnedUntouched()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("(() => { const a = new Uint8Array(0); return crypto.getRandomValues(a) === a; })()")
+            .AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ADetachedViewIsReturnedUntouched()
+    {
+        var engine = WebEngine();
+
+        // A detached view's byte length is zero, so step 4's byte sequence is empty and step 6 writes it into
+        // nothing at all. The quota is a maximum, not a minimum, so there is nothing here to raise about.
+        engine.Evaluate("""
+            (() => {
+                const buffer = new ArrayBuffer(8);
+                const array = new Uint8Array(buffer);
+                buffer.transfer();
+                return crypto.getRandomValues(array) === array && array.length === 0;
+            })()
+            """).AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void AnOutOfBoundsLengthTrackingViewIsReturnedUntouched()
+    {
+        var engine = WebEngine();
+
+        // Same reasoning through the other door: a length-tracking view whose resizable buffer has shrunk
+        // past its offset is out of bounds, and the buffer witness reports its byte length as zero.
+        engine.Evaluate("""
+            (() => {
+                const buffer = new ArrayBuffer(8, { maxByteLength: 16 });
+                const array = new Uint8Array(buffer, 4);
+                buffer.resize(2);
+                return crypto.getRandomValues(array) === array && array.length === 0;
+            })()
+            """).AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void RefusesToWriteIntoAnImmutableBuffer()
+    {
+        var engine = WebEngine();
+
+        // Building the view over an immutable buffer is fine — it is reading it that the proposal allows and
+        // writing it that it does not, so the refusal below is this operation's and not the constructor's.
+        engine.Evaluate("new Uint8Array(new ArrayBuffer(8).transferToImmutable()).length").AsNumber().Should().Be(8);
+
+        // https://tc39.es/proposal-immutable-arraybuffer/ — the same TypeError an ordinary element assignment
+        // raises, because this is an ordinary write into the same bytes.
+        var thrown = Assert.Throws<JavaScriptException>(() => engine.Evaluate("""
+            crypto.getRandomValues(new Uint8Array(new ArrayBuffer(8).transferToImmutable()))
+            """));
+
+        thrown.Error.Get("name").AsString().Should().Be("TypeError");
+        thrown.Message.Should().Contain("immutable");
+    }
+
+    [Fact]
+    public void ProducesAVersion4LowercaseUuid()
+    {
+        var engine = WebEngine();
+
+        // The last step's concatenation, with the version nibble step 3 sets and the variant bits step 4
+        // sets: 8-4-4-4-12 lowercase hex, a '4' opening the third group and one of 8/9/a/b the fourth.
+        engine.Evaluate("""
+            (() => {
+                const pattern = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+                for (let i = 0; i < 100; i++) {
+                    if (!pattern.test(crypto.randomUUID())) return 'bad: ' + crypto.randomUUID();
+                }
+                return 'ok';
+            })()
+            """).AsString().Should().Be("ok");
+    }
+
+    [Fact]
+    public void ProducesADifferentUuidEveryTime()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("new Set(Array.from({ length: 500 }, () => crypto.randomUUID())).size")
+            .AsNumber().Should().Be(500);
+    }
+
+    [Fact]
+    public void BrandChecksBothOperations()
+    {
+        var engine = WebEngine();
+
+        // The WebIDL brand check: an extracted operation cannot be called on anything but a Crypto object.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("crypto.getRandomValues.call({}, new Uint8Array(4))"))
+            .Message.Should().Contain("Crypto");
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("crypto.randomUUID.call(undefined)"))
+            .Message.Should().Contain("Crypto");
+
+        // ... and still works when the receiver is the real one, however it was reached.
+        engine.Evaluate("(() => { const f = crypto.getRandomValues; return f.call(crypto, new Uint8Array(4)).length; })()")
+            .AsNumber().Should().Be(4);
+    }
+
+    [Fact]
+    public void HasNoSubtleCrypto()
+    {
+        var engine = WebEngine();
+
+        // Absent rather than present-and-throwing: `if (crypto.subtle)` is how every library that does
+        // cryptography decides whether it can, and it has to get the truthful answer.
+        engine.Evaluate("typeof crypto.subtle").AsString().Should().Be("undefined");
+        engine.Evaluate("'subtle' in crypto").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsOneStableObjectWithTheInterfacesToStringTag()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("crypto === crypto").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.prototype.toString.call(crypto)").AsString().Should().Be("[object Crypto]");
+        engine.Evaluate("crypto[Symbol.toStringTag]").AsString().Should().Be("Crypto");
+    }
+
+    [Fact]
+    public void GivesItsMembersTheAttributesOfBuiltInMethods()
+    {
+        var engine = WebEngine();
+
+        // There is no Crypto.prototype here, so the operations are own properties of the object with the
+        // attributes an ECMAScript built-in method carries. What a script can observe of that difference is
+        // nothing: a browser answers the empty array for Object.keys(crypto) too, because there the
+        // operations live on the prototype.
+        engine.Evaluate("JSON.stringify(Object.keys(crypto))").AsString().Should().Be("[]");
+
+        foreach (var member in new[] { "getRandomValues", "randomUUID" })
+        {
+            var descriptor = engine.Evaluate($"Object.getOwnPropertyDescriptor(crypto, '{member}')").AsObject();
+            descriptor.Get("writable").AsBoolean().Should().BeTrue();
+            descriptor.Get("configurable").AsBoolean().Should().BeTrue();
+            descriptor.Get("enumerable").AsBoolean().Should().BeFalse();
+        }
+    }
+
+    [Fact]
+    public void HasTheIdlArities()
+    {
+        var engine = WebEngine();
+
+        // WebIDL length counts the required arguments only.
+        engine.Evaluate("crypto.getRandomValues.length").AsNumber().Should().Be(1);
+        engine.Evaluate("crypto.randomUUID.length").AsNumber().Should().Be(0);
+        engine.Evaluate("crypto.getRandomValues.name").AsString().Should().Be("getRandomValues");
+        engine.Evaluate("crypto.randomUUID.name").AsString().Should().Be("randomUUID");
+    }
+
+    [Fact]
+    public void IsNotInstalledWithoutItsFlag()
+    {
+        new Engine(options => options.UseWebApis(WebApiFeatures.Console))
+            .Evaluate("typeof crypto").AsString().Should().Be("undefined");
+
+        // ... and does not reach into a shadow realm when it is.
+        WebEngine().Evaluate("new ShadowRealm().evaluate('typeof crypto')").AsString().Should().Be("undefined");
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/PerformanceTests.cs
+++ b/Jint.Tests/Runtime/WebApi/PerformanceTests.cs
@@ -1,0 +1,279 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// The <c>performance</c> object against High Resolution Time — https://w3c.github.io/hr-time/.
+/// </summary>
+/// <remarks>
+/// Almost everything here runs on a <see cref="ManualClock"/>, because what the two members are is arithmetic
+/// over a clock and not a measurement of anything: with the clock in the test's hand, "now() counts from the
+/// time origin" is an equality rather than a tolerance. The one test that uses the real clock is the one
+/// about monotonicity, where the point is precisely that the readings come from a clock nobody controls.
+/// </remarks>
+public class PerformanceTests
+{
+    /// <summary>
+    /// A <see cref="TimeProvider"/> whose clock only moves when a test moves it. Ticks are the unit, so both
+    /// <see cref="TimeProvider.GetElapsedTime(long, long)"/> and the wall-clock reading behind
+    /// <c>timeOrigin</c> are exact.
+    /// </summary>
+    private sealed class ManualClock : TimeProvider
+    {
+        private long _timestamp;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp() => _timestamp;
+
+        public override DateTimeOffset GetUtcNow() => DateTimeOffset.UnixEpoch.AddTicks(_timestamp);
+
+        internal void Advance(int milliseconds) => _timestamp += milliseconds * TimeSpan.TicksPerMillisecond;
+
+        internal void AdvanceTicks(long ticks) => _timestamp += ticks;
+    }
+
+    private static (Engine Engine, ManualClock Clock) PerformanceEngine(
+        WebApiFeatures features = WebApiFeatures.Performance,
+        ManualClock? clock = null)
+    {
+        clock ??= new ManualClock();
+        var provider = clock;
+        var engine = new Engine(options => options.UseWebApis(webApi =>
+        {
+            webApi.Features = features;
+            webApi.Timers.TimeProvider = provider;
+        }));
+
+        return (engine, clock);
+    }
+
+    [Fact]
+    public void NowCountsMillisecondsFromTheTimeOrigin()
+    {
+        var (engine, clock) = PerformanceEngine();
+
+        // The origin is the moment the engine was built, so nothing has elapsed yet.
+        engine.Evaluate("performance.now()").AsNumber().Should().Be(0);
+
+        clock.Advance(250);
+        engine.Evaluate("performance.now()").AsNumber().Should().Be(250);
+
+        clock.Advance(750);
+        engine.Evaluate("performance.now()").AsNumber().Should().Be(1000);
+    }
+
+    [Fact]
+    public void NowHasSubMillisecondResolution()
+    {
+        var (engine, clock) = PerformanceEngine();
+
+        // A DOMHighResTimeStamp is a double for a reason, and the readings are deliberately not coarsened:
+        // a quarter of a millisecond reads as 0.25, not as 0 or 1. (Both figures here are exact in binary,
+        // so the assertion is an equality rather than a tolerance.)
+        clock.AdvanceTicks(TimeSpan.TicksPerMillisecond / 4);
+        engine.Evaluate("performance.now()").AsNumber().Should().Be(0.25);
+
+        clock.AdvanceTicks(TimeSpan.TicksPerMillisecond / 4);
+        engine.Evaluate("performance.now()").AsNumber().Should().Be(0.5);
+    }
+
+    [Fact]
+    public void TimeOriginIsTheWallClockMomentTheEngineWasBuilt()
+    {
+        var clock = new ManualClock();
+        clock.Advance(5000);
+
+        var (engine, _) = PerformanceEngine(clock: clock);
+
+        // https://w3c.github.io/hr-time/#dom-performance-timeorigin — "the duration from the estimated
+        // monotonic time of the Unix epoch to timeOrigin", in milliseconds.
+        engine.Evaluate("performance.timeOrigin").AsNumber().Should().Be(5000);
+        engine.Evaluate("performance.now()").AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void TimeOriginPlusNowIsTheCurrentWallClockTime()
+    {
+        var (engine, clock) = PerformanceEngine();
+
+        clock.Advance(1234);
+
+        // The property that makes the pair useful, and the reason both halves are read from one clock.
+        engine.Evaluate("performance.timeOrigin + performance.now()").AsNumber().Should().Be(1234);
+    }
+
+    [Fact]
+    public void TimeOriginDoesNotMove()
+    {
+        var (engine, clock) = PerformanceEngine();
+
+        var origin = engine.Evaluate("performance.timeOrigin").AsNumber();
+        clock.Advance(10_000);
+
+        engine.Evaluate("performance.timeOrigin").AsNumber().Should().Be(origin);
+    }
+
+    [Fact]
+    public void NeverGoesBackwardsOnTheRealClock()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Performance));
+
+        // The one hard requirement the specification states: "The difference between any two chronologically
+        // recorded time values returned from the now() method MUST never be negative".
+        engine.Evaluate("""
+            (() => {
+                let previous = performance.now();
+                for (let i = 0; i < 10000; i++) {
+                    const current = performance.now();
+                    if (current < previous) return 'went backwards at ' + i;
+                    previous = current;
+                }
+                return 'monotonic';
+            })()
+            """).AsString().Should().Be("monotonic");
+    }
+
+    [Fact]
+    public void SharesItsClockWithTheTimers()
+    {
+        var (engine, clock) = PerformanceEngine(WebApiFeatures.Performance | WebApiFeatures.Timers);
+
+        engine.Execute("var firedAt = null; setTimeout(() => { firedAt = performance.now(); }, 100);");
+        engine.Evaluate("firedAt").IsNull().Should().BeTrue();
+
+        clock.Advance(100);
+        engine.Advanced.ProcessTasks();
+
+        // One clock, so the timer's due time and the reading its callback takes agree exactly. Two clocks
+        // would make this a tolerance at best, and on a fake provider it would not fire at all.
+        engine.Evaluate("firedAt").AsNumber().Should().Be(100);
+    }
+
+    [Fact]
+    public void WorksWithoutTheTimersFeature()
+    {
+        var (engine, clock) = PerformanceEngine();
+
+        // The engine's web-API state exists for the time origin alone here; the timer queue inside it is
+        // null, and nothing that reads the origin may assume otherwise.
+        engine.Evaluate("typeof setTimeout").AsString().Should().Be("undefined");
+
+        clock.Advance(42);
+        engine.Evaluate("performance.now()").AsNumber().Should().Be(42);
+    }
+
+    [Fact]
+    public void TheTimersFeatureAloneDoesNotBringPerformance()
+    {
+        var (engine, _) = PerformanceEngine(WebApiFeatures.Timers);
+
+        engine.Evaluate("typeof performance").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof setTimeout").AsString().Should().Be("function");
+    }
+
+    [Fact]
+    public void KeepsItsTimeOriginAcrossAGlobalSnapshotRestore()
+    {
+        var (engine, clock) = PerformanceEngine();
+
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+        clock.Advance(1000);
+        var before = engine.Evaluate("performance.now()").AsNumber();
+
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        // The origin belongs to the engine, not to the evaluation cycle: a pooled engine keeps it, so a
+        // reading taken after the restore can never be smaller than one taken before it. Rewinding the origin
+        // is exactly what would make now() go backwards, which the specification forbids.
+        engine.Evaluate("performance.timeOrigin").AsNumber().Should().Be(0);
+        engine.Evaluate("performance.now()").AsNumber().Should().Be(before);
+
+        clock.Advance(500);
+        engine.Evaluate("performance.now()").AsNumber().Should().Be(1500);
+    }
+
+    [Fact]
+    public void BrandChecksBothMembers()
+    {
+        var (engine, _) = PerformanceEngine();
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("performance.now.call({})"))
+            .Message.Should().Contain("Performance");
+        Assert.Throws<JavaScriptException>(
+            () => engine.Evaluate("Object.getOwnPropertyDescriptor(performance, 'timeOrigin').get.call({})"))
+            .Message.Should().Contain("Performance");
+
+        engine.Evaluate("(() => { const f = performance.now; return typeof f.call(performance); })()")
+            .AsString().Should().Be("number");
+    }
+
+    [Fact]
+    public void IsOneStableObjectWithTheInterfacesToStringTag()
+    {
+        var (engine, _) = PerformanceEngine();
+
+        engine.Evaluate("performance === performance").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.prototype.toString.call(performance)").AsString().Should().Be("[object Performance]");
+        engine.Evaluate("performance[Symbol.toStringTag]").AsString().Should().Be("Performance");
+    }
+
+    [Fact]
+    public void ExposesTimeOriginAsAReadOnlyAccessor()
+    {
+        var (engine, _) = PerformanceEngine();
+
+        // A WebIDL readonly attribute is an accessor with no setter — never a data property, so that a host
+        // cannot be fooled by a script assigning to it.
+        var descriptor = engine.Evaluate("Object.getOwnPropertyDescriptor(performance, 'timeOrigin')").AsObject();
+        descriptor.Get("get").IsCallable.Should().BeTrue();
+        descriptor.Get("set").IsUndefined().Should().BeTrue();
+        descriptor.Get("configurable").AsBoolean().Should().BeTrue();
+        descriptor.Get("enumerable").AsBoolean().Should().BeFalse();
+
+        var now = engine.Evaluate("Object.getOwnPropertyDescriptor(performance, 'now')").AsObject();
+        now.Get("writable").AsBoolean().Should().BeTrue();
+        now.Get("configurable").AsBoolean().Should().BeTrue();
+        now.Get("enumerable").AsBoolean().Should().BeFalse();
+
+        // Same observable answer a browser gives, where both live on Performance.prototype.
+        engine.Evaluate("JSON.stringify(Object.keys(performance))").AsString().Should().Be("[]");
+    }
+
+    [Fact]
+    public void HasNoPerformanceTimeline()
+    {
+        var (engine, _) = PerformanceEngine();
+
+        // Absent rather than present-and-throwing, so a library that feature-detects marks takes its
+        // fallback path instead of crashing.
+        foreach (var member in new[] { "mark", "measure", "getEntries", "getEntriesByName", "clearMarks", "toJSON" })
+        {
+            engine.Evaluate($"typeof performance.{member}").AsString().Should().Be("undefined");
+        }
+    }
+
+    [Fact]
+    public void HasTheIdlArity()
+    {
+        var (engine, _) = PerformanceEngine();
+
+        engine.Evaluate("performance.now.length").AsNumber().Should().Be(0);
+        engine.Evaluate("performance.now.name").AsString().Should().Be("now");
+    }
+
+    [Fact]
+    public void IsNotInstalledWithoutItsFlag()
+    {
+        new Engine(options => options.UseWebApis(WebApiFeatures.Console))
+            .Evaluate("typeof performance").AsString().Should().Be("undefined");
+
+        // ... and does not reach into a shadow realm when it is.
+        PerformanceEngine().Engine.Evaluate("new ShadowRealm().evaluate('typeof performance')")
+            .AsString().Should().Be("undefined");
+    }
+}
+#endif

--- a/Jint/Engine.WebApi.cs
+++ b/Jint/Engine.WebApi.cs
@@ -18,25 +18,36 @@ public partial class Engine
     /// <c>AbortSignal.timeout()</c> schedules on.
     /// </summary>
     internal WebApiEngineState? _webApi;
+
 }
 
 /// <summary>
 /// Mutable per-engine state for the opt-in web APIs. Created by <c>WebApiRegistration</c> when a feature that
 /// needs it is enabled, and engine-affine like everything else on <see cref="Engine"/> — two engines built
-/// from one shared <see cref="Options"/> instance get one of these each, so their timers are independent.
+/// from one shared <see cref="Options"/> instance get one of these each, so their timers and their time
+/// origin are independent.
 /// </summary>
 internal sealed class WebApiEngineState
 {
     private readonly Engine _engine;
     private readonly TimeProvider _timeProvider;
-    private readonly long _timeOrigin;
+
+    /// <summary>
+    /// The monotonic reading taken when this state was created, which is the instant
+    /// <see cref="TimeOrigin"/> names and the one <see cref="CurrentHighResolutionTime"/> counts from.
+    /// </summary>
+    private readonly long _originTimestamp;
 
     internal WebApiEngineState(Engine engine, TimeProvider timeProvider, TimerQueue? timers)
     {
         _engine = engine;
         _timeProvider = timeProvider;
-        _timeOrigin = timeProvider.GetTimestamp();
         Timers = timers;
+
+        // Both halves of the time origin, read back to back: the monotonic reading every later now() is a
+        // duration from, and the wall-clock moment that reading corresponds to.
+        _originTimestamp = timeProvider.GetTimestamp();
+        TimeOrigin = (timeProvider.GetUtcNow() - DateTimeOffset.UnixEpoch).TotalMilliseconds;
     }
 
     /// <summary>
@@ -45,13 +56,23 @@ internal sealed class WebApiEngineState
     internal TimerQueue? Timers { get; }
 
     /// <summary>
-    /// Milliseconds since this engine's <i>time origin</i>, which is the instant the web APIs were installed
-    /// on it — https://w3c.github.io/hr-time/#dfn-relative-high-resolution-time. It is what
-    /// <c>Event.timeStamp</c> is measured in, and it reads the same <see cref="TimeProvider"/> the timers do,
-    /// so a fake clock makes both deterministic together.
+    /// <c>performance.timeOrigin</c>: the moment this state was created, as milliseconds since the Unix
+    /// epoch, https://w3c.github.io/hr-time/#dom-performance-timeorigin.
     /// </summary>
-    internal double RelativeHighResolutionTime()
-        => _timeProvider.GetElapsedTime(_timeOrigin, _timeProvider.GetTimestamp()).TotalMilliseconds;
+    /// <remarks>
+    /// Per engine, and deliberately not reset by <see cref="ResetTransientState"/>: a pooled engine keeps the
+    /// origin it was built with, so <c>performance.now()</c> can never go backwards across an evaluation
+    /// cycle.
+    /// </remarks>
+    internal double TimeOrigin { get; }
+
+    /// <summary>
+    /// <c>performance.now()</c>: https://w3c.github.io/hr-time/#dfn-current-high-resolution-time, the
+    /// duration from <see cref="TimeOrigin"/> to now in milliseconds, read from the same monotonic clock the
+    /// timers are scheduled against and deliberately not coarsened.
+    /// </summary>
+    internal double CurrentHighResolutionTime =>
+        _timeProvider.GetElapsedTime(_originTimestamp, _timeProvider.GetTimestamp()).TotalMilliseconds;
 
     /// <summary>
     /// Promotes at most one due timer into an event-loop job. One per call rather than all of them, so that

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -98,8 +98,15 @@ public partial class Options
         /// one makes a suite that exercises timers deterministic and instant.
         /// </summary>
         /// <remarks>
+        /// <para>
+        /// <c>performance.now()</c> and <c>performance.timeOrigin</c> read this same clock, so a fake one
+        /// drives the timers and the high-resolution readings coherently. It is deliberately not the engine's
+        /// <see cref="Options.TimeSystem"/>, which is what <c>Date</c> is built on: one is a monotonic clock
+        /// for measuring durations, the other a wall clock for naming instants.
+        /// </para>
         /// Read once, when the engine is built, so assigning it afterwards does not affect an engine that
-        /// already exists. Only <see cref="TimeProvider.GetTimestamp"/> and
+        /// already exists. Only <see cref="TimeProvider.GetTimestamp"/>,
+        /// <see cref="TimeProvider.GetUtcNow"/> (once, for the time origin) and
         /// <see cref="TimeProvider.GetElapsedTime(long, long)"/> are ever called:
         /// <see cref="TimeProvider.CreateTimer"/> is deliberately not, because a background timer would run
         /// script off the engine's thread. Assigning <see langword="null"/> is read back as
@@ -135,7 +142,6 @@ public partial class Options
 /// <para>
 /// The bit layout is fixed ahead of the implementations so that a value persisted by a host keeps its meaning
 /// as the surface grows. The bits reserved for the features still to land are
-/// <c>Crypto = 1 &lt;&lt; 5</c> and <c>Performance = 1 &lt;&lt; 6</c> and
 /// <c>Fetch = 1 &lt;&lt; 10</c>. A flag is declared here only once the feature behind it actually exists, so
 /// that naming one can never compile into an engine that silently does not have it.
 /// </para>
@@ -186,6 +192,20 @@ public enum WebApiFeatures
     StructuredClone = 1 << 4,
 
     /// <summary>
+    /// The <c>crypto</c> object: <c>getRandomValues</c> and <c>randomUUID</c>, both backed by the BCL's
+    /// cryptographically secure generator. <c>crypto.subtle</c> is not implemented and is absent rather than
+    /// present-and-throwing, so feature detection sees the truth.
+    /// </summary>
+    Crypto = 1 << 5,
+
+    /// <summary>
+    /// The <c>performance</c> object: <c>now()</c> and <c>timeOrigin</c>. Both read the clock in
+    /// <see cref="Options.TimerOptions.TimeProvider"/>, so a fake one drives them and the timers together.
+    /// Marks, measures and the performance timeline are not implemented.
+    /// </summary>
+    Performance = 1 << 6,
+
+    /// <summary>
     /// <c>Event</c>, <c>CustomEvent</c>, <c>EventTarget</c>, <c>AbortController</c> and <c>AbortSignal</c> —
     /// the DOM event and cancellation model, without the node tree a browser dispatches events through.
     /// <c>AbortSignal.timeout()</c> schedules on the same queue the timers use, so it too fires only while the
@@ -209,9 +229,10 @@ public enum WebApiFeatures
     /// <summary>
     /// The web APIs a host normally wants: everything except outbound network access. Today that is
     /// <see cref="Console"/>, <see cref="Timers"/>, <see cref="Encoding"/>, <see cref="Base64"/>,
-    /// <see cref="StructuredClone"/>, <see cref="Events"/>, <see cref="Url"/> and <see cref="Files"/>; it
-    /// grows as further features land, and never comes to include fetch.
+    /// <see cref="StructuredClone"/>, <see cref="Crypto"/>, <see cref="Performance"/>, <see cref="Events"/>,
+    /// <see cref="Url"/> and <see cref="Files"/>; it grows as further features land, and never comes to
+    /// include fetch.
     /// </summary>
-    Default = Console | Timers | Encoding | Base64 | StructuredClone | Events | Url | Files,
+    Default = Console | Timers | Encoding | Base64 | StructuredClone | Crypto | Performance | Events | Url | Files,
 }
 #endif

--- a/Jint/Runtime/Intrinsics.WebApi.cs
+++ b/Jint/Runtime/Intrinsics.WebApi.cs
@@ -2,11 +2,13 @@
 using Jint.WebApi.Abort;
 using Jint.WebApi.Base64;
 using Jint.WebApi.Console;
+using Jint.WebApi.Crypto;
 using Jint.WebApi.DomException;
 using Jint.WebApi.Encoding;
 using Jint.WebApi.Events;
 using Jint.WebApi.Files;
 using Jint.WebApi.StructuredClone;
+using Jint.WebApi.Performance;
 using Jint.WebApi.Timers;
 using Jint.WebApi.Url;
 
@@ -34,6 +36,8 @@ public sealed partial class Intrinsics
     private StructuredCloneFunction? _structuredClone;
     private UrlConstructor? _webApiUrl;
     private UrlSearchParamsConstructor? _webApiUrlSearchParams;
+    private CryptoInstance? _crypto;
+    private PerformanceInstance? _performance;
 
     internal DomExceptionConstructor DomException =>
         _domException ??= new DomExceptionConstructor(_engine, _realm, Function.PrototypeObject, Error.PrototypeObject);
@@ -110,5 +114,14 @@ public sealed partial class Intrinsics
 
     internal AbortControllerConstructor AbortController =>
         _abortController ??= new AbortControllerConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject, AbortSignal);
+    internal CryptoInstance Crypto =>
+        _crypto ??= new CryptoInstance(_engine, _realm, Object.PrototypeObject);
+
+    /// <summary>
+    /// The <c>performance</c> object, which reads the engine's time origin and therefore needs the web-API
+    /// state <c>WebApiRegistration</c> created alongside the global.
+    /// </summary>
+    internal PerformanceInstance Performance =>
+        _performance ??= PerformanceInstance.Create(_engine, _realm, Object.PrototypeObject);
 }
 #endif

--- a/Jint/WebApi/Crypto/CryptoInstance.cs
+++ b/Jint/WebApi/Crypto/CryptoInstance.cs
@@ -1,0 +1,224 @@
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Security.Cryptography;
+using Jint.Native;
+using Jint.Native.ArrayBuffer;
+using Jint.Native.Object;
+using Jint.Native.TypedArray;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.DomException;
+
+namespace Jint.WebApi.Crypto;
+
+/// <summary>
+/// The <c>crypto</c> object — an instance of the <c>Crypto</c> interface.
+/// <para>
+/// https://w3c.github.io/webcrypto/#crypto-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both operations take their randomness from <see cref="RandomNumberGenerator"/>, which is the BCL's
+/// cryptographically secure generator — the only source that can satisfy "fill bytes with cryptographically
+/// secure random bytes", which both algorithms say. <c>Random</c> and <c>Math.random</c> are deliberately
+/// nowhere near this file.
+/// </para>
+/// <para>
+/// <b><c>crypto.subtle</c> is deliberately absent</b> rather than present-and-throwing, so that the feature
+/// detection every library performing cryptography starts with — <c>if (crypto.subtle)</c> — gets the truthful
+/// answer and takes its fallback path.
+/// </para>
+/// <para>
+/// Two documented simplifications against WebIDL, the same pair <c>console</c> carries. There is no
+/// <c>Crypto</c> interface object and no <c>Crypto.prototype</c>, so the two operations and the
+/// <c>@@toStringTag</c> are own properties of this object with the attributes an ECMAScript built-in method
+/// has (writable, configurable, non-enumerable) rather than those of a WebIDL interface prototype's
+/// operations. What a script can actually observe of that is unchanged: <c>Object.keys(crypto)</c> answers
+/// the empty array in a browser too, because there the operations live one level up on the prototype. Both
+/// operations still brand-check their receiver, so extracting one and calling it on something else raises a
+/// <c>TypeError</c> exactly as a browser does. And the object is installed as an ordinary enumerable data
+/// property of the global rather than through the <c>[Replaceable]</c> accessor pair WebIDL gives it.
+/// </para>
+/// </remarks>
+[JsObject]
+internal sealed partial class CryptoInstance : BuiltinShapeObject
+{
+    /// <summary>
+    /// The quota step 3 enforces, https://w3c.github.io/webcrypto/#Crypto-method-getRandomValues: "If
+    /// byteLength is greater than 65536, throw a QuotaExceededError".
+    /// </summary>
+    private const uint MaxRandomBytes = 65536;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString CryptoToStringTag = new("Crypto");
+
+    private readonly Realm _realm;
+
+    internal CryptoInstance(Engine engine, Realm realm, ObjectPrototype objectPrototype) : base(engine)
+    {
+        _realm = realm;
+        _prototype = objectPrototype;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#Crypto-method-getRandomValues
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The IDL is <c>ArrayBufferView getRandomValues(ArrayBufferView array)</c>, so the argument goes through
+    /// two separate gates and they fail differently. WebIDL's own <c>ArrayBufferView</c> conversion runs
+    /// first and raises a <c>TypeError</c> for anything that is not a view at all — and for a view onto a
+    /// <c>SharedArrayBuffer</c>, which only an operation declaring <c>[AllowShared]</c> accepts and this one
+    /// does not (https://webidl.spec.whatwg.org/#es-arraybufferview). Step 1 then raises a
+    /// <c>TypeMismatchError</c> <c>DOMException</c> for a view that <i>is</i> one but holds floats — a
+    /// <c>Float32Array</c> or a <c>DataView</c>.
+    /// </para>
+    /// <para>
+    /// A detached view, and a length-tracking view whose resizable buffer has shrunk past it, both have a
+    /// byte length of zero. Step 4's byte sequence is then empty and step 6 writes it into nothing, so the
+    /// array comes back untouched rather than raising: the quota in step 3 is a maximum, not a minimum.
+    /// </para>
+    /// </remarks>
+    [JsFunction(Name = "getRandomValues", Length = 1)]
+    private JsValue GetRandomValues(JsValue thisObject, JsValue array)
+    {
+        Brand(thisObject, "getRandomValues");
+
+        if (array is JsDataView)
+        {
+            // A DataView passes WebIDL's ArrayBufferView conversion and fails step 1, which is why it is a
+            // DOMException here and a TypeError two lines below.
+            ThrowDomException(
+                DomExceptionNames.TypeMismatch,
+                "Failed to execute 'getRandomValues' on 'Crypto': the provided ArrayBufferView is a DataView, which is not an integer array type.");
+        }
+
+        if (array is not JsTypedArray typedArray)
+        {
+            Throw.TypeError(_realm, "Failed to execute 'getRandomValues' on 'Crypto': parameter 1 is not of type 'ArrayBufferView'.");
+            return Undefined;
+        }
+
+        var buffer = typedArray._viewedArrayBuffer;
+        if (buffer.IsSharedArrayBuffer)
+        {
+            Throw.TypeError(_realm, "Failed to execute 'getRandomValues' on 'Crypto': parameter 1 is a view onto a SharedArrayBuffer, which this operation does not accept.");
+            return Undefined;
+        }
+
+        var elementType = typedArray._arrayElementType;
+        if (!IsIntegerElementType(elementType))
+        {
+            ThrowDomException(
+                DomExceptionNames.TypeMismatch,
+                $"Failed to execute 'getRandomValues' on 'Crypto': the provided ArrayBufferView is a {elementType.GetTypedArrayName()}, which is not an integer array type.");
+        }
+
+        // "Let byteLength be the byte length of array" — from the buffer witness, so a detached view and a
+        // length-tracking view that has fallen out of bounds both answer zero, exactly as the typed array's
+        // own byteLength accessor does.
+        var record = IntrinsicTypedArrayPrototype.MakeTypedArrayWithBufferWitnessRecord(typedArray, ArrayBufferOrder.SeqCst);
+        var byteLength = record.TypedArrayByteLength;
+
+        if (byteLength > MaxRandomBytes)
+        {
+            // WebIDL has since given QuotaExceededError an interface of its own carrying `quota` and
+            // `requested`; Jint exposes the name on a plain DOMException, which is what every browser did
+            // until that change and what the algorithm's own wording asks for.
+            ThrowDomException(
+                DomExceptionNames.QuotaExceeded,
+                $"Failed to execute 'getRandomValues' on 'Crypto': the ArrayBufferView's byte length ({byteLength}) exceeds the {MaxRandomBytes} bytes of entropy this operation provides.");
+        }
+
+        var data = buffer.ArrayBufferData;
+        if (byteLength == 0 || data is null)
+        {
+            return array;
+        }
+
+        // https://tc39.es/proposal-immutable-arraybuffer/#sec-isimmutablebuffer — writing into an immutable
+        // buffer is a TypeError, the same one an ordinary element assignment raises, and for the same reason.
+        // It is asked only once there is something to write, which is also how IntegerIndexedElementSet
+        // orders it: a write that does not happen cannot fail.
+        buffer.AssertNotImmutable();
+
+        RandomNumberGenerator.Fill(data.AsSpan(typedArray._byteOffset, (int) byteLength));
+
+        // Step 7: the very same object, never a copy.
+        return array;
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#Crypto-method-randomUUID
+    /// </summary>
+    /// <remarks>
+    /// The algorithm verbatim: sixteen cryptographically secure random bytes, the four most significant bits
+    /// of byte 6 set to <c>0100</c> (the version) and the two most significant bits of byte 8 set to
+    /// <c>10</c> (the variant), rendered as the lowercase hyphenated form. <c>Guid.NewGuid()</c> would be one
+    /// line, and does produce a version 4 UUID, but which generator backs it is a platform-specific
+    /// implementation detail rather than a documented guarantee — and "cryptographically secure random bytes"
+    /// is the one thing this operation exists to promise. <see cref="RandomNumberGenerator"/> promises it in
+    /// writing, so the bytes come from there and <see cref="Guid"/> is used only to format them: the
+    /// big-endian constructor and <c>ToString("D")</c> are exactly the hex-and-hyphens concatenation the last
+    /// step spells out.
+    /// </remarks>
+    [JsFunction(Name = "randomUUID", Length = 0)]
+    private JsString RandomUuid(JsValue thisObject)
+    {
+        Brand(thisObject, "randomUUID");
+
+        Span<byte> bytes = stackalloc byte[16];
+        RandomNumberGenerator.Fill(bytes);
+
+        bytes[6] = (byte) ((bytes[6] & 0x0F) | 0x40);
+        bytes[8] = (byte) ((bytes[8] & 0x3F) | 0x80);
+
+        return JsString.Create(new Guid(bytes, bigEndian: true).ToString("D", CultureInfo.InvariantCulture));
+    }
+
+    /// <summary>
+    /// Step 1's list of accepted views: every integer typed array, which is every typed array except the
+    /// three floating-point ones. Written as an explicit list rather than as "not a float", so that a typed
+    /// array type added to the engine later is refused until someone has read this algorithm again.
+    /// </summary>
+    private static bool IsIntegerElementType(TypedArrayElementType type) => type
+        is TypedArrayElementType.Int8
+        or TypedArrayElementType.Uint8
+        or TypedArrayElementType.Uint8C
+        or TypedArrayElementType.Int16
+        or TypedArrayElementType.Uint16
+        or TypedArrayElementType.Int32
+        or TypedArrayElementType.Uint32
+        or TypedArrayElementType.BigInt64
+        or TypedArrayElementType.BigUint64;
+
+    /// <summary>
+    /// The WebIDL brand check every operation performs: a receiver that is not a platform object implementing
+    /// the interface raises a <c>TypeError</c>, so an extracted <c>getRandomValues</c> cannot be called on
+    /// anything else.
+    /// </summary>
+    private void Brand(JsValue thisObject, string operation)
+    {
+        if (thisObject is not CryptoInstance)
+        {
+            Throw.TypeError(_realm, $"Failed to execute '{operation}' on 'Crypto': illegal invocation, receiver is not a Crypto object.");
+        }
+    }
+
+    [DoesNotReturn]
+    private void ThrowDomException(string name, string message)
+    {
+        var exception = _realm.Intrinsics.DomException.CreateException(name, message);
+        var location = _engine._lastSyntaxElement?.Location ?? default;
+        Throw.JavaScriptException(_engine, exception, in location);
+    }
+}
+#endif

--- a/Jint/WebApi/Events/EventConstructor.cs
+++ b/Jint/WebApi/Events/EventConstructor.cs
@@ -122,7 +122,7 @@ internal sealed partial class EventConstructor : Constructor
     /// specification is a browser's fingerprinting defence, and an embedded engine has no cross-origin script
     /// to defend against.
     /// </summary>
-    internal static double TimeStampNow(Engine engine) => engine._webApi?.RelativeHighResolutionTime() ?? 0;
+    internal static double TimeStampNow(Engine engine) => engine._webApi?.CurrentHighResolutionTime ?? 0;
 }
 
 /// <summary>

--- a/Jint/WebApi/Performance/PerformanceInstance.cs
+++ b/Jint/WebApi/Performance/PerformanceInstance.cs
@@ -1,0 +1,125 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Performance;
+
+/// <summary>
+/// The <c>performance</c> object — an instance of the <c>Performance</c> interface.
+/// <para>
+/// https://w3c.github.io/hr-time/#sec-performance
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both members are answered from <c>Options.WebApi.Timers.TimeProvider</c>, the very clock the timers are
+/// scheduled against, so a host that installs a fake one drives <c>setTimeout</c> and <c>performance.now()</c>
+/// coherently instead of watching one of them stand still while the other runs. <see cref="TimeOriginGet"/>
+/// and <see cref="Now"/> are the two halves of one reading: the origin is the wall-clock moment the engine's
+/// web-API state was created, and <c>now()</c> is the monotonic duration since that same moment, so
+/// <c>performance.timeOrigin + performance.now()</c> is the current time in Unix milliseconds.
+/// </para>
+/// <para>
+/// <b>The time origin is per engine, not per evaluation cycle.</b> A pooled engine that a host recycles with
+/// <c>Engine.Advanced.RestoreGlobalSnapshot</c> keeps the origin it was built with, so <c>now()</c> goes on
+/// growing across cycles and a script cannot use it to tell how long <i>its own</i> cycle has been running.
+/// That is deliberate: the origin is what makes the readings monotonic, and rewinding it at a restore would
+/// hand the next cycle a clock that had gone backwards — which is the one thing
+/// https://w3c.github.io/hr-time/#dom-performance-now forbids outright.
+/// </para>
+/// <para>
+/// Not implemented, and absent rather than throwing so that feature detection sees the truth: the
+/// <c>Performance Timeline</c> surface (<c>mark</c>, <c>measure</c>, <c>getEntries*</c>, <c>clearMarks</c>),
+/// <c>toJSON</c>, and the <c>EventTarget</c> this interface inherits from.
+/// </para>
+/// <para>
+/// Two documented simplifications against WebIDL, the same pair <c>console</c> and <c>crypto</c> carry. There
+/// is no <c>Performance</c> interface object and no <c>Performance.prototype</c>, so <c>now</c> and
+/// <c>timeOrigin</c> are own properties of this object with the attributes an ECMAScript built-in has, rather
+/// than those of a WebIDL interface prototype's members; both still brand-check their receiver, and
+/// <c>Object.keys(performance)</c> answers the empty array here exactly as it does in a browser. And the
+/// object is installed as an ordinary enumerable data property of the global rather than through the
+/// <c>[Replaceable]</c> accessor pair WebIDL gives it.
+/// </para>
+/// <para>
+/// One deliberate divergence: the readings are <b>not coarsened</b>. https://w3c.github.io/hr-time/#dfn-coarsen-time
+/// asks a browser to round to at best 100 microseconds because a page shares a process with cross-origin
+/// data that a fine clock helps steal. An embedded engine has no cross-origin anything, and a host that wants
+/// a coarse clock supplies a coarse <see cref="TimeProvider"/>; the resolution here is simply whatever that
+/// provider gives, which for <see cref="TimeProvider.System"/> is the <c>Stopwatch</c> tick.
+/// </para>
+/// </remarks>
+[JsObject]
+internal sealed partial class PerformanceInstance : BuiltinShapeObject
+{
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString PerformanceToStringTag = new("Performance");
+
+    private readonly Realm _realm;
+    private readonly WebApiEngineState _state;
+
+    private PerformanceInstance(Engine engine, Realm realm, ObjectPrototype objectPrototype, WebApiEngineState state)
+        : base(engine)
+    {
+        _realm = realm;
+        _state = state;
+        _prototype = objectPrototype;
+    }
+
+    internal static PerformanceInstance Create(Engine engine, Realm realm, ObjectPrototype objectPrototype)
+    {
+        var state = engine._webApi;
+        if (state is null)
+        {
+            // Unreachable: the global that reaches this property is installed only where the state was
+            // created, in the same block of WebApiRegistration.
+            Throw.InvalidOperationException("The performance object was reached on an engine that has no web-API state.");
+        }
+
+        return new PerformanceInstance(engine, realm, objectPrototype, state);
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/hr-time/#dom-performance-now — "the number of milliseconds in the current high
+    /// resolution time", which is the duration from this engine's time origin to now, read from the monotonic
+    /// clock.
+    /// </summary>
+    [JsFunction(Name = "now", Length = 0)]
+    private JsNumber Now(JsValue thisObject)
+    {
+        Brand(thisObject, "Failed to execute 'now' on 'Performance'");
+        return JsNumber.Create(_state.CurrentHighResolutionTime);
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/hr-time/#dom-performance-timeorigin — the duration from the Unix epoch to this
+    /// engine's time origin, in milliseconds.
+    /// </summary>
+    [JsAccessor("timeOrigin")]
+    private JsNumber TimeOriginGet(JsValue thisObject)
+    {
+        Brand(thisObject, "Failed to read the 'timeOrigin' property from 'Performance'");
+        return JsNumber.Create(_state.TimeOrigin);
+    }
+
+    /// <summary>
+    /// The WebIDL brand check every member performs: a receiver that is not a platform object implementing
+    /// the interface raises a <c>TypeError</c>.
+    /// </summary>
+    private void Brand(JsValue thisObject, string what)
+    {
+        if (thisObject is not PerformanceInstance)
+        {
+            Throw.TypeError(_realm, what + ": illegal invocation, receiver is not a Performance object.");
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/WebApiRegistration.cs
+++ b/Jint/WebApi/WebApiRegistration.cs
@@ -101,6 +101,18 @@ internal static class WebApiRegistration
             Install(global, engine, "AbortController", static e => e.Realm.Intrinsics.AbortController, PropertyFlag.NonEnumerable);
             Install(global, engine, "AbortSignal", static e => e.Realm.Intrinsics.AbortSignal, PropertyFlag.NonEnumerable);
         }
+
+        if ((features & WebApiFeatures.Crypto) != WebApiFeatures.None)
+        {
+            // WebIDL exposes crypto through a [Replaceable] accessor pair; an ordinary enumerable data
+            // property is the same simplification console is installed with, documented on CryptoInstance.
+            Install(global, engine, "crypto", static e => e.Realm.Intrinsics.Crypto, PropertyFlag.ConfigurableEnumerableWritable);
+        }
+
+        if ((features & WebApiFeatures.Performance) != WebApiFeatures.None)
+        {
+            Install(global, engine, "performance", static e => e.Realm.Intrinsics.Performance, PropertyFlag.ConfigurableEnumerableWritable);
+        }
     }
 
     /// <summary>
@@ -116,9 +128,10 @@ internal static class WebApiRegistration
     private static void CreateEngineState(Options options, Engine engine, WebApiFeatures features)
     {
         // The timer globals are the obvious reason for a queue; AbortSignal.timeout() is the other, and it
-        // needs one whether or not the host also asked for setTimeout. The events feature additionally reads
-        // the time origin for Event.timeStamp, which is why it wants the state even without the timers flag.
-        const WebApiFeatures NeedsEngineState = WebApiFeatures.Timers | WebApiFeatures.Events;
+        // needs one whether or not the host also asked for setTimeout. The events and performance features
+        // additionally read the time origin (Event.timeStamp, performance.now), which is why they want the state
+        // even without the timers flag.
+        const WebApiFeatures NeedsEngineState = WebApiFeatures.Timers | WebApiFeatures.Events | WebApiFeatures.Performance;
         if ((features & NeedsEngineState) == WebApiFeatures.None)
         {
             return;
@@ -126,7 +139,13 @@ internal static class WebApiRegistration
 
         var timerOptions = options.WebApi.Timers;
         var timeProvider = timerOptions.TimeProvider ?? TimeProvider.System;
-        var timers = new TimerQueue(timeProvider, timerOptions.MaxActiveTimers);
+
+        // The queue exists for the timer globals and for AbortSignal.timeout(), which needs it whether or
+        // not the host also asked for setTimeout; a performance-only engine reads just the time origin and
+        // never schedules, so it carries no queue at all.
+        var timers = (features & (WebApiFeatures.Timers | WebApiFeatures.Events)) != WebApiFeatures.None
+            ? new TimerQueue(timeProvider, timerOptions.MaxActiveTimers)
+            : null;
 
         engine._webApi = new WebApiEngineState(engine, timeProvider, timers);
     }

--- a/README.md
+++ b/README.md
@@ -217,8 +217,8 @@ its own `console` (or any other name in the table below), enabling the feature l
 | `TextEncoder` / `TextDecoder` (UTF-8, UTF-16LE, UTF-16BE; `fatal`, `ignoreBOM`, streaming) | `Encoding` | ✔ shipped |
 | `atob` / `btoa` | `Base64` | ✔ shipped |
 | `structuredClone` (incl. `{ transfer }` of `ArrayBuffer`s) | `StructuredClone` | ✔ shipped |
-| `crypto.getRandomValues` / `crypto.randomUUID` | `Crypto` | in progress |
-| `performance.now` / `performance.timeOrigin` | `Performance` | in progress |
+| `crypto.getRandomValues` / `crypto.randomUUID` | `WebApiFeatures.Crypto` | ✔ shipped |
+| `performance.now` / `performance.timeOrigin` | `WebApiFeatures.Performance` | ✔ shipped |
 | `Event` / `EventTarget` / `CustomEvent` / `AbortController` / `AbortSignal` | `Events` | ✔ shipped |
 | `URL` / `URLSearchParams` | `Url` | ✔ shipped |
 | `Blob` / `File` / `FormData` | `Files` | ✔ shipped |
@@ -907,7 +907,7 @@ var ns = engine.Modules.Import("./my-module.js");
 var value = ns.Get("value").AsString();
 ```
 
-By default, the module resolution algorithm will be restricted to the base path specified in `EnableModules`, and that loader has no package support. You can serve an npm-style `node_modules` tree with [`NodeStyleModuleLoader`](#npm-style-packages-opt-in), or provide your own packages in two further ways.
+By default, the module resolution algorithm will be restricted to the base path specified in `EnableModules`, and there is no package support. However you can provide your own packages in two ways.
 
 Defining modules using JavaScript source code:
 
@@ -947,62 +947,6 @@ Note that you don't need to `EnableModules` if you only use modules created usin
 If you serve the same modules from a pool of engines, see **Sharing a module graph across pooled engines**
 under [Embedding performance](#embedding-performance): a loader that caches prepared modules keeps every
 engine but the first from parsing them again.
-
-### npm-style packages (opt-in)
-
-`NodeStyleModuleLoader` resolves bare specifiers — `import 'lodash'`, `import '@scope/pkg/feature.js'` — the way
-Node.js resolves them for ES modules, so an ordinary `node_modules` tree works as it does everywhere else:
-
-```c#
-var engine = new Engine(options =>
-{
-    options.EnableModules(new NodeStyleModuleLoader(@"C:\app"));
-});
-
-var ns = engine.Modules.Import("./main.js"); // main.js may `import 'some-package'`
-```
-
-It implements [ESM_RESOLVE](https://nodejs.org/api/esm.html#resolution-algorithm-specification) and the
-functions it calls: the `node_modules` walk upwards from the importing module, `"exports"` (string, subpath map,
-[conditional](https://nodejs.org/api/packages.html#conditional-exports), `*` patterns, fallback arrays,
-`null` to block a subpath), its precedence over `"main"`, the encapsulation that makes an unexported subpath an
-error, `"main"` with an `index.js` fallback when there is no `"exports"`, scoped packages, nested
-`node_modules` shadowing, and
-[self-reference](https://nodejs.org/api/packages.html#self-referencing-a-package-using-its-name) by the
-package's own `"name"`. Refusals arrive as `ModuleResolutionException`, whose `ResolverAlgorithmError` carries
-that algorithm's own error name — `Package Path Not Exported`, `Invalid Package Target`,
-`Invalid Package Configuration`, `Module Not Found` — followed by the rule that refused.
-
-Relative and absolute specifiers behave exactly as `DefaultModuleLoader` resolves them, base-path restriction
-included; here that restriction is not optional, because it is also what bounds the `node_modules` walk. Nothing
-outside the base path is read, and no path outside it appears in an error message.
-
-```c#
-new NodeStyleModuleLoader(basePath, new NodeModuleLoaderOptions
-{
-    // Which export conditions match. The default is ["import", "default"]. Order here means nothing:
-    // the package's own key order decides, per the specification. Add "node" to consume packages that
-    // ship a Node-specific entry point — knowing that branch may expect APIs Jint has no counterpart for.
-    Conditions = ["import", "default"],
-
-    // Whether a specifier may resolve to a .json file at all (default true). The `with { type: 'json' }`
-    // attribute is mandatory either way, exactly as it is in Node.
-    AllowJsonModules = true,
-
-    // CommonJS-shaped probing: './util' also finding util.js, or a directory's index.js (default false,
-    // because ES module resolution deliberately does no extension searching).
-    ExtensionProbing = false,
-})
-```
-
-Three things it deliberately does not do. There are no Node builtins, so a `node:` specifier is refused rather
-than resolved; `#imports` are not supported, the same posture `DefaultModuleLoader` takes; and there are no
-module formats — Jint has no CommonJS loader, so a package offering only a `"require"` branch is unusable, as
-it would be in any ESM-only host. A bare specifier matching no package on disk is handed back unresolved
-instead of raising `Module Not Found`, which is what keeps `Engine.Modules.Add` usable alongside it; a package
-that *is* found and then refuses fails there and then. Nothing is cached, so a package edited between two
-imports is picked up — wrap the loader and memoize `Resolve` if a large immutable tree makes those reads worth
-amortizing. The loader holds no mutable state and may be shared by several engines.
 
 ### How a module is named
 


### PR DESCRIPTION
Part of the opt-in web API series (#3079): `crypto.getRandomValues`/`crypto.randomUUID` behind `WebApiFeatures.Crypto` and `performance.now()`/`performance.timeOrigin` behind `WebApiFeatures.Performance` (both in `Default`). Usual rules: BCL only, net8+, opt-in, default engine unchanged.

- **`crypto.getRandomValues`** (https://w3c.github.io/webcrypto/#Crypto-method-getRandomValues): two gates that fail differently, both from the spec's own layering — a non-view is a WebIDL `TypeError`, while a `Float*Array`/`DataView` (which *are* views) reaches step 1 and gets `TypeMismatchError`; byteLength over 65536 is `QuotaExceededError`; the view's own slice is filled via `RandomNumberGenerator.Fill` and the same array returned. Byte length comes from the typed-array-with-buffer-witness record, so detached and out-of-bounds length-tracking views answer zero bytes and return unfilled rather than throwing.
- **`crypto.randomUUID`** implements the spec's byte-level algorithm (16 cryptographically random bytes, version nibble forced to 4, variant to 10xx, hyphenated lowercase hex) rather than trusting a `Guid` — with tests pinning the version nibble, variant bits and lowercase.
- **`performance.now()`** is a monotonic sub-millisecond double measured from **`performance.timeOrigin`** — the wall-clock instant the engine's web-API state was created — reading the same `TimeProvider` the timers use, so a fake clock drives timers, `Event.timeStamp` and `performance` coherently. Coarsening (hr-time's 100µs anti-fingerprinting) is deliberately not applied — a host wanting a coarse clock supplies a coarse provider; documented.
- This PR also completes the shared-state unification the events PR set up: one monotonic origin timestamp on the per-engine state serving `Event.timeStamp` and `performance.now` through a single `CurrentHighResolutionTime`, with the wall-clock `TimeOrigin` alongside — per engine, deliberately not reset by a global-snapshot restore so `now()` can never go backwards across evaluation cycles for a pooled engine.

`crypto.subtle` intentionally arrives separately (digest-first, campaign #3083). Verified: all-TFM build, both suites both frameworks, both host-contract-verification configurations; mutation-verified tests for the quota-in-bytes rule and the view-slice fill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
