### PR TITLE
Stream fetch bodies: Response.body, Request.body and Blob.stream over ReadableStream

### DIFF
--- a/Jint.Tests.PublicInterface/WebApiFetchStreamTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiFetchStreamTests.cs
@@ -1,0 +1,246 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Jint;
+using SystemEncoding = System.Text.Encoding;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// A streaming <c>fetch</c> body seen from outside the assembly: what a host's transport is asked for, when,
+/// and what stops it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This project has no <c>InternalsVisibleTo</c>, so everything here goes in through
+/// <c>Options.WebApi.Fetch.HttpClient</c> — the same door a host uses for a <c>DelegatingHandler</c> or an
+/// <c>IHttpClientFactory</c> client — and comes back out through script.
+/// </para>
+/// <para>
+/// <b>Nothing here races a wall clock.</b> The transport's reads are gated by the test, so what is asserted
+/// is how many of them happened and in which order; the waits on a <see cref="ManualResetEventSlim"/> are
+/// waits for an event at a deliberately generous bound, not measurements.
+/// </para>
+/// </remarks>
+public class WebApiFetchStreamTests
+{
+    /// <summary>
+    /// A response body whose reads are served from a channel the test fills, so a read blocks until the test
+    /// has said what it should answer with.
+    /// </summary>
+    private sealed class GatedBody : Stream
+    {
+        private readonly Channel<byte[]?> _chunks = Channel.CreateUnbounded<byte[]?>();
+
+        private int _readCount;
+
+        internal int ReadCount => Volatile.Read(ref _readCount);
+
+        internal ManualResetEventSlim ReadStarted { get; } = new(false);
+
+        internal ManualResetEventSlim Cancelled { get; } = new(false);
+
+        internal void Emit(string text) => _chunks.Writer.TryWrite(SystemEncoding.UTF8.GetBytes(text));
+
+        internal void Complete() => _chunks.Writer.TryWrite(null);
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref _readCount);
+            ReadStarted.Set();
+
+            byte[]? chunk;
+            try
+            {
+                chunk = await _chunks.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                Cancelled.Set();
+                throw;
+            }
+
+            if (chunk is null)
+            {
+                return 0;
+            }
+
+            chunk.CopyTo(buffer);
+            return chunk.Length;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    private sealed class GatedHandler : HttpMessageHandler
+    {
+        internal GatedBody Body { get; } = new();
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(Body) });
+    }
+
+    private static Engine WebEngine(HttpMessageHandler handler)
+    {
+        var engine = new Engine(options => options.UseFetch(fetch => fetch.HttpClient = new HttpClient(handler)));
+        engine.Execute("function dec(u8) { return String.fromCharCode.apply(null, Array.from(u8)); }");
+        return engine;
+    }
+
+    [Fact]
+    public void EnablingFetchAlsoGivesTheStreamInterfaces()
+    {
+        // response.body is a ReadableStream, so the fetch flag brings the Streams feature with it — the same
+        // reason it brings Blob and AbortSignal.
+        var engine = new Engine(options => options.UseFetch());
+
+        engine.Evaluate("typeof ReadableStream").AsString().Should().Be("function");
+        engine.Evaluate("typeof TransformStream").AsString().Should().Be("function");
+
+        // ... and the host's own reading of Features is untouched by the closure.
+        var options = new Options().UseFetch();
+        options.WebApi.Features.Should().Be(WebApiFeatures.Fetch);
+    }
+
+    [Fact]
+    public void AHostScriptDrainsTheResponseBodyChunkByChunk()
+    {
+        var handler = new GatedHandler();
+        handler.Body.Emit("first ");
+        handler.Body.Emit("second");
+        handler.Body.Complete();
+
+        var engine = WebEngine(handler);
+
+        engine.Evaluate(@"(async () => {
+                const r = await fetch('https://example.org/');
+                const reader = r.body.getReader();
+                const seen = [];
+                while (true) {
+                    const { done, value } = await reader.read();
+                    if (done) break;
+                    seen.push(dec(value));
+                }
+                return seen.join('|');
+            })()").UnwrapIfPromise().AsString().Should().Be("first |second");
+
+        // One read per chunk, plus the one that saw the end of the body.
+        handler.Body.ReadCount.Should().Be(3);
+    }
+
+    [Fact]
+    public void TheTransportIsOnlyReadWhenTheScriptAsks()
+    {
+        // Backpressure, from the host's side: a script that takes the response and never reads its body
+        // leaves the transport untouched however hard the engine is pumped.
+        var handler = new GatedHandler();
+        handler.Body.Emit("ignored");
+        handler.Body.Complete();
+
+        var engine = WebEngine(handler);
+        engine.Execute("var r; fetch('https://example.org/').then(x => r = x);");
+        engine.Advanced.ProcessTasks();
+
+        engine.Evaluate("r.status").AsNumber().Should().Be(200);
+
+        for (var i = 0; i < 10; i++)
+        {
+            engine.Advanced.ProcessTasks();
+        }
+
+        // Deterministic against the shipped implementation rather than a race: with a high water mark of
+        // zero, no pull is ever issued until a consumer asks, so nothing can release the transport loop
+        // however long or hard the engine is pumped.
+        handler.Body.ReadStarted.IsSet.Should().BeFalse();
+        handler.Body.ReadCount.Should().Be(0);
+
+        // The first read is what reaches the socket.
+        engine.Evaluate("r.body.getReader().read().then(x => dec(x.value))").UnwrapIfPromise().AsString().Should().Be("ignored");
+        handler.Body.ReadCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void CancellingTheBodyLetsGoOfTheConnection()
+    {
+        // Nothing is emitted, so the transport is parked in a read and only its token can end it.
+        var handler = new GatedHandler();
+        var engine = WebEngine(handler);
+
+        engine.Execute("var r; fetch('https://example.org/').then(x => r = x);");
+        engine.Advanced.ProcessTasks();
+
+        engine.Execute("var reader = r.body.getReader(); reader.read();");
+        engine.Advanced.ProcessTasks();
+
+        handler.Body.ReadStarted.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue("the read should have reached the transport");
+
+        engine.Execute("reader.cancel();");
+        engine.Advanced.ProcessTasks();
+
+        handler.Body.Cancelled.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ARestoreLetsGoOfAStreamingBodyMidFlight()
+    {
+        var handler = new GatedHandler();
+        var engine = WebEngine(handler);
+
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+        engine.Execute("var r; fetch('https://example.org/').then(x => r = x);");
+        engine.Advanced.ProcessTasks();
+
+        engine.Execute("var reader = r.body.getReader(); reader.read();");
+        engine.Advanced.ProcessTasks();
+
+        handler.Body.ReadStarted.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        // The socket goes with the cycle that opened it: a body still arriving is not something the restored
+        // engine can finish reading, so it is cancelled rather than left holding a connection.
+        handler.Body.Cancelled.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+
+        engine.Evaluate("typeof r").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof fetch").AsString().Should().Be("function");
+    }
+
+    [Fact]
+    public void AResponseBodyCanBePipedThroughATransformStream()
+    {
+        // The two features meeting: a streaming body driving a TransformStream, all on the engine's own job
+        // queue and with nothing but the host's transport off it.
+        var handler = new GatedHandler();
+        handler.Body.Emit("ab");
+        handler.Body.Emit("cd");
+        handler.Body.Complete();
+
+        var engine = WebEngine(handler);
+
+        engine.Evaluate(@"(async () => {
+                const r = await fetch('https://example.org/');
+                const upper = new TransformStream({
+                    transform(chunk, controller) { controller.enqueue(dec(chunk).toUpperCase()); },
+                });
+
+                let out = '';
+                for await (const piece of r.body.pipeThrough(upper)) { out += piece; }
+                return out;
+            })()").UnwrapIfPromise().AsString().Should().Be("ABCD");
+    }
+}
+#endif

--- a/Jint.Tests.PublicInterface/WebApiFetchTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiFetchTests.cs
@@ -187,10 +187,16 @@ public class WebApiFetchTests
     }
 
     [Fact]
-    public void CapsTheResponseBodyWithoutAContentLength()
+    public void CapsTheResponseBodyWithoutAContentLengthWhileItStreams()
     {
         // A server that lies about the length, or uses chunked encoding, is caught by the running total
         // rather than by the declared one.
+        //
+        // Where that failure surfaces changed when response bodies became streams: the fetch promise
+        // resolves as soon as the headers are in — which is what the standard prescribes and what a browser
+        // does — so a cap that is only broken later can no longer reject it. It errors the body stream
+        // instead, and every consumer of that body reports it. The connection is still dropped at the chunk
+        // that crossed the line, so what the cap actually bounds is unchanged.
         var handler = new StubHandler
         {
             Responder = _ => new HttpResponseMessage(HttpStatusCode.OK) { Content = new UnknownLengthContent(4096) },
@@ -198,8 +204,39 @@ public class WebApiFetchTests
 
         var engine = WebEngine(handler, f => f.MaxResponseBytes = 1024);
 
-        engine.Evaluate("fetch('https://example.org/').then(() => 'resolved', e => e.message)")
-            .UnwrapIfPromise().AsString().Should().Contain("exceeded the 1024 byte limit");
+        engine.Evaluate("fetch('https://example.org/').then(r => r.text()).then(() => 'resolved', e => e.constructor.name + '|' + e.message)")
+            .UnwrapIfPromise().AsString().Should().Be("TypeError|Failed to fetch: The response body exceeded the 1024 byte limit set by Options.WebApi.Fetch.MaxResponseBytes.");
+    }
+
+    [Fact]
+    public void TheCapReachesAConsumerThatReadsTheStreamItself()
+    {
+        // The same failure through the other door: a script draining response.body chunk by chunk sees the
+        // reader's promise reject rather than a body mixin method's.
+        var handler = new StubHandler
+        {
+            Responder = _ => new HttpResponseMessage(HttpStatusCode.OK) { Content = new UnknownLengthContent(4096) },
+        };
+
+        var engine = WebEngine(handler, f => f.MaxResponseBytes = 1024);
+
+        engine.Evaluate(@"(async () => {
+                const r = await fetch('https://example.org/');
+                const reader = r.body.getReader();
+                let seen = 0;
+                try
+                {
+                    while (true) {
+                        const { done, value } = await reader.read();
+                        if (done) return 'closed after ' + seen;
+                        seen += value.length;
+                    }
+                }
+                catch (e) { return e.constructor.name + ' after ' + seen; }
+            })()")
+            // How many bytes arrived first depends on how the transport chunked them; that the read ends in
+            // a TypeError rather than in a close is the pin.
+            .UnwrapIfPromise().AsString().Should().StartWith("TypeError after ");
     }
 
     /// <summary>

--- a/Jint.Tests/Runtime/WebApi/BlobTests.cs
+++ b/Jint.Tests/Runtime/WebApi/BlobTests.cs
@@ -336,13 +336,56 @@ public class BlobTests
     }
 
     [Fact]
-    public void HasNoStreamMethod()
+    public void StreamProducesTheBytesAsOneChunkAndThenCloses()
     {
-        // Absent rather than throwing: Jint has no streams yet, and feature detection is written against
-        // absence.
-        Eval("typeof Blob.prototype.stream").AsString().Should().Be("undefined");
-        Eval("'stream' in Blob.prototype").AsBoolean().Should().BeFalse();
-        Eval("typeof Blob.prototype.textStream").AsString().Should().Be("undefined");
+        // https://w3c.github.io/FileAPI/#blob-get-stream. The bytes are already in memory, so they are one
+        // chunk rather than the implementation-defined slices a browser's loop reads.
+        var engine = WebEngine();
+        engine.Execute("var read = []; var s = new Blob(['hello']).stream(); var r = s.getReader();");
+
+        engine.Evaluate("r.read().then(x => x.done + ':' + (x.value instanceof Uint8Array) + ':' + x.value.length)")
+            .UnwrapIfPromise().AsString().Should().Be("false:true:5");
+
+        engine.Evaluate("r.read().then(x => x.done + ':' + (x.value === undefined))")
+            .UnwrapIfPromise().AsString().Should().Be("true:true");
+    }
+
+    [Fact]
+    public void StreamOfAnEmptyBlobIsDoneAtOnce()
+    {
+        Eval("new Blob([]).stream().getReader().read().then(x => x.done + ':' + (x.value === undefined))")
+            .UnwrapIfPromise().AsString().Should().Be("true:true");
+    }
+
+    [Fact]
+    public void StreamIsAReadableStreamEvenWithoutTheStreamsFeature()
+    {
+        // This engine asked for Files and nothing else, so the ReadableStream *global* is absent — but the
+        // object stream() answers is the real interface, reached through its prototype. Naming it takes the
+        // Streams feature (or WebApiFeatures.Default, which has both).
+        var engine = WebEngine();
+
+        engine.Evaluate("typeof ReadableStream").AsString().Should().Be("undefined");
+        engine.Evaluate("Object.prototype.toString.call(new Blob(['x']).stream())").AsString().Should().Be("[object ReadableStream]");
+        engine.Evaluate("new Blob(['x']).stream().locked").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void StreamHandsEachCallItsOwnStreamOverACopyOfTheBytes()
+    {
+        var engine = WebEngine();
+        engine.Execute("var b = new Blob(['ab']); var s1 = b.stream(); var s2 = b.stream();");
+
+        engine.Evaluate("s1 === s2").AsBoolean().Should().BeFalse();
+
+        // Writing through one chunk cannot reach the blob or the other stream: a blob is immutable and what
+        // crosses into script is a copy.
+        engine.Execute("s1.getReader().read().then(x => { x.value[0] = 0x7A; });");
+        engine.Advanced.ProcessTasks();
+
+        engine.Evaluate("b.text()").UnwrapIfPromise().AsString().Should().Be("ab");
+        engine.Evaluate("s2.getReader().read().then(x => String.fromCharCode.apply(null, Array.from(x.value)))")
+            .UnwrapIfPromise().AsString().Should().Be("ab");
     }
 
     [Fact]
@@ -354,6 +397,7 @@ public class BlobTests
         engine.Evaluate("Blob.prototype.text.length").AsNumber().Should().Be(0);
         engine.Evaluate("Blob.prototype.arrayBuffer.length").AsNumber().Should().Be(0);
         engine.Evaluate("Blob.prototype.bytes.length").AsNumber().Should().Be(0);
+        engine.Evaluate("Blob.prototype.stream.length").AsNumber().Should().Be(0);
     }
 }
 #endif

