### PR TITLE
Detect a stack-guard unwind leak by its march, not by depth spread

### DIFF
--- a/Jint.Tests/Runtime/StackOverflowGuardTests.cs
+++ b/Jint.Tests/Runtime/StackOverflowGuardTests.cs
@@ -91,9 +91,9 @@ public class StackOverflowGuardTests
 
     /// <summary>
     /// The recovery test the guard lives or dies by: catching near-exhaustion has to leave the engine in
-    /// the state it was in before, not merely alive. Firing at the very same depth on three successive
-    /// runs is the strongest single signal available here — a frame, an execution context or a native
-    /// stack slot left behind by the unwind would move the third run's number.
+    /// the state it was in before, not merely alive. Firing at a steady depth on successive runs is the
+    /// strongest single signal available here — a frame, an execution context or a native stack slot
+    /// left behind by the unwind would shorten every run after the first.
     /// <para>
     /// The first two runs are warm-ups whose depths are discarded. Depth is a count of native stack
     /// frames, so it moves whenever the JIT re-compiles any interpreter method the recursion runs
@@ -103,6 +103,12 @@ public class StackOverflowGuardTests
     /// the runtime with the defect. Two rounds are discarded rather than one because the
     /// <c>fib(20)</c> recovery check inside each round promotes code of its own, so a single warm-up
     /// still left the second measured round moving.
+    /// </para>
+    /// <para>
+    /// No spread bound survives that wobble: a 25% allowance was still broken by an observed 751/…/533,
+    /// a single recompilation step of 29%. What separates the defect from the runtime is <em>shape</em>,
+    /// not size — a leak leaves the same residue on every fire, so the depths march strictly downward,
+    /// while a recompilation steps once and holds. The assertion below therefore fails only on the march.
     /// </para>
     /// </summary>
     [Fact]
@@ -117,7 +123,8 @@ public class StackOverflowGuardTests
 
                 var depths = new List<double>();
                 const int warmupRounds = 2;
-                for (var round = 0; round < warmupRounds + 3; round++)
+                const int measuredRounds = 5;
+                for (var round = 0; round < warmupRounds + measuredRounds; round++)
                 {
                     engine.Evaluate("depth = 0");
                     Assert.Throws<JavaScriptException>(() => engine.Evaluate("f()"));
@@ -134,15 +141,28 @@ public class StackOverflowGuardTests
                     engine.IsEvaluationInProgress.Should().BeFalse();
                 }
 
-                // Exact equality is too strong on a loaded runner: the JIT may promote an interpreter method
-                // in ANY round, and the promoted code's different frame size moves the depth — observed on CI
-                // as 694/593, 679/671 and 607/565 after the warm-ups above, always a one-off step of under
-                // 15%. A genuine unwind leak produces a march instead: every guard fire leaves the same
-                // residue, so depth falls round after round and the loss compounds. Bounding the total spread
-                // at 25% of the best round rides out any single recompilation while a compounding leak of
-                // meaningful size still trips it — and the deterministic leak signals (CallStack.Count == 0,
+                // A leak marches, a recompilation steps: an unwind that leaves anything behind shortens
+                // EVERY following round, so the leak signature is depth falling round after round with a
+                // compounding total loss. A JIT frame-size change moves the depth once — in either
+                // direction, by up to 29% observed — and then holds, which is why no spread bound works
+                // here (a 25% one was broken on CI). Fail only on the march: at least three of the four
+                // adjacent pairs falling AND more than 10% lost end to end. Five measured rounds give the
+                // shape room to show; three successive downward recompilations this late in warm-up would
+                // be needed to fake it. The deterministic leak signals (CallStack.Count == 0,
                 // IsEvaluationInProgress false, fib recovering) are asserted per round above regardless.
-                depths.Min().Should().BeGreaterThan(depths.Max() * 0.75, "an unwind that left anything behind would shorten every following run, compounding past JIT frame-size wobble");
+                var fallingPairs = 0;
+                for (var i = 1; i < depths.Count; i++)
+                {
+                    if (depths[i] < depths[i - 1])
+                    {
+                        fallingPairs++;
+                    }
+                }
+
+                var totalLoss = 1 - depths[depths.Count - 1] / depths[0];
+                (fallingPairs >= measuredRounds - 2 && totalLoss > 0.10).Should().BeFalse(
+                    $"an unwind that left anything behind would shorten every following run "
+                    + $"(depths: {string.Join("/", depths)}, falling pairs: {fallingPairs}, total loss: {totalLoss:P0})");
                 depths.Min().Should().BeGreaterThan(100, "a guard that fires this early would be a limit, not a backstop");
             },
             maxStackSize: SmallStack);


### PR DESCRIPTION
`TheEngineIsUnchangedAfterTheGuardFires` bounded the measured depths' spread at 25% of the best round (#3123), and CI broke that too: a windows leg observed a single JIT frame-size recompilation move one round by 29% (751 → 533), failing an unrelated PR's run twice.

No spread bound survives that wobble, because what separates the defect from the runtime is **shape**, not size. An unwind that leaves anything behind — a frame, an execution context, a native stack slot — shortens *every* following run, so the leak signature is depths marching strictly downward with a compounding total loss. A JIT recompilation moves the depth once, in either direction, and then holds. The assertion now fails only on the march: at least three of four adjacent pairs falling **and** more than 10% lost end to end, over five measured rounds instead of three (giving the shape room to show; faking it would take three successive downward recompilations after two warm-up rounds and repeated `fib(20)` promotion). The deterministic per-round leak signals — `CallStack.Count == 0`, `IsEvaluationInProgress` false, `fib(20)` recovering — are asserted unchanged and remain the regression net for a sub-threshold residue.

Both `Jint.Tests` legs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G7Ud48VAs1JicxRZxLDxg
