### PR TITLE
Add opt-in scheduler.postTask, scheduler.yield and TaskController

### DIFF
--- a/Jint.Tests.PublicInterface/WebApiSchedulerTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiSchedulerTests.cs
@@ -1,0 +1,300 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.Diagnostics;
+using Jint;
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// The prioritized task scheduling API seen from outside the assembly: what a host has to write to get it,
+/// what it gets when it writes nothing, and how the tasks reach the host's own pump.
+/// </summary>
+/// <remarks>
+/// This project has no <c>InternalsVisibleTo</c>, so nothing here can reach the scheduler's queues directly —
+/// which is the point. Everything is asserted through script and through the public options surface, exactly
+/// as an embedder would have to.
+/// </remarks>
+public class WebApiSchedulerTests
+{
+    private static readonly string[] SchedulerGlobals = ["scheduler", "TaskController", "TaskSignal", "TaskPriorityChangeEvent"];
+
+    /// <summary>
+    /// A host-supplied clock, so that a suite exercising the <c>delay</c> option need not sleep.
+    /// </summary>
+    private sealed class ManualClock : TimeProvider
+    {
+        private long _timestamp;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp() => _timestamp;
+
+        public override DateTimeOffset GetUtcNow() => DateTimeOffset.UnixEpoch.AddTicks(_timestamp);
+
+        internal void Advance(int milliseconds) => _timestamp += milliseconds * TimeSpan.TicksPerMillisecond;
+    }
+
+    [Fact]
+    public void ADefaultEngineHasNoScheduler()
+    {
+        var engine = new Engine();
+
+        foreach (var name in SchedulerGlobals)
+        {
+            engine.Evaluate($"typeof {name}").AsString().Should().Be("undefined");
+            engine.Evaluate($"'{name}' in globalThis").AsBoolean().Should().BeFalse();
+        }
+    }
+
+    [Fact]
+    public void UseWebApisInstallsTheScheduler()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        engine.Evaluate("typeof scheduler").AsString().Should().Be("object");
+        engine.Evaluate("typeof scheduler.postTask").AsString().Should().Be("function");
+        engine.Evaluate("typeof scheduler.yield").AsString().Should().Be("function");
+
+        foreach (var name in new[] { "TaskController", "TaskSignal", "TaskPriorityChangeEvent" })
+        {
+            engine.Evaluate($"typeof {name}").AsString().Should().Be("function");
+        }
+
+        // The default set is what UseWebApis() means, and it names the scheduler.
+        new Options().UseWebApis().WebApi.Features.Should().HaveFlag(WebApiFeatures.Scheduler);
+    }
+
+    [Fact]
+    public void TheFeatureCanBeAskedForOnItsOwn()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Scheduler));
+
+        foreach (var name in SchedulerGlobals)
+        {
+            engine.Evaluate($"typeof {name}").AsString().Should().NotBe("undefined");
+        }
+
+        // ... and a host that asked for something else does not get it.
+        var console = new Engine(options => options.UseWebApis(WebApiFeatures.Console));
+        console.Evaluate("typeof scheduler").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void AGlobalTheHostRegisteredItselfWins()
+    {
+        var engine = new Engine(options => options
+            .Configure(e => e.SetValue("scheduler", "host's own"))
+            .UseWebApis());
+
+        engine.Evaluate("scheduler").AsString().Should().Be("host's own");
+    }
+
+    [Fact]
+    public void AShadowRealmHasNoScheduler()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        foreach (var name in SchedulerGlobals)
+        {
+            engine.Evaluate($"new ShadowRealm().evaluate('typeof {name}')").AsString().Should().Be("undefined");
+        }
+    }
+
+    [Fact]
+    public void TasksRunInPriorityOrderOnTheHostsOwnPump()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        var order = new List<string>();
+        engine.SetValue("record", new Action<string>(order.Add));
+
+        // Nothing has run yet when Execute returns? It has: Execute drains the loop once the script is done.
+        engine.Execute("""
+            scheduler.postTask(() => record('background'), { priority: 'background' });
+            scheduler.postTask(() => record('visible'));
+            scheduler.postTask(() => record('blocking'), { priority: 'user-blocking' });
+            """);
+
+        order.Should().Equal("blocking", "visible", "background");
+    }
+
+    [Fact]
+    public void AHostSuppliedClockDrivesTheDelayOption()
+    {
+        var clock = new ManualClock();
+        var engine = new Engine(options => options.UseWebApis(webApi => webApi.Timers.TimeProvider = clock));
+
+        var ran = false;
+        engine.SetValue("mark", new Action(() => ran = true));
+
+        engine.Execute("scheduler.postTask(mark, { delay: 100 });");
+        ran.Should().BeFalse();
+
+        // The engine is pumped, but the host's clock has not moved.
+        engine.Advanced.ProcessTasks();
+        ran.Should().BeFalse();
+
+        clock.Advance(100);
+        engine.Advanced.ProcessTasks();
+        ran.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AHostsOwnLoopIsEnoughToRunAChainOfTasks()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        var done = false;
+        engine.SetValue("done", new Action(() => done = true));
+
+        engine.Execute("""
+            scheduler.postTask(async () => {
+                await scheduler.yield();
+                await scheduler.postTask(() => {}, { delay: 20 });
+                done();
+            }, { priority: 'user-blocking' });
+            """);
+
+        var deadline = Stopwatch.StartNew();
+        while (!done && deadline.Elapsed < TimeSpan.FromSeconds(5))
+        {
+            // Nothing but the host's own pump: no engine thread, no background timer.
+            engine.Advanced.ProcessTasks();
+            Thread.Sleep(5);
+        }
+
+        done.Should().BeTrue();
+    }
+
+    [Fact]
+    public void APostedTaskIsAnOrdinaryPromiseAHostCanUnwrap()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        engine.Evaluate("scheduler.postTask(() => 6 * 7)").UnwrapIfPromise().AsNumber().Should().Be(42);
+    }
+
+    [Fact]
+    public async Task APostedTaskCanBeAwaitedThroughEvaluateAsync()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        var result = await engine.EvaluateAsync("""
+            (async () => {
+                const value = await scheduler.postTask(() => 'ready', { delay: 5 });
+                await scheduler.yield();
+                return value;
+            })()
+            """);
+
+        result.AsString().Should().Be("ready");
+    }
+
+    [Fact]
+    public void PostTaskReportsEveryFailureAsARejection()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        // A promise-returning operation never throws synchronously, so a host calling Evaluate gets a promise
+        // back even for an argument the engine refuses outright.
+        var rejected = engine.Evaluate("scheduler.postTask('not a function')");
+        Assert.Throws<PromiseRejectedException>(() => rejected.UnwrapIfPromise());
+
+        // The same for an abort, which carries whatever reason the script chose.
+        var aborted = engine.Evaluate("""
+            (() => {
+                const controller = new TaskController();
+                const promise = scheduler.postTask(() => 'never', { signal: controller.signal });
+                controller.abort('stopped');
+                return promise;
+            })()
+            """);
+
+        var exception = Assert.Throws<PromiseRejectedException>(() => aborted.UnwrapIfPromise());
+        exception.RejectedValue.AsString().Should().Be("stopped");
+    }
+
+    [Fact]
+    public void ATaskScheduledBeforeARestoreNeverRunsAfterIt()
+    {
+        var clock = new ManualClock();
+        var engine = new Engine(options => options.UseWebApis(webApi => webApi.Timers.TimeProvider = clock));
+
+        var ran = false;
+        engine.SetValue("mark", new Action(() => ran = true));
+
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+
+        engine.Execute("""
+            scheduler.postTask(mark, { priority: 'background', delay: 50 });
+            scheduler.postTask(mark, { delay: 50 });
+            """);
+
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        clock.Advance(1000);
+        engine.Advanced.ProcessTasks();
+
+        ran.Should().BeFalse();
+
+        // ... and the pooled engine schedules normally in its next cycle.
+        engine.SetValue("mark", new Action(() => ran = true));
+        engine.Execute("scheduler.postTask(mark);");
+        ran.Should().BeTrue();
+    }
+
+    [Fact]
+    public void OneOptionsInstanceGivesEachEngineItsOwnQueues()
+    {
+        var options = new Options().UseWebApis();
+
+        var first = new Engine(options);
+        var second = new Engine(options);
+
+        var order = new List<string>();
+        first.SetValue("record", new Action<string>(s => order.Add("first:" + s)));
+        second.SetValue("record", new Action<string>(s => order.Add("second:" + s)));
+
+        // Each engine's tasks are its own: nothing the first schedules can reach the second.
+        first.Execute("scheduler.postTask(() => record('a'), { priority: 'background' });");
+        second.Execute("scheduler.postTask(() => record('b'), { priority: 'user-blocking' });");
+
+        order.Should().Equal("first:a", "second:b");
+    }
+
+    [Fact]
+    public void AControllerTheHostKeepsCanStopScriptScheduledWorkLater()
+    {
+        var clock = new ManualClock();
+        var engine = new Engine(options => options.UseWebApis(webApi => webApi.Timers.TimeProvider = clock));
+
+        var order = new List<string>();
+        engine.SetValue("record", new Action<string>(order.Add));
+
+        // The controller stays in the host's reach as an ordinary JsValue, so a host can abort a batch of
+        // script-scheduled work between its own calls into the engine.
+        var controller = engine.Evaluate("globalThis.controller = new TaskController({ priority: 'background' })");
+        controller.IsObject().Should().BeTrue();
+
+        engine.Execute("""
+            scheduler.postTask(() => record('governed'), { signal: controller.signal, delay: 5 })
+                .catch(e => record('rejected:' + e.name));
+            scheduler.postTask(() => record('plain'), { priority: 'user-visible' });
+            """);
+
+        // The undelayed task has already run — Execute drains the loop — and the delayed one is still waiting
+        // on the host's clock.
+        order.Should().Equal("plain");
+
+        engine.Execute("controller.abort();");
+
+        clock.Advance(50);
+        engine.Advanced.ProcessTasks();
+
+        order.Should().Equal("plain", "rejected:AbortError");
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/SchedulerTests.cs
+++ b/Jint.Tests/Runtime/WebApi/SchedulerTests.cs
@@ -1,0 +1,965 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.Diagnostics;
+using Jint.Native;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Descriptors.Specialized;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// The prioritized task scheduling API against its specification —
+/// https://wicg.github.io/scheduling-apis/.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Most of these are about <i>order</i>: which of several pending tasks runs next, and where a task sits
+/// relative to the microtasks and the timers around it. <c>Engine.Execute</c> drains the event loop once the
+/// script has finished, so a task posted with no delay has already run by the time it returns; a delayed one
+/// needs the clock moved and an explicit <c>Advanced.ProcessTasks()</c>.
+/// </para>
+/// <para>
+/// The three ordering guarantees under test, all documented on <c>SchedulerQueue</c>: every microtask runs
+/// before the next task, whichever order the two were queued in; among pending tasks the highest effective
+/// priority wins with ties going to the oldest; and every runnable task runs before any due timer.
+/// </para>
+/// </remarks>
+public class SchedulerTests
+{
+    /// <summary>
+    /// A <see cref="TimeProvider"/> whose clock only moves when a test moves it.
+    /// </summary>
+    private sealed class ManualClock : TimeProvider
+    {
+        private long _timestamp;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp() => _timestamp;
+
+        public override DateTimeOffset GetUtcNow() => DateTimeOffset.UnixEpoch.AddTicks(_timestamp);
+
+        internal void Advance(int milliseconds) => _timestamp += milliseconds * TimeSpan.TicksPerMillisecond;
+    }
+
+    private static (Engine Engine, ManualClock Clock) SchedulerEngine(int? maxActiveTimers = null)
+    {
+        var clock = new ManualClock();
+        var engine = new Engine(options => options.UseWebApis(webApi =>
+        {
+            webApi.Timers.TimeProvider = clock;
+            if (maxActiveTimers is { } max)
+            {
+                webApi.Timers.MaxActiveTimers = max;
+            }
+        }));
+
+        engine.Execute("var log = [];");
+        return (engine, clock);
+    }
+
+    private static string Log(Engine engine) => engine.Evaluate("log.join(',')").AsString();
+
+    // --- postTask: the callback, its result and its failures ------------------------------------------
+
+    [Fact]
+    public void PostTaskRunsTheCallbackAsATaskAndResolvesWithItsReturnValue()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("""
+            var result = 'pending';
+            scheduler.postTask(() => 42).then(v => { result = v; log.push('resolved'); });
+            log.push('script');
+            """);
+
+        // The callback did not run synchronously — it ran as its own task, during the drain Execute performs.
+        Log(engine).Should().Be("script,resolved");
+        engine.Evaluate("result").AsNumber().Should().Be(42);
+    }
+
+    [Fact]
+    public void ACallbackThatThrowsRejectsThePromiseWithWhatItThrew()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("""
+            scheduler.postTask(() => { throw new RangeError('boom'); })
+                .then(() => log.push('resolved'), e => log.push(e.name + ':' + e.message));
+            """);
+
+        Log(engine).Should().Be("RangeError:boom");
+    }
+
+    [Fact]
+    public void NeitherOperationEverThrows()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        // A promise-returning operation rejects rather than throws, whatever went wrong —
+        // https://webidl.spec.whatwg.org/#dfn-create-operation-function.
+        engine.Execute("""
+            function outcome(label, thunk) {
+                try {
+                    thunk().then(() => log.push(label + ':resolved'), e => log.push(label + ':' + e.constructor.name));
+                } catch (e) {
+                    log.push(label + ':THREW');
+                }
+            }
+
+            outcome('callable', () => scheduler.postTask(42));
+            outcome('priority', () => scheduler.postTask(() => {}, { priority: 'urgent' }));
+            outcome('signal', () => scheduler.postTask(() => {}, { signal: 5 }));
+            outcome('delay', () => scheduler.postTask(() => {}, { delay: NaN }));
+            outcome('options', () => scheduler.postTask(() => {}, 7));
+            outcome('receiver', () => scheduler.postTask.call({}, () => {}));
+            outcome('yield', () => scheduler.yield.call({}));
+            """);
+
+        Log(engine).Should().Be(
+            "callable:TypeError,priority:TypeError,signal:TypeError,delay:TypeError,options:TypeError,receiver:TypeError,yield:TypeError");
+    }
+
+    [Fact]
+    public void ADictionaryMembersAreReadInLexicographicalOrder()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        // delay, priority, signal — the order https://webidl.spec.whatwg.org/#es-dictionary specifies, not
+        // the order the IDL declares them in.
+        engine.Execute("""
+            const options = {
+                get signal() { log.push('signal'); return undefined; },
+                get priority() { log.push('priority'); return undefined; },
+                get delay() { log.push('delay'); return 0; },
+            };
+
+            scheduler.postTask(() => {}, options);
+            """);
+
+        Log(engine).Should().StartWith("delay,priority,signal");
+    }
+
+    // --- Priority ordering ----------------------------------------------------------------------------
+
+    [Fact]
+    public void TasksRunInStrictPriorityOrder()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("""
+            scheduler.postTask(() => log.push('background'), { priority: 'background' });
+            scheduler.postTask(() => log.push('user-visible'));
+            scheduler.postTask(() => log.push('user-blocking'), { priority: 'user-blocking' });
+            """);
+
+        Log(engine).Should().Be("user-blocking,user-visible,background");
+    }
+
+    [Fact]
+    public void TasksOfEqualPriorityRunInTheOrderTheyWerePosted()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("""
+            for (const name of ['a', 'b', 'c', 'd']) {
+                scheduler.postTask(() => log.push(name));
+            }
+            """);
+
+        Log(engine).Should().Be("a,b,c,d");
+    }
+
+    [Fact]
+    public void AUserBlockingTaskPostedLaterPreemptsQueuedUserVisibleOnes()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("""
+            scheduler.postTask(() => {
+                log.push('first');
+                scheduler.postTask(() => log.push('urgent'), { priority: 'user-blocking' });
+            });
+            scheduler.postTask(() => log.push('second'));
+            scheduler.postTask(() => log.push('third'));
+            """);
+
+        // The choice is made when a task is about to run, not when it was posted, so the urgent one overtakes
+        // the two that were already waiting.
+        Log(engine).Should().Be("first,urgent,second,third");
+    }
+
+    // --- Ordering against microtasks and timers -------------------------------------------------------
+
+    [Fact]
+    public void EveryMicrotaskRunsBeforeTheNextTaskWhicheverWasQueuedFirst()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("""
+            scheduler.postTask(() => log.push('task'), { priority: 'user-blocking' });
+            Promise.resolve().then(() => log.push('microtask'));
+            log.push('script');
+            """);
+
+        // The task was posted first and has the highest priority, and the microtask still wins: HTML runs a
+        // task only at a microtask checkpoint.
+        Log(engine).Should().Be("script,microtask,task");
+    }
+
+    [Fact]
+    public void EachTaskGetsItsOwnMicrotaskCheckpoint()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("""
+            scheduler.postTask(() => {
+                log.push('t1');
+                Promise.resolve().then(() => log.push('t1-micro'));
+            });
+            scheduler.postTask(() => log.push('t2'));
+            """);
+
+        Log(engine).Should().Be("t1,t1-micro,t2");
+    }
+
+    [Fact]
+    public void EveryRunnableTaskRunsBeforeADueTimer()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("""
+            setTimeout(() => log.push('timeout'), 0);
+            scheduler.postTask(() => log.push('background'), { priority: 'background' });
+            """);
+
+        // A documented divergence from a browser, which would run the timer first for a background task: HTML
+        // leaves the choice implementation-defined, and Jint's timers are promoted only once the job queue —
+        // which the scheduler's drain job is part of — has run dry.
+        Log(engine).Should().Be("background,timeout");
+    }
+
+    // --- Signals: priority inheritance and reprioritization -------------------------------------------
+
+    [Fact]
+    public void ATaskSignalGovernsThePriorityWhenNoPriorityOptionIsGiven()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("""
+            const controller = new TaskController({ priority: 'background' });
+            scheduler.postTask(() => log.push('signal'), { signal: controller.signal });
+            scheduler.postTask(() => log.push('plain'));
+            """);
+
+        Log(engine).Should().Be("plain,signal");
+    }
+
+    [Fact]
+    public void SetPriorityReprioritizesTasksThatAreStillQueued()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("""
+            const controller = new TaskController({ priority: 'background' });
+            scheduler.postTask(() => log.push('signal'), { signal: controller.signal });
+            scheduler.postTask(() => log.push('plain'));
+            controller.setPriority('user-blocking');
+            """);
+
+        // Same two tasks as the test above, and the order is reversed by the priority change alone.
+        Log(engine).Should().Be("signal,plain");
+    }
+
+    [Fact]
+    public void AnExplicitPriorityOptionWinsOverTheSignalAndIsImmutable()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("""
+            const controller = new TaskController({ priority: 'background' });
+            scheduler.postTask(() => log.push('fixed'), { signal: controller.signal, priority: 'background' });
+            scheduler.postTask(() => log.push('plain'));
+            controller.setPriority('user-blocking');
+            """);
+
+        // The signal still aborts the task, but its priority no longer has anything to say about it.
+        Log(engine).Should().Be("plain,fixed");
+    }
+
+    [Fact]
+    public void APriorityChangeFiresPrioritychangeAtTheSignalInListenerOrder()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("""
+            const controller = new TaskController();
+            controller.signal.addEventListener('prioritychange', e => log.push('listener:' + e.previousPriority));
+            controller.signal.onprioritychange = e => log.push('handler:' + e.previousPriority);
+            controller.signal.addEventListener('prioritychange', e => log.push('third:' + e.target.priority));
+            controller.setPriority('background');
+            log.push('after:' + controller.signal.priority);
+            """);
+
+        Log(engine).Should().Be("listener:user-visible,handler:user-visible,third:background,after:background");
+    }
+
+    [Fact]
+    public void ThePrioritychangeEventIsATrustedTaskPriorityChangeEvent()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("""
+            const controller = new TaskController({ priority: 'user-blocking' });
+            controller.signal.onprioritychange = e => {
+                log.push(e.type);
+                log.push(e instanceof TaskPriorityChangeEvent);
+                log.push(e instanceof Event);
+                log.push(e.isTrusted);
+                log.push(e.previousPriority);
+                log.push(e.target === controller.signal);
+                log.push(e.target.priority);
+            };
+            controller.setPriority('background');
+            """);
+
+        Log(engine).Should().Be("prioritychange,true,true,true,user-blocking,true,background");
+    }
+
+    [Fact]
+    public void SettingThePriorityASignalAlreadyHasChangesNothing()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("""
+            const controller = new TaskController({ priority: 'background' });
+            controller.signal.onprioritychange = () => log.push('fired');
+            controller.setPriority('background');
+            log.push('done');
+            """);
+
+        Log(engine).Should().Be("done");
+    }
+
+    [Fact]
+    public void ChangingThePriorityFromInsideAPrioritychangeListenerIsANotAllowedError()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("""
+            const controller = new TaskController();
+            controller.signal.onprioritychange = () => {
+                try {
+                    controller.setPriority('background');
+                } catch (e) {
+                    log.push(e.name + ':' + (e instanceof DOMException));
+                }
+            };
+            controller.setPriority('user-blocking');
+
+            // The signal is usable again afterwards: the flag is cleared however the listener ended. The
+            // handler goes first, or it would refuse this change from inside it as well.
+            controller.signal.onprioritychange = null;
+            controller.setPriority('background');
+            log.push(controller.signal.priority);
+            """);
+
+        Log(engine).Should().Be("NotAllowedError:true,background");
+    }
+
+    // --- Aborting -------------------------------------------------------------------------------------
+
+    [Fact]
+    public void AnAlreadyAbortedSignalRejectsWithoutQueueingAnything()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("""
+            const controller = new TaskController();
+            controller.abort('early');
+            scheduler.postTask(() => log.push('never'), { signal: controller.signal })
+                .then(() => log.push('resolved'), reason => log.push('rejected:' + reason));
+            """);
+
+        Log(engine).Should().Be("rejected:early");
+    }
+
+    [Fact]
+    public void AbortingBeforeTheTaskRunsRejectsWithTheReasonAndDropsTheTask()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("""
+            const controller = new TaskController();
+            scheduler.postTask(() => log.push('never'), { signal: controller.signal })
+                .then(() => log.push('resolved'), e => log.push('rejected:' + e.name));
+            scheduler.postTask(() => log.push('survivor'));
+            controller.abort();
+            """);
+
+        // The default reason is an AbortError DOMException, and the aborted task is simply gone.
+        Log(engine).Should().Be("rejected:AbortError,survivor");
+    }
+
+    [Fact]
+    public void AbortingFromInsideTheCallbackRejectsRatherThanResolves()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("""
+            const controller = new TaskController();
+            scheduler.postTask(() => { controller.abort(); return 'value'; }, { signal: controller.signal })
+                .then(v => log.push('resolved:' + v), e => log.push('rejected:' + e.name));
+            """);
+
+        // The abort steps settle the promise first, and settling is once-only — which is the order the
+        // specification's own steps produce.
+        Log(engine).Should().Be("rejected:AbortError");
+    }
+
+    [Fact]
+    public void AbortingAfterTheTaskRanLeavesItsResultAlone()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("""
+            const controller = new TaskController();
+            scheduler.postTask(() => 'done', { signal: controller.signal })
+                .then(v => log.push('resolved:' + v), e => log.push('rejected:' + e.name));
+            """);
+
+        Log(engine).Should().Be("resolved:done");
+
+        engine.Execute("controller.abort(); log.push('aborted');");
+        Log(engine).Should().Be("resolved:done,aborted");
+    }
+
+    [Fact]
+    public void APlainAbortSignalIsEnoughToCancelATask()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("""
+            const controller = new AbortController();
+            scheduler.postTask(() => log.push('never'), { signal: controller.signal })
+                .then(() => log.push('resolved'), e => log.push('rejected:' + e.name));
+            controller.abort();
+
+            // ... and it leaves the task at the default priority, since it carries none.
+            const plain = new AbortController();
+            scheduler.postTask(() => log.push('plain-signal'), { signal: plain.signal });
+            scheduler.postTask(() => log.push('urgent'), { priority: 'user-blocking' });
+            """);
+
+        Log(engine).Should().Be("rejected:AbortError,urgent,plain-signal");
+    }
+
+    // --- delay ----------------------------------------------------------------------------------------
+
+    [Fact]
+    public void ADelayedTaskIsNotEvenQueuedUntilItsDelayElapses()
+    {
+        var (engine, clock) = SchedulerEngine();
+
+        engine.Execute("""
+            scheduler.postTask(() => log.push('delayed'), { delay: 10, priority: 'user-blocking' });
+            scheduler.postTask(() => log.push('background'), { priority: 'background' });
+            """);
+
+        // Priority orders the tasks that are pending; a delayed one is not pending yet, however urgent.
+        Log(engine).Should().Be("background");
+
+        clock.Advance(10);
+        engine.Advanced.ProcessTasks();
+
+        Log(engine).Should().Be("background,delayed");
+    }
+
+    [Fact]
+    public void ADelayedTaskArrivesOnlyOnceTheTasksAheadOfItHaveDrained()
+    {
+        var (engine, clock) = SchedulerEngine();
+
+        engine.Execute("""
+            scheduler.postTask(() => log.push('delayed-blocking'), { delay: 10, priority: 'user-blocking' });
+            setTimeout(() => {
+                scheduler.postTask(() => log.push('visible'));
+                scheduler.postTask(() => log.push('blocking'), { priority: 'user-blocking' });
+            }, 5);
+            """);
+
+        clock.Advance(10);
+        engine.Advanced.ProcessTasks();
+
+        // The consequence of "every runnable task runs before any due timer": the delay is itself a timer, and
+        // a timer is promoted only when the job queue has run dry — which the drain job keeps non-empty while
+        // tasks remain. So the two tasks the 5ms timeout posted both run first, and the delayed task, however
+        // urgent, only joins the queue afterwards. Two delayed tasks that come due together are ordered by due
+        // time for the same reason, rather than by priority.
+        Log(engine).Should().Be("blocking,visible,delayed-blocking");
+    }
+
+    [Fact]
+    public void ADelayedTaskCountsAgainstTheTimerLimitAndTheRefusalIsARejection()
+    {
+        var (engine, _) = SchedulerEngine(maxActiveTimers: 1);
+
+        engine.Execute("""
+            scheduler.postTask(() => log.push('first'), { delay: 50 }).catch(e => log.push('first:' + e.name));
+            scheduler.postTask(() => log.push('second'), { delay: 50 })
+                .then(() => log.push('resolved'), e => log.push('second:' + e.name + ':' + (e instanceof DOMException)));
+            """);
+
+        Log(engine).Should().Be("second:QuotaExceededError:true");
+    }
+
+    [Fact]
+    public void AbortingADelayedTaskGivesItsTimerSlotBack()
+    {
+        var (engine, clock) = SchedulerEngine(maxActiveTimers: 1);
+
+        engine.Execute("""
+            const controller = new TaskController();
+            scheduler.postTask(() => log.push('never'), { delay: 50, signal: controller.signal })
+                .catch(e => log.push('rejected:' + e.name));
+            controller.abort();
+
+            scheduler.postTask(() => log.push('second'), { delay: 10 }).catch(e => log.push('second:' + e.name));
+            """);
+
+        Log(engine).Should().Be("rejected:AbortError");
+        engine._webApi!.Timers!.Count.Should().Be(1);
+
+        clock.Advance(50);
+        engine.Advanced.ProcessTasks();
+
+        Log(engine).Should().Be("rejected:AbortError,second");
+    }
+
+    // --- yield ----------------------------------------------------------------------------------------
+
+    [Fact]
+    public void AContinuationOutranksATaskOfTheSamePriority()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("""
+            scheduler.postTask(() => {
+                log.push('a1');
+                scheduler.postTask(() => log.push('other'));
+                scheduler.yield().then(() => log.push('a2'));
+            });
+            """);
+
+        // 'other' was posted first and is the same user-visible priority, and the continuation still goes
+        // ahead of it — that is the effective-priority table's whole point.
+        Log(engine).Should().Be("a1,a2,other");
+    }
+
+    [Fact]
+    public void AContinuationInheritsThePriorityOfTheTaskItWasCalledIn()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("""
+            scheduler.postTask(() => {
+                log.push('background');
+                scheduler.postTask(() => log.push('other'));
+                scheduler.yield().then(() => log.push('continuation'));
+            }, { priority: 'background' });
+            """);
+
+        // A background continuation (effective priority 1) loses to a user-visible task (2). Had the
+        // continuation defaulted to user-visible it would have won, as the test above shows.
+        Log(engine).Should().Be("background,other,continuation");
+    }
+
+    [Fact]
+    public void AContinuationFollowsASignalsPriorityToo()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("""
+            const controller = new TaskController({ priority: 'background' });
+            scheduler.postTask(() => {
+                log.push('task');
+                scheduler.postTask(() => log.push('other'));
+                scheduler.yield().then(() => log.push('continuation'));
+            }, { signal: controller.signal });
+            """);
+
+        Log(engine).Should().Be("task,other,continuation");
+    }
+
+    [Fact]
+    public void AYieldOutsideATaskIsAUserVisibleContinuation()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("""
+            scheduler.yield().then(() => log.push('continuation'));
+            scheduler.postTask(() => log.push('visible'));
+            scheduler.postTask(() => log.push('blocking'), { priority: 'user-blocking' });
+            """);
+
+        // Effective priorities 3, 2 and 4: the continuation sits between the two tasks.
+        Log(engine).Should().Be("blocking,continuation,visible");
+    }
+
+    [Fact]
+    public void AContinuationInheritsTheAbortSignalOfTheTaskItWasCalledIn()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("""
+            const controller = new TaskController();
+            scheduler.postTask(() => {
+                scheduler.yield().then(() => log.push('continuation'), e => log.push('rejected:' + e.name));
+                controller.abort();
+            }, { signal: controller.signal }).catch(() => {});
+            """);
+
+        Log(engine).Should().Be("rejected:AbortError");
+    }
+
+    [Fact]
+    public void AYieldInsideAnAlreadyAbortedTaskRejectsImmediately()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("""
+            const controller = new TaskController();
+            scheduler.postTask(() => {
+                controller.abort('gone');
+                scheduler.yield().then(() => log.push('continuation'), reason => log.push('rejected:' + reason));
+                log.push('still running');
+            }, { signal: controller.signal }).catch(() => {});
+            """);
+
+        Log(engine).Should().Be("still running,rejected:gone");
+    }
+
+    [Fact]
+    public void AnAwaitedYieldChunksWorkWithoutLosingItsPlace()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("""
+            scheduler.postTask(async () => {
+                log.push('chunk1');
+                await scheduler.yield();
+                log.push('chunk2');
+            }, { priority: 'user-blocking' });
+            scheduler.postTask(() => log.push('other'), { priority: 'user-blocking' });
+            """);
+
+        // The first hop of an `await scheduler.yield()` chain inherits, so the continuation is a
+        // user-blocking one (effective priority 5) and beats the user-blocking task waiting behind it (4). A
+        // continuation that had fallen back to user-visible (3) would have lost.
+        Log(engine).Should().Be("chunk1,chunk2,other");
+    }
+
+    // --- TaskController, TaskSignal, TaskPriorityChangeEvent ------------------------------------------
+
+    [Fact]
+    public void TheInterfacesInheritFromTheirAbortAndEventCounterparts()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("""
+            const controller = new TaskController();
+            log.push(controller instanceof TaskController);
+            log.push(controller instanceof AbortController);
+            log.push(Object.getPrototypeOf(TaskController) === AbortController);
+            log.push(controller.signal instanceof TaskSignal);
+            log.push(controller.signal instanceof AbortSignal);
+            log.push(controller.signal instanceof EventTarget);
+            log.push(Object.getPrototypeOf(TaskSignal) === AbortSignal);
+            log.push(Object.getPrototypeOf(TaskPriorityChangeEvent) === Event);
+            log.push(Object.prototype.toString.call(controller));
+            log.push(Object.prototype.toString.call(controller.signal));
+            log.push(Object.prototype.toString.call(scheduler));
+            """);
+
+        Log(engine).Should().Be(
+            "true,true,true,true,true,true,true,true,[object TaskController],[object TaskSignal],[object Scheduler]");
+    }
+
+    [Fact]
+    public void ATaskControllersSignalCarriesTheInitialPriority()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Evaluate("new TaskController().signal.priority").AsString().Should().Be("user-visible");
+        engine.Evaluate("new TaskController({}).signal.priority").AsString().Should().Be("user-visible");
+        engine.Evaluate("new TaskController({ priority: undefined }).signal.priority").AsString().Should().Be("user-visible");
+        engine.Evaluate("new TaskController({ priority: 'background' }).signal.priority").AsString().Should().Be("background");
+
+        // The signal is [SameObject]: the same instance on every read.
+        engine.Evaluate("(() => { const c = new TaskController(); return c.signal === c.signal; })()").AsBoolean().Should().BeTrue();
+
+        // An unknown enumeration value is a TypeError, never a silent default.
+        var error = Assert.Throws<JavaScriptException>(() => engine.Execute("new TaskController({ priority: 'urgent' })"));
+        error.Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void TaskSignalIsNotConstructibleAndSetPriorityIsBranded()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        Assert.Throws<JavaScriptException>(() => engine.Execute("new TaskSignal()"))
+            .Error.Get("message").AsString().Should().Be("Illegal constructor");
+
+        // A plain AbortController has no priority to change.
+        Assert.Throws<JavaScriptException>(() => engine.Execute("TaskController.prototype.setPriority.call(new AbortController(), 'background')"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+
+        Assert.Throws<JavaScriptException>(() => engine.Execute("Object.getOwnPropertyDescriptor(TaskSignal.prototype, 'priority').get.call({})"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void TaskPriorityChangeEventRequiresItsPreviousPriority()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("""
+            const ev = new TaskPriorityChangeEvent('prioritychange', { previousPriority: 'background', bubbles: true });
+            log.push(ev.previousPriority);
+            log.push(ev.type);
+            log.push(ev.bubbles);
+            log.push(ev.isTrusted);
+            log.push(ev instanceof Event);
+            """);
+
+        Log(engine).Should().Be("background,prioritychange,true,false,true");
+
+        // The dictionary is not optional and previousPriority is required.
+        Assert.Throws<JavaScriptException>(() => engine.Execute("new TaskPriorityChangeEvent('x')"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+        Assert.Throws<JavaScriptException>(() => engine.Execute("new TaskPriorityChangeEvent('x', {})"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+        Assert.Throws<JavaScriptException>(() => engine.Execute("new TaskPriorityChangeEvent('x', { previousPriority: 'nope' })"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void TaskSignalAnyIsATaskSignalWithItsOwnPriority()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("""
+            const first = new AbortController();
+            const composite = TaskSignal.any([first.signal], { priority: 'background' });
+            log.push(composite instanceof TaskSignal);
+            log.push(composite.priority);
+
+            scheduler.postTask(() => log.push('composite'), { signal: composite });
+            scheduler.postTask(() => log.push('plain'));
+            """);
+
+        // The composite's priority is fixed, so the task it governs sits in the ordinary background queue.
+        Log(engine).Should().Be("true,background,plain,composite");
+
+        engine.Execute("log.length = 0; first.abort('stop'); log.push(composite.aborted + ':' + composite.reason);");
+        Log(engine).Should().Be("true:stop");
+    }
+
+    [Fact]
+    public void TaskSignalAnyCanFollowAnotherSignalsPriority()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Execute("""
+            const source = new TaskController({ priority: 'background' });
+            const composite = TaskSignal.any([], { priority: source.signal });
+            log.push(composite.priority);
+
+            composite.onprioritychange = e => log.push('composite:' + e.previousPriority + '->' + e.target.priority);
+            scheduler.postTask(() => log.push('composite-task'), { signal: composite });
+            scheduler.postTask(() => log.push('plain'));
+
+            source.setPriority('user-blocking');
+            """);
+
+        // The change reaches the composite, which fires its own event and re-prioritizes the task following it.
+        Log(engine).Should().Be("background,composite:background->user-blocking,composite-task,plain");
+    }
+
+    // --- Installation ---------------------------------------------------------------------------------
+
+    [Fact]
+    public void NothingIsInstalledUnlessTheSchedulerFeatureIsNamed()
+    {
+        var plain = new Engine();
+        var console = new Engine(options => options.UseWebApis(WebApiFeatures.Console));
+        var scheduler = new Engine(options => options.UseWebApis(WebApiFeatures.Scheduler));
+
+        foreach (var name in new[] { "scheduler", "TaskController", "TaskSignal", "TaskPriorityChangeEvent" })
+        {
+            plain.Evaluate($"typeof {name}").AsString().Should().Be("undefined");
+            console.Evaluate($"typeof {name}").AsString().Should().Be("undefined");
+            scheduler.Evaluate($"typeof {name}").AsString().Should().NotBe("undefined");
+
+            // ... and never inside a shadow realm.
+            scheduler.Evaluate($"new ShadowRealm().evaluate('typeof {name}')").AsString().Should().Be("undefined");
+        }
+
+        // The feature is part of the default set.
+        new Engine(options => options.UseWebApis()).Evaluate("typeof scheduler").AsString().Should().Be("object");
+    }
+
+    [Fact]
+    public void TheGlobalsCarryTheAttributesWebIdlAsksFor()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Scheduler));
+        var global = engine.Realm.GlobalObject;
+
+        // scheduler is an ordinary enumerable data property — the documented simplification of the
+        // [Replaceable] accessor pair, the same one console, crypto and performance carry.
+        var scheduler = global.GetOwnProperty("scheduler");
+        scheduler.Should().BeOfType<LazyPropertyDescriptor<Engine>>();
+        scheduler.Enumerable.Should().BeTrue();
+        scheduler.Writable.Should().BeTrue();
+        scheduler.Configurable.Should().BeTrue();
+
+        // Still unmaterialized: enabling a feature nobody uses costs one descriptor and nothing else.
+        (scheduler._flags & PropertyFlag.CustomJsValue).Should().NotBe(PropertyFlag.None);
+        scheduler._value.Should().BeNull();
+
+        foreach (var name in new[] { "TaskController", "TaskSignal", "TaskPriorityChangeEvent" })
+        {
+            var descriptor = global.GetOwnProperty(name);
+            descriptor.Should().BeOfType<LazyPropertyDescriptor<Engine>>();
+            descriptor.Enumerable.Should().BeFalse();
+            descriptor.Writable.Should().BeTrue();
+            descriptor.Configurable.Should().BeTrue();
+        }
+    }
+
+    [Fact]
+    public void LeavesAGlobalTheHostAlreadyOwns()
+    {
+        var marker = new JsString("host's own");
+        var engine = new Engine(options => options
+            .Configure(e => e.SetValue("scheduler", marker))
+            .UseWebApis());
+
+        engine.Evaluate("scheduler").Should().BeSameAs(marker);
+    }
+
+    [Fact]
+    public void TheOperationsHaveTheirWebIdlShape()
+    {
+        var (engine, _) = SchedulerEngine();
+
+        engine.Evaluate("typeof scheduler.postTask").AsString().Should().Be("function");
+        engine.Evaluate("scheduler.postTask.length").AsNumber().Should().Be(1);
+        engine.Evaluate("scheduler.postTask.name").AsString().Should().Be("postTask");
+        engine.Evaluate("scheduler.yield.length").AsNumber().Should().Be(0);
+        engine.Evaluate("scheduler.yield.name").AsString().Should().Be("yield");
+
+        // The operations are not enumerable, so the object looks as empty as a browser's does.
+        engine.Evaluate("Object.keys(scheduler).length").AsNumber().Should().Be(0);
+
+        // The scheduler object is the same one on every read.
+        engine.Evaluate("scheduler === scheduler").AsBoolean().Should().BeTrue();
+    }
+
+    // --- Engine lifecycle -----------------------------------------------------------------------------
+
+    [Fact]
+    public void AGlobalSnapshotRestoreDropsEverythingStillScheduled()
+    {
+        var (engine, clock) = SchedulerEngine();
+
+        var ran = false;
+        engine.SetValue("mark", new Action(() => ran = true));
+
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+
+        engine.Execute("""
+            const controller = new TaskController({ priority: 'background' });
+            scheduler.postTask(mark, { signal: controller.signal, delay: 50 });
+            scheduler.postTask(mark, { delay: 50 });
+            """);
+
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        clock.Advance(1000);
+        engine.Advanced.ProcessTasks();
+
+        ran.Should().BeFalse();
+        engine._webApi!.Timers!.Count.Should().Be(0);
+
+        // ... and the engine still schedules normally in the next cycle.
+        engine.Execute("var log = []; scheduler.postTask(() => log.push('next'));");
+        Log(engine).Should().Be("next");
+    }
+
+    [Fact]
+    public void ABlockingUnwrapRunsTheWholeChain()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        var result = engine
+            .Evaluate("""
+                (async () => {
+                    let total = 0;
+                    for (let i = 0; i < 5; i++) {
+                        total += await scheduler.postTask(() => i, { priority: 'background' });
+                        await scheduler.yield();
+                    }
+                    return total;
+                })()
+                """)
+            .UnwrapIfPromise();
+
+        result.AsNumber().Should().Be(10);
+    }
+
+    [Fact]
+    public async Task AnAsynchronousEvaluationRunsTheWholeChain()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        var result = await engine.EvaluateAsync("""
+            (async () => {
+                const first = await scheduler.postTask(() => 'a');
+                const second = await scheduler.postTask(() => 'b', { delay: 5 });
+                await scheduler.yield();
+                return first + second;
+            })()
+            """);
+
+        result.AsString().Should().Be("ab");
+    }
+
+    [Fact]
+    public void AHostsOwnPumpRunsTheTasks()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        var done = false;
+        engine.SetValue("done", new Action(() => done = true));
+
+        // Nothing drains here: Evaluate returns as soon as the script has run, and the delayed task is still
+        // waiting on the clock.
+        engine.Execute("scheduler.postTask(() => scheduler.postTask(done, { delay: 20 }), { priority: 'background' });");
+        done.Should().BeFalse();
+
+        var deadline = Stopwatch.StartNew();
+        while (!done && deadline.Elapsed < TimeSpan.FromSeconds(5))
+        {
+            // Nothing but the host's own pump: no engine thread, no background timer.
+            engine.Advanced.ProcessTasks();
+            Thread.Sleep(5);
+        }
+
+        done.Should().BeTrue();
+    }
+}
+#endif

--- a/Jint/Engine.WebApi.cs
+++ b/Jint/Engine.WebApi.cs
@@ -1,5 +1,6 @@
 #if NET8_0_OR_GREATER
 using Jint.WebApi.Fetch;
+using Jint.WebApi.Scheduling;
 using Jint.WebApi.Timers;
 
 namespace Jint;
@@ -20,6 +21,12 @@ public partial class Engine
     /// </summary>
     internal WebApiEngineState? _webApi;
 
+    /// <summary>
+    /// Whether the event loop still has jobs queued behind the one running now. Only the web-API scheduler
+    /// reads it, to keep a task from overtaking the microtasks of the turn it was posted in — see
+    /// <see cref="Runtime.EventLoop.HasPendingJobs"/>.
+    /// </summary>
+    internal bool HasPendingEventLoopJobs => _eventLoop.HasPendingJobs;
 }
 
 /// <summary>
