### PR TITLE
Run FinalizationRegistry cleanup from the event loop and keep async algorithms inside their reaction jobs

### DIFF
--- a/Jint.Tests/Runtime/AlgorithmJobBoundaryTests.cs
+++ b/Jint.Tests/Runtime/AlgorithmJobBoundaryTests.cs
@@ -1,0 +1,137 @@
+#nullable enable
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Where a specification algorithm suspends on an <c>Await</c> and where it merely carries on is observable
+/// from script, because every job boundary lets an unrelated promise chain run a turn. These tests pin the
+/// boundaries of the two algorithms that used to re-enqueue their own continuation through a raw event-loop
+/// job — <c>Array.fromAsync</c> and a <c>for await</c> loop inside an async generator — against a competing
+/// chain of plain <c>.then</c> turns.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The numbers below are change detectors, not a conformance claim. <c>Array.fromAsync</c> still awaits the
+/// iterator's value <em>and</em> the mapped value where
+/// https://tc39.es/proposal-array-from-async/#sec-array.fromAsync awaits only the mapped one, so its turn
+/// count is not yet the specification's. What the algorithm no longer does is spend a job on re-entering its
+/// own loop, which is what every figure here got smaller by.
+/// </para>
+/// </remarks>
+public class AlgorithmJobBoundaryTests
+{
+    /// <summary>
+    /// Runs <paramref name="script"/> and a 30-turn promise chain in the same job, and returns the log both
+    /// wrote to. Same job matters: <c>Execute</c> drains the event loop before it returns, so a chain built
+    /// by a second <c>Execute</c> would start after the algorithm had already finished.
+    /// </summary>
+    private static string Interleave(string script)
+    {
+        var engine = new Engine();
+        engine.Execute(
+            "var log = [];"
+            + script
+            + "var p = Promise.resolve(); for (let i = 0; i < 30; i++) { const j = i; p = p.then(() => log.push('t' + j)); }");
+
+        // Execute's own drain runs the loop to exhaustion; the extra pumps only guard against a future
+        // change that leaves something queued behind it.
+        for (var i = 0; i < 5; i++)
+        {
+            engine.Advanced.ProcessTasks();
+        }
+
+        return engine.Evaluate("log.join(' ')").AsString();
+    }
+
+    /// <summary>How many turns of the competing promise chain ran before <paramref name="marker"/> was logged.</summary>
+    private static int TurnsBefore(string log, string marker)
+    {
+        var entries = log.Split(' ');
+        var index = Array.IndexOf(entries, marker);
+        index.Should().BeGreaterThanOrEqualTo(0, "'{0}' must appear in the log, which was: {1}", marker, log);
+
+        var turns = 0;
+        for (var i = 0; i < index; i++)
+        {
+            if (entries[i].Length > 1 && entries[i][0] == 't')
+            {
+                turns++;
+            }
+        }
+
+        return turns;
+    }
+
+    [Fact]
+    public void ArrayFromAsyncOverASyncIterableSpendsNoJobOnReEnteringItsLoop()
+    {
+        // Was 14: the non-mapping path re-enqueued twice per element, once to store the value and once to
+        // re-enter the loop, so three elements cost six jobs the algorithm never asks for.
+        var log = Interleave("Array.fromAsync([1, 2, 3]).then(a => log.push('done:' + a.join('')));");
+        TurnsBefore(log, "done:123").Should().Be(8);
+    }
+
+    [Fact]
+    public void ArrayFromAsyncOverAnArrayLikeSpendsNoJobOnReEnteringItsLoop()
+    {
+        // Was 6: one re-enqueue per element.
+        var log = Interleave("Array.fromAsync({ length: 3, 0: 1, 1: 2, 2: 3 }).then(a => log.push('done:' + a.join('')));");
+        TurnsBefore(log, "done:123").Should().Be(3);
+    }
+
+    [Fact]
+    public void ArrayFromAsyncWithAMapperSpendsNoJobOnReEnteringItsLoop()
+    {
+        // Was 14: two re-enqueues per element.
+        var log = Interleave("Array.fromAsync([1, 2], x => x * 2).then(a => log.push('done:' + a.join('')));");
+        TurnsBefore(log, "done:24").Should().Be(10);
+    }
+
+    /// <summary>
+    /// The re-enqueue the loop used to make was commented "Queue next iteration to prevent stack overflow".
+    /// It was not what prevented one: every turn of the loop ends in an <c>Await</c>, and
+    /// <c>PerformPromiseThen</c> queues its reaction rather than calling it, so the turn returns before the
+    /// next one starts however many elements there are. Twenty thousand of them is far more than a nested
+    /// frame per element would survive.
+    /// </summary>
+    [Theory]
+    [InlineData("arrayLike")]
+    [InlineData("array")]
+    [InlineData("arrayLike, x => x + 1")]
+    public void ArrayFromAsyncDoesNotRecurPerElement(string arguments)
+    {
+        var engine = new Engine();
+        engine.Execute("""
+            const n = 20000;
+            const arrayLike = { length: n };
+            const array = [];
+            for (let i = 0; i < n; i++) { arrayLike[i] = i; array.push(i); }
+            var outcome = 'pending';
+            """);
+        engine.Execute($"Array.fromAsync({arguments}).then(a => {{ outcome = a.length + '/' + a[a.length - 1]; }}, e => {{ outcome = 'rejected:' + e; }});");
+
+        for (var i = 0; i < 5; i++)
+        {
+            engine.Advanced.ProcessTasks();
+        }
+
+        var expectedLast = arguments.Contains("x + 1", StringComparison.Ordinal) ? 20000 : 19999;
+        engine.Evaluate("outcome").AsString().Should().Be("20000/" + expectedLast);
+    }
+
+    [Fact]
+    public void ForAwaitInsideAnAsyncGeneratorResumesInsideItsOwnReactionJob()
+    {
+        // https://tc39.es/ecma262/#await: the fulfilled closure pushes the suspended context back on and
+        // resumes it there and then, so an Await costs the reaction job and nothing more. The async-generator
+        // branch used to hop once more, which cost one extra turn per loop iteration — 4 / 9 / 13 before.
+        var log = Interleave("""
+            async function* g() { for await (const v of [1, 2]) { yield v; } }
+            (async () => { for await (const v of g()) { log.push('g' + v); } log.push('gdone'); })();
+            """);
+
+        TurnsBefore(log, "g1").Should().Be(3);
+        TurnsBefore(log, "g2").Should().Be(7);
+        TurnsBefore(log, "gdone").Should().Be(10);
+    }
+}

