### PR TITLE
Propagate a rejected iterator return() out of an abandoned for-await loop

### DIFF
--- a/Jint.Tests/Runtime/AsyncIteratorCloseTests.cs
+++ b/Jint.Tests/Runtime/AsyncIteratorCloseTests.cs
@@ -1,0 +1,385 @@
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Pins <a href="https://tc39.es/ecma262/#sec-asynciteratorclose">AsyncIteratorClose</a> for a
+/// <c>for await…of</c> loop that is abandoned before its iterator runs out.
+/// <para>
+/// Steps 4.c and 4.d call the iterator's <c>return</c> and then <em>Await</em> what it answered, and
+/// steps 5-8 rank that against the loop's own completion: a throw completion the loop already carries
+/// wins (step 5), otherwise a rejected <c>return()</c> becomes the loop's completion (step 6) and a
+/// settled value that is not an Object is a <c>TypeError</c> (step 7).
+/// </para>
+/// <para>
+/// Jint used to perform the <em>synchronous</em>
+/// <a href="https://tc39.es/ecma262/#sec-iteratorclose">IteratorClose</a> here, which calls
+/// <c>return()</c>, sees the promise it answered with, finds that it <em>is</em> an Object and stops.
+/// So the whole of steps 4.d-7 was skipped: a <c>return()</c> that rejected was dropped on the floor
+/// and <c>for await (…) { break; }</c> completed normally where V8 throws — issue #3098. The same hole
+/// swallowed a sync iterable's close failure under <c>for await</c>, because
+/// <a href="https://tc39.es/ecma262/#sec-%25asyncfromsynciteratorprototype%25.return">%AsyncFromSyncIteratorPrototype%.return</a>
+/// reports every one of those as a rejection of the promise it hands back.
+/// </para>
+/// </summary>
+public class AsyncIteratorCloseTests
+{
+    private const string Harness = """
+        // An async iterable whose iterator counts its closes and answers return() however the test
+        // says. `opts.limit` ends the iteration after that many steps; `opts.nextRejects` fails the
+        // step itself, which must never reach AsyncIteratorClose at all.
+        function makeAsyncIterable(returnImpl, opts) {
+            opts = opts || {};
+            const record = { closeCount: 0, log: [] };
+            let i = 0;
+            record.iterable = {
+                [Symbol.asyncIterator]() {
+                    return {
+                        next() {
+                            if (opts.nextRejects) { return Promise.reject(new Error('from next')); }
+                            i++;
+                            if (opts.limit !== undefined && i > opts.limit) {
+                                return Promise.resolve({ value: undefined, done: true });
+                            }
+                            return Promise.resolve({ value: i, done: false });
+                        },
+                        return: returnImpl === undefined ? undefined : function () {
+                            record.closeCount++;
+                            record.log.push('return');
+                            return returnImpl();
+                        }
+                    };
+                }
+            };
+            return record;
+        }
+
+        // The same shape with only a SYNC iterator, so for-await drives it through
+        // CreateAsyncFromSyncIterator.
+        function makeSyncIterable(returnImpl) {
+            const record = { closeCount: 0, log: [] };
+            record.iterable = {
+                [Symbol.iterator]() {
+                    return {
+                        next() { return { value: 1, done: false }; },
+                        return: returnImpl === undefined ? undefined : function () {
+                            record.closeCount++;
+                            record.log.push('return');
+                            return returnImpl();
+                        }
+                    };
+                }
+            };
+            return record;
+        }
+
+        const REJECT = function () { return Promise.reject(new Error('cleanup failed')); };
+
+        // Flattens how a promise settled into one assertable string.
+        async function outcome(fn) {
+            try { return 'ok:' + (await fn()); }
+            catch (e) { return 'threw:' + (e && e.name ? e.name : '?') + ':' + (e && e.message !== undefined ? e.message : e); }
+        }
+        """;
+
+    private static string Run(string script) =>
+        new Engine().Evaluate(Harness + "\n" + script).UnwrapIfPromise().AsString();
+
+    /// <summary>
+    /// The report from issue #3098, verbatim in shape: a loop left by <c>break</c> whose
+    /// <c>return()</c> answers a rejected promise. Step 6 makes that rejection the loop's completion.
+    /// </summary>
+    [Fact]
+    public void ARejectedReturnBecomesTheCompletionOfALoopLeftByBreak()
+    {
+        Run("""
+            (async function () {
+                const record = makeAsyncIterable(REJECT);
+                const result = await outcome(async function () {
+                    for await (const x of record.iterable) { break; }
+                    return 'no-throw';
+                });
+                return result + ',closeCount=' + record.closeCount;
+            })()
+            """).Should().Be("threw:Error:cleanup failed,closeCount=1");
+    }
+
+    /// <summary>
+    /// Step 5 — "If completion is a throw completion, return ? completion" — comes before step 6, so a
+    /// throw already in flight outranks the close's rejection. The <c>return()</c> is still called.
+    /// </summary>
+    [Fact]
+    public void AThrowFromTheBodyOutranksARejectedReturn()
+    {
+        Run("""
+            (async function () {
+                const record = makeAsyncIterable(REJECT);
+                const result = await outcome(async function () {
+                    for await (const x of record.iterable) { throw new Error('body error'); }
+                    return 'no-throw';
+                });
+                return result + ',closeCount=' + record.closeCount;
+            })()
+            """).Should().Be("threw:Error:body error,closeCount=1");
+    }
+
+    /// <summary>
+    /// The other direction of the same precedence: a <c>return</c> completion is abrupt but is not a
+    /// throw completion, so step 5 does not fire and step 6 replaces it with the close's rejection.
+    /// </summary>
+    [Fact]
+    public void AReturnFromTheBodyLosesToARejectedReturn()
+    {
+        Run("""
+            (async function () {
+                const record = makeAsyncIterable(REJECT);
+                const result = await outcome(async function () {
+                    for await (const x of record.iterable) { return 'returned'; }
+                    return 'no-throw';
+                });
+                return result + ',closeCount=' + record.closeCount;
+            })()
+            """).Should().Be("threw:Error:cleanup failed,closeCount=1");
+    }
+
+    /// <summary>
+    /// A <c>break</c> naming the loop's own label, and one naming an enclosing label (which leaves the
+    /// loop with a Break completion still carrying its target), both reach the close.
+    /// </summary>
+    [Fact]
+    public void ALabelledBreakStillPropagatesTheRejectedReturn()
+    {
+        Run("""
+            (async function () {
+                const own = makeAsyncIterable(REJECT);
+                const ownResult = await outcome(async function () {
+                    mine: for await (const x of own.iterable) { break mine; }
+                    return 'no-throw';
+                });
+
+                const outerRecord = makeAsyncIterable(REJECT);
+                const outerResult = await outcome(async function () {
+                    outer: {
+                        for await (const x of outerRecord.iterable) { break outer; }
+                    }
+                    return 'no-throw';
+                });
+
+                return 'own=' + ownResult + '|outer=' + outerResult
+                    + '|counts=' + own.closeCount + ',' + outerRecord.closeCount;
+            })()
+            """).Should().Be("own=threw:Error:cleanup failed|outer=threw:Error:cleanup failed|counts=1,1");
+    }
+
+    /// <summary>
+    /// Step 7 checks the value the Await <em>settled</em> with, not the promise the <c>return()</c>
+    /// handed over — which is exactly the check the old synchronous close could never make, since
+    /// every promise is an Object.
+    /// </summary>
+    [Fact]
+    public void TheReturnResultIsCheckedAfterTheAwaitNotBefore()
+    {
+        Run("""
+            (async function () {
+                const rows = [];
+                rows.push('promise-of-non-object=' + await outcome(async function () {
+                    for await (const x of makeAsyncIterable(function () { return Promise.resolve(42); }).iterable) { break; }
+                    return 'no-throw';
+                }));
+                rows.push('plain-non-object=' + await outcome(async function () {
+                    for await (const x of makeAsyncIterable(function () { return 42; }).iterable) { break; }
+                    return 'no-throw';
+                }));
+                rows.push('promise-of-object=' + await outcome(async function () {
+                    for await (const x of makeAsyncIterable(function () { return Promise.resolve({}); }).iterable) { break; }
+                    return 'no-throw';
+                }));
+                rows.push('thenable-of-non-object=' + await outcome(async function () {
+                    for await (const x of makeAsyncIterable(function () { return { then: function (res) { res(123); } }; }).iterable) { break; }
+                    return 'no-throw';
+                }));
+                return rows.join('|');
+            })()
+            """).Should().Be(
+            "promise-of-non-object=threw:TypeError:Iterator returned non-object"
+            + "|plain-non-object=threw:TypeError:Iterator returned non-object"
+            + "|promise-of-object=ok:no-throw"
+            + "|thenable-of-non-object=threw:TypeError:Iterator returned non-object");
+    }
+
+    /// <summary>
+    /// Step 4.b (<c>return</c> is undefined, "return ? completion") and step 4.c throwing on its own.
+    /// </summary>
+    [Fact]
+    public void AnAbsentReturnLeavesTheCompletionAloneAndAThrowingOneReplacesIt()
+    {
+        Run("""
+            (async function () {
+                const absent = await outcome(async function () {
+                    for await (const x of makeAsyncIterable(undefined).iterable) { break; }
+                    return 'no-throw';
+                });
+                const throwing = await outcome(async function () {
+                    for await (const x of makeAsyncIterable(function () { throw new Error('from return'); }).iterable) { break; }
+                    return 'no-throw';
+                });
+                const notCallable = await outcome(async function () {
+                    const it = { [Symbol.asyncIterator]() { return { next() { return Promise.resolve({ value: 1, done: false }); }, return: 1 }; } };
+                    for await (const x of it) { break; }
+                    return 'no-throw';
+                });
+                return 'absent=' + absent + '|throws=' + throwing + '|notCallable=' + notCallable.split(':')[1];
+            })()
+            """).Should().Be("absent=ok:no-throw|throws=threw:Error:from return|notCallable=TypeError");
+    }
+
+    /// <summary>
+    /// The close's Await is a real suspension of the async function, not a value the loop peeks at:
+    /// everything the awaited chain does happens before the loop's own completion is observed. Without
+    /// step 4.d the loop finishes first and <c>awaited</c> lands after <c>after</c>.
+    /// </summary>
+    [Fact]
+    public void TheCloseSuspendsTheAsyncFunctionOnItsAwait()
+    {
+        Run("""
+            (async function () {
+                const log = [];
+                const iterable = {
+                    [Symbol.asyncIterator]() {
+                        return {
+                            next() { return Promise.resolve({ value: 1, done: false }); },
+                            return() {
+                                log.push('return');
+                                return Promise.resolve({}).then(function (v) { log.push('awaited'); return v; });
+                            }
+                        };
+                    }
+                };
+                await (async function () { for await (const x of iterable) { break; } log.push('after'); })();
+                return log.join(',');
+            })()
+            """).Should().Be("return,awaited,after");
+    }
+
+    /// <summary>
+    /// A plain sync iterable under <c>for await</c> is driven through CreateAsyncFromSyncIterator, whose
+    /// <c>return</c> reports a throwing sync <c>return()</c>, a non-object result and a rejected
+    /// <c>value</c> alike as a rejection of the promise it answers with. All three were swallowed.
+    /// </summary>
+    [Fact]
+    public void ASyncIterableUnderForAwaitPropagatesItsCloseFailure()
+    {
+        Run("""
+            (async function () {
+                const throwing = makeSyncIterable(function () { throw new Error('sync return throw'); });
+                const throwingResult = await outcome(async function () {
+                    for await (const x of throwing.iterable) { break; }
+                    return 'no-throw';
+                });
+
+                const nonObject = makeSyncIterable(function () { return 42; });
+                const nonObjectResult = await outcome(async function () {
+                    for await (const x of nonObject.iterable) { break; }
+                    return 'no-throw';
+                });
+
+                const rejectedValue = makeSyncIterable(function () {
+                    return { done: true, value: Promise.reject(new Error('rejected value')) };
+                });
+                const rejectedValueResult = await outcome(async function () {
+                    for await (const x of rejectedValue.iterable) { break; }
+                    return 'no-throw';
+                });
+
+                return 'throws=' + throwingResult
+                    + '|nonObject=' + nonObjectResult.split(':')[1]
+                    + '|rejectedValue=' + rejectedValueResult
+                    + '|counts=' + throwing.closeCount + ',' + nonObject.closeCount + ',' + rejectedValue.closeCount;
+            })()
+            """).Should().Be(
+            "throws=threw:Error:sync return throw|nonObject=TypeError"
+            + "|rejectedValue=threw:Error:rejected value|counts=1,1,1");
+    }
+
+    /// <summary>
+    /// The same for a <c>for await…of</c> in an async <em>generator</em> body, which suspends through a
+    /// different resume path than an async function's.
+    /// </summary>
+    [Fact]
+    public void AnAsyncGeneratorBodyPropagatesTheRejectedClose()
+    {
+        Run("""
+            (async function () {
+                const record = makeAsyncIterable(REJECT);
+                const result = await outcome(async function () {
+                    async function* g(src) { for await (const x of src) { break; } yield 'unreachable'; }
+                    const it = g(record.iterable);
+                    await it.next();
+                    return 'no-throw';
+                });
+                return result + ',closeCount=' + record.closeCount;
+            })()
+            """).Should().Be("threw:Error:cleanup failed,closeCount=1");
+    }
+
+    /// <summary>
+    /// The invariant #3047 established, in its async shape: an abrupt completion produced by the step
+    /// itself sets the record's [[Done]] and is propagated with <c>?</c>, so it never reaches
+    /// AsyncIteratorClose. Running out does not close either — ForIn/OfBodyEvaluation step 8.e returns
+    /// the iteration result before any close.
+    /// </summary>
+    [Fact]
+    public void AFailedStepAndAnExhaustedIteratorStillCloseNothing()
+    {
+        Run("""
+            (async function () {
+                const rejecting = makeAsyncIterable(REJECT, { nextRejects: true });
+                const rejectingResult = await outcome(async function () {
+                    for await (const x of rejecting.iterable) { }
+                    return 'no-throw';
+                });
+
+                const finite = makeAsyncIterable(REJECT, { limit: 2 });
+                const seen = [];
+                const finiteResult = await outcome(async function () {
+                    for await (const x of finite.iterable) { seen.push(x); }
+                    return 'seen=' + seen.join('');
+                });
+
+                return 'stepFailure=' + rejectingResult + ',closeCount=' + rejecting.closeCount
+                    + '|exhausted=' + finiteResult + ',closeCount=' + finite.closeCount;
+            })()
+            """).Should().Be("stepFailure=threw:Error:from next,closeCount=0|exhausted=ok:seen=12,closeCount=0");
+    }
+
+    /// <summary>
+    /// A loop head declaring <c>await using</c> suspends on the per-iteration dispose before it can
+    /// close, so its abrupt exits leave through a second code path (the dispose resume) that owes the
+    /// same AsyncIteratorClose. The dispose runs first, then the close.
+    /// </summary>
+    [Fact]
+    public void ALoopSuspendedOnAnAsyncDisposeStillPropagatesTheRejectedClose()
+    {
+        Run("""
+            (async function () {
+                const log = [];
+                const iterable = {
+                    [Symbol.asyncIterator]() {
+                        return {
+                            next() {
+                                return Promise.resolve({
+                                    value: { async [Symbol.asyncDispose]() { log.push('disposed'); } },
+                                    done: false
+                                });
+                            },
+                            return() { log.push('return'); return Promise.reject(new Error('cleanup failed')); }
+                        };
+                    }
+                };
+                const result = await outcome(async function () {
+                    for await (await using x of iterable) { break; }
+                    return 'no-throw';
+                });
+                return log.join(',') + '|' + result;
+            })()
+            """).Should().Be("disposed,return|threw:Error:cleanup failed");
+    }
+}