--- a/Jint.Tests/Runtime/WebApi/FetchStreamTests.cs
+++ b/Jint.Tests/Runtime/WebApi/FetchStreamTests.cs
@@ -1,0 +1,328 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Jint.WebApi.Streams;
+using SystemEncoding = System.Text.Encoding;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// A network response body as a live <c>ReadableStream</c> — https://fetch.spec.whatwg.org/#concept-response-body
+/// — driven against a transport whose every read is gated by the test, so that nothing here depends on a
+/// clock.
+/// </summary>
+/// <remarks>
+/// <b>No assertion in this file races a wall clock.</b> What is asserted is structural: how many times the
+/// transport was read, in which order the chunks arrived, and what state a stream ended in. The two waits on
+/// a <see cref="ManualResetEventSlim"/> are waits for an event that either happens or fails the test at a
+/// deliberately generous bound, not measurements of how long anything took.
+/// </remarks>
+public class FetchStreamTests
+{
+    /// <summary>
+    /// A response body stream whose reads are served from a channel the test fills, so a read only completes
+    /// when the test has said what it should answer with — and blocks until then.
+    /// </summary>
+    private sealed class GatedBody : Stream
+    {
+        private readonly Channel<byte[]?> _chunks = Channel.CreateUnbounded<byte[]?>();
+
+        private int _readCount;
+
+        /// <summary>How many times the pump has asked the transport for bytes.</summary>
+        internal int ReadCount => Volatile.Read(ref _readCount);
+
+        /// <summary>Set the first time a read is entered, so a test can wait for the pump to be parked in one.</summary>
+        internal ManualResetEventSlim ReadStarted { get; } = new(false);
+
+        /// <summary>Set when a read saw its cancellation token fire — the proof a cancel reached the transport.</summary>
+        internal ManualResetEventSlim Cancelled { get; } = new(false);
+
+        internal void Emit(string text) => _chunks.Writer.TryWrite(SystemEncoding.UTF8.GetBytes(text));
+
+        internal void Complete() => _chunks.Writer.TryWrite(null);
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref _readCount);
+            ReadStarted.Set();
+
+            byte[]? chunk;
+            try
+            {
+                chunk = await _chunks.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                Cancelled.Set();
+                throw;
+            }
+
+            if (chunk is null)
+            {
+                return 0;
+            }
+
+            chunk.CopyTo(buffer);
+            return chunk.Length;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    private sealed class GatedHandler : HttpMessageHandler
+    {
+        internal GatedBody Body { get; } = new();
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            // StreamContent hands the wrapped stream straight back from ReadAsStreamAsync, which is what
+            // makes the gating observable: nothing buffers the body behind our backs.
+            var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(Body) };
+            return Task.FromResult(response);
+        }
+    }
+
+    private static Engine WebEngine(HttpMessageHandler handler)
+    {
+        var engine = new Engine(options => options.UseFetch(fetch => fetch.HttpClient = new HttpClient(handler)));
+
+        // ASCII-only helper, so these tests do not also need the Encoding feature.
+        engine.Execute("function dec(u8) { return String.fromCharCode.apply(null, Array.from(u8)); }");
+        return engine;
+    }
+
+    [Fact]
+    public void TheBodyIsReadOneChunkPerReadAndNotBefore()
+    {
+        var handler = new GatedHandler();
+        handler.Body.Emit("he");
+        handler.Body.Emit("llo");
+        handler.Body.Complete();
+
+        var engine = WebEngine(handler);
+        engine.Execute("var r; fetch('https://example.org/').then(x => r = x);");
+        engine.Advanced.ProcessTasks();
+
+        engine.Evaluate("r.status").AsNumber().Should().Be(200);
+
+        // Backpressure: the stream's high water mark is zero, so the promise resolving with the response has
+        // touched the socket for its headers and for nothing else. Pumping cannot change that — only a
+        // consumer can.
+        engine.Advanced.ProcessTasks();
+        handler.Body.ReadCount.Should().Be(0);
+
+        // Nor does taking a reader, which locks the stream without asking it for anything.
+        engine.Execute("var reader = r.body.getReader();");
+        handler.Body.ReadCount.Should().Be(0);
+
+        engine.Evaluate("reader.read().then(x => x.done + ':' + dec(x.value))").UnwrapIfPromise().AsString().Should().Be("false:he");
+        handler.Body.ReadCount.Should().Be(1);
+
+        engine.Evaluate("reader.read().then(x => x.done + ':' + dec(x.value))").UnwrapIfPromise().AsString().Should().Be("false:llo");
+        handler.Body.ReadCount.Should().Be(2);
+
+        // The read that sees the end of the body closes the stream.
+        engine.Evaluate("reader.read().then(x => x.done + ':' + (x.value === undefined))").UnwrapIfPromise().AsString().Should().Be("true:true");
+        handler.Body.ReadCount.Should().Be(3);
+
+        engine.Evaluate("r.bodyUsed").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ForAwaitOfDrainsAStreamingBody()
+    {
+        var handler = new GatedHandler();
+        handler.Body.Emit("a");
+        handler.Body.Emit("b");
+        handler.Body.Emit("c");
+        handler.Body.Complete();
+
+        var engine = WebEngine(handler);
+
+        engine.Evaluate(@"(async () => {
+                const r = await fetch('https://example.org/');
+                let out = '';
+                for await (const chunk of r.body) { out += dec(chunk) + '|'; }
+                return out;
+            })()").UnwrapIfPromise().AsString().Should().Be("a|b|c|");
+
+        // One read per chunk plus the one that saw the end.
+        handler.Body.ReadCount.Should().Be(4);
+    }
+
+    [Fact]
+    public void TextOverAStreamingBodyEqualsTheBufferedAnswer()
+    {
+        var handler = new GatedHandler();
+        handler.Body.Emit("{\"a\":");
+        handler.Body.Emit("1}");
+        handler.Body.Complete();
+
+        var engine = WebEngine(handler);
+
+        // The mixin's consumers run the standard's fully-read steps over the stream and reassemble the bytes,
+        // so a body split across chunks is indistinguishable from one that arrived whole.
+        var streamed = engine.Evaluate("fetch('https://example.org/').then(r => r.text())").UnwrapIfPromise().AsString();
+        var buffered = engine.Evaluate("new Response('{\"a\":1}').text()").UnwrapIfPromise().AsString();
+
+        streamed.Should().Be(buffered).And.Be("{\"a\":1}");
+    }
+
+    [Fact]
+    public void JsonOverAStreamingBodyParsesAcrossChunkBoundaries()
+    {
+        var handler = new GatedHandler();
+        handler.Body.Emit("{\"a\":");
+        handler.Body.Emit("[1,2,");
+        handler.Body.Emit("3]}");
+        handler.Body.Complete();
+
+        var engine = WebEngine(handler);
+
+        engine.Evaluate("fetch('https://example.org/').then(r => r.json()).then(v => v.a.join('-'))")
+            .UnwrapIfPromise().AsString().Should().Be("1-2-3");
+    }
+
+    [Fact]
+    public void CloneTeesTheStreamAndBothHalvesAreReadable()
+    {
+        var handler = new GatedHandler();
+        handler.Body.Emit("hel");
+        handler.Body.Emit("lo");
+        handler.Body.Complete();
+
+        var engine = WebEngine(handler);
+        engine.Execute("var r; fetch('https://example.org/').then(x => x && (r = x));");
+        engine.Advanced.ProcessTasks();
+
+        // https://fetch.spec.whatwg.org/#concept-body-clone — the original keeps the first branch, the clone
+        // gets the second, and neither is the stream that existed before.
+        engine.Execute("var before = r.body; var copy = r.clone();");
+        engine.Evaluate("r.body === before").AsBoolean().Should().BeFalse();
+        engine.Evaluate("copy.body === r.body").AsBoolean().Should().BeFalse();
+
+        engine.Evaluate("r.text()").UnwrapIfPromise().AsString().Should().Be("hello");
+        engine.Evaluate("r.bodyUsed").AsBoolean().Should().BeTrue();
+
+        // The clone carries its own flag over its own branch, and the branch buffered everything the shared
+        // reader pulled.
+        engine.Evaluate("copy.bodyUsed").AsBoolean().Should().BeFalse();
+        engine.Evaluate("copy.text()").UnwrapIfPromise().AsString().Should().Be("hello");
+
+        // One reader over the original, so the transport is still read exactly once per chunk.
+        handler.Body.ReadCount.Should().Be(3);
+    }
+
+    [Fact]
+    public void CancellingTheBodyStreamCancelsTheTransport()
+    {
+        // Nothing is emitted, so the pump parks inside a read and the only way out is the token.
+        var handler = new GatedHandler();
+        var engine = WebEngine(handler);
+
+        engine.Execute("var r; fetch('https://example.org/').then(x => r = x);");
+        engine.Advanced.ProcessTasks();
+
+        engine.Execute("var state = 'pending'; var reader = r.body.getReader(); reader.read().then(x => state = x.done ? 'done' : 'chunk', () => state = 'error');");
+        engine.Advanced.ProcessTasks();
+
+        handler.Body.ReadStarted.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue("the pull should have reached the transport");
+
+        engine.Execute("reader.cancel('stop');");
+        engine.Advanced.ProcessTasks();
+
+        // The cancel reached the socket, not just the stream.
+        handler.Body.Cancelled.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+
+        // Cancelling closes the stream, so the outstanding read resolves as done rather than hanging.
+        engine.Evaluate("state").AsString().Should().Be("done");
+        engine.Evaluate("r.bodyUsed").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ARestoreErrorsALiveBodyStreamAndCancelsTheTransport()
+    {
+        var handler = new GatedHandler();
+        var engine = WebEngine(handler);
+
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+        engine.Execute("var r; fetch('https://example.org/').then(x => r = x);");
+        engine.Advanced.ProcessTasks();
+
+        // Held on the host side, because the restore is about to revert the global that names it.
+        var body = engine.Evaluate("r.body");
+        var stream = (JsReadableStream) body;
+        stream.State.Should().Be(ReadableStreamState.Readable);
+
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        // The stream reports failure rather than silently never producing another byte ...
+        stream.State.Should().Be(ReadableStreamState.Errored);
+        stream.StoredError.AsObject().Get("message").AsString().Should().Contain("globals were restored");
+
+        // ... and the connection is let go at once.
+        handler.Body.ReadStarted.IsSet.Should().BeFalse("nothing ever asked the transport for bytes");
+        engine.Evaluate("typeof r").AsString().Should().Be("undefined");
+
+        // The engine is perfectly usable afterwards.
+        engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
+    }
+
+    [Fact]
+    public void ARestoreCancelsATransportThatWasAlreadyReading()
+    {
+        var handler = new GatedHandler();
+        var engine = WebEngine(handler);
+
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+        engine.Execute("var r; fetch('https://example.org/').then(x => r = x);");
+        engine.Advanced.ProcessTasks();
+
+        engine.Execute("var reader = r.body.getReader(); reader.read();");
+        engine.Advanced.ProcessTasks();
+
+        handler.Body.ReadStarted.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        handler.Body.Cancelled.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ANullBodyStatusStillHasNoStreamAtAll()
+    {
+        var handler = new NoContentHandler();
+        var engine = WebEngine(handler);
+
+        engine.Execute("var r; fetch('https://example.org/').then(x => r = x);");
+        engine.Advanced.ProcessTasks();
+
+        // https://fetch.spec.whatwg.org/#null-body-status — null, not an empty stream, and reading it never
+        // disturbs anything.
+        engine.Evaluate("r.body").Should().Be(Native.JsValue.Null);
+        engine.Evaluate("r.text()").UnwrapIfPromise().AsString().Should().Be("");
+        engine.Evaluate("r.bodyUsed").AsBoolean().Should().BeFalse();
+    }
+
+    private sealed class NoContentHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NoContent));
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/FetchTests.cs
+++ b/Jint.Tests/Runtime/WebApi/FetchTests.cs
@@ -126,6 +126,42 @@ public class FetchTests
     }
 
     [Fact]
+    public void AStreamRequestBodyIsReadInFullBeforeAnythingIsSent()
+    {
+        // Streaming uploads (the standard's `duplex: "half"`) are out of scope: the stream is drained first
+        // and the request carries the bytes it produced.
+        var handler = new StubHandler();
+
+        Fetch(handler, @"fetch('https://example.org/a', {
+            method: 'POST',
+            body: new ReadableStream({
+                start(c) { c.enqueue(new Uint8Array([104])); c.enqueue(new Uint8Array([105])); c.close(); },
+            }),
+        })");
+
+        var request = handler.Requests.Should().ContainSingle().Subject;
+        request.Method.Should().Be("POST");
+        request.Body.Should().Be("hi");
+
+        // https://fetch.spec.whatwg.org/#concept-bodyinit-extract — the ReadableStream arm implies no type.
+        request.Header("content-type").Should().BeNull();
+    }
+
+    [Fact]
+    public void AStreamRequestBodyThatErrorsRejectsBeforeASocketIsOpened()
+    {
+        var handler = new StubHandler();
+
+        Fetch(handler, @"fetch('https://example.org/a', {
+            method: 'POST',
+            body: new ReadableStream({ start(c) { c.error(new TypeError('boom')); } }),
+        }).then(() => 'resolved', e => e.constructor.name + ': ' + e.message)")
+            .AsString().Should().Be("TypeError: boom");
+
+        handler.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
     public void MapsEveryResponseHeaderIncludingRepeatedOnes()
     {
         var handler = new StubHandler
@@ -337,9 +373,13 @@ public class FetchTests
         engine.Advanced.ProcessTasks();
 
         engine.Evaluate("r.bodyUsed").AsBoolean().Should().BeFalse();
-        engine.Evaluate("r.body").Should().Be(JsValue.Null);
 
+        // A network response streams: body is the live ReadableStream, not null.
+        engine.Evaluate("Object.prototype.toString.call(r.body)").AsString().Should().Be("[object ReadableStream]");
+
+        // clone() tees, so each object gets its own branch — https://fetch.spec.whatwg.org/#concept-body-clone.
         engine.Execute("var copy = r.clone();");
+        engine.Evaluate("r.body === copy.body").AsBoolean().Should().BeFalse();
 
         engine.Evaluate("r.json()").UnwrapIfPromise().AsObject().Get("a").AsNumber().Should().Be(1);
         engine.Evaluate("r.bodyUsed").AsBoolean().Should().BeTrue();

--- a/Jint.Tests/Runtime/WebApi/RequestTests.cs
+++ b/Jint.Tests/Runtime/WebApi/RequestTests.cs
@@ -262,18 +262,69 @@ public class RequestTests
     }
 
     [Fact]