--- a/Jint.Tests/Runtime/FinalizationRegistryTests.cs
+++ b/Jint.Tests/Runtime/FinalizationRegistryTests.cs
@@ -1,0 +1,209 @@
+#nullable enable
+
+using System.Runtime.CompilerServices;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// The <c>FinalizationRegistry</c> cleanup callback is discovered by the CLR garbage collector but must be
+/// <em>run</em> by the engine, on the engine's own thread and from the event loop —
+/// https://tc39.es/ecma262/#sec-host-enqueue-finalization-registry-cleanup-job. These tests pin that split,
+/// and the parts of https://tc39.es/ecma262/#sec-cleanup-finalization-registry a host can observe.
+/// </summary>
+/// <remarks>
+/// Shares the <see cref="GarbageCollectionTests"/> collection, which disables parallelization: every test
+/// here forces a full collection, which cannot be isolated from whatever else the runner is doing.
+/// </remarks>
+[Collection(nameof(GarbageCollectionTests))]
+public class FinalizationRegistryTests
+{
+    /// <summary>
+    /// How many collect / run-finalizers / pump rounds a test gives the runtime to notice that an
+    /// unreachable target really is unreachable. A bound, not a wait: nothing here observes the clock.
+    /// </summary>
+    private const int CollectionRounds = 10;
+
+    private sealed class Recorder
+    {
+        internal List<string> HeldValues { get; } = new();
+
+        internal List<int> ThreadIds { get; } = new();
+
+        internal Action<string> Callback => heldValue =>
+        {
+            HeldValues.Add(heldValue);
+            ThreadIds.Add(Environment.CurrentManagedThreadId);
+        };
+    }
+
+    private static Engine CreateEngine(Recorder recorder)
+    {
+        var engine = new Engine();
+        engine.SetValue("record", recorder.Callback);
+        engine.Execute("globalThis.registry = new FinalizationRegistry(record);");
+        return engine;
+    }
+
+    /// <summary>
+    /// Collects, runs finalizers and does <b>not</b> pump the event loop. Anything the cleanup callback
+    /// would have done on the finalizer thread has happened by the time this returns.
+    /// </summary>
+    private static void CollectWithoutPumping()
+    {
+        for (var i = 0; i < CollectionRounds; i++)
+        {
+            GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+            GC.WaitForPendingFinalizers();
+        }
+
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+    }
+
+    /// <summary>
+    /// Collects and pumps until <paramref name="recorder"/> has seen a callback, or the round budget runs
+    /// out — at which point the caller's assertion is what reports the failure.
+    /// </summary>
+    private static void CollectAndPump(Engine engine, Recorder recorder)
+    {
+        for (var i = 0; i < CollectionRounds && recorder.HeldValues.Count == 0; i++)
+        {
+            GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+            GC.WaitForPendingFinalizers();
+            engine.Advanced.ProcessTasks();
+        }
+    }
+
+    // NoInlining so the object literal's argument slot cannot stay stack-rooted in the caller's frame
+    // across the collections below.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void RegisterUnreachableTarget(Engine engine, string script) => engine.Execute(script);
+
+    [Fact]
+    public void CleanupCallbackRunsOnTheEngineThreadFromTheEventLoop()
+    {
+        var recorder = new Recorder();
+        var engine = CreateEngine(recorder);
+
+        RegisterUnreachableTarget(engine, "registry.register({}, 'held');");
+
+        // Every finalizer that was going to run has run by now. A callback invoked from ~Observer() would
+        // already be recorded here — that is precisely the defect, and this assertion cannot flake, because
+        // a target that was *not* collected produces no callback on any thread.
+        CollectWithoutPumping();
+        recorder.HeldValues.Should().BeEmpty("the cleanup callback must not run on the CLR finalizer thread");
+
+        CollectAndPump(engine, recorder);
+
+        // https://tc39.es/ecma262/#sec-cleanup-finalization-registry step 3.c: the callback is called with
+        // the cell's [[HeldValue]] — Jint used to call it with no arguments at all.
+        recorder.HeldValues.Should().Equal("held");
+        recorder.ThreadIds.Should().Equal(Environment.CurrentManagedThreadId);
+    }
+
+    [Fact]
+    public void CleanupCallbackRunsForACellRegisteredWithALiveUnregisterToken()
+    {
+        var recorder = new Recorder();
+        var engine = CreateEngine(recorder);
+
+        // The token stays reachable for the whole test. It used to be the registry's own strong index that
+        // kept the cell's finalization sentinel alive, so a token-registered cell was never cleaned up at
+        // all; the token must hold the cell, never the sentinel.
+        RegisterUnreachableTarget(engine, "globalThis.token = {}; registry.register({}, 'held', token);");
+
+        CollectAndPump(engine, recorder);
+
+        recorder.HeldValues.Should().Equal("held");
+    }
+
+    [Fact]
+    public void UnregisterBeforeTheCleanupJobRunsSuppressesTheCallback()
+    {
+        var recorder = new Recorder();
+        var engine = CreateEngine(recorder);
+
+        RegisterUnreachableTarget(engine, "globalThis.token = {}; registry.register({}, 'held', token);");
+
+        // The collection is observed, so the cleanup job is queued — but not run.
+        CollectWithoutPumping();
+
+        // https://tc39.es/ecma262/#sec-finalization-registry.prototype.unregister: the cell is still in
+        // [[Cells]] (nothing has removed it yet), so it is removed now and `removed` is true.
+        engine.Evaluate("registry.unregister(token)").AsBoolean().Should().BeTrue();
+
+        engine.Advanced.ProcessTasks();
+        recorder.HeldValues.Should().BeEmpty("an unregistered cell has left [[Cells]] and step 3 no longer sees it");
+    }
+
+    [Fact]
+    public void UnregisterAfterTheCleanupCallbackHasRunReportsNothingRemoved()
+    {
+        var recorder = new Recorder();
+        var engine = CreateEngine(recorder);
+
+        RegisterUnreachableTarget(engine, "globalThis.token = {}; registry.register({}, 'held', token);");
+
+        CollectAndPump(engine, recorder);
+        recorder.HeldValues.Should().Equal("held");
+
+        // The cell left [[Cells]] when its callback ran (step 3.b), so there is nothing left to remove.
+        engine.Evaluate("registry.unregister(token)").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void CollectionObservedAfterARestoreIsDroppedRatherThanRunAgainstRestoredGlobals()
+    {
+        var recorder = new Recorder();
+        var engine = CreateEngine(recorder);
+
+        // A CLR-side reference, so the registry survives the restore that takes its global binding away and
+        // the sentinel below still finds it. Without this the test would pass for the wrong reason.
+        var registry = engine.Evaluate("registry");
+
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+        RegisterUnreachableTarget(engine, "registry.register({}, 'stale');");
+
+        // Ends the cycle the cell was registered in. The cell is not queued yet — the collection has not
+        // been observed — so this is the generation *stamp* being tested, not the queue flush.
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        for (var i = 0; i < CollectionRounds; i++)
+        {
+            GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+            GC.WaitForPendingFinalizers();
+            engine.Advanced.ProcessTasks();
+        }
+
+        recorder.HeldValues.Should().BeEmpty("a cell registered before the restore belongs to a cycle the engine has ended");
+        GC.KeepAlive(registry);
+    }
+
+    [Fact]
+    public void OneCleanupJobNeverDeliversACellFromAnEndedCycleAlongsideACurrentOne()
+    {
+        var recorder = new Recorder();
+        var engine = CreateEngine(recorder);
+        var registry = engine.Evaluate("registry");
+
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+        RegisterUnreachableTarget(engine, "registry.register({}, 'stale');");
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        // The same registry, now used by the cycle that follows the restore: its cell belongs to that cycle,
+        // and the job the *stale* cell queues is the one the event loop drops. The surviving job therefore
+        // drains both cells, which is the whole reason the drain re-checks each cell's own generation rather
+        // than trusting the job's stamp.
+        engine.SetValue("registry", registry);
+        RegisterUnreachableTarget(engine, "registry.register({}, 'current');");
+
+        for (var i = 0; i < CollectionRounds && recorder.HeldValues.Count == 0; i++)
+        {
+            GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+            GC.WaitForPendingFinalizers();
+            engine.Advanced.ProcessTasks();
+        }
+
+        recorder.HeldValues.Should().Equal("current");
+        GC.KeepAlive(registry);
+    }
+}

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -318,13 +318,12 @@ public sealed partial class ArrayConstructor : Constructor
             var promiseResolve = _realm.Intrinsics.Promise.PromiseResolve(next);
 
             var capturedK = k;
-            var onFulfilled = new ClrFunction(_engine, "", (_, args) =>
+            PromiseOperations.UponPromise(_engine, (JsPromise) promiseResolve, iterResult =>
             {
-                var iterResult = args.At(0);
                 if (iterResult is not ObjectInstance iterResultObj)
                 {
                     promiseCapability.Reject(_realm.Intrinsics.TypeError.Construct("Iterator result is not an object"));
-                    return Undefined;
+                    return;
                 }
 
                 var done = TypeConverter.ToBoolean(iterResultObj.Get(CommonProperties.Done));
@@ -341,24 +340,13 @@ public sealed partial class ArrayConstructor : Constructor
                     {
                         promiseCapability.Reject(e.Error);
                     }
-                    return Undefined;
+                    return;
                 }
 
-                ProcessAsyncIteratorValue(value, target, callable, thisArg, promiseCapability, capturedK, iterator, () =>
-                {
-                    // Queue next iteration to prevent stack overflow
-                    _engine.AddToEventLoop(() => FromAsyncIteratorLoop(iterator, target, callable, thisArg, promiseCapability, capturedK + 1));
-                });
-                return Undefined;
-            }, 1, PropertyFlag.Configurable);
-
-            var onRejected = new ClrFunction(_engine, "", (_, args) =>
-            {
-                promiseCapability.Reject(args.At(0));
-                return Undefined;
-            }, 1, PropertyFlag.Configurable);
-
-            PromiseOperations.PerformPromiseThen(_engine, (JsPromise) promiseResolve, onFulfilled, onRejected, null!);
+                ProcessAsyncIteratorValue(value, target, callable, thisArg, promiseCapability, capturedK, iterator,
+                    () => FromAsyncIteratorLoop(iterator, target, callable, thisArg, promiseCapability, capturedK + 1));
+            },
+            reason => promiseCapability.Reject(reason));
         }
         catch (JavaScriptException e)
         {
@@ -366,6 +354,15 @@ public sealed partial class ArrayConstructor : Constructor
         }
     }
 