--- a/Jint/Native/Iterator/IteratorInstance.cs
+++ b/Jint/Native/Iterator/IteratorInstance.cs
@@ -134,6 +134,30 @@ internal abstract class IteratorInstance : ObjectInstance
     }
 
     /// <summary>
+    /// https://tc39.es/ecma262/#sec-asynciteratorclose
+    /// AsyncIteratorClose steps 3 and 4.a-4.c: read the iterator's <c>return</c> method and call it,
+    /// handing back the value whose Await — step 4.d — the caller still owes. Answers
+    /// <see langword="false"/> for step 4.b ("If return is undefined, return ? completion"), where
+    /// there is nothing to await and nothing to check.
+    /// <para>
+    /// Step 4.d is deliberately not performed here: awaiting suspends the surrounding async function
+    /// or async generator, which only the interpreter can do. The caller resumes on the settlement
+    /// and performs steps 5-8 itself, which is why this is split out of <see cref="Close"/> rather
+    /// than being another completion type <see cref="Close"/> understands.
+    /// </para>
+    /// <para>
+    /// An abrupt completion of either step propagates. Step 5 — the one that would swallow it —
+    /// applies only when the caller's own completion is a throw completion, and such a completion
+    /// never reaches this method.
+    /// </para>
+    /// </summary>
+    internal virtual bool TryStartAsyncClose(out JsValue innerResult)
+    {
+        innerResult = Undefined;
+        return false;
+    }
+
+    /// <summary>
     /// Gets the underlying iterator object instance.
     /// For object iterators, this is the wrapped object. For built-in iterators, this is self.
     /// Used by yield* to call methods like "return" and "throw" on the iterator.