-    public void BodyIsAlwaysNullAndBodyUsedTracksConsumption()
+    public void BodyIsAStreamAndBodyUsedTracksConsumption()
     {
         var engine = WebEngine();
         engine.Execute("var a = new Request('https://example.org', { method: 'POST', body: 'hi' });");
 
-        // Streams are a follow-up; the attribute is present and answers null, which is a meaningful answer.
-        engine.Evaluate("a.body").Should().Be(JsValue.Null);
+        // https://fetch.spec.whatwg.org/#dom-body-body — the body's stream, and null only when there is no
+        // body at all, which every GET necessarily has not.
+        engine.Evaluate("Object.prototype.toString.call(a.body)").AsString().Should().Be("[object ReadableStream]");
         engine.Evaluate("new Request('https://example.org').body").Should().Be(JsValue.Null);
+
+        // [SameObject]-like in practice: the stream is created once and kept.
+        engine.Evaluate("a.body === a.body").AsBoolean().Should().BeTrue();
 
         engine.Evaluate("a.bodyUsed").AsBoolean().Should().BeFalse();
         engine.Evaluate("a.arrayBuffer()").UnwrapIfPromise();
         engine.Evaluate("a.bodyUsed").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReadingTheBodyStreamDirectlyIsWhatDisturbsIt()
+    {
+        // bodyUsed is the stream's disturbed flag, so touching the stream is what flips it — not calling one
+        // of the mixin's consumers.
+        var engine = WebEngine();
+        engine.Execute("var a = new Request('https://example.org', { method: 'POST', body: 'hi' }); var s = a.body;");
+
+        engine.Evaluate("a.bodyUsed").AsBoolean().Should().BeFalse();
+
+        engine.Execute("var r = s.getReader();");
+
+        // Locked but not yet disturbed: bodyUsed is still false, and a consumer already rejects.
+        engine.Evaluate("a.bodyUsed").AsBoolean().Should().BeFalse();
+        engine.Evaluate("a.text().then(() => 'resolved', e => e.constructor.name)").UnwrapIfPromise().AsString().Should().Be("TypeError");
+
+        engine.Evaluate("r.read().then(x => x.value.length)").UnwrapIfPromise().AsNumber().Should().Be(2);
+        engine.Evaluate("a.bodyUsed").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void AcceptsAReadableStreamAsTheBody()
+    {
+        var engine = WebEngine();
+        engine.Execute(@"
+            var source = new ReadableStream({ start(c) { c.enqueue(new Uint8Array([104, 105])); c.close(); } });
+            var a = new Request('https://example.org', { method: 'POST', body: source });");
+
+        // https://fetch.spec.whatwg.org/#concept-bodyinit-extract — the ReadableStream arm becomes the
+        // body's stream itself, and implies no Content-Type.
+        engine.Evaluate("a.body === source").AsBoolean().Should().BeTrue();
+        engine.Evaluate("a.headers.has('content-type')").AsBoolean().Should().BeFalse();
+
+        engine.Evaluate("a.text()").UnwrapIfPromise().AsString().Should().Be("hi");
+        engine.Evaluate("a.bodyUsed").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void RefusesAReadableStreamThatIsAlreadyDisturbedOrLocked()
+    {
+        var engine = WebEngine();
+        engine.Execute("var locked = new ReadableStream(); locked.getReader();");
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new Request('https://example.org', { method: 'POST', body: locked })"))
+            .Message.Should().Contain("disturbed or locked");
     }
 
     [Fact]

--- a/Jint/Engine.WebApi.cs
+++ b/Jint/Engine.WebApi.cs
@@ -85,6 +85,16 @@ internal sealed class WebApiEngineState
     /// </summary>
     private List<EventSourceConnection>? _eventSources;
 
+    /// <summary>
+    /// The response bodies still arriving over the wire. Engine-thread-only for the same reason
+    /// <see cref="_fetches"/> is: a body is registered when its stream is built and removed when the stream
+    /// closes, errors or is cancelled, all of which happen on the engine's thread. Separate from
+    /// <see cref="_fetches"/> because a request stops counting against
+    /// <c>Options.FetchOptions.MaxConcurrentRequests</c> when its promise settles, which is before its body
+    /// has finished.
+    /// </summary>
+    private List<FetchBodyStream>? _fetchBodies;
+
     internal WebApiEngineState(Engine engine, TimeProvider timeProvider, TimerQueue? timers, Options.FetchOptions? fetchOptions, SchedulerQueue? scheduler, DiagnosticsSink? diagnostics, Options.StorageOptions? storage = null)
     {
         _engine = engine;
@@ -138,6 +148,10 @@ internal sealed class WebApiEngineState
     internal void RegisterFetch(FetchOperation operation) => (_fetches ??= new List<FetchOperation>()).Add(operation);
 
     internal void UnregisterFetch(FetchOperation operation) => _fetches?.Remove(operation);
+
+    internal void RegisterBodyStream(FetchBodyStream body) => (_fetchBodies ??= new List<FetchBodyStream>()).Add(body);
+
+    internal void UnregisterBodyStream(FetchBodyStream body) => _fetchBodies?.Remove(body);
 
     /// <summary>
     /// The engine's prioritized task queues, or <see langword="null"/> when the scheduler feature is off.
@@ -250,15 +264,21 @@ internal sealed class WebApiEngineState
     /// A request in flight is cancelled rather than merely forgotten: the generation fence already stops its
     /// response reaching the restored engine, but forgetting it would leave the socket open until the server
     /// answered. Its promise stays pending — settling it is exactly what the fence forbids — which is the
-    /// same contract a promise registered before a restore has always had. The sink is deliberately not
-    /// reset: it is configuration the engine was built with, like the time origin beside it, and a pooled
-    /// engine reporting the next cycle's errors nowhere would be a strange thing for a restore to arrange.
+    /// same contract a promise registered before a restore has always had. A response body still streaming is
+    /// the same story one step later: its promise has already settled, so what has to be ended is the
+    /// <c>ReadableStream</c>. Its controller is <b>errored</b>, which is the honest answer to a host still
+    /// holding the response — a stream that reports failure beats one that silently never produces another
+    /// byte — and the reactions that erroring schedules carry the ending cycle's generation, so the fence
+    /// discards them exactly as it discards a chunk still on its way. The sink is deliberately not reset: it
+    /// is configuration the engine was built with, like the time origin beside it, and a pooled engine
+    /// reporting the next cycle's errors nowhere would be a strange thing for a restore to arrange.
     /// </remarks>
     internal void ResetTransientState()
     {
         Timers?.Clear();
         Scheduler?.Clear();
         AbandonFetches();
+        AbandonFetchBodies();
         AbandonEventSources();
     }
 
@@ -281,7 +301,7 @@ internal sealed class WebApiEngineState
     }
 
     /// <summary>
-    /// The same for the event streams, and for the same reasons — with one addition: an abandoned connection
+    /// The same for the event streams, and for the same reasons â with one addition: an abandoned connection
     /// leaves its <c>EventSource</c> object <c>CLOSED</c>, and fires nothing, because the evaluation cycle
     /// those listeners belonged to has ended. The reconnect delay a stream may have been holding is on the
     /// timer queue <see cref="Timers"/> has just cleared.
@@ -299,6 +319,22 @@ internal sealed class WebApiEngineState
         foreach (var source in pending)
         {
             source.Abandon();
+        }
+    }
+
+    private void AbandonFetchBodies()
+    {
+        if (_fetchBodies is not { Count: > 0 } bodies)
+        {
+            return;
+        }
+
+        var pendingBodies = bodies.ToArray();
+        bodies.Clear();
+
+        foreach (var body in pendingBodies)
+        {
+            body.Abandon();
         }
     }
 }

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -232,13 +232,20 @@ public partial class Options
         public Func<Uri, bool> UrlFilter { get; set; } = static _ => true;
 
         /// <summary>
-        /// The most bytes a response body may decompress to. Defaults to 32 MiB; a response that exceeds it is
-        /// abandoned and the promise rejects with a <c>TypeError</c>.
+        /// The most bytes a response body may decompress to. Defaults to 32 MiB; a body that exceeds it is
+        /// abandoned and reported as a <c>TypeError</c>.
         /// </summary>
         /// <remarks>
         /// Counted after decompression, so a compression bomb is bounded by the number a host actually chose
-        /// rather than by its compressed size. The bytes are buffered in memory, so this is also the ceiling on
-        /// what one request can cost the process.
+        /// rather than by its compressed size, and enforced on the running total as the body streams — the
+        /// connection is dropped at the chunk that crosses the line.
+        /// <para>
+        /// <b>Where the failure surfaces depends on when it is known.</b> A <c>Content-Length</c> that already
+        /// exceeds the cap is refused while the headers are being read, so the <c>fetch</c> promise itself
+        /// rejects. A body that only breaks the cap later cannot reject that promise, because it has already
+        /// resolved with the response — as the standard prescribes and as a browser does — so it <i>errors the
+        /// response's body stream</i> instead, and every consumer of that body reports it.
+        /// </para>
         /// <para>
         /// <b><see cref="long.MaxValue"/> means unlimited</b>, and zero or less refuses every body. This is
         /// deliberately unlike the execution constraints' saturated sentinels, where
@@ -485,9 +492,13 @@ public enum WebApiFeatures
 
     /// <summary>
     /// <c>Blob</c>, <c>File</c> and <c>FormData</c> — in-memory byte sequences and the ordered entry list a
-    /// form submission is made of. No streaming (<c>Blob.stream()</c> is absent) and no
-    /// <c>multipart/form-data</c> serialization, which arrives with fetch.
+    /// form submission is made of. No <c>multipart/form-data</c> serialization, which arrives with fetch.
     /// </summary>
+    /// <remarks>
+    /// <c>Blob.stream()</c> answers a real <c>ReadableStream</c> whether or not <see cref="Streams"/> is also
+    /// enabled — the interface is always there, and the flag only decides whether <c>ReadableStream</c> is a
+    /// global a script can name. <see cref="Default"/> has both.
+    /// </remarks>
     Files = 1 << 9,
 
     /// <summary>

--- a/Jint/WebApi/Fetch/FetchBodyObject.cs
+++ b/Jint/WebApi/Fetch/FetchBodyObject.cs
@@ -1,5 +1,6 @@
 #if NET8_0_OR_GREATER
 using SystemEncoding = System.Text.Encoding;
+using System.Buffers;
 using Jint.Native;
 using Jint.Native.Json;
 using Jint.Native.Object;
@@ -7,6 +8,7 @@ using Jint.Native.Promise;
 using Jint.Native.TypedArray;
 using Jint.Runtime;
 using Jint.WebApi.Files;
+using Jint.WebApi.Streams;
 using Jint.WebApi.Url;
 using Jint.WebApi.Url.Parsing;
 
@@ -18,16 +20,32 @@ namespace Jint.WebApi.Fetch;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b>Bodies are buffered, not streamed.</b> The standard's body is a <c>ReadableStream</c>, which Jint does
-/// not have; a body here is a byte array that already exists in full, which is why every consumer answers an
-/// already-resolved promise and why <c>body</c> is always <see langword="null"/> (see
-/// <c>RequestPrototype.BodyGet</c>). What the standard's <i>disturbed</i> flag buys is kept exactly:
-/// <see cref="BodyUsed"/> flips on the first consume and every later one rejects, so a script that reads a
-/// response twice fails the way it would in a browser rather than silently succeeding here and failing there.
+/// The standard's body is a record of a <c>ReadableStream</c> and an optional <i>source</i> — the bytes the
+/// stream was built from, kept so that a body can be re-extracted. Both halves are here, and which one is
+/// present decides how a consumer is served:
+/// </para>
+/// <list type="bullet">
+/// <item>
+/// A body extracted from bytes — a string, a <c>Blob</c>, a <c>BufferSource</c>, <c>URLSearchParams</c> —
+/// keeps its <see cref="Source"/> and creates no stream at all until something asks for
+/// <see cref="Stream"/>. <c>text()</c> on such a body answers an already-resolved promise off the source, so
+/// the common <c>new Response('…').text()</c> costs no stream, no reader and no event-loop turn.
+/// </item>
+/// <item>
+/// A body that arrived as a stream — a network response, or a <c>ReadableStream</c> handed to a constructor
+/// — has no source, and every consumer reads it through the standard's fully-read steps.
+/// </item>
+/// </list>
+/// <para>
+/// <see cref="HasBody"/> distinguishes both from the standard's <i>null body</i>, which is not the same as an
+/// empty one: it can be consumed any number of times and never flips <c>bodyUsed</c>.
 /// </para>
 /// <para>
-/// A <see langword="null"/> <see cref="Body"/> is the standard's null body, which is not the same as an empty
-/// one: it can be consumed any number of times and never flips <see cref="BodyUsed"/>.
+/// <c>bodyUsed</c> and "body is unusable" are the stream's <i>disturbed</i> and <i>locked</i> flags, exactly
+/// as https://fetch.spec.whatwg.org/#dom-body-bodyused defines them. A body that never materialized a stream
+/// has no flags to read, so <see cref="SourceDisturbed"/> stands in for the disturbance the extraction-time
+/// stream would have recorded — the two are indistinguishable from script, because the only way to observe
+/// the stream is to ask for it, which materializes it.
 /// </para>
 /// </remarks>
 internal abstract class FetchBodyObject : ObjectInstance
@@ -44,22 +62,110 @@ internal abstract class FetchBodyObject : ObjectInstance
     internal JsHeaders Headers { get; }
 
     /// <summary>
-    /// https://fetch.spec.whatwg.org/#concept-body — the bytes, or <see langword="null"/> for a null body.
-    /// A clone shares the array with its original, which a buffered body's immutability makes safe.
+    /// https://fetch.spec.whatwg.org/#concept-body-source — the bytes the body was extracted from, or
+    /// <see langword="null"/> when there is no body or the body only ever existed as a stream. A clone shares
+    /// the array with its original, which a buffered body's immutability makes safe.
     /// </summary>
-    internal ReadOnlyMemory<byte>? Body { get; set; }
+    internal ReadOnlyMemory<byte>? Source { get; private set; }
 
     /// <summary>
-    /// https://fetch.spec.whatwg.org/#dom-body-bodyused — whether the body has been consumed. Per object, so
-    /// a clone starts unused however often the original was read.
+    /// https://fetch.spec.whatwg.org/#concept-body-stream — the body's stream, or <see langword="null"/>
+    /// while a buffered body has not been asked for one.
     /// </summary>
-    internal bool BodyUsed { get; set; }
+    internal JsReadableStream? Stream { get; private set; }
 
     /// <summary>
-    /// https://fetch.spec.whatwg.org/#body-unusable — a non-null body that has already been consumed. What
-    /// makes a second <c>text()</c> reject and a <c>clone()</c> after one throw.
+    /// Whether the body concept is non-null at all, which is what
+    /// https://fetch.spec.whatwg.org/#body-unusable and <c>bodyUsed</c> both key on.
     /// </summary>
-    internal bool IsUnusable => Body is not null && BodyUsed;
+    internal bool HasBody { get; private set; }
+
+    /// <summary>
+    /// Stands in for the disturbance of the stream a buffered body never had to create. Only ever read while
+    /// <see cref="Stream"/> is <see langword="null"/>.
+    /// </summary>
+    private bool SourceDisturbed { get; set; }
+
+    /// <summary>
+    /// https://fetch.spec.whatwg.org/#dom-body-bodyused — "this's body is non-null and this's body's stream
+    /// is disturbed".
+    /// </summary>
+    internal bool BodyUsed => HasBody && (Stream is not null ? Stream.Disturbed : SourceDisturbed);
+
+    /// <summary>
+    /// https://fetch.spec.whatwg.org/#body-unusable — a non-null body whose stream is disturbed or locked.
+    /// What makes a second <c>text()</c> reject and a <c>clone()</c> after one throw.
+    /// </summary>
+    internal bool IsUnusable => HasBody && (BodyUsed || (Stream is not null && ReadableStreamOperations.IsLocked(Stream)));
+
+    /// <summary>Sets the body to one extracted from a byte sequence.</summary>
+    internal void SetBufferedBody(ReadOnlyMemory<byte> bytes)
+    {
+        Source = bytes;
+        Stream = null;
+        SourceDisturbed = false;
+        HasBody = true;
+    }
+
+    /// <summary>
+    /// Sets the body to one that only exists as a stream — a network response, or a <c>ReadableStream</c>
+    /// passed as a <c>BodyInit</c>.
+    /// </summary>
+    internal void SetStreamBody(JsReadableStream stream)
+    {
+        Source = null;
+        Stream = stream;
+        SourceDisturbed = false;
+        HasBody = true;
+    }
+
+    /// <summary>
+    /// Replaces the stream in place, which is what <c>clone</c> does with the first branch of its tee —
+    /// https://fetch.spec.whatwg.org/#concept-body-clone step 2.
+    /// </summary>
+    internal void ReplaceStream(JsReadableStream stream) => Stream = stream;
+
+    /// <summary>
+    /// Records that a buffered body's source has been consumed. Never called once a stream exists, because
+    /// the stream's own <c>disturbed</c> flag is then the authority.
+    /// </summary>
+    internal void MarkSourceDisturbed() => SourceDisturbed = true;
+
+    /// <summary>
+    /// https://fetch.spec.whatwg.org/#dom-body-body — the stream, materializing it from the buffered source
+    /// on first ask. <see langword="null"/> for a null body.
+    /// </summary>
+    /// <remarks>
+    /// A body extracted from bytes has a stream from the moment it is extracted, per the standard; deferring
+    /// its creation to the first read of <c>body</c> is invisible, because asking is the only way to observe
+    /// it. What the deferral buys is the buffered fast path in <see cref="FetchBody.Consume"/>: a script that
+    /// only ever calls <c>text()</c> never builds a stream, a controller or a reader.
+    /// </remarks>
+    internal JsReadableStream? GetOrCreateStream(Realm realm)
+    {
+        if (!HasBody)
+        {
+            return null;
+        }
+
+        if (Stream is not null)
+        {
+            return Stream;
+        }
+
+        var bytes = Source!.Value;
+        var stream = ByteStreams.CreateFromBytes(Engine, realm, bytes);
+
+        // A source that has already been consumed hands back a stream that is disturbed to match, so
+        // `r.text(); r.body.locked` and `r.bodyUsed` keep telling the same story.
+        if (SourceDisturbed)
+        {
+            ReadableStreamOperations.Cancel(stream, Undefined);
+        }
+
+        Stream = stream;
+        return stream;
+    }
 }
 
 /// <summary>
@@ -96,27 +202,50 @@ internal static class FetchBody
     private const string JsonType = "application/json";
 
     /// <summary>
-    /// The extract-a-body algorithm, https://fetch.spec.whatwg.org/#concept-bodyinit-extract — the bytes plus
-    /// the <c>Content-Type</c> the source implies, which is <see langword="null"/> when it implies none.
+    /// One arm of the extract-a-body algorithm's result: either the bytes a source was reduced to, or the
+    /// stream the source <i>is</i>.
+    /// </summary>
+    /// <remarks>
+    /// A <c>readonly record struct</c> rather than a tuple because both constructors pass it around and one
+    /// of them stores it, and because <c>Bytes</c>/<c>Stream</c>/<c>Type</c> read better than three
+    /// positional items at those call sites.
+    /// </remarks>
+    internal readonly record struct ExtractedBody(ReadOnlyMemory<byte> Bytes, JsReadableStream? Stream, string? Type);
+
+    /// <summary>
+    /// The extract-a-body algorithm, https://fetch.spec.whatwg.org/#concept-bodyinit-extract — the bytes (or
+    /// the stream) plus the <c>Content-Type</c> the source implies, which is <see langword="null"/> when it
+    /// implies none.
     /// </summary>
     /// <remarks>
     /// The union arms are tried in the order the IDL declares them, which is what makes a <c>Blob</c> a blob
-    /// rather than a stringified object. <c>ReadableStream</c> is absent, and a <c>FormData</c> is refused
-    /// rather than silently stringified — see <see cref="ThrowFormDataUnsupported"/>.
+    /// rather than a stringified object. A <c>FormData</c> is refused rather than silently stringified — see
+    /// <see cref="ThrowFormDataUnsupported"/>.
     /// </remarks>
-    internal static (ReadOnlyMemory<byte> Bytes, string? Type) Extract(Realm realm, JsValue body)
+    internal static ExtractedBody Extract(Realm realm, JsValue body)
     {
         switch (body)
         {
             case JsBlob blob:
-                return (blob.Data.ToArray(), blob.MediaType.Length == 0 ? null : blob.MediaType);
+                return new ExtractedBody(blob.Data.ToArray(), null, blob.MediaType.Length == 0 ? null : blob.MediaType);
 
             case JsFormData:
                 ThrowFormDataUnsupported(realm);
                 return default;
 
             case JsUrlSearchParams parameters:
-                return (SystemEncoding.UTF8.GetBytes(FormUrlEncoded.Serialize(parameters.List)), FormUrlEncodedType);
+                return new ExtractedBody(SystemEncoding.UTF8.GetBytes(FormUrlEncoded.Serialize(parameters.List)), null, FormUrlEncodedType);
+
+            case JsReadableStream stream:
+                // "If object is disturbed or locked, then throw a TypeError" — the stream becomes this
+                // body's stream, so a stream something else is already reading cannot also be one.
+                if (stream.Disturbed || ReadableStreamOperations.IsLocked(stream))
+                {
+                    Throw.TypeError(realm, "The provided ReadableStream is disturbed or locked");
+                }
+
+                // A stream implies no Content-Type: the standard's ReadableStream arm sets no type.
+                return new ExtractedBody(default, stream, null);
         }
 
         if (FileApi.TryGetBufferSourceBytes(body, out var buffered))
@@ -124,11 +253,11 @@ internal static class FetchBody
             // "Set source to a copy of the bytes held by object" — the buffer stays script-writable, and a
             // request body that changed under the engine after it was set would be a request-smuggling
             // primitive rather than a curiosity.
-            return (buffered.ToArray(), null);
+            return new ExtractedBody(buffered.ToArray(), null, null);
         }
 
         // The USVString arm: every unpaired surrogate becomes U+FFFD, which is what UTF8.GetBytes does.
-        return (SystemEncoding.UTF8.GetBytes(UrlValues.ToUsvString(body)), TextPlainType);
+        return new ExtractedBody(SystemEncoding.UTF8.GetBytes(UrlValues.ToUsvString(body)), null, TextPlainType);
     }
 
     /// <summary>
