### PR TITLE
Add opt-in evented script profiling with speedscope export

### DIFF
--- a/Jint.Tests.PublicInterface/HostScriptProfilingTests.cs
+++ b/Jint.Tests.PublicInterface/HostScriptProfilingTests.cs
@@ -1,0 +1,209 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Jint.Profiling;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// The profiler from an embedder's vantage point: <see cref="Options.ProfilingOptions"/>,
+/// <see cref="Engine.AdvancedOperations.StartProfiling"/> / <see cref="Engine.AdvancedOperations.StopProfiling"/>
+/// and the <see cref="ScriptProfile"/> they produce, reached with nothing but the public surface — this suite
+/// has no <c>InternalsVisibleTo</c>, so a test here is proof a third party can do the same.
+///
+/// <para>
+/// The exported document is checked by parsing it back through a <em>second</em> engine's <c>JSON.parse</c>,
+/// which is the same route an embedder has and needs no JSON dependency in this project.
+/// </para>
+/// </summary>
+public class HostScriptProfilingTests
+{
+    private const string SchemaUrl = "https://www.speedscope.app/file-format-schema.json";
+
+    private const string Script = """
+        function leaf() { return 1; }
+        function middle() { return leaf(); }
+        function root() { return middle() + leaf(); }
+        root();
+        """;
+
+    [Fact]
+    public void ADefaultEngineRefusesToProfile()
+    {
+        var engine = new Engine();
+
+        engine.Advanced.IsProfiling.Should().BeFalse();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => engine.Advanced.StartProfiling());
+        exception.Message.Should().Contain("Options.Profiling.Enabled");
+    }
+
+    [Fact]
+    public void AHostCanProfileAnEngineItBuiltForIt()
+    {
+        var engine = new Engine(options => options.Profiling.Enabled = true);
+
+        engine.Advanced.StartProfiling();
+        engine.Advanced.IsProfiling.Should().BeTrue();
+        engine.Execute(Script, "host.js");
+        var profile = engine.Advanced.StopProfiling();
+
+        engine.Advanced.IsProfiling.Should().BeFalse();
+        profile.Truncated.Should().BeFalse();
+        profile.Events.Should().NotBeEmpty();
+        profile.Frames.Select(static f => f.Name).Should().BeEquivalentTo(["root", "middle", "leaf"]);
+        profile.Frames.Should().OnlyContain(f => f.File == "host.js");
+        profile.DurationNanoseconds.Should().BeGreaterThanOrEqualTo(0);
+    }
+
+    [Fact]
+    public void OneOptionsInstanceServesManyEnginesIndependently()
+    {
+        // Options are meant to be shared; a session belongs to the engine, not to the options it came from.
+        var options = new Options();
+        options.Profiling.Enabled = true;
+        options.Profiling.MaxEvents = 5_000;
+
+        var first = new Engine(options);
+        var second = new Engine(options);
+
+        first.Advanced.StartProfiling();
+        second.Advanced.StartProfiling();
+
+        first.Execute("function a() { return 1; } a();");
+        second.Execute("function b() { return 1; } b();");
+
+        first.Advanced.StopProfiling().Frames.Select(static f => f.Name).Should().Equal("a");
+        second.Advanced.StopProfiling().Frames.Select(static f => f.Name).Should().Equal("b");
+    }
+
+    [Fact]
+    public void MaxEventsBoundsWhatASessionCanCost()
+    {
+        var engine = new Engine(options =>
+        {
+            options.Profiling.Enabled = true;
+            options.Profiling.MaxEvents = 50;
+        });
+
+        engine.Advanced.StartProfiling();
+        engine.Execute("function f() { return 1; } for (var i = 0; i < 10000; i++) { f(); }");
+        var profile = engine.Advanced.StopProfiling();
+
+        profile.Truncated.Should().BeTrue();
+        profile.Events.Count.Should().BeLessThanOrEqualTo(50);
+    }
+
+    [Fact]
+    public void TheExportedDocumentIsAValidSpeedscopeEventedProfile()
+    {
+        var engine = new Engine(options => options.Profiling.Enabled = true);
+        engine.Advanced.StartProfiling();
+        engine.Execute(Script, "host.js");
+        var profile = engine.Advanced.StopProfiling();
+
+        using var stream = new MemoryStream();
+        profile.WriteSpeedscopeJson(stream);
+        var json = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false).GetString(stream.ToArray());
+
+        // Parsed by a plain engine through the language's own JSON parser — an embedder's route exactly.
+        var reader = new Engine();
+        reader.SetValue("json", json);
+        reader.Execute("var doc = JSON.parse(json);");
+
+        reader.Evaluate("doc['$schema']").AsString().Should().Be(SchemaUrl);
+        reader.Evaluate("doc.profiles.length").AsNumber().Should().Be(1);
+        reader.Evaluate("doc.profiles[0].type").AsString().Should().Be("evented");
+        reader.Evaluate("doc.profiles[0].unit").AsString().Should().Be("nanoseconds");
+        reader.Evaluate("doc.profiles[0].startValue").AsNumber().Should().Be(0);
+        reader.Evaluate("doc.profiles[0].endValue").AsNumber().Should().Be(profile.DurationNanoseconds);
+        reader.Evaluate("doc.shared.frames.length").AsNumber().Should().Be(profile.Frames.Count);
+        reader.Evaluate("doc.shared.frames.every(function (f) { return typeof f.name === 'string'; })")
+            .AsBoolean().Should().BeTrue();
+
+        // Every event carries the three required members, the types are exactly O and C, timestamps never go
+        // backwards, and the stream closes exactly what it opens.
+        reader.Evaluate("""
+            (function () {
+                var open = 0, previous = 0;
+                var events = doc.profiles[0].events;
+                for (var i = 0; i < events.length; i++) {
+                    var e = events[i];
+                    if (e.type !== 'O' && e.type !== 'C') { return 'bad type ' + e.type; }
+                    if (typeof e.frame !== 'number' || typeof e.at !== 'number') { return 'missing member'; }
+                    if (e.frame < 0 || e.frame >= doc.shared.frames.length) { return 'frame out of range'; }
+                    if (e.at < previous) { return 'timestamps went backwards'; }
+                    previous = e.at;
+                    open += e.type === 'O' ? 1 : -1;
+                    if (open < 0) { return 'closed more than was open'; }
+                }
+                if (open !== 0) { return open + ' frames left open'; }
+                if (previous > doc.profiles[0].endValue) { return 'event after endValue'; }
+                return 'ok';
+            })();
+            """).AsString().Should().Be("ok");
+    }
+
+    /// <summary>
+    /// A profile is a value, not a view onto the engine that produced it: it holds strings and numbers, never
+    /// a function, an AST or an <see cref="Engine"/>. A host that profiles a pooled or per-request engine and
+    /// keeps the profiles must not thereby keep the engines.
+    /// </summary>
+    [Fact]
+    public void AProfileDoesNotRetainTheEngineThatProducedIt()
+    {
+        const int Count = 10;
+        var profiles = new List<ScriptProfile>(Count);
+        var references = new List<WeakReference>(Count);
+
+        for (var i = 0; i < Count; i++)
+        {
+            references.Add(ProfileOnceAndForget(profiles));
+        }
+
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+
+        var alive = references.Count(static r => r.IsAlive);
+
+        // Doubles as the keep-alive for the profiles, and as the assertion that they were ever worth holding.
+        profiles.Should().OnlyContain(p => p.Frames.Count > 0);
+
+        alive.Should().Be(0, $"{alive} of {Count} engines were not collected — a profile still pins its engine.");
+
+        // NoInlining so the engine reference cannot be stack-rooted in the caller's frame across the collect.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static WeakReference ProfileOnceAndForget(List<ScriptProfile> sink)
+        {
+            var engine = new Engine(options => options.Profiling.Enabled = true);
+            engine.Advanced.StartProfiling();
+            engine.Execute(Script);
+            sink.Add(engine.Advanced.StopProfiling());
+            return new WeakReference(engine);
+        }
+    }
+
+    [Fact]
+    public void StoppingWithoutStartingIsAnError()
+    {
+        var engine = new Engine(options => options.Profiling.Enabled = true);
+
+        Assert.Throws<InvalidOperationException>(() => engine.Advanced.StopProfiling());
+    }
+
+    [Fact]
+    public void MaxEventsRejectsANonPositiveBudget()
+    {
+        var options = new Options();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => options.Profiling.MaxEvents = 0);
+        Assert.Throws<ArgumentOutOfRangeException>(() => options.Profiling.MaxEvents = -5);
+        options.Profiling.MaxEvents.Should().Be(Options.ProfilingOptions.DefaultMaxEvents);
+    }
+}

