### PR TITLE
Add opt-in fetch

### DIFF
--- a/.github/THREAT_MODEL.md
+++ b/.github/THREAT_MODEL.md
@@ -82,6 +82,8 @@ Defaults are compatibility choices, not a hardened profile.
 | CLR array conversion | Live view | Script writes can mutate a projected CLR array |
 | Modules | Disabled | The fail-fast loader rejects imports |
 | `require` | Disabled | No CommonJS-like loader global |
+| Web platform APIs (`Options.WebApi.Features`) | `None` | No `console`, timers, `URL`, `Blob`, … globals exist |
+| `fetch` | Disabled, and never part of `WebApiFeatures.Default` | Only `UseFetch()` grants script outbound HTTP |
 | Timeout, statement, memory, recursion limits | None | Untrusted execution is unbounded unless the host opts in |
 | Stack overflow guard | Disabled | Native stack exhaustion can terminate the process |
 | Maximum array size | `uint.MaxValue` | Effectively unbounded for hostile input |
@@ -560,6 +562,81 @@ malformed input into a crash, denial of service, information leak, or sandbox es
 scan dependencies, fuzz the application-specific integration, and retain process isolation
 and least privilege as defense in depth.
 
+### TM-21: `fetch` turns script into a client of the host's network position
+
+**Threat.** Enabling `WebApiFeatures.Fetch` gives script outbound HTTP with the worker's own
+network identity. Whatever the process can reach, script can reach: an internal service, a
+database admin port, a service mesh sidecar, a cloud instance-metadata endpoint. A redirect
+is part of the attack surface, not just of the transport — a reachable server the script is
+allowed to call can answer `302 Location: http://169.254.169.254/latest/meta-data/` and
+launder the request past a first-hop check. A response is attacker-influenced in size: a
+compression bomb or an endless stream buffers into the worker's heap. Concurrency is
+attacker-controlled too, so a loop of `fetch` calls holds sockets, connections, and
+buffers without bound. URLs, headers, and bodies the script composes can carry the host's
+credentials to a destination the script chose, and header values it controls could splice a
+second request into the connection.
+
+This is the same class of threat as [TM-11](#tm-11-module-loaders-expose-files-networks-and-secrets),
+which covers the loader-shaped version of it. The difference is that a module loader is
+host-written and `fetch` is not: the policy has to live in Jint, because there is no host
+code between the script and the socket.
+
+**Existing mitigations.**
+
+- The feature is **off by default and not part of `WebApiFeatures.Default`**. `UseWebApis()`
+  never enables it; `UseFetch()` is the only call that does.
+- `Options.WebApi.Fetch.AllowedSchemes` defaults to `https` and `http`, checked before a
+  socket is opened.
+- `Options.WebApi.Fetch.UrlFilter` is the host's allow-list, and is **re-run on every
+  redirect hop**: Jint drives redirects itself with `AllowAutoRedirect` off, so no hop
+  escapes the check.
+- `Options.WebApi.Fetch.MaxRedirects` (20) bounds the hop count.
+- `Options.WebApi.Fetch.MaxResponseBytes` (32 MiB) bounds the **decompressed** body, checked
+  against the declared `Content-Length` and again as a running total, so a lying or chunked
+  response is caught too.
+- `Options.WebApi.Fetch.Timeout` (30 s) is enforced CLR-side on the request's cancellation
+  token, so it fires even for an engine nobody is pumping.
+- `Options.WebApi.Fetch.MaxConcurrentRequests` (10) bounds in-flight requests per engine, and
+  the excess is refused rather than queued.
+- `Authorization`, `Cookie`, and `Proxy-Authorization` are stripped when a redirect crosses
+  origin; a `303`, and a `301`/`302` on a `POST`, drop the body and its content headers.
+- A URL carrying credentials (`https://user:pass@host/`) is refused by the `Request`
+  constructor.
+- Header names must be RFC 9110 tokens and header values may not contain NUL, CR, or LF, so
+  script cannot splice a second request into the connection.
+- Every network-class failure is one `TypeError` whose message is only `Failed to fetch`; the
+  originating CLR exception rides the error *value* and is readable by the host through
+  `JintException.TryGetClrException`, never by script.
+- The default client has `UseCookies = false`, so no cookie jar is shared between engines or
+  tenants.
+- A request in flight is cancelled by `Engine.Advanced.RestoreGlobalSnapshot`, and its promise
+  never settles into the restored engine.
+- Timer flooding is covered separately by `Options.WebApi.Timers.MaxActiveTimers` (1000), and
+  timers only fire while the host pumps the engine.
+
+**Missing or residual mitigation.**
+
+- `UrlFilter` sees a URL, not a resolved IP. It cannot by itself stop DNS rebinding or a
+  hostname that resolves to a link-local or private address.
+- There is no per-request or per-engine byte, connection, or bandwidth budget beyond the
+  per-response cap and the concurrency cap; a script may still issue many bounded requests in
+  sequence.
+- `credentials`, `cache`, `mode`, `referrer`, and `integrity` are accepted and ignored, so a
+  script cannot rely on them for protection and neither can a host reading the request.
+- The default shared `HttpClient` is process-wide and never disposed; its connection pool is
+  shared by every engine that did not supply a client.
+- Response bodies are buffered in memory, so `MaxResponseBytes` is also the per-request heap
+  cost.
+
+**Required host action.** Do not enable `UseFetch` for untrusted script unless the deployment
+needs it. When it is needed, set a `UrlFilter` that allow-lists destinations rather than
+denying known-bad ones, drop `http` from `AllowedSchemes`, lower `MaxResponseBytes`,
+`MaxRedirects`, `Timeout`, and `MaxConcurrentRequests` to what the workload actually needs,
+and supply an `HttpClient` (or `HttpClientFactory`) whose handler applies the deployment's
+proxy, DNS, and TLS policy. Resolve-and-check the destination address in the handler if
+rebinding is in scope. Keep the worker's egress restricted at the network layer as well:
+`UrlFilter` is a policy inside the process, not a firewall.
+
 ## Hardened deployment baseline
 
 The numbers below are examples only. Measure normal workloads and choose smaller limits that
@@ -629,6 +706,10 @@ Before deploying a host that executes untrusted scripts:
   domains.
 - [ ] Custom module loaders enforce scheme, origin, IP, path, redirect, size, and timeout
   policies and disclose no secrets in names or errors.
+- [ ] `fetch` is off, or its `UrlFilter`, `AllowedSchemes`, `MaxResponseBytes`,
+  `MaxRedirects`, `Timeout`, and `MaxConcurrentRequests` allow-list the destinations and the
+  budgets the workload actually needs, and worker egress is restricted at the network layer
+  as well.
 - [ ] Worker identity, filesystem, network, CPU, memory, and lifetime are restricted outside
   Jint.
 - [ ] Timeout, cancellation, memory, stack, loader, and serialization failures are exercised

--- a/Jint.Tests.PublicInterface/WebApiFetchTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiFetchTests.cs
@@ -1,0 +1,480 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Jint;
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// <c>fetch</c> seen from outside the assembly: the policy a host writes, the failures it produces and the
+/// threads its promise settles on.
+/// </summary>
+/// <remarks>
+/// This project has no <c>InternalsVisibleTo</c>, so everything here is reachable by a third party — the
+/// stub transport goes in through <c>Options.WebApi.Fetch.HttpClient</c>, which is the same door a host uses
+/// for a <c>DelegatingHandler</c> or an <c>IHttpClientFactory</c> client.
+/// </remarks>
+public class WebApiFetchTests
+{
+    /// <summary>
+    /// A handler that answers immediately or hangs until its token is cancelled, and remembers which.
+    /// </summary>
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        internal List<string> Urls { get; } = new();
+
+        internal bool Hang { get; init; }
+
+        internal Func<string, HttpResponseMessage> Responder { get; init; } =
+            static _ => new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") };
+
+        /// <summary>Set when the handler saw its cancellation token fire — the proof an abort reached the socket.</summary>
+        internal ManualResetEventSlim Cancelled { get; } = new(false);
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            lock (Urls)
+            {
+                Urls.Add(request.RequestUri!.ToString());
+            }
+
+            if (!Hang)
+            {
+                return Responder(request.RequestUri!.ToString());
+            }
+
+            try
+            {
+                await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                Cancelled.Set();
+                throw;
+            }
+
+            return Responder(request.RequestUri!.ToString());
+        }
+    }
+
+    private static Engine WebEngine(HttpMessageHandler handler, Action<Options.FetchOptions>? configure = null, Action<Options>? extra = null)
+    {
+        return new Engine(options =>
+        {
+            options.UseWebApis(WebApiFeatures.Timers).UseFetch(fetch =>
+            {
+                fetch.HttpClient = new HttpClient(handler);
+                configure?.Invoke(fetch);
+            });
+
+            extra?.Invoke(options);
+        });
+    }
+
+    [Fact]
+    public void ADefaultEngineAndAUseWebApisEngineHaveNoFetch()
+    {
+        new Engine().Evaluate("typeof fetch").AsString().Should().Be("undefined");
+        new Engine(options => options.UseWebApis()).Evaluate("typeof fetch").AsString().Should().Be("undefined");
+        new Engine(options => options.UseWebApis(WebApiFeatures.Default)).Evaluate("'fetch' in globalThis").AsBoolean().Should().BeFalse();
+
+        // UseFetch is the only call that grants it.
+        new Engine(options => options.UseFetch()).Evaluate("typeof fetch").AsString().Should().Be("function");
+    }
+
+    [Fact]
+    public void TheFetchGlobalCarriesTheAttributesWebIdlAsksFor()
+    {
+        var engine = new Engine(options => options.UseFetch());
+
+        // https://webidl.spec.whatwg.org/#es-operations — a global operation is a writable, enumerable,
+        // configurable data property, unlike an interface object.
+        var descriptor = engine.Evaluate("Object.getOwnPropertyDescriptor(globalThis, 'fetch')").AsObject();
+        descriptor.Get("writable").AsBoolean().Should().BeTrue();
+        descriptor.Get("enumerable").AsBoolean().Should().BeTrue();
+        descriptor.Get("configurable").AsBoolean().Should().BeTrue();
+
+        engine.Evaluate("fetch.length").AsNumber().Should().Be(1);
+        engine.Evaluate("fetch.name").AsString().Should().Be("fetch");
+
+        // ... and never inside a shadow realm.
+        engine.Evaluate("new ShadowRealm().evaluate('typeof fetch')").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void RefusesASchemeTheHostDidNotAllow()
+    {
+        var handler = new StubHandler();
+        var engine = WebEngine(handler, f => f.AllowedSchemes.Remove("http"));
+
+        engine.Evaluate("fetch('http://example.org/').then(() => 'resolved', e => e.constructor.name + ': ' + e.message)")
+            .UnwrapIfPromise().AsString().Should().Be("TypeError: Failed to fetch");
+
+        // Refused before a socket was opened.
+        handler.Urls.Should().BeEmpty();
+
+        // https is still allowed.
+        engine.Evaluate("fetch('https://example.org/').then(r => r.status)").UnwrapIfPromise().AsNumber().Should().Be(200);
+    }
+
+    [Fact]
+    public void RefusesAUrlTheHostFilterRejects()
+    {
+        var handler = new StubHandler();
+        var engine = WebEngine(handler, f => f.UrlFilter = uri => uri.Host.EndsWith(".example.org", StringComparison.OrdinalIgnoreCase));
+
+        engine.Evaluate("fetch('https://169.254.169.254/latest/meta-data/').then(() => 'resolved', e => e.message)")
+            .UnwrapIfPromise().AsString().Should().Be("Failed to fetch");
+
+        handler.Urls.Should().BeEmpty();
+
+        engine.Evaluate("fetch('https://api.example.org/').then(r => r.status)").UnwrapIfPromise().AsNumber().Should().Be(200);
+    }
+
+    [Fact]
+    public void ReRunsTheFilterOnEveryRedirectHop()
+    {
+        // The SSRF shape: the first URL passes the filter and the server answers with a redirect to a URL
+        // that does not. An HttpClient following redirects itself would have reached it.
+        var handler = new StubHandler
+        {
+            Responder = url =>
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.Found);
+                response.Headers.TryAddWithoutValidation("location", "http://169.254.169.254/latest/meta-data/");
+                return response;
+            },
+        };
+
+        var seen = new List<string>();
+        var engine = WebEngine(handler, f => f.UrlFilter = uri =>
+        {
+            lock (seen)
+            {
+                seen.Add(uri.ToString());
+            }
+
+            return uri.Host.EndsWith(".example.org", StringComparison.OrdinalIgnoreCase);
+        });
+
+        engine.Evaluate("fetch('https://api.example.org/a').then(() => 'resolved', e => e.constructor.name + ': ' + e.message)")
+            .UnwrapIfPromise().AsString().Should().Be("TypeError: Failed to fetch");
+
+        // The filter saw both hops, and only the first reached the transport.
+        seen.Should().Equal("https://api.example.org/a", "http://169.254.169.254/latest/meta-data/");
+        handler.Urls.Should().Equal("https://api.example.org/a");
+    }
+
+    [Fact]
+    public void CapsTheResponseBodyWhenContentLengthDeclaresIt()
+    {
+        var handler = new StubHandler
+        {
+            Responder = _ => new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(new string('x', 4096)) },
+        };
+
+        var engine = WebEngine(handler, f => f.MaxResponseBytes = 1024);
+
+        engine.Evaluate("fetch('https://example.org/').then(() => 'resolved', e => e.constructor.name + '|' + e.message)")
+            .UnwrapIfPromise().AsString().Should()
+            .Be("TypeError|Failed to fetch: The response body exceeded the 1024 byte limit set by Options.WebApi.Fetch.MaxResponseBytes.");
+    }
+
+    [Fact]
+    public void CapsTheResponseBodyWithoutAContentLength()
+    {
+        // A server that lies about the length, or uses chunked encoding, is caught by the running total
+        // rather than by the declared one.
+        var handler = new StubHandler
+        {
+            Responder = _ => new HttpResponseMessage(HttpStatusCode.OK) { Content = new UnknownLengthContent(4096) },
+        };
+
+        var engine = WebEngine(handler, f => f.MaxResponseBytes = 1024);
+
+        engine.Evaluate("fetch('https://example.org/').then(() => 'resolved', e => e.message)")
+            .UnwrapIfPromise().AsString().Should().Contain("exceeded the 1024 byte limit");
+    }
+
+    /// <summary>
+    /// Content that streams its bytes and refuses to say how many there are, which is what a chunked
+    /// response looks like.
+    /// </summary>
+    private sealed class UnknownLengthContent : HttpContent
+    {
+        private readonly int _length;
+
+        internal UnknownLengthContent(int length) => _length = length;
+
+        protected override Task SerializeToStreamAsync(Stream stream, System.Net.TransportContext? context)
+            => stream.WriteAsync(new byte[_length], 0, _length);
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return false;
+        }
+    }
+
+    [Fact]
+    public void ABodyUnderTheCapIsReadInFull()
+    {
+        var handler = new StubHandler
+        {
+            Responder = _ => new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(new string('x', 1024)) },
+        };
+
+        var engine = WebEngine(handler, f => f.MaxResponseBytes = 1024);
+        engine.Evaluate("fetch('https://example.org/').then(r => r.text()).then(t => t.length)")
+            .UnwrapIfPromise().AsNumber().Should().Be(1024);
+    }
+
+    [Fact]
+    public void AnAbortMidFlightRejectsWithTheReasonAndCancelsTheRequest()
+    {
+        var handler = new StubHandler { Hang = true };
+        var engine = WebEngine(handler);
+
+        var outcome = engine.Evaluate(@"(() => {
+                const c = new AbortController();
+                setTimeout(() => c.abort('stop'), 0);
+                return fetch('https://example.org/', { signal: c.signal }).then(() => 'resolved', e => e);
+            })()").UnwrapIfPromise();
+
+        outcome.AsString().Should().Be("stop");
+
+        // The abort reached the socket, not just the promise.
+        handler.Cancelled.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ADeadlineRejectsWithATimeoutErrorDomException()
+    {
+        var handler = new StubHandler { Hang = true };
+        var engine = WebEngine(handler, f => f.Timeout = TimeSpan.FromMilliseconds(50));
+
+        engine.Evaluate("fetch('https://example.org/').then(() => 'resolved', e => e.name + '|' + (e instanceof Error))")
+            .UnwrapIfPromise().AsString().Should().Be("TimeoutError|true");
+
+        handler.Cancelled.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void RefusesMoreConcurrentRequestsThanTheHostAllows()
+    {
+        var handler = new StubHandler { Hang = true };
+        var engine = WebEngine(handler, f =>
+        {
+            f.MaxConcurrentRequests = 2;
+            f.Timeout = TimeSpan.FromMilliseconds(50);
+        });
+
+        // Three at once: the third is refused rather than queued.
+        engine.Execute("var outcome; fetch('https://example.org/1'); fetch('https://example.org/2'); fetch('https://example.org/3').then(() => outcome = 'resolved', e => outcome = e.message);");
+        engine.Advanced.ProcessTasks();
+
+        engine.Evaluate("outcome").AsString().Should()
+            .Be("Failed to fetch: the engine already has 2 requests in flight, which is its Options.WebApi.Fetch.MaxConcurrentRequests limit.");
+
+        lock (handler.Urls)
+        {
+            handler.Urls.Should().Equal("https://example.org/1", "https://example.org/2");
+        }
+    }
+
+    [Fact]
+    public void ASlotIsFreedWhenARequestSettles()
+    {
+        var handler = new StubHandler();
+        var engine = WebEngine(handler, f => f.MaxConcurrentRequests = 1);
+
+        for (var i = 0; i < 3; i++)
+        {
+            engine.Evaluate($"fetch('https://example.org/{i}').then(r => r.status)").UnwrapIfPromise().AsNumber().Should().Be(200);
+        }
+
+        handler.Urls.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void ARestoreCancelsTheRequestAndTheOldPromiseNeverSettles()
+    {
+        var handler = new StubHandler { Hang = true };
+        var settled = 0;
+
+        var engine = WebEngine(handler, extra: options => options.Configure(e =>
+            e.SetValue("record", new Action(() => Interlocked.Increment(ref settled)))));
+
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+        engine.Execute("fetch('https://example.org/').then(record, record);");
+
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        // The socket is let go at once...
+        handler.Cancelled.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+
+        // ... and nothing from the ended cycle ever settles into the restored engine.
+        for (var i = 0; i < 20; i++)
+        {
+            engine.Advanced.ProcessTasks();
+            Thread.Sleep(5);
+        }
+
+        Volatile.Read(ref settled).Should().Be(0);
+
+        // The engine is perfectly usable afterwards.
+        engine.Evaluate("typeof fetch").AsString().Should().Be("function");
+    }
+
+    [Fact]
+    public void AnEngineCancellationSettlesNothingAtAll()
+    {
+        // A constraint that became a promise rejection would no longer bound anything: script would observe
+        // an ordinary failed fetch and carry on.
+        var handler = new StubHandler { Hang = true };
+        using var cancellation = new CancellationTokenSource();
+        var settled = 0;
+
+        var engine = WebEngine(
+            handler,
+            extra: options => options
+                .CancellationToken(cancellation.Token)
+                .Configure(e => e.SetValue("record", new Action(() => Interlocked.Increment(ref settled)))));
+
+        engine.Execute("fetch('https://example.org/').then(record, record);");
+
+        cancellation.Cancel();
+        handler.Cancelled.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+
+        for (var i = 0; i < 20; i++)
+        {
+            engine.Advanced.ProcessTasks();
+            Thread.Sleep(5);
+        }
+
+        Volatile.Read(ref settled).Should().Be(0);
+    }
+
+    [Fact]
+    public void CompletesUnderABlockingUnwrap()
+    {
+        var handler = new StubHandler();
+        var engine = WebEngine(handler);
+
+        engine.Evaluate("(async () => { const r = await fetch('https://example.org/'); return await r.text(); })()")
+            .UnwrapIfPromise().AsString().Should().Be("ok");
+    }
+
+    [Fact]
+    public async Task CompletesUnderEvaluateAsync()
+    {
+        var handler = new StubHandler();
+        var engine = WebEngine(handler);
+
+        var result = await engine.EvaluateAsync("(async () => { const r = await fetch('https://example.org/'); return await r.text(); })()");
+        result.AsString().Should().Be("ok");
+    }
+
+    [Fact]
+    public void CompletesUnderAHostProcessTasksLoop()
+    {
+        // The shape a game loop or a message pump uses: every turn provably runs on the host's own thread,
+        // and nothing here ever blocks on the engine.
+        var handler = new StubHandler();
+        var engine = WebEngine(handler);
+
+        engine.Execute("var text, done = false; fetch('https://example.org/').then(r => r.text()).then(t => { text = t; done = true; });");
+
+        var deadline = DateTime.UtcNow.AddSeconds(10);
+        while (DateTime.UtcNow < deadline && !engine.Evaluate("done").AsBoolean())
+        {
+            engine.Advanced.ProcessTasks();
+            Thread.Sleep(5);
+        }
+
+        engine.Evaluate("text").AsString().Should().Be("ok");
+    }
+
+    [Fact]
+    public void TheHostReadsTheClrExceptionBehindAFailure()
+    {
+        // The script sees only "Failed to fetch"; the host gets the real cause off the error value.
+        var handler = new ThrowingHandler();
+        var engine = WebEngine(handler);
+
+        engine.Execute("var error; fetch('https://example.org/').then(() => {}, e => error = e);");
+        engine.Advanced.ProcessTasks();
+
+        var error = engine.Evaluate("error");
+        error.AsObject().Get("message").AsString().Should().Be("Failed to fetch");
+
+        JintException.TryGetClrException(new JavaScriptException(error), out var clrException).Should().BeTrue();
+        clrException!.ToString().Should().Contain("no such host is known");
+    }
+
+    private sealed class ThrowingHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => throw new HttpRequestException("no such host is known");
+    }
+
+    [Fact]
+    public void TheHostClientFactoryWinsAndSeesTheEngine()
+    {
+        var byFactory = new StubHandler { Responder = _ => new HttpResponseMessage(HttpStatusCode.Accepted) };
+        var byProperty = new StubHandler();
+        var seen = new List<object?>();
+
+        var engine = new Engine(options => options
+            .UseFetch(fetch =>
+            {
+                fetch.HttpClient = new HttpClient(byProperty);
+                fetch.HttpClientFactory = e =>
+                {
+                    // Called on the engine thread, so per-request host state is reachable.
+                    seen.Add(e.Advanced.HostDefined);
+                    return new HttpClient(byFactory);
+                };
+            }));
+
+        engine.Advanced.HostDefined = "tenant-a";
+        engine.Evaluate("fetch('https://example.org/').then(r => r.status)").UnwrapIfPromise().AsNumber().Should().Be(202);
+
+        seen.Should().Equal("tenant-a");
+        byProperty.Urls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SeveralEnginesFromOneOptionsInstanceCountTheirRequestsSeparately()
+    {
+        var handler = new StubHandler { Hang = true };
+        var options = new Options().UseFetch(fetch =>
+        {
+            fetch.HttpClient = new HttpClient(handler);
+            fetch.MaxConcurrentRequests = 1;
+            fetch.Timeout = TimeSpan.FromMilliseconds(50);
+        });
+
+        var first = new Engine(options);
+        var second = new Engine(options);
+
+        first.Execute("fetch('https://example.org/1');");
+        second.Execute("var outcome; fetch('https://example.org/2').then(() => outcome = 'resolved', e => outcome = e.name);");
+        second.Advanced.ProcessTasks();
+
+        // The second engine's request was not refused by the first engine's slot being taken.
+        second.Evaluate("typeof outcome").AsString().Should().Be("undefined");
+
+        lock (handler.Urls)
+        {
+            handler.Urls.Should().HaveCount(2);
+        }
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/FetchTests.cs
+++ b/Jint.Tests/Runtime/WebApi/FetchTests.cs
@@ -1,0 +1,388 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Jint.Native;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// <c>fetch</c> as the Fetch Standard specifies it — https://fetch.spec.whatwg.org/#fetch-method — driven
+/// against a stub <see cref="HttpMessageHandler"/> so that nothing here touches a network.
+/// </summary>
+public class FetchTests
+{
+    /// <summary>
+    /// What one request looked like when the transport sent it.
+    /// </summary>
+    /// <remarks>
+    /// A snapshot rather than the <see cref="HttpRequestMessage"/> itself, because the transport disposes
+    /// the message — and with it its content — as soon as the response is in hand. The headers are read
+    /// through <c>NonValidated</c>, which answers the raw value rather than <see cref="HttpClient"/>'s
+    /// re-serialization of its parsed form.
+    /// </remarks>
+    private sealed record RecordedRequest(string Method, string Url, Dictionary<string, string> Headers, string? Body)
+    {
+        internal string? Header(string name) => Headers.TryGetValue(name, out var value) ? value : null;
+    }
+
+    /// <summary>
+    /// A handler that records what it was asked for and answers whatever the test told it to.
+    /// </summary>
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        internal List<RecordedRequest> Requests { get; } = new();
+
+        internal Func<RecordedRequest, HttpResponseMessage>? Responder { get; set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var recorded = Record(request);
+            Requests.Add(recorded);
+
+            var response = Responder is { } responder
+                ? responder(recorded)
+                : new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") };
+
+            return Task.FromResult(response);
+        }
+
+        private static RecordedRequest Record(HttpRequestMessage request)
+        {
+            var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            Collect(headers, request.Headers);
+
+            string? body = null;
+            if (request.Content is { } content)
+            {
+                Collect(headers, content.Headers);
+                using var reader = new StreamReader(content.ReadAsStream());
+                body = reader.ReadToEnd();
+            }
+
+            return new RecordedRequest(request.Method.Method, request.RequestUri!.ToString(), headers, body);
+        }
+
+        private static void Collect(Dictionary<string, string> headers, System.Net.Http.Headers.HttpHeaders source)
+        {
+            foreach (var header in source.NonValidated)
+            {
+                headers[header.Key] = header.Value.ToString();
+            }
+        }
+    }
+
+    private static Engine WebEngine(HttpMessageHandler handler, Action<Options.FetchOptions>? configure = null)
+    {
+        return new Engine(options => options.UseFetch(fetch =>
+        {
+            fetch.HttpClient = new HttpClient(handler);
+            configure?.Invoke(fetch);
+        }));
+    }
+
+    private static JsValue Fetch(HttpMessageHandler handler, string source, Action<Options.FetchOptions>? configure = null)
+    {
+        return WebEngine(handler, configure).Evaluate(source).UnwrapIfPromise();
+    }
+
+    [Fact]
+    public void ResolvesWithAResponseCarryingTheStatusAndBody()
+    {
+        var handler = new StubHandler
+        {
+            Responder = _ => new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = new StringContent("hello"),
+            },
+        };
+
+        var engine = WebEngine(handler);
+        engine.Evaluate("fetch('https://example.org/a').then(r => r.status + ':' + r.ok + ':' + r.type + ':' + r.url + ':' + r.redirected)")
+            .UnwrapIfPromise().AsString().Should().Be("201:true:basic:https://example.org/a:false");
+
+        engine.Evaluate("fetch('https://example.org/a').then(r => r.text())").UnwrapIfPromise().AsString().Should().Be("hello");
+    }
+
+    [Fact]
+    public void SendsTheMethodHeadersAndBodyTheRequestDescribes()
+    {
+        var handler = new StubHandler();
+
+        Fetch(handler, "fetch('https://example.org/a', { method: 'post', body: 'hi', headers: { 'x-a': '1' } })");
+
+        var request = handler.Requests.Should().ContainSingle().Subject;
+        request.Method.Should().Be("POST");
+        request.Url.Should().Be("https://example.org/a");
+        request.Header("x-a").Should().Be("1");
+
+        // The body's implied Content-Type is a content header, so it has to land on the content rather than
+        // being dropped.
+        request.Header("content-type").Should().Be("text/plain;charset=UTF-8");
+        request.Body.Should().Be("hi");
+    }
+
+    [Fact]
+    public void MapsEveryResponseHeaderIncludingRepeatedOnes()
+    {
+        var handler = new StubHandler
+        {
+            Responder = _ =>
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("x") };
+                response.Headers.Add("set-cookie", "a=1");
+                response.Headers.Add("set-cookie", "b=2");
+                response.Headers.Add("x-multi", "one");
+                response.Headers.Add("x-multi", "two");
+                return response;
+            },
+        };
+
+        var engine = WebEngine(handler);
+        engine.Execute("var h; fetch('https://example.org/').then(r => h = r.headers);");
+        engine.Advanced.ProcessTasks();
+
+        // getSetCookie keeps the values apart, which is the whole reason it exists.
+        engine.Evaluate("h.getSetCookie().join('|')").AsString().Should().Be("a=1|b=2");
+
+        // Everything else combines, exactly as get does for a header list built by hand.
+        engine.Evaluate("h.get('x-multi')").AsString().Should().Be("one, two");
+        engine.Evaluate("h.get('content-type')").AsString().Should().StartWith("text/plain");
+    }
+
+    [Fact]
+    public void RejectsRatherThanThrowsForAnUnparsableUrl()
+    {
+        var handler = new StubHandler();
+
+        // https://fetch.spec.whatwg.org/#dom-global-fetch step 2 — the Request constructor's TypeError
+        // becomes a rejection, so a fetch chain never needs a try.
+        Fetch(handler, "fetch('nonsense').then(() => 'resolved', e => e.constructor.name)")
+            .AsString().Should().Be("TypeError");
+
+        handler.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RejectsForAPreAbortedSignalWithItsOwnReason()
+    {
+        var handler = new StubHandler();
+
+        // https://fetch.spec.whatwg.org/#abort-fetch — the reason is the signal's, not a fresh error.
+        Fetch(handler, "(() => { const c = new AbortController(); c.abort('gone'); return fetch('https://example.org/', { signal: c.signal }).then(() => 'resolved', e => e); })()")
+            .AsString().Should().Be("gone");
+
+        // A bare abort() defaults the reason to an AbortError DOMException.
+        Fetch(handler, "(() => { const c = new AbortController(); c.abort(); return fetch('https://example.org/', { signal: c.signal }).then(() => 'resolved', e => e.name); })()")
+            .AsString().Should().Be("AbortError");
+
+        handler.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void FollowsARedirectAndReportsTheFinalUrl()
+    {
+        var handler = Redirecting("https://example.org/b");
+
+        var engine = WebEngine(handler);
+        engine.Evaluate("fetch('https://example.org/a').then(r => r.url + ':' + r.redirected + ':' + r.status)")
+            .UnwrapIfPromise().AsString().Should().Be("https://example.org/b:true:200");
+
+        handler.Requests.Should().HaveCount(2);
+        handler.Requests[1].Url.Should().Be("https://example.org/b");
+    }
+
+    [Fact]
+    public void ResolvesARelativeLocationAgainstTheUrlThatSentIt()
+    {
+        var handler = Redirecting("/b?q");
+
+        Fetch(handler, "fetch('https://example.org/deep/a').then(r => r.url)")
+            .AsString().Should().Be("https://example.org/b?q");
+    }
+
+    [Fact]
+    public void RewritesPostToGetOnA303AndDropsTheBody()
+    {
+        // https://fetch.spec.whatwg.org/#http-redirect-fetch step 11.
+        var handler = Redirecting("https://example.org/b", HttpStatusCode.SeeOther);
+
+        Fetch(handler, "fetch('https://example.org/a', { method: 'POST', body: 'hi' }).then(r => r.status)");
+
+        handler.Requests[0].Method.Should().Be("POST");
+        handler.Requests[1].Method.Should().Be("GET");
+        handler.Requests[1].Body.Should().BeNull();
+
+        // The body headers go with the body.
+        handler.Requests[1].Header("content-type").Should().BeNull();
+    }
+
+    [Fact]
+    public void RewritesPostToGetOnA302ButNotOnA307()
+    {
+        var to302 = Redirecting("https://example.org/b", HttpStatusCode.Found);
+        Fetch(to302, "fetch('https://example.org/a', { method: 'POST', body: 'hi' }).then(r => r.status)");
+        to302.Requests[1].Method.Should().Be("GET");
+
+        // 307 and 308 are the two that keep the method and the body.
+        var to307 = Redirecting("https://example.org/b", HttpStatusCode.TemporaryRedirect);
+        Fetch(to307, "fetch('https://example.org/a', { method: 'POST', body: 'hi' }).then(r => r.status)");
+        to307.Requests[1].Method.Should().Be("POST");
+        to307.Requests[1].Body.Should().Be("hi");
+    }
+
+    [Fact]
+    public void StripsCredentialHeadersWhenARedirectCrossesOrigin()
+    {
+        var handler = Redirecting("https://other.example/b");
+
+        Fetch(handler, "fetch('https://example.org/a', { headers: { authorization: 'Bearer secret', cookie: 'sid=1', 'x-keep': 'yes' } }).then(r => r.status)");
+
+        handler.Requests[1].Header("authorization").Should().BeNull();
+        handler.Requests[1].Header("cookie").Should().BeNull();
+        handler.Requests[1].Header("x-keep").Should().Be("yes");
+    }
+
+    [Fact]
+    public void KeepsCredentialHeadersOnASameOriginRedirect()
+    {
+        var handler = Redirecting("https://example.org/b");
+
+        Fetch(handler, "fetch('https://example.org/a', { headers: { authorization: 'Bearer secret' } }).then(r => r.status)");
+
+        handler.Requests[1].Header("authorization").Should().Be("Bearer secret");
+    }
+
+    [Fact]
+    public void HonoursTheThreeRedirectModes()
+    {
+        // 'error' refuses outright.
+        Fetch(Redirecting("https://example.org/b"), "fetch('https://example.org/a', { redirect: 'error' }).then(() => 'resolved', e => e.constructor.name + ': ' + e.message)")
+            .AsString().Should().Be("TypeError: Failed to fetch");
+
+        // 'manual' hands the redirect response itself to the script — Node's reading, not a browser's
+        // opaque-redirect filtered response.
+        var manual = Redirecting("https://example.org/b");
+        Fetch(manual, "fetch('https://example.org/a', { redirect: 'manual' }).then(r => r.status + ':' + r.redirected + ':' + r.headers.get('location'))")
+            .AsString().Should().Be("301:false:https://example.org/b");
+        manual.Requests.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void ARedirectWithoutALocationIsAnOrdinaryResponse()
+    {
+        // "If locationURL is null, then return actualResponse."
+        var handler = new StubHandler
+        {
+            Responder = _ => new HttpResponseMessage(HttpStatusCode.MovedPermanently) { Content = new StringContent("body") },
+        };
+
+        Fetch(handler, "fetch('https://example.org/a').then(r => r.status + ':' + r.redirected)")
+            .AsString().Should().Be("301:false");
+    }
+
+    [Fact]
+    public void RefusesMoreRedirectsThanTheLimitAllows()
+    {
+        var handler = new StubHandler
+        {
+            Responder = _ =>
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.Found);
+                response.Headers.TryAddWithoutValidation("location", "https://example.org/" + Guid.NewGuid().ToString("N"));
+                return response;
+            },
+        };
+
+        Fetch(handler, "fetch('https://example.org/a').then(() => 'resolved', e => e.constructor.name + '|' + e.message)", f => f.MaxRedirects = 3)
+            .AsString().Should().Be("TypeError|Failed to fetch: The request to 'https://example.org/a' exceeded the limit of 3 redirects.");
+
+        // Four requests: the first plus the three the limit allowed.
+        handler.Requests.Should().HaveCount(4);
+    }
+
+    [Fact]
+    public void ANullBodyStatusCarriesNoBody()
+    {
+        var handler = new StubHandler
+        {
+            Responder = _ => new HttpResponseMessage(HttpStatusCode.NoContent),
+        };
+
+        var engine = WebEngine(handler);
+        engine.Execute("var r; fetch('https://example.org/').then(x => r = x);");
+        engine.Advanced.ProcessTasks();
+
+        engine.Evaluate("r.status").AsNumber().Should().Be(204);
+        engine.Evaluate("r.text()").UnwrapIfPromise().AsString().Should().Be("");
+
+        // A null body is never disturbed, so it reads as often as the script likes.
+        engine.Evaluate("r.bodyUsed").AsBoolean().Should().BeFalse();
+        engine.Evaluate("r.text()").UnwrapIfPromise().AsString().Should().Be("");
+    }
+
+    [Fact]
+    public void TheResponseBodyObeysTheUsualConsumeRules()
+    {
+        var handler = new StubHandler
+        {
+            Responder = _ => new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"a\":1}") },
+        };
+
+        var engine = WebEngine(handler);
+        engine.Execute("var r; fetch('https://example.org/').then(x => r = x);");
+        engine.Advanced.ProcessTasks();
+
+        engine.Evaluate("r.bodyUsed").AsBoolean().Should().BeFalse();
+        engine.Evaluate("r.body").Should().Be(JsValue.Null);
+
+        engine.Execute("var copy = r.clone();");
+
+        engine.Evaluate("r.json()").UnwrapIfPromise().AsObject().Get("a").AsNumber().Should().Be(1);
+        engine.Evaluate("r.bodyUsed").AsBoolean().Should().BeTrue();
+        engine.Evaluate("r.text().then(() => 'resolved', e => e.constructor.name)").UnwrapIfPromise().AsString().Should().Be("TypeError");
+
+        // The clone carries its own flag over the same bytes.
+        engine.Evaluate("copy.bodyUsed").AsBoolean().Should().BeFalse();
+        engine.Evaluate("copy.text()").UnwrapIfPromise().AsString().Should().Be("{\"a\":1}");
+    }
+
+    [Fact]
+    public void ANetworkFailureRejectsWithAnUninformativeTypeError()
+    {
+        var handler = new ThrowingHandler();
+
+        // A message naming the DNS failure or the refused connection would let a script map the host's
+        // internal network by probing it; the CLR exception rides the error value instead, for the host.
+        Fetch(handler, "fetch('https://example.org/').then(() => 'resolved', e => e.constructor.name + ': ' + e.message)")
+            .AsString().Should().Be("TypeError: Failed to fetch");
+    }
+
+    private sealed class ThrowingHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => throw new HttpRequestException("no such host is known");
+    }
+
+    private static StubHandler Redirecting(string location, HttpStatusCode status = HttpStatusCode.MovedPermanently)
+    {
+        var handler = new StubHandler();
+        handler.Responder = _ =>
+        {
+            if (handler.Requests.Count > 1)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("done") };
+            }
+
+            var response = new HttpResponseMessage(status);
+            response.Headers.TryAddWithoutValidation("location", location);
+            return response;
+        };
+
+        return handler;
+    }
+}
+#endif