@@ -137,16 +266,23 @@ internal static class FetchBody
     internal const string JsonContentType = JsonType;
 
     /// <summary>
-    /// The tail of the two constructors' body handling: store the extracted bytes, and append the implied
+    /// The tail of the two constructors' body handling: store the extracted body, and append the implied
     /// <c>Content-Type</c> unless the header list already carries one — steps 39 and 40 of
     /// https://fetch.spec.whatwg.org/#dom-request and step 6 of
     /// https://fetch.spec.whatwg.org/#initialize-a-response.
     /// </summary>
-    internal static void SetBody(FetchBodyObject target, ReadOnlyMemory<byte> bytes, string? type)
+    internal static void SetBody(FetchBodyObject target, in ExtractedBody body)
     {
-        target.Body = bytes;
+        if (body.Stream is { } stream)
+        {
+            target.SetStreamBody(stream);
+        }
+        else
+        {
+            target.SetBufferedBody(body.Bytes);
+        }
 
-        if (type is not null && !target.Headers.List.Contains("content-type"))
+        if (body.Type is { } type && !target.Headers.List.Contains("content-type"))
         {
             target.Headers.List.Append("content-type", type);
         }
@@ -159,7 +295,36 @@ internal static class FetchBody
     /// </summary>
     internal static void ThrowFormDataUnsupported(Realm realm)
     {
-        Throw.TypeError(realm, "A FormData body is not supported yet: Jint has no multipart/form-data serializer. Send a string, a Blob, a BufferSource or a URLSearchParams instead.");
+        Throw.TypeError(realm, "A FormData body is not supported yet: Jint has no multipart/form-data serializer. Send a string, a Blob, a BufferSource, a URLSearchParams or a ReadableStream instead.");
+    }
+
+    /// <summary>
+    /// https://fetch.spec.whatwg.org/#concept-body-clone — "tee body's stream, keep the first branch and give
+    /// the second to the clone".
+    /// </summary>
+    /// <remarks>
+    /// A body that has not materialized a stream is cloned by <i>sharing its source</i> instead, which is
+    /// indistinguishable: neither object has a stream to tee, and each carries its own disturbance. Tee is
+    /// used the moment a stream exists — for a network response, or for a body a script has already asked
+    /// <c>body</c> for — because from then on the two objects' streams have to be different objects with
+    /// independent queues.
+    /// </remarks>
+    internal static void CloneBody(FetchBodyObject source, FetchBodyObject target)
+    {
+        if (!source.HasBody)
+        {
+            return;
+        }
+
+        if (source.Stream is not { } stream)
+        {
+            target.SetBufferedBody(source.Source!.Value);
+            return;
+        }
+
+        var (branch1, branch2) = ReadableStreamTee.Tee(stream);
+        source.ReplaceStream(branch1);
+        target.SetStreamBody(branch2);
     }
 
     /// <summary>
@@ -178,15 +343,69 @@ internal static class FetchBody
         }
 
         // A null body is not disturbed by being read, so bodyUsed stays false and a second read is fine.
-        var bytes = target.Body ?? default;
-        if (target.Body is not null)
+        if (!target.HasBody)
         {
-            target.BodyUsed = true;
+            Settle(engine, realm, target, kind, default, capability);
+            return capability.PromiseInstance;
         }
 
+        if (target.Stream is null)
+        {
+            // The buffered fast path: the bytes are here, so nothing has to wait for an event-loop turn.
+            target.MarkSourceDisturbed();
+            Settle(engine, realm, target, kind, target.Source!.Value.Span, capability);
+            return capability.PromiseInstance;
+        }
+
+        // https://fetch.spec.whatwg.org/#concept-body-fully-read — get a reader and read all bytes.
+        FullyRead(
+            engine,
+            realm,
+            target.Stream!,
+            bytes => Settle(engine, realm, target, kind, bytes.WrittenSpan, capability),
+            capability.Reject);
+
+        return capability.PromiseInstance;
+    }
+
+    /// <summary>
+    /// Reads a request body that only exists as a stream into the bytes the transport has to send.
+    /// </summary>
+    /// <remarks>
+    /// <b>A request body is uploaded buffered.</b> The standard allows a <c>ReadableStream</c> to be streamed
+    /// to the server (<c>duplex: "half"</c>), which needs a request-side <c>HttpContent</c> the transport can
+    /// pull from and a server willing to read it before answering; that is deliberately out of scope, and
+    /// <c>duplex</c> is absent rather than accepted and ignored. What is supported is the shape a script
+    /// actually writes — a stream that produces the bytes, which are collected here and then sent as one
+    /// body. The stream is disturbed by this, exactly as it would be by a streaming upload.
+    /// </remarks>
+    internal static void ReadRequestBody(
+        Engine engine,
+        Realm realm,
+        FetchBodyObject request,
+        Action<ReadOnlyMemory<byte>> onBytes,
+        Action<JsValue> onError)
+    {
+        if (request.IsUnusable)
+        {
+            onError(realm.Intrinsics.TypeError.Construct("Body has already been consumed"));
+            return;
+        }
+
+        FullyRead(engine, realm, request.Stream!, bytes => onBytes(bytes.WrittenSpan.ToArray()), onError);
+    }
+
+    private static void Settle(
+        Engine engine,
+        Realm realm,
+        FetchBodyObject target,
+        BodyConsumeKind kind,
+        ReadOnlySpan<byte> bytes,
+        PromiseCapability capability)
+    {
         try
         {
-            capability.Resolve(Package(engine, realm, target, bytes.Span, kind));
+            capability.Resolve(Package(engine, realm, target, bytes, kind));
         }
         catch (JavaScriptException ex)
         {
@@ -194,8 +413,131 @@ internal static class FetchBody
             // the standard's "if parsing fails, reject with that exception" asks for.
             capability.Reject(ex.Error);
         }
+    }
 
