### PR TITLE
Add Workers-style fetch handler hosting: HttpRequestMessage in, HttpResponseMessage out

### DIFF
--- a/Jint.Tests.PublicInterface/WebApiFetchHandlerTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiFetchHandlerTests.cs
@@ -1,0 +1,618 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Jint;
+using Jint.Native;
+using Jint.Runtime;
+using Jint.WebApi.Fetch;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// Fetch-handler hosting — <c>Engine.Advanced.SetFetchHandler</c> plus the two invoke shapes — seen from
+/// outside the assembly, which is the only place it is meant to be used from.
+/// </summary>
+/// <remarks>
+/// This project has no <c>InternalsVisibleTo</c>, so every type mentioned here is one a third-party host can
+/// reach: <see cref="HttpRequestMessage"/> in, <see cref="HttpResponseMessage"/> out, and nothing in between
+/// that is not already public.
+/// </remarks>
+public class WebApiFetchHandlerTests
+{
+    /// <summary>
+    /// The features fetch-handler hosting needs, and deliberately not <see cref="WebApiFeatures.Fetch"/> —
+    /// handling an inbound request is not a reason to grant the script outbound network access.
+    /// </summary>
+    private const WebApiFeatures ModelFeatures = WebApiFeatures.Events | WebApiFeatures.Url | WebApiFeatures.Files;
+
+    private static Engine Host(WebApiFeatures extra = WebApiFeatures.None, Action<Options>? configure = null)
+    {
+        return new Engine(options =>
+        {
+            options.UseWebApis(ModelFeatures | extra);
+            configure?.Invoke(options);
+        });
+    }
+
+    /// <summary>Builds an engine, evaluates <paramref name="source"/> and registers its <c>handler</c> global.</summary>
+    private static Engine Handler(string source, WebApiFeatures extra = WebApiFeatures.None, Action<Options>? configure = null)
+    {
+        var engine = Host(extra, configure);
+        engine.Execute(source);
+        engine.Advanced.SetFetchHandler(engine.GetValue("handler"));
+        return engine;
+    }
+
+    private static HttpRequestMessage Get(string url = "https://example.org/hello?q=1") => new(HttpMethod.Get, url);
+
+    /// <summary>
+    /// The response body as text. <see cref="HttpContent.ReadAsStream()"/> rather than the asynchronous
+    /// overload because every body here is a buffered <c>ByteArrayContent</c>, so there is nothing to wait
+    /// for and nothing to deadlock on.
+    /// </summary>
+    private static string Text(HttpResponseMessage response)
+    {
+        using var stream = response.Content.ReadAsStream();
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        return reader.ReadToEnd();
+    }
+
+    /// <summary>
+    /// Gives the engine turns until the operation finishes, and fails rather than spinning forever if it
+    /// never does.
+    /// </summary>
+    private static HttpResponseMessage Pump(Engine engine, FetchHandlerOperation operation)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (!operation.IsCompleted)
+        {
+            engine.Advanced.ProcessTasks();
+            if (operation.IsCompleted)
+            {
+                break;
+            }
+
+            if (stopwatch.Elapsed > TimeSpan.FromSeconds(10))
+            {
+                Assert.Fail("The fetch handler never completed.");
+            }
+
+            Thread.Sleep(1);
+        }
+
+        return operation.GetResult();
+    }
+
+    [Fact]
+    public void AnEngineWithoutTheObjectModelRefusesToRegisterAHandler()
+    {
+        var engine = new Engine();
+        engine.Execute("function handle(request) { return null; }");
+
+        var failure = Assert.Throws<InvalidOperationException>(() => engine.Advanced.SetFetchHandler(engine.GetValue("handle")));
+        failure.Message.Should().Contain("WebApiFeatures.Events | WebApiFeatures.Url | WebApiFeatures.Files");
+        failure.Message.Should().Contain("UseFetch");
+
+        // Half the closure is not enough either.
+        var partial = new Engine(options => options.UseWebApis(WebApiFeatures.Events | WebApiFeatures.Url));
+        partial.Execute("function handle(request) { return null; }");
+        Assert.Throws<InvalidOperationException>(() => partial.Advanced.SetFetchHandler(partial.GetValue("handle")));
+
+        // ... and enabling fetch itself satisfies it, because that flag implies all three.
+        var fetching = new Engine(options => options.UseFetch());
+        fetching.Execute("function handle(request) { return null; }");
+        fetching.Advanced.SetFetchHandler(fetching.GetValue("handle"));
+        fetching.Advanced.HasFetchHandler.Should().BeTrue();
+    }
+
+    [Fact]
+    public void RegisteringAHandlerInstallsTheObjectModelButNeverFetch()
+    {
+        var engine = Host();
+
+        // Before: the three interface objects are not there, because no feature flag named them.
+        engine.Evaluate("typeof Response").AsString().Should().Be("undefined");
+        engine.Advanced.HasFetchHandler.Should().BeFalse();
+
+        engine.Execute("function handle(request) { return new Response('x'); }");
+        engine.Advanced.SetFetchHandler(engine.GetValue("handle"));
+
+        engine.Evaluate("typeof Response").AsString().Should().Be("function");
+        engine.Evaluate("typeof Request").AsString().Should().Be("function");
+        engine.Evaluate("typeof Headers").AsString().Should().Be("function");
+        engine.Advanced.HasFetchHandler.Should().BeTrue();
+
+        // The whole point of the split: an inbound request is not a reason to grant outbound network access.
+        engine.Evaluate("typeof fetch").AsString().Should().Be("undefined");
+
+        // WebIDL interface object attributes — https://webidl.spec.whatwg.org/#es-interfaces.
+        var descriptor = engine.Evaluate("Object.getOwnPropertyDescriptor(globalThis, 'Response')").AsObject();
+        descriptor.Get("writable").AsBoolean().Should().BeTrue();
+        descriptor.Get("enumerable").AsBoolean().Should().BeFalse();
+        descriptor.Get("configurable").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void AGlobalTheHostRegisteredItselfIsNotReplaced()
+    {
+        var engine = Host(configure: options => options.Configure(e => e.SetValue("Response", "mine")));
+        engine.Execute("function handle(request) { return null; }");
+        engine.Advanced.SetFetchHandler(engine.GetValue("handle"));
+
+        engine.Evaluate("Response").AsString().Should().Be("mine");
+    }
+
+    [Fact]
+    public void RoutesASynchronousHandlerAndAnswersWithItsResponse()
+    {
+        var engine = Handler("globalThis.handler = { fetch(request) { return new Response('hello ' + request.method, { status: 201, statusText: 'Created' }); } };");
+
+        var operation = engine.Advanced.InvokeFetchHandler(Get());
+
+        // A synchronous answer needs no pump at all.
+        operation.IsCompleted.Should().BeTrue();
+        operation.IsFaulted.Should().BeFalse();
+
+        using var response = operation.GetResult();
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.ReasonPhrase.Should().Be("Created");
+        Text(response).Should().Be("hello GET");
+    }
+
+    [Fact]
+    public void TheRequestTheScriptSeesCarriesTheUrlMethodHeadersAndBody()
+    {
+        var engine = Handler("""
+            globalThis.handler = {
+                fetch(request) {
+                    return request.text().then(body => new Response(JSON.stringify({
+                        url: request.url,
+                        method: request.method,
+                        accept: request.headers.get('accept'),
+                        contentType: request.headers.get('content-type'),
+                        isRequest: request instanceof Request,
+                        hasSignal: !request.signal.aborted,
+                        body,
+                    })));
+                }
+            };
+            """);
+
+        var message = new HttpRequestMessage(HttpMethod.Post, "https://example.org/a/../b?q=1#frag")
+        {
+            Content = new StringContent("{\"n\":1}", Encoding.UTF8, "application/json"),
+        };
+        message.Headers.Add("Accept", "text/plain");
+
+        var payload = Pump(engine, engine.Advanced.InvokeFetchHandler(message));
+        var json = Text(payload);
+
+        // The URL is the WHATWG serialization of the absolute URI, so it is normalized.
+        json.Should().Contain("\"url\":\"https://example.org/b?q=1#frag\"");
+        json.Should().Contain("\"method\":\"POST\"");
+        json.Should().Contain("\"accept\":\"text/plain\"");
+
+        // A content header is part of the one header list the Fetch Standard has, so it has to be visible on
+        // request.headers even though System.Net.Http keeps it on the content.
+        json.Should().Contain("\"contentType\":\"application/json; charset=utf-8\"");
+        json.Should().Contain("\"isRequest\":true");
+        json.Should().Contain("\"hasSignal\":true");
+        json.Should().Contain("\"body\":\"{\\\"n\\\":1}\"");
+
+        payload.Dispose();
+    }
+
+    [Fact]
+    public void TheMethodIsNormalizedTheWayTheRequestConstructorNormalizesIt()
+    {
+        var engine = Handler("globalThis.handler = request => new Response(request.method);");
+
+        // https://fetch.spec.whatwg.org/#concept-method-normalize — the six standard methods only.
+        using var normalized = engine.Advanced.InvokeFetchHandler(new HttpRequestMessage(new HttpMethod("post"), "https://example.org/")).GetResult();
+        Text(normalized).Should().Be("POST");
+
+        using var untouched = engine.Advanced.InvokeFetchHandler(new HttpRequestMessage(new HttpMethod("patch"), "https://example.org/")).GetResult();
+        Text(untouched).Should().Be("patch");
+    }
+
+    [Fact]
+    public void MultiValuedHeadersSurviveInBothDirections()
+    {
+        var engine = Handler("""
+            globalThis.handler = {
+                fetch(request) {
+                    const headers = new Headers();
+                    headers.append('set-cookie', 'a=1; Path=/');
+                    headers.append('set-cookie', 'b=2; Path=/');
+                    headers.append('x-seen', request.headers.getSetCookie().join('|'));
+                    return new Response(null, { status: 204, headers });
+                }
+            };
+            """);
+
+        var message = Get();
+        message.Headers.Add("Set-Cookie", "in1=1");
+        message.Headers.Add("Set-Cookie", "in2=2");
+
+        using var response = engine.Advanced.InvokeFetchHandler(message).GetResult();
+
+        // Inbound: two headers of the same name are two entries, not one comma-joined value — which is the
+        // whole reason getSetCookie() exists.
+        response.Headers.GetValues("x-seen").Single().Should().Be("in1=1|in2=2");
+
+        // Outbound: likewise, because a Set-Cookie value may itself contain a comma.
+        response.Headers.GetValues("Set-Cookie").Should().Equal("a=1; Path=/", "b=2; Path=/");
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        // A response with no body and no content header carries no content of its own, which the framework
+        // reads back as an empty one rather than as null — so a host copying it never has to special-case it.
+        Text(response).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AContentHeaderLandsOnTheContentAndAFramingHeaderIsTheHostsOwn()
+    {
+        var engine = Handler("""
+            globalThis.handler = () => new Response('hi', {
+                headers: {
+                    'content-type': 'text/plain;charset=utf-8',
+                    'content-length': '999',
+                    'cache-control': 'no-store',
+                },
+            });
+            """);
+
+        using var response = engine.Advanced.InvokeFetchHandler(Get()).GetResult();
+
+        // System.Net.Http splits headers in two and refuses a content header on the response collection; the
+        // Fetch Standard has one list, so the conversion has to route each name to the half that accepts it.
+        response.Content.Headers.ContentType!.ToString().Should().Be("text/plain; charset=utf-8");
+        response.Headers.GetValues("cache-control").Single().Should().Be("no-store");
+        response.Headers.Any(header => string.Equals(header.Key, "content-type", StringComparison.OrdinalIgnoreCase)).Should().BeFalse();
+
+        // Content-Length is the host's stack's to compute: a script's claim about a body it is not sending is
+        // a response-splitting primitive, so it is dropped and the content answers for itself.
+        response.Content.Headers.ContentLength.Should().Be(2);
+    }
+
+    [Fact]
+    public void AContentHeaderOnABodilessResponseStillReachesTheWire()
+    {
+        var engine = Handler("globalThis.handler = () => new Response(null, { status: 200, headers: { 'content-type': 'application/json' } });");
+
+        using var response = engine.Advanced.InvokeFetchHandler(Get()).GetResult();
+        response.Content.Headers.ContentType!.MediaType.Should().Be("application/json");
+        Text(response).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ThePromiseHandlerCompletesOnAPumpedTurn()
+    {
+        var engine = Handler("globalThis.handler = { async fetch(request) { return new Response('async'); } };");
+
+        var operation = engine.Advanced.InvokeFetchHandler(Get());
+
+        // An async function's answer is a promise, and a promise needs a turn.
+        operation.IsCompleted.Should().BeFalse();
+        operation.Response.Should().BeNull();
+
+        using var response = Pump(engine, operation);
+        Text(response).Should().Be("async");
+    }
+
+    [Fact]
+    public async Task ThePromiseHandlerCompletesThroughTheAwaitableVariant()
+    {
+        var engine = Handler("globalThis.handler = { async fetch(request) { return new Response('awaited ' + request.url); } };");
+
+        using var response = await engine.Advanced.InvokeFetchHandlerAsync(Get("https://example.org/x"));
+        (await response.Content.ReadAsStringAsync()).Should().Be("awaited https://example.org/x");
+    }
+
+    [Fact]
+    public async Task TheAwaitableVariantReadsARequestBodyWithoutABufferedContent()
+    {
+        var engine = Handler("globalThis.handler = { async fetch(request) { return new Response(await request.text()); } };");
+
+        var message = new HttpRequestMessage(HttpMethod.Put, "https://example.org/")
+        {
+            Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes("streamed"))),
+        };
+
+        using var response = await engine.Advanced.InvokeFetchHandlerAsync(message);
+        (await response.Content.ReadAsStringAsync()).Should().Be("streamed");
+    }
+
+    [Fact]
+    public void ATimerInsideTheHandlerRunsWhileTheHostPumps()
+    {
+        var engine = Handler(
+            "globalThis.handler = () => new Promise(resolve => setTimeout(() => resolve(new Response('late')), 5));",
+            WebApiFeatures.Timers);
+
+        var operation = engine.Advanced.InvokeFetchHandler(Get());
+        operation.IsCompleted.Should().BeFalse();
+
+        using var response = Pump(engine, operation);
+        Text(response).Should().Be("late");
+    }
+
+    [Fact]
+    public void AHandlerThatThrowsFaultsTheOperationWithTheJavaScriptException()
+    {
+        var engine = Handler("globalThis.handler = () => { throw new TypeError('boom'); };");
+
+        var operation = engine.Advanced.InvokeFetchHandler(Get());
+
+        operation.IsCompleted.Should().BeTrue();
+        operation.IsFaulted.Should().BeTrue();
+        operation.Response.Should().BeNull();
+
+        // Never a synthesized 500: what a failure means on the wire is the host's decision, so the failure
+        // arrives as the exception it was.
+        var failure = Assert.IsType<JavaScriptException>(operation.Error);
+        failure.Error.Get("name").AsString().Should().Be("TypeError");
+        failure.Message.Should().Be("boom");
+
+        Assert.Throws<JavaScriptException>(() => operation.GetResult());
+    }
+
+    [Fact]
+    public void AnAsyncHandlerThatThrowsFaultsWithTheRejection()
+    {
+        var engine = Handler("globalThis.handler = { async fetch() { throw new Error('later'); } };");
+
+        var operation = engine.Advanced.InvokeFetchHandler(Get());
+        var stopwatch = Stopwatch.StartNew();
+        while (!operation.IsCompleted && stopwatch.Elapsed < TimeSpan.FromSeconds(10))
+        {
+            engine.Advanced.ProcessTasks();
+        }
+
+        operation.IsFaulted.Should().BeTrue();
+
+        // A throw inside an async function is a rejection, and a rejection reaching a host is a
+        // PromiseRejectedException everywhere else in Jint too.
+        var failure = Assert.IsType<PromiseRejectedException>(operation.Error);
+        failure.RejectedValue.AsObject().Get("message").AsString().Should().Be("later");
+    }
+
+    [Fact]
+    public async Task TheAwaitableVariantThrowsWhatTheHandlerFailedWith()
+    {
+        var throwing = Handler("globalThis.handler = () => { throw new TypeError('sync boom'); };");
+        var syncFailure = await Assert.ThrowsAsync<JavaScriptException>(() => throwing.Advanced.InvokeFetchHandlerAsync(Get()));
+        syncFailure.Message.Should().Be("sync boom");
+
+        var rejecting = Handler("globalThis.handler = { async fetch() { throw new Error('async boom'); } };");
+        var asyncFailure = await Assert.ThrowsAsync<PromiseRejectedException>(() => rejecting.Advanced.InvokeFetchHandlerAsync(Get()));
+        asyncFailure.RejectedValue.AsObject().Get("message").AsString().Should().Be("async boom");
+    }
+
+    [Fact]
+    public void AnExecutionConstraintThatFiresFaultsTheOperation()
+    {
+        var engine = Handler(
+            "globalThis.handler = () => { let n = 0; for (let i = 0; i < 10000; i++) { n += i; } return new Response(String(n)); };",
+            configure: options => options.MaxStatements(50));
+
+        var operation = engine.Advanced.InvokeFetchHandler(Get());
+
+        operation.IsCompleted.Should().BeTrue();
+        operation.IsFaulted.Should().BeTrue();
+        Assert.IsType<StatementsCountOverflowException>(operation.Error);
+
+        // The budget is per entry into the engine, so the engine is still usable afterwards — a handler that
+        // stays inside it answers normally.
+        engine.Execute("globalThis.handler = () => new Response('cheap');");
+        engine.Advanced.SetFetchHandler(engine.GetValue("handler"));
+        using var response = engine.Advanced.InvokeFetchHandler(Get()).GetResult();
+        Text(response).Should().Be("cheap");
+    }
+
+    [Fact]
+    public void TheWorkersModuleConventionIsRegisteredFromAModuleNamespace()
+    {
+        var engine = Host();
+        engine.Modules.Add("worker", "export default { fetch(request) { return new Response('from ' + request.url); } };");
+
+        // The module namespace goes straight in: SetFetchHandler unwraps `default` and then finds `fetch`.
+        engine.Advanced.SetFetchHandler(engine.Modules.Import("worker"));
+
+        using var response = engine.Advanced.InvokeFetchHandler(Get("https://example.org/m")).GetResult();
+        Text(response).Should().Be("from https://example.org/m");
+    }
+
+    [Fact]
+    public void TheHandlerObjectIsTheReceiverSoItsSiblingsAreReachable()
+    {
+        var engine = Handler("""
+            globalThis.handler = {
+                greeting: 'hi',
+                fetch(request) { return new Response(this.greeting); },
+            };
+            """);
+
+        using var response = engine.Advanced.InvokeFetchHandler(Get()).GetResult();
+        Text(response).Should().Be("hi");
+    }
+
+    [Fact]
+    public void APlainFunctionIsAcceptedAndSeesNoReceiver()
+    {
+        var engine = Handler("globalThis.handler = function (request) { return new Response(this === globalThis ? 'global' : 'other'); };");
+
+        using var response = engine.Advanced.InvokeFetchHandler(Get()).GetResult();
+
+        // The handler is called with `this` undefined, which a sloppy-mode function turns into the global
+        // object exactly as a bare call anywhere else does; nothing was invented to stand in for a receiver.
+        Text(response).Should().Be("global");
+    }
+
+    [Fact]
+    public void SomethingThatIsNotAHandlerIsRefusedAtRegistration()
+    {
+        var engine = Host();
+        engine.Execute("globalThis.notAHandler = { fetch: 42 };");
+
+        // Refused where the host made the mistake, not on the first request in production.
+        var failure = Assert.Throws<ArgumentException>(() => engine.Advanced.SetFetchHandler(engine.GetValue("notAHandler")));
+        failure.Message.Should().Contain("export default { fetch(request)");
+
+        Assert.Throws<ArgumentException>(() => engine.Advanced.SetFetchHandler(JsNumber.Create(1)));
+        engine.Advanced.HasFetchHandler.Should().BeFalse();
+    }
+
+    [Fact]
+    public void TheHandlerCanBeReplacedAndCleared()
+    {
+        var engine = Handler("globalThis.handler = () => new Response('first');");
+
+        engine.Execute("globalThis.second = () => new Response('second');");
+        engine.Advanced.SetFetchHandler(engine.GetValue("second"));
+        using (var response = engine.Advanced.InvokeFetchHandler(Get()).GetResult())
+        {
+            Text(response).Should().Be("second");
+        }
+
+        engine.Advanced.SetFetchHandler(null);
+        engine.Advanced.HasFetchHandler.Should().BeFalse();
+
+        var failure = Assert.Throws<InvalidOperationException>(() => engine.Advanced.InvokeFetchHandler(Get()));
+        failure.Message.Should().Contain("SetFetchHandler");
+    }
+
+    [Fact]
+    public void AHandlerThatAnswersSomethingOtherThanAResponseFails()
+    {
+        var direct = Handler("globalThis.handler = () => 'just a string';");
+        var operation = direct.Advanced.InvokeFetchHandler(Get());
+        operation.IsFaulted.Should().BeTrue();
+        Assert.IsType<InvalidOperationException>(operation.Error).Message.Should().Contain("must answer with a Response");
+
+        // ... and the same when it arrives a turn later, where escaping would erupt out of the host's pump.
+        var deferred = Handler("globalThis.handler = { async fetch() { return { status: 200 }; } };");
+        var deferredOperation = deferred.Advanced.InvokeFetchHandler(Get());
+        deferred.Advanced.ProcessTasks();
+        deferredOperation.IsFaulted.Should().BeTrue();
+        Assert.IsType<InvalidOperationException>(deferredOperation.Error);
+    }
+
+    [Fact]
+    public void ANetworkErrorResponseIsNotSendable()
+    {
+        var engine = Handler("globalThis.handler = () => Response.error();");
+
+        var operation = engine.Advanced.InvokeFetchHandler(Get());
+        operation.IsFaulted.Should().BeTrue();
+        Assert.IsType<InvalidOperationException>(operation.Error).Message.Should().Contain("Response.error()");
+    }
+
+    [Fact]
+    public void TheRequestUriMustBeAbsolute()
+    {
+        var engine = Handler("globalThis.handler = () => new Response('x');");
+
+        var relative = new HttpRequestMessage(HttpMethod.Get, new Uri("/hello", UriKind.Relative));
+        var operation = engine.Advanced.InvokeFetchHandler(relative);
+
+        operation.IsFaulted.Should().BeTrue();
+        Assert.IsType<InvalidOperationException>(operation.Error).Message.Should().Contain("relative");
+    }
+
+    [Fact]
+    public void ArgumentFailuresAreTheHostsOwn()
+    {
+        var engine = Handler("globalThis.handler = () => new Response('x');");
+
+        Assert.Throws<ArgumentNullException>(() => engine.Advanced.InvokeFetchHandler(null!));
+
+        var pending = Handler("globalThis.handler = { async fetch() { return new Response('x'); } };");
+        var operation = pending.Advanced.InvokeFetchHandler(Get());
+        Assert.Throws<InvalidOperationException>(() => operation.GetResult())
+            .Message.Should().Contain("ProcessTasks");
+    }
+
+    [Fact]
+    public void SequentialInvocationsReuseTheEngine()
+    {
+        var engine = Handler("""
+            globalThis.seen = [];
+            globalThis.handler = {
+                fetch(request) {
+                    globalThis.seen.push(request.url);
+                    return new Response(String(globalThis.seen.length));
+                }
+            };
+            """);
+
+        for (var i = 1; i <= 3; i++)
+        {
+            using var response = engine.Advanced.InvokeFetchHandler(Get($"https://example.org/{i}")).GetResult();
+            Text(response).Should().Be(i.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        }
+
+        // Each invocation got its own Request; the engine — and everything the script left on it — is shared,
+        // which is exactly the pooled-engine shape a host wants.
+        engine.Evaluate("globalThis.seen.join(',')").AsString()
+            .Should().Be("https://example.org/1,https://example.org/2,https://example.org/3");
+    }
+
+    [Fact]
+    public void APooledEngineRestoresItsGlobalsBetweenRequests()
+    {
+        var engine = Handler("""
+            globalThis.handler = {
+                fetch(request) {
+                    globalThis.leaked = (globalThis.leaked || 0) + 1;
+                    return new Response(String(globalThis.leaked));
+                }
+            };
+            """);
+
+        // Captured after the registration, which is what installs Request/Response/Headers: a snapshot taken
+        // before it would restore a global object that has no Response for the handler to answer with.
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+
+        for (var i = 0; i < 3; i++)
+        {
+            engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+            using var response = engine.Advanced.InvokeFetchHandler(Get()).GetResult();
+
+            // Every request starts from the captured globals, so the previous one's counter is not there.
+            Text(response).Should().Be("1");
+        }
+
+        // The handler is host state and survives the restore, so it never needs re-registering.
+        engine.Advanced.HasFetchHandler.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AnInvocationTheEngineFencedOffCompletesAsFaulted()
+    {
+        var engine = Handler("globalThis.handler = { async fetch() { return new Response('never'); } };");
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+
+        var operation = engine.Advanced.InvokeFetchHandler(Get());
+        operation.IsCompleted.Should().BeFalse();
+
+        // The restore ends the evaluation cycle, so the reaction that would complete this operation is
+        // discarded at dequeue rather than run. A host polling IsCompleted must not poll forever.
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        operation.IsCompleted.Should().BeTrue();
+        operation.IsFaulted.Should().BeTrue();
+        Assert.IsType<InvalidOperationException>(operation.Error).Message.Should().Contain("abandoned");
+
+        // The handler itself is host state and survives, like Engine.Advanced.HostDefined.
+        engine.Advanced.HasFetchHandler.Should().BeTrue();
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/FetchHandlerTests.cs
+++ b/Jint.Tests/Runtime/WebApi/FetchHandlerTests.cs
@@ -1,0 +1,215 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.Net.Http;
+using System.Text;
+using Jint.Native;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// What a fetch handler <i>sees</i> when a host routes an inbound request into it: a real <c>Request</c>,
+/// with the whole of the Body mixin working over the bytes the host handed over.
+/// </summary>
+/// <remarks>
+/// The host-facing contract — the operation, the failure map, the header split on the way out — is pinned
+/// from outside the assembly in <c>Jint.Tests.PublicInterface.WebApiFetchHandlerTests</c>. What is here is
+/// the script's half.
+/// </remarks>
+public class FetchHandlerTests
+{
+    private const WebApiFeatures ModelFeatures = WebApiFeatures.Events | WebApiFeatures.Url | WebApiFeatures.Files;
+
+    private static Engine Handler(string source)
+    {
+        var engine = new Engine(options => options.UseWebApis(ModelFeatures));
+        engine.Execute(source);
+        engine.Advanced.SetFetchHandler(engine.GetValue("handler"));
+        return engine;
+    }
+
+    /// <summary>Runs one request through the handler and answers with the response body as text.</summary>
+    private static string Answer(Engine engine, HttpRequestMessage request)
+    {
+        var operation = engine.Advanced.InvokeFetchHandler(request);
+        for (var i = 0; i < 100 && !operation.IsCompleted; i++)
+        {
+            engine.Advanced.ProcessTasks();
+        }
+
+        using var response = operation.GetResult();
+        using var stream = response.Content.ReadAsStream();
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        return reader.ReadToEnd();
+    }
+
+    private static HttpRequestMessage Post(string body, string mediaType = "application/json")
+        => new(HttpMethod.Post, "https://example.org/")
+        {
+            Content = new StringContent(body, Encoding.UTF8, mediaType),
+        };
+
+    [Fact]
+    public void TheRequestIsARealRequestWithTheWholeBodyMixin()
+    {
+        var engine = Handler("""
+            globalThis.handler = {
+                async fetch(request) {
+                    const before = request.bodyUsed;
+                    const parsed = await request.json();
+                    return new Response([
+                        request instanceof Request,
+                        Object.getPrototypeOf(request) === Request.prototype,
+                        before,
+                        request.bodyUsed,
+                        parsed.n,
+                    ].join(','));
+                }
+            };
+            """);
+
+        // https://fetch.spec.whatwg.org/#dom-body-bodyused — the disturbed flag flips on the first consume.
+        Answer(engine, Post("{\"n\":7}")).Should().Be("true,true,false,true,7");
+    }
+
+    [Fact]
+    public void ASecondReadOfTheBodyRejectsTheWayItWouldInABrowser()
+    {
+        var engine = Handler("""
+            globalThis.handler = {
+                async fetch(request) {
+                    await request.text();
+                    try {
+                        await request.text();
+                        return new Response('read twice');
+                    } catch (e) {
+                        return new Response(e.constructor.name + ': ' + e.message);
+                    }
+                }
+            };
+            """);
+
+        Answer(engine, Post("{}")).Should().Be("TypeError: Body has already been consumed");
+    }
+
+    [Fact]
+    public void AContentWithNoBytesIsANullBodyRatherThanAnEmptyOne()
+    {
+        var engine = Handler("""
+            globalThis.handler = {
+                async fetch(request) {
+                    const first = await request.text();
+                    const second = await request.text();
+                    return new Response([request.bodyUsed, first === '', second === ''].join(','));
+                }
+            };
+            """);
+
+        // The shape an ASP.NET Core host produces for a GET: a content that is there and empty. A null body
+        // is not disturbed by being read, so bodyUsed stays false and a handler may read it as often as it
+        // likes — where an empty body would flip the flag and reject the second read.
+        var request = new HttpRequestMessage(HttpMethod.Get, "https://example.org/")
+        {
+            Content = new ByteArrayContent([]),
+        };
+
+        Answer(engine, request).Should().Be("false,true,true");
+    }
+
+    [Fact]
+    public void TheRequestSignalIsAnAbortSignalThatNothingFires()
+    {
+        var engine = Handler("""
+            globalThis.handler = {
+                fetch(request) {
+                    let fired = false;
+                    request.signal.addEventListener('abort', () => { fired = true; });
+                    return new Response([
+                        request.signal instanceof AbortSignal,
+                        request.signal.aborted,
+                        fired,
+                    ].join(','));
+                }
+            };
+            """);
+
+        // An inbound request has no client-disconnect channel here, so the signal exists to be listened to and
+        // to be forwarded to an outbound fetch — never to fire by itself.
+        Answer(engine, Post("{}")).Should().Be("true,false,false");
+    }
+
+    [Fact]
+    public void EquallyNamedHeadersCombineTheWayTheStandardCombinesThem()
+    {
+        var engine = Handler("globalThis.handler = request => new Response(request.headers.get('X-Trace') + '|' + [...request.headers.keys()].join(','));");
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "https://example.org/");
+        request.Headers.Add("X-Trace", "a");
+        request.Headers.Add("X-Trace", "b");
+        request.Headers.Add("Accept", "*/*");
+
+        // https://fetch.spec.whatwg.org/#concept-header-list-get combines with ", ", and iteration is over
+        // lowercased names in ascending byte order.
+        Answer(engine, request).Should().Be("a, b|accept,x-trace");
+    }
+
+    [Fact]
+    public void TheRequestCanBeCopiedTheWayTheConstructorCopiesOne()
+    {
+        var engine = Handler("""
+            globalThis.handler = {
+                async fetch(request) {
+                    const copy = new Request(request, { method: 'PUT' });
+                    return new Response([copy.url, copy.method, await copy.text()].join('|'));
+                }
+            };
+            """);
+
+        // Step 43 of https://fetch.spec.whatwg.org/#dom-request — the copy shares the bytes and carries its
+        // own used flag, which is what lets a handler forward the request it was given.
+        Answer(engine, Post("payload", "text/plain")).Should().Be("https://example.org/|PUT|payload");
+    }
+
+    [Fact]
+    public void AHandlerCanAnswerWithTheResponseStatics()
+    {
+        var engine = Handler("globalThis.handler = () => Response.json({ ok: true }, { status: 202 });");
+
+        var operation = engine.Advanced.InvokeFetchHandler(new HttpRequestMessage(HttpMethod.Get, "https://example.org/"));
+        using var response = operation.GetResult();
+
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.Accepted);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("application/json");
+    }
+
+    [Fact]
+    public void TheHandlerIsNotVisibleAsAGlobalAndNeitherIsFetch()
+    {
+        var engine = Handler("globalThis.handler = () => new Response('x');");
+
+        // Registering a handler installs the object model and nothing else: no fetch, and no name of Jint's
+        // own invention on the global object.
+        engine.Evaluate("typeof fetch").AsString().Should().Be("undefined");
+        engine.Evaluate("Object.getOwnPropertyNames(globalThis).filter(n => n.toLowerCase().includes('fetch')).join(',')")
+            .AsString().Should().BeEmpty();
+
+        // ... and a ShadowRealm never sees the model, like every other web API.
+        engine.Evaluate("new ShadowRealm().evaluate('typeof Response')").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void TheHandlerRunsWithTheEnginesOwnGlobals()
+    {
+        var engine = new Engine(options => options
+            .UseWebApis(ModelFeatures)
+            .AddLazyGlobal("tenant", static _ => JsString.Create("acme")));
+
+        engine.Execute("globalThis.handler = () => new Response(tenant);");
+        engine.Advanced.SetFetchHandler(engine.GetValue("handler"));
+
+        // A Workers handler takes (request, env, ctx); this one takes the request alone, and per-request host
+        // state reaches the script the way it always has.
+        Answer(engine, new HttpRequestMessage(HttpMethod.Get, "https://example.org/")).Should().Be("acme");
+    }
+}
+#endif

--- a/Jint/Engine.Advanced.WebApi.cs
+++ b/Jint/Engine.Advanced.WebApi.cs
@@ -1,6 +1,11 @@
 #if NET8_0_OR_GREATER
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Jint.Native;
 using Jint.Runtime;
 using Jint.WebApi;
+using Jint.WebApi.Fetch;
 using Jint.WebApi.Messaging;
 
 namespace Jint;
@@ -99,6 +104,284 @@ public partial class Engine
                 Throw.InvalidOperationException(
                     $"CreateMessagePortPair requires WebApiFeatures.Messaging, and {which} was built without it. Enable it with options.UseWebApis(WebApiFeatures.Messaging).");
             }
+        }
+
+        /// <summary>
+        /// The web APIs the fetch object model is built out of, and therefore the ones fetch-handler hosting
+        /// needs an engine to carry. <see cref="WebApiFeatures.Fetch"/> implies all three, so an engine built
+        /// with <c>options.UseFetch()</c> satisfies this too.
+        /// </summary>
+        private const WebApiFeatures FetchModelFeatures = WebApiFeatures.Events | WebApiFeatures.Url | WebApiFeatures.Files;
+
+        /// <summary>
+        /// Whether a fetch handler is registered on this engine. Requires .NET 8 or higher.
+        /// </summary>
+        public bool HasFetchHandler => _engine._webApi?.FetchHandler is not null;
+
+        /// <summary>
+        /// Registers the script function inbound requests are routed to by
+        /// <see cref="InvokeFetchHandler"/> and <see cref="InvokeFetchHandlerAsync"/>, turning the engine into
+        /// a request handler in the style Cloudflare Workers established. Requires .NET 8 or higher.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>The three shapes accepted</b>, in the order they are tried:
+        /// <list type="number">
+        /// <item>a <b>callable</b> — used as the handler, called with <c>this</c> undefined. This is the shape
+        /// for a script that has no modules: <c>engine.Execute("function handle(request) { … }")</c> followed
+        /// by <c>SetFetchHandler(engine.GetValue("handle"))</c>.</item>
+        /// <item>an <b>object with a callable <c>fetch</c> property</b> — called with that object as
+        /// <c>this</c>, so a handler written as a method can reach its siblings.</item>
+        /// <item>an object with a <b><c>default</c></b> property matching either of the two above — which is
+        /// what a module namespace is, so the Workers convention
+        /// <c>export default { fetch(request) { … } }</c> is registered with
+        /// <c>SetFetchHandler(engine.Modules.Import("./worker.js"))</c> and nothing else.</item>
+        /// </list>
+        /// The value is resolved <em>here</em>, once, rather than on every request: a host that passed
+        /// something unusable learns about it at this call rather than on the first request, and the property
+        /// reads happen at a point the host chose.
+        /// </para>
+        /// <para>
+        /// <b>Only the request is passed.</b> A Workers handler receives <c>(request, env, ctx)</c>; this one
+        /// receives the request alone. Per-request host state reaches the script the way it always has — a
+        /// global installed with <see cref="AddLazyGlobal(string, Func{Engine, JsValue}, Runtime.Descriptors.PropertyFlag)"/>, or
+        /// <see cref="HostDefined"/> read by a host function the script calls.
+        /// </para>
+        /// <para>
+        /// <b>What this installs.</b> A handler that cannot build a <c>Response</c> is useless, so registering
+        /// one also installs the <c>Headers</c>, <c>Request</c> and <c>Response</c> globals if they are not
+        /// there already — lazily, and without replacing anything the host or the
+        /// <see cref="WebApiFeatures.Fetch"/> feature already put under those names. It deliberately does
+        /// <b>not</b> install <c>fetch</c>: handling an inbound request is not a reason to grant the script
+        /// outbound network access, which stays behind <c>options.UseFetch()</c>. Since the install happens
+        /// after construction, a <see cref="CaptureGlobalSnapshot"/> taken before this call does not carry
+        /// those globals and <see cref="RestoreGlobalSnapshot"/> removes them again — register the handler
+        /// after the restore, or enable the feature on the options so the globals are part of the engine's
+        /// initial state.
+        /// </para>
+        /// <para>
+        /// <b>Lifetime.</b> The handler is host state, like <see cref="HostDefined"/>: it survives
+        /// <see cref="RestoreGlobalSnapshot"/> rather than being cleared by it, so a pooled engine that
+        /// restores its globals between requests keeps the handler and decides for itself when to replace it.
+        /// An invocation that was already in flight is a different matter and is fenced off — see
+        /// <see cref="FetchHandlerOperation.IsCompleted"/>. Registering again replaces the previous handler;
+        /// passing <see langword="null"/>, <c>undefined</c> or <c>null</c> clears it.
+        /// </para>
+        /// </remarks>
+        /// <param name="handler">The handler, or <see langword="null"/> to clear it.</param>
+        /// <exception cref="ArgumentException"><paramref name="handler"/> matches none of the three shapes.</exception>
+        /// <exception cref="InvalidOperationException">
+        /// The engine was not built with the web APIs the fetch object model needs.
+        /// </exception>
+        public void SetFetchHandler(JsValue? handler)
+        {
+            var state = RequireFetchModel();
+
+            if (handler is null || handler.IsNullOrUndefined())
+            {
+                state.FetchHandler = null;
+                return;
+            }
+
+            state.FetchHandler = FetchHandler.Resolve(handler, nameof(handler));
+
+            // After the resolution, so that a host that passed something unusable has not had its global
+            // object changed by the attempt.
+            WebApiRegistration.InstallFetchModel(_engine);
+        }
+
+        /// <summary>
+        /// Routes an inbound request to the registered fetch handler and hands back an operation the host
+        /// drives with its own pump. Requires .NET 8 or higher.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>Nothing is pumped here.</b> A handler that answers a <c>Response</c> synchronously produces an
+        /// operation that is already complete; one that answers a promise — every <c>async</c> handler, and
+        /// any handler that awaits a timer or an outbound <c>fetch</c> — needs turns, which the host gives it
+        /// by calling <see cref="ProcessTasks"/> until
+        /// <see cref="FetchHandlerOperation.IsCompleted"/>. That is the whole point of the shape: every turn
+        /// provably runs on the thread the host decided, which is what a game loop or a UI thread needs.
+        /// <see cref="InvokeFetchHandlerAsync"/> is the <c>await</c>-shaped alternative.
+        /// </para>
+        /// <para>
+        /// <b>The request body is read on this thread, in full, before the handler runs.</b> Bodies are
+        /// buffered rather than streamed here — Jint has no <c>ReadableStream</c> — so a
+        /// <see cref="HttpContent"/> reading from a live socket blocks the caller until it has all arrived.
+        /// Buffer it yourself (a <see cref="ByteArrayContent"/>) or use
+        /// <see cref="InvokeFetchHandlerAsync"/>, which reads it without blocking.
+        /// </para>
+        /// <para>
+        /// <b>Every failure of the invocation arrives through the operation</b>, even the ones that happen
+        /// before this method returns: the request being unrepresentable as a <c>Request</c>, the handler
+        /// throwing, an execution constraint firing. A host written to the
+        /// poll-then-<see cref="FetchHandlerOperation.GetResult"/> pattern must not also have to guard the
+        /// start call, and a constraint reported this way has still done its work — it ended the run, and the
+        /// host learns of it as an exception the script can neither see nor catch. Only the host's own
+        /// mistakes are thrown from here, because there is no invocation for them to be part of: a
+        /// <see langword="null"/> request, and no handler being registered.
+        /// </para>
+        /// <para>
+        /// <b>The handler runs under this engine's execution constraints</b>, like every other host entry into
+        /// the engine: <c>MaxStatements</c>, <c>TimeoutInterval</c>, <c>LimitMemory</c> and any custom
+        /// <c>Constraint</c> bound one invocation. Read the constraints section of the README before relying
+        /// on that: the budget is per entry into the engine, so the turns the host pumps afterwards each get
+        /// their own — a wall-clock bound over the <em>whole</em> request wants
+        /// <c>Jint.Constraints.OperationDeadlineConstraint</c>, which the host brackets around the pump.
+        /// </para>
+        /// </remarks>
+        /// <param name="request">
+        /// The inbound request. Its <see cref="HttpRequestMessage.RequestUri"/> must be absolute, because a
+        /// <c>Request</c>'s URL is — an embedded engine has no document to resolve a relative one against.
+        /// </param>
+        /// <returns>The invocation in progress; see <see cref="FetchHandlerOperation"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException">No fetch handler is registered on this engine.</exception>
+        public FetchHandlerOperation InvokeFetchHandler(HttpRequestMessage request)
+        {
+            if (request is null)
+            {
+                Throw.ArgumentNullException(nameof(request));
+            }
+
+            var handler = RequireFetchHandler();
+            var operation = new FetchHandlerOperation(_engine);
+
+            JsValue result;
+            try
+            {
+                result = CallHandler(handler, request, ReadBody(request));
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException)
+            {
+                operation.Fail(ex);
+                return operation;
+            }
+
+            operation.Settle(result);
+            return operation;
+        }
+
+        /// <summary>
+        /// Routes an inbound request to the registered fetch handler and awaits its response, without holding
+        /// a thread while the handler's promise is outstanding. Requires .NET 8 or higher.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>Which thread runs what.</b> The body is read first; with an already-buffered
+        /// <see cref="HttpContent"/> — a <see cref="ByteArrayContent"/>, which is what an ASP.NET Core host
+        /// hands over — that read completes synchronously and the handler is invoked on the calling thread.
+        /// With a content still arriving off a socket it does not, and the handler runs on whichever thread
+        /// resumed the read; every continuation afterwards likewise runs on whichever thread resumed the
+        /// await. The engine is single-threaded and this does not change that — the turns are serialized —
+        /// but a host with a thread <em>affinity</em> wants <see cref="InvokeFetchHandler"/> and its own pump.
+        /// </para>
+        /// <para>
+        /// <paramref name="cancellationToken"/> does <b>not</b> preempt the synchronous evaluation loop. The
+        /// handler runs to completion first and the token is only observed afterwards, while awaiting the
+        /// response promise — that is, at event-loop continuation boundaries. A handler that never yields
+        /// (<c>while (true) { }</c>) is therefore not cancellable through this parameter. To bound the
+        /// interpreter itself, register an execution constraint on the engine's <see cref="Options"/>:
+        /// <see cref="ConstraintsOptionsExtensions.CancellationToken"/> for token-driven cancellation or
+        /// <see cref="ConstraintsOptionsExtensions.TimeoutInterval"/> for a wall-clock bound. Both are
+        /// amortizable, so neither disarms the interpreter's tight-loop lane.
+        /// </para>
+        /// <para>
+        /// The wait is additionally bounded by <c>Options.Constraints.PromiseTimeout</c> (ten seconds by
+        /// default), exactly as an <c>await</c> of <see cref="EvaluateAsync(string, string, CancellationToken)"/>
+        /// is: a handler whose promise never settles fails with a <see cref="PromiseRejectedException"/> naming
+        /// the timeout rather than hanging the request forever.
+        /// </para>
+        /// </remarks>
+        /// <param name="request">The inbound request; see <see cref="InvokeFetchHandler"/> for what it must carry.</param>
+        /// <param name="cancellationToken">Observed while awaiting the response promise; see the remarks.</param>
+        /// <returns>The response the handler produced. The caller owns it and disposes it.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException">
+        /// No fetch handler is registered, the request cannot be expressed as a <c>Request</c>, or the handler
+        /// answered with something that is not a <c>Response</c>.
+        /// </exception>
+        /// <exception cref="JavaScriptException">The handler threw.</exception>
+        /// <exception cref="PromiseRejectedException">The handler's promise rejected.</exception>
+        public async Task<HttpResponseMessage> InvokeFetchHandlerAsync(HttpRequestMessage request, CancellationToken cancellationToken = default)
+        {
+            if (request is null)
+            {
+                Throw.ArgumentNullException(nameof(request));
+            }
+
+            var handler = RequireFetchHandler();
+
+            var content = request.Content;
+            var body = content is null
+                ? null
+                : await content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+
+            var result = CallHandler(handler, request, body);
+            var settled = await _engine.UnwrapResultAsync(result, cancellationToken).ConfigureAwait(false);
+            return FetchHandlerHosting.CreateResponse(settled);
+        }
+
+        /// <summary>
+        /// Builds the <c>Request</c> and calls the handler. The call goes through
+        /// <see cref="Engine.Call(JsValue, JsValue, JsValue[])"/>, which is what brackets it in the engine's
+        /// execution constraints the way every public entry is bracketed.
+        /// </summary>
+        /// <remarks>
+        /// The request is built against the <b>principal</b> realm rather than the running one. This is a host
+        /// entry, so the two are the same in every ordinary case; naming the principal realm is what keeps it
+        /// true if a host ever invokes a handler from inside a <c>ShadowRealm</c> callback, whose intrinsics
+        /// are a different set of objects and which deliberately carries none of these globals.
+        /// </remarks>
+        private JsValue CallHandler(FetchHandler handler, HttpRequestMessage request, byte[]? body)
+        {
+            var jsRequest = FetchHandlerHosting.CreateRequest(_engine, _engine._mainRealm, request, body);
+            return _engine.Call(handler.Callable, handler.ThisObject, [jsRequest]);
+        }
+
+        /// <summary>
+        /// Reads the request body on the calling thread. <see cref="HttpContent.ReadAsStream()"/> rather than
+        /// a blocking wait on the asynchronous overload: it is a real synchronous API, so a buffered content —
+        /// the ordinary case — is a copy out of memory rather than a task machine wrapped in a wait.
+        /// </summary>
+        private static byte[]? ReadBody(HttpRequestMessage request)
+        {
+            var content = request.Content;
+            if (content is null)
+            {
+                return null;
+            }
+
+            using var stream = content.ReadAsStream();
+            using var buffer = new MemoryStream();
+            stream.CopyTo(buffer);
+            return buffer.ToArray();
+        }
+
+        private FetchHandler RequireFetchHandler()
+        {
+            var handler = RequireFetchModel().FetchHandler;
+            if (handler is null)
+            {
+                Throw.InvalidOperationException("No fetch handler is registered on this engine. Register one with engine.Advanced.SetFetchHandler — a function, an object with a callable 'fetch' property, or the namespace of a module whose default export is one of those.");
+            }
+
+            return handler;
+        }
+
+        private WebApiEngineState RequireFetchModel()
+        {
+            var state = _engine._webApi;
+            if (state is null || (_engine._webApiFeatures & FetchModelFeatures) != FetchModelFeatures)
+            {
+                // Deliberately not the Fetch feature itself. Fetch grants the script outbound network access,
+                // which handling an inbound request is no reason to want; what the object model actually needs
+                // is the three features its own interfaces are built out of — a Request has an AbortSignal, its
+                // URL is a WHATWG URL, and response.blob() answers with a Blob.
+                Throw.InvalidOperationException("Fetch-handler hosting needs the web APIs the fetch object model is built out of. Build the engine with options.UseWebApis(WebApiFeatures.Events | WebApiFeatures.Url | WebApiFeatures.Files) — or with options.UseFetch(), which implies all three and additionally grants the script outbound network access.");
+            }
+
+            return state;
         }
     }
 }