--- a/Jint/Engine.WebApi.cs
+++ b/Jint/Engine.WebApi.cs
@@ -1,4 +1,5 @@
 #if NET8_0_OR_GREATER
+using Jint.WebApi.Fetch;
 using Jint.WebApi.Timers;
 
 namespace Jint;
@@ -38,11 +39,20 @@ internal sealed class WebApiEngineState
     /// </summary>
     private readonly long _originTimestamp;
 
-    internal WebApiEngineState(Engine engine, TimeProvider timeProvider, TimerQueue? timers)
+    /// <summary>
+    /// The requests this engine has in flight, in registration order. Engine-thread-only, so no lock: a
+    /// request is added by <c>fetch</c> and removed by its own settle job, both of which run on the engine's
+    /// thread. A list rather than a set because it is bounded by
+    /// <c>Options.FetchOptions.MaxConcurrentRequests</c> and never long.
+    /// </summary>
+    private List<FetchOperation>? _fetches;
+
+    internal WebApiEngineState(Engine engine, TimeProvider timeProvider, TimerQueue? timers, Options.FetchOptions? fetchOptions)
     {
         _engine = engine;
         _timeProvider = timeProvider;
         Timers = timers;
+        FetchOptions = fetchOptions;
 
         // Both halves of the time origin, read back to back: the monotonic reading every later now() is a
         // duration from, and the wall-clock moment that reading corresponds to.
@@ -54,6 +64,22 @@ internal sealed class WebApiEngineState
     /// The engine's active timers, or <see langword="null"/> when nothing that schedules one is enabled.
     /// </summary>
     internal TimerQueue? Timers { get; }
+
+    /// <summary>
+    /// The host's fetch settings, or <see langword="null"/> when the feature is off. Read once, when the
+    /// engine is built, so that no background thread ever reaches into <see cref="Options"/>.
+    /// </summary>
+    internal Options.FetchOptions? FetchOptions { get; }
+
+    /// <summary>
+    /// How many requests are in flight, which is what <c>Options.FetchOptions.MaxConcurrentRequests</c>
+    /// bounds.
+    /// </summary>
+    internal int ActiveFetchCount => _fetches?.Count ?? 0;
+
+    internal void RegisterFetch(FetchOperation operation) => (_fetches ??= new List<FetchOperation>()).Add(operation);
+
+    internal void UnregisterFetch(FetchOperation operation) => _fetches?.Remove(operation);
 
     /// <summary>
     /// <c>performance.timeOrigin</c>: the moment this state was created, as milliseconds since the Unix
@@ -102,6 +128,30 @@ internal sealed class WebApiEngineState
     /// <summary>
     /// Drops the state that belongs to the evaluation cycle a <c>RestoreGlobalSnapshot</c> has just ended.
     /// </summary>
-    internal void ResetTransientState() => Timers?.Clear();
+    /// <remarks>
+    /// A request in flight is cancelled rather than merely forgotten: the generation fence already stops its
+    /// response reaching the restored engine, but forgetting it would leave the socket open until the server
+    /// answered. Its promise stays pending — settling it is exactly what the fence forbids — which is the
+    /// same contract a promise registered before a restore has always had.
+    /// </remarks>
+    internal void ResetTransientState()
+    {
+        Timers?.Clear();
+
+        if (_fetches is not { Count: > 0 } fetches)
+        {
+            return;
+        }
+
+        // Copied before the walk: Abandon cancels a token source, and a synchronous continuation on this very
+        // thread would otherwise reach UnregisterFetch and mutate the list under the enumerator.
+        var pending = fetches.ToArray();
+        fetches.Clear();
+
+        foreach (var fetch in pending)
+        {
+            fetch.Abandon();
+        }
+    }
 }
 #endif