-        return capability.PromiseInstance;
+    /// <summary>
+    /// https://fetch.spec.whatwg.org/#concept-body-fully-read, whose read-all-bytes half is
+    /// https://streams.spec.whatwg.org/#readablestream-read-all-bytes.
+    /// </summary>
+    private static void FullyRead(
+        Engine engine,
+        Realm realm,
+        JsReadableStream stream,
+        Action<ArrayBufferWriter<byte>> onBytes,
+        Action<JsValue> onError)
+    {
+        JsReadableStreamDefaultReader reader;
+        try
+        {
+            reader = ReadableStreamOperations.AcquireDefaultReader(stream);
+        }
+        catch (JavaScriptException ex)
+        {
+            // "If acquiring a reader throws, reject promise with that exception" — the locked case, which
+            // IsUnusable above has already ruled out for every caller here.
+            onError(ex.Error);
+            return;
+        }
+
+        new FullyReadRequest(realm, reader, onBytes, onError).Run();
+    }
+
+    /// <summary>
+    /// The read request behind <see cref="FullyRead"/>: accumulate every chunk, then package the bytes.
+    /// </summary>
+    /// <remarks>
+    /// The standard's read-loop is written as recursion — each chunk's steps read again — which for a stream
+    /// whose queue is already full would recurse once per queued chunk. <see cref="Run"/> turns that into a
+    /// loop with the same reentrancy pair a tee uses: a chunk delivered <i>inside</i> the read sets
+    /// <c>readAgain</c> and the loop goes round, while one delivered later starts a fresh loop of its own.
+    /// </remarks>
+    private sealed class FullyReadRequest : ReadRequest
+    {
+        private readonly Realm _realm;
+        private readonly JsReadableStreamDefaultReader _reader;
+        private readonly Action<ArrayBufferWriter<byte>> _onBytes;
+        private readonly Action<JsValue> _onError;
+        private readonly ArrayBufferWriter<byte> _bytes = new();
+
+        private bool _reading;
+        private bool _readAgain;
+        private bool _done;
+
+        internal FullyReadRequest(
+            Realm realm,
+            JsReadableStreamDefaultReader reader,
+            Action<ArrayBufferWriter<byte>> onBytes,
+            Action<JsValue> onError)
+        {
+            _realm = realm;
+            _reader = reader;
+            _onBytes = onBytes;
+            _onError = onError;
+        }
+
+        internal void Run()
+        {
+            do
+            {
+                _readAgain = false;
+                _reading = true;
+                try
+                {
+                    ReadableStreamOperations.DefaultReaderRead(_reader, this);
+                }
+                finally
+                {
+                    _reading = false;
+                }
+            }
+            while (_readAgain && !_done);
+        }
+
+        internal override void ChunkSteps(JsValue chunk)
+        {
+            // "If chunk is not a Uint8Array object, call failureSteps with a TypeError" — a stream carrying
+            // strings or plain objects is not a body, and saying so beats coercing it into one.
+            if (chunk is not JsTypedArray { _arrayElementType: TypedArrayElementType.Uint8 })
+            {
+                Fail(_realm.Intrinsics.TypeError.Construct("The body stream produced a chunk that is not a Uint8Array"));
+                return;
+            }
+
+            if (FileApi.TryGetBufferSourceBytes(chunk, out var bytes) && !bytes.IsEmpty)
+            {
+                _bytes.Write(bytes);
+            }
+
+            if (_reading)
+            {
+                _readAgain = true;
+                return;
+            }
+
+            Run();
+        }
+
+        internal override void CloseSteps()
+        {
+            _done = true;
+            _onBytes(_bytes);
+        }
+
+        internal override void ErrorSteps(JsValue error)
+        {
+            _done = true;
+            _onError(error);
+        }
+
+        private void Fail(JsValue error)
+        {
+            _done = true;
+
+            // The standard's failure steps for a non-Uint8Array chunk release the reader's lock before
+            // reporting, so the stream is left usable rather than pinned by a reader nobody holds.
+            ReadableStreamOperations.DefaultReaderRelease(_reader);
+            _onError(error);
+        }
     }
 
     private static JsValue Package(Engine engine, Realm realm, FetchBodyObject target, ReadOnlySpan<byte> bytes, BodyConsumeKind kind)
@@ -209,10 +551,7 @@ internal static class FetchBody
                 };
 
             case BodyConsumeKind.Bytes:
-                var uint8Array = realm.Intrinsics.Uint8Array;
-                var array = uint8Array.AllocateTypedArray(uint8Array, (uint) bytes.Length);
-                TypedArrayConstructor.FillTypedArrayInstance(array, bytes);
-                return array;
+                return ByteStreams.NewUint8Array(engine, realm, bytes);
 
             case BodyConsumeKind.Blob:
                 return new JsBlob(engine, bytes.ToArray(), MimeType(target))

--- a/Jint/WebApi/Fetch/FetchBodyStream.cs
+++ b/Jint/WebApi/Fetch/FetchBodyStream.cs
@@ -1,0 +1,352 @@
+#if NET8_0_OR_GREATER
+using System.Buffers;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Jint.Native;
+using Jint.Native.Promise;
+using Jint.Runtime;
+using Jint.WebApi.Streams;
+
+namespace Jint.WebApi.Fetch;
+
+/// <summary>
+/// A network response body, streamed: the HTTP content on one side and a <c>ReadableStream</c> on the other,
+/// joined by demand rather than by a buffer.
+/// <para>
+/// https://fetch.spec.whatwg.org/#concept-response-body
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The two halves never touch each other's state directly.</b> The engine half — the underlying source's
+/// <c>pull</c> and <c>cancel</c>, and everything that reaches the controller — runs on the engine thread and
+/// nowhere else. The transport half is an ordinary <c>async</c> loop on the thread pool that reads at most
+/// <see cref="ChunkSize"/> bytes at a time and hands each chunk over as a <b>generation-stamped event-loop
+/// job</b>, which is the same fence every other cross-thread completion in Jint sits behind: a chunk that
+/// arrives after <c>RestoreGlobalSnapshot</c> is discarded at dequeue rather than enqueued into a stream the
+/// restored engine can see.
+/// </para>
+/// <para>
+/// <b>Backpressure is the point.</b> The loop reads nothing until the stream's <c>pull</c> asks, and
+/// <c>pull</c>'s promise stays pending until that chunk has been enqueued — so the standard's own
+/// <c>[[pulling]]</c> guard bounds the loop to one outstanding read, and a consumer that stops reading stops
+/// the socket. The signal between them is a <see cref="SemaphoreSlim"/> released once per pull; nothing
+/// larger is needed, because there is never more than one pull outstanding.
+/// </para>
+/// <para>
+/// <b>The size cap is enforced per chunk</b>, on the running total of decompressed bytes, so a body that
+/// exceeds <c>Options.WebApi.Fetch.MaxResponseBytes</c> errors the stream at the chunk that crossed the line
+/// and drops the connection there. Unlike the buffered implementation this replaces, the cap can no longer
+/// reject the <c>fetch</c> promise itself: by the time a single byte of the body has been read, the promise
+/// has resolved with the response — which is what the standard prescribes and what a browser does. A
+/// <c>Content-Length</c> that already exceeds the cap is still refused before the promise settles, because
+/// that is known while the headers are being read.
+/// </para>
+/// </remarks>
+internal sealed class FetchBodyStream : IDisposable
+{
+    /// <summary>
+    /// The most bytes one read takes, and therefore the largest chunk a script sees. 64 KiB is what one pull
+    /// answers with when the socket has that much ready; a slower server simply produces smaller chunks.
+    /// </summary>
+    private const int ChunkSize = 64 * 1024;
+
+    // ---- transport half: touched on the thread pool, never by the engine ----
+
+    private readonly HttpResponseMessage _message;
+    private readonly Stream _content;
+    private readonly long _maxBytes;
+
+    /// <summary>
+    /// Released once per <c>pull</c>. Never more than one release is outstanding, because the standard's own
+    /// <c>[[pulling]]</c> guard admits one pull at a time.
+    /// </summary>
+    private readonly SemaphoreSlim _demand = new(0);
+
+    private long _total;
+
+    // ---- engine half: touched on the engine thread, never by the transport ----
+
+    private Engine _engine = null!;
+    private Realm _realm = null!;
+    private int _generation;
+    private JsReadableStream _stream = null!;
+    private CancellationTokenSource _cancellation = null!;
+    private PromiseCapability? _pull;
+    private bool _finished;
+
+    internal FetchBodyStream(HttpResponseMessage message, Stream content, long maxBytes)
+    {
+        _message = message;
+        _content = content;
+        _maxBytes = maxBytes;
+    }
+
+    /// <summary>
+    /// Lets go of everything the transport half holds. Called for a body that will never be read — a response
+    /// whose settle job the generation fence discarded, or one abandoned before its stream existed — and
+    /// again from the read loop's own exit, which is why it must be safe to call twice.
+    /// </summary>
+    public void Dispose()
+    {
+        _message.Dispose();
+        _demand.Dispose();
+    }
+
+    /// <summary>
+    /// Builds the <c>ReadableStream</c> the response's <c>body</c> attribute answers with and starts the
+    /// transport loop behind it. Runs on the engine thread, in the realm the fetch was started in.
+    /// </summary>
+    /// <param name="engine">The engine whose event loop the chunks are delivered on.</param>
+    /// <param name="realm">The realm the fetch started in, which owns the stream and its promises.</param>
+    /// <param name="cancellation">
+    /// The body's own token source, linked to the request's <c>AbortSignal</c> and to the engine's
+    /// cancellation constraint. Owned from here on: the read loop disposes it.
+    /// </param>
+    /// <param name="remainingTimeout">
+    /// What is left of <c>Options.WebApi.Fetch.Timeout</c>, which the standard has no counterpart for and
+    /// which is documented as covering the whole request "from the call to the last byte of the body". Kept
+    /// CLR-side, like the header half of the deadline, so that an engine nobody pumps still lets go of its
+    /// socket.
+    /// </param>
+    internal JsReadableStream Attach(
+        Engine engine,
+        Realm realm,
+        CancellationTokenSource cancellation,
+        TimeSpan? remainingTimeout)
+    {
+        _engine = engine;
+        _realm = realm;
+        _generation = engine.EventLoopGeneration;
+        _cancellation = cancellation;
+
+        if (remainingTimeout is { } remaining)
+        {
+            if (remaining <= TimeSpan.Zero)
+            {
+                _cancellation.Cancel();
+            }
+            else
+            {
+                _cancellation.CancelAfter(remaining);
+            }
+        }
+
+        // A high water mark of zero means the transport is only asked for bytes once a consumer wants them:
+        // nothing is read ahead into a queue the script may never drain.
+        _stream = ReadableStreamOperations.CreateReadableStream(
+            engine, realm, static () => JsValue.Undefined, PullAlgorithm, CancelAlgorithm, highWaterMark: 0);
+
+        engine._webApi?.RegisterBodyStream(this);
+
+        // Task.Run rather than a bare call so the first read can never happen on the engine's thread, whatever
+        // the demand count happens to be when this runs.
+        _ = Task.Run(ReadLoopAsync);
+
+        return _stream;
+    }
+
+    /// <summary>
+    /// Ends the body because the evaluation cycle it belongs to has ended — see
+    /// <c>WebApiEngineState.ResetTransientState</c>. Runs on the engine thread, from
+    /// <c>RestoreGlobalSnapshot</c>.
+    /// </summary>
+    /// <remarks>
+    /// The controller is <b>errored</b> rather than left pending: a host holding on to the response across a
+    /// restore gets a stream that says it failed instead of one that never produces another byte. The
+    /// reactions that erroring schedules carry the ending cycle's generation and are discarded when the
+    /// restore bumps it, which is what keeps the previous cycle's continuations out of the restored engine.
+    /// </remarks>
+    internal void Abandon()
+    {
+        if (_finished)
+        {
+            return;
+        }
+
+        _finished = true;
+        CancelTransport();
+
+        ReadableStreamDefaultControllerOperations.Error(
+            _stream.Controller,
+            _realm.Intrinsics.TypeError.Construct("Failed to fetch: the engine's globals were restored while the response body was still streaming"));
+
+        ResolvePull();
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#dictdef-underlyingsource — the pull algorithm. Its promise stays
+    /// pending until the chunk it asked for has been enqueued, which is what makes the standard's
+    /// <c>[[pulling]]</c> guard the backpressure valve for the socket.
+    /// </summary>
+    private JsPromise PullAlgorithm()
+    {
+        if (_finished)
+        {
+            return StreamPromises.ResolvedWithUndefined(_engine, _realm);
+        }
+
+        if (_pull is null)
+        {
+            _pull = StreamPromises.NewPromise(_engine, _realm);
+            try
+            {
+                _demand.Release();
+            }
+            catch (ObjectDisposedException)
+            {
+                // The read loop has already exited and let go of the transport; the outcome it posted is on
+                // its way through the event loop and will settle this pull.
+            }
+        }
+
+        return StreamPromises.PromiseOf(_pull);
+    }
+
+    /// <summary>
+    /// The cancel algorithm: <c>response.body.cancel()</c>, a reader's <c>cancel()</c>, or a pipe that gave
+    /// up. The connection goes with it — there is nothing left to read it for.
+    /// </summary>
+    private JsPromise CancelAlgorithm(JsValue reason)
+    {
+        Finish();
+        return StreamPromises.ResolvedWithUndefined(_engine, _realm);
+    }
+
+    /// <summary>
+    /// The transport loop. Nothing here touches the engine: every outcome leaves as a generation-stamped
+    /// job, and the engine half decides what it means.
+    /// </summary>
+    private async Task ReadLoopAsync()
+    {
+        var token = _cancellation.Token;
+        var buffer = ArrayPool<byte>.Shared.Rent(ChunkSize);
+
+        try
+        {
+            while (true)
+            {
+                await _demand.WaitAsync(token).ConfigureAwait(false);
+
+                int read;
+                try
+                {
+                    read = await _content.ReadAsync(buffer.AsMemory(0, ChunkSize), token).ConfigureAwait(false);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    Post(null, new FetchFailureException(FetchFailureKind.Network, "Reading the response body failed: " + ex.Message, ex));
+                    return;
+                }
+
+                if (read == 0)
+                {
+                    Post(null, null);
+                    return;
+                }
+
+                // Counted before the chunk is handed over, so the cap is never overshot by a whole chunk and
+                // the connection is dropped as soon as the limit is known to be broken.
+                _total += read;
+                if (_total > _maxBytes)
+                {
+                    Post(null, new FetchFailureException(
+                        FetchFailureKind.ResponseTooLarge,
+                        $"The response body exceeded the {_maxBytes} byte limit set by Options.WebApi.Fetch.MaxResponseBytes."));
+                    return;
+                }
+
+                Post(buffer.AsSpan(0, read).ToArray(), null);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // The stream was cancelled, the request aborted, the deadline blown or the engine's cycle ended.
+            // Each of those has already settled the engine half; there is nothing to report back.
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+            Dispose();
+            _cancellation.Dispose();
+        }
+    }
+
+    private void Post(byte[]? chunk, FetchFailureException? failure)
+    {
+        _engine.AddToEventLoop(() => Deliver(chunk, failure), _generation);
+    }
+
+    /// <summary>
+    /// The engine-thread half of one transport outcome: a chunk, the end of the body, or a failure.
+    /// </summary>
+    private void Deliver(byte[]? chunk, FetchFailureException? failure)
+    {
+        if (_finished)
+        {
+            return;
+        }
+
+        if (failure is not null)
+        {
+            _finished = true;
+            _engine._webApi?.UnregisterBodyStream(this);
+            ReadableStreamDefaultControllerOperations.Error(_stream.Controller, FetchOperation.NetworkError(_realm, failure));
+            ResolvePull();
+            return;
+        }
+
+        if (chunk is null)
+        {
+            _finished = true;
+            _engine._webApi?.UnregisterBodyStream(this);
+            ReadableStreamDefaultControllerOperations.Close(_stream.Controller);
+            ResolvePull();
+            return;
+        }
+
+        ReadableStreamDefaultControllerOperations.Enqueue(_stream.Controller, ByteStreams.NewUint8Array(_engine, _realm, chunk));
+
+        // Resolved after the enqueue, so the reaction that lets the controller pull again observes the chunk
+        // already in the queue.
+        ResolvePull();
+    }
+
+    /// <summary>
+    /// Ends the body from the engine side, without touching the stream: the caller has already closed,
+    /// errored or cancelled it.
+    /// </summary>
+    private void Finish()
+    {
+        if (_finished)
+        {
+            return;
+        }
+
+        _finished = true;
+        _engine._webApi?.UnregisterBodyStream(this);
+        CancelTransport();
+        ResolvePull();
+    }
+
+    private void CancelTransport()
+    {
+        try
+        {
+            _cancellation.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // The loop finished and disposed it first; there is nothing left to cancel.
+        }
+    }
+
+    private void ResolvePull()
+    {
+        var pull = _pull;
+        _pull = null;
+        pull?.Resolve(JsValue.Undefined);
+    }
+}
+#endif

--- a/Jint/WebApi/Fetch/FetchHandlerHosting.cs
+++ b/Jint/WebApi/Fetch/FetchHandlerHosting.cs
@@ -117,7 +117,7 @@ internal static class FetchHandlerHosting
         // all: consumable any number of times, and bodyUsed never flipping.
         if (body is { Length: > 0 })
         {
-            request.Body = new ReadOnlyMemory<byte>(body);
+            request.SetBufferedBody(new ReadOnlyMemory<byte>(body));
         }
 
         return request;
@@ -160,7 +160,16 @@ internal static class FetchHandlerHosting
             message.ReasonPhrase = response.StatusText;
         }
 
-        HttpContent? content = response.Body is { } body ? new ByteArrayContent(body.ToArray()) : null;
+        // A handler's response is read from its buffered source. A body that only ever existed as a stream
+        // has no source to read synchronously and would need the engine pumped to produce its chunks; that
+        // integration is deliberately out of scope here, and refusing loudly beats sending an empty body.
+        if (response.HasBody && response.Source is null)
+        {
+            throw new InvalidOperationException(
+                "The fetch handler answered with a streaming response body, which fetch-handler hosting does not support yet. Buffer the body in script — for example 'return new Response(await upstream.arrayBuffer(), upstream)' — before returning it.");
+        }
+
+        HttpContent? content = response.Source is { } body ? new ByteArrayContent(body.ToArray()) : null;
 
         foreach (var header in response.Headers.List.Entries)
         {

--- a/Jint/WebApi/Fetch/FetchOperation.cs
+++ b/Jint/WebApi/Fetch/FetchOperation.cs
@@ -72,7 +72,21 @@ internal sealed class FetchOperation
     private readonly CancellationTokenSource _cancellation;
     private readonly TimeSpan _timeout;
 
+    /// <summary>
+    /// When the deadline started, so that the body half of the request can be given what is left of it. The
+    /// documented contract is that <c>Options.WebApi.Fetch.Timeout</c> bounds the whole call "from the call
+    /// to the last byte of the body", and the body no longer shares the header phase's token source.
+    /// </summary>
+    private readonly long _startedAt = System.Diagnostics.Stopwatch.GetTimestamp();
+
     private int _settled;
+
+    /// <summary>
+    /// The response body the transport handed back, between the pool thread that produced it and the engine
+    /// thread that turns it into a stream. Taken by whichever of <see cref="ResolveWithResponse"/> and
+    /// <see cref="Abandon"/> gets there first, so the connection is let go exactly once.
+    /// </summary>
+    private FetchBodyStream? _pendingBody;
 
     private FetchOperation(Engine engine, Realm realm, PromiseCapability capability, JsAbortSignal signal, TimeSpan timeout)
     {
@@ -185,18 +199,70 @@ internal sealed class FetchOperation
         }
 
         var operation = new FetchOperation(engine, realm, capability, request.Signal, options.Timeout);
-        var snapshot = new FetchRequestSnapshot
+        state.RegisterFetch(operation);
+
+        FetchRequestSnapshot Snapshot(ReadOnlyMemory<byte>? body) => new()
         {
             Method = request.Method,
             Url = request.Url,
             Headers = new List<HeaderEntry>(request.Headers.List.Entries),
-            Body = request.Body,
+            Body = body,
             Redirect = request.Redirect,
         };
 
-        state.RegisterFetch(operation);
-        operation.Run(client, snapshot, policy);
+        // A request body given as a ReadableStream is read in full before anything is sent: a streaming
+        // upload is the standard's `duplex: "half"`, which needs a request-side body the transport can pull
+        // from and is deliberately out of scope. Everything else already holds its bytes.
+        if (request is { HasBody: true, Source: null })
+        {
+            // Reading the stream can take any number of event-loop turns, so both callbacks have to allow for
+            // the operation having been abandoned in between — which is what Abandoned() answers.
+            FetchBody.ReadRequestBody(
+                engine,
+                realm,
+                request,
+                bytes =>
+                {
+                    if (!operation.Abandoned)
+                    {
+                        operation.Run(client, Snapshot(bytes), policy);
+                    }
+                },
+                error =>
+                {
+                    state.UnregisterFetch(operation);
+                    operation.RejectBeforeSending(error);
+                });
+
+            return capability.PromiseInstance;
+        }
+
+        operation.Run(client, Snapshot(request.Source), policy);
         return capability.PromiseInstance;
+    }
+
+    /// <summary>
+    /// Whether the operation has already been settled or abandoned, which is the only thing a callback
+    /// arriving on a later event-loop turn can safely act on.
+    /// </summary>
+    private bool Abandoned => Volatile.Read(ref _settled) != 0;
+
+    /// <summary>
+    /// Fails the fetch before a socket was ever opened, which is what a request body stream that errored
+    /// leaves. The token source has nothing to cancel and is released here rather than by a settle job that
+    /// will never run.
+    /// </summary>
+    private void RejectBeforeSending(JsValue error)
+    {
+        if (Interlocked.Exchange(ref _settled, 1) != 0)
+        {
+            // Abandoned while the request body was still being read: the restore's generation fence is what
+            // this promise is behind now, and settling it is exactly what that forbids.
+            return;
+        }
+
+        _cancellation.Dispose();
+        _capability.Reject(error);
     }
 
     private static HttpClient ResolveClient(Engine engine, Realm realm, Options.FetchOptions options)
@@ -248,9 +314,19 @@ internal sealed class FetchOperation
     /// </summary>
     private void Complete(Task<FetchResponseSnapshot> task)
     {
+        var body = task.Status == TaskStatus.RanToCompletion ? task.Result.Body : null;
+
         if (Interlocked.CompareExchange(ref _settled, 1, 0) != 0)
         {
+            // Abandoned while the headers were in flight. The connection has nobody left to read it, and the
+            // settle job that would have taken ownership of it will never run.
+            body?.Dispose();
             return;
+        }
+
+        if (body is not null)
+        {
+            Interlocked.Exchange(ref _pendingBody, body);
         }
 
         if (task.IsCanceled || task.Exception?.InnerException is OperationCanceledException)
@@ -348,14 +424,32 @@ internal sealed class FetchOperation
         response.Url = snapshot.Url;
         response.Redirected = snapshot.Redirected;
 
-        // A null body status carries no body, and the transport's zero-byte read is not the same thing: a
-        // 204's bodyUsed must stay false however often the script reads it.
-        if (!FetchValues.IsNullBodyStatus(snapshot.Status))
+        // The transport gives no body at all for a null body status, and a zero-byte read would not be the
+        // same thing: a 204's bodyUsed must stay false however often the script reads it.
+        if (Interlocked.Exchange(ref _pendingBody, null) is { } body)
         {
-            response.Body = snapshot.Body;
+            // The body gets a token source of its own rather than sharing the header phase's, which this
+            // settle job is about to dispose: an abort or an engine cancellation still reaches it, and the
+            // rest of the deadline is re-armed on it.
+            var cancellation = CancellationTokenSource.CreateLinkedTokenSource(_signalToken, _engineToken);
+            response.SetStreamBody(body.Attach(_engine, _realm, cancellation, RemainingTimeout()));
         }
 
         _capability.Resolve(response);
+    }
+
+    /// <summary>
+    /// What is left of <c>Options.WebApi.Fetch.Timeout</c> once the headers are in, or <see langword="null"/>
+    /// when the host asked for no deadline at all.
+    /// </summary>
+    private TimeSpan? RemainingTimeout()
+    {
+        if (_timeout <= TimeSpan.Zero || _timeout == Timeout.InfiniteTimeSpan)
+        {
+            return null;
+        }
+
+        return _timeout - System.Diagnostics.Stopwatch.GetElapsedTime(_startedAt);
     }
 
     /// <summary>
@@ -403,7 +497,7 @@ internal sealed class FetchOperation
     /// <c>JintException.TryGetClrException</c> while the script cannot see it at all.
     /// </para>
     /// </remarks>
-    private static JsValue NetworkError(Realm realm, Exception failure)
+    internal static JsValue NetworkError(Realm realm, Exception failure)
     {
         var message = failure is FetchFailureException { Kind: FetchFailureKind.RedirectLimit or FetchFailureKind.ResponseTooLarge } bounded
             ? "Failed to fetch: " + bounded.Message
@@ -441,6 +535,10 @@ internal sealed class FetchOperation
         }
 
         _cancellation.Dispose();
+
+        // A response whose headers arrived but whose settle job the fence will discard: nothing will ever
+        // read the body, so the connection is let go here rather than waiting for a finalizer.
+        Interlocked.Exchange(ref _pendingBody, null)?.Dispose();
     }
 
     private bool EnterFetchRealm()

