### PR TITLE
Add opt-in localStorage and sessionStorage over a host StorageProvider

### DIFF
--- a/Jint.Tests.PublicInterface/WebApiStorageTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiStorageTests.cs
@@ -1,0 +1,337 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint;
+using Jint.Native;
+using Jint.WebApi;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// <c>localStorage</c> and <c>sessionStorage</c> seen from outside the assembly: what a host has to write to
+/// get them, what it has to write to decide where the data lives, and what it gets when it writes nothing.
+/// </summary>
+/// <remarks>
+/// This project has no <c>InternalsVisibleTo</c>, so everything here is reachable by a third party and every
+/// assertion goes through script or the public options surface, exactly as an embedder's would.
+/// </remarks>
+public class WebApiStorageTests
+{
+    [Fact]
+    public void ADefaultEngineHasNoStorage()
+    {
+        var engine = new Engine();
+
+        engine.Evaluate("typeof localStorage").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof sessionStorage").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof Storage").AsString().Should().Be("undefined");
+        engine.Evaluate("'localStorage' in globalThis").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void UseWebApisDoesNotBringStorage()
+    {
+        // Storage is the one non-network feature that is not in the default set: a host asking for "the web
+        // APIs" is asking for globals, not for somewhere a script can leave data behind.
+        var engine = new Engine(options => options.UseWebApis());
+
+        engine.Evaluate("typeof console").AsString().Should().Be("object");
+        engine.Evaluate("typeof localStorage").AsString().Should().Be("undefined");
+
+        new Options().UseWebApis().WebApi.Features.Should().NotHaveFlag(WebApiFeatures.Storage);
+    }
+
+    [Fact]
+    public void UseStorageInstallsBothGlobalsAndTheInterfaceObject()
+    {
+        var engine = new Engine(options => options.UseStorage());
+
+        engine.Evaluate("typeof localStorage").AsString().Should().Be("object");
+        engine.Evaluate("typeof sessionStorage").AsString().Should().Be("object");
+        engine.Evaluate("typeof Storage").AsString().Should().Be("function");
+        engine.Evaluate("localStorage instanceof Storage").AsBoolean().Should().BeTrue();
+
+        new Options().UseStorage().WebApi.Features.Should().HaveFlag(WebApiFeatures.Storage);
+    }
+
+    [Fact]
+    public void NamingTheFlagIsEnough()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Storage));
+
+        engine.Evaluate("localStorage.setItem('a', '1'); localStorage.a").AsString().Should().Be("1");
+
+        // ... and it brings nothing else with it.
+        engine.Evaluate("typeof console").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void TheDefaultStoreIsPerEngineAndDiesWithIt()
+    {
+        var options = new Options().UseStorage();
+
+        var first = new Engine(options);
+        first.Execute("localStorage.setItem('who', 'first')");
+
+        // Nothing is shared and nothing persists: a second engine built from the very same options starts
+        // empty, which is what makes enabling this safe by default.
+        var second = new Engine(options);
+        second.Evaluate("localStorage.length").AsNumber().Should().Be(0);
+        second.Evaluate("String(localStorage.getItem('who'))").AsString().Should().Be("null");
+    }
+
+    [Fact]
+    public void AHostProviderIsWhatMakesStoragePersist()
+    {
+        // The provider outlives the engine, so this is how a host gives a pooled or per-request engine a
+        // store that was there before it and is there after it.
+        var provider = new InMemoryStorageProvider();
+
+        var first = new Engine(options => options.UseStorage(provider));
+        first.Execute("localStorage.setItem('visits', '1')");
+
+        var second = new Engine(options => options.UseStorage(provider));
+        second.Execute("localStorage.setItem('visits', String(Number(localStorage.getItem('visits')) + 1))");
+
+        second.Evaluate("localStorage.getItem('visits')").AsString().Should().Be("2");
+        provider.GetItem("visits").Should().Be("2");
+        provider.Count.Should().Be(1);
+        provider.Keys.Should().ContainSingle().Which.Should().Be("visits");
+    }
+
+    [Fact]
+    public void AHostCanImplementTheProviderItself()
+    {
+        var provider = new DictionaryStorageProvider();
+        provider.Set("seeded", "by the host");
+
+        var engine = new Engine(options => options.UseStorage(provider));
+
+        engine.Evaluate("""
+            (() => {
+                const seeded = localStorage.seeded;
+                localStorage.fromScript = 'hello';
+                localStorage.setItem('another', 'value');
+                localStorage.removeItem('another');
+                return [seeded, localStorage.length, Object.keys(localStorage).join(',')].join('|');
+            })()
+            """).AsString().Should().Be("by the host|2|seeded,fromScript");
+
+        provider.Read("fromScript").Should().Be("hello");
+    }
+
+    [Fact]
+    public void AProviderThatRefusesAWriteRaisesACatchableQuotaExceededError()
+    {
+        var engine = new Engine(options => options.UseStorage(new RefusingStorageProvider()));
+
+        // The host's message reaches the script, which sees a DOMException it can branch on rather than a
+        // CLR exception erupting through the embedder.
+        engine.Evaluate("""
+            (() => {
+                try { localStorage.setItem('a', '1'); }
+                catch (e) { return [e.name, e.message, e instanceof DOMException, e.code].join('|'); }
+                return 'no throw';
+            })()
+            """).AsString().Should().Be("QuotaExceededError|this store is full|true|22");
+    }
+
+    [Fact]
+    public void TheInBoxQuotaIsConfigurable()
+    {
+        var engine = new Engine(options =>
+        {
+            options.UseStorage();
+            options.WebApi.Storage.MaxTotalBytes = 64;
+        });
+
+        // Counted as 2 bytes per UTF-16 code unit of key and value together, so 24 characters is 48 bytes.
+        engine.Evaluate("""
+            (() => {
+                localStorage.setItem('fits', 'x'.repeat(20));
+                try { localStorage.setItem('over', 'y'.repeat(20)); }
+                catch (e) { return e.name + '|' + localStorage.length; }
+                return 'no throw';
+            })()
+            """).AsString().Should().Be("QuotaExceededError|1");
+    }
+
+    [Fact]
+    public void TheHostDecidesWhetherTheTwoGlobalsAreOneStore()
+    {
+        var shared = new InMemoryStorageProvider();
+        var engine = new Engine(options => options.UseStorage(shared, shared));
+
+        engine.Execute("localStorage.setItem('a', '1')");
+
+        // Two objects, one map — something a browser can never do, and occasionally what a host wants.
+        engine.Evaluate("sessionStorage.getItem('a')").AsString().Should().Be("1");
+        engine.Evaluate("localStorage === sessionStorage").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void SessionStorageCanBeGivenItsOwnProviderAlone()
+    {
+        var session = new InMemoryStorageProvider();
+        var engine = new Engine(options =>
+        {
+            options.UseStorage();
+            options.WebApi.Storage.SessionStorageProvider = session;
+        });
+
+        engine.Execute("sessionStorage.setItem('a', '1'); localStorage.setItem('b', '2')");
+
+        session.GetItem("a").Should().Be("1");
+        session.GetItem("b").Should().BeNull();
+        engine.Evaluate("localStorage.getItem('b')").AsString().Should().Be("2");
+    }
+
+    [Fact]
+    public void AHostRegisteredGlobalWins()
+    {
+        var marker = new JsString("the host's own storage");
+
+        var engine = new Engine(options => options
+            .AddLazyGlobal("localStorage", _ => marker)
+            .UseStorage());
+
+        // The host's configuration runs first and the install is non-clobbering.
+        engine.Evaluate("localStorage").Should().BeSameAs(marker);
+        engine.Evaluate("typeof sessionStorage").AsString().Should().Be("object");
+    }
+
+    [Fact]
+    public void HasTheAttributesWebIdlAsksFor()
+    {
+        var engine = new Engine(options => options.UseStorage());
+
+        var descriptor = engine.Evaluate("Object.getOwnPropertyDescriptor(globalThis, 'localStorage')").AsObject();
+        descriptor.Get("writable").AsBoolean().Should().BeTrue();
+        descriptor.Get("enumerable").AsBoolean().Should().BeTrue();
+        descriptor.Get("configurable").AsBoolean().Should().BeTrue();
+
+        // An interface object is writable and configurable but not enumerable.
+        var interfaceObject = engine.Evaluate("Object.getOwnPropertyDescriptor(globalThis, 'Storage')").AsObject();
+        interfaceObject.Get("writable").AsBoolean().Should().BeTrue();
+        interfaceObject.Get("enumerable").AsBoolean().Should().BeFalse();
+        interfaceObject.Get("configurable").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void DoesNotReachIntoAShadowRealm()
+    {
+        var engine = new Engine(options => options.UseStorage());
+
+        engine.Evaluate("new ShadowRealm().evaluate('typeof localStorage')").AsString().Should().Be("undefined");
+        engine.Evaluate("new ShadowRealm().evaluate('typeof Storage')").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof localStorage").AsString().Should().Be("object");
+    }
+
+    [Fact]
+    public void KeepsWhatTheProviderHoldsAcrossAGlobalSnapshotRestore()
+    {
+        var provider = new InMemoryStorageProvider();
+        var engine = new Engine(options => options.UseStorage(provider));
+
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+        engine.Execute("localStorage.setItem('a', '1'); var leaked = true;");
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        // A restore reverts the global binding table, not the world behind it: the script's own global is
+        // gone and the host's store is not. A host pooling an engine per request and wanting the storage
+        // gone too clears the provider itself — it is host state, like Engine.Advanced.HostDefined.
+        engine.Evaluate("typeof leaked").AsString().Should().Be("undefined");
+        engine.Evaluate("localStorage.getItem('a')").AsString().Should().Be("1");
+
+        provider.Clear();
+        engine.Evaluate("localStorage.length").AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void TheInBoxProviderIsUsableOnItsOwn()
+    {
+        var provider = new InMemoryStorageProvider(maxTotalBytes: 32);
+
+        provider.SetItem("a", "1");
+        provider.SetItem("b", "2");
+        provider.SetItem("a", "3");
+
+        provider.Count.Should().Be(2);
+        provider.Keys.Should().Equal("a", "b");
+        provider.GetItem("a").Should().Be("3");
+        provider.GetItem("missing").Should().BeNull();
+        provider.UsedBytes.Should().Be(8);
+
+        // The quota is enforced against the host too, and by the same exception it hands the engine.
+        var quota = Assert.Throws<StorageQuotaExceededException>(() => provider.SetItem("c", new string('x', 32)));
+        quota.Message.Should().Contain("quota");
+        provider.Count.Should().Be(2);
+
+        provider.RemoveItem("a");
+        provider.Keys.Should().Equal("b");
+        provider.UsedBytes.Should().Be(4);
+
+        provider.Clear();
+        provider.Count.Should().Be(0);
+        provider.UsedBytes.Should().Be(0);
+    }
+
+    /// <summary>
+    /// The shape a host writes: a store of its own, reachable from the host as well as from script.
+    /// </summary>
+    private sealed class DictionaryStorageProvider : StorageProvider
+    {
+        private readonly List<string> _order = [];
+        private readonly Dictionary<string, string> _values = new(StringComparer.Ordinal);
+
+        internal void Set(string key, string value) => SetItem(key, value);
+
+        internal string? Read(string key) => GetItem(key);
+
+        public override IReadOnlyList<string> Keys => _order;
+
+        public override string? GetItem(string key) => _values.TryGetValue(key, out var value) ? value : null;
+
+        public override void SetItem(string key, string value)
+        {
+            if (!_values.ContainsKey(key))
+            {
+                _order.Add(key);
+            }
+
+            _values[key] = value;
+        }
+
+        public override void RemoveItem(string key)
+        {
+            if (_values.Remove(key))
+            {
+                _order.Remove(key);
+            }
+        }
+
+        public override void Clear()
+        {
+            _values.Clear();
+            _order.Clear();
+        }
+    }
+
+    private sealed class RefusingStorageProvider : StorageProvider
+    {
+        public override IReadOnlyList<string> Keys => [];
+
+        public override string? GetItem(string key) => null;
+
+        public override void SetItem(string key, string value) => throw new StorageQuotaExceededException("this store is full");
+
+        public override void RemoveItem(string key)
+        {
+        }
+
+        public override void Clear()
+        {
+        }
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/StorageTests.cs
+++ b/Jint.Tests/Runtime/WebApi/StorageTests.cs
@@ -1,0 +1,617 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Native;
+using Jint.Runtime;
+using Jint.WebApi;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// <c>localStorage</c> and <c>sessionStorage</c>: the six members of the <c>Storage</c> interface, and the
+/// named property access that makes <c>storage.foo = 'bar'</c> mean <c>setItem</c>.
+/// </summary>
+public class StorageTests
+{
+    private static Engine StorageEngine() => new(options => options.UseStorage());
+
+    private static Engine StorageEngine(StorageProvider local, StorageProvider? session = null) =>
+        new(options => options.UseStorage(local, session));
+
+    [Fact]
+    public void RoundTripsThroughTheInterfaceMethods()
+    {
+        var engine = StorageEngine();
+
+        engine.Evaluate("""
+            (() => {
+                localStorage.setItem('a', '1');
+                localStorage.setItem('b', '2');
+                const before = [localStorage.length, localStorage.getItem('a'), String(localStorage.getItem('missing'))];
+                localStorage.removeItem('a');
+                const after = [localStorage.length, String(localStorage.getItem('a'))];
+                localStorage.clear();
+                return [...before, ...after, localStorage.length].join('|');
+            })()
+            """).AsString().Should().Be("2|1|null|1|null|0");
+    }
+
+    [Fact]
+    public void CoercesKeysAndValuesToStrings()
+    {
+        var engine = StorageEngine();
+
+        // Both parameters are DOMStrings, so everything is stringified on the way in.
+        engine.Evaluate("""
+            (() => {
+                localStorage.setItem(1, 2);
+                localStorage.setItem(null, undefined);
+                localStorage.setItem({ toString: () => 'obj' }, [1, 2]);
+                return [
+                    typeof localStorage.getItem('1'), localStorage.getItem('1'),
+                    localStorage.getItem('null'), localStorage.getItem('obj'),
+                ].join('|');
+            })()
+            """).AsString().Should().Be("string|2|undefined|1,2");
+    }
+
+    [Fact]
+    public void KeyAnswersTheStoreOrderAndNullBeyondIt()
+    {
+        var engine = StorageEngine();
+
+        engine.Evaluate("""
+            (() => {
+                localStorage.setItem('first', '1');
+                localStorage.setItem('second', '2');
+                // Overwriting does not move a key, and removing one closes the gap.
+                localStorage.setItem('first', 'again');
+                return [
+                    localStorage.key(0), localStorage.key(1), String(localStorage.key(2)),
+                    // unsigned long, neither [EnforceRange] nor [Clamp]: -1 wraps to 4294967295.
+                    String(localStorage.key(-1)), localStorage.key(NaN), localStorage.key(1.9),
+                ].join('|');
+            })()
+            """).AsString().Should().Be("first|second|null|null|first|second");
+    }
+
+    [Fact]
+    public void ChecksArityBeforeConvertingAnything()
+    {
+        var engine = StorageEngine();
+
+        // WebIDL converts arguments only after the arity check, which is observable: the missing second
+        // argument is reported without the first one's toString ever running.
+        engine.Evaluate("""
+            (() => {
+                const seen = [];
+                let converted = false;
+                const loud = { toString() { converted = true; return 'x'; } };
+                try { localStorage.setItem(loud); } catch (e) { seen.push(e.constructor.name); }
+                try { localStorage.getItem(); } catch (e) { seen.push(e.constructor.name); }
+                try { localStorage.key(); } catch (e) { seen.push(e.constructor.name); }
+                return seen.join(',') + '/' + converted;
+            })()
+            """).AsString().Should().Be("TypeError,TypeError,TypeError/false");
+    }
+
+    [Fact]
+    public void ReadsAndWritesStoredKeysAsProperties()
+    {
+        var engine = StorageEngine();
+
+        engine.Evaluate("""
+            (() => {
+                localStorage.foo = 'bar';
+                const asProperty = localStorage.foo;
+                const asMethod = localStorage.getItem('foo');
+                localStorage.setItem('baz', 'qux');
+                const both = localStorage.baz;
+                delete localStorage.foo;
+                return [asProperty, asMethod, both, String(localStorage.foo), String(localStorage.getItem('foo'))].join('|');
+            })()
+            """).AsString().Should().Be("bar|bar|qux|undefined|null");
+    }
+
+    [Fact]
+    public void AnswersExistenceQuestionsFromTheStore()
+    {
+        var engine = StorageEngine();
+
+        engine.Evaluate("""
+            (() => {
+                localStorage.setItem('here', 'yes');
+                return [
+                    'here' in localStorage,
+                    'gone' in localStorage,
+                    localStorage.hasOwnProperty('here'),
+                    localStorage.hasOwnProperty('gone'),
+                    localStorage.propertyIsEnumerable('here'),
+                ].join('|');
+            })()
+            """).AsString().Should().Be("true|false|true|false|true");
+    }
+
+    [Fact]
+    public void EnumeratesTheStoreInItsOwnOrder()
+    {
+        var engine = StorageEngine();
+
+        // The named properties are appended in the store's order, and deliberately NOT sorted the way
+        // OrdinaryOwnPropertyKeys sorts array indices — "b" stays ahead of "1" everywhere the storage
+        // itself is enumerated. The spread is the exception that proves it: the keys leave in that order
+        // and are then re-sorted by the ordinary object they are copied into.
+        engine.Evaluate("""
+            (() => {
+                localStorage.setItem('b', '1');
+                localStorage.setItem('1', 'x');
+                localStorage.setItem('a', '2');
+                const spread = { ...localStorage };
+                return [
+                    Object.keys(localStorage).join(','),
+                    Object.values(localStorage).join(','),
+                    Object.entries(localStorage).map(e => e.join('=')).join(','),
+                    Object.keys(spread).join(','),
+                    JSON.stringify(localStorage),
+                    Object.getOwnPropertyNames(localStorage).join(','),
+                ].join('|');
+            })()
+            """).AsString().Should().Be("b,1,a|1,x,2|b=1,1=x,a=2|1,b,a|{\"b\":\"1\",\"1\":\"x\",\"a\":\"2\"}|b,1,a");
+    }
+
+    [Fact]
+    public void ForInVisitsTheStoredKeysAndTheEnumerableAttribute()
+    {
+        var engine = StorageEngine();
+
+        // for-in walks the prototype chain, and a WebIDL attribute is an enumerable accessor — so `length`
+        // is visited too, exactly as it is in a browser. What a browser additionally visits, and Jint does
+        // not, is the six operations: Jint's prototype methods are non-enumerable, the documented
+        // simplification every prototype it ships carries. Object.keys is the way to ask for the keys alone.
+        engine.Evaluate("""
+            (() => {
+                localStorage.setItem('one', '1');
+                localStorage.setItem('two', '2');
+                const seen = [];
+                for (const key in localStorage) { seen.push(key); }
+                const own = [];
+                for (const key in localStorage) { if (localStorage.hasOwnProperty(key)) own.push(key); }
+                return seen.join(',') + '/' + own.join(',');
+            })()
+            """).AsString().Should().Be("one,two,length/one,two");
+    }
+
+    [Fact]
+    public void LetsTheInterfaceWinOverAStoredKeyOfTheSameName()
+    {
+        var engine = StorageEngine();
+
+        // The named property visibility algorithm: Storage is not [LegacyOverrideBuiltIns], so anything the
+        // prototype chain carries hides the stored key of that name — while the key itself is stored, read
+        // back through getItem, and left out of the enumerations.
+        engine.Evaluate("""
+            (() => {
+                localStorage.setItem('getItem', 'shadowed');
+                localStorage.setItem('length', 'also shadowed');
+                localStorage.setItem('toString', 'inherited from Object.prototype');
+                return [
+                    typeof localStorage.getItem,
+                    localStorage.getItem('getItem'),
+                    localStorage.length,
+                    typeof localStorage.toString,
+                    localStorage.hasOwnProperty('getItem'),
+                    'getItem' in localStorage,
+                    Object.keys(localStorage).join(','),
+                ].join('|');
+            })()
+            """).AsString().Should().Be("function|shadowed|3|function|false|true|");
+    }
+
+    [Fact]
+    public void AssigningOverAMethodNameStoresTheKeyAndKeepsTheMethod()
+    {
+        var engine = StorageEngine();
+
+        // [[Set]] invokes the named property setter whenever the receiver is the storage and the key is a
+        // string — before any own-property or prototype lookup happens at all.
+        engine.Evaluate("""
+            (() => {
+                localStorage.getItem = 'not a function';
+                return [typeof localStorage.getItem, localStorage.getItem('getItem')].join('|');
+            })()
+            """).AsString().Should().Be("function|not a function");
+    }
+
+    [Fact]
+    public void FollowsThePrototypeChainAsItChanges()
+    {
+        var engine = StorageEngine();
+
+        // The visibility answer is recomputed on every read, so a name that becomes a prototype property
+        // starts hiding the stored key, and stops again when it is deleted. A warmed member-read inline
+        // cache must not outlive either transition.
+        engine.Evaluate("""
+            (() => {
+                localStorage.setItem('later', 'from the store');
+                const read = () => localStorage.later;
+                const before = [read(), read()];
+                Storage.prototype.later = 'from the prototype';
+                const during = [read(), read(), Object.keys(localStorage).length];
+                delete Storage.prototype.later;
+                const after = [read(), read()];
+                return [...before, ...during, ...after].join('|');
+            })()
+            """).AsString().Should().Be("from the store|from the store|from the prototype|from the prototype|0|from the store|from the store");
+    }
+
+    [Fact]
+    public void IsALegacyPlatformObjectForDefineAndFreeze()
+    {
+        var engine = StorageEngine();
+
+        engine.Evaluate("""
+            (() => {
+                const seen = [];
+                Object.defineProperty(localStorage, 'defined', { value: 42 });
+                seen.push(localStorage.getItem('defined'));
+
+                const descriptor = Object.getOwnPropertyDescriptor(localStorage, 'defined');
+                seen.push([descriptor.value, descriptor.writable, descriptor.enumerable, descriptor.configurable].join(''));
+
+                // A non-data descriptor is refused, which DefinePropertyOrThrow turns into a TypeError.
+                try { Object.defineProperty(localStorage, 'x', { get: () => 1 }); } catch (e) { seen.push(e.constructor.name); }
+                try { Object.defineProperty(localStorage, 'x', {}); } catch (e) { seen.push(e.constructor.name); }
+
+                // [[PreventExtensions]] returns false for a legacy platform object.
+                seen.push(Object.isExtensible(localStorage));
+                try { Object.freeze(localStorage); } catch (e) { seen.push(e.constructor.name); }
+                try { Object.preventExtensions(localStorage); } catch (e) { seen.push(e.constructor.name); }
+
+                return seen.join('|');
+            })()
+            """).AsString().Should().Be("42|42truetruetrue|TypeError|TypeError|true|TypeError|TypeError");
+    }
+
+    [Fact]
+    public void DeletingAnAbsentOrInheritedNameSucceedsVacuously()
+    {
+        var engine = StorageEngine();
+
+        engine.Evaluate("""
+            (() => {
+                localStorage.setItem('getItem', 'stored');
+                return [
+                    delete localStorage.absent,
+                    delete localStorage.getItem,
+                    typeof localStorage.getItem,
+                    localStorage.getItem('getItem'),
+                ].join('|');
+            })()
+            """).AsString().Should().Be("true|true|function|stored");
+    }
+
+    [Fact]
+    public void CarriesTheInterfaceObjectAndItsPrototype()
+    {
+        var engine = StorageEngine();
+
+        engine.Evaluate("""
+            (() => {
+                const seen = [];
+                seen.push(localStorage instanceof Storage);
+                seen.push(Object.getPrototypeOf(localStorage) === Storage.prototype);
+                seen.push(Object.prototype.toString.call(localStorage));
+                try { new Storage(); } catch (e) { seen.push(e.constructor.name); }
+                try { Storage(); } catch (e) { seen.push(e.constructor.name); }
+                // Every member brand-checks its receiver.
+                try { Storage.prototype.getItem.call({}, 'a'); } catch (e) { seen.push(e.constructor.name); }
+                try { Storage.prototype.length; } catch (e) { seen.push(e.constructor.name); }
+                return seen.join('|');
+            })()
+            """).AsString().Should().Be("true|true|[object Storage]|TypeError|TypeError|TypeError|TypeError");
+    }
+
+    [Fact]
+    public void KeepsLocalAndSessionApart()
+    {
+        var engine = StorageEngine();
+
+        engine.Evaluate("""
+            (() => {
+                localStorage.setItem('shared?', 'no');
+                sessionStorage.setItem('shared?', 'definitely not');
+                return [
+                    localStorage === sessionStorage,
+                    localStorage === localStorage,
+                    localStorage.getItem('shared?'),
+                    sessionStorage.getItem('shared?'),
+                    sessionStorage instanceof Storage,
+                ].join('|');
+            })()
+            """).AsString().Should().Be("false|true|no|definitely not|true");
+    }
+
+    [Fact]
+    public void TurnsAProvidersQuotaRefusalIntoACatchableDomException()
+    {
+        var engine = new Engine(options => options
+            .UseStorage()
+            .WebApi.Storage.MaxTotalBytes = 32);
+
+        engine.Evaluate("""
+            (() => {
+                const seen = [];
+                localStorage.setItem('k', 'small');           // 2 * (1 + 5) = 12 bytes
+                try {
+                    localStorage.setItem('big', 'x'.repeat(64));
+                } catch (e) {
+                    seen.push(e.name, e instanceof DOMException, e.code, String(localStorage.getItem('big')));
+                }
+                // The store is exactly as it was, and still usable.
+                localStorage.setItem('k', 'tiny');
+                seen.push(localStorage.getItem('k'), localStorage.length);
+                return seen.join('|');
+            })()
+            """).AsString().Should().Be("QuotaExceededError|true|22|null|tiny|1");
+    }
+
+    [Fact]
+    public void QuotaAlsoGuardsTheNamedSetter()
+    {
+        var engine = new Engine(options => options
+            .UseStorage()
+            .WebApi.Storage.MaxTotalBytes = 8);
+
+        engine.Evaluate("""
+            (() => {
+                try { localStorage.tooBig = 'well over the quota'; } catch (e) { return e.name; }
+                return 'no throw';
+            })()
+            """).AsString().Should().Be("QuotaExceededError");
+    }
+
+    [Fact]
+    public void DoesNotTouchTheProviderWhenTheValueIsUnchanged()
+    {
+        // "If this's map[key] exists: ... if oldValue is value, return" — the whole operation is a no-op,
+        // which a recording provider can see and a quota cannot refuse.
+        var provider = new RecordingStorageProvider();
+        var engine = StorageEngine(provider);
+
+        engine.Execute("""
+            localStorage.setItem('a', '1');
+            localStorage.setItem('a', '1');
+            localStorage.setItem('a', '2');
+            localStorage.a = '2';
+            """);
+
+        provider.Log.Should().Be("set(a,1)|set(a,2)");
+    }
+
+    [Fact]
+    public void DrivesTheHostsProviderForEveryOperation()
+    {
+        var provider = new RecordingStorageProvider();
+        var engine = StorageEngine(provider);
+
+        engine.Execute("""
+            localStorage.setItem('a', '1');
+            localStorage.b = '2';
+            localStorage.getItem('a');
+            delete localStorage.b;
+            localStorage.removeItem('a');
+            localStorage.clear();
+            """);
+
+        // Named access goes through the same three operations the interface's methods do.
+        provider.Log.Should().Be("set(a,1)|set(b,2)|remove(b)|remove(a)|clear");
+    }
+
+    [Fact]
+    public void ReadsWhateverTheProviderSaysAtThatMoment()
+    {
+        var provider = new InMemoryStorageProvider();
+        var engine = StorageEngine(provider);
+
+        // A host writing behind the engine's back is seen immediately: the store is read live.
+        provider.SetItem("fromHost", "hello");
+        engine.Evaluate("localStorage.fromHost").AsString().Should().Be("hello");
+
+        engine.Execute("localStorage.setItem('fromScript', 'hi')");
+        provider.GetItem("fromScript").Should().Be("hi");
+        provider.Count.Should().Be(2);
+    }
+
+    [Fact]
+    public void GivesTwoEnginesBuiltFromOneOptionsInstanceTheirOwnStores()
+    {
+        var options = new Options().UseStorage();
+
+        var first = new Engine(options);
+        var second = new Engine(options);
+
+        first.Execute("localStorage.setItem('who', 'first')");
+        second.Execute("localStorage.setItem('who', 'second')");
+
+        first.Evaluate("localStorage.getItem('who')").AsString().Should().Be("first");
+        second.Evaluate("localStorage.getItem('who')").AsString().Should().Be("second");
+        second.Evaluate("localStorage.length").AsNumber().Should().Be(1);
+    }
+
+    [Fact]
+    public void SharesAStoreWhenTheProviderIsShared()
+    {
+        var shared = new InMemoryStorageProvider();
+        var options = new Options().UseStorage(shared, shared);
+
+        var first = new Engine(options);
+        var second = new Engine(options);
+
+        first.Execute("localStorage.setItem('who', 'first')");
+
+        // One provider, one store — for both engines and for both globals.
+        second.Evaluate("localStorage.getItem('who')").AsString().Should().Be("first");
+        second.Evaluate("sessionStorage.getItem('who')").AsString().Should().Be("first");
+        first.Evaluate("localStorage === sessionStorage").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsNotPartOfTheDefaultFeatureSet()
+    {
+        // Storage is state a host may not expect, so it is never inherited from "give me the web APIs".
+        new Options().UseWebApis().WebApi.Features.Should().NotHaveFlag(WebApiFeatures.Storage);
+
+        var web = new Engine(options => options.UseWebApis());
+        web.Evaluate("typeof localStorage").AsString().Should().Be("undefined");
+        web.Evaluate("typeof sessionStorage").AsString().Should().Be("undefined");
+        web.Evaluate("typeof Storage").AsString().Should().Be("undefined");
+
+        var plain = new Engine();
+        plain.Evaluate("typeof localStorage").AsString().Should().Be("undefined");
+        plain.Evaluate("'localStorage' in globalThis").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void GivesEachGlobalTheAttributesWebIdlAsksFor()
+    {
+        var engine = StorageEngine();
+
+        // The interface object is writable and configurable but not enumerable.
+        var storage = engine.Realm.GlobalObject.GetOwnProperty("Storage");
+        storage.Writable.Should().BeTrue();
+        storage.Configurable.Should().BeTrue();
+        storage.Enumerable.Should().BeFalse();
+
+        foreach (var name in new[] { "localStorage", "sessionStorage" })
+        {
+            // ... and the two instances are ordinary enumerable data properties, the documented
+            // simplification of the [Replaceable] accessor pair.
+            var descriptor = engine.Realm.GlobalObject.GetOwnProperty(name);
+            descriptor.Writable.Should().BeTrue();
+            descriptor.Configurable.Should().BeTrue();
+            descriptor.Enumerable.Should().BeTrue();
+        }
+    }
+
+    [Fact]
+    public void DoesNotReachIntoAShadowRealm()
+    {
+        var engine = StorageEngine();
+
+        foreach (var name in new[] { "localStorage", "sessionStorage", "Storage" })
+        {
+            engine.Evaluate($"new ShadowRealm().evaluate('typeof {name}')").AsString().Should().Be("undefined");
+        }
+
+        engine.Evaluate("typeof localStorage").AsString().Should().Be("object");
+    }
+
+    [Fact]
+    public void LeavesAGlobalTheHostAlreadyOwns()
+    {
+        var marker = new JsString("the host's own");
+        var engine = new Engine(options => options
+            .Configure(e => e.SetValue("localStorage", marker))
+            .UseStorage());
+
+        engine.Evaluate("localStorage").Should().BeSameAs(marker);
+        engine.Evaluate("typeof sessionStorage").AsString().Should().Be("object");
+    }
+
+    [Fact]
+    public void SurvivesAGlobalSnapshotRestoreWithItsContents()
+    {
+        var engine = StorageEngine();
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+
+        engine.Execute("localStorage.setItem('written', 'in the first cycle'); var x = 1;");
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        // The binding is back to its unmaterialized lazy descriptor, so the object is rebuilt — but the map
+        // behind it is host state, which a restore deliberately does not revert (like the module registry).
+        engine.Evaluate("typeof x").AsString().Should().Be("undefined");
+        engine.Evaluate("localStorage.getItem('written')").AsString().Should().Be("in the first cycle");
+    }
+
+    [Fact]
+    public void SurvivesAKeyThatIsAlsoASymbol()
+    {
+        var engine = StorageEngine();
+
+        // Symbols never reach the named property machinery: they define, read and delete ordinarily.
+        engine.Evaluate("""
+            (() => {
+                const s = Symbol('tag');
+                localStorage[s] = 'not stored';
+                localStorage.setItem('tag', 'stored');
+                return [
+                    localStorage[s],
+                    localStorage.getItem('tag'),
+                    Object.getOwnPropertySymbols(localStorage).length,
+                    Object.keys(localStorage).join(','),
+                    delete localStorage[s],
+                    String(localStorage[s]),
+                ].join('|');
+            })()
+            """).AsString().Should().Be("not stored|stored|1|tag|true|undefined");
+    }
+
+    [Fact]
+    public void ThrowsThroughToTheHostForAnythingButAQuotaRefusal()
+    {
+        var engine = StorageEngine(new ThrowingStorageProvider());
+
+        // Only StorageQuotaExceededException is translated; a host's own failure is not flattened into a
+        // JavaScript error the script could swallow.
+        var exception = Assert.Throws<InvalidOperationException>(() => engine.Execute("localStorage.setItem('a', '1')"));
+        exception.Message.Should().Be("the database is on fire");
+    }
+
+    private sealed class RecordingStorageProvider : StorageProvider
+    {
+        private readonly InMemoryStorageProvider _inner = new();
+        private readonly List<string> _log = [];
+
+        internal string Log => string.Join("|", _log);
+
+        public override IReadOnlyList<string> Keys => _inner.Keys;
+
+        public override string? GetItem(string key) => _inner.GetItem(key);
+
+        public override void SetItem(string key, string value)
+        {
+            _log.Add($"set({key},{value})");
+            _inner.SetItem(key, value);
+        }
+
+        public override void RemoveItem(string key)
+        {
+            _log.Add($"remove({key})");
+            _inner.RemoveItem(key);
+        }
+
+        public override void Clear()
+        {
+            _log.Add("clear");
+            _inner.Clear();
+        }
+    }
+
+    private sealed class ThrowingStorageProvider : StorageProvider
+    {
+        public override IReadOnlyList<string> Keys => [];
+
+        public override string? GetItem(string key) => null;
+
+        public override void SetItem(string key, string value) => throw new InvalidOperationException("the database is on fire");
+
+        public override void RemoveItem(string key)
+        {
+        }
+
+        public override void Clear()
+        {
+        }
+    }
+}
+#endif

--- a/Jint/Engine.WebApi.cs
+++ b/Jint/Engine.WebApi.cs
@@ -67,7 +67,16 @@ internal sealed class WebApiEngineState
     /// </summary>
     private List<FetchOperation>? _fetches;
 
-    internal WebApiEngineState(Engine engine, TimeProvider timeProvider, TimerQueue? timers, Options.FetchOptions? fetchOptions, SchedulerQueue? scheduler, DiagnosticsSink? diagnostics)
+    /// <summary>
+    /// The quota a defaulted <see cref="InMemoryStorageProvider"/> is built with, captured when the engine
+    /// was, so that mutating the options afterwards cannot change an engine that already exists.
+    /// </summary>
+    private readonly long _storageQuotaBytes;
+
+    private StorageProvider? _localStorageProvider;
+    private StorageProvider? _sessionStorageProvider;
+
+    internal WebApiEngineState(Engine engine, TimeProvider timeProvider, TimerQueue? timers, Options.FetchOptions? fetchOptions, SchedulerQueue? scheduler, DiagnosticsSink? diagnostics, Options.StorageOptions? storage = null)
     {
         _engine = engine;
         _timeProvider = timeProvider;
@@ -75,6 +84,12 @@ internal sealed class WebApiEngineState
         FetchOptions = fetchOptions;
         Scheduler = scheduler;
         Diagnostics = diagnostics;
+
+        // Read once, here, exactly as the clock and the timer cap above are: a provider the host assigned is
+        // the one this engine uses forever, and one it did not assign is defaulted per engine on first use.
+        _localStorageProvider = storage?.LocalStorageProvider;
+        _sessionStorageProvider = storage?.SessionStorageProvider;
+        _storageQuotaBytes = storage?.MaxTotalBytes ?? Options.StorageOptions.DefaultMaxTotalBytes;
 
         // Both halves of the time origin, read back to back: the monotonic reading every later now() is a
         // duration from, and the wall-clock moment that reading corresponds to.
@@ -136,6 +151,25 @@ internal sealed class WebApiEngineState
     /// </summary>
     internal double CurrentHighResolutionTime =>
         _timeProvider.GetElapsedTime(_originTimestamp, _timeProvider.GetTimestamp()).TotalMilliseconds;
+
+    /// <summary>
+    /// The map behind <c>localStorage</c>, and behind <c>sessionStorage</c> — two separate stores, and two
+    /// separate <see cref="InMemoryStorageProvider"/> instances when the host supplied neither.
+    /// </summary>
+    /// <remarks>
+    /// Defaulted on first use rather than at construction, so an engine that enabled the feature and never
+    /// touched the global has still allocated nothing. Deliberately <b>not</b> touched by
+    /// <see cref="ResetTransientState"/>: what a storage holds is host state, like the module registry and
+    /// like <c>Engine.Advanced.HostDefined</c>, and a restore reverts the global binding table rather than
+    /// the world behind it. A host that wants a pooled engine to forget the previous cycle's storage swaps
+    /// the provider, or clears it, itself.
+    /// </remarks>
+    internal StorageProvider LocalStorageProvider =>
+        _localStorageProvider ??= new InMemoryStorageProvider(_storageQuotaBytes);
+
+    /// <inheritdoc cref="LocalStorageProvider" />
+    internal StorageProvider SessionStorageProvider =>
+        _sessionStorageProvider ??= new InMemoryStorageProvider(_storageQuotaBytes);
 
     /// <summary>
     /// Promotes at most one due timer into an event-loop job. One per call rather than all of them, so that

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -71,6 +71,74 @@ public partial class Options
         /// <c>reportError</c> function that feeds it.
         /// </summary>
         public DiagnosticsOptions Diagnostics { get; } = new();
+
+        /// <summary>
+        /// Settings for <c>localStorage</c> and <c>sessionStorage</c>, installed when <see cref="Features"/>
+        /// contains <see cref="WebApiFeatures.Storage"/>.
+        /// </summary>
+        public StorageOptions Storage { get; } = new();
+    }
+
+    /// <summary>
+    /// Settings for the <c>localStorage</c> and <c>sessionStorage</c> globals. Requires .NET 8 or higher.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Storage is not in <see cref="WebApiFeatures.Default"/>.</b> Like <c>fetch</c> it has to be asked
+    /// for by name — <see cref="WebApiOptionsExtensions.UseStorage(Options)"/> — because it is the one web
+    /// API that hands a script somewhere to <i>keep</i> things. A host that says "give me the web APIs"
+    /// expects globals, not a place where the script it ran last week left data for the script it runs now;
+    /// with a host-supplied provider that is exactly what this is, and even the in-box default gives a
+    /// script state that outlives an evaluation. Everything in <see cref="WebApiFeatures.Default"/> is
+    /// surprise-free in that sense, and this is how it stays that way.
+    /// </para>
+    /// <para>
+    /// The two providers are read once, when the engine is built. Assigning the same instance to both makes
+    /// <c>localStorage</c> and <c>sessionStorage</c> one store, which is a thing a browser can never do and
+    /// is occasionally what a host wants.
+    /// </para>
+    /// </remarks>
+    public class StorageOptions
+    {
+        /// <summary>
+        /// Five mebibytes: the quota browsers converged on, and what a defaulted
+        /// <see cref="InMemoryStorageProvider"/> is built with.
+        /// </summary>
+        internal const long DefaultMaxTotalBytes = 5 * 1024 * 1024;
+
+        /// <summary>
+        /// The map behind <c>localStorage</c>. <see langword="null"/> — the default — gives each engine its
+        /// own <see cref="InMemoryStorageProvider"/>, which stores nothing anywhere and dies with the engine.
+        /// </summary>
+        /// <remarks>
+        /// <b>Persistence and cross-engine sharing are entirely the provider's business.</b> Assign an
+        /// instance of your own to put storage on disk, in a database or in a per-tenant cache; assign one
+        /// instance to an <see cref="Options"/> object several engines share to give them one store, and
+        /// remember that a provider reached from concurrently running engines must be thread-safe.
+        /// </remarks>
+        public StorageProvider? LocalStorageProvider { get; set; }
+
+        /// <summary>
+        /// The map behind <c>sessionStorage</c>. <see langword="null"/> — the default — gives each engine its
+        /// own <see cref="InMemoryStorageProvider"/>, separate from <c>localStorage</c>'s.
+        /// </summary>
+        /// <remarks>
+        /// With the in-box provider the two globals differ only in that they are two stores: the lifetime
+        /// difference the names carry in a browser is something only a host-supplied provider can express.
+        /// </remarks>
+        public StorageProvider? SessionStorageProvider { get; set; }
+
+        /// <summary>
+        /// The quota a defaulted <see cref="InMemoryStorageProvider"/> enforces, in the UTF-16 bytes its
+        /// documentation describes. Defaults to five mebibytes. A <c>setItem</c> that would exceed it throws
+        /// a <c>DOMException</c> named <c>QuotaExceededError</c>, which the script can catch.
+        /// </summary>
+        /// <remarks>
+        /// Read once, when the engine is built, and only for a provider this engine defaulted: a
+        /// host-supplied provider enforces whatever limit it likes and this value never reaches it. There is
+        /// no "unlimited" sentinel — <see cref="long.MaxValue"/> is how that is spelled.
+        /// </remarks>
+        public long MaxTotalBytes { get; set; } = DefaultMaxTotalBytes;
     }
 
     /// <summary>
@@ -480,12 +548,22 @@ public enum WebApiFeatures
     Reporting = 1 << 15,
 
     /// <summary>
-    /// The web APIs a host normally wants: everything except outbound network access. Today that is
+    /// <c>localStorage</c>, <c>sessionStorage</c> and the <c>Storage</c> interface —
+    /// https://html.spec.whatwg.org/multipage/webstorage.html. <b>Deliberately not part of
+    /// <see cref="Default"/>:</b> like fetch it has to be named, because it is the one web API that gives a
+    /// script somewhere to keep things, and where that somewhere is — memory, a file, a tenant's row in a
+    /// database — is <see cref="Options.StorageOptions.LocalStorageProvider"/>'s business.
+    /// </summary>
+    Storage = 1 << 16,
+
+    /// <summary>
+    /// The web APIs a host normally wants: everything except outbound network access and persistent state.
+    /// Today that is
     /// <see cref="Console"/>, <see cref="Timers"/>, <see cref="Encoding"/>, <see cref="Base64"/>,
     /// <see cref="StructuredClone"/>, <see cref="Crypto"/>, <see cref="Performance"/>, <see cref="Events"/>,
     /// <see cref="Url"/>, <see cref="Files"/>, <see cref="Navigator"/>, <see cref="Streams"/>,
     /// <see cref="Scheduler"/>, <see cref="Messaging"/> and <see cref="Reporting"/>; it grows as further
-    /// features land, and never comes to include fetch.
+    /// features land, and never comes to include fetch or <see cref="Storage"/>.
     /// </summary>
     Default = Console | Timers | Encoding | Base64 | StructuredClone | Crypto | Performance | Events | Url | Files | Navigator | Streams | Scheduler | Messaging | Reporting,
 }

--- a/Jint/Runtime/Intrinsics.WebApi.cs
+++ b/Jint/Runtime/Intrinsics.WebApi.cs
@@ -14,6 +14,7 @@ using Jint.WebApi.StructuredClone;
 using Jint.WebApi.Performance;
 using Jint.WebApi.Reporting;
 using Jint.WebApi.Scheduling;
+using Jint.WebApi.Storage;
 using Jint.WebApi.Streams;
 using Jint.WebApi.Timers;
 using Jint.WebApi.Url;
@@ -285,5 +286,24 @@ public sealed partial class Intrinsics
 
     internal ReportErrorFunction ReportError =>
         _reportError ??= new ReportErrorFunction(_engine, _realm, Function.PrototypeObject);
+
+    private StorageConstructor? _storage;
+    private JsStorage? _localStorage;
+    private JsStorage? _sessionStorage;
+
+    internal StorageConstructor Storage =>
+        _storage ??= new StorageConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
+
+    /// <summary>
+    /// The one <c>localStorage</c> object of this realm. Built on first access and then kept, so
+    /// <c>localStorage === localStorage</c> holds — the HTML Standard achieves the same by remembering the
+    /// object in the document's "local storage holder".
+    /// </summary>
+    internal JsStorage LocalStorage =>
+        _localStorage ??= JsStorage.Create(_engine, _realm, Storage, StorageKind.Local);
+
+    /// <inheritdoc cref="LocalStorage" />
+    internal JsStorage SessionStorage =>
+        _sessionStorage ??= JsStorage.Create(_engine, _realm, Storage, StorageKind.Session);
 }
 #endif

--- a/Jint/WebApi/InMemoryStorageProvider.cs
+++ b/Jint/WebApi/InMemoryStorageProvider.cs
@@ -1,0 +1,128 @@
+#if NET8_0_OR_GREATER
+namespace Jint.WebApi;
+
+/// <summary>
+/// The <see cref="StorageProvider"/> an engine gets when the host supplies none: a plain in-memory map that
+/// keeps insertion order and enforces a byte budget. Requires .NET 8 or higher.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>It stores nothing anywhere.</b> The data lives in this object and dies with it, so with the default
+/// configuration <c>localStorage</c> and <c>sessionStorage</c> are two separate per-engine dictionaries that
+/// do not survive the engine and are not shared with any other engine — the difference the two names carry in
+/// a browser is entirely about lifetime, and a host that wants one is expected to supply a provider that has
+/// one. Assign the same instance to
+/// <see cref="Options.StorageOptions.LocalStorageProvider"/> on an <see cref="Options"/> object shared by
+/// several engines to share a store between them.
+/// </para>
+/// <para>
+/// <b>Not thread-safe.</b> Two engines running concurrently over one instance corrupt it. That is the same
+/// obligation every provider carries (see <see cref="StorageProvider"/>) and the default arrangement never
+/// meets it, because each engine builds its own.
+/// </para>
+/// <para>
+/// <b>The quota.</b> An entry's size is counted as <c>2 × (key.Length + value.Length)</c> — the UTF-16
+/// storage the pair occupies, which is the unit browsers express their own ~5&#160;MB limits in. The
+/// standard requires only that a value which "cannot be stored" raises a <c>QuotaExceededError</c>; how big
+/// the store may get is not specified, so this is a Jint-defined budget rather than a conformance
+/// requirement. Overwriting an existing key charges only the difference, so replacing a large value with a
+/// small one frees space.
+/// </para>
+/// </remarks>
+public sealed class InMemoryStorageProvider : StorageProvider
+{
+    private readonly Dictionary<string, string> _entries = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Insertion order, which is what <see cref="Keys"/> hands back. A list rather than an ordered
+    /// dictionary because .NET 8 has none, and because removal — the only O(n) operation this costs — is by
+    /// far the rarest thing a storage does.
+    /// </summary>
+    private readonly List<string> _order = [];
+
+    private readonly long _maxTotalBytes;
+    private long _totalBytes;
+
+    /// <summary>
+    /// Creates an empty store limited to five mebibytes, the quota browsers converged on.
+    /// </summary>
+    public InMemoryStorageProvider() : this(Options.StorageOptions.DefaultMaxTotalBytes)
+    {
+    }
+
+    /// <summary>
+    /// Creates an empty store limited to <paramref name="maxTotalBytes"/>.
+    /// </summary>
+    /// <param name="maxTotalBytes">
+    /// The most the whole store may occupy, counted as described on the class. There is no "unlimited"
+    /// sentinel: <see cref="long.MaxValue"/> is how that is spelled, and a value of zero or less admits
+    /// nothing but empty keys and values.
+    /// </param>
+    public InMemoryStorageProvider(long maxTotalBytes)
+    {
+        _maxTotalBytes = maxTotalBytes;
+    }
+
+    /// <summary>
+    /// How much of the budget the entries currently occupy, in the unit described on the class. A host that
+    /// wants to report free space to its scripts can project this itself.
+    /// </summary>
+    public long UsedBytes => _totalBytes;
+
+    /// <inheritdoc />
+    public override IReadOnlyList<string> Keys => _order;
+
+    /// <inheritdoc />
+    public override int Count => _order.Count;
+
+    /// <inheritdoc />
+    public override string? GetItem(string key) => _entries.TryGetValue(key, out var value) ? value : null;
+
+    /// <inheritdoc />
+    public override void SetItem(string key, string value)
+    {
+        var existed = _entries.TryGetValue(key, out var previous);
+        var delta = existed
+            ? SizeOf(value) - SizeOf(previous!)
+            : SizeOf(key) + SizeOf(value);
+
+        var total = _totalBytes + delta;
+        if (total > _maxTotalBytes)
+        {
+            throw new StorageQuotaExceededException(
+                $"Setting the value of '{key}' would take this storage to {total} bytes, over its {_maxTotalBytes}-byte quota.");
+        }
+
+        _entries[key] = value;
+        if (!existed)
+        {
+            _order.Add(key);
+        }
+
+        _totalBytes = total;
+    }
+
+    /// <inheritdoc />
+    public override void RemoveItem(string key)
+    {
+        if (!_entries.TryGetValue(key, out var value))
+        {
+            return;
+        }
+
+        _entries.Remove(key);
+        _order.Remove(key);
+        _totalBytes -= SizeOf(key) + SizeOf(value);
+    }
+
+    /// <inheritdoc />
+    public override void Clear()
+    {
+        _entries.Clear();
+        _order.Clear();
+        _totalBytes = 0;
+    }
+
+    private static long SizeOf(string value) => 2L * value.Length;
+}
+#endif

--- a/Jint/WebApi/Storage/JsStorage.cs
+++ b/Jint/WebApi/Storage/JsStorage.cs
@@ -1,0 +1,370 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.DomException;
+
+namespace Jint.WebApi.Storage;
+
+/// <summary>
+/// A <c>Storage</c> instance — the object <c>localStorage</c> and <c>sessionStorage</c> name.
+/// <para>
+/// https://html.spec.whatwg.org/multipage/webstorage.html#the-storage-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// The six members live on <see cref="StoragePrototype"/>; what is here is the other half of the interface,
+/// the one that makes <c>storage.foo = 'bar'</c> work. <c>Storage</c> declares a named property getter,
+/// setter and deleter, which makes it a <b>legacy platform object</b>
+/// (https://webidl.spec.whatwg.org/#legacy-platform-objects) whose <c>[[GetOwnProperty]]</c>,
+/// <c>[[Set]]</c>, <c>[[DefineOwnProperty]]</c>, <c>[[Delete]]</c>, <c>[[OwnPropertyKeys]]</c> and
+/// <c>[[PreventExtensions]]</c> are all specified — each is overridden below, and each cites its section.
+/// </para>
+/// <para>
+/// The rule that ties them together is the <b>named property visibility algorithm</b>
+/// (https://webidl.spec.whatwg.org/#dfn-named-property-visibility): a stored key is exposed as a property
+/// only when nothing on the prototype chain already carries that name, because <c>Storage</c> is not
+/// declared <c>[LegacyOverrideBuiltIns]</c>. So <c>storage.getItem</c> is always the method however the
+/// script stores a key of that name — and storing it still works, and <c>storage.getItem('getItem')</c>
+/// still reads it back. The specification spells the resulting order out: own properties, then the prototype
+/// chain, then named properties.
+/// </para>
+/// <para>
+/// <b>There is no <c>storage</c> event.</b> Every mutating algorithm ends in "broadcast this", which fires a
+/// <c>StorageEvent</c> at <i>other</i> browsing contexts sharing the same origin — a multi-context feature,
+/// and an engine has exactly one context. The step is therefore a no-op here rather than a partial
+/// implementation, and <c>StorageEvent</c> is absent rather than present-and-never-firing so that feature
+/// detection sees the truth.
+/// </para>
+/// </remarks>
+internal sealed class JsStorage : ObjectInstance
+{
+    /// <summary>
+    /// The attributes <c>LegacyPlatformObjectGetOwnProperty</c> gives a named property: writable because the
+    /// interface has a named property setter, enumerable because it is not declared
+    /// <c>[LegacyUnenumerableNamedProperties]</c>, and configurable always. So <c>Object.keys(storage)</c>
+    /// lists the stored keys, exactly as in a browser.
+    /// </summary>
+    private const PropertyFlag NamedPropertyFlags = PropertyFlag.ConfigurableEnumerableWritable;
+
+    private readonly Realm _realm;
+
+    internal JsStorage(Engine engine, Realm realm, StorageProvider provider, ObjectInstance prototype)
+        : base(engine, ObjectClass.Object)
+    {
+        _realm = realm;
+        Provider = provider;
+        _prototype = prototype;
+    }
+
+    /// <summary>
+    /// The host's map. Read live on every operation, so a provider whose contents change behind the engine's
+    /// back is observed as it is at each step.
+    /// </summary>
+    internal StorageProvider Provider { get; }
+
+    /// <summary>
+    /// Builds the storage object one of the two globals names, over the provider the engine resolved for it.
+    /// </summary>
+    /// <remarks>
+    /// The map is the engine's, not the realm's: the intrinsic that calls this is only ever reached from the
+    /// principal realm's global, and the providers live on the engine's web-API state because that is where
+    /// the host's configuration was read into.
+    /// </remarks>
+    internal static JsStorage Create(Engine engine, Realm realm, StorageConstructor constructor, StorageKind kind)
+    {
+        var state = engine._webApi;
+        if (state is null)
+        {
+            // Unreachable: the globals that reach these properties are installed only where the state was
+            // created, in the same block of WebApiRegistration.
+            Throw.InvalidOperationException("A storage object was reached on an engine that has no web-API state.");
+        }
+
+        var provider = kind == StorageKind.Local ? state.LocalStorageProvider : state.SessionStorageProvider;
+        return new JsStorage(engine, realm, provider, constructor.PrototypeObject);
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/webstorage.html#dom-storage-setitem, and the named property
+    /// setter <c>[[Set]]</c> and <c>[[DefineOwnProperty]]</c> invoke.
+    /// </summary>
+    /// <remarks>
+    /// Step 3 in full: an existing entry whose value is already <paramref name="value"/> makes the whole
+    /// operation a no-op — the provider is not called, so it cannot refuse a write that changes nothing, and
+    /// the key does not move. Step 4's "if value cannot be stored" is the provider's
+    /// <see cref="StorageQuotaExceededException"/>, which becomes the <c>QuotaExceededError</c> the
+    /// algorithm names. Step 6's reorder and step 7's broadcast are the implementation-defined and
+    /// multi-context halves, discussed on the class.
+    /// </remarks>
+    internal void SetItem(string key, string value)
+    {
+        if (string.Equals(Provider.GetItem(key), value, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        try
+        {
+            Provider.SetItem(key, value);
+        }
+        catch (StorageQuotaExceededException quota)
+        {
+            var exception = _realm.Intrinsics.DomException.CreateException(DomExceptionNames.QuotaExceeded, quota.Message);
+            var location = _engine._lastSyntaxElement?.Location ?? default;
+            Throw.JavaScriptException(_engine, exception, in location);
+        }
+    }
+
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#dfn-named-property-visibility, with the value the getter produced.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Step 1 is <see cref="StorageProvider.GetItem"/> answering non-null — the supported property names of
+    /// a <c>Storage</c> object are the keys of its map. Step 2 asks whether the object already has an own
+    /// property of that name; a <c>Storage</c> can only ever own symbols (every string define is routed to
+    /// the named setter below), but the check is written out rather than assumed away, because it is what
+    /// keeps this method and <see cref="GetOwnProperty"/> honest if that ever changes. Step 3 does not
+    /// apply: <c>Storage</c> is not <c>[LegacyOverrideBuiltIns]</c>. Steps 4 and 5 walk the prototype chain,
+    /// which is what <c>HasProperty</c> does.
+    /// </para>
+    /// <para>
+    /// The order of the tests is chosen so the common answers are cheap: a name that is not stored — every
+    /// method name, every miss — costs one lookup in the provider and never walks the prototype chain.
+    /// </para>
+    /// <para>
+    /// One deviation, and only for a chain a script has rearranged itself: the walk asks each prototype for
+    /// an <i>own</i> property, and <c>HasProperty</c> asks the chain as a whole. The two answer the same
+    /// question, but a <c>Proxy</c> spliced in with <c>Object.setPrototypeOf</c> sees its <c>has</c> trap
+    /// rather than one <c>getOwnPropertyDescriptor</c> trap per level.
+    /// </para>
+    /// </remarks>
+    private bool TryGetVisibleNamedProperty(JsValue key, out string value)
+    {
+        value = null!;
+
+        if (key is not JsString name)
+        {
+            return false;
+        }
+
+        var stored = Provider.GetItem(name.ToString());
+        if (stored is null)
+        {
+            return false;
+        }
+
+        if (!ReferenceEquals(base.GetOwnProperty(key), PropertyDescriptor.Undefined))
+        {
+            return false;
+        }
+
+        var prototype = GetPrototypeOf();
+        if (prototype is not null && prototype.HasProperty(key))
+        {
+            return false;
+        }
+
+        value = stored;
+        return true;
+    }
+
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#legacy-platform-object-getownproperty — <c>[[GetOwnProperty]]</c> is
+    /// <c>LegacyPlatformObjectGetOwnProperty(O, P, false)</c>, which answers a visible named property with a
+    /// fresh descriptor and everything else ordinarily.
+    /// </summary>
+    public override PropertyDescriptor GetOwnProperty(JsValue property)
+    {
+        var key = TypeConverter.ToPropertyKey(property);
+        if (TryGetVisibleNamedProperty(key, out var value))
+        {
+            return new PropertyDescriptor(JsString.Create(value), NamedPropertyFlags);
+        }
+
+        return base.GetOwnProperty(key);
+    }
+
+    /// <summary>
+    /// The existence-and-enumerability half of <see cref="GetOwnProperty"/>, answered without materializing
+    /// a descriptor — it backs <c>in</c>, <c>hasOwnProperty</c>, <c>Object.keys</c>, spread,
+    /// <c>Object.assign</c> and <c>JSON.stringify</c>.
+    /// </summary>
+    protected internal override OwnPropertyProbe ProbeOwnProperty(JsValue property)
+    {
+        var key = TypeConverter.ToPropertyKey(property);
+        if (TryGetVisibleNamedProperty(key, out _))
+        {
+            return OwnPropertyProbe.Enumerable;
+        }
+
+        return base.ProbeOwnProperty(key);
+    }
+
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#legacy-platform-object-set — with the receiver being this object and
+    /// the key a string, the named property setter runs and nothing else is consulted. That is what makes
+    /// <c>storage.getItem = 1</c> store a key called <c>getItem</c> while <c>storage.getItem</c> goes on
+    /// answering the method.
+    /// </summary>
+    /// <remarks>
+    /// For a different receiver the algorithm reaches
+    /// <c>LegacyPlatformObjectGetOwnProperty(O, P, <b>true</b>)</c> — named properties ignored — and a
+    /// <c>Storage</c> has no own string properties at all, so that descriptor is always undefined and
+    /// <c>OrdinarySetWithOwnDescriptor</c> reduces to continuing on the prototype chain. Symbols take the
+    /// ordinary path throughout.
+    /// </remarks>
+    public override bool Set(JsValue property, JsValue value, JsValue receiver)
+    {
+        var key = TypeConverter.ToPropertyKey(property);
+        if (key is JsString name)
+        {
+            if (ReferenceEquals(this, receiver))
+            {
+                SetItem(name.ToString(), TypeConverter.ToString(value));
+                return true;
+            }
+
+            var prototype = GetPrototypeOf();
+            if (prototype is not null)
+            {
+                return prototype.Set(key, value, receiver);
+            }
+        }
+
+        return base.Set(key, value, receiver);
+    }
+
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#legacy-platform-object-defineownproperty — a string key never reaches
+    /// <c>OrdinaryDefineOwnProperty</c>: an accessor or otherwise non-data descriptor is refused, and a data
+    /// descriptor's value goes to the named property setter with its attributes discarded.
+    /// </summary>
+    /// <remarks>
+    /// So <c>Object.defineProperty(storage, 'a', { value: 1 })</c> stores <c>"1"</c>, and asking for a
+    /// getter, or for a descriptor with no fields at all, is a <c>TypeError</c> — returning <c>false</c> is
+    /// what <c>DefinePropertyOrThrow</c> turns into one.
+    /// </remarks>
+    public override bool DefineOwnProperty(JsValue property, PropertyDescriptor desc)
+    {
+        var key = TypeConverter.ToPropertyKey(property);
+        if (key is JsString name && ReferenceEquals(base.GetOwnProperty(key), PropertyDescriptor.Undefined))
+        {
+            if (!desc.IsDataDescriptor())
+            {
+                return false;
+            }
+
+            SetItem(name.ToString(), TypeConverter.ToString(desc.Value));
+            return true;
+        }
+
+        return base.DefineOwnProperty(key, desc);
+    }
+
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#legacy-platform-object-delete — a visible named property is removed
+    /// through the named property deleter, which for <c>Storage</c> is <c>removeItem</c>. A name the
+    /// algorithm does not consider visible (a method's, or one that is simply not stored) deletes vacuously,
+    /// leaving the prototype's property alone.
+    /// </summary>
+    public override bool Delete(JsValue property)
+    {
+        var key = TypeConverter.ToPropertyKey(property);
+        if (TryGetVisibleNamedProperty(key, out _))
+        {
+            Provider.RemoveItem(key.ToString());
+            return true;
+        }
+
+        return base.Delete(key);
+    }
+
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#legacy-platform-object-ownpropertykeys — the visible named properties
+    /// first, in the store's own order, then the object's own keys. The named ones are deliberately not
+    /// sorted the way <c>OrdinaryOwnPropertyKeys</c> sorts array indices: a store whose keys are
+    /// <c>"b"</c> then <c>"1"</c> enumerates in that order.
+    /// </summary>
+    public override List<JsValue> GetOwnPropertyKeys(Types types = Types.String | Types.Symbol)
+    {
+        if ((types & Types.String) == Types.Empty)
+        {
+            return base.GetOwnPropertyKeys(types);
+        }
+
+        var names = Provider.Keys;
+        var keys = new List<JsValue>(names.Count + 1);
+
+        for (var i = 0; i < names.Count; i++)
+        {
+            if (i > 0 && i % Engine.ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
+            var name = JsString.Create(names[i]);
+            if (TryGetVisibleNamedProperty(name, out _))
+            {
+                keys.Add(name);
+            }
+        }
+
+        keys.AddRange(base.GetOwnPropertyKeys(types));
+        return keys;
+    }
+
+    /// <summary>
+    /// The same order as <see cref="GetOwnPropertyKeys"/>, with the descriptors materialized. The key list
+    /// is snapshotted first because this is a lazy sequence whose consumer may mutate the store between two
+    /// elements.
+    /// </summary>
+    public override IEnumerable<KeyValuePair<JsValue, PropertyDescriptor>> GetOwnProperties()
+    {
+        var live = Provider.Keys;
+        var names = new string[live.Count];
+        for (var i = 0; i < names.Length; i++)
+        {
+            names[i] = live[i];
+        }
+
+        foreach (var name in names)
+        {
+            var key = JsString.Create(name);
+            if (TryGetVisibleNamedProperty(key, out var value))
+            {
+                yield return new KeyValuePair<JsValue, PropertyDescriptor>(key, new PropertyDescriptor(JsString.Create(value), NamedPropertyFlags));
+            }
+        }
+
+        foreach (var entry in base.GetOwnProperties())
+        {
+            yield return entry;
+        }
+    }
+
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#legacy-platform-object-preventextensions — a legacy platform object
+    /// refuses, which keeps it extensible forever and makes <c>Object.freeze(storage)</c> and
+    /// <c>Object.preventExtensions(storage)</c> raise a <c>TypeError</c>, exactly as in a browser.
+    /// </summary>
+    public override bool PreventExtensions() => false;
+}
+
+/// <summary>
+/// Which of the two globals a <see cref="JsStorage"/> is, which is only ever a question of <i>which map</i>
+/// the engine hands it: the objects are otherwise identical, and the lifetime difference the two names carry
+/// in a browser is something only a host-supplied <see cref="StorageProvider"/> can express.
+/// </summary>
+internal enum StorageKind
+{
+    /// <summary><c>localStorage</c>.</summary>
+    Local,
+
+    /// <summary><c>sessionStorage</c>.</summary>
+    Session,
+}
+#endif

--- a/Jint/WebApi/Storage/StorageConstructor.cs
+++ b/Jint/WebApi/Storage/StorageConstructor.cs
@@ -1,0 +1,57 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Storage;
+
+/// <summary>
+/// The <c>Storage</c> interface object.
+/// <para>
+/// https://html.spec.whatwg.org/multipage/webstorage.html#the-storage-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// The interface declares no constructor operation, which in WebIDL means the interface object exists and is
+/// a function but refuses to construct anything — https://webidl.spec.whatwg.org/#es-interface-call. A
+/// storage can only come from the <c>localStorage</c> and <c>sessionStorage</c> globals, which is what makes
+/// the host's provider the only door to one. The object is still worth having: it carries
+/// <c>Storage.prototype</c>, so <c>localStorage instanceof Storage</c> is true and a script may patch the
+/// prototype the way it patches any other.
+/// </remarks>
+internal sealed class StorageConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("Storage");
+
+    internal StorageConstructor(
+        Engine engine,
+        Realm realm,
+        FunctionPrototype functionPrototype,
+        ObjectPrototype objectPrototype)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = functionPrototype;
+        PrototypeObject = new StoragePrototype(engine, realm, this, objectPrototype);
+        _length = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal StoragePrototype PrototypeObject { get; }
+
+    /// <summary>
+    /// An interface without a constructor operation is not constructible.
+    /// </summary>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        Throw.TypeError(_realm, "Illegal constructor");
+        return null!;
+    }
+
+    /// <summary>
+    /// Builds the one storage object a global names, over the map the host supplied.
+    /// </summary>
+    internal JsStorage CreateStorage(StorageProvider provider) => new(_engine, _realm, provider, PrototypeObject);
+}
+#endif

--- a/Jint/WebApi/Storage/StoragePrototype.cs
+++ b/Jint/WebApi/Storage/StoragePrototype.cs
@@ -1,0 +1,180 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Storage;
+
+/// <summary>
+/// <c>Storage.prototype</c> — the interface prototype object.
+/// <para>
+/// https://html.spec.whatwg.org/multipage/webstorage.html#the-storage-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// The whole interface is here, and it is small: <c>length</c>, <c>key</c>, <c>getItem</c>, <c>setItem</c>,
+/// <c>removeItem</c> and <c>clear</c>. The other half of what a <c>Storage</c> can do — <c>storage.foo</c>,
+/// <c>storage.foo = 'bar'</c>, <c>delete storage.foo</c>, <c>Object.keys(storage)</c> — is the named property
+/// getter/setter/deleter, and lives on <see cref="JsStorage"/> because those are internal methods of the
+/// object rather than members of the interface.
+/// </para>
+/// <para>
+/// Every member brand-checks its receiver, so an extracted <c>getItem</c> called on anything that is not a
+/// <c>Storage</c> raises a <c>TypeError</c> — <c>Storage.prototype</c> itself included, which is not one.
+/// The arity checks come first, before any argument is converted, which is the order WebIDL specifies and is
+/// observable: <c>storage.setItem({ toString() { throw 1 } })</c> raises the <c>TypeError</c> about the
+/// missing second argument rather than running the <c>toString</c>.
+/// </para>
+/// <para>
+/// One documented simplification against WebIDL, shared with every other prototype Jint ships: the
+/// operations are non-enumerable, where a WebIDL interface prototype object's operations are enumerable.
+/// <c>length</c> is a real accessor pair, as an attribute must be, because <c>Object.keys(storage)</c>
+/// listing a <c>length</c> would be visible to any script that enumerates a storage.
+/// </para>
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class StoragePrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly StorageConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString StorageToStringTag = new("Storage");
+
+    internal StoragePrototype(
+        Engine engine,
+        Realm realm,
+        StorageConstructor constructor,
+        ObjectInstance objectPrototype) : base(engine, realm)
+    {
+        _prototype = objectPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// "The <c>length</c> getter steps are to return this's map's size" —
+    /// https://html.spec.whatwg.org/multipage/webstorage.html#dom-storage-length.
+    /// </summary>
+    [JsAccessor("length", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsNumber LengthGet(JsValue thisObject)
+    {
+        return JsNumber.Create(Brand(thisObject).Provider.Count);
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/webstorage.html#dom-storage-key
+    /// </summary>
+    /// <remarks>
+    /// The argument is an <c>unsigned long</c> with neither <c>[EnforceRange]</c> nor <c>[Clamp]</c>, so it
+    /// converts exactly as ECMAScript's <c>ToUint32</c> does: <c>NaN</c> and the infinities become zero and
+    /// everything else wraps modulo 2³². <c>storage.key(-1)</c> therefore asks for index 4294967295 and
+    /// answers <c>null</c> rather than raising.
+    /// </remarks>
+    [JsFunction(Name = "key", Length = 1)]
+    private JsValue Key(JsValue thisObject, JsValue index, [ArgCount] int argCount)
+    {
+        var storage = Brand(thisObject);
+        RequireArguments(argCount, 1, "key");
+
+        // Steps 1 and 2 read the same list: the size it is compared against is the size of the very list the
+        // key is then taken from, so the two cannot disagree even if the host's store is changing.
+        var keys = storage.Provider.Keys;
+        var position = TypeConverter.ToUint32(index);
+
+        return position >= (uint) keys.Count ? Null : JsString.Create(keys[(int) position]);
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/webstorage.html#dom-storage-getitem
+    /// </summary>
+    [JsFunction(Name = "getItem", Length = 1)]
+    private JsValue GetItem(JsValue thisObject, JsValue key, [ArgCount] int argCount)
+    {
+        var storage = Brand(thisObject);
+        RequireArguments(argCount, 1, "getItem");
+
+        var value = storage.Provider.GetItem(TypeConverter.ToString(key));
+        return value is null ? Null : JsString.Create(value);
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/webstorage.html#dom-storage-setitem
+    /// </summary>
+    /// <remarks>
+    /// Both arguments are <c>DOMString</c>s, so everything is stringified on the way in:
+    /// <c>storage.setItem(1, 2)</c> stores <c>"2"</c> under <c>"1"</c>, and <c>storage.setItem('a')</c>
+    /// raises the arity <c>TypeError</c> rather than storing <c>"undefined"</c>. The algorithm's steps are
+    /// on <see cref="JsStorage.SetItem"/>, which this and the named property setter share.
+    /// </remarks>
+    [JsFunction(Name = "setItem", Length = 2)]
+    private JsValue SetItem(JsValue thisObject, JsValue key, JsValue value, [ArgCount] int argCount)
+    {
+        var storage = Brand(thisObject);
+        RequireArguments(argCount, 2, "setItem");
+
+        storage.SetItem(TypeConverter.ToString(key), TypeConverter.ToString(value));
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/webstorage.html#dom-storage-removeitem
+    /// </summary>
+    [JsFunction(Name = "removeItem", Length = 1)]
+    private JsValue RemoveItem(JsValue thisObject, JsValue key, [ArgCount] int argCount)
+    {
+        var storage = Brand(thisObject);
+        RequireArguments(argCount, 1, "removeItem");
+
+        // Step 1's "if this's map[key] does not exist, then return" is the provider's own business: removing
+        // an absent key is defined to do nothing, and asking twice would only cost a lookup.
+        storage.Provider.RemoveItem(TypeConverter.ToString(key));
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/webstorage.html#dom-storage-clear
+    /// </summary>
+    [JsFunction(Name = "clear", Length = 0)]
+    private JsValue Clear(JsValue thisObject)
+    {
+        Brand(thisObject).Provider.Clear();
+        return Undefined;
+    }
+
+    /// <summary>
+    /// WebIDL's arity check: an operation whose required arguments were not all supplied raises a
+    /// <c>TypeError</c> before anything else is converted.
+    /// </summary>
+    private void RequireArguments(int argCount, int required, string operationName)
+    {
+        if (argCount < required)
+        {
+            Throw.TypeError(
+                _realm,
+                $"Failed to execute '{operationName}' on 'Storage': {required} argument{(required == 1 ? "" : "s")} required, but only {argCount} present.");
+        }
+    }
+
+    /// <summary>
+    /// The WebIDL brand check every member performs.
+    /// </summary>
+    private JsStorage Brand(JsValue thisObject)
+    {
+        if (thisObject is JsStorage storage)
+        {
+            return storage;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a Storage");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/StorageProvider.cs
+++ b/Jint/WebApi/StorageProvider.cs
@@ -1,0 +1,170 @@
+#if NET8_0_OR_GREATER
+namespace Jint.WebApi;
+
+/// <summary>
+/// The store behind a <c>localStorage</c> or <c>sessionStorage</c> object: the
+/// <see href="https://html.spec.whatwg.org/multipage/webstorage.html#concept-storage-map">storage map</see>
+/// the Web Storage algorithms operate on. Requires .NET 8 or higher.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The HTML Standard describes what a <c>Storage</c> object does to its map and says nothing about where the
+/// map lives — in a browser it is a per-origin bottle backed by disk, and nothing about that is derivable
+/// from script. So Jint implements the algorithms and leaves the map to the host: implement this class to put
+/// storage on a file, a database, a per-tenant cache or a request-scoped dictionary, and
+/// <see cref="InMemoryStorageProvider"/> is what an engine gets when the host says nothing.
+/// </para>
+/// <para>
+/// <b>Persistence and sharing are entirely yours.</b> Nothing in Jint writes a provider to disk, and nothing
+/// makes two engines share one: whether <c>localStorage</c> survives a process restart, and whether two
+/// engines see the same data, is decided by which instance you hand to which
+/// <see cref="Options.StorageOptions"/> — a provider assigned to an <see cref="Options"/> instance shared by
+/// several engines is shared by all of them. The default gives each engine its own in-memory store, which
+/// nothing outlives.
+/// </para>
+/// <para>
+/// <b>Threading.</b> An engine calls its providers only from the thread running that engine, and only inside
+/// a script evaluation. A provider handed to engines that run concurrently is called from each of their
+/// threads and must then be thread-safe; <see cref="InMemoryStorageProvider"/> deliberately is not.
+/// </para>
+/// <para>
+/// <b>Keys and values are arbitrary UTF-16 strings.</b> They are WebIDL <c>DOMString</c>s, never validated
+/// and never normalized: an unpaired surrogate, an embedded NUL and the empty string are all legal, and a
+/// provider that cannot store one of those must say so by throwing
+/// <see cref="StorageQuotaExceededException"/> rather than by silently dropping or altering it.
+/// </para>
+/// <para>
+/// <b>Exceptions.</b> A <see cref="StorageQuotaExceededException"/> from <see cref="SetItem"/> becomes a
+/// <c>QuotaExceededError</c> <c>DOMException</c> the script can catch, which is exactly what the
+/// specification's "if value cannot be stored, then throw a QuotaExceededError" step asks for. Every other
+/// exception propagates to the host as itself: an I/O failure in a database-backed provider is a host
+/// problem, and turning it into a JavaScript error the script swallows would hide it.
+/// </para>
+/// <para>
+/// An abstract class rather than an interface so that later revisions can add members — a byte-size
+/// estimate, an async warm-up — without breaking the hosts that implement it today.
+/// </para>
+/// </remarks>
+public abstract class StorageProvider
+{
+    /// <summary>
+    /// Initializes a new provider.
+    /// </summary>
+    protected StorageProvider()
+    {
+    }
+
+    /// <summary>
+    /// The store's keys, in the order <c>Storage.key(n)</c>, <c>Object.keys</c> and <c>for..in</c> report
+    /// them — the result of
+    /// <see href="https://html.spec.whatwg.org/multipage/webstorage.html#dom-storage-key">"get the keys" on
+    /// the map</see>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The order is implementation-defined: the standard's "reorder a Storage object" step is explicitly
+    /// "in an implementation-defined manner", and notes that iteration order "is not defined and can change
+    /// upon most mutations". Keeping insertion order — what <see cref="InMemoryStorageProvider"/> does — is
+    /// therefore conforming, and so is any other stable order. What a script may rely on is only that the
+    /// order does not change while the store does not.
+    /// </para>
+    /// <para>
+    /// The engine reads the list immediately and never retains it, so returning a live view of the store's
+    /// own key list is fine; no script can run between the call and the copy. It must contain no duplicates
+    /// and no <see langword="null"/>, and it must agree with <see cref="GetItem"/>: a key it lists must
+    /// resolve to a value, and a key it omits must not.
+    /// </para>
+    /// </remarks>
+    public abstract IReadOnlyList<string> Keys { get; }
+
+    /// <summary>
+    /// The number of entries — <c>storage.length</c>, which the standard defines as "this's map's size".
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>Keys.Count</c>, which is always correct; override it when the store can count more
+    /// cheaply than it can list. An override must agree with <see cref="Keys"/>.
+    /// </remarks>
+    public virtual int Count => Keys.Count;
+
+    /// <summary>
+    /// The value stored under <paramref name="key"/>, or <see langword="null"/> when the map has no such
+    /// entry — <see href="https://html.spec.whatwg.org/multipage/webstorage.html#dom-storage-getitem">getItem</see>.
+    /// </summary>
+    /// <remarks>
+    /// <see langword="null"/> means <i>absent</i> and nothing else: a stored value is always a string, so
+    /// there is no ambiguity, and the distinction is what decides whether the key appears in
+    /// <c>Object.keys(storage)</c> and whether <c>'key' in storage</c> is true.
+    /// </remarks>
+    /// <param name="key">The key to read. Never <see langword="null"/>.</param>
+    public abstract string? GetItem(string key);
+
+    /// <summary>
+    /// Stores <paramref name="value"/> under <paramref name="key"/>, replacing any existing entry —
+    /// <see href="https://html.spec.whatwg.org/multipage/webstorage.html#dom-storage-setitem">setItem</see>.
+    /// </summary>
+    /// <remarks>
+    /// The engine has already applied the specification's step 3: a set whose value equals the stored one is
+    /// a no-op and never reaches the provider. A new key goes to the end of <see cref="Keys"/> in the
+    /// in-box provider; an existing key keeps its position, which is what "if reorder is true" leaves open
+    /// to the implementation.
+    /// </remarks>
+    /// <param name="key">The key to write. Never <see langword="null"/>.</param>
+    /// <param name="value">The value to store. Never <see langword="null"/>.</param>
+    /// <exception cref="StorageQuotaExceededException">
+    /// The value cannot be stored. The script sees a catchable <c>QuotaExceededError</c>
+    /// <c>DOMException</c>, and the store must be left exactly as it was.
+    /// </exception>
+    public abstract void SetItem(string key, string value);
+
+    /// <summary>
+    /// Removes the entry under <paramref name="key"/>, doing nothing when there is none —
+    /// <see href="https://html.spec.whatwg.org/multipage/webstorage.html#dom-storage-removeitem">removeItem</see>.
+    /// </summary>
+    /// <param name="key">The key to remove. Never <see langword="null"/>.</param>
+    public abstract void RemoveItem(string key);
+
+    /// <summary>
+    /// Removes every entry —
+    /// <see href="https://html.spec.whatwg.org/multipage/webstorage.html#dom-storage-clear">clear</see>.
+    /// </summary>
+    public abstract void Clear();
+}
+
+/// <summary>
+/// Thrown by a <see cref="StorageProvider"/> that cannot store a value, and turned by the engine into the
+/// <c>QuotaExceededError</c> <c>DOMException</c> the Web Storage standard's <c>setItem</c> raises. Requires
+/// .NET 8 or higher.
+/// </summary>
+/// <remarks>
+/// This is the one exception a provider may use to reach the script: its message becomes the
+/// <c>DOMException</c>'s message, and everything else a provider throws reaches the host unchanged. It is
+/// deliberately not a <c>JintException</c> — a host raises it, the engine only translates it.
+/// </remarks>
+public sealed class StorageQuotaExceededException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance with a default message.
+    /// </summary>
+    public StorageQuotaExceededException()
+        : this("The value could not be stored: the storage quota has been exceeded.")
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance with the message the script's <c>DOMException</c> will carry.
+    /// </summary>
+    /// <param name="message">The message, which reaches the script.</param>
+    public StorageQuotaExceededException(string message) : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance with a message and the exception that caused it.
+    /// </summary>
+    /// <param name="message">The message, which reaches the script.</param>
+    /// <param name="innerException">The underlying failure, which does not.</param>
+    public StorageQuotaExceededException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}
+#endif

--- a/Jint/WebApi/WebApiOptionsExtensions.cs
+++ b/Jint/WebApi/WebApiOptionsExtensions.cs
@@ -198,5 +198,57 @@ public static class WebApiOptionsExtensions
         options.WebApi.Diagnostics.Sink = sink;
         return options;
     }
+
+    /// <summary>
+    /// Enables <c>localStorage</c> and <c>sessionStorage</c>, each over its own in-memory store that dies
+    /// with the engine.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="WebApiFeatures.Storage"/> is not part of <see cref="WebApiFeatures.Default"/>, so this call
+    /// — or naming the flag — is the only way to get it. See <see cref="Options.StorageOptions"/> for why,
+    /// and <see cref="UseStorage(Options, StorageProvider, StorageProvider)"/> for putting the data
+    /// somewhere that outlives the engine.
+    /// </remarks>
+    /// <param name="options">Options to modify.</param>
+    /// <returns>Options instance for fluent syntax.</returns>
+    public static Options UseStorage(this Options options)
+    {
+        if (options is null)
+        {
+            Throw.ArgumentNullException(nameof(options));
+        }
+
+        options.WebApi.Features |= WebApiFeatures.Storage;
+        return options;
+    }
+
+    /// <summary>
+    /// Enables <c>localStorage</c> and <c>sessionStorage</c> over the host's own stores.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var engine = new Engine(o => o.UseStorage(new MyDatabaseStorage(tenantId), new InMemoryStorageProvider()));
+    /// </code>
+    /// </example>
+    /// <param name="options">Options to modify.</param>
+    /// <param name="localStorageProvider">
+    /// The map behind <c>localStorage</c>, or <see langword="null"/> to let each engine default its own.
+    /// </param>
+    /// <param name="sessionStorageProvider">
+    /// The map behind <c>sessionStorage</c>, or <see langword="null"/> to let each engine default its own.
+    /// Pass the same instance as <paramref name="localStorageProvider"/> to make the two globals one store.
+    /// </param>
+    /// <returns>Options instance for fluent syntax.</returns>
+    public static Options UseStorage(
+        this Options options,
+        StorageProvider? localStorageProvider,
+        StorageProvider? sessionStorageProvider = null)
+    {
+        UseStorage(options);
+
+        options.WebApi.Storage.LocalStorageProvider = localStorageProvider;
+        options.WebApi.Storage.SessionStorageProvider = sessionStorageProvider;
+        return options;
+    }
 }
 #endif

--- a/Jint/WebApi/WebApiRegistration.cs
+++ b/Jint/WebApi/WebApiRegistration.cs
@@ -191,6 +191,16 @@ internal static class WebApiRegistration
             // way and a script written for a browser does not have to guard the call.
             Install(global, engine, "reportError", static e => e.Realm.Intrinsics.ReportError, PropertyFlag.ConfigurableEnumerableWritable);
         }
+
+        if ((features & WebApiFeatures.Storage) != WebApiFeatures.None)
+        {
+            Install(global, engine, "Storage", static e => e.Realm.Intrinsics.Storage, PropertyFlag.NonEnumerable);
+
+            // WebIDL exposes both of these through a [Replaceable] accessor pair on Window; an ordinary
+            // enumerable data property is the same simplification console and crypto are installed with.
+            Install(global, engine, "localStorage", static e => e.Realm.Intrinsics.LocalStorage, PropertyFlag.ConfigurableEnumerableWritable);
+            Install(global, engine, "sessionStorage", static e => e.Realm.Intrinsics.SessionStorage, PropertyFlag.ConfigurableEnumerableWritable);
+        }
     }
 
     /// <summary>
@@ -240,10 +250,10 @@ internal static class WebApiRegistration
         // scheduler.postTask() are the others, and they need one whether or not the host also asked for
         // setTimeout. The events, messaging and performance features additionally read the time origin
         // (Event.timeStamp, MessageEvent.timeStamp, performance.now), fetch keeps its settings and its
-        // in-flight set here, and the scheduler keeps its own task queues here, which is why each of them
-        // wants the state even without the timers flag.
+        // in-flight set here, the scheduler keeps its own task queues here, and storage keeps its providers
+        // here, which is why each of them wants the state even without the timers flag.
         const WebApiFeatures NeedsEngineState =
-            WebApiFeatures.Timers | WebApiFeatures.Events | WebApiFeatures.Performance | WebApiFeatures.Fetch | WebApiFeatures.Scheduler | WebApiFeatures.Messaging;
+            WebApiFeatures.Timers | WebApiFeatures.Events | WebApiFeatures.Performance | WebApiFeatures.Fetch | WebApiFeatures.Scheduler | WebApiFeatures.Messaging | WebApiFeatures.Storage;
 
         // The diagnostics sink is the one thing here no feature flag governs: a host that set one gets the
         // channel whatever else it did or did not ask for, which is why it is read before the flags are.
@@ -274,7 +284,11 @@ internal static class WebApiRegistration
             ? new SchedulerQueue(engine)
             : null;
 
-        engine._webApi = new WebApiEngineState(engine, timeProvider, timers, fetch, scheduler, diagnostics);
+        // The storage group is passed whole rather than resolved here: which of the two maps an engine ever
+        // needs is decided by the global a script touches, so defaulting one costs nothing until then.
+        var storage = (features & WebApiFeatures.Storage) != WebApiFeatures.None ? options.WebApi.Storage : null;
+
+        engine._webApi = new WebApiEngineState(engine, timeProvider, timers, fetch, scheduler, diagnostics, storage);
     }
 
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -230,10 +230,12 @@ its own `console` (or any other name in the table below), enabling the feature l
 | `scheduler.postTask` / `scheduler.yield` / `TaskController` / `TaskSignal` | `Scheduler` | ✔ shipped |
 | `MessageChannel` / `MessagePort` / `MessageEvent` (incl. cross-engine ports) | `Messaging` | ✔ shipped |
 | `reportError` (and the `DiagnosticsSink` behind it) | `Reporting` | ✔ shipped |
+| `localStorage` / `sessionStorage` / `Storage` | `Storage` *(not in `Default` — see below)* | ✔ shipped |
 | `fetch` / `Headers` / `Request` / `Response` | `Fetch` — **opt-in on its own, see below** | ✔ shipped |
 
 `WebApiFeatures.Default` — what `UseWebApis()` enables — is every non-network feature that has landed. It
 grows as the table fills in, and it will never include `fetch`: network egress is always an explicit choice.
+`Storage` is the other standing exception, for the reason in its own section below.
 
 `crypto.subtle` carries **`digest` and nothing else** so far. It is the one `SubtleCrypto` operation that
 needs no key material, which is what makes it shippable on its own; `sign`, `verify`, `encrypt`, `importKey`
@@ -503,6 +505,41 @@ Two deliberate reductions:
   `WritableStreamDefaultWriter` and the three controllers exist as ordinary interface objects — a reader's
   `constructor` is the real thing, and `new` on it behaves as the standard says — but they are not installed
   on `globalThis`, where a browser would expose them.
+
+### Storage is opt-in on its own, and you decide where the data lives
+
+`localStorage` and `sessionStorage` are the one non-network feature `UseWebApis()` does **not** turn on. Every
+other web API gives a script something to *do*; this one gives it somewhere to *keep* things, and a host that
+asked for "the web APIs" has not agreed to that. Ask for it by name:
+
+```csharp
+// Two in-memory stores, per engine, gone when the engine is.
+var engine = new Engine(options => options.UseStorage());
+
+// Or your own store, which is what makes anything persist or be shared.
+var tenantStorage = new MyDatabaseStorage(tenantId);
+engine = new Engine(options => options.UseStorage(tenantStorage));
+```
+
+The whole `Storage` interface is there — `length`, `key`, `getItem`, `setItem`, `removeItem`, `clear` — and so
+is the named property access the standard defines alongside it, so `storage.foo = 'bar'`, `delete storage.foo`,
+`'foo' in storage` and `Object.keys(storage)` all work. `Storage` is a WebIDL *legacy platform object*, which
+decides the one rule that surprises people: an interface member always wins over a stored key of the same
+name, so `storage.getItem` is the method even after `storage.setItem('getItem', 'x')` — and the key is still
+stored, and `storage.getItem('getItem')` still reads it back.
+
+**Where the data lives is entirely `StorageProvider`'s business.** Implement it over a file, a database, a
+per-tenant cache or a request-scoped dictionary; the engine implements the algorithms and never persists
+anything itself. With no provider each engine gets its own `InMemoryStorageProvider` — nothing is shared
+between engines, nothing survives one, and `Options.WebApi.Storage.MaxTotalBytes` (5 MB by default) bounds it,
+turning an over-quota `setItem` into the catchable `QuotaExceededError` `DOMException` the standard names.
+Your own provider raises the same error by throwing `StorageQuotaExceededException`; anything else it throws
+reaches you unchanged rather than becoming a JavaScript error the script can swallow. A provider reached from
+engines that run concurrently must be thread-safe.
+
+**There is no `storage` event.** Every mutating step ends in "broadcast", which notifies *other* browsing
+contexts sharing an origin — a multi-context feature, and an engine has one context. `StorageEvent` is absent
+rather than present-and-never-firing, so feature detection sees the truth.
 
 
 ## Node compatibility (opt-in)


### PR DESCRIPTION
The last slice of #3087: `localStorage`, `sessionStorage` and the `Storage` interface per https://html.spec.whatwg.org/multipage/webstorage.html, over a host-implementable `StorageProvider`.

**Not in `Default`, deliberately.** Every other web API gives a script something to *do*; this one gives it somewhere to *keep* things, and a host that asked for "the web APIs" has not agreed to that — so `WebApiFeatures.Storage` has to be named, or enabled via `UseStorage()`. With no provider each engine gets its own `InMemoryStorageProvider` (nothing shared, nothing survives the engine, 5 MB quota → the catchable `QuotaExceededError` `DOMException` the standard names). Supply your own `StorageProvider` to put the data in a file, a database or a per-tenant cache — persistence and cross-engine sharing are entirely the provider's business, and a host provider signals quota by throwing `StorageQuotaExceededException`; anything else it throws reaches the host unchanged rather than becoming a JavaScript error the script can swallow.

**`Storage` is a WebIDL legacy platform object**, and the interesting semantics come straight from §3.9 of WebIDL, fetched and implemented step by step: named getter/setter/deleter (`storage.foo = 'bar'`, `delete storage.foo`, `'foo' in storage`, `Object.keys(storage)` all work), `[[Set]]` invoking the named setter *before* any lookup — so `storage.getItem = 1` stores a key and the method survives — named-property visibility recomputed per access so the prototype chain always wins (no `[LegacyOverrideBuiltIns]`), `[[OwnPropertyKeys]]` in store order with no array-index sorting, and `[[PreventExtensions]]` returning false so `Object.freeze(localStorage)` is a `TypeError`, as in browsers.

Spec algorithms as written: `setItem`'s same-value early return means the provider is never called and a quota cannot refuse a no-op write (mutation-pinned); `key(n)` takes a plain `ToUint32` (`key(-1)` → `null`); arity is checked before any argument converts, per WebIDL. Insertion order is the iteration order, which the standard's "implementation-defined" wording permits.

Documented reductions: no `storage` event (every mutating step ends in "broadcast", a multi-context feature — `StorageEvent` is absent rather than present-and-never-firing), and stored data survives `RestoreGlobalSnapshot` like the module registry and `HostDefined` — it is host state, pinned as such.

45 tests including the legacy-platform-object matrix and mutation evidence on the visibility walk, the same-value no-op, and arity-before-conversion; both suites green on net10.0 and net472, with and without `JINT_HOST_CONTRACT_VERIFICATION=1`.

Closes #3087

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G7Ud48VAs1JicxRZxLDxg