--- a/Jint.Tests/Runtime/ScriptProfilingTests.cs
+++ b/Jint.Tests/Runtime/ScriptProfilingTests.cs
@@ -1,0 +1,565 @@
+#nullable enable
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Jint.Profiling;
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
+
+public class ScriptProfilingTests
+{
+    private static Engine CreateProfilingEngine() => new(options => options.Profiling.Enabled = true);
+
+    /// <summary>
+    /// Replays the event stream the way a consumer does — push on open, pop on close — and fails on anything
+    /// that is not a properly nested, balanced tree. Returns one line per open frame, indented by depth, so a
+    /// test can pin the call tree's shape as text.
+    /// </summary>
+    private static string RenderCallTree(ScriptProfile profile)
+    {
+        var builder = new StringBuilder();
+        var open = new Stack<int>();
+        long previous = 0;
+
+        foreach (var e in profile.Events)
+        {
+            e.TimestampNanoseconds.Should().BeGreaterThanOrEqualTo(previous, "profile timestamps must be non-decreasing");
+            previous = e.TimestampNanoseconds;
+
+            e.FrameIndex.Should().BeInRange(0, profile.Frames.Count - 1);
+
+            if (e.Kind == ScriptProfileEventKind.Open)
+            {
+                builder.Append(' ', open.Count * 2).Append(profile.Frames[e.FrameIndex].Name).Append('\n');
+                open.Push(e.FrameIndex);
+            }
+            else
+            {
+                open.Should().NotBeEmpty("a close event must have a matching open");
+                open.Pop().Should().Be(e.FrameIndex, "closes must match opens in reverse order");
+            }
+        }
+
+        open.Should().BeEmpty("every open frame must be closed by the end of the profile");
+        return builder.ToString();
+    }
+
+    private static int MaxDepth(ScriptProfile profile)
+    {
+        var depth = 0;
+        var max = 0;
+        foreach (var e in profile.Events)
+        {
+            if (e.Kind == ScriptProfileEventKind.Open)
+            {
+                max = System.Math.Max(max, ++depth);
+            }
+            else
+            {
+                depth--;
+            }
+        }
+
+        return max;
+    }
+
+    /// <summary>
+    /// The nesting depth at which <paramref name="name"/> is first entered, or -1 if it never is.
+    /// </summary>
+    private static int DepthOfFirstOpen(ScriptProfile profile, string name)
+    {
+        var depth = 0;
+        foreach (var e in profile.Events)
+        {
+            if (e.Kind == ScriptProfileEventKind.Close)
+            {
+                depth--;
+                continue;
+            }
+
+            if (profile.Frames[e.FrameIndex].Name == name)
+            {
+                return depth;
+            }
+
+            depth++;
+        }
+
+        return -1;
+    }
+
+    private static IEnumerable<string> OpenedNames(ScriptProfile profile) =>
+        profile.Events
+            .Where(static e => e.Kind == ScriptProfileEventKind.Open)
+            .Select(e => profile.Frames[e.FrameIndex].Name);
+
+    [Fact]
+    public void StartProfilingOnADisabledEngineThrowsAndNamesTheOption()
+    {
+        var engine = new Engine();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => engine.Advanced.StartProfiling());
+
+        exception.Message.Should().Contain("Options.Profiling.Enabled");
+        engine.Advanced.IsProfiling.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ADisabledEngineStillRunsAndRecordsNothing()
+    {
+        var engine = new Engine();
+        engine.Execute("function f() { return 1; } f(); f();");
+
+        engine.Advanced.IsProfiling.Should().BeFalse();
+        Assert.Throws<InvalidOperationException>(() => engine.Advanced.StopProfiling());
+    }
+
+    [Fact]
+    public void StopProfilingWithoutStartingThrows()
+    {
+        var engine = CreateProfilingEngine();
+
+        Assert.Throws<InvalidOperationException>(() => engine.Advanced.StopProfiling());
+    }
+
+    [Fact]
+    public void StartProfilingTwiceThrows()
+    {
+        var engine = CreateProfilingEngine();
+        engine.Advanced.StartProfiling();
+
+        Assert.Throws<InvalidOperationException>(() => engine.Advanced.StartProfiling());
+
+        engine.Advanced.StopProfiling();
+    }
+
+    [Fact]
+    public void AnEnabledButUnstartedEngineRecordsNothing()
+    {
+        var engine = CreateProfilingEngine();
+        engine.Execute("function f() { return 1; } f(); f();");
+
+        engine.Advanced.IsProfiling.Should().BeFalse();
+
+        engine.Advanced.StartProfiling();
+        var profile = engine.Advanced.StopProfiling();
+
+        profile.Events.Should().BeEmpty("nothing ran between start and stop");
+        profile.Frames.Should().BeEmpty();
+        profile.Truncated.Should().BeFalse();
+    }
+
+    [Fact]
+    public void EveryEnterIsMatchedByAnExit()
+    {
+        var engine = CreateProfilingEngine();
+        engine.Advanced.StartProfiling();
+        engine.Execute("function inner() { return 1; } function outer() { return inner() + inner(); } outer();");
+        var profile = engine.Advanced.StopProfiling();
+
+        profile.Events.Should().HaveCount(6);
+        RenderCallTree(profile).Should().Be("outer\n  inner\n  inner\n");
+    }
+
+    [Fact]
+    public void NestedCallTreeShapeIsReconstructable()
+    {
+        var engine = CreateProfilingEngine();
+        engine.Advanced.StartProfiling();
+        engine.Execute("""
+            function leaf() { return 1; }
+            function middle() { return leaf(); }
+            function root() { return middle() + leaf(); }
+            root();
+            """);
+        var profile = engine.Advanced.StopProfiling();
+
+        RenderCallTree(profile).Should().Be("root\n  middle\n    leaf\n  leaf\n");
+    }
+
+    [Fact]
+    public void AThrowCaughtInScriptStillClosesEveryFrame()
+    {
+        var engine = CreateProfilingEngine();
+        engine.Advanced.StartProfiling();
+        engine.Execute("""
+            function thrower() { throw new Error('boom'); }
+            function middle() { thrower(); }
+            function root() { try { middle(); } catch (e) { return 'caught'; } }
+            root();
+            """);
+        var profile = engine.Advanced.StopProfiling();
+
+        // The tree is what a consumer sees; the assertion that matters is that RenderCallTree can build one
+        // at all, since it fails on any unbalanced or improperly nested pair.
+        RenderCallTree(profile).Should().StartWith("root\n  middle\n    thrower\n");
+        OpenedNames(profile).Should().Contain("thrower");
+    }
+
+    [Fact]
+    public void AThrowEscapingToTheHostStillClosesEveryFrame()
+    {
+        var engine = CreateProfilingEngine();
+        engine.Advanced.StartProfiling();
+
+        Assert.Throws<JavaScriptException>(() => engine.Execute("""
+            function thrower() { throw new Error('boom'); }
+            function middle() { thrower(); }
+            function root() { middle(); }
+            root();
+            """));
+
+        // An escaping throw unwinds through the same finallys a return does, so every frame is popped on the
+        // way out and the profiler is back at depth zero for whatever the host runs next.
+        engine.Execute("function after() { return 1; } after();");
+        var profile = engine.Advanced.StopProfiling();
+
+        // (The tail of the abandoned tree is the Error constructor and the `stack` accessors the unwinding
+        // reads, so only its head is pinned.)
+        RenderCallTree(profile).Should().StartWith("root\n  middle\n    thrower\n");
+        DepthOfFirstOpen(profile, "after").Should().Be(0, "the abandoned frames were closed, not left open");
+    }
+
+    [Fact]
+    public void ResetCallStackClosesEveryOpenFrame()
+    {
+        var engine = CreateProfilingEngine();
+        engine.SetValue("reset", new Action(() => engine.Advanced.ResetCallStack()));
+
+        engine.Advanced.StartProfiling();
+        engine.Execute("""
+            function inner() { reset(); }
+            function outer() { inner(); }
+            function after() { return 1; }
+            outer();
+            after();
+            """);
+        var profile = engine.Advanced.StopProfiling();
+
+        RenderCallTree(profile).Should().StartWith("outer\n  inner\n");
+        DepthOfFirstOpen(profile, "after").Should().Be(0, "the abandoned frames were closed, not left open");
+    }
+
+    [Fact]
+    public void RecursionIsRecordedAsNestedActivationsOfOneFrame()
+    {
+        var engine = CreateProfilingEngine();
+        engine.Advanced.StartProfiling();
+        engine.Execute("function down(n) { return n === 0 ? 0 : down(n - 1); } down(10);");
+        var profile = engine.Advanced.StopProfiling();
+
+        // Non-strict, so no proper tail call: eleven activations of one function, properly nested.
+        RenderCallTree(profile);
+        profile.Frames.Should().ContainSingle(f => f.Name == "down");
+        MaxDepth(profile).Should().Be(11);
+        profile.Events.Should().HaveCount(22);
+    }
+
+    /// <summary>
+    /// A proper tail call replaces the caller's frame rather than nesting inside it, so the profile shows a
+    /// flat run of sibling activations at constant depth instead of a tree that grows with the recursion.
+    /// This is the shape the call stack itself has — <c>JintCallStack.ReplaceTop</c> — and pinning it here
+    /// is what keeps a future change to tail-call bookkeeping from silently turning a bounded profile into
+    /// an unbounded one.
+    /// </summary>
+    [Fact]
+    public void AProperTailCallIsRecordedAsACloseFollowedByAnOpen()
+    {
+        var engine = CreateProfilingEngine();
+        engine.Advanced.StartProfiling();
+        engine.Execute("""
+            'use strict';
+            function down(n) { return n === 0 ? 0 : down(n - 1); }
+            down(50);
+            """);
+        var profile = engine.Advanced.StopProfiling();
+
+        RenderCallTree(profile);
+        profile.Frames.Should().ContainSingle(f => f.Name == "down");
+
+        MaxDepth(profile).Should().Be(1, "a tail call displaces its caller's frame instead of nesting inside it");
+        profile.Events.Should().HaveCount(102, "51 activations, each one open and one close");
+    }
+
+    [Fact]
+    public void ClosuresOfOneSourceFunctionShareAFrame()
+    {
+        var engine = CreateProfilingEngine();
+        engine.Advanced.StartProfiling();
+        engine.Execute("""
+            function make(n) { return function adder(x) { return x + n; }; }
+            var a = make(1), b = make(2);
+            a(1); b(2); a(3);
+            """);
+        var profile = engine.Advanced.StopProfiling();
+
+        RenderCallTree(profile);
+        profile.Frames.Where(f => f.Name == "adder").Should().HaveCount(1, "closures of one source function are one frame");
+        OpenedNames(profile).Count(static n => n == "adder").Should().Be(3);
+    }
+
+    [Fact]
+    public void FramesCarryTheDeclarationName_And_SourceLocation()
+    {
+        var engine = CreateProfilingEngine();
+        engine.Advanced.StartProfiling();
+        engine.Execute("function named() { return 1; }\nnamed();", "profiled.js");
+        var profile = engine.Advanced.StopProfiling();
+
+        var frame = profile.Frames.Single(f => f.Name == "named");
+        frame.File.Should().Be("profiled.js");
+        frame.Line.Should().Be(1);
+        frame.Column.Should().Be(1, "columns are reported one-based, as in a stack trace");
+    }
+
+    [Fact]
+    public void AnInferredNameIsPreferredToAnonymity()
+    {
+        var engine = CreateProfilingEngine();
+        engine.Advanced.StartProfiling();
+        engine.Execute("var inferred = function () { return 1; }; inferred();");
+        var profile = engine.Advanced.StopProfiling();
+
+        OpenedNames(profile).Should().Contain("inferred");
+    }
+
+    [Fact]
+    public void AFunctionWithNoNameAtAllIsAnonymous()
+    {
+        var engine = CreateProfilingEngine();
+        engine.Advanced.StartProfiling();
+        engine.Execute("(function () { return 1; })();", "anon.js");
+        var profile = engine.Advanced.StopProfiling();
+
+        RenderCallTree(profile);
+        var frame = profile.Frames.Single();
+        frame.Name.Should().Be("<anonymous>");
+        frame.File.Should().Be("anon.js", "an unnamed function still has a source position");
+        frame.Line.Should().Be(1);
+        frame.Column.Should().Be(2);
+    }
+
+    [Fact]
+    public void AGetterIsProfiledUnderTheAccessorName()
+    {
+        var engine = CreateProfilingEngine();
+        engine.Advanced.StartProfiling();
+        engine.Execute("var o = { get p() { return 1; } }; function g() { return o.p; } g();");
+        var profile = engine.Advanced.StopProfiling();
+
+        RenderCallTree(profile).Should().Be("g\n  get p\n");
+    }
+
+    [Fact]
+    public void HostCallablesAreProfiledButCarryNoSourceLocation()
+    {
+        var engine = CreateProfilingEngine();
+        engine.SetValue("hostCall", new Func<int>(static () => 42));
+
+        engine.Advanced.StartProfiling();
+        engine.Execute("function caller() { return hostCall(); } caller();");
+        var profile = engine.Advanced.StopProfiling();
+
+        RenderCallTree(profile);
+        profile.Frames.Should().HaveCount(2);
+
+        var frame = profile.Frames.Single(f => f.Name != "caller");
+        frame.File.Should().BeNull("a CLR callable was never parsed from anywhere");
+        frame.Line.Should().BeNull();
+        frame.Column.Should().BeNull();
+    }
+
+    /// <summary>
+    /// The three documented elisions, pinned together so widening any of them is a deliberate act rather
+    /// than an accident. All three share one property that keeps a profile coherent rather than merely
+    /// incomplete: the eliding call never gets a frame either, so anything the elided function calls is
+    /// recorded at the depth the call stack really has, never at a wrong one.
+    /// </summary>
+    public class Elisions
+    {
+        [Fact]
+        public void AFramelessLeafBuiltInDisappearsOnceItsCallSiteIsWarm()
+        {
+            var engine = CreateProfilingEngine();
+            engine.Advanced.StartProfiling();
+            engine.Execute("function f(x) { return Math.abs(x); } for (var i = 0; i < 5; i++) { f(-1); }");
+            var profile = engine.Advanced.StopProfiling();
+
+            RenderCallTree(profile);
+
+            // The first dispatch has no fast-call shape cached yet and so keeps its frame; from the second
+            // on the site takes the leaf lane, which pushes nothing at all.
+            OpenedNames(profile).Count(static n => n == "f").Should().Be(5);
+            OpenedNames(profile).Count(static n => n == "abs").Should().Be(1);
+        }
+
+        [Fact]
+        public void ACallbackABuiltInInvokesHasNoFrameButItsCalleesDo()
+        {
+            var engine = CreateProfilingEngine();
+            engine.Advanced.StartProfiling();
+            engine.Execute("function helper(v) { return v; } [1, 2].map(function (x) { return helper(x); });");
+            var profile = engine.Advanced.StopProfiling();
+
+            // `map` is framed and the callback is not, so `helper` lands directly under `map` — one level
+            // short of the truth, never at the wrong depth.
+            RenderCallTree(profile).Should().Be("map\n  helper\n  helper\n");
+        }
+
+        [Fact]
+        public void APromiseReactionHandlerHasNoFrameButItsCalleesDo()
+        {
+            var engine = CreateProfilingEngine();
+            engine.Advanced.StartProfiling();
+            engine.Execute("""
+                function helper(v) { return v; }
+                function reaction(v) { return helper(v); }
+                Promise.resolve(1).then(reaction);
+                """);
+            var profile = engine.Advanced.StopProfiling();
+
+            RenderCallTree(profile);
+
+            // The reaction job invokes the handler directly, so `reaction` never gets a frame; `helper` runs
+            // with an empty call stack and is therefore recorded as a root.
+            OpenedNames(profile).Should().NotContain("reaction");
+            DepthOfFirstOpen(profile, "helper").Should().Be(0, "the reaction job runs with an empty call stack");
+        }
+    }
+
+    [Fact]
+    public void TruncationStopsRecordingAndFlagsTheProfile()
+    {
+        var engine = new Engine(options =>
+        {
+            options.Profiling.Enabled = true;
+            options.Profiling.MaxEvents = 20;
+        });
+
+        engine.Advanced.StartProfiling();
+        engine.Execute("function f() { return 1; } for (var i = 0; i < 1000; i++) { f(); }");
+        var profile = engine.Advanced.StopProfiling();
+
+        profile.Truncated.Should().BeTrue();
+        profile.Events.Count.Should().BeLessThanOrEqualTo(20);
+        profile.Events.Should().NotBeEmpty();
+
+        // Truncating must not leave a dangling open frame: the stream stays replayable.
+        RenderCallTree(profile);
+    }
+
+    [Fact]
+    public void TruncationInsideADeepStackClosesEveryOpenFrame()
+    {
+        var engine = new Engine(options =>
+        {
+            options.Profiling.Enabled = true;
+            options.Profiling.MaxEvents = 12;
+        });
+
+        engine.Advanced.StartProfiling();
+        engine.Execute("function down(n) { return n === 0 ? 0 : down(n - 1); } down(50);");
+        var profile = engine.Advanced.StopProfiling();
+
+        profile.Truncated.Should().BeTrue();
+        profile.Events.Count.Should().BeLessThanOrEqualTo(12);
+        RenderCallTree(profile);
+    }
+
+    [Fact]
+    public void AProfileStoppedMidCallClosesWhatIsStillOpen()
+    {
+        var engine = CreateProfilingEngine();
+        ScriptProfile? captured = null;
+        engine.SetValue("stop", new Action(() => captured = engine.Advanced.StopProfiling()));
+
+        engine.Advanced.StartProfiling();
+        engine.Execute("function inner() { stop(); } function outer() { inner(); } outer();");
+
+        captured.Should().NotBeNull();
+        RenderCallTree(captured!).Should().StartWith("outer\n  inner\n");
+        engine.Advanced.IsProfiling.Should().BeFalse();
+    }
+
+    [Fact]
+    public void AProfileStartedMidCallDropsTheExitsItNeverSaw()
+    {
+        var engine = CreateProfilingEngine();
+        engine.SetValue("start", new Action(() => engine.Advanced.StartProfiling()));
+
+        engine.Execute("""
+            function inner() { start(); }
+            function outer() { inner(); return 1; }
+            outer();
+            """);
+        var profile = engine.Advanced.StopProfiling();
+
+        // outer/inner/start were already on the stack when the session opened, so their pops have nothing to
+        // match and are dropped rather than corrupting the stream.
+        RenderCallTree(profile);
+        profile.Events.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ProfilingIsPerEngine()
+    {
+        var options = new Options();
+        options.Profiling.Enabled = true;
+
+        var profiled = new Engine(options);
+        var unprofiled = new Engine(options);
+
+        profiled.Advanced.StartProfiling();
+        unprofiled.Execute("function other() { return 1; } other();");
+        profiled.Execute("function mine() { return 1; } mine();");
+        var profile = profiled.Advanced.StopProfiling();
+
+        unprofiled.Advanced.IsProfiling.Should().BeFalse();
+        OpenedNames(profile).Should().Equal("mine");
+    }
+
+    [Fact]
+    public void NonPositiveMaxEventsIsRejected()
+    {
+        var options = new Options();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => options.Profiling.MaxEvents = 0);
+        Assert.Throws<ArgumentOutOfRangeException>(() => options.Profiling.MaxEvents = -1);
+        options.Profiling.MaxEvents.Should().Be(Options.ProfilingOptions.DefaultMaxEvents);
+    }
+
+    [Fact]
+    public void DurationCoversTheWholeSession()
+    {
+        var engine = CreateProfilingEngine();
+        engine.Advanced.StartProfiling();
+        engine.Execute("function f() { return 1; } for (var i = 0; i < 100; i++) { f(); }");
+        var profile = engine.Advanced.StopProfiling();
+
+        // Structural, not timed: the session cannot be shorter than its own last event, and its TimeSpan
+        // projection must agree with the nanosecond figure the speedscope export uses.
+        profile.DurationNanoseconds.Should().BeGreaterThanOrEqualTo(profile.Events[^1].TimestampNanoseconds);
+        profile.Duration.Ticks.Should().Be(profile.DurationNanoseconds / 100);
+    }
+
+    [Fact]
+    public void ASecondSessionOnTheSameEngineStartsClean()
+    {
+        var engine = CreateProfilingEngine();
+        engine.Execute("function first() { return 1; } function second() { return 2; }");
+
+        engine.Advanced.StartProfiling();
+        engine.Execute("first();");
+        var one = engine.Advanced.StopProfiling();
+
+        engine.Advanced.StartProfiling();
+        engine.Execute("second();");
+        var two = engine.Advanced.StopProfiling();
+
+        OpenedNames(one).Should().Equal("first");
+        OpenedNames(two).Should().Equal("second");
+    }
+
+}

