### PR TITLE
Add opt-in WHATWG streams: ReadableStream, WritableStream and TransformStream

### DIFF
--- a/Jint.Tests.PublicInterface/WebApiStreamsTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiStreamsTests.cs
@@ -1,0 +1,249 @@
+#if NET8_0_OR_GREATER
+using Jint;
+using Jint.Native;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// The WHATWG streams seen from outside the assembly: what a host has to write to get them, what it gets
+/// when it writes nothing, and how the surface behaves at the host boundary.
+/// </summary>
+/// <remarks>
+/// This project has no <c>InternalsVisibleTo</c>, so everything here is reachable by a third party. The pin
+/// that matters most is <see cref="ADefaultEngineHasNoStreamGlobals"/>: the surface is opt-in, and an engine
+/// that did not ask for it must be the engine it was before any of this existed.
+/// </remarks>
+public class WebApiStreamsTests
+{
+    private static readonly string[] _globals =
+    [
+        "ReadableStream", "WritableStream", "TransformStream", "ByteLengthQueuingStrategy", "CountQueuingStrategy",
+    ];
+
+    [Fact]
+    public void ADefaultEngineHasNoStreamGlobals()
+    {
+        var engine = new Engine();
+
+        foreach (var name in _globals)
+        {
+            engine.Evaluate($"typeof {name}").AsString().Should().Be("undefined", name);
+            engine.Evaluate($"'{name}' in globalThis").AsBoolean().Should().BeFalse(name);
+        }
+
+        // Not even an engine that named the group but no feature.
+        new Engine(options => options.WebApi.Features = WebApiFeatures.None)
+            .Evaluate("typeof ReadableStream").AsString().Should().Be("undefined");
+
+        // ... nor one that asked for a different feature.
+        new Engine(options => options.UseWebApis(WebApiFeatures.Console))
+            .Evaluate("typeof ReadableStream").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void TheStreamsFlagInstallsTheFiveInterfacesAScriptConstructs()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Streams));
+
+        foreach (var name in _globals)
+        {
+            engine.Evaluate($"typeof {name}").AsString().Should().Be("function", name);
+        }
+
+        // DOMException comes with any feature, because it is how the web APIs report a failure.
+        engine.Evaluate("typeof DOMException").AsString().Should().Be("function");
+    }
+
+    [Fact]
+    public void TheHelperInterfacesAreReachableButAreNotGlobals()
+    {
+        // A documented narrowing of the browser surface: a browser exposes every stream interface as a
+        // global, and Jint exposes only the five a script constructs by name. The rest are ordinary
+        // interface objects reached through their instances.
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Streams));
+
+        foreach (var name in new[]
+                 {
+                     "ReadableStreamDefaultReader", "ReadableStreamDefaultController", "WritableStreamDefaultWriter",
+                     "WritableStreamDefaultController", "TransformStreamDefaultController",
+                 })
+        {
+            engine.Evaluate($"typeof {name}").AsString().Should().Be("undefined", name);
+        }
+
+        engine.Evaluate("Object.getPrototypeOf(new ReadableStream().getReader()).constructor.name")
+            .AsString().Should().Be("ReadableStreamDefaultReader");
+        engine.Evaluate("Object.getPrototypeOf(new WritableStream().getWriter()).constructor.name")
+            .AsString().Should().Be("WritableStreamDefaultWriter");
+    }
+
+    [Fact]
+    public void ByteStreamsAreAbsentRatherThanBroken()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Streams));
+
+        engine.Evaluate("typeof ReadableByteStreamController").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof ReadableStreamBYOBReader").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof ReadableStreamBYOBRequest").AsString().Should().Be("undefined");
+
+        // Asking for one is refused rather than quietly downgraded.
+        engine.Evaluate("(() => { try { new ReadableStream({ type: 'bytes' }); return 'no throw'; } catch (e) { return e.name; } })()")
+            .AsString().Should().Be("TypeError");
+        engine.Evaluate("(() => { try { new ReadableStream().getReader({ mode: 'byob' }); return 'no throw'; } catch (e) { return e.name; } })()")
+            .AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void TheDefaultSetIncludesStreams()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        engine.Evaluate("typeof ReadableStream").AsString().Should().Be("function");
+        WebApiFeatures.Default.Should().HaveFlag(WebApiFeatures.Streams);
+
+        // The bit is fixed, so a value a host persisted keeps its meaning.
+        ((int) WebApiFeatures.Streams).Should().Be(1 << 12);
+    }
+
+    [Fact]
+    public void TheGlobalsCarryTheAttributesWebIdlAsksFor()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Streams));
+
+        // An interface object is writable and configurable but NOT enumerable —
+        // https://webidl.spec.whatwg.org/#es-interfaces.
+        foreach (var name in _globals)
+        {
+            var descriptor = engine.Evaluate($"Object.getOwnPropertyDescriptor(globalThis, '{name}')").AsObject();
+
+            descriptor.Get("writable").AsBoolean().Should().BeTrue(name);
+            descriptor.Get("configurable").AsBoolean().Should().BeTrue(name);
+            descriptor.Get("enumerable").AsBoolean().Should().BeFalse(name);
+        }
+    }
+
+    [Fact]
+    public void AHostRegisteredGlobalWins()
+    {
+        var marker = new JsString("host's own ReadableStream");
+
+        var engine = new Engine(options => options
+            .AddLazyGlobal("ReadableStream", _ => marker)
+            .UseWebApis(WebApiFeatures.Streams));
+
+        // The host's configuration runs first and the install is non-clobbering.
+        engine.Evaluate("ReadableStream").Should().BeSameAs(marker);
+
+        // The names it did not claim are still installed.
+        engine.Evaluate("typeof TransformStream").AsString().Should().Be("function");
+    }
+
+    [Fact]
+    public void AShadowRealmDoesNotGetThem()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Streams));
+
+        // Only the principal realm's global object is touched — deliberately more conservative than a
+        // browser, where these are [Exposed=*].
+        engine.Evaluate("new ShadowRealm().evaluate('typeof ReadableStream')").AsString().Should().Be("undefined");
+        engine.Evaluate("new ShadowRealm().evaluate('typeof CountQueuingStrategy')").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof ReadableStream").AsString().Should().Be("function");
+    }
+
+    [Fact]
+    public void SurvivesAGlobalSnapshotRestore()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Streams));
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+
+        engine.Execute("var s = new ReadableStream({ start(c) { c.enqueue('x'); c.close(); } });");
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        engine.Evaluate("typeof s").AsString().Should().Be("undefined");
+        engine.Evaluate("new ReadableStream({ start(c) { c.enqueue('y'); } }).locked").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void OneOptionsInstanceServesSeveralEnginesIndependently()
+    {
+        var options = new Options().UseWebApis(WebApiFeatures.Streams);
+
+        var first = new Engine(options);
+        var second = new Engine(options);
+
+        first.Execute("var s = new ReadableStream({ start(c) { c.enqueue('first'); } });");
+        second.Execute("var s = new ReadableStream({ start(c) { c.enqueue('second'); } });");
+
+        // Nothing is shared between the two: each realm builds its own interface objects.
+        first.Evaluate("s instanceof ReadableStream").AsBoolean().Should().BeTrue();
+        second.Evaluate("s instanceof ReadableStream").AsBoolean().Should().BeTrue();
+
+        first.Evaluate("s.getReader().read()").UnwrapIfPromise().AsObject().Get("value").AsString().Should().Be("first");
+        second.Evaluate("s.getReader().read()").UnwrapIfPromise().AsObject().Get("value").AsString().Should().Be("second");
+    }
+
+    [Fact]
+    public void AHostCanDriveAStreamToCompletionThroughTheOrdinaryPromiseSurface()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Streams));
+
+        // Every promise a stream hands out is an ordinary engine promise, so the blocking unwrap a host
+        // already uses works on it.
+        var result = engine.Evaluate("""
+            (async () => {
+              const chunks = [];
+              const ts = new TransformStream({ transform(chunk, c) { c.enqueue(chunk.toUpperCase()); } });
+              const done = new ReadableStream({
+                start(c) { c.enqueue('a'); c.enqueue('b'); c.close(); }
+              }).pipeTo(ts.writable);
+              for await (const chunk of ts.readable) { chunks.push(chunk); }
+              await done;
+              return chunks.join('');
+            })()
+            """).UnwrapIfPromise();
+
+        result.AsString().Should().Be("AB");
+    }
+
+    [Fact]
+    public void StreamsAreUsableWithoutTheEventsFeature()
+    {
+        // The writable controller's `signal` is an AbortSignal, and pipeTo() accepts one — but neither
+        // requires the events globals to have been installed. The objects exist regardless; only the global
+        // names are gated.
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Streams));
+
+        engine.Evaluate("typeof AbortController").AsString().Should().Be("undefined");
+
+        var name = engine.Evaluate("""
+            (() => {
+              let signal;
+              const ws = new WritableStream({ start(c) { signal = c.signal; } });
+              ws.abort('stop');
+              return signal.constructor.name + ':' + signal.aborted + ':' + signal.reason;
+            })()
+            """);
+
+        name.AsString().Should().Be("AbortSignal:true:stop");
+    }
+
+    [Fact]
+    public void TheEventsFeatureIsWhatMakesAbortSignalReachableForPipeTo()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Streams | WebApiFeatures.Events));
+
+        var outcome = engine.Evaluate("""
+            (async () => {
+              const controller = new AbortController();
+              const written = [];
+              const promise = new ReadableStream({ start(c) { c.enqueue('a'); } })
+                .pipeTo(new WritableStream({ write(chunk) { written.push(chunk); } }), { signal: controller.signal });
+              controller.abort();
+              try { await promise; return 'no throw'; } catch (e) { return e.name + ':' + written.join(''); }
+            })()
+            """).UnwrapIfPromise();
+
+        outcome.AsString().Should().Be("AbortError:a");
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/QueuingStrategyTests.cs
+++ b/Jint.Tests/Runtime/WebApi/QueuingStrategyTests.cs
@@ -1,0 +1,263 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// <c>CountQueuingStrategy</c> and <c>ByteLengthQueuingStrategy</c> —
+/// https://streams.spec.whatwg.org/#qs.
+/// </summary>
+public class QueuingStrategyTests
+{
+    private static Engine StreamEngine()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Streams));
+        engine.Execute("var log = [];");
+        return engine;
+    }
+
+    private static string Log(Engine engine) => engine.Evaluate("log.join(',')").AsString();
+
+    [Theory]
+    [InlineData("CountQueuingStrategy")]
+    [InlineData("ByteLengthQueuingStrategy")]
+    public void KeepsTheHighWaterMarkItWasGiven(string strategy)
+    {
+        var engine = StreamEngine();
+        engine.Evaluate($"new {strategy}({{ highWaterMark: 4 }}).highWaterMark").AsNumber().Should().Be(4);
+    }
+
+    [Theory]
+    [InlineData("CountQueuingStrategy")]
+    [InlineData("ByteLengthQueuingStrategy")]
+    public void RequiresAnInitDictionaryWithAHighWaterMark(string strategy)
+    {
+        var engine = StreamEngine();
+
+        // `constructor(QueuingStrategyInit init)` takes a required dictionary with a required member.
+        foreach (var argument in new[] { "", "null", "undefined", "true", "5", "{}" })
+        {
+            Assert.Throws<JavaScriptException>(() => engine.Evaluate($"new {strategy}({argument})"))
+                .Error.Get("name").AsString().Should().Be("TypeError", $"{strategy}({argument})");
+        }
+
+        engine.Evaluate($"{strategy}.length").AsNumber().Should().Be(1);
+    }
+
+    [Theory]
+    [InlineData("CountQueuingStrategy")]
+    [InlineData("ByteLengthQueuingStrategy")]
+    public void ConvertsTheHighWaterMarkWithTheUnrestrictedDoubleRulesAndValidatesNothing(string strategy)
+    {
+        // "Note that the provided high water mark will not be validated ahead of time. Instead, if it is
+        // negative, NaN, or not a number, the resulting strategy will cause the corresponding stream
+        // constructor to throw."
+        var engine = StreamEngine();
+
+        engine.Evaluate($"new {strategy}({{ highWaterMark: -5 }}).highWaterMark").AsNumber().Should().Be(-5);
+        engine.Evaluate($"new {strategy}({{ highWaterMark: true }}).highWaterMark").AsNumber().Should().Be(1);
+        engine.Evaluate($"new {strategy}({{ highWaterMark: '0' }}).highWaterMark").AsNumber().Should().Be(0);
+        engine.Evaluate($"Number.isNaN(new {strategy}({{ highWaterMark: 'foo' }}).highWaterMark)").AsBoolean().Should().BeTrue();
+        engine.Evaluate($"new {strategy}({{ highWaterMark: -Infinity }}).highWaterMark").AsNumber().Should().Be(double.NegativeInfinity);
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate($"new ReadableStream({{}}, new {strategy}({{ highWaterMark: -1 }}))"))
+            .Error.Get("name").AsString().Should().Be("RangeError");
+    }
+
+    [Theory]
+    [InlineData("CountQueuingStrategy")]
+    [InlineData("ByteLengthQueuingStrategy")]
+    public void ReportsAThrowingHighWaterMarkGetter(string strategy)
+    {
+        var engine = StreamEngine();
+        engine.Execute("var e = new Error('wow');");
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate($"new {strategy}({{ get highWaterMark() {{ throw e; }} }})"))
+            .Error.Get("message").AsString().Should().Be("wow");
+    }
+
+    [Theory]
+    [InlineData("CountQueuingStrategy")]
+    [InlineData("ByteLengthQueuingStrategy")]
+    public void SizeIsOneSharedFunctionPerRealmRatherThanAMethod(string strategy)
+    {
+        var engine = StreamEngine();
+        engine.Execute($"var a = new {strategy}({{ highWaterMark: 5 }}); var b = new {strategy}({{ highWaterMark: 10 }});");
+
+        // "This design is somewhat historical. It is motivated by the desire to ensure that size is a
+        // function, not a method, i.e. it does not check its this value."
+        engine.Evaluate("a.size === b.size").AsBoolean().Should().BeTrue();
+        engine.Evaluate("a.size.name").AsString().Should().Be("size");
+        engine.Evaluate("'prototype' in a.size").AsBoolean().Should().BeFalse();
+
+        // Not a constructor either.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new (a.size)()"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Theory]
+    [InlineData("CountQueuingStrategy")]
+    [InlineData("ByteLengthQueuingStrategy")]
+    public void SubclassingWorks(string strategy)
+    {
+        var engine = StreamEngine();
+        engine.Execute($$"""
+            class Sub extends {{strategy}} {
+              size() { return 2; }
+              extra() { return true; }
+            }
+            var sc = new Sub({ highWaterMark: 77 });
+            """);
+
+        engine.Evaluate("sc.constructor.name").AsString().Should().Be("Sub");
+        engine.Evaluate("sc.highWaterMark").AsNumber().Should().Be(77);
+        engine.Evaluate("sc.size()").AsNumber().Should().Be(2);
+        engine.Evaluate("sc.extra()").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void CountSizeAlwaysAnswersOne()
+    {
+        var engine = StreamEngine();
+        engine.Execute("var size = new CountQueuingStrategy({ highWaterMark: 5 }).size;");
+
+        engine.Evaluate("size.length").AsNumber().Should().Be(0);
+        engine.Evaluate("size()").AsNumber().Should().Be(1);
+        engine.Evaluate("size(null)").AsNumber().Should().Be(1);
+        engine.Evaluate("size('potato')").AsNumber().Should().Be(1);
+        engine.Evaluate("size({ get byteLength() { throw new Error('never read'); } })").AsNumber().Should().Be(1);
+    }
+
+    [Fact]
+    public void ByteLengthSizeReadsTheByteLengthProperty()
+    {
+        var engine = StreamEngine();
+        engine.Execute("var size = new ByteLengthQueuingStrategy({ highWaterMark: 5 }).size; var e = new Error('wow');");
+
+        engine.Evaluate("size.length").AsNumber().Should().Be(1);
+        engine.Evaluate("size({ byteLength: 1024 })").AsNumber().Should().Be(1024);
+        engine.Evaluate("size({ get byteLength() { return 7; } })").AsNumber().Should().Be(7);
+
+        // GetV(chunk, "byteLength"): undefined for an object without the property, a TypeError for a value
+        // that cannot be converted to an object, and the getter's own exception when it throws.
+        engine.Evaluate("size({}) === undefined").AsBoolean().Should().BeTrue();
+        engine.Evaluate("size('potato') === undefined").AsBoolean().Should().BeTrue();
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("size()"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("size(null)"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("size({ get byteLength() { throw e; } })"))
+            .Error.Get("message").AsString().Should().Be("wow");
+    }
+
+    [Fact]
+    public void CountQueuingStrategyMeasuresAStreamInChunks()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var controller;
+            new ReadableStream({ start(c) { controller = c; } }, new CountQueuingStrategy({ highWaterMark: 3 }));
+            log.push(controller.desiredSize);
+            controller.enqueue('a longer chunk');
+            log.push(controller.desiredSize);
+            """);
+
+        Log(engine).Should().Be("3,2");
+    }
+
+    [Fact]
+    public void ByteLengthQueuingStrategyMeasuresAStreamInBytes()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var controller;
+            new ReadableStream({ start(c) { controller = c; } }, new ByteLengthQueuingStrategy({ highWaterMark: 1024 }));
+            controller.enqueue(new Uint8Array(100));
+            log.push(controller.desiredSize);
+            controller.enqueue(new Uint8Array(24));
+            log.push(controller.desiredSize);
+            """);
+
+        Log(engine).Should().Be("924,900");
+    }
+
+    [Fact]
+    public void AnyObjectWithTheRightShapeIsAQueuingStrategy()
+    {
+        // "Any object with these properties can be used when a queuing strategy object is expected."
+        var engine = StreamEngine();
+        engine.Execute("""
+            var controller;
+            new ReadableStream(
+              { start(c) { controller = c; } },
+              { highWaterMark: 10, size: chunk => chunk.weight });
+            controller.enqueue({ weight: 4 });
+            log.push(controller.desiredSize);
+            """);
+
+        Log(engine).Should().Be("6");
+    }
+
+    [Fact]
+    public void ANonCallableSizeIsATypeError()
+    {
+        var engine = StreamEngine();
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new ReadableStream({}, { size: 42 })"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void RefusesASizeThatIsNotAFiniteNonNegativeNumber()
+    {
+        var engine = StreamEngine();
+
+        foreach (var size in new[] { "-1", "NaN", "Infinity" })
+        {
+            engine.Execute($$"""
+                log.length = 0;
+                var controller;
+                var stream = new ReadableStream(
+                  { start(c) { controller = c; } },
+                  { size: () => {{size}} });
+                try { controller.enqueue('a'); } catch (e) { log.push('threw:' + e.name); }
+                stream.getReader().closed.catch(e => log.push('closed:' + e.name));
+                """);
+
+            Log(engine).Should().Be("threw:RangeError,closed:RangeError", size);
+        }
+    }
+
+    [Fact]
+    public void MembersCarryTheWebIdlShape()
+    {
+        var engine = StreamEngine();
+
+        foreach (var strategy in new[] { "CountQueuingStrategy", "ByteLengthQueuingStrategy" })
+        {
+            engine.Evaluate($"Object.prototype.toString.call(new {strategy}({{ highWaterMark: 1 }}))")
+                .AsString().Should().Be($"[object {strategy}]");
+            engine.Evaluate($"Object.getOwnPropertyNames(new {strategy}({{ highWaterMark: 1 }})).length")
+                .AsNumber().Should().Be(0, strategy);
+
+            var descriptor = engine.Realm.GlobalObject.GetOwnProperty(strategy);
+            descriptor.Enumerable.Should().BeFalse(strategy);
+            descriptor.Writable.Should().BeTrue(strategy);
+            descriptor.Configurable.Should().BeTrue(strategy);
+
+            Assert.Throws<JavaScriptException>(() => engine.Evaluate($"Object.getOwnPropertyDescriptor({strategy}.prototype, 'highWaterMark').get.call({{}})"))
+                .Error.Get("name").AsString().Should().Be("TypeError", strategy);
+            Assert.Throws<JavaScriptException>(() => engine.Evaluate($"Object.getOwnPropertyDescriptor({strategy}.prototype, 'size').get.call({{}})"))
+                .Error.Get("name").AsString().Should().Be("TypeError", strategy);
+        }
+
+        // Each interface brand-checks against its own type, not against "a queuing strategy".
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate(
+            "Object.getOwnPropertyDescriptor(CountQueuingStrategy.prototype, 'highWaterMark').get.call(new ByteLengthQueuingStrategy({ highWaterMark: 1 }))"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/ReadableStreamAsyncIterationTests.cs
+++ b/Jint.Tests/Runtime/WebApi/ReadableStreamAsyncIterationTests.cs
@@ -1,0 +1,265 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// Asynchronous iteration of a <c>ReadableStream</c> — https://streams.spec.whatwg.org/#rs-asynciterator,
+/// on top of WebIDL's default asynchronous iterator object,
+/// https://webidl.spec.whatwg.org/#js-default-asynchronous-iterator-object.
+/// </summary>
+public class ReadableStreamAsyncIterationTests
+{
+    private static Engine StreamEngine()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Streams));
+        engine.Execute("var log = [];");
+        return engine;
+    }
+
+    private static string Log(Engine engine) => engine.Evaluate("log.join(',')").AsString();
+
+    [Fact]
+    public void IteratesEveryChunkAndReleasesTheLockAtTheEnd()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({ start(c) { c.enqueue('a'); c.enqueue('b'); c.close(); } });
+            (async () => {
+              for await (const chunk of stream) { log.push(chunk); }
+              log.push('locked:' + stream.locked);
+            })();
+            """);
+
+        Log(engine).Should().Be("a,b,locked:false");
+    }
+
+    [Fact]
+    public void LocksTheStreamForTheWholeIteration()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({ start(c) { c.enqueue('a'); } });
+            var iterator = stream[Symbol.asyncIterator]();
+            """);
+
+        engine.Evaluate("stream.locked").AsBoolean().Should().BeTrue();
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("stream.getReader()"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void SymbolAsyncIteratorIsTheValuesFunctionItself()
+    {
+        var engine = StreamEngine();
+
+        engine.Evaluate("ReadableStream.prototype[Symbol.asyncIterator] === ReadableStream.prototype.values")
+            .AsBoolean().Should().BeTrue();
+        engine.Evaluate("ReadableStream.prototype.values.length").AsNumber().Should().Be(0);
+        engine.Evaluate("ReadableStream.prototype.values.name").AsString().Should().Be("values");
+    }
+
+    [Fact]
+    public void TheIteratorPrototypeInheritsFromTheAsyncIteratorPrototype()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var iterator = new ReadableStream().values();
+            var proto = Object.getPrototypeOf(iterator);
+            // %AsyncIteratorPrototype% is two levels above an async generator instance: instance →
+            // its own generator prototype → %AsyncGeneratorPrototype% → %AsyncIteratorPrototype%.
+            var gen = (async function* () {})();
+            var asyncIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf(Object.getPrototypeOf(gen)));
+            """);
+
+        engine.Evaluate("Object.getPrototypeOf(proto) === asyncIteratorPrototype").AsBoolean().Should().BeTrue();
+        engine.Evaluate("proto[Symbol.toStringTag]").AsString().Should().Be("ReadableStream AsyncIterator");
+        engine.Evaluate("typeof proto.next").AsString().Should().Be("function");
+        engine.Evaluate("typeof proto.return").AsString().Should().Be("function");
+
+        // Inheriting from %AsyncIteratorPrototype% means the iterator is itself async-iterable.
+        engine.Evaluate("iterator[Symbol.asyncIterator]() === iterator").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void BreakingOutOfTheLoopCancelsTheStream()
+    {
+        // "By default, calling the async iterator's return() method will also cancel the stream."
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({
+              start(c) { c.enqueue('a'); c.enqueue('b'); },
+              cancel(reason) { log.push('cancel:' + reason); }
+            });
+            (async () => {
+              for await (const chunk of stream) { log.push(chunk); break; }
+              log.push('locked:' + stream.locked);
+            })();
+            """);
+
+        Log(engine).Should().Be("a,cancel:undefined,locked:false");
+    }
+
+    [Fact]
+    public void PreventCancelReleasesTheLockWithoutCancelling()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({
+              start(c) { c.enqueue('a'); c.enqueue('b'); },
+              cancel() { log.push('cancel'); }
+            });
+            (async () => {
+              for await (const chunk of stream.values({ preventCancel: true })) { log.push(chunk); break; }
+              log.push('locked:' + stream.locked);
+              const { value } = await stream.getReader().read();
+              log.push('left:' + value);
+            })();
+            """);
+
+        Log(engine).Should().Be("a,locked:false,left:b");
+    }
+
+    [Fact]
+    public void AnErrorInTheStreamThrowsOutOfTheLoopAndReleasesTheLock()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var controller;
+            var stream = new ReadableStream({ start(c) { controller = c; c.enqueue('a'); } });
+            (async () => {
+              try {
+                for await (const chunk of stream) { log.push(chunk); controller.error(new Error('bad')); }
+              } catch (e) {
+                log.push('caught:' + e.message);
+              }
+              log.push('locked:' + stream.locked);
+            })();
+            """);
+
+        Log(engine).Should().Be("a,caught:bad,locked:false");
+    }
+
+    [Fact]
+    public void ReportsAFailingCancelThroughTheReturnPromise()
+    {
+        // The iterator's return() is what `break` calls, and a cancel() that fails rejects it. Asserted on
+        // return() directly rather than through `for await…of`: the engine's AsyncIteratorClose currently
+        // swallows a rejected return() when the loop is left by `break`, which is a pre-existing gap that
+        // shows for a plain async iterable too and has nothing to do with streams.
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({
+              start(c) { c.enqueue('a'); },
+              cancel() { throw new Error('cancel failed'); }
+            });
+            var iterator = stream.values();
+            iterator.next().then(r => log.push(r.value));
+            iterator.return('bye').then(
+              () => log.push('fulfilled'),
+              e => log.push('rejected:' + e.message));
+            """);
+
+        Log(engine).Should().Be("a,rejected:cancel failed");
+    }
+
+    [Fact]
+    public void NextSerializesConcurrentCalls()
+    {
+        // WebIDL queues a second next() behind the first, so the read requests can never interleave.
+        var engine = StreamEngine();
+        engine.Execute("""
+            var controller;
+            var stream = new ReadableStream({ start(c) { controller = c; } });
+            var iterator = stream.values();
+            iterator.next().then(r => log.push('1:' + r.value));
+            iterator.next().then(r => log.push('2:' + r.value));
+            iterator.next().then(r => log.push('3:' + r.value + ':' + r.done));
+            controller.enqueue('a');
+            controller.enqueue('b');
+            controller.close();
+            """);
+
+        Log(engine).Should().Be("1:a,2:b,3:undefined:true");
+    }
+
+    [Fact]
+    public void NextAfterTheEndKeepsAnsweringDone()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var iterator = new ReadableStream({ start(c) { c.close(); } }).values();
+            (async () => {
+              log.push(JSON.stringify(await iterator.next()));
+              log.push(JSON.stringify(await iterator.next()));
+            })();
+            """);
+
+        Log(engine).Should().Be("{\"done\":true},{\"done\":true}");
+    }
+
+    [Fact]
+    public void ReturnAnswersWithTheValueItWasGiven()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var iterator = new ReadableStream({ start(c) { c.enqueue('a'); }, cancel(r) { log.push('cancel:' + r); } }).values();
+            iterator.return('bye').then(r => log.push('return:' + r.value + ':' + r.done));
+            iterator.next().then(r => log.push('next:' + r.value + ':' + r.done));
+            """);
+
+        Log(engine).Should().Be("cancel:bye,return:bye:true,next:undefined:true");
+    }
+
+    [Fact]
+    public void NextAndReturnBrandCheckTheirReceiverAsARejection()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var proto = Object.getPrototypeOf(new ReadableStream().values());
+            proto.next.call({}).catch(e => log.push('next:' + e.name));
+            proto.return.call({}).catch(e => log.push('return:' + e.name));
+            """);
+
+        Log(engine).Should().Be("next:TypeError,return:TypeError");
+    }
+
+    [Fact]
+    public void ValuesConvertsItsOptionsBeforeLockingTheStream()
+    {
+        var engine = StreamEngine();
+        engine.Execute("var stream = new ReadableStream(); var e = new Error('options');");
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("stream.values({ get preventCancel() { throw e; } })"))
+            .Error.Get("message").AsString().Should().Be("options");
+
+        // The stream is untouched, so it can still be iterated afterwards.
+        engine.Evaluate("stream.locked").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void IteratingALockedStreamThrows()
+    {
+        var engine = StreamEngine();
+        engine.Execute("var stream = new ReadableStream(); stream.getReader();");
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("stream.values()"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void WorksWithTheAsyncIteratorHelpers()
+    {
+        // Inheriting %AsyncIteratorPrototype% is what makes this work at all.
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({ start(c) { c.enqueue(1); c.enqueue(2); c.enqueue(3); c.close(); } });
+            stream.values().map(x => x * 2).toArray().then(a => log.push(a.join('|')));
+            """);
+
+        Log(engine).Should().Be("2|4|6");
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/ReadableStreamTeeTests.cs
+++ b/Jint.Tests/Runtime/WebApi/ReadableStreamTeeTests.cs
@@ -1,0 +1,264 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// <c>ReadableStream.prototype.tee()</c> — https://streams.spec.whatwg.org/#readable-stream-default-tee.
+/// </summary>
+public class ReadableStreamTeeTests
+{
+    private static Engine StreamEngine()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Streams));
+        engine.Execute("""
+            var log = [];
+            async function drain(stream, label) {
+              const reader = stream.getReader();
+              for (;;) {
+                let result;
+                try { result = await reader.read(); }
+                catch (e) { log.push(label + ':error:' + e.message); return; }
+                if (result.done) { log.push(label + ':done'); return; }
+                log.push(label + ':' + result.value);
+              }
+            }
+            """);
+        return engine;
+    }
+
+    private static string Log(Engine engine) => engine.Evaluate("log.join(',')").AsString();
+
+    [Fact]
+    public void ReturnsTwoBranchesAndLocksTheOriginal()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream();
+            var branches = stream.tee();
+            """);
+
+        engine.Evaluate("Array.isArray(branches)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("branches.length").AsNumber().Should().Be(2);
+        engine.Evaluate("branches[0] instanceof ReadableStream && branches[1] instanceof ReadableStream").AsBoolean().Should().BeTrue();
+        engine.Evaluate("branches[0] !== branches[1]").AsBoolean().Should().BeTrue();
+        engine.Evaluate("stream.locked").AsBoolean().Should().BeTrue();
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("stream.getReader()"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void RefusesToTeeALockedStream()
+    {
+        var engine = StreamEngine();
+        engine.Execute("var stream = new ReadableStream(); stream.getReader();");
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("stream.tee()"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void BothBranchesSeeEveryChunkAndTheClose()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({ start(c) { c.enqueue('a'); c.enqueue('b'); c.close(); } });
+            var [one, two] = stream.tee();
+            (async () => { await drain(one, 'one'); await drain(two, 'two'); })();
+            """);
+
+        Log(engine).Should().Be("one:a,one:b,one:done,two:a,two:b,two:done");
+    }
+
+    [Fact]
+    public void HandsBothBranchesTheVerySameChunkObject()
+    {
+        // The non-byte tee never clones: "the chunks seen in each branch will be the same object."
+        var engine = StreamEngine();
+        engine.Execute("""
+            var chunk = { id: 1 };
+            var [one, two] = new ReadableStream({ start(c) { c.enqueue(chunk); c.close(); } }).tee();
+            var a, b;
+            one.getReader().read().then(r => { a = r.value; });
+            two.getReader().read().then(r => { b = r.value; });
+            """);
+
+        engine.Evaluate("a === chunk && b === chunk").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void OneBranchMayRunFarAheadOfTheOther()
+    {
+        // Each branch has its own queue, so a consumer that never reads does not stall the other.
+        var engine = StreamEngine();
+        engine.Execute("""
+            var [one, two] = new ReadableStream({ start(c) { c.enqueue('a'); c.enqueue('b'); c.close(); } }).tee();
+            drain(one, 'one');
+            """);
+
+        Log(engine).Should().Be("one:a,one:b,one:done");
+        engine.Evaluate("two.locked").AsBoolean().Should().BeFalse();
+
+        // The slow branch still has everything waiting for it.
+        engine.Execute("drain(two, 'two');");
+        Log(engine).Should().Be("one:a,one:b,one:done,two:a,two:b,two:done");
+    }
+
+    [Fact]
+    public void AnErrorInTheOriginalErrorsBothBranchesImmediately()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var controller;
+            var stream = new ReadableStream({ start(c) { controller = c; } });
+            var [one, two] = stream.tee();
+            drain(one, 'one');
+            drain(two, 'two');
+            controller.error(new Error('bad'));
+            """);
+
+        Log(engine).Should().Be("one:error:bad,two:error:bad");
+    }
+
+    [Fact]
+    public void AnErrorDoesNotOvertakeASynchronouslyAvailableChunk()
+    {
+        // The tee's chunk steps are deliberately delayed by a microtask, because an error only reaches the
+        // branches through the reader's closed promise, which also takes a microtask. Without the delay a
+        // chunk enqueued and then errored in the same turn would reach the branches out of order.
+        var engine = StreamEngine();
+        engine.Execute("""
+            var controller;
+            var stream = new ReadableStream({ start(c) { controller = c; c.enqueue('a'); } });
+            var [one, two] = stream.tee();
+            drain(one, 'one');
+            controller.error(new Error('bad'));
+            """);
+
+        Log(engine).Should().Be("one:error:bad");
+    }
+
+    [Fact]
+    public void CancellingOneBranchDoesNotCancelTheOriginal()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({
+              start(c) { c.enqueue('a'); },
+              cancel(reason) { log.push('source:' + JSON.stringify(reason)); }
+            });
+            var [one, two] = stream.tee();
+            one.cancel('first').then(() => log.push('one:cancelled'));
+            """);
+
+        // The underlying source has not been told anything, and the branch's own cancel promise is still
+        // pending: it settles only once the other branch is done with the stream too.
+        Log(engine).Should().Be("");
+
+        // Meanwhile the other branch keeps working, chunk and all.
+        engine.Execute("drain(two, 'two');");
+        Log(engine).Should().Be("two:a");
+    }
+
+    [Fact]
+    public void ALoneBranchCancelSettlesOnceTheOtherBranchReachesTheEnd()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var controller;
+            var stream = new ReadableStream({ start(c) { controller = c; } });
+            var [one, two] = stream.tee();
+            one.cancel('first').then(() => log.push('one:cancelled'));
+            drain(two, 'two');
+            log.push('mid');
+            controller.close();
+            """);
+
+        Log(engine).Should().Be("mid,two:done,one:cancelled");
+    }
+
+    [Fact]
+    public void ALoneBranchCancelSettlesOnceTheOriginalErrors()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var controller;
+            var stream = new ReadableStream({ start(c) { controller = c; } });
+            var [one, two] = stream.tee();
+            one.cancel('first').then(() => log.push('one:cancelled'), e => log.push('one:rejected'));
+            controller.error(new Error('bad'));
+            drain(two, 'two');
+            """);
+
+        Log(engine).Should().Be("two:error:bad,one:cancelled");
+    }
+
+    [Fact]
+    public void CancellingBothBranchesCancelsTheOriginalWithACompositeReason()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({ cancel(reason) { log.push('source:' + JSON.stringify(reason)); } });
+            var [one, two] = stream.tee();
+            one.cancel('first').then(() => log.push('one:cancelled'));
+            two.cancel('second').then(() => log.push('two:cancelled'));
+            """);
+
+        Log(engine).Should().Be("""source:["first","second"],one:cancelled,two:cancelled""");
+    }
+
+    [Fact]
+    public void ACompositeCancelReportsTheUnderlyingSourceFailureToBothBranches()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({ cancel() { return Promise.reject(new Error('no')); } });
+            var [one, two] = stream.tee();
+            one.cancel().catch(e => log.push('one:' + e.message));
+            two.cancel().catch(e => log.push('two:' + e.message));
+            """);
+
+        Log(engine).Should().Be("one:no,two:no");
+    }
+
+    [Fact]
+    public void ClosingTheOriginalClosesEveryBranchThatIsStillInterested()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var controller;
+            var stream = new ReadableStream({ start(c) { controller = c; } });
+            var [one, two] = stream.tee();
+            drain(one, 'one');
+            drain(two, 'two');
+            controller.close();
+            """);
+
+        Log(engine).Should().Be("one:done,two:done");
+    }
+
+    [Fact]
+    public void PullsFromTheOriginalOnlyWhenABranchWantsMore()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var pulls = 0;
+            var stream = new ReadableStream({
+              pull(c) { pulls++; c.enqueue('chunk' + pulls); },
+              cancel() {}
+            }, { highWaterMark: 0 });
+            var [one, two] = stream.tee();
+            log.push('teed:' + pulls);
+            one.getReader().read().then(r => log.push('one:' + r.value + ':pulls=' + pulls));
+            """);
+
+        // Teeing itself reads nothing; each branch's own high water mark of 1 is what starts a read. The
+        // second branch's request arrives while the first read is outstanding, so it is remembered and
+        // served once that read completes — which is the second pull.
+        Log(engine).Should().Be("teed:0,one:chunk1:pulls=2");
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/ReadableStreamTests.cs
+++ b/Jint.Tests/Runtime/WebApi/ReadableStreamTests.cs
@@ -1,0 +1,741 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// <c>ReadableStream</c>, its default controller and its default reader, against the Streams Standard —
+/// https://streams.spec.whatwg.org/#rs.
+/// </summary>
+/// <remarks>
+/// <c>Engine.Execute</c> drains the event loop once the script has finished, so a test can write the whole
+/// asynchronous story into a <c>log</c> array and then read it. Nothing here sleeps or starts a thread:
+/// every promise these streams hand out is an ordinary engine promise settled by a job on that same queue.
+/// </remarks>
+public class ReadableStreamTests
+{
+    private static Engine StreamEngine()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Streams));
+        engine.Execute("var log = [];");
+        return engine;
+    }
+
+    private static string Log(Engine engine) => engine.Evaluate("log.join(',')").AsString();
+
+    private static JsValue Eval(string source) => StreamEngine().Evaluate(source);
+
+    [Fact]
+    public void ConstructsWithNoArgumentsAtAll()
+    {
+        Eval("new ReadableStream() instanceof ReadableStream").AsBoolean().Should().BeTrue();
+        Eval("new ReadableStream(undefined, undefined).locked").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void RefusesANonObjectUnderlyingSource()
+    {
+        // `optional object underlyingSource` is not nullable, so an explicit null is a TypeError while an
+        // omitted argument is simply missing — https://webidl.spec.whatwg.org/#es-object.
+        var engine = StreamEngine();
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new ReadableStream(null)"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new ReadableStream(5)"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void ConvertsTheStrategyBeforeTheUnderlyingSource()
+    {
+        // The strategy is a WebIDL dictionary and is converted at the IDL layer; the underlying source is
+        // converted in the constructor's own prose. So the strategy's exception wins.
+        var engine = StreamEngine();
+        engine.Execute("var e1 = new Error('source'); var e2 = new Error('strategy');");
+
+        var error = Assert.Throws<JavaScriptException>(() => engine.Evaluate(
+            "new ReadableStream({ get start() { throw e1; } }, { get size() { throw e2; } })"));
+
+        error.Error.Get("message").AsString().Should().Be("strategy");
+    }
+
+    [Fact]
+    public void RefusesAByteStream()
+    {
+        // Byte streams are not implemented, and `type: "bytes"` is refused rather than quietly ignored, so
+        // feature detection sees the truth.
+        var engine = StreamEngine();
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new ReadableStream({ type: 'bytes' })"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+
+        // An invalid enumeration value is the same TypeError.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new ReadableStream({ type: 'nonsense' })"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+
+        // And a BYOB reader cannot be acquired from a stream that is not a byte stream.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new ReadableStream().getReader({ mode: 'byob' })"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void CallsStartSynchronouslyWithTheController()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var seen;
+            var stream = new ReadableStream({ start(c) { seen = c; log.push('start'); } });
+            log.push('after');
+            """);
+
+        Log(engine).Should().Be("start,after");
+        engine.Evaluate("Object.getPrototypeOf(seen).constructor.name").AsString().Should().Be("ReadableStreamDefaultController");
+    }
+
+    [Fact]
+    public void RethrowsAnExceptionFromStart()
+    {
+        // start()'s return type is `any`, so its exception is not converted into a rejection —
+        // "Any thrown exceptions will be re-thrown by the ReadableStream() constructor."
+        var engine = StreamEngine();
+        var error = Assert.Throws<JavaScriptException>(() => engine.Evaluate(
+            "new ReadableStream({ start() { throw new Error('boom'); } })"));
+
+        error.Error.Get("message").AsString().Should().Be("boom");
+    }
+
+    [Fact]
+    public void ErrorsTheStreamWhenStartRejects()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({ start() { return Promise.reject(new Error('nope')); } });
+            stream.getReader().read().then(() => log.push('resolved'), e => log.push('rejected:' + e.message));
+            """);
+
+        Log(engine).Should().Be("rejected:nope");
+    }
+
+    [Fact]
+    public void ReadsTheChunksAnUnderlyingSourceEnqueued()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({
+              start(c) { c.enqueue('a'); c.enqueue('b'); c.close(); }
+            });
+            var reader = stream.getReader();
+            (async () => {
+              for (;;) {
+                const { value, done } = await reader.read();
+                if (done) { log.push('done'); return; }
+                log.push(value);
+              }
+            })();
+            """);
+
+        Log(engine).Should().Be("a,b,done");
+    }
+
+    [Fact]
+    public void ReadResultIsAPlainObjectWithValueAndDone()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var r = new ReadableStream({ start(c) { c.enqueue('x'); } }).getReader();
+            var result;
+            r.read().then(v => { result = v; });
+            """);
+
+        engine.Evaluate("Object.keys(result).join(',')").AsString().Should().Be("value,done");
+        engine.Evaluate("result.value").AsString().Should().Be("x");
+        engine.Evaluate("result.done").AsBoolean().Should().BeFalse();
+        engine.Evaluate("Object.getPrototypeOf(result) === Object.prototype").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ClosingLeavesAlreadyEnqueuedChunksReadable()
+    {
+        // "Consumers will still be able to read any previously-enqueued chunks from the stream, but once
+        // those are read, the stream will become closed."
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({ start(c) { c.enqueue('a'); c.close(); } });
+            log.push(stream.locked);
+            var reader = stream.getReader();
+            reader.read().then(r => log.push('1:' + r.value + ':' + r.done));
+            reader.read().then(r => log.push('2:' + r.value + ':' + r.done));
+            reader.closed.then(() => log.push('closed'));
+            """);
+
+        Log(engine).Should().Be("false,1:a:false,2:undefined:true,closed");
+    }
+
+    [Fact]
+    public void EnqueueAndCloseThrowOnceCloseHasBeenRequested()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var controller;
+            new ReadableStream({ start(c) { controller = c; c.close(); } });
+            try { controller.close(); } catch (e) { log.push('close:' + e.name); }
+            try { controller.enqueue('x'); } catch (e) { log.push('enqueue:' + e.name); }
+            """);
+
+        Log(engine).Should().Be("close:TypeError,enqueue:TypeError");
+    }
+
+    [Fact]
+    public void ErroringMakesEveryLaterInteractionFail()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({ start(c) { c.error(new Error('bad')); } });
+            var reader = stream.getReader();
+            reader.read().then(() => log.push('resolved'), e => log.push('read:' + e.message));
+            reader.closed.then(() => log.push('closed'), e => log.push('closed:' + e.message));
+            """);
+
+        Log(engine).Should().Be("read:bad,closed:bad");
+    }
+
+    [Fact]
+    public void ErrorOnAnAlreadyErroredStreamIsANoOp()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var controller;
+            var stream = new ReadableStream({ start(c) { controller = c; } });
+            controller.error(new Error('first'));
+            controller.error(new Error('second'));
+            stream.getReader().closed.catch(e => log.push(e.message));
+            """);
+
+        Log(engine).Should().Be("first");
+    }
+
+    [Fact]
+    public void DesiredSizeTracksTheQueueAgainstTheHighWaterMark()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var controller;
+            var stream = new ReadableStream({ start(c) { controller = c; } }, { highWaterMark: 3 });
+            log.push(controller.desiredSize);
+            controller.enqueue('a');
+            log.push(controller.desiredSize);
+            controller.enqueue('b'); controller.enqueue('c'); controller.enqueue('d');
+            log.push(controller.desiredSize);
+            """);
+
+        // The queue may overshoot the high water mark; the desired size simply goes negative.
+        Log(engine).Should().Be("3,2,-1");
+    }
+
+    [Fact]
+    public void DesiredSizeIsZeroWhenClosedAndNullWhenErrored()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var a, b;
+            new ReadableStream({ start(c) { a = c; c.close(); } });
+            new ReadableStream({ start(c) { b = c; c.error(new Error('x')); } });
+            log.push(a.desiredSize);
+            log.push(b.desiredSize);
+            """);
+
+        Log(engine).Should().Be("0,");
+        engine.Evaluate("b.desiredSize").IsNull().Should().BeTrue();
+    }
+
+    [Fact]
+    public void CallsPullOnceStartHasSettledAndTheQueueWantsMore()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({
+              start() { log.push('start'); },
+              pull(c) { log.push('pull:' + c.desiredSize); c.enqueue('x'); }
+            }, { highWaterMark: 2 });
+            log.push('constructed');
+            """);
+
+        // pull() is not called until start() has completed — which is a microtask away even for a
+        // synchronous start — and is then called repeatedly until the high water mark is reached.
+        Log(engine).Should().Be("start,constructed,pull:2,pull:1");
+    }
+
+    [Fact]
+    public void DoesNotCallPullRepeatedlyForANoOpPull()
+    {
+        // "it will only be called repeatedly if it enqueues at least one chunk … a no-op pull()
+        // implementation will not be continually called."
+        var engine = StreamEngine();
+        engine.Execute("""
+            new ReadableStream({ pull() { log.push('pull'); } }, { highWaterMark: 5 });
+            """);
+
+        Log(engine).Should().Be("pull");
+    }
+
+    [Fact]
+    public void DoesNotCallPullAgainUntilItsPromiseFulfils()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var release;
+            var stream = new ReadableStream({
+              pull(c) {
+                log.push('pull');
+                c.enqueue('x');
+                return new Promise(r => { release = r; });
+              }
+            }, { highWaterMark: 3 });
+
+            // pull() has not run yet: it waits for start() to settle, which takes a microtask even when
+            // start is absent. So the release has to be scheduled behind that.
+            log.push('sync:' + (release === undefined));
+            Promise.resolve().then(() => { log.push('releasing'); release(); });
+            """);
+
+        // One pull, then nothing at all until the promise it returned settles. The second pull replaces
+        // `release` with its own resolver and nobody calls it, so there is no third — the high water mark of
+        // 3 still wants a chunk, and the stream simply waits.
+        Log(engine).Should().Be("sync:true,pull,releasing,pull");
+    }
+
+    [Fact]
+    public void ErrorsTheStreamWhenPullRejects()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({ pull() { return Promise.reject(new Error('pull failed')); } });
+            stream.getReader().closed.catch(e => log.push(e.message));
+            """);
+
+        Log(engine).Should().Be("pull failed");
+    }
+
+    [Fact]
+    public void APendingReadOutranksTheHighWaterMark()
+    {
+        // "If IsReadableStreamLocked(stream) is true and ReadableStreamGetNumReadRequests(stream) > 0,
+        // return true" — a waiting consumer pulls even from a stream whose strategy would not.
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({ pull(c) { log.push('pull'); c.enqueue('x'); } }, { highWaterMark: 0 });
+            log.push('constructed');
+            stream.getReader().read().then(r => log.push('read:' + r.value));
+            """);
+
+        Log(engine).Should().Be("constructed,pull,read:x");
+    }
+
+    [Fact]
+    public void HandsAChunkStraightToAWaitingReaderWithoutMeasuringIt()
+    {
+        // A chunk delivered to a pending read never enters the queue, so the strategy's size() is not called
+        // for it.
+        var engine = StreamEngine();
+        engine.Execute("""
+            var controller;
+            var stream = new ReadableStream(
+              { start(c) { controller = c; } },
+              { highWaterMark: 10, size(chunk) { log.push('size:' + chunk); return 1; } });
+            var reader = stream.getReader();
+            reader.read().then(r => log.push('read:' + r.value));
+            controller.enqueue('a');
+            controller.enqueue('b');
+            """);
+
+        Log(engine).Should().Be("size:b,read:a");
+    }
+
+    [Fact]
+    public void CallsTheStrategySizeOncePerQueuedChunk()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var controller;
+            new ReadableStream(
+              { start(c) { controller = c; } },
+              { highWaterMark: 10, size(chunk) { log.push('size:' + chunk); return chunk.length; } });
+            controller.enqueue('a');
+            controller.enqueue('bb');
+            log.push(controller.desiredSize);
+            """);
+
+        Log(engine).Should().Be("size:a,size:bb,7");
+    }
+
+    [Fact]
+    public void ErrorsTheStreamWhenTheStrategySizeThrows()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var controller;
+            var stream = new ReadableStream(
+              { start(c) { controller = c; } },
+              { size() { throw new Error('size failed'); } });
+            try { controller.enqueue('a'); } catch (e) { log.push('threw:' + e.message); }
+            stream.getReader().closed.catch(e => log.push('closed:' + e.message));
+            """);
+
+        Log(engine).Should().Be("threw:size failed,closed:size failed");
+    }
+
+    [Fact]
+    public void RejectsANegativeOrNaNHighWaterMark()
+    {
+        var engine = StreamEngine();
+
+        foreach (var value in new[] { "-1", "NaN", "'foo'" })
+        {
+            Assert.Throws<JavaScriptException>(() => engine.Evaluate($"new ReadableStream({{}}, {{ highWaterMark: {value} }})"))
+                .Error.Get("name").AsString().Should().Be("RangeError");
+        }
+
+        // +∞ is explicitly allowed: it makes backpressure never apply.
+        engine.Evaluate("new ReadableStream({}, { highWaterMark: Infinity }) instanceof ReadableStream").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void LocksTheStreamForOneReaderAtATime()
+    {
+        var engine = StreamEngine();
+        engine.Execute("var stream = new ReadableStream(); var reader = stream.getReader();");
+
+        engine.Evaluate("stream.locked").AsBoolean().Should().BeTrue();
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("stream.getReader()"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+
+        engine.Execute("reader.releaseLock();");
+        engine.Evaluate("stream.locked").AsBoolean().Should().BeFalse();
+        engine.Evaluate("stream.getReader() !== reader").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReleasingTheLockRejectsOutstandingReadsAndKeepsTheChunks()
+    {
+        // "If the reader's lock is released while it still has pending read requests, then the promises
+        // returned by the reader's read() method are immediately rejected with a TypeError. Any unread chunks
+        // remain in the stream's internal queue and can be read later by acquiring a new reader."
+        var engine = StreamEngine();
+        engine.Execute("""
+            var controller;
+            var stream = new ReadableStream({ start(c) { controller = c; } });
+            var reader = stream.getReader();
+            reader.read().then(() => log.push('resolved'), e => log.push('read:' + e.name));
+            reader.closed.catch(e => log.push('closed:' + e.name));
+            reader.releaseLock();
+            controller.enqueue('kept');
+            stream.getReader().read().then(r => log.push('again:' + r.value));
+            """);
+
+        // The closed promise is rejected before the read requests are, which is the order
+        // ReadableStreamDefaultReaderRelease performs them in.
+        Log(engine).Should().Be("closed:TypeError,read:TypeError,again:kept");
+    }
+
+    [Fact]
+    public void AReleasedReaderRefusesEveryOperation()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var reader = new ReadableStream().getReader();
+            reader.releaseLock();
+            reader.read().catch(e => log.push('read:' + e.name));
+            reader.cancel().catch(e => log.push('cancel:' + e.name));
+            reader.closed.catch(e => log.push('closed:' + e.name));
+            log.push('releaseLock:' + reader.releaseLock());
+            """);
+
+        Log(engine).Should().Be("releaseLock:undefined,read:TypeError,cancel:TypeError,closed:TypeError");
+    }
+
+    [Fact]
+    public void CancelClosesTheStreamAndTellsTheUnderlyingSource()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({
+              start(c) { c.enqueue('a'); },
+              cancel(reason) { log.push('cancel:' + reason); }
+            });
+            stream.cancel('because').then(v => log.push('fulfilled:' + v));
+            stream.getReader().read().then(r => log.push('read:' + r.value + ':' + r.done));
+            """);
+
+        // The queue is discarded and the stream becomes closed, not errored. The cancel promise settles one
+        // microtask behind the underlying source's own answer, because ReadableStreamCancel reacts to it to
+        // discard its fulfillment value.
+        Log(engine).Should().Be("cancel:because,read:undefined:true,fulfilled:undefined");
+    }
+
+    [Fact]
+    public void CancelReportsAFailingUnderlyingSourceButStillCloses()
+    {
+        // "Even if the cancelation process fails, the stream will still close … The failure is only
+        // communicated to the immediate caller."
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({ cancel() { throw new Error('cancel failed'); } });
+            stream.cancel().catch(e => log.push('cancel:' + e.message));
+            stream.getReader().closed.then(() => log.push('closed'));
+            """);
+
+        Log(engine).Should().Be("closed,cancel:cancel failed");
+    }
+
+    [Fact]
+    public void CancelOnALockedStreamRejectsWithoutCancelling()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({ cancel() { log.push('should not run'); } });
+            stream.getReader();
+            stream.cancel().catch(e => log.push('cancel:' + e.name));
+            """);
+
+        Log(engine).Should().Be("cancel:TypeError");
+    }
+
+    [Fact]
+    public void CancelIsAResolvedPromiseForAClosedStreamAndARejectionForAnErroredOne()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var closed = new ReadableStream({ start(c) { c.close(); } });
+            var errored = new ReadableStream({ start(c) { c.error(new Error('e')); } });
+            closed.cancel().then(() => log.push('closed:ok'));
+            errored.cancel().catch(e => log.push('errored:' + e.message));
+            """);
+
+        Log(engine).Should().Be("closed:ok,errored:e");
+    }
+
+    [Fact]
+    public void ReadFromInsidePullSeesTheChunkEnqueuedThere()
+    {
+        // Reentrancy: enqueueing from inside pull() while a read is outstanding is the ordinary case, and
+        // the [[pulling]] flag keeps pull() from being re-entered while its promise is outstanding.
+        var engine = StreamEngine();
+        engine.Execute("""
+            var count = 0;
+            var stream = new ReadableStream({
+              pull(c) {
+                count++;
+                log.push('pull' + count);
+                c.enqueue(count);
+                if (count === 3) { c.close(); }
+              }
+            }, { highWaterMark: 0 });
+            var reader = stream.getReader();
+            (async () => {
+              for (;;) {
+                const { value, done } = await reader.read();
+                if (done) { log.push('done'); return; }
+                log.push('got' + value);
+              }
+            })();
+            """);
+
+        Log(engine).Should().Be("pull1,got1,pull2,got2,pull3,got3,done");
+    }
+
+    [Fact]
+    public void InterfaceObjectsAreNonEnumerableGlobalsAndTheHelpersAreNotGlobalsAtAll()
+    {
+        var engine = StreamEngine();
+
+        foreach (var name in new[] { "ReadableStream", "WritableStream", "TransformStream", "ByteLengthQueuingStrategy", "CountQueuingStrategy" })
+        {
+            var descriptor = engine.Realm.GlobalObject.GetOwnProperty(name);
+            descriptor.Writable.Should().BeTrue();
+            descriptor.Configurable.Should().BeTrue();
+            descriptor.Enumerable.Should().BeFalse();
+        }
+
+        // A documented narrowing of the browser surface: the interfaces a script never constructs by name
+        // are reachable through their instances rather than as globals.
+        foreach (var name in new[]
+                 {
+                     "ReadableStreamDefaultReader", "ReadableStreamDefaultController", "WritableStreamDefaultWriter",
+                     "WritableStreamDefaultController", "TransformStreamDefaultController", "ReadableByteStreamController",
+                     "ReadableStreamBYOBReader",
+                 })
+        {
+            engine.Evaluate($"typeof {name}").AsString().Should().Be("undefined", name);
+        }
+
+        engine.Evaluate("Object.getPrototypeOf(new ReadableStream().getReader()).constructor.name")
+            .AsString().Should().Be("ReadableStreamDefaultReader");
+    }
+
+    [Fact]
+    public void TheReaderInterfaceObjectIsConstructibleWithAStream()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({ start(c) { c.enqueue('x'); } });
+            var Ctor = Object.getPrototypeOf(stream.getReader()).constructor;
+            """);
+
+        // "This is equivalent to calling stream.getReader()", including the lock it takes.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new Ctor(stream)"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+
+        engine.Execute("var fresh = new ReadableStream({ start(c) { c.enqueue('y'); } });");
+        engine.Evaluate("new Ctor(fresh) && fresh.locked").AsBoolean().Should().BeTrue();
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new Ctor({})"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void ControllerInterfaceObjectsAreNotConstructible()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var Ctor;
+            new ReadableStream({ start(c) { Ctor = Object.getPrototypeOf(c).constructor; } });
+            """);
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new Ctor()"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void MembersCarryTheWebIdlShape()
+    {
+        var engine = StreamEngine();
+
+        engine.Evaluate("ReadableStream.length").AsNumber().Should().Be(0);
+        engine.Evaluate("ReadableStream.name").AsString().Should().Be("ReadableStream");
+        engine.Evaluate("ReadableStream.from.length").AsNumber().Should().Be(1);
+        engine.Evaluate("ReadableStream.prototype.cancel.length").AsNumber().Should().Be(0);
+        engine.Evaluate("ReadableStream.prototype.pipeTo.length").AsNumber().Should().Be(1);
+        engine.Evaluate("ReadableStream.prototype.pipeThrough.length").AsNumber().Should().Be(1);
+        engine.Evaluate("ReadableStream.prototype[Symbol.toStringTag]").AsString().Should().Be("ReadableStream");
+        engine.Evaluate("Object.prototype.toString.call(new ReadableStream())").AsString().Should().Be("[object ReadableStream]");
+
+        // `locked` is an accessor on the prototype, not an own property of the instance.
+        engine.Evaluate("Object.getOwnPropertyNames(new ReadableStream()).length").AsNumber().Should().Be(0);
+        engine.Evaluate("typeof Object.getOwnPropertyDescriptor(ReadableStream.prototype, 'locked').get").AsString().Should().Be("function");
+    }
+
+    [Fact]
+    public void EveryMemberBrandChecksItsReceiver()
+    {
+        var engine = StreamEngine();
+
+        // A promise-returning operation reports the failure as a rejection …
+        engine.Execute("""
+            ReadableStream.prototype.cancel.call({}).catch(e => log.push('cancel:' + e.name));
+            ReadableStream.prototype.pipeTo.call({}, new WritableStream()).catch(e => log.push('pipeTo:' + e.name));
+            """);
+        Log(engine).Should().Be("cancel:TypeError,pipeTo:TypeError");
+
+        // … while everything else throws.
+        foreach (var member in new[] { "getReader", "tee", "values" })
+        {
+            Assert.Throws<JavaScriptException>(() => engine.Evaluate($"ReadableStream.prototype.{member}.call({{}})"))
+                .Error.Get("name").AsString().Should().Be("TypeError", member);
+        }
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("Object.getOwnPropertyDescriptor(ReadableStream.prototype, 'locked').get.call({})"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void FromAcceptsSyncAndAsyncIterables()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            async function drain(stream, label) {
+              const reader = stream.getReader();
+              for (;;) {
+                const { value, done } = await reader.read();
+                if (done) { log.push(label + ':done'); return; }
+                log.push(label + ':' + value);
+              }
+            }
+            (async () => {
+              await drain(ReadableStream.from(['a', 'b']), 'array');
+              await drain(ReadableStream.from(new Set(['c'])), 'set');
+              await drain(ReadableStream.from((async function* () { yield 'd'; })()), 'gen');
+              await drain(ReadableStream.from([Promise.resolve('e')]), 'promise');
+            })();
+            """);
+
+        // A synchronous iterable is adapted through CreateAsyncFromSyncIterator, so a promise it yields is
+        // awaited rather than handed on.
+        Log(engine).Should().Be("array:a,array:b,array:done,set:c,set:done,gen:d,gen:done,promise:e,promise:done");
+    }
+
+    [Fact]
+    public void FromRefusesEverythingThatIsNotAnObject()
+    {
+        var engine = StreamEngine();
+
+        foreach (var value in new[] { "null", "undefined", "0", "true", "'ab'", "Symbol()", "{}", "{ [Symbol.iterator]: 42 }", "{ [Symbol.iterator]: () => 42 }" })
+        {
+            Assert.Throws<JavaScriptException>(() => engine.Evaluate($"ReadableStream.from({value})"))
+                .Error.Get("name").AsString().Should().Be("TypeError", value);
+        }
+    }
+
+    [Fact]
+    public void FromIgnoresTheSyncIteratorWhenAnAsyncOneExists()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var iterable = {
+              [Symbol.iterator]() { log.push('sync'); },
+              [Symbol.asyncIterator]() { log.push('async'); throw new Error('stop'); }
+            };
+            try { ReadableStream.from(iterable); } catch (e) { log.push('threw:' + e.message); }
+            """);
+
+        Log(engine).Should().Be("async,threw:stop");
+    }
+
+    [Fact]
+    public void FromCallsReturnOnTheIteratorWhenTheStreamIsCancelled()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var iterable = {
+              [Symbol.asyncIterator]() {
+                return {
+                  next() { return Promise.resolve({ value: 'a', done: false }); },
+                  return(reason) { log.push('return:' + reason); return Promise.resolve({ done: true }); }
+                };
+              }
+            };
+            var stream = ReadableStream.from(iterable);
+            stream.cancel('bye').then(() => log.push('cancelled'));
+            """);
+
+        Log(engine).Should().Be("return:bye,cancelled");
+    }
+
+    [Fact]
+    public void FromOnlyAdvancesTheIteratorWhenAConsumerAsks()
+    {
+        // ReadableStreamFromIterable creates its stream with a high water mark of 0.
+        var engine = StreamEngine();
+        engine.Execute("""
+            var n = 0;
+            var iterable = { [Symbol.asyncIterator]() { return { next() { n++; return Promise.resolve({ value: n, done: false }); } }; } };
+            var stream = ReadableStream.from(iterable);
+            log.push('created:' + n);
+            var reader = stream.getReader();
+            reader.read().then(r => log.push('read:' + r.value + ':n=' + n));
+            """);
+
+        Log(engine).Should().Be("created:0,read:1:n=1");
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/StreamPipeTests.cs
+++ b/Jint.Tests/Runtime/WebApi/StreamPipeTests.cs
@@ -1,0 +1,365 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// <c>pipeTo()</c> and <c>pipeThrough()</c> — https://streams.spec.whatwg.org/#readable-stream-pipe-to.
+/// </summary>
+/// <remarks>
+/// The <c>AbortSignal</c> half needs the events feature for the <c>AbortController</c> global, so these
+/// engines opt into both. The piping itself observes the signal through the internal abort-algorithm seam,
+/// not through an <c>abort</c> event listener a script could remove.
+/// </remarks>
+public class StreamPipeTests
+{
+    private static Engine StreamEngine()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Streams | WebApiFeatures.Events));
+        engine.Execute("""
+            var log = [];
+            function sink(name) {
+              return new WritableStream({
+                write(chunk) { log.push(name + ':' + chunk); },
+                close() { log.push(name + ':close'); },
+                abort(reason) { log.push(name + ':abort:' + reason); }
+              });
+            }
+            function source(chunks) {
+              return new ReadableStream({
+                start(c) { for (const chunk of chunks) { c.enqueue(chunk); } c.close(); },
+                cancel(reason) { log.push('source:cancel:' + reason); }
+              });
+            }
+            """);
+        return engine;
+    }
+
+    private static string Log(Engine engine) => engine.Evaluate("log.join(',')").AsString();
+
+    [Fact]
+    public void PipesEveryChunkAndThenClosesTheDestination()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            source(['a', 'b']).pipeTo(sink('dest')).then(() => log.push('piped'));
+            """);
+
+        Log(engine).Should().Be("dest:a,dest:b,dest:close,piped");
+    }
+
+    [Fact]
+    public void LocksBothStreamsForTheDurationAndReleasesThemAtTheEnd()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var from = source(['a']);
+            var to = sink('dest');
+            var promise = from.pipeTo(to);
+            log.push('locked:' + from.locked + ':' + to.locked);
+            promise.then(() => log.push('released:' + from.locked + ':' + to.locked));
+            """);
+
+        Log(engine).Should().Be("locked:true:true,dest:a,dest:close,released:false:false");
+    }
+
+    [Fact]
+    public void RefusesALockedSourceOrDestination()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var from = source(['a']);
+            var to = sink('dest');
+            from.getReader();
+            from.pipeTo(to).catch(e => log.push('source:' + e.name));
+            var other = source(['b']);
+            to.getWriter();
+            other.pipeTo(to).catch(e => log.push('dest:' + e.name));
+            other.pipeTo({}).catch(e => log.push('type:' + e.name));
+            """);
+
+        Log(engine).Should().Be("source:TypeError,dest:TypeError,type:TypeError");
+    }
+
+    [Fact]
+    public void PreventCloseLeavesTheDestinationOpen()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var to = sink('dest');
+            source(['a']).pipeTo(to, { preventClose: true }).then(() => log.push('piped:' + to.locked));
+            """);
+
+        Log(engine).Should().Be("dest:a,piped:false");
+
+        // Still writable afterwards.
+        engine.Execute("to.getWriter().write('later');");
+        Log(engine).Should().Be("dest:a,piped:false,dest:later");
+    }
+
+    [Fact]
+    public void AnErrorInTheSourceAbortsTheDestination()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var controller;
+            var from = new ReadableStream({ start(c) { controller = c; c.enqueue('a'); } });
+            from.pipeTo(sink('dest')).catch(e => log.push('piped:' + e.message));
+            """);
+
+        Log(engine).Should().Be("dest:a");
+
+        engine.Execute("controller.error(new Error('source failed'));");
+        Log(engine).Should().Be("dest:a,dest:abort:Error: source failed,piped:source failed");
+    }
+
+    [Fact]
+    public void PreventAbortLeavesTheDestinationAloneWhenTheSourceFails()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var controller;
+            var to = sink('dest');
+            var from = new ReadableStream({ start(c) { controller = c; } });
+            from.pipeTo(to, { preventAbort: true }).catch(e => log.push('piped:' + e.message));
+            controller.error(new Error('source failed'));
+            """);
+
+        Log(engine).Should().Be("piped:source failed");
+        engine.Evaluate("to.locked").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void AnErrorInTheDestinationCancelsTheSource()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var to = new WritableStream({ write() { throw new Error('dest failed'); } });
+            // Deliberately a source that has not closed: cancelling a stream that is already closed is a
+            // no-op that never reaches the underlying source.
+            var from = new ReadableStream({
+              start(c) { c.enqueue('a'); },
+              cancel(reason) { log.push('source:cancel:' + reason); }
+            });
+            from.pipeTo(to).catch(e => log.push('piped:' + e.message));
+            """);
+
+        Log(engine).Should().Be("source:cancel:Error: dest failed,piped:dest failed");
+    }
+
+    [Fact]
+    public void PreventCancelLeavesTheSourceAloneWhenTheDestinationFails()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var to = new WritableStream({ write() { throw new Error('dest failed'); } });
+            source(['a']).pipeTo(to, { preventCancel: true }).catch(e => log.push('piped:' + e.message));
+            """);
+
+        Log(engine).Should().Be("piped:dest failed");
+    }
+
+    [Fact]
+    public void PipingToAnAlreadyClosingDestinationCancelsTheSource()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var to = sink('dest');
+            var writer = to.getWriter();
+            writer.close();
+            writer.releaseLock();
+            source(['a']).pipeTo(to).catch(e => log.push('piped:' + e.name));
+            """);
+
+        // The source is cancelled with the "destination closed" TypeError, and the destination's own close
+        // — which was already queued — still runs.
+        Log(engine).Should().Be("source:cancel:TypeError: The destination writable stream closed before all data could be piped to it,dest:close,piped:TypeError");
+    }
+
+    [Fact]
+    public void EnforcesTheDestinationsBackpressure()
+    {
+        // "While WritableStreamDefaultWriterGetDesiredSize(writer) is ≤ 0 or is null, the user agent must
+        // not read from reader."
+        var engine = StreamEngine();
+        engine.Execute("""
+            var release;
+            var to = new WritableStream({
+              write(chunk) { log.push('write:' + chunk); return new Promise(r => { release = r; }); }
+            }, { highWaterMark: 1 });
+            var pulls = 0;
+            var from = new ReadableStream({
+              pull(c) { pulls++; c.enqueue('chunk' + pulls); }
+            }, { highWaterMark: 0 });
+            from.pipeTo(to);
+            """);
+
+        // One chunk is read, handed to the sink, and fills the destination's queue; the pipe then waits for
+        // the destination to want more.
+        engine.Execute("log.push('pulls:' + pulls);");
+        Log(engine).Should().Be("write:chunk1,pulls:1");
+
+        engine.Execute("release();");
+        engine.Execute("log.push('pulls:' + pulls);");
+        Log(engine).Should().Be("write:chunk1,pulls:1,write:chunk2,pulls:2");
+    }
+
+    [Fact]
+    public void DoesNotWaitForAWriteBeforeReadingAgain()
+    {
+        // "An implementation that waits for each write to successfully complete before proceeding to the
+        // next read/write operation violates this recommendation."
+        var engine = StreamEngine();
+        engine.Execute("""
+            var pulls = 0;
+            var from = new ReadableStream({ pull(c) { pulls++; c.enqueue('chunk' + pulls); } }, { highWaterMark: 0 });
+            var to = new WritableStream({
+              write(chunk) { log.push('write:' + chunk); return new Promise(() => {}); }
+            }, { highWaterMark: 3 });
+            from.pipeTo(to);
+            """);
+
+        // The first write never settles, and the pipe reads ahead anyway — three chunks, which is exactly
+        // what the destination's queue had room for. An implementation that waited for each write would
+        // have read one.
+        engine.Execute("log.push('pulls:' + pulls);");
+        Log(engine).Should().Be("write:chunk1,pulls:3");
+    }
+
+    [Fact]
+    public void AnAbortSignalStopsThePipeAndShutsBothStreamsDown()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var controller = new AbortController();
+            var to = new WritableStream({
+              write(chunk) { log.push('write:' + chunk); },
+              abort(reason) { log.push('abort:' + reason.name); }
+            });
+            var from = new ReadableStream({
+              start(c) { c.enqueue('a'); c.enqueue('b'); },
+              cancel(reason) { log.push('cancel:' + reason.name); }
+            });
+            from.pipeTo(to, { signal: controller.signal }).catch(e => log.push('piped:' + e.name));
+            """);
+
+        Log(engine).Should().Be("write:a,write:b");
+
+        engine.Execute("controller.abort();");
+
+        // The destination is aborted and the source cancelled, both with the signal's reason, and the pipe's
+        // own promise rejects with it too.
+        Log(engine).Should().Be("write:a,write:b,abort:AbortError,cancel:AbortError,piped:AbortError");
+    }
+
+    [Fact]
+    public void AnAlreadyAbortedSignalStopsThePipeBeforeItReadsAnything()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var signal = AbortSignal.abort('nope');
+            source(['a']).pipeTo(sink('dest'), { signal }).catch(e => log.push('piped:' + e));
+            """);
+
+        Log(engine).Should().Be("dest:abort:nope,source:cancel:nope,piped:nope");
+    }
+
+    [Fact]
+    public void HonoursPreventAbortAndPreventCancelWhenTheSignalFires()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var controller = new AbortController();
+            var to = sink('dest');
+            var from = source(['a']);
+            from.pipeTo(to, { signal: controller.signal, preventAbort: true, preventCancel: true })
+                .catch(e => log.push('piped:' + e.name));
+            controller.abort();
+            """);
+
+        // Neither side is told anything; only the pipe's own promise reports the abort. The chunk that was
+        // already being read when the signal fired still lands — the specification allows a pipe step that
+        // has begun to finish, and only forbids starting new ones.
+        Log(engine).Should().Be("dest:a,piped:AbortError");
+    }
+
+    [Fact]
+    public void RefusesANonAbortSignalOption()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            source(['a']).pipeTo(sink('dest'), { signal: 'nope' }).catch(e => log.push('piped:' + e.name));
+            """);
+
+        // A promise-returning operation reports an argument-conversion failure as a rejection.
+        Log(engine).Should().Be("piped:TypeError");
+    }
+
+    [Fact]
+    public void PipeThroughReturnsTheReadableSideAndThrowsRatherThanRejecting()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var ts = new TransformStream({ transform(chunk, c) { c.enqueue(chunk.toUpperCase()); } });
+            var out = source(['a', 'b']).pipeThrough(ts);
+            log.push('same:' + (out === ts.readable));
+            out.getReader().read().then(r => log.push('read:' + r.value));
+            """);
+
+        Log(engine).Should().Be("same:true,read:A");
+
+        // Unlike pipeTo, pipeThrough returns a stream rather than a promise, so its failures throw.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("source(['x']).pipeThrough({})"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("source(['x']).pipeThrough({ readable: new ReadableStream(), writable: 5 })"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void PipeThroughRefusesALockedPair()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var ts = new TransformStream();
+            ts.writable.getWriter();
+            """);
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("source(['a']).pipeThrough(ts)"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+
+        engine.Execute("var from = source(['a']); from.getReader();");
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("from.pipeThrough(new TransformStream())"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void PipeToWaitsForOutstandingWritesBeforeShuttingDown()
+    {
+        // "Wait until every chunk that has been read has been written (i.e. the corresponding promises have
+        // settled)" before performing the shutdown action.
+        var engine = StreamEngine();
+        engine.Execute("""
+            var release;
+            var controller;
+            var to = new WritableStream({
+              write(chunk) { log.push('write:' + chunk); return new Promise(r => { release = r; }); },
+              abort(reason) { log.push('abort:' + reason.message); }
+            }, { highWaterMark: 5 });
+            var from = new ReadableStream({ start(c) { controller = c; c.enqueue('a'); } });
+            from.pipeTo(to).catch(e => log.push('piped:' + e.message));
+            """);
+
+        Log(engine).Should().Be("write:a");
+
+        engine.Execute("controller.error(new Error('boom'));");
+
+        // The shutdown is pending on the write that is still in flight.
+        Log(engine).Should().Be("write:a");
+
+        engine.Execute("release();");
+        Log(engine).Should().Be("write:a,abort:boom,piped:boom");
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/TransformStreamTests.cs
+++ b/Jint.Tests/Runtime/WebApi/TransformStreamTests.cs
@@ -1,0 +1,411 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// <c>TransformStream</c> and its default controller — https://streams.spec.whatwg.org/#ts.
+/// </summary>
+public class TransformStreamTests
+{
+    private static Engine StreamEngine()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Streams));
+        engine.Execute("""
+            var log = [];
+            async function drain(stream, label) {
+              const reader = stream.getReader();
+              for (;;) {
+                let result;
+                try { result = await reader.read(); }
+                catch (e) { log.push(label + ':error:' + e.message); return; }
+                if (result.done) { log.push(label + ':done'); return; }
+                log.push(label + ':' + result.value);
+              }
+            }
+            """);
+        return engine;
+    }
+
+    private static string Log(Engine engine) => engine.Evaluate("log.join(',')").AsString();
+
+    [Fact]
+    public void ExposesAReadableAndAWritableSide()
+    {
+        var engine = StreamEngine();
+        engine.Execute("var ts = new TransformStream();");
+
+        engine.Evaluate("ts.readable instanceof ReadableStream").AsBoolean().Should().BeTrue();
+        engine.Evaluate("ts.writable instanceof WritableStream").AsBoolean().Should().BeTrue();
+        engine.Evaluate("ts.readable === ts.readable && ts.writable === ts.writable").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.prototype.toString.call(ts)").AsString().Should().Be("[object TransformStream]");
+        engine.Evaluate("Object.getOwnPropertyNames(ts).length").AsNumber().Should().Be(0);
+        engine.Evaluate("TransformStream.length").AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void WithNoTransformerItIsAnIdentityTransform()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var ts = new TransformStream();
+            drain(ts.readable, 'out');
+            var writer = ts.writable.getWriter();
+            writer.write('a');
+            writer.write('b');
+            writer.close();
+            """);
+
+        Log(engine).Should().Be("out:a,out:b,out:done");
+    }
+
+    [Fact]
+    public void RunsTheTransformerForEveryChunk()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var ts = new TransformStream({
+              transform(chunk, controller) { log.push('transform:' + chunk); controller.enqueue(chunk.toUpperCase()); }
+            });
+            drain(ts.readable, 'out');
+            var writer = ts.writable.getWriter();
+            writer.write('a');
+            writer.write('b');
+            writer.close();
+            """);
+
+        Log(engine).Should().Be("transform:a,out:A,transform:b,out:B,out:done");
+    }
+
+    [Fact]
+    public void ATransformerMayProduceZeroOrManyChunksPerInput()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var ts = new TransformStream({
+              transform(chunk, c) {
+                if (chunk === 'skip') { return; }
+                c.enqueue(chunk + '1');
+                c.enqueue(chunk + '2');
+              }
+            });
+            drain(ts.readable, 'out');
+            var writer = ts.writable.getWriter();
+            writer.write('skip');
+            writer.write('x');
+            writer.close();
+            """);
+
+        Log(engine).Should().Be("out:x1,out:x2,out:done");
+    }
+
+    [Fact]
+    public void CallsStartWithTheControllerAndRethrowsItsException()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var ts = new TransformStream({ start(c) { log.push('start:' + (typeof c.enqueue)); c.enqueue('prefix'); } });
+            drain(ts.readable, 'out');
+            ts.writable.getWriter().close();
+            """);
+
+        Log(engine).Should().Be("start:function,out:prefix,out:done");
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new TransformStream({ start() { throw new Error('boom'); } })"))
+            .Error.Get("message").AsString().Should().Be("boom");
+    }
+
+    [Fact]
+    public void NeitherSideRunsBeforeStartHasSettled()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var release;
+            var ts = new TransformStream({
+              start() { return new Promise(r => { release = r; }); },
+              transform(chunk, c) { log.push('transform:' + chunk); c.enqueue(chunk); }
+            });
+            drain(ts.readable, 'out');
+            ts.writable.getWriter().write('a');
+            log.push('written');
+            """);
+
+        Log(engine).Should().Be("written");
+
+        engine.Execute("release();");
+        Log(engine).Should().Be("written,transform:a,out:a");
+    }
+
+    [Fact]
+    public void CallsFlushWhenTheWritableSideIsClosed()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var ts = new TransformStream({
+              transform(chunk, c) { c.enqueue(chunk); },
+              flush(c) { log.push('flush'); c.enqueue('tail'); }
+            });
+            drain(ts.readable, 'out');
+            var writer = ts.writable.getWriter();
+            writer.write('a');
+            writer.close().then(() => log.push('closed'));
+            """);
+
+        Log(engine).Should().Be("out:a,flush,out:tail,out:done,closed");
+    }
+
+    [Fact]
+    public void AFailingTransformErrorsBothSides()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var ts = new TransformStream({ transform() { throw new Error('transform failed'); } });
+            drain(ts.readable, 'out');
+            var writer = ts.writable.getWriter();
+            writer.write('a').catch(e => log.push('write:' + e.message));
+            writer.closed.catch(e => log.push('writable:' + e.message));
+            """);
+
+        Log(engine).Should().Be("out:error:transform failed,write:transform failed,writable:transform failed");
+    }
+
+    [Fact]
+    public void AFailingFlushErrorsTheReadableSideAndTheClose()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var ts = new TransformStream({ flush() { throw new Error('flush failed'); } });
+            drain(ts.readable, 'out');
+            ts.writable.getWriter().close().catch(e => log.push('close:' + e.message));
+            """);
+
+        Log(engine).Should().Be("out:error:flush failed,close:flush failed");
+    }
+
+    [Fact]
+    public void ControllerErrorErrorsBothSides()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var controller;
+            var ts = new TransformStream({ start(c) { controller = c; } });
+            drain(ts.readable, 'out');
+            var writer = ts.writable.getWriter();
+            writer.closed.catch(e => log.push('writable:' + e.message));
+            controller.error(new Error('stopped'));
+            """);
+
+        Log(engine).Should().Be("out:error:stopped,writable:stopped");
+    }
+
+    [Fact]
+    public void TerminateClosesTheReadableSideAndErrorsTheWritableOne()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var ts = new TransformStream({
+              transform(chunk, c) { c.enqueue(chunk); if (chunk === 'stop') { c.terminate(); } }
+            });
+            drain(ts.readable, 'out');
+            var writer = ts.writable.getWriter();
+            writer.write('a');
+            writer.write('stop');
+            writer.write('after').catch(e => log.push('after:' + e.name));
+            writer.closed.catch(e => log.push('writable:' + e.name));
+            """);
+
+        Log(engine).Should().Be("out:a,out:stop,out:done,after:TypeError,writable:TypeError");
+    }
+
+    [Fact]
+    public void EnqueueAfterTheReadableSideIsGoneThrows()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var controller;
+            var ts = new TransformStream({ start(c) { controller = c; } });
+            ts.readable.cancel('done').then(() => {
+              try { controller.enqueue('x'); } catch (e) { log.push('enqueue:' + e.name); }
+            });
+            """);
+
+        Log(engine).Should().Be("enqueue:TypeError");
+    }
+
+    [Fact]
+    public void CancellingTheReadableSideRunsTheTransformersCancel()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var ts = new TransformStream({ cancel(reason) { log.push('cancel:' + reason); } });
+            var writer = ts.writable.getWriter();
+            writer.closed.catch(e => log.push('writable:' + e));
+            ts.readable.cancel('no more').then(() => log.push('cancelled'));
+            """);
+
+        Log(engine).Should().Be("cancel:no more,writable:no more,cancelled");
+    }
+
+    [Fact]
+    public void AbortingTheWritableSideRunsTheTransformersCancel()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var ts = new TransformStream({ cancel(reason) { log.push('cancel:' + reason); } });
+            ts.readable.getReader().closed.catch(e => log.push('readable:' + e));
+            ts.writable.abort('stop').then(() => log.push('aborted'));
+            """);
+
+        // The readable side is errored with the very reason the abort carried.
+        Log(engine).Should().Be("cancel:stop,readable:stop,aborted");
+    }
+
+    [Fact]
+    public void TheTransformersCancelRunsAtMostOnce()
+    {
+        // [[finishPromise]] is what makes cancel() and flush() mutually exclusive, and each of them run only
+        // once however the two sides are shut down.
+        var engine = StreamEngine();
+        engine.Execute("""
+            var ts = new TransformStream({
+              cancel(reason) { log.push('cancel:' + reason); },
+              flush() { log.push('flush'); }
+            });
+            ts.readable.cancel('one').then(() => log.push('readable:ok'), e => log.push('readable:' + e));
+            ts.writable.abort('two').then(() => log.push('writable:ok'), e => log.push('writable:' + e));
+            """);
+
+        // cancel() runs once, for the first shutdown, and flush() never — the second shutdown attaches to
+        // the finish promise the first one created. Both callers then report the writable side's own error,
+        // because aborting it is what settled that promise.
+        Log(engine).Should().Be("cancel:one,readable:two,writable:two");
+    }
+
+    [Fact]
+    public void AFailingCancelIsReportedToTheCaller()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var ts = new TransformStream({ cancel() { throw new Error('cancel failed'); } });
+            drain(ts.readable, 'out');
+            ts.writable.abort('stop').catch(e => log.push('abort:' + e.message));
+            """);
+
+        Log(engine).Should().Be("out:error:cancel failed,abort:cancel failed");
+    }
+
+    [Fact]
+    public void BackpressureFromTheReadableSideThrottlesTheTransformer()
+    {
+        // The readable side's default high water mark is 0, so a transform runs only when a consumer asks
+        // for a chunk. That is what carries backpressure across the stream.
+        var engine = StreamEngine();
+        engine.Execute("""
+            var ts = new TransformStream({ transform(chunk, c) { log.push('transform:' + chunk); c.enqueue(chunk); } });
+            var writer = ts.writable.getWriter();
+            writer.write('a');
+            writer.write('b');
+            writer.write('c');
+            """);
+
+        // Nothing is transformed at all: the readable side's default high water mark is 0, so until a
+        // consumer asks for a chunk the transformer is never invited to produce one.
+        Log(engine).Should().Be("");
+
+        // Each read releases the latch for exactly one more transform.
+        engine.Execute("var reader = ts.readable.getReader(); reader.read().then(r => log.push('read:' + r.value));");
+        Log(engine).Should().Be("transform:a,read:a");
+
+        engine.Execute("reader.read().then(r => log.push('read:' + r.value));");
+        Log(engine).Should().Be("transform:a,read:a,transform:b,read:b");
+    }
+
+    [Fact]
+    public void HonoursExplicitHighWaterMarksOnBothSides()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var ts = new TransformStream(
+              { transform(chunk, c) { log.push('transform:' + chunk); c.enqueue(chunk); } },
+              { highWaterMark: 5 },
+              { highWaterMark: 2 });
+            var writer = ts.writable.getWriter();
+            log.push('desired:' + writer.desiredSize);
+            writer.write('a'); writer.write('b'); writer.write('c');
+            """);
+
+        // The readable side buffers two chunks before it stops asking for more.
+        Log(engine).Should().Be("desired:5,transform:a,transform:b");
+    }
+
+    [Fact]
+    public void RefusesAReadableOrWritableType()
+    {
+        var engine = StreamEngine();
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new TransformStream({ readableType: 'bytes' })"))
+            .Error.Get("name").AsString().Should().Be("RangeError");
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new TransformStream({ writableType: 'bytes' })"))
+            .Error.Get("name").AsString().Should().Be("RangeError");
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new TransformStream(null)"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void TheControllerReportsTheReadableSidesDesiredSize()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var controller;
+            var ts = new TransformStream({ start(c) { controller = c; } }, undefined, { highWaterMark: 3 });
+            log.push(controller.desiredSize);
+            controller.enqueue('a');
+            log.push(controller.desiredSize);
+            """);
+
+        Log(engine).Should().Be("3,2");
+    }
+
+    [Fact]
+    public void TheControllerBrandChecksItsReceiverAndIsNotConstructible()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var controller;
+            new TransformStream({ start(c) { controller = c; } });
+            var Ctor = Object.getPrototypeOf(controller).constructor;
+            """);
+
+        engine.Evaluate("Ctor.name").AsString().Should().Be("TransformStreamDefaultController");
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new Ctor()"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+
+        foreach (var member in new[] { "enqueue.call({}, 'x')", "error.call({})", "terminate.call({})" })
+        {
+            Assert.Throws<JavaScriptException>(() => engine.Evaluate($"Ctor.prototype.{member}"))
+                .Error.Get("name").AsString().Should().Be("TypeError", member);
+        }
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("Object.getOwnPropertyDescriptor(Ctor.prototype, 'desiredSize').get.call({})"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void PipeThroughChainsTwoTransformStreams()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            function mapper(fn) {
+              return new TransformStream({ transform(chunk, c) { c.enqueue(fn(chunk)); } });
+            }
+            var source = new ReadableStream({ start(c) { c.enqueue('a'); c.enqueue('b'); c.close(); } });
+            var result = source.pipeThrough(mapper(x => x.toUpperCase())).pipeThrough(mapper(x => x + '!'));
+            drain(result, 'out');
+            """);
+
+        Log(engine).Should().Be("out:A!,out:B!,out:done");
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/WritableStreamTests.cs
+++ b/Jint.Tests/Runtime/WebApi/WritableStreamTests.cs
@@ -1,0 +1,514 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// <c>WritableStream</c>, its default controller and its default writer, against the Streams Standard —
+/// https://streams.spec.whatwg.org/#ws.
+/// </summary>
+public class WritableStreamTests
+{
+    private static Engine StreamEngine()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Streams));
+        engine.Execute("var log = [];");
+        return engine;
+    }
+
+    private static string Log(Engine engine) => engine.Evaluate("log.join(',')").AsString();
+
+    [Fact]
+    public void ConstructsWithNoArgumentsAtAll()
+    {
+        var engine = StreamEngine();
+        engine.Evaluate("new WritableStream() instanceof WritableStream").AsBoolean().Should().BeTrue();
+        engine.Evaluate("new WritableStream().locked").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void RefusesANonObjectSinkAndAnySinkType()
+    {
+        var engine = StreamEngine();
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new WritableStream(null)"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+
+        // The `type` member is reserved for a future byte-oriented writable stream; any value is a RangeError.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new WritableStream({ type: 'bytes' })"))
+            .Error.Get("name").AsString().Should().Be("RangeError");
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new WritableStream({ type: 'anything' })"))
+            .Error.Get("name").AsString().Should().Be("RangeError");
+    }
+
+    [Fact]
+    public void CallsStartSynchronouslyAndRethrowsItsException()
+    {
+        var engine = StreamEngine();
+        engine.Execute("new WritableStream({ start(c) { log.push('start:' + (typeof c.error)); } }); log.push('after');");
+        Log(engine).Should().Be("start:function,after");
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new WritableStream({ start() { throw new Error('boom'); } })"))
+            .Error.Get("message").AsString().Should().Be("boom");
+    }
+
+    [Fact]
+    public void WritesReachTheSinkInOrderOneAtATime()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var release;
+            var stream = new WritableStream({
+              write(chunk) {
+                log.push('write:' + chunk);
+                return new Promise(r => { release = () => { log.push('done:' + chunk); r(); }; });
+              }
+            });
+            var writer = stream.getWriter();
+            writer.write('a').then(() => log.push('a-settled'));
+            writer.write('b').then(() => log.push('b-settled'));
+            log.push('queued');
+            """);
+
+        // Nothing reaches the sink synchronously: the queue only advances once start() has settled, which
+        // is a microtask away even for an absent start. Then only the first write is handed over; the
+        // second waits behind it.
+        Log(engine).Should().Be("queued,write:a");
+
+        engine.Execute("release();");
+        Log(engine).Should().Be("queued,write:a,done:a,write:b,a-settled");
+
+        engine.Execute("release();");
+        Log(engine).Should().Be("queued,write:a,done:a,write:b,a-settled,done:b,b-settled");
+    }
+
+    [Fact]
+    public void CloseWaitsForTheQueuedWritesAndThenCallsTheSink()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new WritableStream({
+              write(chunk) { log.push('write:' + chunk); },
+              close() { log.push('close'); }
+            });
+            var writer = stream.getWriter();
+            writer.write('a');
+            writer.write('b');
+            writer.close().then(() => log.push('closed'));
+            writer.closed.then(() => log.push('writer-closed'));
+            """);
+
+        Log(engine).Should().Be("write:a,write:b,close,closed,writer-closed");
+    }
+
+    [Fact]
+    public void WritingAfterCloseHasBeenRequestedFails()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var writer = new WritableStream().getWriter();
+            writer.close();
+            writer.write('late').catch(e => log.push('write:' + e.name));
+            writer.close().catch(e => log.push('close:' + e.name));
+            """);
+
+        Log(engine).Should().Be("write:TypeError,close:TypeError");
+    }
+
+    [Fact]
+    public void AFailingWriteErrorsTheStream()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new WritableStream({ write() { return Promise.reject(new Error('write failed')); } });
+            var writer = stream.getWriter();
+            writer.write('a').catch(e => log.push('write:' + e.message));
+            writer.closed.catch(e => log.push('closed:' + e.message));
+            writer.ready.catch(e => log.push('ready:' + e.message));
+            """);
+
+        // The in-flight write's own promise is rejected first, then the writer's ready — which erroring
+        // rejects on the way in — and the writer's closed last, once the stream has finished erroring.
+        Log(engine).Should().Be("write:write failed,ready:write failed,closed:write failed");
+    }
+
+    [Fact]
+    public void ControllerErrorMakesEveryLaterWriteFail()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var controller;
+            var stream = new WritableStream({ start(c) { controller = c; } });
+            var writer = stream.getWriter();
+            controller.error(new Error('stopped'));
+            writer.write('a').catch(e => log.push('write:' + e.message));
+            writer.closed.catch(e => log.push('closed:' + e.message));
+            """);
+
+        Log(engine).Should().Be("write:stopped,closed:stopped");
+    }
+
+    [Fact]
+    public void ControllerErrorIsANoOpOnceTheStreamHasStoppedBeingWritable()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var controller;
+            var stream = new WritableStream({ start(c) { controller = c; } });
+            controller.error(new Error('first'));
+            controller.error(new Error('second'));
+            stream.getWriter().closed.catch(e => log.push(e.message));
+            """);
+
+        Log(engine).Should().Be("first");
+    }
+
+    [Fact]
+    public void ReadyTracksBackpressure()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var release;
+            var stream = new WritableStream({
+              write() { return new Promise(r => { release = r; }); }
+            }, { highWaterMark: 1 });
+            var writer = stream.getWriter();
+            log.push('desired:' + writer.desiredSize);
+            writer.ready.then(() => log.push('ready-1'));
+            writer.write('a');
+            log.push('desired:' + writer.desiredSize);
+            var second = writer.ready;
+            second.then(() => log.push('ready-2'));
+            """);
+
+        // The first ready was already fulfilled; the write pushed the queue to the high water mark, so the
+        // getter now answers a fresh, pending promise.
+        Log(engine).Should().Be("desired:1,desired:0,ready-1");
+
+        engine.Execute("release();");
+        Log(engine).Should().Be("desired:1,desired:0,ready-1,ready-2");
+    }
+
+    [Fact]
+    public void AWriterAcquiredUnderBackpressureStartsNotReady()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new WritableStream({ write() { return new Promise(() => {}); } }, { highWaterMark: 0 });
+            var writer = stream.getWriter();
+            log.push('desired:' + writer.desiredSize);
+            writer.ready.then(() => log.push('ready'));
+            """);
+
+        // A high water mark of 0 means backpressure from the very first moment.
+        Log(engine).Should().Be("desired:0");
+    }
+
+    [Fact]
+    public void DesiredSizeCountsTheQueueAgainstTheHighWaterMark()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new WritableStream({ write() { return new Promise(() => {}); } }, { highWaterMark: 3 });
+            var writer = stream.getWriter();
+            writer.write('a');
+            log.push(writer.desiredSize);
+            writer.write('b');
+            log.push(writer.desiredSize);
+            """);
+
+        // The first chunk is handed to the sink but stays queued until the sink's promise settles.
+        Log(engine).Should().Be("2,1");
+    }
+
+    [Fact]
+    public void DesiredSizeIsZeroWhenClosedAndNullWhenErrored()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var a = new WritableStream().getWriter();
+            a.close();
+            var controller;
+            var b = new WritableStream({ start(c) { controller = c; } }).getWriter();
+            controller.error(new Error('x'));
+            """);
+
+        engine.Evaluate("a.desiredSize").AsNumber().Should().Be(0);
+        engine.Evaluate("b.desiredSize").IsNull().Should().BeTrue();
+    }
+
+    [Fact]
+    public void DesiredSizeThrowsForAReleasedWriter()
+    {
+        // The attribute is an `unrestricted double?`, not a promise type, so this one throws where the rest
+        // of the writer's members reject.
+        var engine = StreamEngine();
+        engine.Execute("var writer = new WritableStream().getWriter(); writer.releaseLock();");
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("writer.desiredSize"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void CallsTheStrategySizeOncePerChunk()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new WritableStream(
+              { write() { return new Promise(() => {}); } },
+              { highWaterMark: 10, size(chunk) { log.push('size:' + chunk); return chunk.length; } });
+            var writer = stream.getWriter();
+            writer.write('a');
+            writer.write('bbb');
+            log.push('desired:' + writer.desiredSize);
+            """);
+
+        Log(engine).Should().Be("size:a,size:bbb,desired:6");
+    }
+
+    [Fact]
+    public void AThrowingStrategySizeErrorsTheStream()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new WritableStream({}, { size() { throw new Error('size failed'); } });
+            var writer = stream.getWriter();
+            writer.write('a').catch(e => log.push('write:' + e.message));
+            writer.closed.catch(e => log.push('closed:' + e.message));
+            """);
+
+        Log(engine).Should().Be("write:size failed,closed:size failed");
+    }
+
+    [Fact]
+    public void AbortErrorsTheStreamAndTellsTheSink()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new WritableStream({ abort(reason) { log.push('abort:' + reason); } });
+            var writer = stream.getWriter();
+            writer.abort('stop').then(() => log.push('aborted'));
+            writer.closed.catch(e => log.push('closed:' + e));
+            writer.write('late').catch(e => log.push('write:' + e));
+            """);
+
+        Log(engine).Should().Be("abort:stop,write:stop,aborted,closed:stop");
+    }
+
+    [Fact]
+    public void AbortReportsAFailingSink()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new WritableStream({ abort() { throw new Error('abort failed'); } });
+            stream.abort('stop').catch(e => log.push('abort:' + e.message));
+            """);
+
+        Log(engine).Should().Be("abort:abort failed");
+    }
+
+    [Fact]
+    public void AbortIsANoOpOnAClosedStream()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new WritableStream({ abort() { log.push('should not run'); }, close() { log.push('close'); } });
+            var writer = stream.getWriter();
+            writer.close().then(() => {
+              writer.releaseLock();
+              stream.abort('late').then(() => log.push('abort-resolved'));
+            });
+            """);
+
+        Log(engine).Should().Be("close,abort-resolved");
+    }
+
+    [Fact]
+    public void AbortingWhileAWriteIsInFlightWaitsForIt()
+    {
+        // "erroring" is the state between noticing the failure and the in-flight sink operation finishing:
+        // abort() never interrupts a write the sink has already been handed.
+        var engine = StreamEngine();
+        engine.Execute("""
+            var release, writeReached;
+            var reached = new Promise(r => { writeReached = r; });
+            var stream = new WritableStream({
+              write() { log.push('write'); writeReached(); return new Promise(r => { release = r; }); },
+              abort(reason) { log.push('abort:' + reason); }
+            });
+            var writer = stream.getWriter();
+            writer.write('a').then(() => log.push('write-settled'), e => log.push('write-rejected:' + e));
+            reached.then(() => {
+              writer.abort('stop').then(() => log.push('aborted'));
+              log.push('requested');
+            });
+            """);
+
+        // The abort has been requested but the sink has not been asked yet.
+        Log(engine).Should().Be("write,requested");
+
+        engine.Execute("release();");
+
+        // The write the sink had already accepted still succeeds; only then is abort() called.
+        Log(engine).Should().Be("write,requested,abort:stop,write-settled,aborted");
+    }
+
+    [Fact]
+    public void TheControllerSignalIsAbortedBeforeTheSinkIsAsked()
+    {
+        // The controller's AbortSignal exists so a sink can abandon a long write immediately, without
+        // waiting to be asked to abort.
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new WritableStream({
+              start(c) {
+                log.push('aborted:' + c.signal.aborted);
+                c.signal.addEventListener('abort', () => log.push('signal:' + c.signal.reason));
+              },
+              abort(reason) { log.push('abort:' + reason); }
+            });
+            stream.abort('stop').then(() => log.push('done'));
+            """);
+
+        Log(engine).Should().Be("aborted:false,signal:stop,abort:stop,done");
+    }
+
+    [Fact]
+    public void TheControllerSignalDefaultsToAnAbortErrorWhenNoReasonIsGiven()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new WritableStream({
+              start(c) { c.signal.addEventListener('abort', () => log.push(c.signal.reason.name + ':' + (c.signal.reason instanceof DOMException))); }
+            });
+            stream.abort();
+            """);
+
+        Log(engine).Should().Be("AbortError:true");
+    }
+
+    [Fact]
+    public void LocksTheStreamForOneWriterAtATime()
+    {
+        var engine = StreamEngine();
+        engine.Execute("var stream = new WritableStream(); var writer = stream.getWriter();");
+
+        engine.Evaluate("stream.locked").AsBoolean().Should().BeTrue();
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("stream.getWriter()"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+
+        engine.Execute("writer.releaseLock();");
+        engine.Evaluate("stream.locked").AsBoolean().Should().BeFalse();
+        engine.Evaluate("stream.getWriter() !== writer").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ALockedStreamRefusesAbortAndClose()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new WritableStream();
+            stream.getWriter();
+            stream.abort().catch(e => log.push('abort:' + e.name));
+            stream.close().catch(e => log.push('close:' + e.name));
+            """);
+
+        Log(engine).Should().Be("abort:TypeError,close:TypeError");
+    }
+
+    [Fact]
+    public void AReleasedWriterRefusesEveryOperation()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var writer = new WritableStream().getWriter();
+            writer.releaseLock();
+            writer.write('a').catch(e => log.push('write:' + e.name));
+            writer.close().catch(e => log.push('close:' + e.name));
+            writer.abort().catch(e => log.push('abort:' + e.name));
+            writer.ready.catch(e => log.push('ready:' + e.name));
+            writer.closed.catch(e => log.push('closed:' + e.name));
+            """);
+
+        Log(engine).Should().Be("write:TypeError,close:TypeError,abort:TypeError,ready:TypeError,closed:TypeError");
+    }
+
+    [Fact]
+    public void ReleasingTheLockLeavesOutstandingWritesAlone()
+    {
+        // "the lock can still be released even if some ongoing writes have not yet finished … the lock
+        // instead simply prevents other producers from writing in an interleaved manner."
+        var engine = StreamEngine();
+        engine.Execute("""
+            var release, writeReached;
+            var reached = new Promise(r => { writeReached = r; });
+            var stream = new WritableStream({ write() { writeReached(); return new Promise(r => { release = r; }); } });
+            var writer = stream.getWriter();
+            writer.write('a').then(() => log.push('write-settled'));
+            reached.then(() => {
+              writer.releaseLock();
+              log.push('released:' + stream.locked);
+              release();
+            });
+            """);
+
+        Log(engine).Should().Be("released:false,write-settled");
+    }
+
+    [Fact]
+    public void MembersCarryTheWebIdlShape()
+    {
+        var engine = StreamEngine();
+
+        engine.Evaluate("WritableStream.length").AsNumber().Should().Be(0);
+        engine.Evaluate("WritableStream.prototype.abort.length").AsNumber().Should().Be(0);
+        engine.Evaluate("WritableStream.prototype.close.length").AsNumber().Should().Be(0);
+        engine.Evaluate("WritableStream.prototype.getWriter.length").AsNumber().Should().Be(0);
+        engine.Evaluate("Object.prototype.toString.call(new WritableStream())").AsString().Should().Be("[object WritableStream]");
+        engine.Evaluate("Object.getOwnPropertyNames(new WritableStream()).length").AsNumber().Should().Be(0);
+
+        engine.Execute("var writer = new WritableStream().getWriter();");
+        engine.Evaluate("Object.prototype.toString.call(writer)").AsString().Should().Be("[object WritableStreamDefaultWriter]");
+        engine.Evaluate("Object.getPrototypeOf(writer).constructor.name").AsString().Should().Be("WritableStreamDefaultWriter");
+        engine.Evaluate("Object.getPrototypeOf(writer).constructor.length").AsNumber().Should().Be(1);
+    }
+
+    [Fact]
+    public void TheWriterInterfaceObjectIsConstructibleWithAStream()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new WritableStream();
+            var Ctor = Object.getPrototypeOf(stream.getWriter()).constructor;
+            var fresh = new WritableStream();
+            """);
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new Ctor(stream)"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+        engine.Evaluate("new Ctor(fresh) && fresh.locked").AsBoolean().Should().BeTrue();
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new Ctor({})"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void EveryMemberBrandChecksItsReceiver()
+    {
+        var engine = StreamEngine();
+
+        engine.Execute("""
+            WritableStream.prototype.abort.call({}).catch(e => log.push('abort:' + e.name));
+            WritableStream.prototype.close.call({}).catch(e => log.push('close:' + e.name));
+            var writerProto = Object.getPrototypeOf(new WritableStream().getWriter());
+            writerProto.write.call({}, 'x').catch(e => log.push('write:' + e.name));
+            Object.getOwnPropertyDescriptor(writerProto, 'ready').get.call({}).catch(e => log.push('ready:' + e.name));
+            """);
+
+        Log(engine).Should().Be("abort:TypeError,close:TypeError,write:TypeError,ready:TypeError");
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("WritableStream.prototype.getWriter.call({})"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+}
+#endif

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -402,12 +402,21 @@ public enum WebApiFeatures
     Navigator = 1 << 11,
 
     /// <summary>
+    /// <c>ReadableStream</c>, <c>WritableStream</c>, <c>TransformStream</c> and the two queuing strategies
+    /// — the whole of the WHATWG Streams Standard's default (non-byte) surface, including <c>tee()</c>,
+    /// <c>pipeTo()</c>/<c>pipeThrough()</c> with <c>AbortSignal</c> support, and asynchronous iteration of a
+    /// readable stream. Byte streams (<c>type: "bytes"</c>, <c>ReadableByteStreamController</c>, BYOB
+    /// readers) are not implemented and are absent rather than present-and-broken.
+    /// </summary>
+    Streams = 1 << 12,
+
+    /// <summary>
     /// The web APIs a host normally wants: everything except outbound network access. Today that is
     /// <see cref="Console"/>, <see cref="Timers"/>, <see cref="Encoding"/>, <see cref="Base64"/>,
     /// <see cref="StructuredClone"/>, <see cref="Crypto"/>, <see cref="Performance"/>, <see cref="Events"/>,
-    /// <see cref="Url"/>, <see cref="Files"/> and <see cref="Navigator"/>; it grows as further features land,
-    /// and never comes to include fetch.
+    /// <see cref="Url"/>, <see cref="Files"/>, <see cref="Navigator"/> and <see cref="Streams"/>; it grows as
+    /// further features land, and never comes to include fetch.
     /// </summary>
-    Default = Console | Timers | Encoding | Base64 | StructuredClone | Crypto | Performance | Events | Url | Files | Navigator,
+    Default = Console | Timers | Encoding | Base64 | StructuredClone | Crypto | Performance | Events | Url | Files | Navigator | Streams,
 }
 #endif

--- a/Jint/Runtime/Intrinsics.WebApi.cs
+++ b/Jint/Runtime/Intrinsics.WebApi.cs
@@ -11,6 +11,7 @@ using Jint.WebApi.Files;
 using Jint.WebApi.Navigator;
 using Jint.WebApi.StructuredClone;
 using Jint.WebApi.Performance;
+using Jint.WebApi.Streams;
 using Jint.WebApi.Timers;
 using Jint.WebApi.Url;
 
@@ -177,5 +178,62 @@ public sealed partial class Intrinsics
 
     internal NavigatorInstance Navigator =>
         _navigator ??= new NavigatorInstance(_engine, _realm, Object.PrototypeObject);
+
+    private ReadableStreamConstructor? _readableStream;
+    private ReadableStreamDefaultReaderConstructor? _readableStreamDefaultReader;
+    private ReadableStreamDefaultControllerConstructor? _readableStreamDefaultController;
+    private ReadableStreamAsyncIteratorPrototype? _readableStreamAsyncIteratorPrototype;
+    private WritableStreamConstructor? _writableStream;
+    private WritableStreamDefaultWriterConstructor? _writableStreamDefaultWriter;
+    private WritableStreamDefaultControllerConstructor? _writableStreamDefaultController;
+    private TransformStreamConstructor? _transformStream;
+    private TransformStreamDefaultControllerConstructor? _transformStreamDefaultController;
+    private CountQueuingStrategyConstructor? _countQueuingStrategy;
+    private ByteLengthQueuingStrategyConstructor? _byteLengthQueuingStrategy;
+
+    internal ReadableStreamConstructor ReadableStream =>
+        _readableStream ??= new ReadableStreamConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
+
+    /// <summary>
+    /// <c>ReadableStreamDefaultReader</c>, <c>ReadableStreamDefaultController</c> and the writable and
+    /// transform interfaces beside them are deliberately <b>not</b> installed as globals — a browser exposes
+    /// every one of them, and Jint exposes only the five a script constructs directly. They are still
+    /// ordinary interface objects reachable as <c>Object.getPrototypeOf(reader).constructor</c>, which is
+    /// where an <c>instanceof</c> check or a prototype patch goes.
+    /// </summary>
+    internal ReadableStreamDefaultReaderConstructor ReadableStreamDefaultReader =>
+        _readableStreamDefaultReader ??= new ReadableStreamDefaultReaderConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
+
+    internal ReadableStreamDefaultControllerConstructor ReadableStreamDefaultController =>
+        _readableStreamDefaultController ??= new ReadableStreamDefaultControllerConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
+
+    /// <summary>
+    /// <c>%ReadableStreamAsyncIteratorPrototype%</c>, whose <c>[[Prototype]]</c> is
+    /// <c>%AsyncIteratorPrototype%</c> — which is what gives an iterator obtained from a stream the async
+    /// iterator helpers.
+    /// </summary>
+    internal ReadableStreamAsyncIteratorPrototype ReadableStreamAsyncIteratorPrototype =>
+        _readableStreamAsyncIteratorPrototype ??= new ReadableStreamAsyncIteratorPrototype(_engine, _realm, AsyncIteratorPrototype);
+
+    internal WritableStreamConstructor WritableStream =>
+        _writableStream ??= new WritableStreamConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
+
+    internal WritableStreamDefaultWriterConstructor WritableStreamDefaultWriter =>
+        _writableStreamDefaultWriter ??= new WritableStreamDefaultWriterConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
+
+    internal WritableStreamDefaultControllerConstructor WritableStreamDefaultController =>
+        _writableStreamDefaultController ??= new WritableStreamDefaultControllerConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
+
+    internal TransformStreamConstructor TransformStream =>
+        _transformStream ??= new TransformStreamConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
+
+    internal TransformStreamDefaultControllerConstructor TransformStreamDefaultController =>
+        _transformStreamDefaultController ??= new TransformStreamDefaultControllerConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
+
+    internal CountQueuingStrategyConstructor CountQueuingStrategy =>
+        _countQueuingStrategy ??= new CountQueuingStrategyConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
+
+    internal ByteLengthQueuingStrategyConstructor ByteLengthQueuingStrategy =>
+        _byteLengthQueuingStrategy ??= new ByteLengthQueuingStrategyConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
 }
 #endif

--- a/Jint/WebApi/Streams/ByteLengthQueuingStrategyConstructor.cs
+++ b/Jint/WebApi/Streams/ByteLengthQueuingStrategyConstructor.cs
@@ -1,0 +1,107 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Interop;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// A <c>ByteLengthQueuingStrategy</c> instance: nothing but the high water mark it was constructed with.
+/// <para>
+/// https://streams.spec.whatwg.org/#blqs-internal-slots
+/// </para>
+/// </summary>
+internal sealed class JsByteLengthQueuingStrategy : ObjectInstance
+{
+    internal JsByteLengthQueuingStrategy(Engine engine, double highWaterMark) : base(engine, ObjectClass.Object)
+    {
+        HighWaterMark = highWaterMark;
+    }
+
+    /// <summary>https://streams.spec.whatwg.org/#bytelengthqueuingstrategy-highwatermark</summary>
+    internal double HighWaterMark { get; }
+}
+
+/// <summary>
+/// The <c>ByteLengthQueuingStrategy</c> interface object.
+/// <para>
+/// https://streams.spec.whatwg.org/#blqs-class
+/// </para>
+/// </summary>
+internal sealed class ByteLengthQueuingStrategyConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("ByteLengthQueuingStrategy");
+    private static readonly JsString _byteLength = new("byteLength");
+
+    private ClrFunction? _sizeFunction;
+
+    internal ByteLengthQueuingStrategyConstructor(
+        Engine engine,
+        Realm realm,
+        FunctionPrototype functionPrototype,
+        ObjectPrototype objectPrototype)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = functionPrototype;
+        PrototypeObject = new ByteLengthQueuingStrategyPrototype(engine, realm, this, objectPrototype);
+        _length = new PropertyDescriptor(JsNumber.PositiveOne, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal ByteLengthQueuingStrategyPrototype PrototypeObject { get; }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#byte-length-queuing-strategy-size-function — one function per realm,
+    /// shared by every instance. Its steps are exactly <c>GetV(chunk, "byteLength")</c>, so it raises a
+    /// <c>TypeError</c> for <see langword="null"/> or <see langword="undefined"/>, answers
+    /// <see langword="undefined"/> for anything without the property, and lets a throwing getter through.
+    /// </summary>
+    internal ClrFunction SizeFunction
+    {
+        get
+        {
+            if (_sizeFunction is not null)
+            {
+                return _sizeFunction;
+            }
+
+            var realm = _realm;
+            _sizeFunction = new ClrFunction(
+                _engine,
+                realm,
+                "size",
+                (_, arguments) =>
+                {
+                    var chunk = arguments.At(0);
+                    return TypeConverter.ToObject(realm, chunk).Get(_byteLength, chunk);
+                },
+                1,
+                PropertyFlag.Configurable);
+
+            return _sizeFunction;
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#blqs-constructor
+    /// </summary>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        if (newTarget.IsUndefined())
+        {
+            Throw.TypeError(_realm, $"Constructor {GetOwnFunctionNameForMessage()} requires 'new'");
+        }
+
+        var highWaterMark = StreamDictionaries.ReadQueuingStrategyInit(_realm, arguments.At(0), "ByteLengthQueuingStrategy");
+
+        return OrdinaryCreateFromConstructor(
+            newTarget,
+            static intrinsics => intrinsics.ByteLengthQueuingStrategy.PrototypeObject,
+            static (Engine engine, Realm _, double state) => new JsByteLengthQueuingStrategy(engine, state),
+            highWaterMark);
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/ByteLengthQueuingStrategyPrototype.cs
+++ b/Jint/WebApi/Streams/ByteLengthQueuingStrategyPrototype.cs
@@ -1,0 +1,69 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Interop;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// <c>ByteLengthQueuingStrategy.prototype</c> — the interface prototype object.
+/// <para>
+/// https://streams.spec.whatwg.org/#blqs-prototype
+/// </para>
+/// </summary>
+[JsObject(UseShape = true)]
+internal sealed partial class ByteLengthQueuingStrategyPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly ByteLengthQueuingStrategyConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString StrategyToStringTag = new("ByteLengthQueuingStrategy");
+
+    internal ByteLengthQueuingStrategyPrototype(
+        Engine engine,
+        Realm realm,
+        ByteLengthQueuingStrategyConstructor constructor,
+        ObjectInstance objectPrototype) : base(engine, realm)
+    {
+        _prototype = objectPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#blqs-high-water-mark
+    /// </summary>
+    [JsAccessor("highWaterMark", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsNumber HighWaterMarkGet(JsValue thisObject) => JsNumber.Create(Brand(thisObject).HighWaterMark);
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#blqs-size — the realm's one byte-length size function, which
+    /// measures a chunk by its <c>byteLength</c> property.
+    /// </summary>
+    [JsAccessor("size", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private ClrFunction SizeGet(JsValue thisObject)
+    {
+        Brand(thisObject);
+        return _constructor.SizeFunction;
+    }
+
+    private JsByteLengthQueuingStrategy Brand(JsValue thisObject)
+    {
+        if (thisObject is JsByteLengthQueuingStrategy strategy)
+        {
+            return strategy;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a ByteLengthQueuingStrategy");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/CountQueuingStrategyConstructor.cs
+++ b/Jint/WebApi/Streams/CountQueuingStrategyConstructor.cs
@@ -1,0 +1,84 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Interop;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// A <c>CountQueuingStrategy</c> instance: nothing but the high water mark it was constructed with.
+/// <para>
+/// https://streams.spec.whatwg.org/#cqs-internal-slots
+/// </para>
+/// </summary>
+internal sealed class JsCountQueuingStrategy : ObjectInstance
+{
+    internal JsCountQueuingStrategy(Engine engine, double highWaterMark) : base(engine, ObjectClass.Object)
+    {
+        HighWaterMark = highWaterMark;
+    }
+
+    /// <summary>https://streams.spec.whatwg.org/#countqueuingstrategy-highwatermark</summary>
+    internal double HighWaterMark { get; }
+}
+
+/// <summary>
+/// The <c>CountQueuingStrategy</c> interface object.
+/// <para>
+/// https://streams.spec.whatwg.org/#cqs-class
+/// </para>
+/// </summary>
+internal sealed class CountQueuingStrategyConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("CountQueuingStrategy");
+
+    private ClrFunction? _sizeFunction;
+
+    internal CountQueuingStrategyConstructor(
+        Engine engine,
+        Realm realm,
+        FunctionPrototype functionPrototype,
+        ObjectPrototype objectPrototype)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = functionPrototype;
+        PrototypeObject = new CountQueuingStrategyPrototype(engine, realm, this, objectPrototype);
+        _length = new PropertyDescriptor(JsNumber.PositiveOne, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal CountQueuingStrategyPrototype PrototypeObject { get; }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#count-queuing-strategy-size-function — one function per realm,
+    /// shared by every instance, which is why <c>a.size === b.size</c> holds for two different strategies.
+    /// It is a plain function rather than a method: it never looks at its <c>this</c>, so
+    /// <c>const { size } = strategy</c> keeps working.
+    /// </summary>
+    internal ClrFunction SizeFunction =>
+        _sizeFunction ??= new ClrFunction(_engine, _realm, "size", static (_, _) => JsNumber.PositiveOne, 0, PropertyFlag.Configurable);
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#cqs-constructor. The high water mark is deliberately not validated
+    /// here — a negative or NaN one is only rejected by the stream constructor it is handed to.
+    /// </summary>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        if (newTarget.IsUndefined())
+        {
+            Throw.TypeError(_realm, $"Constructor {GetOwnFunctionNameForMessage()} requires 'new'");
+        }
+
+        var highWaterMark = StreamDictionaries.ReadQueuingStrategyInit(_realm, arguments.At(0), "CountQueuingStrategy");
+
+        return OrdinaryCreateFromConstructor(
+            newTarget,
+            static intrinsics => intrinsics.CountQueuingStrategy.PrototypeObject,
+            static (Engine engine, Realm _, double state) => new JsCountQueuingStrategy(engine, state),
+            highWaterMark);
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/CountQueuingStrategyPrototype.cs
+++ b/Jint/WebApi/Streams/CountQueuingStrategyPrototype.cs
@@ -1,0 +1,71 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Interop;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// <c>CountQueuingStrategy.prototype</c> — the interface prototype object.
+/// <para>
+/// https://streams.spec.whatwg.org/#cqs-prototype
+/// </para>
+/// </summary>
+[JsObject(UseShape = true)]
+internal sealed partial class CountQueuingStrategyPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly CountQueuingStrategyConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString StrategyToStringTag = new("CountQueuingStrategy");
+
+    internal CountQueuingStrategyPrototype(
+        Engine engine,
+        Realm realm,
+        CountQueuingStrategyConstructor constructor,
+        ObjectInstance objectPrototype) : base(engine, realm)
+    {
+        _prototype = objectPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#cqs-high-water-mark
+    /// </summary>
+    [JsAccessor("highWaterMark", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsNumber HighWaterMarkGet(JsValue thisObject) => JsNumber.Create(Brand(thisObject).HighWaterMark);
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#cqs-size — the realm's one count size function, which always
+    /// answers 1 so that the queue's total size is a count of its chunks.
+    /// </summary>
+    [JsAccessor("size", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private ClrFunction SizeGet(JsValue thisObject)
+    {
+        // The brand check is the attribute's, not the function's: the function it hands back is shared by
+        // the whole realm and belongs to no instance.
+        Brand(thisObject);
+        return _constructor.SizeFunction;
+    }
+
+    private JsCountQueuingStrategy Brand(JsValue thisObject)
+    {
+        if (thisObject is JsCountQueuingStrategy strategy)
+        {
+            return strategy;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a CountQueuingStrategy");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/JsReadableStream.cs
+++ b/Jint/WebApi/Streams/JsReadableStream.cs
@@ -1,0 +1,84 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// The state a <c>ReadableStream</c> is in: the specification's <c>[[state]]</c> slot, whose values are the
+/// strings "<c>readable</c>", "<c>closed</c>" and "<c>errored</c>".
+/// <para>
+/// https://streams.spec.whatwg.org/#rs-internal-slots
+/// </para>
+/// </summary>
+internal enum ReadableStreamState
+{
+    Readable,
+    Closed,
+    Errored,
+}
+
+/// <summary>
+/// A <c>ReadableStream</c> instance.
+/// <para>
+/// https://streams.spec.whatwg.org/#rs-class
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every WebIDL attribute of the interface lives in CLR state here rather than as an own property, and
+/// <see cref="ReadableStreamPrototype"/> reads it through a brand check — so
+/// <c>Object.getOwnPropertyNames(new ReadableStream())</c> is empty, exactly as in a browser.
+/// </para>
+/// <para>
+/// The <c>[[controller]]</c> slot is always a <see cref="JsReadableStreamDefaultController"/>: byte streams
+/// (<c>type: "bytes"</c>, <c>ReadableByteStreamController</c>, BYOB readers) are not implemented, and the
+/// constructor refuses <c>type: "bytes"</c> rather than pretending. <c>[[Detached]]</c> has no counterpart
+/// either, because a stream can only become detached by being transferred through <c>postMessage()</c>, and
+/// there is nothing to transfer it to.
+/// </para>
+/// </remarks>
+internal sealed class JsReadableStream : ObjectInstance
+{
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#initialize-readable-stream — the whole of it: the state starts
+    /// "<c>readable</c>", the reader and stored error start undefined, and the stream starts undisturbed.
+    /// </summary>
+    internal JsReadableStream(Engine engine, Realm realm) : base(engine, ObjectClass.Object)
+    {
+        Realm = realm;
+    }
+
+    /// <summary>
+    /// The realm the stream was created in, which is the realm every promise it hands out belongs to.
+    /// </summary>
+    internal Realm Realm { get; }
+
+    /// <summary>https://streams.spec.whatwg.org/#readablestream-state</summary>
+    internal ReadableStreamState State { get; set; } = ReadableStreamState.Readable;
+
+    /// <summary>https://streams.spec.whatwg.org/#readablestream-storederror</summary>
+    internal JsValue StoredError { get; set; } = Undefined;
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readablestream-disturbed — set once the stream has been read from
+    /// or canceled. Nothing inside this specification reads it; it exists for the specifications built on
+    /// top, and is maintained so that they can be.
+    /// </summary>
+    internal bool Disturbed { get; set; }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readablestream-reader — the reader the stream is locked to, or
+    /// <see langword="null"/> when it is not locked.
+    /// </summary>
+    internal JsReadableStreamDefaultReader? Reader { get; set; }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readablestream-controller. Assigned by
+    /// <see cref="ReadableStreamOperations.SetUpDefaultController"/> before the stream can be reached by
+    /// anything, which is what makes the non-nullable declaration honest.
+    /// </summary>
+    internal JsReadableStreamDefaultController Controller { get; set; } = null!;
+}
+#endif

--- a/Jint/WebApi/Streams/JsReadableStreamDefaultController.cs
+++ b/Jint/WebApi/Streams/JsReadableStreamDefaultController.cs
@@ -1,0 +1,63 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// A <c>ReadableStreamDefaultController</c> instance.
+/// <para>
+/// https://streams.spec.whatwg.org/#rs-default-controller-class
+/// </para>
+/// </summary>
+/// <remarks>
+/// The three algorithm slots are nullable because <c>ReadableStreamDefaultControllerClearAlgorithms</c>
+/// sets them to undefined — which the specification does the moment they can no longer be needed,
+/// specifically so that a stream stops retaining the underlying source's closures once it is closed or
+/// errored.
+/// </remarks>
+internal sealed class JsReadableStreamDefaultController : ObjectInstance
+{
+    internal JsReadableStreamDefaultController(Engine engine, Realm realm) : base(engine, ObjectClass.Object)
+    {
+        Realm = realm;
+    }
+
+    /// <summary>The realm the controller was created in.</summary>
+    internal Realm Realm { get; }
+
+    /// <summary>https://streams.spec.whatwg.org/#readablestreamdefaultcontroller-stream</summary>
+    internal JsReadableStream Stream { get; set; } = null!;
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readablestreamdefaultcontroller-queue and
+    /// <c>[[queueTotalSize]]</c>, which the standard keeps synchronized as one structure.
+    /// </summary>
+    internal StreamQueue Queue { get; } = new();
+
+    /// <summary>https://streams.spec.whatwg.org/#readablestreamdefaultcontroller-started</summary>
+    internal bool Started { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#readablestreamdefaultcontroller-closerequested</summary>
+    internal bool CloseRequested { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#readablestreamdefaultcontroller-pullagain</summary>
+    internal bool PullAgain { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#readablestreamdefaultcontroller-pulling</summary>
+    internal bool Pulling { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#readablestreamdefaultcontroller-strategyhwm</summary>
+    internal double StrategyHighWaterMark { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#readablestreamdefaultcontroller-strategysizealgorithm</summary>
+    internal Func<JsValue, double>? StrategySizeAlgorithm { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#readablestreamdefaultcontroller-pullalgorithm</summary>
+    internal Func<JsPromise>? PullAlgorithm { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#readablestreamdefaultcontroller-cancelalgorithm</summary>
+    internal Func<JsValue, JsPromise>? CancelAlgorithm { get; set; }
+}
+#endif

--- a/Jint/WebApi/Streams/JsReadableStreamDefaultReader.cs
+++ b/Jint/WebApi/Streams/JsReadableStreamDefaultReader.cs
@@ -1,0 +1,71 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Native.Promise;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// A read request: the three algorithms a consumer supplies to react to the stream's internal queue filling
+/// or its state changing.
+/// <para>
+/// https://streams.spec.whatwg.org/#read-request
+/// </para>
+/// </summary>
+/// <remarks>
+/// A class rather than three delegates because every consumer of a read request supplies all three, and the
+/// specification's own consumers (a reader's <c>read()</c>, tee, piping, the async iterator) each keep state
+/// across the three. Exactly one of the three runs per request.
+/// </remarks>
+internal abstract class ReadRequest
+{
+    /// <summary>Called when a chunk is available for reading.</summary>
+    internal abstract void ChunkSteps(JsValue chunk);
+
+    /// <summary>Called when no chunks are available because the stream is closed.</summary>
+    internal abstract void CloseSteps();
+
+    /// <summary>Called when no chunks are available because the stream is errored.</summary>
+    internal abstract void ErrorSteps(JsValue error);
+}
+
+/// <summary>
+/// A <c>ReadableStreamDefaultReader</c> instance.
+/// <para>
+/// https://streams.spec.whatwg.org/#default-reader-class
+/// </para>
+/// </summary>
+/// <remarks>
+/// Carries the <c>ReadableStreamGenericReader</c> mixin's <c>[[stream]]</c> and <c>[[closedPromise]]</c>
+/// slots as well as its own <c>[[readRequests]]</c>. The closed promise is held as a capability rather than
+/// as a bare promise because releasing a lock on a non-readable stream <i>replaces</i> it with a freshly
+/// rejected one rather than rejecting the existing one — the specification distinguishes the two, and so
+/// does this.
+/// </remarks>
+internal sealed class JsReadableStreamDefaultReader : ObjectInstance
+{
+    internal JsReadableStreamDefaultReader(Engine engine, Realm realm) : base(engine, ObjectClass.Object)
+    {
+        Realm = realm;
+    }
+
+    /// <summary>The realm the reader was created in, which owns its <c>closed</c> and <c>read()</c> promises.</summary>
+    internal Realm Realm { get; }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readablestreamgenericreader-stream — the stream the reader is
+    /// active for, or <see langword="null"/> once its lock has been released.
+    /// </summary>
+    internal JsReadableStream? Stream { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#readablestreamgenericreader-closedpromise</summary>
+    internal PromiseCapability ClosedCapability { get; set; } = null!;
+
+    /// <summary>https://streams.spec.whatwg.org/#readablestreamdefaultreader-readrequests</summary>
+    internal Queue<ReadRequest> ReadRequests { get; } = new();
+
+    /// <summary>The promise the <c>closed</c> getter answers with.</summary>
+    internal JsPromise ClosedPromise => StreamPromises.PromiseOf(ClosedCapability);
+}
+#endif

--- a/Jint/WebApi/Streams/JsTransformStream.cs
+++ b/Jint/WebApi/Streams/JsTransformStream.cs
@@ -1,0 +1,54 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Native.Promise;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// A <c>TransformStream</c> instance.
+/// <para>
+/// https://streams.spec.whatwg.org/#ts-class
+/// </para>
+/// </summary>
+/// <remarks>
+/// A transform stream owns nothing but a pair of streams and a backpressure latch: the writable side's sink
+/// runs the transformer, and the readable side's source does nothing but release that latch. Backpressure
+/// from the readable side therefore reaches the producer writing into the writable side, which is the whole
+/// point of the type.
+/// </remarks>
+internal sealed class JsTransformStream : ObjectInstance
+{
+    internal JsTransformStream(Engine engine, Realm realm) : base(engine, ObjectClass.Object)
+    {
+        Realm = realm;
+    }
+
+    /// <summary>The realm the stream was created in.</summary>
+    internal Realm Realm { get; }
+
+    /// <summary>https://streams.spec.whatwg.org/#transformstream-readable</summary>
+    internal JsReadableStream Readable { get; set; } = null!;
+
+    /// <summary>https://streams.spec.whatwg.org/#transformstream-writable</summary>
+    internal JsWritableStream Writable { get; set; } = null!;
+
+    /// <summary>https://streams.spec.whatwg.org/#transformstream-controller</summary>
+    internal JsTransformStreamDefaultController Controller { get; set; } = null!;
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#transformstream-backpressure. The specification starts it as
+    /// undefined purely so that <c>TransformStreamSetBackpressure</c>'s "assert it is changing" holds on the
+    /// first call; a nullable boolean says the same thing without needing the assertion.
+    /// </summary>
+    internal bool? Backpressure { get; set; }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#transformstream-backpressurechangepromise — resolved whenever
+    /// <see cref="Backpressure"/> changes, and replaced by a fresh pending promise each time. A write that
+    /// arrives while there is backpressure waits on it.
+    /// </summary>
+    internal PromiseCapability? BackpressureChangeCapability { get; set; }
+}
+#endif

--- a/Jint/WebApi/Streams/JsTransformStreamDefaultController.cs
+++ b/Jint/WebApi/Streams/JsTransformStreamDefaultController.cs
@@ -1,0 +1,46 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Native.Promise;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// A <c>TransformStreamDefaultController</c> instance.
+/// <para>
+/// https://streams.spec.whatwg.org/#ts-default-controller-class
+/// </para>
+/// </summary>
+/// <remarks>
+/// <see cref="FinishCapability"/> is the specification's <c>[[finishPromise]]</c>: it is unpopulated until
+/// either the flush or the cancel algorithm has been invoked, and its presence is what stops the two from
+/// both running — a transformer's <c>cancel()</c> is never called after its <c>flush()</c>, and neither is
+/// ever called twice, however the two sides are shut down.
+/// </remarks>
+internal sealed class JsTransformStreamDefaultController : ObjectInstance
+{
+    internal JsTransformStreamDefaultController(Engine engine, Realm realm) : base(engine, ObjectClass.Object)
+    {
+        Realm = realm;
+    }
+
+    /// <summary>The realm the controller was created in.</summary>
+    internal Realm Realm { get; }
+
+    /// <summary>https://streams.spec.whatwg.org/#transformstreamdefaultcontroller-stream</summary>
+    internal JsTransformStream Stream { get; set; } = null!;
+
+    /// <summary>https://streams.spec.whatwg.org/#transformstreamdefaultcontroller-transformalgorithm</summary>
+    internal Func<JsValue, JsPromise>? TransformAlgorithm { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#transformstreamdefaultcontroller-flushalgorithm</summary>
+    internal Func<JsPromise>? FlushAlgorithm { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#transformstreamdefaultcontroller-cancelalgorithm</summary>
+    internal Func<JsValue, JsPromise>? CancelAlgorithm { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#transformstreamdefaultcontroller-finishpromise</summary>
+    internal PromiseCapability? FinishCapability { get; set; }
+}
+#endif

--- a/Jint/WebApi/Streams/JsWritableStream.cs
+++ b/Jint/WebApi/Streams/JsWritableStream.cs
@@ -1,0 +1,113 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Native.Promise;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// The state a <c>WritableStream</c> is in: the specification's <c>[[state]]</c> slot, whose values are the
+/// strings "<c>writable</c>", "<c>erroring</c>", "<c>closed</c>" and "<c>errored</c>".
+/// <para>
+/// https://streams.spec.whatwg.org/#ws-internal-slots
+/// </para>
+/// </summary>
+/// <remarks>
+/// "<c>erroring</c>" is the state between a failure being noticed and the in-flight sink operation
+/// finishing; it exists so that an abort never interrupts a write or a close that the sink has already been
+/// handed.
+/// </remarks>
+internal enum WritableStreamState
+{
+    Writable,
+    Erroring,
+    Closed,
+    Errored,
+}
+
+/// <summary>
+/// https://streams.spec.whatwg.org/#pending-abort-request — a request to abort a stream that cannot be
+/// acted on yet because an operation is in flight.
+/// </summary>
+internal sealed class PendingAbortRequest
+{
+    internal PendingAbortRequest(PromiseCapability capability, JsValue reason, bool wasAlreadyErroring)
+    {
+        Capability = capability;
+        Reason = reason;
+        WasAlreadyErroring = wasAlreadyErroring;
+    }
+
+    /// <summary>https://streams.spec.whatwg.org/#pending-abort-request-promise</summary>
+    internal PromiseCapability Capability { get; }
+
+    /// <summary>https://streams.spec.whatwg.org/#pending-abort-request-reason</summary>
+    internal JsValue Reason { get; }
+
+    /// <summary>https://streams.spec.whatwg.org/#pending-abort-request-was-already-erroring</summary>
+    internal bool WasAlreadyErroring { get; }
+}
+
+/// <summary>
+/// A <c>WritableStream</c> instance.
+/// <para>
+/// https://streams.spec.whatwg.org/#ws-class
+/// </para>
+/// </summary>
+/// <remarks>
+/// The write requests are the promises <c>writer.write()</c> handed out and have not settled; one of them
+/// moves into <see cref="InFlightWriteRequest"/> while the sink is processing it, which is what keeps an
+/// error from rejecting a write the sink has already accepted.
+/// </remarks>
+internal sealed class JsWritableStream : ObjectInstance
+{
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#initialize-writable-stream — the whole of it: the state starts
+    /// "<c>writable</c>", every request slot starts undefined and backpressure starts false.
+    /// </summary>
+    internal JsWritableStream(Engine engine, Realm realm) : base(engine, ObjectClass.Object)
+    {
+        Realm = realm;
+    }
+
+    /// <summary>The realm the stream was created in, which owns every promise it hands out.</summary>
+    internal Realm Realm { get; }
+
+    /// <summary>https://streams.spec.whatwg.org/#writablestream-state</summary>
+    internal WritableStreamState State { get; set; } = WritableStreamState.Writable;
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writablestream-storederror — only meaningful while the state is
+    /// "<c>erroring</c>" or "<c>errored</c>", and deliberately allowed to be undefined even then.
+    /// </summary>
+    internal JsValue StoredError { get; set; } = Undefined;
+
+    /// <summary>https://streams.spec.whatwg.org/#writablestream-writer</summary>
+    internal JsWritableStreamDefaultWriter? Writer { get; set; }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writablestream-controller. Assigned by
+    /// <c>SetUpWritableStreamDefaultController</c> before the stream can be reached by anything.
+    /// </summary>
+    internal JsWritableStreamDefaultController Controller { get; set; } = null!;
+
+    /// <summary>https://streams.spec.whatwg.org/#writablestream-inflightwriterequest</summary>
+    internal PromiseCapability? InFlightWriteRequest { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#writablestream-closerequest</summary>
+    internal PromiseCapability? CloseRequest { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#writablestream-inflightcloserequest</summary>
+    internal PromiseCapability? InFlightCloseRequest { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#writablestream-pendingabortrequest</summary>
+    internal PendingAbortRequest? PendingAbortRequest { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#writablestream-writerequests</summary>
+    internal Queue<PromiseCapability> WriteRequests { get; } = new();
+
+    /// <summary>https://streams.spec.whatwg.org/#writablestream-backpressure</summary>
+    internal bool Backpressure { get; set; }
+}
+#endif

--- a/Jint/WebApi/Streams/JsWritableStreamDefaultController.cs
+++ b/Jint/WebApi/Streams/JsWritableStreamDefaultController.cs
@@ -1,0 +1,87 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.WebApi.Abort;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// A <c>WritableStreamDefaultController</c> instance.
+/// <para>
+/// https://streams.spec.whatwg.org/#ws-default-controller-class
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// The <c>[[abortController]]</c> slot is what backs the <c>signal</c> attribute: a sink's <c>write()</c>
+/// can watch it to abandon a long-running write the moment the stream is aborted, without waiting for its
+/// own promise to be listened to. It is an ordinary <see cref="JsAbortSignal"/>, so a sink sees exactly the
+/// interface the DOM defines even on an engine that did not install the <c>AbortSignal</c> global — the
+/// signal is handed to it, never looked up by name.
+/// </para>
+/// <para>
+/// The signal is created lazily, on the first read of <c>controller.signal</c> or the first abort. Most
+/// sinks never look at it, and a writable stream that nobody aborts then costs nothing for having the slot.
+/// </para>
+/// </remarks>
+internal sealed class JsWritableStreamDefaultController : ObjectInstance
+{
+    private JsAbortSignal? _abortSignal;
+
+    internal JsWritableStreamDefaultController(Engine engine, Realm realm) : base(engine, ObjectClass.Object)
+    {
+        Realm = realm;
+    }
+
+    /// <summary>The realm the controller was created in.</summary>
+    internal Realm Realm { get; }
+
+    /// <summary>https://streams.spec.whatwg.org/#writablestreamdefaultcontroller-stream</summary>
+    internal JsWritableStream Stream { get; set; } = null!;
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writablestreamdefaultcontroller-queue and
+    /// <c>[[queueTotalSize]]</c>. The queue holds chunks and, at its tail once close has been requested,
+    /// the close sentinel.
+    /// </summary>
+    internal StreamQueue Queue { get; } = new();
+
+    /// <summary>https://streams.spec.whatwg.org/#writablestreamdefaultcontroller-started</summary>
+    internal bool Started { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#writablestreamdefaultcontroller-strategyhwm</summary>
+    internal double StrategyHighWaterMark { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#writablestreamdefaultcontroller-strategysizealgorithm</summary>
+    internal Func<JsValue, double>? StrategySizeAlgorithm { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#writablestreamdefaultcontroller-writealgorithm</summary>
+    internal Func<JsValue, JsPromise>? WriteAlgorithm { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#writablestreamdefaultcontroller-closealgorithm</summary>
+    internal Func<JsPromise>? CloseAlgorithm { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#writablestreamdefaultcontroller-abortalgorithm</summary>
+    internal Func<JsValue, JsPromise>? AbortAlgorithm { get; set; }
+
+    /// <summary>
+    /// The signal of the controller's <c>[[abortController]]</c>, created on first use.
+    /// </summary>
+    internal JsAbortSignal Signal => _abortSignal ??= Realm.Intrinsics.AbortSignal.CreateSignal();
+
+    /// <summary>
+    /// The <c>[[abortController]]</c>'s <c>abort()</c>, run by <c>WritableStreamAbort</c> before anything
+    /// else so that a sink watching the signal stops as early as possible.
+    /// </summary>
+    /// <remarks>
+    /// <c>abort(reason)</c> takes an optional <c>any</c>, so an omitted reason — which is what
+    /// <c>writer.abort()</c> passes down — becomes a fresh <c>AbortError</c> <c>DOMException</c> rather than
+    /// <see langword="undefined"/>, per https://dom.spec.whatwg.org/#abortsignal-signal-abort. Note that the
+    /// signal's reason and the stream's stored error therefore differ in that case: the stream stores the
+    /// undefined reason it was given.
+    /// </remarks>
+    internal void SignalAbort(JsValue reason)
+        => Signal.SignalAbort(Realm.Intrinsics.AbortSignal.DefaultedReason(reason));
+}
+#endif

--- a/Jint/WebApi/Streams/JsWritableStreamDefaultWriter.cs
+++ b/Jint/WebApi/Streams/JsWritableStreamDefaultWriter.cs
@@ -1,0 +1,50 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Native.Promise;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// A <c>WritableStreamDefaultWriter</c> instance.
+/// <para>
+/// https://streams.spec.whatwg.org/#default-writer-class
+/// </para>
+/// </summary>
+/// <remarks>
+/// Both promises are held as capabilities rather than as bare promises: the specification replaces either
+/// with a freshly settled one when the one it holds has already settled — "ensure the ready promise is
+/// rejected" is a different operation from "reject the ready promise" — and <c>ready</c> is additionally
+/// replaced with a brand new pending promise every time backpressure re-appears, which is the whole of how
+/// <c>await writer.ready</c> works.
+/// </remarks>
+internal sealed class JsWritableStreamDefaultWriter : ObjectInstance
+{
+    internal JsWritableStreamDefaultWriter(Engine engine, Realm realm) : base(engine, ObjectClass.Object)
+    {
+        Realm = realm;
+    }
+
+    /// <summary>The realm the writer was created in, which owns its promises.</summary>
+    internal Realm Realm { get; }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writablestreamdefaultwriter-stream — the stream the writer is
+    /// active for, or <see langword="null"/> once its lock has been released.
+    /// </summary>
+    internal JsWritableStream? Stream { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#writablestreamdefaultwriter-closedpromise</summary>
+    internal PromiseCapability ClosedCapability { get; set; } = null!;
+
+    /// <summary>https://streams.spec.whatwg.org/#writablestreamdefaultwriter-readypromise</summary>
+    internal PromiseCapability ReadyCapability { get; set; } = null!;
+
+    /// <summary>The promise the <c>closed</c> getter answers with.</summary>
+    internal JsPromise ClosedPromise => StreamPromises.PromiseOf(ClosedCapability);
+
+    /// <summary>The promise the <c>ready</c> getter answers with.</summary>
+    internal JsPromise ReadyPromise => StreamPromises.PromiseOf(ReadyCapability);
+}
+#endif

--- a/Jint/WebApi/Streams/ReadableStreamAsyncIterator.cs
+++ b/Jint/WebApi/Streams/ReadableStreamAsyncIterator.cs
@@ -1,0 +1,60 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// The object <c>ReadableStream.prototype.values()</c> returns: WebIDL's "default asynchronous iterator
+/// object" for the <c>async_iterable&lt;any&gt;</c> declaration on <c>ReadableStream</c>.
+/// <para>
+/// https://streams.spec.whatwg.org/#rs-asynciterator and
+/// https://webidl.spec.whatwg.org/#js-default-asynchronous-iterator-object
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// Iterating a stream locks it: the iterator holds a reader for its whole life, and gives it up only when
+/// the iteration ends — which <c>for await…of</c> does through <c>return()</c> when the loop is left by
+/// <c>break</c>, <c>return</c> or a thrown exception. By default that also <b>cancels</b> the stream;
+/// <c>stream.values({ preventCancel: true })</c> releases the lock without cancelling, leaving the remaining
+/// chunks for another consumer.
+/// </para>
+/// <para>
+/// <see cref="OngoingPromise"/> is what serializes the calls: WebIDL requires a second <c>next()</c> to wait
+/// for the first, so the read requests can never interleave and <c>for await…of</c> sees the chunks in
+/// order however impatiently it is driven.
+/// </para>
+/// </remarks>
+internal sealed class ReadableStreamAsyncIterator : ObjectInstance
+{
+    internal ReadableStreamAsyncIterator(Engine engine, Realm realm) : base(engine, ObjectClass.Object)
+    {
+        Realm = realm;
+    }
+
+    /// <summary>The realm the iterator was created in.</summary>
+    internal Realm Realm { get; }
+
+    /// <summary>https://streams.spec.whatwg.org/#readablestream-async-iterator-reader</summary>
+    internal JsReadableStreamDefaultReader Reader { get; set; } = null!;
+
+    /// <summary>https://streams.spec.whatwg.org/#readablestream-async-iterator-prevent-cancel</summary>
+    internal bool PreventCancel { get; set; }
+
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#default-asynchronous-iterator-object-ongoing-promise — the promise a
+    /// further <c>next()</c> or <c>return()</c> queues behind, or <see langword="null"/> when the iterator is
+    /// idle.
+    /// </summary>
+    internal JsPromise? OngoingPromise { get; set; }
+
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#default-asynchronous-iterator-object-is-finished — set once the
+    /// iterator has produced its last result, after which <c>next()</c> answers
+    /// <c>{ value: undefined, done: true }</c> without touching the stream.
+    /// </summary>
+    internal bool IsFinished { get; set; }
+}
+#endif

--- a/Jint/WebApi/Streams/ReadableStreamAsyncIteratorPrototype.cs
+++ b/Jint/WebApi/Streams/ReadableStreamAsyncIteratorPrototype.cs
@@ -1,0 +1,240 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Iterator;
+using Jint.Native.Object;
+using Jint.Native.Promise;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// <c>%ReadableStreamAsyncIteratorPrototype%</c> — WebIDL's "asynchronous iterator prototype object" for
+/// <c>ReadableStream</c>'s <c>async_iterable&lt;any&gt;</c> declaration.
+/// <para>
+/// https://webidl.spec.whatwg.org/#js-asynchronous-iterator-prototype-object
+/// </para>
+/// </summary>
+/// <remarks>
+/// Its <c>[[Prototype]]</c> is <c>%AsyncIteratorPrototype%</c>, which is what gives an iterator obtained from
+/// a stream the whole async-iterator-helper surface (<c>map</c>, <c>filter</c>, <c>toArray</c>, …) and its
+/// <c>@@asyncIterator</c> method. It is reachable only through
+/// <c>Object.getPrototypeOf(stream.values())</c>; no global names it.
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class ReadableStreamAsyncIteratorPrototype : Prototype
+{
+    /// <summary>
+    /// The value the <i>get the next iteration result</i> promise fulfils with when the stream has closed:
+    /// WebIDL's "end of iteration". A symbol nothing can reach — it is never handed to a callback and is
+    /// compared only by reference — so it can never be mistaken for a chunk.
+    /// </summary>
+    private static readonly JsSymbol _endOfIteration = new("[[end of iteration]]");
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString AsyncIteratorToStringTag = new("ReadableStream AsyncIterator");
+
+    internal ReadableStreamAsyncIteratorPrototype(
+        Engine engine,
+        Realm realm,
+        ObjectInstance asyncIteratorPrototype) : base(engine, realm)
+    {
+        _prototype = asyncIteratorPrototype;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// Creates the iterator <c>ReadableStream.prototype.values()</c> hands out, running the specification's
+    /// asynchronous iterator initialization steps for <c>ReadableStream</c>:
+    /// https://streams.spec.whatwg.org/#rs-get-iterator.
+    /// </summary>
+    internal ReadableStreamAsyncIterator Construct(JsReadableStream stream, bool preventCancel)
+    {
+        var iterator = new ReadableStreamAsyncIterator(_engine, _realm)
+        {
+            _prototype = this,
+        };
+
+        // Acquiring the reader is what locks the stream, and what raises the TypeError for a stream that is
+        // already locked.
+        iterator.Reader = ReadableStreamOperations.AcquireDefaultReader(stream);
+        iterator.PreventCancel = preventCancel;
+        return iterator;
+    }
+
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#js-asynchronous-iterator-prototype-object, the <c>next</c> data
+    /// property's steps.
+    /// </summary>
+    [JsFunction(Name = "next", Length = 0)]
+    private JsPromise Next(JsValue thisObject)
+    {
+        if (thisObject is not ReadableStreamAsyncIterator iterator)
+        {
+            // The brand check is reported as a rejection, not a throw: the operation's return type is a
+            // promise type — https://webidl.spec.whatwg.org/#js-operations.
+            return StreamPromises.RejectedWith(
+                _engine,
+                _realm,
+                _realm.Intrinsics.TypeError.Construct("Illegal invocation: receiver is not a ReadableStream async iterator"));
+        }
+
+        if (iterator.OngoingPromise is { } ongoing)
+        {
+            // A next() while another is outstanding queues behind it, whichever way that one settles.
+            iterator.OngoingPromise = StreamPromises.TransformPromiseWith(
+                _engine, _realm, ongoing, _ => NextSteps(iterator), _ => NextSteps(iterator));
+        }
+        else
+        {
+            iterator.OngoingPromise = NextSteps(iterator);
+        }
+
+        return iterator.OngoingPromise;
+    }
+
+    private JsPromise NextSteps(ReadableStreamAsyncIterator iterator)
+    {
+        if (iterator.IsFinished)
+        {
+            return StreamPromises.ResolvedWith(_realm, IteratorResult.CreateValueIteratorPosition(_engine, Undefined, JsBoolean.True));
+        }
+
+        var nextPromise = GetNextIterationResult(iterator);
+
+        return StreamPromises.TransformPromiseWith(
+            _engine,
+            _realm,
+            nextPromise,
+            next =>
+            {
+                iterator.OngoingPromise = null;
+
+                if (ReferenceEquals(next, _endOfIteration))
+                {
+                    iterator.IsFinished = true;
+                    return IteratorResult.CreateValueIteratorPosition(_engine, Undefined, JsBoolean.True);
+                }
+
+                return IteratorResult.CreateValueIteratorPosition(_engine, next, JsBoolean.False);
+            },
+            reason =>
+            {
+                iterator.OngoingPromise = null;
+                iterator.IsFinished = true;
+                throw new JavaScriptException(reason);
+            });
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rs-asynciterator-prototype-next — the <i>get the next iteration
+    /// result</i> steps for a <c>ReadableStream</c>. Both terminal outcomes release the reader's lock, which
+    /// is what lets an iteration that ran to completion leave the stream usable again.
+    /// </summary>
+    private JsPromise GetNextIterationResult(ReadableStreamAsyncIterator iterator)
+    {
+        var reader = iterator.Reader;
+        var capability = StreamPromises.NewPromise(_engine, _realm);
+
+        ReadableStreamOperations.DefaultReaderRead(reader, new IterationReadRequest(reader, capability));
+        return StreamPromises.PromiseOf(capability);
+    }
+
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#js-asynchronous-iterator-prototype-object, the <c>return</c> data
+    /// property's steps.
+    /// </summary>
+    [JsFunction(Name = "return", Length = 1)]
+    private JsPromise Return(JsValue thisObject, JsValue value)
+    {
+        if (thisObject is not ReadableStreamAsyncIterator iterator)
+        {
+            return StreamPromises.RejectedWith(
+                _engine,
+                _realm,
+                _realm.Intrinsics.TypeError.Construct("Illegal invocation: receiver is not a ReadableStream async iterator"));
+        }
+
+        if (iterator.OngoingPromise is { } ongoing)
+        {
+            iterator.OngoingPromise = StreamPromises.TransformPromiseWith(
+                _engine, _realm, ongoing, _ => ReturnSteps(iterator, value), _ => ReturnSteps(iterator, value));
+        }
+        else
+        {
+            iterator.OngoingPromise = ReturnSteps(iterator, value);
+        }
+
+        // Whatever the return steps produced, the iterator result the caller sees is { value, done: true }.
+        return StreamPromises.TransformPromiseWith(
+            _engine,
+            _realm,
+            iterator.OngoingPromise,
+            _ => IteratorResult.CreateValueIteratorPosition(_engine, value, JsBoolean.True),
+            onRejected: null);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rs-asynciterator-prototype-return — the <i>asynchronous iterator
+    /// return</i> steps for a <c>ReadableStream</c>.
+    /// </summary>
+    private JsPromise ReturnSteps(ReadableStreamAsyncIterator iterator, JsValue value)
+    {
+        if (iterator.IsFinished)
+        {
+            return StreamPromises.ResolvedWith(_realm, IteratorResult.CreateValueIteratorPosition(_engine, value, JsBoolean.True));
+        }
+
+        iterator.IsFinished = true;
+
+        var reader = iterator.Reader;
+
+        if (!iterator.PreventCancel)
+        {
+            // Leaving the loop cancels the stream, and the promise the loop awaits is the cancel's — so a
+            // source whose cancel() rejects makes `for await…of` throw on its way out.
+            var result = ReadableStreamOperations.ReaderGenericCancel(reader, value);
+            ReadableStreamOperations.DefaultReaderRelease(reader);
+            return result;
+        }
+
+        ReadableStreamOperations.DefaultReaderRelease(reader);
+        return StreamPromises.ResolvedWithUndefined(_engine, _realm);
+    }
+
+    /// <summary>
+    /// The read request one <c>next()</c> makes. Closing and erroring both release the lock before settling,
+    /// so the stream is free again by the time the consumer observes the end of the iteration.
+    /// </summary>
+    private sealed class IterationReadRequest : ReadRequest
+    {
+        private readonly JsReadableStreamDefaultReader _reader;
+        private readonly PromiseCapability _capability;
+
+        internal IterationReadRequest(JsReadableStreamDefaultReader reader, PromiseCapability capability)
+        {
+            _reader = reader;
+            _capability = capability;
+        }
+
+        internal override void ChunkSteps(JsValue chunk) => _capability.Resolve(chunk);
+
+        internal override void CloseSteps()
+        {
+            ReadableStreamOperations.DefaultReaderRelease(_reader);
+            _capability.Resolve(_endOfIteration);
+        }
+
+        internal override void ErrorSteps(JsValue error)
+        {
+            ReadableStreamOperations.DefaultReaderRelease(_reader);
+            _capability.Reject(error);
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/ReadableStreamConstructor.cs
+++ b/Jint/WebApi/Streams/ReadableStreamConstructor.cs
@@ -1,0 +1,257 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Iterator;
+using Jint.Native.Object;
+using Jint.Native.Symbol;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// The <c>ReadableStream</c> interface object.
+/// <para>
+/// https://streams.spec.whatwg.org/#rs-class
+/// </para>
+/// </summary>
+[JsObject(UseShape = true)]
+internal sealed partial class ReadableStreamConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("ReadableStream");
+
+    internal ReadableStreamConstructor(
+        Engine engine,
+        Realm realm,
+        FunctionPrototype functionPrototype,
+        ObjectPrototype objectPrototype)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = functionPrototype;
+        PrototypeObject = new ReadableStreamPrototype(engine, realm, this, objectPrototype);
+
+        // Both constructor arguments are optional, so the interface object's length is 0 —
+        // https://webidl.spec.whatwg.org/#es-interface-call.
+        _length = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal ReadableStreamPrototype PrototypeObject { get; }
+
+    protected override void Initialize() => CreateProperties_Generated();
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rs-constructor
+    /// </summary>
+    /// <remarks>
+    /// The argument order matters and is observable: <c>strategy</c> is a WebIDL dictionary and is therefore
+    /// converted before the constructor's own steps run, while <c>underlyingSource</c> is converted inside
+    /// them — so a strategy whose <c>size</c> getter throws wins over a source whose <c>start</c> getter
+    /// does.
+    /// </remarks>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        if (newTarget.IsUndefined())
+        {
+            Throw.TypeError(_realm, $"Constructor {GetOwnFunctionNameForMessage()} requires 'new'");
+        }
+
+        var underlyingSource = arguments.At(0);
+        if (!underlyingSource.IsUndefined() && underlyingSource is not ObjectInstance)
+        {
+            // `optional object underlyingSource`: the IDL object type is not nullable, so an explicit null
+            // is a TypeError while an omitted (or explicitly undefined) argument is simply missing.
+            Throw.TypeError(_realm, "Failed to construct 'ReadableStream': the underlying source is not an object");
+        }
+
+        var strategy = StreamDictionaries.ReadQueuingStrategy(_realm, arguments.At(1), "The queuing strategy");
+
+        var stream = OrdinaryCreateFromConstructor(
+            newTarget,
+            static intrinsics => intrinsics.ReadableStream.PrototypeObject,
+            static (Engine engine, Realm realm, object? _) => new JsReadableStream(engine, realm));
+
+        var source = StreamDictionaries.ReadUnderlyingSource(_realm, underlyingSource);
+
+        if (source.TypeExists)
+        {
+            // `type: "bytes"` asks for a readable byte stream, which is not implemented: there is no
+            // ReadableByteStreamController and no BYOB reader. Refusing is the honest answer — the same
+            // TypeError an invalid enumeration value would produce — rather than handing back a stream that
+            // silently is not a byte stream.
+            Throw.TypeError(_realm, "Failed to construct 'ReadableStream': readable byte streams are not supported");
+        }
+
+        var sizeAlgorithm = StreamDictionaries.ExtractSizeAlgorithm(in strategy);
+        var highWaterMark = StreamDictionaries.ExtractHighWaterMark(_realm, in strategy, 1);
+
+        ReadableStreamOperations.SetUpDefaultControllerFromUnderlyingSource(
+            stream, underlyingSource, in source, highWaterMark, sizeAlgorithm);
+
+        return stream;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rs-from, which is
+    /// https://streams.spec.whatwg.org/#readable-stream-from-iterable.
+    /// </summary>
+    /// <remarks>
+    /// The argument is an <c>async_sequence&lt;any&gt;</c>, so anything that is not an object — a string
+    /// included — is a <c>TypeError</c>, and an object carrying <c>@@asyncIterator</c> never has its
+    /// <c>@@iterator</c> looked at. A synchronous iterable is adapted through the same
+    /// <c>CreateAsyncFromSyncIterator</c> the language uses for <c>for await…of</c>, which is what makes
+    /// <c>ReadableStream.from([Promise.resolve('a')])</c> yield <c>'a'</c> rather than the promise.
+    /// </remarks>
+    [JsFunction(Name = "from", Length = 1)]
+    private JsReadableStream From(JsValue thisObject, JsValue asyncIterable)
+    {
+        var iterator = OpenAsyncSequence(asyncIterable);
+
+        JsReadableStream stream = null!;
+
+        JsPromise PullAlgorithm()
+        {
+            var nextPromise = GetNextValue(iterator);
+
+            return StreamPromises.TransformPromiseWith(
+                _engine,
+                _realm,
+                nextPromise,
+                iterationResult =>
+                {
+                    if (iterationResult is not ObjectInstance iterationObject)
+                    {
+                        Throw.TypeError(_realm, "The iterator result is not an object");
+                        return Undefined;
+                    }
+
+                    var controller = stream.Controller;
+                    if (TypeConverter.ToBoolean(iterationObject.Get(CommonProperties.Done)))
+                    {
+                        ReadableStreamDefaultControllerOperations.Close(controller);
+                    }
+                    else
+                    {
+                        ReadableStreamDefaultControllerOperations.Enqueue(controller, iterationObject.Get(CommonProperties.Value));
+                    }
+
+                    return Undefined;
+                },
+                onRejected: null);
+        }
+
+        JsPromise CancelAlgorithm(JsValue reason) => CloseAsyncIterator(iterator, reason);
+
+        // A high water mark of 0 means the iterator is only advanced when a consumer actually asks.
+        stream = ReadableStreamOperations.CreateReadableStream(
+            _engine, _realm, static () => Undefined, PullAlgorithm, CancelAlgorithm, highWaterMark: 0);
+
+        return stream;
+    }
+
+    /// <summary>
+    /// The <c>async_sequence</c> conversion followed by "opening" it —
+    /// https://webidl.spec.whatwg.org/#js-to-async-iterable and
+    /// https://webidl.spec.whatwg.org/#async-sequence-open, which the specification performs as one step
+    /// because <c>ReadableStream.from</c> opens its argument immediately.
+    /// </summary>
+    private IteratorInstance OpenAsyncSequence(JsValue asyncIterable)
+    {
+        if (asyncIterable is not ObjectInstance objectInstance)
+        {
+            Throw.TypeError(_realm, "Failed to execute 'from' on 'ReadableStream': the value is not an object");
+            return null!;
+        }
+
+        var method = objectInstance.GetMethod(GlobalSymbolRegistry.AsyncIterator);
+        if (method is not null)
+        {
+            return asyncIterable.GetIteratorFromMethod(_realm, method);
+        }
+
+        var syncMethod = objectInstance.GetMethod(GlobalSymbolRegistry.Iterator);
+        if (syncMethod is null)
+        {
+            Throw.TypeError(_realm, "Failed to execute 'from' on 'ReadableStream': the value is not async iterable");
+            return null!;
+        }
+
+        // CreateAsyncFromSyncIterator, which is also what `for await…of` uses for a synchronous iterable:
+        // the wrapper's next() awaits each value, so a sequence of promises yields the values they settle to.
+        var syncIterator = asyncIterable.GetIteratorFromMethod(_realm, syncMethod);
+        return new IteratorInstance.ObjectIterator(new AsyncFromSyncIterator(_engine, syncIterator));
+    }
+
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#async-iterator-get-next-value. A <c>next()</c> that throws becomes a
+    /// rejected promise rather than escaping, because the pull algorithm's contract is to return a promise.
+    /// The <c>next</c> method itself is the one read when the sequence was opened, exactly as an Iterator
+    /// Record's <c>[[NextMethod]]</c> is — it is not re-read per step.
+    /// </summary>
+    private JsPromise GetNextValue(IteratorInstance iterator)
+    {
+        try
+        {
+            if (iterator.NextMethod is not { } nextMethod)
+            {
+                Throw.TypeError(_realm, "The iterator has no callable next method");
+                return null!;
+            }
+
+            var nextResult = nextMethod.Call(iterator.Instance, Arguments.Empty);
+            if (nextResult is not ObjectInstance)
+            {
+                Throw.TypeError(_realm, "The iterator's next method did not return an object");
+            }
+
+            return StreamPromises.ResolvedWith(_realm, nextResult);
+        }
+        catch (JavaScriptException e)
+        {
+            return StreamPromises.RejectedWith(_engine, _realm, e.Error);
+        }
+    }
+
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#async-iterator-close — the iterator's <c>return</c> is called with the
+    /// cancellation reason, and its result must be an object.
+    /// </summary>
+    private JsPromise CloseAsyncIterator(IteratorInstance iterator, JsValue reason)
+    {
+        var iteratorObject = iterator.Instance;
+
+        JsValue returnResult;
+        try
+        {
+            var returnMethod = iteratorObject.GetMethod(CommonProperties.Return);
+            if (returnMethod is null)
+            {
+                return StreamPromises.ResolvedWithUndefined(_engine, _realm);
+            }
+
+            returnResult = returnMethod.Call(iteratorObject, reason);
+        }
+        catch (JavaScriptException e)
+        {
+            return StreamPromises.RejectedWith(_engine, _realm, e.Error);
+        }
+
+        var returnPromise = StreamPromises.ResolvedWith(_realm, returnResult);
+
+        return StreamPromises.TransformPromiseWith(
+            _engine,
+            _realm,
+            returnPromise,
+            result =>
+            {
+                if (result is not ObjectInstance)
+                {
+                    Throw.TypeError(_realm, "The iterator's return method did not return an object");
+                }
+
+                return Undefined;
+            },
+            onRejected: null);
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/ReadableStreamDefaultControllerConstructor.cs
+++ b/Jint/WebApi/Streams/ReadableStreamDefaultControllerConstructor.cs
@@ -1,0 +1,48 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// The <c>ReadableStreamDefaultController</c> interface object.
+/// <para>
+/// https://streams.spec.whatwg.org/#rs-default-controller-class
+/// </para>
+/// </summary>
+/// <remarks>
+/// The interface declares no constructor operation, which in WebIDL means the interface object exists and is
+/// a function but refuses to construct anything — https://webidl.spec.whatwg.org/#es-interface-call. A
+/// controller can only come from a stream handing one to its underlying source. Like the other
+/// non-constructed stream interfaces it is not installed as a global, and is reached through
+/// <c>Object.getPrototypeOf(controller).constructor</c>.
+/// </remarks>
+internal sealed class ReadableStreamDefaultControllerConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("ReadableStreamDefaultController");
+
+    internal ReadableStreamDefaultControllerConstructor(
+        Engine engine,
+        Realm realm,
+        FunctionPrototype functionPrototype,
+        ObjectPrototype objectPrototype)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = functionPrototype;
+        PrototypeObject = new ReadableStreamDefaultControllerPrototype(engine, realm, this, objectPrototype);
+        _length = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal ReadableStreamDefaultControllerPrototype PrototypeObject { get; }
+
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        Throw.TypeError(_realm, "Illegal constructor");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/ReadableStreamDefaultControllerOperations.cs
+++ b/Jint/WebApi/Streams/ReadableStreamDefaultControllerOperations.cs
@@ -1,0 +1,254 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// The <c>ReadableStreamDefaultController</c> abstract operations, plus its two internal methods
+/// <c>[[PullSteps]]</c> and <c>[[CancelSteps]]</c>.
+/// <para>
+/// https://streams.spec.whatwg.org/#rs-default-controller-abstract-ops
+/// </para>
+/// </summary>
+internal static class ReadableStreamDefaultControllerOperations
+{
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-stream-default-controller-call-pull-if-needed
+    /// </summary>
+    /// <remarks>
+    /// The <c>[[pulling]]</c>/<c>[[pullAgain]]</c> pair is the reentrancy guard the underlying source API
+    /// promises: <c>pull()</c> is never called again while a previous call's promise is outstanding, and a
+    /// request that arrives during one is remembered and served once it settles. That is what makes
+    /// enqueueing from inside <c>pull()</c> safe.
+    /// </remarks>
+    internal static void CallPullIfNeeded(JsReadableStreamDefaultController controller)
+    {
+        if (!ShouldCallPull(controller))
+        {
+            return;
+        }
+
+        if (controller.Pulling)
+        {
+            controller.PullAgain = true;
+            return;
+        }
+
+        controller.Pulling = true;
+
+        // The algorithm is cleared only once the stream is closed or errored, and both of those make
+        // ShouldCallPull answer false, so it is still present here.
+        var pullPromise = controller.PullAlgorithm!();
+
+        StreamPromises.UponPromise(
+            controller.Engine,
+            pullPromise,
+            _ =>
+            {
+                controller.Pulling = false;
+                if (controller.PullAgain)
+                {
+                    controller.PullAgain = false;
+                    CallPullIfNeeded(controller);
+                }
+            },
+            error => Error(controller, error));
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-stream-default-controller-should-call-pull
+    /// </summary>
+    internal static bool ShouldCallPull(JsReadableStreamDefaultController controller)
+    {
+        var stream = controller.Stream;
+
+        if (!CanCloseOrEnqueue(controller))
+        {
+            return false;
+        }
+
+        // "This function will not be called until start() successfully completes."
+        if (!controller.Started)
+        {
+            return false;
+        }
+
+        // A waiting consumer outranks the high water mark: a read against an empty queue pulls even when the
+        // strategy would otherwise say the queue is full enough.
+        if (ReadableStreamOperations.IsLocked(stream) && ReadableStreamOperations.GetNumReadRequests(stream) > 0)
+        {
+            return true;
+        }
+
+        var desiredSize = GetDesiredSize(controller);
+        return desiredSize > 0;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-stream-default-controller-clear-algorithms
+    /// </summary>
+    /// <remarks>
+    /// Called the moment the algorithms can no longer be needed, which is what stops a closed or errored
+    /// stream from retaining the underlying source and everything it closed over.
+    /// </remarks>
+    internal static void ClearAlgorithms(JsReadableStreamDefaultController controller)
+    {
+        controller.PullAlgorithm = null;
+        controller.CancelAlgorithm = null;
+        controller.StrategySizeAlgorithm = null;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-stream-default-controller-close
+    /// </summary>
+    internal static void Close(JsReadableStreamDefaultController controller)
+    {
+        if (!CanCloseOrEnqueue(controller))
+        {
+            return;
+        }
+
+        var stream = controller.Stream;
+        controller.CloseRequested = true;
+
+        // Already-enqueued chunks stay readable; the stream only becomes closed once they have been read.
+        if (controller.Queue.IsEmpty)
+        {
+            ClearAlgorithms(controller);
+            ReadableStreamOperations.Close(stream);
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-stream-default-controller-enqueue
+    /// </summary>
+    internal static void Enqueue(JsReadableStreamDefaultController controller, JsValue chunk)
+    {
+        if (!CanCloseOrEnqueue(controller))
+        {
+            return;
+        }
+
+        var stream = controller.Stream;
+
+        if (ReadableStreamOperations.IsLocked(stream) && ReadableStreamOperations.GetNumReadRequests(stream) > 0)
+        {
+            // A waiting reader takes the chunk directly: it never enters the queue, so the strategy's
+            // size() is not called for it either.
+            ReadableStreamOperations.FulfillReadRequest(stream, chunk, done: false);
+        }
+        else
+        {
+            double chunkSize;
+            try
+            {
+                chunkSize = controller.StrategySizeAlgorithm!(chunk);
+            }
+            catch (JavaScriptException e)
+            {
+                Error(controller, e.Error);
+                throw;
+            }
+
+            try
+            {
+                controller.Queue.Enqueue(controller.Realm, chunk, chunkSize);
+            }
+            catch (JavaScriptException e)
+            {
+                Error(controller, e.Error);
+                throw;
+            }
+        }
+
+        CallPullIfNeeded(controller);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-stream-default-controller-error
+    /// </summary>
+    internal static void Error(JsReadableStreamDefaultController controller, JsValue error)
+    {
+        var stream = controller.Stream;
+        if (stream.State != ReadableStreamState.Readable)
+        {
+            return;
+        }
+
+        controller.Queue.Reset();
+        ClearAlgorithms(controller);
+        ReadableStreamOperations.Error(stream, error);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-stream-default-controller-get-desired-size — null for an
+    /// errored stream, which is why the getter's type is <c>unrestricted double?</c>.
+    /// </summary>
+    internal static double? GetDesiredSize(JsReadableStreamDefaultController controller)
+    {
+        return controller.Stream.State switch
+        {
+            ReadableStreamState.Errored => null,
+            ReadableStreamState.Closed => 0,
+            _ => controller.StrategyHighWaterMark - controller.Queue.TotalSize,
+        };
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-stream-default-controller-has-backpressure — used by a
+    /// transform stream to decide whether to stop accepting writes.
+    /// </summary>
+    internal static bool HasBackpressure(JsReadableStreamDefaultController controller) => !ShouldCallPull(controller);
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-stream-default-controller-can-close-or-enqueue
+    /// </summary>
+    internal static bool CanCloseOrEnqueue(JsReadableStreamDefaultController controller)
+        => !controller.CloseRequested && controller.Stream.State == ReadableStreamState.Readable;
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rs-default-controller-private-pull
+    /// </summary>
+    internal static void PullSteps(JsReadableStreamDefaultController controller, ReadRequest readRequest)
+    {
+        var stream = controller.Stream;
+
+        if (!controller.Queue.IsEmpty)
+        {
+            var chunk = controller.Queue.Dequeue();
+
+            if (controller.CloseRequested && controller.Queue.IsEmpty)
+            {
+                ClearAlgorithms(controller);
+                ReadableStreamOperations.Close(stream);
+            }
+            else
+            {
+                CallPullIfNeeded(controller);
+            }
+
+            // The chunk steps run last, after the close or the pull: a consumer that reads the final chunk
+            // sees the stream already closed.
+            readRequest.ChunkSteps(chunk);
+            return;
+        }
+
+        ReadableStreamOperations.AddReadRequest(stream, readRequest);
+        CallPullIfNeeded(controller);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rs-default-controller-private-cancel
+    /// </summary>
+    internal static JsPromise CancelSteps(JsReadableStreamDefaultController controller, JsValue reason)
+    {
+        controller.Queue.Reset();
+
+        // Reachable only while the stream is readable, so the algorithm has not been cleared yet.
+        var result = controller.CancelAlgorithm!(reason);
+        ClearAlgorithms(controller);
+        return result;
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/ReadableStreamDefaultControllerPrototype.cs
+++ b/Jint/WebApi/Streams/ReadableStreamDefaultControllerPrototype.cs
@@ -1,0 +1,107 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// <c>ReadableStreamDefaultController.prototype</c> — the interface prototype object.
+/// <para>
+/// https://streams.spec.whatwg.org/#rs-default-controller-prototype
+/// </para>
+/// </summary>
+[JsObject(UseShape = true)]
+internal sealed partial class ReadableStreamDefaultControllerPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly ReadableStreamDefaultControllerConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString ControllerToStringTag = new("ReadableStreamDefaultController");
+
+    internal ReadableStreamDefaultControllerPrototype(
+        Engine engine,
+        Realm realm,
+        ReadableStreamDefaultControllerConstructor constructor,
+        ObjectInstance objectPrototype) : base(engine, realm)
+    {
+        _prototype = objectPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rs-default-controller-desired-size — how much more the queue wants,
+    /// which is negative when it is over-full and <c>null</c> once the stream has errored.
+    /// </summary>
+    [JsAccessor("desiredSize", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue DesiredSizeGet(JsValue thisObject)
+    {
+        var desiredSize = ReadableStreamDefaultControllerOperations.GetDesiredSize(Brand(thisObject));
+        return desiredSize is { } value ? JsNumber.Create(value) : Null;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rs-default-controller-close
+    /// </summary>
+    [JsFunction(Name = "close", Length = 0)]
+    private JsValue Close(JsValue thisObject)
+    {
+        var controller = Brand(thisObject);
+
+        if (!ReadableStreamDefaultControllerOperations.CanCloseOrEnqueue(controller))
+        {
+            Throw.TypeError(_realm, "The stream is not in a state that permits close");
+        }
+
+        ReadableStreamDefaultControllerOperations.Close(controller);
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rs-default-controller-enqueue
+    /// </summary>
+    [JsFunction(Name = "enqueue", Length = 0)]
+    private JsValue Enqueue(JsValue thisObject, JsValue chunk)
+    {
+        var controller = Brand(thisObject);
+
+        if (!ReadableStreamDefaultControllerOperations.CanCloseOrEnqueue(controller))
+        {
+            Throw.TypeError(_realm, "The stream is not in a state that permits enqueue");
+        }
+
+        ReadableStreamDefaultControllerOperations.Enqueue(controller, chunk);
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rs-default-controller-error — silently does nothing for a stream
+    /// that has already stopped being readable, so a source that errors twice is not itself an error.
+    /// </summary>
+    [JsFunction(Name = "error", Length = 0)]
+    private JsValue Error(JsValue thisObject, JsValue error)
+    {
+        ReadableStreamDefaultControllerOperations.Error(Brand(thisObject), error);
+        return Undefined;
+    }
+
+    private JsReadableStreamDefaultController Brand(JsValue thisObject)
+    {
+        if (thisObject is JsReadableStreamDefaultController controller)
+        {
+            return controller;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a ReadableStreamDefaultController");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/ReadableStreamDefaultReaderConstructor.cs
+++ b/Jint/WebApi/Streams/ReadableStreamDefaultReaderConstructor.cs
@@ -1,0 +1,72 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// The <c>ReadableStreamDefaultReader</c> interface object.
+/// <para>
+/// https://streams.spec.whatwg.org/#default-reader-class
+/// </para>
+/// </summary>
+/// <remarks>
+/// The interface declares <c>constructor(ReadableStream stream)</c>, so this <i>is</i> constructible, and
+/// <c>new ReadableStreamDefaultReader(stream)</c> is equivalent to <c>stream.getReader()</c> — including
+/// raising a <c>TypeError</c> for a stream that is already locked.
+/// <para>
+/// It is deliberately not installed as a global: the enabled globals are the five interfaces a script
+/// constructs directly. This one stays reachable, as
+/// <c>Object.getPrototypeOf(stream.getReader()).constructor</c>, which is where <c>reader instanceof</c>
+/// checks and prototype patching go. That is a documented divergence from a browser, where every one of
+/// these interfaces is a global.
+/// </para>
+/// </remarks>
+internal sealed class ReadableStreamDefaultReaderConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("ReadableStreamDefaultReader");
+
+    internal ReadableStreamDefaultReaderConstructor(
+        Engine engine,
+        Realm realm,
+        FunctionPrototype functionPrototype,
+        ObjectPrototype objectPrototype)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = functionPrototype;
+        PrototypeObject = new ReadableStreamDefaultReaderPrototype(engine, realm, this, objectPrototype);
+        _length = new PropertyDescriptor(JsNumber.PositiveOne, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal ReadableStreamDefaultReaderPrototype PrototypeObject { get; }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#default-reader-constructor
+    /// </summary>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        if (newTarget.IsUndefined())
+        {
+            Throw.TypeError(_realm, $"Constructor {GetOwnFunctionNameForMessage()} requires 'new'");
+        }
+
+        if (arguments.At(0) is not JsReadableStream stream)
+        {
+            Throw.TypeError(_realm, "Failed to construct 'ReadableStreamDefaultReader': the argument is not a ReadableStream");
+            return null!;
+        }
+
+        var reader = OrdinaryCreateFromConstructor(
+            newTarget,
+            static intrinsics => intrinsics.ReadableStreamDefaultReader.PrototypeObject,
+            static (Engine engine, Realm realm, object? _) => new JsReadableStreamDefaultReader(engine, realm));
+
+        ReadableStreamOperations.SetUpDefaultReader(reader, stream);
+        return reader;
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/ReadableStreamDefaultReaderPrototype.cs
+++ b/Jint/WebApi/Streams/ReadableStreamDefaultReaderPrototype.cs
@@ -1,0 +1,169 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Iterator;
+using Jint.Native.Object;
+using Jint.Native.Promise;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// <c>ReadableStreamDefaultReader.prototype</c> — the interface prototype object, carrying both the
+/// interface's own members and the <c>ReadableStreamGenericReader</c> mixin's.
+/// <para>
+/// https://streams.spec.whatwg.org/#default-reader-prototype and
+/// https://streams.spec.whatwg.org/#generic-reader-prototype
+/// </para>
+/// </summary>
+[JsObject(UseShape = true)]
+internal sealed partial class ReadableStreamDefaultReaderPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly ReadableStreamDefaultReaderConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString ReaderToStringTag = new("ReadableStreamDefaultReader");
+
+    internal ReadableStreamDefaultReaderPrototype(
+        Engine engine,
+        Realm realm,
+        ReadableStreamDefaultReaderConstructor constructor,
+        ObjectInstance objectPrototype) : base(engine, realm)
+    {
+        _prototype = objectPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#generic-reader-closed. The attribute's type is a promise type, so a
+    /// failed brand check answers with a rejected promise rather than throwing —
+    /// https://webidl.spec.whatwg.org/#dfn-attribute-getter.
+    /// </summary>
+    [JsAccessor("closed", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsPromise ClosedGet(JsValue thisObject)
+    {
+        if (thisObject is not JsReadableStreamDefaultReader reader)
+        {
+            return RejectedTypeError("Illegal invocation: receiver is not a ReadableStreamDefaultReader");
+        }
+
+        return reader.ClosedPromise;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#generic-reader-cancel
+    /// </summary>
+    [JsFunction(Name = "cancel", Length = 0)]
+    private JsPromise Cancel(JsValue thisObject, JsValue reason)
+    {
+        try
+        {
+            var reader = Brand(thisObject);
+
+            if (reader.Stream is null)
+            {
+                Throw.TypeError(_realm, "Cannot cancel a stream using a released reader");
+            }
+
+            return ReadableStreamOperations.ReaderGenericCancel(reader, reason);
+        }
+        catch (JavaScriptException e)
+        {
+            return StreamPromises.RejectedWith(_engine, _realm, e.Error);
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#default-reader-read
+    /// </summary>
+    [JsFunction(Name = "read", Length = 0)]
+    private JsPromise Read(JsValue thisObject)
+    {
+        JsReadableStreamDefaultReader reader;
+        try
+        {
+            reader = Brand(thisObject);
+
+            if (reader.Stream is null)
+            {
+                Throw.TypeError(_realm, "Cannot read from a released reader");
+            }
+        }
+        catch (JavaScriptException e)
+        {
+            return StreamPromises.RejectedWith(_engine, _realm, e.Error);
+        }
+
+        var capability = StreamPromises.NewPromise(_engine, _realm);
+        ReadableStreamOperations.DefaultReaderRead(reader, new ReaderReadRequest(_engine, capability));
+        return StreamPromises.PromiseOf(capability);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#default-reader-release-lock
+    /// </summary>
+    /// <remarks>
+    /// Releasing while reads are outstanding rejects each of them with a <c>TypeError</c>; the chunks they
+    /// were waiting for stay in the stream's queue and can be read by a reader acquired later.
+    /// </remarks>
+    [JsFunction(Name = "releaseLock", Length = 0)]
+    private JsValue ReleaseLock(JsValue thisObject)
+    {
+        var reader = Brand(thisObject);
+
+        if (reader.Stream is null)
+        {
+            return Undefined;
+        }
+
+        ReadableStreamOperations.DefaultReaderRelease(reader);
+        return Undefined;
+    }
+
+    private JsPromise RejectedTypeError(string message)
+        => StreamPromises.RejectedWith(_engine, _realm, _realm.Intrinsics.TypeError.Construct(message));
+
+    private JsReadableStreamDefaultReader Brand(JsValue thisObject)
+    {
+        if (thisObject is JsReadableStreamDefaultReader reader)
+        {
+            return reader;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a ReadableStreamDefaultReader");
+        return null!;
+    }
+
+    /// <summary>
+    /// The read request behind <c>read()</c>: a chunk becomes
+    /// <c>{ value: chunk, done: false }</c>, a close becomes <c>{ value: undefined, done: true }</c>, and an
+    /// error becomes a rejection.
+    /// </summary>
+    private sealed class ReaderReadRequest : ReadRequest
+    {
+        private readonly Engine _engine;
+        private readonly PromiseCapability _capability;
+
+        internal ReaderReadRequest(Engine engine, PromiseCapability capability)
+        {
+            _engine = engine;
+            _capability = capability;
+        }
+
+        internal override void ChunkSteps(JsValue chunk)
+            => _capability.Resolve(IteratorResult.CreateValueIteratorPosition(_engine, chunk, JsBoolean.False));
+
+        internal override void CloseSteps()
+            => _capability.Resolve(IteratorResult.CreateValueIteratorPosition(_engine, JsValue.Undefined, JsBoolean.True));
+
+        internal override void ErrorSteps(JsValue error) => _capability.Reject(error);
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/ReadableStreamOperations.cs
+++ b/Jint/WebApi/Streams/ReadableStreamOperations.cs
@@ -1,0 +1,389 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// The readable-stream abstract operations: "working with readable streams", "interfacing with controllers"
+/// and "readers".
+/// <para>
+/// https://streams.spec.whatwg.org/#rs-abstract-ops
+/// </para>
+/// </summary>
+internal static class ReadableStreamOperations
+{
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#is-readable-stream-locked
+    /// </summary>
+    internal static bool IsLocked(JsReadableStream stream) => stream.Reader is not null;
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#create-readable-stream — the entry point for streams the engine
+    /// builds itself (tee's two branches, <c>ReadableStream.from</c>, a transform stream's readable side)
+    /// rather than ones a script constructs.
+    /// </summary>
+    internal static JsReadableStream CreateReadableStream(
+        Engine engine,
+        Realm realm,
+        Func<JsValue> startAlgorithm,
+        Func<JsPromise> pullAlgorithm,
+        Func<JsValue, JsPromise> cancelAlgorithm,
+        double highWaterMark = 1,
+        Func<JsValue, double>? sizeAlgorithm = null)
+    {
+        var stream = new JsReadableStream(engine, realm)
+        {
+            _prototype = realm.Intrinsics.ReadableStream.PrototypeObject,
+        };
+
+        var controller = new JsReadableStreamDefaultController(engine, realm)
+        {
+            _prototype = realm.Intrinsics.ReadableStreamDefaultController.PrototypeObject,
+        };
+
+        SetUpDefaultController(
+            stream,
+            controller,
+            startAlgorithm,
+            pullAlgorithm,
+            cancelAlgorithm,
+            highWaterMark,
+            sizeAlgorithm ?? (static _ => 1));
+
+        return stream;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-stream-cancel
+    /// </summary>
+    internal static JsPromise Cancel(JsReadableStream stream, JsValue reason)
+    {
+        var engine = stream.Engine;
+        var realm = stream.Realm;
+
+        stream.Disturbed = true;
+
+        if (stream.State == ReadableStreamState.Closed)
+        {
+            return StreamPromises.ResolvedWithUndefined(engine, realm);
+        }
+
+        if (stream.State == ReadableStreamState.Errored)
+        {
+            return StreamPromises.RejectedWith(engine, realm, stream.StoredError);
+        }
+
+        Close(stream);
+
+        // The BYOB half of this step ("if reader implements ReadableStreamBYOBReader, close its pending
+        // read-into requests") has no counterpart: there are no BYOB readers.
+        var sourceCancelPromise = ReadableStreamDefaultControllerOperations.CancelSteps(stream.Controller, reason);
+
+        // "Return the result of reacting to sourceCancelPromise with a fulfillment step that returns
+        // undefined" — the underlying source's own fulfillment value is deliberately discarded, so
+        // `await stream.cancel()` is always undefined.
+        return StreamPromises.TransformPromiseWith(engine, realm, sourceCancelPromise, static _ => JsValue.Undefined, onRejected: null);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-stream-close
+    /// </summary>
+    internal static void Close(JsReadableStream stream)
+    {
+        stream.State = ReadableStreamState.Closed;
+
+        var reader = stream.Reader;
+        if (reader is null)
+        {
+            return;
+        }
+
+        reader.ClosedCapability.Resolve(JsValue.Undefined);
+
+        // Every outstanding read() resolves with { value: undefined, done: true }. The list is emptied
+        // before the steps run, because a close step may start a fresh read.
+        var readRequests = reader.ReadRequests;
+        while (readRequests.Count > 0)
+        {
+            readRequests.Dequeue().CloseSteps();
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-stream-error
+    /// </summary>
+    internal static void Error(JsReadableStream stream, JsValue error)
+    {
+        stream.State = ReadableStreamState.Errored;
+        stream.StoredError = error;
+
+        var reader = stream.Reader;
+        if (reader is null)
+        {
+            return;
+        }
+
+        reader.ClosedCapability.Reject(error);
+        StreamPromises.MarkHandled(reader.ClosedPromise);
+
+        DefaultReaderErrorReadRequests(reader, error);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-stream-add-read-request
+    /// </summary>
+    internal static void AddReadRequest(JsReadableStream stream, ReadRequest readRequest)
+        => stream.Reader!.ReadRequests.Enqueue(readRequest);
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-stream-fulfill-read-request
+    /// </summary>
+    internal static void FulfillReadRequest(JsReadableStream stream, JsValue chunk, bool done)
+    {
+        var readRequest = stream.Reader!.ReadRequests.Dequeue();
+        if (done)
+        {
+            readRequest.CloseSteps();
+        }
+        else
+        {
+            readRequest.ChunkSteps(chunk);
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-stream-get-num-read-requests
+    /// </summary>
+    internal static int GetNumReadRequests(JsReadableStream stream) => stream.Reader!.ReadRequests.Count;
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-stream-has-default-reader. Always equivalent to being
+    /// locked here, since a default reader is the only kind of reader there is.
+    /// </summary>
+    internal static bool HasDefaultReader(JsReadableStream stream) => stream.Reader is not null;
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#acquire-readable-stream-reader
+    /// </summary>
+    internal static JsReadableStreamDefaultReader AcquireDefaultReader(JsReadableStream stream)
+    {
+        var reader = new JsReadableStreamDefaultReader(stream.Engine, stream.Realm)
+        {
+            _prototype = stream.Realm.Intrinsics.ReadableStreamDefaultReader.PrototypeObject,
+        };
+
+        SetUpDefaultReader(reader, stream);
+        return reader;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#set-up-readable-stream-default-reader
+    /// </summary>
+    internal static void SetUpDefaultReader(JsReadableStreamDefaultReader reader, JsReadableStream stream)
+    {
+        if (IsLocked(stream))
+        {
+            Throw.TypeError(reader.Realm, "This readable stream is already locked for exclusive reading by another reader");
+        }
+
+        ReaderGenericInitialize(reader, stream);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-stream-reader-generic-initialize
+    /// </summary>
+    private static void ReaderGenericInitialize(JsReadableStreamDefaultReader reader, JsReadableStream stream)
+    {
+        var engine = reader.Engine;
+        var realm = reader.Realm;
+
+        reader.Stream = stream;
+        stream.Reader = reader;
+
+        var capability = StreamPromises.NewPromise(engine, realm);
+        reader.ClosedCapability = capability;
+
+        switch (stream.State)
+        {
+            case ReadableStreamState.Readable:
+                break;
+
+            case ReadableStreamState.Closed:
+                capability.Resolve(JsValue.Undefined);
+                break;
+
+            default:
+                StreamPromises.MarkHandled(StreamPromises.PromiseOf(capability));
+                capability.Reject(stream.StoredError);
+                break;
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-stream-reader-generic-cancel
+    /// </summary>
+    internal static JsPromise ReaderGenericCancel(JsReadableStreamDefaultReader reader, JsValue reason)
+        => Cancel(reader.Stream!, reason);
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-stream-reader-generic-release
+    /// </summary>
+    private static void ReaderGenericRelease(JsReadableStreamDefaultReader reader)
+    {
+        var engine = reader.Engine;
+        var realm = reader.Realm;
+        var stream = reader.Stream!;
+
+        var released = realm.Intrinsics.TypeError.Construct(
+            "Reader was released and can no longer be used to monitor the stream's closedness");
+
+        if (stream.State == ReadableStreamState.Readable)
+        {
+            reader.ClosedCapability.Reject(released);
+        }
+        else
+        {
+            // The closed promise has already settled, so it cannot be rejected: the reader is given a
+            // freshly rejected one instead, which is what makes `reader.closed` observably a different
+            // promise after releasing the lock on a closed stream.
+            reader.ClosedCapability = StreamPromises.NewPromise(engine, realm);
+            reader.ClosedCapability.Reject(released);
+        }
+
+        StreamPromises.MarkHandled(reader.ClosedPromise);
+
+        // The default controller's [[ReleaseSteps]] do nothing; the byte controller's, which discards
+        // pending pull-intos, has no counterpart here.
+        stream.Reader = null;
+        reader.Stream = null;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-stream-default-reader-read
+    /// </summary>
+    internal static void DefaultReaderRead(JsReadableStreamDefaultReader reader, ReadRequest readRequest)
+    {
+        var stream = reader.Stream!;
+        stream.Disturbed = true;
+
+        switch (stream.State)
+        {
+            case ReadableStreamState.Closed:
+                readRequest.CloseSteps();
+                break;
+
+            case ReadableStreamState.Errored:
+                readRequest.ErrorSteps(stream.StoredError);
+                break;
+
+            default:
+                ReadableStreamDefaultControllerOperations.PullSteps(stream.Controller, readRequest);
+                break;
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#abstract-opdef-readablestreamdefaultreaderrelease
+    /// </summary>
+    internal static void DefaultReaderRelease(JsReadableStreamDefaultReader reader)
+    {
+        var realm = reader.Realm;
+        ReaderGenericRelease(reader);
+        DefaultReaderErrorReadRequests(reader, realm.Intrinsics.TypeError.Construct("Reader was released"));
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#abstract-opdef-readablestreamdefaultreadererrorreadrequests
+    /// </summary>
+    private static void DefaultReaderErrorReadRequests(JsReadableStreamDefaultReader reader, JsValue error)
+    {
+        var readRequests = reader.ReadRequests;
+        while (readRequests.Count > 0)
+        {
+            readRequests.Dequeue().ErrorSteps(error);
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#set-up-readable-stream-default-controller
+    /// </summary>
+    internal static void SetUpDefaultController(
+        JsReadableStream stream,
+        JsReadableStreamDefaultController controller,
+        Func<JsValue> startAlgorithm,
+        Func<JsPromise> pullAlgorithm,
+        Func<JsValue, JsPromise> cancelAlgorithm,
+        double highWaterMark,
+        Func<JsValue, double> sizeAlgorithm)
+    {
+        var engine = stream.Engine;
+        var realm = stream.Realm;
+
+        controller.Stream = stream;
+        controller.Queue.Reset();
+        controller.Started = false;
+        controller.CloseRequested = false;
+        controller.PullAgain = false;
+        controller.Pulling = false;
+        controller.StrategySizeAlgorithm = sizeAlgorithm;
+        controller.StrategyHighWaterMark = highWaterMark;
+        controller.PullAlgorithm = pullAlgorithm;
+        controller.CancelAlgorithm = cancelAlgorithm;
+        stream.Controller = controller;
+
+        // "Let startResult be the result of performing startAlgorithm. (This might throw an exception.)" —
+        // the start callback's return type is `any`, so an exception it raises is not converted to a
+        // rejection and propagates out of the ReadableStream constructor.
+        var startResult = startAlgorithm();
+        var startPromise = StreamPromises.ResolvedWith(realm, startResult);
+
+        StreamPromises.UponPromise(
+            engine,
+            startPromise,
+            _ =>
+            {
+                controller.Started = true;
+                ReadableStreamDefaultControllerOperations.CallPullIfNeeded(controller);
+            },
+            reason => ReadableStreamDefaultControllerOperations.Error(controller, reason));
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#set-up-readable-stream-default-controller-from-underlying-source
+    /// </summary>
+    internal static void SetUpDefaultControllerFromUnderlyingSource(
+        JsReadableStream stream,
+        JsValue underlyingSource,
+        in StreamDictionaries.UnderlyingSourceRecord source,
+        double highWaterMark,
+        Func<JsValue, double> sizeAlgorithm)
+    {
+        var engine = stream.Engine;
+        var realm = stream.Realm;
+
+        var controller = new JsReadableStreamDefaultController(engine, realm)
+        {
+            _prototype = realm.Intrinsics.ReadableStreamDefaultController.PrototypeObject,
+        };
+
+        var start = source.Start;
+        var pull = source.Pull;
+        var cancel = source.Cancel;
+
+        Func<JsValue> startAlgorithm = start is null
+            ? static () => JsValue.Undefined
+            : () => start.Call(underlyingSource, controller);
+
+        Func<JsPromise> pullAlgorithm = pull is null
+            ? () => StreamPromises.ResolvedWithUndefined(engine, realm)
+            : () => StreamPromises.PromiseCall(engine, realm, pull, underlyingSource, [controller]);
+
+        Func<JsValue, JsPromise> cancelAlgorithm = cancel is null
+            ? _ => StreamPromises.ResolvedWithUndefined(engine, realm)
+            : reason => StreamPromises.PromiseCall(engine, realm, cancel, underlyingSource, [reason]);
+
+        SetUpDefaultController(stream, controller, startAlgorithm, pullAlgorithm, cancelAlgorithm, highWaterMark, sizeAlgorithm);
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/ReadableStreamPipe.cs
+++ b/Jint/WebApi/Streams/ReadableStreamPipe.cs
@@ -1,0 +1,449 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Promise;
+using Jint.Runtime;
+using Jint.WebApi.Abort;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// https://streams.spec.whatwg.org/#readable-stream-pipe-to — the piping algorithm behind
+/// <c>pipeTo()</c> and <c>pipeThrough()</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The standard writes this one operation in prose rather than in numbered steps, because it wants to leave
+/// implementations room in how they schedule the reads and writes. What it does <i>not</i> leave room in are
+/// the constraints, and they are what this class is written against:
+/// </para>
+/// <list type="bullet">
+/// <item><description><b>Public API must not be used.</b> The reader, the writer and both streams are
+/// manipulated through the abstract operations, never through the prototype methods a script can
+/// replace.</description></item>
+/// <item><description><b>Backpressure must be enforced.</b> A read happens only after the writer's
+/// <c>ready</c> promise fulfils, so the destination's high water mark throttles the source.</description></item>
+/// <item><description><b>Reads and writes must not be serialized against each other.</b> The pipe does not
+/// wait for a write to complete before reading again — doing so would make the destination's queue useless.
+/// Only shutdown waits for outstanding writes.</description></item>
+/// <item><description><b>Shutdown must stop activity</b>, and the error and close conditions are checked in
+/// the order the standard lists them.</description></item>
+/// </list>
+/// <para>
+/// The whole of it runs on the engine's thread as ordinary promise reactions; an <c>AbortSignal</c> is
+/// observed through the same internal abort-algorithm seam the rest of the web APIs use, so aborting the
+/// pipe does not depend on the <c>abort</c> event reaching any script.
+/// </para>
+/// </remarks>
+internal sealed class ReadableStreamPipe
+{
+    private readonly Engine _engine;
+    private readonly Realm _realm;
+    private readonly JsReadableStream _source;
+    private readonly JsWritableStream _destination;
+    private readonly bool _preventClose;
+    private readonly bool _preventAbort;
+    private readonly bool _preventCancel;
+    private readonly JsAbortSignal? _signal;
+    private readonly JsReadableStreamDefaultReader _reader;
+    private readonly JsWritableStreamDefaultWriter _writer;
+    private readonly PromiseCapability _capability;
+
+    private bool _shuttingDown;
+    private JsPromise _currentWrite;
+    private Action? _abortAlgorithm;
+
+    private ReadableStreamPipe(
+        JsReadableStream source,
+        JsWritableStream destination,
+        bool preventClose,
+        bool preventAbort,
+        bool preventCancel,
+        JsAbortSignal? signal)
+    {
+        _engine = source.Engine;
+        _realm = source.Realm;
+        _source = source;
+        _destination = destination;
+        _preventClose = preventClose;
+        _preventAbort = preventAbort;
+        _preventCancel = preventCancel;
+        _signal = signal;
+
+        _reader = ReadableStreamOperations.AcquireDefaultReader(source);
+        _writer = WritableStreamOperations.AcquireDefaultWriter(destination);
+        source.Disturbed = true;
+
+        _capability = StreamPromises.NewPromise(_engine, _realm);
+        _currentWrite = StreamPromises.ResolvedWithUndefined(_engine, _realm);
+    }
+
+    /// <summary>
+    /// Starts piping and returns the promise that settles when the pipe finishes.
+    /// </summary>
+    internal static JsPromise PipeTo(
+        JsReadableStream source,
+        JsWritableStream destination,
+        bool preventClose,
+        bool preventAbort,
+        bool preventCancel,
+        JsAbortSignal? signal)
+    {
+        var pipe = new ReadableStreamPipe(source, destination, preventClose, preventAbort, preventCancel, signal);
+        pipe.Start();
+        return StreamPromises.PromiseOf(pipe._capability);
+    }
+
+    private void Start()
+    {
+        if (_signal is { } signal)
+        {
+            _abortAlgorithm = Abort;
+
+            // An already-aborted signal shuts the pipe down before it reads anything at all — and, as the
+            // reference algorithm does, without ever attaching the error and close propagation below.
+            if (signal.Aborted)
+            {
+                Abort();
+                return;
+            }
+
+            signal.AddAbortAlgorithm(_abortAlgorithm);
+        }
+
+        // "Errors must be propagated forward": an errored source aborts the destination.
+        IsOrBecomesErrored(
+            () => _source.State == ReadableStreamState.Errored,
+            () => _source.StoredError,
+            _reader.ClosedPromise,
+            storedError =>
+            {
+                if (!_preventAbort)
+                {
+                    ShutdownWithAction(() => WritableStreamOperations.Abort(_destination, storedError), isError: true, storedError);
+                }
+                else
+                {
+                    Shutdown(isError: true, storedError);
+                }
+            });
+
+        // "Errors must be propagated backward": an errored destination cancels the source.
+        IsOrBecomesErrored(
+            () => _destination.State == WritableStreamState.Errored,
+            () => _destination.StoredError,
+            _writer.ClosedPromise,
+            storedError =>
+            {
+                if (!_preventCancel)
+                {
+                    ShutdownWithAction(() => ReadableStreamOperations.Cancel(_source, storedError), isError: true, storedError);
+                }
+                else
+                {
+                    Shutdown(isError: true, storedError);
+                }
+            });
+
+        // "Closing must be propagated forward": a closed source closes the destination.
+        IsOrBecomesClosed(
+            () => _source.State == ReadableStreamState.Closed,
+            _reader.ClosedPromise,
+            () =>
+            {
+                if (!_preventClose)
+                {
+                    ShutdownWithAction(
+                        () => WritableStreamOperations.DefaultWriterCloseWithErrorPropagation(_writer),
+                        isError: false,
+                        JsValue.Undefined);
+                }
+                else
+                {
+                    Shutdown(isError: false, JsValue.Undefined);
+                }
+            });
+
+        // "Closing must be propagated backward": a destination that is already closing or closed cancels the
+        // source, because nothing read from it could ever be written.
+        if (WritableStreamOperations.CloseQueuedOrInFlight(_destination) || _destination.State == WritableStreamState.Closed)
+        {
+            var destinationClosed = _realm.Intrinsics.TypeError.Construct(
+                "The destination writable stream closed before all data could be piped to it");
+
+            if (!_preventCancel)
+            {
+                ShutdownWithAction(() => ReadableStreamOperations.Cancel(_source, destinationClosed), isError: true, destinationClosed);
+            }
+            else
+            {
+                Shutdown(isError: true, destinationClosed);
+            }
+        }
+
+        // The loop's own promise is never handed out: the pipe reports through _capability instead.
+        StreamPromises.MarkHandled(PipeLoop());
+    }
+
+    /// <summary>
+    /// The abort algorithm registered on the signal: abort the destination and cancel the source, then shut
+    /// down with the signal's reason.
+    /// </summary>
+    private void Abort()
+    {
+        var error = _signal!.Reason;
+        var actions = new List<Func<JsPromise>>(2);
+
+        if (!_preventAbort)
+        {
+            actions.Add(() => _destination.State == WritableStreamState.Writable
+                ? WritableStreamOperations.Abort(_destination, error)
+                : StreamPromises.ResolvedWithUndefined(_engine, _realm));
+        }
+
+        if (!_preventCancel)
+        {
+            actions.Add(() => _source.State == ReadableStreamState.Readable
+                ? ReadableStreamOperations.Cancel(_source, error)
+                : StreamPromises.ResolvedWithUndefined(_engine, _realm));
+        }
+
+        ShutdownWithAction(() => WaitForAll(actions), isError: true, error);
+    }
+
+    /// <summary>
+    /// "Getting a promise to wait for all of the actions": the two abort actions are started together and
+    /// the shutdown waits for both. The first rejection is the one reported.
+    /// </summary>
+    private JsPromise WaitForAll(List<Func<JsPromise>> actions)
+    {
+        var capability = StreamPromises.NewPromise(_engine, _realm);
+        var remaining = actions.Count;
+
+        if (remaining == 0)
+        {
+            capability.Resolve(JsValue.Undefined);
+            return StreamPromises.PromiseOf(capability);
+        }
+
+        foreach (var action in actions)
+        {
+            StreamPromises.UponPromise(
+                _engine,
+                action(),
+                _ =>
+                {
+                    remaining--;
+                    if (remaining == 0)
+                    {
+                        capability.Resolve(JsValue.Undefined);
+                    }
+                },
+                capability.Reject);
+        }
+
+        return StreamPromises.PromiseOf(capability);
+    }
+
+    /// <summary>
+    /// Reads and writes until the source closes or the pipe shuts down. One step at a time, but a write is
+    /// never waited on before the next read starts.
+    /// </summary>
+    private JsPromise PipeLoop()
+    {
+        var capability = StreamPromises.NewPromise(_engine, _realm);
+        Next(capability, done: false);
+        return StreamPromises.PromiseOf(capability);
+    }
+
+    private void Next(PromiseCapability loopCapability, bool done)
+    {
+        if (done)
+        {
+            loopCapability.Resolve(JsValue.Undefined);
+            return;
+        }
+
+        StreamPromises.UponPromise(
+            _engine,
+            PipeStep(),
+            value => Next(loopCapability, TypeConverter.ToBoolean(value)),
+            loopCapability.Reject);
+    }
+
+    /// <summary>
+    /// One read, and the write it feeds. Fulfils with <see langword="true"/> once there is nothing left to
+    /// pipe — because the source closed, or because the pipe is shutting down.
+    /// </summary>
+    private JsPromise PipeStep()
+    {
+        if (_shuttingDown)
+        {
+            return StreamPromises.ResolvedWith(_realm, JsBoolean.True);
+        }
+
+        // The read waits for the destination to want more: this is where backpressure is enforced.
+        return StreamPromises.TransformPromiseWith(
+            _engine,
+            _realm,
+            _writer.ReadyPromise,
+            _ =>
+            {
+                var readCapability = StreamPromises.NewPromise(_engine, _realm);
+                ReadableStreamOperations.DefaultReaderRead(_reader, new PipeReadRequest(this, readCapability));
+                return StreamPromises.PromiseOf(readCapability);
+            },
+            onRejected: null);
+    }
+
+    /// <summary>
+    /// Waits for every write that has been started to settle — including one started while waiting for an
+    /// earlier one, which is why the loop re-checks that the current write is still the one it waited on.
+    /// </summary>
+    private JsPromise WaitForWritesToFinish()
+    {
+        var oldCurrentWrite = _currentWrite;
+
+        return StreamPromises.TransformPromiseWith(
+            _engine,
+            _realm,
+            _currentWrite,
+            _ => ReferenceEquals(oldCurrentWrite, _currentWrite) ? JsValue.Undefined : WaitForWritesToFinish(),
+            onRejected: null);
+    }
+
+    private void IsOrBecomesErrored(Func<bool> isErrored, Func<JsValue> storedError, JsPromise promise, Action<JsValue> action)
+    {
+        if (isErrored())
+        {
+            action(storedError());
+            return;
+        }
+
+        StreamPromises.UponRejection(_engine, promise, action);
+    }
+
+    private void IsOrBecomesClosed(Func<bool> isClosed, JsPromise promise, Action action)
+    {
+        if (isClosed())
+        {
+            action();
+            return;
+        }
+
+        StreamPromises.UponFulfillment(_engine, promise, _ => action());
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rs-pipeTo-shutdown-with-action
+    /// </summary>
+    private void ShutdownWithAction(Func<JsPromise> action, bool isError, JsValue error)
+    {
+        if (_shuttingDown)
+        {
+            return;
+        }
+
+        _shuttingDown = true;
+
+        if (_destination.State == WritableStreamState.Writable && !WritableStreamOperations.CloseQueuedOrInFlight(_destination))
+        {
+            StreamPromises.UponFulfillment(_engine, WaitForWritesToFinish(), _ => DoTheRest());
+        }
+        else
+        {
+            DoTheRest();
+        }
+
+        void DoTheRest()
+        {
+            StreamPromises.UponPromise(
+                _engine,
+                action(),
+                _ => Finalize(isError, error),
+                newError => Finalize(isError: true, newError));
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rs-pipeTo-shutdown
+    /// </summary>
+    private void Shutdown(bool isError, JsValue error)
+    {
+        if (_shuttingDown)
+        {
+            return;
+        }
+
+        _shuttingDown = true;
+
+        if (_destination.State == WritableStreamState.Writable && !WritableStreamOperations.CloseQueuedOrInFlight(_destination))
+        {
+            StreamPromises.UponFulfillment(_engine, WaitForWritesToFinish(), _ => Finalize(isError, error));
+        }
+        else
+        {
+            Finalize(isError, error);
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rs-pipeTo-finalize — both locks are released, the signal stops being
+    /// observed, and the pipe's promise settles.
+    /// </summary>
+    private void Finalize(bool isError, JsValue error)
+    {
+        WritableStreamOperations.DefaultWriterRelease(_writer);
+        ReadableStreamOperations.DefaultReaderRelease(_reader);
+
+        if (_signal is { } signal && _abortAlgorithm is { } abortAlgorithm)
+        {
+            signal.RemoveAbortAlgorithm(abortAlgorithm);
+        }
+
+        if (isError)
+        {
+            _capability.Reject(error);
+        }
+        else
+        {
+            _capability.Resolve(JsValue.Undefined);
+        }
+    }
+
+    /// <summary>
+    /// The read request one pipe step makes: a chunk starts a write and lets the loop go round again, a
+    /// close ends the loop, and an error ends it abruptly — though the error itself is reported through the
+    /// propagation rules above, not through here.
+    /// </summary>
+    private sealed class PipeReadRequest : ReadRequest
+    {
+        private readonly ReadableStreamPipe _pipe;
+        private readonly PromiseCapability _readCapability;
+
+        internal PipeReadRequest(ReadableStreamPipe pipe, PromiseCapability readCapability)
+        {
+            _pipe = pipe;
+            _readCapability = readCapability;
+        }
+
+        internal override void ChunkSteps(JsValue chunk)
+        {
+            // The write is started and remembered, but deliberately not waited on: the destination's queue
+            // is what absorbs the difference in speed between the two sides. A failed write is reported
+            // through the destination's closed promise, so the rejection is swallowed here.
+            _pipe._currentWrite = StreamPromises.TransformPromiseWith(
+                _pipe._engine,
+                _pipe._realm,
+                WritableStreamOperations.DefaultWriterWrite(_pipe._writer, chunk),
+                onFulfilled: null,
+                onRejected: static _ => JsValue.Undefined);
+
+            _readCapability.Resolve(JsBoolean.False);
+        }
+
+        internal override void CloseSteps() => _readCapability.Resolve(JsBoolean.True);
+
+        internal override void ErrorSteps(JsValue error) => _readCapability.Reject(error);
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/ReadableStreamPrototype.cs
+++ b/Jint/WebApi/Streams/ReadableStreamPrototype.cs
@@ -1,0 +1,212 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// <c>ReadableStream.prototype</c> — the interface prototype object.
+/// <para>
+/// https://streams.spec.whatwg.org/#rs-prototype
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// Which failures throw and which reject is not a matter of taste: a WebIDL operation whose return type is
+/// a promise type turns <i>every</i> exception — the brand check, the argument conversion, the body — into a
+/// rejected promise, while one that returns anything else lets it propagate
+/// (https://webidl.spec.whatwg.org/#js-operations). So <c>cancel()</c> and <c>pipeTo()</c> reject and
+/// <c>getReader()</c>, <c>pipeThrough()</c>, <c>tee()</c> and <c>values()</c> throw, and the difference is
+/// pinned by tests.
+/// </para>
+/// <para>
+/// <c>@@asyncIterator</c> is the very same function object as <c>values</c>, which is what a WebIDL
+/// <c>async_iterable&lt;&gt;</c> declaration produces and what
+/// <c>ReadableStream.prototype[Symbol.asyncIterator] === ReadableStream.prototype.values</c> asserts.
+/// </para>
+/// </remarks>
+[JsObject(UseShape = true)]
+[JsSymbolAlias("AsyncIterator", "values")]
+internal sealed partial class ReadableStreamPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly ReadableStreamConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString ReadableStreamToStringTag = new("ReadableStream");
+
+    internal ReadableStreamPrototype(
+        Engine engine,
+        Realm realm,
+        ReadableStreamConstructor constructor,
+        ObjectInstance objectPrototype) : base(engine, realm)
+    {
+        _prototype = objectPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rs-locked
+    /// </summary>
+    [JsAccessor("locked", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsBoolean LockedGet(JsValue thisObject)
+        => ReadableStreamOperations.IsLocked(Brand(thisObject)) ? JsBoolean.True : JsBoolean.False;
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rs-cancel
+    /// </summary>
+    [JsFunction(Name = "cancel", Length = 0)]
+    private JsPromise Cancel(JsValue thisObject, JsValue reason)
+    {
+        try
+        {
+            var stream = Brand(thisObject);
+
+            if (ReadableStreamOperations.IsLocked(stream))
+            {
+                Throw.TypeError(_realm, "Cannot cancel a readable stream that is locked to a reader");
+            }
+
+            return ReadableStreamOperations.Cancel(stream, reason);
+        }
+        catch (JavaScriptException e)
+        {
+            return StreamPromises.RejectedWith(_engine, _realm, e.Error);
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rs-get-reader
+    /// </summary>
+    [JsFunction(Name = "getReader", Length = 0)]
+    private JsReadableStreamDefaultReader GetReader(JsValue thisObject, JsValue options)
+    {
+        var stream = Brand(thisObject);
+
+        if (StreamDictionaries.ReadByobModeRequested(_realm, options))
+        {
+            // A BYOB reader can only be acquired from a readable byte stream, and there are none here — so
+            // the specification's own TypeError for that case is the right and only answer.
+            Throw.TypeError(_realm, "Cannot construct a ReadableStreamBYOBReader for a stream not constructed with a byte source");
+        }
+
+        return ReadableStreamOperations.AcquireDefaultReader(stream);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rs-pipe-through
+    /// </summary>
+    [JsFunction(Name = "pipeThrough", Length = 1)]
+    private JsReadableStream PipeThrough(JsValue thisObject, JsValue transform, JsValue options)
+    {
+        var stream = Brand(thisObject);
+        var (readable, writable) = StreamDictionaries.ReadReadableWritablePair(_realm, transform);
+        var pipeOptions = StreamDictionaries.ReadStreamPipeOptions(_realm, options);
+
+        if (ReadableStreamOperations.IsLocked(stream))
+        {
+            Throw.TypeError(_realm, "Cannot pipe from a readable stream that is locked to a reader");
+        }
+
+        if (WritableStreamOperations.IsLocked(writable))
+        {
+            Throw.TypeError(_realm, "Cannot pipe to a writable stream that is locked to a writer");
+        }
+
+        var promise = ReadableStreamPipe.PipeTo(
+            stream, writable, pipeOptions.PreventClose, pipeOptions.PreventAbort, pipeOptions.PreventCancel, pipeOptions.Signal);
+
+        // The pipe's promise is not handed back — the readable side is — so it is marked handled and a
+        // failure surfaces through that stream instead of as an unhandled rejection.
+        StreamPromises.MarkHandled(promise);
+
+        return readable;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rs-pipe-to
+    /// </summary>
+    [JsFunction(Name = "pipeTo", Length = 1)]
+    private JsPromise PipeTo(JsValue thisObject, JsValue destination, JsValue options)
+    {
+        try
+        {
+            var stream = Brand(thisObject);
+
+            if (destination is not JsWritableStream writable)
+            {
+                Throw.TypeError(_realm, "Failed to execute 'pipeTo' on 'ReadableStream': the destination is not a WritableStream");
+                return null!;
+            }
+
+            var pipeOptions = StreamDictionaries.ReadStreamPipeOptions(_realm, options);
+
+            if (ReadableStreamOperations.IsLocked(stream))
+            {
+                Throw.TypeError(_realm, "Cannot pipe from a readable stream that is locked to a reader");
+            }
+
+            if (WritableStreamOperations.IsLocked(writable))
+            {
+                Throw.TypeError(_realm, "Cannot pipe to a writable stream that is locked to a writer");
+            }
+
+            return ReadableStreamPipe.PipeTo(
+                stream, writable, pipeOptions.PreventClose, pipeOptions.PreventAbort, pipeOptions.PreventCancel, pipeOptions.Signal);
+        }
+        catch (JavaScriptException e)
+        {
+            return StreamPromises.RejectedWith(_engine, _realm, e.Error);
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rs-tee
+    /// </summary>
+    [JsFunction(Name = "tee", Length = 0)]
+    private JsArray Tee(JsValue thisObject)
+    {
+        var (branch1, branch2) = ReadableStreamTee.Tee(Brand(thisObject));
+        return new JsArray(_engine, [branch1, branch2]);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rs-asynciterator — the <c>values</c> method a WebIDL
+    /// <c>async_iterable&lt;any&gt;</c> declaration produces, which is also <c>@@asyncIterator</c>.
+    /// </summary>
+    [JsFunction(Name = "values", Length = 0)]
+    private ReadableStreamAsyncIterator Values(JsValue thisObject, JsValue options)
+    {
+        var stream = Brand(thisObject);
+
+        // The options dictionary is converted before the iterator exists, so a preventCancel getter that
+        // throws is reported before the stream is locked.
+        var preventCancel = StreamDictionaries.ReadPreventCancel(_realm, options);
+
+        return _realm.Intrinsics.ReadableStreamAsyncIteratorPrototype.Construct(stream, preventCancel);
+    }
+
+    /// <summary>
+    /// The WebIDL brand check every member performs: a receiver that is not a platform object implementing
+    /// the interface raises a <c>TypeError</c>.
+    /// </summary>
+    private JsReadableStream Brand(JsValue thisObject)
+    {
+        if (thisObject is JsReadableStream stream)
+        {
+            return stream;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a ReadableStream");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/ReadableStreamTee.cs
+++ b/Jint/WebApi/Streams/ReadableStreamTee.cs
@@ -1,0 +1,204 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Promise;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// https://streams.spec.whatwg.org/#readable-stream-default-tee — the algorithm behind
+/// <c>ReadableStream.prototype.tee()</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The two branches read from one reader over the original stream, which is locked for as long as they
+/// exist. Each branch has its own queue and its own consumer, so one may run far ahead of the other; a chunk
+/// is handed to both branches <b>by reference</b> (this is the non-byte-stream tee, which never clones), so
+/// two consumers of a mutable chunk can interfere with each other. That is the standard's own caveat, not an
+/// implementation shortcut.
+/// </para>
+/// <para>
+/// Cancelling one branch does not cancel the original: only when <i>both</i> have been cancelled is the
+/// original cancelled, with an array of the two reasons as its composite reason.
+/// </para>
+/// </remarks>
+internal sealed class ReadableStreamTee
+{
+    private readonly Engine _engine;
+    private readonly Realm _realm;
+    private readonly JsReadableStream _stream;
+    private readonly JsReadableStreamDefaultReader _reader;
+    private readonly PromiseCapability _cancelCapability;
+
+    private bool _reading;
+    private bool _readAgain;
+    private bool _canceled1;
+    private bool _canceled2;
+    private JsValue _reason1 = JsValue.Undefined;
+    private JsValue _reason2 = JsValue.Undefined;
+    private JsReadableStream _branch1 = null!;
+    private JsReadableStream _branch2 = null!;
+
+    private ReadableStreamTee(JsReadableStream stream)
+    {
+        _engine = stream.Engine;
+        _realm = stream.Realm;
+        _stream = stream;
+        _reader = ReadableStreamOperations.AcquireDefaultReader(stream);
+        _cancelCapability = StreamPromises.NewPromise(_engine, _realm);
+    }
+
+    /// <summary>
+    /// Tees <paramref name="stream"/> and returns its two branches, in order.
+    /// </summary>
+    internal static (JsReadableStream Branch1, JsReadableStream Branch2) Tee(JsReadableStream stream)
+    {
+        var tee = new ReadableStreamTee(stream);
+
+        tee._branch1 = ReadableStreamOperations.CreateReadableStream(
+            tee._engine, tee._realm, static () => JsValue.Undefined, tee.PullAlgorithm, tee.Cancel1Algorithm);
+
+        tee._branch2 = ReadableStreamOperations.CreateReadableStream(
+            tee._engine, tee._realm, static () => JsValue.Undefined, tee.PullAlgorithm, tee.Cancel2Algorithm);
+
+        // An error in the original reaches both branches through the reader's closed promise, which is the
+        // only channel that reports an error arriving while no read is outstanding.
+        StreamPromises.UponRejection(tee._engine, tee._reader.ClosedPromise, error =>
+        {
+            ReadableStreamDefaultControllerOperations.Error(tee._branch1.Controller, error);
+            ReadableStreamDefaultControllerOperations.Error(tee._branch2.Controller, error);
+            if (!tee._canceled1 || !tee._canceled2)
+            {
+                tee._cancelCapability.Resolve(JsValue.Undefined);
+            }
+        });
+
+        return (tee._branch1, tee._branch2);
+    }
+
+    /// <summary>
+    /// The pull algorithm both branches share: one read at a time over the original, with a request that
+    /// arrives while a read is outstanding remembered rather than started.
+    /// </summary>
+    private JsPromise PullAlgorithm()
+    {
+        if (_reading)
+        {
+            _readAgain = true;
+            return StreamPromises.ResolvedWithUndefined(_engine, _realm);
+        }
+
+        _reading = true;
+        ReadableStreamOperations.DefaultReaderRead(_reader, new TeeReadRequest(this));
+        return StreamPromises.ResolvedWithUndefined(_engine, _realm);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-stream-default-tee, the cancel algorithm of the first
+    /// branch. The original is only cancelled once both branches have been.
+    /// </summary>
+    private JsPromise Cancel1Algorithm(JsValue reason)
+    {
+        _canceled1 = true;
+        _reason1 = reason;
+
+        if (_canceled2)
+        {
+            ResolveCancelPromiseWithComposite();
+        }
+
+        return StreamPromises.PromiseOf(_cancelCapability);
+    }
+
+    /// <summary>The cancel algorithm of the second branch.</summary>
+    private JsPromise Cancel2Algorithm(JsValue reason)
+    {
+        _canceled2 = true;
+        _reason2 = reason;
+
+        if (_canceled1)
+        {
+            ResolveCancelPromiseWithComposite();
+        }
+
+        return StreamPromises.PromiseOf(_cancelCapability);
+    }
+
+    private void ResolveCancelPromiseWithComposite()
+    {
+        var compositeReason = new JsArray(_engine, [_reason1, _reason2]);
+        var cancelResult = ReadableStreamOperations.Cancel(_stream, compositeReason);
+
+        // Resolving with a promise makes both branches' cancel() promises adopt the underlying source's
+        // outcome, so a source whose cancel() rejects reports that to whichever branch was cancelled last.
+        _cancelCapability.Resolve(cancelResult);
+    }
+
+    /// <summary>
+    /// The read request the shared pull uses. Its chunk steps are deliberately deferred by one microtask:
+    /// an error in the original is only observable through the reader's closed promise, which takes a
+    /// microtask to react to, and a synchronously available chunk must not overtake it.
+    /// </summary>
+    private sealed class TeeReadRequest : ReadRequest
+    {
+        private readonly ReadableStreamTee _tee;
+
+        internal TeeReadRequest(ReadableStreamTee tee)
+        {
+            _tee = tee;
+        }
+
+        internal override void ChunkSteps(JsValue chunk)
+        {
+            _tee._engine.AddToEventLoop(() =>
+            {
+                _tee._readAgain = false;
+
+                // Both branches receive the very same chunk: this tee never clones.
+                if (!_tee._canceled1)
+                {
+                    ReadableStreamDefaultControllerOperations.Enqueue(_tee._branch1.Controller, chunk);
+                }
+
+                if (!_tee._canceled2)
+                {
+                    ReadableStreamDefaultControllerOperations.Enqueue(_tee._branch2.Controller, chunk);
+                }
+
+                _tee._reading = false;
+                if (_tee._readAgain)
+                {
+                    _tee.PullAlgorithm();
+                }
+            });
+        }
+
+        internal override void CloseSteps()
+        {
+            _tee._reading = false;
+
+            if (!_tee._canceled1)
+            {
+                ReadableStreamDefaultControllerOperations.Close(_tee._branch1.Controller);
+            }
+
+            if (!_tee._canceled2)
+            {
+                ReadableStreamDefaultControllerOperations.Close(_tee._branch2.Controller);
+            }
+
+            if (!_tee._canceled1 || !_tee._canceled2)
+            {
+                _tee._cancelCapability.Resolve(JsValue.Undefined);
+            }
+        }
+
+        internal override void ErrorSteps(JsValue error)
+        {
+            // Nothing else: the branches are errored through the reader's closed promise instead, which is
+            // the channel that also covers an error arriving with no read outstanding.
+            _tee._reading = false;
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/StreamDictionaries.cs
+++ b/Jint/WebApi/Streams/StreamDictionaries.cs
@@ -1,0 +1,413 @@
+#if NET8_0_OR_GREATER
+using System.Runtime.InteropServices;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.WebApi.Abort;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// The WebIDL dictionaries the stream constructors and methods take, converted exactly as
+/// https://webidl.spec.whatwg.org/#es-dictionary prescribes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two things about that conversion are observable and therefore load-bearing here. Members are read in
+/// <b>lexicographical order of identifier</b>, not declaration order, so a dictionary of getters sees its
+/// properties touched in a fixed order. And the conversion happens where the argument is declared: a
+/// dictionary argument is converted at the WebIDL layer, <i>before</i> the operation's own steps run, while
+/// the <c>underlyingSource</c>/<c>underlyingSink</c>/<c>transformer</c> objects are converted in the
+/// constructors' prose — which is why <c>new ReadableStream(sourceWhoseStartGetterThrows,
+/// strategyWhoseSizeGetterThrows)</c> reports the <i>strategy's</i> exception.
+/// </para>
+/// <para>
+/// A member whose value is <see langword="undefined"/> does not exist, which is why every "does the member
+/// exist" test below is a test against <see langword="null"/> rather than against
+/// <see cref="JsValue.Undefined"/>.
+/// </para>
+/// </remarks>
+internal static class StreamDictionaries
+{
+    /// <summary>
+    /// The <c>QueuingStrategy</c> dictionary — https://streams.spec.whatwg.org/#dictdef-queuingstrategy.
+    /// </summary>
+    [StructLayout(LayoutKind.Auto)]
+    internal readonly record struct QueuingStrategyRecord(double? HighWaterMark, ICallable? Size);
+
+    /// <summary>
+    /// The <c>UnderlyingSource</c> dictionary — https://streams.spec.whatwg.org/#dictdef-underlyingsource.
+    /// </summary>
+    [StructLayout(LayoutKind.Auto)]
+    internal readonly record struct UnderlyingSourceRecord(ICallable? Start, ICallable? Pull, ICallable? Cancel, bool TypeExists);
+
+    /// <summary>
+    /// The <c>UnderlyingSink</c> dictionary — https://streams.spec.whatwg.org/#dictdef-underlyingsink.
+    /// </summary>
+    [StructLayout(LayoutKind.Auto)]
+    internal readonly record struct UnderlyingSinkRecord(ICallable? Start, ICallable? Write, ICallable? Close, ICallable? Abort, bool TypeExists);
+
+    /// <summary>
+    /// The <c>Transformer</c> dictionary — https://streams.spec.whatwg.org/#dictdef-transformer.
+    /// </summary>
+    [StructLayout(LayoutKind.Auto)]
+    internal readonly record struct TransformerRecord(
+        ICallable? Start,
+        ICallable? Transform,
+        ICallable? Flush,
+        ICallable? Cancel,
+        bool ReadableTypeExists,
+        bool WritableTypeExists);
+
+    /// <summary>
+    /// The <c>StreamPipeOptions</c> dictionary — https://streams.spec.whatwg.org/#dictdef-streampipeoptions.
+    /// </summary>
+    [StructLayout(LayoutKind.Auto)]
+    internal readonly record struct StreamPipeOptionsRecord(bool PreventAbort, bool PreventCancel, bool PreventClose, JsAbortSignal? Signal);
+
+    /// <summary>
+    /// Converts a value to a dictionary's backing object: <see langword="null"/> means every member is
+    /// absent, which is what <see langword="undefined"/> and <c>null</c> convert to.
+    /// </summary>
+    private static ObjectInstance? AsDictionary(Realm realm, JsValue value, string what)
+    {
+        if (value.IsUndefined() || value.IsNull())
+        {
+            return null;
+        }
+
+        if (value is not ObjectInstance objectInstance)
+        {
+            Throw.TypeError(realm, $"{what} is not an object");
+            return null;
+        }
+
+        return objectInstance;
+    }
+
+    /// <summary>
+    /// Reads one member declared as a callback function: present and not callable is a <c>TypeError</c>,
+    /// https://webidl.spec.whatwg.org/#es-callback-function.
+    /// </summary>
+    private static ICallable? ReadCallback(Realm realm, ObjectInstance? dictionary, string name, string what)
+    {
+        if (dictionary is null)
+        {
+            return null;
+        }
+
+        var value = dictionary.Get(name);
+        if (value.IsUndefined())
+        {
+            return null;
+        }
+
+        if (value is not ICallable callable)
+        {
+            Throw.TypeError(realm, $"{what}.{name} is not a function");
+            return null;
+        }
+
+        return callable;
+    }
+
+    /// <summary>Whether a member exists at all, for the members the streams only test for existence.</summary>
+    private static bool Exists(ObjectInstance? dictionary, string name)
+        => dictionary is not null && !dictionary.Get(name).IsUndefined();
+
+    /// <summary>
+    /// The <c>QueuingStrategy</c> conversion. Members in lexicographical order: <c>highWaterMark</c>, then
+    /// <c>size</c>. <c>highWaterMark</c> is an <c>unrestricted double</c>, so it is coerced here and only
+    /// range-checked later by <see cref="ExtractHighWaterMark"/> — which is why
+    /// <c>{ highWaterMark: -1 }</c> is a <c>RangeError</c> from the constructor body rather than a
+    /// conversion failure.
+    /// </summary>
+    internal static QueuingStrategyRecord ReadQueuingStrategy(Realm realm, JsValue value, string what)
+    {
+        var dictionary = AsDictionary(realm, value, what);
+        if (dictionary is null)
+        {
+            return default;
+        }
+
+        var highWaterMarkValue = dictionary.Get("highWaterMark");
+        double? highWaterMark = highWaterMarkValue.IsUndefined() ? null : TypeConverter.ToNumber(highWaterMarkValue);
+        var size = ReadCallback(realm, dictionary, "size", what);
+        return new QueuingStrategyRecord(highWaterMark, size);
+    }
+
+    /// <summary>
+    /// The <c>UnderlyingSource</c> conversion. Members in lexicographical order:
+    /// <c>autoAllocateChunkSize</c>, <c>cancel</c>, <c>pull</c>, <c>start</c>, <c>type</c>.
+    /// </summary>
+    /// <remarks>
+    /// <c>autoAllocateChunkSize</c> is read and converted even though it is meaningless without
+    /// <c>type: "bytes"</c>: the conversion is observable — it is an <c>[EnforceRange] unsigned long long</c>,
+    /// so a getter that throws, or a value out of range, is reported from here — and the specification
+    /// simply ignores the converted value for a non-byte stream.
+    /// </remarks>
+    internal static UnderlyingSourceRecord ReadUnderlyingSource(Realm realm, JsValue value)
+    {
+        const string What = "The underlying source";
+        var dictionary = AsDictionary(realm, value, What);
+        if (dictionary is null)
+        {
+            return default;
+        }
+
+        ReadEnforcedUnsignedLongLong(realm, dictionary, "autoAllocateChunkSize", What);
+        var cancel = ReadCallback(realm, dictionary, "cancel", What);
+        var pull = ReadCallback(realm, dictionary, "pull", What);
+        var start = ReadCallback(realm, dictionary, "start", What);
+        var typeExists = ReadReadableStreamType(realm, dictionary);
+
+        return new UnderlyingSourceRecord(start, pull, cancel, typeExists);
+    }
+
+    /// <summary>
+    /// The <c>ReadableStreamType</c> enumeration — https://streams.spec.whatwg.org/#enumdef-readablestreamtype.
+    /// Its only value is <c>"bytes"</c>; anything else is a <c>TypeError</c> from the enumeration conversion,
+    /// https://webidl.spec.whatwg.org/#es-enumeration.
+    /// </summary>
+    private static bool ReadReadableStreamType(Realm realm, ObjectInstance dictionary)
+    {
+        var type = dictionary.Get("type");
+        if (type.IsUndefined())
+        {
+            return false;
+        }
+
+        if (!string.Equals(TypeConverter.ToString(type), "bytes", StringComparison.Ordinal))
+        {
+            Throw.TypeError(realm, "The underlying source's type is not a valid enumeration value for ReadableStreamType");
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// The <c>UnderlyingSink</c> conversion. Members in lexicographical order: <c>abort</c>, <c>close</c>,
+    /// <c>start</c>, <c>type</c>, <c>write</c>. <c>type</c> is <c>any</c>, so it is only tested for
+    /// existence — the <c>WritableStream</c> constructor rejects any value at all, which is how the
+    /// specification reserves the name.
+    /// </summary>
+    internal static UnderlyingSinkRecord ReadUnderlyingSink(Realm realm, JsValue value)
+    {
+        const string What = "The underlying sink";
+        var dictionary = AsDictionary(realm, value, What);
+        if (dictionary is null)
+        {
+            return default;
+        }
+
+        var abort = ReadCallback(realm, dictionary, "abort", What);
+        var close = ReadCallback(realm, dictionary, "close", What);
+        var start = ReadCallback(realm, dictionary, "start", What);
+        var typeExists = Exists(dictionary, "type");
+        var write = ReadCallback(realm, dictionary, "write", What);
+
+        return new UnderlyingSinkRecord(start, write, close, abort, typeExists);
+    }
+
+    /// <summary>
+    /// The <c>Transformer</c> conversion. Members in lexicographical order: <c>cancel</c>, <c>flush</c>,
+    /// <c>readableType</c>, <c>start</c>, <c>transform</c>, <c>writableType</c>.
+    /// </summary>
+    internal static TransformerRecord ReadTransformer(Realm realm, JsValue value)
+    {
+        const string What = "The transformer";
+        var dictionary = AsDictionary(realm, value, What);
+        if (dictionary is null)
+        {
+            return default;
+        }
+
+        var cancel = ReadCallback(realm, dictionary, "cancel", What);
+        var flush = ReadCallback(realm, dictionary, "flush", What);
+        var readableTypeExists = Exists(dictionary, "readableType");
+        var start = ReadCallback(realm, dictionary, "start", What);
+        var transform = ReadCallback(realm, dictionary, "transform", What);
+        var writableTypeExists = Exists(dictionary, "writableType");
+
+        return new TransformerRecord(start, transform, flush, cancel, readableTypeExists, writableTypeExists);
+    }
+
+    /// <summary>
+    /// The <c>StreamPipeOptions</c> conversion. Members in lexicographical order: <c>preventAbort</c>,
+    /// <c>preventCancel</c>, <c>preventClose</c>, <c>signal</c>. The three booleans default to false; the
+    /// signal has no default, so an explicit <see langword="undefined"/> means "not given" and any other
+    /// non-<c>AbortSignal</c> value is a <c>TypeError</c>.
+    /// </summary>
+    internal static StreamPipeOptionsRecord ReadStreamPipeOptions(Realm realm, JsValue value)
+    {
+        const string What = "The pipe options";
+        var dictionary = AsDictionary(realm, value, What);
+        if (dictionary is null)
+        {
+            return default;
+        }
+
+        var preventAbort = TypeConverter.ToBoolean(dictionary.Get("preventAbort"));
+        var preventCancel = TypeConverter.ToBoolean(dictionary.Get("preventCancel"));
+        var preventClose = TypeConverter.ToBoolean(dictionary.Get("preventClose"));
+
+        var signalValue = dictionary.Get("signal");
+        JsAbortSignal? signal = null;
+        if (!signalValue.IsUndefined())
+        {
+            signal = signalValue as JsAbortSignal;
+            if (signal is null)
+            {
+                Throw.TypeError(realm, "The pipe options' signal is not an AbortSignal");
+            }
+        }
+
+        return new StreamPipeOptionsRecord(preventAbort, preventCancel, preventClose, signal);
+    }
+
+    /// <summary>
+    /// The <c>ReadableWritablePair</c> conversion —
+    /// https://streams.spec.whatwg.org/#dictdef-readablewritablepair. Both members are <c>required</c> and
+    /// of interface type, and are read in lexicographical order: <c>readable</c>, then <c>writable</c>.
+    /// </summary>
+    internal static (JsReadableStream Readable, JsWritableStream Writable) ReadReadableWritablePair(Realm realm, JsValue value)
+    {
+        const string What = "The transform";
+        var dictionary = AsDictionary(realm, value, What);
+
+        var readableValue = dictionary is null ? JsValue.Undefined : dictionary.Get("readable");
+        if (readableValue is not JsReadableStream readable)
+        {
+            Throw.TypeError(realm, $"{What}.readable is not a ReadableStream");
+            return default;
+        }
+
+        var writableValue = dictionary!.Get("writable");
+        if (writableValue is not JsWritableStream writable)
+        {
+            Throw.TypeError(realm, $"{What}.writable is not a WritableStream");
+            return default;
+        }
+
+        return (readable, writable);
+    }
+
+    /// <summary>
+    /// The <c>ReadableStreamGetReaderOptions</c> conversion —
+    /// https://streams.spec.whatwg.org/#dictdef-readablestreamgetreaderoptions. Its single member is the
+    /// <c>ReadableStreamReaderMode</c> enumeration, whose only value is <c>"byob"</c>.
+    /// </summary>
+    /// <returns>Whether the <c>mode</c> member exists, i.e. whether a BYOB reader was asked for.</returns>
+    internal static bool ReadByobModeRequested(Realm realm, JsValue value)
+    {
+        var dictionary = AsDictionary(realm, value, "The reader options");
+        if (dictionary is null)
+        {
+            return false;
+        }
+
+        var mode = dictionary.Get("mode");
+        if (mode.IsUndefined())
+        {
+            return false;
+        }
+
+        if (!string.Equals(TypeConverter.ToString(mode), "byob", StringComparison.Ordinal))
+        {
+            Throw.TypeError(realm, "The reader options' mode is not a valid enumeration value for ReadableStreamReaderMode");
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// The <c>ReadableStreamIteratorOptions</c> conversion —
+    /// https://streams.spec.whatwg.org/#dictdef-readablestreamiteratoroptions. <c>preventCancel</c> has a
+    /// default of false, so an absent member and an explicit <see langword="undefined"/> both mean false.
+    /// </summary>
+    internal static bool ReadPreventCancel(Realm realm, JsValue value)
+    {
+        var dictionary = AsDictionary(realm, value, "The iterator options");
+        return dictionary is not null && TypeConverter.ToBoolean(dictionary.Get("preventCancel"));
+    }
+
+    /// <summary>
+    /// The <c>QueuingStrategyInit</c> conversion —
+    /// https://streams.spec.whatwg.org/#dictdef-queuingstrategyinit. <c>highWaterMark</c> is
+    /// <c>required</c>, so a missing member is a <c>TypeError</c> rather than a default; the value itself is
+    /// deliberately not validated here, which is why <c>new CountQueuingStrategy({highWaterMark: -1})</c>
+    /// succeeds and only the stream built with it fails.
+    /// </summary>
+    internal static double ReadQueuingStrategyInit(Realm realm, JsValue value, string interfaceName)
+    {
+        var dictionary = AsDictionary(realm, value, $"The {interfaceName} init");
+        var highWaterMark = dictionary is null ? JsValue.Undefined : dictionary.Get("highWaterMark");
+        if (highWaterMark.IsUndefined())
+        {
+            Throw.TypeError(realm, $"Failed to construct '{interfaceName}': required member highWaterMark is undefined");
+        }
+
+        return TypeConverter.ToNumber(highWaterMark);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#validate-and-normalize-high-water-mark
+    /// </summary>
+    internal static double ExtractHighWaterMark(Realm realm, in QueuingStrategyRecord strategy, double defaultHighWaterMark)
+    {
+        if (strategy.HighWaterMark is not { } highWaterMark)
+        {
+            return defaultHighWaterMark;
+        }
+
+        if (double.IsNaN(highWaterMark) || highWaterMark < 0)
+        {
+            Throw.RangeError(realm, "The highWaterMark of a queuing strategy must be a non-negative, non-NaN number");
+        }
+
+        // +∞ is explicitly allowed: it makes backpressure never apply.
+        return highWaterMark;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#make-size-algorithm-from-size-function. The callback's return type
+    /// is <c>unrestricted double</c>, so the returned value is coerced with <c>ToNumber</c> here and a throw
+    /// from either the call or the coercion propagates to the caller.
+    /// </summary>
+    internal static Func<JsValue, double> ExtractSizeAlgorithm(in QueuingStrategyRecord strategy)
+    {
+        if (strategy.Size is not { } size)
+        {
+            return static _ => 1;
+        }
+
+        return chunk => TypeConverter.ToNumber(size.Call(JsValue.Undefined, chunk));
+    }
+
+    /// <summary>
+    /// The <c>[EnforceRange] unsigned long long</c> conversion,
+    /// https://webidl.spec.whatwg.org/#js-unsigned-long-long: a value that is not a finite number, or whose
+    /// integer part falls outside the type, is a <c>TypeError</c> rather than a wrap.
+    /// </summary>
+    private static void ReadEnforcedUnsignedLongLong(Realm realm, ObjectInstance dictionary, string name, string what)
+    {
+        var value = dictionary.Get(name);
+        if (value.IsUndefined())
+        {
+            return;
+        }
+
+        var number = TypeConverter.ToNumber(value);
+        if (!double.IsFinite(number))
+        {
+            Throw.TypeError(realm, $"{what}.{name} is not a finite number");
+        }
+
+        var integer = Math.Truncate(number);
+        if (integer < 0 || integer > 18446744073709551615d)
+        {
+            Throw.TypeError(realm, $"{what}.{name} is outside the range of an unsigned long long");
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/StreamPromises.cs
+++ b/Jint/WebApi/Streams/StreamPromises.cs
@@ -1,0 +1,241 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Promise;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// The promise vocabulary the Streams Standard's algorithms are written in — "a new promise", "a promise
+/// resolved with", "upon fulfillment of", "transform promise with" and the rest.
+/// <para>
+/// https://streams.spec.whatwg.org/
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Everything here is an ordinary engine promise settled on the engine's thread.</b> A stream never
+/// touches a CLR <c>Task</c>, never starts a thread and never settles anything off the event loop: a
+/// reaction is a job on the very queue that runs promise reactions and timer callbacks, so the microtask
+/// ordering the specification prescribes falls out of the single queue rather than being arranged for.
+/// </para>
+/// <para>
+/// The reactions are engine-internal <see cref="IPromiseContinuation"/>s rather than JavaScript functions.
+/// That is what <c>await</c> itself uses, and it matters for more than allocation: the specification's
+/// handlers are not observable from script — no <c>Function.prototype.call</c> is looked up, no
+/// <c>name</c>/<c>length</c> descriptors are materialized — and a continuation is exactly that. The job
+/// granularity is identical to a JavaScript handler's, one job per reaction, which is what keeps the
+/// microtask counts the specification depends on (tee's deliberate one-microtask delay, for instance)
+/// honest.
+/// </para>
+/// </remarks>
+internal static class StreamPromises
+{
+    /// <summary>
+    /// https://streams.spec.whatwg.org/ — "a new promise". The capability is what the algorithms settle
+    /// later; it carries the specification's <c>[[AlreadyResolved]]</c> guard, so a second settle of the
+    /// same promise is the no-op the algorithms rely on (tee resolves its <c>cancelPromise</c> from more
+    /// than one place).
+    /// </summary>
+    internal static PromiseCapability NewPromise(Engine engine, Realm realm)
+        => PromiseConstructor.NewPromiseCapability(engine, realm.Intrinsics.Promise);
+
+    /// <summary>The promise a capability was created for, which for the <c>%Promise%</c> intrinsic is always an ordinary promise.</summary>
+    internal static JsPromise PromiseOf(PromiseCapability capability) => (JsPromise) capability.PromiseInstance;
+
+    /// <summary>
+    /// "a promise resolved with <paramref name="value"/>" — <c>PromiseResolve(%Promise%, value)</c>. A
+    /// thenable is adopted, which is how a user callback's return value becomes the promise the algorithms
+    /// wait on.
+    /// </summary>
+    internal static JsPromise ResolvedWith(Realm realm, JsValue value)
+        => (JsPromise) realm.Intrinsics.Promise.PromiseResolve(value);
+
+    /// <summary>"a promise resolved with undefined".</summary>
+    internal static JsPromise ResolvedWithUndefined(Engine engine, Realm realm)
+    {
+        var capability = NewPromise(engine, realm);
+        capability.Resolve(JsValue.Undefined);
+        return PromiseOf(capability);
+    }
+
+    /// <summary>
+    /// "a promise rejected with <paramref name="reason"/>".
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="handled"/> spells the specification's frequent companion step, "set
+    /// <c>promise.[[PromiseIsHandled]]</c> to true", and is set <i>before</i> the rejection rather than
+    /// after so the engine's rejection tracker never sees a rejection the algorithm already accounted for.
+    /// The flag is otherwise exactly the specification's slot.
+    /// </remarks>
+    internal static JsPromise RejectedWith(Engine engine, Realm realm, JsValue reason, bool handled = false)
+    {
+        var capability = NewPromise(engine, realm);
+        var promise = PromiseOf(capability);
+        if (handled)
+        {
+            promise.PromiseIsHandled = true;
+        }
+
+        capability.Reject(reason);
+        return promise;
+    }
+
+    /// <summary>
+    /// Marks a promise as handled: "set <c>promise.[[PromiseIsHandled]]</c> to true". Used for the promises
+    /// the algorithms create and settle for their own bookkeeping, which no script ever attaches to.
+    /// </summary>
+    internal static void MarkHandled(JsPromise promise) => promise.PromiseIsHandled = true;
+
+    /// <summary>
+    /// "Upon fulfillment of <paramref name="promise"/>" / "upon rejection of <paramref name="promise"/>" —
+    /// the specification's <c>uponPromise</c>. The handlers produce no value and the reaction has no result
+    /// promise, exactly as <c>PerformPromiseThen</c> with no capability.
+    /// </summary>
+    internal static void UponPromise(
+        Engine engine,
+        JsPromise promise,
+        Action<JsValue>? onFulfilled,
+        Action<JsValue>? onRejected)
+    {
+        PromiseOperations.PerformPromiseThen(engine, promise, new VoidReaction(onFulfilled, onRejected));
+    }
+
+    /// <summary>"Upon fulfillment of <paramref name="promise"/>".</summary>
+    internal static void UponFulfillment(Engine engine, JsPromise promise, Action<JsValue> onFulfilled)
+        => UponPromise(engine, promise, onFulfilled, onRejected: null);
+
+    /// <summary>"Upon rejection of <paramref name="promise"/>".</summary>
+    internal static void UponRejection(Engine engine, JsPromise promise, Action<JsValue> onRejected)
+        => UponPromise(engine, promise, onFulfilled: null, onRejected);
+
+    /// <summary>
+    /// The specification's <c>transformPromiseWith</c>: <c>promise.then(onFulfilled, onRejected)</c> without
+    /// going through the observable <c>then</c>. A handler that returns a value fulfils the derived promise
+    /// with it (adopting a thenable), and one that raises a JavaScript exception rejects it — which is how
+    /// <c>TransformStreamDefaultControllerPerformTransform</c>'s "error the stream and rethrow" reaches its
+    /// caller.
+    /// </summary>
+    internal static JsPromise TransformPromiseWith(
+        Engine engine,
+        Realm realm,
+        JsPromise promise,
+        Func<JsValue, JsValue>? onFulfilled,
+        Func<JsValue, JsValue>? onRejected)
+    {
+        var capability = NewPromise(engine, realm);
+        PromiseOperations.PerformPromiseThen(engine, promise, new TransformReaction(capability, onFulfilled, onRejected));
+        return PromiseOf(capability);
+    }
+
+    /// <summary>
+    /// The WebIDL rule for invoking a callback function whose return type is a promise type: an abrupt
+    /// completion becomes a rejected promise, and the returned value is converted to
+    /// <c>Promise&lt;undefined&gt;</c>, i.e. handed to <c>PromiseResolve</c>.
+    /// <para>
+    /// https://webidl.spec.whatwg.org/#call-a-user-objects-operation, step "If completion is an abrupt
+    /// completion and the operation has a return type that is not a promise type, throw"; otherwise "return
+    /// a promise rejected with".
+    /// </para>
+    /// </summary>
+    internal static JsPromise PromiseCall(
+        Engine engine,
+        Realm realm,
+        ICallable callback,
+        JsValue thisArgument,
+        JsCallArguments arguments)
+    {
+        try
+        {
+            var result = callback.Call(thisArgument, arguments);
+            return ResolvedWith(realm, result);
+        }
+        catch (JavaScriptException e)
+        {
+            return RejectedWith(engine, realm, e.Error);
+        }
+    }
+
+    /// <summary>
+    /// The reaction behind <see cref="UponPromise"/>: engine-internal handlers, no result promise. A
+    /// JavaScript exception raised by a handler has nowhere to go — the specification asserts these handlers
+    /// do not throw — and is dropped by the reaction job, which is what a JavaScript handler with no result
+    /// capability does too.
+    /// </summary>
+    private sealed class VoidReaction : IPromiseContinuation
+    {
+        private readonly Action<JsValue>? _onFulfilled;
+        private readonly Action<JsValue>? _onRejected;
+
+        internal VoidReaction(Action<JsValue>? onFulfilled, Action<JsValue>? onRejected)
+        {
+            _onFulfilled = onFulfilled;
+            _onRejected = onRejected;
+        }
+
+        public void Invoke(Engine engine, JsValue value, ReactionType type)
+        {
+            if (type == ReactionType.Fulfill)
+            {
+                _onFulfilled?.Invoke(value);
+            }
+            else
+            {
+                _onRejected?.Invoke(value);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The reaction behind <see cref="TransformPromiseWith"/>: the handler's value settles the derived
+    /// promise, and its abrupt completion rejects it — the whole of <c>PerformPromiseThen</c>'s job step for
+    /// a reaction that carries a capability.
+    /// </summary>
+    private sealed class TransformReaction : IPromiseContinuation
+    {
+        private readonly PromiseCapability _capability;
+        private readonly Func<JsValue, JsValue>? _onFulfilled;
+        private readonly Func<JsValue, JsValue>? _onRejected;
+
+        internal TransformReaction(
+            PromiseCapability capability,
+            Func<JsValue, JsValue>? onFulfilled,
+            Func<JsValue, JsValue>? onRejected)
+        {
+            _capability = capability;
+            _onFulfilled = onFulfilled;
+            _onRejected = onRejected;
+        }
+
+        public void Invoke(Engine engine, JsValue value, ReactionType type)
+        {
+            var handler = type == ReactionType.Fulfill ? _onFulfilled : _onRejected;
+
+            // "If handler is empty": a missing handler passes the settlement straight through, which is what
+            // makes transformPromiseWith(p, undefined, r) forward p's fulfillment value unchanged.
+            if (handler is null)
+            {
+                if (type == ReactionType.Fulfill)
+                {
+                    _capability.Resolve(value);
+                }
+                else
+                {
+                    _capability.Reject(value);
+                }
+
+                return;
+            }
+
+            try
+            {
+                _capability.Resolve(handler(value));
+            }
+            catch (JavaScriptException e)
+            {
+                _capability.Reject(e.Error);
+            }
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/StreamQueue.cs
+++ b/Jint/WebApi/Streams/StreamQueue.cs
@@ -1,0 +1,96 @@
+#if NET8_0_OR_GREATER
+using System.Runtime.InteropServices;
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// The "queue-with-sizes" data structure every stream controller keeps: the specification's paired
+/// <c>[[queue]]</c> and <c>[[queueTotalSize]]</c> slots, kept synchronized by construction.
+/// <para>
+/// https://streams.spec.whatwg.org/#queue-with-sizes
+/// </para>
+/// </summary>
+/// <remarks>
+/// The running total is deliberately a running total rather than a sum over the queue, exactly as the
+/// standard prescribes — including the "if the total goes below zero, set it to zero" step, which exists
+/// because floating-point subtraction is not the inverse of floating-point addition.
+/// </remarks>
+internal sealed class StreamQueue
+{
+    private readonly Queue<ValueWithSize> _queue = new();
+
+    /// <summary>The specification's <c>[[queueTotalSize]]</c>.</summary>
+    internal double TotalSize { get; private set; }
+
+    /// <summary>Whether <c>[[queue]]</c> is empty.</summary>
+    internal bool IsEmpty => _queue.Count == 0;
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#dequeue-value
+    /// </summary>
+    internal JsValue Dequeue()
+    {
+        var valueWithSize = _queue.Dequeue();
+        TotalSize -= valueWithSize.Size;
+
+        // "If container.[[queueTotalSize]] < 0, set container.[[queueTotalSize]] to 0. (This can occur due
+        // to rounding errors.)"
+        if (TotalSize < 0)
+        {
+            TotalSize = 0;
+        }
+
+        return valueWithSize.Value;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#enqueue-value-with-size. Raises a <c>RangeError</c> for a size that
+    /// is not a non-negative number, or is <c>+∞</c> — the two ways a queuing strategy's <c>size()</c> can
+    /// make the running total meaningless.
+    /// </summary>
+    internal void Enqueue(Realm realm, JsValue value, double size)
+    {
+        if (!IsNonNegativeNumber(size))
+        {
+            Throw.RangeError(realm, "The return value of a queuing strategy's size function must be a non-negative, non-NaN number");
+        }
+
+        if (double.IsPositiveInfinity(size))
+        {
+            Throw.RangeError(realm, "The return value of a queuing strategy's size function must be a finite number");
+        }
+
+        _queue.Enqueue(new ValueWithSize(value, size));
+        TotalSize += size;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#peek-queue-value
+    /// </summary>
+    internal JsValue Peek() => _queue.Peek().Value;
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#reset-queue
+    /// </summary>
+    internal void Reset()
+    {
+        _queue.Clear();
+        TotalSize = 0;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#is-non-negative-number. The specification's version also answers
+    /// false for a value that is not a Number at all; the conversion to <c>unrestricted double</c> has
+    /// already happened by the time a size reaches this code, so only NaN and the sign are left to check.
+    /// </summary>
+    internal static bool IsNonNegativeNumber(double value) => !double.IsNaN(value) && value >= 0;
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#value-with-size
+    /// </summary>
+    [StructLayout(LayoutKind.Auto)]
+    private readonly record struct ValueWithSize(JsValue Value, double Size);
+}
+#endif

--- a/Jint/WebApi/Streams/TransformStreamConstructor.cs
+++ b/Jint/WebApi/Streams/TransformStreamConstructor.cs
@@ -1,0 +1,107 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// The <c>TransformStream</c> interface object.
+/// <para>
+/// https://streams.spec.whatwg.org/#ts-class
+/// </para>
+/// </summary>
+internal sealed class TransformStreamConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("TransformStream");
+
+    internal TransformStreamConstructor(
+        Engine engine,
+        Realm realm,
+        FunctionPrototype functionPrototype,
+        ObjectPrototype objectPrototype)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = functionPrototype;
+        PrototypeObject = new TransformStreamPrototype(engine, realm, this, objectPrototype);
+        _length = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal TransformStreamPrototype PrototypeObject { get; }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#ts-constructor
+    /// </summary>
+    /// <remarks>
+    /// The default high water marks are asymmetric — 1 for the writable side, 0 for the readable side — so a
+    /// transform stream buffers one chunk on the way in and none on the way out. That is what makes the
+    /// readable side's consumer, rather than the writable side's producer, decide when a transform runs.
+    /// </remarks>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        if (newTarget.IsUndefined())
+        {
+            Throw.TypeError(_realm, $"Constructor {GetOwnFunctionNameForMessage()} requires 'new'");
+        }
+
+        var transformer = arguments.At(0);
+        if (!transformer.IsUndefined() && transformer is not ObjectInstance)
+        {
+            Throw.TypeError(_realm, "Failed to construct 'TransformStream': the transformer is not an object");
+        }
+
+        var writableStrategy = StreamDictionaries.ReadQueuingStrategy(_realm, arguments.At(1), "The writable queuing strategy");
+        var readableStrategy = StreamDictionaries.ReadQueuingStrategy(_realm, arguments.At(2), "The readable queuing strategy");
+
+        var stream = OrdinaryCreateFromConstructor(
+            newTarget,
+            static intrinsics => intrinsics.TransformStream.PrototypeObject,
+            static (Engine engine, Realm realm, object? _) => new JsTransformStream(engine, realm));
+
+        var dictionary = StreamDictionaries.ReadTransformer(_realm, transformer);
+
+        if (dictionary.ReadableTypeExists)
+        {
+            Throw.RangeError(_realm, "Failed to construct 'TransformStream': the transformer's readableType is invalid");
+        }
+
+        if (dictionary.WritableTypeExists)
+        {
+            Throw.RangeError(_realm, "Failed to construct 'TransformStream': the transformer's writableType is invalid");
+        }
+
+        var readableHighWaterMark = StreamDictionaries.ExtractHighWaterMark(_realm, in readableStrategy, 0);
+        var readableSizeAlgorithm = StreamDictionaries.ExtractSizeAlgorithm(in readableStrategy);
+        var writableHighWaterMark = StreamDictionaries.ExtractHighWaterMark(_realm, in writableStrategy, 1);
+        var writableSizeAlgorithm = StreamDictionaries.ExtractSizeAlgorithm(in writableStrategy);
+
+        var startCapability = StreamPromises.NewPromise(_engine, _realm);
+
+        TransformStreamOperations.Initialize(
+            stream,
+            StreamPromises.PromiseOf(startCapability),
+            writableHighWaterMark,
+            writableSizeAlgorithm,
+            readableHighWaterMark,
+            readableSizeAlgorithm);
+
+        TransformStreamOperations.SetUpControllerFromTransformer(stream, transformer, in dictionary);
+
+        // The transformer's start() has return type `any`: an exception it raises propagates out of the
+        // constructor, while a promise it returns simply delays both sides.
+        if (dictionary.Start is { } start)
+        {
+            startCapability.Resolve(start.Call(transformer, stream.Controller));
+        }
+        else
+        {
+            startCapability.Resolve(Undefined);
+        }
+
+        return stream;
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/TransformStreamDefaultControllerConstructor.cs
+++ b/Jint/WebApi/Streams/TransformStreamDefaultControllerConstructor.cs
@@ -1,0 +1,42 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// The <c>TransformStreamDefaultController</c> interface object, which declares no constructor operation and
+/// is therefore not constructible.
+/// <para>
+/// https://streams.spec.whatwg.org/#ts-default-controller-class
+/// </para>
+/// </summary>
+internal sealed class TransformStreamDefaultControllerConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("TransformStreamDefaultController");
+
+    internal TransformStreamDefaultControllerConstructor(
+        Engine engine,
+        Realm realm,
+        FunctionPrototype functionPrototype,
+        ObjectPrototype objectPrototype)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = functionPrototype;
+        PrototypeObject = new TransformStreamDefaultControllerPrototype(engine, realm, this, objectPrototype);
+        _length = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal TransformStreamDefaultControllerPrototype PrototypeObject { get; }
+
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        Throw.TypeError(_realm, "Illegal constructor");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/TransformStreamDefaultControllerPrototype.cs
+++ b/Jint/WebApi/Streams/TransformStreamDefaultControllerPrototype.cs
@@ -1,0 +1,95 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// <c>TransformStreamDefaultController.prototype</c> — the interface prototype object.
+/// <para>
+/// https://streams.spec.whatwg.org/#ts-default-controller-prototype
+/// </para>
+/// </summary>
+[JsObject(UseShape = true)]
+internal sealed partial class TransformStreamDefaultControllerPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly TransformStreamDefaultControllerConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString ControllerToStringTag = new("TransformStreamDefaultController");
+
+    internal TransformStreamDefaultControllerPrototype(
+        Engine engine,
+        Realm realm,
+        TransformStreamDefaultControllerConstructor constructor,
+        ObjectInstance objectPrototype) : base(engine, realm)
+    {
+        _prototype = objectPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#ts-default-controller-desired-size — the desired size of the
+    /// <b>readable</b> side, which is what tells a transformer how much its consumer still wants.
+    /// </summary>
+    [JsAccessor("desiredSize", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue DesiredSizeGet(JsValue thisObject)
+    {
+        var readableController = Brand(thisObject).Stream.Readable.Controller;
+        var desiredSize = ReadableStreamDefaultControllerOperations.GetDesiredSize(readableController);
+        return desiredSize is { } value ? JsNumber.Create(value) : Null;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#ts-default-controller-enqueue
+    /// </summary>
+    [JsFunction(Name = "enqueue", Length = 0)]
+    private JsValue Enqueue(JsValue thisObject, JsValue chunk)
+    {
+        TransformStreamOperations.ControllerEnqueue(Brand(thisObject), chunk);
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#ts-default-controller-error — errors both sides, discarding whatever
+    /// was queued for transformation.
+    /// </summary>
+    [JsFunction(Name = "error", Length = 0)]
+    private JsValue Error(JsValue thisObject, JsValue reason)
+    {
+        TransformStreamOperations.ControllerError(Brand(thisObject), reason);
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#ts-default-controller-terminate — closes the readable side and
+    /// errors the writable side, for a transformer that only wants part of what is written to it.
+    /// </summary>
+    [JsFunction(Name = "terminate", Length = 0)]
+    private JsValue Terminate(JsValue thisObject)
+    {
+        TransformStreamOperations.ControllerTerminate(Brand(thisObject));
+        return Undefined;
+    }
+
+    private JsTransformStreamDefaultController Brand(JsValue thisObject)
+    {
+        if (thisObject is JsTransformStreamDefaultController controller)
+        {
+            return controller;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a TransformStreamDefaultController");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/TransformStreamOperations.cs
+++ b/Jint/WebApi/Streams/TransformStreamOperations.cs
@@ -1,0 +1,465 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// The transform-stream abstract operations: "working with transform streams", the default controller's
+/// operations, and the default sink and source the two sides are built from.
+/// <para>
+/// https://streams.spec.whatwg.org/#ts-abstract-ops
+/// </para>
+/// </summary>
+internal static class TransformStreamOperations
+{
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#initialize-transform-stream
+    /// </summary>
+    internal static void Initialize(
+        JsTransformStream stream,
+        JsPromise startPromise,
+        double writableHighWaterMark,
+        Func<JsValue, double> writableSizeAlgorithm,
+        double readableHighWaterMark,
+        Func<JsValue, double> readableSizeAlgorithm)
+    {
+        var engine = stream.Engine;
+        var realm = stream.Realm;
+
+        // Both sides share one start promise, so neither begins working before the transformer's start()
+        // has settled.
+        Func<JsValue> startAlgorithm = () => startPromise;
+
+        stream.Writable = WritableStreamOperations.CreateWritableStream(
+            engine,
+            realm,
+            startAlgorithm,
+            chunk => SinkWriteAlgorithm(stream, chunk),
+            () => SinkCloseAlgorithm(stream),
+            reason => SinkAbortAlgorithm(stream, reason),
+            writableHighWaterMark,
+            writableSizeAlgorithm);
+
+        stream.Readable = ReadableStreamOperations.CreateReadableStream(
+            engine,
+            realm,
+            startAlgorithm,
+            () => SourcePullAlgorithm(stream),
+            reason => SourceCancelAlgorithm(stream, reason),
+            readableHighWaterMark,
+            readableSizeAlgorithm);
+
+        // Backpressure starts on: nothing is transformed until the readable side is pulled from, which is
+        // what keeps a transformer from running ahead of its consumer.
+        stream.Backpressure = null;
+        stream.BackpressureChangeCapability = null;
+        SetBackpressure(stream, backpressure: true);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#transform-stream-error
+    /// </summary>
+    /// <remarks>
+    /// Works when one or both sides are already errored, which is why the callers never check a state first.
+    /// </remarks>
+    internal static void Error(JsTransformStream stream, JsValue error)
+    {
+        ReadableStreamDefaultControllerOperations.Error(stream.Readable.Controller, error);
+        ErrorWritableAndUnblockWrite(stream, error);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#transform-stream-error-writable-and-unblock-write
+    /// </summary>
+    internal static void ErrorWritableAndUnblockWrite(JsTransformStream stream, JsValue error)
+    {
+        ClearAlgorithms(stream.Controller);
+        WritableStreamDefaultControllerOperations.ErrorIfNeeded(stream.Writable.Controller, error);
+        UnblockWrite(stream);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#transform-stream-unblock-write
+    /// </summary>
+    /// <remarks>
+    /// A write parked on the backpressure latch would otherwise never resume once the readable side is gone,
+    /// so releasing the latch is part of every failure path.
+    /// </remarks>
+    internal static void UnblockWrite(JsTransformStream stream)
+    {
+        if (stream.Backpressure == true)
+        {
+            SetBackpressure(stream, backpressure: false);
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#transform-stream-set-backpressure
+    /// </summary>
+    internal static void SetBackpressure(JsTransformStream stream, bool backpressure)
+    {
+        stream.BackpressureChangeCapability?.Resolve(JsValue.Undefined);
+        stream.BackpressureChangeCapability = StreamPromises.NewPromise(stream.Engine, stream.Realm);
+        stream.Backpressure = backpressure;
+    }
+
+    // ---- Default controllers ----
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#set-up-transform-stream-default-controller
+    /// </summary>
+    private static void SetUpController(
+        JsTransformStream stream,
+        JsTransformStreamDefaultController controller,
+        Func<JsValue, JsPromise> transformAlgorithm,
+        Func<JsPromise> flushAlgorithm,
+        Func<JsValue, JsPromise> cancelAlgorithm)
+    {
+        controller.Stream = stream;
+        stream.Controller = controller;
+        controller.TransformAlgorithm = transformAlgorithm;
+        controller.FlushAlgorithm = flushAlgorithm;
+        controller.CancelAlgorithm = cancelAlgorithm;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#set-up-transform-stream-default-controller-from-transformer
+    /// </summary>
+    internal static void SetUpControllerFromTransformer(
+        JsTransformStream stream,
+        JsValue transformer,
+        in StreamDictionaries.TransformerRecord dictionary)
+    {
+        var engine = stream.Engine;
+        var realm = stream.Realm;
+
+        var controller = new JsTransformStreamDefaultController(engine, realm)
+        {
+            _prototype = realm.Intrinsics.TransformStreamDefaultController.PrototypeObject,
+        };
+
+        var transform = dictionary.Transform;
+        var flush = dictionary.Flush;
+        var cancel = dictionary.Cancel;
+
+        // With no transform() the stream is an identity transform: each chunk is enqueued as it arrives.
+        JsPromise IdentityTransform(JsValue chunk)
+        {
+            try
+            {
+                ControllerEnqueue(controller, chunk);
+                return StreamPromises.ResolvedWithUndefined(engine, realm);
+            }
+            catch (JavaScriptException e)
+            {
+                return StreamPromises.RejectedWith(engine, realm, e.Error);
+            }
+        }
+
+        Func<JsValue, JsPromise> transformAlgorithm = transform is null
+            ? IdentityTransform
+            : chunk => StreamPromises.PromiseCall(engine, realm, transform, transformer, [chunk, controller]);
+
+        Func<JsPromise> flushAlgorithm = flush is null
+            ? () => StreamPromises.ResolvedWithUndefined(engine, realm)
+            : () => StreamPromises.PromiseCall(engine, realm, flush, transformer, [controller]);
+
+        Func<JsValue, JsPromise> cancelAlgorithm = cancel is null
+            ? _ => StreamPromises.ResolvedWithUndefined(engine, realm)
+            : reason => StreamPromises.PromiseCall(engine, realm, cancel, transformer, [reason]);
+
+        SetUpController(stream, controller, transformAlgorithm, flushAlgorithm, cancelAlgorithm);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#transform-stream-default-controller-clear-algorithms
+    /// </summary>
+    internal static void ClearAlgorithms(JsTransformStreamDefaultController controller)
+    {
+        controller.TransformAlgorithm = null;
+        controller.FlushAlgorithm = null;
+        controller.CancelAlgorithm = null;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#transform-stream-default-controller-enqueue
+    /// </summary>
+    internal static void ControllerEnqueue(JsTransformStreamDefaultController controller, JsValue chunk)
+    {
+        var stream = controller.Stream;
+        var readableController = stream.Readable.Controller;
+
+        if (!ReadableStreamDefaultControllerOperations.CanCloseOrEnqueue(readableController))
+        {
+            Throw.TypeError(controller.Realm, "The readable side is not in a state that permits enqueue");
+        }
+
+        // Transform invocations are throttled by the readable side's backpressure, but an enqueue is still
+        // accepted whenever the readable side can take one — a transformer may produce several chunks from
+        // one.
+        try
+        {
+            ReadableStreamDefaultControllerOperations.Enqueue(readableController, chunk);
+        }
+        catch (JavaScriptException e)
+        {
+            // This is the readable strategy's size() throwing. Both sides fail, and the caller is told the
+            // readable side's stored error rather than the raw exception.
+            ErrorWritableAndUnblockWrite(stream, e.Error);
+            throw new JavaScriptException(stream.Readable.StoredError);
+        }
+
+        var backpressure = ReadableStreamDefaultControllerOperations.HasBackpressure(readableController);
+        if (backpressure != stream.Backpressure)
+        {
+            SetBackpressure(stream, backpressure: true);
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#transform-stream-default-controller-error
+    /// </summary>
+    internal static void ControllerError(JsTransformStreamDefaultController controller, JsValue error)
+        => Error(controller.Stream, error);
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#transform-stream-default-controller-perform-transform
+    /// </summary>
+    private static JsPromise PerformTransform(JsTransformStreamDefaultController controller, JsValue chunk)
+    {
+        var engine = controller.Engine;
+        var realm = controller.Realm;
+
+        var transformPromise = controller.TransformAlgorithm!(chunk);
+
+        return StreamPromises.TransformPromiseWith(
+            engine,
+            realm,
+            transformPromise,
+            onFulfilled: null,
+            onRejected: reason =>
+            {
+                // The transformer failed, so both sides fail — and the rejection is passed on unchanged, so
+                // the write that triggered the transform reports the transformer's own error.
+                Error(controller.Stream, reason);
+                throw new JavaScriptException(reason);
+            });
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#transform-stream-default-controller-terminate
+    /// </summary>
+    internal static void ControllerTerminate(JsTransformStreamDefaultController controller)
+    {
+        var stream = controller.Stream;
+
+        ReadableStreamDefaultControllerOperations.Close(stream.Readable.Controller);
+
+        // The writable side is errored rather than closed: a producer still writing has to be told that its
+        // chunks will never be transformed.
+        var error = controller.Realm.Intrinsics.TypeError.Construct("The transform stream has been terminated");
+        ErrorWritableAndUnblockWrite(stream, error);
+    }
+
+    // ---- Default sinks ----
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#transform-stream-default-sink-write-algorithm
+    /// </summary>
+    private static JsPromise SinkWriteAlgorithm(JsTransformStream stream, JsValue chunk)
+    {
+        var engine = stream.Engine;
+        var realm = stream.Realm;
+        var controller = stream.Controller;
+
+        if (stream.Backpressure == true)
+        {
+            var backpressureChangePromise = StreamPromises.PromiseOf(stream.BackpressureChangeCapability!);
+
+            return StreamPromises.TransformPromiseWith(
+                engine,
+                realm,
+                backpressureChangePromise,
+                onFulfilled: _ =>
+                {
+                    var writable = stream.Writable;
+                    if (writable.State == WritableStreamState.Erroring)
+                    {
+                        // The stream started failing while this write waited on the latch; the write reports
+                        // that failure rather than being transformed.
+                        throw new JavaScriptException(writable.StoredError);
+                    }
+
+                    return PerformTransform(controller, chunk);
+                },
+                onRejected: null);
+        }
+
+        return PerformTransform(controller, chunk);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#transform-stream-default-sink-abort-algorithm
+    /// </summary>
+    private static JsPromise SinkAbortAlgorithm(JsTransformStream stream, JsValue reason)
+    {
+        var engine = stream.Engine;
+        var realm = stream.Realm;
+        var controller = stream.Controller;
+
+        if (controller.FinishCapability is { } already)
+        {
+            return StreamPromises.PromiseOf(already);
+        }
+
+        // The readable side cannot change after construction, so caching it across a call into the
+        // transformer is safe.
+        var readable = stream.Readable;
+
+        // Assigned before the transformer runs, so that a cancel() which reaches back into the stream —
+        // readable.cancel(), say — does not start the algorithm a second time.
+        var finish = StreamPromises.NewPromise(engine, realm);
+        controller.FinishCapability = finish;
+
+        var cancelPromise = controller.CancelAlgorithm!(reason);
+        ClearAlgorithms(controller);
+
+        StreamPromises.UponPromise(
+            engine,
+            cancelPromise,
+            _ =>
+            {
+                if (readable.State == ReadableStreamState.Errored)
+                {
+                    finish.Reject(readable.StoredError);
+                }
+                else
+                {
+                    ReadableStreamDefaultControllerOperations.Error(readable.Controller, reason);
+                    finish.Resolve(JsValue.Undefined);
+                }
+            },
+            error =>
+            {
+                ReadableStreamDefaultControllerOperations.Error(readable.Controller, error);
+                finish.Reject(error);
+            });
+
+        return StreamPromises.PromiseOf(finish);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#transform-stream-default-sink-close-algorithm
+    /// </summary>
+    private static JsPromise SinkCloseAlgorithm(JsTransformStream stream)
+    {
+        var engine = stream.Engine;
+        var realm = stream.Realm;
+        var controller = stream.Controller;
+
+        if (controller.FinishCapability is { } already)
+        {
+            return StreamPromises.PromiseOf(already);
+        }
+
+        var readable = stream.Readable;
+
+        var finish = StreamPromises.NewPromise(engine, realm);
+        controller.FinishCapability = finish;
+
+        var flushPromise = controller.FlushAlgorithm!();
+        ClearAlgorithms(controller);
+
+        StreamPromises.UponPromise(
+            engine,
+            flushPromise,
+            _ =>
+            {
+                if (readable.State == ReadableStreamState.Errored)
+                {
+                    finish.Reject(readable.StoredError);
+                }
+                else
+                {
+                    ReadableStreamDefaultControllerOperations.Close(readable.Controller);
+                    finish.Resolve(JsValue.Undefined);
+                }
+            },
+            error =>
+            {
+                ReadableStreamDefaultControllerOperations.Error(readable.Controller, error);
+                finish.Reject(error);
+            });
+
+        return StreamPromises.PromiseOf(finish);
+    }
+
+    // ---- Default sources ----
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#transform-stream-default-source-pull-algorithm
+    /// </summary>
+    /// <remarks>
+    /// The readable side's source does nothing but release the backpressure latch and then wait for it to be
+    /// re-applied — which is what turns a pull on the readable side into permission for one more transform.
+    /// </remarks>
+    private static JsPromise SourcePullAlgorithm(JsTransformStream stream)
+    {
+        SetBackpressure(stream, backpressure: false);
+
+        // Returning the new latch prevents another pull until backpressure re-appears.
+        return StreamPromises.PromiseOf(stream.BackpressureChangeCapability!);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#transform-stream-default-source-cancel-algorithm
+    /// </summary>
+    private static JsPromise SourceCancelAlgorithm(JsTransformStream stream, JsValue reason)
+    {
+        var engine = stream.Engine;
+        var realm = stream.Realm;
+        var controller = stream.Controller;
+
+        if (controller.FinishCapability is { } already)
+        {
+            return StreamPromises.PromiseOf(already);
+        }
+
+        // The writable side cannot change after construction, so caching it across a call into the
+        // transformer is safe.
+        var writable = stream.Writable;
+
+        var finish = StreamPromises.NewPromise(engine, realm);
+        controller.FinishCapability = finish;
+
+        var cancelPromise = controller.CancelAlgorithm!(reason);
+        ClearAlgorithms(controller);
+
+        StreamPromises.UponPromise(
+            engine,
+            cancelPromise,
+            _ =>
+            {
+                if (writable.State == WritableStreamState.Errored)
+                {
+                    finish.Reject(writable.StoredError);
+                }
+                else
+                {
+                    WritableStreamDefaultControllerOperations.ErrorIfNeeded(writable.Controller, reason);
+                    UnblockWrite(stream);
+                    finish.Resolve(JsValue.Undefined);
+                }
+            },
+            error =>
+            {
+                WritableStreamDefaultControllerOperations.ErrorIfNeeded(writable.Controller, error);
+                UnblockWrite(stream);
+                finish.Reject(error);
+            });
+
+        return StreamPromises.PromiseOf(finish);
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/TransformStreamPrototype.cs
+++ b/Jint/WebApi/Streams/TransformStreamPrototype.cs
@@ -1,0 +1,63 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// <c>TransformStream.prototype</c> — the interface prototype object.
+/// <para>
+/// https://streams.spec.whatwg.org/#ts-prototype
+/// </para>
+/// </summary>
+[JsObject(UseShape = true)]
+internal sealed partial class TransformStreamPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly TransformStreamConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString TransformStreamToStringTag = new("TransformStream");
+
+    internal TransformStreamPrototype(
+        Engine engine,
+        Realm realm,
+        TransformStreamConstructor constructor,
+        ObjectInstance objectPrototype) : base(engine, realm)
+    {
+        _prototype = objectPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#ts-readable
+    /// </summary>
+    [JsAccessor("readable", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsReadableStream ReadableGet(JsValue thisObject) => Brand(thisObject).Readable;
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#ts-writable
+    /// </summary>
+    [JsAccessor("writable", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsWritableStream WritableGet(JsValue thisObject) => Brand(thisObject).Writable;
+
+    private JsTransformStream Brand(JsValue thisObject)
+    {
+        if (thisObject is JsTransformStream stream)
+        {
+            return stream;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a TransformStream");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/WritableStreamConstructor.cs
+++ b/Jint/WebApi/Streams/WritableStreamConstructor.cs
@@ -1,0 +1,76 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// The <c>WritableStream</c> interface object.
+/// <para>
+/// https://streams.spec.whatwg.org/#ws-class
+/// </para>
+/// </summary>
+internal sealed class WritableStreamConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("WritableStream");
+
+    internal WritableStreamConstructor(
+        Engine engine,
+        Realm realm,
+        FunctionPrototype functionPrototype,
+        ObjectPrototype objectPrototype)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = functionPrototype;
+        PrototypeObject = new WritableStreamPrototype(engine, realm, this, objectPrototype);
+        _length = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal WritableStreamPrototype PrototypeObject { get; }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#ws-constructor
+    /// </summary>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        if (newTarget.IsUndefined())
+        {
+            Throw.TypeError(_realm, $"Constructor {GetOwnFunctionNameForMessage()} requires 'new'");
+        }
+
+        var underlyingSink = arguments.At(0);
+        if (!underlyingSink.IsUndefined() && underlyingSink is not ObjectInstance)
+        {
+            Throw.TypeError(_realm, "Failed to construct 'WritableStream': the underlying sink is not an object");
+        }
+
+        var strategy = StreamDictionaries.ReadQueuingStrategy(_realm, arguments.At(1), "The queuing strategy");
+
+        var stream = OrdinaryCreateFromConstructor(
+            newTarget,
+            static intrinsics => intrinsics.WritableStream.PrototypeObject,
+            static (Engine engine, Realm realm, object? _) => new JsWritableStream(engine, realm));
+
+        var sink = StreamDictionaries.ReadUnderlyingSink(_realm, underlyingSink);
+
+        if (sink.TypeExists)
+        {
+            // The specification reserves the name so that byte-oriented writable streams can be added later
+            // without a compatibility problem; any value at all is a RangeError today.
+            Throw.RangeError(_realm, "Failed to construct 'WritableStream': the underlying sink's type is invalid");
+        }
+
+        var sizeAlgorithm = StreamDictionaries.ExtractSizeAlgorithm(in strategy);
+        var highWaterMark = StreamDictionaries.ExtractHighWaterMark(_realm, in strategy, 1);
+
+        WritableStreamDefaultControllerOperations.SetUpFromUnderlyingSink(
+            stream, underlyingSink, in sink, highWaterMark, sizeAlgorithm);
+
+        return stream;
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/WritableStreamDefaultControllerConstructor.cs
+++ b/Jint/WebApi/Streams/WritableStreamDefaultControllerConstructor.cs
@@ -1,0 +1,42 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// The <c>WritableStreamDefaultController</c> interface object, which declares no constructor operation and
+/// is therefore not constructible.
+/// <para>
+/// https://streams.spec.whatwg.org/#ws-default-controller-class
+/// </para>
+/// </summary>
+internal sealed class WritableStreamDefaultControllerConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("WritableStreamDefaultController");
+
+    internal WritableStreamDefaultControllerConstructor(
+        Engine engine,
+        Realm realm,
+        FunctionPrototype functionPrototype,
+        ObjectPrototype objectPrototype)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = functionPrototype;
+        PrototypeObject = new WritableStreamDefaultControllerPrototype(engine, realm, this, objectPrototype);
+        _length = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal WritableStreamDefaultControllerPrototype PrototypeObject { get; }
+
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        Throw.TypeError(_realm, "Illegal constructor");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/WritableStreamDefaultControllerOperations.cs
+++ b/Jint/WebApi/Streams/WritableStreamDefaultControllerOperations.cs
@@ -1,0 +1,343 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// The <c>WritableStreamDefaultController</c> abstract operations, plus its two internal methods
+/// <c>[[AbortSteps]]</c> and <c>[[ErrorSteps]]</c>.
+/// <para>
+/// https://streams.spec.whatwg.org/#ws-default-controller-abstract-ops
+/// </para>
+/// </summary>
+internal static class WritableStreamDefaultControllerOperations
+{
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#close-sentinel — "a unique value enqueued into <c>[[queue]]</c>, in
+    /// lieu of a chunk, to signal that the stream is closed. It is only used internally, and is never
+    /// exposed to web developers."
+    /// </summary>
+    /// <remarks>
+    /// A symbol, and one nothing can reach: it is not in the global symbol registry, is never handed to a
+    /// callback and is compared only by reference. Sharing one across engines is safe precisely because it
+    /// is never exposed — a symbol identity that no script can obtain cannot leak between realms.
+    /// </remarks>
+    private static readonly JsSymbol _closeSentinel = new("[[close sentinel]]");
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#set-up-writable-stream-default-controller
+    /// </summary>
+    internal static void SetUp(
+        JsWritableStream stream,
+        JsWritableStreamDefaultController controller,
+        Func<JsValue> startAlgorithm,
+        Func<JsValue, JsPromise> writeAlgorithm,
+        Func<JsPromise> closeAlgorithm,
+        Func<JsValue, JsPromise> abortAlgorithm,
+        double highWaterMark,
+        Func<JsValue, double> sizeAlgorithm)
+    {
+        var engine = stream.Engine;
+        var realm = stream.Realm;
+
+        controller.Stream = stream;
+        stream.Controller = controller;
+        controller.Queue.Reset();
+        controller.Started = false;
+        controller.StrategySizeAlgorithm = sizeAlgorithm;
+        controller.StrategyHighWaterMark = highWaterMark;
+        controller.WriteAlgorithm = writeAlgorithm;
+        controller.CloseAlgorithm = closeAlgorithm;
+        controller.AbortAlgorithm = abortAlgorithm;
+
+        // Backpressure is computed before start() runs, so a stream whose high water mark is 0 applies it
+        // from the very first moment and a writer acquired immediately is not ready.
+        WritableStreamOperations.UpdateBackpressure(stream, GetBackpressure(controller));
+
+        // The sink's start() has return type `any`, so an exception it raises propagates out of the
+        // WritableStream constructor rather than becoming a rejection.
+        var startResult = startAlgorithm();
+        var startPromise = StreamPromises.ResolvedWith(realm, startResult);
+
+        StreamPromises.UponPromise(
+            engine,
+            startPromise,
+            _ =>
+            {
+                controller.Started = true;
+                AdvanceQueueIfNeeded(controller);
+            },
+            reason =>
+            {
+                // Started is set even on failure: the erroring machinery waits for start() to settle before
+                // it may run the sink's abort(), and a start that failed has settled.
+                controller.Started = true;
+                WritableStreamOperations.DealWithRejection(stream, reason);
+            });
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#set-up-writable-stream-default-controller-from-underlying-sink
+    /// </summary>
+    internal static void SetUpFromUnderlyingSink(
+        JsWritableStream stream,
+        JsValue underlyingSink,
+        in StreamDictionaries.UnderlyingSinkRecord sink,
+        double highWaterMark,
+        Func<JsValue, double> sizeAlgorithm)
+    {
+        var engine = stream.Engine;
+        var realm = stream.Realm;
+
+        var controller = new JsWritableStreamDefaultController(engine, realm)
+        {
+            _prototype = realm.Intrinsics.WritableStreamDefaultController.PrototypeObject,
+        };
+
+        var start = sink.Start;
+        var write = sink.Write;
+        var close = sink.Close;
+        var abort = sink.Abort;
+
+        Func<JsValue> startAlgorithm = start is null
+            ? static () => JsValue.Undefined
+            : () => start.Call(underlyingSink, controller);
+
+        Func<JsValue, JsPromise> writeAlgorithm = write is null
+            ? _ => StreamPromises.ResolvedWithUndefined(engine, realm)
+            : chunk => StreamPromises.PromiseCall(engine, realm, write, underlyingSink, [chunk, controller]);
+
+        Func<JsPromise> closeAlgorithm = close is null
+            ? () => StreamPromises.ResolvedWithUndefined(engine, realm)
+            : () => StreamPromises.PromiseCall(engine, realm, close, underlyingSink, []);
+
+        Func<JsValue, JsPromise> abortAlgorithm = abort is null
+            ? _ => StreamPromises.ResolvedWithUndefined(engine, realm)
+            : reason => StreamPromises.PromiseCall(engine, realm, abort, underlyingSink, [reason]);
+
+        SetUp(stream, controller, startAlgorithm, writeAlgorithm, closeAlgorithm, abortAlgorithm, highWaterMark, sizeAlgorithm);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-default-controller-advance-queue-if-needed
+    /// </summary>
+    internal static void AdvanceQueueIfNeeded(JsWritableStreamDefaultController controller)
+    {
+        var stream = controller.Stream;
+
+        if (!controller.Started)
+        {
+            return;
+        }
+
+        // One sink operation at a time: nothing is dequeued while the sink is still working.
+        if (stream.InFlightWriteRequest is not null)
+        {
+            return;
+        }
+
+        if (stream.State == WritableStreamState.Erroring)
+        {
+            WritableStreamOperations.FinishErroring(stream);
+            return;
+        }
+
+        if (controller.Queue.IsEmpty)
+        {
+            return;
+        }
+
+        var value = controller.Queue.Peek();
+        if (ReferenceEquals(value, _closeSentinel))
+        {
+            ProcessClose(controller);
+        }
+        else
+        {
+            ProcessWrite(controller, value);
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-default-controller-clear-algorithms
+    /// </summary>
+    internal static void ClearAlgorithms(JsWritableStreamDefaultController controller)
+    {
+        controller.WriteAlgorithm = null;
+        controller.CloseAlgorithm = null;
+        controller.AbortAlgorithm = null;
+        controller.StrategySizeAlgorithm = null;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-default-controller-close
+    /// </summary>
+    internal static void Close(JsWritableStreamDefaultController controller)
+    {
+        controller.Queue.Enqueue(controller.Realm, _closeSentinel, 0);
+        AdvanceQueueIfNeeded(controller);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-default-controller-error
+    /// </summary>
+    internal static void Error(JsWritableStreamDefaultController controller, JsValue error)
+    {
+        ClearAlgorithms(controller);
+        WritableStreamOperations.StartErroring(controller.Stream, error);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-default-controller-error-if-needed
+    /// </summary>
+    internal static void ErrorIfNeeded(JsWritableStreamDefaultController controller, JsValue error)
+    {
+        if (controller.Stream.State == WritableStreamState.Writable)
+        {
+            Error(controller, error);
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-default-controller-get-backpressure
+    /// </summary>
+    internal static bool GetBackpressure(JsWritableStreamDefaultController controller) => GetDesiredSize(controller) <= 0;
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-default-controller-get-chunk-size
+    /// </summary>
+    /// <remarks>
+    /// A strategy whose <c>size()</c> throws errors the stream and the chunk is then measured as 1 — the
+    /// write itself still goes on to fail, because the stream is no longer writable by the time
+    /// <c>WritableStreamDefaultWriterWrite</c> re-reads its state.
+    /// </remarks>
+    internal static double GetChunkSize(JsWritableStreamDefaultController controller, JsValue chunk)
+    {
+        if (controller.StrategySizeAlgorithm is not { } sizeAlgorithm)
+        {
+            return 1;
+        }
+
+        try
+        {
+            return sizeAlgorithm(chunk);
+        }
+        catch (JavaScriptException e)
+        {
+            ErrorIfNeeded(controller, e.Error);
+            return 1;
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-default-controller-get-desired-size
+    /// </summary>
+    internal static double GetDesiredSize(JsWritableStreamDefaultController controller)
+        => controller.StrategyHighWaterMark - controller.Queue.TotalSize;
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-default-controller-process-close
+    /// </summary>
+    private static void ProcessClose(JsWritableStreamDefaultController controller)
+    {
+        var stream = controller.Stream;
+
+        WritableStreamOperations.MarkCloseRequestInFlight(stream);
+        controller.Queue.Dequeue();
+
+        // Reachable only while the algorithms are present: they are cleared right after this call.
+        var sinkClosePromise = controller.CloseAlgorithm!();
+        ClearAlgorithms(controller);
+
+        StreamPromises.UponPromise(
+            controller.Engine,
+            sinkClosePromise,
+            _ => WritableStreamOperations.FinishInFlightClose(stream),
+            reason => WritableStreamOperations.FinishInFlightCloseWithError(stream, reason));
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-default-controller-process-write
+    /// </summary>
+    private static void ProcessWrite(JsWritableStreamDefaultController controller, JsValue chunk)
+    {
+        var stream = controller.Stream;
+
+        WritableStreamOperations.MarkFirstWriteRequestInFlight(stream);
+
+        var sinkWritePromise = controller.WriteAlgorithm!(chunk);
+
+        StreamPromises.UponPromise(
+            controller.Engine,
+            sinkWritePromise,
+            _ =>
+            {
+                WritableStreamOperations.FinishInFlightWrite(stream);
+
+                var state = stream.State;
+
+                // The chunk leaves the queue only once the sink has taken it, which is what makes
+                // desiredSize describe what is still outstanding rather than what has been handed over.
+                controller.Queue.Dequeue();
+
+                if (!WritableStreamOperations.CloseQueuedOrInFlight(stream) && state == WritableStreamState.Writable)
+                {
+                    WritableStreamOperations.UpdateBackpressure(stream, GetBackpressure(controller));
+                }
+
+                AdvanceQueueIfNeeded(controller);
+            },
+            reason =>
+            {
+                if (stream.State == WritableStreamState.Writable)
+                {
+                    ClearAlgorithms(controller);
+                }
+
+                WritableStreamOperations.FinishInFlightWriteWithError(stream, reason);
+            });
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-default-controller-write
+    /// </summary>
+    internal static void Write(JsWritableStreamDefaultController controller, JsValue chunk, double chunkSize)
+    {
+        try
+        {
+            controller.Queue.Enqueue(controller.Realm, chunk, chunkSize);
+        }
+        catch (JavaScriptException e)
+        {
+            // A size the queue refuses errors the stream rather than escaping to the caller: the caller is
+            // writer.write(), whose promise is the write request already queued for this chunk.
+            ErrorIfNeeded(controller, e.Error);
+            return;
+        }
+
+        var stream = controller.Stream;
+        if (!WritableStreamOperations.CloseQueuedOrInFlight(stream) && stream.State == WritableStreamState.Writable)
+        {
+            WritableStreamOperations.UpdateBackpressure(stream, GetBackpressure(controller));
+        }
+
+        AdvanceQueueIfNeeded(controller);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#ws-default-controller-private-abort
+    /// </summary>
+    internal static JsPromise AbortSteps(JsWritableStreamDefaultController controller, JsValue reason)
+    {
+        var result = controller.AbortAlgorithm!(reason);
+        ClearAlgorithms(controller);
+        return result;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#ws-default-controller-private-error
+    /// </summary>
+    internal static void ErrorSteps(JsWritableStreamDefaultController controller) => controller.Queue.Reset();
+}
+#endif

--- a/Jint/WebApi/Streams/WritableStreamDefaultControllerPrototype.cs
+++ b/Jint/WebApi/Streams/WritableStreamDefaultControllerPrototype.cs
@@ -1,0 +1,78 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.Abort;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// <c>WritableStreamDefaultController.prototype</c> — the interface prototype object.
+/// <para>
+/// https://streams.spec.whatwg.org/#ws-default-controller-prototype
+/// </para>
+/// </summary>
+[JsObject(UseShape = true)]
+internal sealed partial class WritableStreamDefaultControllerPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly WritableStreamDefaultControllerConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString ControllerToStringTag = new("WritableStreamDefaultController");
+
+    internal WritableStreamDefaultControllerPrototype(
+        Engine engine,
+        Realm realm,
+        WritableStreamDefaultControllerConstructor constructor,
+        ObjectInstance objectPrototype) : base(engine, realm)
+    {
+        _prototype = objectPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#ws-default-controller-signal — an <c>AbortSignal</c> a sink can
+    /// watch to abandon a write or a close the moment the stream is aborted, rather than discovering it only
+    /// when its own promise is no longer listened to.
+    /// </summary>
+    [JsAccessor("signal", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsAbortSignal SignalGet(JsValue thisObject) => Brand(thisObject).Signal;
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#ws-default-controller-error — silently does nothing unless the
+    /// stream is still writable.
+    /// </summary>
+    [JsFunction(Name = "error", Length = 0)]
+    private JsValue Error(JsValue thisObject, JsValue error)
+    {
+        var controller = Brand(thisObject);
+
+        if (controller.Stream.State != WritableStreamState.Writable)
+        {
+            return Undefined;
+        }
+
+        WritableStreamDefaultControllerOperations.Error(controller, error);
+        return Undefined;
+    }
+
+    private JsWritableStreamDefaultController Brand(JsValue thisObject)
+    {
+        if (thisObject is JsWritableStreamDefaultController controller)
+        {
+            return controller;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a WritableStreamDefaultController");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/WritableStreamDefaultWriterConstructor.cs
+++ b/Jint/WebApi/Streams/WritableStreamDefaultWriterConstructor.cs
@@ -1,0 +1,65 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// The <c>WritableStreamDefaultWriter</c> interface object.
+/// <para>
+/// https://streams.spec.whatwg.org/#default-writer-class
+/// </para>
+/// </summary>
+/// <remarks>
+/// Constructible with a stream, exactly as <c>ReadableStreamDefaultReader</c> is:
+/// <c>new WritableStreamDefaultWriter(stream)</c> is <c>stream.getWriter()</c>. Not installed as a global;
+/// reached through <c>Object.getPrototypeOf(writer).constructor</c>.
+/// </remarks>
+internal sealed class WritableStreamDefaultWriterConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("WritableStreamDefaultWriter");
+
+    internal WritableStreamDefaultWriterConstructor(
+        Engine engine,
+        Realm realm,
+        FunctionPrototype functionPrototype,
+        ObjectPrototype objectPrototype)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = functionPrototype;
+        PrototypeObject = new WritableStreamDefaultWriterPrototype(engine, realm, this, objectPrototype);
+        _length = new PropertyDescriptor(JsNumber.PositiveOne, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal WritableStreamDefaultWriterPrototype PrototypeObject { get; }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#default-writer-constructor
+    /// </summary>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        if (newTarget.IsUndefined())
+        {
+            Throw.TypeError(_realm, $"Constructor {GetOwnFunctionNameForMessage()} requires 'new'");
+        }
+
+        if (arguments.At(0) is not JsWritableStream stream)
+        {
+            Throw.TypeError(_realm, "Failed to construct 'WritableStreamDefaultWriter': the argument is not a WritableStream");
+            return null!;
+        }
+
+        var writer = OrdinaryCreateFromConstructor(
+            newTarget,
+            static intrinsics => intrinsics.WritableStreamDefaultWriter.PrototypeObject,
+            static (Engine engine, Realm realm, object? _) => new JsWritableStreamDefaultWriter(engine, realm));
+
+        WritableStreamOperations.SetUpDefaultWriter(writer, stream);
+        return writer;
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/WritableStreamDefaultWriterPrototype.cs
+++ b/Jint/WebApi/Streams/WritableStreamDefaultWriterPrototype.cs
@@ -1,0 +1,202 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// <c>WritableStreamDefaultWriter.prototype</c> — the interface prototype object.
+/// <para>
+/// https://streams.spec.whatwg.org/#default-writer-prototype
+/// </para>
+/// </summary>
+/// <remarks>
+/// <c>desiredSize</c> is the odd one out: it is an <c>unrestricted double?</c> rather than a promise, so a
+/// released writer makes it <b>throw</b> where every other member of this prototype answers with a rejected
+/// promise.
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class WritableStreamDefaultWriterPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly WritableStreamDefaultWriterConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString WriterToStringTag = new("WritableStreamDefaultWriter");
+
+    internal WritableStreamDefaultWriterPrototype(
+        Engine engine,
+        Realm realm,
+        WritableStreamDefaultWriterConstructor constructor,
+        ObjectInstance objectPrototype) : base(engine, realm)
+    {
+        _prototype = objectPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#default-writer-closed
+    /// </summary>
+    [JsAccessor("closed", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsPromise ClosedGet(JsValue thisObject)
+    {
+        if (thisObject is not JsWritableStreamDefaultWriter writer)
+        {
+            return RejectedTypeError();
+        }
+
+        return writer.ClosedPromise;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#default-writer-desired-size
+    /// </summary>
+    [JsAccessor("desiredSize", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue DesiredSizeGet(JsValue thisObject)
+    {
+        var writer = Brand(thisObject);
+
+        if (writer.Stream is null)
+        {
+            Throw.TypeError(_realm, "Cannot read the desired size of a released writer");
+        }
+
+        var desiredSize = WritableStreamOperations.DefaultWriterGetDesiredSize(writer);
+        return desiredSize is { } value ? JsNumber.Create(value) : Null;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#default-writer-ready — fulfils when the destination stops applying
+    /// backpressure, and is replaced by a fresh pending promise each time backpressure returns.
+    /// </summary>
+    [JsAccessor("ready", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsPromise ReadyGet(JsValue thisObject)
+    {
+        if (thisObject is not JsWritableStreamDefaultWriter writer)
+        {
+            return RejectedTypeError();
+        }
+
+        return writer.ReadyPromise;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#default-writer-abort
+    /// </summary>
+    [JsFunction(Name = "abort", Length = 0)]
+    private JsPromise Abort(JsValue thisObject, JsValue reason)
+    {
+        try
+        {
+            var writer = Brand(thisObject);
+
+            if (writer.Stream is null)
+            {
+                Throw.TypeError(_realm, "Cannot abort a stream using a released writer");
+            }
+
+            return WritableStreamOperations.DefaultWriterAbort(writer, reason);
+        }
+        catch (JavaScriptException e)
+        {
+            return StreamPromises.RejectedWith(_engine, _realm, e.Error);
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#default-writer-close
+    /// </summary>
+    [JsFunction(Name = "close", Length = 0)]
+    private JsPromise Close(JsValue thisObject)
+    {
+        try
+        {
+            var writer = Brand(thisObject);
+            var stream = writer.Stream;
+
+            if (stream is null)
+            {
+                Throw.TypeError(_realm, "Cannot close a stream using a released writer");
+                return null!;
+            }
+
+            if (WritableStreamOperations.CloseQueuedOrInFlight(stream))
+            {
+                Throw.TypeError(_realm, "Cannot close an already-closing writable stream");
+            }
+
+            return WritableStreamOperations.DefaultWriterClose(writer);
+        }
+        catch (JavaScriptException e)
+        {
+            return StreamPromises.RejectedWith(_engine, _realm, e.Error);
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#default-writer-release-lock — the lock may be released while writes
+    /// are still outstanding: it prevents interleaved producers, it does not span the writes themselves.
+    /// </summary>
+    [JsFunction(Name = "releaseLock", Length = 0)]
+    private JsValue ReleaseLock(JsValue thisObject)
+    {
+        var writer = Brand(thisObject);
+
+        if (writer.Stream is null)
+        {
+            return Undefined;
+        }
+
+        WritableStreamOperations.DefaultWriterRelease(writer);
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#default-writer-write
+    /// </summary>
+    [JsFunction(Name = "write", Length = 0)]
+    private JsPromise Write(JsValue thisObject, JsValue chunk)
+    {
+        try
+        {
+            var writer = Brand(thisObject);
+
+            if (writer.Stream is null)
+            {
+                Throw.TypeError(_realm, "Cannot write to a stream using a released writer");
+            }
+
+            return WritableStreamOperations.DefaultWriterWrite(writer, chunk);
+        }
+        catch (JavaScriptException e)
+        {
+            return StreamPromises.RejectedWith(_engine, _realm, e.Error);
+        }
+    }
+
+    private JsPromise RejectedTypeError()
+        => StreamPromises.RejectedWith(
+            _engine,
+            _realm,
+            _realm.Intrinsics.TypeError.Construct("Illegal invocation: receiver is not a WritableStreamDefaultWriter"));
+
+    private JsWritableStreamDefaultWriter Brand(JsValue thisObject)
+    {
+        if (thisObject is JsWritableStreamDefaultWriter writer)
+        {
+            return writer;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a WritableStreamDefaultWriter");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/WritableStreamOperations.cs
+++ b/Jint/WebApi/Streams/WritableStreamOperations.cs
@@ -1,0 +1,575 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Promise;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// The writable-stream abstract operations: "working with writable streams", "interfacing with controllers"
+/// and "writers".
+/// <para>
+/// https://streams.spec.whatwg.org/#ws-abstract-ops
+/// </para>
+/// </summary>
+internal static class WritableStreamOperations
+{
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#is-writable-stream-locked
+    /// </summary>
+    internal static bool IsLocked(JsWritableStream stream) => stream.Writer is not null;
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#create-writable-stream — the entry point for streams the engine
+    /// builds itself, which today means a transform stream's writable side.
+    /// </summary>
+    internal static JsWritableStream CreateWritableStream(
+        Engine engine,
+        Realm realm,
+        Func<JsValue> startAlgorithm,
+        Func<JsValue, JsPromise> writeAlgorithm,
+        Func<JsPromise> closeAlgorithm,
+        Func<JsValue, JsPromise> abortAlgorithm,
+        double highWaterMark,
+        Func<JsValue, double> sizeAlgorithm)
+    {
+        var stream = new JsWritableStream(engine, realm)
+        {
+            _prototype = realm.Intrinsics.WritableStream.PrototypeObject,
+        };
+
+        var controller = new JsWritableStreamDefaultController(engine, realm)
+        {
+            _prototype = realm.Intrinsics.WritableStreamDefaultController.PrototypeObject,
+        };
+
+        WritableStreamDefaultControllerOperations.SetUp(
+            stream, controller, startAlgorithm, writeAlgorithm, closeAlgorithm, abortAlgorithm, highWaterMark, sizeAlgorithm);
+
+        return stream;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-abort
+    /// </summary>
+    internal static JsPromise Abort(JsWritableStream stream, JsValue reason)
+    {
+        var engine = stream.Engine;
+        var realm = stream.Realm;
+
+        if (stream.State is WritableStreamState.Closed or WritableStreamState.Errored)
+        {
+            return StreamPromises.ResolvedWithUndefined(engine, realm);
+        }
+
+        // The controller's signal is aborted first, so a sink that watches it can abandon an in-flight
+        // write before any of the bookkeeping below runs — and before it is asked to abort.
+        stream.Controller.SignalAbort(reason);
+
+        // Aborting the signal runs author code (the signal's abort event listeners), which may have closed
+        // or errored the stream in the meantime, so the state is re-read.
+        var state = stream.State;
+        if (state is WritableStreamState.Closed or WritableStreamState.Errored)
+        {
+            return StreamPromises.ResolvedWithUndefined(engine, realm);
+        }
+
+        if (stream.PendingAbortRequest is { } existing)
+        {
+            return StreamPromises.PromiseOf(existing.Capability);
+        }
+
+        var wasAlreadyErroring = state == WritableStreamState.Erroring;
+        if (wasAlreadyErroring)
+        {
+            // The reason will not be used — the stream already has a stored error — so it is not retained.
+            reason = JsValue.Undefined;
+        }
+
+        var capability = StreamPromises.NewPromise(engine, realm);
+        stream.PendingAbortRequest = new PendingAbortRequest(capability, reason, wasAlreadyErroring);
+
+        if (!wasAlreadyErroring)
+        {
+            StartErroring(stream, reason);
+        }
+
+        return StreamPromises.PromiseOf(capability);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-close
+    /// </summary>
+    internal static JsPromise Close(JsWritableStream stream)
+    {
+        var engine = stream.Engine;
+        var realm = stream.Realm;
+        var state = stream.State;
+
+        if (state is WritableStreamState.Closed or WritableStreamState.Errored)
+        {
+            return StreamPromises.RejectedWith(
+                engine,
+                realm,
+                realm.Intrinsics.TypeError.Construct(
+                    $"The stream (in {StateName(state)} state) is not in the writable state and cannot be closed"));
+        }
+
+        var capability = StreamPromises.NewPromise(engine, realm);
+        stream.CloseRequest = capability;
+
+        // A producer blocked on `ready` is released: nothing more can be written, so leaving it pending
+        // would strand an `await writer.ready` forever.
+        var writer = stream.Writer;
+        if (writer is not null && stream.Backpressure && state == WritableStreamState.Writable)
+        {
+            writer.ReadyCapability.Resolve(JsValue.Undefined);
+        }
+
+        WritableStreamDefaultControllerOperations.Close(stream.Controller);
+
+        return StreamPromises.PromiseOf(capability);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-add-write-request
+    /// </summary>
+    private static JsPromise AddWriteRequest(JsWritableStream stream)
+    {
+        var capability = StreamPromises.NewPromise(stream.Engine, stream.Realm);
+        stream.WriteRequests.Enqueue(capability);
+        return StreamPromises.PromiseOf(capability);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-close-queued-or-in-flight
+    /// </summary>
+    internal static bool CloseQueuedOrInFlight(JsWritableStream stream)
+        => stream.CloseRequest is not null || stream.InFlightCloseRequest is not null;
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-deal-with-rejection
+    /// </summary>
+    internal static void DealWithRejection(JsWritableStream stream, JsValue error)
+    {
+        if (stream.State == WritableStreamState.Writable)
+        {
+            StartErroring(stream, error);
+            return;
+        }
+
+        FinishErroring(stream);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-start-erroring
+    /// </summary>
+    internal static void StartErroring(JsWritableStream stream, JsValue reason)
+    {
+        var controller = stream.Controller;
+
+        stream.State = WritableStreamState.Erroring;
+        stream.StoredError = reason;
+
+        if (stream.Writer is { } writer)
+        {
+            EnsureReadyPromiseRejected(writer, reason);
+        }
+
+        // The stream cannot finish erroring while the sink is mid-write or mid-close, nor before start()
+        // has settled: either would run abort() out of order.
+        if (!HasOperationMarkedInFlight(stream) && controller.Started)
+        {
+            FinishErroring(stream);
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-finish-erroring
+    /// </summary>
+    internal static void FinishErroring(JsWritableStream stream)
+    {
+        var engine = stream.Engine;
+
+        stream.State = WritableStreamState.Errored;
+        WritableStreamDefaultControllerOperations.ErrorSteps(stream.Controller);
+
+        var storedError = stream.StoredError;
+        while (stream.WriteRequests.Count > 0)
+        {
+            stream.WriteRequests.Dequeue().Reject(storedError);
+        }
+
+        var abortRequest = stream.PendingAbortRequest;
+        if (abortRequest is null)
+        {
+            RejectCloseAndClosedPromiseIfNeeded(stream);
+            return;
+        }
+
+        stream.PendingAbortRequest = null;
+
+        if (abortRequest.WasAlreadyErroring)
+        {
+            // The stream was already failing for another reason, so the abort merely observes it.
+            abortRequest.Capability.Reject(storedError);
+            RejectCloseAndClosedPromiseIfNeeded(stream);
+            return;
+        }
+
+        var promise = WritableStreamDefaultControllerOperations.AbortSteps(stream.Controller, abortRequest.Reason);
+        StreamPromises.UponPromise(
+            engine,
+            promise,
+            _ =>
+            {
+                abortRequest.Capability.Resolve(JsValue.Undefined);
+                RejectCloseAndClosedPromiseIfNeeded(stream);
+            },
+            reason =>
+            {
+                abortRequest.Capability.Reject(reason);
+                RejectCloseAndClosedPromiseIfNeeded(stream);
+            });
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-finish-in-flight-close
+    /// </summary>
+    internal static void FinishInFlightClose(JsWritableStream stream)
+    {
+        stream.InFlightCloseRequest!.Resolve(JsValue.Undefined);
+        stream.InFlightCloseRequest = null;
+
+        if (stream.State == WritableStreamState.Erroring)
+        {
+            // The error arrived too late to matter: the sink closed successfully, so it is discarded and any
+            // abort waiting on it is told the stream shut down cleanly.
+            stream.StoredError = JsValue.Undefined;
+            if (stream.PendingAbortRequest is { } pending)
+            {
+                pending.Capability.Resolve(JsValue.Undefined);
+                stream.PendingAbortRequest = null;
+            }
+        }
+
+        stream.State = WritableStreamState.Closed;
+
+        stream.Writer?.ClosedCapability.Resolve(JsValue.Undefined);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-finish-in-flight-close-with-error
+    /// </summary>
+    internal static void FinishInFlightCloseWithError(JsWritableStream stream, JsValue error)
+    {
+        stream.InFlightCloseRequest!.Reject(error);
+        stream.InFlightCloseRequest = null;
+
+        // The sink's abort() is never run after its close(): a close that failed has already told the sink
+        // everything there is to tell.
+        if (stream.PendingAbortRequest is { } pending)
+        {
+            pending.Capability.Reject(error);
+            stream.PendingAbortRequest = null;
+        }
+
+        DealWithRejection(stream, error);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-finish-in-flight-write
+    /// </summary>
+    internal static void FinishInFlightWrite(JsWritableStream stream)
+    {
+        stream.InFlightWriteRequest!.Resolve(JsValue.Undefined);
+        stream.InFlightWriteRequest = null;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-finish-in-flight-write-with-error
+    /// </summary>
+    internal static void FinishInFlightWriteWithError(JsWritableStream stream, JsValue error)
+    {
+        stream.InFlightWriteRequest!.Reject(error);
+        stream.InFlightWriteRequest = null;
+
+        DealWithRejection(stream, error);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-has-operation-marked-in-flight
+    /// </summary>
+    internal static bool HasOperationMarkedInFlight(JsWritableStream stream)
+        => stream.InFlightWriteRequest is not null || stream.InFlightCloseRequest is not null;
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-mark-close-request-in-flight
+    /// </summary>
+    internal static void MarkCloseRequestInFlight(JsWritableStream stream)
+    {
+        stream.InFlightCloseRequest = stream.CloseRequest;
+        stream.CloseRequest = null;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-mark-first-write-request-in-flight
+    /// </summary>
+    internal static void MarkFirstWriteRequestInFlight(JsWritableStream stream)
+        => stream.InFlightWriteRequest = stream.WriteRequests.Dequeue();
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-reject-close-and-closed-promise-if-needed
+    /// </summary>
+    private static void RejectCloseAndClosedPromiseIfNeeded(JsWritableStream stream)
+    {
+        if (stream.CloseRequest is { } closeRequest)
+        {
+            closeRequest.Reject(stream.StoredError);
+            stream.CloseRequest = null;
+        }
+
+        if (stream.Writer is { } writer)
+        {
+            writer.ClosedCapability.Reject(stream.StoredError);
+            StreamPromises.MarkHandled(writer.ClosedPromise);
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-update-backpressure
+    /// </summary>
+    internal static void UpdateBackpressure(JsWritableStream stream, bool backpressure)
+    {
+        var writer = stream.Writer;
+        if (writer is not null && backpressure != stream.Backpressure)
+        {
+            if (backpressure)
+            {
+                // A fresh pending promise: `await writer.ready` from here on waits for the next transition.
+                writer.ReadyCapability = StreamPromises.NewPromise(stream.Engine, stream.Realm);
+            }
+            else
+            {
+                writer.ReadyCapability.Resolve(JsValue.Undefined);
+            }
+        }
+
+        stream.Backpressure = backpressure;
+    }
+
+    // ---- Writers ----
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#acquire-writable-stream-default-writer
+    /// </summary>
+    internal static JsWritableStreamDefaultWriter AcquireDefaultWriter(JsWritableStream stream)
+    {
+        var writer = new JsWritableStreamDefaultWriter(stream.Engine, stream.Realm)
+        {
+            _prototype = stream.Realm.Intrinsics.WritableStreamDefaultWriter.PrototypeObject,
+        };
+
+        SetUpDefaultWriter(writer, stream);
+        return writer;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#set-up-writable-stream-default-writer
+    /// </summary>
+    internal static void SetUpDefaultWriter(JsWritableStreamDefaultWriter writer, JsWritableStream stream)
+    {
+        var engine = writer.Engine;
+        var realm = writer.Realm;
+
+        if (IsLocked(stream))
+        {
+            Throw.TypeError(realm, "This writable stream is already locked for exclusive writing by another writer");
+        }
+
+        writer.Stream = stream;
+        stream.Writer = writer;
+
+        var ready = StreamPromises.NewPromise(engine, realm);
+        var closed = StreamPromises.NewPromise(engine, realm);
+        writer.ReadyCapability = ready;
+        writer.ClosedCapability = closed;
+
+        switch (stream.State)
+        {
+            case WritableStreamState.Writable:
+                // A writer acquired while the stream is applying backpressure starts out not ready.
+                if (CloseQueuedOrInFlight(stream) || !stream.Backpressure)
+                {
+                    ready.Resolve(JsValue.Undefined);
+                }
+
+                break;
+
+            case WritableStreamState.Erroring:
+                StreamPromises.MarkHandled(StreamPromises.PromiseOf(ready));
+                ready.Reject(stream.StoredError);
+                break;
+
+            case WritableStreamState.Closed:
+                ready.Resolve(JsValue.Undefined);
+                closed.Resolve(JsValue.Undefined);
+                break;
+
+            default:
+                StreamPromises.MarkHandled(StreamPromises.PromiseOf(ready));
+                ready.Reject(stream.StoredError);
+                StreamPromises.MarkHandled(StreamPromises.PromiseOf(closed));
+                closed.Reject(stream.StoredError);
+                break;
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-default-writer-abort
+    /// </summary>
+    internal static JsPromise DefaultWriterAbort(JsWritableStreamDefaultWriter writer, JsValue reason)
+        => Abort(writer.Stream!, reason);
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-default-writer-close
+    /// </summary>
+    internal static JsPromise DefaultWriterClose(JsWritableStreamDefaultWriter writer) => Close(writer.Stream!);
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-default-writer-close-with-error-propagation — what
+    /// piping uses to close the destination: a stream that is already closing or closed is not closed again,
+    /// and an errored one reports its error rather than a "cannot close" <c>TypeError</c>.
+    /// </summary>
+    internal static JsPromise DefaultWriterCloseWithErrorPropagation(JsWritableStreamDefaultWriter writer)
+    {
+        var stream = writer.Stream!;
+        var state = stream.State;
+
+        if (CloseQueuedOrInFlight(stream) || state == WritableStreamState.Closed)
+        {
+            return StreamPromises.ResolvedWithUndefined(stream.Engine, stream.Realm);
+        }
+
+        if (state == WritableStreamState.Errored)
+        {
+            return StreamPromises.RejectedWith(stream.Engine, stream.Realm, stream.StoredError);
+        }
+
+        return DefaultWriterClose(writer);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-default-writer-ensure-closed-promise-rejected
+    /// </summary>
+    private static void EnsureClosedPromiseRejected(JsWritableStreamDefaultWriter writer, JsValue error)
+    {
+        if (writer.ClosedPromise.State != PromiseState.Pending)
+        {
+            writer.ClosedCapability = StreamPromises.NewPromise(writer.Engine, writer.Realm);
+        }
+
+        writer.ClosedCapability.Reject(error);
+        StreamPromises.MarkHandled(writer.ClosedPromise);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-default-writer-ensure-ready-promise-rejected
+    /// </summary>
+    private static void EnsureReadyPromiseRejected(JsWritableStreamDefaultWriter writer, JsValue error)
+    {
+        if (writer.ReadyPromise.State != PromiseState.Pending)
+        {
+            writer.ReadyCapability = StreamPromises.NewPromise(writer.Engine, writer.Realm);
+        }
+
+        writer.ReadyCapability.Reject(error);
+        StreamPromises.MarkHandled(writer.ReadyPromise);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-default-writer-get-desired-size
+    /// </summary>
+    internal static double? DefaultWriterGetDesiredSize(JsWritableStreamDefaultWriter writer)
+    {
+        var stream = writer.Stream!;
+
+        return stream.State switch
+        {
+            WritableStreamState.Errored or WritableStreamState.Erroring => null,
+            WritableStreamState.Closed => 0,
+            _ => WritableStreamDefaultControllerOperations.GetDesiredSize(stream.Controller),
+        };
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-default-writer-release
+    /// </summary>
+    internal static void DefaultWriterRelease(JsWritableStreamDefaultWriter writer)
+    {
+        var stream = writer.Stream!;
+
+        var released = writer.Realm.Intrinsics.TypeError.Construct(
+            "Writer was released and can no longer be used to monitor the stream's closedness");
+
+        EnsureReadyPromiseRejected(writer, released);
+
+        // The state transitions to "errored" before the sink's abort() runs, but the writer's closed promise
+        // is not rejected until afterwards, so testing the state would not be enough here.
+        EnsureClosedPromiseRejected(writer, released);
+
+        stream.Writer = null;
+        writer.Stream = null;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#writable-stream-default-writer-write
+    /// </summary>
+    internal static JsPromise DefaultWriterWrite(JsWritableStreamDefaultWriter writer, JsValue chunk)
+    {
+        var stream = writer.Stream!;
+        var engine = stream.Engine;
+        var realm = stream.Realm;
+        var controller = stream.Controller;
+
+        // The strategy's size() runs first and can do anything, including release this very writer.
+        var chunkSize = WritableStreamDefaultControllerOperations.GetChunkSize(controller, chunk);
+
+        if (!ReferenceEquals(stream, writer.Stream))
+        {
+            return StreamPromises.RejectedWith(
+                engine, realm, realm.Intrinsics.TypeError.Construct("Cannot write to a stream using a released writer"));
+        }
+
+        var state = stream.State;
+        if (state == WritableStreamState.Errored)
+        {
+            return StreamPromises.RejectedWith(engine, realm, stream.StoredError);
+        }
+
+        if (CloseQueuedOrInFlight(stream) || state == WritableStreamState.Closed)
+        {
+            return StreamPromises.RejectedWith(
+                engine, realm, realm.Intrinsics.TypeError.Construct("The stream is closing or closed and cannot be written to"));
+        }
+
+        if (state == WritableStreamState.Erroring)
+        {
+            return StreamPromises.RejectedWith(engine, realm, stream.StoredError);
+        }
+
+        var promise = AddWriteRequest(stream);
+        WritableStreamDefaultControllerOperations.Write(controller, chunk, chunkSize);
+        return promise;
+    }
+
+    /// <summary>The specification's own spelling of a state, for the messages that name one.</summary>
+    private static string StateName(WritableStreamState state) => state switch
+    {
+        WritableStreamState.Writable => "writable",
+        WritableStreamState.Erroring => "erroring",
+        WritableStreamState.Closed => "closed",
+        _ => "errored",
+    };
+}
+#endif

--- a/Jint/WebApi/Streams/WritableStreamPrototype.cs
+++ b/Jint/WebApi/Streams/WritableStreamPrototype.cs
@@ -1,0 +1,116 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// <c>WritableStream.prototype</c> — the interface prototype object.
+/// <para>
+/// https://streams.spec.whatwg.org/#ws-prototype
+/// </para>
+/// </summary>
+[JsObject(UseShape = true)]
+internal sealed partial class WritableStreamPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly WritableStreamConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString WritableStreamToStringTag = new("WritableStream");
+
+    internal WritableStreamPrototype(
+        Engine engine,
+        Realm realm,
+        WritableStreamConstructor constructor,
+        ObjectInstance objectPrototype) : base(engine, realm)
+    {
+        _prototype = objectPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#ws-locked
+    /// </summary>
+    [JsAccessor("locked", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsBoolean LockedGet(JsValue thisObject)
+        => WritableStreamOperations.IsLocked(Brand(thisObject)) ? JsBoolean.True : JsBoolean.False;
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#ws-abort
+    /// </summary>
+    [JsFunction(Name = "abort", Length = 0)]
+    private JsPromise Abort(JsValue thisObject, JsValue reason)
+    {
+        try
+        {
+            var stream = Brand(thisObject);
+
+            if (WritableStreamOperations.IsLocked(stream))
+            {
+                Throw.TypeError(_realm, "Cannot abort a writable stream that is locked to a writer");
+            }
+
+            return WritableStreamOperations.Abort(stream, reason);
+        }
+        catch (JavaScriptException e)
+        {
+            return StreamPromises.RejectedWith(_engine, _realm, e.Error);
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#ws-close
+    /// </summary>
+    [JsFunction(Name = "close", Length = 0)]
+    private JsPromise Close(JsValue thisObject)
+    {
+        try
+        {
+            var stream = Brand(thisObject);
+
+            if (WritableStreamOperations.IsLocked(stream))
+            {
+                Throw.TypeError(_realm, "Cannot close a writable stream that is locked to a writer");
+            }
+
+            if (WritableStreamOperations.CloseQueuedOrInFlight(stream))
+            {
+                Throw.TypeError(_realm, "Cannot close an already-closing writable stream");
+            }
+
+            return WritableStreamOperations.Close(stream);
+        }
+        catch (JavaScriptException e)
+        {
+            return StreamPromises.RejectedWith(_engine, _realm, e.Error);
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#ws-get-writer
+    /// </summary>
+    [JsFunction(Name = "getWriter", Length = 0)]
+    private JsWritableStreamDefaultWriter GetWriter(JsValue thisObject)
+        => WritableStreamOperations.AcquireDefaultWriter(Brand(thisObject));
+
+    private JsWritableStream Brand(JsValue thisObject)
+    {
+        if (thisObject is JsWritableStream stream)
+        {
+            return stream;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a WritableStream");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/WebApiRegistration.cs
+++ b/Jint/WebApi/WebApiRegistration.cs
@@ -138,6 +138,19 @@ internal static class WebApiRegistration
             // the interface objects above — https://webidl.spec.whatwg.org/#es-operations.
             Install(global, engine, "fetch", static e => e.Realm.Intrinsics.Fetch, PropertyFlag.ConfigurableEnumerableWritable);
         }
+
+        if ((features & WebApiFeatures.Streams) != WebApiFeatures.None)
+        {
+            // Only the five interfaces a script constructs directly are globals. ReadableStreamDefaultReader,
+            // the three controllers and WritableStreamDefaultWriter exist as ordinary interface objects and
+            // are reached through their instances' prototypes — a deliberate, documented narrowing of the
+            // browser surface, since nothing but feature detection ever names them.
+            Install(global, engine, "ReadableStream", static e => e.Realm.Intrinsics.ReadableStream, PropertyFlag.NonEnumerable);
+            Install(global, engine, "WritableStream", static e => e.Realm.Intrinsics.WritableStream, PropertyFlag.NonEnumerable);
+            Install(global, engine, "TransformStream", static e => e.Realm.Intrinsics.TransformStream, PropertyFlag.NonEnumerable);
+            Install(global, engine, "ByteLengthQueuingStrategy", static e => e.Realm.Intrinsics.ByteLengthQueuingStrategy, PropertyFlag.NonEnumerable);
+            Install(global, engine, "CountQueuingStrategy", static e => e.Realm.Intrinsics.CountQueuingStrategy, PropertyFlag.NonEnumerable);
+        }
     }
 
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ its own `console` (or any other name in the table below), enabling the feature l
 | `URL` / `URLSearchParams` | `Url` | ✔ shipped |
 | `Blob` / `File` / `FormData` | `Files` | ✔ shipped |
 | `navigator.userAgent` | `Navigator` | ✔ shipped |
+| `ReadableStream` / `WritableStream` / `TransformStream` / `ByteLengthQueuingStrategy` / `CountQueuingStrategy` | `Streams` | ✔ shipped |
 | `fetch` / `Headers` / `Request` / `Response` | `Fetch` — **opt-in on its own, see below** | ✔ shipped |
 
 `WebApiFeatures.Default` — what `UseWebApis()` enables — is every non-network feature that has landed. It
@@ -385,6 +386,28 @@ not carry CR or LF, and a URL with credentials in it is refused. Every network-c
 failures apart; the real cause rides the error value and is readable by the host through
 `JintException.TryGetClrException`. See [THREAT_MODEL.md](.github/THREAT_MODEL.md) TM-21 for the full
 analysis, including what these controls do *not* cover.
+
+### Streams are the default (non-byte) half of the standard
+
+`ReadableStream`, `WritableStream` and `TransformStream` implement the WHATWG Streams Standard operation by
+operation: queuing strategies and `desiredSize`, the `pull` reentrancy rules, `tee()` with its composite
+cancellation, `pipeTo()` / `pipeThrough()` with `preventClose` / `preventAbort` / `preventCancel` and an
+`AbortSignal`, asynchronous iteration of a readable stream (`for await…of`, and `values({ preventCancel })`),
+and `ReadableStream.from()` for any sync or async iterable. Every promise they hand out is an ordinary engine
+promise and every callback you supply — `start`, `pull`, `cancel`, `write`, `close`, `abort`, `transform`,
+`flush`, `size` — runs on the engine's thread from the same job queue that runs promise reactions, so the
+microtask ordering the standard prescribes is the ordering you get, and nothing here ever starts a thread.
+
+Two deliberate reductions:
+
+- **Byte streams are absent, not broken.** There is no `ReadableByteStreamController`, no BYOB reader and no
+  `ReadableStreamBYOBRequest`, and `new ReadableStream({ type: 'bytes' })` raises a `TypeError` rather than
+  handing back something that is not a byte stream. `getReader({ mode: 'byob' })` raises the same `TypeError`
+  the standard gives for a stream that was not constructed with a byte source.
+- **Only the five interfaces a script constructs by name are globals.** `ReadableStreamDefaultReader`,
+  `WritableStreamDefaultWriter` and the three controllers exist as ordinary interface objects — a reader's
+  `constructor` is the real thing, and `new` on it behaves as the standard says — but they are not installed
+  on `globalThis`, where a browser would expose them.
 
 
 ## Performance


### PR DESCRIPTION
First slice of #3082: the WHATWG Streams Standard's default (non-byte) surface as `WebApiFeatures.Streams` (part of `Default`).

`ReadableStream`, `WritableStream` and `TransformStream` are implemented operation by operation from https://streams.spec.whatwg.org/: queuing strategies and `desiredSize`, the `pull` reentrancy rules, `tee()` with its composite cancellation, `pipeTo()`/`pipeThrough()` with `preventClose`/`preventAbort`/`preventCancel` and `AbortSignal` support, asynchronous iteration (`for await…of`, and `values({ preventCancel })`), and `ReadableStream.from()` for any sync or async iterable.

Every promise is an ordinary engine promise, and every host-visible callback — `start`, `pull`, `cancel`, `write`, `close`, `abort`, `transform`, `flush`, `size` — runs on the engine's thread from the same job queue that runs promise reactions, so the microtask ordering the standard prescribes is the ordering scripts observe, and nothing here ever starts a thread.

Two deliberate reductions, both documented:

- **Byte streams are absent, not broken.** No `ReadableByteStreamController`, no BYOB reader; `new ReadableStream({ type: 'bytes' })` raises a `TypeError`, and `getReader({ mode: 'byob' })` raises the same `TypeError` the standard gives for a stream not constructed with a byte source. Byte streams are tracked in #3105.
- **Only the five interfaces a script constructs by name are globals** (`ReadableStream`, `WritableStream`, `TransformStream`, `ByteLengthQueuingStrategy`, `CountQueuingStrategy`). `ReadableStreamDefaultReader`, `WritableStreamDefaultWriter` and the three controllers exist as ordinary interface objects — a reader's `constructor` is the real thing and `new` on it behaves per spec — but they are not installed on `globalThis`, since nothing but feature detection ever names them.

Tests exercise the reentrancy rules, tee cancellation composition, pipe option combinations, abort-mid-pipe, async iteration, and the queuing-strategy math; both suites green on net10.0 and net472, with and without `JINT_HOST_CONTRACT_VERIFICATION=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G7Ud48VAs1JicxRZxLDxg