### PR TITLE
Polish the web APIs: performance marks, console.table, navigator and Error.isError parity

### DIFF
--- a/Jint.Tests.PublicInterface/WebApiNavigatorTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiNavigatorTests.cs
@@ -1,0 +1,89 @@
+#if NET8_0_OR_GREATER
+using Jint;
+using Jint.Native;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// The <c>navigator</c> object seen from outside the assembly: what a host has to write to get it, and what
+/// it gets when it writes nothing.
+/// </summary>
+/// <remarks>
+/// The member exists because WinterTC's Minimum Common API requires
+/// <c>globalThis.navigator.userAgent</c> of a conforming runtime, so the pin that matters is that a script
+/// written against that requirement finds it — and that an engine which did not ask for it does not.
+/// </remarks>
+public class WebApiNavigatorTests
+{
+    [Fact]
+    public void ADefaultEngineHasNoNavigator()
+    {
+        var engine = new Engine();
+
+        engine.Evaluate("typeof navigator").AsString().Should().Be("undefined");
+        engine.Evaluate("'navigator' in globalThis").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void UseWebApisInstallsNavigator()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        engine.Evaluate("typeof navigator").AsString().Should().Be("object");
+        engine.Evaluate("typeof navigator.userAgent").AsString().Should().Be("string");
+
+        new Options().UseWebApis().WebApi.Features.Should().HaveFlag(WebApiFeatures.Navigator);
+    }
+
+    [Fact]
+    public void AskingForConsoleAloneDoesNotBringNavigator()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Console));
+
+        engine.Evaluate("typeof console").AsString().Should().Be("object");
+        engine.Evaluate("typeof navigator").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void ReportsJintAndItsVersion()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Navigator));
+
+        var version = typeof(Engine).Assembly.GetName().Version!;
+        engine.Evaluate("navigator.userAgent").AsString()
+            .Should().Be($"Jint/{version.Major}.{version.Minor}.{version.Build}");
+    }
+
+    [Fact]
+    public void AHostRegisteredNavigatorGlobalWins()
+    {
+        var marker = new JsString("the host's own navigator");
+
+        var engine = new Engine(options => options
+            .AddLazyGlobal("navigator", _ => marker)
+            .UseWebApis());
+
+        engine.Evaluate("navigator").Should().BeSameAs(marker);
+    }
+
+    [Fact]
+    public void IsAnEnumerableDataPropertyOfTheGlobal()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Navigator));
+
+        var descriptor = engine.Evaluate("Object.getOwnPropertyDescriptor(globalThis, 'navigator')").AsObject();
+        descriptor.Get("writable").AsBoolean().Should().BeTrue();
+        descriptor.Get("enumerable").AsBoolean().Should().BeTrue();
+        descriptor.Get("configurable").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void DoesNotReachIntoAShadowRealm()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        engine.Evaluate("new ShadowRealm().evaluate('typeof navigator')").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof navigator").AsString().Should().Be("object");
+    }
+}
+#endif

--- a/Jint.Tests.PublicInterface/WebApiPerformanceTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiPerformanceTests.cs
@@ -166,6 +166,53 @@ public class WebApiPerformanceTests
     }
 
     [Fact]
+    public void MarksAndMeasuresRunOnTheHostsClockToo()
+    {
+        var clock = new ManualClock();
+        var engine = new Engine(options => options.UseWebApis(webApi =>
+        {
+            webApi.Features = WebApiFeatures.Performance;
+            webApi.Timers.TimeProvider = clock;
+        }));
+
+        engine.Execute("performance.mark('start');");
+        clock.Advance(250);
+        engine.Execute("var m = performance.measure('work', 'start');");
+
+        // Everything a mark or a measure is stamped with comes from the same reading performance.now() gives,
+        // so a host that fakes the clock gets an exact duration instead of a tolerance.
+        engine.Evaluate("m.startTime").AsNumber().Should().Be(0);
+        engine.Evaluate("m.duration").AsNumber().Should().Be(250);
+        engine.Evaluate("performance.getEntriesByType('measure')[0] === m").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void TheEntryInterfacesAreReachableFromScript()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Performance));
+
+        engine.Evaluate("performance.mark('a') instanceof PerformanceMark").AsBoolean().Should().BeTrue();
+        engine.Evaluate("performance.measure('a', 'a') instanceof PerformanceEntry").AsBoolean().Should().BeTrue();
+
+        // No observer, so a library that feature-detects one takes its fallback path.
+        engine.Evaluate("typeof PerformanceObserver").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void TheTimelineIsBoundedSoALoopCannotGrowItForever()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Performance));
+
+        // A browser's mark buffer is unbounded because the page it belongs to eventually goes away; an
+        // embedded engine has no such event, so the buffer is capped and the overflow is dropped rather than
+        // thrown. mark() still answers with the entry it built.
+        engine.Execute("for (let i = 0; i < 10050; i++) { performance.mark('m'); }");
+
+        engine.Evaluate("performance.getEntries().length").AsNumber().Should().Be(10000);
+        engine.Evaluate("performance.mark('over') instanceof PerformanceMark").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
     public void OneOptionsInstanceGivesEachEngineItsOwnTimeOrigin()
     {
         var clock = new ManualClock();

--- a/Jint.Tests.PublicInterface/WebApiTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiTests.cs
@@ -168,5 +168,26 @@ public class WebApiTests
         exception.Get("code").AsNumber().Should().Be(20);
         engine.Evaluate("new DOMException('gone', 'AbortError') instanceof Error").AsBoolean().Should().BeTrue();
     }
+
+    [Fact]
+    public void ErrorIsErrorAnswersTrueForADomException()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        // WebIDL gives a DOMException the [[ErrorData]] internal slot that Error.isError brands on, so a
+        // library that routes errors through it treats a platform exception as the error it is.
+        engine.Evaluate("Error.isError(new DOMException())").AsBoolean().Should().BeTrue();
+
+        // ... and nothing else about the predicate moved: a prototype is not an instance and a look-alike is
+        // not an error.
+        engine.Evaluate("Error.isError(Error.prototype)").AsBoolean().Should().BeFalse();
+        engine.Evaluate("Error.isError(DOMException.prototype)").AsBoolean().Should().BeFalse();
+        engine.Evaluate("Error.isError({ name: 'AbortError' })").AsBoolean().Should().BeFalse();
+        engine.Evaluate("Error.isError(new Error())").AsBoolean().Should().BeTrue();
+
+        // A default engine has no DOMException at all, and the predicate is unchanged there.
+        new Engine().Evaluate("Error.isError(new Error()) && !Error.isError(Error.prototype) && !Error.isError({})")
+            .AsBoolean().Should().BeTrue();
+    }
 }
 #endif

--- a/Jint.Tests/Runtime/WebApi/ConsoleTests.cs
+++ b/Jint.Tests/Runtime/WebApi/ConsoleTests.cs
@@ -296,6 +296,185 @@ public class ConsoleTests
     }
 
     [Fact]
+    public void TablesAnArrayOfPrimitivesThroughTheValuesColumn()
+    {
+        Run("console.table(['a', 'b'])").Should().Equal(
+            """
+            +---------+--------+
+            | (index) | Values |
+            +---------+--------+
+            | 0       | 'a'    |
+            | 1       | 'b'    |
+            +---------+--------+
+            """.ReplaceLineEndings("\n"));
+    }
+
+    [Fact]
+    public void TablesAnArrayOfObjectsWithTheUnionOfTheirKeys()
+    {
+        // Columns are unioned across rows in first-seen order, and a row that lacks one renders an empty cell.
+        Run("console.table([{ a: 1, b: 2 }, { a: 3, c: 4 }])").Should().Equal(
+            """
+            +---------+---+---+---+
+            | (index) | a | b | c |
+            +---------+---+---+---+
+            | 0       | 1 | 2 |   |
+            | 1       | 3 |   | 4 |
+            +---------+---+---+---+
+            """.ReplaceLineEndings("\n"));
+    }
+
+    [Fact]
+    public void TablesAPlainObjectByItsKeys()
+    {
+        Run("console.table({ first: { n: 1 }, second: { n: 2 } })").Should().Equal(
+            """
+            +---------+---+
+            | (index) | n |
+            +---------+---+
+            | first   | 1 |
+            | second  | 2 |
+            +---------+---+
+            """.ReplaceLineEndings("\n"));
+    }
+
+    [Fact]
+    public void TheColumnsArgumentReplacesTheDerivedColumnSet()
+    {
+        Run("console.table([{ a: 1, b: 2 }], ['b'])").Should().Equal(
+            """
+            +---------+---+
+            | (index) | b |
+            +---------+---+
+            | 0       | 2 |
+            +---------+---+
+            """.ReplaceLineEndings("\n"));
+
+        // A named column no row has is still a column, with empty cells.
+        Run("console.table([{ a: 1 }], ['zzz'])").Should().Equal(
+            """
+            +---------+-----+
+            | (index) | zzz |
+            +---------+-----+
+            | 0       |     |
+            +---------+-----+
+            """.ReplaceLineEndings("\n"));
+    }
+
+    [Fact]
+    public void MixesObjectRowsAndPrimitiveRowsInOneTable()
+    {
+        Run("console.table([{ a: 1 }, 'plain'])").Should().Equal(
+            """
+            +---------+---+---------+
+            | (index) | a | Values  |
+            +---------+---+---------+
+            | 0       | 1 |         |
+            | 1       |   | 'plain' |
+            +---------+---+---------+
+            """.ReplaceLineEndings("\n"));
+    }
+
+    [Fact]
+    public void TableNeverInvokesAnAccessor()
+    {
+        // The same rule the rest of the formatter follows: a console must not be a way to run script.
+        Run("console.table([{ get x() { throw new Error('nope'); } }])").Should().Equal(
+            """
+            +---------+----------+
+            | (index) | x        |
+            +---------+----------+
+            | 0       | [Getter] |
+            +---------+----------+
+            """.ReplaceLineEndings("\n"));
+    }
+
+    [Fact]
+    public void TablesAnEmptyCollectionAsAnEmptyTable()
+    {
+        // An object with rows is tabular whether or not it has any, so this is a table and not the fallback.
+        var expected =
+            """
+            +---------+
+            | (index) |
+            +---------+
+            """.ReplaceLineEndings("\n");
+
+        Run("console.table([])").Should().Equal(expected);
+        Run("console.table({})").Should().Equal(expected);
+    }
+
+    [Fact]
+    public void TableFallsBackToLoggingWhatCannotBeParsedAsTabular()
+    {
+        // "Fall back to just logging the argument if it can't be parsed as tabular."
+        Run("console.table('hello')").Should().Equal("hello");
+        Run("console.table(42)").Should().Equal("42");
+        Run("console.table(null)").Should().Equal("null");
+        Run("console.table()").Should().Equal("undefined");
+        Run("console.table(function foo() {})").Should().Equal("function foo() { [native code] }");
+    }
+
+    [Fact]
+    public void TableEmitsExactlyOneRecordAtLogLevel()
+    {
+        var (engine, sink) = Recording();
+
+        engine.Execute("console.group('g'); console.table(['a']); console.groupEnd();");
+
+        sink.Records.Should().HaveCount(2);
+        sink.Records[1].Level.Should().Be(ConsoleLogLevel.Log);
+
+        // A table is a single record however many lines it occupies, so the group indents every one of them.
+        sink.Records[1].Message.Should().Be(
+            """
+              +---------+--------+
+              | (index) | Values |
+              +---------+--------+
+              | 0       | 'a'    |
+              +---------+--------+
+            """.ReplaceLineEndings("\n"));
+    }
+
+    [Fact]
+    public void TableBoundsTheRowsItRenders()
+    {
+        var messages = Run("console.table(Array.from({ length: 105 }, (_, i) => i))");
+
+        messages.Should().HaveCount(1);
+
+        // Three border lines, one header, one row per rendered entry, and the trailing note.
+        messages[0].Split('\n').Should().HaveCount(3 + 1 + 100 + 1);
+        messages[0].Should().Contain("| 99 ");
+        messages[0].Should().NotContain("| 100 ");
+        messages[0].Should().EndWith("... 5 more rows");
+    }
+
+    [Fact]
+    public void TheColumnsArgumentIsAWebIdlSequence()
+    {
+        // sequence<DOMString> is iterated with the iterator protocol and each element stringified, so a Set
+        // works and a non-iterable is a TypeError before anything is logged.
+        var (engine, sink) = Recording();
+        engine.Execute("console.table([{ 1: 'x' }], new Set([1]));");
+        sink.Messages[0].Should().Contain("| 'x' |");
+
+        var (other, otherSink) = Recording();
+        Assert.Throws<Jint.Runtime.JavaScriptException>(() => other.Execute("console.table([{a:1}], 5)"));
+        otherSink.Records.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TimeStampEmitsItsLabel()
+    {
+        // Not a Console Standard method — a browser drops a marker on a profiler timeline and prints nothing.
+        // There is no timeline here, so the marker is the record.
+        Run("console.timeStamp('checkpoint')").Should().Equal("checkpoint");
+        Run("console.timeStamp()").Should().Equal("default");
+        Run("console.timeStamp(7)").Should().Equal("7");
+    }
+
+    [Fact]
     public void IsIdentityStableAndTagged()
     {
         var engine = new Engine(options => options.UseWebApis());

--- a/Jint.Tests/Runtime/WebApi/DomExceptionTests.cs
+++ b/Jint.Tests/Runtime/WebApi/DomExceptionTests.cs
@@ -192,5 +192,38 @@ public class DomExceptionTests
         engine.Evaluate("DOMException.length").AsNumber().Should().Be(0);
         engine.Evaluate("DOMException.name").AsString().Should().Be("DOMException");
     }
+
+    [Fact]
+    public void CarriesTheErrorDataInternalSlot()
+    {
+        var engine = WebEngine();
+
+        // https://webidl.spec.whatwg.org/#internally-create-a-new-object-implementing-the-interface — "If
+        // interface is DOMException, append [[ErrorData]] to slots" — and
+        // https://tc39.es/ecma262/#sec-error.iserror is the brand check on exactly that slot.
+        engine.Evaluate("Error.isError(new DOMException())").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Error.isError(new DOMException('x', 'AbortError'))").AsBoolean().Should().BeTrue();
+
+        // Still an Error by every other measure it already was.
+        engine.Evaluate("new DOMException() instanceof Error").AsBoolean().Should().BeTrue();
+
+        // A prototype object is not an instance, whichever hierarchy it belongs to: %Error.prototype% is
+        // "an ordinary object … not an Error instance" per
+        // https://tc39.es/ecma262/#sec-properties-of-the-error-prototype-object, and DOMException.prototype is
+        // left ordinary here for the same reason.
+        engine.Evaluate("Error.isError(Error.prototype)").AsBoolean().Should().BeFalse();
+        engine.Evaluate("Error.isError(TypeError.prototype)").AsBoolean().Should().BeFalse();
+        engine.Evaluate("Error.isError(DOMException.prototype)").AsBoolean().Should().BeFalse();
+
+        // ... and neither is anything merely shaped like one.
+        engine.Evaluate("Error.isError({ name: 'AbortError', message: 'x' })").AsBoolean().Should().BeFalse();
+        engine.Evaluate("Error.isError(Object.create(DOMException.prototype))").AsBoolean().Should().BeFalse();
+        engine.Evaluate("Error.isError('AbortError')").AsBoolean().Should().BeFalse();
+
+        // The ECMAScript errors are unaffected.
+        engine.Evaluate("Error.isError(new Error())").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Error.isError(new TypeError())").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Error.isError(new AggregateError([]))").AsBoolean().Should().BeTrue();
+    }
 }
 #endif