+    /// <summary>
+    /// One element of https://tc39.es/proposal-array-from-async/#sec-array.fromAsync step 3.e's repeat loop.
+    /// </summary>
+    /// <remarks>
+    /// <c>continueLoop</c> is the next turn of that loop, and is invoked directly rather than through a job
+    /// of its own: the loop's only job boundaries are its Awaits, so an extra hop would sever the algorithm
+    /// across jobs the specification does not have. It cannot recurse, because the next turn's own Await
+    /// ends in a <c>PerformPromiseThen</c>, which queues rather than calls.
+    /// </remarks>
     private void ProcessAsyncIteratorValue(
         JsValue value,
         ArrayOperations target,
@@ -381,21 +378,13 @@ public sealed partial class ArrayConstructor : Constructor
             // When mapping, await the value first, then apply mapfn
             var valuePromise = _realm.Intrinsics.Promise.PromiseResolve(value);
 
-            var onFulfilled = new ClrFunction(_engine, "", (_, args) =>
-            {
-                var resolvedValue = args.At(0);
-                ProcessMappedValue(resolvedValue, target, callable, thisArg, promiseCapability, k, continueLoop, iterator);
-                return Undefined;
-            }, 1, PropertyFlag.Configurable);
-
-            var onRejected = new ClrFunction(_engine, "", (_, args) =>
-            {
-                AsyncIteratorClose(_engine, iterator);
-                promiseCapability.Reject(args.At(0));
-                return Undefined;
-            }, 1, PropertyFlag.Configurable);
-
-            PromiseOperations.PerformPromiseThen(_engine, (JsPromise) valuePromise, onFulfilled, onRejected, null!);
+            PromiseOperations.UponPromise(_engine, (JsPromise) valuePromise,
+                resolvedValue => ProcessMappedValue(resolvedValue, target, callable, thisArg, promiseCapability, k, continueLoop, iterator),
+                reason =>
+                {
+                    AsyncIteratorClose(_engine, iterator);
+                    promiseCapability.Reject(reason);
+                });
         }
         else
         {
@@ -435,9 +424,8 @@ public sealed partial class ArrayConstructor : Constructor
                 var mappedPromise = _realm.Intrinsics.Promise.PromiseResolve(mappedValue);
 
                 var capturedIterator = iterator;
-                var onFulfilled = new ClrFunction(_engine, "", (_, args) =>
+                PromiseOperations.UponPromise(_engine, (JsPromise) mappedPromise, resolvedMapped =>
                 {
-                    var resolvedMapped = args.At(0);
                     try
                     {
                         target.CreateDataPropertyOrThrow(k, resolvedMapped);
@@ -446,20 +434,16 @@ public sealed partial class ArrayConstructor : Constructor
                     {
                         if (capturedIterator is not null) AsyncIteratorClose(_engine, capturedIterator);
                         promiseCapability.Reject(e2.Error);
-                        return Undefined;
+                        return;
                     }
-                    _engine.AddToEventLoop(continueLoop);
-                    return Undefined;
-                }, 1, PropertyFlag.Configurable);
 
-                var onRejected = new ClrFunction(_engine, "", (_, args) =>
+                    continueLoop();
+                },
+                reason =>
                 {
                     if (capturedIterator is not null) AsyncIteratorClose(_engine, capturedIterator);
-                    promiseCapability.Reject(args.At(0));
-                    return Undefined;
-                }, 1, PropertyFlag.Configurable);
-
-                PromiseOperations.PerformPromiseThen(_engine, (JsPromise) mappedPromise, onFulfilled, onRejected, null!);
+                    promiseCapability.Reject(reason);
+                });
             }
             else
             {
@@ -473,7 +457,8 @@ public sealed partial class ArrayConstructor : Constructor
                     promiseCapability.Reject(e.Error);
                     return;
                 }