--- a/Jint.Tests/Runtime/SpeedscopeExportTests.cs
+++ b/Jint.Tests/Runtime/SpeedscopeExportTests.cs
@@ -1,0 +1,294 @@
+#nullable enable
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Jint.Native;
+using Jint.Native.Json;
+using Jint.Native.Object;
+using Jint.Profiling;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Pins the exported document against the
+/// <see href="https://www.speedscope.app/file-format-schema.json">speedscope file format schema</see>:
+/// <c>FileFormat.File</c> requires <c>$schema</c>, <c>shared.frames</c> and <c>profiles</c>;
+/// <c>FileFormat.EventedProfile</c> requires <c>type</c>, <c>name</c>, <c>unit</c>, <c>startValue</c>,
+/// <c>endValue</c> and <c>events</c>; each event requires <c>type</c> (<c>"O"</c> or <c>"C"</c>),
+/// <c>frame</c> and <c>at</c>; and <c>FileFormat.Frame</c> requires <c>name</c>, with <c>file</c>,
+/// <c>line</c> and <c>col</c> optional.
+/// <para>
+/// The document is parsed back with Jint's own <see cref="JsonParser"/> rather than compared as text, so
+/// what is asserted is the structure a consumer sees and not a byte layout nobody promised.
+/// </para>
+/// </summary>
+public class SpeedscopeExportTests
+{
+    private const string SchemaUrl = "https://www.speedscope.app/file-format-schema.json";
+
+    private static ScriptProfile Profile(string code, string source = "profiled.js", Action<Engine>? setup = null)
+    {
+        var engine = new Engine(options => options.Profiling.Enabled = true);
+        setup?.Invoke(engine);
+        engine.Advanced.StartProfiling();
+        engine.Execute(code, source);
+        return engine.Advanced.StopProfiling();
+    }
+
+    private static string ToJson(ScriptProfile profile)
+    {
+        var writer = new StringWriter();
+        profile.WriteSpeedscopeJson(writer);
+        return writer.ToString();
+    }
+
+    private static ObjectInstance ParseBack(string json)
+    {
+        // A parser engine of its own, so nothing about the profiled engine can flatter the result.
+        var parsed = new JsonParser(new Engine()).Parse(json);
+        return parsed.Should().BeAssignableTo<ObjectInstance>().Subject;
+    }
+
+    private static ObjectInstance At(JsValue array, int index) =>
+        array.Get(index.ToString(System.Globalization.CultureInfo.InvariantCulture))
+            .Should().BeAssignableTo<ObjectInstance>().Subject;
+
+    private static int Length(JsValue array) => (int) array.Get("length").AsNumber();
+
+    private const string SampleScript = """
+        function leaf() { return 1; }
+        function middle() { return leaf(); }
+        function root() { return middle() + leaf(); }
+        root();
+        """;
+
+    [Fact]
+    public void EmitsTheRequiredTopLevelMembers()
+    {
+        var document = ParseBack(ToJson(Profile(SampleScript)));
+
+        document.Get("$schema").AsString().Should().Be(SchemaUrl);
+        document.Get("exporter").AsString().Should().Be("Jint");
+        document.Get("name").IsString().Should().BeTrue();
+        document.Get("activeProfileIndex").AsNumber().Should().Be(0);
+        document.Get("shared").IsObject().Should().BeTrue();
+        document.Get("profiles").IsArray().Should().BeTrue();
+    }
+
+    [Fact]
+    public void EmitsExactlyOneEventedProfileInNanoseconds()
+    {
+        var profile = Profile(SampleScript);
+        var document = ParseBack(ToJson(profile));
+
+        var profiles = document.Get("profiles");
+        Length(profiles).Should().Be(1);
+
+        var evented = At(profiles, 0);
+        evented.Get("type").AsString().Should().Be("evented");
+        evented.Get("unit").AsString().Should().Be("nanoseconds");
+        evented.Get("name").IsString().Should().BeTrue();
+        evented.Get("startValue").AsNumber().Should().Be(0);
+        evented.Get("endValue").AsNumber().Should().Be(profile.DurationNanoseconds);
+        evented.Get("events").IsArray().Should().BeTrue();
+    }
+
+    [Fact]
+    public void SharedFramesMirrorTheProfileFrames()
+    {
+        var profile = Profile(SampleScript);
+        var frames = ParseBack(ToJson(profile)).Get("shared").Get("frames");
+
+        Length(frames).Should().Be(profile.Frames.Count);
+        profile.Frames.Should().NotBeEmpty();
+
+        for (var i = 0; i < profile.Frames.Count; i++)
+        {
+            var expected = profile.Frames[i];
+            var actual = At(frames, i);
+
+            actual.Get("name").AsString().Should().Be(expected.Name);
+
+            if (expected.File is null)
+            {
+                actual.HasProperty("file").Should().BeFalse("an absent optional member is omitted, not null");
+                actual.HasProperty("line").Should().BeFalse();
+                actual.HasProperty("col").Should().BeFalse();
+            }
+            else
+            {
+                actual.Get("file").AsString().Should().Be(expected.File);
+                actual.Get("line").AsNumber().Should().Be(expected.Line!.Value);
+                actual.Get("col").AsNumber().Should().Be(expected.Column!.Value);
+            }
+        }
+    }
+
+    [Fact]
+    public void EventsAreBalancedAndNonDecreasing()
+    {
+        var profile = Profile(SampleScript);
+        var document = ParseBack(ToJson(profile));
+
+        var events = At(document.Get("profiles"), 0).Get("events");
+        var count = Length(events);
+        count.Should().Be(profile.Events.Count).And.BePositive();
+
+        var frameCount = Length(document.Get("shared").Get("frames"));
+        var open = new Stack<int>();
+        var previous = 0d;
+
+        for (var i = 0; i < count; i++)
+        {
+            var e = At(events, i);
+            var type = e.Get("type").AsString();
+            var frame = (int) e.Get("frame").AsNumber();
+            var at = e.Get("at").AsNumber();
+
+            type.Should().BeOneOf("O", "C");
+            frame.Should().BeInRange(0, frameCount - 1);
+            at.Should().BeGreaterThanOrEqualTo(previous);
+            previous = at;
+
+            if (type == "O")
+            {
+                open.Push(frame);
+            }
+            else
+            {
+                open.Should().NotBeEmpty();
+                open.Pop().Should().Be(frame);
+            }
+        }
+
+        open.Should().BeEmpty();
+        previous.Should().BeLessThanOrEqualTo(At(document.Get("profiles"), 0).Get("endValue").AsNumber());
+    }
+
+    [Fact]
+    public void AnEmptyProfileIsStillAValidDocument()
+    {
+        var engine = new Engine(options => options.Profiling.Enabled = true);
+        engine.Advanced.StartProfiling();
+        var profile = engine.Advanced.StopProfiling();
+
+        var document = ParseBack(ToJson(profile));
+
+        Length(document.Get("shared").Get("frames")).Should().Be(0);
+        Length(At(document.Get("profiles"), 0).Get("events")).Should().Be(0);
+        At(document.Get("profiles"), 0).Get("endValue").AsNumber().Should().BeGreaterThanOrEqualTo(0);
+    }
+
+    /// <summary>
+    /// A function's <c>name</c> is a JS string, so it can hold anything JSON has to escape — including an
+    /// unpaired surrogate, which has no UTF-8 encoding at all and would otherwise make the exported bytes
+    /// undecodable.
+    /// </summary>
+    [Fact]
+    public void HostileFunctionNamesSurviveTheRoundTrip()
+    {
+        const string Hostile = "a\"b\\c\nde\ud800f";
+
+        var profile = Profile("""
+            var f = function () { return 1; };
+            Object.defineProperty(f, 'name', { value: 'a"b\\c\nde\ud800f' });
+            f();
+            """);
+
+        var index = IndexOfFrameNamed(profile, Hostile);
+        index.Should().BeGreaterThanOrEqualTo(0);
+
+        var json = ToJson(profile);
+        json.Should().NotContain("\ud800", "an unpaired surrogate must be escaped rather than emitted raw");
+
+        var frames = ParseBack(json).Get("shared").Get("frames");
+        At(frames, index).Get("name").AsString().Should().Be(Hostile);
+    }
+
+    [Fact]
+    public void APairedSurrogateIsEmittedAsIs()
+    {
+        // U+1F600, a legitimate astral character, must not be mangled by the unpaired-surrogate handling.
+        // Built from code units on both sides so the assertion does not depend on this file's encoding.
+        const string Emoji = "\uD83D\uDE00";
+
+        var profile = Profile("""
+            var f = function () { return 1; };
+            Object.defineProperty(f, 'name', { value: String.fromCharCode(0xD83D, 0xDE00) });
+            f();
+            """);
+
+        var index = IndexOfFrameNamed(profile, Emoji);
+        index.Should().BeGreaterThanOrEqualTo(0);
+
+        var json = ToJson(profile);
+        json.Should().Contain(Emoji);
+        At(ParseBack(json).Get("shared").Get("frames"), index).Get("name").AsString().Should().Be(Emoji);
+    }
+
+    private static int IndexOfFrameNamed(ScriptProfile profile, string name)
+    {
+        for (var i = 0; i < profile.Frames.Count; i++)
+        {
+            if (profile.Frames[i].Name == name)
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    [Fact]
+    public void TheStreamOverloadWritesUtf8WithoutABomAndLeavesTheStreamOpen()
+    {
+        var profile = Profile(SampleScript);
+
+        using var stream = new MemoryStream();
+        profile.WriteSpeedscopeJson(stream);
+
+        var bytes = stream.ToArray();
+        bytes[0].Should().Be((byte) '{', "a byte-order mark is not part of the document");
+
+        // Still writable, so the overload did not dispose what it was handed.
+        stream.WriteByte((byte) ' ');
+
+        new UTF8Encoding(false).GetString(bytes).Should().Be(ToJson(profile));
+    }
+
+    [Fact]
+    public void NullArgumentsAreRejected()
+    {
+        var profile = Profile(SampleScript);
+
+        Assert.Throws<ArgumentNullException>(() => profile.WriteSpeedscopeJson((TextWriter) null!));
+        Assert.Throws<ArgumentNullException>(() => profile.WriteSpeedscopeJson((Stream) null!));
+    }
+
+    [Fact]
+    public void ATruncatedProfileStillExportsABalancedDocument()
+    {
+        var engine = new Engine(options =>
+        {
+            options.Profiling.Enabled = true;
+            options.Profiling.MaxEvents = 10;
+        });
+
+        engine.Advanced.StartProfiling();
+        engine.Execute("function down(n) { return n === 0 ? 0 : down(n - 1); } down(50);");
+        var profile = engine.Advanced.StopProfiling();
+        profile.Truncated.Should().BeTrue();
+
+        var events = At(ParseBack(ToJson(profile)).Get("profiles"), 0).Get("events");
+        var depth = 0;
+        for (var i = 0; i < Length(events); i++)
+        {
+            depth += At(events, i).Get("type").AsString() == "O" ? 1 : -1;
+            depth.Should().BeGreaterThanOrEqualTo(0);
+        }
+
+        depth.Should().Be(0, "truncation closes what it leaves open");
+    }
+}

--- a/Jint/Engine.Advanced.Profiling.cs
+++ b/Jint/Engine.Advanced.Profiling.cs
@@ -1,0 +1,84 @@
+using Jint.Profiling;
+using Jint.Runtime;
+
+namespace Jint;
+
+public partial class Engine
+{
+    public partial class AdvancedOperations
+    {
+        /// <summary>
+        /// Whether a profiling session is currently recording on this engine.
+        /// </summary>
+        public bool IsProfiling => _engine.CallStack._profiler is not null;
+
+        /// <summary>
+        /// Starts recording function enters and leaves on this engine. Requires
+        /// <see cref="Options.ProfilingOptions.Enabled"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The profiler is evented, not sampling: it records at the call boundary on the engine's own
+        /// thread rather than inspecting the engine from another one, which for a runtime with no
+        /// thread-safety story is the only way to get a profile that is not a race. The cost is paid by
+        /// the calls themselves — one interned frame lookup and one 16-byte event per enter and per leave
+        /// — so a profiled run is slower than an unprofiled one, and this is a diagnostic to switch on,
+        /// not a meter to leave running.
+        /// </para>
+        /// <para>
+        /// While a session is open it retains one reference per distinct function it has seen: the
+        /// <em>definition</em> for a script function, so all closures of one source function are one entry
+        /// and nothing engine-affine is held, but the function object itself for a built-in, bound or host
+        /// callable. Both are released by <see cref="StopProfiling"/>, and the
+        /// <see cref="ScriptProfile"/> it returns retains neither.
+        /// </para>
+        /// <para>
+        /// Everything the engine records is bounded by <see cref="Options.ProfilingOptions.MaxEvents"/>;
+        /// see <see cref="ScriptProfile.Truncated"/>. Starting a session while script is already running —
+        /// from a host callable the script invoked — is allowed: the frames already on the call stack were
+        /// never opened, so their leaves are dropped and the profile simply starts at the depth it found.
+        /// </para>
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">
+        /// <see cref="Options.ProfilingOptions.Enabled"/> is <see langword="false"/> on the options this
+        /// engine was built from, or a session is already running.
+        /// </exception>
+        public void StartProfiling()
+        {
+            var options = _engine.Options.Profiling;
+            if (!options.Enabled)
+            {
+                Throw.InvalidOperationException(
+                    "Profiling is not enabled for this engine. Set Options.Profiling.Enabled to true when building it.");
+            }
+
+            var callStack = _engine.CallStack;
+            if (callStack._profiler is not null)
+            {
+                Throw.InvalidOperationException("A profiling session is already running on this engine.");
+            }
+
+            callStack._profiler = new ScriptProfiler(options.MaxEvents);
+        }
+
+        /// <summary>
+        /// Ends the session started by <see cref="StartProfiling"/> and returns what it recorded. Any frame
+        /// still open — the engine being mid-call, because the host stopped the profiler from a callable
+        /// script invoked — is closed at this instant, so the event stream is always balanced.
+        /// </summary>
+        /// <returns>The recorded profile. Never <see langword="null"/>.</returns>
+        /// <exception cref="InvalidOperationException">No profiling session is running on this engine.</exception>
+        public ScriptProfile StopProfiling()
+        {
+            var callStack = _engine.CallStack;
+            var profiler = callStack._profiler;
+            if (profiler is null)
+            {
+                Throw.InvalidOperationException("No profiling session is running on this engine.");
+            }
+
+            callStack._profiler = null;
+            return profiler!.Complete();
+        }
+    }
+}

--- a/Jint/Options.Profiling.cs
+++ b/Jint/Options.Profiling.cs
@@ -1,0 +1,73 @@
+using Jint.Runtime;
+
+namespace Jint;
+
+public partial class Options
+{
+    /// <summary>
+    /// Opt-in evented script profiling. Nothing is recorded — and nothing can be started — unless
+    /// <see cref="ProfilingOptions.Enabled"/> is set, so a default engine is exactly the engine it was
+    /// before this existed.
+    /// </summary>
+    /// <seealso cref="Engine.AdvancedOperations.StartProfiling"/>
+    public ProfilingOptions Profiling { get; } = new();
+
+    /// <summary>
+    /// Configuration for <see cref="Engine.AdvancedOperations.StartProfiling"/>.
+    /// </summary>
+    /// <remarks>
+    /// Like every other <see cref="Options"/> group this may be shared by any number of engines, including
+    /// concurrent ones: nothing on it is engine-affine, and both members are read once, on the thread that
+    /// calls <see cref="Engine.AdvancedOperations.StartProfiling"/>, into the session it starts. Changing
+    /// either afterwards does not reach a session already running.
+    /// </remarks>
+    public class ProfilingOptions
+    {
+        /// <summary>
+        /// The default value of <see cref="MaxEvents"/>.
+        /// </summary>
+        public const int DefaultMaxEvents = 1_000_000;
+
+        private int _maxEvents = DefaultMaxEvents;
+
+        /// <summary>
+        /// Whether <see cref="Engine.AdvancedOperations.StartProfiling"/> is allowed on this engine,
+        /// defaults to <see langword="false"/>. When it is false that method throws and no profiler is
+        /// ever attached, which is what makes the engine's cost of not profiling a single null field test
+        /// per call-stack push and pop.
+        /// </summary>
+        /// <remarks>
+        /// This is a capability gate, not a switch that starts recording: a host still has to call
+        /// <see cref="Engine.AdvancedOperations.StartProfiling"/> to open a session. Recording retains one
+        /// reference per distinct function seen (see <see cref="Engine.AdvancedOperations.StartProfiling"/>),
+        /// so an engine that runs untrusted script can refuse profiling outright by leaving this false.
+        /// </remarks>
+        public bool Enabled { get; set; }
+
+        /// <summary>
+        /// Upper bound on the number of events one profiling session records, defaults to
+        /// <see cref="DefaultMaxEvents"/> (one million). Reaching it stops recording and flags the
+        /// resulting <see cref="Profiling.ScriptProfile.Truncated"/>; the events already recorded stay,
+        /// and every frame still open at that moment is closed so the stream remains balanced.
+        /// </summary>
+        /// <remarks>
+        /// This is a cap on events, not on frames: a frame only enters the profile through an event, so
+        /// the frame table is bounded by the same number. Unlike the execution constraints there is no
+        /// "unlimited" sentinel — a non-positive value is rejected rather than read as no limit.
+        /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">The value is not positive.</exception>
+        public int MaxEvents
+        {
+            get => _maxEvents;
+            set
+            {
+                if (value <= 0)
+                {
+                    Throw.ArgumentOutOfRangeException(nameof(value), "MaxEvents must be positive.");
+                }
+
+                _maxEvents = value;
+            }
+        }
+    }
+}

--- a/Jint/Profiling/ScriptProfile.cs
+++ b/Jint/Profiling/ScriptProfile.cs
@@ -1,0 +1,114 @@
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Text;
+using Jint.Runtime;
+
+namespace Jint.Profiling;
+
+/// <summary>
+/// The result of one profiling session: every function enter and leave the engine recorded between
+/// <see cref="Engine.AdvancedOperations.StartProfiling"/> and
+/// <see cref="Engine.AdvancedOperations.StopProfiling"/>, and the functions they refer to.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Immutable, engine-independent and safe to hand to another thread: it holds strings and numbers only.
+/// In particular it retains no <c>Function</c>, no AST and no <see cref="Engine"/>, so keeping a profile
+/// around does not keep the engine that produced it alive.
+/// </para>
+/// <para>
+/// <see cref="WriteSpeedscopeJson(TextWriter)"/> renders it in the
+/// <see href="https://www.speedscope.app/file-format-schema.json">speedscope file format</see>, whose
+/// evented profile is exactly this event stream.
+/// </para>
+/// </remarks>
+public sealed class ScriptProfile
+{
+    private readonly ScriptProfileFrame[] _frames;
+    private readonly ScriptProfileEvent[] _events;
+
+    internal ScriptProfile(
+        ScriptProfileFrame[] frames,
+        ScriptProfileEvent[] events,
+        bool truncated,
+        long durationNanoseconds)
+    {
+        _frames = frames;
+        _events = events;
+
+        // Wrapped rather than handed over as the arrays themselves, so the immutability this type claims
+        // survives a caller that casts an IReadOnlyList back to what it really is.
+        Frames = new ReadOnlyCollection<ScriptProfileFrame>(frames);
+        Events = new ReadOnlyCollection<ScriptProfileEvent>(events);
+
+        Truncated = truncated;
+        DurationNanoseconds = durationNanoseconds;
+    }
+
+    /// <summary>
+    /// The distinct functions the session saw, in the order they were first entered.
+    /// <see cref="ScriptProfileEvent.FrameIndex"/> indexes into this list.
+    /// </summary>
+    public IReadOnlyList<ScriptProfileFrame> Frames { get; }
+
+    /// <summary>
+    /// The enter and leave events, in the order they happened.
+    /// </summary>
+    public IReadOnlyList<ScriptProfileEvent> Events { get; }
+
+    /// <summary>
+    /// Whether recording stopped early because <see cref="Options.ProfilingOptions.MaxEvents"/> was reached.
+    /// When true, <see cref="Events"/> describes the beginning of the run and says nothing about the rest of
+    /// it; the stream is still balanced, every frame open at the cut-off having been closed there.
+    /// </summary>
+    public bool Truncated { get; }
+
+    /// <summary>
+    /// Wall-clock time between <see cref="Engine.AdvancedOperations.StartProfiling"/> and
+    /// <see cref="Engine.AdvancedOperations.StopProfiling"/>, including whatever the host did in between
+    /// that was not script. Equal to the speedscope profile's <c>endValue</c>.
+    /// </summary>
+    public long DurationNanoseconds { get; }
+
+    /// <summary>
+    /// <see cref="DurationNanoseconds"/> as a <see cref="TimeSpan"/>, rounded down to its 100ns resolution.
+    /// </summary>
+    public TimeSpan Duration => TimeSpan.FromTicks(DurationNanoseconds / NanosecondsPerTimeSpanTick);
+
+    private const long NanosecondsPerTimeSpanTick = 100;
+
+    /// <summary>
+    /// Writes this profile as a speedscope evented profile, in nanoseconds. The output is a complete
+    /// <c>.speedscope.json</c> document that <see href="https://www.speedscope.app">speedscope</see> opens
+    /// as-is.
+    /// </summary>
+    /// <param name="writer">Where to write. Not flushed and not disposed.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="writer"/> is <see langword="null"/>.</exception>
+    public void WriteSpeedscopeJson(TextWriter writer)
+    {
+        if (writer is null)
+        {
+            Throw.ArgumentNullException(nameof(writer));
+        }
+
+        SpeedscopeWriter.Write(writer, _frames, _events, DurationNanoseconds);
+    }
+
+    /// <summary>
+    /// Writes this profile as a speedscope evented profile, UTF-8 encoded without a byte-order mark.
+    /// </summary>
+    /// <param name="stream">Where to write. Flushed, but left open.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="stream"/> is <see langword="null"/>.</exception>
+    public void WriteSpeedscopeJson(Stream stream)
+    {
+        if (stream is null)
+        {
+            Throw.ArgumentNullException(nameof(stream));
+        }
+
+        // A UTF8Encoding of our own rather than Encoding.UTF8, whose GetPreamble() would put a BOM in front
+        // of the document; JSON parsers are not obliged to skip one.
+        using var writer = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), 1024, leaveOpen: true);
+        WriteSpeedscopeJson(writer);
+    }
+}