--- a/Jint.Tests/Runtime/WebApi/NavigatorTests.cs
+++ b/Jint.Tests/Runtime/WebApi/NavigatorTests.cs
@@ -1,0 +1,130 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.Text.RegularExpressions;
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// The <c>navigator</c> object and its one member, which WinterTC's Minimum Common API
+/// (https://min-common-api.proposal.wintertc.org/) requires of a conforming runtime as
+/// <c>globalThis.navigator.userAgent</c>.
+/// </summary>
+public class NavigatorTests
+{
+    private static Engine NavigatorEngine(WebApiFeatures features = WebApiFeatures.Navigator)
+        => new(options => options.UseWebApis(features));
+
+    [Fact]
+    public void ReportsAJintProductToken()
+    {
+        var userAgent = NavigatorEngine().Evaluate("navigator.userAgent").AsString();
+
+        // RFC 7231's product = token ["/" product-version]. No comment component, so nothing about the host
+        // operating system or the embedding application leaks into it.
+        Regex.IsMatch(userAgent, @"^Jint/\d+\.\d+\.\d+$").Should().BeTrue(userAgent);
+
+        // The value the assembly actually carries, not a hard-coded one.
+        var version = typeof(Engine).Assembly.GetName().Version!;
+        userAgent.Should().Be($"Jint/{version.Major}.{version.Minor}.{version.Build}");
+    }
+
+    [Fact]
+    public void IsOneStableObjectWithTheInterfacesToStringTag()
+    {
+        var engine = NavigatorEngine();
+
+        engine.Evaluate("navigator === navigator").AsBoolean().Should().BeTrue();
+        engine.Evaluate("navigator === globalThis.navigator").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.prototype.toString.call(navigator)").AsString().Should().Be("[object Navigator]");
+        engine.Evaluate("navigator[Symbol.toStringTag]").AsString().Should().Be("Navigator");
+    }
+
+    [Fact]
+    public void ExposesUserAgentAsAReadOnlyAccessor()
+    {
+        var engine = NavigatorEngine();
+
+        // A WebIDL readonly attribute is an accessor with no setter, so a script cannot assign a different
+        // user agent and fool the next reader.
+        var descriptor = engine.Evaluate("Object.getOwnPropertyDescriptor(navigator, 'userAgent')").AsObject();
+        descriptor.Get("get").IsCallable.Should().BeTrue();
+        descriptor.Get("set").IsUndefined().Should().BeTrue();
+        descriptor.Get("configurable").AsBoolean().Should().BeTrue();
+        descriptor.Get("enumerable").AsBoolean().Should().BeFalse();
+
+        // Same observable answer a browser gives, where the attribute lives on Navigator.prototype.
+        engine.Evaluate("JSON.stringify(Object.keys(navigator))").AsString().Should().Be("[]");
+    }
+
+    [Fact]
+    public void BrandChecksItsReceiver()
+    {
+        var engine = NavigatorEngine();
+
+        Assert.Throws<JavaScriptException>(
+            () => engine.Evaluate("Object.getOwnPropertyDescriptor(navigator, 'userAgent').get.call({})"))
+            .Message.Should().Contain("Navigator");
+
+        engine.Evaluate("Object.getOwnPropertyDescriptor(navigator, 'userAgent').get.call(navigator)")
+            .AsString().Should().StartWith("Jint/");
+    }
+
+    [Fact]
+    public void CarriesNothingABrowsersNavigatorWouldLieAbout()
+    {
+        var engine = NavigatorEngine();
+
+        // Absent rather than faked: an embedded interpreter has no user, no document and no network stack, so
+        // feature detection should see that rather than a plausible-looking constant.
+        foreach (var member in new[] { "language", "languages", "onLine", "platform", "hardwareConcurrency", "clipboard", "geolocation", "storage", "locks" })
+        {
+            engine.Evaluate($"typeof navigator.{member}").AsString().Should().Be("undefined");
+        }
+
+        // There is no Navigator interface object either, which is the same simplification console, crypto and
+        // performance carry.
+        engine.Evaluate("typeof Navigator").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void IsAnEnumerableDataPropertyOfTheGlobal()
+    {
+        var engine = NavigatorEngine();
+
+        var descriptor = engine.Realm.GlobalObject.GetOwnProperty("navigator");
+        descriptor.Writable.Should().BeTrue();
+        descriptor.Enumerable.Should().BeTrue();
+        descriptor.Configurable.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsPartOfTheDefaultSetButNotOfAnyOtherFeature()
+    {
+        new Engine(options => options.UseWebApis()).Evaluate("typeof navigator.userAgent").AsString().Should().Be("string");
+        new Options().UseWebApis().WebApi.Features.Should().HaveFlag(WebApiFeatures.Navigator);
+
+        new Engine(options => options.UseWebApis(WebApiFeatures.Console))
+            .Evaluate("typeof navigator").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void KeepsTheBitReservedForFetch()
+    {
+        // The layout is a promise to hosts that persist a feature set: 1 << 10 stays free for fetch, so
+        // Navigator is 1 << 11 rather than the next unused bit.
+        ((int) WebApiFeatures.Navigator).Should().Be(1 << 11);
+        ((int) WebApiFeatures.Default & (1 << 10)).Should().Be(0);
+    }
+
+    [Fact]
+    public void DoesNotReachIntoAShadowRealm()
+    {
+        var engine = NavigatorEngine();
+
+        engine.Evaluate("new ShadowRealm().evaluate('typeof navigator')").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof navigator").AsString().Should().Be("object");
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/PerformanceTests.cs
+++ b/Jint.Tests/Runtime/WebApi/PerformanceTests.cs
@@ -244,16 +244,29 @@ public class PerformanceTests
     }
 
     [Fact]
-    public void HasNoPerformanceTimeline()
+    public void CarriesTheUserTimingSurface()
     {
         var (engine, _) = PerformanceEngine();
 
-        // Absent rather than present-and-throwing, so a library that feature-detects marks takes its
+        foreach (var member in new[] { "mark", "measure", "getEntries", "getEntriesByType", "getEntriesByName", "clearMarks", "clearMeasures" })
+        {
+            engine.Evaluate($"typeof performance.{member}").AsString().Should().Be("function");
+        }
+    }
+
+    [Fact]
+    public void HasNoObserverAndNoResourceTiming()
+    {
+        var (engine, _) = PerformanceEngine();
+
+        // Absent rather than present-and-throwing, so a library that feature-detects an observer takes its
         // fallback path instead of crashing.
-        foreach (var member in new[] { "mark", "measure", "getEntries", "getEntriesByName", "clearMarks", "toJSON" })
+        foreach (var member in new[] { "toJSON", "setResourceTimingBufferSize", "getEntriesByObserver", "eventCounts", "addEventListener" })
         {
             engine.Evaluate($"typeof performance.{member}").AsString().Should().Be("undefined");
         }
+
+        engine.Evaluate("typeof PerformanceObserver").AsString().Should().Be("undefined");
     }
 
     [Fact]

--- a/Jint.Tests/Runtime/WebApi/PerformanceTimelineTests.cs
+++ b/Jint.Tests/Runtime/WebApi/PerformanceTimelineTests.cs
@@ -1,0 +1,610 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// <c>performance.mark</c>, <c>performance.measure</c> and the performance timeline they feed — User Timing
+/// (https://w3c.github.io/user-timing/) on top of Performance Timeline
+/// (https://w3c.github.io/performance-timeline/).
+/// </summary>
+/// <remarks>
+/// Everything that involves a timestamp runs on a <see cref="ManualClock"/>, because the arithmetic is the
+/// point: with the clock in the test's hand "a measure from mark a to now lasts 250ms" is an equality rather
+/// than a tolerance.
+/// </remarks>
+public class PerformanceTimelineTests
+{
+    /// <summary>
+    /// A <see cref="TimeProvider"/> whose clock only moves when a test moves it.
+    /// </summary>
+    private sealed class ManualClock : TimeProvider
+    {
+        private long _timestamp;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp() => _timestamp;
+
+        public override DateTimeOffset GetUtcNow() => DateTimeOffset.UnixEpoch.AddTicks(_timestamp);
+
+        internal void Advance(int milliseconds) => _timestamp += milliseconds * TimeSpan.TicksPerMillisecond;
+    }
+
+    private static (Engine Engine, ManualClock Clock) TimelineEngine()
+    {
+        var clock = new ManualClock();
+        var provider = clock;
+        var engine = new Engine(options => options.UseWebApis(webApi =>
+        {
+            webApi.Features = WebApiFeatures.Performance;
+            webApi.Timers.TimeProvider = provider;
+        }));
+
+        return (engine, clock);
+    }
+
+    private static Engine Timeline() => TimelineEngine().Engine;
+
+    [Fact]
+    public void MarkRecordsAnEntryStampedWithTheCurrentTime()
+    {
+        var (engine, clock) = TimelineEngine();
+
+        clock.Advance(120);
+        engine.Execute("var entry = performance.mark('boot');");
+
+        engine.Evaluate("entry.name").AsString().Should().Be("boot");
+        engine.Evaluate("entry.entryType").AsString().Should().Be("mark");
+        engine.Evaluate("entry.startTime").AsNumber().Should().Be(120);
+
+        // https://w3c.github.io/user-timing/#dom-performancemark — "Set entry's duration attribute to 0."
+        engine.Evaluate("entry.duration").AsNumber().Should().Be(0);
+        engine.Evaluate("entry.detail").IsNull().Should().BeTrue();
+
+        engine.Evaluate("performance.getEntries().length").AsNumber().Should().Be(1);
+        engine.Evaluate("performance.getEntries()[0] === entry").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void MarkHonoursAnExplicitStartTimeAndRefusesANegativeOne()
+    {
+        var engine = Timeline();
+
+        engine.Evaluate("performance.mark('m', { startTime: 42.5 }).startTime").AsNumber().Should().Be(42.5);
+
+        // Step 5.2: "If markOptions's startTime is negative, throw a TypeError."
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("performance.mark('m', { startTime: -1 })"))
+            .Message.Should().Contain("negative");
+
+        // DOMHighResTimeStamp is a WebIDL `double`, not an `unrestricted double`, so a non-finite value is a
+        // TypeError at the conversion — https://webidl.spec.whatwg.org/#es-double.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("performance.mark('m', { startTime: NaN })"))
+            .Message.Should().Contain("finite");
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("performance.mark('m', { startTime: Infinity })"))
+            .Message.Should().Contain("finite");
+    }
+
+    [Fact]
+    public void MarkStructuredClonesItsDetail()
+    {
+        var engine = Timeline();
+
+        engine.Execute("""
+            var source = { nested: { n: 1 } };
+            var entry = performance.mark('m', { detail: source });
+            source.nested.n = 2;
+            """);
+
+        // "Run the StructuredSerialize algorithm … then run the StructuredDeserialize algorithm", so the
+        // entry holds a graph of its own that a later mutation cannot reach.
+        engine.Evaluate("entry.detail.nested.n").AsNumber().Should().Be(1);
+        engine.Evaluate("entry.detail === source").AsBoolean().Should().BeFalse();
+        engine.Evaluate("entry.detail.nested === source.nested").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void ADetailThatCannotBeClonedRaisesDataCloneError()
+    {
+        var engine = Timeline();
+
+        engine.Evaluate("""
+            (() => {
+                try { performance.mark('m', { detail: () => 1 }); return 'no throw'; }
+                catch (e) { return e.name + '/' + (e instanceof DOMException); }
+            })()
+            """).AsString().Should().Be("DataCloneError/true");
+    }
+
+    [Fact]
+    public void MeasureWithNoOptionsSpansFromTheTimeOriginToNow()
+    {
+        var (engine, clock) = TimelineEngine();
+
+        clock.Advance(300);
+        engine.Execute("var m = performance.measure('whole');");
+
+        // Step 2 falls through to now() and step 3 falls through to 0.
+        engine.Evaluate("m.entryType").AsString().Should().Be("measure");
+        engine.Evaluate("m.startTime").AsNumber().Should().Be(0);
+        engine.Evaluate("m.duration").AsNumber().Should().Be(300);
+        engine.Evaluate("m.detail").IsNull().Should().BeTrue();
+    }
+
+    [Fact]
+    public void MeasureFromAMarkNameToNowAndBetweenTwoMarks()
+    {
+        var (engine, clock) = TimelineEngine();
+
+        clock.Advance(100);
+        engine.Execute("performance.mark('a');");
+        clock.Advance(150);
+        engine.Execute("performance.mark('b');");
+        clock.Advance(50);
+
+        engine.Evaluate("performance.measure('to-now', 'a').startTime").AsNumber().Should().Be(100);
+        engine.Evaluate("performance.measure('to-now', 'a').duration").AsNumber().Should().Be(200);
+
+        var between = engine.Evaluate("performance.measure('a-to-b', 'a', 'b')").AsObject();
+        between.Get("startTime").AsNumber().Should().Be(100);
+        between.Get("duration").AsNumber().Should().Be(150);
+    }
+
+    [Fact]
+    public void MeasureReadsTheMostRecentMarkOfAName()
+    {
+        var (engine, clock) = TimelineEngine();
+
+        engine.Execute("performance.mark('a');");
+        clock.Advance(400);
+        engine.Execute("performance.mark('a');");
+
+        // "the most recent occurrence of a PerformanceMark object in the performance entry buffer whose name
+        // is mark".
+        engine.Evaluate("performance.measure('m', 'a').startTime").AsNumber().Should().Be(400);
+    }
+
+    [Fact]
+    public void MeasureCoversTheWholeOptionsMatrix()
+    {
+        var (engine, clock) = TimelineEngine();
+
+        clock.Advance(500);
+        engine.Execute("performance.mark('a');");
+
+        // start + end
+        var startEnd = engine.Evaluate("performance.measure('m', { start: 10, end: 60 })").AsObject();
+        startEnd.Get("startTime").AsNumber().Should().Be(10);
+        startEnd.Get("duration").AsNumber().Should().Be(50);
+
+        // start + duration
+        var startDuration = engine.Evaluate("performance.measure('m', { start: 10, duration: 25 })").AsObject();
+        startDuration.Get("startTime").AsNumber().Should().Be(10);
+        startDuration.Get("duration").AsNumber().Should().Be(25);
+
+        // duration + end
+        var durationEnd = engine.Evaluate("performance.measure('m', { duration: 25, end: 60 })").AsObject();
+        durationEnd.Get("startTime").AsNumber().Should().Be(35);
+        durationEnd.Get("duration").AsNumber().Should().Be(25);
+
+        // start alone: the end falls through to now()
+        var startOnly = engine.Evaluate("performance.measure('m', { start: 100 })").AsObject();
+        startOnly.Get("startTime").AsNumber().Should().Be(100);
+        startOnly.Get("duration").AsNumber().Should().Be(400);
+
+        // end alone: the start falls through to 0
+        var endOnly = engine.Evaluate("performance.measure('m', { end: 120 })").AsObject();
+        endOnly.Get("startTime").AsNumber().Should().Be(0);
+        endOnly.Get("duration").AsNumber().Should().Be(120);
+
+        // a mark name is accepted wherever a timestamp is
+        var byMark = engine.Evaluate("performance.measure('m', { start: 'a', end: 700 })").AsObject();
+        byMark.Get("startTime").AsNumber().Should().Be(500);
+        byMark.Get("duration").AsNumber().Should().Be(200);
+    }
+
+    [Fact]
+    public void MeasureClonesTheDetailFromTheOptions()
+    {
+        var engine = Timeline();
+
+        engine.Execute("""
+            var source = { k: 1 };
+            var m = performance.measure('m', { start: 0, detail: source });
+            source.k = 2;
+            """);
+
+        engine.Evaluate("m.detail.k").AsNumber().Should().Be(1);
+
+        // PerformanceMeasureOptions gives `detail` no IDL default, so an absent one is still null on the
+        // entry — that part is the algorithm's step 9, not the dictionary's.
+        engine.Evaluate("performance.measure('n', { start: 0 }).detail").IsNull().Should().BeTrue();
+    }
+
+    [Fact]
+    public void MeasureRejectsTheThreeContradictoryArgumentShapes()
+    {
+        var engine = Timeline();
+        engine.Execute("performance.mark('a');");
+
+        // "If endMark is given, throw a TypeError."
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("performance.measure('m', { start: 0 }, 'a')"))
+            .Message.Should().Contain("end mark");
+
+        // "If both start and end are omitted, throw a TypeError."
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("performance.measure('m', { duration: 5 })"))
+            .Message.Should().Contain("'start' and 'end'");
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("performance.measure('m', { detail: 1 })"))
+            .Message.Should().Contain("'start' and 'end'");
+
+        // "If start, duration and end all exist, throw a TypeError."
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("performance.measure('m', { start: 0, duration: 1, end: 2 })"))
+            .Message.Should().Contain("all three");
+    }
+
+    [Fact]
+    public void AnEmptyOptionsObjectIsNotAContradiction()
+    {
+        var (engine, clock) = TimelineEngine();
+
+        clock.Advance(90);
+
+        // Step 1 is gated on "at least one of start, end, duration and detail exists", so an options object
+        // with none of them behaves exactly like an omitted argument. So do null and undefined, which the
+        // union conversion also routes to the dictionary.
+        engine.Evaluate("performance.measure('m', {}).duration").AsNumber().Should().Be(90);
+        engine.Evaluate("performance.measure('m', undefined).duration").AsNumber().Should().Be(90);
+        engine.Evaluate("performance.measure('m', null).duration").AsNumber().Should().Be(90);
+    }
+
+    [Fact]
+    public void ANumberIsAMarkNameInThePositionalArgumentButATimestampInTheDictionary()
+    {
+        var (engine, clock) = TimelineEngine();
+
+        clock.Advance(700);
+        engine.Execute("performance.mark('5');");
+
+        // The positional argument is (DOMString or PerformanceMeasureOptions) — no numeric member — so 5 is
+        // stringified and looked up as a mark.
+        engine.Evaluate("performance.measure('m', 5).startTime").AsNumber().Should().Be(700);
+
+        // The dictionary's start is (DOMString or DOMHighResTimeStamp), so there 5 really is a timestamp.
+        engine.Evaluate("performance.measure('m', { start: 5 }).startTime").AsNumber().Should().Be(5);
+    }
+
+    [Fact]
+    public void AnUnknownMarkIsASyntaxErrorDomException()
+    {
+        var engine = Timeline();
+
+        // https://webidl.spec.whatwg.org/#syntaxerror — the WebIDL error name, so a DOMException and not the
+        // ECMAScript SyntaxError constructor.
+        engine.Evaluate("""
+            (() => {
+                try { performance.measure('m', 'nope'); return 'no throw'; }
+                catch (e) { return [e.name, e instanceof DOMException, e instanceof SyntaxError].join('/'); }
+            })()
+            """).AsString().Should().Be("SyntaxError/true/false");
+
+        engine.Evaluate("""
+            (() => {
+                try { performance.measure('m', { start: 0, end: 'nope' }); return 'no throw'; }
+                catch (e) { return e.name; }
+            })()
+            """).AsString().Should().Be("SyntaxError");
+    }
+
+    [Fact]
+    public void TheEndTimeIsResolvedBeforeTheStartTime()
+    {
+        var engine = Timeline();
+
+        // Both marks are missing; the algorithm computes the end time first, so it is the end that is named.
+        engine.Evaluate("""
+            (() => {
+                try { performance.measure('m', { start: 'missing-a', end: 'missing-b' }); return 'no throw'; }
+                catch (e) { return e.message; }
+            })()
+            """).AsString().Should().Contain("missing-b");
+    }
+
+    [Fact]
+    public void ANegativeTimestampIsATypeError()
+    {
+        var engine = Timeline();
+
+        // "If mark is negative, throw a TypeError" in convert a mark to a timestamp.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("performance.measure('m', { start: -1 })"))
+            .Message.Should().Contain("negative");
+    }
+
+    [Fact]
+    public void GetEntriesFiltersByNameAndByType()
+    {
+        var (engine, clock) = TimelineEngine();
+
+        engine.Execute("performance.mark('a');");
+        clock.Advance(10);
+        engine.Execute("performance.mark('b'); performance.measure('a', 'a');");
+
+        engine.Evaluate("performance.getEntries().length").AsNumber().Should().Be(3);
+        engine.Evaluate("performance.getEntriesByType('mark').map(e => e.name).join()").AsString().Should().Be("a,b");
+        engine.Evaluate("performance.getEntriesByType('measure').length").AsNumber().Should().Be(1);
+        engine.Evaluate("performance.getEntriesByType('resource').length").AsNumber().Should().Be(0);
+
+        // Name alone matches across types; adding the type narrows it.
+        engine.Evaluate("performance.getEntriesByName('a').map(e => e.entryType).join()").AsString().Should().Be("mark,measure");
+        engine.Evaluate("performance.getEntriesByName('a', 'measure').length").AsNumber().Should().Be(1);
+        engine.Evaluate("performance.getEntriesByName('nothing').length").AsNumber().Should().Be(0);
+
+        // A real, ordinary array of this realm.
+        engine.Evaluate("Array.isArray(performance.getEntries())").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void EntriesComeBackInChronologicalOrder()
+    {
+        var engine = Timeline();
+
+        // Added late but stamped early: "Sort results's entries in chronological order with respect to
+        // startTime" is what makes the answer come back in the other order.
+        engine.Execute("performance.mark('late', { startTime: 300 }); performance.mark('early', { startTime: 100 });");
+
+        engine.Evaluate("performance.getEntries().map(e => e.name).join()").AsString().Should().Be("early,late");
+    }
+
+    [Fact]
+    public void EntriesWithTheSameStartTimeKeepTheirBufferOrder()
+    {
+        var engine = Timeline();
+
+        engine.Execute("""
+            for (const n of ['a', 'b', 'c', 'd']) {
+                performance.mark(n, { startTime: 5 });
+            }
+            performance.mark('first', { startTime: 1 });
+            """);
+
+        engine.Evaluate("performance.getEntries().map(e => e.name).join()").AsString().Should().Be("first,a,b,c,d");
+    }
+
+    [Fact]
+    public void ClearMarksAndClearMeasuresRemoveOnlyTheirOwnKind()
+    {
+        var engine = Timeline();
+
+        engine.Execute("performance.mark('a'); performance.mark('b'); performance.measure('a', 'a');");
+
+        engine.Evaluate("performance.clearMarks('a')").IsUndefined().Should().BeTrue();
+        engine.Evaluate("performance.getEntries().map(e => e.entryType + ':' + e.name).join()")
+            .AsString().Should().Be("mark:b,measure:a");
+
+        engine.Execute("performance.clearMeasures();");
+        engine.Evaluate("performance.getEntries().map(e => e.name).join()").AsString().Should().Be("b");
+
+        engine.Execute("performance.clearMarks();");
+        engine.Evaluate("performance.getEntries().length").AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void AClearedMarkIsNoLongerAMeasureAnchor()
+    {
+        var engine = Timeline();
+
+        engine.Execute("performance.mark('a'); performance.clearMarks('a');");
+
+        engine.Evaluate("""
+            (() => { try { performance.measure('m', 'a'); return 'no throw'; } catch (e) { return e.name; } })()
+            """).AsString().Should().Be("SyntaxError");
+    }
+
+    [Fact]
+    public void TheBufferIsBoundedAndOverflowIsSilent()
+    {
+        var engine = Timeline();
+
+        // 10 000 is the documented cap; the 10 001st entry is built and returned but not buffered, which is
+        // exactly what a full buffer does in
+        // https://w3c.github.io/performance-timeline/#dfn-determine-if-a-performance-entry-buffer-is-full.
+        engine.Execute("for (let i = 0; i < 10001; i++) { performance.mark('m'); }");
+
+        engine.Evaluate("performance.getEntries().length").AsNumber().Should().Be(10000);
+        engine.Evaluate("performance.mark('overflow').name").AsString().Should().Be("overflow");
+        engine.Evaluate("performance.getEntriesByName('overflow').length").AsNumber().Should().Be(0);
+
+        // ... and clearing frees the room again.
+        engine.Execute("performance.clearMarks();");
+        engine.Evaluate("performance.mark('after').name").AsString().Should().Be("after");
+        engine.Evaluate("performance.getEntriesByName('after').length").AsNumber().Should().Be(1);
+    }
+
+    [Fact]
+    public void ConstructingAMarkDoesNotAddItToTheBuffer()
+    {
+        var (engine, clock) = TimelineEngine();
+
+        clock.Advance(80);
+
+        // https://w3c.github.io/user-timing/#dom-performance-mark is "run the constructor, THEN queue and add
+        // the entry", so `new` alone gives an object the timeline never hears about.
+        engine.Execute("var m = new PerformanceMark('solo', { detail: { a: 1 } });");
+
+        engine.Evaluate("m.name").AsString().Should().Be("solo");
+        engine.Evaluate("m.entryType").AsString().Should().Be("mark");
+        engine.Evaluate("m.startTime").AsNumber().Should().Be(80);
+        engine.Evaluate("m.detail.a").AsNumber().Should().Be(1);
+        engine.Evaluate("performance.getEntries().length").AsNumber().Should().Be(0);
+
+        // ... and it is invisible as a measure anchor, for the same reason.
+        engine.Evaluate("""
+            (() => { try { performance.measure('m', 'solo'); return 'no throw'; } catch (e) { return e.name; } })()
+            """).AsString().Should().Be("SyntaxError");
+    }
+
+    [Fact]
+    public void OnlyPerformanceMarkIsConstructible()
+    {
+        var engine = Timeline();
+
+        // Neither of the other two interfaces declares a constructor operation, so their interface objects
+        // exist and are functions but refuse to construct — https://webidl.spec.whatwg.org/#es-interface-call.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new PerformanceEntry()"))
+            .Message.Should().Be("Illegal constructor");
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new PerformanceMeasure()"))
+            .Message.Should().Be("Illegal constructor");
+
+        engine.Evaluate("new PerformanceMark('x') instanceof PerformanceMark").AsBoolean().Should().BeTrue();
+        engine.Evaluate("class Sub extends PerformanceMark {}; new Sub('x') instanceof Sub").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void TheInterfaceHierarchyIsTheOneWebIdlDescribes()
+    {
+        var engine = Timeline();
+
+        engine.Evaluate("Object.getPrototypeOf(PerformanceMark) === PerformanceEntry").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.getPrototypeOf(PerformanceMeasure) === PerformanceEntry").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.getPrototypeOf(PerformanceMark.prototype) === PerformanceEntry.prototype").AsBoolean().Should().BeTrue();
+
+        engine.Execute("var mark = performance.mark('a'); var measure = performance.measure('a', 'a');");
+        engine.Evaluate("mark instanceof PerformanceMark && mark instanceof PerformanceEntry").AsBoolean().Should().BeTrue();
+        engine.Evaluate("measure instanceof PerformanceMeasure && measure instanceof PerformanceEntry").AsBoolean().Should().BeTrue();
+        engine.Evaluate("mark instanceof PerformanceMeasure").AsBoolean().Should().BeFalse();
+
+        engine.Evaluate("Object.prototype.toString.call(mark)").AsString().Should().Be("[object PerformanceMark]");
+        engine.Evaluate("Object.prototype.toString.call(measure)").AsString().Should().Be("[object PerformanceMeasure]");
+        engine.Evaluate("Object.prototype.toString.call(PerformanceEntry.prototype)").AsString().Should().Be("[object PerformanceEntry]");
+    }
+
+    [Fact]
+    public void TheAttributesLiveOnThePrototypeAndBrandCheckTheirReceiver()
+    {
+        var engine = Timeline();
+        engine.Execute("var mark = performance.mark('a'); var measure = performance.measure('a', 'a');");
+
+        // WebIDL attributes: accessors on the interface prototype, so the instance owns nothing.
+        engine.Evaluate("JSON.stringify(Object.getOwnPropertyNames(mark))").AsString().Should().Be("[]");
+
+        var descriptor = engine.Evaluate("Object.getOwnPropertyDescriptor(PerformanceEntry.prototype, 'startTime')").AsObject();
+        descriptor.Get("get").IsCallable.Should().BeTrue();
+        descriptor.Get("set").IsUndefined().Should().BeTrue();
+        descriptor.Get("enumerable").AsBoolean().Should().BeTrue();
+        descriptor.Get("configurable").AsBoolean().Should().BeTrue();
+
+        foreach (var member in new[] { "name", "entryType", "startTime", "duration" })
+        {
+            Assert.Throws<JavaScriptException>(
+                () => engine.Evaluate($"Object.getOwnPropertyDescriptor(PerformanceEntry.prototype, '{member}').get.call({{}})"))
+                .Message.Should().Contain("PerformanceEntry");
+        }
+
+        // detail is declared on each derived interface, so each brand-checks for its own.
+        Assert.Throws<JavaScriptException>(
+            () => engine.Evaluate("Object.getOwnPropertyDescriptor(PerformanceMark.prototype, 'detail').get.call(measure)"))
+            .Message.Should().Contain("PerformanceMark");
+        Assert.Throws<JavaScriptException>(
+            () => engine.Evaluate("Object.getOwnPropertyDescriptor(PerformanceMeasure.prototype, 'detail').get.call(mark)"))
+            .Message.Should().Contain("PerformanceMeasure");
+    }
+
+    [Fact]
+    public void ToJsonCarriesTheFourInheritedAttributesAndNotTheDetail()
+    {
+        var engine = Timeline();
+
+        engine.Execute("var m = performance.mark('a', { startTime: 7, detail: { hidden: true } });");
+
+        // The [Default] toJSON is declared on PerformanceEntry, and the default steps collect only the
+        // declaring interface's own attributes — and only those of a JSON type, which `any` is not.
+        engine.Evaluate("JSON.stringify(m.toJSON())").AsString()
+            .Should().Be("""{"name":"a","entryType":"mark","startTime":7,"duration":0}""");
+
+        engine.Evaluate("JSON.stringify(m)").AsString()
+            .Should().Be("""{"name":"a","entryType":"mark","startTime":7,"duration":0}""");
+    }
+
+    [Fact]
+    public void HasTheIdlArity()
+    {
+        var engine = Timeline();
+
+        engine.Evaluate("performance.mark.length").AsNumber().Should().Be(1);
+        engine.Evaluate("performance.measure.length").AsNumber().Should().Be(1);
+        engine.Evaluate("performance.getEntries.length").AsNumber().Should().Be(0);
+        engine.Evaluate("performance.getEntriesByType.length").AsNumber().Should().Be(1);
+        engine.Evaluate("performance.getEntriesByName.length").AsNumber().Should().Be(1);
+        engine.Evaluate("performance.clearMarks.length").AsNumber().Should().Be(0);
+        engine.Evaluate("performance.clearMeasures.length").AsNumber().Should().Be(0);
+        engine.Evaluate("PerformanceMark.length").AsNumber().Should().Be(1);
+    }
+
+    [Fact]
+    public void EveryMemberBrandChecksItsReceiver()
+    {
+        var engine = Timeline();
+
+        foreach (var member in new[] { "mark", "measure", "getEntries", "getEntriesByType", "getEntriesByName", "clearMarks", "clearMeasures" })
+        {
+            Assert.Throws<JavaScriptException>(() => engine.Evaluate($"performance.{member}.call({{}}, 'x')"))
+                .Message.Should().Contain("Performance");
+        }
+    }
+
+    [Fact]
+    public void TheEntryInterfacesAreInstalledOnlyBehindThePerformanceFlag()
+    {
+        var engine = Timeline();
+
+        foreach (var name in new[] { "PerformanceEntry", "PerformanceMark", "PerformanceMeasure" })
+        {
+            engine.Evaluate($"typeof {name}").AsString().Should().Be("function");
+
+            // Interface objects: writable and configurable, but not enumerable.
+            var descriptor = engine.Realm.GlobalObject.GetOwnProperty(name);
+            descriptor.Enumerable.Should().BeFalse();
+            descriptor.Writable.Should().BeTrue();
+            descriptor.Configurable.Should().BeTrue();
+
+            new Engine(options => options.UseWebApis(WebApiFeatures.Console))
+                .Evaluate($"typeof {name}").AsString().Should().Be("undefined");
+
+            engine.Evaluate($"new ShadowRealm().evaluate('typeof {name}')").AsString().Should().Be("undefined");
+        }
+    }
+
+    [Fact]
+    public void TheBufferBelongsToTheEngineAndSurvivesAGlobalSnapshotRestore()
+    {
+        var engine = Timeline();
+
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+        engine.Execute("performance.mark('before');");
+
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        // A restore reverts the global binding table and explicitly not the object graphs behind the restored
+        // bindings, and the entry buffer is one of those. A pooled host that wants a clean timeline clears it.
+        engine.Evaluate("performance.getEntries().length").AsNumber().Should().Be(1);
+        engine.Execute("performance.clearMarks();");
+        engine.Evaluate("performance.getEntries().length").AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void TwoEnginesFromOneOptionsInstanceHaveSeparateTimelines()
+    {
+        var options = new Options().UseWebApis(WebApiFeatures.Performance);
+
+        var first = new Engine(options);
+        var second = new Engine(options);
+
+        first.Execute("performance.mark('a'); performance.mark('b');");
+        second.Execute("performance.mark('c');");
+
+        first.Evaluate("performance.getEntries().map(e => e.name).join()").AsString().Should().Be("a,b");
+        second.Evaluate("performance.getEntries().map(e => e.name).join()").AsString().Should().Be("c");
+    }
+}
+#endif

--- a/Jint/Native/Error/ErrorConstructor.cs
+++ b/Jint/Native/Error/ErrorConstructor.cs
@@ -94,8 +94,16 @@ public sealed partial class ErrorConstructor : Constructor
     }
 
     /// <summary>
-    /// https://tc39.es/proposal-is-error/
+    /// https://tc39.es/ecma262/#sec-error.iserror — "If arg is not an Object, return false. If arg does not
+    /// have an [[ErrorData]] internal slot, return false. Return true."
     /// </summary>
+    /// <remarks>
+    /// <see cref="JsError"/> is tested first and by its sealed exact type, which is a single cheap check and
+    /// answers every ECMAScript error; the <see cref="IErrorData"/> arm behind it is what a platform object
+    /// carrying the slot is recognized by — a <c>DOMException</c>, which
+    /// https://webidl.spec.whatwg.org/#internally-create-a-new-object-implementing-the-interface gives
+    /// <c>[[ErrorData]]</c> ("If interface is DOMException, append [[ErrorData]] to slots").
+    /// </remarks>
     [JsFunction]
-    private static JsValue IsError(JsValue thisObject, JsValue arg) => arg is JsError;
+    private static JsValue IsError(JsValue thisObject, JsValue arg) => arg is JsError or IErrorData;
 }

--- a/Jint/Native/Error/ErrorInstance.cs
+++ b/Jint/Native/Error/ErrorInstance.cs
@@ -10,6 +10,29 @@ namespace Jint.Native.Error;
 /// </summary>
 internal sealed record ClrErrorContext(Type? ResolutionType, string? ResolutionMemberName, Exception? ClrException);
 
+/// <summary>
+/// Marks an object that carries the specification's <c>[[ErrorData]]</c> internal slot, which is the brand
+/// <c>Error.isError</c> tests — https://tc39.es/ecma262/#sec-error.iserror.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The slot is <b>not</b> a property of <see cref="ErrorInstance"/>: <c>%Error.prototype%</c> and every
+/// <c>%NativeError.prototype%</c> derive from it and must answer <see langword="false"/>, because
+/// https://tc39.es/ecma262/#sec-properties-of-the-error-prototype-object says such a prototype "is an
+/// ordinary object" and "is not an Error instance and does not have an [[ErrorData]] internal slot". So the
+/// slot is asserted by exactly the types that have it, one of which — <see cref="JsError"/> — is sealed and
+/// cannot simply be widened to cover the other.
+/// </para>
+/// <para>
+/// A marker interface rather than an <c>InternalTypes</c> bit: <c>InternalTypes</c> says of itself that "no
+/// int flag bits remain" — <c>FastCallGuard</c> already borrows the two above its top — and the only consumer
+/// is <c>Error.isError</c>, which is on no hot path and would not repay a bit even if one were free. The
+/// check keeps <see cref="JsError"/>'s sealed exact-type test first, so the interface-map scan is reached
+/// only by the rare error object that is not a <see cref="JsError"/>.
+/// </para>
+/// </remarks>
+internal interface IErrorData;
+
 public class ErrorInstance : ObjectInstance
 {
     private protected ErrorInstance(Engine engine, ObjectClass objectClass)

--- a/Jint/Native/JsError.cs
+++ b/Jint/Native/JsError.cs
@@ -6,7 +6,7 @@ using Jint.Runtime.Descriptors;
 
 namespace Jint.Native;
 
-public sealed class JsError : ErrorInstance
+public sealed class JsError : ErrorInstance, IErrorData
 {
     /// <summary>
     /// The rendered implementation-defined stack trace string, materialized on first read from

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -342,9 +342,12 @@ public enum WebApiFeatures
     Crypto = 1 << 5,
 
     /// <summary>
-    /// The <c>performance</c> object: <c>now()</c> and <c>timeOrigin</c>. Both read the clock in
-    /// <see cref="Options.TimerOptions.TimeProvider"/>, so a fake one drives them and the timers together.
-    /// Marks, measures and the performance timeline are not implemented.
+    /// The <c>performance</c> object — <c>now()</c>, <c>timeOrigin</c>, and the User Timing surface
+    /// (<c>mark</c>, <c>measure</c>, <c>getEntries</c> and friends) with the <c>PerformanceEntry</c>,
+    /// <c>PerformanceMark</c> and <c>PerformanceMeasure</c> interface objects behind it. Every reading comes
+    /// from the clock in <see cref="Options.TimerOptions.TimeProvider"/>, so a fake one drives them and the
+    /// timers together. There is no <c>PerformanceObserver</c>, and the entry buffer is bounded rather than
+    /// unbounded — see <c>PerformanceInstance</c>.
     /// </summary>
     Performance = 1 << 6,
 
@@ -391,12 +394,20 @@ public enum WebApiFeatures
     Fetch = 1 << 10,
 
     /// <summary>
+    /// The <c>navigator</c> object, whose single member is <c>userAgent</c> — the one thing WinterTC's
+    /// Minimum Common API (https://min-common-api.proposal.wintertc.org/) requires of it and the one a script
+    /// identifies a runtime by. Everything else a browser's <c>Navigator</c> carries describes a user agent
+    /// with a user, a document and a network stack, so it is absent rather than faked.
+    /// </summary>
+    Navigator = 1 << 11,
+
+    /// <summary>
     /// The web APIs a host normally wants: everything except outbound network access. Today that is
     /// <see cref="Console"/>, <see cref="Timers"/>, <see cref="Encoding"/>, <see cref="Base64"/>,
     /// <see cref="StructuredClone"/>, <see cref="Crypto"/>, <see cref="Performance"/>, <see cref="Events"/>,
-    /// <see cref="Url"/> and <see cref="Files"/>; it grows as further features land, and never comes to
-    /// include fetch.
+    /// <see cref="Url"/>, <see cref="Files"/> and <see cref="Navigator"/>; it grows as further features land,
+    /// and never comes to include fetch.
     /// </summary>
-    Default = Console | Timers | Encoding | Base64 | StructuredClone | Crypto | Performance | Events | Url | Files,
+    Default = Console | Timers | Encoding | Base64 | StructuredClone | Crypto | Performance | Events | Url | Files | Navigator,
 }
 #endif

--- a/Jint/Runtime/Intrinsics.WebApi.cs
+++ b/Jint/Runtime/Intrinsics.WebApi.cs
@@ -8,6 +8,7 @@ using Jint.WebApi.Encoding;
 using Jint.WebApi.Events;
 using Jint.WebApi.Fetch;
 using Jint.WebApi.Files;
+using Jint.WebApi.Navigator;
 using Jint.WebApi.StructuredClone;
 using Jint.WebApi.Performance;
 using Jint.WebApi.Timers;
@@ -40,6 +41,10 @@ public sealed partial class Intrinsics
     private CryptoInstance? _crypto;
     private SubtleCryptoInstance? _subtleCrypto;
     private PerformanceInstance? _performance;
+    private PerformanceEntryConstructor? _performanceEntry;
+    private PerformanceMarkConstructor? _performanceMark;
+    private PerformanceMeasureConstructor? _performanceMeasure;
+    private NavigatorInstance? _navigator;
 
     internal DomExceptionConstructor DomException =>
         _domException ??= new DomExceptionConstructor(_engine, _realm, Function.PrototypeObject, Error.PrototypeObject);
@@ -153,5 +158,24 @@ public sealed partial class Intrinsics
     /// </summary>
     internal PerformanceInstance Performance =>
         _performance ??= PerformanceInstance.Create(_engine, _realm, Object.PrototypeObject);
+
+    internal PerformanceEntryConstructor PerformanceEntry =>
+        _performanceEntry ??= new PerformanceEntryConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
+
+    /// <summary>
+    /// <c>PerformanceMark</c> inherits from <c>PerformanceEntry</c>, so reaching it builds
+    /// <c>PerformanceEntry</c> too — which is what makes
+    /// <c>Object.getPrototypeOf(PerformanceMark) === PerformanceEntry</c> hold however the two were first
+    /// touched.
+    /// </summary>
+    internal PerformanceMarkConstructor PerformanceMark =>
+        _performanceMark ??= new PerformanceMarkConstructor(_engine, _realm, PerformanceEntry);
+
+    /// <summary><c>PerformanceMeasure</c> inherits from <c>PerformanceEntry</c>.</summary>
+    internal PerformanceMeasureConstructor PerformanceMeasure =>
+        _performanceMeasure ??= new PerformanceMeasureConstructor(_engine, _realm, PerformanceEntry);
+
+    internal NavigatorInstance Navigator =>
+        _navigator ??= new NavigatorInstance(_engine, _realm, Object.PrototypeObject);
 }
 #endif

--- a/Jint/WebApi/Console/ConsoleFormatter.cs
+++ b/Jint/WebApi/Console/ConsoleFormatter.cs
@@ -81,6 +81,312 @@ internal static class ConsoleFormatter
         return builder.ToString();
     }
 