--- a/Jint/WebApi/Fetch/FetchTransport.cs
+++ b/Jint/WebApi/Fetch/FetchTransport.cs
@@ -1,5 +1,4 @@
 #if NET8_0_OR_GREATER
-using System.Buffers;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -159,7 +158,13 @@ internal sealed class FetchResponseSnapshot
 
     internal required List<HeaderEntry> Headers { get; init; }
 
-    internal required byte[] Body { get; init; }
+    /// <summary>
+    /// The body still on the wire, or <see langword="null"/> for a status the standard gives no body —
+    /// https://fetch.spec.whatwg.org/#null-body-status. The connection is <b>still open</b> when this
+    /// reaches the engine thread: <see cref="FetchBodyStream.Attach"/> is what starts reading it, and
+    /// <see cref="FetchBodyStream.Dispose"/> is what lets it go if nothing ever will.
+    /// </summary>
+    internal required FetchBodyStream? Body { get; init; }
 
     /// <summary>The last URL the request reached, serialized without its fragment.</summary>
     internal required string Url { get; init; }
@@ -185,6 +190,12 @@ internal sealed class FetchResponseSnapshot
 /// the loop: an automatic redirect would be followed underneath the scheme and <c>UrlFilter</c> checks, so a
 /// server answering <c>302 Location: http://169.254.169.254/latest/meta-data/</c> would reach the cloud
 /// metadata endpoint however carefully the host had written its filter.
+/// </para>
+/// <para>
+/// <b>The final response's body is not read here.</b> Only its headers are: the snapshot carries a
+/// <see cref="FetchBodyStream"/> that still owns the open <see cref="HttpResponseMessage"/>, and the engine
+/// thread turns it into a <c>ReadableStream</c> whose <c>pull</c> drives the reading. Every response the loop
+/// walks <i>past</i> — a redirect — is disposed here as before.
 /// </para>
 /// </remarks>
 internal static class FetchTransport
@@ -256,7 +267,8 @@ internal static class FetchTransport
     }
 
     /// <summary>
-    /// Runs the request, following redirects itself, and reads the body under the size cap.
+    /// Runs the request, following redirects itself, and begins the response: headers in hand, the body left
+    /// on the wire behind a <see cref="FetchBodyStream"/> that owns the connection from here on.
     /// </summary>
     internal static async Task<FetchResponseSnapshot> SendAsync(
         HttpClient client,
@@ -265,13 +277,21 @@ internal static class FetchTransport
         CancellationToken cancellationToken)
     {
         var exchange = await SendForStreamAsync(client, request, policy, cancellationToken).ConfigureAwait(false);
+        var handedOver = false;
         try
         {
-            return await ReadResponseAsync(exchange.Response, exchange.Url, exchange.Redirected, policy, cancellationToken).ConfigureAwait(false);
+            var snapshot = await BeginResponseAsync(exchange.Response, exchange.Url, exchange.Redirected, policy, cancellationToken).ConfigureAwait(false);
+            handedOver = snapshot.Body is not null;
+            return snapshot;
         }
         finally
         {
-            exchange.Dispose();
+            // Cleared only once the body stream has taken ownership of the connection; a bodyless response,
+            // and every path that throws, still disposes here exactly as the buffered path always did.
+            if (!handedOver)
+            {
+                exchange.Dispose();
+            }
         }
     }
 
@@ -482,16 +502,24 @@ internal static class FetchTransport
     }
 
     /// <summary>
-    /// Reads the body under <c>MaxResponseBytes</c> and collects the headers.
+    /// Collects the headers and hands the still-open body over to a <see cref="FetchBodyStream"/>, which the
+    /// engine thread turns into the response's <c>ReadableStream</c>.
     /// </summary>
     /// <remarks>
