### PR TITLE
Add benchmark rows for the web-API surface

### DIFF
--- a/Jint.Benchmark/Program.cs
+++ b/Jint.Benchmark/Program.cs
@@ -29,6 +29,16 @@ if (args.Length > 0 && args[0] == "--profile-alloc-types")
     return AllocTypeProbe.Run(args);
 }
 
+if (args.Length > 0 && args[0] == "--smoke-webapi")
+{
+    // Runs every web-API class's [GlobalSetup] and then each of its rows three times, reporting pass/fail
+    // per class. Measures nothing: it exists so a Jint/WebApi/ change can prove the rows still run — and
+    // still produce the same answer on every operation — in seconds, rather than finding out half an hour
+    // into a benchmark session. See Jint.Benchmark/README.md.
+    Console.WriteLine("== WEB-API ROW SMOKE TEST — correctness only, no measurement ==");
+    return WebApiBenchmarkSupport.Smoke();
+}
+
 if (args.Length > 0 && args[0] == "--smoke-comparison")
 {
     // Runs one Scripts/<name>.js once per comparison engine and reports pass/fail + wall time.

--- a/Jint.Benchmark/README.md
+++ b/Jint.Benchmark/README.md
@@ -7,6 +7,11 @@ the managed engines ([NiL.JS](https://github.com/nilproject/NiL.JS),
 ClearFoundry-maintained bindings to Google's native V8 engine (the JIT inside Chrome and Node.js) —
 across a set of representative scripts.
 
+> Most of this document is about that cross-engine comparison. The rest of the project is Jint-only
+> micro-benchmarks, which need no prose beyond their own XML doc comments — with one exception:
+> the opt-in WHATWG web APIs have their own category, their own smoke mode and their own rules about
+> what to run when. That is [Web API rows](#web-api-rows), at the end.
+
 ## How each engine executes
 
 The engines reach the result in different ways, which shapes the numbers below:
@@ -464,3 +469,97 @@ AMD Ryzen 9 5950X 3.40GHz, 1 CPU, 32 logical and 16 physical cores
 | Okojo                | stopwatch-modern             |   151,840.067 μs |    916.1697 μs |    5 |   21469.24 KB |
 | Okojo_Prepared       | stopwatch-modern             |   155,504.922 μs |  2,858.1551 μs |    5 |   21445.98 KB |
 | NilJS                | stopwatch-modern             |   209,122.986 μs |    815.7981 μs |    6 |  324502.66 KB |
+
+## Web API rows
+
+The opt-in WHATWG web APIs under `Jint/WebApi/` shipped with a strict no-cost-when-off discipline —
+nothing is installed unless `Options.WebApi.Features` names it, and a default engine is byte-for-byte
+the engine it was before they existed. That half was measured. The other half, what the surface costs
+a host that *does* switch it on, had nothing tracking it release to release. These rows are that.
+
+Run the whole category:
+
+```
+dotnet run -c Release --project Jint.Benchmark -- --allCategories WebApi
+```
+
+Unlike the comparison suite, these rows load no files, so it does not matter which directory you run
+them from. As everywhere else here, set `JINT_BENCH_MODE=gate` before quoting any number in a PR.
+
+### Check the rows before measuring them
+
+```
+dotnet run -c Release --project Jint.Benchmark -- --smoke-webapi
+```
+
+This runs every web-API class's `[GlobalSetup]` and then each of its rows three times, and reports
+pass/fail per class in a few seconds. It measures nothing. Two failures it is there to catch, both of
+which otherwise surface half an hour into a benchmark session:
+
+* a row's script throwing — a built-in that moved, or a row asking for the wrong feature flag;
+* a row that works once and **drifts afterwards**. Every deterministic row records what its own first
+  run produced and compares every later run against it, because BenchmarkDotNet will happily average
+  an operation that is doing more work each time it runs — state accumulating on the row's engine, a
+  queue that is never emptied, a buffer that was detached last time and is not now. That check can
+  only bite from the second operation onwards, which is why the smoke mode runs each row more than
+  once.
+
+### Which rows cover which feature
+
+| Class | `WebApiFeatures` | Source | Rows |
+| --- | --- | --- | --- |
+| `WebApiUrlBenchmark` | `Url` | `Url/` | `ParseAbsolute`, `ParseRelative`, `ReadComponents`, `MutateAndSerialize`, `SearchParamsMutate`, `SearchParamsIterate` |
+| `WebApiEncodingBenchmark` | `Encoding` | `Encoding/` | `RoundTripSmall`, `RoundTripLarge`, `DecodeStreaming`, `EncodeIntoSmall` |
+| `WebApiStructuredCloneBenchmark` | `StructuredClone` | `StructuredClone/` | `CloneFlat`, `CloneNested`, `CloneTransfer` |
+| `WebApiFetchObjectModelBenchmark` | `Fetch` (implies `Events`, `Url`, `Files`) | `Fetch/` | `HeadersAppendAndIterate`, `RequestConstruction`, `ResponseConstruction`, `RequestClone` |
+| `WebApiStreamsBenchmark` | `Streams` | `Streams/` | `PumpWithReader`, `PumpWithAsyncIteration`, `PipeThroughTransform` |
+| `WebApiTimerBenchmark` | `Timers` | `Timers/` | `ScheduleAndCancel`, `FanOutFiring`, `IntervalFiring` |
+| `WebApiCryptoBenchmark` | `Crypto` | `Crypto/` | `RandomValuesSmall`, `RandomValuesLarge`, `RandomUuid` |
+
+**No row covers `Console`, `Base64`, `Performance`, `Files`, `Navigator`, `Scheduler` or
+`crypto.subtle` yet**, and `Events` is only reached incidentally, through the `AbortSignal` every
+`Request` carries. A PR touching one of those has nothing here to move, and saying so is the point of
+this paragraph — the alternative is a contributor running the category, seeing it flat, and reading
+that as evidence.
+
+Three properties of these rows are load-bearing and should survive any edit to them:
+
+* **One engine per row, warmed with that row's own workload and nothing else** — see
+  `IsolatedScript`'s doc comment for the measurement defect that rule exists to prevent. It matters
+  more here than elsewhere, because these globals are installed lazily and one row's touch is what
+  materializes them.
+* **Each engine carries only its own feature**, never `WebApiFeatures.Default`, so a change to one
+  feature cannot move another feature's rows through shared installation cost.
+* **The timer rows drive a manual `TimeProvider`.** On `TimeProvider.System` every `setTimeout` would
+  pay a real clock read and a row whose timers fire would be measuring how long the machine took to
+  reach a wall-clock instant. Nothing in these rows sleeps, waits or opens a socket — including the
+  fetch rows, which build `Request`/`Response`/`Headers` and never call `fetch`.
+
+### The pre-release regression pass
+
+Seven rows are the ones to run alongside SunSpider and Dromaeo before a release — one per feature
+area, each chosen as the row a regression in its area reaches first:
+
+```
+dotnet run -c Release --project Jint.Benchmark -- --filter "*WebApiUrlBenchmark.ParseAbsolute" "*WebApiUrlBenchmark.SearchParamsMutate" "*WebApiEncodingBenchmark.RoundTripSmall" "*WebApiStructuredCloneBenchmark.CloneNested" "*WebApiFetchObjectModelBenchmark.RequestConstruction" "*WebApiStreamsBenchmark.PumpWithReader" "*WebApiTimerBenchmark.FanOutFiring"
+```
+
+* `WebApiUrlBenchmark.ParseAbsolute` — the URL parser is the largest hand-written state machine in
+  the subtree, and `Request` construction runs it too.
+* `WebApiUrlBenchmark.SearchParamsMutate` — the other half of `Url/`: the list, its serializer and
+  the URL-object update the setters trigger.
+* `WebApiEncodingBenchmark.RoundTripSmall` — dominated by per-call ceremony (WebIDL argument
+  conversion, result-view allocation), which is the cost every one of these APIs shares, so it is the
+  row a change to that shared layer moves.
+* `WebApiStructuredCloneBenchmark.CloneNested` — the deepest recursive algorithm in the subtree, over
+  a graph carrying a `Map`, a `Set`, a `Date`, a `RegExp`, a typed array and a cycle.
+* `WebApiFetchObjectModelBenchmark.RequestConstruction` — one row crossing URL parsing, header-init
+  conversion, body extraction and `AbortSignal` creation.
+* `WebApiStreamsBenchmark.PumpWithReader` — promise and job-queue traffic, 256 chunks' worth.
+* `WebApiTimerBenchmark.FanOutFiring` — the event loop's timer promotion, 500 timers per operation.
+
+The last two are worth running for a change to the **engine's own** event loop as well, not only for
+one under `Jint/WebApi/`: they are the densest promise-and-job workloads in the suite.
+
+No baseline table is published here yet. The first `JINT_BENCH_MODE=gate` run of a release cycle
+establishes one, and a number measured before that has nothing to be compared against.

--- a/Jint.Benchmark/WebApiBenchmarkSupport.cs
+++ b/Jint.Benchmark/WebApiBenchmarkSupport.cs
@@ -1,0 +1,217 @@
+using System.Diagnostics;
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Shared scaffolding for the rows that measure the opt-in WHATWG web APIs under <c>Jint/WebApi/</c>.
+///
+/// <para>Those APIs shipped with a strict no-cost-when-off discipline, and a default engine is still
+/// byte-for-byte the engine it was before they existed. Nothing tracked their cost <em>when on</em>,
+/// which is what these rows are for: a future <c>Jint/WebApi/</c> change has a table to move rather
+/// than a claim to make. The mapping from row to feature flag is in
+/// <c>Jint.Benchmark/README.md</c>.</para>
+///
+/// <para><b>One engine per row, warmed with that row's own workload.</b> Every row here goes through
+/// <see cref="IsolatedScript"/> (or, where the row needs the host to pump the engine, through a
+/// private <see cref="Engine"/> field warmed by invoking that row's own benchmark body once). No
+/// engine ever sees a sibling row's script — the failure mode <see cref="IsolatedScript"/> documents
+/// applies with full force here, because these globals are lazily installed and one row's touch is
+/// what materializes them.</para>
+///
+/// <para><b>Each engine carries only the feature its row is about.</b> <see cref="Create"/> takes the
+/// exact <see cref="WebApiFeatures"/> set rather than <see cref="WebApiFeatures.Default"/>, so a
+/// change to, say, the URL parser cannot move the encoding rows through some shared installation
+/// cost, and a row that starts depending on a second feature has to say so in its own declaration.</para>
+///
+/// <para><b>Engine construction and the fixture stay out of the measurement.</b> Both happen in
+/// <c>[GlobalSetup]</c>, as everywhere else in this suite; the measured operation is one evaluation of
+/// the row's own script on an already-warm engine.</para>
+/// </summary>
+internal static class WebApiBenchmarkSupport
+{
+    /// <summary>
+    /// The BenchmarkDotNet category every web-API row carries, so the whole surface runs with
+    /// <c>--allCategories WebApi</c> and nothing else has to be enumerated by name.
+    /// </summary>
+    internal const string Category = "WebApi";
+
+    /// <summary>A private engine carrying exactly <paramref name="features"/> and no other web API.</summary>
+    internal static Engine Create(WebApiFeatures features) => new(options => options.UseWebApis(features));
+
+    /// <summary>
+    /// An engine factory for <see cref="IsolatedScript"/>: a fresh engine carrying exactly
+    /// <paramref name="features"/>, with <paramref name="fixture"/> already executed on it.
+    /// </summary>
+    /// <remarks>
+    /// The fixture is the row's own one-off setup — its corpus, the function the row calls, and the
+    /// reference value that function produced on its first run. It is deliberately per row rather than
+    /// per class: a fixture shared by every row would warm each row's engine with its siblings' work,
+    /// which is exactly what <see cref="IsolatedScript"/> exists to prevent.
+    /// </remarks>
+    internal static Func<Engine> WithFixture(WebApiFeatures features, string fixture)
+        => WithFixture(() => Create(features), fixture);
+
+    /// <summary>
+    /// The same, for a row whose engine needs more than a feature flag — a fake clock, say. The factory
+    /// must build a fresh engine per call.
+    /// </summary>
+    internal static Func<Engine> WithFixture(Func<Engine> engineFactory, string fixture)
+    {
+        return () =>
+        {
+            var engine = engineFactory();
+            engine.Execute(fixture);
+            return engine;
+        };
+    }
+
+    /// <summary>
+    /// A row whose workload is a single deterministic JavaScript function call. The fixture runs
+    /// <paramref name="call"/> once and keeps its result as <c>REF</c>; the measured script calls it
+    /// again and throws if the answer moved.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>What it pins is reproducibility, not correctness.</b> The reference is what this row produced
+    /// on this engine on its first run, so it says nothing about whether that answer was right — the
+    /// specification is the test suite's business, and duplicating an expected value here would only
+    /// add a second place to be wrong. What it catches is the failure a benchmark cannot survive: a row
+    /// that works once and then quietly does more work on every subsequent operation, because
+    /// BenchmarkDotNet will average that without complaint. State accumulating on the row's engine, a
+    /// queue that is never emptied, a buffer that was detached last time and is not now — all of them
+    /// move the answer, and all of them are invisible in a table of means.
+    /// </para>
+    /// <para>
+    /// It follows that the check can only bite from the <em>second</em> operation onwards, which is why
+    /// <see cref="Smoke"/> runs each row more than once. It costs one comparison per operation, which is
+    /// noise next to any of the workloads here. Where a row's answer is genuinely knowable in advance —
+    /// the chunk total a stream pump owes, the number of timers that must have fired — the row asserts
+    /// that too, through <see cref="Expect"/>.
+    /// </para>
+    /// </remarks>
+    internal static IsolatedScript DeterministicRow(WebApiFeatures features, string fixture, string call)
+        => DeterministicRow(() => Create(features), fixture, call);
+
+    /// <summary>
+    /// The same, for a row whose engine needs more than a feature flag. The factory must build a fresh
+    /// engine per call.
+    /// </summary>
+    internal static IsolatedScript DeterministicRow(Func<Engine> engineFactory, string fixture, string call)
+    {
+        var measured =
+            $$"""
+              var n = {{call}};
+              if (n !== REF) { throw new Error('{{call}} produced ' + n + ', expected ' + REF); }
+              n;
+              """;
+
+        return IsolatedScript.Warm(measured, WithFixture(engineFactory, fixture + Environment.NewLine + $"var REF = {call};"));
+    }
+
+    /// <summary>
+    /// Checks a value an asynchronous row left in a global once the drain had finished — the rows whose
+    /// answer cannot be the script's own completion value, because the script completes before the event
+    /// loop runs.
+    /// </summary>
+    /// <remarks>
+    /// Called from <c>[GlobalSetup]</c> only, and deliberately kept to a bare identifier read: it runs on
+    /// the row's own engine, so anything heavier would put work on that engine which the row itself never
+    /// does.
+    /// </remarks>
+    internal static void Expect(Engine engine, string expression, string expected)
+    {
+        var actual = engine.Evaluate(expression).ToString();
+        if (!string.Equals(actual, expected, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Web-API benchmark row is not doing its work: '{expression}' evaluated to '{actual}', expected '{expected}'.");
+        }
+    }
+
+    /// <summary>
+    /// Runs every web-API class's <c>[GlobalSetup]</c>, then every one of its <c>[Benchmark]</c> rows a few
+    /// times over, and reports pass/fail per class — the <c>--smoke-webapi</c> mode in <c>Program.cs</c>.
+    /// Takes a few seconds and measures nothing.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Setup is where most of the risk lives: it builds each row's engine, executes each row's fixture, and
+    /// evaluates each row's script once to warm it. So a script that throws, a built-in absent because the
+    /// row asked for the wrong feature flag, or an asynchronous row whose total is wrong all fail there —
+    /// in seconds, instead of half an hour into a BenchmarkDotNet run.
+    /// </para>
+    /// <para>
+    /// <b>Running the rows repeatedly is the other half, and it is not redundant.</b> The failure a
+    /// benchmark cannot afford is a row that works once and drifts afterwards, because BenchmarkDotNet
+    /// will happily average an operation that is doing more work every time it runs — state accumulating
+    /// on the row's engine, a queue that is never emptied, a buffer that was detached last time and is not
+    /// now. That is precisely what <see cref="DeterministicRow"/>'s reference check catches, and it can
+    /// only catch it on the second and later operations. Three operations per row is a cheap number that
+    /// exercises it and still leaves room for a defect that needs one more turn to surface — a leak
+    /// bounded by a quota, say.
+    /// </para>
+    /// <para>
+    /// The precedent is <c>--smoke-comparison</c>, which exists so a new comparison script is known to run
+    /// on every engine before it joins the table. This is the same idea for the web-API rows, and it is why
+    /// <c>Jint.Benchmark/README.md</c> tells a <c>Jint/WebApi/</c> PR to run it first.
+    /// </para>
+    /// </remarks>
+    internal static int Smoke()
+    {
+        object[] classes =
+        [
+            new WebApiUrlBenchmark(),
+            new WebApiEncodingBenchmark(),
+            new WebApiStructuredCloneBenchmark(),
+            new WebApiFetchObjectModelBenchmark(),
+            new WebApiStreamsBenchmark(),
+            new WebApiTimerBenchmark(),
+            new WebApiCryptoBenchmark(),
+        ];
+
+        var failures = 0;
+        foreach (var instance in classes)
+        {
+            var type = instance.GetType();
+            var stopwatch = Stopwatch.StartNew();
+            try
+            {
+                Invoke(instance, typeof(GlobalSetupAttribute), times: 1);
+                Invoke(instance, typeof(BenchmarkAttribute), times: 3);
+                Console.WriteLine($"  {type.Name,-34} OK    {stopwatch.ElapsedMilliseconds,6} ms");
+            }
+            catch (Exception ex)
+            {
+                failures++;
+                var reported = ex is TargetInvocationException { InnerException: { } inner } ? inner : ex;
+                Console.WriteLine(
+                    $"  {type.Name,-34} FAIL  {stopwatch.ElapsedMilliseconds,6} ms  {reported.GetType().Name}: {reported.Message.Split('\n')[0]}");
+            }
+        }
+
+        return failures == 0 ? 0 : 1;
+    }
+
+    /// <summary>
+    /// Invokes every parameterless method carrying <paramref name="attribute"/>, <paramref name="times"/>
+    /// times each. Reflection order is unspecified and deliberately not relied on: no row here depends on
+    /// another having run.
+    /// </summary>
+    private static void Invoke(object instance, Type attribute, int times)
+    {
+        foreach (var method in instance.GetType().GetMethods())
+        {
+            if (method.GetParameters().Length != 0 || !method.IsDefined(attribute, inherit: false))
+            {
+                continue;
+            }
+
+            for (var i = 0; i < times; i++)
+            {
+                method.Invoke(instance, null);
+            }
+        }
+    }
+}

--- a/Jint.Benchmark/WebApiCryptoBenchmark.cs
+++ b/Jint.Benchmark/WebApiCryptoBenchmark.cs
@@ -1,0 +1,89 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// <c>crypto.getRandomValues</c> and <c>crypto.randomUUID</c> — <see cref="WebApiFeatures.Crypto"/>,
+/// https://w3c.github.io/webcrypto/#Crypto-method-getRandomValues.
+///
+/// <para>Three rows, split where the cost is. <see cref="RandomValuesSmall"/> fills a 32-byte view 500
+/// times, which is the token-and-nonce shape a script actually writes and is almost entirely per-call
+/// ceremony: the WebIDL <c>ArrayBufferView</c> check, the detached/immutable-buffer checks and the quota
+/// test. <see cref="RandomValuesLarge"/> fills the 65,536-byte maximum the standard allows in one call
+/// (a larger view is a <c>QuotaExceededError</c>), eight times, so it is dominated by the generator
+/// itself. <see cref="RandomUuid"/> is the other member of the interface, whose cost is formatting rather
+/// than randomness.</para>
+///
+/// <para><b>The rows are deterministic even though their output is not.</b> Each accumulates the
+/// <i>length</i> of what it produced — the number of bytes filled, or the 36 characters of a UUID — so the
+/// reference check in <see cref="WebApiBenchmarkSupport.DeterministicRow"/> still bites: a
+/// <c>getRandomValues</c> that stopped returning its argument, or a <c>randomUUID</c> that stopped
+/// producing a UUID, fails the row rather than making it look faster.</para>
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine carrying
+/// <see cref="WebApiFeatures.Crypto"/> alone, warmed with its own fixture and its own script and nothing
+/// else — see <see cref="WebApiBenchmarkSupport"/>. Engine construction and allocating the destination
+/// views stay in <c>[GlobalSetup]</c> and never enter the measurement.</para>
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+[BenchmarkCategory(WebApiBenchmarkSupport.Category)]
+public class WebApiCryptoBenchmark
+{
+    private IsolatedScript _randomValuesSmall;
+    private IsolatedScript _randomValuesLarge;
+    private IsolatedScript _randomUuid;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _randomValuesSmall = Row(
+            """
+            var SMALL = new Uint8Array(32);
+            function randomValuesSmall() {
+                var n = 0;
+                for (var i = 0; i < 500; i++) { n += crypto.getRandomValues(SMALL).length; }
+                return n;
+            }
+            """,
+            "randomValuesSmall()");
+
+        // 65,536 bytes is the per-call maximum the standard allows; anything larger is a QuotaExceededError.
+        _randomValuesLarge = Row(
+            """
+            var LARGE = new Uint8Array(65536);
+            function randomValuesLarge() {
+                var n = 0;
+                for (var i = 0; i < 8; i++) { n += crypto.getRandomValues(LARGE).length; }
+                return n;
+            }
+            """,
+            "randomValuesLarge()");
+
+        _randomUuid = Row(
+            """
+            function randomUuid() {
+                var n = 0;
+                for (var i = 0; i < 200; i++) { n += crypto.randomUUID().length; }
+                return n;
+            }
+            """,
+            "randomUuid()");
+    }
+
+    private static IsolatedScript Row(string fixture, string call)
+        => WebApiBenchmarkSupport.DeterministicRow(WebApiFeatures.Crypto, fixture, call);
+
+    /// <summary>500 fills of a 32-byte view.</summary>
+    [Benchmark]
+    public JsValue RandomValuesSmall() => _randomValuesSmall.Run();
+
+    /// <summary>Eight fills of the 64 KiB per-call maximum.</summary>
+    [Benchmark]
+    public JsValue RandomValuesLarge() => _randomValuesLarge.Run();
+
+    /// <summary>200 UUIDs.</summary>
+    [Benchmark]
+    public JsValue RandomUuid() => _randomUuid.Run();
+}

--- a/Jint.Benchmark/WebApiEncodingBenchmark.cs
+++ b/Jint.Benchmark/WebApiEncodingBenchmark.cs
@@ -1,0 +1,140 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// <c>TextEncoder</c> and <c>TextDecoder</c> — <see cref="WebApiFeatures.Encoding"/>,
+/// https://encoding.spec.whatwg.org/#api.
+///
+/// <para>Four rows, because the three sizes exercise different halves of the cost.
+/// <see cref="RoundTripSmall"/> is dominated by the per-call ceremony — WebIDL argument conversion,
+/// allocating the result <c>Uint8Array</c>, wrapping the decoded string — which is what a script encoding
+/// a few dozen bytes in a loop actually pays. <see cref="RoundTripLarge"/> moves ~140 KiB per direction, so
+/// it is dominated by the transcoding itself and by the JS-string ↔ managed-buffer crossing.
+/// <see cref="DecodeStreaming"/> feeds the same bytes back in ~1 KiB chunks cut at boundaries that split
+/// multi-byte sequences, which is the only row that exercises the decoder's held-over-bytes state machine
+/// and its final flush. <see cref="EncodeIntoSmall"/> is the allocation-free encoder path a host reaches
+/// for when it owns the destination buffer.</para>
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine carrying
+/// <see cref="WebApiFeatures.Encoding"/> alone, warmed with its own fixture and its own script and nothing
+/// else — see <see cref="WebApiBenchmarkSupport"/>. Building the ~140 KiB source string, encoding it and
+/// slicing it into chunks all happen in <c>[GlobalSetup]</c> and never enter the measurement, as does
+/// engine construction.</para>
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+[BenchmarkCategory(WebApiBenchmarkSupport.Category)]
+public class WebApiEncodingBenchmark
+{
+    /// <summary>
+    /// Mixed ASCII and non-ASCII, so neither the encoder nor the decoder can take an all-ASCII shortcut for
+    /// the whole input while most of it still is ASCII — the realistic shape of text a service handles.
+    /// </summary>
+    private const string SmallText =
+        """
+        var SMALL = 'The quick brown fox jumps over the lazy dog — ☕ 1234567890';
+        var ENCODER = new TextEncoder();
+        var DECODER = new TextDecoder();
+        """;
+
+    /// <summary>Roughly 140 KiB of the same mixture, built once.</summary>
+    private const string LargeText =
+        """
+        var ENCODER = new TextEncoder();
+        var DECODER = new TextDecoder();
+        var parts = [];
+        for (var i = 0; i < 4096; i++) { parts.push('lorem ipsum dolor sit amet — ☕ ' + i + '\n'); }
+        var LARGE = parts.join('');
+        """;
+
+    private IsolatedScript _roundTripSmall;
+    private IsolatedScript _roundTripLarge;
+    private IsolatedScript _decodeStreaming;
+    private IsolatedScript _encodeIntoSmall;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _roundTripSmall = Row(
+            SmallText +
+            """
+
+            function roundTripSmall() {
+                var n = 0;
+                for (var i = 0; i < 500; i++) { n += DECODER.decode(ENCODER.encode(SMALL)).length; }
+                return n;
+            }
+            """,
+            "roundTripSmall()");
+
+        _roundTripLarge = Row(
+            LargeText +
+            """
+
+            function roundTripLarge() {
+                var n = 0;
+                for (var i = 0; i < 4; i++) { n += DECODER.decode(ENCODER.encode(LARGE)).length; }
+                return n;
+            }
+            """,
+            "roundTripLarge()");
+
+        // 997 is deliberately coprime with everything in sight, so the chunk boundaries land inside the
+        // multi-byte sequences and every chunk but the last leaves the decoder holding bytes over. A
+        // chunked decode that never straddles a sequence measures the easy half of the state machine.
+        _decodeStreaming = Row(
+            LargeText +
+            """
+
+            var LARGE_BYTES = ENCODER.encode(LARGE);
+            var CHUNKS = [];
+            for (var i = 0; i < LARGE_BYTES.length; i += 997) {
+                CHUNKS.push(LARGE_BYTES.subarray(i, Math.min(i + 997, LARGE_BYTES.length)));
+            }
+            function decodeStreaming() {
+                var n = 0;
+                for (var r = 0; r < 4; r++) {
+                    var decoder = new TextDecoder();
+                    for (var i = 0; i < CHUNKS.length; i++) { n += decoder.decode(CHUNKS[i], { stream: true }).length; }
+                    n += decoder.decode().length;
+                }
+                return n;
+            }
+            """,
+            "decodeStreaming()");
+
+        _encodeIntoSmall = Row(
+            SmallText +
+            """
+
+            var TARGET = new Uint8Array(1024);
+            function encodeIntoSmall() {
+                var n = 0;
+                for (var i = 0; i < 500; i++) { n += ENCODER.encodeInto(SMALL, TARGET).written; }
+                return n;
+            }
+            """,
+            "encodeIntoSmall()");
+    }
+
+    private static IsolatedScript Row(string fixture, string call)
+        => WebApiBenchmarkSupport.DeterministicRow(WebApiFeatures.Encoding, fixture, call);
+
+    /// <summary>500 encode + decode round trips of a ~60-character string.</summary>
+    [Benchmark]
+    public JsValue RoundTripSmall() => _roundTripSmall.Run();
+
+    /// <summary>Four encode + decode round trips of ~140 KiB.</summary>
+    [Benchmark]
+    public JsValue RoundTripLarge() => _roundTripLarge.Run();
+
+    /// <summary>Four streaming decodes of the same ~140 KiB in ~1 KiB chunks, plus the flush.</summary>
+    [Benchmark]
+    public JsValue DecodeStreaming() => _decodeStreaming.Run();
+
+    /// <summary>500 encodes into a host-owned destination view, which allocates nothing per call.</summary>
+    [Benchmark]
+    public JsValue EncodeIntoSmall() => _encodeIntoSmall.Run();
+}

--- a/Jint.Benchmark/WebApiFetchObjectModelBenchmark.cs
+++ b/Jint.Benchmark/WebApiFetchObjectModelBenchmark.cs
@@ -1,0 +1,163 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// The fetch object model — <c>Headers</c>, <c>Request</c> and <c>Response</c>,
+/// <see cref="WebApiFeatures.Fetch"/>, https://fetch.spec.whatwg.org/#headers-class and
+/// https://fetch.spec.whatwg.org/#request-class.
+///
+/// <para><b>No request is ever made.</b> Enabling the feature installs <c>fetch</c> as well, and no row
+/// here calls it: what is measured is the part of the surface a script pays for on every request it
+/// builds and every response it inspects, which is also the part a host that supplies its own transport
+/// still pays. Nothing in this class opens a socket, reads a clock or depends on a network being
+/// present.</para>
+///
+/// <para>Four rows. <see cref="HeadersAppendAndIterate"/> is the header list itself — sixteen appends,
+/// one of them combining a second value into an existing name, then the full sorted iteration a
+/// serializer or a logger does. <see cref="RequestConstruction"/> and <see cref="ResponseConstruction"/>
+/// are the two constructors, each of which parses a URL or validates a status, converts a header init and
+/// extracts a body. <see cref="RequestClone"/> is the copy path, which a middleware chain runs on every
+/// request it forwards.</para>
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine carrying <see cref="WebApiFeatures.Fetch"/>
+/// (which implies <see cref="WebApiFeatures.Events"/>, <see cref="WebApiFeatures.Url"/> and
+/// <see cref="WebApiFeatures.Files"/>, since a <c>Request</c> always has an <c>AbortSignal</c> and a
+/// WHATWG URL), warmed with its own fixture and its own script and nothing else — see
+/// <see cref="WebApiBenchmarkSupport"/>. Engine construction stays in <c>[GlobalSetup]</c> and never
+/// enters the measurement.</para>
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+[BenchmarkCategory(WebApiBenchmarkSupport.Category)]
+public class WebApiFetchObjectModelBenchmark
+{
+    /// <summary>The header set a browser or a service client actually sends, names already lowercase.</summary>
+    private const string HeaderData =
+        """
+        var HEADER_NAMES = [
+            'accept', 'accept-encoding', 'accept-language', 'authorization', 'cache-control',
+            'content-type', 'cookie', 'if-none-match', 'origin', 'referer', 'user-agent',
+            'x-request-id', 'x-forwarded-for', 'x-correlation-id', 'x-api-version', 'x-tenant'
+        ];
+        var HEADER_VALUES = [
+            'application/json, text/plain, */*', 'gzip, deflate, br', 'en-US,en;q=0.9',
+            'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9', 'no-cache, no-store, max-age=0',
+            'application/json; charset=utf-8', 'sid=8f2c1b4e9a; theme=dark', 'W/"a1b2c3d4"',
+            'https://app.example.org', 'https://app.example.org/dashboard',
+            'Mozilla/5.0 (compatible; Jint/4)', '4f2c1b4e-9a3d-4c1e-9b2a-7d5f0e1c8a6b',
+            '203.0.113.7, 198.51.100.42', 'c0ffee-1234', '3', 'acme-corp'
+        ];
+        """;
+
+    /// <summary>A request and a response init, reused so the rows measure construction and not literal building.</summary>
+    private const string InitData =
+        """
+        var REQUEST_INIT = {
+            method: 'POST',
+            headers: { 'content-type': 'application/json', 'x-api-version': '3', 'authorization': 'Bearer token' },
+            body: '{"id":42,"name":"widget","tags":["a","b","c"]}'
+        };
+        var RESPONSE_INIT = {
+            status: 201,
+            statusText: 'Created',
+            headers: { 'content-type': 'application/json', 'etag': 'W/"a1b2c3d4"', 'x-request-id': 'c0ffee' }
+        };
+        var RESPONSE_BODY = '{"ok":true,"items":[1,2,3,4,5,6,7,8,9,10]}';
+        """;
+
+    private IsolatedScript _headersAppendAndIterate;
+    private IsolatedScript _requestConstruction;
+    private IsolatedScript _responseConstruction;
+    private IsolatedScript _requestClone;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _headersAppendAndIterate = Row(
+            HeaderData +
+            """
+
+            function headersAppendAndIterate() {
+                var n = 0;
+                for (var r = 0; r < 100; r++) {
+                    var headers = new Headers();
+                    for (var i = 0; i < HEADER_NAMES.length; i++) { headers.append(HEADER_NAMES[i], HEADER_VALUES[i]); }
+                    headers.append('accept', 'text/html');
+                    for (var entry of headers) { n += entry[0].length + entry[1].length; }
+                    n += headers.has('cookie') ? 1 : 0;
+                }
+                return n;
+            }
+            """,
+            "headersAppendAndIterate()");
+
+        _requestConstruction = Row(
+            InitData +
+            """
+
+            function requestConstruction() {
+                var n = 0;
+                for (var i = 0; i < 200; i++) {
+                    var request = new Request('https://api.example.org/v3/items/' + i + '?full=1', REQUEST_INIT);
+                    n += request.method.length + request.url.length
+                        + request.headers.get('content-type').length + (request.bodyUsed ? 0 : 1);
+                }
+                return n;
+            }
+            """,
+            "requestConstruction()");
+
+        _responseConstruction = Row(
+            InitData +
+            """
+
+            function responseConstruction() {
+                var n = 0;
+                for (var i = 0; i < 200; i++) {
+                    var response = new Response(RESPONSE_BODY, RESPONSE_INIT);
+                    n += response.status + response.statusText.length
+                        + response.headers.get('etag').length + (response.ok ? 1 : 0);
+                }
+                return n;
+            }
+            """,
+            "responseConstruction()");
+
+        _requestClone = Row(
+            InitData +
+            """
+
+            function requestClone() {
+                var n = 0;
+                for (var i = 0; i < 200; i++) {
+                    var request = new Request('https://api.example.org/v3/items', REQUEST_INIT);
+                    var copy = request.clone();
+                    n += copy.method.length + copy.url.length + (copy.bodyUsed ? 0 : 1);
+                }
+                return n;
+            }
+            """,
+            "requestClone()");
+    }
+
+    private static IsolatedScript Row(string fixture, string call)
+        => WebApiBenchmarkSupport.DeterministicRow(WebApiFeatures.Fetch, fixture, call);
+
+    /// <summary>100 header lists of seventeen appends each, then iterated in full.</summary>
+    [Benchmark]
+    public JsValue HeadersAppendAndIterate() => _headersAppendAndIterate.Run();
+
+    /// <summary>200 <c>Request</c>s, each parsing its own URL and converting a three-name header init.</summary>
+    [Benchmark]
+    public JsValue RequestConstruction() => _requestConstruction.Run();
+
+    /// <summary>200 <c>Response</c>s over a JSON body and a three-name header init.</summary>
+    [Benchmark]
+    public JsValue ResponseConstruction() => _responseConstruction.Run();
+
+    /// <summary>200 construct-then-clone pairs, the middleware-forwarding shape.</summary>
+    [Benchmark]
+    public JsValue RequestClone() => _requestClone.Run();
+}

--- a/Jint.Benchmark/WebApiStreamsBenchmark.cs
+++ b/Jint.Benchmark/WebApiStreamsBenchmark.cs
@@ -1,0 +1,136 @@
+using System.Globalization;
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// <c>ReadableStream</c> pump throughput — <see cref="WebApiFeatures.Streams"/>,
+/// https://streams.spec.whatwg.org/#rs.
+///
+/// <para>Three rows over the same 256-chunk source, because the three ways a script drains a stream cost
+/// different things. <see cref="PumpWithReader"/> is the explicit reader loop
+/// (<c>getReader()</c> + <c>await reader.read()</c>), so it measures one promise and one read request per
+/// chunk. <see cref="PumpWithAsyncIteration"/> is <c>for await</c> over the stream itself
+/// (https://streams.spec.whatwg.org/#rs-asynciterator), which adds WebIDL's default asynchronous iterator
+/// object on top of that reader. <see cref="PipeThroughTransform"/> runs the chunks through a
+/// <c>TransformStream</c> first (https://streams.spec.whatwg.org/#readable-stream-pipe-to), so each chunk
+/// crosses a writable side, a transformer and a second readable side before the consumer sees it.</para>
+///
+/// <para><b>Nothing here sleeps, starts a thread or reads a clock.</b> Every promise a stream hands out is
+/// an ordinary engine promise settled by a job on the engine's own queue, and <c>Engine.Evaluate</c> drains
+/// that queue before it returns — so one measured operation is one complete pump, start to finish, on the
+/// calling thread.</para>
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine carrying
+/// <see cref="WebApiFeatures.Streams"/> alone, warmed with its own fixture and its own script and nothing
+/// else — see <see cref="WebApiBenchmarkSupport"/>. Engine construction stays in <c>[GlobalSetup]</c> and
+/// never enters the measurement. The rows' answers cannot be the script's completion value — the script
+/// completes before the event loop runs — so each pump stores its total in <c>result</c>, which
+/// <c>[GlobalSetup]</c> checks once against the sum the chunk count implies.</para>
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+[BenchmarkCategory(WebApiBenchmarkSupport.Category)]
+public class WebApiStreamsBenchmark
+{
+    /// <summary>Chunks per pump. 256 keeps an operation in the millisecond range without hiding per-chunk cost.</summary>
+    private const int Chunks = 256;
+
+    /// <summary>Sum of <c>0..Chunks-1</c> — what a pump that lost or duplicated a chunk would fail to produce.</summary>
+    private const int ExpectedSum = Chunks * (Chunks - 1) / 2;
+
+    /// <summary>
+    /// The source every row drains. Enqueuing from <c>start</c> fills the queue before any read arrives, so
+    /// the rows measure the consuming side rather than a producer's back-pressure schedule.
+    /// </summary>
+    private static readonly string Source =
+        $$"""
+          var CHUNKS = {{Chunks}};
+          var result = -1;
+          function makeSource() {
+              return new ReadableStream({
+                  start(controller) {
+                      for (var i = 0; i < CHUNKS; i++) { controller.enqueue(i); }
+                      controller.close();
+                  }
+              });
+          }
+          """;
+
+    private IsolatedScript _pumpWithReader;
+    private IsolatedScript _pumpWithAsyncIteration;
+    private IsolatedScript _pipeThroughTransform;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _pumpWithReader = Row(
+            """
+
+            async function pumpWithReader() {
+                var reader = makeSource().getReader();
+                var sum = 0;
+                for (;;) {
+                    var next = await reader.read();
+                    if (next.done) { break; }
+                    sum += next.value;
+                }
+                return sum;
+            }
+            """,
+            "pumpWithReader()",
+            ExpectedSum);
+
+        _pumpWithAsyncIteration = Row(
+            """
+
+            async function pumpWithAsyncIteration() {
+                var sum = 0;
+                for await (const chunk of makeSource()) { sum += chunk; }
+                return sum;
+            }
+            """,
+            "pumpWithAsyncIteration()",
+            ExpectedSum);
+
+        // The transform doubles each chunk, so the expected total doubles too — which is what proves the
+        // chunks actually went through the transformer rather than round the side of it.
+        _pipeThroughTransform = Row(
+            """
+
+            function makeTransform() {
+                return new TransformStream({ transform(chunk, controller) { controller.enqueue(chunk * 2); } });
+            }
+            async function pipeThroughTransform() {
+                var sum = 0;
+                for await (const chunk of makeSource().pipeThrough(makeTransform())) { sum += chunk; }
+                return sum;
+            }
+            """,
+            "pipeThroughTransform()",
+            ExpectedSum * 2);
+    }
+
+    private static IsolatedScript Row(string functions, string call, int expected)
+    {
+        var script = IsolatedScript.Warm(
+            $"{call}.then(function (total) {{ result = total; }});",
+            WebApiBenchmarkSupport.WithFixture(WebApiFeatures.Streams, Source + functions));
+
+        WebApiBenchmarkSupport.Expect(script.Engine, "result", expected.ToString(CultureInfo.InvariantCulture));
+        return script;
+    }
+
+    /// <summary>256 chunks through an explicit <c>getReader()</c> loop.</summary>
+    [Benchmark]
+    public JsValue PumpWithReader() => _pumpWithReader.Run();
+
+    /// <summary>256 chunks through <c>for await</c> on the stream itself.</summary>
+    [Benchmark]
+    public JsValue PumpWithAsyncIteration() => _pumpWithAsyncIteration.Run();
+
+    /// <summary>256 chunks through a <c>TransformStream</c> and out the other side.</summary>
+    [Benchmark]
+    public JsValue PipeThroughTransform() => _pipeThroughTransform.Run();
+}

--- a/Jint.Benchmark/WebApiStructuredCloneBenchmark.cs
+++ b/Jint.Benchmark/WebApiStructuredCloneBenchmark.cs
@@ -1,0 +1,112 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// The global <c>structuredClone</c> function — <see cref="WebApiFeatures.StructuredClone"/>,
+/// https://html.spec.whatwg.org/multipage/structured-data.html#dom-structuredclone.
+///
+/// <para>Three rows along the axis that decides the cost. <see cref="CloneFlat"/> is a twelve-property
+/// record of primitives, so it is per-property ceremony and nothing else — the shape a worker-style
+/// message or a cached configuration object actually has. <see cref="CloneNested"/> is a 32-level graph
+/// carrying the platform objects the algorithm has separate serialization steps for (<c>Map</c>,
+/// <c>Set</c>, <c>Date</c>, <c>RegExp</c>, a typed array) plus a cycle, so it also measures the memo that
+/// makes the algorithm terminate. <see cref="CloneTransfer"/> is the transfer path
+/// (https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer): a 4 KiB
+/// <c>ArrayBuffer</c> moved into the clone rather than copied, with the source detached, so a regression
+/// that turned a transfer back into a copy would show up here as time <i>and</i> as allocated bytes.</para>
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine carrying
+/// <see cref="WebApiFeatures.StructuredClone"/> alone, warmed with its own fixture and its own script and
+/// nothing else — see <see cref="WebApiBenchmarkSupport"/>. Engine construction and building the source
+/// graph stay in <c>[GlobalSetup]</c> and never enter the measurement.</para>
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+[BenchmarkCategory(WebApiBenchmarkSupport.Category)]
+public class WebApiStructuredCloneBenchmark
+{
+    private IsolatedScript _cloneFlat;
+    private IsolatedScript _cloneNested;
+    private IsolatedScript _cloneTransfer;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _cloneFlat = Row(
+            """
+            var FLAT = {
+                id: 1234, name: 'widget', sku: 'WGT-0042', price: 19.99, active: true,
+                tags: 'a,b,c', created: '2026-01-01T00:00:00.000Z', qty: 7, weight: 0.5,
+                note: null, ratio: 0.125, code: 'X'
+            };
+            function cloneFlat() {
+                var n = 0;
+                for (var i = 0; i < 500; i++) { n += structuredClone(FLAT).id; }
+                return n;
+            }
+            """,
+            "cloneFlat()");
+
+        // The cycle is deliberate: without the memo the algorithm would not terminate at all, so a row
+        // that did not carry one would never measure it.
+        _cloneNested = Row(
+            """
+            var NESTED = (function () {
+                var root = {
+                    level: 0, children: [], meta: new Map([['k', 'v'], ['n', 42]]),
+                    seen: new Set([1, 2, 3]), when: new Date(0), pattern: /ab+c/gi,
+                    bytes: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])
+                };
+                var node = root;
+                for (var i = 1; i < 32; i++) {
+                    var child = { level: i, children: [], values: [i, i * 2, 'n' + i] };
+                    node.children.push(child);
+                    node = child;
+                }
+                root.self = root;
+                return root;
+            })();
+            function cloneNested() {
+                var n = 0;
+                for (var i = 0; i < 50; i++) {
+                    var clone = structuredClone(NESTED);
+                    n += clone.children[0].level + clone.meta.size + clone.seen.size + clone.bytes.length;
+                }
+                return n;
+            }
+            """,
+            "cloneNested()");
+
+        _cloneTransfer = Row(
+            """
+            function cloneTransfer() {
+                var n = 0;
+                for (var i = 0; i < 200; i++) {
+                    var buffer = new ArrayBuffer(4096);
+                    new Uint8Array(buffer)[0] = 7;
+                    var clone = structuredClone({ payload: buffer }, { transfer: [buffer] });
+                    n += new Uint8Array(clone.payload)[0] + buffer.byteLength;
+                }
+                return n;
+            }
+            """,
+            "cloneTransfer()");
+    }
+
+    private static IsolatedScript Row(string fixture, string call)
+        => WebApiBenchmarkSupport.DeterministicRow(WebApiFeatures.StructuredClone, fixture, call);
+
+    /// <summary>500 clones of a twelve-property record of primitives.</summary>
+    [Benchmark]
+    public JsValue CloneFlat() => _cloneFlat.Run();
+
+    /// <summary>50 clones of a 32-level graph carrying a Map, a Set, a Date, a RegExp, a typed array and a cycle.</summary>
+    [Benchmark]
+    public JsValue CloneNested() => _cloneNested.Run();
+
+    /// <summary>200 transfers of a 4 KiB <c>ArrayBuffer</c>, each leaving the source detached.</summary>
+    [Benchmark]
+    public JsValue CloneTransfer() => _cloneTransfer.Run();
+}