+    /// <summary>
+    /// <c>console.table</c>'s renderer: "Try to construct a table with the columns of the properties of
+    /// tabularData (or use properties) and rows of tabularData", https://console.spec.whatwg.org/#table.
+    /// </summary>
+    /// <param name="tabularData">The value to tabulate.</param>
+    /// <param name="properties">
+    /// The <c>properties</c> argument, already converted from its WebIDL <c>sequence&lt;DOMString&gt;</c>, or
+    /// <see langword="null"/> when it was not given. When given it is the column set outright, in its own
+    /// order, and a name it lists that a row does not have simply renders an empty cell.
+    /// </param>
+    /// <param name="text">The rendered table, when there is one.</param>
+    /// <returns>
+    /// Whether the value could be parsed as tabular. <see langword="false"/> is the standard's "fall back to
+    /// just logging the argument", which is the caller's job.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// The standard's whole normative text for this method is the sentence quoted above, followed by "TODO:
+    /// This will need a good algorithm." So the shape below is an interpretation, and it is the one every
+    /// implementation converged on: one row per own enumerable property of <paramref name="tabularData"/>,
+    /// keyed in an <c>(index)</c> column; one column per own enumerable property of the row <i>values</i> that
+    /// are objects, unioned across rows in first-seen order; and a <c>Values</c> column for the rows whose
+    /// value is not an object, which is what makes <c>console.table(['a', 'b'])</c> show anything at all.
+    /// </para>
+    /// <para>
+    /// The drawing is deliberately plain ASCII rather than the box-drawing characters a terminal-oriented
+    /// implementation uses: a <see cref="ConsoleSink"/> may be a log file, a structured logger or a test
+    /// assertion, and none of those is a UTF-8 terminal by assumption.
+    /// </para>
+    /// <para>
+    /// It inherits the rest of this class's discipline: no script-visible getter is ever invoked (an accessor
+    /// cell reads <c>[Getter]</c>), cells are rendered by <see cref="Inspect(JsValue)"/> and so are
+    /// depth-capped and cycle-safe, and both the row and the column count are bounded by
+    /// <see cref="MaxEntries"/> with the remainder reported on a trailing line. A console that can be made to
+    /// emit a gigabyte because a script built a large array is a liability, and a table is the easiest way to
+    /// ask for one.
+    /// </para>
+    /// </remarks>
+    internal static bool TryFormatTable(JsValue tabularData, List<string>? properties, out string text)
+    {
+        // "if it can't be parsed as tabular": a primitive has no rows, and a function is an object whose own
+        // properties (`length`, `name`) are not a table anybody wanted.
+        if (tabularData is not ObjectInstance data || data is Native.Function.Function)
+        {
+            text = string.Empty;
+            return false;
+        }
+
+        var rowKeys = new List<string>();
+        var rowValues = new List<PropertyDescriptor>();
+        var droppedRows = CollectRows(data, rowKeys, rowValues);
+
+        var columns = new List<string>();
+        var droppedColumns = CollectColumns(rowValues, properties, columns, out var needsValuesColumn);
+
+        text = Draw(rowKeys, rowValues, columns, needsValuesColumn, droppedRows, droppedColumns);
+        return true;
+    }
+
+    /// <summary>
+    /// One row per own enumerable string-keyed property, in own-key order — which for an array is its
+    /// indices, since <c>length</c> is not enumerable.
+    /// </summary>
+    /// <returns>How many rows were dropped for exceeding <see cref="MaxEntries"/>.</returns>
+    private static int CollectRows(ObjectInstance data, List<string> rowKeys, List<PropertyDescriptor> rowValues)
+    {
+        var dropped = 0;
+        var keys = data.GetOwnPropertyKeys(Types.String);
+
+        for (var i = 0; i < keys.Count; i++)
+        {
+            var descriptor = data.GetOwnProperty(keys[i]);
+            if (ReferenceEquals(descriptor, PropertyDescriptor.Undefined) || !descriptor.Enumerable)
+            {
+                continue;
+            }
+
+            if (rowKeys.Count >= MaxEntries)
+            {
+                dropped++;
+                continue;
+            }
+
+            rowKeys.Add(keys[i].ToString());
+            rowValues.Add(descriptor);
+        }
+
+        return dropped;
+    }
+
+    /// <summary>
+    /// The column set: the caller's <paramref name="properties"/> when it gave one, otherwise the union of
+    /// every object row's own enumerable keys in first-seen order.
+    /// </summary>
+    /// <returns>How many columns were dropped for exceeding <see cref="MaxEntries"/>.</returns>
+    private static int CollectColumns(
+        List<PropertyDescriptor> rowValues,
+        List<string>? properties,
+        List<string> columns,
+        out bool needsValuesColumn)
+    {
+        var dropped = 0;
+        needsValuesColumn = false;
+
+        if (properties is not null)
+        {
+            for (var i = 0; i < properties.Count; i++)
+            {
+                dropped += AddColumn(columns, properties[i]);
+            }
+        }
+
+        for (var i = 0; i < rowValues.Count; i++)
+        {
+            var row = RowObject(rowValues[i]);
+            if (row is null)
+            {
+                // A primitive, a function, or an accessor whose getter must not run: it has no columns of its
+                // own and belongs in the Values column.
+                needsValuesColumn = true;
+                continue;
+            }
+
+            if (properties is not null)
+            {
+                continue;
+            }
+
+            var keys = row.GetOwnPropertyKeys(Types.String);
+            for (var k = 0; k < keys.Count; k++)
+            {
+                var descriptor = row.GetOwnProperty(keys[k]);
+                if (ReferenceEquals(descriptor, PropertyDescriptor.Undefined) || !descriptor.Enumerable)
+                {
+                    continue;
+                }
+
+                dropped += AddColumn(columns, keys[k].ToString());
+            }
+        }
+
+        return dropped;
+    }
+
+    private static int AddColumn(List<string> columns, string name)
+    {
+        if (columns.Contains(name))
+        {
+            return 0;
+        }
+
+        if (columns.Count >= MaxEntries)
+        {
+            return 1;
+        }
+
+        columns.Add(name);
+        return 0;
+    }
+
+    /// <summary>
+    /// The object whose properties become this row's cells, or <see langword="null"/> when the row has no
+    /// such object and so belongs in the <c>Values</c> column.
+    /// </summary>
+    private static ObjectInstance? RowObject(PropertyDescriptor descriptor)
+    {
+        if (descriptor.IsAccessorDescriptor())
+        {
+            return null;
+        }
+
+        return descriptor.Value is ObjectInstance obj && obj is not Native.Function.Function ? obj : null;
+    }
+
+    private static string Draw(
+        List<string> rowKeys,
+        List<PropertyDescriptor> rowValues,
+        List<string> columns,
+        bool needsValuesColumn,
+        int droppedRows,
+        int droppedColumns)
+    {
+        var width = columns.Count + (needsValuesColumn ? 2 : 1);
+
+        var header = new string[width];
+        header[0] = "(index)";
+        for (var i = 0; i < columns.Count; i++)
+        {
+            header[i + 1] = columns[i];
+        }
+
+        if (needsValuesColumn)
+        {
+            header[width - 1] = "Values";
+        }
+
+        var rows = new List<string[]>(rowKeys.Count);
+        for (var r = 0; r < rowKeys.Count; r++)
+        {
+            var cells = new string[width];
+            cells[0] = rowKeys[r];
+
+            var row = RowObject(rowValues[r]);
+            for (var c = 0; c < columns.Count; c++)
+            {
+                cells[c + 1] = row is null ? string.Empty : Cell(row, columns[c]);
+            }
+
+            if (needsValuesColumn)
+            {
+                cells[width - 1] = row is null ? DescriptorText(rowValues[r]) : string.Empty;
+            }
+
+            rows.Add(cells);
+        }
+
+        var widths = new int[width];
+        for (var c = 0; c < width; c++)
+        {
+            var max = header[c].Length;
+            for (var r = 0; r < rows.Count; r++)
+            {
+                max = System.Math.Max(max, rows[r][c].Length);
+            }
+
+            widths[c] = max;
+        }
+
+        var builder = new StringBuilder();
+        AppendBorder(builder, widths);
+        AppendRow(builder, header, widths);
+        AppendBorder(builder, widths);
+
+        // With no rows the separator just drawn IS the closing border; drawing another would put two
+        // identical lines under the header for what is simply an empty table.
+        for (var r = 0; r < rows.Count; r++)
+        {
+            AppendRow(builder, rows[r], widths);
+        }
+
+        if (rows.Count > 0)
+        {
+            AppendBorder(builder, widths);
+        }
+
+        if (droppedRows > 0)
+        {
+            builder.Append('\n').Append("... ").Append(droppedRows.ToString(CultureInfo.InvariantCulture)).Append(" more rows");
+        }
+
+        if (droppedColumns > 0)
+        {
+            builder.Append('\n').Append("... ").Append(droppedColumns.ToString(CultureInfo.InvariantCulture)).Append(" more columns");
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// One cell of an object row. A name the row does not own renders empty, which is what makes a ragged
+    /// array of objects tabulate at all.
+    /// </summary>
+    /// <remarks>
+    /// Enumerability is not re-checked here: an auto-derived column is enumerable by construction, and a
+    /// column the caller named explicitly is shown even when the property behind it is not enumerable,
+    /// because asking for it by name is the whole point of the argument.
+    /// </remarks>
+    private static string Cell(ObjectInstance row, string column)
+    {
+        var descriptor = row.GetOwnProperty(JsString.Create(column));
+        return ReferenceEquals(descriptor, PropertyDescriptor.Undefined) ? string.Empty : DescriptorText(descriptor);
+    }
+
+    private static string DescriptorText(PropertyDescriptor descriptor)
+    {
+        var builder = new StringBuilder();
+        AppendDescriptorValue(builder, descriptor, depth: 0, seen: new List<ObjectInstance>());
+        return builder.ToString();
+    }
+
+    private static void AppendBorder(StringBuilder builder, int[] widths)
+    {
+        if (builder.Length > 0)
+        {
+            builder.Append('\n');
+        }
+
+        for (var c = 0; c < widths.Length; c++)
+        {
+            builder.Append('+').Append('-', widths[c] + 2);
+        }
+
+        builder.Append('+');
+    }
+
+    private static void AppendRow(StringBuilder builder, string[] cells, int[] widths)
+    {
+        builder.Append('\n');
+        for (var c = 0; c < cells.Length; c++)
+        {
+            builder.Append("| ").Append(cells[c]).Append(' ', widths[c] - cells[c].Length + 1);
+        }
+
+        builder.Append('|');
+    }
+
     private static void AppendWithSpecifiers(StringBuilder builder, string target, ReadOnlySpan<JsValue> data, ref int next)
     {
         for (var i = 0; i < target.Length; i++)

--- a/Jint/WebApi/Console/ConsoleInstance.cs
+++ b/Jint/WebApi/Console/ConsoleInstance.cs
@@ -36,8 +36,8 @@ namespace Jint.WebApi.Console;
 /// property attributes.
 /// </para>
 /// <para>
-/// Not implemented: <c>table</c>, <c>dirxml</c>, <c>timeStamp</c>, <c>profile</c> and <c>profileEnd</c>,
-/// none of which has behaviour a string sink can carry.
+/// Not implemented: <c>clear</c>, <c>dirxml</c>, <c>profile</c> and <c>profileEnd</c>, none of which acts on
+/// anything a string sink has.
 /// </para>
 /// </remarks>
 [JsObject]
@@ -188,6 +188,58 @@ internal sealed partial class ConsoleInstance : BuiltinShapeObject
     {
         // `options` is part of the IDL signature and has no member a string sink could honour.
         Emit(ConsoleLogLevel.Log, ConsoleFormatter.Inspect(item));
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://console.spec.whatwg.org/#table — "Try to construct a table with the columns of the properties
+    /// of tabularData (or use properties) and rows of tabularData and log it with a logLevel of 'log'. Fall
+    /// back to just logging the argument if it can't be parsed as tabular."
+    /// </summary>
+    /// <remarks>
+    /// That sentence, followed by "TODO: This will need a good algorithm", is the entire normative text; the
+    /// table itself is drawn by <see cref="ConsoleFormatter.TryFormatTable"/>, whose documentation states the
+    /// interpretation. Either way it is one <see cref="ConsoleSink.Write(ConsoleLogLevel, string)"/> call at
+    /// <see cref="ConsoleLogLevel.Log"/> — a table is a single record however many lines it occupies, and
+    /// group indentation applies to all of them.
+    /// </remarks>
+    [JsFunction(Name = "table", Length = 0)]
+    private JsValue Table(JsValue thisObject, JsValue tabularData, JsValue properties)
+    {
+        // The sequence conversion runs first and can raise a TypeError, exactly as WebIDL specifies, so a
+        // non-iterable second argument fails before anything is logged.
+        var columns = ReadProperties(properties);
+
+        if (ConsoleFormatter.TryFormatTable(tabularData, columns, out var table))
+        {
+            Emit(ConsoleLogLevel.Log, table);
+            return Undefined;
+        }
+
+        Emit(ConsoleLogLevel.Log, ConsoleFormatter.Format(new[] { tabularData }));
+        return Undefined;
+    }
+
+    /// <summary>
+    /// <c>console.timeStamp(label)</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Not part of the Console Standard.</b> https://console.spec.whatwg.org/ specifies <c>time</c>,
+    /// <c>timeLog</c> and <c>timeEnd</c> and nothing else about timing; <c>timeStamp</c> is a de-facto member
+    /// every browser and Node exposes, where it drops a marker onto a profiler's timeline and prints nothing.
+    /// There is no timeline here, so the only thing a string sink can do with the marker is emit it, which is
+    /// also the only behaviour a script can verify.
+    /// </para>
+    /// <para>
+    /// The label defaults to <c>"default"</c>, which is the IDL default every labelled method in the standard
+    /// carries and therefore the least surprising choice for one that has no IDL.
+    /// </para>
+    /// </remarks>
+    [JsFunction(Name = "timeStamp", Length = 0)]
+    private JsValue TimeStamp(JsValue thisObject, JsValue label)
+    {
+        Emit(ConsoleLogLevel.Log, Label(label));
         return Undefined;
     }
 
@@ -398,6 +450,39 @@ internal sealed partial class ConsoleInstance : BuiltinShapeObject
     private static string Label(JsValue label)
     {
         return label.IsUndefined() ? DefaultLabel : TypeConverter.ToString(label);
+    }
+
+    /// <summary>
+    /// The <c>sequence&lt;DOMString&gt;</c> conversion of <c>table</c>'s second argument,
+    /// https://webidl.spec.whatwg.org/#es-sequence: the value is iterated with the iterator protocol and each
+    /// element is stringified. The argument is optional with no default value, so an omitted or explicitly
+    /// <see langword="undefined"/> one is <see langword="null"/> — "not given" — rather than an empty column
+    /// list, which would render a table with no columns at all.
+    /// </summary>
+    private List<string>? ReadProperties(JsValue properties)
+    {
+        if (properties.IsUndefined())
+        {
+            return null;
+        }
+
+        var result = new List<string>();
+        var iterator = properties.GetIterator(_realm);
+
+        try
+        {
+            while (iterator.TryIteratorStepValue(out var value))
+            {
+                result.Add(TypeConverter.ToString(value));
+            }
+        }
+        catch
+        {
+            iterator.CloseIfNotDone(CompletionType.Throw);
+            throw;
+        }
+
+        return result;
     }
 
     private static string FormatDuration(long startTimestamp)

--- a/Jint/WebApi/DomException/JsDomException.cs
+++ b/Jint/WebApi/DomException/JsDomException.cs
@@ -21,13 +21,26 @@ namespace Jint.WebApi.DomException;
 /// </para>
 /// <para>
 /// It derives from <see cref="ErrorInstance"/> for the <c>[[ErrorData]]</c>-shaped behaviour a host expects
-/// of an error object — notably <see cref="object.ToString"/> rendering as <c>name: message</c>. It is not a
-/// <see cref="JsError"/>, which is sealed, so <c>Error.isError(domException)</c> answers <see langword="false"/>
-/// where a browser answers <see langword="true"/>; the prototype chain, <c>instanceof Error</c> and
-/// <c>stack</c> all behave as they should.
+/// of an error object — notably <see cref="object.ToString"/> rendering as <c>name: message</c> — and it
+/// asserts the slot itself through <see cref="IErrorData"/>, because
+/// https://webidl.spec.whatwg.org/#internally-create-a-new-object-implementing-the-interface says "If
+/// interface is DOMException, append [[ErrorData]] to slots". So <c>Error.isError(new DOMException())</c>
+/// answers <see langword="true"/>, as it does in a browser, and the prototype chain,
+/// <c>instanceof Error</c> and <c>stack</c> all behave as they should.
+/// </para>
+/// <para>
+/// One deliberate divergence, in the direction of ECMAScript rather than WebIDL:
+/// https://webidl.spec.whatwg.org/#js-DOMException-specialness also gives the <i>interface prototype
+/// object</i> <c>[[ErrorData]]</c> and <c>[[Stack]]</c> slots, "like all built-in exceptions". Every
+/// ECMAScript built-in exception prototype is in fact an ordinary object that "is not an Error instance and
+/// does not have an [[ErrorData]] internal slot"
+/// (https://tc39.es/ecma262/#sec-properties-of-the-nativeerror-prototype-objects), so the analogy argues the
+/// other way; <c>DOMException.prototype</c> is left an ordinary object here and
+/// <c>Error.isError(DOMException.prototype)</c> answers <see langword="false"/>, the same as
+/// <c>Error.isError(Error.prototype)</c>.
 /// </para>
 /// </remarks>
-internal sealed class JsDomException : ErrorInstance
+internal sealed class JsDomException : ErrorInstance, IErrorData
 {
     internal JsDomException(Engine engine, JsString name, JsString message)
         : base(engine, ObjectClass.Error)

--- a/Jint/WebApi/Navigator/NavigatorInstance.cs
+++ b/Jint/WebApi/Navigator/NavigatorInstance.cs
@@ -1,0 +1,105 @@
+#if NET8_0_OR_GREATER
+using System.Globalization;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Navigator;
+
+/// <summary>
+/// The <c>navigator</c> object.
+/// <para>
+/// https://html.spec.whatwg.org/multipage/system-state.html#navigator
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// It exists for exactly one member. WinterTC's Minimum Common API
+/// (https://min-common-api.proposal.wintertc.org/) requires a conforming runtime to expose
+/// <c>globalThis.navigator.userAgent</c>, and a great deal of published JavaScript feature-detects a runtime
+/// through it; everything else the HTML Standard hangs off <c>Navigator</c> — <c>language</c>,
+/// <c>onLine</c>, <c>hardwareConcurrency</c>, <c>clipboard</c>, <c>geolocation</c> — describes a user agent
+/// with a user, a document and a network stack, none of which an embedded interpreter has. Those members are
+/// <b>absent</b> rather than present-and-lying, so feature detection sees the truth.
+/// </para>
+/// <para>
+/// The value is <c>Jint/&lt;version&gt;</c>. WinterTC asks for a value conforming to RFC 7231's
+/// <c>User-Agent</c> construction and recommends "the value be limited to a single <c>product</c> token
+/// excluding the optional <c>product-version</c>"; the version is kept anyway, because a
+/// <c>product "/" product-version</c> pair is exactly what RFC 7231 defines a product token to be and because
+/// a bare <c>"Jint"</c> tells a script nothing it can branch on. It carries no <c>comment</c> component, which
+/// is the part of that recommendation that matters — nothing here reveals the host operating system or the
+/// embedding application. Read it as WinterTC says to: "a single, complete, opaque, unstructured value".
+/// </para>
+/// <para>
+/// Two documented simplifications against WebIDL, the same pair <c>console</c>, <c>crypto</c> and
+/// <c>performance</c> carry. There is no <c>Navigator</c> interface object and no <c>Navigator.prototype</c>,
+/// so <c>userAgent</c> is an own accessor of this object rather than one on an interface prototype — it still
+/// brand-checks its receiver, and <c>Object.keys(navigator)</c> answers the empty array here exactly as it
+/// does in a browser. And the object is installed as an ordinary enumerable data property of the global
+/// rather than through the <c>[Replaceable]</c> accessor pair WebIDL gives it.
+/// </para>
+/// </remarks>
+[JsObject]
+internal sealed partial class NavigatorInstance : BuiltinShapeObject
+{
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString NavigatorToStringTag = new("Navigator");
+
+    /// <summary>
+    /// The user agent string, built once for the process: the assembly version cannot change while it is
+    /// loaded, so every engine and every realm hands out this one <see cref="JsString"/>.
+    /// </summary>
+    private static readonly JsString UserAgent = new("Jint/" + ProductVersion());
+
+    private readonly Realm _realm;
+
+    internal NavigatorInstance(Engine engine, Realm realm, ObjectPrototype objectPrototype) : base(engine)
+    {
+        _realm = realm;
+        _prototype = objectPrototype;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-useragent — the
+    /// <c>NavigatorID</c> mixin's <c>userAgent</c> attribute, which is where WinterTC's
+    /// <c>globalThis.navigator.userAgent</c> requirement lands.
+    /// </summary>
+    [JsAccessor("userAgent")]
+    private JsString UserAgentGet(JsValue thisObject)
+    {
+        if (thisObject is not NavigatorInstance)
+        {
+            Throw.TypeError(_realm, "Failed to read the 'userAgent' property from 'Navigator': illegal invocation, receiver is not a Navigator object.");
+        }
+
+        return UserAgent;
+    }
+
+    /// <summary>
+    /// The <c>product-version</c> half of the token: Jint's own assembly version, as
+    /// <c>major.minor.patch</c>. The fourth component is dropped because Jint never sets one, and the whole
+    /// thing degrades to <c>"0.0.0"</c> rather than throwing if the assembly somehow carries no version.
+    /// </summary>
+    private static string ProductVersion()
+    {
+        var version = typeof(Engine).Assembly.GetName().Version;
+        if (version is null)
+        {
+            return "0.0.0";
+        }
+
+        var build = version.Build < 0 ? 0 : version.Build;
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"{version.Major}.{version.Minor}.{build}");
+    }
+}
+#endif

--- a/Jint/WebApi/Performance/JsPerformanceEntry.cs
+++ b/Jint/WebApi/Performance/JsPerformanceEntry.cs
@@ -1,0 +1,113 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+
+namespace Jint.WebApi.Performance;
+
+/// <summary>
+/// A <c>PerformanceEntry</c> instance — one metric on the performance timeline.
+/// <para>
+/// https://w3c.github.io/performance-timeline/#dom-performanceentry
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every IDL attribute of <c>PerformanceEntry</c> is read-only, so the whole state lives in CLR fields here
+/// and <see cref="PerformanceEntryPrototype"/> reads it through a brand check, exactly as <c>Event</c> and
+/// <c>DOMException</c> do. An instance therefore has no own property at all, which is what a browser reports
+/// for <c>Object.getOwnPropertyNames(performance.mark('x'))</c>.
+/// </para>
+/// <para>
+/// The class is abstract because the specification never creates a bare <c>PerformanceEntry</c>: the
+/// interface has no constructor operation and every entry is of some registered entry type. The two Jint
+/// implements are <see cref="JsPerformanceMark"/> and <see cref="JsPerformanceMeasure"/>, and each is a CLR
+/// type of its own precisely so the <c>detail</c> getter on either prototype can brand-check for its own
+/// interface rather than for "an entry that happens to carry a detail".
+/// </para>
+/// <para>
+/// Two attributes of the current IDL are deliberately absent rather than faked: <c>id</c>, and
+/// <c>navigationId</c>, which names the document navigation an entry belongs to and so has no meaning where
+/// there is no document.
+/// </para>
+/// </remarks>
+internal abstract class JsPerformanceEntry : ObjectInstance
+{
+    private protected JsPerformanceEntry(Engine engine, JsString name, double startTime, double duration, JsValue detail)
+        : base(engine, ObjectClass.Object)
+    {
+        EntryName = name;
+        StartTime = startTime;
+        Duration = duration;
+        Detail = detail;
+    }
+
+    /// <summary>https://w3c.github.io/performance-timeline/#dom-performanceentry-name.</summary>
+    internal JsString EntryName { get; }
+
+    /// <summary>
+    /// https://w3c.github.io/performance-timeline/#dom-performanceentry-entrytype — <c>"mark"</c> or
+    /// <c>"measure"</c>, the two entry types https://w3c.github.io/timing-entrytypes-registry/ defines for a
+    /// runtime with no document to navigate.
+    /// </summary>
+    internal abstract JsString EntryType { get; }
+
+    /// <summary>https://w3c.github.io/performance-timeline/#dom-performanceentry-starttime.</summary>
+    internal double StartTime { get; }
+
+    /// <summary>https://w3c.github.io/performance-timeline/#dom-performanceentry-duration.</summary>
+    internal double Duration { get; }
+
+    /// <summary>
+    /// The already-cloned <c>detail</c>, or <c>null</c>. It is an attribute of <c>PerformanceMark</c> and
+    /// <c>PerformanceMeasure</c> rather than of <c>PerformanceEntry</c>, but both carry one and the storage is
+    /// identical, so it lives here and the brand check that guards it lives on each prototype.
+    /// </summary>
+    internal JsValue Detail { get; }
+}
+
+/// <summary>
+/// A <c>PerformanceMark</c> instance.
+/// <para>
+/// https://w3c.github.io/user-timing/#dom-performancemark
+/// </para>
+/// </summary>
+internal sealed class JsPerformanceMark : JsPerformanceEntry
+{
+    /// <summary>The one <c>entryType</c> string every mark shares.</summary>
+    internal static readonly JsString MarkEntryType = new("mark");
+
+    internal JsPerformanceMark(Engine engine, JsString name, double startTime, JsValue detail)
+        : base(engine, name, startTime, duration: 0, detail)
+    {
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/user-timing/#dom-performancemark — "Set entry's entryType attribute to
+    /// DOMString 'mark'".
+    /// </summary>
+    internal override JsString EntryType => MarkEntryType;
+}
+
+/// <summary>
+/// A <c>PerformanceMeasure</c> instance.
+/// <para>
+/// https://w3c.github.io/user-timing/#dom-performancemeasure
+/// </para>
+/// </summary>
+internal sealed class JsPerformanceMeasure : JsPerformanceEntry
+{
+    /// <summary>The one <c>entryType</c> string every measure shares.</summary>
+    internal static readonly JsString MeasureEntryType = new("measure");
+
+    internal JsPerformanceMeasure(Engine engine, JsString name, double startTime, double duration, JsValue detail)
+        : base(engine, name, startTime, duration, detail)
+    {
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/user-timing/#dom-performancemeasure — "Set entry's entryType attribute to
+    /// DOMString 'measure'".
+    /// </summary>
+    internal override JsString EntryType => MeasureEntryType;
+}
+#endif

--- a/Jint/WebApi/Performance/PerformanceEntryConstructor.cs
+++ b/Jint/WebApi/Performance/PerformanceEntryConstructor.cs
@@ -1,0 +1,50 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Performance;
+
+/// <summary>
+/// The <c>PerformanceEntry</c> interface object.
+/// <para>
+/// https://w3c.github.io/performance-timeline/#dom-performanceentry
+/// </para>
+/// </summary>
+/// <remarks>
+/// The interface declares no constructor operation, which in WebIDL means the interface object exists and is
+/// a function but refuses to construct anything — https://webidl.spec.whatwg.org/#es-interface-call. It is
+/// exposed all the same, because it is the object <c>entry instanceof PerformanceEntry</c> resolves against
+/// and the holder of every attribute a mark and a measure share.
+/// </remarks>
+internal sealed class PerformanceEntryConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("PerformanceEntry");
+
+    internal PerformanceEntryConstructor(
+        Engine engine,
+        Realm realm,
+        FunctionPrototype functionPrototype,
+        ObjectPrototype objectPrototype)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = functionPrototype;
+        PrototypeObject = new PerformanceEntryPrototype(engine, realm, this, objectPrototype);
+        _length = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal PerformanceEntryPrototype PrototypeObject { get; }
+
+    /// <summary>
+    /// An interface without a constructor operation is not constructible.
+    /// </summary>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        Throw.TypeError(_realm, "Illegal constructor");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Performance/PerformanceEntryPrototype.cs
+++ b/Jint/WebApi/Performance/PerformanceEntryPrototype.cs
@@ -1,0 +1,126 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Performance;
+
+/// <summary>
+/// <c>PerformanceEntry.prototype</c> — the interface prototype object.
+/// <para>
+/// https://w3c.github.io/performance-timeline/#dom-performanceentry
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// The four attributes are accessors here rather than own properties of the instance, as WebIDL specifies
+/// attributes; each brand-checks its receiver and raises a <c>TypeError</c> for anything that is not a
+/// performance entry — including <c>PerformanceEntry.prototype</c> itself, which is not one.
+/// </para>
+/// <para>
+/// <c>toJSON</c> is declared <c>[Default]</c> in the IDL, so its behaviour is
+/// https://webidl.spec.whatwg.org/#default-tojson-steps run for <c>PerformanceEntry</c>: the inheritance
+/// stack it collects from is this interface alone, and only attributes with a <i>JSON type</i> are collected.
+/// Both rules point the same way for <c>detail</c>, which is declared on the two derived interfaces and is of
+/// type <c>any</c> — so it is <b>not</b> part of the result, and a script that wants it reads
+/// <c>entry.detail</c>.
+/// </para>
+/// <para>
+/// One documented simplification against WebIDL: the operation is non-enumerable, where a WebIDL interface
+/// prototype object's operations are enumerable. That is how every built-in Jint has ever shipped declares
+/// its prototype methods, and it is observable only to code inspecting property attributes.
+/// </para>
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class PerformanceEntryPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly PerformanceEntryConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString PerformanceEntryToStringTag = new("PerformanceEntry");
+
+    /// <summary>
+    /// The shape of what <c>toJSON</c> answers, declared once so every result object in an engine shares one
+    /// hidden class and a loop reading <c>.duration</c> off them keeps a monomorphic inline cache. The order
+    /// is the declaration order of the IDL attributes, which is the order the default <c>toJSON</c> steps
+    /// collect them in.
+    /// </summary>
+    private static readonly JsObjectLayout _jsonLayout = JsObjectLayout.CreateBuilder()
+        .Add("name")
+        .Add("entryType")
+        .Add("startTime")
+        .Add("duration")
+        .Build();
+
+    internal PerformanceEntryPrototype(
+        Engine engine,
+        Realm realm,
+        PerformanceEntryConstructor constructor,
+        ObjectInstance objectPrototype) : base(engine, realm)
+    {
+        _prototype = objectPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/performance-timeline/#dom-performanceentry-name
+    /// </summary>
+    [JsAccessor("name", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsString NameGet(JsValue thisObject) => Brand(thisObject).EntryName;
+
+    /// <summary>
+    /// https://w3c.github.io/performance-timeline/#dom-performanceentry-entrytype
+    /// </summary>
+    [JsAccessor("entryType", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsString EntryTypeGet(JsValue thisObject) => Brand(thisObject).EntryType;
+
+    /// <summary>
+    /// https://w3c.github.io/performance-timeline/#dom-performanceentry-starttime
+    /// </summary>
+    [JsAccessor("startTime", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsNumber StartTimeGet(JsValue thisObject) => JsNumber.Create(Brand(thisObject).StartTime);
+
+    /// <summary>
+    /// https://w3c.github.io/performance-timeline/#dom-performanceentry-duration
+    /// </summary>
+    [JsAccessor("duration", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsNumber DurationGet(JsValue thisObject) => JsNumber.Create(Brand(thisObject).Duration);
+
+    /// <summary>
+    /// https://w3c.github.io/performance-timeline/#dom-performanceentry-tojson — the default <c>toJSON</c>
+    /// steps, https://webidl.spec.whatwg.org/#default-tojson-steps.
+    /// </summary>
+    [JsFunction(Name = "toJSON", Length = 0)]
+    private JsObject ToJson(JsValue thisObject)
+    {
+        var entry = Brand(thisObject);
+        return JsObject.Create(
+            _engine,
+            _jsonLayout,
+            [entry.EntryName, entry.EntryType, JsNumber.Create(entry.StartTime), JsNumber.Create(entry.Duration)]);
+    }
+
+    /// <summary>
+    /// The WebIDL brand check every member performs: a receiver that is not a platform object implementing
+    /// the interface raises a <c>TypeError</c>.
+    /// </summary>
+    private JsPerformanceEntry Brand(JsValue thisObject)
+    {
+        if (thisObject is JsPerformanceEntry entry)
+        {
+            return entry;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a PerformanceEntry");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Performance/PerformanceInstance.cs
+++ b/Jint/WebApi/Performance/PerformanceInstance.cs
@@ -3,6 +3,7 @@ using Jint.Native;
 using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
+using Jint.WebApi.DomException;
 
 namespace Jint.WebApi.Performance;
 
@@ -14,12 +15,13 @@ namespace Jint.WebApi.Performance;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Both members are answered from <c>Options.WebApi.Timers.TimeProvider</c>, the very clock the timers are
-/// scheduled against, so a host that installs a fake one drives <c>setTimeout</c> and <c>performance.now()</c>
-/// coherently instead of watching one of them stand still while the other runs. <see cref="TimeOriginGet"/>
-/// and <see cref="Now"/> are the two halves of one reading: the origin is the wall-clock moment the engine's
-/// web-API state was created, and <c>now()</c> is the monotonic duration since that same moment, so
-/// <c>performance.timeOrigin + performance.now()</c> is the current time in Unix milliseconds.
+/// <c>now()</c> and <c>timeOrigin</c> are answered from <c>Options.WebApi.Timers.TimeProvider</c>, the very
+/// clock the timers are scheduled against, so a host that installs a fake one drives <c>setTimeout</c> and
+/// <c>performance.now()</c> coherently instead of watching one of them stand still while the other runs.
+/// <see cref="TimeOriginGet"/> and <see cref="Now"/> are the two halves of one reading: the origin is the
+/// wall-clock moment the engine's web-API state was created, and <c>now()</c> is the monotonic duration since
+/// that same moment, so <c>performance.timeOrigin + performance.now()</c> is the current time in Unix
+/// milliseconds. Every timestamp a mark or a measure carries comes from the same reading.
 /// </para>
 /// <para>
 /// <b>The time origin is per engine, not per evaluation cycle.</b> A pooled engine that a host recycles with
@@ -27,21 +29,27 @@ namespace Jint.WebApi.Performance;
 /// growing across cycles and a script cannot use it to tell how long <i>its own</i> cycle has been running.
 /// That is deliberate: the origin is what makes the readings monotonic, and rewinding it at a restore would
 /// hand the next cycle a clock that had gone backwards — which is the one thing
-/// https://w3c.github.io/hr-time/#dom-performance-now forbids outright.
+/// https://w3c.github.io/hr-time/#dom-performance-now forbids outright. The entry buffer survives a restore
+/// for the plainer reason that a restore reverts the global <i>binding table</i> and explicitly not the object
+/// graphs behind the restored bindings; a pooled host that wants a clean timeline calls <c>clearMarks()</c>
+/// and <c>clearMeasures()</c>, which is what a browser gives it too.
 /// </para>
 /// <para>
-/// Not implemented, and absent rather than throwing so that feature detection sees the truth: the
-/// <c>Performance Timeline</c> surface (<c>mark</c>, <c>measure</c>, <c>getEntries*</c>, <c>clearMarks</c>),
-/// <c>toJSON</c>, and the <c>EventTarget</c> this interface inherits from.
+/// Not implemented, and absent rather than throwing so that feature detection sees the truth:
+/// <c>PerformanceObserver</c> and everything that reports to one, <c>toJSON</c>,
+/// <c>setResourceTimingBufferSize</c> and the resource-timing surface, and the <c>EventTarget</c> this
+/// interface inherits from.
 /// </para>
 /// <para>
 /// Two documented simplifications against WebIDL, the same pair <c>console</c> and <c>crypto</c> carry. There
-/// is no <c>Performance</c> interface object and no <c>Performance.prototype</c>, so <c>now</c> and
-/// <c>timeOrigin</c> are own properties of this object with the attributes an ECMAScript built-in has, rather
-/// than those of a WebIDL interface prototype's members; both still brand-check their receiver, and
+/// is no <c>Performance</c> interface object and no <c>Performance.prototype</c>, so the members are own
+/// properties of this object with the attributes an ECMAScript built-in has, rather than those of a WebIDL
+/// interface prototype's members; they all still brand-check their receiver, and
 /// <c>Object.keys(performance)</c> answers the empty array here exactly as it does in a browser. And the
 /// object is installed as an ordinary enumerable data property of the global rather than through the
-/// <c>[Replaceable]</c> accessor pair WebIDL gives it.
+/// <c>[Replaceable]</c> accessor pair WebIDL gives it. The <i>entries</i> are not simplified in that way:
+/// <c>PerformanceEntry</c>, <c>PerformanceMark</c> and <c>PerformanceMeasure</c> are real interface objects
+/// with real prototypes, because a script holds those objects and hands them around.
 /// </para>
 /// <para>
 /// One deliberate divergence: the readings are <b>not coarsened</b>. https://w3c.github.io/hr-time/#dfn-coarsen-time
@@ -54,11 +62,44 @@ namespace Jint.WebApi.Performance;
 [JsObject]
 internal sealed partial class PerformanceInstance : BuiltinShapeObject
 {
+    /// <summary>
+    /// How many entries the timeline holds before it starts dropping them.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// https://w3c.github.io/timing-entrytypes-registry/ gives both <c>mark</c> and <c>measure</c> a
+    /// <c>maxBufferSize</c> of <i>Infinite</i>, which a browser can afford because a page's timeline dies with
+    /// the page. An engine embedded in a long-lived host has no such event, and
+    /// <c>while (true) performance.mark('x')</c> would otherwise be an unbounded memory leak that no execution
+    /// constraint describes — a statement budget counts statements and a memory limit watches the JavaScript
+    /// heap, neither of which is where this list lives. So the buffer is finite, and the overflow behaviour is
+    /// the specification's own: https://w3c.github.io/performance-timeline/#dfn-determine-if-a-performance-entry-buffer-is-full
+    /// says of a full buffer "Increase tuple's dropped entries count by 1. Return true", and the entry is
+    /// simply not added. Nothing throws — <c>mark()</c> and <c>measure()</c> still return the entry they
+    /// built, exactly as they do for a buffer with room, so the only observable effect is that
+    /// <c>getEntries()</c> stops growing. The count is shared by marks and measures because the memory is;
+    /// <c>clearMarks()</c> and <c>clearMeasures()</c> free it again.
+    /// </para>
+    /// <para>
+    /// The dropped-entries count itself is not exposed, because the only thing that reads it in the
+    /// specification is a <c>PerformanceObserver</c> callback's <c>droppedEntriesCount</c>, and there is no
+    /// <c>PerformanceObserver</c> here.
+    /// </para>
+    /// </remarks>
+    private const int MaxBufferedEntries = 10_000;
+
     [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
     private static readonly JsString PerformanceToStringTag = new("Performance");
 
     private readonly Realm _realm;
     private readonly WebApiEngineState _state;
+
+    /// <summary>
+    /// The performance entry buffer, https://w3c.github.io/performance-timeline/#performance-entry-buffer,
+    /// in the order the entries were added. Null until the first entry, so a script that only reads
+    /// <c>now()</c> allocates nothing.
+    /// </summary>
+    private List<JsPerformanceEntry>? _entries;
 
     private PerformanceInstance(Engine engine, Realm realm, ObjectPrototype objectPrototype, WebApiEngineState state)
         : base(engine)
@@ -70,14 +111,7 @@ internal sealed partial class PerformanceInstance : BuiltinShapeObject
 
     internal static PerformanceInstance Create(Engine engine, Realm realm, ObjectPrototype objectPrototype)
     {
-        var state = engine._webApi;
-        if (state is null)
-        {
-            // Unreachable: the global that reaches this property is installed only where the state was
-            // created, in the same block of WebApiRegistration.
-            Throw.InvalidOperationException("The performance object was reached on an engine that has no web-API state.");
-        }
-
+        var state = UserTiming.RequireState(engine, "The performance object");
         return new PerformanceInstance(engine, realm, objectPrototype, state);
     }
 
@@ -108,6 +142,388 @@ internal sealed partial class PerformanceInstance : BuiltinShapeObject
     {
         Brand(thisObject, "Failed to read the 'timeOrigin' property from 'Performance'");
         return JsNumber.Create(_state.TimeOrigin);
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/user-timing/#dom-performance-mark — run the <c>PerformanceMark</c> constructor,
+    /// queue the entry, add it to the performance entry buffer, and return it.
+    /// </summary>
+    /// <remarks>
+    /// "Queue a PerformanceEntry" (https://w3c.github.io/performance-timeline/#queue-a-performanceentry) is
+    /// almost entirely about <c>PerformanceObserver</c>s, of which there are none here; what survives of it is
+    /// the buffer add, which is why the two steps are one line.
+    /// </remarks>
+    [JsFunction(Name = "mark", Length = 1)]
+    private JsPerformanceMark Mark(JsValue thisObject, JsValue markName, JsValue markOptions)
+    {
+        Brand(thisObject, "Failed to execute 'mark' on 'Performance'");
+
+        var (name, startTime, detail) = PerformanceMarkConstructor.ReadArguments(
+            _engine,
+            _realm,
+            markName,
+            markOptions,
+            "Failed to execute 'mark' on 'Performance'");
+
+        var entry = new JsPerformanceMark(_engine, name, startTime, detail)
+        {
+            _prototype = _realm.Intrinsics.PerformanceMark.PrototypeObject,
+        };
+
+        AddToBuffer(entry);
+        return entry;
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/user-timing/#dom-performance-measure
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The whole of the overload matrix lives in the argument's WebIDL type,
+    /// <c>(DOMString or PerformanceMeasureOptions)</c>: by
+    /// https://webidl.spec.whatwg.org/#es-union a value is the dictionary when it is an Object, or
+    /// <c>null</c>, or absent (the IDL default is <c>{}</c>), and the mark <i>name</i> for everything else —
+    /// so <c>measure('m', 5)</c> looks for a mark called <c>"5"</c> rather than measuring from timestamp 5,
+    /// while <c>measure('m', { start: 5 })</c> does the latter.
+    /// </para>
+    /// <para>
+    /// The end time is computed before the start time, which is the specification's order and is observable:
+    /// with <c>{ start: 'missing-a', end: 'missing-b' }</c> it is <c>missing-b</c> that is reported.
+    /// </para>
+    /// </remarks>
+    [JsFunction(Name = "measure", Length = 1)]
+    private JsPerformanceMeasure Measure(JsValue thisObject, JsValue measureName, JsValue startOrMeasureOptions, JsValue endMark)
+    {
+        const string Context = "Failed to execute 'measure' on 'Performance'";
+
+        Brand(thisObject, Context);
+
+        var name = TypeConverter.ToJsString(measureName);
+
+        // The union conversion. Note that `null` lands in the dictionary arm along with `undefined`, because
+        // the union has a dictionary member — only a primitive that is neither becomes a mark name.
+        var isOptions = startOrMeasureOptions.IsUndefined() || startOrMeasureOptions.IsNull() || startOrMeasureOptions is ObjectInstance;
+        var options = startOrMeasureOptions is ObjectInstance dictionary
+            ? UserTiming.ReadMeasureOptions(_realm, dictionary, Context)
+            : default;
+
+        // An optional argument with no default value is "not given" when it is absent or explicitly
+        // undefined — https://webidl.spec.whatwg.org/#es-overloads.
+        var hasEndMark = !endMark.IsUndefined();
+
+        // Step 1: the three ways the arguments can contradict each other.
+        if (isOptions && options.HasAnyMember)
+        {
+            if (hasEndMark)
+            {
+                Throw.TypeError(_realm, Context + ": an end mark cannot be combined with a PerformanceMeasureOptions argument.");
+            }
+
+            if (!options.HasStart && !options.HasEnd)
+            {
+                Throw.TypeError(_realm, Context + ": at least one of 'start' and 'end' must be specified.");
+            }
+
+            if (options.HasStart && options.HasDuration && options.HasEnd)
+            {
+                Throw.TypeError(_realm, Context + ": 'start', 'duration' and 'end' cannot all three be specified.");
+            }
+        }
+
+        // Step 2: the end time.
+        double endTime;
+        if (hasEndMark)
+        {
+            endTime = TimestampOfMark(TypeConverter.ToString(endMark), Context);
+        }
+        else if (isOptions && options.HasEnd)
+        {
+            endTime = ConvertMarkToTimestamp(options.End, Context);
+        }
+        else if (isOptions && options.HasStart && options.HasDuration)
+        {
+            endTime = ConvertMarkToTimestamp(options.Start, Context) + options.Duration;
+        }
+        else
+        {
+            endTime = _state.CurrentHighResolutionTime;
+        }
+
+        // Step 3: the start time. The `start` mark is deliberately converted again rather than reused from
+        // step 2 — the algorithm says so, and nothing can have changed the buffer in between.
+        double startTime;
+        if (isOptions && options.HasStart)
+        {
+            startTime = ConvertMarkToTimestamp(options.Start, Context);
+        }
+        else if (isOptions && options.HasDuration && options.HasEnd)
+        {
+            startTime = ConvertMarkToTimestamp(options.End, Context) - options.Duration;
+        }
+        else if (!isOptions)
+        {
+            startTime = TimestampOfMark(TypeConverter.ToString(startOrMeasureOptions), Context);
+        }
+        else
+        {
+            startTime = 0;
+        }
+
+        // Steps 4 to 9. The detail is cloned only now, so a measure that cannot be located never serializes
+        // anything.
+        var detail = options.HasDetail ? UserTiming.CloneDetail(_engine, _realm, options.Detail) : JsValue.Null;
+
+        var entry = new JsPerformanceMeasure(_engine, name, startTime, endTime - startTime, detail)
+        {
+            _prototype = _realm.Intrinsics.PerformanceMeasure.PrototypeObject,
+        };
+
+        AddToBuffer(entry);
+        return entry;
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/performance-timeline/#dom-performance-getentries — "filter buffer map by name and
+    /// type" with both filters set to null.
+    /// </summary>
+    [JsFunction(Name = "getEntries", Length = 0)]
+    private JsArray GetEntries(JsValue thisObject)
+    {
+        Brand(thisObject, "Failed to execute 'getEntries' on 'Performance'");
+        return FilterBuffer(name: null, type: null);
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/performance-timeline/#dom-performance-getentriesbytype
+    /// </summary>
+    [JsFunction(Name = "getEntriesByType", Length = 1)]
+    private JsArray GetEntriesByType(JsValue thisObject, JsValue type)
+    {
+        Brand(thisObject, "Failed to execute 'getEntriesByType' on 'Performance'");
+        return FilterBuffer(name: null, TypeConverter.ToString(type));
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/performance-timeline/#dom-performance-getentriesbyname — the entry type is an
+    /// optional argument with no default, so an omitted or explicitly undefined one filters on the name alone.
+    /// </summary>
+    [JsFunction(Name = "getEntriesByName", Length = 1)]
+    private JsArray GetEntriesByName(JsValue thisObject, JsValue name, JsValue type)
+    {
+        Brand(thisObject, "Failed to execute 'getEntriesByName' on 'Performance'");
+        return FilterBuffer(TypeConverter.ToString(name), type.IsUndefined() ? null : TypeConverter.ToString(type));
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/user-timing/#dom-performance-clearmarks
+    /// </summary>
+    [JsFunction(Name = "clearMarks", Length = 0)]
+    private JsValue ClearMarks(JsValue thisObject, JsValue markName)
+    {
+        Brand(thisObject, "Failed to execute 'clearMarks' on 'Performance'");
+        RemoveEntries(JsPerformanceMark.MarkEntryType, markName);
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/user-timing/#dom-performance-clearmeasures
+    /// </summary>
+    [JsFunction(Name = "clearMeasures", Length = 0)]
+    private JsValue ClearMeasures(JsValue thisObject, JsValue measureName)
+    {
+        Brand(thisObject, "Failed to execute 'clearMeasures' on 'Performance'");
+        RemoveEntries(JsPerformanceMeasure.MeasureEntryType, measureName);
+        return Undefined;
+    }
+
+    /// <summary>
+    /// The surviving half of "queue a PerformanceEntry": append unless the buffer is full, in which case the
+    /// entry is silently dropped. See <see cref="MaxBufferedEntries"/>.
+    /// </summary>
+    private void AddToBuffer(JsPerformanceEntry entry)
+    {
+        var entries = _entries ??= new List<JsPerformanceEntry>();
+        if (entries.Count >= MaxBufferedEntries)
+        {
+            return;
+        }
+
+        entries.Add(entry);
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/performance-timeline/#dfn-filter-buffer-map-by-name-and-type, whose last step is
+    /// "Sort results's entries in chronological order with respect to startTime".
+    /// </summary>
+    private JsArray FilterBuffer(string? name, string? type)
+    {
+        var entries = _entries;
+        var matched = new List<JsPerformanceEntry>();
+
+        if (entries is not null)
+        {
+            for (var i = 0; i < entries.Count; i++)
+            {
+                var entry = entries[i];
+                if (name is not null && !string.Equals(entry.EntryName.ToString(), name, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (type is not null && !string.Equals(entry.EntryType.ToString(), type, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                matched.Add(entry);
+            }
+
+            SortChronologically(matched);
+        }
+
+        var values = new List<JsValue>(matched.Count);
+        for (var i = 0; i < matched.Count; i++)
+        {
+            values.Add(matched[i]);
+        }
+
+        return _realm.Intrinsics.Array.ConstructFast(values);
+    }
+
+    /// <summary>
+    /// Orders entries by <c>startTime</c>, keeping buffer order among equal ones.
+    /// </summary>
+    /// <remarks>
+    /// Insertion order is already chronological unless a mark was given an explicit <c>startTime</c> — the one
+    /// way an entry can be added out of order — so the common case is the scan that finds nothing to do. The
+    /// sort itself is stabilized by the buffer index, because <see cref="Array.Sort{T}(T[], Comparison{T})"/>
+    /// is introsort and is not stable, and two marks taken in the same clock tick must not swap.
+    /// </remarks>
+    private static void SortChronologically(List<JsPerformanceEntry> entries)
+    {
+        for (var i = 1; i < entries.Count; i++)
+        {
+            if (entries[i].StartTime < entries[i - 1].StartTime)
+            {
+                StableSort(entries);
+                return;
+            }
+        }
+    }
+
+    private static void StableSort(List<JsPerformanceEntry> entries)
+    {
+        var items = new (double StartTime, int Index, JsPerformanceEntry Entry)[entries.Count];
+        for (var i = 0; i < entries.Count; i++)
+        {
+            items[i] = (entries[i].StartTime, i, entries[i]);
+        }
+
+        Array.Sort(items, static (a, b) =>
+        {
+            var comparison = a.StartTime.CompareTo(b.StartTime);
+            return comparison != 0 ? comparison : a.Index.CompareTo(b.Index);
+        });
+
+        for (var i = 0; i < items.Length; i++)
+        {
+            entries[i] = items[i].Entry;
+        }
+    }
+
+    /// <summary>
+    /// The body both <c>clearMarks</c> and <c>clearMeasures</c> share: remove every entry of the given type,
+    /// or only those of that type with the given name.
+    /// </summary>
+    private void RemoveEntries(JsString entryType, JsValue name)
+    {
+        var entries = _entries;
+        if (entries is null || entries.Count == 0)
+        {
+            return;
+        }
+
+        // Optional with no default: an omitted or explicitly undefined name clears them all.
+        var filter = name.IsUndefined() ? null : TypeConverter.ToString(name);
+
+        var write = 0;
+        for (var read = 0; read < entries.Count; read++)
+        {
+            var entry = entries[read];
+
+            // Reference equality is exact here: every entry answers with the one shared JsString its type
+            // declares.
+            var remove = ReferenceEquals(entry.EntryType, entryType)
+                && (filter is null || string.Equals(entry.EntryName.ToString(), filter, StringComparison.Ordinal));
+
+            if (!remove)
+            {
+                entries[write] = entry;
+                write++;
+            }
+        }
+
+        entries.RemoveRange(write, entries.Count - write);
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/user-timing/#convert-a-mark-to-a-timestamp
+    /// </summary>
+    /// <remarks>
+    /// Step 1, the <c>PerformanceTiming</c> branch, is guarded by "if mark … has the same name as a read only
+    /// attribute in the PerformanceTiming interface", an interface that belongs to a document's navigation.
+    /// There is no document here, so that branch is absent and a name that happens to be
+    /// <c>"domComplete"</c> is looked up as an ordinary mark.
+    /// </remarks>
+    private double ConvertMarkToTimestamp(in UserTiming.MarkOrTimestamp mark, string context)
+    {
+        if (mark.Mark is not null)
+        {
+            return TimestampOfMark(mark.Mark, context);
+        }
+
+        // Step 3.1: "If mark is negative, throw a TypeError."
+        if (mark.Timestamp < 0)
+        {
+            Throw.TypeError(_realm, context + ": a timestamp cannot be negative.");
+        }
+
+        return mark.Timestamp;
+    }
+
+    /// <summary>
+    /// "let end time be the value of the startTime attribute from the most recent occurrence of a
+    /// PerformanceMark object in the performance entry buffer whose name is mark. If no matching entry is
+    /// found, throw a SyntaxError."
+    /// </summary>
+    /// <remarks>
+    /// That <c>SyntaxError</c> is the WebIDL error <i>name</i>
+    /// (https://webidl.spec.whatwg.org/#syntaxerror), so it is a <c>DOMException</c> named
+    /// <c>SyntaxError</c> and not the ECMAScript <c>SyntaxError</c> constructor — which is what a browser
+    /// throws here, and what <c>e.name === 'SyntaxError' &amp;&amp; e instanceof DOMException</c> tests for.
+    /// </remarks>
+    private double TimestampOfMark(string name, string context)
+    {
+        var entries = _entries;
+        if (entries is not null)
+        {
+            for (var i = entries.Count - 1; i >= 0; i--)
+            {
+                if (entries[i] is JsPerformanceMark mark
+                    && string.Equals(mark.EntryName.ToString(), name, StringComparison.Ordinal))
+                {
+                    return mark.StartTime;
+                }
+            }
+        }
+
+        var exception = _realm.Intrinsics.DomException.CreateException(
+            DomExceptionNames.Syntax,
+            context + ": the mark '" + name + "' does not exist.");
+
+        var location = _engine._lastSyntaxElement?.Location ?? default;
+        Throw.JavaScriptException(_engine, exception, in location);
+        return 0;
     }
 
     /// <summary>

--- a/Jint/WebApi/Performance/PerformanceMarkConstructor.cs
+++ b/Jint/WebApi/Performance/PerformanceMarkConstructor.cs
@@ -1,0 +1,119 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Performance;
+
+/// <summary>
+/// The <c>PerformanceMark</c> interface object.
+/// <para>
+/// https://w3c.github.io/user-timing/#dom-performancemark
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>PerformanceMark</c> inherits from <c>PerformanceEntry</c>, so its <c>[[Prototype]]</c> is the
+/// <c>PerformanceEntry</c> interface object rather than <c>%Function.prototype%</c> —
+/// https://webidl.spec.whatwg.org/#interface-object.
+/// </para>
+/// <para>
+/// It is the one entry type with a constructor operation, and constructing one is deliberately <b>not</b> the
+/// same as calling <c>performance.mark()</c>: https://w3c.github.io/user-timing/#dom-performance-mark runs
+/// this constructor and <i>then</i> queues the entry and adds it to the buffer, so a mark built with
+/// <c>new</c> exists as an object but is invisible to <c>getEntries()</c> and unreachable as the start or end
+/// of a <c>measure</c>.
+/// </para>
+/// </remarks>
+internal sealed class PerformanceMarkConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("PerformanceMark");
+
+    internal PerformanceMarkConstructor(Engine engine, Realm realm, PerformanceEntryConstructor entryConstructor)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = entryConstructor;
+        PrototypeObject = new PerformanceMarkPrototype(engine, realm, this, entryConstructor.PrototypeObject);
+        _length = new PropertyDescriptor(JsNumber.PositiveOne, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal PerformanceMarkPrototype PrototypeObject { get; }
+
+    /// <summary>
+    /// https://w3c.github.io/user-timing/#dom-performancemark-performancemark
+    /// </summary>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        if (newTarget.IsUndefined())
+        {
+            Throw.TypeError(_realm, $"Constructor {GetOwnFunctionNameForMessage()} requires 'new'");
+        }
+
+        var (name, startTime, detail) = ReadArguments(
+            _engine,
+            _realm,
+            arguments.At(0),
+            arguments.At(1),
+            "Failed to construct 'PerformanceMark'");
+
+        return OrdinaryCreateFromConstructor(
+            newTarget,
+            static intrinsics => intrinsics.PerformanceMark.PrototypeObject,
+            static (Engine engine, Realm _, (JsString Name, double StartTime, JsValue Detail) state)
+                => new JsPerformanceMark(engine, state.Name, state.StartTime, state.Detail),
+            (Name: name, StartTime: startTime, Detail: detail));
+    }
+
+    /// <summary>
+    /// Steps 1 and 3 to 7 of the constructor, shared with <c>performance.mark()</c>, whose step 1 is "run the
+    /// PerformanceMark constructor".
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Step 1 — the <c>SyntaxError</c> for a name that collides with a read-only <c>PerformanceTiming</c>
+    /// attribute — is guarded by "if the current global object is a Window object", which is never true here,
+    /// so it is deliberately absent. The same goes for the <c>convert a name to a timestamp</c> branch of
+    /// <c>measure</c>: <c>PerformanceTiming</c> belongs to a document's navigation and there is none.
+    /// </para>
+    /// <para>
+    /// The order matters and is the WebIDL binding's, not the algorithm's: the arguments are converted left to
+    /// right, so <c>markName</c> is stringified and then the whole options dictionary is read — including its
+    /// <c>detail</c>, whose getter therefore runs before the negative-<c>startTime</c> <c>TypeError</c> can be
+    /// raised. The <c>detail</c> <i>clone</i> is step 7 and happens after that check, so a mark with a
+    /// negative start time never serializes anything.
+    /// </para>
+    /// </remarks>
+    internal static (JsString Name, double StartTime, JsValue Detail) ReadArguments(
+        Engine engine,
+        Realm realm,
+        JsValue markName,
+        JsValue markOptions,
+        string context)
+    {
+        var name = TypeConverter.ToJsString(markName);
+        var options = UserTiming.ReadMarkOptions(realm, markOptions, context);
+
+        double startTime;
+        if (options.HasStartTime)
+        {
+            // Step 5.2: "If markOptions's startTime is negative, throw a TypeError."
+            if (options.StartTime < 0)
+            {
+                Throw.TypeError(realm, context + ": the 'startTime' value is negative.");
+            }
+
+            startTime = options.StartTime;
+        }
+        else
+        {
+            // Step 5.3: "Otherwise, set entry's startTime attribute to the value that would be returned by the
+            // Performance object's now() method."
+            startTime = UserTiming.RequireState(engine, "The PerformanceMark constructor").CurrentHighResolutionTime;
+        }
+
+        return (name, startTime, UserTiming.CloneDetail(engine, realm, options.Detail));
+    }
+}
+#endif

--- a/Jint/WebApi/Performance/PerformanceMarkPrototype.cs
+++ b/Jint/WebApi/Performance/PerformanceMarkPrototype.cs
@@ -1,0 +1,61 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Performance;
+
+/// <summary>
+/// <c>PerformanceMark.prototype</c> — the interface prototype object.
+/// <para>
+/// https://w3c.github.io/user-timing/#dom-performancemark
+/// </para>
+/// </summary>
+/// <remarks>
+/// The interface adds exactly one attribute to <c>PerformanceEntry</c>, and its brand check is for a
+/// <c>PerformanceMark</c> specifically: reading it off a <c>PerformanceMeasure</c>, which carries a
+/// <c>detail</c> of its own, is still a <c>TypeError</c>.
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class PerformanceMarkPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly PerformanceMarkConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString PerformanceMarkToStringTag = new("PerformanceMark");
+
+    internal PerformanceMarkPrototype(
+        Engine engine,
+        Realm realm,
+        PerformanceMarkConstructor constructor,
+        ObjectInstance entryPrototype) : base(engine, realm)
+    {
+        _prototype = entryPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/user-timing/#dom-performancemark-detail — "The detail attribute must return the
+    /// value it is set to (it's copied from the PerformanceMarkOptions dictionary)."
+    /// </summary>
+    [JsAccessor("detail", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue DetailGet(JsValue thisObject)
+    {
+        if (thisObject is not JsPerformanceMark mark)
+        {
+            Throw.TypeError(_realm, "Illegal invocation: receiver is not a PerformanceMark");
+            return null!;
+        }
+
+        return mark.Detail;
+    }
+}
+#endif

--- a/Jint/WebApi/Performance/PerformanceMeasureConstructor.cs
+++ b/Jint/WebApi/Performance/PerformanceMeasureConstructor.cs
@@ -1,0 +1,45 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Performance;
+
+/// <summary>
+/// The <c>PerformanceMeasure</c> interface object.
+/// <para>
+/// https://w3c.github.io/user-timing/#dom-performancemeasure
+/// </para>
+/// </summary>
+/// <remarks>
+/// <c>PerformanceMeasure</c> inherits from <c>PerformanceEntry</c>, so its <c>[[Prototype]]</c> is the
+/// <c>PerformanceEntry</c> interface object. It declares no constructor operation — a measure only ever comes
+/// from <c>performance.measure()</c> — which in WebIDL means the interface object exists and is a function
+/// but refuses to construct anything, https://webidl.spec.whatwg.org/#es-interface-call.
+/// </remarks>
+internal sealed class PerformanceMeasureConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("PerformanceMeasure");
+
+    internal PerformanceMeasureConstructor(Engine engine, Realm realm, PerformanceEntryConstructor entryConstructor)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = entryConstructor;
+        PrototypeObject = new PerformanceMeasurePrototype(engine, realm, this, entryConstructor.PrototypeObject);
+        _length = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal PerformanceMeasurePrototype PrototypeObject { get; }
+
+    /// <summary>
+    /// An interface without a constructor operation is not constructible.
+    /// </summary>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        Throw.TypeError(_realm, "Illegal constructor");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Performance/PerformanceMeasurePrototype.cs
+++ b/Jint/WebApi/Performance/PerformanceMeasurePrototype.cs
@@ -1,0 +1,60 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Performance;
+
+/// <summary>
+/// <c>PerformanceMeasure.prototype</c> — the interface prototype object.
+/// <para>
+/// https://w3c.github.io/user-timing/#dom-performancemeasure
+/// </para>
+/// </summary>
+/// <remarks>
+/// The sibling of <see cref="PerformanceMarkPrototype"/>: one added attribute, brand-checked for this
+/// interface alone.
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class PerformanceMeasurePrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly PerformanceMeasureConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString PerformanceMeasureToStringTag = new("PerformanceMeasure");
+
+    internal PerformanceMeasurePrototype(
+        Engine engine,
+        Realm realm,
+        PerformanceMeasureConstructor constructor,
+        ObjectInstance entryPrototype) : base(engine, realm)
+    {
+        _prototype = entryPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/user-timing/#dom-performancemeasure-detail — "The detail attribute must return
+    /// the value it is set to (it's copied from the PerformanceMeasureOptions dictionary)."
+    /// </summary>
+    [JsAccessor("detail", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue DetailGet(JsValue thisObject)
+    {
+        if (thisObject is not JsPerformanceMeasure measure)
+        {
+            Throw.TypeError(_realm, "Illegal invocation: receiver is not a PerformanceMeasure");
+            return null!;
+        }
+
+        return measure.Detail;
+    }
+}
+#endif

--- a/Jint/WebApi/Performance/UserTiming.cs
+++ b/Jint/WebApi/Performance/UserTiming.cs
@@ -1,0 +1,195 @@
+#if NET8_0_OR_GREATER
+using System.Runtime.InteropServices;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.WebApi.StructuredClone;
+
+namespace Jint.WebApi.Performance;
+
+/// <summary>
+/// The argument conversions the User Timing API shares between <c>performance.mark</c>,
+/// <c>performance.measure</c> and the <c>PerformanceMark</c> constructor.
+/// <para>
+/// https://w3c.github.io/user-timing/
+/// </para>
+/// </summary>
+/// <remarks>
+/// The WebIDL dictionary conversion happens <b>before</b> the algorithm's own steps run, and it reads the
+/// members in <i>lexicographical order of their identifiers</i>
+/// (https://webidl.spec.whatwg.org/#es-dictionary) — not in the order the algorithm consults them. That is
+/// observable whenever a member is an accessor, so the readers here follow it exactly: <c>detail</c> then
+/// <c>startTime</c> for a mark, and <c>detail</c>, <c>duration</c>, <c>end</c>, <c>start</c> for a measure.
+/// A member whose value is <see langword="undefined"/> and which has no default is <i>not present</i>, which
+/// is what makes <c>{ start: undefined }</c> mean "no start" rather than "start of NaN".
+/// </remarks>
+internal static class UserTiming
+{
+    /// <summary>
+    /// A <c>(DOMString or DOMHighResTimeStamp)</c> that has already been through the WebIDL union
+    /// conversion: either the name of a mark to look up, or a timestamp to use as it stands.
+    /// </summary>
+    [StructLayout(LayoutKind.Auto)]
+    internal readonly record struct MarkOrTimestamp(string? Mark, double Timestamp)
+    {
+        /// <summary>Whether this is a mark name rather than a timestamp.</summary>
+        internal bool IsMark => Mark is not null;
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/user-timing/#dictdef-performancemarkoptions — <c>detail</c> defaults to
+    /// <c>null</c>, <c>startTime</c> has no default and so may be absent.
+    /// </summary>
+    [StructLayout(LayoutKind.Auto)]
+    internal readonly record struct MarkOptions(JsValue Detail, bool HasStartTime, double StartTime);
+
+    /// <summary>
+    /// https://w3c.github.io/user-timing/#dictdef-performancemeasureoptions — every member is optional and
+    /// none has a default, so each carries its own "is present" flag. Which combinations are legal is
+    /// <c>measure</c>'s business, not the conversion's.
+    /// </summary>
+    [StructLayout(LayoutKind.Auto)]
+    internal readonly record struct MeasureOptions(
+        bool HasDetail,
+        JsValue Detail,
+        bool HasDuration,
+        double Duration,
+        bool HasEnd,
+        MarkOrTimestamp End,
+        bool HasStart,
+        MarkOrTimestamp Start)
+    {
+        /// <summary>
+        /// Whether the value was a dictionary carrying at least one member, which is the condition
+        /// https://w3c.github.io/user-timing/#dom-performance-measure step 1 gates its three
+        /// <c>TypeError</c>s on.
+        /// </summary>
+        internal bool HasAnyMember => HasDetail || HasDuration || HasEnd || HasStart;
+    }
+
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#es-double — "Let x be ? ToNumber(V). If x is NaN, +∞, or −∞, throw a
+    /// TypeError." <c>DOMHighResTimeStamp</c> is a <c>double</c>, not an <c>unrestricted double</c>, so an
+    /// infinite or NaN timestamp is rejected at the boundary rather than propagated into the arithmetic.
+    /// </summary>
+    internal static double ToHighResTimeStamp(Realm realm, JsValue value, string context, string member)
+    {
+        var number = TypeConverter.ToNumber(value);
+        if (!double.IsFinite(number))
+        {
+            Throw.TypeError(realm, context + ": the '" + member + "' value is not a finite number.");
+        }
+
+        return number;
+    }
+
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#es-union for <c>(DOMString or DOMHighResTimeStamp)</c>: a Number
+    /// becomes the timestamp and everything else — a string, an object, a boolean, <c>null</c>, a BigInt —
+    /// becomes the mark name, because the union has no object or dictionary member for them to land in.
+    /// </summary>
+    /// <remarks>
+    /// The test is on the JavaScript type, so a boxed <c>new Number(5)</c> is an Object and is stringified to
+    /// the mark name <c>"5"</c>, exactly as the union conversion requires.
+    /// </remarks>
+    internal static MarkOrTimestamp ToMarkOrTimestamp(Realm realm, JsValue value, string context, string member)
+    {
+        if (value is JsNumber)
+        {
+            return new MarkOrTimestamp(Mark: null, ToHighResTimeStamp(realm, value, context, member));
+        }
+
+        return new MarkOrTimestamp(TypeConverter.ToString(value), Timestamp: 0);
+    }
+
+    /// <summary>
+    /// The <c>PerformanceMarkOptions</c> dictionary conversion.
+    /// </summary>
+    /// <remarks>
+    /// The IDL default of <c>detail</c> is <c>null</c>, which is why an absent dictionary, an absent member
+    /// and an explicit <see langword="undefined"/> all give the same answer — and why
+    /// <c>performance.mark('x').detail</c> is <c>null</c> rather than <c>undefined</c>.
+    /// </remarks>
+    internal static MarkOptions ReadMarkOptions(Realm realm, JsValue options, string context)
+    {
+        if (options is not ObjectInstance dictionary)
+        {
+            return new MarkOptions(JsValue.Null, HasStartTime: false, StartTime: 0);
+        }
+
+        var detail = dictionary.Get("detail");
+        if (detail.IsUndefined())
+        {
+            detail = JsValue.Null;
+        }
+
+        var startTime = dictionary.Get("startTime");
+        if (startTime.IsUndefined())
+        {
+            return new MarkOptions(detail, HasStartTime: false, StartTime: 0);
+        }
+
+        return new MarkOptions(detail, HasStartTime: true, ToHighResTimeStamp(realm, startTime, context, "startTime"));
+    }
+
+    /// <summary>
+    /// The <c>PerformanceMeasureOptions</c> dictionary conversion.
+    /// </summary>
+    internal static MeasureOptions ReadMeasureOptions(Realm realm, ObjectInstance dictionary, string context)
+    {
+        var detail = dictionary.Get("detail");
+        var hasDetail = !detail.IsUndefined();
+
+        var durationValue = dictionary.Get("duration");
+        var hasDuration = !durationValue.IsUndefined();
+        var duration = hasDuration ? ToHighResTimeStamp(realm, durationValue, context, "duration") : 0;
+
+        var endValue = dictionary.Get("end");
+        var hasEnd = !endValue.IsUndefined();
+        var end = hasEnd ? ToMarkOrTimestamp(realm, endValue, context, "end") : default;
+
+        var startValue = dictionary.Get("start");
+        var hasStart = !startValue.IsUndefined();
+        var start = hasStart ? ToMarkOrTimestamp(realm, startValue, context, "start") : default;
+
+        return new MeasureOptions(hasDetail, detail, hasDuration, duration, hasEnd, end, hasStart, start);
+    }
+
+    /// <summary>
+    /// "Run the StructuredSerialize algorithm … then run the StructuredDeserialize algorithm", which is what
+    /// both entry types do with their <c>detail</c> — https://w3c.github.io/user-timing/#dom-performancemark.
+    /// </summary>
+    /// <remarks>
+    /// So a detail that cannot be cloned (a function, a symbol, a host-wrapped CLR object) raises a
+    /// <c>DataCloneError</c> <c>DOMException</c> from the very same code <c>structuredClone</c> uses, and a
+    /// detail that can is disconnected from whatever the caller goes on to do with the original object.
+    /// </remarks>
+    internal static JsValue CloneDetail(Engine engine, Realm realm, JsValue detail)
+    {
+        if (detail.IsNull())
+        {
+            return JsValue.Null;
+        }
+
+        return new StructuredCloner(engine, realm).Clone(detail, transferList: null);
+    }
+
+    /// <summary>
+    /// The engine's web-API state, which every high resolution time reading comes from.
+    /// </summary>
+    /// <remarks>
+    /// Unreachable in the failing direction: the globals that reach this are installed only where
+    /// <c>WebApiRegistration</c> created the state, in the same block.
+    /// </remarks>
+    internal static WebApiEngineState RequireState(Engine engine, string what)
+    {
+        var state = engine._webApi;
+        if (state is null)
+        {
+            Throw.InvalidOperationException(what + " was reached on an engine that has no web-API state.");
+        }
+
+        return state;
+    }
+}
+#endif

--- a/Jint/WebApi/WebApiRegistration.cs
+++ b/Jint/WebApi/WebApiRegistration.cs
@@ -112,6 +112,20 @@ internal static class WebApiRegistration
         if ((features & WebApiFeatures.Performance) != WebApiFeatures.None)
         {
             Install(global, engine, "performance", static e => e.Realm.Intrinsics.Performance, PropertyFlag.ConfigurableEnumerableWritable);
+
+            // The entry types are ordinary WebIDL interface objects — a script holds a mark and asks
+            // `entry instanceof PerformanceMark`, which only works if the interface object is reachable.
+            Install(global, engine, "PerformanceEntry", static e => e.Realm.Intrinsics.PerformanceEntry, PropertyFlag.NonEnumerable);
+            Install(global, engine, "PerformanceMark", static e => e.Realm.Intrinsics.PerformanceMark, PropertyFlag.NonEnumerable);
+            Install(global, engine, "PerformanceMeasure", static e => e.Realm.Intrinsics.PerformanceMeasure, PropertyFlag.NonEnumerable);
+        }
+
+        if ((features & WebApiFeatures.Navigator) != WebApiFeatures.None)
+        {
+            // WebIDL exposes navigator through a [Replaceable] accessor pair; an ordinary enumerable data
+            // property is the same simplification console and crypto are installed with, documented on
+            // NavigatorInstance.
+            Install(global, engine, "navigator", static e => e.Realm.Intrinsics.Navigator, PropertyFlag.ConfigurableEnumerableWritable);
         }
 
         if ((features & WebApiFeatures.Fetch) != WebApiFeatures.None)

--- a/README.md
+++ b/README.md
@@ -204,24 +204,28 @@ engine.Execute("console.log('hello %s', 'world')");
 `console` output goes to a `ConsoleSink`, which defaults to `ConsoleSink.Null` and discards everything —
 enabling the feature never starts writing to your process's standard output by surprise. `ConsoleSink.FromTextWriter`
 covers the common case; implement the abstract class to route records to your own logger, where the
-`ConsoleLogLevel` tells you how loud each one is.
+`ConsoleLogLevel` tells you how loud each one is. Every method emits exactly one `Write` call per record, so a
+`console.table(rows)` reaches your sink as one multi-line ASCII table rather than as a line per row, and the
+formatter never invokes a script-visible getter — an accessor renders as `[Getter]`, because a console must
+not be a way to run arbitrary script.
 
 A global you registered yourself always wins: the install is non-clobbering, so if your host already exposes
 its own `console` (or any other name in the table below), enabling the feature leaves yours exactly as it is.
 
 | API | Feature flag | Status |
 | --- | --- | --- |
-| `console` (`log`/`warn`/`error`/`group`/`count`/`time`/`assert`/`trace`/`dir`) | `WebApiFeatures.Console` | ✔ shipped |
+| `console` (`log`/`warn`/`error`/`group`/`count`/`time`/`assert`/`trace`/`dir`/`table`) | `WebApiFeatures.Console` | ✔ shipped |
 | `DOMException` | *(no flag — installed whenever any feature is enabled)* | ✔ shipped |
 | `setTimeout` / `setInterval` / `clearTimeout` / `clearInterval` / `queueMicrotask` | `WebApiFeatures.Timers` | ✔ shipped |
 | `TextEncoder` / `TextDecoder` (UTF-8, UTF-16LE, UTF-16BE; `fatal`, `ignoreBOM`, streaming) | `Encoding` | ✔ shipped |
 | `atob` / `btoa` | `Base64` | ✔ shipped |
 | `structuredClone` (incl. `{ transfer }` of `ArrayBuffer`s) | `StructuredClone` | ✔ shipped |
 | `crypto.getRandomValues` / `crypto.randomUUID` / `crypto.subtle.digest` (SHA-1/256/384/512) | `WebApiFeatures.Crypto` | ✔ shipped |
-| `performance.now` / `performance.timeOrigin` | `WebApiFeatures.Performance` | ✔ shipped |
+| `performance.now` / `timeOrigin` / `mark` / `measure` / `getEntries*` / `clearMarks` / `clearMeasures` | `WebApiFeatures.Performance` | ✔ shipped |
 | `Event` / `EventTarget` / `CustomEvent` / `AbortController` / `AbortSignal` | `Events` | ✔ shipped |
 | `URL` / `URLSearchParams` | `Url` | ✔ shipped |
 | `Blob` / `File` / `FormData` | `Files` | ✔ shipped |
+| `navigator.userAgent` | `Navigator` | ✔ shipped |
 | `fetch` / `Headers` / `Request` / `Response` | `Fetch` — **opt-in on its own, see below** | ✔ shipped |
 
 `WebApiFeatures.Default` — what `UseWebApis()` enables — is every non-network feature that has landed. It
@@ -294,6 +298,38 @@ and the target stay usable.
 being pumped and it counts against `MaxActiveTimers`; that queue exists whenever the `Events` feature does,
 whether or not you also asked for `setTimeout`. `AbortSignal.any(signals)` builds a composite that is
 retained by its sources until one of them aborts, at which point every link is dropped.
+
+### The performance timeline is bounded
+
+`performance.mark` and `performance.measure` behave as [User Timing](https://w3c.github.io/user-timing/)
+describes them — the whole overload matrix, mark names or raw timestamps, `detail` deep-copied through the
+same structured-clone algorithm `structuredClone` uses, and `PerformanceEntry` / `PerformanceMark` /
+`PerformanceMeasure` as real interface objects so `entry instanceof PerformanceMark` works. Entries come back
+from `getEntries()`, `getEntriesByType(type)` and `getEntriesByName(name, type?)` sorted by `startTime`, and
+`clearMarks(name?)` / `clearMeasures(name?)` remove them.
+
+```js
+performance.mark('parse');
+// ... work ...
+const m = performance.measure('parse-to-now', 'parse');
+console.log(m.duration);
+```
+
+One thing is deliberately not the browser's: the entry buffer holds **10,000 entries**, not an unbounded
+number. A page's timeline dies with the page, and an engine embedded in a long-lived host has no such event —
+`while (true) performance.mark('x')` would otherwise be a memory leak that no execution constraint describes.
+Once the buffer is full, further entries are dropped exactly as the Performance Timeline standard says a full
+buffer drops them: nothing throws, `mark()` and `measure()` still return the entry they built, and
+`getEntries()` simply stops growing until you clear it. There is no `PerformanceObserver`, and it is absent
+rather than present-and-throwing so feature detection takes its fallback path. Readings are **not coarsened** —
+an embedded engine has no cross-origin data for a fine clock to help steal, and a host that wants a coarse one
+supplies a coarse `TimeProvider`.
+
+`navigator` carries `userAgent` and nothing else. It reports `Jint/<version>` — a single RFC 7231 product
+token with no comment component, so nothing about your operating system or your application leaks into it —
+and it is there because [WinterTC's Minimum Common API](https://min-common-api.proposal.wintertc.org/)
+requires `globalThis.navigator.userAgent` of a conforming runtime. Everything else a browser's `Navigator`
+carries describes a user agent with a user, a document and a network stack, so it is absent rather than faked.
 
 **A `ShadowRealm` does not get these globals.** Only the principal realm's global object is touched, which is
 deliberately more conservative than a browser (where these APIs are `[Exposed=*]`); a host that wants them


### PR DESCRIPTION
The polish wave from #3087: User Timing, `console.table`, `navigator.userAgent`, and `Error.isError` parity for `DOMException`.

**`performance.mark` / `performance.measure`** implement [User Timing](https://w3c.github.io/user-timing/) — the full overload matrix (mark names or raw timestamps), `detail` deep-copied through the same structured-clone algorithm `structuredClone` uses (so an uncloneable detail is the usual `DataCloneError`), and `PerformanceEntry` / `PerformanceMark` / `PerformanceMeasure` as real interface objects with the correct inheritance chain, so `entry instanceof PerformanceMark` holds. Entries come back from `getEntries()` / `getEntriesByType()` / `getEntriesByName()` sorted by `startTime`; `clearMarks` / `clearMeasures` remove them.

One thing is deliberately not the browser's, documented in the README: the entry buffer holds 10,000 entries rather than an unbounded number — a page's timeline dies with the page, but an embedded engine has no such event, and `while (true) performance.mark('x')` must not be a memory leak no constraint describes. A full buffer drops further entries exactly as the Performance Timeline standard says a full buffer behaves: nothing throws, `mark()`/`measure()` still return the entry they built, `getEntries()` stops growing until cleared. `PerformanceObserver` is absent rather than present-and-throwing.

**`console.table`** renders per the console standard's table algorithm, through the same `ConsoleSink` every other method uses.

**`navigator.userAgent`** reports `Jint/<version>` — a single RFC 7231 product token, no comment component, so nothing about the OS or the host application leaks into it. It exists because WinterTC's Minimum Common API requires `globalThis.navigator.userAgent`; everything else a browser's `Navigator` carries describes a user agent with a user, a document and a network stack, so it is absent rather than faked. `WebApiFeatures.Navigator = 1 << 11`, part of `Default`.

**`Error.isError(new DOMException())` now answers `true`**, as it does in browsers: `DOMException` instances carry the `[[ErrorData]]` internal slot per WebIDL's "DOMException is an exception" integration with ECMA-262.

Tests cover the overload matrix, the buffer bound, entry ordering, the clone semantics of `detail`, the inheritance chain, and the `Error.isError` pin; both suites green on net10.0 and net472, with and without `JINT_HOST_CONTRACT_VERIFICATION=1`.

Closes #3081

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G7Ud48VAs1JicxRZxLDxg