--- a/Jint/Engine.WebApi.cs
+++ b/Jint/Engine.WebApi.cs
@@ -26,12 +26,13 @@ public partial class Engine
     internal WebApiEngineState? _webApi;
 
     /// <summary>
-    /// Which opt-in web APIs this engine was built with, as <c>WebApiRegistration.Apply</c> recorded them, or
-    /// <see cref="WebApiFeatures.None"/> for an engine that asked for nothing. Read by the one host API that
-    /// has to refuse an engine which never opted in — <see cref="AdvancedOperations.CreateMessagePortPair"/> —
-    /// and by nothing on any hot path. It lives here rather than being read back from <c>Options</c> because
-    /// an <c>Options</c> instance is shareable and mutable, so the set an engine was actually built with is
-    /// only knowable at build time.
+    /// Which opt-in web APIs this engine was built with, as <c>WebApiRegistration.Apply</c> recorded them
+    /// after computing the feature closure, or <see cref="WebApiFeatures.None"/> for an engine that asked for
+    /// nothing. Read by the host APIs that have to refuse an engine which never opted in —
+    /// <see cref="AdvancedOperations.CreateMessagePortPair"/> and
+    /// <see cref="AdvancedOperations.SetFetchHandler"/> — and by nothing on any hot path. It lives here rather
+    /// than being read back from <c>Options</c> because an <c>Options</c> instance is shareable and mutable,
+    /// so the set an engine was actually built with is only knowable at build time.
     /// </summary>
     internal WebApiFeatures _webApiFeatures;
 