--- a/Jint/Profiling/ScriptProfileEvent.cs
+++ b/Jint/Profiling/ScriptProfileEvent.cs
@@ -1,0 +1,41 @@
+using System.Runtime.InteropServices;
+
+namespace Jint.Profiling;
+
+/// <summary>
+/// Which end of a function's activation a <see cref="ScriptProfileEvent"/> marks.
+/// </summary>
+public enum ScriptProfileEventKind
+{
+    /// <summary>
+    /// The function was entered. Corresponds to speedscope's <c>"O"</c> event.
+    /// </summary>
+    Open,
+
+    /// <summary>
+    /// The function was left, by return or by exception. Corresponds to speedscope's <c>"C"</c> event.
+    /// </summary>
+    Close,
+}
+
+/// <summary>
+/// One function enter or leave, timestamped against the start of the profiling session.
+/// </summary>
+/// <param name="Kind">Whether the frame was entered or left.</param>
+/// <param name="FrameIndex">Index into <see cref="ScriptProfile.Frames"/> of the function involved.</param>
+/// <param name="TimestampNanoseconds">
+/// Nanoseconds since the session started, derived from <see cref="System.Diagnostics.Stopwatch"/>
+/// timestamps and therefore monotonically non-decreasing across the event list.
+/// </param>
+/// <remarks>
+/// The events of a session are well-formed as a stream: every <see cref="ScriptProfileEventKind.Open"/> is
+/// matched by a later <see cref="ScriptProfileEventKind.Close"/> of the same frame, and the matching is
+/// properly nested, so the list can be replayed into a call tree by pushing and popping. That holds through
+/// exceptions, through <see cref="Engine.AdvancedOperations.ResetCallStack"/>, through truncation and
+/// through a session stopped while script is still running.
+/// </remarks>
+[StructLayout(LayoutKind.Auto)]
+public readonly record struct ScriptProfileEvent(
+    ScriptProfileEventKind Kind,
+    int FrameIndex,
+    long TimestampNanoseconds);