@@ -248,6 +272,25 @@ internal abstract class IteratorInstance : ObjectInstance
             {
                 Throw.TypeError(_target.Engine.Realm, "Iterator returned non-object");
             }
+        }
+
+        /// <summary>
+        /// https://tc39.es/ecma262/#sec-asynciteratorclose steps 3 and 4.a-4.c.
+        /// </summary>
+        internal override bool TryStartAsyncClose(out JsValue innerResult)
+        {
+            // Step 3: Let innerResult be Completion(GetMethod(iterator, "return")).
+            var callable = _target.GetMethod(CommonProperties.Return);
+            if (callable is null)
+            {
+                // Step 4.b: If return is undefined, return ? completion.
+                innerResult = Undefined;
+                return false;
+            }
+
+            // Step 4.c: Set innerResult to Completion(Call(return, iterator)).
+            innerResult = callable.Call(_target, Arguments.Empty);
+            return true;
         }
     }
 

--- a/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
@@ -229,6 +229,14 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                     return ResumeFromDispose(context, suspendable, forAwaitSuspendData);
                 }
 
+                // Resuming from AsyncIteratorClose's Await (step 4.d). The settlement is read from
+                // the suspend data, never from _resumeWithThrow below: a rejected close is only
+                // sometimes a throw, and steps 5-8 are what decide.
+                if (forAwaitSuspendData.CloseInProgress)
+                {
+                    return ResumeFromAsyncClose(context, suspendable, forAwaitSuspendData);
+                }
+
                 // Check if we're resuming from a rejection in an async function - if so, throw the error
                 var asyncFunction = engine.ExecutionContext.AsyncFunction;
                 if (asyncFunction is not null && asyncFunction._lastAwaitNode == this && asyncFunction._resumeWithThrow)