@@ -104,6 +105,18 @@ internal sealed class WebApiEngineState
         _originTimestamp = timeProvider.GetTimestamp();
         TimeOrigin = (timeProvider.GetUtcNow() - DateTimeOffset.UnixEpoch).TotalMilliseconds;
     }
+
+    /// <summary>
+    /// The script function inbound requests are routed to by <c>Engine.Advanced.InvokeFetchHandler</c>, or
+    /// <see langword="null"/> when the host has registered none.
+    /// </summary>
+    /// <remarks>
+    /// Host state rather than evaluation state, so — like <c>Engine.Advanced.HostDefined</c> — it is
+    /// deliberately not cleared by <see cref="ResetTransientState"/>: a pooled engine that restores its
+    /// globals between requests keeps the handler it was given, and the host replaces it when it wants to.
+    /// An invocation that was in flight at the restore is fenced off by its own generation instead.
+    /// </remarks>
+    internal FetchHandler? FetchHandler { get; set; }
 
     /// <summary>
     /// The engine's active timers, or <see langword="null"/> when nothing that schedules one is enabled.

--- a/Jint/WebApi/Fetch/FetchHandler.cs
+++ b/Jint/WebApi/Fetch/FetchHandler.cs
@@ -1,0 +1,93 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Fetch;
+
+/// <summary>
+/// The script function an inbound request is routed to, plus the <c>this</c> it is called with — the resolved
+/// form of whatever a host handed <c>Engine.Advanced.SetFetchHandler</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The resolution happens once, when the handler is registered</b>, rather than on every request: a host
+/// that passed something unusable learns about it at the call it made, not on the first request in
+/// production, and a member read here cannot be observed per request by a script that made <c>fetch</c> a
+/// getter.
+/// </para>
+/// <para>
+/// This is a host-facing convention, not a specification: nothing in the Fetch Standard says how a runtime
+/// finds a handler. The shape is the one Cloudflare Workers established and Deno adopted —
+/// <c>export default { fetch(request) { … } }</c> — because that is what scripts written for those runtimes
+/// already look like.
+/// </para>
+/// </remarks>
+internal sealed class FetchHandler
+{
+    private FetchHandler(JsValue callable, JsValue thisObject)
+    {
+        Callable = callable;
+        ThisObject = thisObject;
+    }
+
+    /// <summary>The function itself, already known to be callable.</summary>
+    internal JsValue Callable { get; }
+
+    /// <summary>
+    /// The receiver the function is called with: the object it was found on for the
+    /// <c>{ fetch(request) { … } }</c> shape, so a handler written as a method may use <c>this</c> to reach
+    /// its siblings, and <c>undefined</c> for a bare function.
+    /// </summary>
+    internal JsValue ThisObject { get; }
+
+    /// <summary>
+    /// Resolves the value a host registered into the function to call. The three accepted shapes, in the order
+    /// they are tried:
+    /// <list type="number">
+    /// <item>a callable — used as the handler, with <c>this</c> undefined;</item>
+    /// <item>an object with a callable <c>fetch</c> property — the Workers convention, called with the object
+    /// as <c>this</c>;</item>
+    /// <item>an object with a <c>default</c> property matching either of the two above — a module namespace,
+    /// so <c>engine.Advanced.SetFetchHandler(engine.Modules.Import("./worker.js"))</c> works directly.</item>
+    /// </list>
+    /// </summary>
+    /// <exception cref="ArgumentException">The value matches none of the three shapes.</exception>
+    internal static FetchHandler Resolve(JsValue handler, string paramName)
+    {
+        var resolved = TryResolve(handler, allowDefault: true);
+        if (resolved is null)
+        {
+            Throw.ArgumentException(
+                "The fetch handler must be a function, an object with a callable 'fetch' property (the 'export default { fetch(request) { … } }' convention), or a module namespace whose default export is one of those.",
+                paramName);
+        }
+
+        return resolved;
+    }
+
+    private static FetchHandler? TryResolve(JsValue handler, bool allowDefault)
+    {
+        if (handler.IsCallable)
+        {
+            return new FetchHandler(handler, JsValue.Undefined);
+        }
+
+        if (handler is not ObjectInstance holder)
+        {
+            return null;
+        }
+
+        var member = holder.Get("fetch");
+        if (member.IsCallable)
+        {
+            return new FetchHandler(member, holder);
+        }
+
+        // One level only. A module namespace's default export may itself be the object carrying fetch, but a
+        // default export whose own default export carries it is not a shape anything writes, and chasing it
+        // would turn a typo into a silent walk through the script's object graph.
+        return allowDefault ? TryResolve(holder.Get("default"), allowDefault: false) : null;
+    }
+}
+#endif