--- a/Jint/Profiling/ScriptProfileFrame.cs
+++ b/Jint/Profiling/ScriptProfileFrame.cs
@@ -1,0 +1,32 @@
+using System.Runtime.InteropServices;
+
+namespace Jint.Profiling;
+
+/// <summary>
+/// A function as it appears in a profile: the name to show, and where its source is.
+/// </summary>
+/// <param name="Name">
+/// The function's name at the moment the profiler first saw it, or <c>&lt;anonymous&gt;</c> when it has
+/// none. Never <see langword="null"/> and never empty.
+/// </param>
+/// <param name="File">
+/// The source file the function was parsed from — the <c>source</c> argument of the <c>Execute</c> /
+/// <c>Evaluate</c> / <c>PrepareScript</c> call, or a module's location — or <see langword="null"/> for a
+/// function with no source position (every built-in, and every host CLR callable).
+/// </param>
+/// <param name="Line">One-based line of the function's declaration, or <see langword="null"/> with <see cref="File"/>.</param>
+/// <param name="Column">One-based column of the function's declaration, or <see langword="null"/> with <see cref="File"/>.</param>
+/// <remarks>
+/// <para>
+/// Frames are interned by <em>definition</em>, not by function object: every closure instantiated from one
+/// source function is one frame, which is what makes a profile of a closure-heavy program readable. Functions
+/// with no definition — built-ins, bound functions, host callables — are interned per object instead, there
+/// being nothing else to share.
+/// </para>
+/// <para>
+/// <see cref="Column"/> is one-based to match the column Jint reports in a stack trace, where the underlying
+/// parser position is a zero-based index.
+/// </para>
+/// </remarks>
+[StructLayout(LayoutKind.Auto)]
+public readonly record struct ScriptProfileFrame(string Name, string? File, int? Line, int? Column);