@@ -928,6 +936,15 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                 if (result.Type == CompletionType.Break && (result.Target == null || string.Equals(result.Target, _statement?.LabelSet?.Name, StringComparison.Ordinal)))
                 {
                     completionType = CompletionType.Normal;
+                    if (iteratorKind == IteratorKind.Async)
+                    {
+                        // step 8.j.ii.3: "If iteratorKind is async, return ? AsyncIteratorClose(
+                        // iteratorRecord, status)". The close awaits, so it may suspend, and its
+                        // rejection outranks this (non-throw) completion — see CloseAsyncIterator.
+                        close = false;
+                        return CloseAsyncIterator(context, iteratorRecord, new Completion(CompletionType.Normal, v, _statement!));
+                    }
+
                     suspendable?.Data.Clear(this);
                     return new Completion(CompletionType.Normal, v, _statement!);
                 }
@@ -937,6 +954,15 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                     completionType = result.Type;
                     if (result.IsAbrupt())
                     {
+                        // Same step, for a return or a jump naming an enclosing label. A throw
+                        // completion stays on the synchronous close below: step 5 returns it
+                        // whatever the close does.
+                        if (iteratorKind == IteratorKind.Async && result.Type != CompletionType.Throw)
+                        {
+                            close = false;
+                            return CloseAsyncIterator(context, iteratorRecord, result);
+                        }
+
                         close = true;
                         suspendable?.Data.Clear(this);
                         return result;
@@ -1245,6 +1271,260 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
     }
 
     /// <summary>
