### PR TITLE
Add opt-in node: builtin modules for path, querystring and url

### DIFF
--- a/Jint.Tests.PublicInterface/HostNodeBuiltinModuleTests.cs
+++ b/Jint.Tests.PublicInterface/HostNodeBuiltinModuleTests.cs
@@ -1,0 +1,132 @@
+#nullable enable
+
+using System;
+using System.IO;
+using Jint.NodeCompat;
+using Jint.Runtime.Modules;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// The opt-in <c>node:</c> builtin modules from an embedder's side. These tests live in the public-interface
+/// suite on purpose: the project has no <c>InternalsVisibleTo</c> grant, so every green assertion here is
+/// proof that a third-party host can reach the capability through <see cref="NodeBuiltinModuleOptions"/>,
+/// <c>options.UseNodeBuiltinModules</c>, <see cref="NodeStyleModuleLoader"/> and <c>Engine.Modules.Add</c>
+/// alone.
+/// </summary>
+public class HostNodeBuiltinModuleTests
+{
+    /// <summary>
+    /// The plain case, and the two options a host has any reason to set: which platform <c>node:path</c>
+    /// follows, and what stands in for <c>process.cwd()</c>.
+    /// </summary>
+    [Fact]
+    public void AHostCanEnableAndConfigureTheBuiltins()
+    {
+        var engine = new Engine(options => options.UseNodeBuiltinModules(o =>
+        {
+            o.Platform = "linux";
+            o.WorkingDirectory = "/srv/app";
+        }));
+
+        var path = engine.Modules.Import("node:path");
+
+        engine.SetValue("path", path.Get("default"));
+
+        engine.Evaluate("path.sep").AsString().Should().Be("/");
+        engine.Evaluate("path.join('a', 'b', '..', 'c')").AsString().Should().Be("a/c");
+        engine.Evaluate("path.resolve('x')").AsString().Should().Be("/srv/app/x");
+    }
+
+    /// <summary>
+    /// Composing with a real <c>node_modules</c> tree, which is the arrangement the feature exists for: the
+    /// package resolves through <see cref="NodeStyleModuleLoader"/> and imports a builtin of its own.
+    /// </summary>
+    [Fact]
+    public void APackageOnDiskCanImportABuiltin()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "jint-node-builtins-public", Guid.NewGuid().ToString("N"));
+        try
+        {
+            Write(root, "main.js", "import { titleOf } from 'tiny-titles'; export const title = titleOf('/docs/getting-started.md');");
+            Write(root, "node_modules/tiny-titles/package.json", "{ \"name\": \"tiny-titles\", \"main\": \"index.js\" }");
+            Write(root, "node_modules/tiny-titles/index.js", "import { basename, extname } from 'node:path'; export function titleOf(p) { return basename(p, extname(p)); }");
+
+            var engine = new Engine(options => options
+                .EnableModules(new NodeStyleModuleLoader(root))
+                .UseNodeBuiltinModules(o => o.Platform = "linux"));
+
+            engine.Modules.Import("./main.js").Get("title").AsString().Should().Be("getting-started");
+        }
+        finally
+        {
+            Delete(root);
+        }
+    }
+
+    /// <summary>
+    /// A module the host registers itself wins over the builtin, which is also how it supplies one of the
+    /// modules Jint deliberately does not provide.
+    /// </summary>
+    [Fact]
+    public void AHostRegistrationTakesPrecedence()
+    {
+        var engine = new Engine(options => options.UseNodeBuiltinModules());
+
+        engine.Modules.Add("node:path", "export const sep = '::';");
+        engine.Modules.Add("node:fs", "export function readFileSync() { return 'host'; }");
+
+        engine.Modules.Import("node:path").Get("sep").AsString().Should().Be("::");
+        engine.SetValue("fs", engine.Modules.Import("node:fs").Get("readFileSync"));
+        engine.Evaluate("fs()").AsString().Should().Be("host");
+    }
+
+    /// <summary>
+    /// An unknown <c>node:</c> specifier fails with a message naming what is available, so a host reading the
+    /// exception can tell the difference between "not implemented" and "typo".
+    /// </summary>
+    [Fact]
+    public void AnUnknownBuiltinReportsWhatIsAvailable()
+    {
+        var engine = new Engine(options => options.UseNodeBuiltinModules());
+
+        var exception = Assert.Throws<ModuleResolutionException>(() => engine.Modules.Import("node:child_process"));
+
+        exception.ResolverAlgorithmError.Should().Contain("node:path");
+        exception.ResolverAlgorithmError.Should().Contain("deliberately not provided");
+    }
+
+    /// <summary>
+    /// An engine that did not ask is unchanged, which is what makes the feature safe to add to the engine at
+    /// all.
+    /// </summary>
+    [Fact]
+    public void AnEngineThatDidNotOptInIsUnchanged()
+    {
+        var engine = new Engine();
+
+        Assert.ThrowsAny<Exception>(() => engine.Modules.Import("node:path"));
+    }
+
+    private static void Write(string root, string relativePath, string contents)
+    {
+        var path = Path.Combine(root, relativePath.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, contents);
+    }
+
+    private static void Delete(string root)
+    {
+        try
+        {
+            Directory.Delete(root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // A file left open by a failing test must not replace that test's own failure.
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}

--- a/Jint.Tests/Runtime/NodeCompat/BuiltinModuleTests.cs
+++ b/Jint.Tests/Runtime/NodeCompat/BuiltinModuleTests.cs
@@ -1,0 +1,455 @@
+#nullable enable
+
+using System.Threading;
+using System.Threading.Tasks;
+using Jint.Native;
+using Jint.Runtime;
+using Jint.Runtime.Modules;
+
+namespace Jint.Tests.Runtime.NodeCompat;
+
+/// <summary>
+/// How the opt-in <c>node:</c> builtin modules are reached: what an engine that did not ask for them sees,
+/// how they compose with a configured module loader and with <c>Engine.Modules.Add</c>, and what an unknown
+/// <c>node:</c> specifier reports.
+/// </summary>
+public class BuiltinModuleTests
+{
+    // -------------------------------------------------------------------------------------------------
+    // Opting in, and what an engine that did not.
+    // -------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// The default engine is the engine it always was: a <c>node:</c> specifier is refused exactly as it was
+    /// before these modules existed.
+    /// </summary>
+    [Fact]
+    public void ADefaultEngineCannotImportABuiltin()
+    {
+        var engine = new Engine();
+
+        Assert.ThrowsAny<Exception>(() => engine.Modules.Import("node:path"));
+    }
+
+    /// <summary>
+    /// And so is one with a real loader that never asked for the builtins - <see cref="NodeStyleModuleLoader"/>
+    /// keeps refusing a <c>node:</c> scheme with its own message.
+    /// </summary>
+    [Fact]
+    public void ANodeStyleLoaderThatDidNotOptInStillRefusesTheNodeScheme()
+    {
+        using var tree = new PackageTree();
+        tree.Add("main.js", "export const x = 1;");
+
+        var engine = new Engine(options => options.EnableModules(new NodeStyleModuleLoader(tree.Root)));
+
+        var exception = Assert.Throws<ModuleResolutionException>(() => engine.Modules.Import("node:path"));
+
+        exception.ResolverAlgorithmError.Should().StartWith("Unsupported Module Scheme");
+    }
+
+    /// <summary>
+    /// The builtins need no file-based loader at all: an engine that enabled nothing else still gets them, and
+    /// everything else keeps failing the way it did.
+    /// </summary>
+    [Fact]
+    public void TheBuiltinsWorkWithoutAModuleLoader()
+    {
+        var engine = new Engine(options => options.UseNodeBuiltinModules(o => o.Platform = "linux"));
+
+        engine.Modules.Import("node:path").Get("sep").AsString().Should().Be("/");
+
+        Assert.ThrowsAny<Exception>(() => engine.Modules.Import("./main.js"));
+    }
+
+    /// <summary>
+    /// Every builtin the running build provides is importable, and each carries a default export beside its
+    /// named ones.
+    /// </summary>
+    [Theory]
+    [InlineData("node:path")]
+    [InlineData("node:path/posix")]
+    [InlineData("node:path/win32")]
+#if NET8_0_OR_GREATER
+    [InlineData("node:querystring")]
+    [InlineData("node:url")]
+#endif
+    public void EveryProvidedBuiltinIsImportable(string specifier)
+    {
+        var engine = new Engine(options => options.UseNodeBuiltinModules());
+
+        engine.Modules.Import(specifier).Get("default").IsObject().Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A dynamic <c>import()</c> reaches them too, which is the shape a lazily loaded package uses.
+    /// </summary>
+    [Fact]
+    public void ADynamicImportReachesABuiltin()
+    {
+        var engine = new Engine(options => options.UseNodeBuiltinModules(o => o.Platform = "linux"));
+
+        engine.Execute("var result; import('node:path').then(m => { result = m.join('a', 'b'); });");
+        engine.Advanced.ProcessTasks();
+
+        engine.Evaluate("result").AsString().Should().Be("a/b");
+    }
+
+    // -------------------------------------------------------------------------------------------------
+    // Unknown node: specifiers.
+    // -------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// An unknown <c>node:</c> specifier fails with a message that names what <em>is</em> available, and says
+    /// that the modules needing platform resources are absent on purpose.
+    /// </summary>
+    [Theory]
+    [InlineData("node:fs")]
+    [InlineData("node:buffer")]
+    [InlineData("node:crypto")]
+    [InlineData("node:os")]
+    public void AnUnknownBuiltinNamesWhatIsAvailable(string specifier)
+    {
+        var engine = new Engine(options => options.UseNodeBuiltinModules());
+
+        var exception = Assert.Throws<ModuleResolutionException>(() => engine.Modules.Import(specifier));
+
+        exception.ResolverAlgorithmError.Should().StartWith("Unknown Node Builtin Module");
+        exception.ResolverAlgorithmError.Should().Contain("node:path");
+        exception.ResolverAlgorithmError.Should().Contain("node:path/posix");
+        exception.ResolverAlgorithmError.Should().Contain("node:path/win32");
+        exception.ResolverAlgorithmError.Should().Contain("deliberately not provided");
+#if NET8_0_OR_GREATER
+        exception.ResolverAlgorithmError.Should().Contain("node:querystring");
+        exception.ResolverAlgorithmError.Should().Contain("node:url");
+#endif
+    }
+
+    /// <summary>
+    /// The un-prefixed spelling of an absent module is <em>not</em> claimed: <c>import 'fs'</c> is an ordinary
+    /// bare specifier that a package in <c>node_modules</c> - or a host registration - may answer.
+    /// </summary>
+    [Fact]
+    public void AnUnprefixedNameThatIsNotABuiltinIsLeftToTheLoader()
+    {
+        var engine = new Engine(options => options.UseNodeBuiltinModules());
+        engine.Modules.Add("fs", "export const mine = true;");
+
+        engine.Modules.Import("fs").Get("mine").AsBoolean().Should().BeTrue();
+    }
+
+    // -------------------------------------------------------------------------------------------------
+    // The two spellings.
+    // -------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// PACKAGE_RESOLVE step 3 of ESM_RESOLVE: "if specifier is a Node.js builtin module name, return the
+    /// string 'node:' concatenated with specifier". So both spellings work, and both name one module record.
+    /// </summary>
+    [Fact]
+    public void BothSpellingsNameOneModule()
+    {
+        var engine = new Engine(options => options.UseNodeBuiltinModules(o => o.Platform = "linux"));
+
+        engine.SetValue("prefixed", engine.Modules.Import("node:path").Get("default"));
+        engine.SetValue("bare", engine.Modules.Import("path").Get("default"));
+
+        engine.Evaluate("prefixed === bare").AsBoolean().Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("path")]
+    [InlineData("path/posix")]
+    [InlineData("path/win32")]
+#if NET8_0_OR_GREATER
+    [InlineData("querystring")]
+    [InlineData("url")]
+#endif
+    public void TheUnprefixedSpellingsResolveToTheBuiltins(string specifier)
+    {
+        var engine = new Engine(options => options.UseNodeBuiltinModules());
+
+        engine.Modules.Import(specifier).Get("default").IsObject().Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Turning the alias off leaves the un-prefixed names to the loader, which is what a tree that really does
+    /// depend on an npm package called <c>path</c> needs.
+    /// </summary>
+    [Fact]
+    public void TheUnprefixedSpellingCanBeTurnedOff()
+    {
+        var engine = new Engine(options => options.UseNodeBuiltinModules(o => o.AllowUnprefixedSpecifiers = false));
+        engine.Modules.Add("path", "export const mine = true;");
+
+        engine.Modules.Import("path").Get("mine").AsBoolean().Should().BeTrue();
+        engine.Modules.Import("node:path").Get("sep").IsString().Should().BeTrue();
+    }
+
+    // -------------------------------------------------------------------------------------------------
+    // Composition with Engine.Modules.Add.
+    // -------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// A module the host registered under the builtin's own name replaces it - the non-clobbering posture the
+    /// <c>process</c> shim and the web APIs take, arrived at here by leaving the precedence the module system
+    /// already has alone.
+    /// </summary>
+    [Fact]
+    public void AHostRegistrationUnderThePrefixedNameWins()
+    {
+        var engine = new Engine(options => options.UseNodeBuiltinModules());
+        engine.Modules.Add("node:path", "export const sep = '@'; export default { sep: '@' };");
+
+        engine.Modules.Import("node:path").Get("sep").AsString().Should().Be("@");
+    }
+
+    /// <summary>
+    /// And a registration under the un-prefixed name claims both spellings, because both resolve to the one
+    /// <c>node:</c> key.
+    /// </summary>
+    [Fact]
+    public void AHostRegistrationUnderTheUnprefixedNameClaimsBothSpellings()
+    {
+        var engine = new Engine(options => options.UseNodeBuiltinModules());
+        engine.Modules.Add("path", "export const sep = '@';");
+
+        engine.Modules.Import("path").Get("sep").AsString().Should().Be("@");
+        engine.Modules.Import("node:path").Get("sep").AsString().Should().Be("@");
+    }
+
+    /// <summary>
+    /// The same door is how a host supplies one of the modules Jint deliberately does not provide.
+    /// </summary>
+    [Fact]
+    public void AHostCanSupplyAModuleJintDoesNotProvide()
+    {
+        var engine = new Engine(options => options.UseNodeBuiltinModules());
+        engine.Modules.Add("node:fs", "export function readFileSync() { return 'from the host'; }");
+
+        engine.Modules.Add("main", "import { readFileSync } from 'node:fs'; export const contents = readFileSync();");
+
+        engine.Modules.Import("main").Get("contents").AsString().Should().Be("from the host");
+    }
+
+    // -------------------------------------------------------------------------------------------------
+    // Composition with a module loader.
+    // -------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// The configured loader keeps answering everything that is not a builtin, and reading
+    /// <c>options.Modules.ModuleLoader</c> back keeps giving the host what it set: the decorator is applied
+    /// when the engine is built, not to the options object.
+    /// </summary>
+    [Fact]
+    public void TheConfiguredLoaderIsUnchangedAndStillAnswersEverythingElse()
+    {
+        using var tree = new PackageTree();
+        tree.Add("main.js", "export const x = 41;");
+
+        var loader = new NodeStyleModuleLoader(tree.Root);
+        var options = new Options().EnableModules(loader).UseNodeBuiltinModules();
+
+        options.Modules.ModuleLoader.Should().BeSameAs(loader);
+
+        var engine = new Engine(options);
+
+        engine.Modules.Import("./main.js").Get("x").AsNumber().Should().Be(41);
+        engine.Modules.Import("node:path").Get("sep").IsString().Should().BeTrue();
+    }
+
+    /// <summary>
+    /// And the order of the two calls does not matter, which is the whole reason the wrap happens at engine
+    /// build rather than inside <c>UseNodeBuiltinModules</c>.
+    /// </summary>
+    [Fact]
+    public void TheOrderOfEnableModulesAndUseNodeBuiltinModulesDoesNotMatter()
+    {
+        using var tree = new PackageTree();
+        tree.Add("main.js", "export const x = 1;");
+
+        var first = new Engine(options => options.UseNodeBuiltinModules().EnableModules(new NodeStyleModuleLoader(tree.Root)));
+        var second = new Engine(options => options.EnableModules(new NodeStyleModuleLoader(tree.Root)).UseNodeBuiltinModules());
+
+        foreach (var engine in new[] { first, second })
+        {
+            engine.Modules.Import("node:path").Get("sep").IsString().Should().BeTrue();
+            engine.Modules.Import("./main.js").Get("x").AsNumber().Should().Be(1);
+        }
+    }
+
+    /// <summary>
+    /// A package in <c>node_modules</c> reached through <see cref="NodeStyleModuleLoader"/>, importing
+    /// <c>node:path</c> across two files of its own - the shape a real published package has, and the thing
+    /// the whole slice exists to make work.
+    /// </summary>
+    [Fact]
+    public void APackageInNodeModulesCanImportTheBuiltins()
+    {
+        using var tree = new PackageTree();
+        tree
+            .Add("package.json", "{ \"name\": \"app\", \"type\": \"module\" }")
+            .Add("app/main.js", """
+                import { pathOf, extensionOf } from 'tiny-router';
+                export const route = pathOf('posts', '2026', 'hello.md');
+                export const extension = extensionOf(route);
+                """)
+            .Add("node_modules/tiny-router/package.json", """
+                { "name": "tiny-router", "version": "1.0.0", "exports": { ".": "./index.js", "./naming": "./lib/naming.js" } }
+                """)
+            .Add("node_modules/tiny-router/index.js", """
+                import path from 'node:path';
+                import { slugify } from './lib/naming.js';
+                export function pathOf(...segments) {
+                    return path.posix.join('/', ...segments.map(slugify));
+                }
+                export { extensionOf } from 'tiny-router/naming';
+                """)
+            .Add("node_modules/tiny-router/lib/naming.js", """
+                import { extname } from 'node:path/posix';
+                export function slugify(segment) {
+                    return segment.toLowerCase().replace(/\s+/g, '-');
+                }
+                export function extensionOf(candidate) {
+                    return extname(candidate);
+                }
+                """);
+
+        var engine = new Engine(options => options
+            .EnableModules(new NodeStyleModuleLoader(tree.Root))
+            .UseNodeBuiltinModules(o => o.Platform = "linux"));
+
+        var namespaceObject = engine.Modules.Import("./app/main.js");
+
+        namespaceObject.Get("route").AsString().Should().Be("/posts/2026/hello.md");
+        namespaceObject.Get("extension").AsString().Should().Be(".md");
+    }
+
+    /// <summary>
+    /// A package that imports the un-prefixed spelling - which is still the commoner one in published code -
+    /// gets the builtin rather than whatever <c>node_modules</c> happens to hold under that name, exactly as
+    /// Node resolves it.
+    /// </summary>
+    [Fact]
+    public void ABuiltinOutranksAPackageOfTheSameName()
+    {
+        using var tree = new PackageTree();
+        tree
+            .Add("main.js", "import { sep } from 'path'; export const separator = sep;")
+            .Add("node_modules/path/package.json", "{ \"name\": \"path\", \"main\": \"index.js\" }")
+            .Add("node_modules/path/index.js", "export const sep = 'from the polyfill';");
+
+        var withBuiltins = new Engine(options => options
+            .EnableModules(new NodeStyleModuleLoader(tree.Root))
+            .UseNodeBuiltinModules(o => o.Platform = "linux"));
+
+        withBuiltins.Modules.Import("./main.js").Get("separator").AsString().Should().Be("/");
+
+        // And with the alias turned off the package is what the same tree resolves to.
+        var withoutAlias = new Engine(options => options
+            .EnableModules(new NodeStyleModuleLoader(tree.Root))
+            .UseNodeBuiltinModules(o => o.AllowUnprefixedSpecifiers = false));
+
+        withoutAlias.Modules.Import("./main.js").Get("separator").AsString().Should().Be("from the polyfill");
+    }
+
+    /// <summary>
+    /// An asynchronous loader stays asynchronous through the decorator - the engine keys its whole load path
+    /// on that interface - and a builtin settles on the stack it was asked on, so importing one costs the
+    /// event loop nothing.
+    /// </summary>
+    [Fact]
+    public async Task ComposesWithAnAsynchronousLoader()
+    {
+        var loader = new RecordingAsyncLoader();
+        var engine = new Engine(options => options
+            .EnableModules(loader)
+            .UseNodeBuiltinModules(o => o.Platform = "linux"));
+
+        engine.Modules.ModuleLoader.Should().BeAssignableTo<IAsyncModuleLoader>();
+
+        var builtin = await engine.Modules.ImportAsync("node:path");
+        builtin.Get("sep").AsString().Should().Be("/");
+        loader.Requested.Should().BeEmpty();
+
+        var hosted = await engine.Modules.ImportAsync("./main.js");
+        hosted.Get("value").AsNumber().Should().Be(7);
+        loader.Requested.Should().ContainSingle();
+    }
+
+    /// <summary>
+    /// A loader that only loads synchronously must not be turned into an asynchronous one, because that would
+    /// change which failures become promise rejections rather than exceptions on the caller's thread.
+    /// </summary>
+    [Fact]
+    public void ASynchronousLoaderStaysSynchronous()
+    {
+        using var tree = new PackageTree();
+        tree.Add("main.js", "export const x = 1;");
+
+        var engine = new Engine(options => options
+            .EnableModules(new NodeStyleModuleLoader(tree.Root))
+            .UseNodeBuiltinModules());
+
+        engine.Modules.ModuleLoader.Should().NotBeAssignableTo<IAsyncModuleLoader>();
+    }
+
+    /// <summary>
+    /// A loader that fetches over I/O, recording what it was asked for so that a builtin can be shown never to
+    /// reach it.
+    /// </summary>
+    private sealed class RecordingAsyncLoader : AsyncModuleLoader
+    {
+        public List<string> Requested { get; } = new();
+
+        public override ResolvedSpecifier Resolve(string? referencingModuleLocation, ModuleRequest moduleRequest)
+            => new(moduleRequest, moduleRequest.Specifier, Uri: null, SpecifierType.Bare);
+
+        protected override async Task<string> LoadModuleContentsAsync(Engine engine, ResolvedSpecifier resolved, CancellationToken cancellationToken)
+        {
+            Requested.Add(resolved.Key);
+            await Task.Yield();
+            return "export const value = 7;";
+        }
+    }
+
+    /// <summary>
+    /// A throwaway <c>node_modules</c> tree on disk. Every path is written relative to the root with forward
+    /// slashes, whatever the platform separator is.
+    /// </summary>
+    private sealed class PackageTree : IDisposable
+    {
+        public PackageTree()
+        {
+            Root = Path.Combine(Path.GetTempPath(), "jint-node-builtins", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Root);
+        }
+
+        public string Root { get; }
+
+        public string PathOf(string relativePath) => Path.Combine(Root, relativePath.Replace('/', Path.DirectorySeparatorChar));
+
+        public PackageTree Add(string relativePath, string contents)
+        {
+            var path = PathOf(relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, contents);
+            return this;
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(Root, recursive: true);
+            }
+            catch (IOException)
+            {
+                // A file left open by a failing test must not replace that test's own failure.
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+}

--- a/Jint.Tests/Runtime/NodeCompat/PathTests.cs
+++ b/Jint.Tests/Runtime/NodeCompat/PathTests.cs
@@ -1,0 +1,483 @@
+#nullable enable
+
+using Jint.NodeCompat;
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime.NodeCompat;
+
+/// <summary>
+/// The opt-in <c>node:path</c> builtin module - https://nodejs.org/api/path.html - against Node's own
+/// documented behaviour, and against the corners the documentation does not describe.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The expectations in <see cref="MatchesNode"/> were produced by running each expression under a real Node
+/// (v24) with <c>process.cwd()</c> stubbed to the working directory this fixture configures, on the
+/// <c>win32</c> platform - so <c>path.posix</c>'s own view of that directory is <c>/base</c>, exactly as
+/// Node's <c>posixCwd</c> derives it. Every case names its flavour explicitly, so none of them depends on
+/// which platform the test run happens on.
+/// </para>
+/// <para>
+/// The list is deliberately long. <c>path</c> is the module whose edge cases bite - a trailing separator that
+/// <c>normalize</c> keeps and <c>resolve</c> drops, a <c>..</c> that stops popping at a root, a drive-relative
+/// <c>c:foo</c>, a UNC share that is its own directory - and none of them is expressible as a rule that could
+/// be checked once.
+/// </para>
+/// </remarks>
+public class PathTests
+{
+    private const string WorkingDirectory = @"C:\base";
+
+    /// <summary>
+    /// An engine with <c>node:path</c> imported and its default export bound to the global <c>path</c>, which
+    /// is the shape <c>const path = require('node:path')</c> gives a script.
+    /// </summary>
+    private static Engine PathEngine(string platform = "win32", string workingDirectory = WorkingDirectory)
+    {
+        var engine = new Engine(options => options.UseNodeBuiltinModules(o =>
+        {
+            o.Platform = platform;
+            o.WorkingDirectory = workingDirectory;
+        }));
+
+        engine.SetValue("path", engine.Modules.Import("node:path").Get("default"));
+        return engine;
+    }
+
+    [Theory]
+    [InlineData("path.posix.join('/foo', 'bar', 'baz/asdf', 'quux', '..')", "/foo/bar/baz/asdf")]
+    [InlineData("path.posix.join('.', 'x/b', '..', '/b/c.js')", "x/b/c.js")]
+    [InlineData("path.posix.join('/.', 'x/b', '..', '/b/c.js')", "/x/b/c.js")]
+    [InlineData("path.posix.join('/foo', '../../../bar')", "/bar")]
+    [InlineData("path.posix.join('foo', '../../../bar')", "../../bar")]
+    [InlineData("path.posix.join('foo/', '../../../bar')", "../../bar")]
+    [InlineData("path.posix.join('a', 'b', 'c')", "a/b/c")]
+    [InlineData("path.posix.join('a/', 'b/', 'c/')", "a/b/c/")]
+    [InlineData("path.posix.join('')", ".")]
+    [InlineData("path.posix.join('', '')", ".")]
+    [InlineData("path.posix.join('/', '')", "/")]
+    [InlineData("path.posix.join('/', 'foo')", "/foo")]
+    [InlineData("path.posix.join('//foo', 'bar')", "/foo/bar")]
+    [InlineData("path.posix.join('foo', '')", "foo")]
+    [InlineData("path.posix.join('', 'foo')", "foo")]
+    [InlineData("path.posix.join('.', '.', '.')", ".")]
+    [InlineData("path.posix.join('..', '..')", "../..")]
+    [InlineData("path.posix.join()", ".")]
+    [InlineData("path.posix.normalize('/foo/bar//baz/asdf/quux/..')", "/foo/bar/baz/asdf")]
+    [InlineData("path.posix.normalize('')", ".")]
+    [InlineData("path.posix.normalize('.')", ".")]
+    [InlineData("path.posix.normalize('./')", "./")]
+    [InlineData("path.posix.normalize('/')", "/")]
+    [InlineData("path.posix.normalize('//')", "/")]
+    [InlineData("path.posix.normalize('///')", "/")]
+    [InlineData("path.posix.normalize('a//b//../b')", "a/b")]
+    [InlineData("path.posix.normalize('a//b//./c')", "a/b/c")]
+    [InlineData("path.posix.normalize('a//b//.')", "a/b")]
+    [InlineData("path.posix.normalize('../../')", "../../")]
+    [InlineData("path.posix.normalize('../../foo')", "../../foo")]
+    [InlineData("path.posix.normalize('/../../foo')", "/foo")]
+    [InlineData("path.posix.normalize('foo/bar/')", "foo/bar/")]
+    [InlineData("path.posix.normalize('foo/bar/..')", "foo")]
+    [InlineData("path.posix.normalize('foo/bar/../..')", ".")]
+    [InlineData("path.posix.normalize('foo/bar/../../..')", "..")]
+    [InlineData("path.posix.normalize('foo/bar/../../../..')", "../..")]
+    [InlineData("path.posix.normalize('/foo/../..')", "/")]
+    [InlineData("path.posix.normalize('a/b/c/../../../x/y/z')", "x/y/z")]
+    [InlineData("path.posix.normalize('.././.././..')", "../../..")]
+    [InlineData("path.posix.normalize('bar/foo../../')", "bar/")]
+    [InlineData("path.posix.normalize('bar/foo../..')", "bar")]
+    [InlineData("path.posix.normalize('..a/b/c')", "..a/b/c")]
+    [InlineData("path.posix.normalize('a\\\\b')", "a\\b")]
+    [InlineData("path.posix.resolve('/foo/bar', './baz')", "/foo/bar/baz")]
+    [InlineData("path.posix.resolve('/foo/bar', '/tmp/file/')", "/tmp/file")]
+    [InlineData("path.posix.resolve('wwwroot', 'static_files/png/', '../gif/image.gif')", "/base/wwwroot/static_files/gif/image.gif")]
+    [InlineData("path.posix.resolve()", "/base")]
+    [InlineData("path.posix.resolve('')", "/base")]
+    [InlineData("path.posix.resolve('.')", "/base")]
+    [InlineData("path.posix.resolve('a')", "/base/a")]
+    [InlineData("path.posix.resolve('a', '')", "/base/a")]
+    [InlineData("path.posix.resolve('/a/b', '..')", "/a")]
+    [InlineData("path.posix.resolve('/a/b/', '../../../..')", "/")]
+    [InlineData("path.posix.resolve('/', '/')", "/")]
+    [InlineData("path.posix.resolve('/foo/tmp.3/', '../tmp.3/cycles/root.js')", "/foo/tmp.3/cycles/root.js")]
+    [InlineData("path.posix.relative('/data/orandea/test/aaa', '/data/orandea/impl/bbb')", "../../impl/bbb")]
+    [InlineData("path.posix.relative('/var/lib', '/var')", "..")]
+    [InlineData("path.posix.relative('/var/lib', '/bin')", "../../bin")]
+    [InlineData("path.posix.relative('/var/lib', '/var/lib')", "")]
+    [InlineData("path.posix.relative('/var/lib', '/var/apache')", "../apache")]
+    [InlineData("path.posix.relative('/var/', '/var/lib')", "lib")]
+    [InlineData("path.posix.relative('/', '/var/lib')", "var/lib")]
+    [InlineData("path.posix.relative('/foo/test', '/foo/test/bar/package.json')", "bar/package.json")]
+    [InlineData("path.posix.relative('/Users/a/web/b/test/mails', '/Users/a/web/b')", "../..")]
+    [InlineData("path.posix.relative('foo/bar/baz-quux', 'foo/bar/baz')", "../baz")]
+    [InlineData("path.posix.relative('foo/bar/baz', 'foo/bar/baz-quux')", "../baz-quux")]
+    [InlineData("path.posix.relative('', '')", "")]
+    [InlineData("path.posix.relative('', 'foo')", "foo")]
+    [InlineData("path.posix.dirname('/foo/bar/baz/asdf/quux')", "/foo/bar/baz/asdf")]
+    [InlineData("path.posix.dirname('/a/b/')", "/a")]
+    [InlineData("path.posix.dirname('/a/b')", "/a")]
+    [InlineData("path.posix.dirname('/a')", "/")]
+    [InlineData("path.posix.dirname('a')", ".")]
+    [InlineData("path.posix.dirname('a/')", ".")]
+    [InlineData("path.posix.dirname('/')", "/")]
+    [InlineData("path.posix.dirname('//')", "/")]
+    [InlineData("path.posix.dirname('///')", "/")]
+    [InlineData("path.posix.dirname('//a')", "//")]
+    [InlineData("path.posix.dirname('')", ".")]
+    [InlineData("path.posix.dirname('foo')", ".")]
+    [InlineData("path.posix.basename('/foo/bar/baz/asdf/quux.html')", "quux.html")]
+    [InlineData("path.posix.basename('/foo/bar/baz/asdf/quux.html', '.html')", "quux")]
+    [InlineData("path.posix.basename('/a/b/')", "b")]
+    [InlineData("path.posix.basename('/a/b//')", "b")]
+    [InlineData("path.posix.basename('basename.ext')", "basename.ext")]
+    [InlineData("path.posix.basename('basename.ext/')", "basename.ext")]
+    [InlineData("path.posix.basename('basename.ext//')", "basename.ext")]
+    [InlineData("path.posix.basename('aaa/bbb', '/bbb')", "bbb")]
+    [InlineData("path.posix.basename('aaa/bbb', 'a/bbb')", "bbb")]
+    [InlineData("path.posix.basename('aaa/bbb', 'bbb')", "bbb")]
+    [InlineData("path.posix.basename('aaa/bbb//', 'bbb')", "bbb")]
+    [InlineData("path.posix.basename('aaa/bbb', 'bb')", "b")]
+    [InlineData("path.posix.basename('aaa/bbb', 'b')", "bb")]
+    [InlineData("path.posix.basename('/aaa/bbb', '/bbb')", "bbb")]
+    [InlineData("path.posix.basename('a', 'a')", "")]
+    [InlineData("path.posix.basename('')", "")]
+    [InlineData("path.posix.basename('/')", "")]
+    [InlineData("path.posix.basename('///')", "")]
+    [InlineData("path.posix.basename('///', 'x')", "///")]
+    [InlineData("path.posix.basename('/dir/basename.ext')", "basename.ext")]
+    [InlineData("path.posix.basename('.')", ".")]
+    [InlineData("path.posix.basename('..')", "..")]
+    [InlineData("path.posix.extname('index.html')", ".html")]
+    [InlineData("path.posix.extname('index.coffee.md')", ".md")]
+    [InlineData("path.posix.extname('index.')", ".")]
+    [InlineData("path.posix.extname('index')", "")]
+    [InlineData("path.posix.extname('.index')", "")]
+    [InlineData("path.posix.extname('.index.md')", ".md")]
+    [InlineData("path.posix.extname('')", "")]
+    [InlineData("path.posix.extname('/path/to/file')", "")]
+    [InlineData("path.posix.extname('/path/to/file.ext')", ".ext")]
+    [InlineData("path.posix.extname('/path.to/file.ext')", ".ext")]
+    [InlineData("path.posix.extname('/path.to/.file')", "")]
+    [InlineData("path.posix.extname('file.')", ".")]
+    [InlineData("path.posix.extname('.')", "")]
+    [InlineData("path.posix.extname('..')", "")]
+    [InlineData("path.posix.extname('file..')", ".")]
+    [InlineData("path.posix.extname('..file')", ".file")]
+    [InlineData("path.posix.extname('..file.baz')", ".baz")]
+    [InlineData("path.posix.extname('/dir/file.')", ".")]
+    [InlineData("String(path.posix.isAbsolute('/foo/bar'))", "true")]
+    [InlineData("String(path.posix.isAbsolute('/baz/..'))", "true")]
+    [InlineData("String(path.posix.isAbsolute('qux/'))", "false")]
+    [InlineData("String(path.posix.isAbsolute('.'))", "false")]
+    [InlineData("String(path.posix.isAbsolute(''))", "false")]
+    [InlineData("JSON.stringify(path.posix.parse('/home/user/dir/file.txt'))", "{\"root\":\"/\",\"dir\":\"/home/user/dir\",\"base\":\"file.txt\",\"ext\":\".txt\",\"name\":\"file\"}")]
+    [InlineData("JSON.stringify(path.posix.parse('/'))", "{\"root\":\"/\",\"dir\":\"/\",\"base\":\"\",\"ext\":\"\",\"name\":\"\"}")]
+    [InlineData("JSON.stringify(path.posix.parse(''))", "{\"root\":\"\",\"dir\":\"\",\"base\":\"\",\"ext\":\"\",\"name\":\"\"}")]
+    [InlineData("JSON.stringify(path.posix.parse('.'))", "{\"root\":\"\",\"dir\":\"\",\"base\":\".\",\"ext\":\"\",\"name\":\".\"}")]
+    [InlineData("JSON.stringify(path.posix.parse('..'))", "{\"root\":\"\",\"dir\":\"\",\"base\":\"..\",\"ext\":\"\",\"name\":\"..\"}")]
+    [InlineData("JSON.stringify(path.posix.parse('file.txt'))", "{\"root\":\"\",\"dir\":\"\",\"base\":\"file.txt\",\"ext\":\".txt\",\"name\":\"file\"}")]
+    [InlineData("JSON.stringify(path.posix.parse('/file'))", "{\"root\":\"/\",\"dir\":\"/\",\"base\":\"file\",\"ext\":\"\",\"name\":\"file\"}")]
+    [InlineData("JSON.stringify(path.posix.parse('/.foo'))", "{\"root\":\"/\",\"dir\":\"/\",\"base\":\".foo\",\"ext\":\"\",\"name\":\".foo\"}")]
+    [InlineData("JSON.stringify(path.posix.parse('/a/b/'))", "{\"root\":\"/\",\"dir\":\"/a\",\"base\":\"b\",\"ext\":\"\",\"name\":\"b\"}")]
+    [InlineData("path.posix.format({ root: '/ignored', dir: '/home/user/dir', base: 'file.txt' })", "/home/user/dir/file.txt")]
+    [InlineData("path.posix.format({ root: '/', base: 'file.txt', ext: 'ignored' })", "/file.txt")]
+    [InlineData("path.posix.format({ root: '/', name: 'file', ext: '.txt' })", "/file.txt")]
+    [InlineData("path.posix.format({ root: '/', name: 'file', ext: 'txt' })", "/file.txt")]
+    [InlineData("path.posix.format({})", "")]
+    [InlineData("path.posix.format({ dir: 'a', base: 'b' })", "a/b")]
+    [InlineData("path.posix.format({ name: 'file' })", "file")]
+    [InlineData("path.win32.join('/foo', 'bar', 'baz/asdf', 'quux', '..')", "\\foo\\bar\\baz\\asdf")]
+    [InlineData("path.win32.join('c:/ignore', 'd:\\\\a/b', '..', '/e.exe')", "c:\\ignore\\d:\\a\\e.exe")]
+    [InlineData("path.win32.join('c:/ignore', 'c:/some/file')", "c:\\ignore\\c:\\some\\file")]
+    [InlineData("path.win32.join('//server/share', '..', 'relative\\\\')", "\\\\server\\share\\relative\\")]
+    [InlineData("path.win32.join('c:/', '//')", "c:\\")]
+    [InlineData("path.win32.join('c:/', '//dir')", "c:\\dir")]
+    [InlineData("path.win32.join('c:/', '//server/share')", "c:\\server\\share")]
+    [InlineData("path.win32.join('c:/', '//server//share')", "c:\\server\\share")]
+    [InlineData("path.win32.join('c:/', '///some//dir')", "c:\\some\\dir")]
+    [InlineData("path.win32.join('C:\\\\foo\\\\tmp.3\\\\', '..\\\\tmp.3\\\\cycles\\\\root.js')", "C:\\foo\\tmp.3\\cycles\\root.js")]
+    [InlineData("path.win32.join('//server', 'share')", "\\\\server\\share\\")]
+    [InlineData("path.win32.join('\\\\\\\\server', 'share')", "\\\\server\\share\\")]
+    [InlineData("path.win32.join('.', 'x/b', '..', '/b/c.js')", "x\\b\\c.js")]
+    [InlineData("path.win32.join('foo', '')", "foo")]
+    [InlineData("path.win32.join('', 'foo')", "foo")]
+    [InlineData("path.win32.join('')", ".")]
+    [InlineData("path.win32.join()", ".")]
+    [InlineData("path.win32.join('a', 'b', 'c')", "a\\b\\c")]
+    [InlineData("path.win32.join('\\\\\\\\foo', 'bar')", "\\\\foo\\bar\\")]
+    [InlineData("path.win32.join('\\\\\\\\', 'foo')", "\\foo")]
+    [InlineData("path.win32.normalize('C:\\\\temp\\\\\\\\foo\\\\bar\\\\..\\\\')", "C:\\temp\\foo\\")]
+    [InlineData("path.win32.normalize('C:////temp\\\\\\\\/\\\\/\\\\/foo/bar')", "C:\\temp\\foo\\bar")]
+    [InlineData("path.win32.normalize('')", ".")]
+    [InlineData("path.win32.normalize('.')", ".")]
+    [InlineData("path.win32.normalize('/')", "\\")]
+    [InlineData("path.win32.normalize('\\\\')", "\\")]
+    [InlineData("path.win32.normalize('c:')", "c:.")]
+    [InlineData("path.win32.normalize('c:\\\\')", "c:\\")]
+    [InlineData("path.win32.normalize('c:foo')", "c:foo")]
+    [InlineData("path.win32.normalize('c:foo\\\\bar')", "c:foo\\bar")]
+    [InlineData("path.win32.normalize('c:..\\\\foo')", "c:..\\foo")]
+    [InlineData("path.win32.normalize('\\\\\\\\server\\\\share\\\\dir\\\\file.ext')", "\\\\server\\share\\dir\\file.ext")]
+    [InlineData("path.win32.normalize('\\\\\\\\server\\\\share')", "\\\\server\\share\\")]
+    [InlineData("path.win32.normalize('\\\\\\\\server\\\\share\\\\')", "\\\\server\\share\\")]
+    [InlineData("path.win32.normalize('\\\\\\\\server\\\\share\\\\..\\\\..\\\\x')", "\\\\server\\share\\x")]
+    [InlineData("path.win32.normalize('//server/share/dir/file.ext')", "\\\\server\\share\\dir\\file.ext")]
+    [InlineData("path.win32.normalize('a/b/c/../../../x/y/z')", "x\\y\\z")]
+    [InlineData("path.win32.normalize('bar\\\\foo..\\\\..')", "bar")]
+    [InlineData("path.win32.normalize('bar\\\\foo..\\\\..\\\\')", "bar\\")]
+    [InlineData("path.win32.normalize('..\\\\..\\\\')", "..\\..\\")]
+    [InlineData("path.win32.normalize('\\\\\\\\.\\\\PHYSICALDRIVE0')", "\\\\.\\PHYSICALDRIVE0")]
+    [InlineData("path.win32.normalize('\\\\\\\\?\\\\UNC\\\\server\\\\share\\\\dir')", "\\\\?\\UNC\\server\\share\\dir")]
+    [InlineData("path.win32.resolve('c:/blah\\\\blah', 'd:/games', 'c:../a')", "c:\\blah\\a")]
+    [InlineData("path.win32.resolve('c:/ignore', 'd:\\\\a/b', '..', '/e.exe')", "d:\\e.exe")]
+    [InlineData("path.win32.resolve('c:/blah\\\\blah', 'd:/games', 'c:/a')", "c:\\a")]
+    [InlineData("path.win32.resolve()", "C:\\base")]
+    [InlineData("path.win32.resolve('')", "C:\\base")]
+    [InlineData("path.win32.resolve('.')", "C:\\base")]
+    [InlineData("path.win32.resolve('a')", "C:\\base\\a")]
+    [InlineData("path.win32.resolve('\\\\\\\\server\\\\share', 'file')", "\\\\server\\share\\file")]
+    [InlineData("path.win32.resolve('c:/', 'foo')", "c:\\foo")]
+    [InlineData("path.win32.resolve('c:foo')", "c:\\base\\foo")]
+    [InlineData("path.win32.resolve('C:\\\\foo\\\\bar', '..')", "C:\\foo")]
+    [InlineData("path.win32.relative('C:\\\\orandea\\\\test\\\\aaa', 'C:\\\\orandea\\\\impl\\\\bbb')", "..\\..\\impl\\bbb")]
+    [InlineData("path.win32.relative('c:/blah\\\\blah', 'd:/games')", "d:\\games")]
+    [InlineData("path.win32.relative('c:/aaaa/bbbb', 'c:/aaaa')", "..")]
+    [InlineData("path.win32.relative('c:/aaaa/bbbb', 'c:/cccc')", "..\\..\\cccc")]
+    [InlineData("path.win32.relative('c:/aaaa/bbbb', 'c:/aaaa/bbbb')", "")]
+    [InlineData("path.win32.relative('c:/aaaa/bbbb', 'c:/aaaa/cccc')", "..\\cccc")]
+    [InlineData("path.win32.relative('c:/aaaa/', 'c:/aaaa/cccc')", "cccc")]
+    [InlineData("path.win32.relative('c:/', 'c:\\\\aaaa\\\\bbbb')", "aaaa\\bbbb")]
+    [InlineData("path.win32.relative('C:\\\\foo\\\\bar\\\\baz-quux', 'C:\\\\foo\\\\bar\\\\baz')", "..\\baz")]
+    [InlineData("path.win32.relative('\\\\\\\\foo\\\\bar', '\\\\\\\\foo\\\\bar\\\\baz')", "baz")]
+    [InlineData("path.win32.relative('\\\\\\\\foo\\\\bar\\\\baz', '\\\\\\\\foo\\\\bar')", "..")]
+    [InlineData("path.win32.relative('C:\\\\baz-quux', 'C:\\\\baz')", "..\\baz")]
+    [InlineData("path.win32.dirname('c:\\\\')", "c:\\")]
+    [InlineData("path.win32.dirname('c:\\\\foo')", "c:\\")]
+    [InlineData("path.win32.dirname('c:\\\\foo\\\\')", "c:\\")]
+    [InlineData("path.win32.dirname('c:\\\\foo\\\\bar')", "c:\\foo")]
+    [InlineData("path.win32.dirname('c:foo')", "c:")]
+    [InlineData("path.win32.dirname('\\\\\\\\unc\\\\share')", "\\\\unc\\share")]
+    [InlineData("path.win32.dirname('\\\\\\\\unc\\\\share\\\\foo')", "\\\\unc\\share\\")]
+    [InlineData("path.win32.dirname('\\\\\\\\unc\\\\share\\\\foo\\\\bar')", "\\\\unc\\share\\foo")]
+    [InlineData("path.win32.dirname('/a/b/')", "/a")]
+    [InlineData("path.win32.dirname('/a/b')", "/a")]
+    [InlineData("path.win32.dirname('/a')", "/")]
+    [InlineData("path.win32.dirname('')", ".")]
+    [InlineData("path.win32.dirname('/')", "/")]
+    [InlineData("path.win32.dirname('////')", "/")]
+    [InlineData("path.win32.dirname('foo')", ".")]
+    [InlineData("path.win32.basename('C:\\\\temp\\\\myfile.html')", "myfile.html")]
+    [InlineData("path.win32.basename('C:\\\\foo.html', '.html')", "foo")]
+    [InlineData("path.win32.basename('C:\\\\foo.HTML', '.html')", "foo.HTML")]
+    [InlineData("path.win32.basename('C:')", "")]
+    [InlineData("path.win32.basename('C:.')", ".")]
+    [InlineData("path.win32.basename('C:\\\\')", "")]
+    [InlineData("path.win32.basename('C:\\\\dir\\\\base.ext')", "base.ext")]
+    [InlineData("path.win32.basename('C:\\\\basename.ext')", "basename.ext")]
+    [InlineData("path.win32.basename('C:basename.ext')", "basename.ext")]
+    [InlineData("path.win32.basename('C:basename.ext\\\\')", "basename.ext")]
+    [InlineData("path.win32.basename('\\\\dir\\\\basename.ext')", "basename.ext")]
+    [InlineData("path.win32.basename('foo')", "foo")]
+    [InlineData("path.win32.basename('a', 'a')", "")]
+    [InlineData("path.win32.extname('C:\\\\path\\\\dir\\\\file.txt')", ".txt")]
+    [InlineData("path.win32.extname('C:\\\\path.to\\\\file')", "")]
+    [InlineData("path.win32.extname('C:file.ext')", ".ext")]
+    [InlineData("path.win32.extname('C:.ext')", "")]
+    [InlineData("path.win32.extname('.')", "")]
+    [InlineData("path.win32.extname('..')", "")]
+    [InlineData("String(path.win32.isAbsolute('//server'))", "true")]
+    [InlineData("String(path.win32.isAbsolute('\\\\\\\\server'))", "true")]
+    [InlineData("String(path.win32.isAbsolute('C:/foo/..'))", "true")]
+    [InlineData("String(path.win32.isAbsolute('C:\\\\foo\\\\..'))", "true")]
+    [InlineData("String(path.win32.isAbsolute('bar\\\\baz'))", "false")]
+    [InlineData("String(path.win32.isAbsolute('bar/baz'))", "false")]
+    [InlineData("String(path.win32.isAbsolute('.'))", "false")]
+    [InlineData("String(path.win32.isAbsolute('C:'))", "false")]
+    [InlineData("String(path.win32.isAbsolute('C:cwd/another'))", "false")]
+    [InlineData("JSON.stringify(path.win32.parse('C:\\\\path\\\\dir\\\\file.txt'))", "{\"root\":\"C:\\\\\",\"dir\":\"C:\\\\path\\\\dir\",\"base\":\"file.txt\",\"ext\":\".txt\",\"name\":\"file\"}")]
+    [InlineData("JSON.stringify(path.win32.parse('C:\\\\'))", "{\"root\":\"C:\\\\\",\"dir\":\"C:\\\\\",\"base\":\"\",\"ext\":\"\",\"name\":\"\"}")]
+    [InlineData("JSON.stringify(path.win32.parse('C:'))", "{\"root\":\"C:\",\"dir\":\"C:\",\"base\":\"\",\"ext\":\"\",\"name\":\"\"}")]
+    [InlineData("JSON.stringify(path.win32.parse('\\\\\\\\server\\\\share'))", "{\"root\":\"\\\\\\\\server\\\\share\",\"dir\":\"\\\\\\\\server\\\\share\",\"base\":\"\",\"ext\":\"\",\"name\":\"\"}")]
+    [InlineData("JSON.stringify(path.win32.parse('\\\\\\\\server\\\\share\\\\file.txt'))", "{\"root\":\"\\\\\\\\server\\\\share\\\\\",\"dir\":\"\\\\\\\\server\\\\share\\\\\",\"base\":\"file.txt\",\"ext\":\".txt\",\"name\":\"file\"}")]
+    [InlineData("JSON.stringify(path.win32.parse('c:\\\\foo\\\\.bar.baz'))", "{\"root\":\"c:\\\\\",\"dir\":\"c:\\\\foo\",\"base\":\".bar.baz\",\"ext\":\".baz\",\"name\":\".bar\"}")]
+    [InlineData("JSON.stringify(path.win32.parse(''))", "{\"root\":\"\",\"dir\":\"\",\"base\":\"\",\"ext\":\"\",\"name\":\"\"}")]
+    [InlineData("JSON.stringify(path.win32.parse('\\\\'))", "{\"root\":\"\\\\\",\"dir\":\"\\\\\",\"base\":\"\",\"ext\":\"\",\"name\":\"\"}")]
+    [InlineData("path.win32.format({ dir: 'C:\\\\path\\\\dir', base: 'file.txt' })", "C:\\path\\dir\\file.txt")]
+    [InlineData("path.win32.format({ root: 'C:\\\\', base: 'file.txt' })", "C:\\file.txt")]
+    [InlineData("path.win32.format({ root: 'C:\\\\', name: 'file', ext: 'txt' })", "C:\\file.txt")]
+    [InlineData("path.win32.toNamespacedPath('C:\\\\foo')", "\\\\?\\C:\\foo")]
+    [InlineData("path.win32.toNamespacedPath('\\\\\\\\server\\\\share\\\\foo')", "\\\\?\\UNC\\server\\share\\foo")]
+    [InlineData("path.win32.toNamespacedPath('\\\\\\\\?\\\\C:\\\\foo')", "\\\\?\\C:\\foo")]
+    [InlineData("path.win32.toNamespacedPath('')", "")]
+    [InlineData("path.posix.toNamespacedPath('/foo/bar')", "/foo/bar")]
+    [InlineData("path.posix.sep", "/")]
+    [InlineData("path.win32.sep", "\\")]
+    [InlineData("path.posix.delimiter", ":")]
+    [InlineData("path.win32.delimiter", ";")]
+
+    public void MatchesNode(string expression, string expected)
+    {
+        var engine = PathEngine();
+
+        engine.Evaluate(expression).AsString().Should().Be(expected, expression);
+    }
+
+    /// <summary>
+    /// "The default operation of the <c>node:path</c> module varies based on the operating system on which a
+    /// Node.js application is running" — here, on the platform the <c>process</c> shim would report.
+    /// </summary>
+    [Theory]
+    [InlineData("win32", "\\", ";")]
+    [InlineData("linux", "/", ":")]
+    [InlineData("darwin", "/", ":")]
+    public void TheDefaultFlavourFollowsTheConfiguredPlatform(string platform, string separator, string delimiter)
+    {
+        var engine = PathEngine(platform);
+
+        engine.Evaluate("path.sep").AsString().Should().Be(separator);
+        engine.Evaluate("path.delimiter").AsString().Should().Be(delimiter);
+        engine.Evaluate("path.join('a', 'b')").AsString().Should().Be("a" + separator + "b");
+    }
+
+    /// <summary>
+    /// A default engine's platform is the one it is running on, which is the same answer
+    /// <c>process.platform</c> gives — the two shims read one detection.
+    /// </summary>
+    [Fact]
+    public void TheDefaultPlatformAgreesWithTheProcessShim()
+    {
+        var engine = new Engine(options => options.UseNodeProcess().UseNodeBuiltinModules());
+        engine.SetValue("path", engine.Modules.Import("node:path").Get("default"));
+
+        var expected = engine.Evaluate("process.platform").AsString() == "win32" ? "\\" : "/";
+
+        engine.Evaluate("path.sep").AsString().Should().Be(expected);
+    }
+
+    /// <summary>
+    /// Both flavours are reachable from either, and each is its own <c>posix</c>/<c>win32</c> — Node's
+    /// <c>posix.win32 === win32</c> and <c>win32.posix === posix</c>.
+    /// </summary>
+    [Fact]
+    public void TheTwoFlavoursCrossReferenceEachOther()
+    {
+        var engine = PathEngine();
+
+        engine.Evaluate("path.posix.win32 === path.win32").AsBoolean().Should().BeTrue();
+        engine.Evaluate("path.win32.posix === path.posix").AsBoolean().Should().BeTrue();
+        engine.Evaluate("path.posix.posix === path.posix").AsBoolean().Should().BeTrue();
+        engine.Evaluate("path.win32.win32 === path.win32").AsBoolean().Should().BeTrue();
+        engine.Evaluate("path.win32 === path").AsBoolean().Should().BeTrue();
+    }
+
+    /// <summary>
+    /// <c>node:path/posix</c> and <c>node:path/win32</c> are the two flavours as modules of their own, which
+    /// is how Node exposes them since v15.3.0.
+    /// </summary>
+    [Theory]
+    [InlineData("node:path/posix", "/")]
+    [InlineData("node:path/win32", "\\")]
+    public void TheFlavoursAreImportableAsModulesOfTheirOwn(string specifier, string separator)
+    {
+        var engine = PathEngine();
+
+        engine.SetValue("flavour", engine.Modules.Import(specifier).Get("default"));
+
+        engine.Evaluate("flavour.sep").AsString().Should().Be(separator);
+    }
+
+    /// <summary>
+    /// Named exports beside the default one, so <c>import { join, sep } from 'node:path'</c> works.
+    /// </summary>
+    [Fact]
+    public void ExposesNamedExports()
+    {
+        var engine = new Engine(options => options.UseNodeBuiltinModules(o => o.Platform = "linux"));
+        engine.Modules.Add("main", "import { join, resolve, sep, posix, win32 } from 'node:path'; export const result = [join('a', 'b'), typeof resolve, sep, posix.sep, win32.sep].join(',');");
+
+        engine.Modules.Import("main").Get("result").AsString().Should().Be("a/b,function,/,/,\\");
+    }
+
+    /// <summary>
+    /// <c>path.resolve()</c> and <c>path.relative()</c> answer from the configured working directory and never
+    /// from the real one — <see cref="NodeBuiltinModuleOptions.WorkingDirectory"/>'s whole point.
+    /// </summary>
+    [Fact]
+    public void ResolveUsesTheConfiguredWorkingDirectory()
+    {
+        var engine = PathEngine("linux", "/srv/app");
+
+        engine.Evaluate("path.resolve()").AsString().Should().Be("/srv/app");
+        engine.Evaluate("path.resolve('x')").AsString().Should().Be("/srv/app/x");
+        engine.Evaluate("path.relative('', '/srv/app/x')").AsString().Should().Be("x");
+        engine.Evaluate("path.resolve()").AsString().Should().NotBe(Environment.CurrentDirectory);
+    }
+
+    /// <summary>
+    /// Node's <c>posixCwd</c>: on Windows the working directory has its separators turned around and its drive
+    /// dropped before <c>path.posix</c> sees it, so the two flavours never disagree about where "here" is.
+    /// </summary>
+    [Fact]
+    public void ThePosixFlavourSeesTheWorkingDirectoryWithoutItsDrive()
+    {
+        var engine = PathEngine("win32", @"C:\srv\app");
+
+        engine.Evaluate("path.win32.resolve()").AsString().Should().Be(@"C:\srv\app");
+        engine.Evaluate("path.posix.resolve()").AsString().Should().Be("/srv/app");
+    }
+
+    /// <summary>
+    /// "Throws a <c>TypeError</c> if any of the path segments is not a string" — the argument has to
+    /// <em>be</em> a string, so a number is refused rather than coerced.
+    /// </summary>
+    [Theory]
+    [InlineData("path.join('a', 1)")]
+    [InlineData("path.join(1, 'a')")]
+    [InlineData("path.resolve(1)")]
+    [InlineData("path.normalize(null)")]
+    [InlineData("path.dirname(undefined)")]
+    [InlineData("path.basename({})")]
+    [InlineData("path.basename('a', 1)")]
+    [InlineData("path.extname(true)")]
+    [InlineData("path.isAbsolute(1)")]
+    [InlineData("path.relative('a', 1)")]
+    [InlineData("path.relative(1, 'a')")]
+    [InlineData("path.parse(1)")]
+    [InlineData("path.format(null)")]
+    [InlineData("path.format('x')")]
+    public void RefusesAnArgumentOfTheWrongType(string expression)
+    {
+        var engine = PathEngine();
+
+        var exception = Assert.Throws<JavaScriptException>(() => engine.Evaluate(expression));
+
+        exception.Error.Get("name").AsString().Should().Be("TypeError");
+        exception.Message.Should().Contain("must be of type");
+    }
+
+    /// <summary>
+    /// <c>path.toNamespacedPath</c> is the exception: "if <c>path</c> is not a string, <c>path</c> will be
+    /// returned without modifications".
+    /// </summary>
+    [Fact]
+    public void ToNamespacedPathReturnsANonStringUnchanged()
+    {
+        var engine = PathEngine();
+
+        engine.Evaluate("path.toNamespacedPath(42)").AsNumber().Should().Be(42);
+        engine.Evaluate("path.toNamespacedPath(undefined) === undefined").AsBoolean().Should().BeTrue();
+    }
+
+    /// <summary>
+    /// <c>path.matchesGlob</c> is deliberately absent, so a script feature-detecting it takes its other branch
+    /// rather than receiving an approximation of glob semantics.
+    /// </summary>
+    [Fact]
+    public void MatchesGlobIsAbsent()
+    {
+        var engine = PathEngine();
+
+        engine.Evaluate("typeof path.matchesGlob").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof path.posix.matchesGlob").AsString().Should().Be("undefined");
+    }
+}

--- a/Jint.Tests/Runtime/NodeCompat/QueryStringTests.cs
+++ b/Jint.Tests/Runtime/NodeCompat/QueryStringTests.cs
@@ -1,0 +1,183 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+namespace Jint.Tests.Runtime.NodeCompat;
+
+/// <summary>
+/// The opt-in <c>node:querystring</c> builtin module - https://nodejs.org/api/querystring.html - against the
+/// real Node implementation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The expectations in <see cref="MatchesNode"/> were produced by running each expression under a real Node
+/// (v24). Nothing here depends on the platform or the working directory: <c>querystring</c> is pure string
+/// arithmetic over its arguments.
+/// </para>
+/// <para>
+/// The cases that matter most are the ones where <c>querystring</c> is deliberately <em>not</em>
+/// <c>URLSearchParams</c>: a space escapes as <c>%20</c> rather than <c>+</c>, <c>!'()*~</c> are left alone, a
+/// repeated key becomes an array, the result carries no prototype, and the separators are parameters.
+/// </para>
+/// </remarks>
+public class QueryStringTests
+{
+    /// <summary>
+    /// An engine with <c>node:querystring</c> imported and its default export bound to the global
+    /// <c>querystring</c>, which is the shape <c>const querystring = require('node:querystring')</c> gives a
+    /// script.
+    /// </summary>
+    private static Engine QueryStringEngine()
+    {
+        var engine = new Engine(options => options.UseNodeBuiltinModules());
+
+        engine.SetValue("querystring", engine.Modules.Import("node:querystring").Get("default"));
+        return engine;
+    }
+
+    [Theory]
+    [InlineData("querystring.escape('hello world')", "hello%20world")]
+    [InlineData("querystring.escape('a=b&c=d')", "a%3Db%26c%3Dd")]
+    [InlineData("querystring.escape(\"!'()*-._~\")", "!'()*-._~")]
+    [InlineData("querystring.escape('abcABC123')", "abcABC123")]
+    [InlineData("querystring.escape('+')", "%2B")]
+    [InlineData("querystring.escape('/?:@&=$,#[]')", "%2F%3F%3A%40%26%3D%24%2C%23%5B%5D")]
+    [InlineData("querystring.escape('\\u00e9')", "%C3%A9")]
+    [InlineData("querystring.escape('\\u4e2d\\u6587')", "%E4%B8%AD%E6%96%87")]
+    [InlineData("querystring.escape('\\ud83d\\ude00')", "%F0%9F%98%80")]
+    [InlineData("querystring.escape('')", "")]
+    [InlineData("querystring.escape(123)", "123")]
+    [InlineData("querystring.escape(true)", "true")]
+    [InlineData("querystring.unescape('hello%20world')", "hello world")]
+    [InlineData("querystring.unescape('a%3Db')", "a=b")]
+    [InlineData("querystring.unescape('%E4%B8%AD%E6%96%87')", "\u4e2d\u6587")]
+    [InlineData("querystring.unescape('a+b')", "a+b")]
+    [InlineData("querystring.unescape('%')", "%")]
+    [InlineData("querystring.unescape('%zz')", "%zz")]
+    [InlineData("querystring.unescape('%C3%28')", "\ufffd(")]
+    [InlineData("querystring.unescape('100%')", "100%")]
+    [InlineData("querystring.unescape('')", "")]
+    [InlineData("querystring.stringify({ foo: 'bar', baz: ['qux', 'quux'], corge: '' })", "foo=bar&baz=qux&baz=quux&corge=")]
+    [InlineData("querystring.stringify({ foo: 'bar', baz: 'qux' }, ';', ':')", "foo:bar;baz:qux")]
+    [InlineData("querystring.stringify({})", "")]
+    [InlineData("querystring.stringify({ a: 1, b: true, c: null, d: undefined })", "a=1&b=true&c=&d=")]
+    [InlineData("querystring.stringify({ a: [] })", "")]
+    [InlineData("querystring.stringify({ a: [1, 2, 3] })", "a=1&a=2&a=3")]
+    [InlineData("querystring.stringify({ 'a b': 'c d' })", "a%20b=c%20d")]
+    [InlineData("querystring.stringify({ a: NaN, b: Infinity })", "a=&b=")]
+    [InlineData("querystring.stringify({ a: 1e21 })", "a=1e%2B21")]
+    [InlineData("querystring.stringify({ a: 1e20 })", "a=100000000000000000000")]
+    [InlineData("querystring.stringify(null)", "")]
+    [InlineData("querystring.stringify('nope')", "")]
+    [InlineData("querystring.stringify({ a: { b: 1 } })", "a=")]
+    [InlineData("querystring.stringify({ a: 10n })", "a=10")]
+    [InlineData("querystring.stringify({ w: '\\u4e2d\\u6587', foo: 'bar' })", "w=%E4%B8%AD%E6%96%87&foo=bar")]
+    [InlineData("querystring.stringify({ a: 'b' }, null, null)", "a=b")]
+    [InlineData("querystring.stringify({ a: 'b', c: 'd' }, '', '')", "a=b&c=d")]
+    [InlineData("querystring.stringify({ a: 'x' }, null, null, { encodeURIComponent: (s) => s.toUpperCase() })", "A=X")]
+    [InlineData("querystring.encode({ a: 'b' })", "a=b")]
+    [InlineData("JSON.stringify(querystring.parse('foo=bar&abc=xyz&abc=123'))", "{\"foo\":\"bar\",\"abc\":[\"xyz\",\"123\"]}")]
+    [InlineData("JSON.stringify(querystring.parse(''))", "{}")]
+    [InlineData("JSON.stringify(querystring.parse('&=&='))", "{\"\":[\"\",\"\"]}")]
+    [InlineData("JSON.stringify(querystring.parse('a=b&&c=d'))", "{\"a\":\"b\",\"c\":\"d\"}")]
+    [InlineData("JSON.stringify(querystring.parse('a'))", "{\"a\":\"\"}")]
+    [InlineData("JSON.stringify(querystring.parse('a='))", "{\"a\":\"\"}")]
+    [InlineData("JSON.stringify(querystring.parse('=b'))", "{\"\":\"b\"}")]
+    [InlineData("JSON.stringify(querystring.parse('a=b&'))", "{\"a\":\"b\"}")]
+    [InlineData("JSON.stringify(querystring.parse('&a=b'))", "{\"a\":\"b\"}")]
+    [InlineData("JSON.stringify(querystring.parse('a=b&a=c&a=d'))", "{\"a\":[\"b\",\"c\",\"d\"]}")]
+    [InlineData("JSON.stringify(querystring.parse('hello+world=foo+bar'))", "{\"hello world\":\"foo bar\"}")]
+    [InlineData("JSON.stringify(querystring.parse('a%20b=c%20d'))", "{\"a b\":\"c d\"}")]
+    [InlineData("JSON.stringify(querystring.parse('w=%E4%B8%AD%E6%96%87'))", "{\"w\":\"\u4e2d\u6587\"}")]
+    [InlineData("JSON.stringify(querystring.parse('a=%'))", "{\"a\":\"%\"}")]
+    [InlineData("JSON.stringify(querystring.parse('a=%C3%28'))", "{\"a\":\"\ufffd(\"}")]
+    [InlineData("JSON.stringify(querystring.parse('foo:bar;baz:qux', ';', ':'))", "{\"foo\":\"bar\",\"baz\":\"qux\"}")]
+    [InlineData("JSON.stringify(querystring.parse('a==b'))", "{\"a\":\"=b\"}")]
+    [InlineData("JSON.stringify(querystring.parse('a=b=c'))", "{\"a\":\"b=c\"}")]
+    [InlineData("JSON.stringify(querystring.parse('a=1&b=2&c=3', null, null, { maxKeys: 2 }))", "{\"a\":\"1\",\"b\":\"2\"}")]
+    [InlineData("JSON.stringify(querystring.parse('a=1&b=2&c=3', null, null, { maxKeys: 0 }))", "{\"a\":\"1\",\"b\":\"2\",\"c\":\"3\"}")]
+    [InlineData("JSON.stringify(querystring.parse('toString=x'))", "{\"toString\":\"x\"}")]
+    [InlineData("String(querystring.parse('a=b').hasOwnProperty)", "undefined")]
+    [InlineData("String(Object.getPrototypeOf(querystring.parse('a=b')))", "null")]
+    [InlineData("JSON.stringify(querystring.parse('a=b', null, null, { decodeURIComponent: (s) => s.toUpperCase() }))", "{\"A\":\"B\"}")]
+    [InlineData("JSON.stringify(querystring.parse('a+b=c+d', null, null, { decodeURIComponent: (s) => s }))", "{\"a%20b\":\"c%20d\"}")]
+    [InlineData("JSON.stringify(querystring.decode('a=b'))", "{\"a\":\"b\"}")]
+    [InlineData("JSON.stringify(querystring.parse(123))", "{}")]
+    [InlineData("JSON.stringify(querystring.parse('a=b&c', '&&'))", "{\"a\":\"b&c\"}")]
+    public void MatchesNode(string expression, string expected)
+    {
+        var engine = QueryStringEngine();
+
+        engine.Evaluate(expression).AsString().Should().Be(expected, expression);
+    }
+
+    /// <summary>
+    /// Node documents <c>escape</c> and <c>unescape</c> as replaceable - "exported primarily to allow
+    /// application code to provide a replacement percent-encoding implementation if necessary by assigning
+    /// <c>querystring.escape</c> to an alternative function" - and <c>stringify</c> reads the current one
+    /// every time it runs.
+    /// </summary>
+    [Fact]
+    public void StringifyUsesAReassignedEscape()
+    {
+        var engine = QueryStringEngine();
+
+        engine.Evaluate("querystring.escape = (s) => '<' + s + '>';");
+
+        engine.Evaluate("querystring.stringify({ a: 'b' })").AsString().Should().Be("<a>=<b>");
+    }
+
+    /// <summary>
+    /// The other half of the same contract: <c>parse</c> reads the current <c>unescape</c>, and a decoder that
+    /// is not the built-in one is handed every component - including the <c>%20</c> a <c>+</c> was turned into,
+    /// rather than an already-substituted space.
+    /// </summary>
+    [Fact]
+    public void ParseUsesAReassignedUnescape()
+    {
+        var engine = QueryStringEngine();
+
+        engine.Evaluate("querystring.unescape = (s) => '[' + s + ']';");
+
+        engine.Evaluate("JSON.stringify(querystring.parse('a+b=c'))").AsString().Should().Be("{\"[a%20b]\":\"[c]\"}");
+    }
+
+    /// <summary>
+    /// A decoder that throws is not fatal: Node falls back to the built-in one rather than failing the parse.
+    /// </summary>
+    [Fact]
+    public void ParseFallsBackWhenACustomDecoderThrows()
+    {
+        var engine = QueryStringEngine();
+
+        var result = engine.Evaluate(
+            "JSON.stringify(querystring.parse('a%20b=c', null, null, { decodeURIComponent() { throw new Error('no'); } }))");
+
+        result.AsString().Should().Be("{\"a b\":\"c\"}");
+    }
+
+    /// <summary>
+    /// <c>unescapeBuffer</c> is absent because it answers with a <c>Buffer</c>, and <c>node:buffer</c> is not
+    /// one of the modules Jint provides.
+    /// </summary>
+    [Fact]
+    public void UnescapeBufferIsAbsent()
+    {
+        var engine = QueryStringEngine();
+
+        engine.Evaluate("typeof querystring.unescapeBuffer").AsString().Should().Be("undefined");
+    }
+
+    /// <summary>
+    /// The named exports are there beside the default one, so <c>import { parse } from 'node:querystring'</c>
+    /// works as it does in Node.
+    /// </summary>
+    [Fact]
+    public void ExposesNamedExports()
+    {
+        var engine = new Engine(options => options.UseNodeBuiltinModules());
+        engine.Modules.Add("main", "import { parse, stringify, escape, unescape, encode, decode } from 'node:querystring'; export const ok = [parse, stringify, escape, unescape, encode, decode].every(f => typeof f === 'function');");
+
+        engine.Modules.Import("main").Get("ok").AsBoolean().Should().BeTrue();
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/NodeCompat/UrlTests.cs
+++ b/Jint.Tests/Runtime/NodeCompat/UrlTests.cs
@@ -1,0 +1,271 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Runtime;
+using Jint.WebApi.Url.Parsing;
+
+namespace Jint.Tests.Runtime.NodeCompat;
+
+/// <summary>
+/// The opt-in <c>node:url</c> builtin module - https://nodejs.org/api/url.html - against the real Node
+/// implementation.
+/// </summary>
+/// <remarks>
+/// Every case in <see cref="MatchesNode"/> passes the <c>windows</c> option explicitly, so none of them
+/// depends on which platform the test run happens on; the platform default is asserted separately.
+/// </remarks>
+public class UrlTests
+{
+    /// <summary>
+    /// An engine with <c>node:url</c> imported and its default export bound to the global <c>url</c>, plus the
+    /// <c>URL</c> constructor it re-exports - which is the shape <c>const url = require('node:url')</c> gives a
+    /// script. The <c>URL</c> global is deliberately <em>not</em> enabled through
+    /// <c>options.UseWebApis</c>: the module has to work without it.
+    /// </summary>
+    private static Engine UrlEngine(string platform = "linux")
+    {
+        var engine = new Engine(options => options.UseNodeBuiltinModules(o => o.Platform = platform));
+
+        var module = engine.Modules.Import("node:url");
+        engine.SetValue("url", module.Get("default"));
+        engine.SetValue("URL", module.Get("URL"));
+        return engine;
+    }
+
+    [Theory]
+    [InlineData("url.fileURLToPath('file:///hello world', { windows: false })", "/hello world")]
+    [InlineData("url.fileURLToPath('file:///%E4%BD%A0%E5%A5%BD.txt', { windows: false })", "/\u4f60\u597d.txt")]
+    [InlineData("url.fileURLToPath('file:///foo/bar', { windows: false })", "/foo/bar")]
+    [InlineData("url.fileURLToPath('file:///', { windows: false })", "/")]
+    [InlineData("url.fileURLToPath('file://localhost/foo', { windows: false })", "/foo")]
+    [InlineData("url.fileURLToPath('file:///a/%2e%2e/b', { windows: false })", "/b")]
+    [InlineData("url.fileURLToPath(new URL('file:///foo/bar'), { windows: false })", "/foo/bar")]
+    [InlineData("url.fileURLToPath('file:///C:/path/', { windows: false })", "/C:/path/")]
+    [InlineData("url.fileURLToPath('file:///C:/path/', { windows: true })", "C:\\path\\")]
+    [InlineData("url.fileURLToPath('file:///C:/path/file.txt', { windows: true })", "C:\\path\\file.txt")]
+    [InlineData("url.fileURLToPath('file://nas/foo.txt', { windows: true })", "\\\\nas\\foo.txt")]
+    [InlineData("url.fileURLToPath('file:///c:/foo%20bar', { windows: true })", "c:\\foo bar")]
+    [InlineData("url.fileURLToPath('file:///D:/a/b/c', { windows: true })", "D:\\a\\b\\c")]
+    [InlineData("url.pathToFileURL('/foo#1', { windows: false }).href", "file:///foo%231")]
+    [InlineData("url.pathToFileURL('/some/path%.c', { windows: false }).href", "file:///some/path%25.c")]
+    [InlineData("url.pathToFileURL('/foo/bar', { windows: false }).href", "file:///foo/bar")]
+    [InlineData("url.pathToFileURL('/foo/bar/', { windows: false }).href", "file:///foo/bar/")]
+    [InlineData("url.pathToFileURL('/hello world', { windows: false }).href", "file:///hello%20world")]
+    [InlineData("url.pathToFileURL('/a?b', { windows: false }).href", "file:///a%3Fb")]
+    [InlineData("url.pathToFileURL('/\\u4e2d\\u6587.txt', { windows: false }).href", "file:///%E4%B8%AD%E6%96%87.txt")]
+    [InlineData("url.pathToFileURL('/a/../b', { windows: false }).href", "file:///b")]
+    [InlineData("url.pathToFileURL('C:\\\\path\\\\', { windows: true }).href", "file:///C:/path/")]
+    [InlineData("url.pathToFileURL('C:\\\\path\\\\file.txt', { windows: true }).href", "file:///C:/path/file.txt")]
+    [InlineData("url.pathToFileURL('\\\\\\\\nas\\\\share\\\\file.txt', { windows: true }).href", "file://nas/share/file.txt")]
+    [InlineData("url.pathToFileURL('C:\\\\a b\\\\c#d', { windows: true }).href", "file:///C:/a%20b/c%23d")]
+    [InlineData("url.fileURLToPath(url.pathToFileURL('/a b/c#d', { windows: false }), { windows: false })", "/a b/c#d")]
+    [InlineData("url.fileURLToPath(url.pathToFileURL('C:\\\\a b\\\\c#d', { windows: true }), { windows: true })", "C:\\a b\\c#d")]
+    public void MatchesNode(string expression, string expected)
+    {
+        var engine = UrlEngine();
+
+        engine.Evaluate(expression).AsString().Should().Be(expected, expression);
+    }
+
+    /// <summary>
+    /// Whether the platform's IDNA implementation is the one the URL Standard asks for. The two domain
+    /// mappings are the platform's, so a machine doing transitional processing — or none at all — is not a
+    /// machine these assertions can be made on. <see cref="Idna"/> documents the divergences in full.
+    /// </summary>
+    public static bool FullIdna => Idna.Fidelity == IdnaFidelity.Full;
+
+    /// <summary>
+    /// <c>url.domainToASCII(domain)</c>, with the documentation's own examples.
+    /// </summary>
+    [Theory(Skip = "The platform's IDNA implementation is not the URL Standard's", SkipUnless = nameof(FullIdna))]
+    [InlineData("espa\u00f1ol.com", "xn--espaol-zwa.com")]
+    [InlineData("\u4e2d\u6587.com", "xn--fiq228c.com")]
+    [InlineData("xn--i\u00f1valid.com", "")]
+    public void DomainToAsciiMatchesNode(string domain, string expected)
+    {
+        var engine = UrlEngine();
+
+        engine.SetValue("domain", domain);
+
+        engine.Evaluate("url.domainToASCII(domain)").AsString().Should().Be(expected);
+    }
+
+    /// <summary>
+    /// <c>url.domainToUnicode(domain)</c>, "the inverse operation to <c>url.domainToASCII()</c>".
+    /// </summary>
+    [Theory(Skip = "The platform's IDNA implementation is not the URL Standard's", SkipUnless = nameof(FullIdna))]
+    [InlineData("xn--espaol-zwa.com", "espa\u00f1ol.com")]
+    [InlineData("xn--fiq228c.com", "\u4e2d\u6587.com")]
+    [InlineData("xn--i\u00f1valid.com", "")]
+    public void DomainToUnicodeMatchesNode(string domain, string expected)
+    {
+        var engine = UrlEngine();
+
+        engine.SetValue("domain", domain);
+
+        engine.Evaluate("url.domainToUnicode(domain)").AsString().Should().Be(expected);
+    }
+
+    /// <summary>
+    /// An ASCII domain needs no IDNA at all, so these hold on every machine — including the empty string,
+    /// which is the failure value both mappings report.
+    /// </summary>
+    [Theory]
+    [InlineData("url.domainToASCII('example.com')", "example.com")]
+    [InlineData("url.domainToASCII('EXAMPLE.com')", "example.com")]
+    [InlineData("url.domainToASCII('')", "")]
+    [InlineData("url.domainToUnicode('example.com')", "example.com")]
+    [InlineData("url.domainToUnicode('')", "")]
+    public void TheDomainMappingsHandleAnAsciiDomain(string expression, string expected)
+    {
+        var engine = UrlEngine();
+
+        engine.Evaluate(expression).AsString().Should().Be(expected, expression);
+    }
+
+    /// <summary>
+    /// Node's only argument check on the two mappings is that one was passed at all — everything else is
+    /// coerced.
+    /// </summary>
+    [Fact]
+    public void TheDomainMappingsRequireAnArgument()
+    {
+        var engine = UrlEngine();
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("url.domainToASCII()"));
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("url.domainToUnicode()"));
+
+        engine.Evaluate("url.domainToASCII(123)").AsString().Should().Be("123");
+    }
+
+    /// <summary>
+    /// The failures <c>fileURLToPath</c> reports, each of which is a <c>TypeError</c> in Node too.
+    /// </summary>
+    [Theory]
+    [InlineData("url.fileURLToPath('https://example.com/x')", "scheme file")]
+    [InlineData("url.fileURLToPath('file://host/x', { windows: false })", "must be \"localhost\" or empty")]
+    [InlineData("url.fileURLToPath('file:///a%2Fb', { windows: false })", "encoded / characters")]
+    [InlineData("url.fileURLToPath('file:///a%2fb', { windows: true })", "encoded \\ or / characters")]
+    [InlineData("url.fileURLToPath('file:///a%5Cb', { windows: true })", "encoded \\ or / characters")]
+    [InlineData("url.fileURLToPath('file:///foo', { windows: true })", "must be absolute")]
+    [InlineData("url.fileURLToPath('not a url')", "Invalid URL")]
+    [InlineData("url.fileURLToPath(42)", "string or URL")]
+    public void FileUrlToPathReportsTheReasonItRefused(string expression, string fragment)
+    {
+        var engine = UrlEngine();
+
+        var exception = Assert.Throws<JavaScriptException>(() => engine.Evaluate(expression));
+
+        exception.Error.Get("name").AsString().Should().Be("TypeError");
+        exception.Message.Should().Contain(fragment);
+    }
+
+    /// <summary>
+    /// A percent sequence that is not valid UTF-8 is what <c>decodeURIComponent</c> raises a <c>URIError</c>
+    /// for, and Node lets that one escape <c>fileURLToPath</c> as itself.
+    /// </summary>
+    [Fact]
+    public void FileUrlToPathRaisesAUriErrorForAMalformedSequence()
+    {
+        var engine = UrlEngine();
+
+        var exception = Assert.Throws<JavaScriptException>(
+            () => engine.Evaluate("url.fileURLToPath('file:///a%C3%28b', { windows: false })"));
+
+        exception.Error.Get("name").AsString().Should().Be("URIError");
+    }
+
+    /// <summary>
+    /// The UNC refusals of <c>pathToFileURL</c>, which need a server and a resource path.
+    /// </summary>
+    [Theory]
+    [InlineData(@"url.pathToFileURL('\\\\server', { windows: true })", "missing UNC resource path")]
+    [InlineData(@"url.pathToFileURL('\\\\\\share', { windows: true })", "empty UNC servername")]
+    public void PathToFileUrlRefusesAnIncompleteUncPath(string expression, string fragment)
+    {
+        var engine = UrlEngine();
+
+        var exception = Assert.Throws<JavaScriptException>(() => engine.Evaluate(expression));
+
+        exception.Message.Should().Contain(fragment);
+    }
+
+    /// <summary>
+    /// "<c>windows</c>: <c>true</c> for windows path, <c>false</c> for posix path, <c>undefined</c> for system
+    /// default" — and the default here is the configured platform rather than the host's.
+    /// </summary>
+    [Theory]
+    [InlineData("win32", "C:\\path\\file.txt")]
+    [InlineData("linux", "/C:/path/file.txt")]
+    public void TheDefaultConversionFollowsTheConfiguredPlatform(string platform, string expected)
+    {
+        var engine = UrlEngine(platform);
+
+        engine.Evaluate("url.fileURLToPath('file:///C:/path/file.txt')").AsString().Should().Be(expected);
+    }
+
+    /// <summary>
+    /// The <c>URL</c> the module re-exports is the engine's own, so it is the very interface object the
+    /// <c>URL</c> global names when the host also enabled that web API — one class, not two.
+    /// </summary>
+    [Fact]
+    public void ReExportsTheEnginesOwnUrlInterfaceObjects()
+    {
+        var engine = new Engine(options => options
+            .UseNodeBuiltinModules()
+            .UseWebApis(WebApiFeatures.Url));
+
+        var module = engine.Modules.Import("node:url");
+        engine.SetValue("moduleUrl", module.Get("URL"));
+        engine.SetValue("moduleSearchParams", module.Get("URLSearchParams"));
+
+        engine.Evaluate("moduleUrl === URL").AsBoolean().Should().BeTrue();
+        engine.Evaluate("moduleSearchParams === URLSearchParams").AsBoolean().Should().BeTrue();
+        engine.Evaluate("new moduleUrl('https://example.org/') instanceof URL").AsBoolean().Should().BeTrue();
+    }
+
+    /// <summary>
+    /// And importing the module is itself the opt-in: <c>URL</c> works through it in an engine that enabled no
+    /// web API at all, where the global is absent.
+    /// </summary>
+    [Fact]
+    public void WorksWithoutTheUrlGlobal()
+    {
+        var engine = new Engine(options => options.UseNodeBuiltinModules());
+
+        engine.Evaluate("typeof globalThis.URL").AsString().Should().Be("undefined");
+
+        engine.SetValue("ModuleUrl", engine.Modules.Import("node:url").Get("URL"));
+
+        engine.Evaluate("new ModuleUrl('https://example.org/a?b=c').search").AsString().Should().Be("?b=c");
+    }
+
+    /// <summary>
+    /// Named exports beside the default one, so <c>import { fileURLToPath } from 'node:url'</c> works.
+    /// </summary>
+    [Fact]
+    public void ExposesNamedExports()
+    {
+        var engine = new Engine(options => options.UseNodeBuiltinModules(o => o.Platform = "linux"));
+        engine.Modules.Add("main", "import { fileURLToPath, pathToFileURL, domainToASCII, domainToUnicode, URL, URLSearchParams } from 'node:url'; export const result = fileURLToPath('file:///a/b') + ',' + typeof URL + ',' + typeof URLSearchParams + ',' + [pathToFileURL, domainToASCII, domainToUnicode].every(f => typeof f === 'function');");
+
+        engine.Modules.Import("main").Get("result").AsString().Should().Be("/a/b,function,function,true");
+    }
+
+    /// <summary>
+    /// The legacy URL API is deliberately absent — Node documents it as legacy, its parser diverges from the
+    /// WHATWG one, and the <c>URL</c> class beside it does the same job.
+    /// </summary>
+    [Fact]
+    public void TheLegacyApiIsAbsent()
+    {
+        var engine = UrlEngine();
+
+        engine.Evaluate("typeof url.parse").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof url.resolve").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof url.format").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof url.Url").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof url.urlToHttpOptions").AsString().Should().Be("undefined");
+    }
+}
+#endif

--- a/Jint/NodeCompat/NodeBuiltinHelpers.cs
+++ b/Jint/NodeCompat/NodeBuiltinHelpers.cs
@@ -1,0 +1,230 @@
+using System.Text;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Interop;
+
+namespace Jint.NodeCompat;
+
+/// <summary>
+/// The small amount of JavaScript-facing plumbing every <c>node:</c> builtin module shares: how a function is
+/// created, and how an argument of the wrong type is refused.
+/// </summary>
+internal static class NodeBuiltinHelpers
+{
+    /// <summary>
+    /// A strict UTF-8 decoder, so that an invalid byte sequence is a failure rather than a run of U+FFFD —
+    /// which is how <c>decodeURIComponent</c>'s <c>URIError</c> is detected without running any script.
+    /// </summary>
+    private static readonly Encoding _strictUtf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
+    /// <summary>
+    /// One exported function. The realm-pinned constructor, for the same reason <c>process</c>'s methods use
+    /// it: a module's exports are built lazily, and the function must belong to the realm that owns the object
+    /// it came from. <c>length</c> counts the declared parameters and is configurable but neither writable nor
+    /// enumerable, as an ordinary function's is.
+    /// </summary>
+    internal static ClrFunction Operation(Engine engine, Realm realm, string name, int length, JsCallDelegate body)
+        => new(engine, realm, name, body, length, PropertyFlag.Configurable);
+
+    /// <summary>
+    /// Node's <c>validateString</c>: the argument has to <em>be</em> a string, never merely convert to one, so
+    /// <c>path.join(1)</c> throws rather than joining <c>"1"</c>.
+    /// </summary>
+    /// <remarks>
+    /// The message is the shape of Node's <c>ERR_INVALID_ARG_TYPE</c>, which is a <c>TypeError</c> there too,
+    /// with one deliberate omission: Node appends the offending value (<c>Received type number (42)</c>) and
+    /// this does not. Rendering a value means calling its <c>toString</c>, which is script the host never
+    /// asked to run and which can throw from inside the error path; naming the type is what the caller
+    /// actually needs.
+    /// </remarks>
+    internal static string RequireString(Realm realm, JsValue value, string argumentName)
+    {
+        if (value is JsString text)
+        {
+            return text.ToString();
+        }
+
+        Throw.TypeError(realm, $"The \"{argumentName}\" argument must be of type string. Received {Describe(value)}");
+        return null!;
+    }
+
+    /// <summary>
+    /// Node's <c>validateObject</c>, as <c>path.format</c> applies it: <see langword="null"/> and every
+    /// primitive are refused.
+    /// </summary>
+    internal static ObjectInstance RequireObject(Realm realm, JsValue value, string argumentName)
+    {
+        if (value is ObjectInstance instance)
+        {
+            return instance;
+        }
+
+        Throw.TypeError(realm, $"The \"{argumentName}\" argument must be of type object. Received {Describe(value)}");
+        return null!;
+    }
+
+    /// <summary>
+    /// <c>decodeURIComponent</c>, https://tc39.es/ecma262/#sec-decodeuricomponent, reduced to the question its
+    /// two callers actually have: did it succeed, and with what. Both of them — <c>querystring.unescape</c>
+    /// and <c>url.fileURLToPath</c> — need the failure rather than an exception, because Node catches it in one
+    /// and rethrows it as its own error in the other.
+    /// </summary>
+    /// <remarks>
+    /// The two failure modes are the specification's: a <c>%</c> not followed by two hexadecimal digits, and a
+    /// run of percent-decoded bytes that is not a valid UTF-8 sequence. A run has to be complete and
+    /// well-formed on its own, because a multi-byte sequence interrupted by a literal character is exactly what
+    /// <c>decodeURIComponent</c> rejects.
+    /// </remarks>
+    internal static bool TryDecodeUriComponent(string value, out string result)
+    {
+        if (value.IndexOf('%') < 0)
+        {
+            // Nothing to decode and nothing that can fail: every other character is copied through.
+            result = value;
+            return true;
+        }
+
+        var builder = new ValueStringBuilder(stackalloc char[128]);
+        var bytes = new List<byte>();
+        try
+        {
+            for (var i = 0; i < value.Length;)
+            {
+                var c = value[i];
+                if (c != '%')
+                {
+                    if (!FlushUtf8(ref builder, bytes))
+                    {
+                        result = string.Empty;
+                        return false;
+                    }
+
+                    builder.Append(c);
+                    i++;
+                    continue;
+                }
+
+                if (i + 2 >= value.Length
+                    || !TryHexDigit(value[i + 1], out var high)
+                    || !TryHexDigit(value[i + 2], out var low))
+                {
+                    result = string.Empty;
+                    return false;
+                }
+
+                bytes.Add((byte) ((high << 4) | low));
+                i += 3;
+            }
+
+            if (!FlushUtf8(ref builder, bytes))
+            {
+                result = string.Empty;
+                return false;
+            }
+
+            result = builder.AsSpan().ToString();
+            return true;
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    private static bool FlushUtf8(ref ValueStringBuilder builder, List<byte> bytes)
+    {
+        if (bytes.Count == 0)
+        {
+            return true;
+        }
+
+        string text;
+        try
+        {
+            text = _strictUtf8.GetString(bytes.ToArray());
+        }
+        catch (DecoderFallbackException)
+        {
+            return false;
+        }
+
+        builder.Append(text);
+        bytes.Clear();
+        return true;
+    }
+
+    private static bool TryHexDigit(char c, out int value)
+    {
+        if (c >= '0' && c <= '9')
+        {
+            value = c - '0';
+            return true;
+        }
+
+        if (c >= 'A' && c <= 'F')
+        {
+            value = c - 'A' + 10;
+            return true;
+        }
+
+        if (c >= 'a' && c <= 'f')
+        {
+            value = c - 'a' + 10;
+            return true;
+        }
+
+        value = 0;
+        return false;
+    }
+
+    /// <summary>
+    /// The tail of an <c>ERR_INVALID_ARG_TYPE</c> message. Never touches the value itself, so building it can
+    /// neither run user code nor throw.
+    /// </summary>
+    private static string Describe(JsValue value)
+    {
+        if (value.IsUndefined())
+        {
+            return "undefined";
+        }
+
+        if (value.IsNull())
+        {
+            return "null";
+        }
+
+        if (value.IsObject())
+        {
+            return "an instance of Object";
+        }
+
+        return "type " + TypeOf(value);
+    }
+
+    private static string TypeOf(JsValue value)
+    {
+        if (value.IsBoolean())
+        {
+            return "boolean";
+        }
+
+        if (value.IsNumber())
+        {
+            return "number";
+        }
+
+        if (value.IsBigInt())
+        {
+            return "bigint";
+        }
+
+        if (value.IsSymbol())
+        {
+            return "symbol";
+        }
+
+        return "string";
+    }
+}

--- a/Jint/NodeCompat/NodeBuiltinModuleConfiguration.cs
+++ b/Jint/NodeCompat/NodeBuiltinModuleConfiguration.cs
@@ -1,0 +1,75 @@
+namespace Jint.NodeCompat;
+
+/// <summary>
+/// The immutable snapshot of a <see cref="NodeBuiltinModuleOptions"/> that the registration keeps: taken once,
+/// when <c>UseNodeBuiltinModules</c> returns, and read afterwards by every engine built from those options.
+/// </summary>
+/// <remarks>
+/// It exists so that nothing an engine build reads can be written by the host at the same time — the same
+/// reason <see cref="NodeProcessConfiguration"/> exists, and what keeps a shared <see cref="Options"/>
+/// instance safe to hand to any number of concurrently constructed engines.
+/// </remarks>
+internal sealed class NodeBuiltinModuleConfiguration
+{
+    private NodeBuiltinModuleConfiguration(
+        string platform,
+        string workingDirectory,
+        string posixWorkingDirectory,
+        bool allowUnprefixedSpecifiers)
+    {
+        Platform = platform;
+        PlatformIsWindows = NodePlatform.IsWindows(platform);
+        WorkingDirectory = workingDirectory;
+        PosixWorkingDirectory = posixWorkingDirectory;
+        AllowUnprefixedSpecifiers = allowUnprefixedSpecifiers;
+    }
+
+    internal string Platform { get; }
+
+    /// <summary>Whether <c>node:path</c> defaults to the Windows flavour.</summary>
+    internal bool PlatformIsWindows { get; }
+
+    /// <summary>The working directory as the Windows flavour reads it: verbatim.</summary>
+    internal string WorkingDirectory { get; }
+
+    /// <summary>The working directory as the POSIX flavour reads it — Node's <c>posixCwd</c>.</summary>
+    internal string PosixWorkingDirectory { get; }
+
+    internal bool AllowUnprefixedSpecifiers { get; }
+
+    internal static NodeBuiltinModuleConfiguration Snapshot(NodeBuiltinModuleOptions options)
+    {
+        var platform = options.Platform;
+        var workingDirectory = options.WorkingDirectory;
+
+        return new NodeBuiltinModuleConfiguration(
+            platform,
+            workingDirectory,
+            ToPosixWorkingDirectory(workingDirectory, NodePlatform.IsWindows(platform)),
+            options.AllowUnprefixedSpecifiers);
+    }
+
+    /// <summary>
+    /// Node's <c>posixCwd</c>: on Windows the working directory is spelled with backslashes and carries a
+    /// drive letter, neither of which means anything to <c>path.posix</c>, so the separators are turned around
+    /// and everything before the first <c>/</c> is dropped. On every other platform it is already a POSIX path.
+    /// </summary>
+    private static string ToPosixWorkingDirectory(string workingDirectory, bool platformIsWindows)
+    {
+        if (!platformIsWindows)
+        {
+            return workingDirectory;
+        }
+
+        var forwardSlashed = workingDirectory.Replace('\\', '/');
+        var index = forwardSlashed.IndexOf('/');
+        if (index >= 0)
+        {
+            return forwardSlashed.Substring(index);
+        }
+
+        // What JavaScript's slice(-1) answers for a string with no separator at all: its last character, and
+        // nothing for an empty string.
+        return forwardSlashed.Length == 0 ? string.Empty : forwardSlashed.Substring(forwardSlashed.Length - 1);
+    }
+}

--- a/Jint/NodeCompat/NodeBuiltinModuleLoader.cs
+++ b/Jint/NodeCompat/NodeBuiltinModuleLoader.cs
@@ -1,0 +1,185 @@
+using Jint.Runtime;
+using Jint.Runtime.Modules;
+using Module = Jint.Runtime.Modules.Module;
+
+namespace Jint.NodeCompat;
+
+/// <summary>
+/// Wraps the engine's configured module loader so that <c>node:</c> specifiers resolve to Jint's builtin
+/// modules and everything else is answered exactly as before.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A decorator rather than a loader of its own, because a host that wants the builtins almost always also
+/// wants a real loader underneath: <see cref="NodeStyleModuleLoader"/> reading a <c>node_modules</c> tree is
+/// the whole point of the exercise. Nothing about the inner loader changes — its base path, its conditions,
+/// its refusals — and a specifier that is not a builtin never reaches this class's own code at all.
+/// </para>
+/// <para>
+/// <b>A host registration wins.</b> The engine consults <c>Engine.Modules.Add</c>'s registrations before it
+/// asks a loader to load anything, so a module the host registered under <c>node:path</c> — or under
+/// <c>path</c>, which resolves to the same key — is what an import of either spelling gets. That is the
+/// non-clobbering posture the <c>process</c> shim and the web APIs take, arrived at here by leaving the
+/// precedence the module system already has alone rather than by checking anything.
+/// </para>
+/// <para>
+/// <b>An unknown <c>node:</c> specifier is deferred, not refused, at resolution time.</b> It resolves to
+/// itself as a bare specifier, so a host that supplies its own <c>node:fs</c> is found; only when nothing is
+/// registered under the name does the load fail, with a message naming the modules that do exist. Resolution
+/// therefore stays a mapping rather than a veto, which is what <see cref="IModuleLoader.Resolve"/> documents
+/// it to be.
+/// </para>
+/// </remarks>
+internal sealed class NodeBuiltinModuleLoader : IModuleLoader
+{
+    private readonly IModuleLoader _inner;
+    private readonly NodeBuiltinModuleConfiguration _configuration;
+
+    private NodeBuiltinModuleLoader(IModuleLoader inner, NodeBuiltinModuleConfiguration configuration)
+    {
+        _inner = inner;
+        _configuration = configuration;
+    }
+
+    /// <summary>
+    /// Wraps <paramref name="inner"/>, keeping whichever faces it has.
+    /// </summary>
+    /// <remarks>
+    /// An <see cref="IAsyncModuleLoader"/> has to stay one: the engine switches onto the asynchronous load
+    /// path by testing the registered loader for that interface, and a decorator that dropped it would turn
+    /// every fetch into a blocking one. Implementing it unconditionally is not an option either — a loader
+    /// that is <em>not</em> asynchronous must not be driven as though it were, because that changes which
+    /// failures become promise rejections rather than exceptions on the caller's thread.
+    /// </remarks>
+    internal static IModuleLoader Wrap(IModuleLoader inner, NodeBuiltinModuleConfiguration configuration)
+    {
+        var loader = new NodeBuiltinModuleLoader(inner, configuration);
+
+        return inner is IAsyncModuleLoader asyncInner
+            ? new AsyncLoader(loader, asyncInner)
+            : loader;
+    }
+
+    /// <inheritdoc />
+    public ResolvedSpecifier Resolve(string? referencingModuleLocation, ModuleRequest moduleRequest)
+    {
+        var specifier = moduleRequest.Specifier;
+        if (!string.IsNullOrEmpty(specifier))
+        {
+            if (NodeBuiltinModules.TryCanonicalize(specifier, _configuration.AllowUnprefixedSpecifiers, out var canonical))
+            {
+                // Both spellings land on the one `node:` key, so `import 'path'` and `import 'node:path'`
+                // denote one module record - which is also what makes a host registration under either name
+                // claim both.
+                return new ResolvedSpecifier(moduleRequest, canonical!, Uri: null, SpecifierType.Bare);
+            }
+
+            if (NodeBuiltinModules.IsNodeScheme(specifier))
+            {
+                return new ResolvedSpecifier(moduleRequest, specifier, Uri: null, SpecifierType.Bare);
+            }
+        }
+
+        return _inner.Resolve(referencingModuleLocation, moduleRequest);
+    }
+
+    /// <inheritdoc />
+    public Module LoadModule(Engine engine, ResolvedSpecifier resolved)
+    {
+        if (TryLoadBuiltin(engine, resolved, out var module))
+        {
+            return module!;
+        }
+
+        return _inner.LoadModule(engine, resolved);
+    }
+
+    /// <summary>
+    /// Builds a builtin, or reports an unknown <c>node:</c> name. Answers <see langword="false"/> for
+    /// everything else, which is what the inner loader is for.
+    /// </summary>
+    private bool TryLoadBuiltin(Engine engine, ResolvedSpecifier resolved, out Module? module)
+    {
+        var key = resolved.Key;
+
+        // The key is already canonical: Resolve is the only thing that produces one.
+        if (NodeBuiltinModules.TryCanonicalize(key, allowUnprefixed: false, out var canonical))
+        {
+            module = Build(engine, canonical!);
+            return true;
+        }
+
+        if (NodeBuiltinModules.IsNodeScheme(key))
+        {
+            Throw.ModuleResolutionException(
+                $"Unknown Node Builtin Module: Jint provides {NodeBuiltinModules.AvailableNames}, and no module is registered under '{key}' with {nameof(Engine)}.{nameof(Engine.Modules)}.{nameof(Engine.ModuleOperations.Add)}(). Node modules that need platform resources - node:fs, node:buffer, node:crypto, node:os, node:child_process and the rest - are deliberately not provided.",
+                resolved.ModuleRequest.Specifier,
+                parent: null);
+        }
+
+        module = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Assembles one builtin as a module with named exports plus a <c>default</c>, which is what
+    /// <c>Engine.Modules.Add</c> produces for an exports-only registration - the same record type, built
+    /// directly so that nothing has to be registered up front and a module nobody imports costs nothing.
+    /// </summary>
+    private BuilderModule Build(Engine engine, string canonicalName)
+    {
+        var builder = new ModuleBuilder(engine, canonicalName);
+
+        var exports = NodeBuiltinModules.CreateExports(engine, _configuration, canonicalName);
+        for (var i = 0; i < exports.Count; i++)
+        {
+            builder.ExportValue(exports[i].Key, exports[i].Value);
+        }
+
+        var parsed = builder.Parse(canonicalName);
+        var module = new BuilderModule(engine, engine.Realm, in parsed, canonicalName, async: false);
+        builder.BindExportedValues(module);
+        return module;
+    }
+
+    /// <summary>
+    /// The same decorator for an inner loader that is also an <see cref="IAsyncModuleLoader"/>.
+    /// </summary>
+    /// <remarks>
+    /// A separate type rather than a flag, because the interface a loader implements is what the engine keys
+    /// its whole load path on: it cannot be decided per call. A builtin settles the completion on the stack it
+    /// was asked on, inside the window <c>ModuleLoadCompletion</c> opens for exactly that, so importing
+    /// <c>node:path</c> from an engine with an asynchronous loader touches the event loop no more than it
+    /// would with a synchronous one.
+    /// </remarks>
+    private sealed class AsyncLoader : IModuleLoader, IAsyncModuleLoader
+    {
+        private readonly NodeBuiltinModuleLoader _builtins;
+        private readonly IAsyncModuleLoader _inner;
+
+        public AsyncLoader(NodeBuiltinModuleLoader builtins, IAsyncModuleLoader inner)
+        {
+            _builtins = builtins;
+            _inner = inner;
+        }
+
+        /// <inheritdoc />
+        public ResolvedSpecifier Resolve(string? referencingModuleLocation, ModuleRequest moduleRequest)
+            => _builtins.Resolve(referencingModuleLocation, moduleRequest);
+
+        /// <inheritdoc />
+        public Module LoadModule(Engine engine, ResolvedSpecifier resolved) => _builtins.LoadModule(engine, resolved);
+
+        /// <inheritdoc />
+        public void LoadModuleAsync(Engine engine, ResolvedSpecifier resolved, ModuleLoadCompletion completion)
+        {
+            if (_builtins.TryLoadBuiltin(engine, resolved, out var module))
+            {
+                completion.SetModule(module!);
+                return;
+            }
+
+            _inner.LoadModuleAsync(engine, resolved, completion);
+        }
+    }
+}

--- a/Jint/NodeCompat/NodeBuiltinModuleOptions.cs
+++ b/Jint/NodeCompat/NodeBuiltinModuleOptions.cs
@@ -1,0 +1,100 @@
+namespace Jint.NodeCompat;
+
+/// <summary>
+/// Configuration for the opt-in <c>node:</c> builtin modules, installed by
+/// <see cref="NodeBuiltinModuleOptionsExtensions.UseNodeBuiltinModules(Options, Action{NodeBuiltinModuleOptions}?)"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The modules provided are the ones npm code reaches for that are <b>pure string utilities</b>:
+/// <c>node:path</c> (with <c>node:path/posix</c> and <c>node:path/win32</c>), <c>node:querystring</c> and
+/// <c>node:url</c>. Nothing here touches a platform resource, which is the line drawn deliberately:
+/// <c>node:fs</c>, <c>node:buffer</c>, <c>node:crypto</c>, <c>node:os</c>, <c>node:child_process</c>,
+/// <c>node:http</c> and everything else that would hand a script the host's file system, memory or network are
+/// <b>not</b> provided and will not be. An unknown <c>node:</c> specifier fails with a message naming what is
+/// available.
+/// </para>
+/// <para>
+/// <c>node:querystring</c> and <c>node:url</c> need .NET 8 or newer, because both are built on the engine's
+/// WHATWG URL implementation, which is. <c>node:path</c> depends on nothing but <see cref="string"/> and is
+/// available on every target framework Jint has. The failure message lists what the running build actually
+/// provides, so it stays truthful either way.
+/// </para>
+/// <para>
+/// Every value here is read once, when <c>UseNodeBuiltinModules</c> returns, and copied into an immutable
+/// snapshot. Mutating this object afterwards changes nothing, which is what makes one <see cref="Options"/>
+/// instance shared by concurrently constructed engines safe.
+/// </para>
+/// </remarks>
+public sealed class NodeBuiltinModuleOptions
+{
+    private string _platform = NodePlatform.Default();
+    private string _workingDirectory = "/";
+
+    /// <summary>
+    /// Which flavour <c>node:path</c> defaults to, as one of Node's platform strings. Defaults to the platform
+    /// this process is running on, which is the same answer <c>process.platform</c> gives.
+    /// </summary>
+    /// <remarks>
+    /// <c>win32</c> selects the Windows flavour and every other value selects the POSIX one, exactly as Node's
+    /// own module does. <c>path.posix</c> and <c>path.win32</c> are reachable whatever this says, so a script
+    /// that has to reason about the other platform's paths still can. Assigning <see langword="null"/> is read
+    /// back as the detected default.
+    /// </remarks>
+    /// <seealso cref="NodeProcessOptions.Platform"/>
+    public string Platform
+    {
+        get => _platform;
+        set => _platform = value ?? NodePlatform.Default();
+    }
+
+    /// <summary>
+    /// What <c>path.resolve()</c> and <c>path.relative()</c> use where Node reads <c>process.cwd()</c>.
+    /// Defaults to <c>"/"</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The real current directory is never used</b>, for the reason
+    /// <see cref="NodeProcessOptions.WorkingDirectory"/> gives: it names a deployment layout and often a user
+    /// account, and a script resolving against it would be building absolute paths that mean something to the
+    /// host and nothing to it. A host that wants the script to see a directory names one here — typically the
+    /// same directory its module loader is rooted at, and the same string it gave the <c>process</c> shim.
+    /// </para>
+    /// <para>
+    /// The value is used verbatim by the Windows flavour and, by the POSIX one, exactly as Node transforms it:
+    /// when <see cref="Platform"/> is <c>win32</c> the separators are turned around and the drive letter
+    /// dropped, so <c>C:\app</c> is seen as <c>/app</c>. Assigning <see langword="null"/> is read back as
+    /// <c>"/"</c>.
+    /// </para>
+    /// </remarks>
+    public string WorkingDirectory
+    {
+        get => _workingDirectory;
+        set => _workingDirectory = value ?? "/";
+    }
+
+    /// <summary>
+    /// Whether the un-prefixed spellings — <c>import 'path'</c> rather than <c>import 'node:path'</c> — name
+    /// the builtins too. <see langword="true"/> by default.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is what Node does: PACKAGE_RESOLVE step 3 of
+    /// <see href="https://nodejs.org/api/esm.html#resolution-algorithm-specification">ESM_RESOLVE</see> says
+    /// "if <em>specifier</em> is a Node.js builtin module name, return the string <em>'node:'</em> concatenated
+    /// with <em>specifier</em>", so a builtin outranks any package of that name in <c>node_modules</c>. Published
+    /// packages are full of both spellings, and the un-prefixed one is the older and still the commoner.
+    /// </para>
+    /// <para>
+    /// Both spellings name <b>one</b> module either way: <c>path</c> resolves to the key <c>node:path</c>, so
+    /// the two imports share a module record, and a host that registers its own module under <em>either</em>
+    /// name with <c>Engine.Modules.Add</c> is found by both and takes precedence over the builtin.
+    /// </para>
+    /// <para>
+    /// Turn it off for a tree that really does depend on a <c>node_modules</c> package called <c>path</c>,
+    /// <c>url</c> or <c>querystring</c> — all three exist on npm as browser polyfills — or to keep the
+    /// builtins reachable only by a spelling no package manager can shadow.
+    /// </para>
+    /// </remarks>
+    public bool AllowUnprefixedSpecifiers { get; set; } = true;
+}

--- a/Jint/NodeCompat/NodeBuiltinModuleOptionsExtensions.cs
+++ b/Jint/NodeCompat/NodeBuiltinModuleOptionsExtensions.cs
@@ -1,0 +1,83 @@
+using Jint.NodeCompat;
+using Jint.Runtime;
+
+// ReSharper disable once CheckNamespace
+namespace Jint;
+
+/// <summary>
+/// Enables the opt-in <c>node:</c> builtin modules.
+/// </summary>
+public static class NodeBuiltinModuleOptionsExtensions
+{
+    /// <summary>
+    /// Makes Node's pure-string builtin modules importable: <c>node:path</c> (with <c>node:path/posix</c> and
+    /// <c>node:path/win32</c>), <c>node:querystring</c> and <c>node:url</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// After module resolution, the absence of these is the next wall a package published for Node runs into,
+    /// and they are the ones it is cheapest to provide honestly: every function here computes its answer from
+    /// its arguments, with no file system, process, network or clock behind it.
+    /// </para>
+    /// <para>
+    /// <b>Nothing that touches a platform resource is provided</b>, and that is not a gap to be filled later:
+    /// <c>node:fs</c>, <c>node:buffer</c>, <c>node:crypto</c>, <c>node:os</c>, <c>node:child_process</c>,
+    /// <c>node:http</c> and their kind are deliberately absent, so a script feature-detecting one takes its
+    /// other branch instead of walking into a stub. An unknown <c>node:</c> specifier fails with a message
+    /// naming what is available.
+    /// </para>
+    /// <para>
+    /// <b>It composes rather than replaces.</b> The engine's configured module loader keeps answering
+    /// everything else, whichever loader that is and whichever order the calls were made in — pair it with
+    /// <c>options.EnableModules(new NodeStyleModuleLoader(dir))</c> and a package in <c>node_modules</c> can
+    /// import <c>node:path</c>. It also needs no loader at all: an engine that enabled nothing else can still
+    /// import the builtins, and everything else keeps failing as it did.
+    /// </para>
+    /// <para>
+    /// <b>A module the host registered wins.</b> <c>engine.Modules.Add("node:path", …)</c> — or
+    /// <c>Add("path", …)</c>, which resolves to the same key — replaces the builtin, and is also how a host
+    /// supplies one of the modules Jint does not provide.
+    /// </para>
+    /// <para>
+    /// <c>node:querystring</c> and <c>node:url</c> need .NET 8 or newer, because both build on the engine's
+    /// WHATWG URL implementation. <c>node:path</c> is available on every target framework.
+    /// </para>
+    /// <para>
+    /// Calling this twice is harmless; the last call's configuration is the one that wins. Every value is read
+    /// here, when this method returns, so mutating <paramref name="configure"/>'s argument afterwards changes
+    /// nothing.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// var engine = new Engine(options => options
+    ///     .EnableModules(new NodeStyleModuleLoader(@"C:\app"))
+    ///     .UseNodeBuiltinModules());
+    ///
+    /// engine.Modules.Add("main", "import { join } from 'node:path'; export const p = join('a', 'b');");
+    /// engine.Modules.Import("main").Get("p"); // "a/b" on a POSIX host
+    /// </code>
+    /// </example>
+    /// <param name="options">Options to modify.</param>
+    /// <param name="configure">
+    /// Configures which platform <c>node:path</c> follows and what stands in for <c>process.cwd()</c>.
+    /// Omitting it leaves every default in place.
+    /// </param>
+    /// <returns>Options instance for fluent syntax.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="options"/> is <see langword="null"/>.</exception>
+    public static Options UseNodeBuiltinModules(this Options options, Action<NodeBuiltinModuleOptions>? configure = null)
+    {
+        if (options is null)
+        {
+            Throw.ArgumentNullException(nameof(options));
+        }
+
+        var moduleOptions = new NodeBuiltinModuleOptions();
+        configure?.Invoke(moduleOptions);
+
+        // Snapshotted here rather than at engine build: the host owns what it configured and may go on
+        // changing it, and Options is meant to be shared by concurrently constructed engines.
+        options._nodeBuiltinModules = NodeBuiltinModuleConfiguration.Snapshot(moduleOptions);
+        return options;
+    }
+}

--- a/Jint/NodeCompat/NodeBuiltinModules.cs
+++ b/Jint/NodeCompat/NodeBuiltinModules.cs
@@ -1,0 +1,131 @@
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.NodeCompat;
+
+/// <summary>
+/// The registry of <c>node:</c> builtin modules Jint provides: which specifiers name one, and what each one
+/// exports.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The line drawn here is the whole design. Everything provided is a <b>pure string utility</b> — path
+/// arithmetic, query-string encoding, URL parsing — computable from its arguments alone, with no file system,
+/// no process, no network and no clock behind it. Everything that would need one of those is deliberately
+/// absent rather than stubbed: <c>node:fs</c>, <c>node:buffer</c>, <c>node:crypto</c>, <c>node:os</c>,
+/// <c>node:child_process</c>, <c>node:http</c>, <c>node:net</c>, <c>node:worker_threads</c>. An absent module
+/// is a better answer than a throwing one, because a package that feature-detects can take its other branch.
+/// </para>
+/// <para>
+/// A host that wants one of the absent names supplies it itself: a module registered under it with
+/// <c>Engine.Modules.Add</c> is found before this registry is consulted, for the prefixed and un-prefixed
+/// spellings alike.
+/// </para>
+/// </remarks>
+internal static class NodeBuiltinModules
+{
+    internal const string Prefix = "node:";
+
+    private const string PathModule = "node:path";
+    private const string PathPosixModule = "node:path/posix";
+    private const string PathWin32Module = "node:path/win32";
+#if NET8_0_OR_GREATER
+    private const string QueryStringModule = "node:querystring";
+    private const string UrlModule = "node:url";
+#endif
+
+    /// <summary>
+    /// The provided names, in the order the failure message lists them. Which entries exist depends on the
+    /// target framework: the two URL-based modules are built on the engine's WHATWG URL implementation, which
+    /// needs .NET 8.
+    /// </summary>
+    private static readonly string[] _names =
+    [
+        PathModule,
+        PathPosixModule,
+        PathWin32Module,
+#if NET8_0_OR_GREATER
+        QueryStringModule,
+        UrlModule,
+#endif
+    ];
+
+    /// <summary>The provided names as a message fragment: <c>a, b and c</c>.</summary>
+    internal static string AvailableNames { get; } = FormatNames(_names);
+
+    /// <summary>
+    /// Whether <paramref name="specifier"/> names a builtin, and under which canonical <c>node:</c> key.
+    /// </summary>
+    /// <param name="specifier">The specifier as written in the import.</param>
+    /// <param name="allowUnprefixed">
+    /// Whether the un-prefixed spelling counts. Both spellings canonicalize to the same
+    /// <c>node:</c> key, so they name one module record however the importer wrote it.
+    /// </param>
+    /// <param name="canonical">The canonical key, or null.</param>
+    internal static bool TryCanonicalize(string specifier, bool allowUnprefixed, out string? canonical)
+    {
+        for (var i = 0; i < _names.Length; i++)
+        {
+            var name = _names[i];
+            if (string.Equals(specifier, name, StringComparison.Ordinal))
+            {
+                canonical = name;
+                return true;
+            }
+
+            if (allowUnprefixed
+                && specifier.Length == name.Length - Prefix.Length
+                && string.CompareOrdinal(specifier, 0, name, Prefix.Length, specifier.Length) == 0)
+            {
+                canonical = name;
+                return true;
+            }
+        }
+
+        canonical = null;
+        return false;
+    }
+
+    /// <summary>Whether <paramref name="specifier"/> uses the <c>node:</c> scheme at all.</summary>
+    internal static bool IsNodeScheme(string specifier)
+        => specifier.StartsWith(Prefix, StringComparison.Ordinal);
+
+    /// <summary>
+    /// The exports of one builtin: its named exports, plus a <c>default</c> carrying the module object a
+    /// CommonJS <c>require</c> would have produced.
+    /// </summary>
+    internal static List<KeyValuePair<string, JsValue>> CreateExports(
+        Engine engine,
+        NodeBuiltinModuleConfiguration configuration,
+        string canonicalName)
+    {
+        switch (canonicalName)
+        {
+            case PathModule:
+                return NodePathModule.CreateExports(engine, configuration, NodePathFlavor.Platform);
+            case PathPosixModule:
+                return NodePathModule.CreateExports(engine, configuration, NodePathFlavor.Posix);
+            case PathWin32Module:
+                return NodePathModule.CreateExports(engine, configuration, NodePathFlavor.Win32);
+#if NET8_0_OR_GREATER
+            case QueryStringModule:
+                return NodeQueryStringModule.CreateExports(engine);
+            case UrlModule:
+                return NodeUrlModule.CreateExports(engine, configuration);
+#endif
+            default:
+                Throw.InvalidOperationException($"'{canonicalName}' is not a Node builtin module Jint provides.");
+                return null!;
+        }
+    }
+
+    private static string FormatNames(string[] names)
+    {
+        if (names.Length == 1)
+        {
+            return names[0];
+        }
+
+        return string.Join(", ", names, 0, names.Length - 1) + " and " + names[names.Length - 1];
+    }
+}

--- a/Jint/NodeCompat/NodePathAlgorithms.cs
+++ b/Jint/NodeCompat/NodePathAlgorithms.cs
@@ -1,0 +1,252 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Jint.NodeCompat;
+
+/// <summary>
+/// What <c>path.parse()</c> answers with, and what <c>path.format()</c> consumes.
+/// <para>
+/// https://nodejs.org/api/path.html#pathparsepath
+/// </para>
+/// </summary>
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct ParsedPath(string Root, string Dir, string Base, string Ext, string Name)
+{
+    /// <summary>The all-empty result <c>path.parse('')</c> answers with.</summary>
+    internal static readonly ParsedPath Empty = new("", "", "", "", "");
+}
+
+/// <summary>
+/// The parts of Node's <c>node:path</c> that the POSIX and Windows flavours share: <c>normalizeString</c>,
+/// which resolves <c>.</c> and <c>..</c> segments, and <c>_format</c>.
+/// <para>
+/// https://nodejs.org/api/path.html
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// Everything here is string arithmetic over the strings the caller supplies. Nothing reads the file system,
+/// and nothing consults the real working directory — <c>resolve</c> and <c>relative</c> take one as an
+/// argument, which is what keeps the whole module answerable without the host process leaking into it. It is
+/// also why this compiles for every target framework Jint has: it depends on nothing but <see cref="string"/>.
+/// </para>
+/// <para>
+/// The algorithms follow Node's own implementation rather than only its prose, because the prose does not
+/// describe the corners — what a trailing separator does to <c>normalize</c> but not to <c>resolve</c>, when a
+/// <c>..</c> stops popping, how a drive-relative <c>C:foo</c> differs from an absolute <c>C:\foo</c>. The
+/// documentation is the contract; the implementation is what settles the cases the contract leaves unsaid.
+/// </para>
+/// </remarks>
+internal static class NodePathAlgorithms
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool IsPosixSeparator(char c) => c == '/';
+
+    /// <summary>
+    /// On Windows "both forward slash (<c>/</c>) and backward slash (<c>\</c>) are accepted as path segment
+    /// separators; however, the <c>path</c> methods only add backward slashes".
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool IsWindowsSeparator(char c) => c == '/' || c == '\\';
+
+    /// <summary>Whether <paramref name="c"/> can be the letter of a Windows device root, as in <c>C:</c>.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool IsWindowsDeviceRoot(char c) => (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+
+    /// <summary>
+    /// Node's <c>normalizeString</c>: resolves <c>.</c> and <c>..</c> segments and collapses runs of
+    /// separators, writing <paramref name="separator"/> between the segments it keeps.
+    /// </summary>
+    /// <param name="path">The path to normalize, with its root (if any) already stripped off.</param>
+    /// <param name="allowAboveRoot">
+    /// Whether a <c>..</c> that has nothing left to pop may be kept. True for a relative path, where
+    /// <c>../a</c> still names something, and false for an absolute one, where the root is where popping stops.
+    /// </param>
+    /// <param name="separator">The separator to write, <c>/</c> or <c>\</c>.</param>
+    /// <param name="windowsSeparators">Whether <c>\</c> counts as a separator on input as well as <c>/</c>.</param>
+    internal static string NormalizeString(string path, bool allowAboveRoot, char separator, bool windowsSeparators)
+    {
+        var res = new ValueStringBuilder(stackalloc char[128]);
+        try
+        {
+            var lastSegmentLength = 0;
+            var lastSlash = -1;
+            var dots = 0;
+            var code = '\0';
+
+            for (var i = 0; i <= path.Length; ++i)
+            {
+                if (i < path.Length)
+                {
+                    code = path[i];
+                }
+                else if (IsSeparator(code, windowsSeparators))
+                {
+                    // The trailing separator was already accounted for by the iteration that saw it.
+                    break;
+                }
+                else
+                {
+                    // One virtual separator past the end, so the final segment is flushed by the same branch
+                    // every other segment goes through.
+                    code = '/';
+                }
+
+                if (IsSeparator(code, windowsSeparators))
+                {
+                    if (lastSlash == i - 1 || dots == 1)
+                    {
+                        // An empty segment, or a "." segment: nothing to write.
+                    }
+                    else if (dots == 2)
+                    {
+                        if (res.Length < 2
+                            || lastSegmentLength != 2
+                            || res[res.Length - 1] != '.'
+                            || res[res.Length - 2] != '.')
+                        {
+                            if (res.Length > 2)
+                            {
+                                var lastSlashIndex = res.Length - lastSegmentLength - 1;
+                                if (lastSlashIndex == -1)
+                                {
+                                    res.Length = 0;
+                                    lastSegmentLength = 0;
+                                }
+                                else
+                                {
+                                    res.Length = lastSlashIndex;
+                                    lastSegmentLength = res.Length - 1 - res.AsSpan().LastIndexOf(separator);
+                                }
+
+                                lastSlash = i;
+                                dots = 0;
+                                continue;
+                            }
+
+                            if (res.Length != 0)
+                            {
+                                res.Length = 0;
+                                lastSegmentLength = 0;
+                                lastSlash = i;
+                                dots = 0;
+                                continue;
+                            }
+                        }
+
+                        if (allowAboveRoot)
+                        {
+                            if (res.Length > 0)
+                            {
+                                res.Append(separator);
+                            }
+
+                            res.Append("..");
+                            lastSegmentLength = 2;
+                        }
+                    }
+                    else
+                    {
+                        if (res.Length > 0)
+                        {
+                            res.Append(separator);
+                        }
+
+                        res.Append(path.AsSpan(lastSlash + 1, i - lastSlash - 1));
+                        lastSegmentLength = i - lastSlash - 1;
+                    }
+
+                    lastSlash = i;
+                    dots = 0;
+                }
+                else if (code == '.' && dots != -1)
+                {
+                    ++dots;
+                }
+                else
+                {
+                    dots = -1;
+                }
+            }
+
+            return res.AsSpan().ToString();
+        }
+        finally
+        {
+            res.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Node's <c>_format</c>, the body behind both <c>path.posix.format</c> and <c>path.win32.format</c>:
+    /// "<c>pathObject.root</c> is ignored if <c>pathObject.dir</c> is provided", "<c>pathObject.ext</c> and
+    /// <c>pathObject.name</c> are ignored if <c>pathObject.base</c> exists", and "the dot will be added if it
+    /// is not specified in <c>ext</c>".
+    /// </summary>
+    /// <remarks>
+    /// The three "provided" tests are JavaScript truthiness over the already-coerced strings, so an empty
+    /// string counts as absent — which is why <c>{ root: '/', base: 'file.txt' }</c> formats as
+    /// <c>/file.txt</c> rather than <c>//file.txt</c>: <c>dir</c> is empty, so <c>root</c> stands in for it,
+    /// and a <c>dir</c> equal to <c>root</c> is joined without a separator.
+    /// </remarks>
+    internal static string Format(char separator, string dir, string root, string @base, string name, string ext)
+    {
+        var directory = dir.Length != 0 ? dir : root;
+        var fileName = @base.Length != 0 ? @base : name + FormatExtension(ext);
+
+        if (directory.Length == 0)
+        {
+            return fileName;
+        }
+
+        return string.Equals(directory, root, StringComparison.Ordinal)
+            ? directory + fileName
+            : directory + separator + fileName;
+    }
+
+    /// <summary>
+    /// <c>String.prototype.slice</c> for the one place the path algorithms need its exact semantics: the
+    /// <c>basename</c> suffix branch, whose <c>end</c> can still be <c>-1</c> or below <c>start</c> when the
+    /// path is nothing but separators. JavaScript answers with an empty string there; <c>Substring</c> would
+    /// throw, and clamping the wrong way would answer with the separators themselves.
+    /// </summary>
+    internal static string Slice(string value, int start, int end)
+    {
+        var length = value.Length;
+
+        if (start < 0)
+        {
+            start = Math.Max(length + start, 0);
+        }
+        else if (start > length)
+        {
+            start = length;
+        }
+
+        if (end < 0)
+        {
+            end = Math.Max(length + end, 0);
+        }
+        else if (end > length)
+        {
+            end = length;
+        }
+
+        return end <= start ? string.Empty : value.Substring(start, end - start);
+    }
+
+    private static string FormatExtension(string ext)
+    {
+        if (ext.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        return ext[0] == '.' ? ext : "." + ext;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsSeparator(char c, bool windowsSeparators)
+        => windowsSeparators ? IsWindowsSeparator(c) : IsPosixSeparator(c);
+}

--- a/Jint/NodeCompat/NodePathModule.cs
+++ b/Jint/NodeCompat/NodePathModule.cs
@@ -1,0 +1,257 @@
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.NodeCompat;
+
+/// <summary>Which flavour of <c>node:path</c> a module exposes.</summary>
+internal enum NodePathFlavor
+{
+    /// <summary><c>node:path</c>, which follows the configured platform.</summary>
+    Platform,
+
+    /// <summary><c>node:path/posix</c>.</summary>
+    Posix,
+
+    /// <summary><c>node:path/win32</c>.</summary>
+    Win32,
+}
+
+/// <summary>
+/// Builds the JavaScript surface of <c>node:path</c>, <c>node:path/posix</c> and <c>node:path/win32</c> over
+/// <see cref="NodePosixPath"/> and <see cref="NodeWin32Path"/>.
+/// <para>
+/// https://nodejs.org/api/path.html
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both flavours are built whichever module was imported, because each one exposes the other: Node's
+/// <c>path.posix.win32 === path.win32</c> and <c>path.win32.posix === path.posix</c>, and a script that
+/// normalizes a Windows path on a Linux host reaches the Windows flavour exactly that way. The two objects and
+/// their cross-links are per module record, so importing <c>node:path</c> and <c>node:path/win32</c> in one
+/// engine yields two <c>win32</c> objects rather than one — Node's are the same object, and nothing in the
+/// documented surface distinguishes them beyond identity.
+/// </para>
+/// <para>
+/// <c>path.matchesGlob</c> is deliberately absent. It is the one member of the module that is not string
+/// arithmetic: Node implements it with a bundled <c>minimatch</c>, and an absent function is what lets a
+/// script feature-detect it instead of receiving an approximation of glob semantics.
+/// </para>
+/// </remarks>
+internal static class NodePathModule
+{
+    internal static List<KeyValuePair<string, JsValue>> CreateExports(
+        Engine engine,
+        NodeBuiltinModuleConfiguration configuration,
+        NodePathFlavor flavor)
+    {
+        var realm = engine.Realm;
+
+        var posixEntries = CreateEntries(engine, realm, configuration, windows: false);
+        var win32Entries = CreateEntries(engine, realm, configuration, windows: true);
+
+        var posix = JsObject.CreateFromEntries(engine, posixEntries);
+        var win32 = JsObject.CreateFromEntries(engine, win32Entries);
+
+        // The two placeholders written above are replaced now that both objects exist. Writing an existing
+        // slot keeps the shared layout the objects were created with; adding a property would not.
+        LinkFlavours(posix, posixEntries, posix, win32);
+        LinkFlavours(win32, win32Entries, posix, win32);
+
+        var selectedIsWindows = flavor switch
+        {
+            NodePathFlavor.Posix => false,
+            NodePathFlavor.Win32 => true,
+            _ => configuration.PlatformIsWindows,
+        };
+
+        var entries = selectedIsWindows ? win32Entries : posixEntries;
+        var selected = selectedIsWindows ? win32 : posix;
+
+        var exports = new List<KeyValuePair<string, JsValue>>(entries.Count + 1);
+        exports.AddRange(entries);
+
+        // What `import path from 'node:path'` binds. Node's builtins are CommonJS modules whose
+        // `module.exports` becomes the default export, with the named exports detected beside it.
+        exports.Add(new KeyValuePair<string, JsValue>("default", selected));
+        return exports;
+    }
+
+    private static void LinkFlavours(
+        JsObject target,
+        List<KeyValuePair<string, JsValue>> entries,
+        JsObject posix,
+        JsObject win32)
+    {
+        target.Set("posix", posix);
+        target.Set("win32", win32);
+
+        for (var i = 0; i < entries.Count; i++)
+        {
+            if (string.Equals(entries[i].Key, "posix", StringComparison.Ordinal))
+            {
+                entries[i] = new KeyValuePair<string, JsValue>("posix", posix);
+            }
+            else if (string.Equals(entries[i].Key, "win32", StringComparison.Ordinal))
+            {
+                entries[i] = new KeyValuePair<string, JsValue>("win32", win32);
+            }
+        }
+    }
+
+    /// <summary>
+    /// One flavour's members, in the order Node's own module object carries them.
+    /// </summary>
+    private static List<KeyValuePair<string, JsValue>> CreateEntries(
+        Engine engine,
+        Realm realm,
+        NodeBuiltinModuleConfiguration configuration,
+        bool windows)
+    {
+        var cwd = windows ? configuration.WorkingDirectory : configuration.PosixWorkingDirectory;
+        var platformIsWindows = configuration.PlatformIsWindows;
+        var separator = windows ? NodeWin32Path.Separator : NodePosixPath.Separator;
+        var delimiter = windows ? NodeWin32Path.Delimiter : NodePosixPath.Delimiter;
+
+        return
+        [
+            Member(engine, realm, "resolve", 0, (_, arguments) =>
+                JsString.Create(windows
+                    ? NodeWin32Path.Resolve(cwd, platformIsWindows, RequirePaths(realm, arguments))
+                    : NodePosixPath.Resolve(cwd, RequirePaths(realm, arguments)))),
+
+            Member(engine, realm, "normalize", 1, (_, arguments) =>
+                JsString.Create(windows
+                    ? NodeWin32Path.Normalize(Path(realm, arguments))
+                    : NodePosixPath.Normalize(Path(realm, arguments)))),
+
+            Member(engine, realm, "isAbsolute", 1, (_, arguments) =>
+                JsBoolean.Create(windows
+                    ? NodeWin32Path.IsAbsolute(Path(realm, arguments))
+                    : NodePosixPath.IsAbsolute(Path(realm, arguments)))),
+
+            Member(engine, realm, "join", 0, (_, arguments) =>
+                JsString.Create(windows
+                    ? NodeWin32Path.Join(RequirePaths(realm, arguments))
+                    : NodePosixPath.Join(RequirePaths(realm, arguments)))),
+
+            Member(engine, realm, "relative", 2, (_, arguments) =>
+            {
+                var from = NodeBuiltinHelpers.RequireString(realm, arguments.At(0), "from");
+                var to = NodeBuiltinHelpers.RequireString(realm, arguments.At(1), "to");
+                return JsString.Create(windows
+                    ? NodeWin32Path.Relative(cwd, platformIsWindows, from, to)
+                    : NodePosixPath.Relative(cwd, from, to));
+            }),
+
+            // Node returns a non-string argument unchanged rather than validating it, so this one deliberately
+            // does not go through RequireString.
+            Member(engine, realm, "toNamespacedPath", 1, (_, arguments) =>
+            {
+                var argument = arguments.At(0);
+                if (argument is not JsString text)
+                {
+                    return argument;
+                }
+
+                return JsString.Create(windows
+                    ? NodeWin32Path.ToNamespacedPath(cwd, platformIsWindows, text.ToString())
+                    : NodePosixPath.ToNamespacedPath(text.ToString()));
+            }),
+
+            Member(engine, realm, "dirname", 1, (_, arguments) =>
+                JsString.Create(windows
+                    ? NodeWin32Path.Dirname(Path(realm, arguments))
+                    : NodePosixPath.Dirname(Path(realm, arguments)))),
+
+            Member(engine, realm, "basename", 2, (_, arguments) =>
+            {
+                // Node validates the suffix first, so two bad arguments report the suffix.
+                var suffixArgument = arguments.At(1);
+                var suffix = suffixArgument.IsUndefined()
+                    ? null
+                    : NodeBuiltinHelpers.RequireString(realm, suffixArgument, "suffix");
+                var path = Path(realm, arguments);
+                return JsString.Create(windows
+                    ? NodeWin32Path.Basename(path, suffix)
+                    : NodePosixPath.Basename(path, suffix));
+            }),
+
+            Member(engine, realm, "extname", 1, (_, arguments) =>
+                JsString.Create(windows
+                    ? NodeWin32Path.Extname(Path(realm, arguments))
+                    : NodePosixPath.Extname(Path(realm, arguments)))),
+
+            Member(engine, realm, "format", 1, (_, arguments) =>
+                JsString.Create(Format(realm, separator, arguments.At(0)))),
+
+            Member(engine, realm, "parse", 1, (_, arguments) =>
+            {
+                var path = Path(realm, arguments);
+                var parsed = windows ? NodeWin32Path.Parse(path) : NodePosixPath.Parse(path);
+                return JsObject.CreateFromEntries(engine,
+                [
+                    new KeyValuePair<string, JsValue>("root", JsString.Create(parsed.Root)),
+                    new KeyValuePair<string, JsValue>("dir", JsString.Create(parsed.Dir)),
+                    new KeyValuePair<string, JsValue>("base", JsString.Create(parsed.Base)),
+                    new KeyValuePair<string, JsValue>("ext", JsString.Create(parsed.Ext)),
+                    new KeyValuePair<string, JsValue>("name", JsString.Create(parsed.Name)),
+                ]);
+            }),
+
+            new KeyValuePair<string, JsValue>("sep", JsString.Create(separator.ToString())),
+            new KeyValuePair<string, JsValue>("delimiter", JsString.Create(delimiter.ToString())),
+
+            // Filled in by LinkFlavours once both objects exist.
+            new KeyValuePair<string, JsValue>("win32", JsValue.Undefined),
+            new KeyValuePair<string, JsValue>("posix", JsValue.Undefined),
+        ];
+    }
+
+    private static KeyValuePair<string, JsValue> Member(Engine engine, Realm realm, string name, int length, JsCallDelegate body)
+        => new(name, NodeBuiltinHelpers.Operation(engine, realm, name, length, body));
+
+    private static string Path(Realm realm, JsCallArguments arguments)
+        => NodeBuiltinHelpers.RequireString(realm, arguments.At(0), "path");
+
+    /// <summary>
+    /// The variadic <c>path</c> arguments of <c>join</c> and <c>resolve</c>.
+    /// </summary>
+    /// <remarks>
+    /// Every argument is validated, which is what the documentation promises — "throws a <c>TypeError</c> if
+    /// any of the arguments is not a string". Node's <c>resolve</c> is in fact laxer than its own contract: it
+    /// walks the segments right to left and stops at the first absolute one, so a non-string to the left of an
+    /// absolute segment is never looked at. Following the documented rule is both stricter and the behaviour a
+    /// caller can reason about.
+    /// </remarks>
+    private static string[] RequirePaths(Realm realm, JsCallArguments arguments)
+    {
+        var paths = new string[arguments.Length];
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            paths[i] = NodeBuiltinHelpers.RequireString(realm, arguments[i], "path");
+        }
+
+        return paths;
+    }
+
+    /// <summary>
+    /// <c>path.format(pathObject)</c>. The three "is it provided" tests are JavaScript truthiness, so a
+    /// property that is absent, empty or otherwise falsy counts as absent and the next fallback applies.
+    /// </summary>
+    private static string Format(Realm realm, char separator, JsValue argument)
+    {
+        var pathObject = NodeBuiltinHelpers.RequireObject(realm, argument, "pathObject");
+
+        var dir = Coerce(pathObject.Get("dir"));
+        var root = Coerce(pathObject.Get("root"));
+        var @base = Coerce(pathObject.Get("base"));
+        var name = Coerce(pathObject.Get("name"));
+        var ext = Coerce(pathObject.Get("ext"));
+
+        return NodePathAlgorithms.Format(separator, dir, root, @base, name, ext);
+
+        static string Coerce(JsValue value)
+            => TypeConverter.ToBoolean(value) ? TypeConverter.ToString(value) : string.Empty;
+    }
+}

--- a/Jint/NodeCompat/NodePlatform.cs
+++ b/Jint/NodeCompat/NodePlatform.cs
@@ -1,0 +1,58 @@
+#if !NET8_0_OR_GREATER && !NETFRAMEWORK
+using System.Runtime.InteropServices;
+#endif
+
+namespace Jint.NodeCompat;
+
+/// <summary>
+/// The one platform answer the Node compatibility shims share: what <c>process.platform</c> reports, and
+/// therefore which flavour <c>node:path</c> defaults to.
+/// </summary>
+/// <remarks>
+/// A script that branches on the platform has to see one answer, not two — <c>process.platform === 'win32'</c>
+/// deciding a separator while <c>path.sep</c> answers <c>'/'</c> would be worse than either being wrong on its
+/// own. So both read their default from here, and each option group lets the host override it independently
+/// for the cases where that is deliberate.
+/// </remarks>
+internal static class NodePlatform
+{
+    internal const string Windows = "win32";
+    internal const string MacOs = "darwin";
+    internal const string Linux = "linux";
+
+    /// <summary>
+    /// The running platform as one of Node's platform strings.
+    /// </summary>
+    /// <remarks>
+    /// Not an API gap but a genuine three-way, and the same one <c>DefaultTimeZoneProvider</c> answers:
+    /// <see cref="OperatingSystem"/>'s predicates arrived in .NET 5, netstandard has to ask the runtime, and
+    /// <c>net462</c> only ever runs on Windows.
+    /// </remarks>
+    internal static string Default()
+    {
+#if NET8_0_OR_GREATER
+        if (OperatingSystem.IsWindows())
+        {
+            return Windows;
+        }
+
+        return OperatingSystem.IsMacOS() ? MacOs : Linux;
+#elif NETFRAMEWORK
+        return Windows;
+#else
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return Windows;
+        }
+
+        return RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? MacOs : Linux;
+#endif
+    }
+
+    /// <summary>
+    /// Whether <paramref name="platform"/> is the one platform whose paths are spelled the Windows way. Every
+    /// other value Node can report — <c>darwin</c>, <c>linux</c>, <c>aix</c>, <c>freebsd</c> — is POSIX.
+    /// </summary>
+    internal static bool IsWindows(string platform)
+        => string.Equals(platform, Windows, StringComparison.Ordinal);
+}

--- a/Jint/NodeCompat/NodePosixPath.cs
+++ b/Jint/NodeCompat/NodePosixPath.cs
@@ -1,0 +1,604 @@
+using System.Text;
+
+namespace Jint.NodeCompat;
+
+/// <summary>
+/// The POSIX flavour of <c>node:path</c> — what <c>path.posix</c> and <c>node:path/posix</c> expose.
+/// <para>
+/// https://nodejs.org/api/path.html#pathposix
+/// </para>
+/// </summary>
+/// <remarks>
+/// The only separator is <c>/</c>; a <c>\</c> is an ordinary character in a file name, which is exactly why a
+/// script that has to reason about a POSIX path on a Windows host reaches for this flavour by name rather than
+/// for the platform default.
+/// </remarks>
+internal static class NodePosixPath
+{
+    internal const char Separator = '/';
+    internal const char Delimiter = ':';
+
+    /// <summary>
+    /// <c>path.resolve([...paths])</c>: "resolves a sequence of paths or path segments into an absolute path",
+    /// processing them right to left until one is absolute, then normalizing and stripping trailing slashes.
+    /// <para>
+    /// https://nodejs.org/api/path.html#pathresolvepaths
+    /// </para>
+    /// </summary>
+    /// <param name="cwd">
+    /// What Node reads from <c>process.cwd()</c>. Supplied by the caller so that nothing here can reach the
+    /// host's real directory.
+    /// </param>
+    /// <param name="paths">The segments, already coerced to strings.</param>
+    internal static string Resolve(string cwd, IReadOnlyList<string> paths)
+    {
+        if (paths.Count == 0 || (paths.Count == 1 && (paths[0].Length == 0 || string.Equals(paths[0], ".", StringComparison.Ordinal))))
+        {
+            if (cwd.Length > 0 && cwd[0] == Separator)
+            {
+                return cwd;
+            }
+        }
+
+        // Right to left, stopping at the first absolute segment, then written back out left to right - the
+        // shape Node's own loop produces by prepending "segment + '/'" to what it has so far.
+        var segments = new List<string>(paths.Count + 1);
+        var resolvedAbsolute = false;
+
+        for (var i = paths.Count - 1; i >= 0 && !resolvedAbsolute; i--)
+        {
+            var path = paths[i];
+            if (path.Length == 0)
+            {
+                continue;
+            }
+
+            segments.Add(path);
+            resolvedAbsolute = path[0] == Separator;
+        }
+
+        if (!resolvedAbsolute)
+        {
+            segments.Add(cwd);
+            resolvedAbsolute = cwd.Length > 0 && cwd[0] == Separator;
+        }
+
+        var resolvedPath = new ValueStringBuilder(stackalloc char[128]);
+        try
+        {
+            for (var i = segments.Count - 1; i >= 0; i--)
+            {
+                resolvedPath.Append(segments[i]);
+                resolvedPath.Append(Separator);
+            }
+
+            // At this point the path should be resolved to a full absolute path, but a relative one is still
+            // handled: a host may have configured a working directory that is not itself absolute.
+            var normalized = NodePathAlgorithms.NormalizeString(resolvedPath.AsSpan().ToString(), !resolvedAbsolute, Separator, windowsSeparators: false);
+
+            if (resolvedAbsolute)
+            {
+                return "/" + normalized;
+            }
+
+            return normalized.Length > 0 ? normalized : ".";
+        }
+        finally
+        {
+            resolvedPath.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// <c>path.normalize(path)</c>: "resolving <c>'..'</c> and <c>'.'</c> segments", collapsing runs of
+    /// separators, and preserving a trailing separator. A zero-length path answers <c>'.'</c>.
+    /// <para>
+    /// https://nodejs.org/api/path.html#pathnormalizepath
+    /// </para>
+    /// </summary>
+    internal static string Normalize(string path)
+    {
+        if (path.Length == 0)
+        {
+            return ".";
+        }
+
+        var isAbsolute = path[0] == Separator;
+        var trailingSeparator = path[path.Length - 1] == Separator;
+
+        var normalized = NodePathAlgorithms.NormalizeString(path, !isAbsolute, Separator, windowsSeparators: false);
+
+        if (normalized.Length == 0)
+        {
+            if (isAbsolute)
+            {
+                return "/";
+            }
+
+            return trailingSeparator ? "./" : ".";
+        }
+
+        if (trailingSeparator)
+        {
+            normalized += "/";
+        }
+
+        return isAbsolute ? "/" + normalized : normalized;
+    }
+
+    /// <summary>
+    /// <c>path.isAbsolute(path)</c>. "If the given path is a zero-length string, <c>false</c> will be
+    /// returned."
+    /// <para>
+    /// https://nodejs.org/api/path.html#pathisabsolutepath
+    /// </para>
+    /// </summary>
+    internal static bool IsAbsolute(string path) => path.Length > 0 && path[0] == Separator;
+
+    /// <summary>
+    /// <c>path.join([...paths])</c>: joins with the separator and normalizes. "Zero-length path segments are
+    /// ignored. If the joined path string is a zero-length string then <c>'.'</c> will be returned."
+    /// <para>
+    /// https://nodejs.org/api/path.html#pathjoinpaths
+    /// </para>
+    /// </summary>
+    internal static string Join(IReadOnlyList<string> paths)
+    {
+        if (paths.Count == 0)
+        {
+            return ".";
+        }
+
+        var joined = new ValueStringBuilder(stackalloc char[128]);
+        try
+        {
+            for (var i = 0; i < paths.Count; ++i)
+            {
+                var segment = paths[i];
+                if (segment.Length == 0)
+                {
+                    continue;
+                }
+
+                if (joined.Length > 0)
+                {
+                    joined.Append(Separator);
+                }
+
+                joined.Append(segment);
+            }
+
+            if (joined.Length == 0)
+            {
+                return ".";
+            }
+
+            return Normalize(joined.AsSpan().ToString());
+        }
+        finally
+        {
+            joined.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// <c>path.relative(from, to)</c>: "the relative path from <c>from</c> to <c>to</c>". Both are resolved
+    /// first, so a zero-length argument means the working directory, and two paths resolving to the same place
+    /// answer with a zero-length string.
+    /// <para>
+    /// https://nodejs.org/api/path.html#pathrelativefrom-to
+    /// </para>
+    /// </summary>
+    internal static string Relative(string cwd, string from, string to)
+    {
+        if (string.Equals(from, to, StringComparison.Ordinal))
+        {
+            return string.Empty;
+        }
+
+        from = Resolve(cwd, [from]);
+        to = Resolve(cwd, [to]);
+
+        if (string.Equals(from, to, StringComparison.Ordinal))
+        {
+            return string.Empty;
+        }
+
+        const int FromStart = 1;
+        var fromEnd = from.Length;
+        var fromLen = fromEnd - FromStart;
+        const int ToStart = 1;
+        var toLen = to.Length - ToStart;
+
+        // The longest common path from the root.
+        var length = fromLen < toLen ? fromLen : toLen;
+        var lastCommonSep = -1;
+        var i = 0;
+        for (; i < length; i++)
+        {
+            var fromCode = from[FromStart + i];
+            if (fromCode != to[ToStart + i])
+            {
+                break;
+            }
+
+            if (fromCode == Separator)
+            {
+                lastCommonSep = i;
+            }
+        }
+
+        if (i == length)
+        {
+            if (toLen > length)
+            {
+                if (to[ToStart + i] == Separator)
+                {
+                    // `from` is the exact base path of `to`: from='/foo/bar', to='/foo/bar/baz'.
+                    return to.Substring(ToStart + i + 1);
+                }
+
+                if (i == 0)
+                {
+                    // `from` is the root: from='/', to='/foo'.
+                    return to.Substring(ToStart + i);
+                }
+            }
+            else if (fromLen > length)
+            {
+                if (from[FromStart + i] == Separator)
+                {
+                    // `to` is the exact base path of `from`: from='/foo/bar/baz', to='/foo/bar'.
+                    lastCommonSep = i;
+                }
+                else if (i == 0)
+                {
+                    // `to` is the root: from='/foo/bar', to='/'.
+                    lastCommonSep = 0;
+                }
+            }
+        }
+
+        var result = new ValueStringBuilder(stackalloc char[64]);
+        try
+        {
+            for (i = FromStart + lastCommonSep + 1; i <= fromEnd; ++i)
+            {
+                if (i == fromEnd || from[i] == Separator)
+                {
+                    result.Append(result.Length == 0 ? ".." : "/..");
+                }
+            }
+
+            result.Append(to.AsSpan(ToStart + lastCommonSep));
+            return result.AsSpan().ToString();
+        }
+        finally
+        {
+            result.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// <c>path.toNamespacedPath(path)</c>. "On POSIX systems, this function is non-operational and always
+    /// returns <c>path</c> without modifications."
+    /// <para>
+    /// https://nodejs.org/api/path.html#pathtonamespacedpathpath
+    /// </para>
+    /// </summary>
+    internal static string ToNamespacedPath(string path) => path;
+
+    /// <summary>
+    /// <c>path.dirname(path)</c>: "the directory name of a <c>path</c>, similar to the Unix <c>dirname</c>
+    /// command. Trailing directory separators are ignored."
+    /// <para>
+    /// https://nodejs.org/api/path.html#pathdirnamepath
+    /// </para>
+    /// </summary>
+    internal static string Dirname(string path)
+    {
+        if (path.Length == 0)
+        {
+            return ".";
+        }
+
+        var hasRoot = path[0] == Separator;
+        var end = -1;
+        var matchedSlash = true;
+        for (var i = path.Length - 1; i >= 1; --i)
+        {
+            if (path[i] == Separator)
+            {
+                if (!matchedSlash)
+                {
+                    end = i;
+                    break;
+                }
+            }
+            else
+            {
+                matchedSlash = false;
+            }
+        }
+
+        if (end == -1)
+        {
+            return hasRoot ? "/" : ".";
+        }
+
+        if (hasRoot && end == 1)
+        {
+            return "//";
+        }
+
+        return path.Substring(0, end);
+    }
+
+    /// <summary>
+    /// <c>path.basename(path[, suffix])</c>: "the last portion of a <c>path</c>, similar to the Unix
+    /// <c>basename</c> command. Trailing directory separators are ignored."
+    /// <para>
+    /// https://nodejs.org/api/path.html#pathbasenamepath-suffix
+    /// </para>
+    /// </summary>
+    /// <param name="path">The path to take the last portion of.</param>
+    /// <param name="suffix">"An optional suffix to remove", or null when the argument was absent.</param>
+    internal static string Basename(string path, string? suffix)
+    {
+        var start = 0;
+        var end = -1;
+        var matchedSlash = true;
+
+        if (suffix is not null && suffix.Length > 0 && suffix.Length <= path.Length)
+        {
+            if (string.Equals(suffix, path, StringComparison.Ordinal))
+            {
+                return string.Empty;
+            }
+
+            var extIdx = suffix.Length - 1;
+            var firstNonSlashEnd = -1;
+            for (var i = path.Length - 1; i >= 0; --i)
+            {
+                var code = path[i];
+                if (code == Separator)
+                {
+                    if (!matchedSlash)
+                    {
+                        start = i + 1;
+                        break;
+                    }
+                }
+                else
+                {
+                    if (firstNonSlashEnd == -1)
+                    {
+                        matchedSlash = false;
+                        firstNonSlashEnd = i + 1;
+                    }
+
+                    if (extIdx >= 0)
+                    {
+                        if (code == suffix[extIdx])
+                        {
+                            if (--extIdx == -1)
+                            {
+                                end = i;
+                            }
+                        }
+                        else
+                        {
+                            // The suffix does not match, so the result is the whole path component.
+                            extIdx = -1;
+                            end = firstNonSlashEnd;
+                        }
+                    }
+                }
+            }
+
+            if (start == end)
+            {
+                end = firstNonSlashEnd;
+            }
+            else if (end == -1)
+            {
+                end = path.Length;
+            }
+
+            return NodePathAlgorithms.Slice(path, start, end);
+        }
+
+        for (var i = path.Length - 1; i >= 0; --i)
+        {
+            if (path[i] == Separator)
+            {
+                if (!matchedSlash)
+                {
+                    start = i + 1;
+                    break;
+                }
+            }
+            else if (end == -1)
+            {
+                matchedSlash = false;
+                end = i + 1;
+            }
+        }
+
+        if (end == -1)
+        {
+            return string.Empty;
+        }
+
+        return path.Substring(start, end - start);
+    }
+
+    /// <summary>
+    /// <c>path.extname(path)</c>: "the extension of the <c>path</c>, from the last occurrence of the <c>.</c>
+    /// (period) character to end of string in the last portion of the <c>path</c>. If there is no <c>.</c> in
+    /// the last portion of the <c>path</c>, or if there are no <c>.</c> characters other than the first
+    /// character of the basename of <c>path</c>, an empty string is returned."
+    /// <para>
+    /// https://nodejs.org/api/path.html#pathextnamepath
+    /// </para>
+    /// </summary>
+    internal static string Extname(string path)
+    {
+        var startDot = -1;
+        var startPart = 0;
+        var end = -1;
+        var matchedSlash = true;
+
+        // The state of the characters seen before the first dot and after any separator: 0 while nothing but
+        // dots has been seen, 1 once a second dot follows, -1 once an ordinary character precedes the dot.
+        var preDotState = 0;
+
+        for (var i = path.Length - 1; i >= 0; --i)
+        {
+            var code = path[i];
+            if (code == Separator)
+            {
+                if (!matchedSlash)
+                {
+                    startPart = i + 1;
+                    break;
+                }
+
+                continue;
+            }
+
+            if (end == -1)
+            {
+                matchedSlash = false;
+                end = i + 1;
+            }
+
+            if (code == '.')
+            {
+                if (startDot == -1)
+                {
+                    startDot = i;
+                }
+                else if (preDotState != 1)
+                {
+                    preDotState = 1;
+                }
+            }
+            else if (startDot != -1)
+            {
+                preDotState = -1;
+            }
+        }
+
+        // The last two disjuncts are the ones the prose describes: a non-dot character immediately before
+        // the dot, and a right-most trimmed component that is exactly "..".
+        if (startDot == -1
+            || end == -1
+            || preDotState == 0
+            || (preDotState == 1 && startDot == end - 1 && startDot == startPart + 1))
+        {
+            return string.Empty;
+        }
+
+        return path.Substring(startDot, end - startDot);
+    }
+
+    /// <summary>
+    /// <c>path.parse(path)</c>: "an object whose properties represent significant elements of the <c>path</c>.
+    /// Trailing directory separators are ignored."
+    /// <para>
+    /// https://nodejs.org/api/path.html#pathparsepath
+    /// </para>
+    /// </summary>
+    internal static ParsedPath Parse(string path)
+    {
+        if (path.Length == 0)
+        {
+            return ParsedPath.Empty;
+        }
+
+        var isAbsolute = path[0] == Separator;
+        var root = isAbsolute ? "/" : string.Empty;
+        var scanStart = isAbsolute ? 1 : 0;
+
+        var startDot = -1;
+        var startPart = 0;
+        var end = -1;
+        var matchedSlash = true;
+        var preDotState = 0;
+
+        for (var i = path.Length - 1; i >= scanStart; --i)
+        {
+            var code = path[i];
+            if (code == Separator)
+            {
+                if (!matchedSlash)
+                {
+                    startPart = i + 1;
+                    break;
+                }
+
+                continue;
+            }
+
+            if (end == -1)
+            {
+                matchedSlash = false;
+                end = i + 1;
+            }
+
+            if (code == '.')
+            {
+                if (startDot == -1)
+                {
+                    startDot = i;
+                }
+                else if (preDotState != 1)
+                {
+                    preDotState = 1;
+                }
+            }
+            else if (startDot != -1)
+            {
+                preDotState = -1;
+            }
+        }
+
+        var name = string.Empty;
+        var baseName = string.Empty;
+        var ext = string.Empty;
+
+        if (end != -1)
+        {
+            var start = startPart == 0 && isAbsolute ? 1 : startPart;
+            if (startDot == -1
+                || preDotState == 0
+                || (preDotState == 1 && startDot == end - 1 && startDot == startPart + 1))
+            {
+                baseName = name = path.Substring(start, end - start);
+            }
+            else
+            {
+                name = path.Substring(start, startDot - start);
+                baseName = path.Substring(start, end - start);
+                ext = path.Substring(startDot, end - startDot);
+            }
+        }
+
+        string dir;
+        if (startPart > 0)
+        {
+            dir = path.Substring(0, startPart - 1);
+        }
+        else if (isAbsolute)
+        {
+            dir = "/";
+        }
+        else
+        {
+            dir = string.Empty;
+        }
+
+        return new ParsedPath(root, dir, baseName, ext, name);
+    }
+}

--- a/Jint/NodeCompat/NodeProcessOptions.cs
+++ b/Jint/NodeCompat/NodeProcessOptions.cs
@@ -1,7 +1,3 @@
-#if !NET8_0_OR_GREATER && !NETFRAMEWORK
-using System.Runtime.InteropServices;
-#endif
-
 namespace Jint.NodeCompat;
 
 /// <summary>
@@ -36,7 +32,7 @@ public sealed class NodeProcessOptions
     internal const string JintVersionString = "v0.0.0-jint";
 
     private IReadOnlyCollection<string> _environmentVariableAllowlist = [];
-    private string _platform = DefaultPlatform();
+    private string _platform = NodePlatform.Default();
     private string _version = JintVersionString;
     private string _workingDirectory = "/";
 
@@ -110,7 +106,7 @@ public sealed class NodeProcessOptions
     public string Platform
     {
         get => _platform;
-        set => _platform = value ?? DefaultPlatform();
+        set => _platform = value ?? NodePlatform.Default();
     }
 
     /// <summary>
@@ -160,34 +156,5 @@ public sealed class NodeProcessOptions
     {
         get => _workingDirectory;
         set => _workingDirectory = value ?? "/";
-    }
-
-    /// <summary>
-    /// The running platform as one of Node's platform strings.
-    /// </summary>
-    /// <remarks>
-    /// Not an API gap but a genuine three-way, and the same one <c>DefaultTimeZoneProvider</c> answers:
-    /// <see cref="OperatingSystem"/>'s predicates arrived in .NET 5, netstandard has to ask the runtime, and
-    /// <c>net462</c> only ever runs on Windows.
-    /// </remarks>
-    private static string DefaultPlatform()
-    {
-#if NET8_0_OR_GREATER
-        if (OperatingSystem.IsWindows())
-        {
-            return "win32";
-        }
-
-        return OperatingSystem.IsMacOS() ? "darwin" : "linux";
-#elif NETFRAMEWORK
-        return "win32";
-#else
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            return "win32";
-        }
-
-        return RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "darwin" : "linux";
-#endif
     }
 }

--- a/Jint/NodeCompat/NodeQueryString.cs
+++ b/Jint/NodeCompat/NodeQueryString.cs
@@ -1,0 +1,135 @@
+#if NET8_0_OR_GREATER
+using System.Text;
+using Jint.WebApi.Url.Parsing;
+
+namespace Jint.NodeCompat;
+
+/// <summary>
+/// The two string algorithms behind <c>node:querystring</c>: <c>querystring.escape</c> and
+/// <c>querystring.unescape</c>, which <c>stringify</c> and <c>parse</c> are defined in terms of.
+/// <para>
+/// https://nodejs.org/api/querystring.html
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// Node's escape set is <b>not</b> the WHATWG application/x-www-form-urlencoded set that
+/// <see cref="FormUrlEncoded"/> serializes with — it is exactly <c>encodeURIComponent</c>'s: everything except
+/// ASCII letters, digits and <c>- . _ ~ ! ' ( ) *</c> is escaped, and a space becomes <c>%20</c> rather than
+/// <c>+</c>. That is the whole difference between the two modules, and the reason <c>querystring</c> "is more
+/// performant but is not a standardized API" while <c>URLSearchParams</c> is the standard one. The percent
+/// encoding and decoding themselves are the URL implementation's, so there is one of each in the assembly.
+/// </para>
+/// <para>
+/// One deliberate deviation. Node's encoder throws <c>ERR_INVALID_URI</c> on a trailing unpaired surrogate and
+/// silently mangles a leading one — its own comment says the branch "should never happen because all
+/// URLSearchParams entries should already be converted to USVString". Jint performs that conversion instead,
+/// so an unpaired surrogate encodes as U+FFFD, which is what every other percent-encoding path in the engine
+/// does.
+/// </para>
+/// </remarks>
+internal static class NodeQueryString
+{
+    /// <summary>
+    /// One byte per ASCII code point: 1 for the characters <c>querystring.escape</c> leaves alone. Above
+    /// U+007F everything is escaped, which needs no lookup.
+    /// </summary>
+    /// <remarks>
+    /// A <c>ReadOnlySpan&lt;byte&gt;</c> over a constant array initializer compiles to a direct reference into
+    /// the assembly's data section, so this costs no static constructor and no allocation.
+    /// </remarks>
+    private static ReadOnlySpan<byte> NoEscape =>
+    [
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0x00
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0x10
+        0, 1, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 1, 1, 0, // 0x20  SP ! " # $ % & ' ( ) * + , - . /
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, // 0x30  0-9 : ; < = > ?
+        0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x40  @ A-O
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, // 0x50  P-Z [ \ ] ^ _
+        0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x60  ` a-o
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 0, // 0x70  p-z { | } ~ DEL
+    ];
+
+    /// <summary>
+    /// <c>querystring.escape(str)</c>: "performs URL percent-encoding on the given <c>str</c> in a manner that
+    /// is optimized for the specific requirements of URL query strings".
+    /// <para>
+    /// https://nodejs.org/api/querystring.html#querystringescapestr
+    /// </para>
+    /// </summary>
+    internal static string Escape(string value)
+    {
+        if (value.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        var builder = new ValueStringBuilder(stackalloc char[128]);
+        try
+        {
+            var i = 0;
+            while (i < value.Length)
+            {
+                var c = value[i];
+                if (c < 0x80)
+                {
+                    i++;
+                    if (NoEscape[c] == 1)
+                    {
+                        builder.Append(c);
+                    }
+                    else
+                    {
+                        PercentEncoding.AppendPercentEncodedByte(ref builder, (byte) c);
+                    }
+
+                    continue;
+                }
+
+                // Decoding the scalar value is what keeps a surrogate pair one code point rather than two
+                // lone halves, and turns an unpaired half into U+FFFD.
+                Rune.DecodeFromUtf16(value.AsSpan(i), out var rune, out var consumed);
+                i += consumed;
+                PercentEncoding.AppendUtf8PercentEncoded(ref builder, rune);
+            }
+
+            return builder.AsSpan().ToString();
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// <c>querystring.unescape(str)</c>: "performs decoding of URL percent-encoded characters", using
+    /// <c>decodeURIComponent</c> and falling back to "a safer equivalent that does not throw on malformed
+    /// URLs".
+    /// <para>
+    /// https://nodejs.org/api/querystring.html#querystringunescapestr
+    /// </para>
+    /// </summary>
+    /// <param name="value">The string to decode.</param>
+    /// <param name="decodeSpaces">
+    /// Whether the fallback turns <c>+</c> into a space. Node's second parameter, which the exported function
+    /// never sets and <c>parse</c> does — the fallback is the only place a <c>+</c> has not already been
+    /// substituted.
+    /// </param>
+    /// <remarks>
+    /// The fallback deviates from Node's on one point: Node truncates every UTF-16 code unit of the input to a
+    /// single byte before percent-decoding, which mangles any non-ASCII text that got that far, while this
+    /// percent-decodes the UTF-8 form and reads it back with U+FFFD for what is left invalid. It only ever
+    /// runs for input <c>decodeURIComponent</c> already refused.
+    /// </remarks>
+    internal static string Unescape(string value, bool decodeSpaces)
+    {
+        if (NodeBuiltinHelpers.TryDecodeUriComponent(value, out var decoded))
+        {
+            return decoded;
+        }
+
+        var input = decodeSpaces ? value.Replace('+', ' ') : value;
+        return PercentEncoding.DecodeToString(input);
+    }
+}
+#endif

--- a/Jint/NodeCompat/NodeQueryStringModule.cs
+++ b/Jint/NodeCompat/NodeQueryStringModule.cs
@@ -1,0 +1,419 @@
+#if NET8_0_OR_GREATER
+using System.Text;
+using Jint.Native;
+using Jint.Native.Array;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.WebApi.Url.Parsing;
+
+namespace Jint.NodeCompat;
+
+/// <summary>
+/// Builds the JavaScript surface of <c>node:querystring</c> over <see cref="NodeQueryString"/>.
+/// <para>
+/// https://nodejs.org/api/querystring.html
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>querystring</c> predates <c>URLSearchParams</c> and differs from it in three ways a caller notices, all
+/// of them kept: the result of <c>parse</c> is prototype-less, so <c>obj.toString</c> and
+/// <c>obj.hasOwnProperty</c> are <see langword="undefined"/> and a query string cannot smuggle a property in
+/// through the prototype chain; a repeated key becomes an array rather than a multi-valued list; and the
+/// separators are parameters, so <c>a:1;b:2</c> parses as readily as <c>a=1&amp;b=2</c>.
+/// </para>
+/// <para>
+/// <c>escape</c> and <c>unescape</c> are replaceable, as Node documents them: <c>stringify</c> and
+/// <c>parse</c> read them off the module object every time they run, so assigning <c>querystring.escape</c>
+/// changes what <c>stringify</c> uses. The identity test Node makes against the original function is kept too
+/// — it is what decides whether a number is written out directly or handed to the encoder first.
+/// </para>
+/// <para>
+/// <c>querystring.unescapeBuffer</c> is absent: it answers with a <c>Buffer</c>, and <c>node:buffer</c> is
+/// deliberately not one of the modules Jint provides.
+/// </para>
+/// </remarks>
+internal static class NodeQueryStringModule
+{
+    private const int DefaultMaxKeys = 1000;
+
+    internal static List<KeyValuePair<string, JsValue>> CreateExports(Engine engine)
+    {
+        var realm = engine.Realm;
+
+        // The module object every export also hangs off, captured by the closures below so that a script
+        // reassigning querystring.escape is observed by stringify, as Node documents.
+        JsObject? moduleObject = null;
+
+        var escape = NodeBuiltinHelpers.Operation(engine, realm, "escape", 1, (_, arguments) =>
+            JsString.Create(NodeQueryString.Escape(Coerce(arguments.At(0)))));
+
+        var unescape = NodeBuiltinHelpers.Operation(engine, realm, "unescape", 2, (_, arguments) =>
+            JsString.Create(NodeQueryString.Unescape(
+                TypeConverter.ToString(arguments.At(0)),
+                TypeConverter.ToBoolean(arguments.At(1)))));
+
+        var stringify = NodeBuiltinHelpers.Operation(engine, realm, "stringify", 4, (_, arguments) =>
+            JsString.Create(Stringify(moduleObject!, escape, arguments)));
+
+        var parse = NodeBuiltinHelpers.Operation(engine, realm, "parse", 4, (_, arguments) =>
+            Parse(engine, moduleObject!, unescape, arguments));
+
+        var entries = new List<KeyValuePair<string, JsValue>>
+        {
+            new("unescape", unescape),
+            new("escape", escape),
+            new("stringify", stringify),
+            new("encode", stringify),
+            new("parse", parse),
+            new("decode", parse),
+        };
+
+        moduleObject = JsObject.CreateFromEntries(engine, entries);
+
+        var exports = new List<KeyValuePair<string, JsValue>>(entries.Count + 1);
+        exports.AddRange(entries);
+        exports.Add(new KeyValuePair<string, JsValue>("default", moduleObject));
+        return exports;
+    }
+
+    /// <summary>
+    /// <c>querystring.stringify(obj[, sep[, eq[, options]]])</c>.
+    /// <para>
+    /// https://nodejs.org/api/querystring.html#querystringstringifyobj-sep-eq-options
+    /// </para>
+    /// </summary>
+    private static string Stringify(JsObject moduleObject, JsValue originalEscape, JsCallArguments arguments)
+    {
+        var target = arguments.At(0);
+        if (target is not ObjectInstance obj)
+        {
+            // "obj: The object to serialize into a URL query string" — anything else answers with "".
+            return string.Empty;
+        }
+
+        var sep = Separator(arguments.At(1), "&");
+        var eq = Separator(arguments.At(2), "=");
+
+        var encode = moduleObject.Get("escape");
+        var options = arguments.At(3);
+        if (options is ObjectInstance optionsObject && optionsObject.Get("encodeURIComponent") is ICallable custom)
+        {
+            encode = (JsValue) custom;
+        }
+
+        // The identity test Node makes: only the built-in encoder is trusted to leave a finite number alone.
+        var builtinEncoder = ReferenceEquals(encode, originalEscape);
+
+        var fields = new StringBuilder();
+        var keys = obj.EnumerableOwnProperties(ObjectInstance.EnumerableOwnPropertyNamesKind.Key);
+
+        for (uint i = 0; i < keys.Length; i++)
+        {
+            keys.TryGetValue(i, out var keyValue);
+            var key = TypeConverter.ToString(keyValue);
+            var value = obj.Get(key);
+            var encodedKey = Convert(JsString.Create(key), encode, builtinEncoder) + eq;
+
+            if (value.IsArray())
+            {
+                var array = ArrayOperations.For(value.AsObject(), forWrite: false);
+                var count = array.GetLongLength();
+                if (count == 0)
+                {
+                    continue;
+                }
+
+                if (fields.Length > 0)
+                {
+                    fields.Append(sep);
+                }
+
+                for (ulong j = 0; j < count; j++)
+                {
+                    if (j > 0)
+                    {
+                        fields.Append(sep);
+                    }
+
+                    fields.Append(encodedKey);
+                    fields.Append(Convert(array.Get(j), encode, builtinEncoder));
+                }
+
+                continue;
+            }
+
+            if (fields.Length > 0)
+            {
+                fields.Append(sep);
+            }
+
+            fields.Append(encodedKey);
+            fields.Append(Convert(value, encode, builtinEncoder));
+        }
+
+        return fields.ToString();
+    }
+
+    /// <summary>
+    /// Node's <c>encodeStringified</c> and <c>encodeStringifiedCustom</c>. "Numeric values must be finite. Any
+    /// other input values will be coerced to empty strings."
+    /// </summary>
+    /// <remarks>
+    /// The two differ in one place: with the built-in encoder a finite number below <c>1e21</c> is written out
+    /// as-is, because none of its characters needs escaping, while <c>1e21</c> and above switch to exponential
+    /// notation whose <c>+</c> does. A custom encoder is handed every value, since only it knows what it
+    /// escapes.
+    /// </remarks>
+    private static string Convert(JsValue value, JsValue encode, bool builtinEncoder)
+    {
+        if (!builtinEncoder)
+        {
+            return CallEncoder(encode, StringifyPrimitive(value));
+        }
+
+        if (value is JsString text)
+        {
+            return text.Length == 0 ? string.Empty : NodeQueryString.Escape(text.ToString());
+        }
+
+        if (value.IsNumber())
+        {
+            var number = value.AsNumber();
+            if (double.IsFinite(number))
+            {
+                var rendered = TypeConverter.ToString(number);
+                return Math.Abs(number) < 1e21 ? rendered : NodeQueryString.Escape(rendered);
+            }
+
+            return string.Empty;
+        }
+
+        return StringifyPrimitive(value);
+    }
+
+    /// <summary>Node's <c>stringifyPrimitive</c>.</summary>
+    private static string StringifyPrimitive(JsValue value)
+    {
+        if (value is JsString text)
+        {
+            return text.ToString();
+        }
+
+        if (value.IsNumber())
+        {
+            var number = value.AsNumber();
+            return double.IsFinite(number) ? TypeConverter.ToString(number) : string.Empty;
+        }
+
+        if (value.IsBigInt())
+        {
+            return TypeConverter.ToString(value);
+        }
+
+        if (value.IsBoolean())
+        {
+            return value.AsBoolean() ? "true" : "false";
+        }
+
+        return string.Empty;
+    }
+
+    private static string CallEncoder(JsValue encode, string value)
+    {
+        var callable = (ICallable) encode;
+        return TypeConverter.ToString(callable.Call(JsValue.Undefined, [JsString.Create(value)]));
+    }
+
+    /// <summary>
+    /// <c>querystring.parse(str[, sep[, eq[, options]]])</c>.
+    /// <para>
+    /// https://nodejs.org/api/querystring.html#querystringparsestr-sep-eq-options
+    /// </para>
+    /// </summary>
+    private static JsObject Parse(Engine engine, JsObject moduleObject, JsValue originalUnescape, JsCallArguments arguments)
+    {
+        // "The object returned by the querystring.parse() method does not prototypically inherit from the
+        // JavaScript Object", so a key called "toString" is just a key.
+        var result = new JsObject(engine);
+        result.SetPrototypeOf(JsValue.Null);
+
+        if (arguments.At(0) is not JsString input || input.Length == 0)
+        {
+            return result;
+        }
+
+        var sep = Separator(arguments.At(1), "&");
+        var eq = Separator(arguments.At(2), "=");
+
+        var pairs = DefaultMaxKeys;
+        var decode = moduleObject.Get("unescape");
+        var options = arguments.At(3);
+        if (options is ObjectInstance optionsObject)
+        {
+            var maxKeys = optionsObject.Get("maxKeys");
+            if (maxKeys.IsNumber())
+            {
+                var requested = TypeConverter.ToInt32(maxKeys);
+
+                // "-1 is used in place of a value like Infinity for meaning unlimited pairs."
+                pairs = requested > 0 ? requested : -1;
+            }
+
+            if (optionsObject.Get("decodeURIComponent") is ICallable custom)
+            {
+                decode = (JsValue) custom;
+            }
+        }
+
+        var customDecode = !ReferenceEquals(decode, originalUnescape);
+
+        // With a custom decoder Node hands it "%20" rather than an already-substituted space, so the decoder
+        // sees the query string as written.
+        var plusReplacement = customDecode ? "%20" : " ";
+
+        var segments = Split(input.ToString(), sep);
+        var accumulated = new List<KeyValuePair<string, JsValue>>();
+        var index = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        for (var i = 0; i < segments.Count; i++)
+        {
+            var segment = segments[i];
+            if (segment.Length == 0)
+            {
+                if (i == segments.Count - 1)
+                {
+                    // "We ended on an empty substring": nothing to add, and the budget is not spent.
+                    break;
+                }
+
+                if (--pairs == 0)
+                {
+                    break;
+                }
+
+                continue;
+            }
+
+            string rawKey;
+            string rawValue;
+            var separatorIndex = segment.IndexOf(eq, StringComparison.Ordinal);
+            if (separatorIndex < 0)
+            {
+                rawKey = segment;
+                rawValue = string.Empty;
+            }
+            else
+            {
+                rawKey = segment.Substring(0, separatorIndex);
+                rawValue = segment.Substring(separatorIndex + eq.Length);
+            }
+
+            var key = Decode(rawKey, plusReplacement, customDecode, decode);
+            var value = Decode(rawValue, plusReplacement, customDecode, decode);
+
+            AddKeyValue(engine, accumulated, index, key, value);
+
+            if (--pairs == 0)
+            {
+                break;
+            }
+        }
+
+        for (var i = 0; i < accumulated.Count; i++)
+        {
+            result.FastSetDataProperty(accumulated[i].Key, accumulated[i].Value);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Node's <c>addKeyVal</c>: "the first value is the string value, the second and later ones extend it into
+    /// an array".
+    /// </summary>
+    private static void AddKeyValue(
+        Engine engine,
+        List<KeyValuePair<string, JsValue>> accumulated,
+        Dictionary<string, int> index,
+        string key,
+        string value)
+    {
+        var entry = JsString.Create(value);
+
+        if (!index.TryGetValue(key, out var position))
+        {
+            index[key] = accumulated.Count;
+            accumulated.Add(new KeyValuePair<string, JsValue>(key, entry));
+            return;
+        }
+
+        var existing = accumulated[position].Value;
+        if (existing is JsArray array)
+        {
+            array.Push(entry);
+            return;
+        }
+
+        var replacement = new JsArray(engine, [existing, entry]);
+        accumulated[position] = new KeyValuePair<string, JsValue>(key, replacement);
+    }
+
+    /// <summary>
+    /// One component of a pair: <c>+</c> first, then the decoder — and only when there is something to decode,
+    /// which for the built-in decoder means a percent-encoded byte is actually present.
+    /// </summary>
+    private static string Decode(string component, string plusReplacement, bool customDecode, JsValue decode)
+    {
+        var substituted = component.IndexOf('+') < 0 ? component : component.Replace("+", plusReplacement);
+        if (substituted.Length == 0)
+        {
+            return substituted;
+        }
+
+        if (!customDecode)
+        {
+            return PercentEncoding.ContainsPercentEncodedByte(substituted.AsSpan())
+                ? NodeQueryString.Unescape(substituted, decodeSpaces: false)
+                : substituted;
+        }
+
+        // Node's decodeStr: a decoder that throws is not fatal, the built-in one answers instead.
+        try
+        {
+            return TypeConverter.ToString(((ICallable) decode).Call(JsValue.Undefined, [JsString.Create(substituted)]));
+        }
+        catch (JavaScriptException)
+        {
+            return NodeQueryString.Unescape(substituted, decodeSpaces: true);
+        }
+    }
+
+    /// <summary>
+    /// A <c>sep</c> or <c>eq</c> argument. Node applies <c>||</c> to it, so every falsy value — absent, null,
+    /// an empty string, <c>0</c> — means the default.
+    /// </summary>
+    private static string Separator(JsValue value, string fallback)
+        => TypeConverter.ToBoolean(value) ? TypeConverter.ToString(value) : fallback;
+
+    private static List<string> Split(string input, string separator)
+    {
+        var result = new List<string>();
+        var start = 0;
+        while (true)
+        {
+            var next = input.IndexOf(separator, start, StringComparison.Ordinal);
+            if (next < 0)
+            {
+                result.Add(input.Substring(start));
+                return result;
+            }
+
+            result.Add(input.Substring(start, next - start));
+            start = next + separator.Length;
+        }
+    }
+
+    private static string Coerce(JsValue value) => TypeConverter.ToString(value);
+}
+#endif

--- a/Jint/NodeCompat/NodeUrlModule.cs
+++ b/Jint/NodeCompat/NodeUrlModule.cs
@@ -1,0 +1,414 @@
+#if NET8_0_OR_GREATER
+using System.Text;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.WebApi.Url;
+using Jint.WebApi.Url.Parsing;
+
+namespace Jint.NodeCompat;
+
+/// <summary>
+/// Builds the JavaScript surface of <c>node:url</c>.
+/// <para>
+/// https://nodejs.org/api/url.html
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>URL</c> and <c>URLSearchParams</c> are the engine's own WHATWG implementations, re-exported rather than
+/// reimplemented — so <c>new (await import('node:url')).URL(…) instanceof URL</c> holds against the global one
+/// whenever the host also enabled <c>WebApiFeatures.Url</c>, and the module works when it did not. Importing
+/// this module is itself the opt-in: the interface objects are per-realm intrinsics that exist whether or not
+/// anything installed them as globals.
+/// </para>
+/// <para>
+/// Four functions are the module's own, and each is the reason a Node script imports it at all: the two path
+/// conversions, which are how an ES module turns <c>import.meta.url</c> into something the file system
+/// understands, and the two IDNA mappings, which run over the same <see cref="Idna"/> the URL host parser
+/// uses.
+/// </para>
+/// <para>
+/// What is absent, and why. The <b>legacy URL API</b> — <c>url.parse</c>, <c>url.format(string)</c>,
+/// <c>url.resolve</c>, <c>Url</c> — is documented by Node as legacy and its parser diverges from the WHATWG
+/// one in ways that have been a source of security advisories; the WHATWG <c>URL</c> beside it does the same
+/// job. <c>urlToHttpOptions</c> shapes an options object for <c>node:http</c>, which Jint does not have.
+/// <c>fileURLToPathBuffer</c> answers with a <c>Buffer</c>. <c>URLPattern</c> is a separate specification, and
+/// <c>url.format(URL, options)</c> is left for a later slice rather than guessed at.
+/// </para>
+/// </remarks>
+internal static class NodeUrlModule
+{
+    internal static List<KeyValuePair<string, JsValue>> CreateExports(Engine engine, NodeBuiltinModuleConfiguration configuration)
+    {
+        var realm = engine.Realm;
+        var platformIsWindows = configuration.PlatformIsWindows;
+        var workingDirectory = configuration.WorkingDirectory;
+        var posixWorkingDirectory = configuration.PosixWorkingDirectory;
+
+        var entries = new List<KeyValuePair<string, JsValue>>
+        {
+            new("URL", realm.Intrinsics.WebApiUrl),
+            new("URLSearchParams", realm.Intrinsics.WebApiUrlSearchParams),
+
+            new("domainToASCII", NodeBuiltinHelpers.Operation(engine, realm, "domainToASCII", 1, (_, arguments) =>
+                JsString.Create(DomainToAscii(realm, arguments)))),
+
+            new("domainToUnicode", NodeBuiltinHelpers.Operation(engine, realm, "domainToUnicode", 1, (_, arguments) =>
+                JsString.Create(DomainToUnicode(realm, arguments)))),
+
+            new("fileURLToPath", NodeBuiltinHelpers.Operation(engine, realm, "fileURLToPath", 1, (_, arguments) =>
+                JsString.Create(FileUrlToPath(realm, platformIsWindows, arguments)))),
+
+            new("pathToFileURL", NodeBuiltinHelpers.Operation(engine, realm, "pathToFileURL", 1, (_, arguments) =>
+                PathToFileUrl(engine, realm, platformIsWindows, workingDirectory, posixWorkingDirectory, arguments))),
+        };
+
+        var moduleObject = JsObject.CreateFromEntries(engine, entries);
+
+        var exports = new List<KeyValuePair<string, JsValue>>(entries.Count + 1);
+        exports.AddRange(entries);
+        exports.Add(new KeyValuePair<string, JsValue>("default", moduleObject));
+        return exports;
+    }
+
+    /// <summary>
+    /// <c>url.domainToASCII(domain)</c>: "returns the Punycode ASCII serialization of the <c>domain</c>. If
+    /// <c>domain</c> is an invalid domain, the empty string is returned."
+    /// <para>
+    /// https://nodejs.org/api/url.html#urldomaintoasciidomain
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// An ASCII domain is lowercased without consulting IDNA at all, which is what
+    /// https://url.spec.whatwg.org/#concept-domain-to-ascii step 4 requires — "return the result of ASCII
+    /// lowercasing <em>domain</em> … regardless of Unicode ToASCII's outcome, due to web compatibility" — and
+    /// what keeps this answering the way the engine's own URL host parser does for the same input.
+    /// </para>
+    /// <para>
+    /// Node validates an ASCII domain as well, so its <c>domainToASCII('a b')</c> is the empty string where
+    /// this answers <c>'a b'</c>, and it percent-decodes one, so its <c>domainToASCII('a%2Eb')</c> is
+    /// <c>'a.b'</c>. Both come from running full UTS-46 with parameters <c>IdnMapping</c> cannot be
+    /// given; the divergence is confined to domains that are not domains, and <see cref="Idna"/> documents the
+    /// rest of the family it belongs to.
+    /// </para>
+    /// </remarks>
+    private static string DomainToAscii(Realm realm, JsCallArguments arguments)
+    {
+        var domain = RequireDomain(realm, arguments);
+
+        if (IsAscii(domain))
+        {
+            return domain.ToLowerInvariant();
+        }
+
+        return Idna.TryToAscii(domain, out var result) ? result : string.Empty;
+    }
+
+    private static bool IsAscii(string value)
+    {
+        foreach (var c in value)
+        {
+            if (c > 0x7F)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// <c>url.domainToUnicode(domain)</c>: "returns the Unicode serialization of the <c>domain</c>. If
+    /// <c>domain</c> is an invalid domain, the empty string is returned. It performs the inverse operation to
+    /// <c>url.domainToASCII()</c>."
+    /// <para>
+    /// https://nodejs.org/api/url.html#urldomaintounicodedomain
+    /// </para>
+    /// </summary>
+    private static string DomainToUnicode(Realm realm, JsCallArguments arguments)
+    {
+        var domain = RequireDomain(realm, arguments);
+        return Idna.TryToUnicode(domain, out var result) ? result : string.Empty;
+    }
+
+    /// <summary>
+    /// Both mappings coerce their argument rather than validating it — Node's only check is that one was
+    /// passed at all, which it reports as <c>ERR_MISSING_ARGS</c>.
+    /// </summary>
+    private static string RequireDomain(Realm realm, JsCallArguments arguments)
+    {
+        if (arguments.Length < 1)
+        {
+            Throw.TypeError(realm, "The \"domain\" argument must be specified");
+        }
+
+        return TypeConverter.ToString(arguments[0]);
+    }
+
+    /// <summary>
+    /// <c>url.fileURLToPath(url[, options])</c>: "ensures that the percent-encoded characters are decoded
+    /// correctly as well as ensuring a cross-platform valid absolute path string".
+    /// <para>
+    /// https://nodejs.org/api/url.html#urlfileurltopathurl-options
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// Node's own security note applies unchanged, and is the reason it is repeated here: the function decodes
+    /// percent-encoded dot segments, so <c>%2e%2e</c> becomes <c>..</c> in the answer. An encoded separator is
+    /// refused, but an encoded traversal is not, and a host must validate the path it gets back rather than
+    /// treating this as a sandbox check.
+    /// </remarks>
+    private static string FileUrlToPath(Realm realm, bool platformIsWindows, JsCallArguments arguments)
+    {
+        var windows = WindowsOption(arguments.At(1), platformIsWindows);
+        var record = ToUrlRecord(realm, arguments.At(0));
+
+        if (!string.Equals(record.Scheme, "file", StringComparison.Ordinal))
+        {
+            Throw.TypeError(realm, "The URL must be of scheme file");
+        }
+
+        var hostname = record.SerializeHost();
+        var pathname = record.SerializePath();
+
+        if (!windows)
+        {
+            if (hostname.Length != 0)
+            {
+                Throw.TypeError(realm, "File URL host must be \"localhost\" or empty on " + (platformIsWindows ? NodePlatform.Windows : NodePlatform.Linux));
+            }
+
+            RejectEncodedSeparators(realm, pathname, windows: false);
+            return Decode(realm, pathname);
+        }
+
+        RejectEncodedSeparators(realm, pathname, windows: true);
+        pathname = Decode(realm, pathname.Replace('/', '\\'));
+
+        if (hostname.Length != 0)
+        {
+            // A host means a UNC path. The host is put back through IDNA in case it is an internationalized
+            // name the URL parser stored in its Punycode form.
+            var unicodeHost = Idna.TryToUnicode(hostname, out var decoded) ? decoded : string.Empty;
+            return @"\\" + unicodeHost + pathname;
+        }
+
+        // Otherwise it is a local path, which needs a drive letter: "/C:/x" becomes "C:\x".
+        var letter = pathname.Length > 1 ? (char) (pathname[1] | 0x20) : '\0';
+        var separator = pathname.Length > 2 ? pathname[2] : '\0';
+        if (letter < 'a' || letter > 'z' || separator != ':')
+        {
+            Throw.TypeError(realm, "File URL path must be absolute");
+        }
+
+        return pathname.Substring(1);
+    }
+
+    /// <summary>
+    /// A percent-encoded separator would survive the decode and change which directory the path names, so it
+    /// is refused rather than decoded — the one traversal check Node does make here.
+    /// </summary>
+    private static void RejectEncodedSeparators(Realm realm, string pathname, bool windows)
+    {
+        for (var i = 0; i < pathname.Length; i++)
+        {
+            if (pathname[i] != '%' || i + 2 >= pathname.Length)
+            {
+                continue;
+            }
+
+            var third = (char) (pathname[i + 2] | 0x20);
+            if (pathname[i + 1] == '2' && third == 'f')
+            {
+                Throw.TypeError(realm, windows
+                    ? "File URL path must not include encoded \\ or / characters"
+                    : "File URL path must not include encoded / characters");
+            }
+
+            if (windows && pathname[i + 1] == '5' && third == 'c')
+            {
+                Throw.TypeError(realm, "File URL path must not include encoded \\ or / characters");
+            }
+        }
+    }
+
+    private static string Decode(Realm realm, string pathname)
+    {
+        if (pathname.IndexOf('%') < 0)
+        {
+            return pathname;
+        }
+
+        if (!NodeBuiltinHelpers.TryDecodeUriComponent(pathname, out var decoded))
+        {
+            // What decodeURIComponent raises, which Node lets escape from fileURLToPath unchanged.
+            Throw.UriError(realm, "URI malformed");
+        }
+
+        return decoded;
+    }
+
+    /// <summary>
+    /// <c>url.pathToFileURL(path[, options])</c>: "this function ensures that <c>path</c> is resolved
+    /// absolutely, and that the URL control characters are correctly encoded when converting into a File URL."
+    /// <para>
+    /// https://nodejs.org/api/url.html#urlpathtofileurlpath-options
+    /// </para>
+    /// </summary>
+    private static JsUrl PathToFileUrl(
+        Engine engine,
+        Realm realm,
+        bool platformIsWindows,
+        string workingDirectory,
+        string posixWorkingDirectory,
+        JsCallArguments arguments)
+    {
+        var windows = WindowsOption(arguments.At(1), platformIsWindows);
+        var filePath = NodeBuiltinHelpers.RequireString(realm, arguments.At(0), "path");
+
+        var isUnc = windows && filePath.StartsWith(@"\\", StringComparison.Ordinal);
+        var resolved = isUnc
+            ? filePath
+            : windows
+                ? NodeWin32Path.Resolve(workingDirectory, platformIsWindows, [filePath])
+                : NodePosixPath.Resolve(posixWorkingDirectory, [filePath]);
+
+        if (isUnc || (windows && resolved.StartsWith(@"\\", StringComparison.Ordinal)))
+        {
+            // UNC: \\server\share\resource, with the extended \\?\UNC\ prefix skipped when present.
+            var isExtendedUnc = resolved.StartsWith(@"\\?\UNC\", StringComparison.Ordinal);
+            var prefixLength = isExtendedUnc ? 8 : 2;
+            var hostnameEnd = resolved.IndexOf('\\', prefixLength);
+            if (hostnameEnd == -1)
+            {
+                Throw.TypeError(realm, "The argument 'path' must be a valid UNC path: missing UNC resource path");
+            }
+
+            if (hostnameEnd == 2)
+            {
+                Throw.TypeError(realm, "The argument 'path' must be a valid UNC path: empty UNC servername");
+            }
+
+            var host = resolved.Substring(prefixLength, hostnameEnd - prefixLength);
+            return CreateUrl(engine, realm, host, resolved.Substring(hostnameEnd), windows: true);
+        }
+
+        // resolve() strips a trailing separator, and the URL is expected to keep it.
+        var last = filePath.Length > 0 ? filePath[filePath.Length - 1] : '\0';
+        var separator = windows ? NodeWin32Path.Separator : NodePosixPath.Separator;
+        if ((last == '/' || (windows && last == '\\'))
+            && resolved.Length > 0
+            && resolved[resolved.Length - 1] != separator)
+        {
+            resolved += '/';
+        }
+
+        return CreateUrl(engine, realm, host: string.Empty, resolved, windows);
+    }
+
+    /// <summary>
+    /// Builds the <c>file:</c> URL for a resolved path.
+    /// </summary>
+    /// <remarks>
+    /// The characters escaped by hand are the ones that would otherwise change what the URL <em>means</em>
+    /// rather than merely how it is spelled: <c>%</c> first, so an already-percent-looking sequence in the file
+    /// name survives as itself, then <c>#</c> and <c>?</c>, which would start a fragment or a query, then the
+    /// three whitespace characters the URL parser strips outright. A backslash is escaped on POSIX for the same
+    /// reason: <c>file:</c> is a special scheme, so the parser treats a backslash as a separator, and a POSIX
+    /// file name is allowed to contain one. Everything else — a space, a non-ASCII character — is left for the
+    /// parser to percent-encode with the path set, which is what makes the result identical to what the URL
+    /// class would produce for the same path.
+    /// </remarks>
+    private static JsUrl CreateUrl(Engine engine, Realm realm, string host, string path, bool windows)
+    {
+        var builder = new StringBuilder("file://");
+        builder.Append(host);
+
+        if (path.Length == 0 || path[0] != '/' && path[0] != '\\')
+        {
+            builder.Append('/');
+        }
+
+        foreach (var c in path)
+        {
+            switch (c)
+            {
+                case '%':
+                    builder.Append("%25");
+                    break;
+                case '#':
+                    builder.Append("%23");
+                    break;
+                case '?':
+                    builder.Append("%3F");
+                    break;
+                case '\n':
+                    builder.Append("%0A");
+                    break;
+                case '\r':
+                    builder.Append("%0D");
+                    break;
+                case '\t':
+                    builder.Append("%09");
+                    break;
+                case '\\':
+                    builder.Append(windows ? "/" : "%5C");
+                    break;
+                default:
+                    builder.Append(c);
+                    break;
+            }
+        }
+
+        var record = UrlParser.ParseApi(builder.ToString(), baseHref: null);
+        if (record is null)
+        {
+            Throw.TypeError(realm, "The argument 'path' cannot be converted to a file URL");
+        }
+
+        return new JsUrl(engine, realm, record) { _prototype = realm.Intrinsics.WebApiUrl.PrototypeObject };
+    }
+
+    /// <summary>
+    /// The <c>windows</c> option both conversions take: "<c>true</c> for windows path, <c>false</c> for posix
+    /// path, <c>undefined</c> for system default".
+    /// </summary>
+    private static bool WindowsOption(JsValue options, bool platformIsWindows)
+    {
+        if (options is not ObjectInstance optionsObject)
+        {
+            return platformIsWindows;
+        }
+
+        var windows = optionsObject.Get("windows");
+        return windows.IsUndefined() ? platformIsWindows : TypeConverter.ToBoolean(windows);
+    }
+
+    /// <summary>
+    /// The <c>url</c> argument of <c>fileURLToPath</c>, which "may be a <c>URL</c> object or a string".
+    /// </summary>
+    private static UrlRecord ToUrlRecord(Realm realm, JsValue value)
+    {
+        if (value is JsUrl url)
+        {
+            return url.Url;
+        }
+
+        if (value is JsString text)
+        {
+            var record = UrlParser.ParseApi(text.ToString(), baseHref: null);
+            if (record is null)
+            {
+                Throw.TypeError(realm, UrlConstructor.InvalidUrlMessage(text.ToString(), baseHref: null));
+            }
+
+            return record!;
+        }
+
+        Throw.TypeError(realm, "The \"path\" argument must be one of type string or URL");
+        return null!;
+    }
+}
+#endif

--- a/Jint/NodeCompat/NodeWin32Path.cs
+++ b/Jint/NodeCompat/NodeWin32Path.cs
@@ -1,0 +1,1282 @@
+using System.Text;
+
+namespace Jint.NodeCompat;
+
+/// <summary>
+/// The Windows flavour of <c>node:path</c> — what <c>path.win32</c> and <c>node:path/win32</c> expose.
+/// <para>
+/// https://nodejs.org/api/path.html#pathwin32
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// Three things separate it from <see cref="NodePosixPath"/>, and every documented Windows oddity follows from
+/// one of them: both <c>/</c> and <c>\</c> are accepted as separators while only <c>\</c> is ever written; a
+/// path can carry a <em>device</em> — a drive letter, a UNC share, or a <c>\\?\</c> namespace prefix — that
+/// sits above the part <c>..</c> is allowed to pop; and a drive letter without a separator after it
+/// (<c>C:foo</c>) is <em>relative to that drive</em> rather than absolute.
+/// </para>
+/// <para>
+/// The reserved device names (<c>CON</c>, <c>NUL</c>, <c>COM1</c> …) are honoured because Windows resolves
+/// them from any directory: a path carrying one is deliberately not normalized into something the operating
+/// system would reopen as a device. That, and the <c>.\</c> prefixing of a drive-relative result, are Node's
+/// own mitigations rather than embellishments here.
+/// </para>
+/// </remarks>
+internal static class NodeWin32Path
+{
+    internal const char Separator = '\\';
+    internal const char Delimiter = ';';
+
+    /// <summary>
+    /// The DOS device names Windows resolves from every directory. The superscript spellings are the ones
+    /// Node carries too: <c>COM¹</c>, <c>COM²</c>, <c>COM³</c> and their <c>LPT</c> counterparts map to the
+    /// same devices.
+    /// </summary>
+    private static readonly string[] ReservedNames =
+    [
+        "CON", "PRN", "AUX", "NUL",
+        "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+        "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+        "COM\u00b9", "COM\u00b2", "COM\u00b3",
+        "LPT\u00b9", "LPT\u00b2", "LPT\u00b3",
+    ];
+
+    /// <summary>
+    /// Whether everything before <paramref name="colonIndex"/> names a reserved device. A
+    /// <paramref name="colonIndex"/> of <c>-1</c> is deliberately not rejected: the callers that pass one
+    /// through are asking about a path with no colon at all, and JavaScript's <c>slice(0, -1)</c> then tests
+    /// the path without its last character, which is how <c>CON\</c> is recognized.
+    /// </summary>
+    private static bool IsReservedName(string path, int colonIndex)
+    {
+        var devicePart = NodePathAlgorithms.Slice(path, 0, colonIndex).ToUpperInvariant();
+        for (var i = 0; i < ReservedNames.Length; i++)
+        {
+            if (string.Equals(ReservedNames[i], devicePart, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// <c>path.resolve([...paths])</c> for Windows paths.
+    /// <para>
+    /// https://nodejs.org/api/path.html#pathresolvepaths
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// Node consults <c>process.env['=C:']</c> for the per-drive working directory Windows keeps, which is why
+    /// "<c>path.resolve('C:\\')</c> can potentially return a different result than <c>path.resolve('C:')</c>".
+    /// Jint has no such environment to read — <c>process.env</c> is an allowlist and this module never reaches
+    /// it — so a drive-relative segment falls straight through to Node's own fallback: the configured working
+    /// directory when it names that drive, and the drive's root otherwise.
+    /// </remarks>
+    /// <param name="cwd">What Node reads from <c>process.cwd()</c>.</param>
+    /// <param name="platformIsWindows">
+    /// Whether the configured platform is <c>win32</c>. It decides one thing only: whether the working
+    /// directory is already spelled with backslashes, or is a POSIX path whose separators have to be turned
+    /// around first — exactly the <c>isWindows</c> test Node makes at the same point.
+    /// </param>
+    /// <param name="paths">The segments, already coerced to strings.</param>
+    internal static string Resolve(string cwd, bool platformIsWindows, IReadOnlyList<string> paths)
+    {
+        var resolvedDevice = string.Empty;
+        var resolvedTail = new ValueStringBuilder(stackalloc char[128]);
+
+        try
+        {
+            var resolvedAbsolute = false;
+
+            for (var i = paths.Count - 1; i >= -1; i--)
+            {
+                string path;
+                if (i >= 0)
+                {
+                    path = paths[i];
+                    if (path.Length == 0)
+                    {
+                        continue;
+                    }
+                }
+                else if (resolvedDevice.Length == 0)
+                {
+                    path = cwd;
+                    if (paths.Count == 0
+                        || (paths.Count == 1
+                            && (paths[0].Length == 0 || string.Equals(paths[0], ".", StringComparison.Ordinal))
+                            && path.Length > 0
+                            && NodePathAlgorithms.IsWindowsSeparator(path[0])))
+                    {
+                        return platformIsWindows ? path : path.Replace('/', Separator);
+                    }
+                }
+                else
+                {
+                    // A drive was resolved but no absolute path yet. Node asks for that drive's own working
+                    // directory and falls back to process.cwd(); Jint has only the configured one.
+                    path = cwd;
+                    if (!string.Equals(NodePathAlgorithms.Slice(path, 0, 2), resolvedDevice, StringComparison.OrdinalIgnoreCase)
+                        && path.Length > 2
+                        && path[2] == Separator)
+                    {
+                        path = resolvedDevice + Separator;
+                    }
+                }
+
+                var len = path.Length;
+                var rootEnd = 0;
+                var device = string.Empty;
+                var isAbsolute = false;
+                var code = len > 0 ? path[0] : '\0';
+
+                if (len == 1)
+                {
+                    if (NodePathAlgorithms.IsWindowsSeparator(code))
+                    {
+                        rootEnd = 1;
+                        isAbsolute = true;
+                    }
+                }
+                else if (NodePathAlgorithms.IsWindowsSeparator(code))
+                {
+                    // A leading separator means the path is absolute one way or another, UNC or not.
+                    isAbsolute = true;
+
+                    if (NodePathAlgorithms.IsWindowsSeparator(path[1]))
+                    {
+                        var j = 2;
+                        var last = j;
+                        while (j < len && !NodePathAlgorithms.IsWindowsSeparator(path[j]))
+                        {
+                            j++;
+                        }
+
+                        if (j < len && j != last)
+                        {
+                            var firstPart = path.Substring(last, j - last);
+                            last = j;
+                            while (j < len && NodePathAlgorithms.IsWindowsSeparator(path[j]))
+                            {
+                                j++;
+                            }
+
+                            if (j < len && j != last)
+                            {
+                                last = j;
+                                while (j < len && !NodePathAlgorithms.IsWindowsSeparator(path[j]))
+                                {
+                                    j++;
+                                }
+
+                                if (j == len || j != last)
+                                {
+                                    if (!string.Equals(firstPart, ".", StringComparison.Ordinal)
+                                        && !string.Equals(firstPart, "?", StringComparison.Ordinal))
+                                    {
+                                        // A UNC root: \\server\share.
+                                        device = @"\\" + firstPart + Separator + path.Substring(last, j - last);
+                                        rootEnd = j;
+                                    }
+                                    else
+                                    {
+                                        // A device root, as in \\.\PHYSICALDRIVE0.
+                                        device = @"\\" + firstPart;
+                                        rootEnd = 4;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        rootEnd = 1;
+                    }
+                }
+                else if (NodePathAlgorithms.IsWindowsDeviceRoot(code) && path[1] == ':')
+                {
+                    device = path.Substring(0, 2);
+                    rootEnd = 2;
+                    if (len > 2 && NodePathAlgorithms.IsWindowsSeparator(path[2]))
+                    {
+                        // A separator after the drive name is what makes it absolute rather than
+                        // relative to that drive's own current directory.
+                        isAbsolute = true;
+                        rootEnd = 3;
+                    }
+                }
+
+                if (device.Length > 0)
+                {
+                    if (resolvedDevice.Length > 0)
+                    {
+                        if (!string.Equals(device, resolvedDevice, StringComparison.OrdinalIgnoreCase))
+                        {
+                            // Another device entirely, so this segment cannot contribute.
+                            continue;
+                        }
+                    }
+                    else
+                    {
+                        resolvedDevice = device;
+                    }
+                }
+
+                if (resolvedAbsolute)
+                {
+                    if (resolvedDevice.Length > 0)
+                    {
+                        break;
+                    }
+                }
+                else
+                {
+                    resolvedTail.Insert(0, Separator, 1);
+                    resolvedTail.Insert(0, path.Substring(rootEnd));
+                    resolvedAbsolute = isAbsolute;
+                    if (isAbsolute && resolvedDevice.Length > 0)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            var normalized = NodePathAlgorithms.NormalizeString(
+                resolvedTail.AsSpan().ToString(),
+                !resolvedAbsolute,
+                Separator,
+                windowsSeparators: true);
+
+            if (resolvedAbsolute)
+            {
+                return resolvedDevice + Separator + normalized;
+            }
+
+            var relative = resolvedDevice + normalized;
+            return relative.Length > 0 ? relative : ".";
+        }
+        finally
+        {
+            resolvedTail.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// <c>path.normalize(path)</c> for Windows paths. "Multiple, sequential path segment separation characters
+    /// are replaced by a single instance of the platform-specific path segment separator", <c>..</c> and
+    /// <c>.</c> are resolved, and a trailing separator is preserved.
+    /// <para>
+    /// https://nodejs.org/api/path.html#pathnormalizepath
+    /// </para>
+    /// </summary>
+    internal static string Normalize(string path)
+    {
+        var len = path.Length;
+        if (len == 0)
+        {
+            return ".";
+        }
+
+        var rootEnd = 0;
+        string? device = null;
+        var isAbsolute = false;
+        var code = path[0];
+
+        if (len == 1)
+        {
+            // A lone forward slash becomes the platform separator; anything else is already normal.
+            return NodePathAlgorithms.IsPosixSeparator(code) ? "\\" : path;
+        }
+
+        if (NodePathAlgorithms.IsWindowsSeparator(code))
+        {
+            isAbsolute = true;
+
+            if (NodePathAlgorithms.IsWindowsSeparator(path[1]))
+            {
+                var j = 2;
+                var last = j;
+                while (j < len && !NodePathAlgorithms.IsWindowsSeparator(path[j]))
+                {
+                    j++;
+                }
+
+                if (j < len && j != last)
+                {
+                    var firstPart = path.Substring(last, j - last);
+                    last = j;
+                    while (j < len && NodePathAlgorithms.IsWindowsSeparator(path[j]))
+                    {
+                        j++;
+                    }
+
+                    if (j < len && j != last)
+                    {
+                        last = j;
+                        while (j < len && !NodePathAlgorithms.IsWindowsSeparator(path[j]))
+                        {
+                            j++;
+                        }
+
+                        if (j == len || j != last)
+                        {
+                            if (string.Equals(firstPart, ".", StringComparison.Ordinal)
+                                || string.Equals(firstPart, "?", StringComparison.Ordinal))
+                            {
+                                // A device root, as in \\.\PHYSICALDRIVE0.
+                                device = @"\\" + firstPart;
+                                rootEnd = 4;
+
+                                var deviceColonIndex = path.IndexOf(':');
+                                var possibleDevice = NodePathAlgorithms.Slice(path, 4, deviceColonIndex + 1);
+                                if (IsReservedName(possibleDevice, possibleDevice.Length - 1))
+                                {
+                                    // \\?\COM1: and friends: the reserved name is part of the root.
+                                    device = @"\\?\" + possibleDevice;
+                                    rootEnd = 4 + possibleDevice.Length;
+                                }
+                            }
+                            else if (j == len)
+                            {
+                                // A UNC root and nothing else, so there is nothing left to normalize.
+                                return @"\\" + firstPart + Separator + path.Substring(last) + Separator;
+                            }
+                            else
+                            {
+                                device = @"\\" + firstPart + Separator + path.Substring(last, j - last);
+                                rootEnd = j;
+                            }
+                        }
+                    }
+                }
+            }
+            else
+            {
+                rootEnd = 1;
+            }
+        }
+        else
+        {
+            var colonIndex = path.IndexOf(':');
+            if (colonIndex > 0)
+            {
+                if (NodePathAlgorithms.IsWindowsDeviceRoot(code) && colonIndex == 1)
+                {
+                    device = path.Substring(0, 2);
+                    rootEnd = 2;
+                    if (len > 2 && NodePathAlgorithms.IsWindowsSeparator(path[2]))
+                    {
+                        isAbsolute = true;
+                        rootEnd = 3;
+                    }
+                }
+                else if (IsReservedName(path, colonIndex))
+                {
+                    device = path.Substring(0, colonIndex + 1);
+                    rootEnd = colonIndex + 1;
+                }
+            }
+        }
+
+        var tail = rootEnd < len
+            ? NodePathAlgorithms.NormalizeString(path.Substring(rootEnd), !isAbsolute, Separator, windowsSeparators: true)
+            : string.Empty;
+
+        if (tail.Length == 0 && !isAbsolute)
+        {
+            tail = ".";
+        }
+
+        if (tail.Length > 0 && NodePathAlgorithms.IsWindowsSeparator(path[len - 1]))
+        {
+            tail += Separator;
+        }
+
+        if (!isAbsolute && device is null && path.Contains(':'))
+        {
+            // A relative path that has not been pinned to a device must not normalize into something Windows
+            // would read as absolute. See CVE-2024-36139.
+            if (tail.Length >= 2 && NodePathAlgorithms.IsWindowsDeviceRoot(tail[0]) && tail[1] == ':')
+            {
+                return ".\\" + tail;
+            }
+
+            var index = path.IndexOf(':');
+            do
+            {
+                if (index == len - 1 || NodePathAlgorithms.IsWindowsSeparator(path[index + 1]))
+                {
+                    return ".\\" + tail;
+                }
+
+                index = path.IndexOf(':', index + 1);
+            }
+            while (index != -1);
+        }
+
+        if (IsReservedName(path, path.IndexOf(':')))
+        {
+            return ".\\" + (device ?? string.Empty) + tail;
+        }
+
+        if (device is null)
+        {
+            return isAbsolute ? Separator + tail : tail;
+        }
+
+        return isAbsolute ? device + Separator + tail : device + tail;
+    }
+
+    /// <summary>
+    /// <c>path.isAbsolute(path)</c> for Windows paths: a leading separator, or a drive letter followed by a
+    /// colon and a separator. "It's not safe for mitigating path traversals."
+    /// <para>
+    /// https://nodejs.org/api/path.html#pathisabsolutepath
+    /// </para>
+    /// </summary>
+    internal static bool IsAbsolute(string path)
+    {
+        var len = path.Length;
+        if (len == 0)
+        {
+            return false;
+        }
+
+        var code = path[0];
+        return NodePathAlgorithms.IsWindowsSeparator(code)
+               || (len > 2
+                   && NodePathAlgorithms.IsWindowsDeviceRoot(code)
+                   && path[1] == ':'
+                   && NodePathAlgorithms.IsWindowsSeparator(path[2]));
+    }
+
+    /// <summary>
+    /// <c>path.join([...paths])</c> for Windows paths.
+    /// <para>
+    /// https://nodejs.org/api/path.html#pathjoinpaths
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// The leading-slash dance is Node's: a joined path must not start with two separators, because
+    /// <c>normalize</c> would then read it as a UNC root — unless the first non-empty segment itself starts
+    /// with exactly two, which is how <c>path.join('//server', 'share')</c> deliberately builds one.
+    /// </remarks>
+    internal static string Join(IReadOnlyList<string> paths)
+    {
+        if (paths.Count == 0)
+        {
+            return ".";
+        }
+
+        var segments = new List<string>(paths.Count);
+        for (var i = 0; i < paths.Count; ++i)
+        {
+            if (paths[i].Length > 0)
+            {
+                segments.Add(paths[i]);
+            }
+        }
+
+        if (segments.Count == 0)
+        {
+            return ".";
+        }
+
+        var firstPart = segments[0];
+        var joined = string.Join(Separator, segments);
+
+        var needsReplace = true;
+        var slashCount = 0;
+        if (NodePathAlgorithms.IsWindowsSeparator(firstPart[0]))
+        {
+            ++slashCount;
+            var firstLen = firstPart.Length;
+            if (firstLen > 1 && NodePathAlgorithms.IsWindowsSeparator(firstPart[1]))
+            {
+                ++slashCount;
+                if (firstLen > 2)
+                {
+                    if (NodePathAlgorithms.IsWindowsSeparator(firstPart[2]))
+                    {
+                        ++slashCount;
+                    }
+                    else
+                    {
+                        // The first part is itself a UNC path, so its two leading separators stay.
+                        needsReplace = false;
+                    }
+                }
+            }
+        }
+
+        if (needsReplace)
+        {
+            while (slashCount < joined.Length && NodePathAlgorithms.IsWindowsSeparator(joined[slashCount]))
+            {
+                slashCount++;
+            }
+
+            if (slashCount >= 2)
+            {
+                joined = Separator + joined.Substring(slashCount);
+            }
+        }
+
+        // A reserved device name anywhere in the joined path skips normalization entirely; only the forward
+        // slashes are turned around, so nothing collapses a segment Windows would resolve as a device.
+        if (ContainsReservedSegment(joined))
+        {
+            return joined.Replace('/', Separator);
+        }
+
+        return Normalize(joined);
+    }
+
+    private static bool ContainsReservedSegment(string joined)
+    {
+        var start = 0;
+        for (var i = 0; i <= joined.Length; i++)
+        {
+            if (i != joined.Length && joined[i] != Separator)
+            {
+                continue;
+            }
+
+            if (i > start)
+            {
+                var part = joined.Substring(start, i - start);
+                var colonIndex = part.IndexOf(':');
+                if (colonIndex != -1 && IsReservedName(part, colonIndex))
+                {
+                    return true;
+                }
+            }
+
+            start = i + 1;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// <c>path.relative(from, to)</c> for Windows paths. Comparison is case-insensitive, as the file system
+    /// is; the answer is spelled with the casing <c>to</c> resolved to.
+    /// <para>
+    /// https://nodejs.org/api/path.html#pathrelativefrom-to
+    /// </para>
+    /// </summary>
+    internal static string Relative(string cwd, bool platformIsWindows, string from, string to)
+    {
+        if (string.Equals(from, to, StringComparison.Ordinal))
+        {
+            return string.Empty;
+        }
+
+        var fromOrig = Resolve(cwd, platformIsWindows, [from]);
+        var toOrig = Resolve(cwd, platformIsWindows, [to]);
+
+        if (string.Equals(fromOrig, toOrig, StringComparison.Ordinal))
+        {
+            return string.Empty;
+        }
+
+        from = fromOrig.ToLowerInvariant();
+        to = toOrig.ToLowerInvariant();
+
+        if (string.Equals(from, to, StringComparison.Ordinal))
+        {
+            return string.Empty;
+        }
+
+        if (fromOrig.Length != from.Length || toOrig.Length != to.Length)
+        {
+            // Lowercasing changed the length, so the character-by-character walk below would compare
+            // misaligned strings. Node falls back to a segment-wise comparison for exactly this case.
+            return RelativeBySegments(fromOrig, toOrig);
+        }
+
+        // Leading backslashes, then trailing ones (which only a UNC path can carry).
+        var fromStart = 0;
+        while (fromStart < from.Length && from[fromStart] == Separator)
+        {
+            fromStart++;
+        }
+
+        var fromEnd = from.Length;
+        while (fromEnd - 1 > fromStart && from[fromEnd - 1] == Separator)
+        {
+            fromEnd--;
+        }
+
+        var fromLen = fromEnd - fromStart;
+
+        var toStart = 0;
+        while (toStart < to.Length && to[toStart] == Separator)
+        {
+            toStart++;
+        }
+
+        var toEnd = to.Length;
+        while (toEnd - 1 > toStart && to[toEnd - 1] == Separator)
+        {
+            toEnd--;
+        }
+
+        var toLen = toEnd - toStart;
+
+        var length = fromLen < toLen ? fromLen : toLen;
+        var lastCommonSep = -1;
+        var i = 0;
+        for (; i < length; i++)
+        {
+            var fromCode = from[fromStart + i];
+            if (fromCode != to[toStart + i])
+            {
+                break;
+            }
+
+            if (fromCode == Separator)
+            {
+                lastCommonSep = i;
+            }
+        }
+
+        if (i != length)
+        {
+            if (lastCommonSep == -1)
+            {
+                // The two paths diverge before the first shared separator, so there is no relative route.
+                return toOrig;
+            }
+        }
+        else
+        {
+            if (toLen > length)
+            {
+                if (to[toStart + i] == Separator)
+                {
+                    // `from` is the exact base path of `to`: from='C:\foo\bar', to='C:\foo\bar\baz'.
+                    return toOrig.Substring(toStart + i + 1);
+                }
+
+                if (i == 2)
+                {
+                    // `from` is the device root: from='C:\', to='C:\foo'.
+                    return toOrig.Substring(toStart + i);
+                }
+            }
+
+            if (fromLen > length)
+            {
+                if (from[fromStart + i] == Separator)
+                {
+                    // `to` is the exact base path of `from`: from='C:\foo\bar', to='C:\foo'.
+                    lastCommonSep = i;
+                }
+                else if (i == 2)
+                {
+                    // `to` is the device root: from='C:\foo\bar', to='C:\'.
+                    lastCommonSep = 3;
+                }
+            }
+
+            if (lastCommonSep == -1)
+            {
+                lastCommonSep = 0;
+            }
+        }
+
+        var output = new ValueStringBuilder(stackalloc char[64]);
+        try
+        {
+            for (i = fromStart + lastCommonSep + 1; i <= fromEnd; ++i)
+            {
+                if (i == fromEnd || from[i] == Separator)
+                {
+                    output.Append(output.Length == 0 ? ".." : @"\..");
+                }
+            }
+
+            toStart += lastCommonSep;
+
+            if (output.Length > 0)
+            {
+                output.Append(NodePathAlgorithms.Slice(toOrig, toStart, toEnd));
+                return output.AsSpan().ToString();
+            }
+
+            if (toStart < toOrig.Length && toOrig[toStart] == Separator)
+            {
+                ++toStart;
+            }
+
+            return NodePathAlgorithms.Slice(toOrig, toStart, toEnd);
+        }
+        finally
+        {
+            output.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// The segment-wise half of <c>relative</c>, taken when lowercasing changed a string's length — a Turkish
+    /// dotted capital, say. Comparing segment by segment is what keeps the two sides aligned.
+    /// </summary>
+    private static string RelativeBySegments(string fromOrig, string toOrig)
+    {
+        var fromSplit = new List<string>(fromOrig.Split(Separator));
+        var toSplit = new List<string>(toOrig.Split(Separator));
+
+        if (fromSplit.Count > 0 && fromSplit[fromSplit.Count - 1].Length == 0)
+        {
+            fromSplit.RemoveAt(fromSplit.Count - 1);
+        }
+
+        if (toSplit.Count > 0 && toSplit[toSplit.Count - 1].Length == 0)
+        {
+            toSplit.RemoveAt(toSplit.Count - 1);
+        }
+
+        var fromLen = fromSplit.Count;
+        var toLen = toSplit.Count;
+        var length = fromLen < toLen ? fromLen : toLen;
+
+        int i;
+        for (i = 0; i < length; i++)
+        {
+            if (!string.Equals(fromSplit[i], toSplit[i], StringComparison.OrdinalIgnoreCase))
+            {
+                break;
+            }
+        }
+
+        if (i == 0)
+        {
+            return toOrig;
+        }
+
+        if (i == length)
+        {
+            if (toLen > length)
+            {
+                return string.Join(Separator, toSplit.GetRange(i, toLen - i));
+            }
+
+            if (fromLen > length)
+            {
+                return Repeat(@"..\", fromLen - 1 - i) + "..";
+            }
+
+            return string.Empty;
+        }
+
+        return Repeat(@"..\", fromLen - i) + string.Join(Separator, toSplit.GetRange(i, toLen - i));
+    }
+
+    private static string Repeat(string value, int count)
+    {
+        if (count <= 0)
+        {
+            return string.Empty;
+        }
+
+        var builder = new ValueStringBuilder(stackalloc char[32]);
+        try
+        {
+            for (var i = 0; i < count; i++)
+            {
+                builder.Append(value);
+            }
+
+            return builder.AsSpan().ToString();
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// <c>path.toNamespacedPath(path)</c>: "an equivalent namespace-prefixed path", which is what lets Windows
+    /// open a path longer than <c>MAX_PATH</c>. A path that is not absolute, or already prefixed, is returned
+    /// unchanged.
+    /// <para>
+    /// https://nodejs.org/api/path.html#pathtonamespacedpathpath
+    /// </para>
+    /// </summary>
+    internal static string ToNamespacedPath(string cwd, bool platformIsWindows, string path)
+    {
+        if (path.Length == 0)
+        {
+            return path;
+        }
+
+        var resolvedPath = Resolve(cwd, platformIsWindows, [path]);
+
+        if (resolvedPath.Length <= 2)
+        {
+            return path;
+        }
+
+        if (resolvedPath[0] == Separator)
+        {
+            if (resolvedPath[1] == Separator)
+            {
+                var code = resolvedPath[2];
+                if (code != '?' && code != '.')
+                {
+#pragma warning disable CA1845 // string.Concat(ReadOnlySpan<char>, ...) is netstandard2.1+, and net462 is a target
+                    return @"\\?\UNC\" + resolvedPath.Substring(2);
+#pragma warning restore CA1845
+                }
+            }
+        }
+        else if (NodePathAlgorithms.IsWindowsDeviceRoot(resolvedPath[0])
+                 && resolvedPath[1] == ':'
+                 && resolvedPath[2] == Separator)
+        {
+            return @"\\?\" + resolvedPath;
+        }
+
+        return resolvedPath;
+    }
+
+    /// <summary>
+    /// <c>path.dirname(path)</c> for Windows paths. "Trailing directory separators are ignored", and a UNC
+    /// root with nothing under it is its own directory.
+    /// <para>
+    /// https://nodejs.org/api/path.html#pathdirnamepath
+    /// </para>
+    /// </summary>
+    internal static string Dirname(string path)
+    {
+        var len = path.Length;
+        if (len == 0)
+        {
+            return ".";
+        }
+
+        var rootEnd = -1;
+        var offset = 0;
+        var code = path[0];
+
+        if (len == 1)
+        {
+            return NodePathAlgorithms.IsWindowsSeparator(code) ? path : ".";
+        }
+
+        if (NodePathAlgorithms.IsWindowsSeparator(code))
+        {
+            rootEnd = offset = 1;
+
+            if (NodePathAlgorithms.IsWindowsSeparator(path[1]))
+            {
+                var j = 2;
+                var last = j;
+                while (j < len && !NodePathAlgorithms.IsWindowsSeparator(path[j]))
+                {
+                    j++;
+                }
+
+                if (j < len && j != last)
+                {
+                    last = j;
+                    while (j < len && NodePathAlgorithms.IsWindowsSeparator(path[j]))
+                    {
+                        j++;
+                    }
+
+                    if (j < len && j != last)
+                    {
+                        last = j;
+                        while (j < len && !NodePathAlgorithms.IsWindowsSeparator(path[j]))
+                        {
+                            j++;
+                        }
+
+                        if (j == len)
+                        {
+                            // A UNC root and nothing else.
+                            return path;
+                        }
+
+                        if (j != last)
+                        {
+                            // Past the separator that follows the UNC root, so the root is treated as an
+                            // ordinary root on top of a root.
+                            rootEnd = offset = j + 1;
+                        }
+                    }
+                }
+            }
+        }
+        else if (NodePathAlgorithms.IsWindowsDeviceRoot(code) && path[1] == ':')
+        {
+            rootEnd = len > 2 && NodePathAlgorithms.IsWindowsSeparator(path[2]) ? 3 : 2;
+            offset = rootEnd;
+        }
+
+        var end = -1;
+        var matchedSlash = true;
+        for (var i = len - 1; i >= offset; --i)
+        {
+            if (NodePathAlgorithms.IsWindowsSeparator(path[i]))
+            {
+                if (!matchedSlash)
+                {
+                    end = i;
+                    break;
+                }
+            }
+            else
+            {
+                matchedSlash = false;
+            }
+        }
+
+        if (end == -1)
+        {
+            if (rootEnd == -1)
+            {
+                return ".";
+            }
+
+            end = rootEnd;
+        }
+
+        return path.Substring(0, end);
+    }
+
+    /// <summary>
+    /// <c>path.basename(path[, suffix])</c> for Windows paths. "File extensions are treated case-sensitively
+    /// even on Windows", which is why <c>path.win32.basename('C:\\foo.HTML', '.html')</c> answers
+    /// <c>foo.HTML</c>.
+    /// <para>
+    /// https://nodejs.org/api/path.html#pathbasenamepath-suffix
+    /// </para>
+    /// </summary>
+    internal static string Basename(string path, string? suffix)
+    {
+        var start = 0;
+        var end = -1;
+        var matchedSlash = true;
+
+        // A drive prefix is skipped so that the separator after it is not mistaken for a trailing one.
+        if (path.Length >= 2 && NodePathAlgorithms.IsWindowsDeviceRoot(path[0]) && path[1] == ':')
+        {
+            start = 2;
+        }
+
+        if (suffix is not null && suffix.Length > 0 && suffix.Length <= path.Length)
+        {
+            if (string.Equals(suffix, path, StringComparison.Ordinal))
+            {
+                return string.Empty;
+            }
+
+            var extIdx = suffix.Length - 1;
+            var firstNonSlashEnd = -1;
+            for (var i = path.Length - 1; i >= start; --i)
+            {
+                var code = path[i];
+                if (NodePathAlgorithms.IsWindowsSeparator(code))
+                {
+                    if (!matchedSlash)
+                    {
+                        start = i + 1;
+                        break;
+                    }
+                }
+                else
+                {
+                    if (firstNonSlashEnd == -1)
+                    {
+                        matchedSlash = false;
+                        firstNonSlashEnd = i + 1;
+                    }
+
+                    if (extIdx >= 0)
+                    {
+                        if (code == suffix[extIdx])
+                        {
+                            if (--extIdx == -1)
+                            {
+                                end = i;
+                            }
+                        }
+                        else
+                        {
+                            extIdx = -1;
+                            end = firstNonSlashEnd;
+                        }
+                    }
+                }
+            }
+
+            if (start == end)
+            {
+                end = firstNonSlashEnd;
+            }
+            else if (end == -1)
+            {
+                end = path.Length;
+            }
+
+            return NodePathAlgorithms.Slice(path, start, end);
+        }
+
+        for (var i = path.Length - 1; i >= start; --i)
+        {
+            if (NodePathAlgorithms.IsWindowsSeparator(path[i]))
+            {
+                if (!matchedSlash)
+                {
+                    start = i + 1;
+                    break;
+                }
+            }
+            else if (end == -1)
+            {
+                matchedSlash = false;
+                end = i + 1;
+            }
+        }
+
+        if (end == -1)
+        {
+            return string.Empty;
+        }
+
+        return path.Substring(start, end - start);
+    }
+
+    /// <summary>
+    /// <c>path.extname(path)</c> for Windows paths.
+    /// <para>
+    /// https://nodejs.org/api/path.html#pathextnamepath
+    /// </para>
+    /// </summary>
+    internal static string Extname(string path)
+    {
+        var start = 0;
+        var startDot = -1;
+        var startPart = 0;
+        var end = -1;
+        var matchedSlash = true;
+        var preDotState = 0;
+
+        if (path.Length >= 2 && path[1] == ':' && NodePathAlgorithms.IsWindowsDeviceRoot(path[0]))
+        {
+            start = startPart = 2;
+        }
+
+        for (var i = path.Length - 1; i >= start; --i)
+        {
+            var code = path[i];
+            if (NodePathAlgorithms.IsWindowsSeparator(code))
+            {
+                if (!matchedSlash)
+                {
+                    startPart = i + 1;
+                    break;
+                }
+
+                continue;
+            }
+
+            if (end == -1)
+            {
+                matchedSlash = false;
+                end = i + 1;
+            }
+
+            if (code == '.')
+            {
+                if (startDot == -1)
+                {
+                    startDot = i;
+                }
+                else if (preDotState != 1)
+                {
+                    preDotState = 1;
+                }
+            }
+            else if (startDot != -1)
+            {
+                preDotState = -1;
+            }
+        }
+
+        if (startDot == -1
+            || end == -1
+            || preDotState == 0
+            || (preDotState == 1 && startDot == end - 1 && startDot == startPart + 1))
+        {
+            return string.Empty;
+        }
+
+        return path.Substring(startDot, end - startDot);
+    }
+
+    /// <summary>
+    /// <c>path.parse(path)</c> for Windows paths. "If the directory is the root, use the entire root as the
+    /// <c>dir</c> including the trailing slash if any."
+    /// <para>
+    /// https://nodejs.org/api/path.html#pathparsepath
+    /// </para>
+    /// </summary>
+    internal static ParsedPath Parse(string path)
+    {
+        if (path.Length == 0)
+        {
+            return ParsedPath.Empty;
+        }
+
+        var len = path.Length;
+        var rootEnd = 0;
+        var code = path[0];
+
+        if (len == 1)
+        {
+            if (NodePathAlgorithms.IsWindowsSeparator(code))
+            {
+                return new ParsedPath(path, path, "", "", "");
+            }
+
+            return new ParsedPath("", "", path, "", path);
+        }
+
+        if (NodePathAlgorithms.IsWindowsSeparator(code))
+        {
+            rootEnd = 1;
+            if (NodePathAlgorithms.IsWindowsSeparator(path[1]))
+            {
+                var j = 2;
+                var last = j;
+                while (j < len && !NodePathAlgorithms.IsWindowsSeparator(path[j]))
+                {
+                    j++;
+                }
+
+                if (j < len && j != last)
+                {
+                    last = j;
+                    while (j < len && NodePathAlgorithms.IsWindowsSeparator(path[j]))
+                    {
+                        j++;
+                    }
+
+                    if (j < len && j != last)
+                    {
+                        last = j;
+                        while (j < len && !NodePathAlgorithms.IsWindowsSeparator(path[j]))
+                        {
+                            j++;
+                        }
+
+                        if (j == len)
+                        {
+                            rootEnd = j;
+                        }
+                        else if (j != last)
+                        {
+                            rootEnd = j + 1;
+                        }
+                    }
+                }
+            }
+        }
+        else if (NodePathAlgorithms.IsWindowsDeviceRoot(code) && path[1] == ':')
+        {
+            if (len <= 2)
+            {
+                return new ParsedPath(path, path, "", "", "");
+            }
+
+            rootEnd = 2;
+            if (NodePathAlgorithms.IsWindowsSeparator(path[2]))
+            {
+                if (len == 3)
+                {
+                    return new ParsedPath(path, path, "", "", "");
+                }
+
+                rootEnd = 3;
+            }
+        }
+
+        var root = rootEnd > 0 ? path.Substring(0, rootEnd) : string.Empty;
+
+        var startDot = -1;
+        var startPart = rootEnd;
+        var end = -1;
+        var matchedSlash = true;
+        var preDotState = 0;
+
+        for (var i = len - 1; i >= rootEnd; --i)
+        {
+            code = path[i];
+            if (NodePathAlgorithms.IsWindowsSeparator(code))
+            {
+                if (!matchedSlash)
+                {
+                    startPart = i + 1;
+                    break;
+                }
+
+                continue;
+            }
+
+            if (end == -1)
+            {
+                matchedSlash = false;
+                end = i + 1;
+            }
+
+            if (code == '.')
+            {
+                if (startDot == -1)
+                {
+                    startDot = i;
+                }
+                else if (preDotState != 1)
+                {
+                    preDotState = 1;
+                }
+            }
+            else if (startDot != -1)
+            {
+                preDotState = -1;
+            }
+        }
+
+        var name = string.Empty;
+        var baseName = string.Empty;
+        var ext = string.Empty;
+
+        if (end != -1)
+        {
+            if (startDot == -1
+                || preDotState == 0
+                || (preDotState == 1 && startDot == end - 1 && startDot == startPart + 1))
+            {
+                baseName = name = path.Substring(startPart, end - startPart);
+            }
+            else
+            {
+                name = path.Substring(startPart, startDot - startPart);
+                baseName = path.Substring(startPart, end - startPart);
+                ext = path.Substring(startDot, end - startDot);
+            }
+        }
+
+        var dir = startPart > 0 && startPart != rootEnd
+            ? path.Substring(0, startPart - 1)
+            : root;
+
+        return new ParsedPath(root, dir, baseName, ext, name);
+    }
+}

--- a/Jint/Options.NodeCompat.cs
+++ b/Jint/Options.NodeCompat.cs
@@ -1,0 +1,21 @@
+using Jint.NodeCompat;
+
+namespace Jint;
+
+public partial class Options
+{
+    /// <summary>
+    /// The <c>node:</c> builtin modules an engine built from these options provides, or null when the host
+    /// never asked for them — which is the default, and the state in which nothing about module resolution
+    /// changes at all.
+    /// </summary>
+    /// <remarks>
+    /// Set by <see cref="NodeBuiltinModuleOptionsExtensions.UseNodeBuiltinModules"/> and read by
+    /// <c>Options.Apply</c>, which is where the configured module loader is wrapped. Deliberately not a
+    /// mutation of <see cref="Modules"/>'s loader: the host's <see cref="ModuleOptions.ModuleLoader"/> keeps
+    /// reading back exactly what the host set — the same posture <c>WebApiFeatures</c> takes about the feature
+    /// closure fetch brings with it — and the order of <c>UseNodeBuiltinModules</c> and
+    /// <c>EnableModules</c> stops mattering.
+    /// </remarks>
+    internal NodeBuiltinModuleConfiguration? _nodeBuiltinModules;
+}

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -202,7 +202,15 @@ public partial class Options
         // Modules must exist before the configuration callbacks run: a host's
         // options.Configure(e => e.Modules.Add(...)) is the documented way to
         // register programmatic modules at construction time.
-        engine.Modules = new Engine.ModuleOperations(engine, Modules.ModuleLoader);
+        //
+        // The opt-in node: builtins are a decorator over whatever loader the host configured, applied here
+        // rather than in UseNodeBuiltinModules so that the order of that call and EnableModules cannot
+        // matter, and so that options.Modules.ModuleLoader keeps reading back what the host set.
+        var moduleLoader = _nodeBuiltinModules is null
+            ? Modules.ModuleLoader
+            : NodeCompat.NodeBuiltinModuleLoader.Wrap(Modules.ModuleLoader, _nodeBuiltinModules);
+
+        engine.Modules = new Engine.ModuleOperations(engine, moduleLoader);
 
         foreach (var configuration in _configurations)
         {

--- a/Jint/Runtime/Throw.cs
+++ b/Jint/Runtime/Throw.cs
@@ -163,6 +163,13 @@ internal static class Throw
         throw new JavaScriptException(realm.Intrinsics.RangeError, message).SetJavaScriptLocation(in location);
     }
 
+    [DoesNotReturn]
+    public static void UriError(Realm realm, string? message = null)
+    {
+        var location = realm.GlobalObject.Engine.GetLastSyntaxElement()?.Location ?? default;
+        throw new JavaScriptException(realm.Intrinsics.UriError, message).SetJavaScriptLocation(in location);
+    }
+
     public static ErrorDispatchInfo CreateUriError(Realm realm, string message)
     {
         return new ErrorDispatchInfo(realm.Intrinsics.UriError, message);

--- a/Jint/WebApi/Url/Parsing/Idna.cs
+++ b/Jint/WebApi/Url/Parsing/Idna.cs
@@ -126,6 +126,38 @@ internal static class Idna
         }
     }
 
+    /// <summary>
+    /// Unicode ToUnicode: the inverse mapping, which turns every <c>xn--</c> label back into the characters it
+    /// encodes. Returns <see langword="false"/> when the platform reports the domain as invalid, which is the
+    /// failure value <c>url.domainToUnicode</c> reports as an empty string.
+    /// </summary>
+    /// <remarks>
+    /// The URL Standard never needs this direction — a URL record stores the ASCII form — so it exists for
+    /// <c>node:url</c>'s <c>domainToUnicode</c> and for the UNC host of <c>fileURLToPath</c>, which is the one
+    /// place Node decodes a host back before handing it to the file system. The same platform divergences
+    /// listed above apply.
+    /// </remarks>
+    internal static bool TryToUnicode(string domain, out string result)
+    {
+        try
+        {
+            var mapping = _mapping ??= new IdnMapping { AllowUnassigned = true, UseStd3AsciiRules = false };
+            result = mapping.GetUnicode(domain);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            result = string.Empty;
+            return false;
+        }
+        catch (NotSupportedException)
+        {
+            // Globalization-invariant mode, or a platform without the ICU data. Reported by Fidelity.
+            result = string.Empty;
+            return false;
+        }
+    }
+
     private static IdnaFidelity Probe()
     {
         if (!TryToAscii(ProbeDomain, out var result))

--- a/README.md
+++ b/README.md
@@ -603,6 +603,51 @@ option is read once, when `UseNodeProcess` returns, so one `Options` instance st
 engines. **Unlike the web APIs above, this needs no particular target framework**: it compiles for every one
 Jint targets.
 
+### `node:` builtin modules (opt-in)
+
+After resolution, the next wall a package published for Node runs into is `import 'node:path'`.
+`UseNodeBuiltinModules()` supplies the ones that are pure string utilities — no file system, no process, no
+network, no clock — and nothing else.
+
+```csharp
+var engine = new Engine(options => options
+    .EnableModules(new NodeStyleModuleLoader(@"C:\app"))
+    .UseNodeBuiltinModules());
+
+engine.Modules.Import("./main.js"); // main.js, and anything in node_modules, may import 'node:path'
+```
+
+| Module | What it provides |
+| --- | --- |
+| `node:path` | `resolve`, `normalize`, `isAbsolute`, `join`, `relative`, `dirname`, `basename`, `extname`, `format`, `parse`, `toNamespacedPath`, `sep`, `delimiter`, and both flavours as `posix` and `win32`. `matchesGlob` is absent — it is the one member that is not string arithmetic. |
+| `node:path/posix`, `node:path/win32` | The two flavours as modules of their own. |
+| `node:querystring` | `parse`/`decode`, `stringify`/`encode`, `escape`, `unescape`. `unescapeBuffer` is absent: it answers with a `Buffer`. |
+| `node:url` | `URL` and `URLSearchParams` (the engine's own WHATWG implementations, re-exported), `fileURLToPath`, `pathToFileURL`, `domainToASCII`, `domainToUnicode`. The legacy `url.parse`/`url.resolve`/`url.format` API is absent. |
+
+**Nothing that touches a platform resource is provided, and that is not a gap to be filled later.**
+`node:fs`, `node:buffer`, `node:crypto`, `node:os`, `node:child_process`, `node:http` and their kind are
+deliberately absent, so a script feature-detecting one takes its other branch instead of walking into a stub.
+An unknown `node:` specifier fails with a message naming what *is* available.
+
+Both spellings work — `import 'path'` as well as `import 'node:path'` — and both name one module, because a
+builtin outranks a `node_modules` package of the same name exactly as it does in Node
+([ESM_RESOLVE](https://nodejs.org/api/esm.html#resolution-algorithm-specification), PACKAGE_RESOLVE step 3).
+Set `AllowUnprefixedSpecifiers = false` for a tree that really does depend on an npm package called `path`,
+`url` or `querystring`.
+
+A module you register yourself wins: `engine.Modules.Add("node:path", …)` — or `Add("path", …)`, which
+resolves to the same key — replaces the builtin, and is also how you supply one of the modules Jint does not
+provide. Everything that is not a builtin keeps going to whichever loader you configured, in whichever order
+you called the two methods, and `options.Modules.ModuleLoader` still reads back exactly what you set.
+
+Two options are worth setting. `Platform` decides which flavour `node:path` defaults to and defaults to the
+platform you are on, the same answer `process.platform` gives. `WorkingDirectory` is what `path.resolve()` and
+`path.relative()` use where Node reads `process.cwd()`; like the `process` shim's, it defaults to `"/"` and
+**never** answers the real current directory.
+
+`node:querystring` and `node:url` need .NET 8 or newer, because both build on the engine's WHATWG URL
+implementation. `node:path` is available on every target framework Jint has.
+
 
 ## Performance
 


### PR DESCRIPTION
The next slice of #3088's npm-interop track: opt-in `node:` builtin modules — `node:path` (posix and win32 flavors plus the platform default, every TFM), `node:querystring` and `node:url` (net8+, over the in-tree WHATWG machinery) — via `options.UseNodeBuiltinModules()`.

Registration is a **loader decorator**, not a registration set: `Options.Apply` wraps whatever `Modules.ModuleLoader` the host configured (order can't matter, and it works with no loader at all), preserving async loaders through a second decorator type so a synchronous loader keeps its synchronous failure semantics. A host's own `Engine.Modules.Add("node:path", …)` wins with nothing checking for it, because builder registrations are consulted first; unknown `node:` names are deferred to load time so a host-registered `node:fs` is found, and only a genuinely unregistered one fails — with a message listing what is available. Both `path` and `node:path` spellings canonicalize to one module record, per ESM_RESOLVE's own step.

Semantics come from Node's docs plus its v22 sources for the corners the prose omits, and the test suite is largely **generated from real Node v24** (269 path cases with `process.cwd()` stubbed so no case depends on the host OS, 70 querystring, 28 url), plus a realistic `node_modules` package exercising `exports`, self-reference and the builtins end-to-end through the merged resolution loader. Seven small deviations are each documented with their rationale in the XML docs — the largest being that `path.resolve` validates every argument as the docs state rather than reproducing Node's stop-early quirk, and that error messages never render user values (the `SafeToDisplayString` concern).

Explicitly out, stated in code, README and the failure message: `node:fs`, `node:buffer`, `node:crypto` and everything else touching platform resources — that remains #3088's discussion.

815 new test cases across the TFMs; both suites green with and without `JINT_HOST_CONTRACT_VERIFICATION=1`.

Closes #3108

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G7Ud48VAs1JicxRZxLDxg