--- a/Jint/Profiling/ScriptProfiler.cs
+++ b/Jint/Profiling/ScriptProfiler.cs
@@ -1,0 +1,335 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Interpreter;
+
+namespace Jint.Profiling;
+
+/// <summary>
+/// The recording half of a profiling session. Owned by <see cref="Runtime.CallStack.JintCallStack"/>, which
+/// is the engine's single choke point for a function activation becoming visible: everything that gives a
+/// call a frame goes through its push, and everything that ends one goes through its pop, replace or clear.
+/// Hooking there is what makes the enter/exit stream balanced by construction — including for a throw, whose
+/// unwinding pops through the same <c>finally</c>s the normal return does.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Engine-thread only, like the call stack it hangs off. Nothing here is synchronized and nothing may be
+/// touched while script is running on another thread — which the engine does not support anyway.
+/// </para>
+/// <para>
+/// <b>What is not recorded.</b> A built-in dispatched through the interpreter's frameless leaf lane
+/// (<c>FastCallShape.IsLeafFor</c>) never reaches the call stack and so never appears. That lane is entered
+/// only when the built-in provably cannot reach user code with these arguments, so no <em>script</em>
+/// function is ever missing from a profile and no recorded frame ever spans a gap: what is elided is the
+/// self time of some trivial built-in calls, which is attributed to their caller instead.
+/// </para>
+/// </remarks>
+internal sealed class ScriptProfiler
+{
+    /// <summary>
+    /// Ticks-to-nanoseconds factor. Multiplying by a positive constant is monotone, so nanosecond
+    /// timestamps are non-decreasing exactly as the underlying <see cref="Stopwatch"/> ticks are — which
+    /// the speedscope format requires of an evented profile.
+    /// </summary>
+    private static readonly double NanosecondsPerTick = 1_000_000_000.0 / Stopwatch.Frequency;
+
+    internal const string AnonymousFrameName = "<anonymous>";
+
+    private readonly int _maxEvents;
+    private readonly long _startTimestamp;
+
+    private readonly List<RecordedEvent> _events = new();
+    private readonly List<ScriptProfileFrame> _frames = new();
+    private readonly Dictionary<object, int> _frameIndexes = new(ReferenceComparer.Instance);
+
+    /// <summary>
+    /// The frames currently open, innermost last — the profiler's own mirror of the call stack. It exists
+    /// because a close has to name the frame it closes and re-deriving that from the popped element would
+    /// be both slower and, after a truncation or a session started mid-call, wrong.
+    /// </summary>
+    private readonly List<int> _openFrames = new();
+
+    private bool _recording = true;
+    private bool _truncated;
+
+    internal ScriptProfiler(int maxEvents)
+    {
+        _maxEvents = maxEvents;
+        _startTimestamp = Stopwatch.GetTimestamp();
+    }
+
+    /// <summary>
+    /// Records <paramref name="function"/> being entered.
+    /// </summary>
+    internal void RecordEnter(Function function)
+    {
+        if (!_recording)
+        {
+            return;
+        }
+
+        var timestamp = Stopwatch.GetTimestamp();
+        if (!HasRoomForOneMoreCall())
+        {
+            Truncate(timestamp);
+            return;
+        }
+
+        var frame = GetFrameIndex(function);
+        _openFrames.Add(frame);
+        _events.Add(new RecordedEvent(timestamp, frame));
+    }
+
+    /// <summary>
+    /// Records the innermost open frame being left, by return or by exception.
+    /// </summary>
+    /// <remarks>
+    /// A pop with nothing open is dropped rather than treated as an error: a host may start a session from
+    /// inside a CLR callable that script invoked, in which case the frames already on the call stack were
+    /// never opened here and their pops have nothing to match.
+    /// </remarks>
+    internal void RecordExit()
+    {
+        var open = _openFrames.Count;
+        if (!_recording || open == 0)
+        {
+            return;
+        }
+
+        var frame = _openFrames[open - 1];
+        _openFrames.RemoveAt(open - 1);
+        _events.Add(new RecordedEvent(Stopwatch.GetTimestamp(), Close(frame)));
+    }
+
+    /// <summary>
+    /// Records a proper tail call displacing the innermost open frame with <paramref name="function"/>.
+    /// </summary>
+    /// <remarks>
+    /// A tail call is recorded as a close of the displaced function immediately followed by an open of its
+    /// target, both at the same instant — which is what the frame replacement actually is, and the only
+    /// shape a strictly nested event stream can express it in. So an unbounded tail recursion profiles as a
+    /// flat run of sibling frames at constant depth, not as a call tree that grows without bound; the
+    /// displaced function's activation is over as far as the profile is concerned, exactly as it is as far
+    /// as the stack trace is concerned. (Recursion-depth accounting deliberately disagrees — the
+    /// occurrence is retained there until the trampoline returns — but that is a budget, not a shape.)
+    /// </remarks>
+    internal void RecordTailReplace(Function function)
+    {
+        if (!_recording)
+        {
+            return;
+        }
+
+        var open = _openFrames.Count;
+        if (open == 0)
+        {
+            // The displaced frame predates the session (see RecordExit); the target's is still worth having.
+            RecordEnter(function);
+            return;
+        }
+
+        var timestamp = Stopwatch.GetTimestamp();
+        if (!HasRoomForOneMoreCall())
+        {
+            Truncate(timestamp);
+            return;
+        }
+
+        _events.Add(new RecordedEvent(timestamp, Close(_openFrames[open - 1])));
+
+        var frame = GetFrameIndex(function);
+        _openFrames[open - 1] = frame;
+        _events.Add(new RecordedEvent(timestamp, frame));
+    }
+
+    /// <summary>
+    /// Records the whole call stack being abandoned — an unhandled exception unwinding an evaluation, or a
+    /// host calling <see cref="Engine.AdvancedOperations.ResetCallStack"/>. Everything open is closed, and
+    /// recording continues from depth zero, which is where the call stack now is too.
+    /// </summary>
+    internal void RecordAbandon()
+    {
+        if (!_recording || _openFrames.Count == 0)
+        {
+            return;
+        }
+
+        CloseOpenFrames(Stopwatch.GetTimestamp());
+    }
+
+    /// <summary>
+    /// Ends the session and renders it. Anything still open — a host stopping the profiler from inside a
+    /// callback script invoked — is closed at the stop instant, so the returned stream is balanced whatever
+    /// the engine was in the middle of.
+    /// </summary>
+    internal ScriptProfile Complete()
+    {
+        var endTimestamp = Stopwatch.GetTimestamp();
+
+        if (_recording)
+        {
+            CloseOpenFrames(endTimestamp);
+            _recording = false;
+        }
+
+        var events = new ScriptProfileEvent[_events.Count];
+        for (var i = 0; i < events.Length; i++)
+        {
+            var recorded = _events[i];
+            var encoded = recorded.EncodedFrame;
+            var open = encoded >= 0;
+            events[i] = new ScriptProfileEvent(
+                open ? ScriptProfileEventKind.Open : ScriptProfileEventKind.Close,
+                open ? encoded : ~encoded,
+                ToNanoseconds(recorded.Timestamp - _startTimestamp));
+        }
+
+        // The frame table is handed over as plain strings and the interning map dropped, so the profile
+        // stops retaining the functions (and through them the closures, ASTs and engine) it was built from.
+        var frames = _frames.ToArray();
+        _frames.Clear();
+        _frameIndexes.Clear();
+        _events.Clear();
+
+        return new ScriptProfile(frames, events, _truncated, ToNanoseconds(endTimestamp - _startTimestamp));
+    }
+
+    /// <summary>
+    /// Whether one more call can be recorded without the eventual balancing closes exceeding the cap.
+    /// </summary>
+    /// <remarks>
+    /// The budget for a call is two events — its own open plus the close it will need — on top of the
+    /// closes every currently open frame will need. Checking that before each open maintains
+    /// <c>_events.Count + _openFrames.Count &lt;= _maxEvents</c> as an invariant, which is what lets
+    /// <see cref="Truncate"/> close everything open and still land inside the cap.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool HasRoomForOneMoreCall() => _events.Count + _openFrames.Count + 2 <= _maxEvents;
+
+    private void Truncate(long timestamp)
+    {
+        CloseOpenFrames(timestamp);
+        _truncated = true;
+        _recording = false;
+    }
+
+    private void CloseOpenFrames(long timestamp)
+    {
+        for (var i = _openFrames.Count - 1; i >= 0; i--)
+        {
+            _events.Add(new RecordedEvent(timestamp, Close(_openFrames[i])));
+        }
+
+        _openFrames.Clear();
+    }
+
+    private int GetFrameIndex(Function function)
+    {
+        // Interned by definition where there is one, so all closures of a source function share a frame;
+        // by object otherwise, there being nothing else for a built-in or host callable to share.
+        var definition = function._functionDefinition;
+        var key = (object?) definition ?? function;
+
+        if (_frameIndexes.TryGetValue(key, out var index))
+        {
+            return index;
+        }
+
+        index = _frames.Count;
+        _frames.Add(Describe(function, definition));
+        _frameIndexes.Add(key, index);
+        return index;
+    }
+
+    private static ScriptProfileFrame Describe(Function function, JintFunctionDefinition? definition)
+    {
+        var name = ResolveName(function, definition);
+
+        var node = (Node?) definition?.Function;
+        if (node is null)
+        {
+            return new ScriptProfileFrame(name, File: null, Line: null, Column: null);
+        }
+
+        var location = node.Location;
+        if (location == default)
+        {
+            return new ScriptProfileFrame(name, File: null, Line: null, Column: null);
+        }
+
+        var file = string.IsNullOrEmpty(location.SourceFile) ? null : location.SourceFile;
+
+        // Column is reported one-based, matching the column Jint puts in a stack trace; the parser's is an
+        // index.
+        return new ScriptProfileFrame(name, file, location.Start.Line, location.Start.Column + 1);
+    }
+
+    /// <summary>
+    /// The name to show for a function, resolved once when its frame is interned and without running any
+    /// script: the name its declaration carries, else the own <c>name</c> property's stored value when that
+    /// is a plain string (which is where an inferred name such as the <c>f</c> of
+    /// <c>var f = function () {}</c> lives), else <see cref="AnonymousFrameName"/>.
+    /// </summary>
+    /// <remarks>
+    /// Two things decide the order. A frame is interned by definition, so the declared name is the one that
+    /// identifies all of its instances, and reading it first also means a script function's <em>pending</em>
+    /// name descriptor — the shared sentinel whose value accessors throw to make a leak loud — is never
+    /// touched, since that sentinel only stands in for a declared name in the first place. And a descriptor
+    /// carrying <see cref="PropertyFlag.CustomJsValue"/> is declined rather than read: resolving one runs
+    /// host code, which is the profiler's business least of all.
+    /// </remarks>
+    private static string ResolveName(Function function, JintFunctionDefinition? definition)
+    {
+        var declared = definition?.Name;
+        if (!string.IsNullOrEmpty(declared))
+        {
+            return declared!;
+        }
+
+        var descriptor = function._nameDescriptor;
+        if (descriptor is not null
+            && (descriptor.Flags & PropertyFlag.CustomJsValue) == PropertyFlag.None
+            && descriptor.Value is JsString ownName)
+        {
+            var name = ownName.ToString();
+            if (name.Length > 0)
+            {
+                return name;
+            }
+        }
+
+        return AnonymousFrameName;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int Close(int frame) => ~frame;
+
+    private static long ToNanoseconds(long ticks) => (long) (ticks * NanosecondsPerTick);
+
+    /// <summary>
+    /// An event as recorded: the raw <see cref="Stopwatch"/> timestamp (converted only at readout, so the
+    /// hot path is one <see cref="Stopwatch.GetTimestamp"/> call and no arithmetic) and the frame index,
+    /// bit-complemented to mark a close. Kept to two fields so a million events cost 16 bytes each.
+    /// </summary>
+    [StructLayout(LayoutKind.Auto)]
+    private readonly record struct RecordedEvent(long Timestamp, int EncodedFrame);
+
+    /// <summary>
+    /// Identity comparison for the frame-interning map. Hand-written because
+    /// <c>ReferenceEqualityComparer</c> is .NET 5+ and Jint still targets net462 and netstandard2.0, and
+    /// because the keys — a <see cref="JintFunctionDefinition"/> or a <see cref="Function"/> — must not be
+    /// compared by any <c>Equals</c> override they may have.
+    /// </summary>
+    private sealed class ReferenceComparer : IEqualityComparer<object>
+    {
+        internal static readonly ReferenceComparer Instance = new();
+
+        public new bool Equals(object? x, object? y) => ReferenceEquals(x, y);
+
+        public int GetHashCode(object obj) => RuntimeHelpers.GetHashCode(obj);
+    }
+}

--- a/Jint/Profiling/SpeedscopeWriter.cs
+++ b/Jint/Profiling/SpeedscopeWriter.cs
@@ -1,0 +1,173 @@
+using System.Globalization;
+using System.IO;
+
+namespace Jint.Profiling;
+
+/// <summary>
+/// Renders a <see cref="ScriptProfile"/> as a speedscope <c>evented</c> profile, per
+/// <see href="https://www.speedscope.app/file-format-schema.json">the published schema</see>: a
+/// <c>FileFormat.File</c> whose required members are <c>$schema</c>, <c>shared.frames</c> and
+/// <c>profiles</c>, carrying a single <c>FileFormat.EventedProfile</c> whose required members are
+/// <c>type</c>, <c>name</c>, <c>unit</c>, <c>startValue</c>, <c>endValue</c> and <c>events</c>, each event
+/// being an <c>{ type: "O" | "C", frame, at }</c>.
+/// </summary>
+/// <remarks>
+/// Written by hand rather than through a JSON library because Jint takes no dependency it does not need,
+/// and because the document's shape is fixed: the only values that vary are two integers per event, four
+/// members per frame, and the strings among them.
+/// </remarks>
+internal static class SpeedscopeWriter
+{
+    private const string SchemaUrl = "https://www.speedscope.app/file-format-schema.json";
+    private const string ProfileName = "Jint";
+
+    internal static void Write(
+        TextWriter writer,
+        ScriptProfileFrame[] frames,
+        ScriptProfileEvent[] events,
+        long durationNanoseconds)
+    {
+        writer.Write("{\"$schema\":\"");
+        writer.Write(SchemaUrl);
+        writer.Write("\",\"exporter\":\"Jint\",\"name\":\"");
+        writer.Write(ProfileName);
+        writer.Write("\",\"activeProfileIndex\":0,\"shared\":{\"frames\":[");
+
+        for (var i = 0; i < frames.Length; i++)
+        {
+            if (i > 0)
+            {
+                writer.Write(',');
+            }
+
+            WriteFrame(writer, in frames[i]);
+        }
+
+        writer.Write("]},\"profiles\":[{\"type\":\"evented\",\"name\":\"");
+        writer.Write(ProfileName);
+        writer.Write("\",\"unit\":\"nanoseconds\",\"startValue\":0,\"endValue\":");
+        WriteNumber(writer, durationNanoseconds);
+        writer.Write(",\"events\":[");
+
+        for (var i = 0; i < events.Length; i++)
+        {
+            if (i > 0)
+            {
+                writer.Write(',');
+            }
+
+            var e = events[i];
+            writer.Write(e.Kind == ScriptProfileEventKind.Open ? "{\"type\":\"O\",\"frame\":" : "{\"type\":\"C\",\"frame\":");
+            WriteNumber(writer, e.FrameIndex);
+            writer.Write(",\"at\":");
+            WriteNumber(writer, e.TimestampNanoseconds);
+            writer.Write('}');
+        }
+
+        writer.Write("]}]}");
+    }
+
+    private static void WriteFrame(TextWriter writer, in ScriptProfileFrame frame)
+    {
+        writer.Write("{\"name\":");
+        WriteString(writer, frame.Name);
+
+        if (frame.File is not null)
+        {
+            writer.Write(",\"file\":");
+            WriteString(writer, frame.File);
+        }
+
+        if (frame.Line is { } line)
+        {
+            writer.Write(",\"line\":");
+            WriteNumber(writer, line);
+        }
+
+        if (frame.Column is { } column)
+        {
+            writer.Write(",\"col\":");
+            WriteNumber(writer, column);
+        }
+
+        writer.Write('}');
+    }
+
+    /// <summary>
+    /// Numbers go through <see cref="CultureInfo.InvariantCulture"/> explicitly rather than through
+    /// <c>TextWriter.Write(long)</c>, which formats with the writer's own provider — the current culture
+    /// for a <see cref="StreamWriter"/>.
+    /// </summary>
+    private static void WriteNumber(TextWriter writer, long value)
+    {
+        writer.Write(value.ToString(CultureInfo.InvariantCulture));
+    }
+
+    private static void WriteString(TextWriter writer, string value)
+    {
+        writer.Write('"');
+
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+            switch (c)
+            {
+                case '"':
+                    writer.Write("\\\"");
+                    break;
+                case '\\':
+                    writer.Write("\\\\");
+                    break;
+                case '\b':
+                    writer.Write("\\b");
+                    break;
+                case '\f':
+                    writer.Write("\\f");
+                    break;
+                case '\n':
+                    writer.Write("\\n");
+                    break;
+                case '\r':
+                    writer.Write("\\r");
+                    break;
+                case '\t':
+                    writer.Write("\\t");
+                    break;
+                default:
+                    if (c < ' ')
+                    {
+                        WriteEscaped(writer, c);
+                    }
+                    else if (char.IsSurrogate(c))
+                    {
+                        // A JS function name is a string of UTF-16 code units and may hold an unpaired
+                        // surrogate, which has no UTF-8 encoding; escaping it keeps the document decodable.
+                        if (char.IsHighSurrogate(c) && i + 1 < value.Length && char.IsLowSurrogate(value[i + 1]))
+                        {
+                            writer.Write(c);
+                            writer.Write(value[i + 1]);
+                            i++;
+                        }
+                        else
+                        {
+                            WriteEscaped(writer, c);
+                        }
+                    }
+                    else
+                    {
+                        writer.Write(c);
+                    }
+
+                    break;
+            }
+        }
+
+        writer.Write('"');
+    }
+
+    private static void WriteEscaped(TextWriter writer, char c)
+    {
+        writer.Write("\\u");
+        writer.Write(((int) c).ToString("x4", CultureInfo.InvariantCulture));
+    }
+}

