### PR TITLE
Add crypto.subtle HMAC and AES-GCM with CryptoKey and JWK support

### DIFF
--- a/Jint.Tests.PublicInterface/WebApiCryptoKeyTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiCryptoKeyTests.cs
@@ -1,0 +1,292 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.Security.Cryptography;
+using Jint;
+using Jint.Native;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// The keyed <c>crypto.subtle</c> operations seen from outside the assembly: what a host has to write to get
+/// them, what it can hand a script, what it can read back, and what it cannot read at all.
+/// </summary>
+/// <remarks>
+/// This project has no <c>InternalsVisibleTo</c>, so everything here is reachable by a third party and every
+/// assertion goes through script or the public options surface, exactly as an embedder's would. The
+/// interoperability assertions are the point of the file: a MAC a script produced has to equal the one the
+/// host computes with <see cref="HMACSHA256"/>, and a ciphertext a script produced has to be one the host can
+/// open with <see cref="AesGcm"/> — otherwise the API is only self-consistent.
+/// </remarks>
+public class WebApiCryptoKeyTests
+{
+    private static Engine WebEngine() => new(options => options.UseWebApis(WebApiFeatures.Crypto));
+
+    private static string Hex(byte[] bytes) => Convert.ToHexString(bytes).ToLowerInvariant();
+
+    [Fact]
+    public void ADefaultEngineHasNoKeyedCrypto()
+    {
+        var engine = new Engine();
+
+        engine.Evaluate("typeof crypto").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof CryptoKey").AsString().Should().Be("undefined");
+        engine.Evaluate("'CryptoKey' in globalThis").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void TheCryptoFlagIsWhatInstallsThem()
+    {
+        WebEngine().Evaluate("typeof crypto.subtle.generateKey").AsString().Should().Be("function");
+        WebEngine().Evaluate("typeof CryptoKey").AsString().Should().Be("function");
+
+        new Engine(options => options.UseWebApis(WebApiFeatures.Console))
+            .Evaluate("typeof CryptoKey").AsString().Should().Be("undefined");
+
+        new Options().UseWebApis().WebApi.Features.Should().HaveFlag(WebApiFeatures.Crypto);
+    }
+
+    [Fact]
+    public void AScriptsMacIsTheOneTheHostComputes()
+    {
+        var engine = WebEngine();
+
+        var keyMaterial = new byte[32];
+        for (var i = 0; i < keyMaterial.Length; i++)
+        {
+            keyMaterial[i] = (byte) (i * 7);
+        }
+
+        var message = "the message the host and the script agree on"u8.ToArray();
+
+        engine.SetValue("keyMaterial", keyMaterial);
+        engine.SetValue("message", message);
+
+        var fromScript = engine.Evaluate("""
+            (async () => {
+                const key = await crypto.subtle.importKey('raw', new Uint8Array(keyMaterial), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+                const mac = await crypto.subtle.sign('HMAC', key, new Uint8Array(message));
+                return Array.from(new Uint8Array(mac)).map(b => b.toString(16).padStart(2, '0')).join('');
+            })()
+            """).UnwrapIfPromise().AsString();
+
+        fromScript.Should().Be(Hex(HMACSHA256.HashData(keyMaterial, message)));
+    }
+
+    [Fact]
+    public void AHostCanVerifyWithTheKeyMaterialItExported()
+    {
+        var engine = WebEngine();
+
+        // The other direction, and the one an embedder actually needs: the script mints the key, hands the
+        // host the exported bytes, and the host checks a signature with its own primitives.
+        var exported = engine.Evaluate("""
+            (async () => {
+                const hex = b => Array.from(new Uint8Array(b)).map(x => x.toString(16).padStart(2, '0')).join('');
+                const key = await crypto.subtle.generateKey({ name: 'HMAC', hash: 'SHA-512', length: 256 }, true, ['sign']);
+                const raw = await crypto.subtle.exportKey('raw', key);
+                const mac = await crypto.subtle.sign('HMAC', key, Uint8Array.from('payload', c => c.charCodeAt(0)));
+                return hex(raw) + ':' + hex(mac);
+            })()
+            """).UnwrapIfPromise().AsString().Split(':');
+
+        var raw = Convert.FromHexString(exported[0]);
+        var mac = Convert.FromHexString(exported[1]);
+
+        raw.Should().HaveCount(32);
+        mac.Should().HaveCount(64);
+        HMACSHA512.HashData(raw, "payload"u8.ToArray()).Should().Equal(mac);
+    }
+
+    [Fact]
+    public void AHostCanOpenWhatAScriptEncrypted()
+    {
+        var engine = WebEngine();
+
+        // The specification's layout is ciphertext || tag, and AesGcm wants them apart — which is the one
+        // thing an embedder has to know to read a script's output. Nothing else is needed: no headers, no
+        // framing, no length prefix.
+        var key = new byte[16];
+        RandomNumberGenerator.Fill(key);
+        var iv = new byte[12];
+        RandomNumberGenerator.Fill(iv);
+
+        engine.SetValue("keyMaterial", key);
+        engine.SetValue("iv", iv);
+
+        var sealedBytes = Convert.FromHexString(engine.Evaluate("""
+            (async () => {
+                const key = await crypto.subtle.importKey('raw', new Uint8Array(keyMaterial), 'AES-GCM', false, ['encrypt']);
+                const ciphertext = await crypto.subtle.encrypt(
+                    { name: 'AES-GCM', iv: new Uint8Array(iv), additionalData: Uint8Array.from('v1', c => c.charCodeAt(0)) },
+                    key,
+                    Uint8Array.from('a message for the host', c => c.charCodeAt(0)));
+                return Array.from(new Uint8Array(ciphertext)).map(x => x.toString(16).padStart(2, '0')).join('');
+            })()
+            """).UnwrapIfPromise().AsString());
+
+        var tag = sealedBytes.AsSpan(sealedBytes.Length - 16).ToArray();
+        var ciphertext = sealedBytes.AsSpan(0, sealedBytes.Length - 16).ToArray();
+        var plaintext = new byte[ciphertext.Length];
+
+        using var aes = new AesGcm(key, tagSizeInBytes: 16);
+        aes.Decrypt(iv, ciphertext, tag, plaintext, "v1"u8);
+
+        System.Text.Encoding.UTF8.GetString(plaintext).Should().Be("a message for the host");
+    }
+
+    [Fact]
+    public void AScriptCanOpenWhatTheHostEncrypted()
+    {
+        var engine = WebEngine();
+
+        var key = new byte[32];
+        RandomNumberGenerator.Fill(key);
+        var iv = new byte[12];
+        RandomNumberGenerator.Fill(iv);
+
+        var plaintext = "a message for the script"u8.ToArray();
+        var ciphertext = new byte[plaintext.Length];
+        var tag = new byte[16];
+
+        using (var aes = new AesGcm(key, tagSizeInBytes: 16))
+        {
+            aes.Encrypt(iv, plaintext, ciphertext, tag, "v1"u8);
+        }
+
+        engine.SetValue("keyMaterial", key);
+        engine.SetValue("iv", iv);
+        engine.SetValue("sealedBytes", ciphertext.Concat(tag).ToArray());
+
+        engine.Evaluate("""
+            (async () => {
+                const key = await crypto.subtle.importKey('raw', new Uint8Array(keyMaterial), 'AES-GCM', false, ['decrypt']);
+                const opened = await crypto.subtle.decrypt(
+                    { name: 'AES-GCM', iv: new Uint8Array(iv), additionalData: Uint8Array.from('v1', c => c.charCodeAt(0)) },
+                    key,
+                    new Uint8Array(sealedBytes));
+                return String.fromCharCode(...new Uint8Array(opened));
+            })()
+            """).UnwrapIfPromise().AsString().Should().Be("a message for the script");
+    }
+
+    [Fact]
+    public void AHostHoldingAKeyStillCannotReadIt()
+    {
+        var engine = WebEngine();
+
+        // A host may hold a CryptoKey as an ordinary JsValue and hand it back to script. What it cannot do —
+        // through the public surface, which is all an embedder has — is read the key material off it: the
+        // object has no own properties, the four attributes are all it exposes, and a non-extractable key
+        // refuses exportKey.
+        var key = engine.Evaluate("""
+            crypto.subtle.generateKey({ name: 'HMAC', hash: 'SHA-256' }, false, ['sign'])
+            """).UnwrapIfPromise();
+
+        key.IsObject().Should().BeTrue();
+        var keyObject = key.AsObject();
+        keyObject.GetOwnPropertyKeys().Should().BeEmpty();
+        keyObject.Get("type").AsString().Should().Be("secret");
+        keyObject.Get("extractable").AsBoolean().Should().BeFalse();
+
+        engine.SetValue("hostHeldKey", key);
+        engine.Evaluate("JSON.stringify(hostHeldKey)").AsString().Should().Be("{}");
+        engine.Evaluate("Object.keys(hostHeldKey).length").AsNumber().Should().Be(0);
+
+        engine.Evaluate("""
+            crypto.subtle.exportKey('raw', hostHeldKey).then(() => 'exported', e => e.name)
+            """).UnwrapIfPromise().AsString().Should().Be("InvalidAccessError");
+
+        // ... and it is still a working key.
+        engine.Evaluate("""
+            crypto.subtle.sign('HMAC', hostHeldKey, new Uint8Array(3)).then(mac => mac.byteLength)
+            """).UnwrapIfPromise().AsNumber().Should().Be(32);
+    }
+
+    [Fact]
+    public void NeverThrowsIntoTheHost()
+    {
+        var engine = WebEngine();
+
+        // A promise-returning WebIDL operation converts every exception into a rejection, so a host calling
+        // Evaluate on a line of nonsense gets a promise back rather than a JavaScriptException.
+        var value = engine.Evaluate("crypto.subtle.importKey('pem', 42, 'MD5', 'yes', 'sign')");
+
+        value.IsObject().Should().BeTrue();
+        engine.SetValue("hostHeldPromise", value);
+        engine.Evaluate("hostHeldPromise.then(() => 'resolved', e => e.constructor.name)")
+            .UnwrapIfPromise().AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void ReportsItsFailuresAsRejectionsAScriptCanCatch()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("""
+            (async () => {
+                const seen = [];
+                try { await crypto.subtle.generateKey({ name: 'AES-GCM', length: 111 }, false, ['encrypt']); }
+                catch (e) { seen.push(e.name); }
+                try { await crypto.subtle.importKey('jwk', { kty: 'RSA' }, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']); }
+                catch (e) { seen.push(e.name); }
+                try { await crypto.subtle.generateKey({ name: 'HMAC', hash: 'SHA-256' }, false, []); }
+                catch (e) { seen.push(e.name); }
+                try { await crypto.subtle.importKey('spki', new Uint8Array(16), 'AES-GCM', false, ['encrypt']); }
+                catch (e) { seen.push(e.name); }
+                try {
+                    const key = await crypto.subtle.generateKey({ name: 'HMAC', hash: 'SHA-256' }, false, ['verify']);
+                    await crypto.subtle.sign('HMAC', key, new Uint8Array(0));
+                } catch (e) { seen.push(e.name); }
+                return seen.join(',');
+            })()
+            """).UnwrapIfPromise().AsString()
+            .Should().Be("OperationError,DataError,SyntaxError,NotSupportedError,InvalidAccessError");
+    }
+
+    [Fact]
+    public void IsOneSetOfObjectsPerEngineAndNeverShared()
+    {
+        var options = new Options().UseWebApis(WebApiFeatures.Crypto);
+
+        var first = new Engine(options);
+        var second = new Engine(options);
+
+        // Two engines built from one shared Options instance each get their own interface object, which is
+        // the same promise every other web-API object makes.
+        first.Evaluate("typeof CryptoKey").AsString().Should().Be("function");
+        second.Evaluate("typeof CryptoKey").AsString().Should().Be("function");
+
+        var key = first.Evaluate("crypto.subtle.generateKey({ name: 'AES-GCM', length: 128 }, false, ['encrypt'])")
+            .UnwrapIfPromise();
+
+        first.SetValue("key", key);
+        first.Evaluate("key instanceof CryptoKey").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void AHostRegisteredCryptoKeyGlobalWins()
+    {
+        var marker = new JsString("the host's own CryptoKey");
+
+        var engine = new Engine(options => options
+            .AddLazyGlobal("CryptoKey", _ => marker)
+            .UseWebApis());
+
+        // The host's configuration runs first and the install is non-clobbering, so nothing of ours reaches
+        // that name — and the operations still work, because they never look the global up.
+        engine.Evaluate("CryptoKey").Should().BeSameAs(marker);
+        engine.Evaluate("crypto.subtle.generateKey({ name: 'AES-GCM', length: 128 }, false, ['encrypt']).then(k => k.type)")
+            .UnwrapIfPromise().AsString().Should().Be("secret");
+    }
+
+    [Fact]
+    public void DoesNotReachIntoAShadowRealm()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        engine.Evaluate("new ShadowRealm().evaluate('typeof CryptoKey')").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof CryptoKey").AsString().Should().Be("function");
+    }
+}
+#endif

--- a/Jint.Tests.PublicInterface/WebApiCryptoTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiCryptoTests.cs
@@ -101,14 +101,19 @@ public class WebApiCryptoTests
         var engine = new Engine(options => options.UseWebApis());
 
         // `subtle` rides the Crypto flag rather than carrying one of its own — it is an attribute of the very
-        // same interface — so a host that asked for crypto has it.
+        // same interface — so a host that asked for crypto has it, and so is `CryptoKey`, which is the type of
+        // the keys it hands out.
         engine.Evaluate("typeof crypto.subtle").AsString().Should().Be("object");
         engine.Evaluate("typeof crypto.subtle.digest").AsString().Should().Be("function");
+        engine.Evaluate("typeof crypto.subtle.sign").AsString().Should().Be("function");
+        engine.Evaluate("typeof crypto.subtle.importKey").AsString().Should().Be("function");
+        engine.Evaluate("typeof CryptoKey").AsString().Should().Be("function");
 
-        // Everything that needs key material is absent, not present-and-throwing.
-        engine.Evaluate("typeof crypto.subtle.sign").AsString().Should().Be("undefined");
-        engine.Evaluate("typeof crypto.subtle.importKey").AsString().Should().Be("undefined");
-        engine.Evaluate("typeof CryptoKey").AsString().Should().Be("undefined");
+        // Key derivation and key wrapping are absent, not present-and-throwing, so a library that checks
+        // before reaching for one takes its fallback path.
+        engine.Evaluate("""
+            ['deriveKey', 'deriveBits', 'wrapKey', 'unwrapKey'].map(name => typeof crypto.subtle[name]).join(',')
+            """).AsString().Should().Be("undefined,undefined,undefined,undefined");
     }
 
     [Fact]

--- a/Jint.Tests/Runtime/WebApi/CryptoTests.cs
+++ b/Jint.Tests/Runtime/WebApi/CryptoTests.cs
@@ -267,23 +267,27 @@ public class CryptoTests
     }
 
     [Fact]
