### PR TITLE
Never read a pending lazy name descriptor when rendering an error message

### DIFF
--- a/Jint.Tests/Runtime/FunctionNameForMessageTests.cs
+++ b/Jint.Tests/Runtime/FunctionNameForMessageTests.cs
@@ -1,0 +1,36 @@
+using Jint.Native.Function;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// <see cref="Function.GetOwnFunctionNameForMessage"/> exists to render a name inside an error message
+/// without running script — so it must never throw itself. A script function's own <c>name</c> starts as
+/// the shared pending-lazy sentinel, whose value accessors throw by design to make a leak loud; reading
+/// the descriptor's <c>Value</c> before anything materialized the property is exactly such a leak.
+/// </summary>
+public class FunctionNameForMessageTests
+{
+    [Fact]
+    public void APendingLazyNameFallsBackToTheClrTypeNameInsteadOfThrowing()
+    {
+        using var engine = new Engine();
+
+        // The function's own "name" property exists from birth, but its descriptor is the pending
+        // sentinel until something reads the property — which nothing here does.
+        var function = (Function) engine.Evaluate("(function foo() {})");
+
+        var name = function.GetOwnFunctionNameForMessage();
+
+        Assert.Equal(function.GetType().Name, name);
+    }
+
+    [Fact]
+    public void AMaterializedNameIsQuoted()
+    {
+        using var engine = new Engine();
+
+        var function = (Function) engine.Evaluate("const f = function foo() {}; void f.name; f");
+
+        Assert.Equal("foo", function.GetOwnFunctionNameForMessage());
+    }
+}

--- a/Jint/Native/Function/Function.cs
+++ b/Jint/Native/Function/Function.cs
@@ -663,13 +663,22 @@ public abstract partial class Function : ObjectInstance, ICallable
     /// <c>toString</c> throws. <see cref="GetOwnFunctionName"/> coerces through <c>TypeConverter.ToString</c>
     /// and would let that object hijack the error being built — an extra observable call, and a thrown
     /// value replacing the <c>TypeError</c> the caller meant to raise. So only an actual string is quoted
-    /// here; anything else falls back to the CLR type's name, which no script can influence. Reading
-    /// <see cref="PropertyDescriptor.Value"/> touches the raw field and never invokes an accessor.
+    /// here; anything else falls back to the CLR type's name, which no script can influence. A descriptor
+    /// carrying <see cref="PropertyFlag.CustomJsValue"/> is skipped for the same reason: its
+    /// <see cref="PropertyDescriptor.Value"/> routes through the <c>CustomValue</c> accessor rather than the
+    /// raw field, and one of those accessors — the shared pending-lazy sentinel a script function's name
+    /// starts with — throws by design. An error-message path must never introduce a throw of its own.
     /// </para>
     /// </summary>
     internal string GetOwnFunctionNameForMessage()
     {
-        return _nameDescriptor?.Value is JsString name ? name.ToString() : GetType().Name;
+        var descriptor = _nameDescriptor;
+        if (descriptor is null || (descriptor.Flags & PropertyFlag.CustomJsValue) != PropertyFlag.None)
+        {
+            return GetType().Name;
+        }
+
+        return descriptor.Value is JsString name ? name.ToString() : GetType().Name;
     }
 
     /// <summary>


### PR DESCRIPTION
`GetOwnFunctionNameForMessage` read `_nameDescriptor?.Value` under a doc comment claiming the read *"touches the raw field and never invokes an accessor"*. That is false for a descriptor carrying `PropertyFlag.CustomJsValue`: `Value` routes through the `CustomValue` accessor, and a script function's own `name` starts as the shared pending-lazy sentinel whose accessors throw by design to make a leak loud. Rendering an error message for a function whose name was never materialized could therefore itself throw `InvalidOperationException` — a latent throw inside error-message construction, the one place that must never produce one.

The method now skips any `CustomJsValue` descriptor and falls back to the CLR type name — which is also the right answer for the message's purpose, since only a plain materialized string was ever quoted — and the doc comment says why.

Today every caller is a built-in constructor whose name descriptor is materialized eagerly, so the throw is latent rather than user-reachable; it was hit for real while building profiler frame naming, which had to order its reads defensively around exactly this. The new test calls the method directly on a script function whose name is still pending; without the fix it fails with `System.InvalidOperationException : a pending lazy property descriptor leaked without being materialized` on both net10.0 and net472.

Closes #3112

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G7Ud48VAs1JicxRZxLDxg
