### PR TITLE
Pin the unwrap-timeout timer test to a clock the runner cannot advance

### DIFF
--- a/Jint.Tests/Runtime/WebApi/TimerTests.cs
+++ b/Jint.Tests/Runtime/WebApi/TimerTests.cs
@@ -578,7 +578,11 @@ public class TimerTests
     [Fact]
     public void ATimerLongerThanTheUnwrapTimeoutTimesOutByDesign()
     {
-        var engine = new Engine(options => options.UseWebApis());
+        // The timer rides a clock this test never advances, so it can never come due — a wall-clock margin
+        // ("5000 ms is much longer than 200 ms") is still a race on a CI runner that can stall this thread
+        // for seconds inside the drain, at which point the timer fires and the unwrap succeeds instead of
+        // timing out. The unwrap's own budget is real time by design, which is exactly the half under test.
+        var (engine, _) = TimerEngine();
 
         var pending = engine.Evaluate("new Promise(r => setTimeout(r, 5000))");
 


### PR DESCRIPTION
`TimerTests.ATimerLongerThanTheUnwrapTimeoutTimesOutByDesign` raced two real clocks: a 5000 ms timer against a 200 ms unwrap budget. That margin reads as safe, but on a CI runner that stalls the test thread for a few seconds inside the drain the timer comes due, the promise fulfills, and the unwrap *succeeds* — the failure on one windows leg read `Assert.Throws() Failure: No exception was thrown`, which cost a rerun on an unrelated PR.

The timer now rides the file's existing `ManualClock`, which this test never advances, so it can never fire — while the unwrap's own budget stays real time, which is precisely the half the test exists to prove (the blocking unwrap's timeout bounds the wait regardless of what the engine has scheduled). Deterministic on any runner.

Both `Jint.Tests` legs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G7Ud48VAs1JicxRZxLDxg
