### PR TITLE
Skip the host-loop constraint pins when the runner provably stalled

### DIFF
--- a/Jint.Tests.PublicInterface/HostCallLoopConstraintTests.cs
+++ b/Jint.Tests.PublicInterface/HostCallLoopConstraintTests.cs
@@ -375,6 +375,15 @@ public class HostCallLoopConstraintTests
         }
 
         engineTime.Should().BeGreaterThan(HostCallTimeout);
+
+        // A loaded CI runner can stall one call past the whole timeout, which makes a single completion
+        // indistinguishable from the accumulation bug this test exists to refute. The stall is detectable —
+        // the loop then spent far longer than its healthy total — and a detected stall is a skip, not a
+        // verdict either way.
+        Assert.SkipWhen(
+            completed <= 1 && engineTime > HostCallTimeout + HostCallTimeout,
+            "the runner stalled a single call past the whole timeout, so this run cannot distinguish the behaviours");
+
         completed.Should().BeGreaterThan(
             1,
             "the host-loop check measures the time since the last entry returned and re-armed the "
@@ -496,6 +505,14 @@ public class HostCallLoopConstraintTests
         stopwatch.Elapsed.Should().BeGreaterThanOrEqualTo(
             OperationBudget - AttributionSlack,
             "the deadline may only fire once the budget has actually elapsed");
+
+        // A loaded CI runner can stall the very first call past the whole budget, which makes one call
+        // exhausting it correct behaviour rather than mis-arming. The stall is detectable — the elapsed
+        // wall time then dwarfs the budget one healthy call would have spent — and a detected stall is a
+        // skip, not a verdict either way.
+        Assert.SkipWhen(
+            calls <= 1 && stopwatch.Elapsed > OperationBudget + OperationBudget,
+            "the runner stalled the first call past the whole budget, so this run cannot distinguish the behaviours");
 
         calls.Should().BeGreaterThan(
             1,


### PR DESCRIPTION
Two `HostCallLoopConstraintTests` rows assert that more than one short call completes before a wall-clock budget trips (`completed > 1` / `calls > 1`). On a CI runner that stalls a single call past the entire budget, one completion is *correct* behaviour rather than the accumulation bug the tests exist to refute — and both rows failed a windows leg exactly that way this week, costing a rerun on an unrelated PR.

These pins are inherently wall-clock (that is their subject), so they cannot be made fully deterministic — but the stall *is* detectable from the measurements the tests already take: the loop's elapsed time then reaches double its healthy total. A detected stall now skips with a reason instead of failing, and a healthy run asserts exactly what it always did. The one-sided lower-bound assertion (a throw may only come from a budget that really elapsed) is untouched — a stall cannot invent one, so it needs no guard.

Both `Jint.Tests.PublicInterface` legs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G7Ud48VAs1JicxRZxLDxg