--- a/Jint.Benchmark/WebApiTimerBenchmark.cs
+++ b/Jint.Benchmark/WebApiTimerBenchmark.cs
@@ -1,0 +1,163 @@
+using System.Globalization;
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// The timer globals — <see cref="WebApiFeatures.Timers"/>,
+/// https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timers.
+///
+/// <para><b>Every row drives a <see cref="ManualClock"/>, and nothing here sleeps or waits.</b> That is
+/// not a convenience: on <see cref="TimeProvider.System"/> each <c>setTimeout</c> would pay a real
+/// <c>QueryPerformanceCounter</c> read, and a row whose timers fire would be measuring how long the
+/// machine took to reach a wall-clock instant. A clock that moves only when this class moves it makes
+/// the rows deterministic, instant, and about the queue rather than about the host.</para>
+///
+/// <para>Three rows over the three things the queue does.
+/// <see cref="ScheduleAndCancel"/> is pure registration churn — 500 <c>setTimeout</c>/<c>clearTimeout</c>
+/// pairs, so it measures the id map, the min-heap insert and the lazy discard of a cancelled entry, and
+/// no callback ever runs. <see cref="FanOutFiring"/> is the other half: 500 zero-delay timers that are all
+/// due immediately, so the script's own drain promotes and dispatches every one of them.
+/// <see cref="IntervalFiring"/> is the re-arm path, which no <c>setTimeout</c> reaches — one
+/// <c>setInterval</c> fired 200 times, each firing re-arming the entry before its callback runs.</para>
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine and its own clock, carrying
+/// <see cref="WebApiFeatures.Timers"/> alone and warmed with that row's own workload and nothing else.
+/// Engine construction stays in <c>[GlobalSetup]</c> for all three. <see cref="IntervalFiring"/> is the one
+/// row whose body is not a single <c>Evaluate</c> — the host has to move the clock and pump between
+/// firings, exactly as an embedder does — so its measured operation includes 200 <c>ProcessTasks()</c>
+/// calls and 200 clock advances; the advance is one addition to a <see cref="long"/> and the pump is what
+/// the row is about.</para>
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+[BenchmarkCategory(WebApiBenchmarkSupport.Category)]
+public class WebApiTimerBenchmark
+{
+    /// <summary>How many times <see cref="IntervalFiring"/> lets its interval fire.</summary>
+    private const int IntervalFirings = 200;
+
+    /// <summary>
+    /// Milliseconds the clock moves per pump in <see cref="IntervalFiring"/>. Four rather than one because
+    /// HTML clamps a timer nested more than five deep to a 4ms minimum, and an interval re-arming itself
+    /// reaches that depth after six firings — so a 1ms step would fire on one pump in four from there on,
+    /// and the row's cost would depend on where in the ramp it happened to be.
+    /// </summary>
+    private const int IntervalStepMilliseconds = 4;
+
+    /// <summary>
+    /// A <see cref="TimeProvider"/> whose clock moves only when this class moves it. Ticks are the unit, so
+    /// the due-time arithmetic in <c>TimerQueue.Arm</c> is exact.
+    /// </summary>
+    private sealed class ManualClock : TimeProvider
+    {
+        private long _timestamp;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp() => _timestamp;
+
+        public override DateTimeOffset GetUtcNow() => DateTimeOffset.UnixEpoch.AddTicks(_timestamp);
+
+        internal void Advance(int milliseconds) => _timestamp += milliseconds * TimeSpan.TicksPerMillisecond;
+    }
+
+    private IsolatedScript _scheduleAndCancel;
+    private IsolatedScript _fanOutFiring;
+
+    private Engine _intervalEngine = null!;
+    private ManualClock _intervalClock = null!;
+    private Prepared<Script> _intervalStart;
+    private Prepared<Script> _intervalStop;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // Every entry is cancelled, and TimerQueue discards a cancelled entry the moment it surfaces at
+        // the head of the schedule — so the drain at the end of the script empties the whole batch and the
+        // operation leaves the queue as it found it. That matters more than it looks: a row that let
+        // entries pile up would grow the heap for the length of the run and report the growth as its own
+        // cost, and the reference check would see the drift.
+        _scheduleAndCancel = WebApiBenchmarkSupport.DeterministicRow(
+            TimerEngine,
+            """
+            function noop() { }
+            function scheduleAndCancel() {
+                var n = 0;
+                for (var i = 0; i < 500; i++) {
+                    var id = setTimeout(noop, i % 8);
+                    clearTimeout(id);
+                    n++;
+                }
+                return n;
+            }
+            """,
+            "scheduleAndCancel()");
+
+        // The completion value is read before the event loop runs, so it is always zero — the count the row
+        // is about lands in `fired` during the drain, which is what [GlobalSetup] checks below.
+        _fanOutFiring = IsolatedScript.Warm(
+            """
+            fired = 0;
+            for (var i = 0; i < 500; i++) { setTimeout(bump, 0); }
+            fired;
+            """,
+            WebApiBenchmarkSupport.WithFixture(
+                TimerEngine,
+                """
+                var fired = 0;
+                function bump() { fired++; }
+                """));
+
+        _fanOutFiring.Run();
+        WebApiBenchmarkSupport.Expect(_fanOutFiring.Engine, "fired", "500");
+
+        _intervalClock = new ManualClock();
+        _intervalEngine = TimerEngine(_intervalClock);
+        _intervalEngine.Execute(
+            """
+            var ticks = 0;
+            var intervalId = 0;
+            function startInterval() { ticks = 0; intervalId = setInterval(function () { ticks++; }, 1); }
+            function stopInterval() { clearInterval(intervalId); }
+            """);
+        _intervalStart = Engine.PrepareScript("startInterval();");
+        _intervalStop = Engine.PrepareScript("stopInterval();");
+
+        // Warmed with this row's own workload and nothing else: one full operation, then the check.
+        IntervalFiring();
+        WebApiBenchmarkSupport.Expect(_intervalEngine, "ticks", IntervalFirings.ToString(CultureInfo.InvariantCulture));
+    }
+
+    private static Engine TimerEngine() => TimerEngine(new ManualClock());
+
+    private static Engine TimerEngine(TimeProvider clock) => new(options => options.UseWebApis(webApi =>
+    {
+        webApi.Features = WebApiFeatures.Timers;
+        webApi.Timers.TimeProvider = clock;
+    }));
+
+    /// <summary>500 <c>setTimeout</c>/<c>clearTimeout</c> pairs, no callback ever run.</summary>
+    [Benchmark]
+    public JsValue ScheduleAndCancel() => _scheduleAndCancel.Run();
+
+    /// <summary>500 zero-delay timers, all promoted and dispatched by the script's own drain.</summary>
+    [Benchmark]
+    public JsValue FanOutFiring() => _fanOutFiring.Run();
+
+    /// <summary>One <c>setInterval</c> fired 200 times, the host moving the clock and pumping between firings.</summary>
+    [Benchmark]
+    public void IntervalFiring()
+    {
+        _intervalEngine.Execute(_intervalStart);
+
+        for (var i = 0; i < IntervalFirings; i++)
+        {
+            _intervalClock.Advance(IntervalStepMilliseconds);
+            _intervalEngine.Advanced.ProcessTasks();
+        }
+
+        _intervalEngine.Execute(_intervalStop);
+    }
+}

