### PR TITLE
Add opt-in EventSource over the fetch transport

### DIFF
--- a/.github/THREAT_MODEL.md
+++ b/.github/THREAT_MODEL.md
@@ -637,6 +637,66 @@ proxy, DNS, and TLS policy. Resolve-and-check the destination address in the han
 rebinding is in scope. Keep the worker's egress restricted at the network layer as well:
 `UrlFilter` is a policy inside the process, not a firewall.
 
+### TM-22: `EventSource` holds that network position open
+
+**Threat.** `WebApiFeatures.EventSource` is a second, separate grant of the egress
+[TM-21](#tm-21-fetch-turns-script-into-a-client-of-the-hosts-network-position) describes, and
+the destination reachability question is identical — including the redirect-laundering one.
+What differs is duration and persistence. A connection is **long-lived by design**, so a
+script can pin sockets, connections, and server-side resources for as long as the engine
+lives rather than for one exchange. The response is a **stream**, so no total-size cap can
+apply to it. And the protocol **reconnects by itself**: a stream that ends, or fails at the
+network layer, comes back on a delay the *server* chooses through its `retry:` field, so an
+attacker-controlled endpoint also controls how often the host retries it.
+
+**Existing mitigations.**
+
+- The feature is **off by default and not part of `WebApiFeatures.Default`**. `UseWebApis()`
+  never enables it, and — unlike every other implication in the feature set — **`UseFetch()`
+  does not either**, nor does enabling this one enable `fetch`.
+- Destination policy is the same object and the same code as fetch's:
+  `Options.WebApi.Fetch.AllowedSchemes`, `UrlFilter` (re-run on every redirect hop **and on
+  every reconnection**, so revoking a destination between two attempts stops the next one) and
+  `MaxRedirects`.
+- `Options.WebApi.Fetch.MaxResponseBytes` is repurposed as the **maximum size of one event**
+  — the data buffer plus the line being read — which is what the parser has to hold; exceeding
+  it fails the connection.
+- `Options.WebApi.Fetch.MaxConcurrentRequests` bounds the streams one engine may have open,
+  counted separately from the fetches in flight.
+- A refused URL, a non-`200` response, a `Content-Type` that is not `text/event-stream`, and a
+  blown per-event cap all **fail the connection for good**: `readyState` becomes `CLOSED` and
+  nothing retries, so none of them can become a retry loop.
+- The reconnect delay is an entry on the engine's timer queue, so it counts against
+  `Options.WebApi.Timers.MaxActiveTimers` and **fires only while the host pumps the engine**.
+  A connection likewise delivers nothing to an engine nobody pumps.
+- `close()` cancels the request in flight, and so does
+  `Engine.Advanced.RestoreGlobalSnapshot`, which additionally drops the pending reconnection
+  and delivers nothing from the ended cycle into the restored engine. An engine cancellation
+  ends the connection silently rather than becoming an `error` event a script could react to.
+- The event a script receives carries no detail about the failure — the standard gives an
+  event source's `error` event none — so failures cannot be read apart to map the network.
+
+**Missing or residual mitigation.**
+
+- **`Options.WebApi.Fetch.Timeout` deliberately does not apply**, because an idle connection
+  is what the protocol is for. There is therefore no wall-clock bound on how long one stream
+  may stay open; `close()`, a restore, or dropping the engine is what ends it.
+- There is no floor on the server-announced `retry:` value and no exponential backoff, so a
+  hostile endpoint that ends every stream immediately with `retry: 0` makes the engine
+  reconnect as fast as the host pumps it. The concurrency cap bounds how many such streams
+  exist, not how often each retries.
+- No cap on total bytes or on event count over the life of a connection: the per-event cap
+  bounds memory, not throughput.
+- `withCredentials` is accepted and ignored, so neither a script nor a host may rely on it.
+- The residuals of TM-21 that are about destinations rather than duration — DNS rebinding, the
+  shared process-wide `HttpClient` — apply here unchanged.
+
+**Required host action.** Treat it as you would `UseFetch`: allow-list destinations with
+`UrlFilter`, drop `http` from `AllowedSchemes`, and lower `MaxResponseBytes` and
+`MaxConcurrentRequests`. Additionally, because there is no deadline: bound the *lifetime* of
+the engine itself for untrusted script — one worker per request, discarded when the request
+ends — rather than pooling an engine that a script may leave streaming.
+
 ## Hardened deployment baseline
 
 The numbers below are examples only. Measure normal workloads and choose smaller limits that

--- a/Jint.Tests.PublicInterface/WebApiEventSourceTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiEventSourceTests.cs
@@ -1,0 +1,525 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Jint;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// <c>EventSource</c> seen from outside the assembly: the policy a host writes, the thread its events arrive
+/// on, and what a restore does to a connection that is still open.
+/// </summary>
+/// <remarks>
+/// This project has no <c>InternalsVisibleTo</c>, so everything here is reachable by a third party — the stub
+/// transport goes in through <c>Options.WebApi.Fetch.HttpClient</c>, the same door a host uses for a
+/// <c>DelegatingHandler</c> or an <c>IHttpClientFactory</c> client, and it is the same group <c>fetch</c>
+/// reads because server-sent events deliberately share it.
+/// </remarks>
+public class WebApiEventSourceTests
+{
+    private const string StreamUrl = "https://example.org/stream";
+
+    /// <summary>
+    /// A clock that only moves when a test moves it, so the reconnect delay is exact and instant.
+    /// </summary>
+    private sealed class ManualClock : TimeProvider
+    {
+        private long _timestamp;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp() => Volatile.Read(ref _timestamp);
+
+        public override DateTimeOffset GetUtcNow() => DateTimeOffset.UnixEpoch.AddTicks(Volatile.Read(ref _timestamp));
+
+        internal void Advance(long milliseconds) => Volatile.Write(ref _timestamp, Volatile.Read(ref _timestamp) + (milliseconds * TimeSpan.TicksPerMillisecond));
+    }
+
+    /// <summary>
+    /// A handler that answers each attempt with what the test told it to, or hangs until its token is
+    /// cancelled, and remembers which.
+    /// </summary>
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        internal List<string> Urls { get; } = new();
+
+        internal bool Hang { get; init; }
+
+        internal Func<int, HttpResponseMessage> Responder { get; init; } = static _ => Answer("data: ok\n\n");
+
+        /// <summary>Set when the handler saw its cancellation token fire — the proof a close reached the socket.</summary>
+        internal ManualResetEventSlim Cancelled { get; } = new(false);
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            int attempt;
+            lock (Urls)
+            {
+                Urls.Add(request.RequestUri!.ToString());
+                attempt = Urls.Count - 1;
+            }
+
+            if (!Hang)
+            {
+                return Responder(attempt);
+            }
+
+            try
+            {
+                await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                Cancelled.Set();
+                throw;
+            }
+
+            return Responder(attempt);
+        }
+
+        internal int RequestCount
+        {
+            get
+            {
+                lock (Urls)
+                {
+                    return Urls.Count;
+                }
+            }
+        }
+    }
+
+    private static HttpResponseMessage Answer(string body, string contentType = "text/event-stream", HttpStatusCode status = HttpStatusCode.OK)
+    {
+        var content = new ByteArrayContent(Encoding.UTF8.GetBytes(body));
+        content.Headers.TryAddWithoutValidation("content-type", contentType);
+        return new HttpResponseMessage(status) { Content = content };
+    }
+
+    private static (Engine Engine, ManualClock Clock, List<string> Records) SseEngine(
+        HttpMessageHandler handler,
+        Action<Options.FetchOptions>? configure = null,
+        Action<Options>? extra = null)
+    {
+        var clock = new ManualClock();
+        var records = new List<string>();
+
+        var engine = new Engine(options =>
+        {
+            options.WebApi.Timers.TimeProvider = clock;
+            options.UseEventSource(net =>
+            {
+                net.HttpClient = new HttpClient(handler);
+                configure?.Invoke(net);
+            });
+
+            options.Configure(e => e.SetValue("record", new Action<string>(entry =>
+            {
+                lock (records)
+                {
+                    records.Add(entry);
+                }
+            })));
+
+            extra?.Invoke(options);
+        });
+
+        return (engine, clock, records);
+    }
+
+    private static int Count(List<string> records)
+    {
+        lock (records)
+        {
+            return records.Count;
+        }
+    }
+
+    private static string Joined(List<string> records)
+    {
+        lock (records)
+        {
+            return string.Join("|", records);
+        }
+    }
+
+    /// <summary>
+    /// Pumps the engine from the host's own thread, which is the only way anything an event source produces
+    /// is delivered at all.
+    /// </summary>
+    private static void Pump(Engine engine, Func<bool> until, string expectation)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(15);
+        while (DateTime.UtcNow < deadline)
+        {
+            engine.Advanced.ProcessTasks();
+            if (until())
+            {
+                return;
+            }
+
+            Thread.Sleep(2);
+        }
+
+        throw new TimeoutException($"Timed out waiting for {expectation}.");
+    }
+
+    private static void Idle(Engine engine)
+    {
+        for (var i = 0; i < 25; i++)
+        {
+            engine.Advanced.ProcessTasks();
+            Thread.Sleep(2);
+        }
+    }
+
+    /// <summary>
+    /// Opens a stream and attaches the three handlers in <b>one</b> script, because <c>Execute</c> drains the
+    /// event loop on its way out: a failure the constructor queued — a URL the policy refused, a slot the
+    /// concurrency limit would not give — has already been delivered by the time a second <c>Execute</c>
+    /// could attach a listener to hear it.
+    /// </summary>
+    private static void Start(Engine engine, string variable, string url)
+    {
+        engine.Execute($$"""
+            var {{variable}} = new EventSource('{{url}}');
+            {{variable}}.onopen = () => record('open');
+            {{variable}}.onmessage = e => record('message:' + e.data);
+            {{variable}}.onerror = () => record('error:' + {{variable}}.readyState);
+            """);
+    }
+
+    [Fact]
+    public void ADefaultEngineAndAUseWebApisEngineHaveNoEventSource()
+    {
+        new Engine().Evaluate("typeof EventSource").AsString().Should().Be("undefined");
+        new Engine(options => options.UseWebApis()).Evaluate("typeof EventSource").AsString().Should().Be("undefined");
+        new Engine(options => options.UseWebApis(WebApiFeatures.Default)).Evaluate("'EventSource' in globalThis").AsBoolean().Should().BeFalse();
+
+        // Network access is granted one API at a time: fetch does not bring server-sent events with it.
+        new Engine(options => options.UseFetch()).Evaluate("typeof EventSource").AsString().Should().Be("undefined");
+
+        // ... and server-sent events do not bring fetch.
+        var engine = new Engine(options => options.UseEventSource());
+        engine.Evaluate("typeof EventSource").AsString().Should().Be("function");
+        engine.Evaluate("typeof MessageEvent").AsString().Should().Be("function");
+        engine.Evaluate("typeof fetch").AsString().Should().Be("undefined");
+
+        // The features it does bring are the ones its own surface is built from.
+        engine.Evaluate("typeof EventTarget").AsString().Should().Be("function");
+    }
+
+    [Fact]
+    public void RefusesASchemeTheHostDidNotAllow()
+    {
+        var handler = new StubHandler();
+        var (engine, _, records) = SseEngine(handler, net => net.AllowedSchemes.Remove("http"));
+
+        Start(engine, "es", "http://example.org/stream");
+        Pump(engine, () => Count(records) > 0, "the error event");
+
+        Joined(records).Should().Be("error:2");
+        handler.RequestCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void RefusesAUrlTheHostFilterRejects()
+    {
+        var handler = new StubHandler();
+        var (engine, _, records) = SseEngine(handler, net => net.UrlFilter = uri => uri.Host.EndsWith(".example.org", StringComparison.OrdinalIgnoreCase));
+
+        Start(engine, "es", "https://169.254.169.254/latest/meta-data/");
+        Pump(engine, () => Count(records) > 0, "the error event");
+
+        // The failure carries no detail at all — the standard gives an event source's error event none — and
+        // nothing reached a socket.
+        Joined(records).Should().Be("error:2");
+        handler.RequestCount.Should().Be(0);
+
+        engine.Execute("var allowed = new EventSource('https://api.example.org/stream');");
+        Pump(engine, () => handler.RequestCount == 1, "the allowed stream");
+    }
+
+    [Fact]
+    public void ReRunsTheFilterOnEveryRedirectHop()
+    {
+        // The SSRF shape, and the reason Jint follows redirects itself: the first URL passes the filter and
+        // the server answers with a redirect to one that does not.
+        var handler = new StubHandler
+        {
+            Responder = _ =>
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.Found);
+                response.Headers.TryAddWithoutValidation("location", "http://169.254.169.254/latest/meta-data/");
+                return response;
+            },
+        };
+
+        var seen = new List<string>();
+        var (engine, clock, records) = SseEngine(handler, net => net.UrlFilter = uri =>
+        {
+            lock (seen)
+            {
+                seen.Add(uri.ToString());
+            }
+
+            return uri.Host.EndsWith(".example.org", StringComparison.OrdinalIgnoreCase);
+        });
+
+        Start(engine, "es", "https://api.example.org/a");
+        Pump(engine, () => Count(records) > 0, "the failure of the redirected connection");
+
+        // CLOSED, not CONNECTING: a policy refusal is the host's own rule rather than a network error, and
+        // retrying it would only run into the same rule again — so, like every other host limit, it fails the
+        // connection for good instead of reconnecting.
+        Joined(records).Should().Be("error:2");
+
+        lock (seen)
+        {
+            seen.Should().Equal("https://api.example.org/a", "http://169.254.169.254/latest/meta-data/");
+        }
+
+        handler.Urls.Should().Equal("https://api.example.org/a");
+
+        engine.Execute("es.close();");
+        clock.Advance(60_000);
+        Idle(engine);
+        handler.RequestCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void CloseCancelsTheRequestInFlight()
+    {
+        var handler = new StubHandler { Hang = true };
+        var (engine, _, records) = SseEngine(handler);
+
+        Start(engine, "es", StreamUrl);
+        Pump(engine, () => handler.RequestCount == 1, "the request to reach the transport");
+
+        engine.Execute("es.close();");
+
+        // The abort reached the socket, not just the object.
+        handler.Cancelled.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+
+        engine.Evaluate("es.readyState").AsNumber().Should().Be(2);
+
+        // And closing fires nothing: it is not a failure, so there is no error event.
+        Idle(engine);
+        Joined(records).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ARestoreCancelsTheConnectionAndDeliversNothingIntoTheRestoredEngine()
+    {
+        var handler = new StubHandler { Hang = true };
+        var (engine, _, records) = SseEngine(handler);
+
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+        Start(engine, "es", StreamUrl);
+        Pump(engine, () => handler.RequestCount == 1, "the request to reach the transport");
+
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        // The socket is let go at once ...
+        handler.Cancelled.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+
+        // ... and nothing from the ended cycle ever reaches the restored engine.
+        Idle(engine);
+        Count(records).Should().Be(0);
+
+        // The engine is perfectly usable afterwards.
+        engine.Evaluate("typeof EventSource").AsString().Should().Be("function");
+        engine.Evaluate("typeof es").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void ARestoreAlsoTakesTheReconnectDelayWithIt()
+    {
+        // The stream ends by itself, which is a reestablish: an error event and a delay on the timer queue.
+        var handler = new StubHandler { Responder = _ => Answer("retry: 10\ndata: one\n\n") };
+        var (engine, clock, records) = SseEngine(handler);
+
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+        Start(engine, "es", StreamUrl);
+        Pump(engine, () => Count(records) >= 3, "the open, message and error events");
+
+        Joined(records).Should().Be("open|message:one|error:0");
+
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        // A timer registered by the ended cycle can never fire into the restored globals, so the reconnection
+        // that was pending simply never happens.
+        clock.Advance(60_000);
+        Idle(engine);
+
+        handler.RequestCount.Should().Be(1);
+        Count(records).Should().Be(3);
+    }
+
+    [Fact]
+    public void AnEngineCancellationEndsTheConnectionSilently()
+    {
+        // A constraint that became an error event would let the script carry on — and reconnect — which is
+        // precisely what the constraint exists to stop.
+        var handler = new StubHandler { Hang = true };
+        using var cancellation = new CancellationTokenSource();
+
+        var (engine, clock, records) = SseEngine(handler, extra: options => options.CancellationToken(cancellation.Token));
+
+        Start(engine, "es", StreamUrl);
+        Pump(engine, () => handler.RequestCount == 1, "the request to reach the transport");
+
+        cancellation.Cancel();
+        handler.Cancelled.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+
+        clock.Advance(60_000);
+        Idle(engine);
+
+        Count(records).Should().Be(0);
+        handler.RequestCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void BoundsHowManyStreamsOneEngineMayHaveOpen()
+    {
+        var handler = new StubHandler { Hang = true };
+        var (engine, _, records) = SseEngine(handler, net => net.MaxConcurrentRequests = 1);
+
+        engine.Execute($$"""
+            var first = new EventSource('{{StreamUrl}}/1');
+            var second = new EventSource('{{StreamUrl}}/2');
+            second.onerror = () => record('error:' + second.readyState);
+            """);
+        Pump(engine, () => Count(records) > 0, "the second connection failing");
+
+        Joined(records).Should().Be("error:2");
+        engine.Evaluate("first.readyState").AsNumber().Should().Be(0);
+        handler.RequestCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void TheHostClientFactoryWinsAndSeesTheEngine()
+    {
+        var byFactory = new StubHandler();
+        var byProperty = new StubHandler();
+        var seen = new List<object?>();
+
+        var (engine, _, records) = SseEngine(byProperty, net => net.HttpClientFactory = e =>
+        {
+            // Called on the engine thread, once per connection, so per-request host state is reachable.
+            lock (seen)
+            {
+                seen.Add(e.Advanced.HostDefined);
+            }
+
+            return new HttpClient(byFactory);
+        });
+
+        engine.Advanced.HostDefined = "tenant-a";
+        Start(engine, "es", StreamUrl);
+        Pump(engine, () => Count(records) >= 2, "the open and message events");
+
+        Joined(records).Should().StartWith("open|message:ok");
+        byProperty.RequestCount.Should().Be(0);
+
+        lock (seen)
+        {
+            // The stream ends by itself, so a reconnection is pending — the factory has been asked once, for
+            // the one connection that has been made, and the clock has not moved.
+            seen.Should().Equal("tenant-a");
+        }
+    }
+
+    [Fact]
+    public void SeveralEnginesFromOneOptionsInstanceCountTheirStreamsSeparately()
+    {
+        var handler = new StubHandler { Hang = true };
+        var options = new Options().UseEventSource(net =>
+        {
+            net.HttpClient = new HttpClient(handler);
+            net.MaxConcurrentRequests = 1;
+        });
+
+        var first = new Engine(options);
+        var second = new Engine(options);
+
+        first.Execute("var es = new EventSource('" + StreamUrl + "/1');");
+        second.Execute("var es = new EventSource('" + StreamUrl + "/2');");
+
+        Pump(second, () => handler.RequestCount == 2, "both engines reaching the transport");
+
+        // The second engine's stream was not refused by the first engine's slot being taken.
+        second.Evaluate("es.readyState").AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void TheGlobalsCarryTheAttributesWebIdlAsksFor()
+    {
+        var engine = new Engine(options => options.UseEventSource());
+
+        foreach (var name in new[] { "EventSource", "MessageEvent" })
+        {
+            // https://webidl.spec.whatwg.org/#es-interfaces — an interface object is writable and
+            // configurable but not enumerable.
+            var descriptor = engine.Evaluate($"Object.getOwnPropertyDescriptor(globalThis, '{name}')").AsObject();
+            descriptor.Get("writable").AsBoolean().Should().BeTrue();
+            descriptor.Get("enumerable").AsBoolean().Should().BeFalse();
+            descriptor.Get("configurable").AsBoolean().Should().BeTrue();
+
+            // ... and never inside a shadow realm.
+            engine.Evaluate($"new ShadowRealm().evaluate('typeof {name}')").AsString().Should().Be("undefined");
+        }
+    }
+
+    [Fact]
+    public void AHostGlobalOfTheSameNameWins()
+    {
+        var engine = new Engine(options => options
+            .Configure(e => e.SetValue("EventSource", "host's own"))
+            .UseEventSource());
+
+        engine.Evaluate("EventSource").AsString().Should().Be("host's own");
+    }
+
+    [Fact]
+    public void EveryListenerRunsOnTheHostsOwnThread()
+    {
+        // The shape a game loop or a message pump uses. The response is read on a thread pool thread, but
+        // every listener runs on whichever thread pumped the engine — which is the whole point of the design,
+        // and the reason a host can touch its own state from one without a lock.
+        var handler = new StubHandler { Responder = _ => Answer("data: one\n\ndata: two\n\n") };
+        var (engine, _, records) = SseEngine(handler);
+
+        var threads = new List<int>();
+        engine.SetValue("recordThread", new Action(() =>
+        {
+            lock (threads)
+            {
+                threads.Add(Environment.CurrentManagedThreadId);
+            }
+        }));
+
+        engine.Execute($$"""
+            var es = new EventSource('{{StreamUrl}}');
+            es.onopen = () => { recordThread(); record('open'); };
+            es.onmessage = e => { recordThread(); record('message:' + e.data); };
+            """);
+
+        Pump(engine, () => Count(records) >= 3, "the open event and two messages");
+        Joined(records).Should().StartWith("open|message:one|message:two");
+
+        lock (threads)
+        {
+            threads.Should().HaveCountGreaterThanOrEqualTo(3);
+            threads.Should().AllSatisfy(id => id.Should().Be(Environment.CurrentManagedThreadId));
+        }
+
+        engine.Execute("es.close();");
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/EventSourceTests.cs
+++ b/Jint.Tests/Runtime/WebApi/EventSourceTests.cs
@@ -1,0 +1,864 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// <c>EventSource</c> against the server-sent events section —
+/// https://html.spec.whatwg.org/multipage/server-sent-events.html — driven by a stub
+/// <see cref="HttpMessageHandler"/>, so nothing here touches a network.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every engine here runs on a <see cref="ManualClock"/>, so the reconnect delay — which rides the engine's
+/// timer queue — only elapses when a test says so. A test that never advances it therefore never sees a
+/// reconnection, however long it takes to run.
+/// </para>
+/// <para>
+/// The events themselves arrive as event-loop jobs queued from a thread pool thread, so a test pumps until it
+/// sees what it is waiting for rather than asserting straight after <c>Execute</c>. That is the same contract
+/// a host has: nothing at all is delivered to an engine nobody pumps.
+/// </para>
+/// </remarks>
+public class EventSourceTests
+{
+    private const string StreamUrl = "https://example.org/stream";
+
+    /// <summary>
+    /// A clock that only moves when a test moves it, so the reconnect delay is exact and instant.
+    /// </summary>
+    private sealed class ManualClock : TimeProvider
+    {
+        private long _timestamp;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp() => Volatile.Read(ref _timestamp);
+
+        public override DateTimeOffset GetUtcNow() => DateTimeOffset.UnixEpoch.AddTicks(Volatile.Read(ref _timestamp));
+
+        internal void Advance(long milliseconds) => Volatile.Write(ref _timestamp, Volatile.Read(ref _timestamp) + (milliseconds * TimeSpan.TicksPerMillisecond));
+    }
+
+    /// <summary>
+    /// A stream a test writes into and completes by hand, which is what an open connection looks like.
+    /// </summary>
+    private sealed class PushStream : Stream
+    {
+        private readonly Channel<byte[]> _chunks = Channel.CreateUnbounded<byte[]>();
+        private byte[]? _current;
+        private int _offset;
+
+        internal void Push(string text) => _chunks.Writer.TryWrite(Encoding.UTF8.GetBytes(text));
+
+        internal void Push(byte[] bytes) => _chunks.Writer.TryWrite(bytes);
+
+        /// <summary>Ends the response body, which is what makes the next read answer zero.</summary>
+        internal void Complete() => _chunks.Writer.TryComplete();
+
+        /// <summary>
+        /// Set when a read was cancelled — the proof that ending the connection reached the transport rather
+        /// than only the <c>EventSource</c> object.
+        /// </summary>
+        internal ManualResetEventSlim ReadCancelled { get; } = new(false);
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            while (_current is null || _offset == _current.Length)
+            {
+                _current = null;
+                _offset = 0;
+
+                bool available;
+                try
+                {
+                    available = await _chunks.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    ReadCancelled.Set();
+                    throw;
+                }
+
+                if (!available)
+                {
+                    return 0;
+                }
+
+                _chunks.Reader.TryRead(out _current);
+            }
+
+            var count = Math.Min(buffer.Length, _current.Length - _offset);
+            _current.AsSpan(_offset, count).CopyTo(buffer.Span);
+            _offset += count;
+            return count;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// A handler that answers each attempt with whatever the test told it to, and remembers what it was asked.
+    /// </summary>
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly List<CancellationTokenRegistration> _registrations = new();
+
+        internal List<RecordedRequest> Requests { get; } = new();
+
+        internal Func<int, HttpResponseMessage> Responder { get; set; } = static _ => Answer("");
+
+        /// <summary>Set when the handler saw its cancellation token fire — the proof a close reached the socket.</summary>
+        internal ManualResetEventSlim Cancelled { get; } = new(false);
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            int attempt;
+            lock (Requests)
+            {
+                var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var header in request.Headers.NonValidated)
+                {
+                    headers[header.Key] = header.Value.ToString();
+                }
+
+                Requests.Add(new RecordedRequest(request.Method.Method, request.RequestUri!.ToString(), headers));
+                attempt = Requests.Count - 1;
+            }
+
+            _registrations.Add(cancellationToken.Register(() => Cancelled.Set()));
+            return Task.FromResult(Responder(attempt));
+        }
+    }
+
+    private sealed record RecordedRequest(string Method, string Url, Dictionary<string, string> Headers)
+    {
+        internal string? Header(string name) => Headers.TryGetValue(name, out var value) ? value : null;
+    }
+
+    private static HttpResponseMessage Answer(string body, string contentType = "text/event-stream", HttpStatusCode status = HttpStatusCode.OK)
+    {
+        var content = new ByteArrayContent(Encoding.UTF8.GetBytes(body));
+        content.Headers.TryAddWithoutValidation("content-type", contentType);
+        return new HttpResponseMessage(status) { Content = content };
+    }
+
+    private static HttpResponseMessage Answer(PushStream stream, string contentType = "text/event-stream")
+    {
+        var content = new StreamContent(stream);
+        content.Headers.TryAddWithoutValidation("content-type", contentType);
+        return new HttpResponseMessage(HttpStatusCode.OK) { Content = content };
+    }
+
+    private static (Engine Engine, ManualClock Clock) SseEngine(HttpMessageHandler handler, Action<Options.FetchOptions>? configure = null)
+    {
+        var clock = new ManualClock();
+        var engine = new Engine(options =>
+        {
+            options.WebApi.Timers.TimeProvider = clock;
+            options.UseEventSource(net =>
+            {
+                net.HttpClient = new HttpClient(handler);
+                configure?.Invoke(net);
+            });
+        });
+
+        // The separator is a tilde rather than a colon because an event's data may be empty, or may itself
+        // contain a colon, and an ambiguous log makes for an assertion that cannot fail honestly.
+        engine.Execute("""
+            var log = [];
+            function watch(source) {
+                source.onopen = () => log.push('open~' + source.readyState);
+                source.onmessage = e => log.push('message~' + e.type + '~' + e.data + '~' + e.lastEventId + '~' + e.origin);
+                source.onerror = () => log.push('error~' + source.readyState);
+                return source;
+            }
+            """);
+
+        return (engine, clock);
+    }
+
+    private static string Log(Engine engine) => engine.Evaluate("log.join('|')").AsString();
+
+    /// <summary>
+    /// The first <paramref name="entries"/> of the log. A stream that has ended queues an <c>error</c> of its
+    /// own, and whether that has arrived yet is a race; what each test is about is what came before it.
+    /// </summary>
+    private static string Log(Engine engine, int entries) => engine.Evaluate($"log.slice(0, {entries}).join('|')").AsString();
+
+    /// <summary>
+    /// Pumps the engine until <paramref name="until"/> holds, which is what a host's own loop does. Nothing
+    /// an event source produces is delivered any other way.
+    /// </summary>
+    private static void Pump(Engine engine, Func<bool> until, string expectation)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(15);
+        while (DateTime.UtcNow < deadline)
+        {
+            engine.Advanced.ProcessTasks();
+            if (until())
+            {
+                return;
+            }
+
+            Thread.Sleep(2);
+        }
+
+        throw new TimeoutException($"Timed out waiting for {expectation}. The log holds: {Log(engine)}");
+    }
+
+    private static void PumpUntilLogHas(Engine engine, int entries, string expectation)
+        => Pump(engine, () => engine.Evaluate("log.length").AsNumber() >= entries, expectation);
+
+    [Fact]
+    public void DispatchesAMessageEventForEachBlankLineTerminatedBlock()
+    {
+        // The standard's own example: "the event's data attribute would contain the string YHOO\n+2\n10".
+        var handler = new StubHandler { Responder = _ => Answer("data: YHOO\ndata: +2\ndata: 10\n\n") };
+        var (engine, _) = SseEngine(handler);
+
+        engine.Execute($"var es = watch(new EventSource('{StreamUrl}'));");
+        PumpUntilLogHas(engine, 2, "the open and message events");
+
+        Log(engine, 2).Should().Be("open~1|message~message~YHOO\n+2\n10~~https://example.org");
+
+        // The request the standard describes: a GET announcing what it wants and refusing a cached answer.
+        var request = handler.Requests.Should().ContainSingle().Subject;
+        request.Method.Should().Be("GET");
+        request.Header("accept").Should().Be("text/event-stream");
+        request.Header("cache-control").Should().Be("no-cache");
+        request.Header("last-event-id").Should().BeNull();
+    }
+
+    [Fact]
+    public void AnEventFieldRenamesTheEventAndAnIdFieldOutlivesIt()
+    {
+        // The standard's second worked example, minus the comment: an id sticks until the server changes it,
+        // and an "id" with no value resets it.
+        var handler = new StubHandler
+        {
+            Responder = _ => Answer(": keep-alive\n\ndata: first\nid: 1\n\nevent: ping\ndata: second\n\ndata: third\nid\n\n"),
+        };
+
+        var (engine, _) = SseEngine(handler);
+
+        engine.Execute($"""
+            var es = watch(new EventSource('{StreamUrl}'));
+            es.addEventListener('ping', e => log.push('ping~' + e.data + '~' + e.lastEventId));
+            """);
+
+        PumpUntilLogHas(engine, 4, "the open event and three dispatches");
+
+        // The renamed event reaches addEventListener and not onmessage, which is what makes a custom type
+        // worth sending; the id set by the first block is still on the second and third.
+        Log(engine, 4).Should().Be(
+            "open~1|message~message~first~1~https://example.org|ping~second~1|message~message~third~~https://example.org");
+    }
+
+    [Fact]
+    public void ACommentOnlyStreamDispatchesNothingAndKeepsTheConnectionOpen()
+    {
+        var stream = new PushStream();
+        var handler = new StubHandler { Responder = _ => Answer(stream) };
+        var (engine, _) = SseEngine(handler);
+
+        engine.Execute($"var es = watch(new EventSource('{StreamUrl}'));");
+
+        // A comment is the keep-alive of the protocol: it is a line, so it proves the connection is alive,
+        // and it produces no event.
+        stream.Push(":\n: keep-alive\n\n");
+        PumpUntilLogHas(engine, 1, "the open event");
+
+        for (var i = 0; i < 20; i++)
+        {
+            engine.Advanced.ProcessTasks();
+            Thread.Sleep(2);
+        }
+
+        Log(engine).Should().Be("open~1");
+        engine.Evaluate("es.readyState").AsNumber().Should().Be(1);
+
+        engine.Execute("es.close();");
+        stream.Complete();
+    }
+
+    [Fact]
+    public void ParsesTheFieldGrammarTheStandardSpellsOut()
+    {
+        // "The following stream fires two events" — the first with the empty string, the middle with a single
+        // newline, and the last block discarded because no blank line follows it.
+        var handler = new StubHandler { Responder = _ => Answer("data\n\ndata\ndata\n\ndata:\n") };
+        var (engine, _) = SseEngine(handler);
+
+        engine.Execute($"var es = watch(new EventSource('{StreamUrl}'));");
+        PumpUntilLogHas(engine, 3, "the open event and two dispatches");
+
+        Log(engine, 3).Should().Be("open~1|message~message~~~https://example.org|message~message~\n~~https://example.org");
+    }
+
+    [Fact]
+    public void RemovesExactlyOneSpaceAfterTheColon()
+    {
+        // "The following stream fires two identical events … because the space after the colon is ignored."
+        var handler = new StubHandler { Responder = _ => Answer("data:test\n\ndata: test\n\ndata:  test\n\n") };
+        var (engine, _) = SseEngine(handler);
+
+        engine.Execute($"var es = watch(new EventSource('{StreamUrl}'));");
+        PumpUntilLogHas(engine, 4, "three dispatches");
+
+        engine.Evaluate("log.slice(1, 4).map(x => x.split('~')[2]).join('|')").AsString().Should().Be("test|test| test");
+    }
+
+    [Fact]
+    public void HandlesEveryLineEndingAndAChunkBoundaryInsideOne()
+    {
+        var stream = new PushStream();
+        var handler = new StubHandler { Responder = _ => Answer(stream) };
+        var (engine, _) = SseEngine(handler);
+
+        engine.Execute($"var es = watch(new EventSource('{StreamUrl}'));");
+        PumpUntilLogHas(engine, 1, "the open event");
+
+        // A CRLF split across two reads: the CR ends the line and the LF that opens the next chunk must not
+        // end an empty one, or the event would be dispatched a field early.
+        stream.Push("data: crlf\r");
+        PumpUntilLogHas(engine, 1, "no dispatch yet");
+        stream.Push("\ndata: more\r\n\r\n");
+
+        // A lone CR and a lone LF are line endings of their own.
+        stream.Push("data: cr\r\rdata: lf\n\n");
+        PumpUntilLogHas(engine, 4, "three dispatches");
+
+        Log(engine, 4).Should().Be(
+            "open~1|message~message~crlf\nmore~~https://example.org|message~message~cr~~https://example.org|message~message~lf~~https://example.org");
+
+        engine.Execute("es.close();");
+        stream.Complete();
+    }
+
+    [Fact]
+    public void StripsOneLeadingByteOrderMark()
+    {
+        // "The UTF-8 decode algorithm strips one leading UTF-8 Byte Order Mark (BOM), if any" — a BOM left in
+        // place would make the first field name "﻿data", which is not a field name at all.
+        var body = new List<byte> { 0xEF, 0xBB, 0xBF };
+        body.AddRange(Encoding.UTF8.GetBytes("data: hello\n\n"));
+
+        var handler = new StubHandler
+        {
+            Responder = _ =>
+            {
+                var content = new ByteArrayContent(body.ToArray());
+                content.Headers.TryAddWithoutValidation("content-type", "text/event-stream");
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = content };
+            },
+        };
+
+        var (engine, _) = SseEngine(handler);
+        engine.Execute($"var es = watch(new EventSource('{StreamUrl}'));");
+        PumpUntilLogHas(engine, 2, "the message event");
+
+        Log(engine, 2).Should().Be("open~1|message~message~hello~~https://example.org");
+    }
+
+    [Fact]
+    public void DecodesUtf8AcrossAChunkBoundary()
+    {
+        var stream = new PushStream();
+        var handler = new StubHandler { Responder = _ => Answer(stream) };
+        var (engine, _) = SseEngine(handler);
+
+        engine.Execute($"var es = watch(new EventSource('{StreamUrl}'));");
+        PumpUntilLogHas(engine, 1, "the open event");
+
+        // The two halves of one UTF-8 sequence, in two reads.
+        var bytes = Encoding.UTF8.GetBytes("data: héllo\n\n");
+        stream.Push(bytes[..7]);
+        stream.Push(bytes[7..]);
+
+        PumpUntilLogHas(engine, 2, "the message event");
+        Log(engine, 2).Should().Be("open~1|message~message~héllo~~https://example.org");
+
+        engine.Execute("es.close();");
+        stream.Complete();
+    }
+
+    [Fact]
+    public void ReadyStateFollowsTheConnectionAndTheConstantsAreOnBothObjects()
+    {
+        var stream = new PushStream();
+        var handler = new StubHandler { Responder = _ => Answer(stream) };
+        var (engine, _) = SseEngine(handler);
+
+        // "When the object is created, its readyState must be set to CONNECTING (0)." Read inside the script,
+        // because Execute drains the event loop on its way out and the connection may have opened by then.
+        engine.Evaluate($"(() => {{ var s = new EventSource('{StreamUrl}'); var state = s.readyState; s.close(); return state; }})()")
+            .AsNumber().Should().Be(0);
+
+        engine.Execute($"var es = watch(new EventSource('{StreamUrl}'));");
+        engine.Evaluate("es.url").AsString().Should().Be(StreamUrl);
+        engine.Evaluate("es.withCredentials").AsBoolean().Should().BeFalse();
+
+        PumpUntilLogHas(engine, 1, "the open event");
+        engine.Evaluate("es.readyState").AsNumber().Should().Be(1);
+
+        engine.Execute("es.close();");
+        engine.Evaluate("es.readyState").AsNumber().Should().Be(2);
+
+        // https://webidl.spec.whatwg.org/#es-constants — on the interface object and on the prototype.
+        engine.Evaluate("[EventSource.CONNECTING, EventSource.OPEN, EventSource.CLOSED].join(',')").AsString().Should().Be("0,1,2");
+        engine.Evaluate("[EventSource.prototype.CONNECTING, EventSource.prototype.OPEN, EventSource.prototype.CLOSED].join(',')").AsString().Should().Be("0,1,2");
+
+        var descriptor = engine.Evaluate("Object.getOwnPropertyDescriptor(EventSource, 'OPEN')").AsObject();
+        descriptor.Get("writable").AsBoolean().Should().BeFalse();
+        descriptor.Get("enumerable").AsBoolean().Should().BeTrue();
+        descriptor.Get("configurable").AsBoolean().Should().BeFalse();
+
+        stream.Complete();
+    }
+
+    [Fact]
+    public void CloseStopsEverythingAndDispatchesNothingFurther()
+    {
+        var stream = new PushStream();
+        var handler = new StubHandler { Responder = _ => Answer(stream) };
+        var (engine, _) = SseEngine(handler);
+
+        engine.Execute($"var es = watch(new EventSource('{StreamUrl}'));");
+        PumpUntilLogHas(engine, 1, "the open event");
+
+        // Pushed before the close and delivered after it: step 8 of the dispatch steps only dispatches "if
+        // the readyState attribute is set to a value other than CLOSED".
+        stream.Push("data: dropped\n\n");
+        engine.Execute("es.close();");
+
+        for (var i = 0; i < 20; i++)
+        {
+            engine.Advanced.ProcessTasks();
+            Thread.Sleep(2);
+        }
+
+        Log(engine).Should().Be("open~1");
+        engine.Evaluate("es.readyState").AsNumber().Should().Be(2);
+
+        // The transport was told, not just the object: the read in flight was cancelled.
+        stream.ReadCancelled.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+
+        stream.Complete();
+    }
+
+    [Fact]
+    public void CloseFromInsideAListenerStopsTheRestOfTheSameChunk()
+    {
+        // Both events arrive in one read and are delivered by one job, so the readyState is what stops the
+        // second — step 8 of the dispatch steps is a task per event, and each of them asks again.
+        var handler = new StubHandler { Responder = _ => Answer("data: one\n\ndata: two\n\n") };
+        var (engine, _) = SseEngine(handler);
+
+        engine.Execute($$"""
+            var es = watch(new EventSource('{{StreamUrl}}'));
+            es.addEventListener('message', e => { if (e.data === 'one') { es.close(); } });
+            """);
+
+        PumpUntilLogHas(engine, 2, "the open and first message events");
+
+        for (var i = 0; i < 20; i++)
+        {
+            engine.Advanced.ProcessTasks();
+            Thread.Sleep(2);
+        }
+
+        Log(engine).Should().Be("open~1|message~message~one~~https://example.org");
+        engine.Evaluate("es.readyState").AsNumber().Should().Be(2);
+    }
+
+    [Fact]
+    public void AWrongContentTypeFailsTheConnectionForGood()
+    {
+        // "if res's status is not 200, or if res's Content-Type is not text/event-stream, then fail the
+        // connection" — and "once the user agent has failed the connection, it does not attempt to reconnect".
+        var handler = new StubHandler { Responder = _ => Answer("data: nope\n\n", "text/plain") };
+        var (engine, clock) = SseEngine(handler);
+
+        engine.Execute($"var es = watch(new EventSource('{StreamUrl}'));");
+        PumpUntilLogHas(engine, 1, "the error event");
+
+        Log(engine).Should().Be("error~2");
+        engine.Evaluate("es.readyState").AsNumber().Should().Be(2);
+
+        clock.Advance(60_000);
+        engine.Advanced.ProcessTasks();
+        handler.Requests.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void AContentTypeWithParametersIsStillAnEventStream()
+    {
+        // The check is on the MIME type essence, so a charset parameter changes nothing.
+        var handler = new StubHandler { Responder = _ => Answer("data: ok\n\n", "TEXT/Event-Stream; charset=utf-8") };
+        var (engine, _) = SseEngine(handler);
+
+        engine.Execute($"var es = watch(new EventSource('{StreamUrl}'));");
+        PumpUntilLogHas(engine, 2, "the message event");
+
+        engine.Evaluate("log[1]").AsString().Should().Be("message~message~ok~~https://example.org");
+    }
+
+    [Fact]
+    public void ANon200StatusFailsTheConnectionForGood()
+    {
+        var handler = new StubHandler { Responder = _ => Answer("", "text/event-stream", HttpStatusCode.NoContent) };
+        var (engine, clock) = SseEngine(handler);
+
+        engine.Execute($"var es = watch(new EventSource('{StreamUrl}'));");
+        PumpUntilLogHas(engine, 1, "the error event");
+
+        Log(engine).Should().Be("error~2");
+
+        clock.Advance(60_000);
+        engine.Advanced.ProcessTasks();
+        handler.Requests.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void AUrlThePolicyRefusesFailsTheConnectionWithoutOpeningASocket()
+    {
+        var handler = new StubHandler();
+        var (engine, _) = SseEngine(handler, net => net.UrlFilter = uri => !uri.Host.StartsWith("169.254.", StringComparison.Ordinal));
+
+        engine.Execute("var es = watch(new EventSource('https://169.254.169.254/latest/meta-data/'));");
+
+        // The failure is a queued task, not a throw: the constructor answered with an object, exactly as the
+        // standard's step 16 says, and the object then failed.
+        PumpUntilLogHas(engine, 1, "the error event");
+        Log(engine).Should().Be("error~2");
+        handler.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ASchemeTheHostDidNotAllowFailsTheConnection()
+    {
+        var handler = new StubHandler();
+        var (engine, _) = SseEngine(handler, net => net.AllowedSchemes.Remove("http"));
+
+        engine.Execute("var es = watch(new EventSource('http://example.org/stream'));");
+        PumpUntilLogHas(engine, 1, "the error event");
+
+        Log(engine).Should().Be("error~2");
+        handler.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ReconnectsAfterTheStreamEndsUsingTheAnnouncedRetryAndTheLastEventId()
+    {
+        var handler = new StubHandler
+        {
+            Responder = attempt => attempt == 0
+                ? Answer("retry: 250\ndata: one\nid: 42\n\n")
+                : Answer("data: two\n\n"),
+        };
+
+        var (engine, clock) = SseEngine(handler);
+        engine.Execute($"var es = watch(new EventSource('{StreamUrl}'));");
+
+        // The first stream ends by itself, which is a reestablish: error, CONNECTING, and a delay.
+        PumpUntilLogHas(engine, 3, "the open, message and error events");
+        Log(engine).Should().Be("open~1|message~message~one~42~https://example.org|error~0");
+        engine.Evaluate("es.readyState").AsNumber().Should().Be(0);
+
+        // Nothing has been retried yet: the delay is on the timer queue, and this clock has not moved.
+        for (var i = 0; i < 10; i++)
+        {
+            engine.Advanced.ProcessTasks();
+            Thread.Sleep(2);
+        }
+
+        handler.Requests.Should().ContainSingle();
+
+        // Just short of the announced 250ms, then past it.
+        clock.Advance(200);
+        engine.Advanced.ProcessTasks();
+        handler.Requests.Should().ContainSingle();
+
+        clock.Advance(60);
+        PumpUntilLogHas(engine, 5, "the second connection's open and message events");
+
+        Log(engine, 5).Should().Be(
+            "open~1|message~message~one~42~https://example.org|error~0|open~1|message~message~two~42~https://example.org");
+
+        // Step 5 of reestablishing the connection: the last event ID string rides the retry.
+        handler.Requests.Should().HaveCount(2);
+        handler.Requests[1].Header("last-event-id").Should().Be("42");
+    }
+
+    [Fact]
+    public void AReconnectionRunsTheUrlPolicyAgain()
+    {
+        var handler = new StubHandler { Responder = _ => Answer("retry: 10\ndata: one\n\n") };
+        var allow = 1;
+
+        var (engine, clock) = SseEngine(handler, net => net.UrlFilter = _ => Volatile.Read(ref allow) != 0);
+        engine.Execute($"var es = watch(new EventSource('{StreamUrl}'));");
+
+        PumpUntilLogHas(engine, 3, "the first connection ending");
+
+        // Revoking the destination between two attempts really does stop the next one.
+        Volatile.Write(ref allow, 0);
+        clock.Advance(50);
+        PumpUntilLogHas(engine, 4, "the failure of the retry");
+
+        Log(engine).Should().Be("open~1|message~message~one~~https://example.org|error~0|error~2");
+        engine.Evaluate("es.readyState").AsNumber().Should().Be(2);
+        handler.Requests.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void CloseDuringTheReconnectDelayStopsTheRetry()
+    {
+        var handler = new StubHandler { Responder = _ => Answer("retry: 10\ndata: one\n\n") };
+        var (engine, clock) = SseEngine(handler);
+
+        engine.Execute($"var es = watch(new EventSource('{StreamUrl}'));");
+        PumpUntilLogHas(engine, 3, "the first connection ending");
+
+        engine.Execute("es.close();");
+        clock.Advance(1000);
+
+        for (var i = 0; i < 20; i++)
+        {
+            engine.Advanced.ProcessTasks();
+            Thread.Sleep(2);
+        }
+
+        // "If the EventSource object's readyState attribute is not set to CONNECTING, then return."
+        handler.Requests.Should().ContainSingle();
+        engine.Evaluate("es.readyState").AsNumber().Should().Be(2);
+    }
+
+    [Fact]
+    public void AnEventLargerThanTheCapFailsTheConnection()
+    {
+        // MaxResponseBytes cannot bound a stream, so it bounds one event — which is what has to be held in
+        // memory. Like every host limit, exceeding it does not reconnect.
+        var handler = new StubHandler { Responder = _ => Answer("data: " + new string('x', 200) + "\n\n") };
+        var (engine, clock) = SseEngine(handler, net => net.MaxResponseBytes = 64);
+
+        engine.Execute($"var es = watch(new EventSource('{StreamUrl}'));");
+        PumpUntilLogHas(engine, 2, "the open and error events");
+
+        Log(engine).Should().Be("open~1|error~2");
+
+        clock.Advance(60_000);
+        engine.Advanced.ProcessTasks();
+        handler.Requests.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void AnEventAtTheCapStillArrives()
+    {
+        // Fifty x's, plus the "data: " the line itself costs, is what fits under a cap of sixty-four: the cap
+        // is on what the parser holds, which is the data buffer plus the line it is reading.
+        var handler = new StubHandler { Responder = _ => Answer("data: " + new string('x', 50) + "\n\n") };
+        var (engine, _) = SseEngine(handler, net => net.MaxResponseBytes = 64);
+
+        engine.Execute($"var es = watch(new EventSource('{StreamUrl}'));");
+        PumpUntilLogHas(engine, 2, "the message event");
+
+        engine.Evaluate("log[1].split('~')[2].length").AsNumber().Should().Be(50);
+    }
+
+    [Fact]
+    public void RefusesMoreStreamsThanTheHostAllows()
+    {
+        var stream = new PushStream();
+        var handler = new StubHandler { Responder = _ => Answer(stream) };
+        var (engine, _) = SseEngine(handler, net => net.MaxConcurrentRequests = 1);
+
+        engine.Execute($"var first = watch(new EventSource('{StreamUrl}')); var second = watch(new EventSource('{StreamUrl}'));");
+        PumpUntilLogHas(engine, 2, "the first connection opening and the second failing");
+
+        engine.Evaluate("second.readyState").AsNumber().Should().Be(2);
+        engine.Evaluate("first.readyState").AsNumber().Should().Be(1);
+        handler.Requests.Should().ContainSingle();
+
+        // The slot comes back when the stream that held it closes.
+        engine.Execute("first.close();");
+        engine.Execute($"var third = watch(new EventSource('{StreamUrl}'));");
+        Pump(engine, () => engine.Evaluate("third.readyState").AsNumber() == 1, "the third connection opening");
+
+        engine.Execute("third.close();");
+        stream.Complete();
+    }
+
+    [Fact]
+    public void AnUnparsableUrlIsASyntaxErrorDomException()
+    {
+        // Constructor step 4: "if urlRecord is failure, then throw a SyntaxError DOMException" — which is not
+        // the TypeError the fetch interfaces raise for the same mistake.
+        var handler = new StubHandler();
+        var (engine, _) = SseEngine(handler);
+
+        engine.Evaluate("(() => { try { new EventSource('nonsense'); } catch (e) { return e.name + '|' + (e instanceof DOMException); } })()")
+            .AsString().Should().Be("SyntaxError|true");
+
+        engine.Evaluate("(() => { try { new EventSource(); } catch (e) { return e.constructor.name; } })()")
+            .AsString().Should().Be("TypeError");
+
+        handler.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void WithCredentialsIsRememberedAndChangesNothing()
+    {
+        var handler = new StubHandler { Responder = _ => Answer("data: ok\n\n") };
+        var (engine, _) = SseEngine(handler);
+
+        engine.Execute($"var es = watch(new EventSource('{StreamUrl}', {{ withCredentials: true }}));");
+        PumpUntilLogHas(engine, 2, "the message event");
+
+        engine.Evaluate("es.withCredentials").AsBoolean().Should().BeTrue();
+
+        // There is no cookie jar and no credential store for it to select, so the request is the same one.
+        handler.Requests[0].Header("cookie").Should().BeNull();
+        handler.Requests[0].Header("authorization").Should().BeNull();
+    }
+
+    [Fact]
+    public void AnEventSourceIsAnEventTargetAndItsEventsAreEvents()
+    {
+        var handler = new StubHandler { Responder = _ => Answer("data: ok\n\n") };
+        var (engine, _) = SseEngine(handler);
+
+        engine.Execute($"""
+            var es = new EventSource('{StreamUrl}');
+            var seen;
+            es.addEventListener('message', e => seen = e);
+            """);
+
+        Pump(engine, () => !engine.Evaluate("seen").IsUndefined(), "the message event");
+
+        engine.Evaluate("es instanceof EventTarget").AsBoolean().Should().BeTrue();
+        engine.Evaluate("seen instanceof MessageEvent").AsBoolean().Should().BeTrue();
+        engine.Evaluate("seen instanceof Event").AsBoolean().Should().BeTrue();
+        engine.Evaluate("seen.isTrusted").AsBoolean().Should().BeTrue();
+        engine.Evaluate("seen.target === es").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.prototype.toString.call(seen)").AsString().Should().Be("[object MessageEvent]");
+        engine.Evaluate("seen.source").Should().Be(Jint.Native.JsValue.Null);
+        engine.Evaluate("Array.isArray(seen.ports) && seen.ports.length === 0 && Object.isFrozen(seen.ports)").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void MessageEventIsConstructibleWithTheMembersItsDictionaryDeclares()
+    {
+        var handler = new StubHandler();
+        var (engine, _) = SseEngine(handler);
+
+        engine.Evaluate("new MessageEvent('x').data").Should().Be(Jint.Native.JsValue.Null);
+        engine.Evaluate("new MessageEvent('x').origin").AsString().Should().BeEmpty();
+        engine.Evaluate("new MessageEvent('x').lastEventId").AsString().Should().BeEmpty();
+        engine.Evaluate("new MessageEvent('x', { data: 1, origin: 'o', lastEventId: '7' }).data + ':' + new MessageEvent('x', { origin: 'o' }).origin")
+            .AsString().Should().Be("1:o");
+        engine.Evaluate("new MessageEvent('x').isTrusted").AsBoolean().Should().BeFalse();
+        engine.Evaluate("Object.getPrototypeOf(MessageEvent) === Event").AsBoolean().Should().BeTrue();
+
+        // Nothing in this engine is a MessagePort, so anything in either member is a TypeError.
+        engine.Evaluate("(() => { try { new MessageEvent('x', { source: {} }); } catch (e) { return e.constructor.name; } })()")
+            .AsString().Should().Be("TypeError");
+        engine.Evaluate("(() => { try { new MessageEvent('x', { ports: [{}] }); } catch (e) { return e.constructor.name; } })()")
+            .AsString().Should().Be("TypeError");
+        engine.Evaluate("new MessageEvent('x', { ports: [] }).ports.length").AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void InstallsTheInterfaceObjectsBehindItsOwnFlagAndNowhereElse()
+    {
+        foreach (var name in new[] { "EventSource", "MessageEvent" })
+        {
+            new Engine().Evaluate($"typeof {name}").AsString().Should().Be("undefined");
+
+            // EventSource is not in the default set and is not brought along by fetch either: two separate
+            // grants. MessageEvent is different — the messaging feature is part of Default and installs the
+            // same intrinsic — so only the network grant claims hold for it.
+            if (name == "EventSource")
+            {
+                new Engine(options => options.UseWebApis()).Evaluate($"typeof {name}").AsString().Should().Be("undefined");
+            }
+
+            new Engine(options => options.UseFetch()).Evaluate($"typeof {name}").AsString().Should().Be("undefined");
+
+            var engine = new Engine(options => options.UseEventSource());
+            engine.Evaluate($"typeof {name}").AsString().Should().Be("function");
+
+            // An interface object: writable and configurable, but not enumerable.
+            var descriptor = engine.Realm.GlobalObject.GetOwnProperty(name);
+            descriptor.Enumerable.Should().BeFalse();
+            descriptor.Writable.Should().BeTrue();
+            descriptor.Configurable.Should().BeTrue();
+
+            // ... and never inside a shadow realm.
+            engine.Evaluate($"new ShadowRealm().evaluate('typeof {name}')").AsString().Should().Be("undefined");
+        }
+    }
+
+    [Fact]
+    public void BringsTheEventsFeatureAndNotTheFetchOne()
+    {
+        // The closure is computed at install, so it catches a host that assigned Features directly.
+        var options = new Options();
+        options.WebApi.Features = WebApiFeatures.EventSource;
+
+        var engine = new Engine(options);
+        engine.Evaluate("typeof EventTarget").AsString().Should().Be("function");
+        engine.Evaluate("typeof AbortController").AsString().Should().Be("function");
+        engine.Evaluate("typeof fetch").AsString().Should().Be("undefined");
+
+        // ... and the option value still reads back exactly what the host asked for.
+        options.WebApi.Features.Should().Be(WebApiFeatures.EventSource);
+    }
+
+    [Fact]
+    public void TheInterfaceObjectRefusesToBeCalledWithoutNew()
+    {
+        var engine = new Engine(options => options.UseEventSource());
+
+        engine.Evaluate("(() => { try { EventSource('https://example.org/'); } catch (e) { return e.constructor.name; } })()")
+            .AsString().Should().Be("TypeError");
+
+        engine.Evaluate("EventSource.length").AsNumber().Should().Be(1);
+        engine.Evaluate("EventSource.name").AsString().Should().Be("EventSource");
+        engine.Evaluate("Object.getPrototypeOf(EventSource) === EventTarget").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.getPrototypeOf(EventSource.prototype) === EventTarget.prototype").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void TheAccessorsRefuseAForeignReceiver()
+    {
+        var engine = new Engine(options => options.UseEventSource());
+
+        foreach (var member in new[] { "url", "readyState", "withCredentials", "onmessage" })
+        {
+            engine.Evaluate($"(() => {{ try {{ Object.getOwnPropertyDescriptor(EventSource.prototype, '{member}').get.call({{}}); }} catch (e) {{ return e.constructor.name; }} }})()")
+                .AsString().Should().Be("TypeError");
+        }
+
+        engine.Evaluate("(() => { try { EventSource.prototype.close.call({}); } catch (e) { return e.constructor.name; } })()")
+            .AsString().Should().Be("TypeError");
+    }
+}
+#endif

--- a/Jint/Engine.WebApi.cs
+++ b/Jint/Engine.WebApi.cs
@@ -4,6 +4,7 @@ using Jint.Native.Promise;
 using Jint.WebApi;
 using Jint.WebApi.Fetch;
 using Jint.WebApi.Scheduling;
+using Jint.WebApi.ServerSentEvents;
 using Jint.WebApi.Timers;
 
 namespace Jint;
@@ -76,6 +77,13 @@ internal sealed class WebApiEngineState
     private StorageProvider? _localStorageProvider;
     private StorageProvider? _sessionStorageProvider;
 
+    /// <summary>
+    /// The event streams this engine has open, in registration order. Engine-thread-only for the same reason
+    /// <see cref="_fetches"/> is, and bounded by the same <c>Options.FetchOptions.MaxConcurrentRequests</c> —
+    /// separately, because a stream holds its socket for as long as it lives rather than for one exchange.
+    /// </summary>
+    private List<EventSourceConnection>? _eventSources;
+
     internal WebApiEngineState(Engine engine, TimeProvider timeProvider, TimerQueue? timers, Options.FetchOptions? fetchOptions, SchedulerQueue? scheduler, DiagnosticsSink? diagnostics, Options.StorageOptions? storage = null)
     {
         _engine = engine;
@@ -132,6 +140,17 @@ internal sealed class WebApiEngineState
     /// that is already running.
     /// </summary>
     internal DiagnosticsSink? Diagnostics { get; }
+
+    /// <summary>
+    /// How many event streams are open, which is what <c>Options.FetchOptions.MaxConcurrentRequests</c>
+    /// bounds for <c>EventSource</c>.
+    /// </summary>
+    internal int ActiveEventSourceCount => _eventSources?.Count ?? 0;
+
+    internal void RegisterEventSource(EventSourceConnection connection)
+        => (_eventSources ??= new List<EventSourceConnection>()).Add(connection);
+
+    internal void UnregisterEventSource(EventSourceConnection connection) => _eventSources?.Remove(connection);
 
     /// <summary>
     /// <c>performance.timeOrigin</c>: the moment this state was created, as milliseconds since the Unix
@@ -226,7 +245,12 @@ internal sealed class WebApiEngineState
     {
         Timers?.Clear();
         Scheduler?.Clear();
+        AbandonFetches();
+        AbandonEventSources();
+    }
 
+    private void AbandonFetches()
+    {
         if (_fetches is not { Count: > 0 } fetches)
         {
             return;
@@ -240,6 +264,28 @@ internal sealed class WebApiEngineState
         foreach (var fetch in pending)
         {
             fetch.Abandon();
+        }
+    }
+
+    /// <summary>
+    /// The same for the event streams, and for the same reasons — with one addition: an abandoned connection
+    /// leaves its <c>EventSource</c> object <c>CLOSED</c>, and fires nothing, because the evaluation cycle
+    /// those listeners belonged to has ended. The reconnect delay a stream may have been holding is on the
+    /// timer queue <see cref="Timers"/> has just cleared.
+    /// </summary>
+    private void AbandonEventSources()
+    {
+        if (_eventSources is not { Count: > 0 } sources)
+        {
+            return;
+        }
+
+        var pending = sources.ToArray();
+        sources.Clear();
+
+        foreach (var source in pending)
+        {
+            source.Abandon();
         }
     }
 }

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -159,6 +159,11 @@ public partial class Options
     /// from whichever thread the HTTP stack happens to be on — see <see cref="UrlFilter"/> and
     /// <see cref="HttpClientFactory"/>.
     /// </para>
+    /// <para>
+    /// <b>Not only <c>fetch</c> reads this.</b> <see cref="WebApiFeatures.EventSource"/> is a second, separate
+    /// grant of outbound network access and takes its transport and its policy from here too; three members
+    /// mean something different for a stream than for a document, and that flag's documentation says which.
+    /// </para>
     /// </remarks>
     public class FetchOptions
     {
@@ -559,6 +564,48 @@ public enum WebApiFeatures
     /// database — is <see cref="Options.StorageOptions.LocalStorageProvider"/>'s business.
     /// </summary>
     Storage = 1 << 16,
+
+    /// <summary>
+    /// <c>EventSource</c> and <c>MessageEvent</c> — server-sent events,
+    /// https://html.spec.whatwg.org/multipage/server-sent-events.html. <b>Never part of
+    /// <see cref="Default"/>:</b> like <see cref="Fetch"/> it is outbound network access, and it is a
+    /// <i>separate</i> decision — enabling fetch does not enable this, and enabling this does not enable
+    /// fetch.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Implies <see cref="Events"/>, whose <c>EventTarget</c> an <c>EventSource</c> is and on whose timer
+    /// queue the reconnect delay rides.
+    /// </para>
+    /// <para>
+    /// <b>It reads its transport and its policy from <see cref="Options.FetchOptions"/></b>, the same group
+    /// <c>fetch</c> uses — <see cref="Options.FetchOptions.HttpClient"/> or
+    /// <see cref="Options.FetchOptions.HttpClientFactory"/>, <see cref="Options.FetchOptions.AllowedSchemes"/>,
+    /// <see cref="Options.FetchOptions.UrlFilter"/> (re-run on every redirect hop <i>and</i> on every
+    /// reconnection) and <see cref="Options.FetchOptions.MaxRedirects"/>. So a host that has written a policy
+    /// for fetch has already written this one, and a host that enables only this still configures it through
+    /// <c>options.WebApi.Fetch</c>. Two members mean something different here, because a connection is a
+    /// stream rather than a document:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description>
+    /// <see cref="Options.FetchOptions.Timeout"/> is <b>not</b> applied. A connection that is idle for an
+    /// hour is what an event stream is for, so a deadline on the whole exchange would end every one of them.
+    /// </description></item>
+    /// <item><description>
+    /// <see cref="Options.FetchOptions.MaxResponseBytes"/> does <b>not</b> bound the stream, which is
+    /// unbounded by nature. It bounds <i>one event</i>: the data a single event accumulates before its blank
+    /// line, which is what actually has to be held in memory. Exceeding it fails the connection, and — like
+    /// every other failure the host's own limits produce — that failure does not reconnect.
+    /// </description></item>
+    /// <item><description>
+    /// <see cref="Options.FetchOptions.MaxConcurrentRequests"/> bounds the streams one engine may have open,
+    /// counted separately from the fetches in flight. A stream holds its socket for as long as it lives, so
+    /// this is the setting that stops a script from opening them without end.
+    /// </description></item>
+    /// </list>
+    /// </remarks>
+    EventSource = 1 << 17,
 
     /// <summary>
     /// The web APIs a host normally wants: everything except outbound network access and persistent state.

--- a/Jint/Runtime/Intrinsics.WebApi.cs
+++ b/Jint/Runtime/Intrinsics.WebApi.cs
@@ -10,6 +10,7 @@ using Jint.WebApi.Fetch;
 using Jint.WebApi.Files;
 using Jint.WebApi.Messaging;
 using Jint.WebApi.Navigator;
+using Jint.WebApi.ServerSentEvents;
 using Jint.WebApi.StructuredClone;
 using Jint.WebApi.Performance;
 using Jint.WebApi.Reporting;
@@ -127,6 +128,13 @@ public sealed partial class Intrinsics
 
     internal AbortControllerConstructor AbortController =>
         _abortController ??= new AbortControllerConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject, AbortSignal);
+
+    private EventSourceConstructor? _eventSource;
+
+    /// <summary><c>EventSource</c> inherits from <c>EventTarget</c>.</summary>
+    internal EventSourceConstructor EventSource =>
+        _eventSource ??= new EventSourceConstructor(_engine, _realm, EventTarget);
+
     private HeadersConstructor? _headers;
     private RequestConstructor? _request;
     private ResponseConstructor? _response;

--- a/Jint/WebApi/Fetch/FetchOperation.cs
+++ b/Jint/WebApi/Fetch/FetchOperation.cs
@@ -201,20 +201,15 @@ internal sealed class FetchOperation
 
     private static HttpClient ResolveClient(Engine engine, Realm realm, Options.FetchOptions options)
     {
-        if (options.HttpClientFactory is { } factory)
+        // Called on the engine thread, once per fetch, so a host factory may read per-request state through
+        // engine.Advanced.HostDefined.
+        var client = FetchTransport.ResolveClient(engine, options);
+        if (client is null)
         {
-            // Called on the engine thread, once per fetch, so it may read per-request host state through
-            // engine.Advanced.HostDefined.
-            var client = factory(engine);
-            if (client is null)
-            {
-                Throw.TypeError(realm, "Failed to fetch: Options.WebApi.Fetch.HttpClientFactory returned null.");
-            }
-
-            return client;
+            Throw.TypeError(realm, "Failed to fetch: Options.WebApi.Fetch.HttpClientFactory returned null.");
         }
 
-        return options.HttpClient ?? FetchTransport.SharedClient;
+        return client;
     }
 
     private void Run(HttpClient client, FetchRequestSnapshot snapshot, FetchPolicy policy)

--- a/Jint/WebApi/Fetch/FetchTransport.cs
+++ b/Jint/WebApi/Fetch/FetchTransport.cs
@@ -127,6 +127,27 @@ internal sealed class FetchPolicy
 }
 
 /// <summary>
+/// A response whose body has <b>not</b> been read: the message itself, plus the two facts about the request
+/// that produced it which only the redirect loop knows.
+/// </summary>
+/// <remarks>
+/// What <see cref="FetchTransport.SendForStreamAsync"/> answers with, for the one consumer that must not have
+/// its body buffered — <c>EventSource</c>, whose response is a stream that stays open. The caller owns the
+/// <see cref="HttpResponseMessage"/> and must dispose it; the buffered path does that for itself.
+/// </remarks>
+internal sealed class FetchExchange : IDisposable
+{
+    internal required HttpResponseMessage Response { get; init; }
+
+    /// <summary>The URL that produced this response, i.e. the last hop of the redirect chain.</summary>
+    internal required UrlRecord Url { get; init; }
+
+    internal required bool Redirected { get; init; }
+
+    public void Dispose() => Response.Dispose();
+}
+
+/// <summary>
 /// A response as plain CLR data, classified off the engine thread. <c>FetchOperation</c> turns it into a
 /// <c>Response</c> object on the engine thread, in the realm the fetch started in.
 /// </summary>
@@ -216,9 +237,54 @@ internal static class FetchTransport
     }
 
     /// <summary>
+    /// The <see cref="HttpClient"/> a request goes through: the host's per-request factory, the host's own
+    /// client, or the shared default — in that order of precedence.
+    /// </summary>
+    /// <remarks>
+    /// Called on the engine thread, once per request, which is what lets a host factory read per-request state
+    /// through <c>engine.Advanced.HostDefined</c>. Answers <see langword="null"/> only when a host factory
+    /// did; each caller decides what that failure looks like to script.
+    /// </remarks>
+    internal static HttpClient? ResolveClient(Engine engine, Options.FetchOptions options)
+    {
+        if (options.HttpClientFactory is { } factory)
+        {
+            return factory(engine);
+        }
+
+        return options.HttpClient ?? SharedClient;
+    }
+
+    /// <summary>
     /// Runs the request, following redirects itself, and reads the body under the size cap.
     /// </summary>
     internal static async Task<FetchResponseSnapshot> SendAsync(
+        HttpClient client,
+        FetchRequestSnapshot request,
+        FetchPolicy policy,
+        CancellationToken cancellationToken)
+    {
+        var exchange = await SendForStreamAsync(client, request, policy, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            return await ReadResponseAsync(exchange.Response, exchange.Url, exchange.Redirected, policy, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            exchange.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// The half of <see cref="SendAsync"/> that reaches the response: the redirect loop and the per-hop policy
+    /// re-check, stopping with the headers in hand and the body untouched.
+    /// </summary>
+    /// <remarks>
+    /// <b>The caller owns the returned <see cref="FetchExchange"/></b> and must dispose it — which is exactly
+    /// what makes it usable for a response that is a stream rather than a document. <c>EventSource</c> reads
+    /// that stream itself; <see cref="SendAsync"/> hands it straight to the bounded read below.
+    /// </remarks>
+    internal static async Task<FetchExchange> SendForStreamAsync(
         HttpClient client,
         FetchRequestSnapshot request,
         FetchPolicy policy,
@@ -252,6 +318,9 @@ internal static class FetchTransport
                 throw new FetchFailureException(FetchFailureKind.Network, $"The request to '{uri}' failed: {ex.Message}", ex);
             }
 
+            // The response is disposed here only while the loop goes on to another hop; the one it ends with
+            // belongs to the caller, whose body may not have been read yet.
+            var handedOver = false;
             try
             {
                 // https://fetch.spec.whatwg.org/#concept-http-fetch step 6, the three redirect modes. "manual"
@@ -262,7 +331,8 @@ internal static class FetchTransport
                 if (!FetchValues.IsRedirectStatus(status)
                     || string.Equals(request.Redirect, JsRequest.RedirectManual, StringComparison.Ordinal))
                 {
-                    return await ReadResponseAsync(response, url, redirectCount > 0, policy, cancellationToken).ConfigureAwait(false);
+                    handedOver = true;
+                    return new FetchExchange { Response = response, Url = url, Redirected = redirectCount > 0 };
                 }
 
                 if (string.Equals(request.Redirect, JsRequest.RedirectError, StringComparison.Ordinal))
@@ -275,7 +345,8 @@ internal static class FetchTransport
                 var location = TryGetRedirectTarget(response, url);
                 if (location is null)
                 {
-                    return await ReadResponseAsync(response, url, redirectCount > 0, policy, cancellationToken).ConfigureAwait(false);
+                    handedOver = true;
+                    return new FetchExchange { Response = response, Url = url, Redirected = redirectCount > 0 };
                 }
 
                 if (++redirectCount > policy.MaxRedirects)
@@ -290,7 +361,10 @@ internal static class FetchTransport
             }
             finally
             {
-                response.Dispose();
+                if (!handedOver)
+                {
+                    response.Dispose();
+                }
             }
         }
     }

--- a/Jint/WebApi/Messaging/MessageEventConstructor.cs
+++ b/Jint/WebApi/Messaging/MessageEventConstructor.cs
@@ -84,6 +84,16 @@ internal sealed class MessageEventConstructor : Constructor
     /// takes its IDL default, because the message port post message steps set nothing else.
     /// </summary>
     internal JsMessageEvent CreateTrustedMessageEvent(JsString type, JsValue data)
+        => CreateTrustedMessageEvent(type, data, JsString.Empty, JsString.Empty);
+
+    /// <summary>
+    /// <see cref="CreateTrustedMessageEvent(JsString, JsValue)"/> with the two members <c>EventSource</c>'s
+    /// dispatch steps additionally set — the stream's origin and the last event ID,
+    /// https://html.spec.whatwg.org/multipage/server-sent-events.html#dispatchMessage. <c>source</c> and
+    /// <c>ports</c> keep their IDL defaults there too: both name a <c>MessagePort</c>, and an event source
+    /// has none to hand over.
+    /// </summary>
+    internal JsMessageEvent CreateTrustedMessageEvent(JsString type, JsValue data, JsString origin, JsString lastEventId)
     {
         return new JsMessageEvent(
             _engine,
@@ -91,8 +101,8 @@ internal sealed class MessageEventConstructor : Constructor
             default,
             EventConstructor.TimeStampNow(_engine),
             data,
-            JsString.Empty,
-            JsString.Empty,
+            origin,
+            lastEventId,
             Null,
             EmptyPorts)
         {

--- a/Jint/WebApi/ServerSentEvents/EventSourceConnection.cs
+++ b/Jint/WebApi/ServerSentEvents/EventSourceConnection.cs
@@ -1,0 +1,357 @@
+#if NET8_0_OR_GREATER
+using System.Buffers;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Jint.Constraints;
+using Jint.Runtime;
+using Jint.WebApi.Fetch;
+
+namespace Jint.WebApi.ServerSentEvents;
+
+/// <summary>
+/// How one connection of an <c>EventSource</c> ended, and therefore which of the standard's three algorithms
+/// the engine thread has to run.
+/// </summary>
+internal enum EventSourceOutcome
+{
+    /// <summary>
+    /// The engine took the connection away — <c>close()</c>, a <c>RestoreGlobalSnapshot</c>, or the engine's
+    /// own cancellation. Nothing is announced, nothing is fired and nothing reconnects.
+    /// </summary>
+    Abandoned,
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/server-sent-events.html#fail-the-connection — and "once the user
+    /// agent has failed the connection, it does not attempt to reconnect".
+    /// </summary>
+    Fail,
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/server-sent-events.html#reestablish-the-connection.
+    /// </summary>
+    Reestablish,
+}
+
+/// <summary>
+/// One connection of an <c>EventSource</c>: the HTTP request, the read loop that decodes its body, and the
+/// generation-stamped jobs that carry what it found back to the engine thread.
+/// <para>
+/// https://html.spec.whatwg.org/multipage/server-sent-events.html#the-eventsource-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The same threading discipline as <c>FetchOperation</c>, which is not a coincidence.</b> The realm and
+/// the event-loop generation are captured <i>here</i>, when the connection is created on the engine thread,
+/// and every result crosses back as a job stamped with that generation — so a chunk that arrives after
+/// <c>RestoreGlobalSnapshot</c> is discarded at dequeue rather than dispatched into the restored engine.
+/// Nothing on the pool thread touches the engine: the read loop hands the parser bytes and the parser answers
+/// with plain CLR records.
+/// </para>
+/// <para>
+/// The differences from a fetch are the ones a stream forces. The response body is <b>not</b> buffered, so
+/// <c>Options.WebApi.Fetch.MaxResponseBytes</c> cannot bound it and bounds a single event instead. The
+/// per-request <c>Options.WebApi.Fetch.Timeout</c> is <b>not</b> armed, because a connection that is idle for
+/// an hour is exactly what a server-sent event stream is for. And the operation does not settle once: it
+/// delivers, possibly for as long as the engine lives, until something ends it.
+/// </para>
+/// </remarks>
+internal sealed class EventSourceConnection
+{
+    /// <summary>The MIME type essence a response must carry, https://html.spec.whatwg.org/multipage/server-sent-events.html#text/event-stream.</summary>
+    private const string EventStreamMimeType = "text/event-stream";
+
+    private readonly JsEventSource _source;
+    private readonly Engine _engine;
+
+    /// <summary>
+    /// The realm the connection was opened in, captured at creation for the same reason
+    /// <c>FetchOperation</c> captures one: a job running on a later turn would otherwise build its
+    /// <c>MessageEvent</c> against whatever realm happened to be ambient.
+    /// </summary>
+    private readonly Realm _realm;
+
+    /// <summary>The evaluation cycle this connection belongs to; every job it queues carries it.</summary>
+    private readonly int _generation;
+
+    /// <summary>
+    /// The engine's own cancellation token, from <see cref="CancellationConstraint"/>. A connection cancelled
+    /// through it ends silently — a constraint that turned into an <c>error</c> event would let the script
+    /// carry on, and reconnect, which is precisely what the constraint exists to stop.
+    /// </summary>
+    private readonly CancellationToken _engineToken;
+
+    private readonly CancellationTokenSource _cancellation;
+
+    /// <summary>
+    /// <see cref="_cancellation"/>'s token, taken once and held. Deliberately not read from the source on
+    /// each use: <see cref="Abandon"/> disposes it, and a token read afterwards throws
+    /// <see cref="ObjectDisposedException"/> — so a loop that asked again would end in an exception rather
+    /// than in the cancellation it was told about, and would do so only in the timing where the abandon
+    /// happened to land between two reads.
+    /// </summary>
+    private readonly CancellationToken _token;
+
+    private readonly EventStreamParser _parser;
+
+    private int _finished;
+
+    internal EventSourceConnection(JsEventSource source, Engine engine, Realm realm, long maxEventLength, string lastEventId)
+    {
+        _source = source;
+        _engine = engine;
+        _realm = realm;
+        _generation = engine.EventLoopGeneration;
+        _engineToken = engine.Constraints.Find<CancellationConstraint>()?.Token ?? CancellationToken.None;
+        _cancellation = CancellationTokenSource.CreateLinkedTokenSource(_engineToken);
+        _token = _cancellation.Token;
+        _parser = new EventStreamParser(maxEventLength, lastEventId);
+    }
+
+    /// <summary>
+    /// Starts the request. Returns as soon as the transport goes asynchronous, so the constructor that
+    /// ultimately called this does not wait for a socket.
+    /// </summary>
+    internal void Start(HttpClient client, FetchRequestSnapshot request, FetchPolicy policy)
+    {
+        // Fire and forget by design: every outcome the loop can reach, including a synchronous throw from a
+        // host's own handler, is turned into an engine-thread job inside it.
+        _ = RunAsync(client, request, policy);
+    }
+
+    private async Task RunAsync(HttpClient client, FetchRequestSnapshot request, FetchPolicy policy)
+    {
+        try
+        {
+            using var exchange = await FetchTransport
+                .SendForStreamAsync(client, request, policy, _token)
+                .ConfigureAwait(false);
+
+            var response = exchange.Response;
+
+            // Constructor step 15.iii: "if res's status is not 200, or if res's Content-Type is not
+            // text/event-stream, then fail the connection" — a failure the standard deliberately does not
+            // reconnect from, because retrying an answer the server meant would only repeat it.
+            if ((int) response.StatusCode != 200 || !IsEventStream(response))
+            {
+                Finish(EventSourceOutcome.Fail);
+                return;
+            }
+
+            var origin = exchange.Url.SerializeOrigin();
+            Enqueue(() => _source.AnnounceConnection(this));
+
+            await ReadAsync(response, origin).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // close(), a restore, or the engine's own cancellation: the only three things that cancel this
+            // token. None of them announces anything, and none of them reconnects.
+            Finish(EventSourceOutcome.Abandoned);
+        }
+        catch (FetchFailureException failure) when (failure.Kind is FetchFailureKind.ResponseTooLarge or FetchFailureKind.PolicyDenied or FetchFailureKind.RedirectLimit)
+        {
+            // The host's own limits, all three of which a reconnect would run straight back into.
+            Finish(EventSourceOutcome.Fail);
+        }
+        catch (Exception exception) when (!ConstraintFailure.MustPropagate(exception))
+        {
+            // Constructor step 15.ii: a network error reestablishes the connection. A DNS failure, a refused
+            // connection and a stream the server dropped are the ordinary life of a long-lived stream.
+            Finish(EventSourceOutcome.Reestablish);
+        }
+    }
+
+    /// <summary>
+    /// The read loop: "announce the connection and interpret res's body line by line".
+    /// </summary>
+    private async Task ReadAsync(HttpResponseMessage response, string origin)
+    {
+        using var stream = await response.Content.ReadAsStreamAsync(_token).ConfigureAwait(false);
+
+        var buffer = ArrayPool<byte>.Shared.Rent(8 * 1024);
+        try
+        {
+            while (true)
+            {
+                var read = await stream.ReadAsync(buffer.AsMemory(), _token).ConfigureAwait(false);
+                if (read == 0)
+                {
+                    // processResponseEndOfBody: "if res is not a network error, then reestablish the
+                    // connection". A server closing the stream is how it asks to be polled again.
+                    Finish(EventSourceOutcome.Reestablish);
+                    return;
+                }
+
+                Deliver(buffer, read, origin);
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    /// <summary>
+    /// Parses one chunk and queues whatever it produced. A separate method because a <see cref="Span{T}"/>
+    /// cannot live in an <see langword="async"/> one, and the parser works in spans.
+    /// </summary>
+    private void Deliver(byte[] buffer, int count, string origin)
+    {
+        var messages = new List<EventStreamMessage>();
+        _parser.Feed(buffer, count, messages);
+
+        var reconnectionTime = _parser.TakeReconnectionTime();
+        if (reconnectionTime is null && messages.Count == 0)
+        {
+            // A chunk that completed nothing — a comment keeping the connection alive, or half a line.
+            return;
+        }
+
+        Enqueue(() => _source.DeliverMessages(this, reconnectionTime, messages, origin));
+    }
+
+    /// <summary>
+    /// https://mimesniff.spec.whatwg.org/#mime-type-essence of the response's <c>Content-Type</c>, compared
+    /// ASCII-case-insensitively — so <c>text/event-stream; charset=utf-8</c> is the same type as
+    /// <c>text/event-stream</c>.
+    /// </summary>
+    /// <remarks>
+    /// Read through <c>NonValidated</c> and cut by hand rather than through <c>Content.Headers.ContentType</c>,
+    /// whose parser answers null for a value it dislikes — which would turn a malformed parameter into a
+    /// failed connection. The last value wins, which is what
+    /// https://fetch.spec.whatwg.org/#concept-header-extract-mime-type does.
+    /// </remarks>
+    private static bool IsEventStream(HttpResponseMessage response)
+    {
+        string? essence = null;
+
+        foreach (var header in response.Content.Headers.NonValidated)
+        {
+            if (!string.Equals(header.Key, "Content-Type", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            foreach (var value in header.Value)
+            {
+                var semicolon = value.IndexOf(';');
+                var candidate = (semicolon < 0 ? value : value.Substring(0, semicolon)).Trim();
+                if (candidate.Length != 0)
+                {
+                    essence = candidate;
+                }
+            }
+        }
+
+        return essence is not null && string.Equals(essence, EventStreamMimeType, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Queues one engine-thread job carrying this connection's generation. A job whose cycle has ended is
+    /// discarded at dequeue — the fence every cross-thread completion in Jint sits behind.
+    /// </summary>
+    private void Enqueue(Action job)
+    {
+        if (Volatile.Read(ref _finished) != 0)
+        {
+            return;
+        }
+
+        _engine.AddToEventLoop(() => Run(job), _generation);
+    }
+
+    /// <summary>
+    /// Ends the connection exactly once, whichever of the terminal paths got here first.
+    /// </summary>
+    private void Finish(EventSourceOutcome outcome)
+    {
+        if (Interlocked.CompareExchange(ref _finished, 1, 0) != 0)
+        {
+            return;
+        }
+
+        _engine.AddToEventLoop(() => Complete(outcome), _generation);
+    }
+
+    /// <summary>
+    /// On the engine thread, in the realm the connection was opened in: the bookkeeping first, so that a
+    /// listener throwing out of the event that follows cannot leave the engine holding a connection that has
+    /// already ended.
+    /// </summary>
+    private void Complete(EventSourceOutcome outcome)
+    {
+        Run(() =>
+        {
+            _engine._webApi?.UnregisterEventSource(this);
+            _cancellation.Dispose();
+            _source.OnConnectionEnded(this, outcome);
+        });
+    }
+
+    /// <summary>
+    /// Runs an engine-thread job in the connection's own realm.
+    /// </summary>
+    /// <remarks>
+    /// A listener that throws erupts from whatever is pumping the event loop, which is the contract every
+    /// event Jint fires already has — see <c>JsEventTarget</c>. There is no promise here to reject it into.
+    /// </remarks>
+    private void Run(Action job)
+    {
+        var entered = EnterRealm();
+        try
+        {
+            job();
+        }
+        finally
+        {
+            LeaveRealm(entered);
+        }
+    }
+
+    /// <summary>
+    /// Ends the connection from the engine thread: <c>close()</c>, or the fence a
+    /// <c>RestoreGlobalSnapshot</c> puts up. Cancels the request so the socket is freed at once, and settles
+    /// nothing — a job already on its way is discarded by the generation fence, and nothing new is queued.
+    /// </summary>
+    internal void Abandon()
+    {
+        Interlocked.Exchange(ref _finished, 1);
+
+        try
+        {
+            _cancellation.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // Raced with a completion that already released it; there is nothing left to cancel.
+        }
+
+        _cancellation.Dispose();
+
+        // Runs here rather than from a job, because a job is exactly what an abandoned connection may no
+        // longer queue. The caller is on the engine thread either way — close() or the restore fence.
+        _source.AbandonConnection(this);
+    }
+
+    private bool EnterRealm()
+    {
+        if (ReferenceEquals(_engine.Realm, _realm))
+        {
+            return false;
+        }
+
+        _engine.EnterExecutionContext(_realm.GlobalEnv, _realm.GlobalEnv, _realm, privateEnvironment: null, strict: _engine.Options.Strict);
+        return true;
+    }
+
+    private void LeaveRealm(bool entered)
+    {
+        if (entered)
+        {
+            _engine.LeaveExecutionContext();
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/ServerSentEvents/EventSourceConstructor.cs
+++ b/Jint/WebApi/ServerSentEvents/EventSourceConstructor.cs
@@ -1,0 +1,126 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.DomException;
+using Jint.WebApi.Events;
+using Jint.WebApi.Url;
+using Jint.WebApi.Url.Parsing;
+
+namespace Jint.WebApi.ServerSentEvents;
+
+/// <summary>
+/// The <c>EventSource</c> interface object.
+/// <para>
+/// https://html.spec.whatwg.org/multipage/server-sent-events.html#the-eventsource-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// <c>EventSource</c> inherits from <c>EventTarget</c>, so its <c>[[Prototype]]</c> is the <c>EventTarget</c>
+/// interface object and <c>source instanceof EventTarget</c> holds. The three readyState constants appear
+/// here as well as on the prototype, per https://webidl.spec.whatwg.org/#es-constants, with the attributes
+/// constants are given there: <c>{ writable: false, enumerable: true, configurable: false }</c>.
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class EventSourceConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("EventSource");
+    private static readonly JsString _withCredentials = new("withCredentials");
+
+    [JsProperty(Name = "CONNECTING", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber Connecting = JsNumber.Create(JsEventSource.Connecting);
+    [JsProperty(Name = "OPEN", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber Open = JsNumber.Create(JsEventSource.Open);
+    [JsProperty(Name = "CLOSED", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber Closed = JsNumber.Create(JsEventSource.Closed);
+
+    internal EventSourceConstructor(Engine engine, Realm realm, EventTargetConstructor eventTargetConstructor)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = eventTargetConstructor;
+        PrototypeObject = new EventSourcePrototype(engine, realm, this, eventTargetConstructor.PrototypeObject);
+        _length = new PropertyDescriptor(JsNumber.PositiveOne, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal EventSourcePrototype PrototypeObject { get; }
+
+    protected override void Initialize() => CreateProperties_Generated();
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/server-sent-events.html#dom-eventsource — the whole of the
+    /// constructor, ending in step 15, "fetch request", and step 16, "return ev".
+    /// </summary>
+    /// <remarks>
+    /// The steps a browser needs and this engine has no counterpart for are the ones about the environment
+    /// the object lives in: there is no settings object to parse the URL relative to (so the URL must be
+    /// absolute), no CORS attribute state to select (see <c>withCredentials</c>) and no client to attribute
+    /// the request to.
+    /// </remarks>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        var state = _engine._webApi;
+        if (state?.FetchOptions is null)
+        {
+            // Unreachable: the global that reaches this is installed only where the state was created, in the
+            // same block of WebApiRegistration.
+            Throw.InvalidOperationException("The EventSource global was reached on an engine that has no fetch configuration.");
+        }
+
+        if (arguments.Length == 0)
+        {
+            Throw.TypeError(_realm, "Failed to construct 'EventSource': 1 argument required, but only 0 present.");
+        }
+
+        // The arguments are converted in order — the USVString first, then the dictionary — and only then do
+        // the constructor steps run, which is why an unparsable URL is diagnosed after the dictionary is read.
+        var href = UrlValues.ToUsvString(arguments[0]);
+        var withCredentials = ReadWithCredentials(arguments.At(1));
+
+        // Step 3: "let urlRecord be the result of encoding-parsing a URL given url, relative to settings", and
+        // step 4: "if urlRecord is failure, then throw a SyntaxError DOMException" — a DOMException, not the
+        // TypeError the fetch interfaces raise for the same mistake.
+        var url = UrlParser.Parse(href);
+        if (url is null)
+        {
+            ThrowDomException(DomExceptionNames.Syntax, $"Failed to construct 'EventSource': Cannot open an EventSource to '{href}'. The URL is invalid.");
+        }
+
+        var source = OrdinaryCreateFromConstructor(
+            newTarget,
+            static intrinsics => intrinsics.EventSource.PrototypeObject,
+            static (Engine engine, Realm realm, (WebApiEngineState State, UrlRecord Url, bool WithCredentials) created)
+                => new JsEventSource(engine, realm, created.State, created.Url, created.WithCredentials),
+            (State: state, Url: url!, WithCredentials: withCredentials));
+
+        source.Connect();
+        return source;
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/server-sent-events.html#dictdef-eventsourceinit converted per
+    /// https://webidl.spec.whatwg.org/#es-dictionary: <see langword="undefined"/> and <see langword="null"/>
+    /// give the member its default, and anything that is not an object is a <c>TypeError</c>.
+    /// </summary>
+    private bool ReadWithCredentials(JsValue init)
+    {
+        if (init.IsUndefined() || init.IsNull())
+        {
+            return false;
+        }
+
+        if (init is not ObjectInstance dictionary)
+        {
+            Throw.TypeError(_realm, "Failed to construct 'EventSource': the provided value is not of type 'EventSourceInit'.");
+            return false;
+        }
+
+        return TypeConverter.ToBoolean(dictionary.Get(_withCredentials));
+    }
+
+    private void ThrowDomException(string name, string message)
+    {
+        var exception = _realm.Intrinsics.DomException.CreateException(name, message);
+        var location = _engine._lastSyntaxElement?.Location ?? default;
+        Throw.JavaScriptException(_engine, exception, in location);
+    }
+}
+#endif

--- a/Jint/WebApi/ServerSentEvents/EventSourcePrototype.cs
+++ b/Jint/WebApi/ServerSentEvents/EventSourcePrototype.cs
@@ -1,0 +1,180 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.Events;
+
+namespace Jint.WebApi.ServerSentEvents;
+
+/// <summary>
+/// <c>EventSource.prototype</c> — the interface prototype object.
+/// <para>
+/// https://html.spec.whatwg.org/multipage/server-sent-events.html#the-eventsource-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// Its <c>[[Prototype]]</c> is <c>EventTarget.prototype</c>, so an event source has <c>addEventListener</c>
+/// and the rest. The three readyState constants appear here as well as on the interface object, per
+/// https://webidl.spec.whatwg.org/#es-constants.
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class EventSourcePrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly EventSourceConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString EventSourceToStringTag = new("EventSource");
+
+    [JsProperty(Name = "CONNECTING", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber Connecting = JsNumber.Create(JsEventSource.Connecting);
+    [JsProperty(Name = "OPEN", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber Open = JsNumber.Create(JsEventSource.Open);
+    [JsProperty(Name = "CLOSED", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber Closed = JsNumber.Create(JsEventSource.Closed);
+
+    internal EventSourcePrototype(
+        Engine engine,
+        Realm realm,
+        EventSourceConstructor constructor,
+        ObjectInstance eventTargetPrototype) : base(engine, realm)
+    {
+        _prototype = eventTargetPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/server-sent-events.html#dom-eventsource-url — "must return the
+    /// serialization of this EventSource object's url".
+    /// </summary>
+    [JsAccessor("url", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsString UrlGet(JsValue thisObject) => Brand(thisObject).Href;
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/server-sent-events.html#dom-eventsource-withcredentials — the
+    /// value the object was initialized with. See <see cref="JsEventSource.WithCredentials"/> for why it
+    /// changes nothing.
+    /// </summary>
+    [JsAccessor("withCredentials", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsBoolean WithCredentialsGet(JsValue thisObject) => JsBoolean.Create(Brand(thisObject).WithCredentials);
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/server-sent-events.html#dom-eventsource-readystate
+    /// </summary>
+    [JsAccessor("readyState", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsNumber ReadyStateGet(JsValue thisObject) => JsNumber.Create(Brand(thisObject).ReadyState);
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/server-sent-events.html#handler-eventsource-onopen
+    /// </summary>
+    [JsAccessor("onopen", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue OnOpenGet(JsValue thisObject) => HandlerGet(thisObject, JsEventSource.OpenEventType);
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/server-sent-events.html#handler-eventsource-onopen, setter half.
+    /// </summary>
+    [JsAccessor("onopen", AccessorKind.Set, Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue OnOpenSet(JsValue thisObject, JsValue value) => HandlerSet(thisObject, JsEventSource.OpenEventType, value);
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/server-sent-events.html#handler-eventsource-onmessage
+    /// </summary>
+    [JsAccessor("onmessage", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue OnMessageGet(JsValue thisObject) => HandlerGet(thisObject, EventStreamParser.DefaultEventType);
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/server-sent-events.html#handler-eventsource-onmessage, setter
+    /// half. It is the handler for the <c>message</c> type only: an event the stream renamed with an
+    /// <c>event</c> field reaches <c>addEventListener(thatName, …)</c> and nothing else, which is what makes
+    /// custom event types worth sending.
+    /// </summary>
+    [JsAccessor("onmessage", AccessorKind.Set, Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue OnMessageSet(JsValue thisObject, JsValue value) => HandlerSet(thisObject, EventStreamParser.DefaultEventType, value);
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/server-sent-events.html#handler-eventsource-onerror
+    /// </summary>
+    [JsAccessor("onerror", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue OnErrorGet(JsValue thisObject) => HandlerGet(thisObject, JsEventSource.ErrorEventType);
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/server-sent-events.html#handler-eventsource-onerror, setter
+    /// half. The event it receives is a plain <c>Event</c> carrying no detail at all — the standard gives an
+    /// event source no way to say <i>why</i> a connection failed, and <c>readyState</c> is what tells a script
+    /// whether this one is retrying (<c>CONNECTING</c>) or over (<c>CLOSED</c>).
+    /// </summary>
+    [JsAccessor("onerror", AccessorKind.Set, Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue OnErrorSet(JsValue thisObject, JsValue value) => HandlerSet(thisObject, JsEventSource.ErrorEventType, value);
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/server-sent-events.html#dom-eventsource-close — "must abort any
+    /// instances of the fetch algorithm started for this EventSource object, and must set the readyState
+    /// attribute to CLOSED". Calling it twice, or on a source that already failed, does nothing.
+    /// </summary>
+    [JsFunction(Name = "close", Length = 0)]
+    private JsValue Close(JsValue thisObject)
+    {
+        Brand(thisObject).Close();
+        return Undefined;
+    }
+
+    /// <summary>
+    /// The getter half of an event handler IDL attribute,
+    /// https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes.
+    /// </summary>
+    private JsValue HandlerGet(JsValue thisObject, string type)
+        => Brand(thisObject).FindEventHandler(type)?.Callback ?? Null;
+
+    /// <summary>
+    /// The setter half. <c>EventHandler</c> is a nullable callback function annotated
+    /// <c>[LegacyTreatNonObjectAsNull]</c>, so assigning anything that is not an object clears the handler
+    /// rather than raising a <c>TypeError</c>; an object that is not callable is stored and read back but
+    /// never invoked.
+    /// </summary>
+    /// <remarks>
+    /// The handler is one entry of the object's own event listener list, so it takes its turn in registration
+    /// order among the <c>addEventListener</c> listeners rather than running before or after all of them.
+    /// Reassigning replaces the value in place — the entry keeps the position it was first given — and
+    /// assigning a non-object removes the entry outright.
+    /// </remarks>
+    private JsValue HandlerSet(JsValue thisObject, string type, JsValue value)
+    {
+        var source = Brand(thisObject);
+        var existing = source.FindEventHandler(type);
+
+        if (value is not ObjectInstance)
+        {
+            if (existing is not null)
+            {
+                source.RemoveListener(existing);
+            }
+
+            return Undefined;
+        }
+
+        if (existing is not null)
+        {
+            existing.Callback = value;
+            return Undefined;
+        }
+
+        source.AddListener(new EventListenerRegistration(type, value) { IsEventHandler = true });
+        return Undefined;
+    }
+
+    private JsEventSource Brand(JsValue thisObject)
+    {
+        if (thisObject is JsEventSource source)
+        {
+            return source;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not an EventSource");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/ServerSentEvents/EventStreamParser.cs
+++ b/Jint/WebApi/ServerSentEvents/EventStreamParser.cs
@@ -1,0 +1,365 @@
+#if NET8_0_OR_GREATER
+using System.Runtime.InteropServices;
+using System.Text;
+using Jint.WebApi.Fetch;
+using SystemEncoding = System.Text.Encoding;
+
+namespace Jint.WebApi.ServerSentEvents;
+
+/// <summary>
+/// One event a stream produced, ready for the engine thread to turn into a <c>MessageEvent</c>.
+/// </summary>
+/// <param name="Type">
+/// The event type: the event type buffer, or <c>message</c> when that buffer was empty — step 6 of
+/// https://html.spec.whatwg.org/multipage/server-sent-events.html#dispatchMessage.
+/// </param>
+/// <param name="Data">The data buffer, its trailing U+000A already removed.</param>
+/// <param name="LastEventId">
+/// The last event ID buffer as it stood when this event was dispatched. The buffer is deliberately not reset
+/// between events, so an event without an <c>id</c> field carries whatever the last one set.
+/// </param>
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct EventStreamMessage(string Type, string Data, string LastEventId);
+
+/// <summary>
+/// The event stream parser, https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation —
+/// UTF-8 decode, line splitting, field processing and the dispatch steps.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Deliberately engine-free</b>, like <c>HeaderList</c> and the URL parser beside it: it mentions no
+/// <see cref="Engine"/>, <c>Realm</c> or <c>JsValue</c>, because it runs on a thread pool thread while the
+/// engine goes on running script. It produces plain CLR records; the engine thread turns them into events.
+/// </para>
+/// <para>
+/// Feeding is incremental in every dimension, because a network read boundary can fall anywhere: inside a
+/// UTF-8 sequence (the <see cref="Decoder"/> holds the partial bytes), between the CR and the LF of a CRLF
+/// (<see cref="_afterCarriageReturn"/> holds that), or in the middle of a line (the line buffer holds that).
+/// A chunk therefore produces zero or more messages, and "the end of the file" discards whatever is left —
+/// "if the file ends in the middle of an event, before the final empty line, the incomplete event is not
+/// dispatched", which falls out of never dispatching without a blank line.
+/// </para>
+/// </remarks>
+internal sealed class EventStreamParser
+{
+    private const string DataField = "data";
+    private const string EventField = "event";
+    private const string IdField = "id";
+    private const string RetryField = "retry";
+
+    /// <summary>The type an event whose event type buffer is empty is dispatched with.</summary>
+    internal const string DefaultEventType = "message";
+
+    /// <summary>U+FEFF, spelled as a code point so that no source file has to carry one.</summary>
+    private const char ByteOrderMark = (char) 0xFEFF;
+
+    /// <summary>
+    /// https://encoding.spec.whatwg.org/#utf-8-decode. The UTF-8 decoder replaces a malformed sequence with
+    /// U+FFFD rather than throwing, which is what that algorithm requires.
+    /// </summary>
+    private readonly Decoder _decoder = SystemEncoding.UTF8.GetDecoder();
+
+    /// <summary>The data buffer, https://html.spec.whatwg.org/multipage/server-sent-events.html#data-buffer.</summary>
+    private readonly StringBuilder _data = new();
+
+    /// <summary>The line being read, which a chunk boundary may fall in the middle of.</summary>
+    private readonly StringBuilder _line = new();
+
+    private readonly long _maxEventLength;
+
+    /// <summary>The event type buffer.</summary>
+    private string _eventType = string.Empty;
+
+    /// <summary>The last event ID buffer, which is never reset between events.</summary>
+    private string _lastEventId;
+
+    /// <summary>
+    /// Whether the previous character was a CR, so that an LF opening the next chunk is recognized as the
+    /// second half of a CRLF rather than as a line ending of its own.
+    /// </summary>
+    private bool _afterCarriageReturn;
+
+    /// <summary>Whether no character has been consumed yet, which is the only place a BOM may be stripped.</summary>
+    private bool _atStreamStart = true;
+
+    private long? _reconnectionTime;
+
+    /// <param name="maxEventLength">
+    /// The most characters one event may accumulate — the data buffer plus the line being read — before the
+    /// connection is failed. <see cref="long.MaxValue"/> means unbounded.
+    /// </param>
+    /// <param name="lastEventId">
+    /// What the last event ID buffer starts as, which is the event source's last event ID string.
+    /// </param>
+    /// <remarks>
+    /// Seeding that buffer is a <b>deliberate divergence from a literal reading</b> of "when a stream is
+    /// parsed, a data buffer, an event type buffer, and a last event ID buffer must be associated with it …
+    /// initialized to the empty string". Taken literally, the first event of a reconnected stream that
+    /// carries no <c>id</c> field would set the event source's last event ID string back to the empty string
+    /// — and the <i>next</i> reconnection would then resume from the beginning, silently, which is the one
+    /// thing the whole mechanism exists to prevent. Browsers seed it, and so does this.
+    /// </remarks>
+    internal EventStreamParser(long maxEventLength, string lastEventId)
+    {
+        _maxEventLength = maxEventLength;
+        _lastEventId = lastEventId;
+    }
+
+    /// <summary>
+    /// Decodes a chunk of the response body and appends whatever events it completed to
+    /// <paramref name="messages"/>.
+    /// </summary>
+    /// <exception cref="FetchFailureException">
+    /// One event grew past the cap this parser was built with. There is no such failure in the standard — a
+    /// browser's event stream is bounded by the tab's memory — but a stream is unbounded by nature and an
+    /// engine embedded in a server cannot buffer whatever a server chooses to send.
+    /// </exception>
+    internal void Feed(byte[] buffer, int count, List<EventStreamMessage> messages)
+    {
+        Span<char> chars = stackalloc char[512];
+        var bytes = new ReadOnlySpan<byte>(buffer, 0, count);
+
+        while (!bytes.IsEmpty)
+        {
+            _decoder.Convert(bytes, chars, flush: false, out var bytesUsed, out var charsUsed, out _);
+            Consume(chars.Slice(0, charsUsed), messages);
+
+            if (bytesUsed == 0 && charsUsed == 0)
+            {
+                // Everything left is an incomplete UTF-8 sequence the decoder is holding on to; it completes
+                // when the next chunk arrives.
+                break;
+            }
+
+            bytes = bytes.Slice(bytesUsed);
+        }
+    }
+
+    /// <summary>
+    /// The reconnection time a <c>retry</c> field last set, taken once. It is applied on the engine thread,
+    /// which is where the event source's own state lives.
+    /// </summary>
+    internal long? TakeReconnectionTime()
+    {
+        var value = _reconnectionTime;
+        _reconnectionTime = null;
+        return value;
+    }
+
+    /// <summary>
+    /// The line splitting: "a CRLF character pair, a single LF character not preceded by a CR character, and a
+    /// single CR character not followed by an LF character being the ways in which a line can end".
+    /// </summary>
+    private void Consume(ReadOnlySpan<char> chars, List<EventStreamMessage> messages)
+    {
+        foreach (var c in chars)
+        {
+            if (_atStreamStart)
+            {
+                _atStreamStart = false;
+
+                // "The UTF-8 decode algorithm strips one leading UTF-8 Byte Order Mark (BOM), if any."
+                if (c == ByteOrderMark)
+                {
+                    continue;
+                }
+            }
+
+            if (_afterCarriageReturn)
+            {
+                _afterCarriageReturn = false;
+
+                // The CR already ended the line; the LF completing a CRLF adds nothing.
+                if (c == '\n')
+                {
+                    continue;
+                }
+            }
+
+            switch (c)
+            {
+                case '\r':
+                    _afterCarriageReturn = true;
+                    EndLine(messages);
+                    break;
+                case '\n':
+                    EndLine(messages);
+                    break;
+                default:
+                    EnsureRoom(1);
+                    _line.Append(c);
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// "Lines must be processed, in the order they are received, as follows" — the four cases of
+    /// https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation.
+    /// </summary>
+    private void EndLine(List<EventStreamMessage> messages)
+    {
+        var line = _line.ToString();
+        _line.Clear();
+
+        if (line.Length == 0)
+        {
+            // "If the line is empty (a blank line): dispatch the event."
+            Dispatch(messages);
+            return;
+        }
+
+        if (line[0] == ':')
+        {
+            // "If the line starts with a U+003A COLON character (:): ignore the line." This is what a
+            // server's keep-alive comment is, and why one keeps a connection alive without producing an event.
+            return;
+        }
+
+        var colon = line.IndexOf(':');
+        if (colon < 0)
+        {
+            // "the string is not empty but does not contain a U+003A COLON character": the whole line is the
+            // field name and the value is the empty string.
+            ProcessField(line, string.Empty);
+            return;
+        }
+
+        var value = line.Substring(colon + 1);
+
+        // "If value starts with a U+0020 SPACE character, remove it from value." One space, not a trim.
+        if (value.Length > 0 && value[0] == ' ')
+        {
+            value = value.Substring(1);
+        }
+
+        ProcessField(line.Substring(0, colon), value);
+    }
+
+    /// <summary>
+    /// "The steps to process the field given a field name and a field value" — the names are compared
+    /// literally, with no case folding, and an unknown field is ignored.
+    /// </summary>
+    private void ProcessField(string field, string value)
+    {
+        switch (field)
+        {
+            case EventField:
+                _eventType = value;
+                break;
+
+            case DataField:
+                EnsureRoom(value.Length + 1);
+                _data.Append(value).Append('\n');
+                break;
+
+            case IdField:
+                // "If the field value does not contain U+0000 NULL, then set the last event ID buffer to the
+                // field value. Otherwise, ignore the field." An empty value is not ignored: it resets the
+                // buffer, so no Last-Event-ID header is sent on the next reconnect.
+                if (!value.Contains('\0', StringComparison.Ordinal))
+                {
+                    _lastEventId = value;
+                }
+
+                break;
+
+            case RetryField:
+                if (TryParseReconnectionTime(value, out var milliseconds))
+                {
+                    _reconnectionTime = milliseconds;
+                }
+
+                break;
+        }
+    }
+
+    /// <summary>
+    /// "If the field value consists of only ASCII digits, then interpret the field value as an integer in base
+    /// ten … Otherwise, ignore the field."
+    /// </summary>
+    /// <remarks>
+    /// The integer is unbounded in the standard and clamped to <see cref="int.MaxValue"/> milliseconds here —
+    /// about 24.8 days — which is the same ceiling <c>setTimeout</c> has, and for the same reason: the delay
+    /// rides the engine's timer queue. Nothing can observe the difference.
+    /// </remarks>
+    private static bool TryParseReconnectionTime(string value, out long milliseconds)
+    {
+        milliseconds = 0;
+
+        if (value.Length == 0)
+        {
+            return false;
+        }
+
+        foreach (var c in value)
+        {
+            if (c is < '0' or > '9')
+            {
+                return false;
+            }
+
+            milliseconds = milliseconds * 10 + (c - '0');
+            if (milliseconds > int.MaxValue)
+            {
+                milliseconds = int.MaxValue;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/server-sent-events.html#dispatchMessage, steps 1 to 7. Step 8 —
+    /// "queue a task which, if the readyState attribute is set to a value other than CLOSED, dispatches the
+    /// newly created event" — is the caller's, because only the engine thread may create or dispatch one.
+    /// </summary>
+    private void Dispatch(List<EventStreamMessage> messages)
+    {
+        // Step 2: "If the data buffer is an empty string, set the data buffer and the event type buffer to the
+        // empty string and return." Step 1 has already happened, in that the last event ID buffer was set by
+        // the id field itself and is never reset here.
+        if (_data.Length == 0)
+        {
+            _eventType = string.Empty;
+            return;
+        }
+
+        // Step 3: "If the data buffer's last character is a U+000A LINE FEED (LF) character, then remove the
+        // last character from the data buffer." It always is — every data field appends one — so this undoes
+        // the separator after the last field rather than trimming the data.
+        if (_data[_data.Length - 1] == '\n')
+        {
+            _data.Length--;
+        }
+
+        // Steps 4 to 6.
+        var type = _eventType.Length == 0 ? DefaultEventType : _eventType;
+        messages.Add(new EventStreamMessage(type, _data.ToString(), _lastEventId));
+
+        // Step 7.
+        _data.Clear();
+        _eventType = string.Empty;
+    }
+
+    /// <summary>
+    /// The per-event cap. Measured in decoded characters rather than bytes, which for UTF-8 can only be
+    /// stricter — a character never costs less than one byte — and which is what actually bounds the memory
+    /// this parser holds.
+    /// </summary>
+    private void EnsureRoom(int additional)
+    {
+        if (_maxEventLength == long.MaxValue)
+        {
+            return;
+        }
+
+        if (_data.Length + (long) _line.Length + additional > _maxEventLength)
+        {
+            throw new FetchFailureException(
+                FetchFailureKind.ResponseTooLarge,
+                $"A single event exceeded the {_maxEventLength} character limit set by Options.WebApi.Fetch.MaxResponseBytes.");
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/ServerSentEvents/JsEventSource.cs
+++ b/Jint/WebApi/ServerSentEvents/JsEventSource.cs
@@ -1,0 +1,467 @@
+#if NET8_0_OR_GREATER
+using System.Net.Http;
+using Jint.Native;
+using Jint.Runtime;
+using Jint.WebApi.Events;
+using Jint.WebApi.Fetch;
+using Jint.WebApi.Timers;
+using Jint.WebApi.Url.Parsing;
+
+namespace Jint.WebApi.ServerSentEvents;
+
+/// <summary>
+/// An <c>EventSource</c> instance: the connection state machine of the server-sent events protocol, and an
+/// <see cref="JsEventTarget"/> so that a script can listen for <c>open</c>, <c>message</c> and <c>error</c>.
+/// <para>
+/// https://html.spec.whatwg.org/multipage/server-sent-events.html#the-eventsource-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Everything here runs on the engine's thread.</b> The readyState transitions, the event dispatches and
+/// the decision to reconnect all happen inside the pump; the connection's own thread only ever hands over
+/// plain CLR data through a generation-stamped job. That is what makes the state machine safe to read from
+/// script without a lock, and it is the reason nothing at all happens in an engine nobody pumps.
+/// </para>
+/// <para>
+/// <b>The reconnect delay rides the engine's timer queue</b> — the same queue <c>setTimeout</c> and
+/// <c>AbortSignal.timeout()</c> use — so a reconnection, like everything else, happens only while the engine
+/// is being pumped, and it counts against <c>Options.WebApi.Timers.MaxActiveTimers</c>. Each attempt re-runs
+/// the URL policy from scratch: the scheme list and the host's <c>UrlFilter</c> are asked again, so revoking
+/// a destination between two attempts really does stop the next one.
+/// </para>
+/// </remarks>
+internal sealed class JsEventSource : JsEventTarget
+{
+    /// <summary>https://html.spec.whatwg.org/multipage/server-sent-events.html#dom-eventsource-connecting.</summary>
+    internal const int Connecting = 0;
+
+    /// <summary>https://html.spec.whatwg.org/multipage/server-sent-events.html#dom-eventsource-open.</summary>
+    internal const int Open = 1;
+
+    /// <summary>https://html.spec.whatwg.org/multipage/server-sent-events.html#dom-eventsource-closed.</summary>
+    internal const int Closed = 2;
+
+    internal const string OpenEventType = "open";
+    internal const string ErrorEventType = "error";
+
+    /// <summary>
+    /// The reconnection time an event source starts with. The standard leaves it implementation-defined,
+    /// "probably in the region of a few seconds"; three seconds is what browsers use, and a <c>retry</c> field
+    /// replaces it for the rest of the connection's life.
+    /// </summary>
+    private const long DefaultReconnectionTime = 3000;
+
+    private static readonly JsString _openEventName = new(OpenEventType);
+    private static readonly JsString _errorEventName = new(ErrorEventType);
+
+    private readonly WebApiEngineState _state;
+    private readonly Options.FetchOptions _options;
+
+    private EventSourceConnection? _connection;
+
+    /// <summary>The id of the timer holding the reconnect delay, or zero when none is pending.</summary>
+    private int _reconnectTimerId;
+
+    internal JsEventSource(Engine engine, Realm realm, WebApiEngineState state, UrlRecord url, bool withCredentials)
+        : base(engine, realm)
+    {
+        _state = state;
+        _options = state.FetchOptions!;
+        Url = url;
+        Href = JsString.Create(url.Serialize());
+        WithCredentials = withCredentials;
+    }
+
+    /// <summary>The event source's url, https://html.spec.whatwg.org/multipage/server-sent-events.html#dom-eventsource-url.</summary>
+    internal UrlRecord Url { get; }
+
+    /// <summary>
+    /// The serialization of <see cref="Url"/>, which is what the <c>url</c> getter answers — built once,
+    /// because the URL can never change.
+    /// </summary>
+    internal JsString Href { get; }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/server-sent-events.html#dom-eventsource-withcredentials —
+    /// "must return the value to which it was last initialized".
+    /// </summary>
+    /// <remarks>
+    /// Accepted and remembered, and it changes nothing about the request. The member selects the CORS
+    /// attribute state, which decides whether a browser attaches cookies and HTTP authentication to a
+    /// cross-origin request; an embedded engine has no origin, no cookie jar and no credential store, so
+    /// there is nothing for it to select. It is the same treatment <c>fetch</c> gives <c>credentials</c>, and
+    /// the same one Node and workerd give it.
+    /// </remarks>
+    internal bool WithCredentials { get; }
+
+    /// <summary>https://html.spec.whatwg.org/multipage/server-sent-events.html#dom-eventsource-readystate.</summary>
+    internal int ReadyState { get; private set; } = Connecting;
+
+    /// <summary>
+    /// The event source's last event ID string, https://html.spec.whatwg.org/multipage/server-sent-events.html#last-event-id-string.
+    /// Sent as <c>Last-Event-ID</c> on every reconnect once it is non-empty.
+    /// </summary>
+    internal string LastEventId { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// The event source's reconnection time, in milliseconds — replaced by any <c>retry</c> field the stream
+    /// sends.
+    /// </summary>
+    internal long ReconnectionTime { get; private set; } = DefaultReconnectionTime;
+
+    /// <summary>
+    /// Constructor step 15: "fetch request". Also the last step of reestablishing the connection, which is why
+    /// the whole of the policy — the scheme list, the host's filter, the client and the concurrency limit — is
+    /// resolved here rather than once at construction.
+    /// </summary>
+    internal void Connect()
+    {
+        var urlFilter = _options.UrlFilter ?? (static _ => true);
+
+        var policy = new FetchPolicy
+        {
+            AllowedSchemes = [.. _options.AllowedSchemes],
+            UrlFilter = urlFilter,
+            MaxResponseBytes = _options.MaxResponseBytes,
+            MaxRedirects = _options.MaxRedirects,
+        };
+
+        // The first hop's check runs on the engine thread, so a refused URL never reaches a socket. Every
+        // redirect hop is re-checked inside the transport, and every reconnect comes back through here.
+        if (!policy.Allows(Url, out _))
+        {
+            FailConnectionLater();
+            return;
+        }
+
+        // Counted per engine and per kind: a host's MaxConcurrentRequests bounds the fetches in flight and,
+        // separately, the event streams open, because a stream holds its socket for as long as it lives.
+        if (_state.ActiveEventSourceCount >= _options.MaxConcurrentRequests)
+        {
+            FailConnectionLater();
+            return;
+        }
+
+        HttpClient? client;
+        try
+        {
+            client = FetchTransport.ResolveClient(_engine, _options);
+        }
+        catch (Exception exception) when (!ConstraintFailure.MustPropagate(exception))
+        {
+            // A host HttpClientFactory that threw. Unlike fetch — where the failure becomes the rejection of
+            // the promise the call returned — there is no caller to hand it to on a reconnect, so both the
+            // first attempt and the later ones fail the connection.
+            client = null;
+        }
+
+        if (client is null)
+        {
+            FailConnectionLater();
+            return;
+        }
+
+        // The new stream's last event ID buffer starts as this object's last event ID string, so an event
+        // that carries no id of its own still reports the last one the server sent — see the parser.
+        var connection = new EventSourceConnection(this, _engine, _realm, _options.MaxResponseBytes, LastEventId);
+        _connection = connection;
+        _state.RegisterEventSource(connection);
+        connection.Start(client, BuildRequest(), policy);
+    }
+
+    /// <summary>
+    /// The request the constructor built, plus the <c>Last-Event-ID</c> header a reconnect adds — steps 8 to
+    /// 13 of the constructor and step 5 of reestablishing the connection.
+    /// </summary>
+    /// <remarks>
+    /// The cache mode the standard sets (<c>no-store</c>) has nothing to act on here — Jint has no HTTP cache
+    /// — so it is expressed on the wire as <c>Cache-Control: no-cache</c>, which is what a browser sends for
+    /// an event stream and what keeps an intermediary from replaying one. A <c>Last-Event-ID</c> whose value
+    /// is not a valid header value is dropped rather than sent: it comes from the server, and the alternative
+    /// is letting a server's own <c>id</c> field shape the next request's headers.
+    /// </remarks>
+    private FetchRequestSnapshot BuildRequest()
+    {
+        var headers = new List<HeaderEntry>
+        {
+            new("accept", "text/event-stream"),
+            new("cache-control", "no-cache"),
+        };
+
+        if (LastEventId.Length != 0 && HeaderList.IsValue(LastEventId))
+        {
+            headers.Add(new HeaderEntry("last-event-id", LastEventId));
+        }
+
+        return new FetchRequestSnapshot
+        {
+            Method = "GET",
+            Url = Url,
+            Headers = headers,
+            Body = null,
+            Redirect = JsRequest.RedirectFollow,
+        };
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/server-sent-events.html#announce-the-connection — "queue a task
+    /// which, if the readyState attribute is set to a value other than CLOSED, sets the readyState attribute
+    /// to OPEN and fires an event named open".
+    /// </summary>
+    internal void AnnounceConnection(EventSourceConnection connection)
+    {
+        if (!ReferenceEquals(_connection, connection) || ReadyState == Closed)
+        {
+            return;
+        }
+
+        ReadyState = Open;
+        FireEvent(_openEventName);
+    }
+
+    /// <summary>
+    /// Step 8 of https://html.spec.whatwg.org/multipage/server-sent-events.html#dispatchMessage, for every
+    /// event one chunk of the stream produced: "queue a task which, if the readyState attribute is set to a
+    /// value other than CLOSED, dispatches the newly created event at the EventSource object".
+    /// </summary>
+    /// <remarks>
+    /// One job per chunk rather than one per event, which is what keeps the events of a chunk in order and
+    /// contiguous. The readyState is re-read for each of them, because a listener may call <c>close()</c>
+    /// halfway through — and then the rest are not dispatched, exactly as separate tasks would behave. Step 1
+    /// still happens for those: the last event ID string is set as each event is reached, so a reconnect
+    /// resumes from the last <c>id</c> the server sent rather than from the last one a listener saw.
+    /// </remarks>
+    internal void DeliverMessages(EventSourceConnection connection, long? reconnectionTime, List<EventStreamMessage> messages, string origin)
+    {
+        if (!ReferenceEquals(_connection, connection))
+        {
+            return;
+        }
+
+        if (reconnectionTime is { } milliseconds)
+        {
+            ReconnectionTime = milliseconds;
+        }
+
+        var originValue = JsString.Create(origin);
+
+        foreach (var message in messages)
+        {
+            // Step 1: "set the last event ID string of the event source to the value of the last event ID
+            // buffer".
+            LastEventId = message.LastEventId;
+
+            if (ReadyState == Closed)
+            {
+                continue;
+            }
+
+            var messageEvent = _realm.Intrinsics.MessageEvent.CreateTrustedMessageEvent(
+                JsString.Create(message.Type),
+                JsString.Create(message.Data),
+                originValue,
+                JsString.Create(message.LastEventId));
+
+            DispatchEvent(messageEvent);
+        }
+    }
+
+    /// <summary>
+    /// What the engine thread does once a connection has ended, chosen by how it ended.
+    /// </summary>
+    internal void OnConnectionEnded(EventSourceConnection connection, EventSourceOutcome outcome)
+    {
+        if (!ReferenceEquals(_connection, connection))
+        {
+            // Superseded by a later connection, which can only happen if something ended this one first.
+            return;
+        }
+
+        _connection = null;
+
+        switch (outcome)
+        {
+            case EventSourceOutcome.Fail:
+                FailConnection();
+                break;
+            case EventSourceOutcome.Reestablish:
+                ReestablishConnection();
+                break;
+            default:
+                // Abandoned: close(), a restore or the engine's own cancellation. Nothing is fired.
+                break;
+        }
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/server-sent-events.html#fail-the-connection — "queue a task
+    /// which, if the readyState attribute is set to a value other than CLOSED, sets the readyState attribute
+    /// to CLOSED and fires an event named error at the EventSource object. Once the user agent has failed the
+    /// connection, it does not attempt to reconnect."
+    /// </summary>
+    private void FailConnection()
+    {
+        if (ReadyState == Closed)
+        {
+            return;
+        }
+
+        ReadyState = Closed;
+        CancelReconnectTimer();
+        FireEvent(_errorEventName);
+    }
+
+    /// <summary>
+    /// The same, queued: the failures the engine detects before anything is sent — a URL the policy refuses,
+    /// too many streams already open, a client the host would not supply — happen inside the constructor,
+    /// where the standard's failures are all in a task rather than in the caller's stack.
+    /// </summary>
+    private void FailConnectionLater() => _engine.AddToEventLoop(FailConnection);
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/server-sent-events.html#reestablish-the-connection: set
+    /// CONNECTING and fire <c>error</c>, wait the reconnection time, then fetch again unless something closed
+    /// the source in the meantime.
+    /// </summary>
+    /// <remarks>
+    /// The delay is armed <i>before</i> the <c>error</c> event rather than after it, which is both what the
+    /// standard describes — the wait runs in parallel with that task, not after it — and what keeps a
+    /// listener that throws from cancelling a reconnection the object has already committed to.
+    /// </remarks>
+    private void ReestablishConnection()
+    {
+        if (ReadyState == Closed)
+        {
+            return;
+        }
+
+        ReadyState = Connecting;
+
+        if (!TryScheduleReconnect())
+        {
+            // The engine's timer queue is full, so there is nothing to hold the delay. Failing is the honest
+            // answer: the alternative is an object that says CONNECTING forever.
+            FailConnection();
+            return;
+        }
+
+        FireEvent(_errorEventName);
+    }
+
+    private bool TryScheduleReconnect()
+    {
+        var timers = _state.Timers;
+        if (timers is null || timers.Count >= timers.MaxActiveTimers)
+        {
+            return false;
+        }
+
+        var entry = new TimerEntry(
+            timers,
+            new ReconnectAlgorithm(this),
+            [],
+            ReconnectionTime,
+            repeat: false,
+            _engine.EventLoopGeneration);
+
+        _reconnectTimerId = timers.Schedule(entry);
+        return true;
+    }
+
+    private void CancelReconnectTimer()
+    {
+        if (_reconnectTimerId == 0)
+        {
+            return;
+        }
+
+        _state.Timers?.Cancel(_reconnectTimerId);
+        _reconnectTimerId = 0;
+    }
+
+    /// <summary>
+    /// The last task of reestablishing the connection: "if the EventSource object's readyState attribute is
+    /// not set to CONNECTING, then return … fetch request and process the response".
+    /// </summary>
+    private void Reconnect()
+    {
+        _reconnectTimerId = 0;
+
+        if (ReadyState != Connecting)
+        {
+            return;
+        }
+
+        Connect();
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/server-sent-events.html#dom-eventsource-close — "must abort any
+    /// instances of the fetch algorithm started for this EventSource object, and must set the readyState
+    /// attribute to CLOSED". No event is fired, and nothing reconnects.
+    /// </summary>
+    internal void Close()
+    {
+        ReadyState = Closed;
+        CancelReconnectTimer();
+
+        var connection = _connection;
+        if (connection is null)
+        {
+            return;
+        }
+
+        _connection = null;
+        _state.UnregisterEventSource(connection);
+        connection.Abandon();
+    }
+
+    /// <summary>
+    /// The fence a <c>RestoreGlobalSnapshot</c> puts up, reached from the connection the engine state is
+    /// abandoning. The socket is already being let go; this is the object's own half of it.
+    /// </summary>
+    /// <remarks>
+    /// The source ends up <c>CLOSED</c> with no <c>error</c> event, which is the same shape <c>close()</c>
+    /// has and the only honest one: the evaluation cycle those listeners belonged to has ended, so there is
+    /// nobody left to tell.
+    /// </remarks>
+    internal void AbandonConnection(EventSourceConnection connection)
+    {
+        if (!ReferenceEquals(_connection, connection))
+        {
+            return;
+        }
+
+        _connection = null;
+        ReadyState = Closed;
+
+        // The queue this id belongs to has been cleared by the same restore; forgetting it keeps a later
+        // close() from cancelling an id another timer has since been given.
+        _reconnectTimerId = 0;
+    }
+
+    /// <summary>
+    /// What the reconnect delay's timer runs.
+    /// </summary>
+    /// <remarks>
+    /// An <see cref="ICallable"/> rather than a <c>ClrFunction</c>, so that a reconnection creates no
+    /// JavaScript function object for something no script can reach — the timer queue is the only caller.
+    /// </remarks>
+    private sealed class ReconnectAlgorithm : ICallable
+    {
+        private readonly JsEventSource _source;
+
+        internal ReconnectAlgorithm(JsEventSource source)
+        {
+            _source = source;
+        }
+
+        public JsValue Call(JsValue thisObject, params JsCallArguments arguments)
+        {
+            _source.Reconnect();
+            return JsValue.Undefined;
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/WebApiOptionsExtensions.cs
+++ b/Jint/WebApi/WebApiOptionsExtensions.cs
@@ -133,6 +133,51 @@ public static class WebApiOptionsExtensions
     }
 
     /// <summary>
+    /// Enables <c>EventSource</c> and <c>MessageEvent</c> — server-sent events — and with them
+    /// <see cref="WebApiFeatures.Events"/>, whose <c>EventTarget</c> an <c>EventSource</c> is.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>This is a grant of outbound network access</b>, separate from <see cref="UseFetch"/>: neither
+    /// implies the other, and <see cref="UseWebApis(Options)"/> grants neither. It reads its transport and
+    /// its policy from the same <see cref="Options.FetchOptions"/> group <c>fetch</c> does — which is what
+    /// <paramref name="configure"/> hands you — so a host that has already written a
+    /// <see cref="Options.FetchOptions.UrlFilter"/> has written this one too. Three of those settings mean
+    /// something different for a stream than for a document; see <see cref="WebApiFeatures.EventSource"/>.
+    /// </para>
+    /// <para>
+    /// A connection delivers, and reconnects, only while the engine is being pumped. Nothing arrives in an
+    /// engine nobody pumps, and nothing arrives on a thread the host did not choose.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// var engine = new Engine(options => options.UseWebApis().UseEventSource(net =>
+    /// {
+    ///     net.UrlFilter = uri => uri.Host.EndsWith(".example.org", StringComparison.OrdinalIgnoreCase);
+    ///     net.MaxResponseBytes = 64 * 1024;      // the largest single event, not the largest stream
+    ///     net.MaxConcurrentRequests = 2;         // at most two streams open at once
+    /// }));
+    /// </code>
+    /// </example>
+    /// <param name="options">Options to modify.</param>
+    /// <param name="configure">
+    /// Optional configuration of the shared network settings, run after the feature is enabled.
+    /// </param>
+    /// <returns>Options instance for fluent syntax.</returns>
+    public static Options UseEventSource(this Options options, Action<Options.FetchOptions>? configure = null)
+    {
+        if (options is null)
+        {
+            Throw.ArgumentNullException(nameof(options));
+        }
+
+        options.WebApi.Features |= WebApiFeatures.EventSource;
+        configure?.Invoke(options.WebApi.Fetch);
+        return options;
+    }
+
+    /// <summary>
     /// Enables the <c>console</c> object and sends its output to <paramref name="sink"/>.
     /// </summary>
     /// <param name="options">Options to modify.</param>

--- a/Jint/WebApi/WebApiRegistration.cs
+++ b/Jint/WebApi/WebApiRegistration.cs
@@ -205,6 +205,16 @@ internal static class WebApiRegistration
             Install(global, engine, "localStorage", static e => e.Realm.Intrinsics.LocalStorage, PropertyFlag.ConfigurableEnumerableWritable);
             Install(global, engine, "sessionStorage", static e => e.Realm.Intrinsics.SessionStorage, PropertyFlag.ConfigurableEnumerableWritable);
         }
+
+        if ((features & WebApiFeatures.EventSource) != WebApiFeatures.None)
+        {
+            Install(global, engine, "EventSource", static e => e.Realm.Intrinsics.EventSource, PropertyFlag.NonEnumerable);
+
+            // MessageEvent is the interface an event source dispatches with, so it exists wherever one does.
+            // The messaging feature installs the same intrinsic; Install is non-clobbering, so an engine with
+            // both flags gets one object either way.
+            Install(global, engine, "MessageEvent", static e => e.Realm.Intrinsics.MessageEvent, PropertyFlag.NonEnumerable);
+        }
     }
 
     /// <summary>
@@ -221,11 +231,12 @@ internal static class WebApiRegistration
     /// features — while the engine carries the closure.
     /// </para>
     /// <para>
-    /// Fetch is the only feature with implications today. <c>Request</c> always has an <c>AbortSignal</c>
-    /// (<see cref="WebApiFeatures.Events"/>), its URL is a WHATWG URL record
-    /// (<see cref="WebApiFeatures.Url"/>) and <c>response.blob()</c> answers with a <c>Blob</c>
-    /// (<see cref="WebApiFeatures.Files"/>); none of the three is optional to the implementation, so
-    /// installing fetch without them would ship an interface that throws on its own members.
+    /// <c>Request</c> always has an <c>AbortSignal</c> (<see cref="WebApiFeatures.Events"/>), its URL is a
+    /// WHATWG URL record (<see cref="WebApiFeatures.Url"/>) and <c>response.blob()</c> answers with a
+    /// <c>Blob</c> (<see cref="WebApiFeatures.Files"/>); none of the three is optional to the implementation,
+    /// so installing fetch without them would ship an interface that throws on its own members. An
+    /// <c>EventSource</c> is an <c>EventTarget</c> for the same kind of reason, and the reconnect delay it
+    /// schedules rides the queue that flag creates.
     /// </para>
     /// </remarks>
     private static WebApiFeatures ExpandFeatures(WebApiFeatures features)
@@ -233,6 +244,13 @@ internal static class WebApiRegistration
         if ((features & WebApiFeatures.Fetch) != WebApiFeatures.None)
         {
             features |= WebApiFeatures.Events | WebApiFeatures.Url | WebApiFeatures.Files;
+        }
+
+        // Deliberately not the other way round: fetch does not bring server-sent events and server-sent
+        // events do not bring fetch. They are two separate grants of outbound network access.
+        if ((features & WebApiFeatures.EventSource) != WebApiFeatures.None)
+        {
+            features |= WebApiFeatures.Events;
         }
 
         return features;
@@ -282,7 +300,10 @@ internal static class WebApiRegistration
 
         // The fetch settings are read here, once, so that nothing on a background thread ever reaches into
         // Options — and so that a host mutating them afterwards does not change an engine that already exists.
-        var fetch = (features & WebApiFeatures.Fetch) != WebApiFeatures.None ? options.WebApi.Fetch : null;
+        // EventSource reads the same group: it is a second grant of network access over the same transport
+        // and the same policy, so either flag is reason enough to keep them.
+        const WebApiFeatures NeedsFetchOptions = WebApiFeatures.Fetch | WebApiFeatures.EventSource;
+        var fetch = (features & NeedsFetchOptions) != WebApiFeatures.None ? options.WebApi.Fetch : null;
 
         var scheduler = (features & WebApiFeatures.Scheduler) != WebApiFeatures.None
             ? new SchedulerQueue(engine)

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ its own `console` (or any other name in the table below), enabling the feature l
 | `reportError` (and the `DiagnosticsSink` behind it) | `Reporting` | ✔ shipped |
 | `localStorage` / `sessionStorage` / `Storage` | `Storage` *(not in `Default` — see below)* | ✔ shipped |
 | `fetch` / `Headers` / `Request` / `Response` | `Fetch` — **opt-in on its own, see below** | ✔ shipped |
+| `EventSource` / `MessageEvent` (server-sent events) | `EventSource` — **opt-in on its own, see below** | ✔ shipped |
 
 `WebApiFeatures.Default` — what `UseWebApis()` enables — is every non-network feature that has landed. It
 grows as the table fills in, and it will never include `fetch`: network egress is always an explicit choice.
@@ -554,6 +555,60 @@ engines that run concurrently must be thread-safe.
 **There is no `storage` event.** Every mutating step ends in "broadcast", which notifies *other* browsing
 contexts sharing an origin — a multi-context feature, and an engine has one context. `StorageEvent` is absent
 rather than present-and-never-firing, so feature detection sees the truth.
+
+### `EventSource` is a second, separate grant
+
+Server-sent events are their own opt-in: `UseFetch()` does not enable `EventSource`, `UseEventSource()` does
+not enable `fetch`, and `UseWebApis()` enables neither.
+
+```csharp
+var engine = new Engine(options => options.UseWebApis().UseEventSource(net =>
+{
+    net.UrlFilter = uri => uri.Host.EndsWith(".example.org", StringComparison.OrdinalIgnoreCase);
+    net.MaxResponseBytes = 64 * 1024;   // the largest single event, not the largest stream
+    net.MaxConcurrentRequests = 2;      // at most two streams open at once
+}));
+
+engine.Execute("""
+    const events = new EventSource('https://api.example.org/updates');
+    events.onmessage = e => console.log(e.lastEventId, e.data);
+    """);
+
+while (running) { engine.Advanced.ProcessTasks(); Thread.Sleep(5); }   // your loop, your thread
+```
+
+It is the standard's own object: `url`, `readyState` with `CONNECTING`/`OPEN`/`CLOSED`, `onopen`/`onmessage`/
+`onerror`, `close()`, and `addEventListener` for the custom types an `event:` field names. The stream is
+parsed exactly as the specification writes it — UTF-8 with a leading BOM stripped, CRLF/CR/LF line endings,
+`data`/`event`/`id`/`retry` fields, one leading space removed after the colon, comment lines as keep-alives,
+`data` values joined with a newline, and an event dispatched only at a blank line. `withCredentials` is
+accepted, remembered and ignored, the same treatment `fetch` gives `credentials`: there is no origin, cookie
+jar or credential store here for it to select.
+
+**It reads `Options.WebApi.Fetch`** — the same transport (`HttpClient` / `HttpClientFactory`) and the same
+policy (`AllowedSchemes`, `UrlFilter`, `MaxRedirects`) that `fetch` uses, so a filter you have already written
+covers both, and every redirect hop is re-checked exactly as it is for a fetch. Three of those settings mean
+something different for a stream:
+
+- **`Timeout` does not apply.** A connection that is idle for an hour is what an event stream is *for*.
+- **`MaxResponseBytes` does not bound the stream** — nothing could — it bounds **one event**: the data buffer
+  plus the line being read, which is what actually has to be held in memory. Exceeding it fails the connection.
+- **`MaxConcurrentRequests` bounds the streams one engine may have open**, counted separately from the
+  fetches in flight, because a stream holds its socket for as long as it lives.
+
+**Reconnection rides the timer queue**, so it too happens only while you are pumping, and it counts against
+`MaxActiveTimers`. A stream that ends, or a network error, sets `readyState` back to `CONNECTING`, fires
+`error`, waits the server's `retry:` value (3 seconds by default) and connects again — re-running the URL
+policy from scratch and sending `Last-Event-ID` so the server can resume. A response that is not `200
+text/event-stream`, a URL your policy refuses and an event over the size cap all *fail* the connection
+instead: `readyState` becomes `CLOSED` and nothing retries. `close()` cancels the request in flight, and so
+does `Engine.Advanced.RestoreGlobalSnapshot` — after a restore the connection is gone, its pending
+reconnection with it, and nothing from the ended cycle is ever dispatched into the restored engine.
+
+**Security.** Everything TM-21 says about destinations applies here, and one thing more: a connection is
+long-lived and reconnects *on a delay the server chooses*, with no deadline to end it. See
+[THREAT_MODEL.md](.github/THREAT_MODEL.md) TM-22 — the short version is to bound the engine's own lifetime
+for untrusted script rather than pooling an engine a script may leave streaming.
 
 
 ## Node compatibility (opt-in)


### PR DESCRIPTION
Part of #3086: `EventSource` over the fetch transport — server-sent events per https://html.spec.whatwg.org/multipage/server-sent-events.html, as `WebApiFeatures.EventSource`, **never part of `Default`** and a separate grant from fetch: enabling one does not enable the other, and both read the same `Options.WebApi.Fetch` policy group (`UrlFilter` re-runs on every redirect hop *and* every reconnection).

The stream interpreter is the spec's, implemented verbatim and mutation-pinned: UTF-8 with one leading BOM stripped, CRLF/CR/LF line endings incremental across chunk boundaries, the field grammar, and dispatch with `readyState` re-checked **per event** on the engine thread — `close()` inside a listener stops the rest of the same chunk. Reconnection follows the spec's fail-vs-reestablish split: not-200 or wrong `Content-Type` essence fails the connection; a network error or normal end of body reestablishes with `Last-Event-ID`, honoring a server's `retry:`. One documented divergence matches browsers over the letter of the text: a new connection's last-event-ID buffer is seeded from the object's current ID so the resume point survives a second reconnect.

Three of the shared fetch settings mean something different for a stream and are documented as such: `Timeout` is not applied (an idle hour is what an event stream is for), `MaxResponseBytes` bounds one *event*, `MaxConcurrentRequests` bounds open streams counted separately. Host-limit failures fail the connection rather than retrying into the same rule. `.github/THREAT_MODEL.md` gains TM-22 (server-chosen retry cadence with no deadline).

`MessageEvent` is the messaging feature's intrinsic, extended here with the origin/lastEventId trusted-creation overload the dispatch steps set — one interface object however many features install it.

44 tests including a scripted fake transport, two real bugs found by tests during development (a disposed-token race in the read loop, the reconnect ID seed); both suites green on net10.0 and net472, with and without `JINT_HOST_CONTRACT_VERIFICATION=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G7Ud48VAs1JicxRZxLDxg