-                _engine.AddToEventLoop(continueLoop);
+
+                continueLoop();
             }
         }
         catch (JavaScriptException e)
@@ -574,20 +559,9 @@ public sealed partial class ArrayConstructor : Constructor
             var valuePromise = _realm.Intrinsics.Promise.PromiseResolve(kValue);
 
             var capturedK = k;
-            var onFulfilled = new ClrFunction(_engine, "", (_, args) =>
-            {
-                var resolvedValue = args.At(0);
-                ProcessArrayLikeMappedValue(arrayLike, resolvedValue, target, callable, thisArg, promiseCapability, capturedK, len);
-                return Undefined;
-            }, 1, PropertyFlag.Configurable);
-
-            var onRejected = new ClrFunction(_engine, "", (_, args) =>
-            {
-                promiseCapability.Reject(args.At(0));
-                return Undefined;
-            }, 1, PropertyFlag.Configurable);
-
-            PromiseOperations.PerformPromiseThen(_engine, (JsPromise) valuePromise, onFulfilled, onRejected, null!);
+            PromiseOperations.UponPromise(_engine, (JsPromise) valuePromise,
+                resolvedValue => ProcessArrayLikeMappedValue(arrayLike, resolvedValue, target, callable, thisArg, promiseCapability, capturedK, len),
+                reason => promiseCapability.Reject(reason));
         }
         catch (JavaScriptException e)
         {
@@ -616,28 +590,20 @@ public sealed partial class ArrayConstructor : Constructor
                 var mappedPromise = _realm.Intrinsics.Promise.PromiseResolve(mappedValue);
 
                 var capturedK = k;
-                var onFulfilled = new ClrFunction(_engine, "", (_, args) =>
+                PromiseOperations.UponPromise(_engine, (JsPromise) mappedPromise, resolvedMapped =>
                 {
-                    var resolvedMapped = args.At(0);
                     target.CreateDataPropertyOrThrow(capturedK, resolvedMapped);
-                    // Queue next iteration to prevent stack overflow
-                    _engine.AddToEventLoop(() => FromAsyncArrayLikeLoop(arrayLike, target, callable, thisArg, promiseCapability, capturedK + 1, len));
-                    return Undefined;
-                }, 1, PropertyFlag.Configurable);
 
-                var onRejected = new ClrFunction(_engine, "", (_, args) =>
-                {
-                    promiseCapability.Reject(args.At(0));
-                    return Undefined;
-                }, 1, PropertyFlag.Configurable);
-
-                PromiseOperations.PerformPromiseThen(_engine, (JsPromise) mappedPromise, onFulfilled, onRejected, null!);
+                    // The next turn of the repeat loop, in this very job: the loop's job boundaries are its
+                    // Awaits and nothing else, and the next turn's own Await keeps this from recursing.
+                    FromAsyncArrayLikeLoop(arrayLike, target, callable, thisArg, promiseCapability, capturedK + 1, len);
+                },
+                reason => promiseCapability.Reject(reason));
             }
             else
             {
                 target.CreateDataPropertyOrThrow(k, value);
-                // Queue next iteration to prevent stack overflow
-                _engine.AddToEventLoop(() => FromAsyncArrayLikeLoop(arrayLike, target, callable, thisArg, promiseCapability, k + 1, len));
+                FromAsyncArrayLikeLoop(arrayLike, target, callable, thisArg, promiseCapability, k + 1, len);
             }
         }
         catch (JavaScriptException e)

--- a/Jint/Native/FinalizationRegistry/FinalizationRegistryInstance.cs
+++ b/Jint/Native/FinalizationRegistry/FinalizationRegistryInstance.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using Jint.Native.Object;
 using Jint.Runtime;
@@ -6,58 +7,278 @@ namespace Jint.Native.FinalizationRegistry;
 
 internal sealed record Cell(JsValue WeakRefTarget, JsValue HeldValue, JsValue? UnregisterToken);
 