--- a/Jint/Runtime/CallStack/JintCallStack.cs
+++ b/Jint/Runtime/CallStack/JintCallStack.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using Jint.Collections;
 using Jint.Native.Function;
+using Jint.Profiling;
 using Jint.Runtime.Environments;
 using Jint.Runtime.Interpreter.Expressions;
 using Environment = Jint.Runtime.Environments.Environment;
@@ -44,6 +45,19 @@ internal sealed class JintCallStack
     private readonly RefStack<CallStackElement> _stack = new();
     private readonly Dictionary<CallStackElement, int>? _statistics;
 
+    /// <summary>
+    /// The profiling session recording this stack's activations, or <see langword="null"/> — which it is
+    /// unless a host has called <see cref="Engine.AdvancedOperations.StartProfiling"/>. Every mutation of
+    /// <see cref="_stack"/> happens in this class, so hooking the four of them here is what makes a
+    /// profile's enter/exit stream balanced by construction, exceptions included: an unwinding throw pops
+    /// through the same <c>finally</c>s a return does.
+    /// </summary>
+    /// <remarks>
+    /// The cost of not profiling is exactly this: one field load and one null test per push and per pop,
+    /// on a field of an object the push is already writing to.
+    /// </remarks>
+    internal ScriptProfiler? _profiler;
+
     // Internal for use by DebugHandler
     internal RefStack<CallStackElement> Stack => _stack;
 