@@ -47,12 +54,13 @@ internal sealed class WebApiEngineState
     /// </summary>
     private List<FetchOperation>? _fetches;
 
-    internal WebApiEngineState(Engine engine, TimeProvider timeProvider, TimerQueue? timers, Options.FetchOptions? fetchOptions)
+    internal WebApiEngineState(Engine engine, TimeProvider timeProvider, TimerQueue? timers, Options.FetchOptions? fetchOptions, SchedulerQueue? scheduler)
     {
         _engine = engine;
         _timeProvider = timeProvider;
         Timers = timers;
         FetchOptions = fetchOptions;
+        Scheduler = scheduler;
 
         // Both halves of the time origin, read back to back: the monotonic reading every later now() is a
         // duration from, and the wall-clock moment that reading corresponds to.
@@ -80,6 +88,13 @@ internal sealed class WebApiEngineState
     internal void RegisterFetch(FetchOperation operation) => (_fetches ??= new List<FetchOperation>()).Add(operation);
 
     internal void UnregisterFetch(FetchOperation operation) => _fetches?.Remove(operation);
+
+    /// <summary>
+    /// The engine's prioritized task queues, or <see langword="null"/> when the scheduler feature is off.
+    /// Nothing else consults it: the scheduler drains itself through an ordinary event-loop job, so unlike the
+    /// timers it needs no hook in the pump.
+    /// </summary>
+    internal SchedulerQueue? Scheduler { get; }
 
     /// <summary>
     /// <c>performance.timeOrigin</c>: the moment this state was created, as milliseconds since the Unix
@@ -137,6 +152,7 @@ internal sealed class WebApiEngineState
     internal void ResetTransientState()
     {
         Timers?.Clear();
+        Scheduler?.Clear();
 
         if (_fetches is not { Count: > 0 } fetches)
         {

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -411,12 +411,20 @@ public enum WebApiFeatures
     Streams = 1 << 12,
 
     /// <summary>
+    /// The <c>scheduler</c> object — <c>postTask()</c> and <c>yield()</c> — with <c>TaskController</c>,
+    /// <c>TaskSignal</c> and <c>TaskPriorityChangeEvent</c>: prioritized tasks, from
+    /// https://wicg.github.io/scheduling-apis/. Tasks run only while the engine is being pumped, exactly as
+    /// the timers do, and a <c>delay</c> rides the same timer queue.
+    /// </summary>
+    Scheduler = 1 << 13,
+
+    /// <summary>
     /// The web APIs a host normally wants: everything except outbound network access. Today that is
     /// <see cref="Console"/>, <see cref="Timers"/>, <see cref="Encoding"/>, <see cref="Base64"/>,
     /// <see cref="StructuredClone"/>, <see cref="Crypto"/>, <see cref="Performance"/>, <see cref="Events"/>,
-    /// <see cref="Url"/>, <see cref="Files"/>, <see cref="Navigator"/> and <see cref="Streams"/>; it grows as
-    /// further features land, and never comes to include fetch.
+    /// <see cref="Url"/>, <see cref="Files"/>, <see cref="Navigator"/>, <see cref="Streams"/> and
+    /// <see cref="Scheduler"/>; it grows as further features land, and never comes to include fetch.
     /// </summary>
-    Default = Console | Timers | Encoding | Base64 | StructuredClone | Crypto | Performance | Events | Url | Files | Navigator | Streams,
+    Default = Console | Timers | Encoding | Base64 | StructuredClone | Crypto | Performance | Events | Url | Files | Navigator | Streams | Scheduler,
 }
 #endif

--- a/Jint/Runtime/EventLoop.cs
+++ b/Jint/Runtime/EventLoop.cs
@@ -73,6 +73,14 @@ internal sealed record EventLoop
     internal bool IsRunningJob => Volatile.Read(ref _isProcessing) == 1;
 
     /// <summary>
+    /// Whether any job is still queued. Read from inside a running job by work that must not overtake the
+    /// jobs behind it: the web-API scheduler's drain job consults it to reproduce HTML's <i>microtask
+    /// checkpoint</i>, re-queueing itself while anything else is pending so that a scheduler task never runs
+    /// before a promise reaction that was queued in the same turn.
+    /// </summary>
+    internal bool HasPendingJobs => !_events.IsEmpty;
+
+    /// <summary>
     /// Tracks the thread ID of the thread that is currently waiting on a promise.
     /// Only this thread (or any thread if -1) is allowed to process continuations.
     /// This prevents background threads (e.g., Task.ContinueWith callbacks) from

--- a/Jint/Runtime/Intrinsics.WebApi.cs
+++ b/Jint/Runtime/Intrinsics.WebApi.cs
@@ -11,6 +11,7 @@ using Jint.WebApi.Files;
 using Jint.WebApi.Navigator;
 using Jint.WebApi.StructuredClone;
 using Jint.WebApi.Performance;
+using Jint.WebApi.Scheduling;
 using Jint.WebApi.Streams;
 using Jint.WebApi.Timers;
 using Jint.WebApi.Url;
@@ -235,5 +236,32 @@ public sealed partial class Intrinsics
 
     internal ByteLengthQueuingStrategyConstructor ByteLengthQueuingStrategy =>
         _byteLengthQueuingStrategy ??= new ByteLengthQueuingStrategyConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
+
+    private SchedulerInstance? _scheduler;
+    private TaskSignalConstructor? _taskSignal;
+    private TaskControllerConstructor? _taskController;
+    private TaskPriorityChangeEventConstructor? _taskPriorityChangeEvent;
+
+    /// <summary>
+    /// The <c>scheduler</c> object, which reaches the engine's prioritized task queues and the timer queue a
+    /// delayed <c>postTask</c> waits on — both created by <c>WebApiRegistration</c> alongside the global.
+    /// </summary>
+    internal SchedulerInstance Scheduler =>
+        _scheduler ??= SchedulerInstance.Create(_engine, _realm, Object.PrototypeObject);
+
+    /// <summary>
+    /// <c>TaskSignal</c> inherits from <c>AbortSignal</c>, so reaching it builds <c>AbortSignal</c> — and
+    /// therefore <c>EventTarget</c> — too, whether or not the events feature installed their globals.
+    /// </summary>
+    internal TaskSignalConstructor TaskSignal =>
+        _taskSignal ??= new TaskSignalConstructor(_engine, _realm, AbortSignal);
+
+    /// <summary><c>TaskController</c> inherits from <c>AbortController</c>.</summary>
+    internal TaskControllerConstructor TaskController =>
+        _taskController ??= new TaskControllerConstructor(_engine, _realm, AbortController, TaskSignal);
+
+    /// <summary><c>TaskPriorityChangeEvent</c> inherits from <c>Event</c>.</summary>
+    internal TaskPriorityChangeEventConstructor TaskPriorityChangeEvent =>
+        _taskPriorityChangeEvent ??= new TaskPriorityChangeEventConstructor(_engine, _realm, Event);
 }
 #endif

--- a/Jint/WebApi/Abort/AbortSignalConstructor.cs
+++ b/Jint/WebApi/Abort/AbortSignalConstructor.cs
@@ -107,7 +107,7 @@ internal sealed partial class AbortSignalConstructor : Constructor
     [JsFunction(Name = "any", Length = 1)]
     private JsAbortSignal StaticAny(JsValue thisObject, JsValue signals)
     {
-        var sources = ReadSignalSequence(signals);
+        var sources = ReadSignalSequence(signals, "AbortSignal");
         return JsAbortSignal.CreateDependent(_engine, _realm, sources);
     }
 
@@ -142,8 +142,13 @@ internal sealed partial class AbortSignalConstructor : Constructor
     /// <summary>
     /// The <c>sequence&lt;AbortSignal&gt;</c> conversion, https://webidl.spec.whatwg.org/#es-sequence: the
     /// argument is iterated with the iterator protocol and every element must be an <c>AbortSignal</c>.
+    /// <para>
+    /// Shared with <c>TaskSignal.any()</c>, whose first argument is the same <c>sequence&lt;AbortSignal&gt;</c>
+    /// — hence the interface name, which is only there so the <c>TypeError</c> names the operation the script
+    /// actually called.
+    /// </para>
     /// </summary>
-    private List<JsAbortSignal> ReadSignalSequence(JsValue signals)
+    internal List<JsAbortSignal> ReadSignalSequence(JsValue signals, string interfaceName)
     {
         var result = new List<JsAbortSignal>();
         var iterator = signals.GetIterator(_realm);
@@ -154,7 +159,7 @@ internal sealed partial class AbortSignalConstructor : Constructor
             {
                 if (value is not JsAbortSignal signal)
                 {
-                    Throw.TypeError(_realm, "Failed to execute 'any' on 'AbortSignal': the provided value is not of type 'AbortSignal'.");
+                    Throw.TypeError(_realm, $"Failed to execute 'any' on '{interfaceName}': the provided value is not of type 'AbortSignal'.");
                     return result;
                 }
 

--- a/Jint/WebApi/Abort/JsAbortSignal.cs
+++ b/Jint/WebApi/Abort/JsAbortSignal.cs
@@ -35,8 +35,13 @@ namespace Jint.WebApi.Abort;
 /// specification's "must not be garbage collected while it has listeners" rule too, which .NET cannot express
 /// as cheaply as a browser's garbage collector can.
 /// </para>
+/// <para>
+/// The class is not sealed because <c>Jint.WebApi.Scheduling.JsTaskSignal</c> derives from it —
+/// <c>TaskSignal</c> is an <c>AbortSignal</c> that also carries a priority,
+/// https://wicg.github.io/scheduling-apis/#tasksignal.
+/// </para>
 /// </remarks>
-internal sealed class JsAbortSignal : JsEventTarget
+internal class JsAbortSignal : JsEventTarget
 {
     /// <summary>The event type an abort fires, and the one <c>onabort</c> is the handler for.</summary>
     internal const string AbortEventType = "abort";
@@ -62,8 +67,12 @@ internal sealed class JsAbortSignal : JsEventTarget
     /// <summary>https://dom.spec.whatwg.org/#abortsignal-abort-reason.</summary>
     internal JsValue Reason { get; private set; } = Undefined;
 
-    /// <summary>https://dom.spec.whatwg.org/#abortsignal-dependent.</summary>
-    private bool Dependent { get; set; }
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#abortsignal-dependent. Readable by <c>JsTaskSignal</c>, which needs it for
+    /// https://wicg.github.io/scheduling-apis/#tasksignal-has-fixed-priority — "a TaskSignal has fixed
+    /// priority if it is a dependent signal with a null source signal".
+    /// </summary>
+    internal bool Dependent { get; private protected set; }
 
     /// <summary>
     /// A token that is cancelled when this signal is aborted — the handle a CLR-side operation links against,
@@ -197,6 +206,17 @@ internal sealed class JsAbortSignal : JsEventTarget
             _prototype = realm.Intrinsics.AbortSignal.PrototypeObject,
         };
 
+        return InitializeDependent(result, signals);
+    }
+
+    /// <summary>
+    /// Steps 2 to 5 of https://dom.spec.whatwg.org/#create-a-dependent-abort-signal, applied to a signal the
+    /// caller has already created. Split out so that <c>TaskSignal.any()</c>, whose result is a
+    /// <c>TaskSignal</c> rather than a plain <c>AbortSignal</c>, runs exactly these steps rather than a copy
+    /// of them — https://wicg.github.io/scheduling-apis/#create-a-dependent-task-signal step 1.
+    /// </summary>
+    internal static T InitializeDependent<T>(T result, List<JsAbortSignal> signals) where T : JsAbortSignal
+    {
         // Step 2: an already-aborted source wins outright, and the result is not dependent on anything — so
         // it registers nowhere and is retained by nobody.
         foreach (var signal in signals)

--- a/Jint/WebApi/DomException/DomExceptionNames.cs
+++ b/Jint/WebApi/DomException/DomExceptionNames.cs
@@ -36,6 +36,7 @@ internal static class DomExceptionNames
     internal const string Timeout = "TimeoutError";
     internal const string InvalidNodeType = "InvalidNodeTypeError";
     internal const string DataClone = "DataCloneError";
+    internal const string NotAllowed = "NotAllowedError";
 
     /// <summary>
     /// The legacy code for an error name, or <c>0</c> when the name has none.

--- a/Jint/WebApi/Scheduling/JsTaskSignal.cs
+++ b/Jint/WebApi/Scheduling/JsTaskSignal.cs
@@ -1,0 +1,211 @@
+#if NET8_0_OR_GREATER
+using Jint.Runtime;
+using Jint.WebApi.Abort;
+using Jint.WebApi.DomException;
+
+namespace Jint.WebApi.Scheduling;
+
+/// <summary>
+/// A <c>TaskSignal</c> instance: an <see cref="JsAbortSignal"/> that also carries a
+/// <see cref="SchedulerTaskPriority"/> the tasks scheduled with it follow.
+/// <para>
+/// https://wicg.github.io/scheduling-apis/#tasksignal
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// Everything an <c>AbortSignal</c> does it does here unchanged — a <c>TaskSignal</c> is accepted wherever one
+/// is, which is the whole reason the specification made it a subclass. What it adds is the priority half:
+/// <see cref="SignalPriorityChange"/> is what <c>TaskController.setPriority()</c> runs, and a scheduler
+/// registers a <i>priority change algorithm</i> so that the queue holding this signal's pending tasks is
+/// re-prioritized without the tasks moving.
+/// </para>
+/// <para>
+/// The <i>source signal</i> and <i>dependent signals</i> of the priority graph are strong references here, the
+/// same deliberate divergence <see cref="JsAbortSignal"/> documents for the abort graph: the specification
+/// makes them weak and adds a "must not be garbage collected while it has listeners" rule
+/// (https://wicg.github.io/scheduling-apis/#sec-task-signal-garbage-collection) that .NET cannot express as
+/// cheaply as a browser's collector can. A composite built by <c>TaskSignal.any()</c> is therefore retained by
+/// the signal its priority follows.
+/// </para>
+/// </remarks>
+internal sealed class JsTaskSignal : JsAbortSignal
+{
+    /// <summary>The event type a priority change fires, and the one <c>onprioritychange</c> handles.</summary>
+    internal const string PriorityChangeEventType = "prioritychange";
+
+    private List<Action>? _priorityChangeAlgorithms;
+    private List<JsTaskSignal>? _dependentSignals;
+    private JsTaskSignal? _sourceSignal;
+
+    internal JsTaskSignal(Engine engine, Realm realm, SchedulerTaskPriority priority) : base(engine, realm)
+    {
+        Priority = priority;
+    }
+
+    /// <summary>https://wicg.github.io/scheduling-apis/#tasksignal-priority.</summary>
+    internal SchedulerTaskPriority Priority { get; private set; }
+
+    /// <summary>
+    /// https://wicg.github.io/scheduling-apis/#tasksignal-priority-changing. Guards
+    /// <see cref="SignalPriorityChange"/> against a <c>prioritychange</c> listener that changes the priority
+    /// again, which the specification makes a <c>NotAllowedError</c> rather than a recursion.
+    /// </summary>
+    private bool PriorityChanging { get; set; }
+
+    /// <summary>
+    /// https://wicg.github.io/scheduling-apis/#tasksignal-has-fixed-priority — "a TaskSignal has fixed priority
+    /// if it is a dependent signal with a null source signal". A scheduler reads it to decide whether the tasks
+    /// this signal governs need a queue of their own, or can share the queue of everything else at that
+    /// priority.
+    /// </summary>
+    internal bool HasFixedPriority => Dependent && _sourceSignal is null;
+
+    /// <summary>
+    /// https://wicg.github.io/scheduling-apis/#tasksignal-add-a-priority-change-algorithm.
+    /// </summary>
+    internal void AddPriorityChangeAlgorithm(Action algorithm)
+    {
+        (_priorityChangeAlgorithms ??= new List<Action>()).Add(algorithm);
+    }
+
+    /// <summary>
+    /// Takes an algorithm off again. The specification has no such operation — its scheduler task queues are
+    /// garbage collected instead — but a queue that empties is dropped here, and leaving its algorithm behind
+    /// would make a long-lived signal retain every queue ever built from it.
+    /// </summary>
+    internal void RemovePriorityChangeAlgorithm(Action algorithm) => _priorityChangeAlgorithms?.Remove(algorithm);
+
+    /// <summary>
+    /// https://wicg.github.io/scheduling-apis/#tasksignal-signal-priority-change, the algorithm behind
+    /// <c>TaskController.setPriority()</c>.
+    /// </summary>
+    /// <remarks>
+    /// One deliberate difference from the numbered steps: the <i>priority changing</i> flag is cleared in a
+    /// <c>finally</c> rather than as step 9. A <c>prioritychange</c> listener that throws erupts from here —
+    /// which is what every event listener in this engine does, see <see cref="Events.JsEventTarget"/> — and
+    /// leaving the flag set would make the signal refuse every later priority change with a
+    /// <c>NotAllowedError</c>, which is not a state the specification can reach.
+    /// </remarks>
+    internal void SignalPriorityChange(SchedulerTaskPriority priority)
+    {
+        // Step 1.
+        if (PriorityChanging)
+        {
+            var exception = _realm.Intrinsics.DomException.CreateException(
+                DomExceptionNames.NotAllowed,
+                "Failed to execute 'setPriority' on 'TaskController': the signal's priority is already changing.");
+
+            var location = _engine._lastSyntaxElement?.Location ?? default;
+            Throw.JavaScriptException(_engine, exception, in location);
+        }
+
+        // Step 2: setting the priority a signal already has is not a change, so it fires nothing.
+        if (Priority == priority)
+        {
+            return;
+        }
+
+        // Steps 3 to 5.
+        PriorityChanging = true;
+        try
+        {
+            var previousPriority = Priority;
+            Priority = priority;
+
+            // Step 6. Over a snapshot: an algorithm belongs to a scheduler task queue, and a queue that runs
+            // dry takes its algorithm off the signal, which would otherwise be a mutation mid-iteration.
+            if (_priorityChangeAlgorithms is { Count: > 0 } algorithms)
+            {
+                foreach (var algorithm in algorithms.ToArray())
+                {
+                    algorithm();
+                }
+            }
+
+            // Step 7. The event carries the priority the signal had; the new one is read from
+            // event.target.priority, which is why this is dispatched after the assignment above.
+            FirePriorityChangeEvent(previousPriority);
+
+            // Step 8: a dependent signal follows this one, and its own listeners and algorithms run in turn.
+            if (_dependentSignals is { Count: > 0 } dependents)
+            {
+                foreach (var dependent in dependents.ToArray())
+                {
+                    dependent.SignalPriorityChange(priority);
+                }
+            }
+        }
+        finally
+        {
+            // Step 9.
+            PriorityChanging = false;
+        }
+    }
+
+    /// <summary>
+    /// https://wicg.github.io/scheduling-apis/#create-a-dependent-task-signal, the algorithm behind
+    /// <c>TaskSignal.any()</c>.
+    /// </summary>
+    /// <param name="engine">The engine the signal belongs to.</param>
+    /// <param name="realm">The realm whose <c>TaskSignal.prototype</c> the result gets.</param>
+    /// <param name="signals">The abort sources, which may be plain <c>AbortSignal</c>s.</param>
+    /// <param name="priority">A fixed priority, when <c>init["priority"]</c> was a <c>TaskPriority</c>.</param>
+    /// <param name="prioritySource">The signal to follow, when <c>init["priority"]</c> was a <c>TaskSignal</c>.</param>
+    internal static JsTaskSignal CreateDependent(
+        Engine engine,
+        Realm realm,
+        List<JsAbortSignal> signals,
+        SchedulerTaskPriority priority,
+        JsTaskSignal? prioritySource)
+    {
+        // Step 1: the abort half is exactly AbortSignal's, run against a TaskSignal instance.
+        var result = InitializeDependent(
+            new JsTaskSignal(engine, realm, priority)
+            {
+                _prototype = realm.Intrinsics.TaskSignal.PrototypeObject,
+            },
+            signals);
+
+        // Step 2. Unconditionally, unlike the abort algorithm's step 3, which skips it when a source was
+        // already aborted: "has fixed priority" is derived from this flag, and an aborted composite still has
+        // a priority a script can read.
+        result.Dependent = true;
+
+        // Step 3: a fixed TaskPriority — the priority is already in place and nothing follows anything.
+        if (prioritySource is null)
+        {
+            return result;
+        }
+
+        // Step 4.
+        result.Priority = prioritySource.Priority;
+
+        if (prioritySource.HasFixedPriority)
+        {
+            return result;
+        }
+
+        // Step 4.3.1: the graph is flattened to one level, so a change reaches every follower in one pass.
+        var source = prioritySource.Dependent ? prioritySource._sourceSignal : prioritySource;
+        if (source is null)
+        {
+            return result;
+        }
+
+        result._sourceSignal = source;
+        (source._dependentSignals ??= new List<JsTaskSignal>()).Add(result);
+        return result;
+    }
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#concept-event-fire with a <c>TaskPriorityChangeEvent</c> rather than a
+    /// plain <c>Event</c>, which is what step 7 of signal priority change asks for.
+    /// </summary>
+    private void FirePriorityChangeEvent(SchedulerTaskPriority previousPriority)
+    {
+        var ev = _realm.Intrinsics.TaskPriorityChangeEvent.CreateTrustedEvent(previousPriority);
+        DispatchEvent(ev);
+    }
+}
+#endif

--- a/Jint/WebApi/Scheduling/SchedulerInstance.cs
+++ b/Jint/WebApi/Scheduling/SchedulerInstance.cs
@@ -1,0 +1,351 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Native.Promise;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.Abort;
+using Jint.WebApi.DomException;
+using Jint.WebApi.Timers;
+
+namespace Jint.WebApi.Scheduling;
+
+/// <summary>
+/// The <c>scheduler</c> object — an instance of the <c>Scheduler</c> interface.
+/// <para>
+/// https://wicg.github.io/scheduling-apis/#sec-scheduler
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>postTask()</c> runs a callback as its own event-loop task and answers with a promise for what it
+/// returned; <c>yield()</c> answers with a promise that resolves in a fresh task, which is how a long piece of
+/// work breaks itself up without losing its place in the queue. Both order themselves by
+/// <see cref="SchedulerTaskPriority"/> — see <see cref="SchedulerQueue"/> for the ordering guarantees against
+/// microtasks and timers, which are the part a host has to know.
+/// </para>
+/// <para>
+/// <b>Tasks run only while the engine is being pumped</b>, exactly like the timers: the scheduler puts a job
+/// on the engine's event loop and Jint never starts a thread to drain it. A <c>delay</c> rides the very same
+/// timer queue <c>setTimeout</c> uses, and so counts against
+/// <c>Options.WebApi.Timers.MaxActiveTimers</c> while it waits.
+/// </para>
+/// <para>
+/// <b>Neither method ever throws.</b> Both return promises, and WebIDL turns every exception a
+/// promise-returning operation would raise — a bad argument, a receiver that is not a scheduler — into a
+/// rejection of the returned promise instead ("And then, if an exception E was thrown: if op has a return type
+/// that is a promise type, then return ! Call(%Promise.reject%, %Promise%, «E»)",
+/// https://webidl.spec.whatwg.org/#dfn-create-operation-function).
+/// </para>
+/// <para>
+/// Two documented simplifications against WebIDL, the same pair <c>console</c>, <c>crypto</c> and
+/// <c>performance</c> carry. There is no <c>Scheduler</c> interface object and no <c>Scheduler.prototype</c>,
+/// so <c>postTask</c> and <c>yield</c> are own properties of this object with the attributes an ECMAScript
+/// built-in has; both still brand-check their receiver. And the object is installed as an ordinary enumerable
+/// data property of the global rather than through the <c>[Replaceable]</c> accessor pair
+/// https://wicg.github.io/scheduling-apis/#dom-windoworworkerglobalscope-scheduler gives it.
+/// </para>
+/// </remarks>
+[JsObject]
+internal sealed partial class SchedulerInstance : BuiltinShapeObject
+{
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString SchedulerToStringTag = new("Scheduler");
+
+    private static readonly JsString _delayProperty = new("delay");
+    private static readonly JsString _priorityProperty = new("priority");
+    private static readonly JsString _signalProperty = new("signal");
+
+    private readonly Realm _realm;
+    private readonly SchedulerQueue _tasks;
+    private readonly TimerQueue _timers;
+
+    private SchedulerInstance(
+        Engine engine,
+        Realm realm,
+        ObjectPrototype objectPrototype,
+        SchedulerQueue tasks,
+        TimerQueue timers)
+        : base(engine)
+    {
+        _realm = realm;
+        _tasks = tasks;
+        _timers = timers;
+        _prototype = objectPrototype;
+    }
+
+    internal static SchedulerInstance Create(Engine engine, Realm realm, ObjectPrototype objectPrototype)
+    {
+        var state = engine._webApi;
+        if (state?.Scheduler is not { } tasks || state.Timers is not { } timers)
+        {
+            // Unreachable: the global that reaches this property is installed only where both queues were
+            // created, in the same block of WebApiRegistration.
+            Throw.InvalidOperationException("The scheduler object was reached on an engine that has no scheduler queue.");
+            return null!;
+        }
+
+        return new SchedulerInstance(engine, realm, objectPrototype, tasks, timers);
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://wicg.github.io/scheduling-apis/#dom-scheduler-posttask — "the postTask(callback, options)
+    /// method steps are to return the result of scheduling a postTask task for this given callback and
+    /// options", https://wicg.github.io/scheduling-apis/#schedule-a-posttask-task.
+    /// </summary>
+    [JsFunction(Name = "postTask", Length = 1)]
+    private JsValue PostTask(JsValue thisObject, JsValue callback, JsValue options)
+    {
+        // Step 1: the promise exists before anything can fail, because everything that can fail from here on
+        // rejects it rather than throwing.
+        var capability = NewPromiseCapability();
+
+        try
+        {
+            Brand(thisObject, "Failed to execute 'postTask' on 'Scheduler'");
+
+            if (callback is not ICallable callable)
+            {
+                Throw.TypeError(_realm, "Failed to execute 'postTask' on 'Scheduler': the callback provided as parameter 1 is not a function.");
+                return capability.PromiseInstance;
+            }
+
+            var (delay, priority, signal) = ReadPostTaskOptions(options);
+
+            // Step 3: an already-aborted signal means the task never exists at all.
+            if (signal is { Aborted: true })
+            {
+                capability.Reject(signal.Reason);
+                return capability.PromiseInstance;
+            }
+
+            // Steps 4 to 8: the priority option wins and is immutable; otherwise a TaskSignal governs the
+            // priority dynamically; otherwise user-visible.
+            var prioritySource = priority is null ? signal as JsTaskSignal : null;
+            var state = new SchedulingState(signal, prioritySource, priority ?? SchedulerTaskPriority.UserVisible);
+
+            // Steps 9 and 10.
+            var task = new SchedulerTask(_tasks, capability, callable, in state, isContinuation: false);
+            task.RegisterAbortSteps();
+
+            // Steps 12 to 14: a delay defers the *enqueueing*, so the task takes its enqueue order — and
+            // therefore its place among equal-priority tasks — from the moment the delay elapses, not from
+            // the moment postTask was called.
+            if (delay > 0)
+            {
+                ScheduleAfterDelay(task, delay);
+            }
+            else
+            {
+                _tasks.Enqueue(task);
+            }
+        }
+        catch (JavaScriptException ex)
+        {
+            capability.Reject(ex.Error);
+        }
+
+        return capability.PromiseInstance;
+    }
+
+    /// <summary>
+    /// https://wicg.github.io/scheduling-apis/#dom-scheduler-yield — "the yield() method steps are to return
+    /// the result of scheduling a yield continuation for this",
+    /// https://wicg.github.io/scheduling-apis/#schedule-a-yield-continuation.
+    /// </summary>
+    /// <remarks>
+    /// The continuation inherits the abort source and the priority source of the task it is called in, and a
+    /// continuation outranks a task of the same priority — which is what makes a chunked piece of work resume
+    /// ahead of the work queued behind it. See <see cref="SchedulerQueue.CurrentState"/> for how far that
+    /// inheritance reaches here.
+    /// </remarks>
+    [JsFunction(Name = "yield", Length = 0)]
+    private JsValue Yield(JsValue thisObject)
+    {
+        var capability = NewPromiseCapability();
+
+        try
+        {
+            Brand(thisObject, "Failed to execute 'yield' on 'Scheduler'");
+
+            // Steps 2 to 6: the inherited state, or user-visible with nothing to abort it.
+            var inherited = _tasks.CurrentState ?? new SchedulingState(null, null, SchedulerTaskPriority.UserVisible);
+
+            // Step 4.
+            if (inherited.AbortSource is { Aborted: true } abortSource)
+            {
+                capability.Reject(abortSource.Reason);
+                return capability.PromiseInstance;
+            }
+
+            // Steps 7 to 10: no callback — the task's only step is to resolve the promise — and the queue is
+            // the continuation one, whose effective priority is a notch above the task queue beside it.
+            var task = new SchedulerTask(_tasks, capability, callback: null, in inherited, isContinuation: true);
+            task.RegisterAbortSteps();
+            _tasks.Enqueue(task);
+        }
+        catch (JavaScriptException ex)
+        {
+            capability.Reject(ex.Error);
+        }
+
+        return capability.PromiseInstance;
+    }
+
+    /// <summary>
+    /// Step 13 of https://wicg.github.io/scheduling-apis/#schedule-a-posttask-task, "run steps after a timeout
+    /// … given delay": the wait is an entry on the engine's own timer queue, so it elapses only while the
+    /// engine is being pumped and it occupies one of the engine's timer slots until then.
+    /// </summary>
+    private void ScheduleAfterDelay(SchedulerTask task, long delay)
+    {
+        if (_timers.Count >= _timers.MaxActiveTimers)
+        {
+            // Not a specified failure mode — the specification assumes a browser's resources — but a delayed
+            // task is a timer, and a script must not be able to register them without bound.
+            ThrowDomException(
+                DomExceptionNames.QuotaExceeded,
+                $"Failed to execute 'postTask' on 'Scheduler': the engine already has {_timers.MaxActiveTimers} active timers, which is its Options.WebApi.Timers.MaxActiveTimers limit.");
+        }
+
+        var entry = new TimerEntry(_timers, new DelayedEnqueue(_tasks, task), [], delay, repeat: false, _engine.EventLoopGeneration);
+        task.SetDelayTimer(_timers, _timers.Schedule(entry));
+    }
+
+    /// <summary>
+    /// The <c>SchedulerPostTaskOptions</c> dictionary,
+    /// https://wicg.github.io/scheduling-apis/#dictdef-schedulerposttaskoptions.
+    /// </summary>
+    /// <remarks>
+    /// The members are read in lexicographical order — <c>delay</c>, <c>priority</c>, <c>signal</c> — which is
+    /// the order https://webidl.spec.whatwg.org/#es-dictionary specifies and not the order the IDL declares
+    /// them in. It is observable: an options object whose getters throw, or whose members are each invalid,
+    /// reports the first failure in that order.
+    /// </remarks>
+    private (long Delay, SchedulerTaskPriority? Priority, JsAbortSignal? Signal) ReadPostTaskOptions(JsValue options)
+    {
+        const string What = "Failed to execute 'postTask' on 'Scheduler'";
+
+        if (options.IsUndefined() || options.IsNull())
+        {
+            return (0, null, null);
+        }
+
+        if (options is not ObjectInstance dictionary)
+        {
+            Throw.TypeError(_realm, $"{What}: the provided value is not of type 'SchedulerPostTaskOptions'.");
+            return default;
+        }
+
+        var delayValue = dictionary.Get(_delayProperty);
+        var delay = delayValue.IsUndefined() ? 0 : EnforceRangeMilliseconds(delayValue, What);
+
+        var priorityValue = dictionary.Get(_priorityProperty);
+        SchedulerTaskPriority? priority = priorityValue.IsUndefined()
+            ? null
+            : TaskPriorityNames.Parse(_realm, priorityValue, What);
+
+        var signalValue = dictionary.Get(_signalProperty);
+        JsAbortSignal? signal = null;
+        if (!signalValue.IsUndefined())
+        {
+            // The member is typed AbortSignal, not AbortSignal?, so null is a TypeError rather than "no
+            // signal" — https://webidl.spec.whatwg.org/#es-interface.
+            if (signalValue is not JsAbortSignal abortSignal)
+            {
+                Throw.TypeError(_realm, $"{What}: member signal is not of type 'AbortSignal'.");
+                return default;
+            }
+
+            signal = abortSignal;
+        }
+
+        return (delay, priority, signal);
+    }
+
+    /// <summary>
+    /// The <c>[EnforceRange] unsigned long long</c> conversion,
+    /// https://webidl.spec.whatwg.org/#js-unsigned-long-long: a value that is not a finite number, or whose
+    /// integer part falls outside the type, is a <c>TypeError</c> rather than a wrap.
+    /// </summary>
+    /// <remarks>
+    /// The result is then clamped to <see cref="int.MaxValue"/> milliseconds — about 24.8 days — before it
+    /// reaches the timer queue, the same ceiling <c>setTimeout</c> and <c>AbortSignal.timeout()</c> have.
+    /// </remarks>
+    private long EnforceRangeMilliseconds(JsValue value, string what)
+    {
+        var number = TypeConverter.ToNumber(value);
+        if (!double.IsFinite(number))
+        {
+            Throw.TypeError(_realm, $"{what}: member delay is not a finite number.");
+        }
+
+        var integer = Math.Truncate(number);
+        if (integer < 0 || integer > 18446744073709551615d)
+        {
+            Throw.TypeError(_realm, $"{what}: member delay is outside the range of an unsigned long long.");
+        }
+
+        return integer > int.MaxValue ? int.MaxValue : (long) integer;
+    }
+
+    private PromiseCapability NewPromiseCapability()
+        => PromiseConstructor.NewPromiseCapability(_engine, _realm.Intrinsics.Promise);
+
+    private void ThrowDomException(string name, string message)
+    {
+        var exception = _realm.Intrinsics.DomException.CreateException(name, message);
+        var location = _engine._lastSyntaxElement?.Location ?? default;
+        Throw.JavaScriptException(_engine, exception, in location);
+    }
+
+    /// <summary>
+    /// The WebIDL brand check every member performs: a receiver that is not a platform object implementing the
+    /// interface raises a <c>TypeError</c> — which, for these two, the caller turns into a rejection.
+    /// </summary>
+    private void Brand(JsValue thisObject, string what)
+    {
+        if (thisObject is not SchedulerInstance)
+        {
+            Throw.TypeError(_realm, what + ": illegal invocation, receiver is not a Scheduler object.");
+        }
+    }
+
+    /// <summary>
+    /// What a delayed <c>postTask</c>'s timer runs: enqueue the task, unless it was aborted while it waited.
+    /// </summary>
+    /// <remarks>
+    /// An <see cref="ICallable"/> rather than a <c>ClrFunction</c> so that a delayed task creates no
+    /// JavaScript function object for something no script can reach — the timer queue only ever calls it.
+    /// </remarks>
+    private sealed class DelayedEnqueue : ICallable
+    {
+        private readonly SchedulerQueue _scheduler;
+        private readonly SchedulerTask _task;
+
+        internal DelayedEnqueue(SchedulerQueue scheduler, SchedulerTask task)
+        {
+            _scheduler = scheduler;
+            _task = task;
+        }
+
+        public JsValue Call(JsValue thisObject, params JsCallArguments arguments)
+        {
+            // "If signal is null or signal is not aborted, then run enqueueSteps": an abort during the delay
+            // has already rejected the promise, and there is nothing left to schedule.
+            if (!_task.Cancelled)
+            {
+                _scheduler.Enqueue(_task);
+            }
+
+            return JsValue.Undefined;
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/Scheduling/SchedulerQueue.cs
+++ b/Jint/WebApi/Scheduling/SchedulerQueue.cs
@@ -1,0 +1,585 @@
+#if NET8_0_OR_GREATER
+using System.Runtime.InteropServices;
+using Jint.Native;
+using Jint.Native.Promise;
+using Jint.Runtime;
+using Jint.WebApi.Abort;
+using Jint.WebApi.Timers;
+
+namespace Jint.WebApi.Scheduling;
+
+/// <summary>
+/// One engine's scheduler: the task queues behind <c>scheduler.postTask()</c> and <c>scheduler.yield()</c>,
+/// and the single event-loop job that drains them in priority order.
+/// <para>
+/// https://wicg.github.io/scheduling-apis/#sec-scheduling-tasks-processing-model
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Engine-thread only, and deliberately lock-free</b>, like the timer queue beside it: every member is
+/// reached from the engine's pump or from a scheduler method running on it.
+/// </para>
+/// <para>
+/// <b>The engine's pump is not modified.</b> HTML would have the event loop itself choose between its task
+/// queues and the scheduler's; Jint's pump has one job queue, so the scheduler puts <i>one</i> job on it —
+/// <see cref="RunNextTask"/> — which runs the highest-priority pending task and re-enqueues itself while any
+/// remain. Three ordering guarantees follow, and they are what the tests pin:
+/// </para>
+/// <list type="number">
+/// <item><description>
+/// <b>Every microtask runs before the next task.</b> A drain job that finds other jobs still queued re-queues
+/// itself behind them rather than running a task, which is HTML's microtask checkpoint: both
+/// <c>Promise.resolve().then(f); postTask(g)</c> and <c>postTask(g); Promise.resolve().then(f)</c> run
+/// <c>f</c> first, whatever priority <c>g</c> has.
+/// </description></item>
+/// <item><description>
+/// Everything a task queues — promise reactions, <c>queueMicrotask</c> — likewise runs before the <i>next</i>
+/// task, because the drain job re-enqueues itself behind them.
+/// </description></item>
+/// <item><description>
+/// Among tasks pending at the moment one is chosen, the one with the highest
+/// <see cref="SchedulerTaskQueue.EffectivePriority"/> wins, ties going to the oldest — which is exactly
+/// https://wicg.github.io/scheduling-apis/#select-the-next-scheduler-task-queue-from-all-schedulers, reduced
+/// to the one scheduler an engine has. A <c>user-blocking</c> task posted while <c>user-visible</c> ones are
+/// still queued therefore overtakes them.
+/// </description></item>
+/// </list>
+/// <para>
+/// <b>One deliberate divergence, in the other direction:</b> every runnable scheduler task runs before any due
+/// timer. A timer is promoted only when the job queue has run dry (see <c>Engine.TryPromoteDueTimerJob</c>) and
+/// the pump job keeps it non-empty while tasks remain, so even a <c>background</c> task beats a
+/// <c>setTimeout(f, 0)</c> that is already due. HTML makes this choice implementation-defined — "selecting
+/// between the next Scheduler task and the next task from an event loop's task queues is
+/// implementation-defined" — and a browser would typically run the timer first for a background task. An
+/// unbroken chain of scheduler tasks can starve the timers exactly as an unbroken chain of promise reactions
+/// already can.
+/// </para>
+/// <para>
+/// That has one consequence worth knowing for the <c>delay</c> option, which is a timer like any other: a
+/// delayed task joins the queues only once the tasks ahead of it have drained, so it cannot overtake them
+/// however urgent it is, and two delayed tasks that come due together run in due-time order rather than
+/// priority order. Priority orders the tasks that are <i>pending together</i>, which is what a delay defers a
+/// task from being.
+/// </para>
+/// </remarks>
+internal sealed class SchedulerQueue
+{
+    private readonly Engine _engine;
+
+    /// <summary>
+    /// Every non-empty scheduler task queue: the static ones, keyed by (priority, is continuation), and the
+    /// dynamic ones, keyed by (signal, is continuation). The specification keeps two maps; one list is the
+    /// same thing for the handful of queues an engine has, and it is what the selection walks.
+    /// </summary>
+    private readonly List<SchedulerTaskQueue> _queues = new();
+
+    /// <summary>
+    /// https://wicg.github.io/scheduling-apis/#event-loop-next-enqueue-order — "a strictly increasing number
+    /// that is used to determine task execution order across scheduler task queues of the same TaskPriority".
+    /// </summary>
+    private long _nextEnqueueOrder = 1;
+
+    private Action? _pumpJob;
+    private bool _pumpScheduled;
+
+    internal SchedulerQueue(Engine engine)
+    {
+        _engine = engine;
+    }
+
+    /// <summary>
+    /// The scheduling state of the task currently running, or <see langword="null"/> outside one —
+    /// https://wicg.github.io/scheduling-apis/#get-the-current-scheduling-state, which is what
+    /// <c>scheduler.yield()</c> inherits its priority and its abort signal from.
+    /// </summary>
+    /// <remarks>
+    /// <b>Synchronous inheritance only.</b> HTML carries the state into every job callback created while a
+    /// task runs (its <c>HostMakeJobCallback</c> / <c>HostCallJobCallback</c> patches), so a
+    /// <c>scheduler.yield()</c> after an <c>await</c> still inherits. Jint has no such hook, so the state is
+    /// ambient for the synchronous part of a task only: the first <c>yield()</c> a callback makes inherits,
+    /// and one made after an <c>await</c> — including the second hop of an
+    /// <c>await scheduler.yield()</c> chain — falls back to a <c>user-visible</c> continuation with no abort
+    /// source. Nothing silently inherits the <i>wrong</i> state, which is why the fallback is a default rather
+    /// than a guess.
+    /// </remarks>
+    internal SchedulingState? CurrentState { get; set; }
+
+    /// <summary>
+    /// https://wicg.github.io/scheduling-apis/#schedule-a-task-to-invoke-an-algorithm: give the task the next
+    /// enqueue order, append it to the queue selected for its scheduling state, and make sure the pump job is
+    /// on the event loop.
+    /// </summary>
+    internal void Enqueue(SchedulerTask task)
+    {
+        var queue = SelectQueue(task.State, task.IsContinuation);
+        task.EnqueueOrder = _nextEnqueueOrder++;
+        queue.Append(task);
+        SchedulePump();
+    }
+
+    /// <summary>
+    /// Forgets every pending task. Called from <c>Engine.ResetTransientEvaluationState</c>, so a task
+    /// scheduled by one evaluation cycle can never run against the globals a <c>RestoreGlobalSnapshot</c> put
+    /// back — and, like a timer, its promise simply never settles, which is what that API documents for every
+    /// promise registered before a restore.
+    /// </summary>
+    internal void Clear()
+    {
+        foreach (var queue in _queues)
+        {
+            queue.Cancel();
+        }
+
+        _queues.Clear();
+
+        // The pump job that is still on the event loop belongs to the ended cycle and is dropped at dequeue by
+        // the generation fence; clearing the flag is what lets the next cycle schedule a fresh one.
+        _pumpScheduled = false;
+        CurrentState = null;
+    }
+
+    /// <summary>
+    /// https://wicg.github.io/scheduling-apis/#select-the-scheduler-task-queue, with the two maps flattened
+    /// into one list.
+    /// </summary>
+    private SchedulerTaskQueue SelectQueue(in SchedulingState state, bool isContinuation)
+    {
+        var signal = state.PrioritySource;
+
+        // "If signal does not have fixed priority": its tasks need a queue of their own, whose priority moves
+        // when the signal's does. Everything else shares the queue for its (priority, is continuation) pair.
+        if (signal is not null && !signal.HasFixedPriority)
+        {
+            foreach (var candidate in _queues)
+            {
+                if (ReferenceEquals(candidate.Signal, signal) && candidate.IsContinuation == isContinuation)
+                {
+                    return candidate;
+                }
+            }
+
+            var dynamicQueue = new SchedulerTaskQueue(signal.Priority, isContinuation, signal);
+
+            // The priority change algorithm: re-prioritizing the queue is all a priority change has to do, so
+            // the tasks in it never move. That is the specification's own note on why the queues are keyed by
+            // signal.
+            var algorithm = new Action(() => dynamicQueue.Priority = signal.Priority);
+            dynamicQueue.PriorityChangeAlgorithm = algorithm;
+            signal.AddPriorityChangeAlgorithm(algorithm);
+
+            _queues.Add(dynamicQueue);
+            return dynamicQueue;
+        }
+
+        var priority = signal?.Priority ?? state.FixedPriority;
+        foreach (var candidate in _queues)
+        {
+            if (candidate.Signal is null && candidate.Priority == priority && candidate.IsContinuation == isContinuation)
+            {
+                return candidate;
+            }
+        }
+
+        var staticQueue = new SchedulerTaskQueue(priority, isContinuation, signal: null);
+        _queues.Add(staticQueue);
+        return staticQueue;
+    }
+
+    /// <summary>
+    /// Puts the drain job on the event loop, unless one is already there. One job at a time is what keeps the
+    /// microtask checkpoint between two tasks — see the class remarks.
+    /// </summary>
+    private void SchedulePump()
+    {
+        if (_pumpScheduled)
+        {
+            return;
+        }
+
+        _pumpScheduled = true;
+
+        // The current generation: the job is registered and queued in one act, so there is no window in which
+        // the cycle could have ended in between.
+        _engine.AddToEventLoop(_pumpJob ??= RunNextTask);
+    }
+
+    /// <summary>
+    /// The drain job: run one task, then queue itself again if anything is left.
+    /// </summary>
+    private void RunNextTask()
+    {
+        _pumpScheduled = false;
+
+        // The microtask checkpoint: HTML runs a task only once the microtask queue has drained, and Jint's
+        // single job queue is that microtask queue. So a drain job that finds anything queued behind it steps
+        // to the back of the line instead of running a task. It converges — each pass runs the jobs that were
+        // ahead of it, and a job queue that never empties starves the tasks exactly as it starves everything
+        // else — and it is what makes `postTask(f); Promise.resolve().then(g)` run g first, as a browser does.
+        if (_engine.HasPendingEventLoopJobs)
+        {
+            SchedulePump();
+            return;
+        }
+
+        var task = TakeNextTask();
+        if (task is null)
+        {
+            // Everything left had been aborted; TakeNextTask dropped the empty queues on its way through.
+            return;
+        }
+
+        try
+        {
+            task.Run();
+        }
+        finally
+        {
+            // Even when the callback threw something that is not a JavaScript exception — a constraint, a
+            // cancellation — the tasks behind it are still scheduled, exactly as the promise reactions behind
+            // a throwing one are.
+            if (_queues.Count > 0)
+            {
+                SchedulePump();
+            }
+        }
+    }
+
+    /// <summary>
+    /// https://wicg.github.io/scheduling-apis/#select-the-next-scheduler-task-queue-from-all-schedulers, for
+    /// the one scheduler an engine has: the oldest task of the highest-effective-priority queue that has one.
+    /// </summary>
+    private SchedulerTask? TakeNextTask()
+    {
+        SchedulerTaskQueue? bestQueue = null;
+        SchedulerTask? bestTask = null;
+
+        // Backwards so that a queue found empty can be removed without disturbing the walk.
+        for (var i = _queues.Count - 1; i >= 0; i--)
+        {
+            var queue = _queues[i];
+            var head = queue.PeekRunnable();
+            if (head is null)
+            {
+                // "If queue is empty, then run queue's removal steps."
+                RemoveQueueAt(i);
+                continue;
+            }
+
+            if (bestQueue is null
+                || queue.EffectivePriority > bestQueue.EffectivePriority
+                || (queue.EffectivePriority == bestQueue.EffectivePriority && head.EnqueueOrder < bestTask!.EnqueueOrder))
+            {
+                bestQueue = queue;
+                bestTask = head;
+            }
+        }
+
+        if (bestQueue is null)
+        {
+            return null;
+        }
+
+        bestQueue.RemoveHead();
+        if (bestQueue.IsEmpty)
+        {
+            RemoveQueueAt(_queues.IndexOf(bestQueue));
+        }
+
+        return bestTask;
+    }
+
+    private void RemoveQueueAt(int index)
+    {
+        var queue = _queues[index];
+        _queues.RemoveAt(index);
+
+        // The removal steps of a dynamic queue also take its priority change algorithm off the signal, which
+        // the specification leaves to garbage collection. A long-lived TaskSignal would otherwise accumulate
+        // one algorithm per queue it ever governed.
+        if (queue.Signal is { } signal && queue.PriorityChangeAlgorithm is { } algorithm)
+        {
+            signal.RemovePriorityChangeAlgorithm(algorithm);
+            queue.PriorityChangeAlgorithm = null;
+        }
+    }
+}
+
+/// <summary>
+/// One scheduler task queue: https://wicg.github.io/scheduling-apis/#scheduler-task-queue — a priority, an
+/// is-continuation flag and the tasks themselves, which are in enqueue order because they are only ever
+/// appended.
+/// </summary>
+internal sealed class SchedulerTaskQueue
+{
+    private readonly Queue<SchedulerTask> _tasks = new();
+
+    internal SchedulerTaskQueue(SchedulerTaskPriority priority, bool isContinuation, JsTaskSignal? signal)
+    {
+        Priority = priority;
+        IsContinuation = isContinuation;
+        Signal = signal;
+    }
+
+    /// <summary>
+    /// https://wicg.github.io/scheduling-apis/#scheduler-task-queue-priority. Mutable: a dynamic queue's
+    /// priority is what a <c>TaskSignal</c>'s priority change updates.
+    /// </summary>
+    internal SchedulerTaskPriority Priority { get; set; }
+
+    /// <summary>https://wicg.github.io/scheduling-apis/#scheduler-task-queue-is-continuation.</summary>
+    internal bool IsContinuation { get; }
+
+    /// <summary>
+    /// The signal whose priority this queue follows, or <see langword="null"/> for a queue whose priority is
+    /// fixed. It is the key the dynamic queues are found by.
+    /// </summary>
+    internal JsTaskSignal? Signal { get; }
+
+    /// <summary>The algorithm registered on <see cref="Signal"/>, so it can be taken off again.</summary>
+    internal Action? PriorityChangeAlgorithm { get; set; }
+
+    /// <summary>
+    /// https://wicg.github.io/scheduling-apis/#scheduler-task-queue-effective-priority, whose table this
+    /// reproduces exactly: <c>background</c> 0/1, <c>user-visible</c> 2/3, <c>user-blocking</c> 4/5, the
+    /// higher of each pair being the continuation queue. Higher runs first.
+    /// </summary>
+    internal int EffectivePriority => ((int) Priority * 2) + (IsContinuation ? 1 : 0);
+
+    internal bool IsEmpty => _tasks.Count == 0;
+
+    internal void Append(SchedulerTask task) => _tasks.Enqueue(task);
+
+    /// <summary>
+    /// The queue's first runnable task, discarding aborted ones on the way — which is what makes an abort
+    /// O(1): the abort steps only mark the task and settle its promise, and the queue drops it when it
+    /// surfaces.
+    /// </summary>
+    internal SchedulerTask? PeekRunnable()
+    {
+        while (_tasks.TryPeek(out var candidate))
+        {
+            if (!candidate.Cancelled)
+            {
+                return candidate;
+            }
+
+            _tasks.Dequeue();
+        }
+
+        return null;
+    }
+
+    internal void RemoveHead() => _tasks.Dequeue();
+
+    /// <summary>Marks every task as gone, for <see cref="SchedulerQueue.Clear"/>.</summary>
+    internal void Cancel()
+    {
+        foreach (var task in _tasks)
+        {
+            task.Drop();
+        }
+
+        _tasks.Clear();
+    }
+}
+
+/// <summary>
+/// One scheduler task: https://wicg.github.io/scheduling-apis/#scheduler-task, together with the
+/// https://wicg.github.io/scheduling-apis/#task-handle that owns its promise and its abort steps.
+/// </summary>
+/// <remarks>
+/// A <c>postTask</c> task calls its callback and settles the promise with the result; a <c>yield</c>
+/// continuation has no callback and simply resolves. The two differ in that one field and in the
+/// is-continuation flag, which is what puts them in different queues.
+/// </remarks>
+internal sealed class SchedulerTask
+{
+    private readonly SchedulerQueue _scheduler;
+    private readonly PromiseCapability _capability;
+    private readonly ICallable? _callback;
+    private readonly JsAbortSignal? _abortSource;
+
+    private Action? _abortAlgorithm;
+    private TimerQueue? _timers;
+    private int _timerId;
+
+    internal SchedulerTask(
+        SchedulerQueue scheduler,
+        PromiseCapability capability,
+        ICallable? callback,
+        in SchedulingState state,
+        bool isContinuation)
+    {
+        _scheduler = scheduler;
+        _capability = capability;
+        _callback = callback;
+        _abortSource = state.AbortSource;
+        State = state;
+        IsContinuation = isContinuation;
+    }
+
+    /// <summary>
+    /// https://wicg.github.io/scheduling-apis/#scheduling-state — the abort source and the priority source
+    /// this task was scheduled with, and what a <c>yield()</c> inside it inherits.
+    /// </summary>
+    internal SchedulingState State { get; }
+
+    /// <summary>Whether this is a <c>yield()</c> continuation, which outranks a task of the same priority.</summary>
+    internal bool IsContinuation { get; }
+
+    /// <summary>https://wicg.github.io/scheduling-apis/#scheduler-task-enqueue-order.</summary>
+    internal long EnqueueOrder { get; set; }
+
+    /// <summary>
+    /// Whether the task has been aborted or dropped. A queue discards a marked task rather than running it,
+    /// and a delayed task that is marked before its delay elapses is never enqueued at all.
+    /// </summary>
+    internal bool Cancelled { get; private set; }
+
+    /// <summary>
+    /// "If signal is not null, then add handle's abort steps to signal" — step 10 of
+    /// https://wicg.github.io/scheduling-apis/#schedule-a-posttask-task. Aborting a signal therefore rejects
+    /// every task still pending on it, wherever in the schedule it sits.
+    /// </summary>
+    internal void RegisterAbortSteps()
+    {
+        if (_abortSource is null)
+        {
+            return;
+        }
+
+        _abortAlgorithm = Abort;
+        _abortSource.AddAbortAlgorithm(_abortAlgorithm);
+    }
+
+    /// <summary>
+    /// Remembers the timer a delayed <c>postTask</c> is waiting on, so that aborting the task frees the
+    /// timer's slot instead of leaving it to expire into nothing.
+    /// </summary>
+    internal void SetDelayTimer(TimerQueue timers, int timerId)
+    {
+        _timers = timers;
+        _timerId = timerId;
+    }
+
+    /// <summary>
+    /// The abort steps of https://wicg.github.io/scheduling-apis/#create-a-task-handle: reject the promise
+    /// with the signal's reason and take the task out of its queue — lazily here, since a marked task is
+    /// discarded when it surfaces.
+    /// </summary>
+    private void Abort()
+    {
+        if (Cancelled)
+        {
+            return;
+        }
+
+        Cancelled = true;
+        CancelDelayTimer();
+        _capability.Reject(_abortSource!.Reason);
+    }
+
+    /// <summary>
+    /// Drops the task without settling its promise, which is what a <c>RestoreGlobalSnapshot</c> does to
+    /// everything the ended cycle scheduled.
+    /// </summary>
+    internal void Drop()
+    {
+        Cancelled = true;
+        CancelDelayTimer();
+        RemoveAbortSteps();
+    }
+
+    /// <summary>
+    /// The steps https://wicg.github.io/scheduling-apis/#schedule-a-posttask-task queues: run the callback,
+    /// settle the promise with what it returned or threw, then the task complete steps.
+    /// </summary>
+    internal void Run()
+    {
+        // "Set the current scheduling state for scheduler to state" — restored rather than nulled afterwards,
+        // so that a host re-entering the engine from inside a task cannot lose the outer task's state.
+        var previousState = _scheduler.CurrentState;
+        _scheduler.CurrentState = State;
+
+        try
+        {
+            if (_callback is null)
+            {
+                // A yield continuation: "schedule a task to invoke an algorithm ... that performs: resolve
+                // result".
+                _capability.Resolve(JsValue.Undefined);
+                return;
+            }
+
+            JsValue result;
+            try
+            {
+                result = _callback.Call(JsValue.Undefined);
+            }
+            catch (JavaScriptException ex)
+            {
+                // "If that threw an exception, then reject result with that." Only a JavaScript exception:
+                // a constraint, a cancellation or a stack-depth failure is not something a script may catch as
+                // a rejection, and erupts from the pump like any other job's would.
+                _capability.Reject(ex.Error);
+                return;
+            }
+
+            // A callback that aborted its own signal has already rejected the promise; settling is once-only,
+            // so this is then the no-op the specification's "reject, then resolve" ordering also produces.
+            _capability.Resolve(result);
+        }
+        finally
+        {
+            _scheduler.CurrentState = previousState;
+
+            // The task complete steps: "if signal is not null, then remove handle's abort steps from signal".
+            RemoveAbortSteps();
+        }
+    }
+
+    private void RemoveAbortSteps()
+    {
+        if (_abortAlgorithm is { } algorithm)
+        {
+            _abortSource?.RemoveAbortAlgorithm(algorithm);
+            _abortAlgorithm = null;
+        }
+    }
+
+    private void CancelDelayTimer()
+    {
+        if (_timerId != 0)
+        {
+            _timers?.Cancel(_timerId);
+            _timerId = 0;
+            _timers = null;
+        }
+    }
+}
+
+/// <summary>
+/// https://wicg.github.io/scheduling-apis/#scheduling-state — the abort source and priority source a task
+/// carries, and what <c>scheduler.yield()</c> inherits from the task it is called in.
+/// </summary>
+/// <param name="AbortSource">
+/// The <c>signal</c> option, or <see langword="null"/>. May be a plain <c>AbortSignal</c>: cancellation does
+/// not need a task signal.
+/// </param>
+/// <param name="PrioritySource">
+/// The <c>TaskSignal</c> whose priority the task follows, or <see langword="null"/> when the priority is
+/// fixed.
+/// </param>
+/// <param name="FixedPriority">
+/// The priority when <paramref name="PrioritySource"/> is <see langword="null"/>: the <c>priority</c> option
+/// if one was given, and <c>user-visible</c> otherwise. The specification spells this as a "fixed priority
+/// unabortable task signal" and notes that implementations may cache them; not creating one at all is the
+/// same thing without the object.
+/// </param>
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct SchedulingState(
+    JsAbortSignal? AbortSource,
+    JsTaskSignal? PrioritySource,
+    SchedulerTaskPriority FixedPriority);
+#endif

--- a/Jint/WebApi/Scheduling/SchedulerTaskPriority.cs
+++ b/Jint/WebApi/Scheduling/SchedulerTaskPriority.cs
@@ -1,0 +1,90 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Scheduling;
+
+/// <summary>
+/// The <c>TaskPriority</c> enumeration,
+/// https://wicg.github.io/scheduling-apis/#enumdef-taskpriority.
+/// </summary>
+/// <remarks>
+/// The members are declared lowest first so that the numeric value <i>is</i> the priority order, which is what
+/// <see cref="SchedulerTaskQueue.EffectivePriority"/> multiplies out into the specification's own table — see
+/// https://wicg.github.io/scheduling-apis/#scheduler-task-queue-effective-priority.
+/// </remarks>
+internal enum SchedulerTaskPriority
+{
+    /// <summary>https://wicg.github.io/scheduling-apis/#dom-taskpriority-background — the lowest.</summary>
+    Background = 0,
+
+    /// <summary>
+    /// https://wicg.github.io/scheduling-apis/#dom-taskpriority-user-visible — the default for a task that
+    /// names no priority and carries no <c>TaskSignal</c>.
+    /// </summary>
+    UserVisible = 1,
+
+    /// <summary>https://wicg.github.io/scheduling-apis/#dom-taskpriority-user-blocking — the highest.</summary>
+    UserBlocking = 2,
+}
+
+/// <summary>
+/// The three <c>TaskPriority</c> strings and the WebIDL enumeration conversion between them and
+/// <see cref="SchedulerTaskPriority"/>.
+/// </summary>
+internal static class TaskPriorityNames
+{
+    internal static readonly JsString UserBlocking = new("user-blocking");
+    internal static readonly JsString UserVisible = new("user-visible");
+    internal static readonly JsString Background = new("background");
+
+    /// <summary>
+    /// The result of converting an IDL enumeration value to a JavaScript value: "the String value that
+    /// represents the same sequence of code units as the enumeration value",
+    /// https://webidl.spec.whatwg.org/#es-enumeration.
+    /// </summary>
+    internal static JsString ToJsString(SchedulerTaskPriority priority) => priority switch
+    {
+        SchedulerTaskPriority.UserBlocking => UserBlocking,
+        SchedulerTaskPriority.Background => Background,
+        _ => UserVisible,
+    };
+
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#es-enumeration: <c>ToString</c> the value, and a string that is not one
+    /// of the enumeration's values is a <c>TypeError</c> — never a silent fallback to the default.
+    /// </summary>
+    internal static SchedulerTaskPriority Parse(Realm realm, JsValue value, string what)
+    {
+        var text = TypeConverter.ToString(value);
+        if (TryParse(text, out var priority))
+        {
+            return priority;
+        }
+
+        Throw.TypeError(
+            realm,
+            $"{what}: the provided value '{text}' is not a valid enum value of type TaskPriority.");
+        return default;
+    }
+
+    private static bool TryParse(string text, out SchedulerTaskPriority priority)
+    {
+        switch (text)
+        {
+            case "user-blocking":
+                priority = SchedulerTaskPriority.UserBlocking;
+                return true;
+            case "user-visible":
+                priority = SchedulerTaskPriority.UserVisible;
+                return true;
+            case "background":
+                priority = SchedulerTaskPriority.Background;
+                return true;
+            default:
+                priority = default;
+                return false;
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/Scheduling/TaskControllerConstructor.cs
+++ b/Jint/WebApi/Scheduling/TaskControllerConstructor.cs
@@ -1,0 +1,99 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.Abort;
+
+namespace Jint.WebApi.Scheduling;
+
+/// <summary>
+/// The <c>TaskController</c> interface object.
+/// <para>
+/// https://wicg.github.io/scheduling-apis/#taskcontroller
+/// </para>
+/// </summary>
+/// <remarks>
+/// <c>TaskController</c> inherits from <c>AbortController</c>, so its <c>[[Prototype]]</c> is the
+/// <c>AbortController</c> interface object and a task controller aborts exactly the way an abort controller
+/// does — the only thing it adds is <c>setPriority()</c>. It declares no static member, so it needs nothing
+/// from the source generator.
+/// </remarks>
+internal sealed class TaskControllerConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("TaskController");
+    private static readonly JsString _priorityProperty = new("priority");
+
+    private readonly TaskSignalConstructor _signalConstructor;
+
+    internal TaskControllerConstructor(
+        Engine engine,
+        Realm realm,
+        AbortControllerConstructor abortControllerConstructor,
+        TaskSignalConstructor signalConstructor)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = abortControllerConstructor;
+        _signalConstructor = signalConstructor;
+        PrototypeObject = new TaskControllerPrototype(engine, realm, this, abortControllerConstructor.PrototypeObject);
+        _length = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal TaskControllerPrototype PrototypeObject { get; }
+
+    /// <summary>
+    /// https://wicg.github.io/scheduling-apis/#dom-taskcontroller-taskcontroller — "let signal be a new
+    /// TaskSignal object; set signal's priority to init["priority"]; set this's signal to signal".
+    /// </summary>
+    /// <remarks>
+    /// The instance is a <see cref="JsAbortController"/> like any other controller: a task controller adds no
+    /// state of its own, only a signal that happens to be a <see cref="JsTaskSignal"/>. That is also the brand
+    /// <c>setPriority()</c> checks, so calling it on a plain <c>AbortController</c> is the <c>TypeError</c>
+    /// WebIDL asks for.
+    /// </remarks>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        var priority = ReadInit(arguments.At(0));
+
+        // The signal is built before the controller and handed to the creator, so that
+        // `class C extends TaskController {}` still gets a plain TaskSignal — the specification's "let signal
+        // be a new TaskSignal object" says nothing about the subclass.
+        var signal = _signalConstructor.CreateSignal(priority);
+
+        return OrdinaryCreateFromConstructor(
+            newTarget,
+            static intrinsics => intrinsics.TaskController.PrototypeObject,
+            static (Engine engine, Realm _, JsTaskSignal? state) => new JsAbortController(engine, state!),
+            signal);
+    }
+
+    /// <summary>
+    /// The <c>TaskControllerInit</c> dictionary,
+    /// https://wicg.github.io/scheduling-apis/#dictdef-taskcontrollerinit, whose one member defaults to
+    /// <c>"user-visible"</c>. An absent dictionary, an absent member and an explicit <see langword="undefined"/>
+    /// all take that default, per https://webidl.spec.whatwg.org/#es-dictionary.
+    /// </summary>
+    private SchedulerTaskPriority ReadInit(JsValue init)
+    {
+        if (init.IsUndefined() || init.IsNull())
+        {
+            return SchedulerTaskPriority.UserVisible;
+        }
+
+        if (init is not ObjectInstance dictionary)
+        {
+            Throw.TypeError(_realm, "Failed to construct 'TaskController': the provided value is not of type 'TaskControllerInit'.");
+            return default;
+        }
+
+        var priority = dictionary.Get(_priorityProperty);
+        if (priority.IsUndefined())
+        {
+            return SchedulerTaskPriority.UserVisible;
+        }
+
+        return TaskPriorityNames.Parse(_realm, priority, "Failed to construct 'TaskController'");
+    }
+}
+#endif

--- a/Jint/WebApi/Scheduling/TaskControllerPrototype.cs
+++ b/Jint/WebApi/Scheduling/TaskControllerPrototype.cs
@@ -1,0 +1,79 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.Abort;
+
+namespace Jint.WebApi.Scheduling;
+
+/// <summary>
+/// <c>TaskController.prototype</c> — the interface prototype object.
+/// <para>
+/// https://wicg.github.io/scheduling-apis/#taskcontroller
+/// </para>
+/// </summary>
+/// <remarks>
+/// Its <c>[[Prototype]]</c> is <c>AbortController.prototype</c>, which is where <c>signal</c> and
+/// <c>abort()</c> come from; the only member declared here is <c>setPriority()</c>.
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class TaskControllerPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly TaskControllerConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString TaskControllerToStringTag = new("TaskController");
+
+    internal TaskControllerPrototype(
+        Engine engine,
+        Realm realm,
+        TaskControllerConstructor constructor,
+        ObjectInstance abortControllerPrototype) : base(engine, realm)
+    {
+        _prototype = abortControllerPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://wicg.github.io/scheduling-apis/#dom-taskcontroller-setpriority — "the setPriority(priority)
+    /// method steps are to signal priority change on this's signal given priority".
+    /// </summary>
+    /// <remarks>
+    /// Everything that follows is that one algorithm: the tasks already queued against this signal are
+    /// re-prioritized where they stand, then <c>prioritychange</c> is fired at the signal, then any signal
+    /// whose priority follows this one is changed in turn. Setting the priority the signal already has does
+    /// nothing at all, and calling this from inside a <c>prioritychange</c> listener is a
+    /// <c>NotAllowedError</c>.
+    /// </remarks>
+    [JsFunction(Name = "setPriority", Length = 1)]
+    private JsValue SetPriority(JsValue thisObject, JsValue priority)
+    {
+        var signal = Brand(thisObject);
+        signal.SignalPriorityChange(TaskPriorityNames.Parse(_realm, priority, "Failed to execute 'setPriority' on 'TaskController'"));
+        return Undefined;
+    }
+
+    /// <summary>
+    /// The WebIDL brand check: the receiver must be a <c>TaskController</c>, which here means a controller
+    /// whose signal is a <see cref="JsTaskSignal"/> — a plain <c>AbortController</c> has no priority to change.
+    /// </summary>
+    private JsTaskSignal Brand(JsValue thisObject)
+    {
+        if (thisObject is JsAbortController { Signal: JsTaskSignal signal })
+        {
+            return signal;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a TaskController");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Scheduling/TaskPriorityChangeEventConstructor.cs
+++ b/Jint/WebApi/Scheduling/TaskPriorityChangeEventConstructor.cs
@@ -1,0 +1,139 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.Events;
+
+namespace Jint.WebApi.Scheduling;
+
+/// <summary>
+/// The <c>TaskPriorityChangeEvent</c> interface object.
+/// <para>
+/// https://wicg.github.io/scheduling-apis/#taskprioritychangeevent
+/// </para>
+/// </summary>
+/// <remarks>
+/// <c>TaskPriorityChangeEvent</c> inherits from <c>Event</c>, so its <c>[[Prototype]]</c> is the <c>Event</c>
+/// interface object — https://webidl.spec.whatwg.org/#interface-object. Unlike every other event constructor
+/// here its dictionary argument is <b>not</b> optional and its <c>previousPriority</c> member is
+/// <c>required</c>, so <c>new TaskPriorityChangeEvent('prioritychange')</c> is a <c>TypeError</c>.
+/// </remarks>
+internal sealed class TaskPriorityChangeEventConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("TaskPriorityChangeEvent");
+    private static readonly JsString _previousPriorityProperty = new("previousPriority");
+    private static readonly JsString _priorityChangeEventName = new(JsTaskSignal.PriorityChangeEventType);
+
+    internal TaskPriorityChangeEventConstructor(Engine engine, Realm realm, EventConstructor eventConstructor)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = eventConstructor;
+        PrototypeObject = new TaskPriorityChangeEventPrototype(engine, realm, this, eventConstructor.PrototypeObject);
+        _length = new PropertyDescriptor(JsNumber.Create(2), PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal TaskPriorityChangeEventPrototype PrototypeObject { get; }
+
+    /// <summary>
+    /// https://wicg.github.io/scheduling-apis/#dom-taskprioritychangeevent-taskprioritychangeevent
+    /// </summary>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        var type = EventConstructor.RequireType(_realm, arguments, "TaskPriorityChangeEvent");
+
+        if (arguments.Length < 2)
+        {
+            Throw.TypeError(_realm, "Failed to construct 'TaskPriorityChangeEvent': 2 arguments required, but only 1 present.");
+        }
+
+        // The inherited dictionary's members are converted before the interface's own —
+        // https://webidl.spec.whatwg.org/#es-dictionary, "for each dictionary dictionary in dictionaries, in
+        // order".
+        var initArgument = arguments.At(1);
+        var init = EventConstructor.ReadEventInit(_realm, initArgument, "TaskPriorityChangeEvent");
+        var previousPriority = ReadPreviousPriority(initArgument);
+
+        return OrdinaryCreateFromConstructor(
+            newTarget,
+            static intrinsics => intrinsics.TaskPriorityChangeEvent.PrototypeObject,
+            static (Engine engine, Realm _, (JsString Type, EventInit Init, double TimeStamp, SchedulerTaskPriority Previous) state)
+                => new JsTaskPriorityChangeEvent(engine, state.Type, state.Init, state.TimeStamp, state.Previous),
+            (Type: type, Init: init, TimeStamp: EventConstructor.TimeStampNow(_engine), Previous: previousPriority));
+    }
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#concept-event-fire step 2 for the <c>prioritychange</c> event: an event
+    /// the engine creates for itself, so <c>isTrusted</c> is true. Not reachable from script.
+    /// </summary>
+    internal JsTaskPriorityChangeEvent CreateTrustedEvent(SchedulerTaskPriority previousPriority)
+    {
+        return new JsTaskPriorityChangeEvent(
+            _engine,
+            _priorityChangeEventName,
+            default,
+            EventConstructor.TimeStampNow(_engine),
+            previousPriority)
+        {
+            IsTrusted = true,
+            _prototype = PrototypeObject,
+        };
+    }
+
+    /// <summary>
+    /// The <c>previousPriority</c> member of
+    /// https://wicg.github.io/scheduling-apis/#dictdef-taskprioritychangeeventinit, which is <c>required</c>:
+    /// an absent member — or an explicit <see langword="undefined"/>, which
+    /// https://webidl.spec.whatwg.org/#es-dictionary treats as absent — is a <c>TypeError</c> rather than a
+    /// default.
+    /// </summary>
+    private SchedulerTaskPriority ReadPreviousPriority(JsValue init)
+    {
+        const string What = "Failed to construct 'TaskPriorityChangeEvent'";
+
+        if (init is not ObjectInstance dictionary)
+        {
+            // A non-object init already raised the TypeError above; null and undefined reach here, and a
+            // required member cannot be defaulted.
+            Throw.TypeError(_realm, $"{What}: required member previousPriority is undefined.");
+            return default;
+        }
+
+        var previousPriority = dictionary.Get(_previousPriorityProperty);
+        if (previousPriority.IsUndefined())
+        {
+            Throw.TypeError(_realm, $"{What}: required member previousPriority is undefined.");
+        }
+
+        return TaskPriorityNames.Parse(_realm, previousPriority, What);
+    }
+}
+
+/// <summary>
+/// A <c>TaskPriorityChangeEvent</c> instance: an <see cref="JsEvent"/> that also carries the priority its
+/// target had before the change.
+/// <para>
+/// https://wicg.github.io/scheduling-apis/#taskprioritychangeevent
+/// </para>
+/// </summary>
+internal sealed class JsTaskPriorityChangeEvent : JsEvent
+{
+    internal JsTaskPriorityChangeEvent(
+        Engine engine,
+        JsString type,
+        EventInit init,
+        double timeStamp,
+        SchedulerTaskPriority previousPriority)
+        : base(engine, type, init, timeStamp)
+    {
+        PreviousPriority = previousPriority;
+    }
+
+    /// <summary>
+    /// https://wicg.github.io/scheduling-apis/#dom-taskprioritychangeevent-previouspriority. The <i>new</i>
+    /// priority is not on the event at all — it is read from <c>event.target.priority</c>.
+    /// </summary>
+    internal SchedulerTaskPriority PreviousPriority { get; }
+}
+#endif

--- a/Jint/WebApi/Scheduling/TaskPriorityChangeEventPrototype.cs
+++ b/Jint/WebApi/Scheduling/TaskPriorityChangeEventPrototype.cs
@@ -1,0 +1,62 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Scheduling;
+
+/// <summary>
+/// <c>TaskPriorityChangeEvent.prototype</c> — the interface prototype object.
+/// <para>
+/// https://wicg.github.io/scheduling-apis/#taskprioritychangeevent
+/// </para>
+/// </summary>
+/// <remarks>
+/// Its <c>[[Prototype]]</c> is <c>Event.prototype</c>, which is what gives the event <c>type</c>,
+/// <c>target</c>, <c>timeStamp</c> and the rest, and makes
+/// <c>new TaskPriorityChangeEvent(…) instanceof Event</c> hold.
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class TaskPriorityChangeEventPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly TaskPriorityChangeEventConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString TaskPriorityChangeEventToStringTag = new("TaskPriorityChangeEvent");
+
+    internal TaskPriorityChangeEventPrototype(
+        Engine engine,
+        Realm realm,
+        TaskPriorityChangeEventConstructor constructor,
+        ObjectInstance eventPrototype) : base(engine, realm)
+    {
+        _prototype = eventPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://wicg.github.io/scheduling-apis/#dom-taskprioritychangeevent-previouspriority — "the
+    /// previousPriority getter steps are to return the value that the corresponding attribute was initialized
+    /// to".
+    /// </summary>
+    [JsAccessor("previousPriority", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsString PreviousPriorityGet(JsValue thisObject)
+    {
+        if (thisObject is JsTaskPriorityChangeEvent priorityChange)
+        {
+            return TaskPriorityNames.ToJsString(priorityChange.PreviousPriority);
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a TaskPriorityChangeEvent");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Scheduling/TaskSignalConstructor.cs
+++ b/Jint/WebApi/Scheduling/TaskSignalConstructor.cs
@@ -1,0 +1,115 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.Abort;
+
+namespace Jint.WebApi.Scheduling;
+
+/// <summary>
+/// The <c>TaskSignal</c> interface object.
+/// <para>
+/// https://wicg.github.io/scheduling-apis/#tasksignal
+/// </para>
+/// </summary>
+/// <remarks>
+/// <c>TaskSignal</c> inherits from <c>AbortSignal</c>, so its <c>[[Prototype]]</c> is the <c>AbortSignal</c>
+/// interface object — https://webidl.spec.whatwg.org/#interface-object. It declares no constructor operation,
+/// which in WebIDL means the interface object is a function that refuses to construct anything, so a task
+/// signal can only come from a <c>TaskController</c> or from <see cref="StaticAny"/>.
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class TaskSignalConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("TaskSignal");
+    private static readonly JsString _priorityProperty = new("priority");
+
+    internal TaskSignalConstructor(Engine engine, Realm realm, AbortSignalConstructor abortSignalConstructor)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = abortSignalConstructor;
+        PrototypeObject = new TaskSignalPrototype(engine, realm, this, abortSignalConstructor.PrototypeObject);
+        _length = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal TaskSignalPrototype PrototypeObject { get; }
+
+    protected override void Initialize() => CreateProperties_Generated();
+
+    /// <summary>
+    /// An interface without a constructor operation is not constructible.
+    /// </summary>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        Throw.TypeError(_realm, "Illegal constructor");
+        return null!;
+    }
+
+    /// <summary>
+    /// Builds a fresh, non-aborted task signal in this realm at the given priority. Used by
+    /// <see cref="TaskControllerConstructor"/>.
+    /// </summary>
+    internal JsTaskSignal CreateSignal(SchedulerTaskPriority priority)
+    {
+        return new JsTaskSignal(_engine, _realm, priority)
+        {
+            _prototype = PrototypeObject,
+        };
+    }
+
+    /// <summary>
+    /// https://wicg.github.io/scheduling-apis/#dom-tasksignal-any — a signal aborted by whichever of
+    /// <paramref name="signals"/> aborts first, whose priority is either fixed or follows another task signal.
+    /// </summary>
+    /// <remarks>
+    /// Shadowing the inherited <c>AbortSignal.any</c> is the point: without it a script calling
+    /// <c>TaskSignal.any(…)</c> would reach the parent interface's static through the interface object's
+    /// prototype chain and get back a plain <c>AbortSignal</c>, which has no priority at all.
+    /// </remarks>
+    [JsFunction(Name = "any", Length = 1)]
+    private JsTaskSignal StaticAny(JsValue thisObject, JsValue signals, JsValue init)
+    {
+        var sources = _realm.Intrinsics.AbortSignal.ReadSignalSequence(signals, "TaskSignal");
+        var (priority, prioritySource) = ReadAnyInit(init);
+        return JsTaskSignal.CreateDependent(_engine, _realm, sources, priority, prioritySource);
+    }
+
+    /// <summary>
+    /// The <c>TaskSignalAnyInit</c> dictionary, https://wicg.github.io/scheduling-apis/#dictdef-tasksignalanyinit,
+    /// whose one member is the union <c>(TaskPriority or TaskSignal)</c> defaulting to <c>"user-visible"</c>.
+    /// </summary>
+    /// <remarks>
+    /// https://webidl.spec.whatwg.org/#es-union sends a platform object implementing one of the union's
+    /// interface types down that branch, and everything else down the enumeration one — so a <c>TaskSignal</c>
+    /// is the priority source and any other value is stringified and matched against the three priority names.
+    /// </remarks>
+    private (SchedulerTaskPriority Priority, JsTaskSignal? Source) ReadAnyInit(JsValue init)
+    {
+        if (init.IsUndefined() || init.IsNull())
+        {
+            return (SchedulerTaskPriority.UserVisible, null);
+        }
+
+        if (init is not ObjectInstance dictionary)
+        {
+            Throw.TypeError(_realm, "Failed to execute 'any' on 'TaskSignal': the provided value is not of type 'TaskSignalAnyInit'.");
+            return default;
+        }
+
+        var priority = dictionary.Get(_priorityProperty);
+        if (priority.IsUndefined())
+        {
+            return (SchedulerTaskPriority.UserVisible, null);
+        }
+
+        if (priority is JsTaskSignal source)
+        {
+            return (source.Priority, source);
+        }
+
+        return (TaskPriorityNames.Parse(_realm, priority, "Failed to execute 'any' on 'TaskSignal'"), null);
+    }
+}
+#endif

--- a/Jint/WebApi/Scheduling/TaskSignalPrototype.cs
+++ b/Jint/WebApi/Scheduling/TaskSignalPrototype.cs
@@ -1,0 +1,112 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.Events;
+
+namespace Jint.WebApi.Scheduling;
+
+/// <summary>
+/// <c>TaskSignal.prototype</c> — the interface prototype object.
+/// <para>
+/// https://wicg.github.io/scheduling-apis/#tasksignal
+/// </para>
+/// </summary>
+/// <remarks>
+/// Its <c>[[Prototype]]</c> is <c>AbortSignal.prototype</c>, so a task signal has <c>aborted</c>,
+/// <c>reason</c>, <c>throwIfAborted()</c> and the whole of <c>EventTarget</c>, and
+/// <c>signal instanceof AbortSignal</c> holds.
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class TaskSignalPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly TaskSignalConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString TaskSignalToStringTag = new("TaskSignal");
+
+    internal TaskSignalPrototype(
+        Engine engine,
+        Realm realm,
+        TaskSignalConstructor constructor,
+        ObjectInstance abortSignalPrototype) : base(engine, realm)
+    {
+        _prototype = abortSignalPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://wicg.github.io/scheduling-apis/#dom-tasksignal-priority — "the priority getter steps are to
+    /// return this's priority".
+    /// </summary>
+    [JsAccessor("priority", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsString PriorityGet(JsValue thisObject) => TaskPriorityNames.ToJsString(Brand(thisObject).Priority);
+
+    /// <summary>
+    /// https://wicg.github.io/scheduling-apis/#dom-tasksignal-onprioritychange — an event handler IDL
+    /// attribute, https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes, whose
+    /// event handler event type is <c>prioritychange</c>.
+    /// </summary>
+    /// <remarks>
+    /// The same registration mechanics <c>onabort</c> has: the handler is one entry of the signal's own
+    /// listener list, so it takes its turn in registration order among the
+    /// <c>addEventListener('prioritychange', …)</c> listeners; reassigning replaces the value in place, and
+    /// assigning a non-object removes the entry outright.
+    /// </remarks>
+    [JsAccessor("onprioritychange", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue OnPriorityChangeGet(JsValue thisObject)
+    {
+        return Brand(thisObject).FindEventHandler(JsTaskSignal.PriorityChangeEventType)?.Callback ?? Null;
+    }
+
+    /// <summary>
+    /// https://wicg.github.io/scheduling-apis/#dom-tasksignal-onprioritychange, setter half. <c>EventHandler</c>
+    /// is a nullable callback function annotated <c>[LegacyTreatNonObjectAsNull]</c>, so assigning anything
+    /// that is not an object clears the handler rather than raising a <c>TypeError</c>.
+    /// </summary>
+    [JsAccessor("onprioritychange", AccessorKind.Set, Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue OnPriorityChangeSet(JsValue thisObject, JsValue value)
+    {
+        var signal = Brand(thisObject);
+        var existing = signal.FindEventHandler(JsTaskSignal.PriorityChangeEventType);
+
+        if (value is not ObjectInstance)
+        {
+            if (existing is not null)
+            {
+                signal.RemoveListener(existing);
+            }
+
+            return Undefined;
+        }
+
+        if (existing is not null)
+        {
+            existing.Callback = value;
+            return Undefined;
+        }
+
+        signal.AddListener(new EventListenerRegistration(JsTaskSignal.PriorityChangeEventType, value) { IsEventHandler = true });
+        return Undefined;
+    }
+
+    private JsTaskSignal Brand(JsValue thisObject)
+    {
+        if (thisObject is JsTaskSignal signal)
+        {
+            return signal;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a TaskSignal");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/WebApiRegistration.cs
+++ b/Jint/WebApi/WebApiRegistration.cs
@@ -3,6 +3,7 @@ using Jint.Native;
 using Jint.Native.Object;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Descriptors.Specialized;
+using Jint.WebApi.Scheduling;
 using Jint.WebApi.Timers;
 
 namespace Jint.WebApi;
@@ -151,6 +152,18 @@ internal static class WebApiRegistration
             Install(global, engine, "ByteLengthQueuingStrategy", static e => e.Realm.Intrinsics.ByteLengthQueuingStrategy, PropertyFlag.NonEnumerable);
             Install(global, engine, "CountQueuingStrategy", static e => e.Realm.Intrinsics.CountQueuingStrategy, PropertyFlag.NonEnumerable);
         }
+
+        if ((features & WebApiFeatures.Scheduler) != WebApiFeatures.None)
+        {
+            // WebIDL exposes scheduler through a [Replaceable] accessor pair; an ordinary enumerable data
+            // property is the same simplification console, crypto and performance are installed with, and it
+            // is documented on SchedulerInstance.
+            Install(global, engine, "scheduler", static e => e.Realm.Intrinsics.Scheduler, PropertyFlag.ConfigurableEnumerableWritable);
+
+            Install(global, engine, "TaskController", static e => e.Realm.Intrinsics.TaskController, PropertyFlag.NonEnumerable);
+            Install(global, engine, "TaskSignal", static e => e.Realm.Intrinsics.TaskSignal, PropertyFlag.NonEnumerable);
+            Install(global, engine, "TaskPriorityChangeEvent", static e => e.Realm.Intrinsics.TaskPriorityChangeEvent, PropertyFlag.NonEnumerable);
+        }
     }
 
     /// <summary>
@@ -196,12 +209,14 @@ internal static class WebApiRegistration
     /// </remarks>
     private static void CreateEngineState(Options options, Engine engine, WebApiFeatures features)
     {
-        // The timer globals are the obvious reason for a queue; AbortSignal.timeout() is the other, and it
-        // needs one whether or not the host also asked for setTimeout. The events and performance features
-        // additionally read the time origin (Event.timeStamp, performance.now), and fetch keeps its settings
-        // and its in-flight set here, which is why each of them wants the state.
+        // The timer globals are the obvious reason for a queue; AbortSignal.timeout() and a delayed
+        // scheduler.postTask() are the others, and they need one whether or not the host also asked for
+        // setTimeout. The events and performance features additionally read the time origin
+        // (Event.timeStamp, performance.now), fetch keeps its settings and its in-flight set here, and the
+        // scheduler keeps its own task queues here, which is why each of them wants the state even without
+        // the timers flag.
         const WebApiFeatures NeedsEngineState =
-            WebApiFeatures.Timers | WebApiFeatures.Events | WebApiFeatures.Performance | WebApiFeatures.Fetch;
+            WebApiFeatures.Timers | WebApiFeatures.Events | WebApiFeatures.Performance | WebApiFeatures.Fetch | WebApiFeatures.Scheduler;
         if ((features & NeedsEngineState) == WebApiFeatures.None)
         {
             return;
@@ -210,10 +225,12 @@ internal static class WebApiRegistration
         var timerOptions = options.WebApi.Timers;
         var timeProvider = timerOptions.TimeProvider ?? TimeProvider.System;
 
-        // The queue exists for the timer globals and for AbortSignal.timeout(), which needs it whether or
-        // not the host also asked for setTimeout; a performance-only engine reads just the time origin and
-        // never schedules, so it carries no queue at all.
-        var timers = (features & (WebApiFeatures.Timers | WebApiFeatures.Events)) != WebApiFeatures.None
+        // The queue exists for the timer globals, for AbortSignal.timeout() and for a delayed
+        // scheduler.postTask(), each of which needs it whether or not the host also asked for setTimeout; a
+        // performance-only engine reads just the time origin and never schedules, so it carries no queue at
+        // all.
+        const WebApiFeatures NeedsTimerQueue = WebApiFeatures.Timers | WebApiFeatures.Events | WebApiFeatures.Scheduler;
+        var timers = (features & NeedsTimerQueue) != WebApiFeatures.None
             ? new TimerQueue(timeProvider, timerOptions.MaxActiveTimers)
             : null;
 
@@ -221,7 +238,11 @@ internal static class WebApiRegistration
         // Options — and so that a host mutating them afterwards does not change an engine that already exists.
         var fetch = (features & WebApiFeatures.Fetch) != WebApiFeatures.None ? options.WebApi.Fetch : null;
 
-        engine._webApi = new WebApiEngineState(engine, timeProvider, timers, fetch);
+        var scheduler = (features & WebApiFeatures.Scheduler) != WebApiFeatures.None
+            ? new SchedulerQueue(engine)
+            : null;
+
+        engine._webApi = new WebApiEngineState(engine, timeProvider, timers, fetch, scheduler);
     }
 
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ its own `console` (or any other name in the table below), enabling the feature l
 | `Blob` / `File` / `FormData` | `Files` | ✔ shipped |
 | `navigator.userAgent` | `Navigator` | ✔ shipped |
 | `ReadableStream` / `WritableStream` / `TransformStream` / `ByteLengthQueuingStrategy` / `CountQueuingStrategy` | `Streams` | ✔ shipped |
+| `scheduler.postTask` / `scheduler.yield` / `TaskController` / `TaskSignal` | `Scheduler` | ✔ shipped |
 | `fetch` / `Headers` / `Request` / `Response` | `Fetch` — **opt-in on its own, see below** | ✔ shipped |
 
 `WebApiFeatures.Default` — what `UseWebApis()` enables — is every non-network feature that has landed. It
@@ -276,6 +277,22 @@ deterministic and instant; `MaxActiveTimers` (1000 by default) bounds how many a
 and turns the excess into a catchable `QuotaExceededError` `DOMException`. A callback that throws erupts out
 of whatever was pumping — the same contract a promise reaction has — and the rest of the queue runs on the
 next pump.
+
+### Prioritized tasks: `scheduler.postTask` and `scheduler.yield`
+
+`scheduler.postTask(callback, { priority, signal, delay })` runs a callback as its own task and hands back a
+promise for what it returned; `scheduler.yield()` hands back a promise that resolves in a fresh *continuation*
+task, which is how a long piece of work breaks itself up and still resumes ahead of the work queued behind it.
+Priorities are the standard's three — `user-blocking` > `user-visible` (the default) > `background` — and a
+`TaskController` can abort a batch of tasks or reprioritize the ones still waiting, firing `prioritychange` at
+its `TaskSignal` as it does. Neither method ever throws: a bad argument, an aborted signal or a callback that
+throws all become a rejection of the promise you were handed.
+
+Tasks run only while the engine is being pumped, exactly as timers do, and a `delay` rides the very same timer
+queue. Three ordering guarantees, which the tests pin: every microtask runs before the next task, whichever
+order the two were queued in; among the tasks pending together the highest priority wins, ties going to the
+oldest; and every runnable task runs before any *due* timer — the one place this deliberately differs from a
+browser, which is free to make the opposite choice for a `background` task and typically does.
 
 ### Events dispatch to one target, because there is no tree
 


### PR DESCRIPTION
Part of #3084: `scheduler.postTask()`, `scheduler.yield()`, `TaskController`, `TaskSignal` and `TaskPriorityChangeEvent` from https://wicg.github.io/scheduling-apis/, as `WebApiFeatures.Scheduler` (part of `Default`).

Tasks run only while the engine is being pumped, exactly as timers do — the scheduler drains itself through an ordinary event-loop job, so it needs no hook in the pump. The spec's effective-priority table is implemented verbatim (`(int)Priority * 2 + (isContinuation ? 1 : 0)`), giving `yield()` continuations their half-step boost over same-priority tasks; a `yield()` inside a running task inherits that task's priority, and `TaskController.setPriority()` reprioritizes queued tasks and fires `prioritychange` per spec. A task posted from inside a task cannot overtake the microtasks of the turn it was posted in — the drain job checks `EventLoop.HasPendingJobs` and requeues itself behind them, which is the microtask-checkpoint semantics the spec's per-task turn implies (mutation-verified: dispatching inline reorders observable output and fails the pinned ordering tests).

`TaskSignal` extends `AbortSignal` and `TaskController` extends `AbortController`, so an abort posted through a controller rejects the pending task's promise with the signal's reason; a `delay` option rides the existing timer queue. Fixed-priority `postTask` calls do not allocate a signal at all, per the spec's own optimization note.

`scheduler` is installed as an enumerable data property (the same `[Replaceable]` simplification `console`/`crypto`/`performance` use, documented); the three interface objects are non-enumerable globals. A restore clears the task queues alongside the timers.

Tests cover the full priority matrix, continuation ordering, inheritance, reprioritization, abort-before-run and abort-mid-queue, the delay path, and restore semantics; both suites green on net10.0 and net472, with and without `JINT_HOST_CONTRACT_VERIFICATION=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G7Ud48VAs1JicxRZxLDxg