+/// <summary>
+/// https://tc39.es/ecma262/#sec-properties-of-finalization-registry-instances
+/// </summary>
+/// <remarks>
+/// <para>
+/// The specification's <c>[[Cells]]</c> list is spread over three structures here, because the CLR's garbage
+/// collector — not the engine — is what discovers that a cell's <c>[[WeakRefTarget]]</c> has become empty.
+/// A cell's <see cref="FinalizationCell"/> record holds the parts the engine needs later
+/// (<c>[[HeldValue]]</c>, the cycle it was registered in, and whether it has left <c>[[Cells]]</c>); an
+/// <see cref="Observer"/> is the finalizable sentinel whose lifetime is tied to the target's through
+/// <see cref="_cells"/>, so its finalizer running <em>is</em> the observation that the target was collected;
+/// and <see cref="_byToken"/> indexes the cells by <c>[[UnregisterToken]]</c>.
+/// </para>
+/// <para>
+/// Which structure holds which object is load-bearing, not incidental. The sentinel must be reachable
+/// <b>only</b> from the target-keyed table, or a live unregister token would keep it alive after its target
+/// died and the collection would never be observed at all — which is exactly what the earlier strongly-keyed
+/// token dictionary did. The token table therefore holds the record, never the sentinel, and both tables are
+/// <see cref="ConditionalWeakTable{TKey,TValue}"/>s so that neither target nor token is kept alive by being
+/// registered: "registering an object with itself as its unregister token would not keep the object alive
+/// forever" (the note under https://tc39.es/ecma262/#sec-finalization-registry.prototype.register). The
+/// record is held strongly, which is the other half of that note — <c>cell.[[HeldValue]]</c> is live while
+/// <c>[[Cells]]</c> contains the cell, and it stays live across the target's collection because the sentinel
+/// references it and the CLR keeps everything a finalizable object references alive until its finalizer has
+/// run.
+/// </para>
+/// <para>
+/// The sentinel's reference back to the registry is weak, for two reasons. A strong one would make every
+/// live registered target keep the registry — and through it the whole <see cref="Engine"/> — alive. And a
+/// registry that is itself unreachable must not have its callback called: without the weak reference,
+/// dropping the registry while its targets are still live finalizes the sentinels and reports collections
+/// that never happened.
+/// </para>
+/// </remarks>
 internal sealed class FinalizationRegistryInstance : ObjectInstance
 {
     private readonly Realm _realm;
+
+    /// <summary>The specification's <c>[[CleanupCallback]]</c>.</summary>
     private readonly JobCallback _callable;
+
+    /// <summary>
+    /// The finalization sentinels, keyed by the cell's <c>[[WeakRefTarget]]</c>: a target may be registered
+    /// more than once, so the value is a list. Ephemeron semantics are the whole point — the sentinels for a
+    /// target become unreachable exactly when the target does.
+    /// </summary>
     private readonly ConditionalWeakTable<JsValue, List<Observer>> _cells = new();
-    private readonly Dictionary<JsValue, List<Observer>> _byToken = new();
+
+    /// <summary>
+    /// The cells indexed by their <c>[[UnregisterToken]]</c>, for <see cref="Remove"/>. Deliberately holds
+    /// <see cref="FinalizationCell"/> records rather than <see cref="Observer"/> sentinels; see the remarks
+    /// on the class.
+    /// </summary>
+    private readonly ConditionalWeakTable<JsValue, List<FinalizationCell>> _byToken = new();
+
+    /// <summary>
+    /// The cells whose <c>[[WeakRefTarget]]</c> has been observed to be empty and whose callback has not run
+    /// yet. Written from the CLR finalizer thread and drained on the engine's thread, which is why it is a
+    /// concurrent queue: it is the whole of the hand-off between the two.
+    /// </summary>
+    private readonly ConcurrentQueue<FinalizationCell> _dirtyCells = new();
+
+    /// <summary>
+    /// The job <see cref="CleanupFinalizationRegistry"/> is enqueued as, allocated once per registry rather
+    /// than once per collected target — a finalizer thread should allocate as little as it can.
+    /// </summary>
+    private readonly Action _cleanupJob;
+
+    /// <summary>
+    /// The one weak self-reference every <see cref="Observer"/> of this registry shares, and the reason it is
+    /// a field here rather than one per sentinel: <see cref="WeakReference{T}"/> is <b>itself finalizable</b>
+    /// — its finalizer frees the underlying handle — finalization order between two unreachable objects is
+    /// unspecified, and a sentinel's private handle would become unreachable at exactly the moment the
+    /// sentinel does. Such a sentinel finds a possibly already-finalized handle in its own finalizer and
+    /// reads every collection as "the registry has gone away", which presents as a FinalizationRegistry that
+    /// silently never fires rather than as a crash. Rooting the handle on the registry keeps it alive for
+    /// precisely as long as the answer it gives can be anything but "gone".
+    /// </summary>
+    private readonly WeakReference<FinalizationRegistryInstance> _self;
 
     public FinalizationRegistryInstance(Engine engine, Realm realm, ICallable cleanupCallback) : base(engine)
     {
         _realm = realm;
         _callable = engine._host.MakeJobCallBack(cleanupCallback);
+        _cleanupJob = CleanupFinalizationRegistry;
+        _self = new WeakReference<FinalizationRegistryInstance>(this);
     }
 
-    public static void CleanupFinalizationRegistry(ICallable? callback)
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-cleanup-finalization-registry
+    /// <para>
+    /// Runs as an event-loop job, never on the thread that discovered the collection: see
+    /// <see cref="OnTargetCollected"/>.
+    /// </para>
+    /// </summary>
+    private void CleanupFinalizationRegistry()
     {
+        // 2. Let callback be finalizationRegistry.[[CleanupCallback]].
+        var callback = _callable.Callback;
+        var generation = _engine.EventLoopGeneration;
+
+        // 3. While finalizationRegistry.[[Cells]] contains a Record cell such that cell.[[WeakRefTarget]] is
+        //    empty, an implementation may perform the following steps:
+        //      a. Choose any such cell.
+        while (_dirtyCells.TryDequeue(out var cell))
+        {
+            // b. Remove cell from finalizationRegistry.[[Cells]]. Before the callback runs, so that an
+            // unregister() from inside it correctly reports the cell as already gone, and so that a cell can
+            // never be delivered twice however many jobs are queued for this registry.
+            if (cell.Removed)
+            {
+                // Unregistered between the collection being observed and this job running: the cell left
+                // [[Cells]] then, so step 3 no longer sees it at all.
+                continue;
+            }
+
+            cell.Removed = true;
+
+            // Work registered before a RestoreGlobalSnapshot belongs to a cycle the engine has ended, and a
+            // cleanup callback from it would run against the restored globals — the same fence the event
+            // loop applies to whole jobs, applied per cell because one job may drain cells that were
+            // registered in different cycles.
+            if (cell.Generation != generation)
+            {
+                continue;
+            }
+
+            // c. Perform ? HostCallJobCallback(callback, undefined, « cell.[[HeldValue]] »).
+            //
+            // The "?" is what ends the loop on an abrupt completion: the throw propagates out of the job and
+            // out of whatever is pumping the event loop, which is Jint's usual "perform any host-defined
+            // steps for reporting the error" and the same thing a timer callback's exception does. Nothing
+            // is stranded by it — every dirty cell was enqueued with a job of its own, so the cells behind
+            // this one are delivered by those.
+            callback.Call(JsValue.Undefined, cell.HeldValue);
+        }
     }
 
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-finalization-registry.prototype.register steps 7-8: build the cell and
+    /// append it to <c>[[Cells]]</c>.
+    /// </summary>
     public void AddCell(Cell cell)
     {
-        var observer = new Observer(_callable);
-        var observerList = _cells.GetOrCreateValue(cell.WeakRefTarget);
-        observerList.Add(observer);
+        // The cycle the cell is registered in, read here on the engine's thread. The collection may be
+        // observed arbitrarily later, on the finalizer thread, and stamping the job with the generation
+        // captured now is what lets the drain tell work this engine is still waiting for from work whose
+        // cycle a RestoreGlobalSnapshot has since ended. Per cell rather than per registry: a host that kept
+        // a reference to the registry across a restore may register new cells on it afterwards, and those
+        // belong to the new cycle.
+        var finalizationCell = new FinalizationCell(cell.HeldValue, _engine.EventLoopGeneration);
 
+        var observers = _cells.GetOrCreateValue(cell.WeakRefTarget);
+        observers.Add(new Observer(_self, finalizationCell));
+
+        // "If CanBeHeldWeakly(unregisterToken) is false, then ... Set unregisterToken to empty" — the
+        // prototype passes null for empty, and a cell with an empty token is reachable through the target
+        // alone.
         if (cell.UnregisterToken is not null)
         {
             if (!_byToken.TryGetValue(cell.UnregisterToken, out var list))
             {
-                _byToken[cell.UnregisterToken] = list = new List<Observer>();
+                list = new List<FinalizationCell>();
+                _byToken.Add(cell.UnregisterToken, list);
             }
-            list.Add(observer);
+
+            list.Add(finalizationCell);
         }
     }
 
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-finalization-registry.prototype.unregister steps 4-6.
+    /// </summary>
     public JsValue Remove(JsValue unregisterToken)
     {
-        if (_byToken.TryGetValue(unregisterToken, out var list))
+        if (!_byToken.TryGetValue(unregisterToken, out var cells))
         {
-            var any = list.Count > 0;
-            list.Clear();
-            return any;
+            return JsBoolean.False;
         }
 
-        return false;
+        // 5. For each Record cell of finalizationRegistry.[[Cells]], do
+        //      a. If cell.[[UnregisterToken]] is not empty and SameValue(cell.[[UnregisterToken]],
+        //         unregisterToken) is true, then
+        //          i. Remove cell from finalizationRegistry.[[Cells]].
+        //          ii. Set removed to true.
+        //
+        // A cell whose callback has already run left [[Cells]] then and must not be counted now, which is
+        // what the flag distinguishes.
+        var removed = false;
+        for (var i = 0; i < cells.Count; i++)
+        {
+            var cell = cells[i];
+            if (cell.Removed)
+            {
+                continue;
+            }
+
+            cell.Removed = true;
+            removed = true;
+        }
+
+        _byToken.Remove(unregisterToken);
+        return removed ? JsBoolean.True : JsBoolean.False;
     }
 
+    /// <summary>
+    /// Called from the CLR finalizer thread when a cell's <c>[[WeakRefTarget]]</c> has been collected. Runs
+    /// on a thread that is not the engine's, so it does exactly two things: hand the cell over through a
+    /// concurrent queue, and enqueue the cleanup job. Everything the specification's algorithm does happens
+    /// later, on the engine's thread, in <see cref="CleanupFinalizationRegistry"/>.
+    /// </summary>
+    /// <remarks>
+    /// One job per collected cell rather than one coalesced job for the registry. Coalescing would have to
+    /// pick a single generation for cells that may not share one, and a coalesced job dropped by the restore
+    /// fence would strand every cell behind it; a job per cell carries each cell's own generation and can
+    /// strand nothing. The extra jobs are cheap — the drain is shared, so all but the first find the queue
+    /// empty.
+    /// <para>
+    /// The stamp on the job is the belt and the drain's per-cell check is the braces, the same way
+    /// <c>TimerEntry.Generation</c> is: a surviving job may reach a cell of any generation, so the check that
+    /// decides whether a callback runs has to be the one on the cell.
+    /// </para>
+    /// </remarks>
+    private void OnTargetCollected(FinalizationCell cell)
+    {
+        _dirtyCells.Enqueue(cell);
+        _engine._host.HostEnqueueFinalizationRegistryCleanupJob(_cleanupJob, cell.Generation);
+    }
+
+    /// <summary>
+    /// One entry of the registry's <c>[[Cells]]</c>, minus the target — which is the key it is stored under
+    /// and is deliberately not referenced from here, so that nothing about a cell keeps its target alive.
+    /// </summary>
+    internal sealed class FinalizationCell
+    {
+        /// <summary>
+        /// Whether the cell has left <c>[[Cells]]</c>, by <c>unregister</c> or by its callback having run.
+        /// Only the engine's thread ever sets it; the finalizer thread reads it to skip a cell that is
+        /// already gone, which is what makes it volatile.
+        /// </summary>
+        internal volatile bool Removed;
+
+        internal FinalizationCell(JsValue heldValue, int generation)
+        {
+            HeldValue = heldValue;
+            Generation = generation;
+        }
+
+        /// <summary>The specification's <c>[[HeldValue]]</c>, the sole argument the cleanup callback receives.</summary>
+        internal JsValue HeldValue { get; }
+
+        /// <summary>The evaluation cycle the cell was registered in; see <see cref="AddCell"/>.</summary>
+        internal int Generation { get; }
+    }
+
+    /// <summary>
+    /// The finalizable sentinel that stands for one cell's <c>[[WeakRefTarget]]</c>. It is stored as the
+    /// value of a <see cref="ConditionalWeakTable{TKey,TValue}"/> entry keyed by that target, so it becomes
+    /// unreachable exactly when the target does and its finalizer running is the engine's only way of
+    /// learning that the target was collected.
+    /// </summary>
     private sealed class Observer
     {
-        private readonly JobCallback _callable;
+        /// <summary>The registry's own <see cref="_self"/> handle, never one this sentinel owns; see its remarks.</summary>
+        private readonly WeakReference<FinalizationRegistryInstance> _registry;
 
-        public Observer(JobCallback callable)
+        private readonly FinalizationCell _cell;
+
+        internal Observer(WeakReference<FinalizationRegistryInstance> registry, FinalizationCell cell)
         {
-            _callable = callable;
+            _registry = registry;
+            _cell = cell;
         }
 
 #pragma warning disable MA0055
@@ -66,13 +287,29 @@ internal sealed class FinalizationRegistryInstance : ObjectInstance
         {
             try
             {
-                _callable.Callback.Call(Undefined);
+                if (_cell.Removed)
+                {
+                    return;
+                }
+
+                // A registry nothing can reach any more must not have its callback called: script cannot
+                // observe a collection through a registry it has already dropped, and the sentinels of its
+                // still-live targets are being finalized here only because the registry went away, not
+                // because those targets did.
+                if (!_registry.TryGetTarget(out var registry))
+                {
+                    return;
+                }
+
+                registry.OnTargetCollected(_cell);
             }
             catch
             {
-                // FinalizationRegistry cleanup callbacks are spec'd to run in a Job
-                // isolated from any calling context. Exceptions must never escape
-                // the GC finalizer thread or they will terminate the host process.
+                // Nothing may escape a finalizer — an exception on the finalizer thread terminates the host
+                // process. The body above only pushes onto a concurrent queue and signals the event loop, so
+                // the only way here is an allocation failure, and losing one cleanup callback is by far the
+                // better outcome. Note that the callback itself is emphatically not called from here: it
+                // runs on the engine's thread, from the job the push above queued.
             }
         }
     }

--- a/Jint/Native/FinalizationRegistry/FinalizationRegistryPrototype.cs
+++ b/Jint/Native/FinalizationRegistry/FinalizationRegistryPrototype.cs
@@ -49,15 +49,25 @@ internal sealed partial class FinalizationRegistryPrototype : Prototype
             Throw.TypeError(_realm, "target and holdings must not be same");
         }
 