+    /// https://tc39.es/ecma262/#sec-asynciteratorclose
+    /// AsyncIteratorClose for a for-await-of leaving its loop with a completion that is <em>not</em>
+    /// a throw completion — a break, a return, or a jump naming an enclosing label. Steps 3 and
+    /// 4.a-4.c run here; step 4.d's Await suspends the async function or async generator, and
+    /// <see cref="ResumeFromAsyncClose"/> performs steps 5-8 once it settles.
+    /// <para>
+    /// The suspension is the whole point. Jint used to perform the synchronous IteratorClose here,
+    /// which calls <c>return()</c>, sees the promise it answers with, finds it <em>is</em> an object
+    /// and stops — so a <c>return()</c> that rejects was dropped on the floor and
+    /// <c>for await (…) { break; }</c> completed normally where step 6 requires the rejection to
+    /// become the loop's completion (#3098).
+    /// </para>
+    /// <para>
+    /// A throw completion deliberately does not come here, and keeps taking the synchronous close in
+    /// <see cref="BodyEvaluation"/>'s <c>finally</c>. Step 5 returns that completion whatever the
+    /// close does, so the outcome is already the spec's; and the throw reaches that <c>finally</c> as
+    /// a CLR unwind, which could only be suspended by catching it — the very thing
+    /// <see cref="LeavingOnException"/> exists to avoid. What is given up is confined to the
+    /// microtask the discarded Await would have taken.
+    /// </para>
+    /// </summary>
+    private Completion CloseAsyncIterator(EvaluationContext context, IteratorInstance iteratorRecord, Completion completion)
+    {
+        var engine = context.Engine;
+        var suspendable = engine.ExecutionContext.Suspendable;
+
+        // The loop is over either way: whatever happens from here, it never resumes iterating.
+        suspendable?.Data.Clear(this);
+
+        // Step 5 folded forward for a throw completion, so that every caller may hand one over. The
+        // close still happens, but its abrupt completion, its awaited value and therefore the Await
+        // itself are all discarded — which is precisely the synchronous IteratorClose.
+        if (completion.Type == CompletionType.Throw)
+        {
+            TryCloseIterator(iteratorRecord, CompletionType.Throw);
+            return completion;
+        }
+
+        // Steps 3 and 4.a-4.c. An abrupt completion of either propagates as the loop's own, which
+        // is step 6 — step 5, the one that would swallow it, needs a throw completion and this
+        // method never sees one.
+        if (!iteratorRecord.TryStartAsyncClose(out var innerResult))
+        {
+            // Step 4.b: If return is undefined, return ? completion.
+            return completion;
+        }
+
+        // Step 4.d: Await(innerResult).
+        var suspended = SuspendForAsyncClose(context, iteratorRecord, innerResult, completion);
+        if (suspended is { } suspension)
+        {
+            return suspension;
+        }
+
+        // No async context to suspend in. for-await-of outside one is an early error, so this is the
+        // same unreachable fallback SuspendForAsyncIteration keeps: unwrap synchronously and finish
+        // the algorithm inline rather than lose the completion.
+        try
+        {
+            var resolved = innerResult.UnwrapIfPromise(engine.Options.Constraints.PromiseTimeout);
+            return FinishAsyncIteratorClose(context, completion, resolved, rejected: false);
+        }
+        catch (PromiseRejectedException e)
+        {
+            return FinishAsyncIteratorClose(context, completion, e.RejectedValue, rejected: true);
+        }
+    }
+
+    /// <summary>
+    /// Suspends the surrounding async function or async generator on AsyncIteratorClose's Await
+    /// (step 4.d), parking the completion steps 5 and 8 still owe. Returns <see langword="null"/>
+    /// when there is no async context to suspend in.
+    /// </summary>
+    private Completion? SuspendForAsyncClose(
+        EvaluationContext context,
+        IteratorInstance iteratorRecord,
+        JsValue innerResult,
+        Completion completion)
+    {
+        var engine = context.Engine;
+        var suspendable = engine.ExecutionContext.Suspendable;
+        var asyncInstance = engine.ExecutionContext.AsyncFunction;
+        var asyncGenerator = engine.ExecutionContext.AsyncGenerator;
+
+        if (suspendable is null || (asyncInstance is null && asyncGenerator is null))
+        {
+            return null;
+        }
+
+        // Await step 1: PromiseResolve(%Promise%, value).
+        var promise = innerResult as JsPromise
+            ?? (JsPromise) engine.Realm.Intrinsics.Promise.PromiseResolve(innerResult);
+
+        var data = suspendable.Data.GetOrCreate<ForAwaitSuspendData>(this, iteratorRecord);
+        data.Iterator = iteratorRecord;
+        data.CloseInProgress = true;
+        data.CloseCompletion = completion;
+        data.CloseSettledValue = null;
+        data.CloseSettledRejected = false;
+
+        if (asyncInstance is not null)
+        {
+            asyncInstance._lastAwaitNode = this;
+            asyncInstance._state = AsyncFunctionState.SuspendedAwait;
+            asyncInstance._savedContext = engine.ExecutionContext;
+            PromiseOperations.PerformPromiseThen(engine, promise, new AsyncCloseFunctionContinuation(this, asyncInstance));
+        }
+        else
+        {
+            asyncGenerator!._lastYieldNode = this;
+            asyncGenerator._awaitSuspended = true;
+            PromiseOperations.PerformPromiseThen(
+                engine,
+                promise,
+                new AsyncCloseGeneratorContinuation(this, asyncGenerator, asyncGenerator._currentPromiseCapability!));
+        }
+
+        return new Completion(CompletionType.Normal, JsValue.Undefined, _statement!);
+    }
+
+    /// <summary>
+    /// Resume entry point for a for-await-of suspended on AsyncIteratorClose's Await, reached from
+    /// <see cref="ExecuteInternal"/> when the parked data says the close is what is in flight.
+    /// </summary>
+    private Completion ResumeFromAsyncClose(EvaluationContext context, ISuspendable suspendable, ForAwaitSuspendData data)
+    {
+        var engine = context.Engine;
+        var completion = data.CloseCompletion;
+        var settled = data.CloseSettledValue ?? JsValue.Undefined;
+        var rejected = data.CloseSettledRejected;
+
+        suspendable.IsResuming = false;
+        suspendable.Data.Clear(this);
+
+        // Undo exactly the suspension that was armed, and nothing else: the async-function branch is
+        // preferred there (both fields can be set on one context — UpdateAsyncFunction carries the
+        // generator's over), so clearing an async generator's yield node here when a function was
+        // what suspended would discard a suspension point that is still live.
+        var asyncFn = engine.ExecutionContext.AsyncFunction;
+        if (asyncFn is not null)
+        {
+            asyncFn._resumeValue = null;
+            asyncFn._resumeWithThrow = false;
+            asyncFn._lastAwaitNode = null;
+        }
+        else if (engine.ExecutionContext.AsyncGenerator is { } asyncGenerator)
+        {
+            asyncGenerator._resumeWithThrow = false;
+            asyncGenerator._lastYieldNode = null;
+        }
+
+        return FinishAsyncIteratorClose(context, completion, settled, rejected);
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-asynciteratorclose steps 5-8, applied once the Await of step 4.d
+    /// has settled.
+    /// </summary>
+    private Completion FinishAsyncIteratorClose(EvaluationContext context, Completion completion, JsValue settled, bool rejected)
+    {
+        var engine = context.Engine;
+
+        // Step 5: If completion is a throw completion, return ? completion. Kept whole even though
+        // CloseAsyncIterator now answers a throw completion before it can reach here, so this
+        // method reads as the algorithm's tail rather than as the half of it that happens to remain.
+        if (completion.Type == CompletionType.Throw)
+        {
+            Throw.JavaScriptException(engine, completion.Value, _statement!.Location);
+        }
+
+        // Step 6: If innerResult is a throw completion, return ? innerResult.
+        if (rejected)
+        {
+            Throw.JavaScriptException(engine, settled, _statement!.Location);
+        }
+
+        // Step 7: If innerResult.[[Value]] is not an Object, throw a TypeError exception. The Await
+        // is what makes this bite for an async iterator: the check is against the *settled* value,
+        // so a return() answering Promise.resolve(42) fails it exactly as a sync one answering 42.
+        if (!settled.IsObject())
+        {
+            Throw.TypeError(engine.Realm, "Iterator returned non-object");
+        }
+
+        // Step 8: Return ? completion.
+        return completion;
+    }
+
+    /// <summary>
+    /// Await continuation for AsyncIteratorClose step 4.d inside an async function: records how the
+    /// close settled and resumes the function, which re-enters this statement at
+    /// <see cref="ResumeFromAsyncClose"/>.
+    /// </summary>
+    private sealed class AsyncCloseFunctionContinuation : IPromiseContinuation
+    {
+        private readonly JintForInForOfStatement _statement;
+        private readonly AsyncFunctionInstance _asyncInstance;
+
+        public AsyncCloseFunctionContinuation(JintForInForOfStatement statement, AsyncFunctionInstance asyncInstance)
+        {
+            _statement = statement;
+            _asyncInstance = asyncInstance;
+        }
+
+        public void Invoke(Engine engine, JsValue value, ReactionType type)
+        {
+            var data = _asyncInstance.Data.GetOrCreate<ForAwaitSuspendData>(_statement);
+            data.CloseSettledValue = value;
+            data.CloseSettledRejected = type == ReactionType.Reject;
+
+            // The generic resume path must stay neutral: steps 5-8, not _resumeWithThrow, decide
+            // whether a rejected close becomes a throw.
+            _asyncInstance._resumeValue = JsValue.Undefined;
+            _asyncInstance._resumeWithThrow = false;
+
+            JintAwaitExpression.AsyncFunctionResume(engine, _asyncInstance);
+        }
+    }
+
+    /// <summary>
+    /// Await continuation for AsyncIteratorClose step 4.d inside an async generator. Mirrors
+    /// <see cref="AsyncCloseFunctionContinuation"/>, resuming the current request the way a plain
+    /// <c>await</c> in a generator body does.
+    /// </summary>
+    private sealed class AsyncCloseGeneratorContinuation : IPromiseContinuation
+    {
+        private readonly JintForInForOfStatement _statement;
+        private readonly Native.AsyncGenerator.AsyncGeneratorInstance _asyncGenerator;
+        private readonly PromiseCapability _capability;
+
+        public AsyncCloseGeneratorContinuation(
+            JintForInForOfStatement statement,
+            Native.AsyncGenerator.AsyncGeneratorInstance asyncGenerator,
+            PromiseCapability capability)
+        {
+            _statement = statement;
+            _asyncGenerator = asyncGenerator;
+            _capability = capability;
+        }
+
+        public void Invoke(Engine engine, JsValue value, ReactionType type)
+        {
+            var data = _asyncGenerator.Data.GetOrCreate<ForAwaitSuspendData>(_statement);
+            data.CloseSettledValue = value;
+            data.CloseSettledRejected = type == ReactionType.Reject;
+
+            _asyncGenerator._nextValue = JsValue.Undefined;
+            _asyncGenerator._resumeWithThrow = false;
+            _asyncGenerator._awaitSuspended = false;
+            _asyncGenerator.AsyncGeneratorContinueForAwait(_capability);
+        }
+    }
+
+    /// <summary>
     /// Drives the iteration env's dispose state machine. If the next step is a
     /// suspend (await), suspends the surrounding async function on the pending
     /// promise — same machinery as a JS <c>await</c> — and returns a completion
@@ -1381,13 +1661,24 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
             && (result.Target is null || string.Equals(result.Target, _statement?.LabelSet?.Name, StringComparison.Ordinal)))
         {
             suspendable.Data.Clear(this);
+            var breakCompletion = new Completion(CompletionType.Normal, v, _statement!);
+            if (iteratorKind == IteratorKind.Async)
+            {
+                return CloseAsyncIterator(context, iteratorRecord, breakCompletion);
+            }
+
             TryCloseIterator(iteratorRecord, CompletionType.Normal);
-            return new Completion(CompletionType.Normal, v, _statement!);
+            return breakCompletion;
         }
 
         if (result.Type == CompletionType.Return)
         {
             suspendable.Data.Clear(this);
+            if (iteratorKind == IteratorKind.Async)
+            {
+                return CloseAsyncIterator(context, iteratorRecord, result);
+            }
+
             TryCloseIterator(iteratorRecord, CompletionType.Return);
             return result;
         }