--- a/Jint/WebApi/Fetch/FetchHandlerHosting.cs
+++ b/Jint/WebApi/Fetch/FetchHandlerHosting.cs
@@ -1,0 +1,240 @@
+#if NET8_0_OR_GREATER
+using System.Net;
+using System.Net.Http;
+using Jint.Native;
+using Jint.Runtime;
+using Jint.WebApi.Abort;
+using Jint.WebApi.Url.Parsing;
+
+namespace Jint.WebApi.Fetch;
+
+/// <summary>
+/// The inbound half of the fetch object model: an <see cref="HttpRequestMessage"/> becomes the
+/// <c>Request</c> a handler is called with, and the <c>Response</c> it answers becomes an
+/// <see cref="HttpResponseMessage"/> the host can send.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the mirror image of <see cref="FetchTransport"/>, over the same objects, and the differences are
+/// all in who is being protected. Outbound, a malformed value comes from a script and becomes a
+/// <c>TypeError</c> it can catch; inbound, a malformed value comes from the <b>host</b> and becomes an
+/// <see cref="InvalidOperationException"/> naming what to fix, because a host bug that quietly produced a
+/// half-built <c>Request</c> would surface as a script bug somewhere else entirely.
+/// </para>
+/// <para>
+/// <b>Everything here runs on the engine's thread</b>, and none of it runs script — the objects are built and
+/// read through their internal state rather than through their prototypes' accessors, so a script that
+/// replaced <c>Response.prototype.status</c> changes what other script sees and not what the host sends.
+/// </para>
+/// </remarks>
+internal static class FetchHandlerHosting
+{
+    /// <summary>
+    /// The headers the host's own HTTP stack owns rather than the handler. A framing header copied out of a
+    /// <c>Response</c> would describe the body the script <i>said</i> it was sending rather than the one it
+    /// actually is, which is a response-splitting primitive when the two disagree; the
+    /// <see cref="HttpContent"/> computes its own length, and the transfer coding belongs to the connection.
+    /// </summary>
+    private static readonly string[] _hostOwnedResponseHeaders = ["content-length", "transfer-encoding"];
+
+    /// <summary>
+    /// Builds the <c>Request</c> the handler is called with.
+    /// </summary>
+    /// <remarks>
+    /// The URL is required to be absolute, because the Fetch Standard's request URL is absolute and this
+    /// engine has no document to resolve a relative one against — the same reason
+    /// <c>new Request('/a')</c> is a <c>TypeError</c> in script.
+    /// </remarks>
+    /// <param name="engine">The engine the request is built for.</param>
+    /// <param name="realm">The principal realm, whose intrinsics the request's prototypes come from.</param>
+    /// <param name="message">The host's request.</param>
+    /// <param name="body">The request body, already read; <see langword="null"/> when there is no content.</param>
+    /// <exception cref="InvalidOperationException">The message cannot be expressed as a <c>Request</c>.</exception>
+    internal static JsRequest CreateRequest(Engine engine, Realm realm, HttpRequestMessage message, byte[]? body)
+    {
+        var method = message.Method.Method;
+        if (!FetchValues.IsMethod(method))
+        {
+            Throw.InvalidOperationException($"The request method '{method}' is not an HTTP token, so it cannot be given to a fetch handler.");
+        }
+
+        // Normalized exactly as the Request constructor normalizes it, so a handler comparing
+        // request.method against 'GET' sees the same value however the host spelled it.
+        method = FetchValues.NormalizeMethod(method);
+
+        var uri = message.RequestUri;
+        if (uri is null)
+        {
+            Throw.InvalidOperationException("The request has no RequestUri. A fetch handler is called with a Request, whose URL is absolute — set HttpRequestMessage.RequestUri to the absolute URL the client asked for.");
+        }
+
+        if (!uri.IsAbsoluteUri)
+        {
+            Throw.InvalidOperationException($"The request URI '{uri.OriginalString}' is relative. A fetch handler is called with a Request, whose URL is absolute — build the absolute URL from your server's scheme, host and path first.");
+        }
+
+        var url = UrlParser.Parse(uri.AbsoluteUri);
+        if (url is null)
+        {
+            Throw.InvalidOperationException($"The request URI '{uri.AbsoluteUri}' is not a URL the WHATWG URL parser accepts, so it cannot become a Request's URL.");
+        }
+
+        if (url.IncludesCredentials)
+        {
+            // The same refusal the Request constructor makes, and for the same reason: a URL carrying a
+            // username and password hands the script a credential it can echo into a log or a Referer.
+            Throw.InvalidOperationException($"The request URI '{uri.AbsoluteUri}' carries credentials, which a Request may not. Move them into an Authorization header.");
+        }
+
+        var list = new HeaderList();
+        Collect(list, message.Headers);
+        if (message.Content is not null)
+        {
+            // Content headers are part of the one header list the Fetch Standard has — the split into request
+            // headers and content headers is System.Net.Http's, not the standard's, so a handler reading
+            // request.headers.get('content-type') has to find it.
+            Collect(list, message.Content.Headers);
+        }
+
+        var headers = realm.Intrinsics.Headers.CreateInstance(list);
+        headers.List.Guard = HeadersGuard.Request;
+
+        var request = new JsRequest(engine, headers)
+        {
+            _prototype = realm.Intrinsics.Request.PrototypeObject,
+            Method = method,
+            Url = url,
+            Redirect = JsRequest.RedirectFollow,
+
+            // A Request's signal is never null. Nothing aborts this one: an inbound request has no
+            // client-disconnect channel here, so it exists to be forwarded to an outbound fetch and to be
+            // listened to, not to fire.
+            Signal = new JsAbortSignal(engine, realm) { _prototype = realm.Intrinsics.AbortSignal.PrototypeObject },
+        };
+
+        // A zero-byte content is a null body rather than an empty one, which is what makes a GET carrying an
+        // empty stream — the ordinary shape an ASP.NET Core host produces — behave like a GET with no body at
+        // all: consumable any number of times, and bodyUsed never flipping.
+        if (body is { Length: > 0 })
+        {
+            request.Body = new ReadOnlyMemory<byte>(body);
+        }
+
+        return request;
+    }
+
+    /// <summary>
+    /// Turns the <c>Response</c> a handler answered with into the message the host sends.
+    /// </summary>
+    /// <remarks>
+    /// The body is taken without consuming it, so the script's own <c>bodyUsed</c> is untouched: the bytes are
+    /// immutable and buffered, and flipping a flag the host's read cannot be observed through would only
+    /// surprise a handler that logs its own response afterwards.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// The value is not a <c>Response</c>, or is one that has no wire representation.
+    /// </exception>
+    internal static HttpResponseMessage CreateResponse(JsValue result)
+    {
+        if (result is not JsResponse response)
+        {
+            Throw.InvalidOperationException($"The fetch handler must answer with a Response or a promise of one, but it produced {Throw.SafeToDisplayString(result)}.");
+            return null!;
+        }
+
+        if (response.Kind == ResponseType.Error)
+        {
+            // https://fetch.spec.whatwg.org/#dom-response-error — a network error, whose status is 0. It is
+            // what fetch produces when a request could not be made at all, and there is no status line that
+            // means that.
+            Throw.InvalidOperationException("The fetch handler answered with Response.error(), which represents a network error and has no HTTP representation. Answer with a real response — new Response(null, { status: 502 }) — and let the host decide what a failure looks like on the wire.");
+        }
+
+        var message = new HttpResponseMessage((HttpStatusCode) response.Status);
+
+        // Left null for an empty statusText so that the framework's own reason phrase for the status is used;
+        // an empty string would send an empty reason phrase, which is legal but is not what the script asked
+        // for by leaving it out.
+        if (response.StatusText.Length > 0)
+        {
+            message.ReasonPhrase = response.StatusText;
+        }
+
+        HttpContent? content = response.Body is { } body ? new ByteArrayContent(body.ToArray()) : null;
+
+        foreach (var header in response.Headers.List.Entries)
+        {
+            if (IsHostOwned(header.LowerName))
+            {
+                continue;
+            }
+
+            // The same split FetchTransport performs in the other direction: the response-header collection
+            // refuses a content header, and that refusal is how a content header is recognized. Both calls
+            // are TryAddWithoutValidation, because the header list has already been validated against the
+            // Fetch Standard's own grammar — which is stricter than System.Net.Http's about CR and LF and is
+            // what the script was measured against.
+            if (message.Headers.TryAddWithoutValidation(header.LowerName, header.Value))
+            {
+                continue;
+            }
+
+            // A content header on a response with no body still has to go somewhere, so an empty content is
+            // created to carry it rather than the header being dropped.
+            content ??= new ByteArrayContent([]);
+            content.Headers.TryAddWithoutValidation(header.LowerName, header.Value);
+        }
+
+        if (content is not null)
+        {
+            message.Content = content;
+        }
+
+        return message;
+    }
+
+    private static bool IsHostOwned(string lowerName)
+    {
+        foreach (var name in _hostOwnedResponseHeaders)
+        {
+            if (string.Equals(lowerName, name, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Every value of every header becomes its own entry, so that a request carrying a header twice is not
+    /// folded into one — the same collection <see cref="FetchTransport"/> performs for a response.
+    /// </summary>
+    /// <remarks>
+    /// A name or value the Fetch Standard's grammar refuses is a host bug rather than something to sanitize:
+    /// a value carrying CR or LF is exactly the request-splitting shape the grammar exists to stop, and
+    /// silently trimming it would hand the handler a header that is not the one that arrived.
+    /// </remarks>
+    private static void Collect(HeaderList list, System.Net.Http.Headers.HttpHeaders source)
+    {
+        foreach (var header in source.NonValidated)
+        {
+            if (!HeaderList.IsName(header.Key))
+            {
+                Throw.InvalidOperationException($"The request header name '{header.Key}' is not an HTTP token, so it cannot become a Request header.");
+            }
+
+            foreach (var value in header.Value)
+            {
+                var normalized = HeaderList.Normalize(value);
+                if (!HeaderList.IsValue(normalized))
+                {
+                    Throw.InvalidOperationException($"The value of request header '{header.Key}' contains a NUL, CR or LF, so it cannot become a Request header.");
+                }
+
+                list.Append(header.Key, normalized);
+            }
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/Fetch/FetchHandlerOperation.cs
+++ b/Jint/WebApi/Fetch/FetchHandlerOperation.cs
@@ -1,0 +1,243 @@
+#if NET8_0_OR_GREATER
+using System.Net.Http;
+using System.Runtime.ExceptionServices;
+using Jint.Native;
+using Jint.Native.Promise;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Interop;
+
+namespace Jint.WebApi.Fetch;
+
+/// <summary>
+/// An inbound request being handled by script, handed back by
+/// <c>Engine.Advanced.InvokeFetchHandler</c>. The engine makes progress on it only when it is given turns, so
+/// a host drives it by calling <c>engine.Advanced.ProcessTasks()</c> and watching <see cref="IsCompleted"/>.
+/// Requires .NET 8 or higher.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the same shape <c>Engine.Modules.StartImport</c> hands back, for the same reason: a host with a
+/// thread it must not block — a game loop, a UI thread, a request pipeline that owns its own scheduling —
+/// needs every turn of the engine to run where it decided, not on whichever thread a continuation happened to
+/// resume on. A host that is content to <c>await</c> wants
+/// <c>Engine.Advanced.InvokeFetchHandlerAsync</c> instead.
+/// </para>
+/// <para>
+/// A handler that answers a <c>Response</c> synchronously produces an operation that is already
+/// <see cref="IsCompleted"/> when this is returned; one that answers a promise needs at least one turn.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// var operation = engine.Advanced.InvokeFetchHandler(request);
+/// while (!operation.IsCompleted)
+/// {
+///     engine.Advanced.ProcessTasks();
+/// }
+///
+/// // Throws whatever the handler failed with — the host decides what that means on the wire.
+/// using var response = operation.GetResult();
+/// </code>
+/// </example>
+public sealed class FetchHandlerOperation
+{
+    private readonly Engine _engine;
+
+    /// <summary>
+    /// The evaluation cycle the invocation was started in. Once the engine has moved past it, no turn of the
+    /// event loop can finish this operation; see <see cref="ObserveAbandonment"/>.
+    /// </summary>
+    private readonly int _generation;
+
+    private bool _completed;
+    private HttpResponseMessage? _response;
+    private ExceptionDispatchInfo? _failure;
+
+    internal FetchHandlerOperation(Engine engine)
+    {
+        _engine = engine;
+        _generation = engine.EventLoopGeneration;
+    }
+
+    /// <summary>
+    /// Whether the handler has finished, successfully or not. It becomes true during a turn of the event loop
+    /// unless the handler answered synchronously, so it is only worth re-reading after the engine has been
+    /// given one.
+    /// </summary>
+    /// <remarks>
+    /// There is one way for an invocation to end without a turn:
+    /// <c>Engine.Advanced.RestoreGlobalSnapshot</c> ends the evaluation cycle it was started in, and a promise
+    /// fenced off that way can never settle into the engine again. Such an operation is reported here as
+    /// completed and <see cref="IsFaulted"/>, so a host polling this cannot poll forever.
+    /// </remarks>
+    public bool IsCompleted
+    {
+        get
+        {
+            ObserveAbandonment();
+            return _completed;
+        }
+    }
+
+    /// <summary>Whether the handler finished by failing.</summary>
+    public bool IsFaulted
+    {
+        get
+        {
+            ObserveAbandonment();
+            return _failure is not null;
+        }
+    }
+
+    /// <summary>
+    /// The response the handler produced once it has succeeded, otherwise <see langword="null"/>. The host
+    /// owns it and is responsible for disposing it.
+    /// </summary>
+    public HttpResponseMessage? Response
+    {
+        get
+        {
+            ObserveAbandonment();
+            return _response;
+        }
+    }
+
+    /// <summary>
+    /// What the invocation failed with once it has failed, otherwise <see langword="null"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>A handler failure is never turned into a status code here.</b> What a failing handler should send —
+    /// a 500, a rendered error page, a retry — is a policy question only the host can answer, so the failure
+    /// arrives as the exception it was and the host maps it.
+    /// </para>
+    /// <para>
+    /// The exception says which kind of failure it was. A handler that threw gives a
+    /// <see cref="JavaScriptException"/>, whose <see cref="JavaScriptException.Error"/> is the thrown value; a
+    /// handler whose promise rejected gives a <see cref="PromiseRejectedException"/>, whose
+    /// <see cref="PromiseRejectedException.RejectedValue"/> is the rejection reason — which is what an
+    /// <c>async</c> handler's <c>throw</c> becomes. An execution constraint that fired gives its own exception
+    /// (<c>StatementsCountOverflowException</c>, <c>TimeoutException</c>, …), and a handler that answered with
+    /// something that is not a <c>Response</c> gives an <see cref="InvalidOperationException"/>. All of Jint's
+    /// own exceptions derive from <see cref="JintException"/>, so that is the one type a host has to catch to
+    /// tell "the script failed" from "the host called this wrongly".
+    /// </para>
+    /// </remarks>
+    public Exception? Error
+    {
+        get
+        {
+            ObserveAbandonment();
+            return _failure?.SourceException;
+        }
+    }
+
+    /// <summary>
+    /// The response the handler produced, or the failure it produced, rethrown with its original stack trace.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">The handler has not finished yet.</exception>
+    public HttpResponseMessage GetResult()
+    {
+        if (!IsCompleted)
+        {
+            Throw.InvalidOperationException("The fetch handler has not completed. Give the engine turns with engine.Advanced.ProcessTasks() until IsCompleted is true, or await Engine.Advanced.InvokeFetchHandlerAsync instead.");
+        }
+
+        _failure?.Throw();
+        return _response!;
+    }
+
+    /// <summary>
+    /// Wires the operation to whatever the handler returned: a <c>Response</c> completes it here and now, a
+    /// promise completes it on the turn it settles on.
+    /// </summary>
+    /// <remarks>
+    /// Only a native promise is awaited. A thenable that is not one is refused as "not a Response" rather than
+    /// adopted, because adopting it would make the synchronous answer — the common case, and the one that
+    /// needs no pump at all — asynchronous for everybody.
+    /// </remarks>
+    internal void Settle(JsValue result)
+    {
+        if (result is not JsPromise promise)
+        {
+            CompleteFrom(result);
+            return;
+        }
+
+        // Reactions rather than polling the promise's state, so that the operation is also what marks the
+        // rejection handled and a failing handler does not read as an unhandled promise rejection to a host
+        // watching for those.
+        var onFulfilled = new ClrFunction(_engine, "", (_, args) =>
+        {
+            CompleteFrom(args.At(0));
+            return JsValue.Undefined;
+        }, 1, PropertyFlag.Configurable);
+
+        var onRejected = new ClrFunction(_engine, "", (_, args) =>
+        {
+            Fail(new PromiseRejectedException(args.At(0)));
+            return JsValue.Undefined;
+        }, 1, PropertyFlag.Configurable);
+
+        PromiseOperations.PerformPromiseThen(_engine, promise, onFulfilled, onRejected, resultCapability: null);
+    }
+
+    /// <summary>
+    /// Converts on the engine's thread, inside whichever turn produced the value, and keeps a conversion
+    /// failure inside the operation: escaping here would erupt out of whatever is pumping the engine, leaving
+    /// the host polling an operation that can never complete.
+    /// </summary>
+    private void CompleteFrom(JsValue value)
+    {
+        try
+        {
+            Complete(FetchHandlerHosting.CreateResponse(value));
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException)
+        {
+            Fail(ex);
+        }
+    }
+
+    internal void Complete(HttpResponseMessage response)
+    {
+        if (_completed)
+        {
+            response.Dispose();
+            return;
+        }
+
+        _completed = true;
+        _response = response;
+    }
+
+    internal void Fail(Exception error)
+    {
+        if (_completed)
+        {
+            return;
+        }
+
+        _completed = true;
+        _failure = ExceptionDispatchInfo.Capture(error);
+    }
+
+    /// <summary>
+    /// Fails an invocation the engine has fenced off. <c>Engine.Advanced.RestoreGlobalSnapshot</c> ends the
+    /// evaluation cycle, and every job registered in it is discarded at dequeue rather than run — so the
+    /// reaction that would complete this operation is exactly the one that can no longer fire. Nothing pushes
+    /// that news: the documented contract is that the host polls, and deriving the abandonment from the
+    /// engine's generation on read is what keeps that poll from being a poll forever.
+    /// </summary>
+    private void ObserveAbandonment()
+    {
+        if (_completed || _engine.EventLoopGeneration == _generation)
+        {
+            return;
+        }
+
+        Fail(new InvalidOperationException("The fetch handler invocation was abandoned: Engine.Advanced.RestoreGlobalSnapshot ended the evaluation cycle it was started in, so nothing it is waiting for can settle into this engine any more. Invoke the handler again on the restored engine."));
+    }
+}
+#endif

--- a/Jint/WebApi/WebApiRegistration.cs
+++ b/Jint/WebApi/WebApiRegistration.cs
@@ -147,9 +147,7 @@ internal static class WebApiRegistration
 
         if ((features & WebApiFeatures.Fetch) != WebApiFeatures.None)
         {
-            Install(global, engine, "Headers", static e => e.Realm.Intrinsics.Headers, PropertyFlag.NonEnumerable);
-            Install(global, engine, "Request", static e => e.Realm.Intrinsics.Request, PropertyFlag.NonEnumerable);
-            Install(global, engine, "Response", static e => e.Realm.Intrinsics.Response, PropertyFlag.NonEnumerable);
+            InstallFetchModel(engine);
 
             // A WebIDL operation on the global is a writable, enumerable, configurable data property, unlike
             // the interface objects above — https://webidl.spec.whatwg.org/#es-operations.
@@ -215,6 +213,25 @@ internal static class WebApiRegistration
             // both flags gets one object either way.
             Install(global, engine, "MessageEvent", static e => e.Realm.Intrinsics.MessageEvent, PropertyFlag.NonEnumerable);
         }
+    }
+
+    /// <summary>
+    /// Installs the three interface objects of the fetch object model, and deliberately not <c>fetch</c>
+    /// itself.
+    /// </summary>
+    /// <remarks>
+    /// Split out because the model has a second door: <c>Engine.Advanced.SetFetchHandler</c> routes an
+    /// inbound request into script, which needs <c>Response</c> to answer with and is no reason at all to
+    /// grant the script outbound network access. Both doors install the same three globals, the same way and
+    /// with the same WebIDL attributes — an interface object is writable and configurable but not enumerable,
+    /// https://webidl.spec.whatwg.org/#es-interfaces.
+    /// </remarks>
+    internal static void InstallFetchModel(Engine engine)
+    {
+        var global = engine.Realm.GlobalObject;
+        Install(global, engine, "Headers", static e => e.Realm.Intrinsics.Headers, PropertyFlag.NonEnumerable);
+        Install(global, engine, "Request", static e => e.Realm.Intrinsics.Request, PropertyFlag.NonEnumerable);
+        Install(global, engine, "Response", static e => e.Realm.Intrinsics.Response, PropertyFlag.NonEnumerable);
     }
 
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -610,6 +610,190 @@ long-lived and reconnects *on a delay the server chooses*, with no deadline to e
 [THREAT_MODEL.md](.github/THREAT_MODEL.md) TM-22 — the short version is to bound the engine's own lifetime
 for untrusted script rather than pooling an engine a script may leave streaming.
 
+### Hosting a fetch handler
+
+`Headers`, `Request` and `Response` work in both directions, so an engine can *be* a request handler: you
+hand it an `HttpRequestMessage` and get an `HttpResponseMessage` back, with the script in between written
+exactly the way a Cloudflare Workers or Deno script is.
+
+```js
+// worker.js
+export default {
+    async fetch(request) {
+        const body = await request.json();
+        return Response.json({ echoed: body, path: new URL(request.url).pathname });
+    }
+};
+```
+
+```csharp
+var engine = new Engine(options => options.UseWebApis(
+    WebApiFeatures.Events | WebApiFeatures.Url | WebApiFeatures.Files | WebApiFeatures.Timers));
+
+engine.Advanced.SetFetchHandler(engine.Modules.Import("./worker.js"));
+
+using var response = await engine.Advanced.InvokeFetchHandlerAsync(request);
+```
+
+`SetFetchHandler` accepts three shapes, tried in this order: a **function**; an **object with a callable
+`fetch` property** (called with that object as `this`, so a handler written as a method can reach its
+siblings); or an object with a **`default`** property matching either — which is what a module namespace is,
+so the `export default { fetch }` convention above is registered in one call. A script that has no modules
+registers its handler just as directly:
+
+```csharp
+engine.Execute("function handle(request) { return new Response('hi'); }");
+engine.Advanced.SetFetchHandler(engine.GetValue("handle"));
+```
+
+**There is no feature flag for this, and registering a handler never grants network access.** What the object
+model needs is the three features its own interfaces are built out of — a `Request` has an `AbortSignal`, its
+URL is a WHATWG URL, `response.blob()` answers with a `Blob` — so an engine built without `Events | Url |
+Files` refuses the registration with a message naming them. Registering the handler is itself what installs
+the `Headers`, `Request` and `Response` globals, lazily and without replacing anything already under those
+names; `fetch` is deliberately *not* installed, because handling an inbound request is no reason to let the
+script make outbound ones. (`options.UseFetch()` satisfies the requirement too, and does grant them.) One
+ordering consequence: those globals appear when you register the handler, so a module that builds a `Response`
+at *top level* has to be evaluated after the registration — the ordinary shape, where the handler builds its
+response when it runs, does not care.
+
+Only the request is passed. A Workers handler takes `(request, env, ctx)`; per-request host state reaches this
+one the way it always has, through `engine.Advanced.AddLazyGlobal(...)` or a host function reading
+`engine.Advanced.HostDefined`.
+
+**Two invoke shapes**, and the difference is who owns the thread. `InvokeFetchHandlerAsync` is the one an
+ASP.NET Core host wants — `await` it and the continuations run wherever the await resumes.
+`InvokeFetchHandler` returns a `FetchHandlerOperation` and runs nothing on its own: you pump the engine and
+watch the operation, which is the shape a game loop or a UI thread needs, because then every turn provably
+runs where you decided. It is the same pair `Engine.Modules.ImportAsync` / `StartImport` offers, for the same
+reason.
+
+```csharp
+var operation = engine.Advanced.InvokeFetchHandler(request);
+while (!operation.IsCompleted)
+{
+    engine.Advanced.ProcessTasks();     // your loop, your thread
+}
+
+using var response = operation.GetResult();
+```
+
+A handler answering a `Response` synchronously produces an operation that is already complete; one answering
+a promise — every `async` handler, and anything that awaits a timer or an outbound `fetch` — needs turns. As
+everywhere else in these APIs, a `setTimeout` inside a handler only fires while somebody is pumping.
+
+**A failing handler is never turned into a 500 for you.** What a failure means on the wire is a policy
+question only the host can answer, so it arrives as the exception it was: a `JavaScriptException` when the
+handler threw, a `PromiseRejectedException` when its promise rejected, the constraint's own exception when an
+execution constraint fired, an `InvalidOperationException` when the handler answered with something that is
+not a `Response` (including `Response.error()`, which represents a network error and has no status line).
+All of Jint's own exceptions derive from `JintException`, so that is the one type to catch:
+
+```csharp
+try
+{
+    using var handled = await engine.Advanced.InvokeFetchHandlerAsync(request, context.RequestAborted);
+    // ... copy it onto the real response
+}
+catch (JintException ex)
+{
+    logger.LogWarning(ex, "the script handler failed");
+    context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+}
+```
+
+With the polled shape the same failures arrive through the operation instead — `IsFaulted`, `Error`, or
+rethrown by `GetResult()` — including a failure of the invoke call itself, so a host written to
+poll-then-`GetResult` never has to guard the start call as well.
+
+The handler runs under the engine's execution constraints like every other host entry, so `MaxStatements`,
+`TimeoutInterval`, `LimitMemory` and any custom `Constraint` bound one invocation. Read
+[Execution Constraints](#execution-constraints) before relying on that: the budget is per *entry* into the
+engine, so each turn you pump afterwards gets a fresh one — a wall-clock bound over the whole request is what
+`Jint.Constraints.OperationDeadlineConstraint` is for, bracketed around the invoke and the pump. The
+`CancellationToken` taken by `InvokeFetchHandlerAsync` behaves exactly as `EvaluateAsync`'s does: it is
+observed at event-loop continuation boundaries and does **not** preempt the interpreter, so bounding a handler
+that never yields is a constraint's job.
+
+Request bodies are read in full before the handler runs — bodies here are buffered, not streamed. The
+awaitable shape reads them without blocking; the polled shape reads them on the calling thread, so buffer the
+content yourself (a `ByteArrayContent`) if it is still arriving off a socket. On the way out, `Content-Length`
+and `Transfer-Encoding` are dropped: those describe the message your HTTP stack is actually writing, and a
+script's claim about a body it is not sending would be a response-splitting primitive. Everything else is
+copied verbatim, with equally-named headers kept apart — several `Set-Cookie`s stay several.
+
+<details>
+<summary>ASP.NET Core: a sandboxed per-request script handler</summary>
+
+A documented sample rather than a package: Jint takes no dependency on ASP.NET Core, and this is all the glue
+there is. The engine comes from a pool the host owns — one engine per concurrent request, since an `Engine` is
+not thread-safe — and every one of them has had `SetFetchHandler` called on it.
+
+```csharp
+var scriptOptions = new Options()
+    .UseWebApis(WebApiFeatures.Events | WebApiFeatures.Url | WebApiFeatures.Files | WebApiFeatures.Timers)
+    .MaxStatements(100_000)
+    .LimitMemory(16 * 1024 * 1024)
+    .TimeoutInterval(TimeSpan.FromSeconds(2));
+
+app.Map("/{**path}", async (HttpContext context, EnginePool pool, ILogger<Program> logger) =>
+{
+    using var lease = pool.Rent();                       // an engine with the handler already registered
+
+    var buffer = new MemoryStream();
+    await context.Request.Body.CopyToAsync(buffer, context.RequestAborted);
+
+    var inbound = new HttpRequestMessage(new HttpMethod(context.Request.Method), context.Request.GetEncodedUrl())
+    {
+        Content = new ByteArrayContent(buffer.ToArray()),
+    };
+
+    foreach (var header in context.Request.Headers)
+    {
+        // A content header is refused by the request collection and accepted by the content's, which is how
+        // the two halves of System.Net.Http's split are told apart. Jint merges them back into one list.
+        if (!inbound.Headers.TryAddWithoutValidation(header.Key, (IEnumerable<string>) header.Value))
+        {
+            inbound.Content.Headers.TryAddWithoutValidation(header.Key, (IEnumerable<string>) header.Value);
+        }
+    }
+
+    HttpResponseMessage handled;
+    try
+    {
+        handled = await lease.Engine.Advanced.InvokeFetchHandlerAsync(inbound, context.RequestAborted);
+    }
+    catch (JintException ex)
+    {
+        // The host's policy, not Jint's: a script failure is a 500 here, a rendered error page elsewhere.
+        logger.LogWarning(ex, "the script handler failed");
+        context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+        return;
+    }
+
+    using (handled)
+    {
+        context.Response.StatusCode = (int) handled.StatusCode;
+        foreach (var header in handled.Headers.Concat(handled.Content.Headers))
+        {
+            context.Response.Headers[header.Key] = new StringValues(header.Value.ToArray());
+        }
+
+        await handled.Content.CopyToAsync(context.Response.Body, context.RequestAborted);
+    }
+});
+```
+
+Two things worth keeping when you adapt it. The engine must not be shared between concurrent requests, and a
+pooled one should have `engine.Advanced.RestoreGlobalSnapshot(...)` called on it between leases so one
+request's globals are not visible to the next. Take that snapshot **after** registering the handler, since
+registering is what installs `Request`/`Response`/`Headers` and a restore returns the global object to its
+state at capture; the handler itself is host state and survives the restore either way, so it never needs
+re-registering. And bound the script: the constraints above are what stand between a rented engine and a
+handler that decides to loop forever.
+
+</details>
+
 
 ## Node compatibility (opt-in)
 


### PR DESCRIPTION
Part of #3085: Workers-style fetch-handler hosting — `HttpRequestMessage` in, `HttpResponseMessage` out, with the script in between written exactly the way a Cloudflare Workers or Deno handler is.

`engine.Advanced.SetFetchHandler(value)` accepts the three shapes those runtimes established, tried in order: a callable, an object with a callable `fetch` (called with that object as `this`), and one `default` unwrap so a module namespace goes straight in — `SetFetchHandler(engine.Modules.Import("./worker.js"))` is one call. Registering the handler installs `Headers`/`Request`/`Response` (lazily, non-clobbering) but deliberately **not** `fetch`: handling an inbound request is no reason to grant outbound network access, and the guard asks for the model's three features (`Events | Url | Files`) rather than the `Fetch` flag.

`InvokeFetchHandler` returns a polled operation (the `ModuleImportOperation` pattern) so a host that owns its thread pumps with `ProcessTasks()` and watches `IsCompleted`; `InvokeFetchHandlerAsync` awaits, with its token documented identically to `EvaluateAsync`'s. The conversions follow the Fetch Standard's own concepts: method normalization and RFC 9110 token validation, request+content headers merged into the standard's one header list, zero-byte content as a *null* body (the ordinary ASP.NET Core GET stays repeatable-read), response headers split back by the framework's own content-header rule with `Content-Length`/`Transfer-Encoding` dropped as host-stack-owned. Failure policy: never a synthesized 500 — a sync throw, a rejection, a constraint failure and a non-`Response` answer each surface as their own exception type to the host, all under `JintException`; the README shows the map-to-500 example. Constraints bound one invocation via the ordinary `ExecuteWithConstraints` entry, with `OperationDeadlineConstraint` named as the whole-request bound.

38 tests with mutation evidence on multi-valued headers, host-owned framing headers, the fenced-off invocation faulting, and null-vs-empty bodies; both suites green on net10.0 and net472, with and without `JINT_HOST_CONTRACT_VERIFICATION=1`.

With messaging's cross-engine ports (#3127) and this, both #3085 items are in.

Closes #3085

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G7Ud48VAs1JicxRZxLDxg