+        // 5. If CanBeHeldWeakly(unregisterToken) is false, then
+        //      a. If unregisterToken is not undefined, throw a TypeError exception.
+        //      b. Set unregisterToken to empty.
+        //
+        // "empty" is null here, and the distinction matters: a cell with an empty token must not be indexed
+        // by one, or every registration made without a token would pile up under the immortal `undefined`
+        // and never be released.
+        JsValue? token = unregisterToken;
         if (!unregisterToken.CanBeHeldWeakly())
         {
             if (!unregisterToken.IsUndefined())
             {
                 Throw.TypeError(_realm, unregisterToken + " must be an object");
             }
+
+            token = null;
         }
 
-        var cell = new Cell(target, heldValue, unregisterToken);
+        var cell = new Cell(target, heldValue, token);
         finalizationRegistry.AddCell(cell);
         return Undefined;
     }

--- a/Jint/Native/Promise/PromiseOperations.cs
+++ b/Jint/Native/Promise/PromiseOperations.cs
@@ -224,4 +224,25 @@ internal static class PromiseOperations
             engine._host.HostPromiseRejectionTracker(promise, PromiseRejectionOperation.Handle);
         }
     }
+
+    /// <summary>
+    /// "Upon fulfillment of <paramref name="promise"/>, do ..." / "upon rejection of <paramref name="promise"/>,
+    /// do ...", the shape most specification algorithms attach to a promise in: engine-internal handlers, no
+    /// result promise. <see cref="PerformPromiseThen(Engine, JsPromise, IPromiseContinuation)"/> with a
+    /// <see cref="VoidPromiseContinuation"/>, which is what an algorithm should reach for instead of building
+    /// a pair of JavaScript functions no script can ever see.
+    /// </summary>
+    /// <remarks>
+    /// A JavaScript exception raised by a handler has nowhere to go — there is no result capability to
+    /// reject — and is dropped by the reaction job, exactly as one from a JavaScript handler attached
+    /// without a capability is.
+    /// </remarks>
+    internal static void UponPromise(
+        Engine engine,
+        JsPromise promise,
+        Action<JsValue>? onFulfilled,
+        Action<JsValue>? onRejected)
+    {
+        PerformPromiseThen(engine, promise, new VoidPromiseContinuation(onFulfilled, onRejected));
+    }
 }