--- a/Jint.Benchmark/WebApiUrlBenchmark.cs
+++ b/Jint.Benchmark/WebApiUrlBenchmark.cs
@@ -1,0 +1,214 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// The <c>URL</c> and <c>URLSearchParams</c> interfaces — <see cref="WebApiFeatures.Url"/>, implemented on
+/// the WHATWG URL Standard's own parser rather than on <see cref="Uri"/>
+/// (https://url.spec.whatwg.org/#dom-url-url).
+///
+/// <para>Five rows, chosen so that a change to one part of the parser cannot hide in another:
+/// <see cref="ParseAbsolute"/> is the full parse of a representative corpus (special and non-special
+/// schemes, credentials, a non-default port, an IPv4 and an IPv6 host, an already-punycoded domain,
+/// percent-encoding, and the two cannot-be-a-base shapes <c>mailto:</c> and <c>data:</c>);
+/// <see cref="ParseRelative"/> is the base-relative path of the same parser, which is the one a module
+/// resolver or a link rewriter actually runs; <see cref="ReadComponents"/> never parses at all and is
+/// pure serialization, since every component getter rebuilds its string on each read
+/// (<c>UrlRecord.Serialize*</c>); <see cref="MutateAndSerialize"/> is the setter path plus the
+/// re-serialization each write implies; and the two <c>URLSearchParams</c> rows separate its mutation
+/// surface from its iterator.</para>
+///
+/// <para><b>Engine isolation.</b> Every row gets its own engine carrying <see cref="WebApiFeatures.Url"/>
+/// alone, warmed with its own fixture and its own script and nothing else — see
+/// <see cref="WebApiBenchmarkSupport"/>. Engine construction, the corpus and the reference values stay in
+/// <c>[GlobalSetup]</c> and never enter the measurement; the measured operation is one evaluation of the
+/// row's script, which calls one function and compares its answer with the reference.</para>
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+[BenchmarkCategory(WebApiBenchmarkSupport.Category)]
+public class WebApiUrlBenchmark
+{
+    /// <summary>
+    /// Ten inputs a real embedding sees, not ten variations on one shape. Kept in one place so the parse
+    /// and the serialize rows are talking about the same URLs.
+    /// </summary>
+    private const string Corpus =
+        """
+        var CORPUS = [
+            'https://example.org/',
+            'https://user:pass@example.org:8443/a/b/../c/./d?x=1&y=2#frag',
+            'https://192.168.0.1:8080/status',
+            'https://[2001:db8::1]/v6/index.html',
+            'https://cdn.example.com/assets/app.4f2c1b.js?v=3',
+            'https://example.org/search?q=hello+world&lang=en-US&page=2',
+            'http://xn--8i7caa.example/%E2%9C%93?ok=1',
+            'file:///C:/tmp/report.txt',
+            'mailto:someone@example.org',
+            'data:text/plain;base64,SGVsbG8sIHdvcmxkIQ=='
+        ];
+        var BASE = 'https://example.org/a/b/c?x=1#f';
+        """;
+
+    /// <summary>
+    /// The relative references a resolver meets: a plain segment, dot segments, an absolute path, a
+    /// query-only and a fragment-only reference, a scheme-relative one, an absolute URL that ignores the
+    /// base entirely, and the empty string, which resolves to the base minus its fragment.
+    /// </summary>
+    private const string Relatives =
+        """
+        var RELATIVE = ['d', '../e', '/f/g', '?q=2', '#g', '//other.example/h', 'https://abs.example/i', 'j/k/', '../../l', ''];
+        """;
+
+    /// <summary>
+    /// A query string with repeated names, a plus-encoded space and a mix of lengths — the shape
+    /// <c>getAll</c>, <c>sort</c> and the serializer all have something to do.
+    /// </summary>
+    private const string Query =
+        """
+        var QUERY = 'a=1&b=2&c=3&tag=x&tag=y&tag=z&q=hello+world&lang=en-US&page=2&sort=desc';
+        """;
+
+    private IsolatedScript _parseAbsolute;
+    private IsolatedScript _parseRelative;
+    private IsolatedScript _readComponents;
+    private IsolatedScript _mutateAndSerialize;
+    private IsolatedScript _searchParamsMutate;
+    private IsolatedScript _searchParamsIterate;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _parseAbsolute = Row(
+            Corpus +
+            """
+
+            function parseAbsolute() {
+                var n = 0;
+                for (var r = 0; r < 20; r++) {
+                    for (var i = 0; i < CORPUS.length; i++) { n += new URL(CORPUS[i]).href.length; }
+                }
+                return n;
+            }
+            """,
+            "parseAbsolute()");
+
+        _parseRelative = Row(
+            Corpus + Environment.NewLine + Relatives +
+            """
+
+            function parseRelative() {
+                var n = 0;
+                for (var r = 0; r < 20; r++) {
+                    for (var i = 0; i < RELATIVE.length; i++) { n += new URL(RELATIVE[i], BASE).href.length; }
+                }
+                return n;
+            }
+            """,
+            "parseRelative()");
+
+        // The corpus is parsed once, at fixture time: this row is about serialization only, and every
+        // getter below rebuilds its string on each read rather than answering from a cache.
+        _readComponents = Row(
+            Corpus +
+            """
+
+            var PARSED = CORPUS.map(function (s) { return new URL(s); });
+            function readComponents() {
+                var n = 0;
+                for (var r = 0; r < 20; r++) {
+                    for (var i = 0; i < PARSED.length; i++) {
+                        var u = PARSED[i];
+                        n += u.href.length + u.protocol.length + u.host.length + u.hostname.length
+                            + u.port.length + u.pathname.length + u.search.length + u.hash.length
+                            + u.origin.length;
+                    }
+                }
+                return n;
+            }
+            """,
+            "readComponents()");
+
+        _mutateAndSerialize = Row(
+            Corpus +
+            """
+
+            function mutateAndSerialize() {
+                var url = new URL(BASE);
+                var n = 0;
+                for (var i = 0; i < 200; i++) {
+                    url.pathname = '/p/' + i;
+                    url.search = 'q=' + i + '&r=' + (i * 2);
+                    url.hash = 'h' + i;
+                    url.port = String(8000 + (i % 100));
+                    n += url.href.length;
+                }
+                return n;
+            }
+            """,
+            "mutateAndSerialize()");
+
+        _searchParamsMutate = Row(
+            Query +
+            """
+
+            function searchParamsMutate() {
+                var n = 0;
+                for (var r = 0; r < 50; r++) {
+                    var p = new URLSearchParams(QUERY);
+                    p.append('extra', 'v' + r);
+                    p.set('page', 'p' + r);
+                    p.delete('sort');
+                    p.sort();
+                    n += p.toString().length + p.size;
+                }
+                return n;
+            }
+            """,
+            "searchParamsMutate()");
+
+        _searchParamsIterate = Row(
+            Query +
+            """
+
+            var PARAMS = new URLSearchParams(QUERY);
+            function searchParamsIterate() {
+                var n = 0;
+                for (var r = 0; r < 50; r++) {
+                    for (var entry of PARAMS) { n += entry[0].length + entry[1].length; }
+                    n += PARAMS.getAll('tag').length + PARAMS.get('q').length;
+                }
+                return n;
+            }
+            """,
+            "searchParamsIterate()");
+    }
+
+    private static IsolatedScript Row(string fixture, string call)
+        => WebApiBenchmarkSupport.DeterministicRow(WebApiFeatures.Url, fixture, call);
+
+    /// <summary>200 full parses: the whole corpus, twenty times.</summary>
+    [Benchmark]
+    public JsValue ParseAbsolute() => _parseAbsolute.Run();
+
+    /// <summary>200 base-relative parses, the path a module resolver runs.</summary>
+    [Benchmark]
+    public JsValue ParseRelative() => _parseRelative.Run();
+
+    /// <summary>1,800 component reads over ten already-parsed URLs — serialization with no parsing at all.</summary>
+    [Benchmark]
+    public JsValue ReadComponents() => _readComponents.Run();
+
+    /// <summary>200 rounds of four setters plus the <c>href</c> each round re-serializes.</summary>
+    [Benchmark]
+    public JsValue MutateAndSerialize() => _mutateAndSerialize.Run();
+
+    /// <summary>50 rounds of parse, append, set, delete, sort and serialize over a ten-pair query.</summary>
+    [Benchmark]
+    public JsValue SearchParamsMutate() => _searchParamsMutate.Run();
+
+    /// <summary>500 iterator steps plus the lookups, over one already-parsed parameter list.</summary>
+    [Benchmark]
+    public JsValue SearchParamsIterate() => _searchParamsIterate.Run();
+}