--- a/Jint/Runtime/ConstraintFailure.cs
+++ b/Jint/Runtime/ConstraintFailure.cs
@@ -1,0 +1,31 @@
+namespace Jint.Runtime;
+
+/// <summary>
+/// The failures that must keep propagating out of an event-loop job rather than becoming that job's own
+/// error value.
+/// </summary>
+/// <remarks>
+/// Every one of them exists to bound or abort execution, and a bound that turns into a promise rejection no
+/// longer bounds anything — script observes it as an ordinary failed operation and carries on, in a loop if
+/// it likes. Any cross-thread completion that catches broadly on a queued turn — an asynchronous module load,
+/// a <c>fetch</c> — has to consult this list, which is why it lives here rather than on one of them.
+/// </remarks>
+internal static class ConstraintFailure
+{
+    /// <summary>
+    /// Whether <paramref name="exception"/> must escape the job it was raised in.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="RecursionDepthOverflowException"/> belongs here for the same reason as the rest, and reaches
+    /// these paths whenever host code re-enters the engine — a module resolve hook or a virtual file system
+    /// written in script, which is a shape hosts really do use.
+    /// </remarks>
+    internal static bool MustPropagate(Exception exception) => exception
+        is ExecutionCanceledException
+        or MemoryLimitExceededException
+        or StatementsCountOverflowException
+        or RecursionDepthOverflowException
+        or TimeoutException
+        or OperationCanceledException
+        or OutOfMemoryException;
+}