--- a/Jint/Native/Promise/VoidPromiseContinuation.cs
+++ b/Jint/Native/Promise/VoidPromiseContinuation.cs
@@ -1,0 +1,45 @@
+namespace Jint.Native.Promise;
+
+/// <summary>
+/// The specification's "upon fulfillment of <i>promise</i>, do ..." / "upon rejection of <i>promise</i>,
+/// do ...": a reaction whose handlers produce no value and which carries no result promise, i.e.
+/// <see href="https://tc39.es/ecma262/#sec-performpromisethen">PerformPromiseThen</see> with no
+/// <c>resultCapability</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The handlers of an algorithm written in the specification's own prose are not observable from script —
+/// no <c>Function.prototype.call</c> is looked up, no <c>name</c>/<c>length</c> descriptors are
+/// materialized, and script can never get hold of the function object because there is none. An
+/// <see cref="IPromiseContinuation"/> is exactly that, which is why <c>await</c> itself uses one, and why an
+/// engine-internal algorithm that reaches for a <c>ClrFunction</c> handler pair is both allocating two
+/// function objects per step and mis-describing what it is doing.
+/// </para>
+/// <para>
+/// The job granularity is identical to a JavaScript handler's — one job per reaction — so substituting this
+/// for a handler pair cannot move a microtask boundary.
+/// </para>
+/// </remarks>
+internal sealed class VoidPromiseContinuation : IPromiseContinuation
+{
+    private readonly Action<JsValue>? _onFulfilled;
+    private readonly Action<JsValue>? _onRejected;
+
+    internal VoidPromiseContinuation(Action<JsValue>? onFulfilled, Action<JsValue>? onRejected)
+    {
+        _onFulfilled = onFulfilled;
+        _onRejected = onRejected;
+    }
+
+    public void Invoke(Engine engine, JsValue value, ReactionType type)
+    {
+        if (type == ReactionType.Fulfill)
+        {
+            _onFulfilled?.Invoke(value);
+        }
+        else
+        {
+            _onRejected?.Invoke(value);
+        }
+    }
+}