-    public void HasASubtleCryptoCarryingDigestAlone()
+    public void HasASubtleCryptoCarryingTheOperationsThisEngineImplements()
     {
         var engine = WebEngine();
 
-        // `crypto.subtle` exists and answers a SubtleCrypto object, but only its digest operation does. The
-        // rest is absent rather than present-and-throwing, because `if (crypto.subtle.sign)` is how a library
-        // that does cryptography decides whether it can, and it has to get the truthful answer — see
-        // SubtleCryptoTests for the operation itself.
+        // `crypto.subtle` exists and answers a SubtleCrypto object. What it carries is the eight operations
+        // over SHA, HMAC and AES-GCM; key derivation and key wrapping are absent rather than
+        // present-and-throwing, because `if (crypto.subtle.deriveBits)` is how a library that does
+        // cryptography decides whether it can, and it has to get the truthful answer — see SubtleCryptoTests
+        // and SubtleCryptoKeyTests for the operations themselves.
         engine.Evaluate("typeof crypto.subtle").AsString().Should().Be("object");
         engine.Evaluate("'subtle' in crypto").AsBoolean().Should().BeTrue();
-        engine.Evaluate("typeof crypto.subtle.digest").AsString().Should().Be("function");
 
         engine.Evaluate("""
-            ['encrypt', 'decrypt', 'sign', 'verify', 'generateKey', 'deriveKey', 'deriveBits',
-             'importKey', 'exportKey', 'wrapKey', 'unwrapKey']
+            ['digest', 'encrypt', 'decrypt', 'sign', 'verify', 'generateKey', 'importKey', 'exportKey']
                 .map(name => typeof crypto.subtle[name]).join(',')
-            """).AsString().Should().Be("undefined,undefined,undefined,undefined,undefined,undefined,undefined,undefined,undefined,undefined,undefined");
+            """).AsString().Should().Be("function,function,function,function,function,function,function,function");
+
+        engine.Evaluate("""
+            ['deriveKey', 'deriveBits', 'wrapKey', 'unwrapKey']
+                .map(name => typeof crypto.subtle[name]).join(',')
+            """).AsString().Should().Be("undefined,undefined,undefined,undefined");
     }
 
     [Fact]

--- a/Jint.Tests/Runtime/WebApi/SubtleCryptoKeyTests.cs
+++ b/Jint.Tests/Runtime/WebApi/SubtleCryptoKeyTests.cs
@@ -1,0 +1,1439 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Native;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// The keyed half of <c>crypto.subtle</c> — https://w3c.github.io/webcrypto/#subtlecrypto-interface:
+/// <c>CryptoKey</c>, <c>generateKey</c>, <c>importKey</c>, <c>exportKey</c>, <c>sign</c>, <c>verify</c>,
+/// <c>encrypt</c> and <c>decrypt</c> over HMAC and AES-GCM.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The cryptography itself is checked against published vectors, which is the only way to check it: HMAC
+/// against RFC 2202 (SHA-1) and RFC 4231 (SHA-256, SHA-384, SHA-512), and AES-GCM against the NIST CAVP
+/// vectors, whose <c>ciphertext || tag</c> concatenation with a 96-bit IV is exactly the byte layout the Web
+/// Cryptography API specifies. A round trip through this engine's own code would prove only that it agrees
+/// with itself.
+/// </para>
+/// <para>
+/// Everything else is about the shape of the operations: which failure each rejection is, in which order the
+/// failures come, what a key does and does not expose, and the usage matrix.
+/// </para>
+/// </remarks>
+public class SubtleCryptoKeyTests
+{
+    /// <summary>
+    /// Helpers every script here shares. Bytes are built from hex or from character codes rather than
+    /// through <c>TextEncoder</c>, so that the crypto feature is the only one the engine carries and nothing
+    /// can be passing because of a neighbour.
+    /// </summary>
+    private const string Prelude = """
+        const hex = b => Array.from(new Uint8Array(b)).map(x => x.toString(16).padStart(2, '0')).join('');
+        const bytes = h => Uint8Array.from(h.match(/../g) || [], x => parseInt(x, 16));
+        const ascii = s => Uint8Array.from(s, c => c.charCodeAt(0));
+        const repeat = (byte, count) => new Uint8Array(count).fill(byte);
+        """;
+
+    private static Engine WebEngine() => new(options => options.UseWebApis(WebApiFeatures.Crypto));
+
+    /// <summary>Runs an async body to completion and answers what it returned.</summary>
+    private static JsValue Run(string body, Engine? engine = null)
+    {
+        engine ??= WebEngine();
+        return engine.Evaluate(Prelude + "\n(async () => {\n" + body + "\n})()").UnwrapIfPromise();
+    }
+
+    /// <summary>Settles one expression's promise and answers whatever it resolved or rejected to.</summary>
+    private static JsValue Settle(Engine engine, string source) => engine.Evaluate(source).UnwrapIfPromise();
+
+    // ---------------------------------------------------------------------------------------------------
+    // HMAC: the published vectors
+    // ---------------------------------------------------------------------------------------------------
+
+    [Theory]
+    // https://www.rfc-editor.org/rfc/rfc2202 section 3, test cases 1 to 4.
+    [InlineData("SHA-1", "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b", "4869205468657265", "b617318655057264e28bc0b6fb378c8ef146be00")]
+    [InlineData("SHA-1", "4a656665", "7768617420646f2079612077616e7420666f72206e6f7468696e673f", "effcdf6ae5eb2fa2d27416d5f184df9c259a7c79")]
+    [InlineData("SHA-1", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", "125d7342b9ac11cd91a39af48aa17b4f63f175d3")]
+    [InlineData("SHA-1", "0102030405060708090a0b0c0d0e0f10111213141516171819", "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd", "4c9007f4026250c6bc8414f9bf50c86c2d7235da")]
+    // https://www.rfc-editor.org/rfc/rfc4231 section 4, test cases 1 to 4.
+    [InlineData("SHA-256", "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b", "4869205468657265", "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7")]
+    [InlineData("SHA-256", "4a656665", "7768617420646f2079612077616e7420666f72206e6f7468696e673f", "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843")]
+    [InlineData("SHA-256", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", "773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514ced565fe")]
+    [InlineData("SHA-256", "0102030405060708090a0b0c0d0e0f10111213141516171819", "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd", "82558a389a443c0ea4cc819899f2083a85f0faa3e578f8077a2e3ff46729665b")]
+    [InlineData("SHA-384", "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b", "4869205468657265", "afd03944d84895626b0825f4ab46907f15f9dadbe4101ec682aa034c7cebc59cfaea9ea9076ede7f4af152e8b2fa9cb6")]
+    [InlineData("SHA-384", "4a656665", "7768617420646f2079612077616e7420666f72206e6f7468696e673f", "af45d2e376484031617f78d2b58a6b1b9c7ef464f5a01b47e42ec3736322445e8e2240ca5e69e2c78b3239ecfab21649")]
+    [InlineData("SHA-384", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", "88062608d3e6ad8a0aa2ace014c8a86f0aa635d947ac9febe83ef4e55966144b2a5ab39dc13814b94e3ab6e101a34f27")]
+    [InlineData("SHA-384", "0102030405060708090a0b0c0d0e0f10111213141516171819", "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd", "3e8a69b7783c25851933ab6290af6ca77a9981480850009cc5577c6e1f573b4e6801dd23c4a7d679ccf8a386c674cffb")]
+    [InlineData("SHA-512", "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b", "4869205468657265", "87aa7cdea5ef619d4ff0b4241a1d6cb02379f4e2ce4ec2787ad0b30545e17cdedaa833b7d6b8a702038b274eaea3f4e4be9d914eeb61f1702e696c203a126854")]
+    [InlineData("SHA-512", "4a656665", "7768617420646f2079612077616e7420666f72206e6f7468696e673f", "164b7a7bfcf819e2e395fbe73b56e0a387bd64222e831fd610270cd7ea2505549758bf75c05a994a6d034f65f8f0e6fdcaeab1a34d4a6b4b636e070a38bce737")]
+    [InlineData("SHA-512", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", "fa73b0089d56a284efb0f0756c890be9b1b5dbdd8ee81a3655f83e33b2279d39bf3e848279a722c806b485a47e67c807b946a337bee8942674278859e13292fb")]
+    [InlineData("SHA-512", "0102030405060708090a0b0c0d0e0f10111213141516171819", "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd", "b0ba465637458c6990e5a8c5f61d4af7e576d97ff94b872de76f8050361ee3dba91ca5c11aa25eb4d679275cc5788063a5f19741120c4f2de2adebeb10a298dd")]
+    public void SignsThePublishedHmacVectors(string hash, string keyHex, string dataHex, string expected)
+    {
+        Run($$"""
+            const key = await crypto.subtle.importKey('raw', bytes('{{keyHex}}'), { name: 'HMAC', hash: '{{hash}}' }, false, ['sign']);
+            return hex(await crypto.subtle.sign('HMAC', key, bytes('{{dataHex}}')));
+            """).AsString().Should().Be(expected);
+    }
+
+    [Fact]
+    public void VerifiesWhatItSignedAndRefusesAnythingElse()
+    {
+        Run("""
+            const key = await crypto.subtle.generateKey({ name: 'HMAC', hash: 'SHA-256' }, false, ['sign', 'verify']);
+            const message = ascii('the message');
+            const signature = await crypto.subtle.sign('HMAC', key, message);
+
+            const results = [
+                await crypto.subtle.verify('HMAC', key, signature, message),
+                await crypto.subtle.verify('HMAC', key, signature, ascii('the messagf')),
+                await crypto.subtle.verify('HMAC', key, new Uint8Array(32), message),
+                await crypto.subtle.verify('HMAC', key, new Uint8Array(0), message),
+                await crypto.subtle.verify('HMAC', key, new Uint8Array(33), message),
+            ];
+            return results.join(',');
+            """).AsString().Should().Be("true,false,false,false,false");
+    }
+
+    [Fact]
+    public void TwoEnginesEachMintTheirOwnKeys()
+    {
+        // A CryptoKey holds a hard reference to the realm that built it, and the brand check is by CLR type,
+        // so a key can cross engines only if a host hands it across — which is unsupported for every JsValue.
+        // What is pinned here is the ordinary case: two engines each mint their own and neither sees the
+        // other's.
+        var options = new Options().UseWebApis(WebApiFeatures.Crypto);
+        var first = new Engine(options);
+        var second = new Engine(options);
+
+        Run("""
+            const key = await crypto.subtle.importKey('raw', repeat(0x0b, 20), { name: 'HMAC', hash: 'SHA-1' }, false, ['sign']);
+            return hex(await crypto.subtle.sign('HMAC', key, ascii('Hi There')));
+            """, first).AsString().Should().Be("b617318655057264e28bc0b6fb378c8ef146be00");
+
+        Run("""
+            const key = await crypto.subtle.importKey('raw', repeat(0x0b, 20), { name: 'HMAC', hash: 'SHA-1' }, false, ['sign']);
+            return hex(await crypto.subtle.sign('HMAC', key, ascii('Hi There')));
+            """, second).AsString().Should().Be("b617318655057264e28bc0b6fb378c8ef146be00");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // AES-GCM: the published vectors
+    // ---------------------------------------------------------------------------------------------------
+
+    [Theory]
+    // The NIST CAVP AES-GCM vectors (gcmEncryptExtIV*.rsp), as vendored by Go's crypto/cipher tests. Each
+    // `expected` is the specification's own `ciphertext || tag` layout with a 128-bit tag, so it is what
+    // encrypt must answer with byte for byte. At least two per key length, plus two carrying additionalData.
+    [InlineData("11754cd72aec309bf52f7687212e8957", "3c819d9a9bed087615030b65", "", "", "250327c674aaf477aef2675748cf6971")]
+    [InlineData("7fddb57453c241d03efbed3ac44e371c", "ee283a3fc75575e33efd4887", "d5de42b461646c255c87bd2962d3b9a2", "", "2ccda4a5415cb91e135c2a0f78c9b2fdb36d1df9b9d5e596f83e8b7f52971cb3")]
+    [InlineData("fbe3467cc254f81be8e78d765a2e6333", "c6697351ff4aec29cdbaabf2", "", "67", "3659cdc25288bf499ac736c03bfc1159")]
+    [InlineData("fe47fcce5fc32665d2ae399e4eec72ba", "5adb9609dbaeb58cbd6e7275", "7c0e88c88899a779228465074797cd4c2e1498d259b54390b85e3eef1c02df60e743f1b840382c4bccaf3bafb4ca8429bea063", "88319d6e1d3ffa5f987199166c8a9b56c2aeba5a", "98f4826f05a265e6dd2be82db241c0fbbbf9ffb1c173aa83964b7cf5393043736365253ddbc5db8778371495da76d269e5db3e291ef1982e4defedaa2249f898556b47")]
+    [InlineData("e2e001a36c60d2bf40d69ff5b2b1161ea218db263be16a4e", "3c819d9a9bed087615030b65", "", "", "c7b8da1fe2e3dccc4071ba92a0a57ba8")]
+    [InlineData("feffe9928665731c6d6a8f9467308308feffe9928665731c", "54cc7dc2c37ec006bcc6d1da", "007c5e5b3e59df24a7c355584fc1518d", "", "7bd53594c28b6c6596feb240199cad4c9badb907fd65bde541b8df3bd444d3a8")]
+    [InlineData("5394e890d37ba55ec9d5f327f15680f6a63ef5279c79331643ad0af6d2623525", "3c819d9a9bed087615030b65", "", "", "d9b260d4bc4630733ffb642f5ce45726")]
+    [InlineData("feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308", "54cc7dc2c37ec006bcc6d1da", "007c5e5b3e59df24a7c355584fc1518d", "", "d50b9e252b70945d4240d351677eb10f937cdaef6f2822b6a3191654ba41b197")]
+    public void EncryptsAndDecryptsThePublishedAesGcmVectors(string keyHex, string ivHex, string plaintextHex, string aadHex, string expected)
+    {
+        Run($$"""
+            const key = await crypto.subtle.importKey('raw', bytes('{{keyHex}}'), 'AES-GCM', false, ['encrypt', 'decrypt']);
+            const params = { name: 'AES-GCM', iv: bytes('{{ivHex}}'), additionalData: bytes('{{aadHex}}') };
+
+            const ciphertext = await crypto.subtle.encrypt(params, key, bytes('{{plaintextHex}}'));
+            const roundTripped = await crypto.subtle.decrypt(params, key, ciphertext);
+
+            return hex(ciphertext) + '|' + hex(roundTripped);
+            """).AsString().Should().Be(expected + "|" + plaintextHex);
+    }
+
+    /// <summary>
+    /// Whether this platform's own AES-GCM produces a tag of the given bit length. OpenSSL and CNG take
+    /// 96..128 bits; Apple's CryptoKit takes 128 and nothing else, which is why the two tests below ask
+    /// instead of assuming.
+    /// </summary>
+    private static bool PlatformSupportsTagBits(int bits)
+    {
+        var sizes = System.Security.Cryptography.AesGcm.TagByteSizes;
+        var tagBytes = bits / 8;
+        if (tagBytes < sizes.MinSize || tagBytes > sizes.MaxSize)
+        {
+            return false;
+        }
+
+        return sizes.SkipSize == 0 || (tagBytes - sizes.MinSize) % sizes.SkipSize == 0;
+    }
+
+    [Fact]
+    public void ATruncatedTagIsThePrefixOfTheFullOne()
+    {
+        Assert.SkipUnless(PlatformSupportsTagBits(96), "this platform's AES-GCM produces only 128-bit tags");
+
+        // NIST SP 800-38D defines a t-bit tag as MSB_t of the 128-bit one, and the ciphertext does not depend
+        // on t at all — so the whole output for tagLength 96 is the first twelve bytes shorter. Checking it
+        // against the 128-bit vector proves both the truncation and the ciphertext || tag layout.
+        Run("""
+            const key = await crypto.subtle.importKey('raw', bytes('7fddb57453c241d03efbed3ac44e371c'), 'AES-GCM', false, ['encrypt', 'decrypt']);
+            const iv = bytes('ee283a3fc75575e33efd4887');
+            const plaintext = bytes('d5de42b461646c255c87bd2962d3b9a2');
+
+            const full = hex(await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, plaintext));
+            const short_ = await crypto.subtle.encrypt({ name: 'AES-GCM', iv, tagLength: 96 }, key, plaintext);
+
+            const decrypted = await crypto.subtle.decrypt({ name: 'AES-GCM', iv, tagLength: 96 }, key, short_);
+            return [full, hex(short_), hex(decrypted)].join('|');
+            """).AsString().Should().Be(
+                "2ccda4a5415cb91e135c2a0f78c9b2fdb36d1df9b9d5e596f83e8b7f52971cb3|"
+                + "2ccda4a5415cb91e135c2a0f78c9b2fdb36d1df9b9d5e596f83e8b7f|"
+                + "d5de42b461646c255c87bd2962d3b9a2");
+    }
+
+    [Theory]
+    [InlineData(96)]
+    [InlineData(104)]
+    [InlineData(112)]
+    [InlineData(120)]
+    [InlineData(128)]
+    public void RoundTripsEveryTagLengthThePlatformSupports(int tagLength)
+    {
+        if (!PlatformSupportsTagBits(tagLength))
+        {
+            // A spec-valid length the platform cannot produce is the OperationError the platform gate maps
+            // it to — never a raw ArgumentException erupting out of a promise-returning operation.
+            Run($$"""
+                const key = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 128 }, false, ['encrypt', 'decrypt']);
+                try
+                {
+                    await crypto.subtle.encrypt({ name: 'AES-GCM', iv: repeat(9, 12), tagLength: {{tagLength}} }, key, ascii('hello'));
+                    return 'encrypted';
+                }
+                catch (e)
+                {
+                    return e.name;
+                }
+                """).AsString().Should().Be("OperationError");
+            return;
+        }
+
+        Run($$"""
+            const key = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 128 }, false, ['encrypt', 'decrypt']);
+            const params = { name: 'AES-GCM', iv: repeat(9, 12), tagLength: {{tagLength}} };
+            const ciphertext = await crypto.subtle.encrypt(params, key, ascii('hello'));
+            const plaintext = await crypto.subtle.decrypt(params, key, ciphertext);
+            return (ciphertext.byteLength - 5) * 8 + ':' + String.fromCharCode(...new Uint8Array(plaintext));
+            """).AsString().Should().Be(tagLength + ":hello");
+    }
+
+    [Fact]
+    public void EveryWayTheDecryptionCanFailIsTheSameOperationError()
+    {
+        // The one thing an authenticated cipher promises is that a ciphertext, a tag, an iv or an
+        // additionalData that does not belong are one answer rather than four. Nothing here may distinguish
+        // them — not the error name, and not the message.
+        Run("""
+            const key = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, false, ['encrypt', 'decrypt']);
+            const iv = repeat(1, 12);
+            const params = { name: 'AES-GCM', iv, additionalData: ascii('context') };
+            const ciphertext = new Uint8Array(await crypto.subtle.encrypt(params, key, ascii('hello')));
+
+            const flipped = ciphertext.slice();
+            flipped[0] ^= 1;
+            const tagFlipped = ciphertext.slice();
+            tagFlipped[tagFlipped.length - 1] ^= 1;
+
+            const attempts = [
+                { name: 'AES-GCM', iv, additionalData: ascii('context') },  // the honest one
+                { name: 'AES-GCM', iv },                                     // no additionalData
+                { name: 'AES-GCM', iv: repeat(2, 12), additionalData: ascii('context') },
+            ];
+
+            const outcomes = [];
+            for (const attempt of attempts) {
+                try {
+                    await crypto.subtle.decrypt(attempt, key, ciphertext);
+                    outcomes.push('decrypted');
+                } catch (e) {
+                    outcomes.push(e.name + '/' + e.message);
+                }
+            }
+            for (const data of [flipped, tagFlipped, ciphertext.slice(0, 4)]) {
+                try {
+                    await crypto.subtle.decrypt(params, key, data);
+                    outcomes.push('decrypted');
+                } catch (e) {
+                    outcomes.push(e.name + '/' + e.message);
+                }
+            }
+            return outcomes.join('\n');
+            """).AsString().Should().Be(string.Join('\n',
+                "decrypted",
+                "OperationError/Failed to execute 'decrypt' on 'SubtleCrypto': the data could not be decrypted.",
+                "OperationError/Failed to execute 'decrypt' on 'SubtleCrypto': the data could not be decrypted.",
+                "OperationError/Failed to execute 'decrypt' on 'SubtleCrypto': the data could not be decrypted.",
+                "OperationError/Failed to execute 'decrypt' on 'SubtleCrypto': the data could not be decrypted.",
+                "OperationError/Failed to execute 'decrypt' on 'SubtleCrypto': the ciphertext is 32 bits long, which is shorter than the 128-bit authentication tag it must end with."));
+    }
+
+    [Theory]
+    [InlineData(128)]
+    [InlineData(192)]
+    [InlineData(256)]
+    public void GeneratesAnAesKeyOfEachLength(int length)
+    {
+        Run($$"""
+            const key = await crypto.subtle.generateKey({ name: 'AES-GCM', length: {{length}} }, true, ['encrypt', 'decrypt']);
+            const raw = await crypto.subtle.exportKey('raw', key);
+            return [key.algorithm.name, key.algorithm.length, raw.byteLength * 8, key.type].join('|');
+            """).AsString().Should().Be("AES-GCM|" + length + "|" + length + "|secret");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // CryptoKey
+    // ---------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void AKeyExposesTheFourAttributesAndNothingElse()
+    {
+        Run("""
+            const key = await crypto.subtle.generateKey({ name: 'HMAC', hash: 'SHA-384' }, true, ['verify', 'sign']);
+
+            return [
+                key.type,
+                key.extractable,
+                // The usages are the "normalized value" of what was asked for: the recognized values in the
+                // specification's own order, whatever order they arrived in.
+                key.usages.join(','),
+                JSON.stringify(key.algorithm),
+                Object.keys(key.algorithm).join(','),
+                // A platform object's state lives in internal slots, so the key itself has no own properties.
+                JSON.stringify(Object.getOwnPropertyNames(key)),
+                Object.prototype.toString.call(key),
+                key instanceof CryptoKey,
+            ].join('|');
+            """).AsString().Should().Be(
+                "secret|true|sign,verify|{\"name\":\"HMAC\",\"hash\":{\"name\":\"SHA-384\"},\"length\":1024}|name,hash,length|[]|[object CryptoKey]|true");
+    }
+
+    [Fact]
+    public void DuplicateUsagesCollapseAndOrderIsCanonical()
+    {
+        // "The normalized value of a usages list" is the usage intersection with the recognized values, and
+        // an intersection is a set: `['verify','sign','verify']` normalizes to `['sign','verify']`.
+        Run("""
+            const key = await crypto.subtle.generateKey({ name: 'HMAC', hash: 'SHA-256' }, false, ['verify', 'sign', 'verify']);
+            return key.usages.join(',');
+            """).AsString().Should().Be("sign,verify");
+    }
+
+    [Fact]
+    public void TheAlgorithmAndUsagesObjectsAreCachedAndCannotChangeTheKey()
+    {
+        // https://w3c.github.io/webcrypto/#dfn-cached-ecmascript-object — one object per slot, built on the
+        // first read. It is an ordinary object, so a script may write to it; nothing the engine decides is
+        // read back out of it, which is the half that matters.
+        Run("""
+            const key = await crypto.subtle.generateKey({ name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+
+            const stable = key.algorithm === key.algorithm && key.usages === key.usages;
+
+            key.algorithm.name = 'AES-GCM';
+            key.usages.push('verify');
+
+            let afterwards;
+            try {
+                await crypto.subtle.verify('HMAC', key, new Uint8Array(32), ascii('x'));
+                afterwards = 'verified';
+            } catch (e) {
+                afterwards = e.name;
+            }
+
+            return stable + '|' + afterwards;
+            """).AsString().Should().Be("true|InvalidAccessError");
+    }
+
+    [Fact]
+    public void TheInterfaceObjectRefusesToConstructAnything()
+    {
+        var engine = WebEngine();
+
+        // CryptoKey declares no constructor operation, so the interface object exists, is a function, and
+        // constructs nothing — https://webidl.spec.whatwg.org/#es-interface-call.
+        engine.Evaluate("typeof CryptoKey").AsString().Should().Be("function");
+        engine.Evaluate("(() => { try { new CryptoKey(); } catch (e) { return e.constructor.name + ': ' + e.message; } })()")
+            .AsString().Should().Be("TypeError: Illegal constructor");
+        engine.Evaluate("(() => { try { CryptoKey(); } catch (e) { return e.constructor.name; } })()")
+            .AsString().Should().Be("TypeError");
+
+        engine.Evaluate("CryptoKey.name").AsString().Should().Be("CryptoKey");
+        engine.Evaluate("CryptoKey.length").AsNumber().Should().Be(0);
+        engine.Evaluate("CryptoKey.prototype.constructor === CryptoKey").AsBoolean().Should().BeTrue();
+        engine.Evaluate("CryptoKey.prototype[Symbol.toStringTag]").AsString().Should().Be("CryptoKey");
+    }
+
+    [Fact]
+    public void EveryAttributeBrandChecksItsReceiver()
+    {
+        var engine = WebEngine();
+
+        // The attributes live on the prototype, so they can be extracted — and then they must refuse anything
+        // that is not a key, including CryptoKey.prototype itself, which is not one.
+        engine.Evaluate("""
+            (() => {
+                const names = ['type', 'extractable', 'algorithm', 'usages'];
+                return names.map(name => {
+                    const getter = Object.getOwnPropertyDescriptor(CryptoKey.prototype, name).get;
+                    try { getter.call({}); } catch (e) { return e.constructor.name; }
+                    return 'no error';
+                }).join(',');
+            })()
+            """).AsString().Should().Be("TypeError,TypeError,TypeError,TypeError");
+
+        engine.Evaluate("(() => { try { return CryptoKey.prototype.type; } catch (e) { return e.constructor.name; } })()")
+            .AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void AKeyIsBuiltInTheRealmsOwnPrototype()
+    {
+        Run("""
+            const key = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 128 }, false, ['encrypt']);
+            return [
+                Object.getPrototypeOf(key) === CryptoKey.prototype,
+                Array.isArray(key.usages),
+                Object.getPrototypeOf(key.usages) === Array.prototype,
+                Object.getPrototypeOf(key.algorithm) === Object.prototype,
+            ].join('|');
+            """).AsString().Should().Be("true|true|true|true");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // Key material never escapes except through exportKey
+    // ---------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void ANonExtractableKeyCannotBeExportedInAnyFormat()
+    {
+        Run("""
+            const key = await crypto.subtle.generateKey({ name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+            const outcomes = [];
+            for (const format of ['raw', 'jwk']) {
+                try {
+                    await crypto.subtle.exportKey(format, key);
+                    outcomes.push('exported');
+                } catch (e) {
+                    outcomes.push(e.name + '/' + (e instanceof DOMException));
+                }
+            }
+            // ... and it still signs: extractable is about the material, not about the key's use.
+            outcomes.push((await crypto.subtle.sign('HMAC', key, ascii('x'))).byteLength);
+            return outcomes.join('|');
+            """).AsString().Should().Be("InvalidAccessError/true|InvalidAccessError/true|32");
+    }
+
+    [Fact]
+    public void WhatWasExportedIsACopyOfTheKeyAndNotTheKey()
+    {
+        // The exported buffer crosses into script, where it is mutable. If it aliased the key material, a
+        // script could change what the key signs with — from the outside, without the key ever being told.
+        Run("""
+            const key = await crypto.subtle.importKey('raw', repeat(0x0b, 20), { name: 'HMAC', hash: 'SHA-1' }, true, ['sign']);
+
+            const first = await crypto.subtle.exportKey('raw', key);
+            new Uint8Array(first).fill(0xff);
+
+            const second = await crypto.subtle.exportKey('raw', key);
+            const signature = await crypto.subtle.sign('HMAC', key, ascii('Hi There'));
+
+            return [hex(second), hex(signature), first !== second].join('|');
+            """).AsString().Should().Be(
+                "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b|b617318655057264e28bc0b6fb378c8ef146be00|true");
+    }
+
+    [Fact]
+    public void RoundTripsAGeneratedKeyThroughEveryFormat()
+    {
+        // The shape a script actually writes: generate, export, import somewhere else, and get the same MAC.
+        Run("""
+            const original = await crypto.subtle.generateKey({ name: 'HMAC', hash: 'SHA-512', length: 256 }, true, ['sign', 'verify']);
+            const message = ascii('round trip');
+            const expected = hex(await crypto.subtle.sign('HMAC', original, message));
+
+            const raw = await crypto.subtle.exportKey('raw', original);
+            const fromRaw = await crypto.subtle.importKey('raw', raw, { name: 'HMAC', hash: 'SHA-512' }, false, ['sign']);
+
+            const jwk = await crypto.subtle.exportKey('jwk', original);
+            const fromJwk = await crypto.subtle.importKey('jwk', jwk, { name: 'HMAC', hash: 'SHA-512' }, false, ['verify']);
+
+            return [
+                hex(await crypto.subtle.sign('HMAC', fromRaw, message)) === expected,
+                await crypto.subtle.verify('HMAC', fromJwk, bytes(expected), message),
+                raw.byteLength * 8,
+                fromRaw.algorithm.length,
+            ].join('|');
+            """).AsString().Should().Be("true|true|256|256");
+    }
+
+    [Fact]
+    public void RoundTripsAnAesKeyThroughJwkAndDecryptsWithIt()
+    {
+        Run("""
+            const original = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 192 }, true, ['encrypt', 'decrypt']);
+            const iv = repeat(3, 12);
+            const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, original, ascii('secret'));
+
+            const jwk = await crypto.subtle.exportKey('jwk', original);
+            const imported = await crypto.subtle.importKey('jwk', jwk, 'AES-GCM', false, ['decrypt']);
+
+            const plaintext = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, imported, ciphertext);
+            return String.fromCharCode(...new Uint8Array(plaintext)) + '|' + imported.algorithm.length + '|' + imported.usages.join(',');
+            """).AsString().Should().Be("secret|192|decrypt");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // JSON Web Key
+    // ---------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void ExportsAJwkWithTheFieldsAndTheOrderWebIdlGivesIt()
+    {
+        // A dictionary is converted to an object member by member in lexicographical order —
+        // https://webidl.spec.whatwg.org/#es-dictionary — which is what a browser's JSON.stringify of a JWK
+        // shows too. `k` is base64url with no padding, per Section 6.4 of JSON Web Algorithms.
+        Run("""
+            const key = await crypto.subtle.importKey('raw', repeat(0x0b, 20), { name: 'HMAC', hash: 'SHA-256' }, true, ['sign', 'verify']);
+            const jwk = await crypto.subtle.exportKey('jwk', key);
+            return Object.keys(jwk).join(',') + '|' + JSON.stringify(jwk);
+            """).AsString().Should().Be(
+                "alg,ext,k,key_ops,kty|{\"alg\":\"HS256\",\"ext\":true,\"k\":\"CwsLCwsLCwsLCwsLCwsLCwsLCws\",\"key_ops\":[\"sign\",\"verify\"],\"kty\":\"oct\"}");
+    }
+
+    [Theory]
+    [InlineData("SHA-1", "HS1")]
+    [InlineData("SHA-256", "HS256")]
+    [InlineData("SHA-384", "HS384")]
+    [InlineData("SHA-512", "HS512")]
+    public void TheJwkAlgorithmNamesTheInnerHash(string hash, string alg)
+    {
+        Run($$"""
+            const key = await crypto.subtle.generateKey({ name: 'HMAC', hash: '{{hash}}' }, true, ['sign']);
+            const jwk = await crypto.subtle.exportKey('jwk', key);
+            const imported = await crypto.subtle.importKey('jwk', jwk, { name: 'HMAC', hash: '{{hash}}' }, true, ['sign']);
+            return jwk.alg + '|' + imported.algorithm.hash.name;
+            """).AsString().Should().Be(alg + "|" + hash);
+    }
+
+    [Theory]
+    [InlineData(128, "A128GCM")]
+    [InlineData(192, "A192GCM")]
+    [InlineData(256, "A256GCM")]
+    public void TheJwkAlgorithmNamesTheAesKeyLength(int length, string alg)
+    {
+        Run($$"""
+            const key = await crypto.subtle.generateKey({ name: 'AES-GCM', length: {{length}} }, true, ['encrypt']);
+            const jwk = await crypto.subtle.exportKey('jwk', key);
+            return jwk.alg + '|' + jwk.key_ops.join(',') + '|' + jwk.ext;
+            """).AsString().Should().Be(alg + "|encrypt|true");
+    }
+
+    [Fact]
+    public void ImportsAJwkWrittenByHand()
+    {
+        // The shape a script reads out of a configuration file: a plain object literal, base64url without
+        // padding, and no fields beyond the ones the key needs.
+        Run("""
+            const key = await crypto.subtle.importKey(
+                'jwk',
+                { kty: 'oct', k: 'CwsLCwsLCwsLCwsLCwsLCwsLCws' },
+                { name: 'HMAC', hash: 'SHA-1' },
+                false,
+                ['sign']);
+
+            return hex(await crypto.subtle.sign('HMAC', key, ascii('Hi There')));
+            """).AsString().Should().Be("b617318655057264e28bc0b6fb378c8ef146be00");
+    }
+
+    [Theory]
+    // The kty must be "oct" for a symmetric key, and it must be there at all.
+    [InlineData("{ k: 'AAAAAAAAAAAAAAAAAAAAAA' }", "DataError")]
+    [InlineData("{ kty: 'RSA', k: 'AAAAAAAAAAAAAAAAAAAAAA' }", "DataError")]
+    [InlineData("{ kty: 'OCT', k: 'AAAAAAAAAAAAAAAAAAAAAA' }", "DataError")]
+    // Section 6.4.1 of JSON Web Algorithms: "This member MUST be present."
+    [InlineData("{ kty: 'oct' }", "DataError")]
+    // k must be base64url: no padding, no + or /, no whitespace, and no length that decodes to a fraction of
+    // a byte.
+    [InlineData("{ kty: 'oct', k: 'CwsLCwsLCwsLCwsLCwsLCwsLCws=' }", "DataError")]
+    [InlineData("{ kty: 'oct', k: 'Cws+CwsLCwsLCwsLCwsLCwsLCws' }", "DataError")]
+    [InlineData("{ kty: 'oct', k: 'Cws/CwsLCwsLCwsLCwsLCwsLCws' }", "DataError")]
+    [InlineData("{ kty: 'oct', k: 'Cws CwsLCwsLCwsLCwsLCwsLCws' }", "DataError")]
+    [InlineData("{ kty: 'oct', k: 'CwsLC' }", "DataError")]
+    // An empty key is an empty key, whichever way it is spelled.
+    [InlineData("{ kty: 'oct', k: '' }", "DataError")]
+    // The alg field must agree with the hash the import asks for.
+    [InlineData("{ kty: 'oct', k: 'CwsLCwsLCwsLCwsLCwsLCwsLCws', alg: 'HS512' }", "DataError")]
+    [InlineData("{ kty: 'oct', k: 'CwsLCwsLCwsLCwsLCwsLCwsLCws', alg: 'A128GCM' }", "DataError")]
+    // "If usages is non-empty and the use field of jwk is present and is not 'sig', throw a DataError."
+    [InlineData("{ kty: 'oct', k: 'CwsLCwsLCwsLCwsLCwsLCwsLCws', use: 'enc' }", "DataError")]
+    // key_ops must be valid JSON Web Key and must cover the requested usages.
+    [InlineData("{ kty: 'oct', k: 'CwsLCwsLCwsLCwsLCwsLCwsLCws', key_ops: ['verify'] }", "DataError")]
+    [InlineData("{ kty: 'oct', k: 'CwsLCwsLCwsLCwsLCwsLCwsLCws', key_ops: ['sign', 'sign'] }", "DataError")]
+    // "If the ext field of jwk is present and has the value false and extractable is true, throw a DataError."
+    [InlineData("{ kty: 'oct', k: 'CwsLCwsLCwsLCwsLCwsLCwsLCws', ext: false }", "DataError")]
+    public void RefusesAMalformedJwkWithADataError(string jwk, string expected)
+    {
+        var engine = WebEngine();
+
+        // Every one of these is imported as extractable with the single usage 'sign', so the `ext: false` row
+        // and the `key_ops` rows are about the JWK rather than about the request.
+        Settle(engine, $$"""
+            crypto.subtle.importKey('jwk', {{jwk}}, { name: 'HMAC', hash: 'SHA-256' }, true, ['sign'])
+                .then(() => 'imported', e => e.name + '/' + (e instanceof DOMException))
+            """).AsString().Should().Be(expected + "/true");
+    }
+
+    [Fact]
+    public void AcceptsTheJwkFieldsThatDoAgree()
+    {
+        // The mirror image of the rows above: each field, present and correct, imports.
+        Run("""
+            const key = await crypto.subtle.importKey(
+                'jwk',
+                { kty: 'oct', k: 'CwsLCwsLCwsLCwsLCwsLCwsLCws', alg: 'HS256', use: 'sig', key_ops: ['sign', 'verify'], ext: true },
+                { name: 'HMAC', hash: 'SHA-256' },
+                true,
+                ['sign']);
+
+            // key_ops may name more than was asked for; the key carries what was asked for.
+            return key.usages.join(',') + '|' + key.extractable + '|' + key.algorithm.length;
+            """).AsString().Should().Be("sign|true|160");
+    }
+
+    [Fact]
+    public void AnExtFalseJwkImportsWhenTheKeyIsNotAskedToBeExtractable()
+    {
+        // The check is about the pair: a key marked non-extractable may be imported, as long as it stays
+        // non-extractable.
+        Run("""
+            const key = await crypto.subtle.importKey(
+                'jwk',
+                { kty: 'oct', k: 'CwsLCwsLCwsLCwsLCwsLCwsLCws', ext: false },
+                { name: 'HMAC', hash: 'SHA-256' },
+                false,
+                ['sign']);
+            return key.extractable + '|' + key.usages.join(',');
+            """).AsString().Should().Be("false|sign");
+    }
+
+    [Fact]
+    public void AJwkUseFieldIsIgnoredWhenNothingIsAskedOfTheKey()
+    {
+        // "If usages is non-empty and the use field …" — but an empty usages list cannot reach the check,
+        // because the operation ends in the SyntaxError for a secret key with no usages instead.
+        var engine = WebEngine();
+
+        Settle(engine, """
+            crypto.subtle.importKey('jwk', { kty: 'oct', k: 'CwsLCwsLCwsLCwsLCwsLCwsLCws', use: 'enc' },
+                { name: 'HMAC', hash: 'SHA-256' }, false, [])
+                .then(() => 'imported', e => e.name)
+            """).AsString().Should().Be("SyntaxError");
+    }
+
+    [Fact]
+    public void ReadsTheJwkFieldsInWebIdlsOwnOrderAndOnlyOnce()
+    {
+        // A dictionary's members are converted in lexicographical order, each read exactly once. A second
+        // read would be a second chance for a getter to change the answer between the check and the import.
+        Run("""
+            const reads = [];
+            const jwk = {
+                get kty() { reads.push('kty'); return 'oct'; },
+                get k() { reads.push('k'); return 'CwsLCwsLCwsLCwsLCwsLCwsLCws'; },
+                get alg() { reads.push('alg'); return 'HS256'; },
+                get use() { reads.push('use'); return 'sig'; },
+                get ext() { reads.push('ext'); return true; },
+                get key_ops() { reads.push('key_ops'); return ['sign']; },
+            };
+
+            await crypto.subtle.importKey('jwk', jwk, { name: 'HMAC', hash: 'SHA-256' }, true, ['sign']);
+            return reads.join(',');
+            """).AsString().Should().Be("alg,ext,k,key_ops,kty,use");
+    }
+
+    [Fact]
+    public void TheJwkIsReadBeforeTheAlgorithmIsNormalized()
+    {
+        // WebIDL converts every argument before a single step of the method body runs, and the JsonWebKey
+        // conversion is one of those argument conversions — so the getters run even though the algorithm is
+        // about to be rejected.
+        Run("""
+            let read = false;
+            const jwk = { kty: 'oct', get k() { read = true; return 'CwsLCwsLCwsLCwsLCwsLCwsLCws'; } };
+
+            let failure;
+            try {
+                await crypto.subtle.importKey('jwk', jwk, 'RSA-OAEP', true, ['sign']);
+            } catch (e) {
+                failure = e.name;
+            }
+            return read + '|' + failure;
+            """).AsString().Should().Be("true|NotSupportedError");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // The usage matrix
+    // ---------------------------------------------------------------------------------------------------
+
+    [Theory]
+    // A key must permit the operation being asked of it, or the answer is an InvalidAccessError — never a
+    // silent success and never a TypeError.
+    [InlineData("sign", "['verify']", "InvalidAccessError")]
+    [InlineData("verify", "['sign']", "InvalidAccessError")]
+    [InlineData("sign", "['sign']", "ok")]
+    [InlineData("verify", "['verify']", "ok")]
+    [InlineData("sign", "['sign', 'verify']", "ok")]
+    public void EnforcesTheHmacUsageMatrix(string operation, string usages, string expected)
+    {
+        var call = string.Equals(operation, "sign", StringComparison.Ordinal)
+            ? "crypto.subtle.sign('HMAC', key, ascii('m'))"
+            : "crypto.subtle.verify('HMAC', key, new Uint8Array(32), ascii('m'))";
+
+        Run($$"""
+            const key = await crypto.subtle.generateKey({ name: 'HMAC', hash: 'SHA-256' }, false, {{usages}});
+            try {
+                await {{call}};
+                return 'ok';
+            } catch (e) {
+                return e.name;
+            }
+            """).AsString().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("encrypt", "['decrypt']", "InvalidAccessError")]
+    [InlineData("decrypt", "['encrypt']", "InvalidAccessError")]
+    [InlineData("encrypt", "['encrypt']", "ok")]
+    [InlineData("decrypt", "['decrypt']", "ok")]
+    [InlineData("encrypt", "['wrapKey']", "InvalidAccessError")]
+    [InlineData("decrypt", "['encrypt', 'decrypt']", "ok")]
+    public void EnforcesTheAesGcmUsageMatrix(string operation, string usages, string expected)
+    {
+        // The same key material is imported twice - once with the usages under test and once as an encryptor
+        // - so that the decrypt rows have something to decrypt that was made with their own key.
+        var data = string.Equals(operation, "encrypt", StringComparison.Ordinal) ? "ascii('m')" : "sample";
+
+        Run($$"""
+            const material = repeat(5, 16);
+            const iv = repeat(4, 12);
+            const encryptor = await crypto.subtle.importKey('raw', material, 'AES-GCM', false, ['encrypt']);
+            const sample = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, encryptor, ascii('m'));
+
+            const key = await crypto.subtle.importKey('raw', material, 'AES-GCM', false, {{usages}});
+            try {
+                await crypto.subtle.{{operation}}({ name: 'AES-GCM', iv }, key, {{data}});
+                return 'ok';
+            } catch (e) {
+                return e.name;
+            }
+            """).AsString().Should().Be(expected);
+    }
+
+    [Fact]
+    public void AKeyMadeForOneAlgorithmRefusesAnother()
+    {
+        Run("""
+            const hmac = await crypto.subtle.generateKey({ name: 'HMAC', hash: 'SHA-256' }, false, ['sign', 'verify']);
+            const aes = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 128 }, false, ['encrypt', 'decrypt']);
+
+            const outcomes = [];
+            // The name check comes before the usage check, and both are InvalidAccessError.
+            try { await crypto.subtle.encrypt({ name: 'AES-GCM', iv: repeat(0, 12) }, hmac, ascii('m')); outcomes.push('ok'); }
+            catch (e) { outcomes.push(e.name); }
+            try { await crypto.subtle.sign('HMAC', aes, ascii('m')); outcomes.push('ok'); }
+            catch (e) { outcomes.push(e.name); }
+
+            // An algorithm that is not registered for the operation at all is a different failure: the
+            // registry is consulted before any key is looked at.
+            try { await crypto.subtle.sign('AES-GCM', aes, ascii('m')); outcomes.push('ok'); }
+            catch (e) { outcomes.push(e.name); }
+            try { await crypto.subtle.encrypt({ name: 'HMAC', iv: repeat(0, 12) }, hmac, ascii('m')); outcomes.push('ok'); }
+            catch (e) { outcomes.push(e.name); }
+
+            return outcomes.join(',');
+            """).AsString().Should().Be("InvalidAccessError,InvalidAccessError,NotSupportedError,NotSupportedError");
+    }
+
+    [Theory]
+    [InlineData("{ name: 'HMAC', hash: 'SHA-256' }", "['encrypt']")]
+    [InlineData("{ name: 'HMAC', hash: 'SHA-256' }", "['sign', 'deriveKey']")]
+    [InlineData("{ name: 'AES-GCM', length: 128 }", "['sign']")]
+    [InlineData("{ name: 'AES-GCM', length: 128 }", "['encrypt', 'verify']")]
+    public void RefusesAUsageTheAlgorithmDoesNotSupportWithASyntaxError(string algorithm, string usages)
+    {
+        var engine = WebEngine();
+
+        // A recognized usage that is wrong for the algorithm is the SyntaxError the algorithm's own first
+        // step raises — "a required parameter was missing or out-of-range".
+        Settle(engine, $$"""
+            crypto.subtle.generateKey({{algorithm}}, false, {{usages}}).then(() => 'generated', e => e.name)
+            """).AsString().Should().Be("SyntaxError");
+
+        Settle(engine, $$"""
+            crypto.subtle.importKey('raw', new Uint8Array(16), {{algorithm}}, false, {{usages}}).then(() => 'imported', e => e.name)
+            """).AsString().Should().Be("SyntaxError");
+    }
+
+    [Fact]
+    public void RefusesASecretKeyWithNoUsagesAtAll()
+    {
+        var engine = WebEngine();
+
+        foreach (var source in new[]
+        {
+            "crypto.subtle.generateKey({ name: 'HMAC', hash: 'SHA-256' }, false, [])",
+            "crypto.subtle.generateKey({ name: 'AES-GCM', length: 128 }, false, [])",
+            "crypto.subtle.importKey('raw', new Uint8Array(16), 'AES-GCM', false, [])",
+        })
+        {
+            Settle(engine, source + ".then(() => 'made', e => e.name + '/' + (e instanceof DOMException))")
+                .AsString().Should().Be("SyntaxError/true");
+        }
+    }
+
+    [Fact]
+    public void AnUnrecognizedUsageIsATypeErrorRatherThanASyntaxError()
+    {
+        var engine = WebEngine();
+
+        // The IDL type is `sequence<KeyUsage>`, and a value outside an enumeration fails the WebIDL
+        // conversion. That is a different failure from a usage that is recognized but wrong for the
+        // algorithm, and it happens earlier — before the algorithm is normalized at all.
+        Settle(engine, """
+            crypto.subtle.generateKey('nonsense', false, ['encipher']).then(() => 'generated', e => e.constructor.name)
+            """).AsString().Should().Be("TypeError");
+
+        Settle(engine, """
+            crypto.subtle.generateKey({ name: 'HMAC', hash: 'SHA-256' }, false, 'sign').then(() => 'generated', e => e.constructor.name)
+            """).AsString().Should().Be("TypeError");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // Formats and algorithms that are not there
+    // ---------------------------------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("spki")]
+    [InlineData("pkcs8")]
+    public void RefusesAnAsymmetricKeyFormatWithANotSupportedError(string format)
+    {
+        var engine = WebEngine();
+
+        // A recognized KeyFormat that the algorithm's own steps do not handle — "Otherwise: throw a
+        // NotSupportedError" — which for a symmetric key is every format but raw and jwk, in a browser too.
+        Settle(engine, $$"""
+            crypto.subtle.importKey('{{format}}', new Uint8Array(16), 'AES-GCM', false, ['encrypt'])
+                .then(() => 'imported', e => e.name)
+            """).AsString().Should().Be("NotSupportedError");
+
+        Settle(engine, $$"""
+            crypto.subtle.generateKey({ name: 'AES-GCM', length: 128 }, true, ['encrypt'])
+                .then(key => crypto.subtle.exportKey('{{format}}', key))
+                .then(() => 'exported', e => e.name)
+            """).AsString().Should().Be("NotSupportedError");
+    }
+
+    [Theory]
+    [InlineData("'RAW'")]
+    [InlineData("'pem'")]
+    [InlineData("''")]
+    [InlineData("undefined")]
+    [InlineData("42")]
+    public void RefusesAFormatOutsideTheEnumerationWithATypeError(string format)
+    {
+        var engine = WebEngine();
+
+        // KeyFormat is a WebIDL enumeration, matched case-sensitively; anything else is a TypeError rather
+        // than a NotSupportedError.
+        Settle(engine, $$"""
+            crypto.subtle.importKey({{format}}, new Uint8Array(16), 'AES-GCM', false, ['encrypt'])
+                .then(() => 'imported', e => e.constructor.name)
+            """).AsString().Should().Be("TypeError");
+    }
+
+    [Theory]
+    [InlineData("sign", "'RSASSA-PKCS1-v1_5'")]
+    [InlineData("verify", "'ECDSA'")]
+    [InlineData("encrypt", "'AES-CBC'")]
+    [InlineData("decrypt", "{ name: 'AES-CTR' }")]
+    [InlineData("generateKey", "'RSA-OAEP'")]
+    [InlineData("importKey", "'PBKDF2'")]
+    public void RefusesAnUnregisteredAlgorithmWithANotSupportedError(string operation, string algorithm)
+    {
+        var engine = WebEngine();
+
+        var call = operation switch
+        {
+            "sign" => $"crypto.subtle.sign({algorithm}, key, new Uint8Array(0))",
+            "verify" => $"crypto.subtle.verify({algorithm}, key, new Uint8Array(0), new Uint8Array(0))",
+            "encrypt" => $"crypto.subtle.encrypt({algorithm}, key, new Uint8Array(0))",
+            "decrypt" => $"crypto.subtle.decrypt({algorithm}, key, new Uint8Array(0))",
+            "generateKey" => $"crypto.subtle.generateKey({algorithm}, false, ['sign'])",
+            _ => $"crypto.subtle.importKey('raw', new Uint8Array(16), {algorithm}, false, ['sign'])",
+        };
+
+        Settle(engine, $$"""
+            crypto.subtle.generateKey({ name: 'HMAC', hash: 'SHA-256' }, false, ['sign', 'verify'])
+                .then(key => {{call}})
+                .then(() => 'succeeded', e => e.name + '/' + e.code)
+            """).AsString().Should().Be("NotSupportedError/9");
+    }
+
+    [Fact]
+    public void OnlyTheOperationsThisEngineImplementsExist()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("""
+            ['digest', 'sign', 'verify', 'encrypt', 'decrypt', 'generateKey', 'importKey', 'exportKey']
+                .map(name => typeof crypto.subtle[name]).join(',')
+            """).AsString().Should().Be("function,function,function,function,function,function,function,function");
+
+        // Absent rather than present-and-throwing: `typeof crypto.subtle.deriveBits` is how a library that
+        // does cryptography decides whether it can, and it has to get the truthful answer.
+        engine.Evaluate("""
+            ['deriveKey', 'deriveBits', 'wrapKey', 'unwrapKey'].filter(name => name in crypto.subtle).join(',')
+            """).AsString().Should().Be("");
+    }
+
+    [Fact]
+    public void EveryOperationHasTheIdlArityAndTheAttributesOfABuiltInMethod()
+    {
+        var engine = WebEngine();
+
+        // WebIDL's length counts the required arguments only.
+        engine.Evaluate("""
+            ['digest', 'sign', 'verify', 'encrypt', 'decrypt', 'generateKey', 'importKey', 'exportKey']
+                .map(name => name + ':' + crypto.subtle[name].length + ':' + crypto.subtle[name].name).join(',')
+            """).AsString().Should().Be(
+                "digest:2:digest,sign:3:sign,verify:4:verify,encrypt:3:encrypt,decrypt:3:decrypt,"
+                + "generateKey:3:generateKey,importKey:5:importKey,exportKey:2:exportKey");
+
+        engine.Evaluate("JSON.stringify(Object.keys(crypto.subtle))").AsString().Should().Be("[]");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // Normalization, argument conversion, and the order the failures come in
+    // ---------------------------------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("'hmac'")]
+    [InlineData("'Hmac'")]
+    [InlineData("{ name: 'hMaC' }")]
+    public void MatchesTheRegisteredAlgorithmNameCaseInsensitively(string algorithm)
+    {
+        // "If registeredAlgorithms contains a key that is a case-insensitive string match for algName: set
+        // algName to the value of the matching key" - and every operation then matches the registered key
+        // case-sensitively, so normalization is the only thing that lets a lowercase spelling reach HMAC at
+        // all. The key remembers the registered spelling, not the caller's.
+        Run($$"""
+            const key = await crypto.subtle.importKey('raw', repeat(0x0b, 20), { name: 'hmac', hash: 'sha-1' }, false, ['sign']);
+            return hex(await crypto.subtle.sign({{algorithm}}, key, ascii('Hi There')))
+                + '|' + key.algorithm.name + '|' + key.algorithm.hash.name;
+            """).AsString().Should().Be("b617318655057264e28bc0b6fb378c8ef146be00|HMAC|SHA-1");
+    }
+
+    [Fact]
+    public void TheHashMemberIsNormalizedAsADigestAlgorithm()
+    {
+        var engine = WebEngine();
+
+        // "If member is of the type HashAlgorithmIdentifier: set it to the result of normalizing an
+        // algorithm, with op set to 'digest'" — so the hash may be a string or an object, and a name that is
+        // not a registered digest is a NotSupportedError.
+        Settle(engine, """
+            crypto.subtle.generateKey({ name: 'HMAC', hash: { name: 'SHA-384' } }, false, ['sign'])
+                .then(key => key.algorithm.hash.name + '|' + key.algorithm.length, e => e.name)
+            """).AsString().Should().Be("SHA-384|1024");
+
+        Settle(engine, """
+            crypto.subtle.generateKey({ name: 'HMAC', hash: 'MD5' }, false, ['sign']).then(() => 'generated', e => e.name)
+            """).AsString().Should().Be("NotSupportedError");
+
+        // A required dictionary member that is missing is the TypeError WebIDL raises for it, not a
+        // NotSupportedError for the name "undefined" — and a bare 'HMAC' string is a dictionary with no hash.
+        foreach (var algorithm in new[] { "'HMAC'", "{ name: 'HMAC' }", "{ name: 'HMAC', hash: undefined }" })
+        {
+            Settle(engine, $$"""
+                crypto.subtle.generateKey({{algorithm}}, false, ['sign']).then(() => 'generated', e => e.constructor.name)
+                """).AsString().Should().Be("TypeError");
+        }
+    }
+
+    [Fact]
+    public void TheAesKeyLengthIsARequiredMember()
+    {
+        var engine = WebEngine();
+
+        foreach (var algorithm in new[] { "'AES-GCM'", "{ name: 'AES-GCM' }" })
+        {
+            Settle(engine, $$"""
+                crypto.subtle.generateKey({{algorithm}}, false, ['encrypt']).then(() => 'generated', e => e.constructor.name)
+                """).AsString().Should().Be("TypeError");
+        }
+
+        // A length outside the three AES has is the algorithm's own OperationError, not a TypeError: it
+        // passed the IDL conversion and failed step 2.
+        foreach (var length in new[] { "0", "64", "129", "512" })
+        {
+            Settle(engine, $$"""
+                crypto.subtle.generateKey({ name: 'AES-GCM', length: {{length}} }, false, ['encrypt'])
+                    .then(() => 'generated', e => e.name)
+                """).AsString().Should().Be("OperationError");
+        }
+
+        // ... and one outside `unsigned short` fails the [EnforceRange] conversion instead.
+        Settle(engine, """
+            crypto.subtle.generateKey({ name: 'AES-GCM', length: 65536 }, false, ['encrypt'])
+                .then(() => 'generated', e => e.constructor.name)
+            """).AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void TheHmacKeyLengthFollowsTheHashBlockSizeUnlessItIsGiven()
+    {
+        Run("""
+            const lengths = [];
+            for (const hash of ['SHA-1', 'SHA-256', 'SHA-384', 'SHA-512']) {
+                const key = await crypto.subtle.generateKey({ name: 'HMAC', hash }, true, ['sign']);
+                lengths.push(key.algorithm.length + ':' + (await crypto.subtle.exportKey('raw', key)).byteLength);
+            }
+
+            const asked = await crypto.subtle.generateKey({ name: 'HMAC', hash: 'SHA-256', length: 128 }, true, ['sign']);
+            lengths.push(asked.algorithm.length + ':' + (await crypto.subtle.exportKey('raw', asked)).byteLength);
+            return lengths.join(',');
+            """).AsString().Should().Be("512:64,512:64,1024:128,1024:128,128:16");
+    }
+
+    [Fact]
+    public void RefusesToGenerateAnHmacKeyItCannotRepresent()
+    {
+        var engine = WebEngine();
+
+        // A zero length is the specification's own OperationError. A length that is not a whole number of
+        // bytes is one of the ways "the key generation step fails" here, which the class documents: an
+        // eight-byte key whose last seven bits were a lie would be worse than a refusal.
+        Settle(engine, """
+            crypto.subtle.generateKey({ name: 'HMAC', hash: 'SHA-256', length: 0 }, false, ['sign'])
+                .then(() => 'generated', e => e.name)
+            """).AsString().Should().Be("OperationError");
+
+        Settle(engine, """
+            crypto.subtle.generateKey({ name: 'HMAC', hash: 'SHA-256', length: 57 }, false, ['sign'])
+                .then(() => 'generated', e => e.name)
+            """).AsString().Should().Be("OperationError");
+    }
+
+    [Fact]
+    public void TheImportedHmacLengthMustNameTheBytesThatArrived()
+    {
+        var engine = WebEngine();
+
+        // Step 9: a requested length may trim bits off the last byte but never a whole byte, in either
+        // direction — greater than the material is a DataError, and so is a byte less.
+        Settle(engine, """
+            crypto.subtle.importKey('raw', new Uint8Array(20), { name: 'HMAC', hash: 'SHA-256', length: 161 }, false, ['sign'])
+                .then(() => 'imported', e => e.name)
+            """).AsString().Should().Be("DataError");
+
+        Settle(engine, """
+            crypto.subtle.importKey('raw', new Uint8Array(20), { name: 'HMAC', hash: 'SHA-256', length: 152 }, false, ['sign'])
+                .then(() => 'imported', e => e.name)
+            """).AsString().Should().Be("DataError");
+
+        Settle(engine, """
+            crypto.subtle.importKey('raw', new Uint8Array(20), { name: 'HMAC', hash: 'SHA-256', length: 153 }, false, ['sign'])
+                .then(key => key.algorithm.length, e => e.name)
+            """).AsNumber().Should().Be(153);
+
+        // A present zero is a DataError here where generateKey calls the same value an OperationError.
+        Settle(engine, """
+            crypto.subtle.importKey('raw', new Uint8Array(20), { name: 'HMAC', hash: 'SHA-256', length: 0 }, false, ['sign'])
+                .then(() => 'imported', e => e.name)
+            """).AsString().Should().Be("DataError");
+
+        // An empty key has no bits to name at all.
+        Settle(engine, """
+            crypto.subtle.importKey('raw', new Uint8Array(0), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'])
+                .then(() => 'imported', e => e.name)
+            """).AsString().Should().Be("DataError");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(8)]
+    [InlineData(17)]
+    [InlineData(64)]
+    public void RefusesAnAesKeyOfTheWrongSizeWithADataError(int bytes)
+    {
+        var engine = WebEngine();
+
+        Settle(engine, $$"""
+            crypto.subtle.importKey('raw', new Uint8Array({{bytes}}), 'AES-GCM', false, ['encrypt'])
+                .then(() => 'imported', e => e.name)
+            """).AsString().Should().Be("DataError");
+    }
+
+    [Theory]
+    // The tag lengths the specification lists but this platform's AES-GCM cannot produce.
+    [InlineData("32", "OperationError")]
+    [InlineData("64", "OperationError")]
+    // A value that is not in the list at all.
+    [InlineData("8", "OperationError")]
+    [InlineData("100", "OperationError")]
+    [InlineData("255", "OperationError")]
+    // ... and one outside `octet`, which fails the [EnforceRange] conversion first.
+    [InlineData("256", "TypeError")]
+    [InlineData("-8", "TypeError")]
+    public void RefusesATagLengthItCannotProduce(string tagLength, string expected)
+    {
+        var engine = WebEngine();
+
+        Settle(engine, $$"""
+            crypto.subtle.generateKey({ name: 'AES-GCM', length: 128 }, false, ['encrypt'])
+                .then(key => crypto.subtle.encrypt({ name: 'AES-GCM', iv: new Uint8Array(12), tagLength: {{tagLength}} }, key, new Uint8Array(0)))
+                .then(() => 'encrypted', e => e.name === 'OperationError' ? 'OperationError' : e.constructor.name)
+            """).AsString().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(8)]
+    [InlineData(11)]
+    [InlineData(13)]
+    [InlineData(16)]
+    public void RefusesAnIvThePlatformCannotUse(int ivLength)
+    {
+        var engine = WebEngine();
+
+        // A documented limit of the platform's AES-GCM, reported as the OperationError the algorithm's own
+        // steps end in. 96 bits is what NIST SP 800-38D recommends and what nearly every protocol uses.
+        Settle(engine, $$"""
+            crypto.subtle.generateKey({ name: 'AES-GCM', length: 128 }, false, ['encrypt'])
+                .then(key => crypto.subtle.encrypt({ name: 'AES-GCM', iv: new Uint8Array({{ivLength}}) }, key, new Uint8Array(0)))
+                .then(() => 'encrypted', e => e.name)
+            """).AsString().Should().Be("OperationError");
+    }
+
+    [Fact]
+    public void TheIvIsARequiredMemberOfAesGcmParams()
+    {
+        var engine = WebEngine();
+
+        foreach (var algorithm in new[] { "'AES-GCM'", "{ name: 'AES-GCM' }", "{ name: 'AES-GCM', iv: undefined }", "{ name: 'AES-GCM', iv: 'twelve bytes' }" })
+        {
+            Settle(engine, $$"""
+                crypto.subtle.generateKey({ name: 'AES-GCM', length: 128 }, false, ['encrypt'])
+                    .then(key => crypto.subtle.encrypt({{algorithm}}, key, new Uint8Array(0)))
+                    .then(() => 'encrypted', e => e.constructor.name)
+                """).AsString().Should().Be("TypeError");
+        }
+    }
+
+    [Fact]
+    public void ABufferSourceMemberIsCopiedWhenItIsRead()
+    {
+        // "If member is of the type BufferSource and is present: set the dictionary member … to the result of
+        // getting a copy of the bytes held by idlValue." The iv is read before `tagLength` is, so a getter on
+        // tagLength that rewrites the iv cannot change the one the operation uses — the ciphertext must be
+        // the one the original iv produces.
+        Run("""
+            const key = await crypto.subtle.importKey('raw', bytes('7fddb57453c241d03efbed3ac44e371c'), 'AES-GCM', false, ['encrypt']);
+            const iv = bytes('ee283a3fc75575e33efd4887');
+
+            const ciphertext = await crypto.subtle.encrypt(
+                { name: 'AES-GCM', iv, get tagLength() { iv.fill(0xff); return 128; } },
+                key,
+                bytes('d5de42b461646c255c87bd2962d3b9a2'));
+
+            return hex(ciphertext) + '|' + hex(iv);
+            """).AsString().Should().Be(
+                "2ccda4a5415cb91e135c2a0f78c9b2fdb36d1df9b9d5e596f83e8b7f52971cb3|ffffffffffffffffffffffff");
+    }
+
+    [Fact]
+    public void TheDataArgumentIsCopiedBeforeAnyGetterCanRun()
+    {
+        // The argument conversions run before the method body, and the body's first step normalizes an
+        // algorithm — which reads `name` and may run a script's getter, with the caller's buffer in scope. A
+        // window onto the engine's own array would hash what the getter left behind.
+        Run("""
+            const data = ascii('abc');
+            const digest = await crypto.subtle.digest({ get name() { data.fill(0x21); return 'SHA-256'; } }, data);
+            return hex(digest) + '|' + hex(data);
+            """).AsString().Should().Be(
+                "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad|212121");
+    }
+
+    [Fact]
+    public void ArgumentsAreConvertedLeftToRightBeforeTheBodyRuns()
+    {
+        var engine = WebEngine();
+
+        // sign(algorithm, key, data): a bad key outranks an unregistered algorithm, and a bad data outranks
+        // a bad key, because argument conversion runs before normalization and runs left to right.
+        Settle(engine, """
+            crypto.subtle.sign('nonsense', {}, new Uint8Array(0)).then(() => 'signed', e => e.constructor.name)
+            """).AsString().Should().Be("TypeError");
+
+        Settle(engine, """
+            crypto.subtle.sign('nonsense', 'not a key', 'not a buffer').then(() => 'signed', e => e.constructor.name)
+            """).AsString().Should().Be("TypeError");
+
+        // ... and with both arguments valid the algorithm name does earn its own failure.
+        Settle(engine, """
+            crypto.subtle.generateKey({ name: 'HMAC', hash: 'SHA-256' }, false, ['sign'])
+                .then(key => crypto.subtle.sign('nonsense', key, new Uint8Array(0)))
+                .then(() => 'signed', e => e.name)
+            """).AsString().Should().Be("NotSupportedError");
+    }
+
+    [Fact]
+    public void RefusesAKeyDataThatIsNeitherABufferSourceNorAJwk()
+    {
+        var engine = WebEngine();
+
+        // The union's two arms, each with the format that does not match it.
+        Settle(engine, """
+            crypto.subtle.importKey('jwk', new Uint8Array(16), 'AES-GCM', false, ['encrypt'])
+                .then(() => 'imported', e => e.constructor.name)
+            """).AsString().Should().Be("TypeError");
+
+        Settle(engine, """
+            crypto.subtle.importKey('raw', { kty: 'oct', k: 'CwsLCwsLCwsLCwsLCwsLCwsLCws' }, 'AES-GCM', false, ['encrypt'])
+                .then(() => 'imported', e => e.constructor.name)
+            """).AsString().Should().Be("TypeError");
+
+        // Converting a non-object to a dictionary is a TypeError, so a primitive fails whichever format is
+        // asked for.
+        foreach (var keyData in new[] { "42", "'a string'", "true", "Symbol('nope')" })
+        {
+            Settle(engine, $$"""
+                crypto.subtle.importKey('jwk', {{keyData}}, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'])
+                    .then(() => 'imported', e => e.constructor.name)
+                """).AsString().Should().Be("TypeError");
+        }
+    }
+
+    [Fact]
+    public void RefusesABufferSourceBackedByASharedArrayBuffer()
+    {
+        var engine = WebEngine();
+
+        // The IDL is BufferSource, not AllowSharedBufferSource, and WebIDL refuses a shared buffer for any
+        // type not carrying [AllowShared] — the rule crypto.getRandomValues refuses one under.
+        Settle(engine, """
+            crypto.subtle.importKey('raw', new Uint8Array(new SharedArrayBuffer(16)), 'AES-GCM', false, ['encrypt'])
+                .then(() => 'imported', e => e.constructor.name)
+            """).AsString().Should().Be("TypeError");
+
+        Settle(engine, """
+            crypto.subtle.generateKey({ name: 'HMAC', hash: 'SHA-256' }, false, ['sign'])
+                .then(key => crypto.subtle.sign('HMAC', key, new SharedArrayBuffer(8)))
+                .then(() => 'signed', e => e.constructor.name)
+            """).AsString().Should().Be("TypeError");
+
+        Settle(engine, """
+            crypto.subtle.generateKey({ name: 'AES-GCM', length: 128 }, false, ['encrypt'])
+                .then(key => crypto.subtle.encrypt({ name: 'AES-GCM', iv: new Uint8Array(new SharedArrayBuffer(12)) }, key, new Uint8Array(0)))
+                .then(() => 'encrypted', e => e.constructor.name)
+            """).AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void AcceptsEveryShapeOfBufferSourceForTheKeyAndTheMessage()
+    {
+        // `BufferSource` is "an ArrayBuffer, or any view over one" — the element type of a view is not
+        // consulted, only the bytes underneath it.
+        Run("""
+            const material = repeat(0x0b, 20);
+            const shapes = [
+                material,
+                material.buffer,
+                new DataView(material.buffer),
+                new Int8Array(material.buffer),
+            ];
+
+            const results = [];
+            for (const shape of shapes) {
+                const key = await crypto.subtle.importKey('raw', shape, { name: 'HMAC', hash: 'SHA-1' }, false, ['sign']);
+                results.push(hex(await crypto.subtle.sign('HMAC', key, new DataView(ascii('Hi There').buffer))));
+            }
+            return new Set(results).size + '|' + results[0];
+            """).AsString().Should().Be("1|b617318655057264e28bc0b6fb378c8ef146be00");
+    }
+
+    [Fact]
+    public void ADetachedBufferIsTheEmptyByteSequence()
+    {
+        var engine = WebEngine();
+
+        // https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy step 7: a detached buffer contributes
+        // the empty byte sequence. For an AES key that is a DataError about the length, not a TypeError.
+        Settle(engine, """
+            (() => {
+                const buffer = new ArrayBuffer(16);
+                const view = new Uint8Array(buffer);
+                buffer.transfer();
+                return crypto.subtle.importKey('raw', view, 'AES-GCM', false, ['encrypt'])
+                    .then(() => 'imported', e => e.name);
+            })()
+            """).AsString().Should().Be("DataError");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // Promises, rejections and the receiver
+    // ---------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void NoOperationEverThrowsSynchronously()
+    {
+        var engine = WebEngine();
+
+        // Every failure is a rejection, so the call itself always answers a promise — even when every
+        // argument is nonsense and even when the receiver is wrong.
+        engine.Evaluate("""
+            (() => {
+                const results = [
+                    crypto.subtle.sign('nope', 'nope', 'nope'),
+                    crypto.subtle.verify(Symbol.iterator, {}, 1, 2),
+                    crypto.subtle.encrypt(null, null, null),
+                    crypto.subtle.decrypt(undefined, undefined, undefined),
+                    crypto.subtle.generateKey(Symbol('x'), 0, 0),
+                    crypto.subtle.importKey('nope', 'nope', 'nope', 'nope', 'nope'),
+                    crypto.subtle.exportKey('raw', {}),
+                    crypto.subtle.sign.call({}, 'HMAC', {}, new Uint8Array(0)),
+                    crypto.subtle.exportKey.call(null, 'raw', {}),
+                ];
+                results.forEach(p => p.catch(() => {}));
+                return results.every(p => p instanceof Promise);
+            })()
+            """).AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void EveryOperationBrandChecksItsReceiverAsARejection()
+    {
+        var engine = WebEngine();
+
+        // The brand check sits inside the same try whose exception a promise-returning operation converts
+        // into a rejection — https://webidl.spec.whatwg.org/#dfn-create-operation-function.
+        Settle(engine, """
+            Promise.all(['sign', 'verify', 'encrypt', 'decrypt', 'generateKey', 'importKey', 'exportKey']
+                .map(name => crypto.subtle[name].call({}).then(() => 'resolved', e => e.constructor.name)))
+                .then(names => names.join(','))
+            """).AsString().Should().Be("TypeError,TypeError,TypeError,TypeError,TypeError,TypeError,TypeError");
+
+        // ... and an extracted operation still works when the receiver is the real one.
+        Settle(engine, """
+            (() => {
+                const generateKey = crypto.subtle.generateKey;
+                return generateKey.call(crypto.subtle, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'])
+                    .then(key => key.type);
+            })()
+            """).AsString().Should().Be("secret");
+    }
+
+    [Fact]
+    public void AnErrorFromAGetterBecomesTheRejection()
+    {
+        var engine = WebEngine();
+
+        // Whatever a script's own getter throws is what the promise rejects with — the operation still never
+        // throws to its caller, and the error is not replaced by one of ours.
+        Settle(engine, """
+            crypto.subtle.generateKey({ get name() { throw new RangeError('from the getter'); } }, false, ['sign'])
+                .then(() => 'generated', e => e.constructor.name + ': ' + e.message)
+            """).AsString().Should().Be("RangeError: from the getter");
+
+        Settle(engine, """
+            crypto.subtle.importKey('jwk', { get kty() { throw new EvalError('from the jwk'); } },
+                { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'])
+                .then(() => 'imported', e => e.constructor.name + ': ' + e.message)
+            """).AsString().Should().Be("EvalError: from the jwk");
+    }
+
+    [Fact]
+    public void EveryOperationSettlesOnAMicrotaskTurn()
+    {
+        var engine = WebEngine();
+
+        // The work is synchronous, but the promises are promises: their reactions run on the microtask turn,
+        // after the rest of the current script.
+        engine.Evaluate("""
+            (() => {
+                const order = [];
+                crypto.subtle.generateKey({ name: 'AES-GCM', length: 128 }, false, ['encrypt']).then(() => order.push('generateKey'));
+                crypto.subtle.digest('SHA-256', new Uint8Array(0)).then(() => order.push('digest'));
+                order.push('sync');
+                return Promise.resolve().then(() => order.join(','));
+            })()
+            """).UnwrapIfPromise().AsString().Should().Be("sync,generateKey,digest");
+    }
+
+    [Fact]
+    public void AFailureIsCatchableInScript()
+    {
+        Run("""
+            const outcomes = [];
+            try {
+                await crypto.subtle.generateKey({ name: 'AES-GCM', length: 100 }, false, ['encrypt']);
+            } catch (e) {
+                outcomes.push(e.name + '/' + (e instanceof DOMException) + '/' + (e instanceof Error));
+            }
+            return outcomes.join(',');
+            """).AsString().Should().Be("OperationError/true/true");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // Installation
+    // ---------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void CryptoKeyRidesTheCryptoFlagAndNeverReachesAShadowRealm()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("typeof CryptoKey").AsString().Should().Be("function");
+        engine.Evaluate("new ShadowRealm().evaluate('typeof CryptoKey')").AsString().Should().Be("undefined");
+
+        // A WebIDL interface object is writable and configurable but not enumerable —
+        // https://webidl.spec.whatwg.org/#es-interfaces.
+        engine.Evaluate("""
+            (() => {
+                const d = Object.getOwnPropertyDescriptor(globalThis, 'CryptoKey');
+                return [d.enumerable, d.writable, d.configurable].join('|');
+            })()
+            """).AsString().Should().Be("false|true|true");
+
+        new Engine(options => options.UseWebApis(WebApiFeatures.Console))
+            .Evaluate("typeof CryptoKey").AsString().Should().Be("undefined");
+
+        new Engine().Evaluate("typeof CryptoKey").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void AKeyIsNotStructuredCloneable()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Crypto | WebApiFeatures.StructuredClone));
+
+        // A CryptoKey is a serializable object per the specification, and this engine's structuredClone
+        // refuses everything it does not recognize rather than producing a clone that has silently lost the
+        // state its source carried — which for a key would be the key.
+        Settle(engine, """
+            crypto.subtle.generateKey({ name: 'HMAC', hash: 'SHA-256' }, false, ['sign'])
+                .then(key => { try { structuredClone(key); return 'cloned'; } catch (e) { return e.name; } })
+            """).AsString().Should().Be("DataCloneError");
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/SubtleCryptoTests.cs
+++ b/Jint.Tests/Runtime/WebApi/SubtleCryptoTests.cs
@@ -6,9 +6,11 @@ using Jint.Native;
 namespace Jint.Tests.Runtime.WebApi;
 
 /// <summary>
-/// <c>crypto.subtle</c> against the Web Cryptography API — https://w3c.github.io/webcrypto/#subtlecrypto-interface.
-/// Only <c>digest</c> exists, so only <c>digest</c> is tested; the absence of everything else is pinned too,
-/// because "absent rather than throwing" is a promise feature detection is written against.
+/// <c>crypto.subtle.digest</c> against the Web Cryptography API — https://w3c.github.io/webcrypto/#subtlecrypto-interface.
+/// The keyed operations, which have their own vectors and their own failure modes, are in
+/// <see cref="SubtleCryptoKeyTests"/>; what is pinned here is the one operation that needs no key at all,
+/// plus the absence of key derivation and key wrapping, because "absent rather than throwing" is a promise
+/// feature detection is written against.
 /// </summary>
 /// <remarks>
 /// The digests are asserted against the published example vectors of FIPS-180-4 (and, for SHA-1, RFC 3174),
@@ -485,23 +487,18 @@ public class SubtleCryptoTests
     }
 
     [Fact]
-    public void ExposesDigestAloneAndEveryOtherOperationIsAbsent()
+    public void ExposesDigestAndTheKeyedOperationsButNotKeyDerivation()
     {
         var engine = WebEngine();
 
-        // Absent rather than present-and-throwing: a library checking `typeof crypto.subtle.sign` before
-        // reaching for it has to get the truthful answer, which is the same reason `crypto.subtle` itself is
-        // absent from an engine without the crypto feature.
+        // Absent rather than present-and-throwing: a library checking `typeof crypto.subtle.deriveBits`
+        // before reaching for it has to get the truthful answer, which is the same reason `crypto.subtle`
+        // itself is absent from an engine without the crypto feature.
         engine.Evaluate("typeof crypto.subtle.digest").AsString().Should().Be("function");
 
         engine.Evaluate("""
-            ['encrypt', 'decrypt', 'sign', 'verify', 'generateKey', 'deriveKey', 'deriveBits',
-             'importKey', 'exportKey', 'wrapKey', 'unwrapKey']
-                .filter(name => name in crypto.subtle).join(',')
+            ['deriveKey', 'deriveBits', 'wrapKey', 'unwrapKey'].filter(name => name in crypto.subtle).join(',')
             """).AsString().Should().Be("");
-
-        // CryptoKey has no interface object either — nothing in the engine can produce one.
-        engine.Evaluate("typeof CryptoKey").AsString().Should().Be("undefined");
 
         // As with crypto itself, the operation is an own property with a built-in method's attributes, so
         // enumeration sees nothing.

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -442,11 +442,15 @@ public enum WebApiFeatures
 
     /// <summary>
     /// The <c>crypto</c> object: <c>getRandomValues</c> and <c>randomUUID</c>, both backed by the BCL's
-    /// cryptographically secure generator, plus <c>crypto.subtle.digest</c> for SHA-1, SHA-256, SHA-384 and
-    /// SHA-512. Every other <c>SubtleCrypto</c> operation — everything needing key material — is not
-    /// implemented and is absent rather than present-and-throwing, so feature detection sees the truth.
-    /// <c>subtle</c> has no flag of its own because it is a readonly attribute of the very same
-    /// <c>Crypto</c> interface: asking for one is asking for the other.
+    /// cryptographically secure generator, plus <c>crypto.subtle</c> and the <c>CryptoKey</c> interface
+    /// object. <c>subtle</c> carries <c>digest</c> (SHA-1, SHA-256, SHA-384, SHA-512), <c>sign</c>,
+    /// <c>verify</c>, <c>encrypt</c>, <c>decrypt</c>, <c>generateKey</c>, <c>importKey</c> and
+    /// <c>exportKey</c> over HMAC and AES-GCM, with <c>raw</c> and <c>jwk</c> key formats. Key derivation,
+    /// key wrapping and the asymmetric algorithms are not implemented and are absent rather than
+    /// present-and-throwing, so feature detection sees the truth. Neither <c>subtle</c> nor
+    /// <c>CryptoKey</c> has a flag of its own: <c>subtle</c> is a readonly attribute of the very same
+    /// <c>Crypto</c> interface and <c>CryptoKey</c> is the type of what it hands out, so asking for one is
+    /// asking for all three.
     /// </summary>
     Crypto = 1 << 5,
 

--- a/Jint/Runtime/Intrinsics.WebApi.cs
+++ b/Jint/Runtime/Intrinsics.WebApi.cs
@@ -45,6 +45,7 @@ public sealed partial class Intrinsics
     private UrlSearchParamsConstructor? _webApiUrlSearchParams;
     private CryptoInstance? _crypto;
     private SubtleCryptoInstance? _subtleCrypto;
+    private CryptoKeyConstructor? _cryptoKey;
     private PerformanceInstance? _performance;
     private PerformanceEntryConstructor? _performanceEntry;
     private PerformanceMarkConstructor? _performanceMark;
@@ -171,6 +172,14 @@ public sealed partial class Intrinsics
     /// </summary>
     internal SubtleCryptoInstance SubtleCrypto =>
         _subtleCrypto ??= new SubtleCryptoInstance(_engine, _realm, Object.PrototypeObject);
+
+    /// <summary>
+    /// The <c>CryptoKey</c> interface object. It is reached both from the global of an engine with the crypto
+    /// feature and from the operations that build keys, so a key made before the script ever mentions
+    /// <c>CryptoKey</c> still has that very object's <c>prototype</c> as its <c>[[Prototype]]</c>.
+    /// </summary>
+    internal CryptoKeyConstructor CryptoKey =>
+        _cryptoKey ??= new CryptoKeyConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
 
     /// <summary>
     /// The <c>performance</c> object, which reads the engine's time origin and therefore needs the web-API

--- a/Jint/WebApi/Crypto/AesGcmAlgorithm.cs
+++ b/Jint/WebApi/Crypto/AesGcmAlgorithm.cs
@@ -1,0 +1,327 @@
+#if NET8_0_OR_GREATER
+using System.Security.Cryptography;
+using Jint.Native;
+
+namespace Jint.WebApi.Crypto;
+
+/// <summary>
+/// The AES-GCM operations — https://w3c.github.io/webcrypto/#aes-gcm, "authenticated encryption and
+/// decryption using AES in Galois/Counter Mode mode, as described in [NIST-SP800-38D]".
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The ciphertext carries its tag.</b> The encrypt operation's last step is "Let ciphertext be equal to
+/// C | T, where '|' denotes concatenation", and decrypt takes "the last tagLength bits of ciphertext" back
+/// off again. That layout is the Web Cryptography API's own, not GCM's — a host decrypting the same bytes
+/// with <see cref="AesGcm"/> directly has to split them itself, and a host encrypting for a script has to
+/// append the tag.
+/// </para>
+/// <para>
+/// <b>Two limits of the platform's AES-GCM are visible here</b>, and both are reported as the
+/// <c>OperationError</c> the algorithm's own steps end in rather than pretended away.
+/// <see cref="AesGcm"/> accepts a 96-bit nonce and nothing else (<see cref="AesGcm.NonceByteSizes"/> is
+/// 12 to 12), where the specification allows an <c>iv</c> "up to 2^64-1 bytes long"; and it accepts a tag of
+/// 96 to 128 bits (<see cref="AesGcm.TagByteSizes"/> is 12 to 16), where the specification's list also
+/// contains 32 and 64. A 96-bit IV is what [NIST-SP800-38D] itself recommends — it is the only length GCM
+/// uses directly rather than folding through GHASH — and a tag shorter than 96 bits carries a forgery
+/// probability the same document restricts to a short list of applications, so the shapes refused here are
+/// the ones a new protocol should not be choosing anyway. Reading data another implementation produced with
+/// them is the case this cannot serve, and the message says so.
+/// </para>
+/// <para>
+/// Truncating a 128-bit tag on the way out would have covered the 32- and 64-bit cases for encryption, since
+/// a GCM tag of <c>t</c> bits is by definition the first <c>t</c> bits of the full one. It is deliberately
+/// not done: verification cannot be built the same way, because the platform will not check a tag it
+/// considers too short and the full tag cannot be recomputed without the plaintext, so the result would be an
+/// engine that encrypts what it cannot decrypt.
+/// </para>
+/// </remarks>
+internal static class AesGcmAlgorithm
+{
+    /// <summary>The usages an AES-GCM key may carry.</summary>
+    private const KeyUsage AllowedUsages = KeyUsage.Encrypt | KeyUsage.Decrypt | KeyUsage.WrapKey | KeyUsage.UnwrapKey;
+
+    /// <summary>The only nonce length <see cref="AesGcm"/> accepts, in bytes.</summary>
+    private const int SupportedIvLength = 12;
+
+    /// <summary>The default tag length in bits, "If the tagLength member of normalizedAlgorithm is not present".</summary>
+    private const int DefaultTagLength = 128;
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#aes-gcm-operations-generate-key
+    /// </summary>
+    internal static (byte[] Handle, CryptoKeyAlgorithm Algorithm) GenerateKey(
+        CryptoContext context,
+        NormalizedAlgorithm normalized,
+        KeyUsage usages,
+        string what)
+    {
+        // Step 1.
+        if ((usages & ~AllowedUsages) != KeyUsage.None)
+        {
+            context.ThrowSyntaxError(
+                what + ": an AES-GCM key supports the usages encrypt, decrypt, wrapKey and unwrapKey, not " + KeyUsages.Describe(usages & ~AllowedUsages) + ".");
+        }
+
+        // Step 2: "If the length member of normalizedAlgorithm is not equal to one of 128, 192 or 256, then
+        // throw an OperationError."
+        var length = normalized.Length!.Value;
+        if (!IsValidKeyLength(length))
+        {
+            context.ThrowOperationError(what + ": " + length + " is not a valid AES key length (128, 192 or 256 bits).");
+        }
+
+        var handle = new byte[length / 8];
+        RandomNumberGenerator.Fill(handle);
+
+        return (handle, new CryptoKeyAlgorithm(AlgorithmNormalization.AesGcm, length, HashName: null));
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#aes-gcm-operations-import-key
+    /// </summary>
+    internal static (byte[] Handle, CryptoKeyAlgorithm Algorithm) ImportKey(
+        CryptoContext context,
+        KeyFormat format,
+        byte[]? rawData,
+        JsonWebKeyData? jwk,
+        bool extractable,
+        KeyUsage usages,
+        string what)
+    {
+        // Step 1.
+        if ((usages & ~AllowedUsages) != KeyUsage.None)
+        {
+            context.ThrowSyntaxError(
+                what + ": an AES-GCM key supports the usages encrypt, decrypt, wrapKey and unwrapKey, not " + KeyUsages.Describe(usages & ~AllowedUsages) + ".");
+        }
+
+        byte[] data;
+
+        switch (format)
+        {
+            case KeyFormat.Raw:
+                data = rawData!;
+                if (!IsValidKeyLength((uint) data.Length * 8))
+                {
+                    context.ThrowDataError(
+                        what + ": " + ((uint) data.Length * 8) + " is not a valid AES key length (128, 192 or 256 bits).");
+                }
+
+                break;
+
+            case KeyFormat.Jwk:
+                data = jwk!.RequireOctAndDecodeKey(context, what);
+
+                // "If the length in bits of data is 128 / 192 / 256: if the alg field of jwk is present and
+                // is not A128GCM / A192GCM / A256GCM, then throw a DataError. Otherwise: throw a DataError."
+                // The final "otherwise" is what catches a key of any other length, so the length check and
+                // the alg check are one step here rather than two.
+                if (!IsValidKeyLength((uint) data.Length * 8))
+                {
+                    context.ThrowDataError(
+                        what + ": " + ((uint) data.Length * 8) + " is not a valid AES key length (128, 192 or 256 bits).");
+                }
+
+                var expectedAlg = JwkAlgorithm((uint) data.Length * 8);
+                if (jwk.Alg is not null && !string.Equals(jwk.Alg, expectedAlg, StringComparison.Ordinal))
+                {
+                    context.ThrowDataError(
+                        what + ": the alg field of the JSON Web Key is '" + jwk.Alg + "' rather than '" + expectedAlg + "', which is what a " + (data.Length * 8) + "-bit AES-GCM key requires.");
+                }
+
+                jwk.ValidateUseKeyOpsAndExt(context, usages, extractable, "enc", what);
+                break;
+
+            default:
+                context.ThrowNotSupportedError(what + ": an AES-GCM key cannot be imported from the '" + KeyFormats.NameOf(format) + "' format.");
+                return default;
+        }
+
+        return (data, new CryptoKeyAlgorithm(AlgorithmNormalization.AesGcm, (uint) data.Length * 8, HashName: null));
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#aes-gcm-operations-export-key
+    /// </summary>
+    internal static JsValue ExportKey(CryptoContext context, JsCryptoKey key, KeyFormat format, string what)
+    {
+        switch (format)
+        {
+            case KeyFormat.Raw:
+                // Copied on the way out: what a script is handed is mutable, and the key is not.
+                return context.CreateArrayBuffer(key.Handle.ToArray());
+
+            case KeyFormat.Jwk:
+                return JsonWebKeyData.CreateExport(
+                    context.Engine,
+                    key.Handle,
+                    JwkAlgorithm(key.Algorithm.Length),
+                    key.Usages,
+                    key.Extractable);
+
+            default:
+                context.ThrowNotSupportedError(what + ": an AES-GCM key cannot be exported to the '" + KeyFormats.NameOf(format) + "' format.");
+                return JsValue.Undefined;
+        }
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#aes-gcm-operations-encrypt
+    /// </summary>
+    internal static byte[] Encrypt(
+        CryptoContext context,
+        NormalizedAlgorithm normalized,
+        JsCryptoKey key,
+        ReadOnlySpan<byte> plaintext,
+        string what)
+    {
+        // Steps 1, 2 and 4 — the length ceilings on iv, additionalData and plaintext — cannot be reached: a
+        // byte sequence in this engine comes from an ArrayBuffer, whose length is an int.
+        var tagLength = ResolveTagLength(context, normalized, what);
+        var iv = RequireSupportedIv(context, normalized, what);
+        var additionalData = normalized.AdditionalData ?? [];
+
+        var tagBytes = tagLength / 8;
+        var ciphertext = new byte[plaintext.Length + tagBytes];
+
+        using var aes = CreateAes(context, key, tagBytes, what);
+
+        // Steps 6 and 7 in one write: the authenticated encryption function's C goes to the front of the
+        // buffer and its T straight after it, which is the concatenation the operation returns.
+        aes.Encrypt(iv, plaintext, ciphertext.AsSpan(0, plaintext.Length), ciphertext.AsSpan(plaintext.Length), additionalData);
+
+        return ciphertext;
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#aes-gcm-operations-decrypt
+    /// </summary>
+    internal static byte[] Decrypt(
+        CryptoContext context,
+        NormalizedAlgorithm normalized,
+        JsCryptoKey key,
+        ReadOnlySpan<byte> ciphertext,
+        string what)
+    {
+        // Step 1 comes before the iv checks here as it does there, so a bad tagLength outranks a bad iv.
+        var tagLength = ResolveTagLength(context, normalized, what);
+        var iv = RequireSupportedIv(context, normalized, what);
+        var additionalData = normalized.AdditionalData ?? [];
+
+        var tagBytes = tagLength / 8;
+
+        // Step 4: "If ciphertext has a length in bits less than tagLength, then throw an OperationError."
+        if (ciphertext.Length < tagBytes)
+        {
+            context.ThrowOperationError(
+                what + ": the ciphertext is " + (ciphertext.Length * 8) + " bits long, which is shorter than the " + tagLength + "-bit authentication tag it must end with.");
+        }
+
+        // Steps 5 and 6.
+        var actualCiphertext = ciphertext.Slice(0, ciphertext.Length - tagBytes);
+        var tag = ciphertext.Slice(ciphertext.Length - tagBytes);
+
+        var plaintext = new byte[actualCiphertext.Length];
+
+        using var aes = CreateAes(context, key, tagBytes, what);
+
+        try
+        {
+            aes.Decrypt(iv, actualCiphertext, tag, plaintext, additionalData);
+        }
+        catch (CryptographicException)
+        {
+            // Step 7: "If the result of the algorithm is the indication of inauthenticity, 'FAIL': throw an
+            // OperationError." One message for every way the decryption can fail, carrying nothing about
+            // which part of the input was wrong — the whole value of an authenticated cipher is that a
+            // ciphertext, a tag, an IV or an additionalData that does not belong are one answer, not four.
+            // .NET clears the plaintext buffer before it throws, so nothing unauthenticated survives either.
+            context.ThrowOperationError(what + ": the data could not be decrypted.");
+        }
+
+        return plaintext;
+    }
+
+    /// <summary>
+    /// Step 3 of both operations: the tag length is 128 bits when the member is absent, one of the seven
+    /// listed values when it is present, and an <c>OperationError</c> otherwise.
+    /// </summary>
+    private static int ResolveTagLength(CryptoContext context, NormalizedAlgorithm normalized, string what)
+    {
+        if (normalized.TagLength is not { } tagLength)
+        {
+            return DefaultTagLength;
+        }
+
+        if (tagLength is not (32 or 64 or 96 or 104 or 112 or 120 or 128))
+        {
+            context.ThrowOperationError(
+                what + ": " + tagLength + " is not a valid AES-GCM tag length (32, 64, 96, 104, 112, 120 or 128 bits).");
+        }
+
+        // What the platform's own implementation accepts, which is narrower than the specification's list
+        // everywhere and differs per OS: OpenSSL and CNG take 96..128 bits, Apple's CryptoKit takes 128 and
+        // nothing else. Asking rather than assuming is what keeps this an OperationError instead of a raw
+        // ArgumentException erupting out of a promise-returning operation.
+        if (AesGcm.IsSupported && !IsSupportedTagSize(tagLength / 8))
+        {
+            context.ThrowOperationError(
+                what + ": a " + tagLength + "-bit authentication tag is not supported by this platform's AES-GCM implementation.");
+        }
+
+        return tagLength;
+    }
+
+    private static bool IsSupportedTagSize(int tagBytes)
+    {
+        var sizes = AesGcm.TagByteSizes;
+        if (tagBytes < sizes.MinSize || tagBytes > sizes.MaxSize)
+        {
+            return false;
+        }
+
+        return sizes.SkipSize == 0 || (tagBytes - sizes.MinSize) % sizes.SkipSize == 0;
+    }
+
+    /// <summary>
+    /// The <c>iv</c>, checked against what <see cref="AesGcm"/> accepts. See the remarks on this class for
+    /// why an IV of another length is refused rather than folded through GHASH.
+    /// </summary>
+    private static byte[] RequireSupportedIv(CryptoContext context, NormalizedAlgorithm normalized, string what)
+    {
+        var iv = normalized.Iv!;
+        if (iv.Length != SupportedIvLength)
+        {
+            context.ThrowOperationError(
+                what + ": the iv is " + (iv.Length * 8) + " bits long, and this platform's AES-GCM implementation accepts only the 96-bit iv that NIST SP 800-38D recommends.");
+        }
+
+        return iv;
+    }
+
+    private static AesGcm CreateAes(CryptoContext context, JsCryptoKey key, int tagBytes, string what)
+    {
+        if (!AesGcm.IsSupported)
+        {
+            context.ThrowOperationError(what + ": this platform has no AES-GCM implementation.");
+        }
+
+        return new AesGcm(key.Handle, tagBytes);
+    }
+
+    /// <summary>The three key lengths AES has, in bits.</summary>
+    private static bool IsValidKeyLength(uint bits) => bits is 128 or 192 or 256;
+
+    /// <summary>
+    /// The JWK <c>alg</c> field naming an AES-GCM key of a given length —
+    /// https://www.rfc-editor.org/rfc/rfc7518#section-4.7.
+    /// </summary>
+    private static string JwkAlgorithm(uint bits) => bits switch
+    {
+        128 => "A128GCM",
+        192 => "A192GCM",
+        _ => "A256GCM",
+    };
+}
+#endif

--- a/Jint/WebApi/Crypto/AlgorithmNormalization.cs
+++ b/Jint/WebApi/Crypto/AlgorithmNormalization.cs
@@ -1,0 +1,449 @@
+#if NET8_0_OR_GREATER
+using System.Text;
+using Jint.Native;
+using Jint.Native.ArrayBuffer;
+using Jint.Native.Object;
+using Jint.Native.TypedArray;
+using Jint.Runtime;
+using Jint.WebApi.Encoding;
+
+namespace Jint.WebApi.Crypto;
+
+/// <summary>
+/// The operations <c>supportedAlgorithms</c> is keyed by —
+/// https://w3c.github.io/webcrypto/#algorithm-normalization-internal — restricted to the ones this engine
+/// implements. <c>deriveBits</c>, <c>wrapKey</c>, <c>unwrapKey</c> and <c>get key length</c> are absent
+/// because no method that would reach them exists.
+/// </summary>
+internal enum CryptoOperation
+{
+    Digest,
+    Encrypt,
+    Decrypt,
+    Sign,
+    Verify,
+    GenerateKey,
+    ImportKey,
+    ExportKey,
+}
+
+/// <summary>
+/// The <c>KeyFormat</c> enumeration — https://w3c.github.io/webcrypto/#dfn-KeyFormat.
+/// </summary>
+/// <remarks>
+/// All four values are recognized by the WebIDL conversion, and a fifth spelling is a <c>TypeError</c>
+/// because the argument's IDL type is an enumeration. <c>spki</c> and <c>pkcs8</c> then reach the
+/// algorithm's own import steps and earn the <c>NotSupportedError</c> those steps specify for a format they
+/// do not handle — which for a symmetric key is every format but <c>raw</c> and <c>jwk</c>, in a browser as
+/// much as here.
+/// </remarks>
+internal enum KeyFormat
+{
+    Raw,
+    Spki,
+    Pkcs8,
+    Jwk,
+}
+
+/// <summary>
+/// The <c>KeyFormat</c> values as the specification spells them, which is what an error message names and
+/// what the WebIDL enumeration conversion matches against.
+/// </summary>
+internal static class KeyFormats
+{
+    internal const string Raw = "raw";
+    internal const string Spki = "spki";
+    internal const string Pkcs8 = "pkcs8";
+    internal const string Jwk = "jwk";
+
+    internal static string NameOf(KeyFormat format) => format switch
+    {
+        KeyFormat.Raw => Raw,
+        KeyFormat.Spki => Spki,
+        KeyFormat.Pkcs8 => Pkcs8,
+        _ => Jwk,
+    };
+}
+
+/// <summary>
+/// The result of "normalizing an algorithm": the registered name, plus whichever members the IDL dictionary
+/// registered for that (algorithm, operation) pair declares.
+/// </summary>
+/// <remarks>
+/// One class rather than a dictionary type per pair, because the union of the members across the pairs this
+/// engine registers is six fields and nothing reads a field its own operation did not fill in. A member that
+/// the specification calls "not present" is <see langword="null"/> here, which is the distinction several
+/// steps turn on — <c>HmacKeyGenParams</c>'s absent <c>length</c> means the hash's block size, where a
+/// present zero is an <c>OperationError</c>.
+/// </remarks>
+internal sealed class NormalizedAlgorithm
+{
+    internal NormalizedAlgorithm(string name)
+    {
+        Name = name;
+    }
+
+    /// <summary>The <c>name</c> member, always the registered spelling rather than the caller's.</summary>
+    internal string Name { get; }
+
+    /// <summary>The <c>hash</c> member of <c>HmacKeyGenParams</c>/<c>HmacImportParams</c>, itself normalized.</summary>
+    internal string? HashName { get; set; }
+
+    /// <summary>The <c>length</c> member of <c>HmacKeyGenParams</c>, <c>HmacImportParams</c> or <c>AesKeyGenParams</c>.</summary>
+    internal uint? Length { get; set; }
+
+    /// <summary>The <c>iv</c> member of <c>AesGcmParams</c>, copied at normalization time as the specification says.</summary>
+    internal byte[]? Iv { get; set; }
+
+    /// <summary>The <c>additionalData</c> member of <c>AesGcmParams</c>.</summary>
+    internal byte[]? AdditionalData { get; set; }
+
+    /// <summary>The <c>tagLength</c> member of <c>AesGcmParams</c>, in bits.</summary>
+    internal int? TagLength { get; set; }
+}
+
+/// <summary>
+/// "Normalize an algorithm" — https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm —
+/// together with the registry it consults.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The registry is written out as explicit lists rather than derived from anything, because an algorithm that
+/// the BCL grows support for later must not become reachable from script until someone has read this
+/// specification again. It is also what makes feature detection honest: an operation an algorithm is not
+/// registered for is a <c>NotSupportedError</c>, never a half-working call.
+/// </para>
+/// <para>
+/// The whole of it runs synchronously, before the operation does any work, which is the point the
+/// specification makes in its own description: "Web IDL type mapping can occur before any control is returned
+/// to the calling script, which would potentially allow the mutation of parameters or the script
+/// environment". Every member is read exactly once, in the order WebIDL reads them, and never looked at
+/// again.
+/// </para>
+/// </remarks>
+internal static class AlgorithmNormalization
+{
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#sha-registration — "The recognized algorithm names are
+    /// <c>SHA-1</c>, <c>SHA-256</c>, <c>SHA-384</c>, and <c>SHA-512</c> for the respective SHA algorithms".
+    /// </summary>
+    internal const string Sha1 = "SHA-1";
+    internal const string Sha256 = "SHA-256";
+    internal const string Sha384 = "SHA-384";
+    internal const string Sha512 = "SHA-512";
+
+    /// <summary>https://w3c.github.io/webcrypto/#hmac-registration</summary>
+    internal const string Hmac = "HMAC";
+
+    /// <summary>https://w3c.github.io/webcrypto/#aes-gcm-registration</summary>
+    internal const string AesGcm = "AES-GCM";
+
+    private static readonly string[] _digestAlgorithms = [Sha1, Sha256, Sha384, Sha512];
+    private static readonly string[] _hmacOnly = [Hmac];
+    private static readonly string[] _aesGcmOnly = [AesGcm];
+    private static readonly string[] _keyAlgorithms = [Hmac, AesGcm];
+    private static readonly string[] _none = [];
+
+    private static readonly JsString _nameKey = new("name");
+    private static readonly JsString _hashKey = new("hash");
+    private static readonly JsString _lengthKey = new("length");
+    private static readonly JsString _ivKey = new("iv");
+    private static readonly JsString _additionalDataKey = new("additionalData");
+    private static readonly JsString _tagLengthKey = new("tagLength");
+
+    /// <summary>
+    /// The associative container "stored at the <c>op</c> key of <c>supportedAlgorithms</c>".
+    /// </summary>
+    internal static string[] RegisteredFor(CryptoOperation operation) => operation switch
+    {
+        CryptoOperation.Digest => _digestAlgorithms,
+        CryptoOperation.Encrypt or CryptoOperation.Decrypt => _aesGcmOnly,
+        CryptoOperation.Sign or CryptoOperation.Verify => _hmacOnly,
+        CryptoOperation.GenerateKey or CryptoOperation.ImportKey or CryptoOperation.ExportKey => _keyAlgorithms,
+        _ => _none,
+    };
+
+    /// <summary>The name an error message calls the operation, which is also the method's own name.</summary>
+    internal static string NameOf(CryptoOperation operation) => operation switch
+    {
+        CryptoOperation.Digest => "digest",
+        CryptoOperation.Encrypt => "encrypt",
+        CryptoOperation.Decrypt => "decrypt",
+        CryptoOperation.Sign => "sign",
+        CryptoOperation.Verify => "verify",
+        CryptoOperation.GenerateKey => "generateKey",
+        CryptoOperation.ImportKey => "importKey",
+        _ => "exportKey",
+    };
+
+    /// <summary>
+    /// The <c>AlgorithmIdentifier</c> conversion alone — <c>typedef (object or DOMString)</c>, so an object
+    /// stays an object and everything else is stringified.
+    /// </summary>
+    /// <remarks>
+    /// It is separated from <see cref="Normalize"/> because the two happen at different times: this is an
+    /// argument conversion, which WebIDL runs before a single step of the method body, while normalization is
+    /// the body's own step 2. Between them sits the conversion of the <i>later</i> arguments, which is why
+    /// <c>digest('nonsense', 42)</c> is the <c>TypeError</c> the second argument earns rather than the
+    /// <c>NotSupportedError</c> the first one would.
+    /// </remarks>
+    internal static JsValue ConvertIdentifier(JsValue alg)
+    {
+        return alg is ObjectInstance ? alg : JsString.Create(TypeConverter.ToString(alg));
+    }
+
+    /// <summary>
+    /// Normalizes <paramref name="alg"/> for <paramref name="operation"/>.
+    /// </summary>
+    /// <remarks>
+    /// <c>AlgorithmIdentifier</c> is <c>typedef (object or DOMString)</c>, so an object stays an object and
+    /// everything else is stringified — which is where a symbol raises its <c>TypeError</c>, and why
+    /// <c>digest(null, …)</c> normalizes the name "null" rather than failing differently. A string is then
+    /// "a new Algorithm dictionary whose name attribute is alg", which is a dictionary with no other members
+    /// at all: <c>generateKey('HMAC', …)</c> is a <c>TypeError</c> for the missing required <c>hash</c>, not
+    /// a key with a default hash.
+    /// </remarks>
+    internal static NormalizedAlgorithm Normalize(CryptoContext context, JsValue alg, CryptoOperation operation, string what)
+    {
+        var algorithmObject = alg as ObjectInstance;
+        var algName = algorithmObject is null ? TypeConverter.ToString(alg) : ReadRequiredName(context, algorithmObject, what);
+
+        var normalized = new NormalizedAlgorithm(MatchRegistered(context, algName, operation, what));
+        ReadMembers(context, normalized, algorithmObject, operation, what);
+        return normalized;
+    }
+
+    /// <summary>
+    /// The <c>Algorithm</c> dictionary conversion, whose one member is <c>required DOMString name</c>.
+    /// </summary>
+    /// <remarks>
+    /// The single <c>Get</c> is the whole of that conversion, and it may run script — a getter on
+    /// <c>name</c> is called exactly once, and whatever it throws becomes the rejection. An absent member
+    /// reads as <c>undefined</c>, which for a required member is the <c>TypeError</c> WebIDL raises rather
+    /// than a <c>NotSupportedError</c> for the name "undefined".
+    /// </remarks>
+    private static string ReadRequiredName(CryptoContext context, ObjectInstance algorithm, string what)
+    {
+        var name = algorithm.Get(_nameKey);
+        if (name.IsUndefined())
+        {
+            context.ThrowTypeError(what + ": Algorithm: required member name is undefined.");
+        }
+
+        return TypeConverter.ToString(name);
+    }
+
+    /// <summary>
+    /// The lookup at the heart of normalization: "If registeredAlgorithms contains a key that is a
+    /// case-insensitive string match for algName: Set algName to the value of the matching key. …
+    /// Otherwise: Return a new NotSupportedError".
+    /// </summary>
+    /// <remarks>
+    /// "Case-insensitive" is defined by the specification, at
+    /// https://w3c.github.io/webcrypto/#case-insensitive, as <i>ASCII</i> case-insensitive — so
+    /// <see cref="Ascii.EqualsIgnoreCase(ReadOnlySpan{char}, ReadOnlySpan{char})"/> is the comparison that
+    /// says exactly that and nothing else, rather than a string comparison whose treatment of the letters
+    /// outside ASCII has to be reasoned about. It allocates nothing. The <i>registered</i> key is returned
+    /// rather than the caller's spelling, because every operation below matches its name
+    /// <i>case-sensitively</i> — normalization is what makes <c>'sha-256'</c> reach SHA-256 at all.
+    /// </remarks>
+    private static string MatchRegistered(CryptoContext context, string algName, CryptoOperation operation, string what)
+    {
+        var registeredAlgorithms = RegisteredFor(operation);
+
+        foreach (var registered in registeredAlgorithms)
+        {
+            if (Ascii.EqualsIgnoreCase(algName, registered))
+            {
+                return registered;
+            }
+        }
+
+        context.ThrowNotSupportedError(
+            what + ": the algorithm name '" + algName + "' is not one this engine registers for the "
+            + NameOf(operation) + " operation (" + string.Join(", ", registeredAlgorithms) + ").");
+        return null!;
+    }
+
+    /// <summary>
+    /// "Let normalizedAlgorithm be the result of converting the ECMAScript object represented by alg to the
+    /// IDL dictionary type desiredType": the members the registered (algorithm, operation) pair declares,
+    /// read from the very object the caller passed, in WebIDL's own order.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="algorithm"/> is <see langword="null"/> when the caller passed a string, which is the
+    /// synthesized <c>Algorithm</c> dictionary — every member is then absent, so a required one is a
+    /// <c>TypeError</c> and an optional one takes its default.
+    /// </remarks>
+    private static void ReadMembers(
+        CryptoContext context,
+        NormalizedAlgorithm normalized,
+        ObjectInstance? algorithm,
+        CryptoOperation operation,
+        string what)
+    {
+        switch (normalized.Name, operation)
+        {
+            // HmacKeyGenParams and HmacImportParams declare the same two members, and the difference between
+            // them is entirely in what the two operations do with `length`.
+            case (Hmac, CryptoOperation.GenerateKey):
+            case (Hmac, CryptoOperation.ImportKey):
+                normalized.HashName = ReadRequiredHash(context, algorithm, what);
+                normalized.Length = ReadOptionalUnsignedLong(context, algorithm, _lengthKey, what);
+                break;
+
+            // AesKeyGenParams: `required [EnforceRange] unsigned short length`.
+            case (AesGcm, CryptoOperation.GenerateKey):
+                normalized.Length = ReadRequiredUnsignedShort(context, algorithm, _lengthKey, what);
+                break;
+
+            // AesGcmParams.
+            case (AesGcm, CryptoOperation.Encrypt):
+            case (AesGcm, CryptoOperation.Decrypt):
+                normalized.Iv = ReadRequiredBufferSource(context, algorithm, _ivKey, what);
+                normalized.AdditionalData = ReadOptionalBufferSource(context, algorithm, _additionalDataKey, what);
+                normalized.TagLength = ReadOptionalOctet(context, algorithm, _tagLengthKey, what);
+                break;
+
+            // Every remaining pair registers `None` as its parameters, so the Algorithm dictionary — the one
+            // member of which has already been read — is the whole of it.
+            default:
+                break;
+        }
+    }
+
+    /// <summary>
+    /// A <c>required HashAlgorithmIdentifier hash</c> member. Normalizing it with <c>op</c> set to "digest"
+    /// is what the last step of normalization says to do for a member of that type, so an unregistered hash
+    /// name is a <c>NotSupportedError</c> and the value stored is the registered spelling.
+    /// </summary>
+    private static string ReadRequiredHash(CryptoContext context, ObjectInstance? algorithm, string what)
+    {
+        var hash = algorithm?.Get(_hashKey) ?? JsValue.Undefined;
+        if (hash.IsUndefined())
+        {
+            context.ThrowTypeError(what + ": required member hash is undefined.");
+        }
+
+        return Normalize(context, hash, CryptoOperation.Digest, what).Name;
+    }
+
+    private static byte[] ReadRequiredBufferSource(CryptoContext context, ObjectInstance? algorithm, JsString key, string what)
+    {
+        var value = algorithm?.Get(key) ?? JsValue.Undefined;
+        if (value.IsUndefined())
+        {
+            context.ThrowTypeError(what + ": required member " + key + " is undefined.");
+        }
+
+        return CopyBufferSource(context, value, key, what);
+    }
+
+    private static byte[]? ReadOptionalBufferSource(CryptoContext context, ObjectInstance? algorithm, JsString key, string what)
+    {
+        var value = algorithm?.Get(key) ?? JsValue.Undefined;
+        return value.IsUndefined() ? null : CopyBufferSource(context, value, key, what);
+    }
+
+    /// <summary>
+    /// "If member is of the type BufferSource and is present: set the dictionary member … to the result of
+    /// getting a copy of the bytes held by idlValue."
+    /// </summary>
+    /// <remarks>
+    /// The copy is real here, unlike the one the message of a digest is read through: an <c>iv</c> is held
+    /// across the rest of normalization, which can run a script's getter, so a window onto the engine's own
+    /// backing array could be mutated — or detached — between being read and being used.
+    /// </remarks>
+    private static byte[] CopyBufferSource(CryptoContext context, JsValue value, JsString key, string what)
+    {
+        if (!BufferSource.TryGetBytes(value, out var bytes))
+        {
+            context.ThrowTypeError(what + ": member " + key + " is not of type 'BufferSource'.");
+        }
+
+        if (IsSharedBufferSource(value))
+        {
+            context.ThrowTypeError(what + ": member " + key + " is backed by a SharedArrayBuffer, which this operation does not accept.");
+        }
+
+        return bytes.ToArray();
+    }
+
+    /// <summary>
+    /// A view onto a <c>SharedArrayBuffer</c>, and a <c>SharedArrayBuffer</c> itself, are refused wherever the
+    /// IDL says <c>BufferSource</c> rather than <c>AllowSharedBufferSource</c>: WebIDL refuses a shared buffer
+    /// for any type not carrying <c>[AllowShared]</c>, https://webidl.spec.whatwg.org/#es-buffer-source-types.
+    /// </summary>
+    internal static bool IsSharedBufferSource(JsValue value)
+    {
+        var buffer = value switch
+        {
+            JsTypedArray typedArray => typedArray._viewedArrayBuffer,
+            JsDataView dataView => dataView._viewedArrayBuffer,
+            _ => value as JsArrayBuffer,
+        };
+
+        return buffer is not null && buffer.IsSharedArrayBuffer;
+    }
+
+    /// <summary>
+    /// An optional <c>[EnforceRange] unsigned long</c> member. A member whose value is <c>undefined</c> is
+    /// "not present" — https://webidl.spec.whatwg.org/#es-dictionary — which is why an explicit
+    /// <c>{ length: undefined }</c> means the same as omitting it.
+    /// </summary>
+    private static uint? ReadOptionalUnsignedLong(CryptoContext context, ObjectInstance? algorithm, JsString key, string what)
+    {
+        var value = algorithm?.Get(key) ?? JsValue.Undefined;
+        if (value.IsUndefined())
+        {
+            return null;
+        }
+
+        return (uint) EnforceRange(context, value, key, what, uint.MaxValue);
+    }
+
+    private static uint ReadRequiredUnsignedShort(CryptoContext context, ObjectInstance? algorithm, JsString key, string what)
+    {
+        var value = algorithm?.Get(key) ?? JsValue.Undefined;
+        if (value.IsUndefined())
+        {
+            context.ThrowTypeError(what + ": required member " + key + " is undefined.");
+        }
+
+        return (uint) EnforceRange(context, value, key, what, ushort.MaxValue);
+    }
+
+    private static int? ReadOptionalOctet(CryptoContext context, ObjectInstance? algorithm, JsString key, string what)
+    {
+        var value = algorithm?.Get(key) ?? JsValue.Undefined;
+        if (value.IsUndefined())
+        {
+            return null;
+        }
+
+        return (int) EnforceRange(context, value, key, what, byte.MaxValue);
+    }
+
+    /// <summary>
+    /// The <c>[EnforceRange]</c> integer conversion, https://webidl.spec.whatwg.org/#abstract-opdef-converttoint:
+    /// a value that is not a finite number, or whose truncated value falls outside the type, is a
+    /// <c>TypeError</c> rather than a wrap or a clamp.
+    /// </summary>
+    private static double EnforceRange(CryptoContext context, JsValue value, JsString key, string what, double max)
+    {
+        var number = TypeConverter.ToNumber(value);
+        if (!double.IsFinite(number))
+        {
+            context.ThrowTypeError(what + ": member " + key + " is not a finite number.");
+        }
+
+        var integer = double.Truncate(number);
+        if (integer < 0 || integer > max)
+        {
+            context.ThrowTypeError(what + ": member " + key + " is outside the range [0, " + max + "].");
+        }
+
+        return integer;
+    }
+}
+#endif

--- a/Jint/WebApi/Crypto/CryptoContext.cs
+++ b/Jint/WebApi/Crypto/CryptoContext.cs
@@ -1,0 +1,83 @@
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+using Jint.Native;
+using Jint.Runtime;
+using Jint.WebApi.DomException;
+
+namespace Jint.WebApi.Crypto;
+
+/// <summary>
+/// The engine and realm a <c>SubtleCrypto</c> operation raises its failures in, handed to the algorithm
+/// implementations so that each of them can spell the specification's "throw a DataError" as one call.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every throw here is a real exception, and every one of them is caught one frame below script by the
+/// operation that started it and turned into a <i>rejection</i> — a promise-returning WebIDL operation
+/// reports nothing any other way, https://webidl.spec.whatwg.org/#dfn-create-operation-function. Writing the
+/// algorithm steps as throws is what lets them read like the specification's own numbered prose.
+/// </para>
+/// <para>
+/// The error object is "associated with the relevant realm of this" — https://w3c.github.io/webcrypto/#dfn-exceptions —
+/// which is the realm carried here, never the current one, so an operation reached across realms still
+/// rejects with its own realm's error type.
+/// </para>
+/// </remarks>
+internal readonly struct CryptoContext
+{
+    internal CryptoContext(Engine engine, Realm realm)
+    {
+        Engine = engine;
+        Realm = realm;
+    }
+
+    internal Engine Engine { get; }
+
+    internal Realm Realm { get; }
+
+    /// <summary>
+    /// "Creating an ArrayBuffer in realm, containing <c>bytes</c>" — the last step of nearly every operation
+    /// here. The array is handed over rather than copied, so every caller passes one nobody else holds:
+    /// script may write into what it is given, and a key's material must not be reachable that way.
+    /// </summary>
+    internal JsArrayBuffer CreateArrayBuffer(byte[] bytes)
+    {
+        return new JsArrayBuffer(Engine, bytes)
+        {
+            _prototype = Realm.Intrinsics.ArrayBuffer.PrototypeObject,
+        };
+    }
+
+    /// <summary>A <c>TypeError</c> — what a WebIDL type-mapping failure raises.</summary>
+    [DoesNotReturn]
+    internal void ThrowTypeError(string message) => Throw.TypeError(Realm, message);
+
+    /// <summary>"The algorithm is not supported."</summary>
+    [DoesNotReturn]
+    internal void ThrowNotSupportedError(string message) => ThrowDomException(DomExceptionNames.NotSupported, message);
+
+    /// <summary>"A required parameter was missing or out-of-range."</summary>
+    [DoesNotReturn]
+    internal void ThrowSyntaxError(string message) => ThrowDomException(DomExceptionNames.Syntax, message);
+
+    /// <summary>"The requested operation is not valid for the provided key."</summary>
+    [DoesNotReturn]
+    internal void ThrowInvalidAccessError(string message) => ThrowDomException(DomExceptionNames.InvalidAccess, message);
+
+    /// <summary>"Data provided to an operation does not meet requirements."</summary>
+    [DoesNotReturn]
+    internal void ThrowDataError(string message) => ThrowDomException(DomExceptionNames.Data, message);
+
+    /// <summary>"The operation failed for an operation-specific reason."</summary>
+    [DoesNotReturn]
+    internal void ThrowOperationError(string message) => ThrowDomException(DomExceptionNames.Operation, message);
+
+    [DoesNotReturn]
+    private void ThrowDomException(string name, string message)
+    {
+        var exception = Realm.Intrinsics.DomException.CreateException(name, message);
+        var location = Engine._lastSyntaxElement?.Location ?? default;
+        Throw.JavaScriptException(Engine, exception, in location);
+    }
+}
+#endif

--- a/Jint/WebApi/Crypto/CryptoKeyConstructor.cs
+++ b/Jint/WebApi/Crypto/CryptoKeyConstructor.cs
@@ -1,0 +1,62 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Crypto;
+
+/// <summary>
+/// The <c>CryptoKey</c> interface object.
+/// <para>
+/// https://w3c.github.io/webcrypto/#cryptokey-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// The interface declares no constructor operation, which in WebIDL means the interface object exists and is
+/// a function but refuses to construct anything — https://webidl.spec.whatwg.org/#es-interface-call. A key
+/// can therefore only come from <c>generateKey</c> or <c>importKey</c>, which is what makes
+/// <c>key instanceof CryptoKey</c> a statement about provenance rather than about shape.
+/// </remarks>
+internal sealed class CryptoKeyConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("CryptoKey");
+
+    internal CryptoKeyConstructor(
+        Engine engine,
+        Realm realm,
+        FunctionPrototype functionPrototype,
+        ObjectPrototype objectPrototype)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = functionPrototype;
+        PrototypeObject = new CryptoKeyPrototype(engine, realm, this, objectPrototype);
+        _length = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal CryptoKeyPrototype PrototypeObject { get; }
+
+    /// <summary>
+    /// An interface without a constructor operation is not constructible.
+    /// </summary>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        Throw.TypeError(_realm, "Illegal constructor");
+        return null!;
+    }
+
+    /// <summary>
+    /// Builds a key in this realm. The one place a <see cref="JsCryptoKey"/> is created, so the prototype
+    /// cannot be forgotten on some path.
+    /// </summary>
+    internal JsCryptoKey CreateKey(byte[] handle, CryptoKeyAlgorithm algorithm, bool extractable, KeyUsage usages)
+    {
+        return new JsCryptoKey(_engine, handle, algorithm, extractable, usages)
+        {
+            _prototype = PrototypeObject,
+        };
+    }
+}
+#endif

--- a/Jint/WebApi/Crypto/CryptoKeyPrototype.cs
+++ b/Jint/WebApi/Crypto/CryptoKeyPrototype.cs
@@ -1,0 +1,108 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Array;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Crypto;
+
+/// <summary>
+/// <c>CryptoKey.prototype</c> — the interface prototype object.
+/// <para>
+/// https://w3c.github.io/webcrypto/#cryptokey-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// All four members are WebIDL attributes, so they are accessors here rather than own properties of the key,
+/// and each brand-checks its receiver with a <c>TypeError</c> — including <c>CryptoKey.prototype</c> itself,
+/// which is not a key. None of them can reach the key material; see <see cref="JsCryptoKey"/>.
+/// </para>
+/// <para>
+/// One documented simplification against WebIDL, which every prototype in this subtree carries: the members
+/// are non-enumerable, where a WebIDL interface prototype object's attributes are enumerable. That is how
+/// every built-in Jint has ever shipped declares its prototype members, and it is observable only to code
+/// inspecting property attributes.
+/// </para>
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class CryptoKeyPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly CryptoKeyConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString CryptoKeyToStringTag = new("CryptoKey");
+
+    internal CryptoKeyPrototype(
+        Engine engine,
+        Realm realm,
+        CryptoKeyConstructor constructor,
+        ObjectInstance objectPrototype) : base(engine, realm)
+    {
+        _prototype = objectPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#dom-cryptokey-type — "Reflects the [[type]] internal slot".
+    /// </summary>
+    [JsAccessor("type", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsString TypeGet(JsValue thisObject)
+    {
+        return JsString.Create(Brand(thisObject).KeyType);
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#dom-cryptokey-extractable
+    /// </summary>
+    [JsAccessor("extractable", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsBoolean ExtractableGet(JsValue thisObject)
+    {
+        return Brand(thisObject).Extractable ? JsBoolean.True : JsBoolean.False;
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#dom-cryptokey-algorithm — "Returns the cached ECMAScript object
+    /// associated with the [[algorithm]] internal slot".
+    /// </summary>
+    [JsAccessor("algorithm", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private ObjectInstance AlgorithmGet(JsValue thisObject)
+    {
+        return Brand(thisObject).AlgorithmObject();
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#dom-cryptokey-usages — "Returns the cached ECMAScript object
+    /// associated with the [[usages]] internal slot".
+    /// </summary>
+    [JsAccessor("usages", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsArray UsagesGet(JsValue thisObject)
+    {
+        return Brand(thisObject).UsagesObject();
+    }
+
+    /// <summary>
+    /// The WebIDL brand check every member performs: a receiver that is not a platform object implementing
+    /// the interface raises a <c>TypeError</c>. An attribute is not a promise-returning operation, so this is
+    /// an ordinary throw rather than a rejection.
+    /// </summary>
+    private JsCryptoKey Brand(JsValue thisObject)
+    {
+        if (thisObject is JsCryptoKey key)
+        {
+            return key;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a CryptoKey");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Crypto/HmacAlgorithm.cs
+++ b/Jint/WebApi/Crypto/HmacAlgorithm.cs
@@ -1,0 +1,286 @@
+#if NET8_0_OR_GREATER
+using System.Security.Cryptography;
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Crypto;
+
+/// <summary>
+/// The HMAC operations — https://w3c.github.io/webcrypto/#hmac, which calculates and verifies hash-based
+/// message authentication codes according to [FIPS-198-1] using the SHA hash functions this specification
+/// defines.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The key material is whole bytes here, which is the one place this implementation is narrower than the
+/// algorithm's prose. <c>importKey</c> follows the specification exactly, including a <c>length</c> that is
+/// not a multiple of eight: the constraint the steps impose on it — greater than <c>length - 8</c> and at
+/// most <c>length</c> — means the byte count never changes, so the bits the key is short by are recorded on
+/// the key and the MAC is still computed over the bytes that were imported, exactly as every other
+/// implementation does with them. <c>generateKey</c> is where the difference is visible: a length that is
+/// not a multiple of eight is refused with an <c>OperationError</c> ("If the key generation step fails, then
+/// throw an OperationError"), because generating a key of, say, 57 bits would mean handing back an eight-byte
+/// key whose last seven bits are a lie. Node's WebCrypto refuses the same shape for the same reason.
+/// </para>
+/// </remarks>
+internal static class HmacAlgorithm
+{
+    /// <summary>
+    /// The block size, in bits, of each hash function — [FIPS-180-4] §1: 512 bits for SHA-1 and SHA-256,
+    /// 1024 for SHA-384 and SHA-512. It is the "recommended length" an <c>HmacKeyGenParams</c> without a
+    /// <c>length</c> member asks for.
+    /// </summary>
+    internal static uint BlockSizeInBits(string hashName) => hashName switch
+    {
+        AlgorithmNormalization.Sha1 or AlgorithmNormalization.Sha256 => 512,
+        _ => 1024,
+    };
+
+    /// <summary>
+    /// The JWK <c>alg</c> field naming an HMAC key with a given inner hash —
+    /// https://www.rfc-editor.org/rfc/rfc7518#section-3.1, plus <c>HS1</c>, which the Web Cryptography API
+    /// names for SHA-1.
+    /// </summary>
+    internal static string JwkAlgorithm(string hashName) => hashName switch
+    {
+        AlgorithmNormalization.Sha1 => "HS1",
+        AlgorithmNormalization.Sha256 => "HS256",
+        AlgorithmNormalization.Sha384 => "HS384",
+        _ => "HS512",
+    };
+
+    /// <summary>The usages an HMAC key may carry: "sign" and "verify".</summary>
+    private const KeyUsage AllowedUsages = KeyUsage.Sign | KeyUsage.Verify;
+
+    /// <summary>
+    /// The ceiling on a generated HMAC key, in bits — 8 KiB of key material, which is more than a hundred
+    /// times the largest block size any registered hash has.
+    /// </summary>
+    private const uint MaxKeyLengthInBits = 65536;
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#hmac-operations-generate-key
+    /// </summary>
+    internal static (byte[] Handle, CryptoKeyAlgorithm Algorithm) GenerateKey(
+        CryptoContext context,
+        NormalizedAlgorithm normalized,
+        KeyUsage usages,
+        string what)
+    {
+        // Step 1: "If usages contains an entry which is not 'sign' or 'verify', then throw a SyntaxError."
+        if ((usages & ~AllowedUsages) != KeyUsage.None)
+        {
+            context.ThrowSyntaxError(
+                what + ": an HMAC key supports the usages sign and verify, not " + KeyUsages.Describe(usages & ~AllowedUsages) + ".");
+        }
+
+        var hashName = normalized.HashName!;
+
+        // Step 2: an absent length means the hash's block size, a present non-zero one is taken as it is, and
+        // a present zero is an OperationError.
+        uint length;
+        if (normalized.Length is null)
+        {
+            length = BlockSizeInBits(hashName);
+        }
+        else if (normalized.Length.Value != 0)
+        {
+            length = normalized.Length.Value;
+        }
+        else
+        {
+            context.ThrowOperationError(what + ": a key length of zero bits was requested.");
+            return default;
+        }
+
+        // Steps 3 and 4: generate a key of `length` bits, and report a generation that fails as an
+        // OperationError. See the remarks on this class for why a length that is not a whole number of bytes
+        // is one of the ways it fails here.
+        if (length % 8 != 0)
+        {
+            context.ThrowOperationError(
+                what + ": a key length of " + length + " bits is not a whole number of bytes, which this engine's key generation cannot produce.");
+        }
+
+        // A key large enough to be a denial of service rather than a key: the algorithm has no ceiling of its
+        // own, but a 4 GiB `length` would otherwise be an allocation request from one line of script.
+        if (length > MaxKeyLengthInBits)
+        {
+            context.ThrowOperationError(
+                what + ": a key length of " + length + " bits exceeds the " + MaxKeyLengthInBits + " bits this engine will generate.");
+        }
+
+        var handle = new byte[length / 8];
+        RandomNumberGenerator.Fill(handle);
+
+        return (handle, new CryptoKeyAlgorithm(AlgorithmNormalization.Hmac, length, hashName));
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#hmac-operations-import-key
+    /// </summary>
+    internal static (byte[] Handle, CryptoKeyAlgorithm Algorithm) ImportKey(
+        CryptoContext context,
+        KeyFormat format,
+        byte[]? rawData,
+        JsonWebKeyData? jwk,
+        NormalizedAlgorithm normalized,
+        bool extractable,
+        KeyUsage usages,
+        string what)
+    {
+        // Step 1: "If the length member of normalizedAlgorithm is present and is zero, then throw a
+        // DataError." Note the difference from generateKey, where the same value is an OperationError.
+        if (normalized.Length == 0)
+        {
+            context.ThrowDataError(what + ": a key length of zero bits was requested.");
+        }
+
+        // Step 3.
+        if ((usages & ~AllowedUsages) != KeyUsage.None)
+        {
+            context.ThrowSyntaxError(
+                what + ": an HMAC key supports the usages sign and verify, not " + KeyUsages.Describe(usages & ~AllowedUsages) + ".");
+        }
+
+        var hashName = normalized.HashName!;
+        byte[] data;
+
+        switch (format)
+        {
+            case KeyFormat.Raw:
+                data = rawData!;
+                break;
+
+            case KeyFormat.Jwk:
+                data = jwk!.RequireOctAndDecodeKey(context, what);
+
+                // "If the alg field of jwk is present and is not <HS1|HS256|HS384|HS512>, then throw a
+                // DataError" — one branch per registered hash, which is the same table JwkAlgorithm holds.
+                var expectedAlg = JwkAlgorithm(hashName);
+                if (jwk.Alg is not null && !string.Equals(jwk.Alg, expectedAlg, StringComparison.Ordinal))
+                {
+                    context.ThrowDataError(
+                        what + ": the alg field of the JSON Web Key is '" + jwk.Alg + "' rather than '" + expectedAlg + "', which is what " + hashName + " requires.");
+                }
+
+                jwk.ValidateUseKeyOpsAndExt(context, usages, extractable, "sig", what);
+                break;
+
+            default:
+                // "Otherwise: throw a NotSupportedError" — spki and pkcs8 describe asymmetric keys.
+                context.ThrowNotSupportedError(what + ": an HMAC key cannot be imported from the '" + KeyFormats.NameOf(format) + "' format.");
+                return default;
+        }
+
+        // Steps 7 and 8: the length of the imported material, which may not be zero.
+        var length = (uint) data.Length * 8;
+        if (length == 0)
+        {
+            context.ThrowDataError(what + ": the imported key is empty.");
+        }
+
+        // Step 9: a requested length must name the same bytes — at most what arrived, and more than a whole
+        // byte less, so that the material is neither truncated to fewer bytes nor padded.
+        if (normalized.Length is { } requested)
+        {
+            if (requested > length)
+            {
+                context.ThrowDataError(
+                    what + ": a key length of " + requested + " bits was requested, but the imported key is only " + length + " bits long.");
+            }
+
+            if (requested <= length - 8)
+            {
+                context.ThrowDataError(
+                    what + ": a key length of " + requested + " bits was requested, which discards whole bytes of the " + length + "-bit imported key.");
+            }
+
+            length = requested;
+        }
+
+        return (data, new CryptoKeyAlgorithm(AlgorithmNormalization.Hmac, length, hashName));
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#hmac-operations-export-key
+    /// </summary>
+    internal static JsValue ExportKey(CryptoContext context, JsCryptoKey key, KeyFormat format, string what)
+    {
+        switch (format)
+        {
+            case KeyFormat.Raw:
+                // The bytes are copied on the way out: what a script is handed is mutable, and the key is not.
+                return context.CreateArrayBuffer(key.Handle.ToArray());
+
+            case KeyFormat.Jwk:
+                return JsonWebKeyData.CreateExport(
+                    context.Engine,
+                    key.Handle,
+                    JwkAlgorithm(key.Algorithm.HashName!),
+                    key.Usages,
+                    key.Extractable);
+
+            default:
+                context.ThrowNotSupportedError(what + ": an HMAC key cannot be exported to the '" + KeyFormats.NameOf(format) + "' format.");
+                return JsValue.Undefined;
+        }
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#hmac-operations-sign — "the MAC Generation operation described in
+    /// Section 4 of [FIPS-198-1] using the key represented by the [[handle]] internal slot of key, the hash
+    /// function identified by the hash attribute … and message as the input data text".
+    /// </summary>
+    /// <remarks>
+    /// The one-shot <c>HashData</c> statics rather than an <see cref="HMAC"/> instance: the message is one
+    /// contiguous span already in memory, so there is nothing to feed in chunks, and the one-shot form
+    /// allocates only the result — no hash object and no <c>IDisposable</c> to get wrong.
+    /// </remarks>
+    internal static byte[] Sign(JsCryptoKey key, ReadOnlySpan<byte> message)
+    {
+        var handle = key.Handle;
+
+        switch (key.Algorithm.HashName)
+        {
+            case AlgorithmNormalization.Sha1:
+                // SHA-1 is one of the four hashes the specification registers, every browser offers HMAC over
+                // it, and HMAC-SHA-1 is not broken by the collision attacks that retired plain SHA-1 — it is
+                // what TOTP and a great deal of existing infrastructure is built on. A script asking for it
+                // has already chosen; nothing in the engine picks it for anybody.
+#pragma warning disable CA5350 // Do Not Use Weak Cryptographic Algorithms -- the caller named SHA-1, we did not choose it
+                return HMACSHA1.HashData(handle, message);
+#pragma warning restore CA5350
+            case AlgorithmNormalization.Sha256:
+                return HMACSHA256.HashData(handle, message);
+            case AlgorithmNormalization.Sha384:
+                return HMACSHA384.HashData(handle, message);
+            case AlgorithmNormalization.Sha512:
+                return HMACSHA512.HashData(handle, message);
+            default:
+                // Unreachable: the hash name was matched against the registry when the key was made. It is
+                // spelled out rather than folded into the last case so that a hash registered later cannot
+                // silently be MAC'd with the wrong one.
+                Throw.InvalidOperationException("Unhandled HMAC hash algorithm '" + key.Algorithm.HashName + "'.");
+                return null!;
+        }
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#hmac-operations-verify — the MAC is generated again and compared
+    /// with the signature, and "this comparison must be performed in constant-time".
+    /// </summary>
+    /// <remarks>
+    /// <see cref="CryptographicOperations.FixedTimeEquals"/> is the BCL's constant-time comparison, and the
+    /// only correct way to spell this step: an ordinary comparison returns as soon as two bytes differ, which
+    /// tells an attacker how much of a forged MAC was right and turns a forgery into a byte-at-a-time search.
+    /// It answers <see langword="false"/> for lengths that differ, which the specification's "true if mac is
+    /// equal to signature" also does.
+    /// </remarks>
+    internal static bool Verify(JsCryptoKey key, ReadOnlySpan<byte> signature, ReadOnlySpan<byte> message)
+    {
+        var mac = Sign(key, message);
+        return CryptographicOperations.FixedTimeEquals(mac, signature);
+    }
+}
+#endif

--- a/Jint/WebApi/Crypto/JsCryptoKey.cs
+++ b/Jint/WebApi/Crypto/JsCryptoKey.cs
@@ -1,0 +1,157 @@
+#if NET8_0_OR_GREATER
+using System.Runtime.InteropServices;
+using Jint.Native;
+using Jint.Native.Array;
+using Jint.Native.Object;
+
+namespace Jint.WebApi.Crypto;
+
+/// <summary>
+/// The <c>[[algorithm]]</c> internal slot of a <see cref="JsCryptoKey"/>: a <c>KeyAlgorithm</c>, or one of
+/// the two dictionaries derived from it that the algorithms here produce.
+/// <para>
+/// https://w3c.github.io/webcrypto/#key-algorithm-dictionary
+/// </para>
+/// </summary>
+/// <param name="Name">The recognized algorithm name — <c>HMAC</c> or <c>AES-GCM</c>.</param>
+/// <param name="Length">The length of the key in bits, which both dictionaries carry.</param>
+/// <param name="HashName">
+/// The <c>hash</c> member of an <c>HmacKeyAlgorithm</c>, or <see langword="null"/> for an
+/// <c>AesKeyAlgorithm</c>, which has none.
+/// </param>
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct CryptoKeyAlgorithm(string Name, uint Length, string? HashName);
+
+/// <summary>
+/// A <c>CryptoKey</c> — "an opaque reference to keying material".
+/// <para>
+/// https://w3c.github.io/webcrypto/#cryptokey-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The key material never reaches script except through <c>exportKey</c> on an extractable key.</b> The
+/// <c>[[handle]]</c> internal slot is the private <see cref="_handle"/> field: the object has no own
+/// properties at all (<c>Object.getOwnPropertyNames(key)</c> is empty, as in a browser), the four attributes
+/// live on <see cref="CryptoKeyPrototype"/> and none of them can reach the bytes, and <c>exportKey</c> hands
+/// out a fresh copy so that a script writing into what it exported cannot write into the key. A
+/// non-extractable key has no door at all: <c>exportKey</c> refuses it with an <c>InvalidAccessError</c>
+/// before asking the algorithm for anything.
+/// </para>
+/// <para>
+/// <c>algorithm</c> and <c>usages</c> are the specification's <i>cached</i> ECMAScript objects —
+/// https://w3c.github.io/webcrypto/#dfn-cached-ecmascript-object: built on the first read and returned by
+/// reference forever after, so <c>key.algorithm === key.algorithm</c> holds. They are ordinary objects, not
+/// frozen ones, which is what WebIDL's conversion of a dictionary and of a sequence produces; a script that
+/// mutates one changes only its own copy of the answer, because everything the engine decides is decided from
+/// <see cref="Algorithm"/> and <see cref="Usages"/>, which are CLR state a script cannot reach.
+/// </para>
+/// </remarks>
+internal sealed class JsCryptoKey : ObjectInstance
+{
+    /// <summary>
+    /// <c>KeyAlgorithm</c>, https://w3c.github.io/webcrypto/#key-algorithm-dictionary — the one member every
+    /// key algorithm dictionary inherits. It is the whole of the <c>hash</c> member of an
+    /// <c>HmacKeyAlgorithm</c>.
+    /// </summary>
+    private static readonly JsObjectLayout _keyAlgorithmLayout = JsObjectLayout.CreateBuilder()
+        .Add("name")
+        .Build();
+
+    /// <summary>
+    /// <c>HmacKeyAlgorithm</c>, https://w3c.github.io/webcrypto/#HmacKeyAlgorithm-dictionary. WebIDL converts
+    /// a dictionary to an object by walking the inherited dictionaries from least to most derived and each
+    /// dictionary's own members in lexicographical order — https://webidl.spec.whatwg.org/#es-dictionary — so
+    /// <c>name</c> (from <c>KeyAlgorithm</c>) comes first and then <c>hash</c> before <c>length</c>.
+    /// </summary>
+    private static readonly JsObjectLayout _hmacKeyAlgorithmLayout = JsObjectLayout.CreateBuilder()
+        .Add("name")
+        .Add("hash")
+        .Add("length")
+        .Build();
+
+    /// <summary>
+    /// <c>AesKeyAlgorithm</c>, https://w3c.github.io/webcrypto/#AesKeyAlgorithm-dictionary.
+    /// </summary>
+    private static readonly JsObjectLayout _aesKeyAlgorithmLayout = JsObjectLayout.CreateBuilder()
+        .Add("name")
+        .Add("length")
+        .Build();
+
+    private readonly byte[] _handle;
+
+    private ObjectInstance? _algorithmCached;
+    private JsArray? _usagesCached;
+
+    internal JsCryptoKey(
+        Engine engine,
+        byte[] handle,
+        CryptoKeyAlgorithm algorithm,
+        bool extractable,
+        KeyUsage usages) : base(engine, ObjectClass.Object)
+    {
+        _handle = handle;
+        Algorithm = algorithm;
+        Extractable = extractable;
+        Usages = usages;
+    }
+
+    /// <summary>
+    /// The <c>[[handle]]</c> internal slot. Never handed out: the two callers that need the bytes —
+    /// <c>sign</c>/<c>verify</c> and <c>encrypt</c>/<c>decrypt</c> — read them and produce something else,
+    /// and <c>exportKey</c> copies.
+    /// </summary>
+    internal ReadOnlySpan<byte> Handle => _handle;
+
+    /// <summary>
+    /// The <c>[[type]]</c> internal slot. Every key this engine can build is a symmetric one, so it is always
+    /// <c>"secret"</c>; the attribute is nevertheless read from here rather than hard-coded at the accessor,
+    /// so that a public or private key added later cannot silently answer wrongly. It is not called
+    /// <c>Type</c> because <see cref="JsValue.Type"/> already is.
+    /// </summary>
+    internal string KeyType { get; } = "secret";
+
+    /// <summary>The <c>[[extractable]]</c> internal slot.</summary>
+    internal bool Extractable { get; }
+
+    /// <summary>The <c>[[usages]]</c> internal slot, already the "normalized value" of what was requested.</summary>
+    internal KeyUsage Usages { get; }
+
+    /// <summary>The <c>[[algorithm]]</c> internal slot.</summary>
+    internal CryptoKeyAlgorithm Algorithm { get; }
+
+    /// <summary>Whether the key permits <paramref name="usage"/> — the check every operation makes.</summary>
+    internal bool Allows(KeyUsage usage) => (Usages & usage) != KeyUsage.None;
+
+    /// <summary>
+    /// The cached ECMAScript object for the <c>[[algorithm]]</c> slot.
+    /// </summary>
+    internal ObjectInstance AlgorithmObject()
+    {
+        if (_algorithmCached is not null)
+        {
+            return _algorithmCached;
+        }
+
+        var name = JsString.Create(Algorithm.Name);
+        var length = JsNumber.Create(Algorithm.Length);
+
+        if (Algorithm.HashName is null)
+        {
+            _algorithmCached = JsObject.Create(_engine, _aesKeyAlgorithmLayout, [name, length]);
+        }
+        else
+        {
+            var hash = JsObject.Create(_engine, _keyAlgorithmLayout, [JsString.Create(Algorithm.HashName)]);
+            _algorithmCached = JsObject.Create(_engine, _hmacKeyAlgorithmLayout, [name, hash, length]);
+        }
+
+        return _algorithmCached;
+    }
+
+    /// <summary>
+    /// The cached ECMAScript object for the <c>[[usages]]</c> slot.
+    /// </summary>
+    internal JsArray UsagesObject() => _usagesCached ??= KeyUsages.ToArray(_engine, Usages);
+}
+#endif

--- a/Jint/WebApi/Crypto/JsonWebKeyData.cs
+++ b/Jint/WebApi/Crypto/JsonWebKeyData.cs
@@ -1,0 +1,289 @@
+#if NET8_0_OR_GREATER
+using Jint.Extensions;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Crypto;
+
+/// <summary>
+/// The members of a <c>JsonWebKey</c> dictionary that a symmetric key uses —
+/// https://w3c.github.io/webcrypto/#JsonWebKey-dictionary, whose fields are those of
+/// https://www.rfc-editor.org/rfc/rfc7517 and https://www.rfc-editor.org/rfc/rfc7518.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A documented simplification: the dictionary declares eighteen members and this reads the six an
+/// <c>oct</c> key can be described by (<c>alg</c>, <c>ext</c>, <c>k</c>, <c>key_ops</c>, <c>kty</c>,
+/// <c>use</c>). A getter on one of the twelve asymmetric-key members — <c>crv</c>, <c>n</c>, <c>d</c> and the
+/// rest — is therefore not invoked, where a browser's WebIDL conversion would invoke it and could raise a
+/// <c>TypeError</c> from converting its value. Nothing else can observe the difference: the specification's
+/// own note says that "fields that are not explicitly referred to in the key import procedures for an
+/// algorithm are ignored".
+/// </para>
+/// <para>
+/// The six that <i>are</i> read are read in lexicographical order, which is the order WebIDL converts a
+/// dictionary's members in, so a JWK built out of getters sees them run in the order a browser runs them.
+/// </para>
+/// </remarks>
+internal sealed class JsonWebKeyData
+{
+    private static readonly JsString _algKey = new("alg");
+    private static readonly JsString _extKey = new("ext");
+    private static readonly JsString _kKey = new("k");
+    private static readonly JsString _keyOpsKey = new("key_ops");
+    private static readonly JsString _ktyKey = new("kty");
+    private static readonly JsString _useKey = new("use");
+
+    /// <summary>
+    /// The shape <c>exportKey("jwk")</c> answers with. Both algorithms set every one of the five, and WebIDL
+    /// converts a dictionary to an object in lexicographical order of its members —
+    /// https://webidl.spec.whatwg.org/#es-dictionary — so one layout describes both and
+    /// <c>Object.keys(jwk)</c> is stable.
+    /// </summary>
+    private static readonly JsObjectLayout _exportLayout = JsObjectLayout.CreateBuilder()
+        .Add("alg")
+        .Add("ext")
+        .Add("k")
+        .Add("key_ops")
+        .Add("kty")
+        .Build();
+
+    /// <summary>The <c>alg</c> field, or <see langword="null"/> when it is not present.</summary>
+    internal string? Alg { get; private set; }
+
+    /// <summary>The <c>ext</c> field, or <see langword="null"/> when it is not present.</summary>
+    internal bool? Ext { get; private set; }
+
+    /// <summary>The <c>k</c> field, or <see langword="null"/> when it is not present.</summary>
+    internal string? K { get; private set; }
+
+    /// <summary>The <c>key_ops</c> field, or <see langword="null"/> when it is not present.</summary>
+    internal List<string>? KeyOps { get; private set; }
+
+    /// <summary>The <c>kty</c> field, or <see langword="null"/> when it is not present.</summary>
+    internal string? Kty { get; private set; }
+
+    /// <summary>The <c>use</c> field, or <see langword="null"/> when it is not present.</summary>
+    internal string? Use { get; private set; }
+
+    /// <summary>
+    /// Converts the ECMAScript object a script passed as <c>keyData</c> to the dictionary.
+    /// </summary>
+    internal static JsonWebKeyData Read(CryptoContext context, ObjectInstance source, string what)
+    {
+        var jwk = new JsonWebKeyData
+        {
+            Alg = ReadString(source, _algKey),
+            Ext = ReadBoolean(source, _extKey),
+            K = ReadString(source, _kKey),
+            KeyOps = ReadStringSequence(context, source, what),
+            Kty = ReadString(source, _ktyKey),
+            Use = ReadString(source, _useKey),
+        };
+
+        return jwk;
+    }
+
+    private static string? ReadString(ObjectInstance source, JsString key)
+    {
+        var value = source.Get(key);
+        return value.IsUndefined() ? null : TypeConverter.ToString(value);
+    }
+
+    private static bool? ReadBoolean(ObjectInstance source, JsString key)
+    {
+        var value = source.Get(key);
+        return value.IsUndefined() ? null : TypeConverter.ToBoolean(value);
+    }
+
+    /// <summary>
+    /// <c>sequence&lt;DOMString&gt; key_ops</c>: iterated with the iterator protocol, so a value that is not
+    /// iterable is the <c>TypeError</c> WebIDL raises rather than a <c>DataError</c>.
+    /// </summary>
+    private static List<string>? ReadStringSequence(CryptoContext context, ObjectInstance source, string what)
+    {
+        var value = source.Get(_keyOpsKey);
+        if (value.IsUndefined())
+        {
+            return null;
+        }
+
+        var result = new List<string>();
+        var iterator = value.GetIterator(context.Realm);
+
+        try
+        {
+            while (iterator.TryIteratorStepValue(out var element))
+            {
+                result.Add(TypeConverter.ToString(element));
+            }
+        }
+        catch
+        {
+            iterator.CloseIfNotDone(CompletionType.Throw);
+            throw;
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// The first three JWK steps both algorithms share: the key type must be <c>oct</c>, the key must meet
+    /// "the requirements of Section 6.4 of JSON Web Algorithms" — which for an <c>oct</c> key is that
+    /// <c>k</c> is present, https://www.rfc-editor.org/rfc/rfc7518#section-6.4.1 saying "This member MUST be
+    /// present" — and <c>k</c> is then decoded.
+    /// </summary>
+    internal byte[] RequireOctAndDecodeKey(CryptoContext context, string what)
+    {
+        if (!string.Equals(Kty, "oct", StringComparison.Ordinal))
+        {
+            context.ThrowDataError(what + ": the kty field of the JSON Web Key is " + Describe(Kty) + " rather than 'oct'.");
+        }
+
+        if (K is null)
+        {
+            context.ThrowDataError(what + ": the JSON Web Key has no k field, which Section 6.4.1 of JSON Web Algorithms requires for a key of type 'oct'.");
+        }
+
+        return DecodeBase64Url(context, K, what);
+    }
+
+    /// <summary>
+    /// "Let data be the byte sequence obtained by decoding the k field of jwk" — decoded as the base64url
+    /// encoding of https://www.rfc-editor.org/rfc/rfc7515#section-2, which is the alphabet <c>A-Za-z0-9-_</c>
+    /// "with all trailing '=' characters omitted".
+    /// </summary>
+    /// <remarks>
+    /// The alphabet is checked here rather than left to the decoder: <see cref="WebEncoders"/> maps
+    /// <c>-</c> and <c>_</c> back to the standard alphabet and then hands the whole string to
+    /// <see cref="Convert"/>, which accepts <c>+</c>, <c>/</c>, padding and whitespace — all of which are
+    /// exactly what a base64url string may not contain. Accepting them would mean importing a key from a
+    /// document that no other implementation would read.
+    /// </remarks>
+    private static byte[] DecodeBase64Url(CryptoContext context, string k, string what)
+    {
+        foreach (var c in k)
+        {
+            var valid = char.IsAsciiLetterOrDigit(c) || c == '-' || c == '_';
+            if (!valid)
+            {
+                context.ThrowDataError(what + ": the k field of the JSON Web Key contains '" + c + "', which is not a base64url character.");
+            }
+        }
+
+        // A base64url string of length 4n+1 encodes a fractional byte and cannot be decoded at all.
+        if (k.Length % 4 == 1)
+        {
+            context.ThrowDataError(what + ": the k field of the JSON Web Key has a length of " + k.Length + ", which no base64url encoding has.");
+        }
+
+        try
+        {
+            return WebEncoders.Base64UrlDecode(k.AsSpan());
+        }
+        catch (FormatException)
+        {
+            context.ThrowDataError(what + ": the k field of the JSON Web Key is not a valid base64url encoding.");
+            return null!;
+        }
+    }
+
+    /// <summary>
+    /// The last three JWK steps both algorithms share, in the order they appear in both: <c>use</c>,
+    /// <c>key_ops</c> and <c>ext</c>. <c>expectedUse</c> is "sig" for a signing key and "enc" for an
+    /// encryption key, which is the only part of these three steps that differs between the two.
+    /// </summary>
+    internal void ValidateUseKeyOpsAndExt(
+        CryptoContext context,
+        KeyUsage usages,
+        bool extractable,
+        string expectedUse,
+        string what)
+    {
+        // "If usages is non-empty and the use field of jwk is present and is not <expectedUse>, then throw a
+        // DataError." An empty usages list makes the field irrelevant, because nothing is being asked of the
+        // key.
+        if (usages != KeyUsage.None && Use is not null && !string.Equals(Use, expectedUse, StringComparison.Ordinal))
+        {
+            context.ThrowDataError(
+                what + ": the use field of the JSON Web Key is '" + Use + "' rather than '" + expectedUse + "', so it cannot be imported with these usages.");
+        }
+
+        // "If the key_ops field of jwk is present, and is invalid according to the requirements of JSON Web
+        // Key or does not contain all of the specified usages values, then throw a DataError."
+        if (KeyOps is not null)
+        {
+            // https://www.rfc-editor.org/rfc/rfc7517#section-4.3: "Duplicate key operation values MUST NOT be
+            // present in the array." Nothing else about the array is checkable here — an unrecognized
+            // operation name is allowed to be there, it simply cannot match a usage.
+            for (var i = 0; i < KeyOps.Count; i++)
+            {
+                for (var j = i + 1; j < KeyOps.Count; j++)
+                {
+                    if (string.Equals(KeyOps[i], KeyOps[j], StringComparison.Ordinal))
+                    {
+                        context.ThrowDataError(
+                            what + ": the key_ops field of the JSON Web Key lists '" + KeyOps[i] + "' more than once, which JSON Web Key forbids.");
+                    }
+                }
+            }
+
+            var missing = MissingFromKeyOps(usages);
+            if (missing != KeyUsage.None)
+            {
+                context.ThrowDataError(
+                    what + ": the key_ops field of the JSON Web Key does not contain the requested usage(s) " + KeyUsages.Describe(missing) + ".");
+            }
+        }
+
+        // "If the ext field of jwk is present and has the value false and extractable is true, then throw a
+        // DataError." A key marked non-extractable cannot be imported as an extractable one, which is the one
+        // promise a JWK can make about its own future.
+        if (Ext == false && extractable)
+        {
+            context.ThrowDataError(what + ": the JSON Web Key has ext: false, so it cannot be imported as an extractable key.");
+        }
+    }
+
+    private KeyUsage MissingFromKeyOps(KeyUsage usages)
+    {
+        var present = KeyUsage.None;
+        foreach (var name in KeyOps!)
+        {
+            if (KeyUsages.TryParse(name, out var usage))
+            {
+                present |= usage;
+            }
+        }
+
+        return usages & ~present;
+    }
+
+    /// <summary>
+    /// The object <c>exportKey("jwk")</c> resolves with: the five fields both algorithms set, with <c>k</c>
+    /// carrying the key material "encoded according to Section 6.4 of JSON Web Algorithms" — base64url with
+    /// no padding.
+    /// </summary>
+    internal static JsObject CreateExport(
+        Engine engine,
+        ReadOnlySpan<byte> keyMaterial,
+        string alg,
+        KeyUsage usages,
+        bool extractable)
+    {
+        return JsObject.Create(
+            engine,
+            _exportLayout,
+            [
+                JsString.Create(alg),
+                extractable ? JsBoolean.True : JsBoolean.False,
+                JsString.Create(WebEncoders.Base64UrlEncode(keyMaterial, omitPadding: true)),
+                KeyUsages.ToArray(engine, usages),
+                JsString.Create("oct"),
+            ]);
+    }
+
+    private static string Describe(string? value) => value is null ? "absent" : "'" + value + "'";
+}
+#endif

--- a/Jint/WebApi/Crypto/KeyUsages.cs
+++ b/Jint/WebApi/Crypto/KeyUsages.cs
@@ -1,0 +1,149 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Array;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Crypto;
+
+/// <summary>
+/// The <c>KeyUsage</c> enumeration — https://w3c.github.io/webcrypto/#dfn-KeyUsage — as a flag set.
+/// </summary>
+/// <remarks>
+/// The bits are declared in the order the specification lists the recognized key usage values, which is what
+/// makes <see cref="KeyUsages.ToArray"/> produce the "normalized value" of a usages list by iterating them:
+/// "the usage intersection of usages and a sequence containing all recognized key usage values" is, for a
+/// flag set, simply the bits that are set, read in declaration order —
+/// https://w3c.github.io/webcrypto/#concept-usage-intersection. Duplicates in the script's own sequence
+/// collapse on the way in for the same reason.
+/// </remarks>
+[Flags]
+internal enum KeyUsage
+{
+    None = 0,
+    Encrypt = 1 << 0,
+    Decrypt = 1 << 1,
+    Sign = 1 << 2,
+    Verify = 1 << 3,
+    DeriveKey = 1 << 4,
+    DeriveBits = 1 << 5,
+    WrapKey = 1 << 6,
+    UnwrapKey = 1 << 7,
+}
+
+/// <summary>
+/// Conversions between a script's <c>sequence&lt;KeyUsage&gt;</c> and <see cref="KeyUsage"/>.
+/// </summary>
+internal static class KeyUsages
+{
+    /// <summary>
+    /// The recognized key usage values, in the order the specification lists them. Index <c>i</c> names bit
+    /// <c>1 &lt;&lt; i</c> of <see cref="KeyUsage"/>.
+    /// </summary>
+    private static readonly string[] _names =
+    [
+        "encrypt", "decrypt", "sign", "verify", "deriveKey", "deriveBits", "wrapKey", "unwrapKey",
+    ];
+
+    private static readonly JsString[] _jsNames =
+    [
+        new("encrypt"), new("decrypt"), new("sign"), new("verify"),
+        new("deriveKey"), new("deriveBits"), new("wrapKey"), new("unwrapKey"),
+    ];
+
+    /// <summary>
+    /// The WebIDL <c>sequence&lt;KeyUsage&gt;</c> conversion, https://webidl.spec.whatwg.org/#es-sequence:
+    /// the value is iterated with the iterator protocol and every element is converted to the
+    /// <c>KeyUsage</c> enumeration, https://webidl.spec.whatwg.org/#es-enumeration — a string that is not one
+    /// of the eight recognized values is a <c>TypeError</c>, not a <c>SyntaxError</c>. The
+    /// <c>SyntaxError</c>s in this API are about usages that are recognized but wrong <i>for the algorithm</i>,
+    /// which is a decision each algorithm's own steps make later.
+    /// </summary>
+    internal static KeyUsage ReadSequence(CryptoContext context, JsValue value, string what)
+    {
+        var usages = KeyUsage.None;
+        var iterator = value.GetIterator(context.Realm);
+
+        try
+        {
+            while (iterator.TryIteratorStepValue(out var element))
+            {
+                var name = TypeConverter.ToString(element);
+                if (!TryParse(name, out var usage))
+                {
+                    context.ThrowTypeError(
+                        what + ": '" + name + "' is not a valid value for the enumeration KeyUsage (encrypt, decrypt, sign, verify, deriveKey, deriveBits, wrapKey, unwrapKey).");
+                }
+
+                usages |= usage;
+            }
+        }
+        catch
+        {
+            iterator.CloseIfNotDone(CompletionType.Throw);
+            throw;
+        }
+
+        return usages;
+    }
+
+    /// <summary>
+    /// The <c>key_ops</c> field of a JWK carries the very same names, so importing one reuses this. A name
+    /// that is not a recognized usage is not an error here — it merely cannot match a requested usage.
+    /// </summary>
+    internal static bool TryParse(string name, out KeyUsage usage)
+    {
+        for (var i = 0; i < _names.Length; i++)
+        {
+            if (string.Equals(name, _names[i], StringComparison.Ordinal))
+            {
+                usage = (KeyUsage) (1 << i);
+                return true;
+            }
+        }
+
+        usage = KeyUsage.None;
+        return false;
+    }
+
+    /// <summary>
+    /// The usages as an ECMAScript array of strings, in the recognized order — what the <c>usages</c>
+    /// attribute and a JWK's <c>key_ops</c> field are both made of.
+    /// </summary>
+    internal static JsArray ToArray(Engine engine, KeyUsage usages)
+    {
+        var count = System.Numerics.BitOperations.PopCount((uint) usages);
+        var values = new JsValue[count];
+
+        var next = 0;
+        for (var i = 0; i < _jsNames.Length; i++)
+        {
+            if (((int) usages & (1 << i)) != 0)
+            {
+                values[next++] = _jsNames[i];
+            }
+        }
+
+        return new JsArray(engine, values);
+    }
+
+    /// <summary>The usages as a comma-separated list, for an error message.</summary>
+    internal static string Describe(KeyUsage usages)
+    {
+        if (usages == KeyUsage.None)
+        {
+            return "(none)";
+        }
+
+        var parts = new List<string>();
+        for (var i = 0; i < _names.Length; i++)
+        {
+            if (((int) usages & (1 << i)) != 0)
+            {
+                parts.Add(_names[i]);
+            }
+        }
+
+        return string.Join(", ", parts);
+    }
+}
+#endif

--- a/Jint/WebApi/Crypto/SubtleCryptoInstance.cs
+++ b/Jint/WebApi/Crypto/SubtleCryptoInstance.cs
@@ -1,15 +1,10 @@
 #if NET8_0_OR_GREATER
-using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
-using System.Text;
 using Jint.Native;
-using Jint.Native.ArrayBuffer;
 using Jint.Native.Object;
 using Jint.Native.Promise;
-using Jint.Native.TypedArray;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.WebApi.DomException;
 using Jint.WebApi.Encoding;
 
 namespace Jint.WebApi.Crypto;
@@ -22,14 +17,17 @@ namespace Jint.WebApi.Crypto;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b><c>digest</c> is the whole of the interface here.</b> Every other operation the IDL declares —
-/// <c>encrypt</c>, <c>decrypt</c>, <c>sign</c>, <c>verify</c>, <c>generateKey</c>, <c>deriveKey</c>,
-/// <c>deriveBits</c>, <c>importKey</c>, <c>exportKey</c>, <c>wrapKey</c> and <c>unwrapKey</c> — is
-/// <b>absent</b> rather than present-and-throwing, and <c>CryptoKey</c> does not exist at all. Digest is the
-/// one operation that needs no key material, no key store and no <c>CryptoKey</c> object, which is what makes
-/// it shippable on its own; a library that checks <c>typeof crypto.subtle.sign === 'function'</c> before
-/// reaching for it gets the truthful answer and takes its fallback path, exactly as it does for
-/// <c>crypto.subtle</c> itself in an engine without the crypto feature.
+/// <b>Eight of the twelve operations exist</b>: <c>digest</c>, <c>sign</c>, <c>verify</c>, <c>encrypt</c>,
+/// <c>decrypt</c>, <c>generateKey</c>, <c>importKey</c> and <c>exportKey</c>, over the algorithms
+/// <c>HMAC</c> (SHA-1, SHA-256, SHA-384, SHA-512) and <c>AES-GCM</c> (128, 192 and 256 bits), plus the four
+/// SHA hashes for <c>digest</c>. <c>deriveKey</c>, <c>deriveBits</c>, <c>wrapKey</c> and <c>unwrapKey</c> are
+/// <b>absent</b> rather than present-and-throwing, and so is every asymmetric algorithm, so a library that
+/// checks <c>typeof crypto.subtle.deriveBits === 'function'</c> before reaching for it gets the truthful
+/// answer and takes its fallback path — the same promise <c>crypto.subtle</c> itself makes to an engine
+/// without the crypto feature. An algorithm that is absent for a <i>particular</i> operation is a
+/// <c>NotSupportedError</c>, which is what the specification says a name that is not registered for an
+/// operation is: <c>sign</c> with <c>AES-GCM</c> fails that way, and so does <c>encrypt</c> with
+/// <c>HMAC</c>.
 /// </para>
 /// <para>
 /// <b>Nothing here ever throws to its caller.</b> WebIDL turns an exception out of a promise-returning
@@ -44,46 +42,27 @@ namespace Jint.WebApi.Crypto;
 /// constraint that became a rejection would no longer bound anything.
 /// </para>
 /// <para>
-/// The promise is already resolved when it is handed back: hashing a byte sequence already in memory is
-/// synchronous CPU work, so there is nothing for an event-loop turn to wait for. Step 7's "perform the
-/// remaining steps in parallel" exists so that a browser's main thread is not blocked by a slow key
-/// operation, and observing the difference needs a second thread to mutate something in between — which an
-/// engine that runs script on one thread does not have. It is still a real promise: <c>await</c> works, and
-/// the value arrives on the microtask turn a <c>then</c> would give it.
+/// The promise is already resolved when it is handed back: every operation here is synchronous CPU work over
+/// bytes that are already in memory, so there is nothing for an event-loop turn to wait for. "Return promise
+/// and perform the remaining steps in parallel" exists so that a browser's main thread is not blocked by a
+/// slow key operation, and observing the difference needs a second thread to mutate something in between —
+/// which an engine that runs script on one thread does not have. It is still a real promise: <c>await</c>
+/// works, and the value arrives on the microtask turn a <c>then</c> would give it.
 /// </para>
 /// <para>
 /// Two documented simplifications against WebIDL, both of which <c>console</c>, <c>crypto</c> and
 /// <c>performance</c> carry too. There is no <c>SubtleCrypto</c> interface object and no
-/// <c>SubtleCrypto.prototype</c>, so <c>digest</c> and the <c>@@toStringTag</c> are own properties of this
+/// <c>SubtleCrypto.prototype</c>, so the operations and the <c>@@toStringTag</c> are own properties of this
 /// object with the attributes an ECMAScript built-in method has rather than those of a WebIDL interface
 /// prototype's operations; <c>Object.keys(crypto.subtle)</c> answers the empty array here exactly as it does
-/// in a browser, where the operation lives one level up. And <c>[SecureContext]</c> has no meaning for an
-/// embedded engine — there is no origin, no transport and no browsing context — so the operation is exposed
-/// unconditionally, which is the same reading Node and workerd take.
+/// in a browser, where the operations live one level up. And <c>[SecureContext]</c> has no meaning for an
+/// embedded engine — there is no origin, no transport and no browsing context — so the operations are
+/// exposed unconditionally, which is the same reading Node and workerd take.
 /// </para>
 /// </remarks>
 [JsObject]
 internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
 {
-    /// <summary>
-    /// https://w3c.github.io/webcrypto/#sha-registration — "The recognized algorithm names are
-    /// <c>SHA-1</c>, <c>SHA-256</c>, <c>SHA-384</c>, and <c>SHA-512</c> for the respective SHA algorithms",
-    /// each registered for the <c>digest</c> operation.
-    /// </summary>
-    private const string Sha1 = "SHA-1";
-    private const string Sha256 = "SHA-256";
-    private const string Sha384 = "SHA-384";
-    private const string Sha512 = "SHA-512";
-
-    /// <summary>
-    /// The associative container "stored at the <c>op</c> key of supportedAlgorithms" for <c>op</c> =
-    /// "digest". Written as an explicit list rather than derived from anything, because an algorithm added to
-    /// the BCL later must not become reachable from script until someone has read this specification again.
-    /// </summary>
-    private static readonly string[] RegisteredDigestAlgorithms = [Sha1, Sha256, Sha384, Sha512];
-
-    private static readonly JsString _nameKey = new("name");
-
     [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
     private static readonly JsString SubtleCryptoToStringTag = new("SubtleCrypto");
 
@@ -101,66 +80,269 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
         CreateSymbols_Generated();
     }
 
+    private CryptoContext Context => new(_engine, _realm);
+
     /// <summary>
     /// https://w3c.github.io/webcrypto/#SubtleCrypto-method-digest, whose IDL is
     /// <c>Promise&lt;ArrayBuffer&gt; digest(AlgorithmIdentifier algorithm, BufferSource data)</c>.
     /// </summary>
     /// <remarks>
-    /// <para>
     /// The order the failures come in is WebIDL's, not the algorithm's: the brand check, then the conversion
     /// of <c>algorithm</c> to <c>(object or DOMString)</c>, then the conversion of <c>data</c> to
     /// <c>BufferSource</c>, and only then step 2's normalization. So <c>digest('nonsense', 42)</c> rejects
     /// with the <c>TypeError</c> the second argument earns rather than the <c>NotSupportedError</c> the first
     /// one would — argument conversion runs before a single step of the method body does.
-    /// </para>
-    /// <para>
-    /// Step 4 says to <i>copy</i> the bytes. Nothing here copies them: the digest is computed from a window
-    /// onto the engine's own backing array before this method returns, and the copy exists only so that a
-    /// mutation from another agent cannot be observed halfway through — see
-    /// <see cref="BufferSource"/>. The bytes are read once, in order, and never again.
-    /// </para>
     /// </remarks>
     [JsFunction(Name = "digest", Length = 2)]
     private JsValue Digest(JsValue thisObject, JsValue algorithm, JsValue data)
     {
+        return Perform(thisObject, CryptoOperation.Digest, what =>
+        {
+            var identifier = AlgorithmNormalization.ConvertIdentifier(algorithm);
+            var message = GetBufferSourceBytes(data, what, "parameter 2");
+
+            var normalized = AlgorithmNormalization.Normalize(Context, identifier, CryptoOperation.Digest, what);
+
+            return Context.CreateArrayBuffer(ComputeDigest(normalized.Name, message));
+        });
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#SubtleCrypto-method-sign, whose IDL is
+    /// <c>Promise&lt;ArrayBuffer&gt; sign(AlgorithmIdentifier algorithm, CryptoKey key, BufferSource data)</c>.
+    /// </summary>
+    [JsFunction(Name = "sign", Length = 3)]
+    private JsValue Sign(JsValue thisObject, JsValue algorithm, JsValue key, JsValue data)
+    {
+        return Perform(thisObject, CryptoOperation.Sign, what =>
+        {
+            var identifier = AlgorithmNormalization.ConvertIdentifier(algorithm);
+            var cryptoKey = RequireCryptoKey(key, what, "parameter 2");
+            var message = GetBufferSourceBytes(data, what, "parameter 3");
+
+            var normalized = AlgorithmNormalization.Normalize(Context, identifier, CryptoOperation.Sign, what);
+
+            RequireKeyFor(normalized, cryptoKey, KeyUsage.Sign, "sign", what);
+
+            // HMAC is the only algorithm registered for this operation, and the check above has just proved
+            // the key was made for the algorithm that normalization returned — so the dispatch is decided.
+            return Context.CreateArrayBuffer(HmacAlgorithm.Sign(cryptoKey, message));
+        });
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#SubtleCrypto-method-verify, whose IDL is
+    /// <c>Promise&lt;boolean&gt; verify(AlgorithmIdentifier algorithm, CryptoKey key, BufferSource signature,
+    /// BufferSource data)</c>.
+    /// </summary>
+    [JsFunction(Name = "verify", Length = 4)]
+    private JsValue Verify(JsValue thisObject, JsValue algorithm, JsValue key, JsValue signature, JsValue data)
+    {
+        return Perform(thisObject, CryptoOperation.Verify, what =>
+        {
+            var identifier = AlgorithmNormalization.ConvertIdentifier(algorithm);
+            var cryptoKey = RequireCryptoKey(key, what, "parameter 2");
+            var signatureBytes = GetBufferSourceBytes(signature, what, "parameter 3");
+            var message = GetBufferSourceBytes(data, what, "parameter 4");
+
+            var normalized = AlgorithmNormalization.Normalize(Context, identifier, CryptoOperation.Verify, what);
+
+            RequireKeyFor(normalized, cryptoKey, KeyUsage.Verify, "verify", what);
+
+            return HmacAlgorithm.Verify(cryptoKey, signatureBytes, message) ? JsBoolean.True : JsBoolean.False;
+        });
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#SubtleCrypto-method-encrypt, whose IDL is
+    /// <c>Promise&lt;ArrayBuffer&gt; encrypt(AlgorithmIdentifier algorithm, CryptoKey key, BufferSource data)</c>.
+    /// </summary>
+    [JsFunction(Name = "encrypt", Length = 3)]
+    private JsValue Encrypt(JsValue thisObject, JsValue algorithm, JsValue key, JsValue data)
+    {
+        return Perform(thisObject, CryptoOperation.Encrypt, what =>
+        {
+            var identifier = AlgorithmNormalization.ConvertIdentifier(algorithm);
+            var cryptoKey = RequireCryptoKey(key, what, "parameter 2");
+            var plaintext = GetBufferSourceBytes(data, what, "parameter 3");
+
+            var normalized = AlgorithmNormalization.Normalize(Context, identifier, CryptoOperation.Encrypt, what);
+
+            RequireKeyFor(normalized, cryptoKey, KeyUsage.Encrypt, "encrypt", what);
+
+            // AES-GCM is the only algorithm registered for this operation, so — as in sign above — the check
+            // that the key was made for the normalized algorithm is what decides the dispatch.
+            return Context.CreateArrayBuffer(AesGcmAlgorithm.Encrypt(Context, normalized, cryptoKey, plaintext, what));
+        });
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#SubtleCrypto-method-decrypt, whose IDL is
+    /// <c>Promise&lt;ArrayBuffer&gt; decrypt(AlgorithmIdentifier algorithm, CryptoKey key, BufferSource data)</c>.
+    /// </summary>
+    [JsFunction(Name = "decrypt", Length = 3)]
+    private JsValue Decrypt(JsValue thisObject, JsValue algorithm, JsValue key, JsValue data)
+    {
+        return Perform(thisObject, CryptoOperation.Decrypt, what =>
+        {
+            var identifier = AlgorithmNormalization.ConvertIdentifier(algorithm);
+            var cryptoKey = RequireCryptoKey(key, what, "parameter 2");
+            var ciphertext = GetBufferSourceBytes(data, what, "parameter 3");
+
+            var normalized = AlgorithmNormalization.Normalize(Context, identifier, CryptoOperation.Decrypt, what);
+
+            RequireKeyFor(normalized, cryptoKey, KeyUsage.Decrypt, "decrypt", what);
+
+            return Context.CreateArrayBuffer(AesGcmAlgorithm.Decrypt(Context, normalized, cryptoKey, ciphertext, what));
+        });
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#SubtleCrypto-method-generateKey, whose IDL is
+    /// <c>Promise&lt;(CryptoKey or CryptoKeyPair)&gt; generateKey(AlgorithmIdentifier algorithm,
+    /// boolean extractable, sequence&lt;KeyUsage&gt; keyUsages)</c>.
+    /// </summary>
+    /// <remarks>
+    /// Both algorithms here produce a single secret key, never a pair, so the union's second arm — and with
+    /// it <c>CryptoKeyPair</c>, which has no interface object in this engine — is unreachable.
+    /// </remarks>
+    [JsFunction(Name = "generateKey", Length = 3)]
+    private JsValue GenerateKey(JsValue thisObject, JsValue algorithm, JsValue extractable, JsValue keyUsages)
+    {
+        return Perform(thisObject, CryptoOperation.GenerateKey, what =>
+        {
+            var identifier = AlgorithmNormalization.ConvertIdentifier(algorithm);
+            var isExtractable = TypeConverter.ToBoolean(extractable);
+            var usages = KeyUsages.ReadSequence(Context, keyUsages, what);
+
+            var normalized = AlgorithmNormalization.Normalize(Context, identifier, CryptoOperation.GenerateKey, what);
+
+            var material = string.Equals(normalized.Name, AlgorithmNormalization.Hmac, StringComparison.Ordinal)
+                ? HmacAlgorithm.GenerateKey(Context, normalized, usages, what)
+                : AesGcmAlgorithm.GenerateKey(Context, normalized, usages, what);
+
+            // "If result is a CryptoKey object: If the [[type]] internal slot of result is 'secret' or
+            // 'private' and usages is empty, then throw a SyntaxError." A secret key nobody may use is a
+            // mistake, not a key, and it is caught here rather than inside the algorithm because it is the
+            // same mistake whichever algorithm made the key.
+            RequireNonEmptyUsages(usages, what);
+
+            return _realm.Intrinsics.CryptoKey.CreateKey(material.Handle, material.Algorithm, isExtractable, usages);
+        });
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#SubtleCrypto-method-importKey, whose IDL is
+    /// <c>Promise&lt;CryptoKey&gt; importKey(KeyFormat format, (BufferSource or JsonWebKey) keyData,
+    /// AlgorithmIdentifier algorithm, boolean extractable, sequence&lt;KeyUsage&gt; keyUsages)</c>.
+    /// </summary>
+    /// <remarks>
+    /// The union's arms are told apart the way WebIDL tells them apart — https://webidl.spec.whatwg.org/#es-union:
+    /// a buffer source is one, and anything else that is an object (or <c>null</c>, or <c>undefined</c>)
+    /// becomes a <c>JsonWebKey</c> dictionary, which is read <i>here</i>, with the other arguments, and not
+    /// when the algorithm's steps get to it. So the getters on a JWK run before the algorithm is even
+    /// normalized. Step 4 then rejects the mismatches: a JWK with a format that is not <c>"jwk"</c>, and a
+    /// buffer source with the format that is.
+    /// </remarks>
+    [JsFunction(Name = "importKey", Length = 5)]
+    private JsValue ImportKey(JsValue thisObject, JsValue format, JsValue keyData, JsValue algorithm, JsValue extractable, JsValue keyUsages)
+    {
+        return Perform(thisObject, CryptoOperation.ImportKey, what =>
+        {
+            var keyFormat = ReadKeyFormat(format, what);
+            var (rawData, jwk) = ReadKeyData(keyData, what);
+            var identifier = AlgorithmNormalization.ConvertIdentifier(algorithm);
+            var isExtractable = TypeConverter.ToBoolean(extractable);
+            var usages = KeyUsages.ReadSequence(Context, keyUsages, what);
+
+            var normalized = AlgorithmNormalization.Normalize(Context, identifier, CryptoOperation.ImportKey, what);
+
+            // Step 4, after normalization as the numbering says.
+            if (keyFormat == KeyFormat.Jwk && jwk is null)
+            {
+                Context.ThrowTypeError(what + ": the 'jwk' format needs a JsonWebKey object, not a buffer source.");
+            }
+
+            if (keyFormat != KeyFormat.Jwk && jwk is not null)
+            {
+                Context.ThrowTypeError(what + ": the '" + KeyFormats.NameOf(keyFormat) + "' format needs a buffer source, not a JsonWebKey object.");
+            }
+
+            var material = string.Equals(normalized.Name, AlgorithmNormalization.Hmac, StringComparison.Ordinal)
+                ? HmacAlgorithm.ImportKey(Context, keyFormat, rawData, jwk, normalized, isExtractable, usages, what)
+                : AesGcmAlgorithm.ImportKey(Context, keyFormat, rawData, jwk, isExtractable, usages, what);
+
+            RequireNonEmptyUsages(usages, what);
+
+            return _realm.Intrinsics.CryptoKey.CreateKey(material.Handle, material.Algorithm, isExtractable, usages);
+        });
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#SubtleCrypto-method-exportKey, whose IDL is
+    /// <c>Promise&lt;(ArrayBuffer or JsonWebKey)&gt; exportKey(KeyFormat format, CryptoKey key)</c>.
+    /// </summary>
+    /// <remarks>
+    /// This is the only door the key material has, and it is shut by two checks before the algorithm is
+    /// asked for anything: the key's algorithm must be registered for the export operation, and the key must
+    /// be extractable. Neither is a property of the request — both are properties of the key, decided when it
+    /// was made.
+    /// </remarks>
+    [JsFunction(Name = "exportKey", Length = 2)]
+    private JsValue ExportKey(JsValue thisObject, JsValue format, JsValue key)
+    {
+        return Perform(thisObject, CryptoOperation.ExportKey, what =>
+        {
+            var keyFormat = ReadKeyFormat(format, what);
+            var cryptoKey = RequireCryptoKey(key, what, "parameter 2");
+
+            // "If the name member of the [[algorithm]] internal slot of key does not identify a registered
+            // algorithm that supports the export key operation, then throw a NotSupportedError."
+            if (Array.IndexOf(AlgorithmNormalization.RegisteredFor(CryptoOperation.ExportKey), cryptoKey.Algorithm.Name) < 0)
+            {
+                Context.ThrowNotSupportedError(
+                    what + ": " + cryptoKey.Algorithm.Name + " is not registered for the exportKey operation.");
+            }
+
+            // "If the [[extractable]] internal slot of key is false, then throw an InvalidAccessError."
+            if (!cryptoKey.Extractable)
+            {
+                Context.ThrowInvalidAccessError(what + ": the key is not extractable.");
+            }
+
+            return string.Equals(cryptoKey.Algorithm.Name, AlgorithmNormalization.Hmac, StringComparison.Ordinal)
+                ? HmacAlgorithm.ExportKey(Context, cryptoKey, keyFormat, what)
+                : AesGcmAlgorithm.ExportKey(Context, cryptoKey, keyFormat, what);
+        });
+    }
+
+    /// <summary>
+    /// Runs one operation's steps and settles a promise with whatever they produce — the whole of what
+    /// https://webidl.spec.whatwg.org/#dfn-create-operation-function does around a promise-returning
+    /// operation, including the brand check.
+    /// </summary>
+    /// <remarks>
+    /// The three exceptions caught are the whole of what a failure here can arrive as. They are the
+    /// script-visible arm of <c>JintStatementList.ShouldCatch</c> — the exceptions the interpreter itself
+    /// turns into a throw completion — minus <c>SyntaxErrorException</c>, which nothing on this path can
+    /// raise because nothing on it parses. Everything else a <c>JintException</c> covers is deliberately not
+    /// caught: an execution constraint, a cancellation or a stack-depth overflow is not a value a script may
+    /// catch, and a constraint that became a rejection would no longer bound anything.
+    /// </remarks>
+    private JsValue Perform(JsValue thisObject, CryptoOperation operation, Func<string, JsValue> steps)
+    {
         var capability = PromiseConstructor.NewPromiseCapability(_engine, _realm.Intrinsics.Promise);
+        var what = "Failed to execute '" + AlgorithmNormalization.NameOf(operation) + "' on 'SubtleCrypto'";
 
         try
         {
             if (thisObject is not SubtleCryptoInstance)
             {
-                Throw.TypeError(_realm, "Failed to execute 'digest' on 'SubtleCrypto': illegal invocation, receiver is not a SubtleCrypto object.");
+                Throw.TypeError(_realm, what + ": illegal invocation, receiver is not a SubtleCrypto object.");
             }
 
-            // `AlgorithmIdentifier` is `typedef (object or DOMString)`, so an object stays an object and
-            // everything else is stringified here — which is where a symbol raises its TypeError, and why
-            // `digest(null, …)` normalizes the name "null" rather than failing differently.
-            var algorithmObject = algorithm as ObjectInstance;
-            var algorithmName = algorithmObject is null ? TypeConverter.ToString(algorithm) : null;
-
-            // `BufferSource data`: converted before the method body runs, hence before normalization.
-            var message = GetMessageBytes(data);
-
-            // Steps 2 and 3: normalize an algorithm, with op set to "digest".
-            var normalizedAlgorithm = algorithmObject is not null
-                ? NormalizeAlgorithm(algorithmObject)
-                : MatchRegisteredAlgorithm(algorithmName!);
-
-            // Steps 9 to 12: the digest operation, then an ArrayBuffer over its bytes.
-            var digest = ComputeDigest(normalizedAlgorithm, message);
-
-            capability.Resolve(new JsArrayBuffer(_engine, digest)
-            {
-                _prototype = _realm.Intrinsics.ArrayBuffer.PrototypeObject,
-            });
+            capability.Resolve(steps(what));
         }
-        // Every failure of a promise-returning operation is a rejection, and these three are the whole of
-        // what a failure here can arrive as. They are the script-visible arm of
-        // `JintStatementList.ShouldCatch` — the exceptions the interpreter itself turns into a throw
-        // completion — minus SyntaxErrorException, which nothing on this path can raise because nothing on
-        // it parses. Everything else a JintException covers is deliberately not caught: an execution
-        // constraint, a cancellation or a stack-depth overflow is not a value a script may catch, and a
-        // constraint that became a rejection would no longer bound anything.
         catch (JavaScriptException e)
         {
             capability.Reject(e.Error);
@@ -168,7 +350,8 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
         catch (TypeErrorException e)
         {
             // TypeConverter raises this shape when no engine is at hand — `ToString` of a symbol, which is
-            // reachable both as the algorithm identifier and as an algorithm object's `name` member.
+            // reachable as an algorithm identifier, as an algorithm object's `name` member, as a key format
+            // and as a JWK field.
             capability.Reject(_realm.Intrinsics.TypeError.Construct(e.Message));
         }
         catch (RangeErrorException e)
@@ -180,10 +363,126 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
     }
 
     /// <summary>
-    /// WebIDL's conversion of the <c>data</c> argument to <c>BufferSource</c>, which is
-    /// <c>(ArrayBufferView or ArrayBuffer)</c> — https://webidl.spec.whatwg.org/#BufferSource.
+    /// The two <c>InvalidAccessError</c>s every keyed operation makes before doing any work: the key was made
+    /// for this algorithm, and the key permits this use.
+    /// </summary>
+    private void RequireKeyFor(NormalizedAlgorithm normalized, JsCryptoKey key, KeyUsage usage, string usageName, string what)
+    {
+        if (!string.Equals(normalized.Name, key.Algorithm.Name, StringComparison.Ordinal))
+        {
+            Context.ThrowInvalidAccessError(
+                what + ": the key was created for " + key.Algorithm.Name + ", not for " + normalized.Name + ".");
+        }
+
+        if (!key.Allows(usage))
+        {
+            Context.ThrowInvalidAccessError(
+                what + ": the key's usages are " + KeyUsages.Describe(key.Usages) + ", which does not include '" + usageName + "'.");
+        }
+    }
+
+    /// <summary>
+    /// "If the [[type]] internal slot of result is 'secret' or 'private' and usages is empty, then throw a
+    /// SyntaxError" — the step <c>generateKey</c> and <c>importKey</c> both end in. Every key this engine
+    /// makes is a secret one.
+    /// </summary>
+    private void RequireNonEmptyUsages(KeyUsage usages, string what)
+    {
+        if (usages == KeyUsage.None)
+        {
+            Context.ThrowSyntaxError(what + ": a secret key must be created with at least one usage.");
+        }
+    }
+
+    /// <summary>
+    /// The WebIDL <c>CryptoKey</c> conversion: a platform object of that interface, or a <c>TypeError</c>.
+    /// </summary>
+    private JsCryptoKey RequireCryptoKey(JsValue value, string what, string parameter)
+    {
+        if (value is JsCryptoKey key)
+        {
+            return key;
+        }
+
+        Context.ThrowTypeError(what + ": " + parameter + " is not of type 'CryptoKey'.");
+        return null!;
+    }
+
+    /// <summary>
+    /// The WebIDL <c>KeyFormat</c> enumeration conversion, https://webidl.spec.whatwg.org/#es-enumeration:
+    /// the value is stringified and matched <i>case-sensitively</i> against the four recognized values, and
+    /// anything else is a <c>TypeError</c>. That is a different failure from asking a symmetric algorithm for
+    /// <c>"spki"</c>, which is a recognized format the algorithm's own steps refuse with a
+    /// <c>NotSupportedError</c>.
+    /// </summary>
+    private KeyFormat ReadKeyFormat(JsValue value, string what)
+    {
+        var name = TypeConverter.ToString(value);
+
+        switch (name)
+        {
+            case KeyFormats.Raw:
+                return KeyFormat.Raw;
+            case KeyFormats.Spki:
+                return KeyFormat.Spki;
+            case KeyFormats.Pkcs8:
+                return KeyFormat.Pkcs8;
+            case KeyFormats.Jwk:
+                return KeyFormat.Jwk;
+            default:
+                Context.ThrowTypeError(
+                    what + ": '" + name + "' is not a valid value for the enumeration KeyFormat (raw, spki, pkcs8, jwk).");
+                return default;
+        }
+    }
+
+    /// <summary>
+    /// The <c>(BufferSource or JsonWebKey)</c> union conversion. Exactly one of the two results is non-null.
     /// </summary>
     /// <remarks>
+    /// <c>null</c> and <c>undefined</c> become a <c>JsonWebKey</c> with every member absent, which is what
+    /// WebIDL does for a union containing a dictionary type; a number, a string or a boolean is a
+    /// <c>TypeError</c>, because converting a non-object to a dictionary is one.
+    /// </remarks>
+    private (byte[]? Raw, JsonWebKeyData? Jwk) ReadKeyData(JsValue keyData, string what)
+    {
+        if (BufferSource.TryGetBytes(keyData, out var bytes))
+        {
+            if (AlgorithmNormalization.IsSharedBufferSource(keyData))
+            {
+                Context.ThrowTypeError(what + ": parameter 2 is backed by a SharedArrayBuffer, which this operation does not accept.");
+            }
+
+            return (bytes.ToArray(), null);
+        }
+
+        if (keyData.IsNull() || keyData.IsUndefined())
+        {
+            return (null, new JsonWebKeyData());
+        }
+
+        if (keyData is ObjectInstance source)
+        {
+            return (null, JsonWebKeyData.Read(Context, source, what));
+        }
+
+        Context.ThrowTypeError(what + ": parameter 2 is neither a BufferSource nor a JsonWebKey object.");
+        return default;
+    }
+
+    /// <summary>
+    /// WebIDL's conversion of a <c>BufferSource</c> argument, which is
+    /// <c>(ArrayBufferView or ArrayBuffer)</c> — https://webidl.spec.whatwg.org/#BufferSource — followed by
+    /// "getting a copy of the bytes" it holds.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The copy is real, and it has to be: the argument conversions run before the method body, and the
+    /// first thing the body does is normalize an algorithm, which reads a <c>name</c> member and may
+    /// therefore run a script's getter — with the buffer this argument came from in scope. A window onto the
+    /// engine's own backing array would then be a window onto what that getter left behind, and the operation
+    /// would run over bytes the caller never passed.
+    /// </para>
     /// <para>
     /// A view onto a <c>SharedArrayBuffer</c> is refused, and so is a <c>SharedArrayBuffer</c> itself: the
     /// IDL says <c>BufferSource</c> and not <c>AllowSharedBufferSource</c>, and WebIDL refuses a shared
@@ -196,90 +495,30 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
     /// <para>
     /// One deliberate divergence, in the permissive direction: a <b>resizable</b> <c>ArrayBuffer</c>, or a
     /// view onto one, is accepted. WebIDL's conversion refuses those too for a type without
-    /// <c>[AllowResizable]</c>, which <c>BufferSource</c> does not carry — but the bytes hashed are exactly
+    /// <c>[AllowResizable]</c>, which <c>BufferSource</c> does not carry — but the bytes taken are exactly
     /// the ones the view spans at the moment of the call, so the answer is right rather than merely
     /// tolerated, and no engine an embedder is likely to be replacing refuses it.
     /// </para>
     /// </remarks>
-    private ReadOnlySpan<byte> GetMessageBytes(JsValue data)
+    private byte[] GetBufferSourceBytes(JsValue data, string what, string parameter)
     {
         if (!BufferSource.TryGetBytes(data, out var bytes))
         {
-            Throw.TypeError(_realm, "Failed to execute 'digest' on 'SubtleCrypto': parameter 2 is not of type 'BufferSource'.");
+            Context.ThrowTypeError(what + ": " + parameter + " is not of type 'BufferSource'.");
         }
 
-        var buffer = data switch
+        if (AlgorithmNormalization.IsSharedBufferSource(data))
         {
-            JsTypedArray typedArray => typedArray._viewedArrayBuffer,
-            JsDataView dataView => dataView._viewedArrayBuffer,
-            _ => data as JsArrayBuffer,
-        };
-
-        if (buffer is not null && buffer.IsSharedArrayBuffer)
-        {
-            Throw.TypeError(_realm, "Failed to execute 'digest' on 'SubtleCrypto': parameter 2 is backed by a SharedArrayBuffer, which this operation does not accept.");
+            Context.ThrowTypeError(what + ": " + parameter + " is backed by a SharedArrayBuffer, which this operation does not accept.");
         }
 
-        return bytes;
-    }
-
-    /// <summary>
-    /// https://w3c.github.io/webcrypto/#dfn-normalize-an-algorithm, the branch for an <c>alg</c> that is an
-    /// object: convert it to the IDL dictionary type <c>Algorithm</c>, whose one member is
-    /// <c>required DOMString name</c>, and match that name against the algorithms registered for the
-    /// operation.
-    /// </summary>
-    /// <remarks>
-    /// The single <c>Get</c> is the whole of the dictionary conversion, and it may run script — a getter on
-    /// <c>name</c> is called exactly once, and whatever it throws becomes the rejection. An absent member
-    /// reads as <c>undefined</c>, which for a required member is the <c>TypeError</c> WebIDL raises rather
-    /// than a <c>NotSupportedError</c> for the name "undefined".
-    /// </remarks>
-    private string NormalizeAlgorithm(ObjectInstance algorithm)
-    {
-        var name = algorithm.Get(_nameKey);
-        if (name.IsUndefined())
-        {
-            Throw.TypeError(_realm, "Failed to execute 'digest' on 'SubtleCrypto': Algorithm: required member name is undefined.");
-        }
-
-        return MatchRegisteredAlgorithm(TypeConverter.ToString(name));
-    }
-
-    /// <summary>
-    /// The lookup at the heart of normalization: "If registeredAlgorithms contains a key that is a
-    /// case-insensitive string match for algName: Set algName to the value of the matching key. …
-    /// Otherwise: Return a new NotSupportedError".
-    /// </summary>
-    /// <remarks>
-    /// "Case-insensitive" is defined by the specification, at
-    /// https://w3c.github.io/webcrypto/#case-insensitive, as <i>ASCII</i> case-insensitive — so
-    /// <see cref="Ascii.EqualsIgnoreCase(ReadOnlySpan{char}, ReadOnlySpan{char})"/> is the comparison that
-    /// says exactly that and nothing else, rather than a string comparison whose treatment of the letters
-    /// outside ASCII has to be reasoned about. It allocates nothing. The <i>registered</i> key is returned
-    /// rather than the caller's spelling, because the digest operation below matches its name
-    /// <i>case-sensitively</i> — normalization is what makes <c>'sha-256'</c> reach SHA-256 at all.
-    /// </remarks>
-    private string MatchRegisteredAlgorithm(string algName)
-    {
-        foreach (var registered in RegisteredDigestAlgorithms)
-        {
-            if (Ascii.EqualsIgnoreCase(algName, registered))
-            {
-                return registered;
-            }
-        }
-
-        ThrowDomException(
-            DomExceptionNames.NotSupported,
-            "Failed to execute 'digest' on 'SubtleCrypto': the algorithm name '" + algName + "' is not one this engine registers for the digest operation (SHA-1, SHA-256, SHA-384, SHA-512).");
-        return null!;
+        return bytes.ToArray();
     }
 
     /// <summary>
     /// https://w3c.github.io/webcrypto/#sha-operations-digest — the digest operation of the SHA algorithms,
     /// which is the hash function of [FIPS-180-4] applied to the message. The name is matched
-    /// case-sensitively there, which is why normalization above returns the registered spelling.
+    /// case-sensitively there, which is why normalization returns the registered spelling.
     /// </summary>
     /// <remarks>
     /// The one-shot <c>HashData</c> statics rather than <see cref="IncrementalHash"/>: the message is one
@@ -293,7 +532,7 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
     {
         switch (normalizedAlgorithm)
         {
-            case Sha1:
+            case AlgorithmNormalization.Sha1:
                 // SHA-1 is one of the four names the specification registers for this operation and every
                 // browser implements it, so refusing it here would be Jint deciding what a script may hash —
                 // and a script asking for it has already chosen. It is reached only through that name, is
@@ -301,25 +540,17 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
 #pragma warning disable CA5350 // Do Not Use Weak Cryptographic Algorithms -- the caller named SHA-1, we did not choose it
                 return SHA1.HashData(message);
 #pragma warning restore CA5350
-            case Sha256:
+            case AlgorithmNormalization.Sha256:
                 return SHA256.HashData(message);
-            case Sha384:
+            case AlgorithmNormalization.Sha384:
                 return SHA384.HashData(message);
-            case Sha512:
+            case AlgorithmNormalization.Sha512:
                 return SHA512.HashData(message);
             default:
-                // Unreachable: the name came from RegisteredDigestAlgorithms one call ago.
+                // Unreachable: the name came from the registry one call ago.
                 Throw.InvalidOperationException("Unhandled digest algorithm '" + normalizedAlgorithm + "'.");
                 return null!;
         }
-    }
-
-    [DoesNotReturn]
-    private void ThrowDomException(string name, string message)
-    {
-        var exception = _realm.Intrinsics.DomException.CreateException(name, message);
-        var location = _engine._lastSyntaxElement?.Location ?? default;
-        Throw.JavaScriptException(_engine, exception, in location);
     }
 }
 #endif

--- a/Jint/WebApi/DomException/DomExceptionNames.cs
+++ b/Jint/WebApi/DomException/DomExceptionNames.cs
@@ -39,6 +39,14 @@ internal static class DomExceptionNames
     internal const string NotAllowed = "NotAllowedError";
 
     /// <summary>
+    /// The two names the Web Cryptography API adds — https://w3c.github.io/webcrypto/#dfn-exceptions. Neither
+    /// is in the legacy code table, so both report <c>code</c> 0, which is what
+    /// <see cref="CodeFor"/> already answers for a name it does not know.
+    /// </summary>
+    internal const string Data = "DataError";
+    internal const string Operation = "OperationError";
+
+    /// <summary>
     /// The legacy code for an error name, or <c>0</c> when the name has none.
     /// </summary>
     internal static ushort CodeFor(string name) => name switch

--- a/Jint/WebApi/WebApiRegistration.cs
+++ b/Jint/WebApi/WebApiRegistration.cs
@@ -120,6 +120,10 @@ internal static class WebApiRegistration
             // WebIDL exposes crypto through a [Replaceable] accessor pair; an ordinary enumerable data
             // property is the same simplification console is installed with, documented on CryptoInstance.
             Install(global, engine, "crypto", static e => e.Realm.Intrinsics.Crypto, PropertyFlag.ConfigurableEnumerableWritable);
+
+            // The interface object of the keys crypto.subtle hands out, so that `key instanceof CryptoKey`
+            // works. It is not constructible, which is what its own IDL says.
+            Install(global, engine, "CryptoKey", static e => e.Realm.Intrinsics.CryptoKey, PropertyFlag.NonEnumerable);
         }
 
         if ((features & WebApiFeatures.Performance) != WebApiFeatures.None)

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ its own `console` (or any other name in the table below), enabling the feature l
 | `TextEncoder` / `TextDecoder` (UTF-8, UTF-16LE, UTF-16BE; `fatal`, `ignoreBOM`, streaming) | `Encoding` | ✔ shipped |
 | `atob` / `btoa` | `Base64` | ✔ shipped |
 | `structuredClone` (incl. `{ transfer }` of `ArrayBuffer`s) | `StructuredClone` | ✔ shipped |
-| `crypto.getRandomValues` / `crypto.randomUUID` / `crypto.subtle.digest` (SHA-1/256/384/512) | `WebApiFeatures.Crypto` | ✔ shipped |
+| `crypto.getRandomValues` / `crypto.randomUUID` / `crypto.subtle` (SHA digests, HMAC, AES-GCM, `CryptoKey`) | `WebApiFeatures.Crypto` | ✔ shipped |
 | `performance.now` / `timeOrigin` / `mark` / `measure` / `getEntries*` / `clearMarks` / `clearMeasures` | `WebApiFeatures.Performance` | ✔ shipped |
 | `Event` / `EventTarget` / `CustomEvent` / `AbortController` / `AbortSignal` | `Events` | ✔ shipped |
 | `URL` / `URLSearchParams` | `Url` | ✔ shipped |
@@ -237,13 +237,27 @@ its own `console` (or any other name in the table below), enabling the feature l
 grows as the table fills in, and it will never include `fetch`: network egress is always an explicit choice.
 `Storage` is the other standing exception, for the reason in its own section below.
 
-`crypto.subtle` carries **`digest` and nothing else** so far. It is the one `SubtleCrypto` operation that
-needs no key material, which is what makes it shippable on its own; `sign`, `verify`, `encrypt`, `importKey`
-and the rest are *absent* rather than present-and-throwing, so `typeof crypto.subtle.sign` tells a library the
-truth and it takes its fallback path. `digest` never throws — a promise-returning WebIDL operation converts
-every failure into a rejection, so an unregistered algorithm name is a `NotSupportedError` `DOMException`
-rejection and a `data` argument that is not an `ArrayBuffer` or a view over one is a `TypeError` rejection.
-The work is synchronous, so the promise is already settled when you get it.
+`crypto.subtle` carries **`digest`, `sign`, `verify`, `encrypt`, `decrypt`, `generateKey`, `importKey` and
+`exportKey`**, over SHA-1/256/384/512 (for `digest` and as HMAC's inner hash), **HMAC**, and **AES-GCM** at
+128, 192 and 256 bits. Keys are real `CryptoKey` objects with `type`, `extractable`, `algorithm` and
+`usages`; the key material is never reachable from script except through `exportKey` on an extractable key,
+as `raw` bytes or as a JSON Web Key (`kty: "oct"`). `deriveKey`, `deriveBits`, `wrapKey`, `unwrapKey` and
+every asymmetric algorithm are *absent* rather than present-and-throwing, so
+`typeof crypto.subtle.deriveBits` tells a library the truth and it takes its fallback path.
+
+Nothing here ever throws: a promise-returning WebIDL operation converts every failure into a rejection. An
+algorithm that is not registered for the operation is a `NotSupportedError` `DOMException`, a key used
+against its own `usages` or against another algorithm is an `InvalidAccessError`, a malformed JWK is a
+`DataError`, a usage list an algorithm does not support is a `SyntaxError`, and anything an argument
+conversion refuses is a `TypeError`. An AES-GCM decryption that does not authenticate is one
+`OperationError` carrying nothing about which part of the input was wrong. The work is synchronous, so the
+promise is already settled when you get it.
+
+Two limits of .NET's AES-GCM are visible, and both are reported as the `OperationError` the algorithm's own
+steps end in: the `iv` must be the 96 bits NIST SP 800-38D recommends, and `tagLength` must be 96, 104, 112,
+120 or 128 — the specification also lists 32 and 64, which `System.Security.Cryptography.AesGcm` will not
+produce. The ciphertext is `ciphertext || tag`, exactly as the specification defines it, so a host reading a
+script's output with `AesGcm` splits the last `tagLength / 8` bytes off itself.
 
 ### Timers fire only while the engine is being pumped
 


### PR DESCRIPTION
Completes #3083's key-based surface: `crypto.subtle` gains **HMAC** (`importKey`/`generateKey`/`sign`/`verify`/`exportKey`) and **AES-GCM** (`encrypt`/`decrypt`/`generateKey`/`importKey`/`exportKey`), with the `CryptoKey` object model (`type`/`extractable`/`algorithm`/`usages`, non-constructible interface object installed for `instanceof`) and **JWK import/export** alongside `raw`.

Everything follows https://w3c.github.io/webcrypto/ as promise-returning WebIDL operations — every failure is a rejection with the spec's own error type (`NotSupportedError`/`OperationError`/`DataError`/`InvalidAccessError` `DOMException`s, `TypeError` where the spec says so), usages are validated against the algorithm's recognized set at import, and an un-extractable key rejects `exportKey`. The work is synchronous over `System.Security.Cryptography`, so promises come back settled and the event loop is untouched. Exported key material is a fresh copy each time (mutation-pinned), and JWK members are emitted in the spec's order (mutation-pinned).

The remaining #3083 item — RSA-PSS/RSASSA-PKCS1/ECDSA sign+verify and the derive family — is explicitly "later, on demand" in the issue and stays out until someone asks; `typeof crypto.subtle.deriveKey` still tells a library the truth.

Both suites green on net10.0 and net472, with and without `JINT_HOST_CONTRACT_VERIFICATION=1`.

Closes #3083

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G7Ud48VAs1JicxRZxLDxg