-    /// The bytes counted are the <b>decompressed</b> ones, because the handler decompresses before this sees
-    /// the stream — so the cap bounds what the process actually spends rather than what the server sent, and
-    /// a compression bomb is refused at the number the host chose. A <c>Content-Length</c> that already
-    /// exceeds the cap short-circuits the read, but it is only a shortcut: a server that lies, or that uses
-    /// chunked encoding, is caught by the running total.
+    /// <para>
+    /// The only body check made here is the declared length: a <c>Content-Length</c> that already exceeds
+    /// <c>MaxResponseBytes</c> is refused before the <c>fetch</c> promise settles, which is worth keeping
+    /// because it costs nothing and it is the one case the cap can still report as a failed fetch. Everything
+    /// else is the running total inside <see cref="FetchBodyStream"/>, which is what catches a server that
+    /// lies about the length or answers with chunked encoding.
+    /// </para>
+    /// <para>
+    /// The bytes counted either way are the <b>decompressed</b> ones, because the handler decompresses before
+    /// anything here sees the stream — so the cap bounds what the process actually spends rather than what
+    /// the server sent, and a compression bomb is refused at the number the host chose.
+    /// </para>
     /// </remarks>
-    private static async Task<FetchResponseSnapshot> ReadResponseAsync(
+    private static async Task<FetchResponseSnapshot> BeginResponseAsync(
         HttpResponseMessage response,
         UrlRecord url,
         bool redirected,
@@ -504,60 +532,39 @@ internal static class FetchTransport
             throw TooLarge(policy);
         }
 
-        byte[] body;
-        try
-        {
-            using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
-            body = await ReadBoundedAsync(stream, policy, cancellationToken).ConfigureAwait(false);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException and not FetchFailureException)
-        {
-            throw new FetchFailureException(FetchFailureKind.Network, $"Reading the response body of '{url.Serialize()}' failed: {ex.Message}", ex);
-        }
-
         var headers = new List<HeaderEntry>();
         Collect(headers, response.Headers);
         Collect(headers, response.Content.Headers);
 
+        var status = (int) response.StatusCode;
+
+        FetchBodyStream? body = null;
+        if (!FetchValues.IsNullBodyStatus(status))
+        {
+            Stream content;
+            try
+            {
+                content = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException and not FetchFailureException)
+            {
+                throw new FetchFailureException(FetchFailureKind.Network, $"Reading the response body of '{url.Serialize()}' failed: {ex.Message}", ex);
+            }
+
+            // From here the connection belongs to the body stream: the caller sees a non-null body and stops
+            // disposing the message underneath it.
+            body = new FetchBodyStream(response, content, policy.MaxResponseBytes);
+        }
+
         return new FetchResponseSnapshot
         {
-            Status = (int) response.StatusCode,
+            Status = status,
             StatusText = response.ReasonPhrase ?? string.Empty,
             Headers = headers,
             Body = body,
             Url = url.Serialize(excludeFragment: true),
             Redirected = redirected,
         };
-    }
-
-    private static async Task<byte[]> ReadBoundedAsync(Stream stream, FetchPolicy policy, CancellationToken cancellationToken)
-    {
-        var writer = new ArrayBufferWriter<byte>();
-        var buffer = ArrayPool<byte>.Shared.Rent(16 * 1024);
-        try
-        {
-            while (true)
-            {
-                var read = await stream.ReadAsync(buffer.AsMemory(), cancellationToken).ConfigureAwait(false);
-                if (read == 0)
-                {
-                    return writer.WrittenSpan.ToArray();
-                }
-
-                // Checked before the copy, so the cap is never overshot by a whole chunk and the connection
-                // is dropped as soon as the limit is known to be broken.
-                if (writer.WrittenCount + (long) read > policy.MaxResponseBytes)
-                {
-                    throw TooLarge(policy);
-                }
-
-                writer.Write(buffer.AsSpan(0, read));
-            }
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(buffer);
-        }
     }
 
     private static FetchFailureException TooLarge(FetchPolicy policy)

--- a/Jint/WebApi/Fetch/RequestConstructor.cs
+++ b/Jint/WebApi/Fetch/RequestConstructor.cs
@@ -71,7 +71,6 @@ internal sealed class RequestConstructor : Constructor
         var method = "GET";
         var redirect = JsRequest.RedirectFollow;
         HeaderList headerList;
-        ReadOnlyMemory<byte>? inputBody = null;
         JsAbortSignal? signal = null;
 
         if (inputRequest is not null)
@@ -80,7 +79,6 @@ internal sealed class RequestConstructor : Constructor
             method = inputRequest.Method;
             redirect = inputRequest.Redirect;
             headerList = inputRequest.Headers.List.Clone();
-            inputBody = inputRequest.Body;
             signal = inputRequest.Signal;
         }
         else
@@ -168,9 +166,10 @@ internal sealed class RequestConstructor : Constructor
         }
 
         var hasInitBody = bodyInit is not null && !bodyInit.IsNull();
+        var hasInputBody = inputRequest is { HasBody: true };
 
         // Step 37: a body — from either source — is refused for the two methods that cannot carry one.
-        if ((hasInitBody || inputBody is not null) && method is "GET" or "HEAD")
+        if ((hasInitBody || hasInputBody) && method is "GET" or "HEAD")
         {
             Throw.TypeError(_realm, "Failed to construct 'Request': Request with GET/HEAD method cannot have body.");
         }
@@ -179,20 +178,19 @@ internal sealed class RequestConstructor : Constructor
         {
             // Steps 38-40: extract, then append the implied Content-Type unless the header list — which the
             // step above has already filled — carries one of its own.
-            var (bytes, type) = FetchBody.Extract(_realm, bodyInit!);
-            FetchBody.SetBody(request, bytes, type);
+            var extracted = FetchBody.Extract(_realm, bodyInit!);
+            FetchBody.SetBody(request, in extracted);
         }
-        else if (inputBody is not null)
+        else if (hasInputBody)
         {
-            // Step 43: "create a proxy for inputBody". A buffered body has nothing to tee, so the two share
-            // the bytes and each carries its own used flag; what survives the reduction is the check that the
-            // input still had a body to share.
+            // Step 42: "create a proxy for inputBody", which is the clone-a-body algorithm — a tee when the
+            // input has a stream, and a shared source when it does not.
             if (inputRequest!.IsUnusable)
             {
                 Throw.TypeError(_realm, "Failed to construct 'Request': Request body is already used");
             }
 
-            request.Body = inputBody;
+            FetchBody.CloneBody(inputRequest, request);
         }
 
         return request;

--- a/Jint/WebApi/Fetch/RequestPrototype.cs
+++ b/Jint/WebApi/Fetch/RequestPrototype.cs
@@ -90,21 +90,18 @@ internal sealed partial class RequestPrototype : Prototype
     private JsAbortSignal SignalGet(JsValue thisObject) => Brand(thisObject).Signal;
 
     /// <summary>
-    /// https://fetch.spec.whatwg.org/#dom-body-body — <b>always null in this version.</b>
+    /// https://fetch.spec.whatwg.org/#dom-body-body — the body's <c>ReadableStream</c>, or <c>null</c> when
+    /// the request has no body, which every <c>GET</c> and <c>HEAD</c> necessarily has not.
     /// </summary>
     /// <remarks>
-    /// The attribute's type is <c>ReadableStream?</c> and Jint has no streams, so there is nothing truthful to
-    /// answer with. It is present rather than absent because null is a meaningful answer the standard itself
-    /// gives — every request and response without a body has it — and because a script that guards on
-    /// <c>if (response.body)</c> then takes the buffered path rather than crashing. Streams, and with them a
-    /// real body, are a follow-up.
+    /// A body given as bytes materializes its stream here, on first ask. <b>A request body is still uploaded
+    /// buffered:</b> a <c>ReadableStream</c> handed to the constructor is read in full before the request is
+    /// sent, so a streaming upload — the standard's <c>duplex: 'half'</c> — is out of scope, and
+    /// <c>duplex</c> is absent rather than present and ignored.
     /// </remarks>
     [JsAccessor("body", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
     private JsValue BodyGet(JsValue thisObject)
-    {
-        Brand(thisObject);
-        return Null;
-    }
+        => Brand(thisObject).GetOrCreateStream(_realm) ?? (JsValue) Null;
 
     /// <summary>
     /// https://fetch.spec.whatwg.org/#dom-body-bodyused
@@ -158,7 +155,7 @@ internal sealed partial class RequestPrototype : Prototype
         var headers = _realm.Intrinsics.Headers.CreateInstance(request.Headers.List.Clone());
         headers.List.Guard = request.Headers.List.Guard;
 
-        return new JsRequest(_engine, headers)
+        var clone = new JsRequest(_engine, headers)
         {
             _prototype = _realm.Intrinsics.Request.PrototypeObject,
             Method = request.Method,
@@ -168,11 +165,12 @@ internal sealed partial class RequestPrototype : Prototype
             // Step 4: "set clonedRequestObject's signal to the result of creating a dependent abort signal
             // given « this's signal »" — the clone aborts with the original, never the other way round.
             Signal = JsAbortSignal.CreateDependent(_engine, _realm, [request.Signal]),
-
-            // The bytes are shared; only the used flag is the clone's own, which is the whole point of
-            // cloning a response before reading it twice.
-            Body = request.Body,
         };
+
+        // A streaming body is teed and a buffered one shares its bytes; only the used flag is the clone's
+        // own, which is the whole point of cloning before reading twice.
+        FetchBody.CloneBody(request, clone);
+        return clone;
     }
 
     private JsValue Consume(JsValue thisObject, BodyConsumeKind kind)

--- a/Jint/WebApi/Fetch/ResponseConstructor.cs
+++ b/Jint/WebApi/Fetch/ResponseConstructor.cs
@@ -61,13 +61,13 @@ internal sealed partial class ResponseConstructor : Constructor
         // Steps 3 and 4: the body is extracted *before* initialize runs its range checks, so
         // `new Response(new FormData(), { status: 999 })` reports the unsupported body rather than the
         // status. body is optional and nullable, so an omitted argument and an explicit null both mean none.
-        (ReadOnlyMemory<byte> Bytes, string? Type)? bodyWithType = null;
+        FetchBody.ExtractedBody? extracted = null;
         if (!body.IsNullOrUndefined())
         {
-            bodyWithType = FetchBody.Extract(_realm, body);
+            extracted = FetchBody.Extract(_realm, body);
         }
 
-        Initialize(response, init, bodyWithType);
+        Initialize(response, init, extracted);
         return response;
     }
 
@@ -135,7 +135,7 @@ internal sealed partial class ResponseConstructor : Constructor
         }
 
         var response = NewResponse();
-        Initialize(response, init, (writer.WrittenMemory, FetchBody.JsonContentType));
+        Initialize(response, init, new FetchBody.ExtractedBody(writer.WrittenMemory, null, FetchBody.JsonContentType));
         return response;
     }
 
@@ -144,7 +144,7 @@ internal sealed partial class ResponseConstructor : Constructor
     /// message, headers and body a <c>ResponseInit</c> carries, shared by the constructor and by
     /// <c>Response.json</c>.
     /// </summary>
-    private void Initialize(JsResponse response, JsValue init, (ReadOnlyMemory<byte> Bytes, string? Type)? body)
+    private void Initialize(JsResponse response, JsValue init, FetchBody.ExtractedBody? body)
     {
         var initObject = ToInit(init);
 
@@ -174,7 +174,7 @@ internal sealed partial class ResponseConstructor : Constructor
             response.Headers.Fill(_realm, headersInit);
         }
 
-        if (body is not { } bodyWithType)
+        if (body is not { } extracted)
         {
             return;
         }
@@ -186,7 +186,7 @@ internal sealed partial class ResponseConstructor : Constructor
             Throw.TypeError(_realm, "Failed to construct 'Response': Response with null body status cannot have body");
         }
 
-        FetchBody.SetBody(response, bodyWithType.Bytes, bodyWithType.Type);
+        FetchBody.SetBody(response, in extracted);
     }
 
     private ObjectInstance? ToInit(JsValue init)

--- a/Jint/WebApi/Fetch/ResponsePrototype.cs
+++ b/Jint/WebApi/Fetch/ResponsePrototype.cs
@@ -104,15 +104,17 @@ internal sealed partial class ResponsePrototype : Prototype
     private JsHeaders HeadersGet(JsValue thisObject) => Brand(thisObject).Headers;
 
     /// <summary>
-    /// https://fetch.spec.whatwg.org/#dom-body-body — <b>always null in this version</b>; see
-    /// <see cref="RequestPrototype"/> for why it is present rather than absent.
+    /// https://fetch.spec.whatwg.org/#dom-body-body — the body's <c>ReadableStream</c>, or <c>null</c> when
+    /// the response has no body at all (a bodyless <c>new Response()</c>, a 204, <c>Response.error()</c>).
     /// </summary>