@@ -1395,6 +1686,11 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
         if (result.IsAbrupt() && result.Type != CompletionType.Continue)
         {
             suspendable.Data.Clear(this);
+            if (iteratorKind == IteratorKind.Async)
+            {
+                return CloseAsyncIterator(context, iteratorRecord, result);
+            }
+
             TryCloseIterator(iteratorRecord, result.Type);
             return result;
         }

--- a/Jint/Runtime/SuspendData.cs
+++ b/Jint/Runtime/SuspendData.cs
@@ -413,6 +413,39 @@ internal sealed class ForAwaitSuspendData : SuspendData
     /// is resumed.
     /// </summary>
     public Completion DisposeResult { get; set; }
+
+    /// <summary>
+    /// True while AsyncIteratorClose's Await — step 4.d of
+    /// https://tc39.es/ecma262/#sec-asynciteratorclose — is in flight. On resume, the for-await-of
+    /// statement finishes steps 5-8 from <see cref="CloseCompletion"/> and the settled value below
+    /// instead of resuming the loop.
+    /// </summary>
+    public bool CloseInProgress { get; set; }
+
+    /// <summary>
+    /// The completion AsyncIteratorClose was called with: the loop's own completion, which steps 5
+    /// and 8 hand back when the close produces none of its own.
+    /// <para>
+    /// Parked whole rather than as a type and a value, for the reason
+    /// <see cref="TrySuspendData.PendingCompletion"/> documents: a Break or Continue keeps its
+    /// [[Target]] in the jump statement the record carries, so a type-and-value pair could not
+    /// express it.
+    /// </para>
+    /// </summary>
+    public Completion CloseCompletion { get; set; }
+
+    /// <summary>
+    /// The value AsyncIteratorClose's Await settled with, recorded by the close continuation.
+    /// </summary>
+    public JsValue? CloseSettledValue { get; set; }
+
+    /// <summary>
+    /// Whether <see cref="CloseSettledValue"/> arrived as a rejection — step 6's "If innerResult is
+    /// a throw completion". It is deliberately not carried in the suspendable's own
+    /// <c>_resumeWithThrow</c>: a rejected close is not always a throw, since step 5 discards it
+    /// when the loop already has a throw completion of its own.
+    /// </summary>
+    public bool CloseSettledRejected { get; set; }
 }
 
 /// <summary>