--- a/Jint/Runtime/Intrinsics.WebApi.cs
+++ b/Jint/Runtime/Intrinsics.WebApi.cs
@@ -118,6 +118,13 @@ public sealed partial class Intrinsics
     private HeadersConstructor? _headers;
     private RequestConstructor? _request;
     private ResponseConstructor? _response;
+    private FetchFunction? _fetch;
+
+    /// <summary>
+    /// The global <c>fetch</c> function — one per realm, built on first access like every intrinsic beside it.
+    /// </summary>
+    internal FetchFunction Fetch =>
+        _fetch ??= FetchFunction.Create(_engine, _realm, Function.PrototypeObject);
 
     internal HeadersConstructor Headers =>
         _headers ??= new HeadersConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);

--- a/Jint/Runtime/Modules/ModuleLoadCompletion.cs
+++ b/Jint/Runtime/Modules/ModuleLoadCompletion.cs
@@ -343,20 +343,14 @@ public sealed class ModuleLoadCompletion
     /// script observes it as an ordinary failed import and carries on, in a loop if it likes.
     /// </summary>
     /// <remarks>
-    /// <see cref="RecursionDepthOverflowException"/> belongs here for the same reason as the rest, and reaches
-    /// these paths whenever the loader itself re-enters the engine — a resolve hook or a virtual file system
-    /// written in script, which is a shape hosts really do use. It is not raised by anything the load pipeline
-    /// does on its own; a module <em>body</em> that recurses too deeply fails outside every one of these
-    /// catches.
+    /// The list itself lives on <see cref="ConstraintFailure"/>, because <c>fetch</c>'s settle job needs the
+    /// same one and the two must not be able to drift. <see cref="RecursionDepthOverflowException"/> is on it
+    /// for the same reason as the rest, and reaches <i>these</i> paths whenever the loader itself re-enters
+    /// the engine — a resolve hook or a virtual file system written in script, which is a shape hosts really
+    /// do use. It is not raised by anything the load pipeline does on its own; a module <em>body</em> that
+    /// recurses too deeply fails outside every one of these catches.
     /// </remarks>
-    internal static bool MustPropagate(Exception exception) => exception
-        is ExecutionCanceledException
-        or MemoryLimitExceededException
-        or StatementsCountOverflowException
-        or RecursionDepthOverflowException
-        or TimeoutException
-        or OperationCanceledException
-        or OutOfMemoryException;
+    internal static bool MustPropagate(Exception exception) => ConstraintFailure.MustPropagate(exception);
 
     private Native.Object.ObjectInstance CreateError(string message) => Engine.Realm.Intrinsics.Error.Construct(message);
 

--- a/Jint/WebApi/Fetch/FetchFunction.cs
+++ b/Jint/WebApi/Fetch/FetchFunction.cs
@@ -1,0 +1,66 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Fetch;
+
+/// <summary>
+/// The global <c>fetch(input, init)</c> function.
+/// <para>
+/// https://fetch.spec.whatwg.org/#fetch-method
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// A WebIDL operation whose return type is a promise, which is what makes it total: every failure — a
+/// malformed URL, a body the engine cannot serialize, a refused scheme, a DNS failure, a blown size cap —
+/// becomes a rejection of the promise it hands back, and the call itself never throws. The algorithm lives in
+/// <see cref="FetchOperation"/>.
+/// </para>
+/// <para>
+/// <b>Nothing runs until the engine is pumped.</b> The request is started on the calling thread and completes
+/// on a thread pool thread, but the promise settles from an event-loop job, so the script's continuation runs
+/// where every other continuation runs: inside a blocking <c>UnwrapIfPromise</c>, an <c>await</c> of
+/// <c>EvaluateAsync</c>, or the host's own <c>engine.Advanced.ProcessTasks()</c> loop. The deadline is the
+/// one exception, and deliberately so — it is enforced CLR-side, so an engine nobody pumps still lets go of
+/// its socket.
+/// </para>
+/// </remarks>
+internal sealed class FetchFunction : Jint.Native.Function.Function
+{
+    private static readonly JsString _functionName = new("fetch");
+
+    private readonly WebApiEngineState _state;
+
+    private FetchFunction(Engine engine, Realm realm, FunctionPrototype functionPrototype, WebApiEngineState state)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = functionPrototype;
+        _state = state;
+
+        // A WebIDL operation's length counts the required arguments only, and is configurable but neither
+        // writable nor enumerable — https://webidl.spec.whatwg.org/#dfn-create-operation-function.
+        _length = new PropertyDescriptor(JsNumber.PositiveOne, PropertyFlag.Configurable);
+    }
+
+    internal static FetchFunction Create(Engine engine, Realm realm, FunctionPrototype functionPrototype)
+    {
+        var state = engine._webApi;
+        if (state?.FetchOptions is null)
+        {
+            // Unreachable: the global that reaches this is installed only where the state was created, in the
+            // same block of WebApiRegistration.
+            Throw.InvalidOperationException("The fetch global was reached on an engine that has no fetch configuration.");
+        }
+
+        return new FetchFunction(engine, realm, functionPrototype, state);
+    }
+
+    protected internal override JsValue Call(JsValue thisObject, JsCallArguments arguments)
+    {
+        return FetchOperation.Start(_engine, _realm, _state, arguments);
+    }
+}
+#endif