+    /// <remarks>
+    /// A response that came off the network streams its bytes as they arrive; one built from a string or a
+    /// <c>Blob</c> answers a stream over the bytes it already holds, created here on first ask — see
+    /// <see cref="FetchBodyObject.GetOrCreateStream"/>.
+    /// </remarks>
     [JsAccessor("body", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
     private JsValue BodyGet(JsValue thisObject)
-    {
-        Brand(thisObject);
-        return Null;
-    }
+        => Brand(thisObject).GetOrCreateStream(_realm) ?? (JsValue) Null;
 
     /// <summary>
     /// https://fetch.spec.whatwg.org/#dom-body-bodyused
@@ -155,7 +157,9 @@ internal sealed partial class ResponsePrototype : Prototype
     /// body, because <c>clone</c> does not return a promise to reject.
     /// </summary>
     /// <remarks>
-    /// The clone shares the original's bytes and carries its own used flag, which is what makes the
+    /// The body is cloned per https://fetch.spec.whatwg.org/#concept-body-clone: a streaming body is
+    /// <c>tee()</c>d, so each object gets its own branch with its own queue, and a body still held as bytes
+    /// simply shares them. Either way the used flag is the clone's own, which is what makes the
     /// <c>const copy = response.clone(); await response.json(); await copy.text();</c> pattern work.
     /// </remarks>
     [JsFunction(Name = "clone", Length = 0)]
@@ -170,7 +174,7 @@ internal sealed partial class ResponsePrototype : Prototype
         var headers = _realm.Intrinsics.Headers.CreateInstance(response.Headers.List.Clone());
         headers.List.Guard = response.Headers.List.Guard;
 
-        return new JsResponse(_engine, headers)
+        var clone = new JsResponse(_engine, headers)
         {
             _prototype = _realm.Intrinsics.Response.PrototypeObject,
             Status = response.Status,
@@ -178,8 +182,10 @@ internal sealed partial class ResponsePrototype : Prototype
             Kind = response.Kind,
             Url = response.Url,
             Redirected = response.Redirected,
-            Body = response.Body,
         };
+
+        FetchBody.CloneBody(response, clone);
+        return clone;
     }
 
     private JsValue Consume(JsValue thisObject, BodyConsumeKind kind)

--- a/Jint/WebApi/Files/BlobPrototype.cs
+++ b/Jint/WebApi/Files/BlobPrototype.cs
@@ -22,12 +22,11 @@ namespace Jint.WebApi.Files;
 /// not a <c>Blob</c> — including <c>Blob.prototype</c> itself, which is not one.
 /// </para>
 /// <para>
-/// <c>stream()</c> and <c>textStream()</c> are <b>absent</b>, not throwing: Jint has no streams yet, and an
-/// absent method is what feature detection is written against. <c>text()</c>, <c>arrayBuffer()</c> and
-/// <c>bytes()</c> are the whole of the read surface, and each answers an already-resolved promise — the
+/// <c>text()</c>, <c>arrayBuffer()</c> and <c>bytes()</c> each answer an already-resolved promise — the
 /// bytes are in memory, so there is nothing for an event-loop turn to wait for. They are still real
 /// promises: <c>await blob.text()</c> works exactly as it does in a browser, and the value arrives on the
-/// microtask turn a <c>then</c> would give it.
+/// microtask turn a <c>then</c> would give it. <c>stream()</c> is the fourth, and answers a
+/// <c>ReadableStream</c> over those same bytes.
 /// </para>
 /// <para>
 /// One documented simplification against WebIDL: the operations are non-enumerable, where a WebIDL
@@ -157,6 +156,31 @@ internal sealed partial class BlobPrototype : Prototype
     private JsValue ArrayBuffer(JsValue thisObject)
     {
         return Resolved(NewArrayBuffer(Brand(thisObject)));
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/FileAPI/#dom-blob-stream, which is the "get stream" algorithm,
+    /// https://w3c.github.io/FileAPI/#blob-get-stream.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Two reductions against the algorithm as written, both forced by there being no byte streams here.
+    /// The stream is an ordinary (non-byte) <c>ReadableStream</c> rather than one "set up with byte reading
+    /// support", so it has no BYOB reader — which is exactly what <c>getReader()</c> already answers for
+    /// every other stream in this implementation. And the blob's bytes are one chunk rather than the
+    /// implementation-defined slices the algorithm's loop reads: the bytes are already in memory, so
+    /// slicing them would manufacture event-loop turns rather than model any I/O. An empty blob enqueues
+    /// nothing and closes, so its first <c>read()</c> is done.
+    /// </para>
+    /// <para>
+    /// The chunk is a <c>Uint8Array</c> over a fresh copy, like every other way a blob's bytes cross into
+    /// script: a blob is immutable and what script is handed is writable.
+    /// </para>
+    /// </remarks>
+    [JsFunction(Name = "stream", Length = 0)]
+    private Streams.JsReadableStream Stream(JsValue thisObject)
+    {
+        return Streams.ByteStreams.CreateFromBytes(_engine, _realm, Brand(thisObject).Data);
     }
 
     /// <summary>

--- a/Jint/WebApi/Streams/ByteStreams.cs
+++ b/Jint/WebApi/Streams/ByteStreams.cs
@@ -1,0 +1,70 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.TypedArray;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// The two pieces every specification that hands bytes to a stream needs: a chunk, which is always a
+/// <c>Uint8Array</c>, and a stream over a byte sequence that already exists in full.
+/// </summary>
+/// <remarks>
+/// Used by <c>Blob.stream()</c> (https://w3c.github.io/FileAPI/#blob-get-stream) and by the <c>Body</c>
+/// mixin's <c>body</c> attribute for a body that was extracted from bytes
+/// (https://fetch.spec.whatwg.org/#concept-bodyinit-extract). Both specifications ask for a stream "set up
+/// with byte reading support" — a readable <i>byte</i> stream — which is not implemented here; an ordinary
+/// stream carrying <c>Uint8Array</c> chunks is what those algorithms reduce to once BYOB readers are out of
+/// the picture, and it is what every consumer in this implementation reads.
+/// </remarks>
+internal static class ByteStreams
+{
+    /// <summary>
+    /// A fresh <c>Uint8Array</c> over a copy of <paramref name="bytes"/>. The copy is the point: what crosses
+    /// into script is writable, and the source rarely is.
+    /// </summary>
+    internal static JsTypedArray NewUint8Array(Engine engine, Realm realm, ReadOnlySpan<byte> bytes)
+    {
+        var uint8Array = realm.Intrinsics.Uint8Array;
+        var array = uint8Array.AllocateTypedArray(uint8Array, (uint) bytes.Length);
+        TypedArrayConstructor.FillTypedArrayInstance(array, bytes);
+        return array;
+    }
+
+    /// <summary>
+    /// A <c>ReadableStream</c> over a byte sequence that is already in memory: one chunk, then close.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The whole sequence is one chunk rather than the implementation-defined slices a browser hands out.
+    /// That is observable — a reader sees one <c>read()</c> resolve with everything — and it is the honest
+    /// shape here, because there is no I/O to interleave: the bytes exist, and slicing them would only
+    /// manufacture event-loop turns.
+    /// </para>
+    /// <para>
+    /// An empty sequence enqueues nothing and closes immediately, so the first <c>read()</c> answers
+    /// <c>{ value: undefined, done: true }</c>.
+    /// </para>
+    /// </remarks>
+    internal static JsReadableStream CreateFromBytes(Engine engine, Realm realm, ReadOnlyMemory<byte> bytes)
+    {
+        var stream = ReadableStreamOperations.CreateReadableStream(
+            engine,
+            realm,
+            static () => JsValue.Undefined,
+            () => StreamPromises.ResolvedWithUndefined(engine, realm),
+            _ => StreamPromises.ResolvedWithUndefined(engine, realm));
+
+        // Filled after the stream exists rather than from its start algorithm, which runs while the
+        // controller is still being wired up and has no way to reach it.
+        var controller = stream.Controller;
+        if (!bytes.IsEmpty)
+        {
+            ReadableStreamDefaultControllerOperations.Enqueue(controller, NewUint8Array(engine, realm, bytes.Span));
+        }
+
+        ReadableStreamDefaultControllerOperations.Close(controller);
+        return stream;
+    }
+}
+#endif

--- a/Jint/WebApi/WebApiRegistration.cs
+++ b/Jint/WebApi/WebApiRegistration.cs
@@ -260,7 +260,9 @@ internal static class WebApiRegistration
     {
         if ((features & WebApiFeatures.Fetch) != WebApiFeatures.None)
         {
-            features |= WebApiFeatures.Events | WebApiFeatures.Url | WebApiFeatures.Files;
+            // Streams joined the closure when bodies became streams: response.body is a ReadableStream, so
+            // installing fetch without it would ship an interface returning an unnameable object.
+            features |= WebApiFeatures.Events | WebApiFeatures.Url | WebApiFeatures.Files | WebApiFeatures.Streams;
         }
 
         // Deliberately not the other way round: fetch does not bring server-sent events and server-sent

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ its own `console` (or any other name in the table below), enabling the feature l
 | `performance.now` / `timeOrigin` / `mark` / `measure` / `getEntries*` / `clearMarks` / `clearMeasures` | `WebApiFeatures.Performance` | ✔ shipped |
 | `Event` / `EventTarget` / `CustomEvent` / `AbortController` / `AbortSignal` | `Events` | ✔ shipped |
 | `URL` / `URLSearchParams` | `Url` | ✔ shipped |
-| `Blob` / `File` / `FormData` | `Files` | ✔ shipped |
+| `Blob` (incl. `stream()`) / `File` / `FormData` | `Files` | ✔ shipped |
 | `navigator.userAgent` | `Navigator` | ✔ shipped |
 | `ReadableStream` / `WritableStream` / `TransformStream` / `ByteLengthQueuingStrategy` / `CountQueuingStrategy` | `Streams` | ✔ shipped |
 | `scheduler.postTask` / `scheduler.yield` / `TaskController` / `TaskSignal` | `Scheduler` | ✔ shipped |
@@ -466,24 +466,56 @@ var engine = new Engine(options => options.UseWebApis().UseFetch(fetch =>
 var body = engine.Evaluate("fetch('https://api.example.org/x').then(r => r.json())").UnwrapIfPromise();
 ```
 
-Enabling it also brings `Events`, `Url` and `Files`, because fetch's own surface is built out of them: a
-`Request` always has an `AbortSignal`, its URL is a WHATWG URL, and `response.blob()` answers with a `Blob`.
+Enabling it also brings `Events`, `Url`, `Files` and `Streams`, because fetch's own surface is built out of
+them: a `Request` always has an `AbortSignal`, its URL is a WHATWG URL, `response.blob()` answers with a
+`Blob`, and `response.body` is a `ReadableStream`.
 
 `Headers`, `Request` and `Response` are the standard's own classes — the full `Headers` (sorted, combined
 iteration, `getSetCookie`), method normalization, `redirect` modes, `clone()`, `Response.error()`,
-`Response.redirect()`, `Response.json()`. Bodies are **buffered rather than streamed**: `text()`, `json()`,
-`arrayBuffer()`, `bytes()` and `blob()` answer already-resolved promises, `bodyUsed` flips on the first read
-and a second one rejects, and `response.body` is always `null` because Jint has no streams yet. `formData()`
-is absent and a `FormData` request body is a `TypeError` — the `multipart/form-data` serializer is a
-follow-up. `credentials`, `cache`, `mode`, `referrer` and `integrity` are accepted and ignored, the same
-convention Node and workerd follow, because there is no origin, cookie jar or HTTP cache here to honour them
-with.
+`Response.redirect()`, `Response.json()`. `formData()` is absent and a `FormData` request body is a
+`TypeError` — the `multipart/form-data` serializer is a follow-up. `credentials`, `cache`, `mode`, `referrer`
+and `integrity` are accepted and ignored, the same convention Node and workerd follow, because there is no
+origin, cookie jar or HTTP cache here to honour them with.
+
+### Response bodies stream
+
+`response.body` is a real `ReadableStream`, and a network response is read **on demand**: the promise
+resolves as soon as the headers are in, and the socket is only read when a consumer asks for the next chunk.
+
+```js
+const r = await fetch('https://api.example.org/big.ndjson');
+for await (const chunk of r.body) {
+    // one Uint8Array per read; the transport is not read again until this loop comes back for more
+}
+```
+
+The stream's high water mark is zero, so a script that takes the response and never reads its body never
+touches the socket again — and `body.cancel()`, or a reader's `cancel()`, drops the connection. Chunks are
+delivered as generation-stamped event-loop jobs, exactly like every other cross-thread completion in Jint,
+so nothing about a body arrives on a thread the host did not pump. `MaxResponseBytes` is enforced on the
+running total per chunk; because the promise has already resolved by the time a body byte is read, a body
+that breaks the cap **errors the stream** rather than rejecting the `fetch` promise (a `Content-Length` that
+already exceeds it is still refused before the promise settles).
+
+The `Body` mixin sits on top of that and is unchanged in behaviour: `text()`, `json()`, `arrayBuffer()`,
+`bytes()` and `blob()` read the stream to the end and answer with the whole body, `bodyUsed` is the stream's
+*disturbed* flag, and a body that is disturbed or locked makes the next consumer reject. `clone()` `tee()`s
+the stream, so each half has its own queue and its own flags. A body built from bytes — `new Response('…')`,
+a `Blob`, a `BufferSource` — keeps its bytes and only materializes a stream if something reads `body`, so the
+common `new Response(x).text()` costs no stream at all.
+
+`Blob.stream()` is there too, and a `ReadableStream` is accepted as a `BodyInit` for both `Request` and
+`Response`. **Uploads are still buffered:** a request body given as a stream is read in full before anything
+is sent, so the standard's `duplex: 'half'` streaming upload is out of scope and `duplex` is absent rather
+than accepted and ignored.
 
 Like every other web API, `fetch` settles only while the engine is being pumped: the promise resolves inside a
 blocking `UnwrapIfPromise`, an `await` of `EvaluateAsync`, or your own `engine.Advanced.ProcessTasks()` loop.
 The deadline is the one exception, and deliberately so — it is enforced CLR-side, so an engine nobody pumps
-still lets go of its socket. An in-flight request is cancelled by `Engine.Advanced.RestoreGlobalSnapshot`, and
-its promise never settles into the restored engine.
+still lets go of its socket, and it covers the body as well as the headers. An in-flight request is cancelled
+by `Engine.Advanced.RestoreGlobalSnapshot`, and its promise never settles into the restored engine; a body
+still arriving when that happens has its connection dropped and its stream errored, so a host holding the
+response is told rather than left waiting.
 
 **Security.** Enabling `fetch` gives the script your process's network position: anything the worker can
 reach, the script can reach. The defaults bound the resource questions — 32 MiB per response body (counted


### PR DESCRIPTION
Part of #3082: fetch bodies become real streams. `response.body` and `request.body` are `ReadableStream`s, a network response is read **on demand**, and `Blob.stream()` exists.

The body model now carries the standard's own pair — a stream plus an optional byte *source* — and `bodyUsed`/unusable are the stream's *disturbed*/*locked* flags, exactly as https://fetch.spec.whatwg.org/#dom-body-bodyused defines them. The buffered fast path is kept: `new Response('x').text()` builds no stream, no controller and no reader, and a buffered body that never materialized a stream tracks its disturbance in a stand-in flag that is observably identical. `clone()` tees when a stream exists and shares the source when none does (indistinguishable, and what keeps the existing clone suite green).

Network streaming: the transport reads headers only and hands the open connection to a `FetchBodyStream` whose `pull()` releases one bounded read at a time — high water mark **zero**, so the standard's `[[pulling]]` guard *is* the backpressure valve, a response nobody reads never touches the socket again, and `cancel()` drops the connection. Chunks arrive as generation-stamped event-loop jobs like every other cross-thread completion; a restore **errors** live body streams before the generation bump, so the host-visible state flips while nothing settles into the restored engine (mutation-pinned). The body gets its own deadline linked to signal and engine tokens, preserving "from the call to the last byte".

One documented semantics shift: `MaxResponseBytes` broken mid-body errors the *stream* rather than rejecting the `fetch` promise — the promise resolved with the headers, as in a browser — while a `Content-Length` already over the cap is still refused before the promise settles. A `ReadableStream` request body is accepted and read fully before sending; streaming upload (`duplex: 'half'`) stays out with #3105.

20 new stream-specific tests gated through a channel-backed body (no clock racing), with mutation evidence on the high-water-mark, the restore abandonment, and cancel-propagates-to-transport; both suites green on net10.0 and net472, with and without `JINT_HOST_CONTRACT_VERIFICATION=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G7Ud48VAs1JicxRZxLDxg