### PR DESCRIPTION
A `for await…of` loop exited by `break` (or any abrupt non-throw completion) called the iterator's `return()` but discarded its result: the spec's AsyncIteratorClose awaits `innerResult` and, per step 6, a rejected `return()` becomes the completion of the loop — Jint swallowed it and completed normally.

The fix implements AsyncIteratorClose's await: `CloseAsyncIterator` starts the close (`TryStartAsyncClose` on `IteratorInstance`, overridden by `ObjectIterator` to do steps 3 and 4.a–4.c), suspends the async function on the value `return()` handed back, and `FinishAsyncIteratorClose` applies the spec's precedence when it settles. The precedence is pinned in both directions, verified against the spec text and cross-checked against V8 on a 19-case matrix:

- `break` + rejected close → the close rejection wins (step 6);
- `throw` in the body + rejected close → the original throw wins (step 5 precedes step 6);
- `return` in the body + rejected close → the close rejection wins (a return completion is abrupt but not a throw completion).

Step 7's `Type(innerResult.[[Value]])` check now runs after the await, so `return() { return Promise.resolve(42) }` is the `TypeError` the spec asks for — previously unreachable because every promise is an object.

One deliberate reduction, documented on `CloseAsyncIterator`: a **throw** completion keeps the synchronous close. Step 5 returns that completion whatever the close does, so the outcome is already correct; suspending would mean catching the CLR unwind, which is exactly what `LeavingOnException` exists to avoid. The only observable difference is the microtask tick the discarded await would have taken.

`#3047`'s invariant is preserved — a throw from the iterator *step* still closes nothing — pinned by `AFailedStepAndAnExhaustedIteratorStillCloseNothing` plus the untouched `IteratorCloseTests`.

Tests: `Jint.Tests/Runtime/AsyncIteratorCloseTests.cs` (11 tests; 8 fail without the fix, and the 3 that pass are the intended unchanged-behaviour controls). All 2431 test262 `for-await-of` cases pass, full test262 green modulo known load flakes.

Closes #3098

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G7Ud48VAs1JicxRZxLDxg