--- a/Jint/WebApi/Fetch/FetchOperation.cs
+++ b/Jint/WebApi/Fetch/FetchOperation.cs
@@ -1,0 +1,470 @@
+#if NET8_0_OR_GREATER
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Jint.Constraints;
+using Jint.Native;
+using Jint.Native.Promise;
+using Jint.Runtime;
+using Jint.WebApi.Abort;
+using Jint.WebApi.DomException;
+
+namespace Jint.WebApi.Fetch;
+
+/// <summary>
+/// One <c>fetch</c> call, from the synchronous checks on the engine thread to the promise settling on a later
+/// event-loop turn.
+/// <para>
+/// https://fetch.spec.whatwg.org/#fetch-method
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// Patterned on <c>ModuleLoadCompletion</c>, which solves the same problem for an asynchronous module load,
+/// and obeys the same three rules. The <b>event-loop generation and the realm are captured at
+/// registration</b>, not read at settle time: the two differ exactly when the engine's globals were restored
+/// while the request was in flight, and that is the case the fence exists for. The outcome is <b>classified
+/// off the engine thread into plain CLR data</b>, and only a generation-stamped job — which runs on the
+/// engine thread — turns it into a <c>Response</c> or an error. And the settle is <b>once</b>, by
+/// compare-and-swap, because a cancellation and a completion can race.
+/// </para>
+/// <para>
+/// The one thing it does <i>not</i> copy is <c>ModuleLoadCompletion</c>'s inline-settle window. A module
+/// loader may answer from a warm cache on the engine's own stack; a network request cannot, so there is never
+/// a completion to run inline.
+/// </para>
+/// </remarks>
+internal sealed class FetchOperation
+{
+    private readonly Engine _engine;
+
+    /// <summary>
+    /// The realm the fetch was started in, captured at registration. A settle arriving on a later event-loop
+    /// turn runs under whatever realm is ambient then, and would otherwise build the <c>Response</c> — and
+    /// mint the <c>TypeError</c> — against the wrong realm's intrinsics.
+    /// </summary>
+    private readonly Realm _realm;
+
+    private readonly PromiseCapability _capability;
+
+    /// <summary>
+    /// The evaluation cycle this request was registered in. A settle carrying an earlier generation is
+    /// discarded at dequeue, so a response that arrives after <c>RestoreGlobalSnapshot</c> never reaches the
+    /// restored engine — the fence every other cross-thread completion in Jint sits behind.
+    /// </summary>
+    private readonly int _generation;
+
+    /// <summary>
+    /// The request's signal. Read only on the engine thread — the off-thread classification asks
+    /// <see cref="_signalToken"/> instead, which is a thread-safe CLR object rather than engine state.
+    /// </summary>
+    private readonly JsAbortSignal _signal;
+
+    private readonly CancellationToken _signalToken;
+
+    /// <summary>
+    /// The engine's own cancellation token, from <see cref="CancellationConstraint"/>. A request cancelled
+    /// through it settles nothing at all: a constraint that became a promise rejection would no longer bound
+    /// anything — the script would observe an ordinary failed fetch and carry on, in a loop if it liked.
+    /// </summary>
+    private readonly CancellationToken _engineToken;
+
+    private readonly CancellationTokenSource _cancellation;
+    private readonly TimeSpan _timeout;
+
+    private int _settled;
+
+    private FetchOperation(Engine engine, Realm realm, PromiseCapability capability, JsAbortSignal signal, TimeSpan timeout)
+    {
+        _engine = engine;
+        _realm = realm;
+        _capability = capability;
+        _generation = engine.EventLoopGeneration;
+        _timeout = timeout;
+        _signal = signal;
+
+        _signalToken = signal.CancellationToken;
+        _engineToken = engine.Constraints.Find<CancellationConstraint>()?.Token ?? CancellationToken.None;
+        _cancellation = CancellationTokenSource.CreateLinkedTokenSource(_signalToken, _engineToken);
+    }
+
+    /// <summary>
+    /// https://fetch.spec.whatwg.org/#dom-global-fetch — the whole of the method's synchronous half.
+    /// </summary>
+    /// <remarks>
+    /// <b>It never throws.</b> Every failure the standard names, and every policy failure this implementation
+    /// adds, becomes a rejection of the promise it returns — which is what lets a fetch chain be written
+    /// without a <c>try</c>. The only things that escape are the failures that must: a constraint firing, an
+    /// engine cancellation, an out-of-memory.
+    /// </remarks>
+    internal static JsValue Start(Engine engine, Realm realm, WebApiEngineState state, JsCallArguments arguments)
+    {
+        // Step 1: the promise exists before anything can fail, so that everything below is a rejection.
+        var capability = PromiseConstructor.NewPromiseCapability(engine, realm.Intrinsics.Promise);
+
+        JsRequest request;
+        try
+        {
+            // Step 2: "invoke the initial value of Request as constructor" — so a bad method, an unparsable
+            // URL, a FormData body and a GET with a body are all rejections rather than throws.
+            request = (JsRequest) realm.Intrinsics.Request.Construct(arguments, realm.Intrinsics.Request);
+        }
+        catch (JavaScriptException ex)
+        {
+            capability.Reject(ex.Error);
+            return capability.PromiseInstance;
+        }
+        catch (Exception ex) when (!ConstraintFailure.MustPropagate(ex))
+        {
+            // A CLR failure raised by host code the conversion reached — a projected object's ToString, an
+            // interop getter. The promise is what fetch answers with, so this is a rejection too; only the
+            // failures that bound execution are allowed to escape.
+            capability.Reject(NetworkError(realm, ex));
+            return capability.PromiseInstance;
+        }
+
+        // Step 6: an already-aborted signal ends the fetch before anything is sent, with the signal's own
+        // reason — https://fetch.spec.whatwg.org/#abort-fetch.
+        if (request.Signal.Aborted)
+        {
+            capability.Reject(request.Signal.Reason);
+            return capability.PromiseInstance;
+        }
+
+        var options = state.FetchOptions!;
+
+        var urlFilter = options.UrlFilter;
+        if (urlFilter is null)
+        {
+            urlFilter = static _ => true;
+        }
+
+        var policy = new FetchPolicy
+        {
+            AllowedSchemes = [.. options.AllowedSchemes],
+            UrlFilter = urlFilter,
+            MaxResponseBytes = options.MaxResponseBytes,
+            MaxRedirects = options.MaxRedirects,
+        };
+
+        // The first hop's policy check runs here, on the engine thread, so a refused URL never reaches a
+        // socket and never costs a task. Every redirect hop is re-checked inside the transport.
+        if (!policy.Allows(request.Url, out _))
+        {
+            var denial = new FetchFailureException(FetchFailureKind.PolicyDenied, $"The fetch policy refused '{request.Url.Serialize()}'.");
+            capability.Reject(NetworkError(realm, denial));
+            return capability.PromiseInstance;
+        }
+
+        if (state.ActiveFetchCount >= options.MaxConcurrentRequests)
+        {
+            // Not a specified failure mode — the standard assumes a browser's connection manager — but an
+            // engine embedded in a server cannot let a script hold sockets without bound. Rejecting rather
+            // than queueing is the honest answer: a queue would turn a burst into an unbounded backlog.
+            capability.Reject(realm.Intrinsics.TypeError.Construct(
+                $"Failed to fetch: the engine already has {options.MaxConcurrentRequests} requests in flight, which is its Options.WebApi.Fetch.MaxConcurrentRequests limit."));
+            return capability.PromiseInstance;
+        }
+
+        HttpClient client;
+        try
+        {
+            client = ResolveClient(engine, realm, options);
+        }
+        catch (JavaScriptException ex)
+        {
+            capability.Reject(ex.Error);
+            return capability.PromiseInstance;
+        }
+        catch (Exception ex) when (!ConstraintFailure.MustPropagate(ex))
+        {
+            // A host HttpClientFactory that threw. Its failure belongs to the fetch, not to the statement
+            // that happened to call it.
+            capability.Reject(NetworkError(realm, ex));
+            return capability.PromiseInstance;
+        }
+
+        var operation = new FetchOperation(engine, realm, capability, request.Signal, options.Timeout);
+        var snapshot = new FetchRequestSnapshot
+        {
+            Method = request.Method,
+            Url = request.Url,
+            Headers = new List<HeaderEntry>(request.Headers.List.Entries),
+            Body = request.Body,
+            Redirect = request.Redirect,
+        };
+
+        state.RegisterFetch(operation);
+        operation.Run(client, snapshot, policy);
+        return capability.PromiseInstance;
+    }
+
+    private static HttpClient ResolveClient(Engine engine, Realm realm, Options.FetchOptions options)
+    {
+        if (options.HttpClientFactory is { } factory)
+        {
+            // Called on the engine thread, once per fetch, so it may read per-request host state through
+            // engine.Advanced.HostDefined.
+            var client = factory(engine);
+            if (client is null)
+            {
+                Throw.TypeError(realm, "Failed to fetch: Options.WebApi.Fetch.HttpClientFactory returned null.");
+            }
+
+            return client;
+        }
+
+        return options.HttpClient ?? FetchTransport.SharedClient;
+    }
+
+    private void Run(HttpClient client, FetchRequestSnapshot snapshot, FetchPolicy policy)
+    {
+        // The deadline is CLR-side rather than on the timer queue, deliberately: it must fire even for an
+        // engine nobody is pumping, so an abandoned request cannot hold a socket open forever.
+        if (_timeout > TimeSpan.Zero && _timeout != Timeout.InfiniteTimeSpan)
+        {
+            _cancellation.CancelAfter(_timeout);
+        }
+
+        Task<FetchResponseSnapshot> task;
+        try
+        {
+            task = FetchTransport.SendAsync(client, snapshot, policy, _cancellation.Token);
+        }
+        catch (Exception ex)
+        {
+            // A client whose handler throws synchronously — a host DelegatingHandler, a disposed client.
+            Complete(Task.FromException<FetchResponseSnapshot>(ex));
+            return;
+        }
+
+        _ = task.ContinueWith(
+            static (t, state) => ((FetchOperation) state!).Complete(t),
+            this,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
+    /// <summary>
+    /// Off the engine thread: classify the outcome into plain CLR data and queue the engine-thread half.
+    /// Nothing here may touch the engine, which is why the classification asks the tokens rather than the
+    /// signal, and mints no JavaScript value.
+    /// </summary>
+    private void Complete(Task<FetchResponseSnapshot> task)
+    {
+        if (Interlocked.CompareExchange(ref _settled, 1, 0) != 0)
+        {
+            return;
+        }
+
+        if (task.IsCanceled || task.Exception?.InnerException is OperationCanceledException)
+        {
+            // The engine's own cancellation is the one outcome with no settlement at all — see _engineToken.
+            // Checked first, because a request that is also past its deadline is still bounded by the
+            // constraint, and the constraint is what must not become a rejection.
+            if (_engineToken.IsCancellationRequested)
+            {
+                Enqueue(null);
+                return;
+            }
+
+            if (_signalToken.IsCancellationRequested)
+            {
+                Enqueue(RejectWithAbortReason);
+                return;
+            }
+
+            // Neither token fired, so either the deadline did or the engine abandoned the request at a
+            // global-snapshot restore — and the restore's own generation fence discards the job below.
+            Enqueue(RejectWithTimeout);
+            return;
+        }
+
+        if (task.IsFaulted)
+        {
+            var failure = Unwrap(task.Exception);
+            Enqueue(() => RejectWithNetworkError(failure));
+            return;
+        }
+
+        var response = task.Result;
+        Enqueue(() => ResolveWithResponse(response));
+    }
+
+    private static Exception Unwrap(AggregateException? exception)
+    {
+        if (exception is null)
+        {
+            return new FetchFailureException(FetchFailureKind.Network, "The request failed.");
+        }
+
+        // The AggregateException wrapper says nothing a host can use; the transport failure itself is the
+        // single inner exception in every ordinary case.
+        return exception.InnerExceptions.Count == 1 ? exception.InnerExceptions[0] : exception;
+    }
+
+    /// <summary>
+    /// Queues the engine-thread half, carrying the generation the fetch was registered in. A
+    /// <see langword="null"/> settle deregisters and settles nothing, which is what an engine cancellation
+    /// asks for — the bookkeeping still has to happen on the engine thread.
+    /// </summary>
+    private void Enqueue(Action? settle)
+    {
+        _engine.AddToEventLoop(() => RunSettle(settle), _generation);
+    }
+
+    /// <summary>
+    /// On the engine thread, in the realm the fetch started in.
+    /// </summary>
+    private void RunSettle(Action? settle)
+    {
+        var entered = EnterFetchRealm();
+        try
+        {
+            Release();
+            settle?.Invoke();
+        }
+        catch (JavaScriptException ex)
+        {
+            _capability.Reject(ex.Error);
+        }
+        catch (Exception ex) when (_engine.EventLoop.IsRunningJob && !ConstraintFailure.MustPropagate(ex))
+        {
+            // On a queued event-loop turn there is no caller left to throw to: escaping would erupt out of
+            // whatever is pumping, with the promise permanently pending. The failure becomes the fetch's
+            // failure instead — and carries the original exception on the error value, for the host.
+            _capability.Reject(NetworkError(_realm, ex));
+        }
+        finally
+        {
+            LeaveFetchRealm(entered);
+        }
+    }
+
+    private void ResolveWithResponse(FetchResponseSnapshot snapshot)
+    {
+        var list = new HeaderList();
+        list.Entries.AddRange(snapshot.Headers);
+
+        var response = _realm.Intrinsics.Response.CreateInstance(list);
+        response.Status = snapshot.Status;
+        response.StatusText = snapshot.StatusText;
+        response.Url = snapshot.Url;
+        response.Redirected = snapshot.Redirected;
+
+        // A null body status carries no body, and the transport's zero-byte read is not the same thing: a
+        // 204's bodyUsed must stay false however often the script reads it.
+        if (!FetchValues.IsNullBodyStatus(snapshot.Status))
+        {
+            response.Body = snapshot.Body;
+        }
+
+        _capability.Resolve(response);
+    }
+
+    /// <summary>
+    /// https://fetch.spec.whatwg.org/#abort-fetch — the rejection value is the signal's own abort reason,
+    /// which for a bare <c>controller.abort()</c> is an <c>AbortError</c> <c>DOMException</c>.
+    /// </summary>
+    private void RejectWithAbortReason()
+    {
+        var reason = _signal.Aborted
+            ? _signal.Reason
+            : _realm.Intrinsics.DomException.CreateException(DomExceptionNames.Abort, "The operation was aborted.");
+
+        _capability.Reject(reason);
+    }
+
+    /// <summary>
+    /// The failure a blown <c>Options.WebApi.Fetch.Timeout</c> produces — the same one
+    /// <c>AbortSignal.timeout()</c> raises, so a script can handle a deadline uniformly however it was set.
+    /// </summary>
+    private void RejectWithTimeout()
+    {
+        _capability.Reject(_realm.Intrinsics.DomException.CreateException(
+            DomExceptionNames.Timeout,
+            $"The request exceeded the {_timeout} timeout set by Options.WebApi.Fetch.Timeout."));
+    }
+
+    private void RejectWithNetworkError(Exception failure)
+    {
+        _capability.Reject(NetworkError(_realm, failure));
+    }
+
+    /// <summary>
+    /// The one error value every network-class failure produces —
+    /// https://fetch.spec.whatwg.org/#concept-network-error, whose own answer is a <c>TypeError</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The message is deliberately uninformative</b>, which is what a browser does too: a message naming
+    /// the DNS failure, the refused connection or the policy rule would let a script map the host's internal
+    /// network by probing it and reading the answers apart. Two failures do carry a number — the redirect and
+    /// size caps — because those are the host's own limits and say nothing about the network.
+    /// </para>
+    /// <para>
+    /// The originating CLR exception rides the error <i>value</i>, so the host can read it with
+    /// <c>JintException.TryGetClrException</c> while the script cannot see it at all.
+    /// </para>
+    /// </remarks>
+    private static JsValue NetworkError(Realm realm, Exception failure)
+    {
+        var message = failure is FetchFailureException { Kind: FetchFailureKind.RedirectLimit or FetchFailureKind.ResponseTooLarge } bounded
+            ? "Failed to fetch: " + bounded.Message
+            : "Failed to fetch";
+
+        return new JavaScriptException(realm.Intrinsics.TypeError, message, failure).Error;
+    }
+
+    /// <summary>
+    /// Leaves the engine's in-flight set and frees the request's cancellation source. Runs on the engine
+    /// thread, from the settle job.
+    /// </summary>
+    private void Release()
+    {
+        _engine._webApi?.UnregisterFetch(this);
+        _cancellation.Dispose();
+    }
+
+    /// <summary>
+    /// Abandons the request because the evaluation cycle it belongs to has ended. Cancels the transport so
+    /// the socket is freed at once; any settle already on its way is discarded by the generation fence rather
+    /// than applied to the restored engine.
+    /// </summary>
+    internal void Abandon()
+    {
+        Interlocked.Exchange(ref _settled, 1);
+
+        try
+        {
+            _cancellation.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // Raced with a settle that already released it; there is nothing left to cancel.
+        }
+
+        _cancellation.Dispose();
+    }
+
+    private bool EnterFetchRealm()
+    {
+        if (ReferenceEquals(_engine.Realm, _realm))
+        {
+            return false;
+        }
+
+        _engine.EnterExecutionContext(_realm.GlobalEnv, _realm.GlobalEnv, _realm, privateEnvironment: null, strict: _engine.Options.Strict);
+        return true;
+    }
+
+    private void LeaveFetchRealm(bool entered)
+    {
+        if (entered)
+        {
+            _engine.LeaveExecutionContext();
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/Fetch/FetchTransport.cs
+++ b/Jint/WebApi/Fetch/FetchTransport.cs
@@ -1,0 +1,507 @@
+#if NET8_0_OR_GREATER
+using System.Buffers;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Jint.WebApi.Url.Parsing;
+
+namespace Jint.WebApi.Fetch;
+
+/// <summary>
+/// Why a fetch failed, for the failure map <c>FetchOperation</c> turns into a rejection.
+/// </summary>
+internal enum FetchFailureKind
+{
+    /// <summary>The scheme list or the host's <c>UrlFilter</c> refused the URL — on the first hop or on a redirect.</summary>
+    PolicyDenied,
+
+    /// <summary>More redirects than <c>Options.FetchOptions.MaxRedirects</c> allows.</summary>
+    RedirectLimit,
+
+    /// <summary>A redirect arrived and the request's redirect mode is <c>error</c>.</summary>
+    RedirectRefused,
+
+    /// <summary>The body exceeded <c>Options.FetchOptions.MaxResponseBytes</c>.</summary>
+    ResponseTooLarge,
+
+    /// <summary>DNS, connection, TLS, protocol — anything the transport itself reported.</summary>
+    Network,
+}
+
+/// <summary>
+/// The failure a fetch ended in, as a CLR exception. It never reaches script: <c>FetchOperation</c> turns it
+/// into a <c>TypeError</c> whose message says only "Failed to fetch", and attaches this to the error
+/// <i>value</i> so that the host — and only the host — can read the detail through
+/// <see cref="JintException.TryGetClrException"/>.
+/// </summary>
+internal sealed class FetchFailureException : Exception
+{
+    internal FetchFailureException(FetchFailureKind kind, string message, Exception? innerException = null)
+        : base(message, innerException)
+    {
+        Kind = kind;
+    }
+
+    internal FetchFailureKind Kind { get; }
+}
+
+/// <summary>
+/// The request as a plain CLR value, taken on the engine thread and handed to the transport.
+/// </summary>
+/// <remarks>
+/// Nothing here is engine state: the URL record and the header list are both from the deliberately
+/// engine-free layers, and the body is a byte window. That is what lets the whole of
+/// <see cref="FetchTransport"/> run on a thread pool thread while the engine goes on running script.
+/// </remarks>
+internal sealed class FetchRequestSnapshot
+{
+    internal required string Method { get; init; }
+
+    internal required UrlRecord Url { get; init; }
+
+    internal required List<HeaderEntry> Headers { get; init; }
+
+    internal required ReadOnlyMemory<byte>? Body { get; init; }
+
+    /// <summary>One of <c>follow</c>, <c>error</c> or <c>manual</c>.</summary>
+    internal required string Redirect { get; init; }
+}
+
+/// <summary>
+/// The host's policy, read once on the engine thread so the transport never touches
+/// <see cref="Options"/> from a background thread.
+/// </summary>
+internal sealed class FetchPolicy
+{
+    internal required string[] AllowedSchemes { get; init; }
+
+    internal required Func<Uri, bool> UrlFilter { get; init; }
+
+    internal required long MaxResponseBytes { get; init; }
+
+    internal required int MaxRedirects { get; init; }
+
+    /// <summary>
+    /// The whole check one hop passes: the scheme list, the <see cref="Uri"/> grammar and the host's filter.
+    /// Refusing is what stops a redirect to <c>http://169.254.169.254/</c> from reaching the socket.
+    /// </summary>
+    internal bool Allows(UrlRecord url, out Uri uri) => TryResolve(url, out uri) && UrlFilter(uri);
+
+    /// <summary>
+    /// The half of <see cref="Allows"/> that has no side effect: the scheme list and the <see cref="Uri"/>
+    /// grammar. It exists so that the first hop — whose filter the engine thread has already run — is not
+    /// asked a second time, because <see cref="UrlFilter"/> is host code and being invoked twice per request
+    /// is observable to it.
+    /// </summary>
+    internal bool TryResolve(UrlRecord url, out Uri uri)
+    {
+        uri = null!;
+
+        var scheme = url.Scheme;
+        var allowed = false;
+        foreach (var candidate in AllowedSchemes)
+        {
+            if (string.Equals(candidate, scheme, StringComparison.OrdinalIgnoreCase))
+            {
+                allowed = true;
+                break;
+            }
+        }
+
+        if (!allowed)
+        {
+            return false;
+        }
+
+        // The WHATWG serialization is always an absolute URL, but Uri has its own grammar and a host it
+        // cannot represent must be refused rather than guessed at.
+        if (!Uri.TryCreate(url.Serialize(), UriKind.Absolute, out var parsed))
+        {
+            return false;
+        }
+
+        uri = parsed;
+        return true;
+    }
+}
+
+/// <summary>
+/// A response as plain CLR data, classified off the engine thread. <c>FetchOperation</c> turns it into a
+/// <c>Response</c> object on the engine thread, in the realm the fetch started in.
+/// </summary>
+internal sealed class FetchResponseSnapshot
+{
+    internal required int Status { get; init; }
+
+    internal required string StatusText { get; init; }
+
+    internal required List<HeaderEntry> Headers { get; init; }
+
+    internal required byte[] Body { get; init; }
+
+    /// <summary>The last URL the request reached, serialized without its fragment.</summary>
+    internal required string Url { get; init; }
+
+    internal required bool Redirected { get; init; }
+}
+
+/// <summary>
+/// The HTTP half of <c>fetch</c>: the redirect loop, the per-hop policy re-check and the bounded body read.
+/// <para>
+/// https://fetch.spec.whatwg.org/#http-fetch
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Nothing here touches the engine.</b> It takes a <see cref="FetchRequestSnapshot"/> and a
+/// <see cref="FetchPolicy"/> and answers a <see cref="FetchResponseSnapshot"/> or throws a
+/// <see cref="FetchFailureException"/>; every type it mentions is a plain CLR value. The engine is not
+/// thread-safe and the script that started the fetch goes on running while this does its work.
+/// </para>
+/// <para>
+/// <b>Redirects are followed here rather than by <see cref="HttpClient"/>.</b> That is the whole reason for
+/// the loop: an automatic redirect would be followed underneath the scheme and <c>UrlFilter</c> checks, so a
+/// server answering <c>302 Location: http://169.254.169.254/latest/meta-data/</c> would reach the cloud
+/// metadata endpoint however carefully the host had written its filter.
+/// </para>
+/// </remarks>
+internal static class FetchTransport
+{
+    /// <summary>
+    /// The headers a redirect that rewrites the method to GET must drop with the body it drops —
+    /// https://fetch.spec.whatwg.org/#request-body-header-name.
+    /// </summary>
+    private static readonly string[] _bodyHeaderNames = ["content-encoding", "content-language", "content-location", "content-type"];
+
+    /// <summary>
+    /// The headers stripped when a redirect crosses to another origin. The Fetch Standard removes
+    /// <c>Authorization</c> (https://fetch.spec.whatwg.org/#http-redirect-fetch step 13); <c>Cookie</c> and
+    /// <c>Proxy-Authorization</c> are stripped for the same reason, and are what every server-side client
+    /// does — a credential a script attached for one host must not travel to whichever host that one names.
+    /// </summary>
+    private static readonly string[] _crossOriginHeaderNames = ["authorization", "cookie", "proxy-authorization"];
+
+    /// <summary>
+    /// The client used when the host supplied none. Created once per process and <b>never disposed</b>: it
+    /// holds a connection pool that is worth sharing, and there is no moment at which Jint knows no engine
+    /// will fetch again. A host that needs to control the lifetime — or to interpose a
+    /// <c>DelegatingHandler</c> — supplies its own through <c>Options.FetchOptions.HttpClient</c>.
+    /// </summary>
+    /// <remarks>
+    /// <c>AllowAutoRedirect</c> is off because the loop below owns redirects; <c>UseCookies</c> is off
+    /// because a cookie jar shared by every engine in the process would be a cross-tenant channel;
+    /// <c>PooledConnectionLifetime</c> is two minutes so that DNS changes are picked up; and the client's own
+    /// <c>Timeout</c> is infinite because the deadline rides the cancellation token, where the operation can
+    /// tell a timeout apart from an abort.
+    /// </remarks>
+    private static readonly Lazy<HttpClient> _sharedClient = new(CreateSharedClient, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    internal static HttpClient SharedClient => _sharedClient.Value;
+
+    private static HttpClient CreateSharedClient()
+    {
+        var handler = new SocketsHttpHandler
+        {
+            PooledConnectionLifetime = TimeSpan.FromMinutes(2),
+            AutomaticDecompression = DecompressionMethods.All,
+            AllowAutoRedirect = false,
+            UseCookies = false,
+        };
+
+        return new HttpClient(handler, disposeHandler: true)
+        {
+            Timeout = Timeout.InfiniteTimeSpan,
+        };
+    }
+
+    /// <summary>
+    /// Runs the request, following redirects itself, and reads the body under the size cap.
+    /// </summary>
+    internal static async Task<FetchResponseSnapshot> SendAsync(
+        HttpClient client,
+        FetchRequestSnapshot request,
+        FetchPolicy policy,
+        CancellationToken cancellationToken)
+    {
+        var url = request.Url;
+        var method = request.Method;
+        var body = request.Body;
+        var headers = new List<HeaderEntry>(request.Headers);
+        var redirectCount = 0;
+
+        while (true)
+        {
+            // The first hop's filter has already been run on the engine thread, where the fetch was started;
+            // running it again here would call host code twice for one request, which the host can see.
+            Uri uri;
+            var allowed = redirectCount == 0 ? policy.TryResolve(url, out uri) : policy.Allows(url, out uri);
+            if (!allowed)
+            {
+                throw new FetchFailureException(FetchFailureKind.PolicyDenied, $"The fetch policy refused '{url.Serialize()}'.");
+            }
+
+            HttpResponseMessage response;
+            try
+            {
+                using var message = BuildRequest(method, uri, headers, body);
+                response = await client.SendAsync(message, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException and not FetchFailureException)
+            {
+                throw new FetchFailureException(FetchFailureKind.Network, $"The request to '{uri}' failed: {ex.Message}", ex);
+            }
+
+            try
+            {
+                // https://fetch.spec.whatwg.org/#concept-http-fetch step 6, the three redirect modes. "manual"
+                // is Node's reading of it: the redirect response itself is handed to the script, Location and
+                // all, rather than a browser's opaque-redirect filtered response — which exists to hide a
+                // cross-origin redirect from a page, a concern an embedded engine with no origin does not have.
+                var status = (int) response.StatusCode;
+                if (!FetchValues.IsRedirectStatus(status)
+                    || string.Equals(request.Redirect, JsRequest.RedirectManual, StringComparison.Ordinal))
+                {
+                    return await ReadResponseAsync(response, url, redirectCount > 0, policy, cancellationToken).ConfigureAwait(false);
+                }
+
+                if (string.Equals(request.Redirect, JsRequest.RedirectError, StringComparison.Ordinal))
+                {
+                    throw new FetchFailureException(FetchFailureKind.RedirectRefused, $"'{uri}' answered a redirect and the request's redirect mode is 'error'.");
+                }
+
+                // "If locationURL is null, then return actualResponse" — a 301 with no Location header is an
+                // ordinary response, not a failure.
+                var location = TryGetRedirectTarget(response, url);
+                if (location is null)
+                {
+                    return await ReadResponseAsync(response, url, redirectCount > 0, policy, cancellationToken).ConfigureAwait(false);
+                }
+
+                if (++redirectCount > policy.MaxRedirects)
+                {
+                    throw new FetchFailureException(
+                        FetchFailureKind.RedirectLimit,
+                        $"The request to '{request.Url.Serialize()}' exceeded the limit of {policy.MaxRedirects} redirects.");
+                }
+
+                Rewrite(status, ref method, ref body, headers, url, location);
+                url = location;
+            }
+            finally
+            {
+                response.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
+    /// The location a redirect points at, resolved against the URL that produced it, or <see langword="null"/>
+    /// when this response is not a redirect to follow.
+    /// </summary>
+    /// <remarks>
+    /// A <c>Location</c> that does not parse is a network error, which is what the standard's "if locationURL
+    /// is failure, then return a network error" says.
+    /// </remarks>
+    private static UrlRecord? TryGetRedirectTarget(HttpResponseMessage response, UrlRecord current)
+    {
+        // Read the raw header rather than response.Headers.Location, whose Uri parsing is not the WHATWG
+        // parser and rejects some relative forms the standard accepts.
+        if (!response.Headers.TryGetValues("Location", out var values))
+        {
+            return null;
+        }
+
+        string? location = null;
+        foreach (var value in values)
+        {
+            location = value;
+            break;
+        }
+
+        if (location is null)
+        {
+            return null;
+        }
+
+        var target = UrlParser.Parse(location, current);
+        if (target is null)
+        {
+            throw new FetchFailureException(FetchFailureKind.Network, $"'{current.Serialize()}' answered a redirect to an unparsable location.");
+        }
+
+        return target;
+    }
+
+    /// <summary>
+    /// The method and header rewrites a redirect performs —
+    /// https://fetch.spec.whatwg.org/#http-redirect-fetch steps 11 to 13.
+    /// </summary>
+    private static void Rewrite(int status, ref string method, ref ReadOnlyMemory<byte>? body, List<HeaderEntry> headers, UrlRecord from, UrlRecord to)
+    {
+        var dropsBody = (status is 301 or 302 && string.Equals(method, "POST", StringComparison.Ordinal))
+            || (status == 303 && method is not ("GET" or "HEAD"));
+
+        if (dropsBody)
+        {
+            method = "GET";
+            body = null;
+            Remove(headers, _bodyHeaderNames);
+        }
+
+        if (!IsSameOrigin(from, to))
+        {
+            Remove(headers, _crossOriginHeaderNames);
+        }
+    }
+
+    private static void Remove(List<HeaderEntry> headers, string[] names)
+    {
+        headers.RemoveAll(entry =>
+        {
+            foreach (var name in names)
+            {
+                if (string.Equals(entry.LowerName, name, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        });
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/browsers.html#same-origin — scheme, host and port, with the
+    /// default port already normalized away by the URL parser.
+    /// </summary>
+    private static bool IsSameOrigin(UrlRecord a, UrlRecord b)
+        => string.Equals(a.Scheme, b.Scheme, StringComparison.Ordinal)
+        && string.Equals(a.SerializeHost(), b.SerializeHost(), StringComparison.Ordinal)
+        && a.Port == b.Port;
+
+    private static HttpRequestMessage BuildRequest(string method, Uri uri, List<HeaderEntry> headers, ReadOnlyMemory<byte>? body)
+    {
+        var message = new HttpRequestMessage(new HttpMethod(method), uri);
+
+        if (body is { } bytes)
+        {
+            message.Content = new ReadOnlyMemoryContent(bytes);
+
+            // ReadOnlyMemoryContent guesses a Content-Type of its own; the header list is the only authority
+            // on what the request carries, and it already holds whatever the body implied.
+            message.Content.Headers.ContentType = null;
+        }
+
+        foreach (var header in headers)
+        {
+            // A content header belongs on the content, and the request-header collection refuses it. Both
+            // calls are TryAddWithoutValidation: the header list has already been validated against the
+            // Fetch Standard's own grammar, which is what a script is entitled to be measured against.
+            if (!message.Headers.TryAddWithoutValidation(header.LowerName, header.Value))
+            {
+                message.Content?.Headers.TryAddWithoutValidation(header.LowerName, header.Value);
+            }
+        }
+
+        return message;
+    }
+
+    /// <summary>
+    /// Reads the body under <c>MaxResponseBytes</c> and collects the headers.
+    /// </summary>
+    /// <remarks>
+    /// The bytes counted are the <b>decompressed</b> ones, because the handler decompresses before this sees
+    /// the stream — so the cap bounds what the process actually spends rather than what the server sent, and
+    /// a compression bomb is refused at the number the host chose. A <c>Content-Length</c> that already
+    /// exceeds the cap short-circuits the read, but it is only a shortcut: a server that lies, or that uses
+    /// chunked encoding, is caught by the running total.
+    /// </remarks>
+    private static async Task<FetchResponseSnapshot> ReadResponseAsync(
+        HttpResponseMessage response,
+        UrlRecord url,
+        bool redirected,
+        FetchPolicy policy,
+        CancellationToken cancellationToken)
+    {
+        var declaredLength = response.Content.Headers.ContentLength;
+        if (declaredLength is { } length && length > policy.MaxResponseBytes)
+        {
+            throw TooLarge(policy);
+        }
+
+        byte[] body;
+        try
+        {
+            using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            body = await ReadBoundedAsync(stream, policy, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException and not FetchFailureException)
+        {
+            throw new FetchFailureException(FetchFailureKind.Network, $"Reading the response body of '{url.Serialize()}' failed: {ex.Message}", ex);
+        }
+
+        var headers = new List<HeaderEntry>();
+        Collect(headers, response.Headers);
+        Collect(headers, response.Content.Headers);
+
+        return new FetchResponseSnapshot
+        {
+            Status = (int) response.StatusCode,
+            StatusText = response.ReasonPhrase ?? string.Empty,
+            Headers = headers,
+            Body = body,
+            Url = url.Serialize(excludeFragment: true),
+            Redirected = redirected,
+        };
+    }
+
+    private static async Task<byte[]> ReadBoundedAsync(Stream stream, FetchPolicy policy, CancellationToken cancellationToken)
+    {
+        var writer = new ArrayBufferWriter<byte>();
+        var buffer = ArrayPool<byte>.Shared.Rent(16 * 1024);
+        try
+        {
+            while (true)
+            {
+                var read = await stream.ReadAsync(buffer.AsMemory(), cancellationToken).ConfigureAwait(false);
+                if (read == 0)
+                {
+                    return writer.WrittenSpan.ToArray();
+                }
+
+                // Checked before the copy, so the cap is never overshot by a whole chunk and the connection
+                // is dropped as soon as the limit is known to be broken.
+                if (writer.WrittenCount + (long) read > policy.MaxResponseBytes)
+                {
+                    throw TooLarge(policy);
+                }
+
+                writer.Write(buffer.AsSpan(0, read));
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    private static FetchFailureException TooLarge(FetchPolicy policy)
+        => new(FetchFailureKind.ResponseTooLarge, $"The response body exceeded the {policy.MaxResponseBytes} byte limit set by Options.WebApi.Fetch.MaxResponseBytes.");
+
+    /// <summary>
+    /// Every value of every header becomes its own entry, so that a response carrying several
+    /// <c>Set-Cookie</c> headers is not silently folded into one.
+    /// </summary>
+    private static void Collect(List<HeaderEntry> headers, System.Net.Http.Headers.HttpHeaders source)
+    {
+        foreach (var header in source.NonValidated)
+        {
+            foreach (var value in header.Value)
+            {
+                headers.Add(new HeaderEntry(HeaderList.Lowercase(header.Key), value));
+            }
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/WebApiRegistration.cs
+++ b/Jint/WebApi/WebApiRegistration.cs
@@ -119,6 +119,10 @@ internal static class WebApiRegistration
             Install(global, engine, "Headers", static e => e.Realm.Intrinsics.Headers, PropertyFlag.NonEnumerable);
             Install(global, engine, "Request", static e => e.Realm.Intrinsics.Request, PropertyFlag.NonEnumerable);
             Install(global, engine, "Response", static e => e.Realm.Intrinsics.Response, PropertyFlag.NonEnumerable);
+
+            // A WebIDL operation on the global is a writable, enumerable, configurable data property, unlike
+            // the interface objects above — https://webidl.spec.whatwg.org/#es-operations.
+            Install(global, engine, "fetch", static e => e.Realm.Intrinsics.Fetch, PropertyFlag.ConfigurableEnumerableWritable);
         }
     }
 
@@ -167,9 +171,10 @@ internal static class WebApiRegistration
     {
         // The timer globals are the obvious reason for a queue; AbortSignal.timeout() is the other, and it
         // needs one whether or not the host also asked for setTimeout. The events and performance features
-        // additionally read the time origin (Event.timeStamp, performance.now), which is why they want the state
-        // even without the timers flag.
-        const WebApiFeatures NeedsEngineState = WebApiFeatures.Timers | WebApiFeatures.Events | WebApiFeatures.Performance;
+        // additionally read the time origin (Event.timeStamp, performance.now), and fetch keeps its settings
+        // and its in-flight set here, which is why each of them wants the state.
+        const WebApiFeatures NeedsEngineState =
+            WebApiFeatures.Timers | WebApiFeatures.Events | WebApiFeatures.Performance | WebApiFeatures.Fetch;
         if ((features & NeedsEngineState) == WebApiFeatures.None)
         {
             return;
@@ -185,7 +190,11 @@ internal static class WebApiRegistration
             ? new TimerQueue(timeProvider, timerOptions.MaxActiveTimers)
             : null;
 
-        engine._webApi = new WebApiEngineState(engine, timeProvider, timers);
+        // The fetch settings are read here, once, so that nothing on a background thread ever reaches into
+        // Options — and so that a host mutating them afterwards does not change an engine that already exists.
+        var fetch = (features & WebApiFeatures.Fetch) != WebApiFeatures.None ? options.WebApi.Fetch : null;
+
+        engine._webApi = new WebApiEngineState(engine, timeProvider, timers, fetch);
     }
 
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ its own `console` (or any other name in the table below), enabling the feature l
 | `Event` / `EventTarget` / `CustomEvent` / `AbortController` / `AbortSignal` | `Events` | ✔ shipped |
 | `URL` / `URLSearchParams` | `Url` | ✔ shipped |
 | `Blob` / `File` / `FormData` | `Files` | ✔ shipped |
-| `fetch` / `Headers` / `Request` / `Response` | `Fetch` | in progress |
+| `fetch` / `Headers` / `Request` / `Response` | `Fetch` — **opt-in on its own, see below** | ✔ shipped |
 
 `WebApiFeatures.Default` — what `UseWebApis()` enables — is every non-network feature that has landed. It
 grows as the table fills in, and it will never include `fetch`: network egress is always an explicit choice.
@@ -290,6 +290,57 @@ retained by its sources until one of them aborts, at which point every link is d
 **A `ShadowRealm` does not get these globals.** Only the principal realm's global object is touched, which is
 deliberately more conservative than a browser (where these APIs are `[Exposed=*]`); a host that wants them
 inside a shadow realm can install them through `Host.InitializeShadowRealm`.
+
+### `fetch` is opt-in on its own
+
+`UseWebApis()` never enables `fetch`, and `WebApiFeatures.Default` will never include it. Network egress from
+script is a decision you make explicitly:
+
+```csharp
+var engine = new Engine(options => options.UseWebApis().UseFetch(fetch =>
+{
+    fetch.AllowedSchemes.Remove("http");                     // https only
+    fetch.UrlFilter = uri => uri.Host.EndsWith(".example.org", StringComparison.OrdinalIgnoreCase);
+    fetch.MaxResponseBytes = 1024 * 1024;
+    fetch.Timeout = TimeSpan.FromSeconds(5);
+    fetch.HttpClient = myClient;                             // or HttpClientFactory, for a per-tenant client
+}));
+
+var body = engine.Evaluate("fetch('https://api.example.org/x').then(r => r.json())").UnwrapIfPromise();
+```
+
+Enabling it also brings `Events`, `Url` and `Files`, because fetch's own surface is built out of them: a
+`Request` always has an `AbortSignal`, its URL is a WHATWG URL, and `response.blob()` answers with a `Blob`.
+
+`Headers`, `Request` and `Response` are the standard's own classes — the full `Headers` (sorted, combined
+iteration, `getSetCookie`), method normalization, `redirect` modes, `clone()`, `Response.error()`,
+`Response.redirect()`, `Response.json()`. Bodies are **buffered rather than streamed**: `text()`, `json()`,
+`arrayBuffer()`, `bytes()` and `blob()` answer already-resolved promises, `bodyUsed` flips on the first read
+and a second one rejects, and `response.body` is always `null` because Jint has no streams yet. `formData()`
+is absent and a `FormData` request body is a `TypeError` — the `multipart/form-data` serializer is a
+follow-up. `credentials`, `cache`, `mode`, `referrer` and `integrity` are accepted and ignored, the same
+convention Node and workerd follow, because there is no origin, cookie jar or HTTP cache here to honour them
+with.
+
+Like every other web API, `fetch` settles only while the engine is being pumped: the promise resolves inside a
+blocking `UnwrapIfPromise`, an `await` of `EvaluateAsync`, or your own `engine.Advanced.ProcessTasks()` loop.
+The deadline is the one exception, and deliberately so — it is enforced CLR-side, so an engine nobody pumps
+still lets go of its socket. An in-flight request is cancelled by `Engine.Advanced.RestoreGlobalSnapshot`, and
+its promise never settles into the restored engine.
+
+**Security.** Enabling `fetch` gives the script your process's network position: anything the worker can
+reach, the script can reach. The defaults bound the resource questions — 32 MiB per response body (counted
+after decompression, so a compression bomb is bounded too), 20 redirects, a 30-second deadline, 10 concurrent
+requests — but they cannot know which *hosts* are legitimate. That is what `UrlFilter` is for, and a
+deployment running untrusted script wants one. Jint follows redirects itself with `AllowAutoRedirect` off
+precisely so that **every hop is re-checked** against the scheme list and your filter: a server you allow
+answering `302 Location: http://169.254.169.254/…` does not get to launder the request past a first-hop check.
+`Authorization`, `Cookie` and `Proxy-Authorization` are stripped across an origin change, header values may
+not carry CR or LF, and a URL with credentials in it is refused. Every network-class failure is one
+`TypeError` saying only `Failed to fetch`, so a script cannot map your internal network by reading the
+failures apart; the real cause rides the error value and is readable by the host through
+`JintException.TryGetClrException`. See [THREAT_MODEL.md](.github/THREAT_MODEL.md) TM-21 for the full
+analysis, including what these controls do *not* cover.
 
 
 ## Performance


### PR DESCRIPTION
Adds the fetch algorithm on top of the object model from #3101: `fetch(input, init)` as an opt-in global, driven entirely by the engine's own event loop.

## How a request runs

`FetchOperation` follows the `ModuleLoadCompletion` pattern. The synchronous phase (argument coercion, scheme + `UrlFilter` policy, pre-aborted signal) runs on the engine thread and produces a rejection, never a throw. The network phase runs on the thread pool via `SendAsync(..., ResponseHeadersRead)` and never touches the engine: the outcome is classified off-thread into a plain CLR record, then enqueued as a generation-stamped job that enters the captured realm, builds the `Response` (or error) there, and settles the capability. A settle that arrives after `RestoreGlobalSnapshot` is discarded by the same generation fence every other cross-thread completion sits behind, and the restore path cancels the in-flight requests' CTSes so their sockets are freed rather than leaked.

`ConstraintFailure.MustPropagate` is hoisted out of `ModuleLoadCompletion` so both completion paths share one definition of "a constraint failure never becomes a rejection".

## Transport and policy

`FetchTransport` owns the HTTP mechanics: a lazily-created shared `SocketsHttpHandler` client (`AllowAutoRedirect = false`, `UseCookies = false`, decompression on) unless the host supplies `HttpClient` or a per-request `HttpClientFactory`, and a **manual redirect loop** so every hop re-runs the scheme check and `UrlFilter` — a redirect to `169.254.169.254` fails policy exactly like a direct request (the SSRF shape TM-21 documents). Cross-origin hops strip `Authorization`/`Cookie`/`Proxy-Authorization`; 301/302/303 rewrite the method per spec; `redirect: 'follow' | 'error' | 'manual'` follows undici's server-side semantics. The response body is a bounded manual read of the decompressed bytes (`MaxResponseBytes`), so an oversized or lying `Content-Length` ends in a clean `TypeError` rejection.

Failure map: policy/DNS/connection/TLS/redirect-cap/size-cap → `TypeError` with the CLR exception attached to the error value (readable via `TryGetClrException`); abort → the signal's reason; the default 30 s timeout → `TimeoutError` `DOMException` (armed with `CancelAfter`, so it fires even when nobody pumps); an engine `CancellationConstraint` → no settlement at all.

## Bounds

Defaults: `https`/`http` only, 32 MB response cap, 20 redirects, 30 s timeout, 10 concurrent requests per engine, header name/value validation (CR/LF/NUL → `TypeError`) as request-splitting defense. `credentials`/`cache`/`mode`/`referrer`/`integrity` are accepted and ignored, per the server-side runtime convention.

`WebApiFeatures.Fetch` is never part of `Default` — it implies `Events | Url | Files` but is only ever enabled by naming it or calling `UseFetch(...)`. `.github/THREAT_MODEL.md` gains TM-21 covering the egress surface.

## Tests

`Jint.Tests/Runtime/WebApi/FetchTests.cs` and `Jint.Tests.PublicInterface/WebApiFetchTests.cs` (stub-handler `HttpClient`, no sockets): policy refusal per hop, redirect semantics and header stripping, size cap, timeout and abort mid-flight, restore-fence-drops-the-settle-and-cancels-HTTP, constraint-never-rejects, and the full failure map. Both suites green on net10.0 and net472, with and without `JINT_HOST_CONTRACT_VERIFICATION=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G7Ud48VAs1JicxRZxLDxg