--- a/Jint/Runtime/Host.cs
+++ b/Jint/Runtime/Host.cs
@@ -483,6 +483,28 @@ public class Host
         Engine.AddToEventLoop(job);
     }
 
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-host-enqueue-finalization-registry-cleanup-job
+    /// <para>
+    /// "An implementation of HostEnqueueFinalizationRegistryCleanupJob schedules cleanupJob to be performed
+    /// at some future time, if possible." Jint schedules it on the event loop, so the callback runs on the
+    /// engine's thread on a later turn — never on the CLR finalizer thread that discovered the collection,
+    /// which is the only thread the discovery is available on and the one thread that must never enter the
+    /// engine.
+    /// </para>
+    /// </summary>
+    /// <param name="cleanupJob">The job, which runs <c>CleanupFinalizationRegistry</c> for one registry.</param>
+    /// <param name="generation">
+    /// The evaluation cycle the collected cell was registered in, so that a collection observed after a
+    /// <c>RestoreGlobalSnapshot</c> is dropped rather than run against the restored globals. Callable from
+    /// any thread for exactly that reason: the stamp is read at registration on the engine's thread and
+    /// checked at dequeue on the engine's thread, and this enqueue in between is the only cross-thread step.
+    /// </param>
+    internal void HostEnqueueFinalizationRegistryCleanupJob(Action cleanupJob, int generation)
+    {
+        Engine.AddToEventLoop(cleanupJob, generation);
+    }
+
     internal virtual List<string> GetSupportedImportAttributes()
     {
         return _supportedImportAttributes;

--- a/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
@@ -1161,9 +1161,11 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
             // the request was already dequeued by AsyncGeneratorResumeNext() before
             // reaching here, so the queue is now empty. On resume we must continue
             // THIS request's execution, not start a new one via AsyncGeneratorResumeNext().
-            // The continuation re-enqueues via AddToEventLoop (like the async-function path)
-            // so the actual resumption happens in a distinct event-loop turn, matching spec
-            // microtask ordering.
+            //
+            // Per spec Await step 3, exactly as the async-function branch above: the continuation resumes
+            // inside the reaction job. Await's fulfilledClosure pushes the suspended context back on and
+            // resumes it there and then, so the reaction job *is* the resumption and a hop of its own would
+            // be a job boundary the algorithm does not have.
             PromiseOperations.PerformPromiseThen(
                 engine,
                 promise,
@@ -1229,8 +1231,9 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
 
     /// <summary>
     /// Await continuation for a for-await-of running inside an async generator: hands the
-    /// settled value to the suspend data and resumes the current request in a distinct
-    /// event-loop turn (see the enqueueing comment at the PerformPromiseThen call site).
+    /// settled value to the suspend data and resumes the current request, inside this reaction
+    /// job — the same shape as <see cref="ForAwaitFunctionContinuation"/>, and the same shape
+    /// https://tc39.es/ecma262/#await gives every other Await.
     /// </summary>
     private sealed class ForAwaitGeneratorContinuation : IPromiseContinuation
     {
@@ -1250,23 +1253,20 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
 
         public void Invoke(Engine engine, JsValue value, ReactionType type)
         {
-            engine.AddToEventLoop(() =>
+            var resumeSuspendData = _asyncGenerator.Data.GetOrCreate<ForAwaitSuspendData>(_statement);
+            if (type == ReactionType.Fulfill)
             {
-                var resumeSuspendData = _asyncGenerator.Data.GetOrCreate<ForAwaitSuspendData>(_statement);
-                if (type == ReactionType.Fulfill)
-                {
-                    // Store the resolved iterator result so the for-await-of loop can use it
-                    resumeSuspendData.ResolvedIteratorResult = value as ObjectInstance;
-                }
-                else
-                {
-                    // Store the rejection so ExecuteInternal can propagate it as a throw
-                    resumeSuspendData.RejectedValue = value;
-                }
+                // Store the resolved iterator result so the for-await-of loop can use it
+                resumeSuspendData.ResolvedIteratorResult = value as ObjectInstance;
+            }
+            else
+            {
+                // Store the rejection so ExecuteInternal can propagate it as a throw
+                resumeSuspendData.RejectedValue = value;
+            }
 
-                // Resume the current request's execution (queue is empty – cannot use AsyncGeneratorResumeNext)
-                _asyncGenerator.AsyncGeneratorContinueForAwait(_capability);
-            });
+            // Resume the current request's execution (queue is empty – cannot use AsyncGeneratorResumeNext)
+            _asyncGenerator.AsyncGeneratorContinueForAwait(_capability);
         }
     }
 

--- a/Jint/WebApi/Streams/StreamPromises.cs
+++ b/Jint/WebApi/Streams/StreamPromises.cs
@@ -98,7 +98,7 @@ internal static class StreamPromises
         Action<JsValue>? onFulfilled,
         Action<JsValue>? onRejected)
     {
-        PromiseOperations.PerformPromiseThen(engine, promise, new VoidReaction(onFulfilled, onRejected));
+        PromiseOperations.UponPromise(engine, promise, onFulfilled, onRejected);
     }
 
     /// <summary>"Upon fulfillment of <paramref name="promise"/>".</summary>
@@ -153,36 +153,6 @@ internal static class StreamPromises
         catch (JavaScriptException e)
         {
             return RejectedWith(engine, realm, e.Error);
-        }
-    }
-
-    /// <summary>
-    /// The reaction behind <see cref="UponPromise"/>: engine-internal handlers, no result promise. A
-    /// JavaScript exception raised by a handler has nowhere to go — the specification asserts these handlers
-    /// do not throw — and is dropped by the reaction job, which is what a JavaScript handler with no result
-    /// capability does too.
-    /// </summary>
-    private sealed class VoidReaction : IPromiseContinuation
-    {
-        private readonly Action<JsValue>? _onFulfilled;
-        private readonly Action<JsValue>? _onRejected;
-
-        internal VoidReaction(Action<JsValue>? onFulfilled, Action<JsValue>? onRejected)
-        {
-            _onFulfilled = onFulfilled;
-            _onRejected = onRejected;
-        }
-
-        public void Invoke(Engine engine, JsValue value, ReactionType type)
-        {
-            if (type == ReactionType.Fulfill)
-            {
-                _onFulfilled?.Invoke(value);
-            }
-            else
-            {
-                _onRejected?.Invoke(value);
-            }
         }
     }
 


### PR DESCRIPTION
Fixes the two actionable #3125 items, and turned up three more real defects on the way.

**FinalizationRegistry cleanup now runs on the event loop, not the CLR finalizer thread.** The finalizer enqueues a generation-stamped job through a new `Host.HostEnqueueFinalizationRegistryCleanupJob` (mirroring `HostEnqueuePromiseJob`), and `CleanupFinalizationRegistry` is implemented per §9.12 — including passing `cell.[[HeldValue]]` to the callback, which Jint previously omitted entirely. The stamp is the generation current when the *cell* was registered (the same discipline every other cross-thread completion uses), with a per-cell re-check in the drain so one job never delivers a stale cell alongside a current one (mutation-pinned); a collection observed after `RestoreGlobalSnapshot` is dropped rather than run against restored globals.

The three extra defects, each load-bearing for cleanup to be reachable at all: the token table held targets **strongly**, so no collection was ever observed and cleanup never ran in any scenario — the new failing-first evidence is exactly that, 3 of the new tests fail on the unmodified engine with "found empty collection"; the sentinel held the callback strongly, so live targets pinned the realm and dropping the registry reported collections that never happened; and a per-sentinel `WeakReference` is itself finalizable with unspecified ordering against the sentinel, which silently reads as "registry gone" about half the time — the handle is now one shared, deliberately-rooted field on the registry, documented prominently.

**The five raw `AddToEventLoop(Action)` continuations are gone.** `for await` in an async generator and `Array.fromAsync`'s four handler pairs now run inside the reaction job their own Await owns, per §Await — matching what the async-function branch beside them already did. Every ordering delta is measured and pinned (one to two fewer turns per element/iteration; the before/after table is in the new `AlgorithmJobBoundaryTests`), and the old comment's stack-overflow justification is disproven with a 20,000-element pin: each turn ends in a `PerformPromiseThen`, which queues rather than recurses.

The third #3125 item (replay double-invoke) was analysis-only per the issue: 39 shapes probed, the defect narrowed to two scoped `SuspendData` additions, filed as #3133.

Full test262 at the pinned SHA: identical to the upstream baseline (102,495 passed). Both suites green on net10.0 and net472, with and without `JINT_HOST_CONTRACT_VERIFICATION=1`.

Closes #3125

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G7Ud48VAs1JicxRZxLDxg