### PR DESCRIPTION
Benchmark rows for the web-API surface: 26 rows across seven classes (URL, encoding, structuredClone, fetch object model, streams, timers, crypto), all under a `WebApi` category so `--allCategories WebApi` selects exactly them.

The suite's own rules are followed to the letter: one engine per row, warmed with that row's own workload through `IsolatedScript` with **per-row** fixtures; each engine carries only its row's feature flag rather than `Default`; `[MemoryDiagnoser]` everywhere; no `[IterationSetup]`. The three timer rows drive a manual `TimeProvider` — nothing in the suite sleeps, waits or opens a socket. `IntervalFiring` is the one row whose measurement is not a single `Evaluate`, and its doc comment states exactly what enters the number.

Two guards keep the rows honest: a reference check at setup verifies each row's script produces its expected value (so a row can never quietly measure a failure path — mutation-verified against a de-fanged interval re-arm, which the smoke run catches with "row is not doing its work"), and `--smoke-webapi` runs every row once outside BenchmarkDotNet for CI-able liveness.

The README maps rows to features and nominates the seven most regression-sensitive rows for the standing pre-release pass, with the `--filter` line verified via `--list flat` to select exactly those. **No measurements were run** — per the repo's rule, numbers come from the gate machine when they're needed.

Closes #3109

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G7Ud48VAs1JicxRZxLDxg