@@ -68,6 +82,7 @@ internal sealed class JintCallStack
     private int Push(in CallStackElement item)
     {
         _stack.Push(in item);
+        _profiler?.RecordEnter(item.Function);
         if (_statistics is not null)
         {
 #pragma warning disable CA1854
@@ -96,6 +111,7 @@ internal sealed class JintCallStack
     public CallStackElement Pop()
     {
         var item = _stack.Pop();
+        _profiler?.RecordExit();
         if (_statistics is not null)
         {
             if (_statistics[item] == 0)
@@ -154,6 +170,7 @@ internal sealed class JintCallStack
         ref var top = ref _stack._array[_stack._size - 1];
         var replacement = new CallStackElement(function, expression, in top.CallingExecutionContext);
         top = replacement;
+        _profiler?.RecordTailReplace(function);
 
         if (_statistics is null)
         {
@@ -218,6 +235,7 @@ internal sealed class JintCallStack
     {
         _stack.Clear();
         _statistics?.Clear();
+        _profiler?.RecordAbandon();
     }
 
     public override string ToString()

--- a/README.md
+++ b/README.md
@@ -578,6 +578,47 @@ and realm that created it, and passing one to a different engine is not supporte
 nor made safe. `Prepared<Script>` / `Prepared<Module>` and `ModuleBuilder` are the supported ways to share
 work between engines; convert to CLR values (`ToObject()`) to move data.
 
+## Profiling scripts (opt-in)
+
+When a script is slow and you want to know which of *its* functions is responsible, opt the engine in and
+bracket the run. The profiler is **evented, not sampling** — it records at the call boundary on the engine's
+own thread, because inspecting a running engine from another thread is not something Jint supports.
+
+```csharp
+var engine = new Engine(options => options.Profiling.Enabled = true);
+
+engine.Advanced.StartProfiling();
+engine.Execute(script);
+var profile = engine.Advanced.StopProfiling();
+
+using var file = File.Create("run.speedscope.json");
+profile.WriteSpeedscopeJson(file);
+```
+
+Drop the file onto [speedscope.app](https://www.speedscope.app) — it is written in that tool's
+[evented profile format](https://www.speedscope.app/file-format-schema.json), in nanoseconds. The
+`ScriptProfile` is also readable directly: `Frames` (name, file, line, column), `Events` (open/close plus a
+timestamp), `Truncated` and `Duration`. It holds strings and numbers only, so keeping a profile does not keep
+the engine that produced it alive.
+
+Worth knowing before you read a profile:
+
+- **It costs.** Every recorded call pays a frame lookup and a 16-byte event, so a profiled run is slower than
+  an unprofiled one. An engine that is not profiling pays one null test per call-stack push and pop.
+- **`Options.Profiling.MaxEvents`** (default one million) caps a session. Reaching it stops recording, closes
+  whatever was open and sets `Truncated`; the event stream stays balanced and replayable either way — through
+  exceptions, through `ResetCallStack()`, and through a session stopped mid-call.
+- **A tail call is a close followed by an open**, since it replaces its caller's frame rather than nesting in
+  it. Unbounded tail recursion therefore profiles as a flat run of siblings, not as a bottomless tree.
+- **Some calls are elided**, and always in a way that keeps the tree coherent rather than merely incomplete —
+  the eliding call has no frame either, so anything it calls is still recorded at the depth the call stack
+  really has. Those are: trivial built-ins taken through the frameless fast-call lane (`Math.abs(1)` on a warm
+  call site), callbacks a built-in invokes per element (`arr.map(cb)` records `map`, not `cb`), and promise
+  reaction handlers (`p.then(cb)` records `then`, not `cb`).
+
+`StartProfiling()` throws `InvalidOperationException` when `Options.Profiling.Enabled` is false, which is the
+default — an engine running untrusted script can refuse profiling outright.
+
 ## Discussion
 
 Join the chat on [Gitter](https://gitter.im/sebastienros/jint) or post your questions with the `jint` tag on [stackoverflow](http://stackoverflow.com/questions/tagged/jint).


### PR DESCRIPTION
Part of #3089: opt-in evented script profiling with speedscope export — `options.Profiling.Enabled = true`, then `engine.Advanced.StartProfiling(name)` / `StopProfiling()` around any workload, and the returned `ScriptProfile` renders to https://www.speedscope.app's evented format (schema followed field for field from its published JSON schema) or is walked programmatically.

**The recorder hooks `JintCallStack` and nothing else.** That class is the only mutator of the interpreter's call stack, through exactly four operations — push, pop, replace-top (proper tail calls) and clear — so hooking those four gives open/close balance *by construction*, exceptions included: an unwinding throw pops through the same `finally`s a return does. Off-path cost is one field load + null test at push and at pop; no build-time gating, which is also what lets a session start on an already-warm engine. A proper tail call records close-of-displaced + open-of-target at one timestamp, so unbounded strict tail recursion profiles as a flat run of siblings rather than a bottomless tree — deliberately different from recursion-depth accounting, which is a budget, not a shape.

Frames are interned by `JintFunctionDefinition` (all closures of one source function are one frame) with names resolved without ever running script; `Complete()` drops the interning map so a retained profile holds only strings and numbers (GC-pinned). `MaxEvents` (default 1,000,000) bounds the buffer with a provable invariant — on overflow every open frame is closed at the cut instant and `Truncated` is set, so even a truncated profile exports a balanced document.

**Three call families are documented as not recorded**, each pinned by test: built-ins taken through the frameless leaf fast-call lane, per-element callbacks a built-in invokes (`[1,2].map(cb)` records `map`, not `cb`), and promise reaction handlers. All three keep the tree coherent rather than merely incomplete — the eliding call has no frame either, so callees land at their true call-stack depth. Recording them would add a test to per-element hot paths; left as a measured follow-up.

47 tests including mutation evidence on the tail-call record, truncation balance, mid-session start, and abandon-on-`ResetCallStack`; no timing-sensitive assertions. Both suites green on net10.0 and net472, with and without `JINT_HOST_CONTRACT_VERIFICATION=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G7Ud48VAs1JicxRZxLDxg
