### PR TITLE
Web API: TransformStream, CompressionStream and DecompressionStream

### DIFF
--- a/Jint.Tests.PublicInterface/WebApiTransformStreamTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiTransformStreamTests.cs
@@ -1,0 +1,216 @@
+#if NET8_0_OR_GREATER
+using Jint;
+using Jint.Native;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// The four transform streams other standards define — <c>TextEncoderStream</c>,
+/// <c>TextDecoderStream</c>, <c>CompressionStream</c> and <c>DecompressionStream</c> — seen from outside
+/// the assembly.
+/// </summary>
+/// <remarks>
+/// This project has no <c>InternalsVisibleTo</c>, so everything here is reachable by a third party. What
+/// these pins are about is the <b>two-flag</b> rule: each of the four is one standard's algorithm running
+/// inside the Streams Standard's machinery, so an engine that named only one half of a pair gets neither
+/// global — and a host reading the table in the README has to be able to rely on that.
+/// </remarks>
+public class WebApiTransformStreamTests
+{
+    private static readonly string[] _textGlobals = ["TextEncoderStream", "TextDecoderStream"];
+    private static readonly string[] _compressionGlobals = ["CompressionStream", "DecompressionStream"];
+
+    [Fact]
+    public void ADefaultEngineHasNoTransformStreamGlobals()
+    {
+        var engine = new Engine();
+
+        foreach (var name in _textGlobals.Concat(_compressionGlobals))
+        {
+            engine.Evaluate($"typeof {name}").AsString().Should().Be("undefined", name);
+            engine.Evaluate($"'{name}' in globalThis").AsBoolean().Should().BeFalse(name);
+        }
+    }
+
+    [Fact]
+    public void TheTextStreamsNeedBothEncodingAndStreams()
+    {
+        foreach (var name in _textGlobals)
+        {
+            new Engine(options => options.UseWebApis(WebApiFeatures.Encoding))
+                .Evaluate($"typeof {name}").AsString().Should().Be("undefined", name);
+            new Engine(options => options.UseWebApis(WebApiFeatures.Streams))
+                .Evaluate($"typeof {name}").AsString().Should().Be("undefined", name);
+            new Engine(options => options.UseWebApis(WebApiFeatures.Encoding | WebApiFeatures.Streams))
+                .Evaluate($"typeof {name}").AsString().Should().Be("function", name);
+        }
+
+        // The non-streaming pair still comes with the Encoding flag alone, which is what makes the rule a
+        // narrowing rather than a change to what that flag means.
+        new Engine(options => options.UseWebApis(WebApiFeatures.Encoding))
+            .Evaluate("typeof TextEncoder + ',' + typeof TextDecoder").AsString().Should().Be("function,function");
+    }
+
+    [Fact]
+    public void TheCompressionStreamsNeedBothCompressionAndStreams()
+    {
+        foreach (var name in _compressionGlobals)
+        {
+            new Engine(options => options.UseWebApis(WebApiFeatures.Compression))
+                .Evaluate($"typeof {name}").AsString().Should().Be("undefined", name);
+            new Engine(options => options.UseWebApis(WebApiFeatures.Streams))
+                .Evaluate($"typeof {name}").AsString().Should().Be("undefined", name);
+            new Engine(options => options.UseWebApis(WebApiFeatures.Compression | WebApiFeatures.Streams))
+                .Evaluate($"typeof {name}").AsString().Should().Be("function", name);
+        }
+    }
+
+    [Fact]
+    public void TheDefaultSetIncludesCompression()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        foreach (var name in _textGlobals.Concat(_compressionGlobals))
+        {
+            engine.Evaluate($"typeof {name}").AsString().Should().Be("function", name);
+        }
+
+        WebApiFeatures.Default.Should().HaveFlag(WebApiFeatures.Compression);
+
+        // The bit is fixed, so a value a host persisted keeps its meaning.
+        ((int) WebApiFeatures.Compression).Should().Be(1 << 20);
+    }
+
+    [Fact]
+    public void TheGlobalsCarryTheAttributesWebIdlAsksFor()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        foreach (var name in _textGlobals.Concat(_compressionGlobals))
+        {
+            var descriptor = engine.Evaluate($"Object.getOwnPropertyDescriptor(globalThis, '{name}')").AsObject();
+
+            descriptor.Get("writable").AsBoolean().Should().BeTrue(name);
+            descriptor.Get("configurable").AsBoolean().Should().BeTrue(name);
+            descriptor.Get("enumerable").AsBoolean().Should().BeFalse(name);
+        }
+    }
+
+    [Fact]
+    public void AHostRegisteredGlobalWins()
+    {
+        var marker = new JsString("host's own CompressionStream");
+
+        var engine = new Engine(options => options
+            .AddLazyGlobal("CompressionStream", _ => marker)
+            .UseWebApis());
+
+        engine.Evaluate("CompressionStream").Should().BeSameAs(marker);
+        engine.Evaluate("typeof DecompressionStream").AsString().Should().Be("function");
+    }
+
+    [Fact]
+    public void AShadowRealmDoesNotGetThem()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        engine.Evaluate("new ShadowRealm().evaluate('typeof CompressionStream')").AsString().Should().Be("undefined");
+        engine.Evaluate("new ShadowRealm().evaluate('typeof TextDecoderStream')").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof CompressionStream").AsString().Should().Be("function");
+    }
+
+    [Fact]
+    public void AHostCanRoundTripDataThroughTheOrdinaryPromiseSurface()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        // Everything a compression stream hands out is an ordinary engine promise, so the blocking unwrap a
+        // host already uses drives the whole pipeline.
+        var result = engine.Evaluate("""
+            (async () => {
+              const original = 'jint '.repeat(500);
+              const source = new ReadableStream({
+                start(c) { c.enqueue(new TextEncoder().encode(original)); c.close(); }
+              });
+              let text = '';
+              const piped = source
+                .pipeThrough(new CompressionStream('gzip'))
+                .pipeThrough(new DecompressionStream('gzip'))
+                .pipeThrough(new TextDecoderStream());
+              for await (const chunk of piped) { text += chunk; }
+              return text === original;
+            })()
+            """).UnwrapIfPromise();
+
+        result.AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ACorruptStreamIsATypeErrorTheScriptCanCatch()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        var outcome = engine.Evaluate("""
+            (async () => {
+              const ds = new DecompressionStream('gzip');
+              const reading = (async () => {
+                try {
+                  for await (const chunk of ds.readable) { /* nothing arrives */ }
+                  return 'no throw';
+                } catch (e) { return e.name; }
+              })();
+              const writer = ds.writable.getWriter();
+              writer.write(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])).catch(() => {});
+              writer.close().catch(() => {});
+              return await reading;
+            })()
+            """).UnwrapIfPromise();
+
+        outcome.AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void SurvivesAGlobalSnapshotRestore()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+
+        engine.Execute("var s = new CompressionStream('deflate');");
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        engine.Evaluate("typeof s").AsString().Should().Be("undefined");
+        engine.Evaluate("new CompressionStream('deflate').readable.locked").AsBoolean().Should().BeFalse();
+        engine.Evaluate("new TextEncoderStream().encoding").AsString().Should().Be("utf-8");
+    }
+
+    [Fact]
+    public void OneOptionsInstanceServesSeveralEnginesIndependently()
+    {
+        var options = new Options().UseWebApis();
+
+        var first = new Engine(options);
+        var second = new Engine(options);
+
+        // Each realm builds its own interface objects, and neither engine's compression context is visible
+        // to the other.
+        first.Execute("var s = new CompressionStream('gzip');");
+        second.Execute("var s = new CompressionStream('gzip');");
+
+        first.Evaluate("s instanceof CompressionStream").AsBoolean().Should().BeTrue();
+        second.Evaluate("s instanceof CompressionStream").AsBoolean().Should().BeTrue();
+
+        var firstBytes = first.Evaluate("""
+            (async () => {
+              const writer = s.writable.getWriter();
+              writer.write(new TextEncoder().encode('first'));
+              writer.close();
+              const chunks = [];
+              for await (const chunk of s.readable) { chunks.push(...chunk); }
+              return chunks.length;
+            })()
+            """).UnwrapIfPromise();
+
+        firstBytes.AsNumber().Should().BeGreaterThan(0);
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/CompressionStreamTests.cs
+++ b/Jint.Tests/Runtime/WebApi/CompressionStreamTests.cs
@@ -1,0 +1,388 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// <c>CompressionStream</c> and <c>DecompressionStream</c> — https://compression.spec.whatwg.org/.
+/// </summary>
+/// <remarks>
+/// The pin that matters most is <see cref="DeflateIsTheZlibWrapperNotRawDeflate"/>: the standard's
+/// <c>"deflate"</c> is RFC 1950's ZLIB container, and only <c>"deflate-raw"</c> is RFC 1951's bare bit
+/// stream. The vectors the tests decompress were produced by CPython's <c>zlib</c> module, so they are an
+/// independent implementation's idea of each format rather than a round trip against ourselves.
+/// </remarks>
+public class CompressionStreamTests
+{
+    /// <summary>"Hello, Jint!" as zlib-wrapped DEFLATE — <c>zlib.compress(b"Hello, Jint!", 6)</c>.</summary>
+    private const string ZlibVector = "120,156,243,72,205,201,201,215,81,240,202,204,43,81,4,0,26,156,3,247";
+
+    /// <summary>
+    /// The same payload as raw DEFLATE — <c>zlib.compressobj(6, zlib.DEFLATED, -15)</c>. It is exactly the
+    /// zlib vector without its two-byte header and four-byte ADLER32, which is the whole difference between
+    /// the two formats.
+    /// </summary>
+    private const string RawDeflateVector = "243,72,205,201,201,215,81,240,202,204,43,81,4,0";
+
+    /// <summary>The same payload as gzip — <c>gzip.GzipFile(mtime=0, compresslevel=6)</c>.</summary>
+    private const string GzipVector =
+        "31,139,8,0,0,0,0,0,0,255,243,72,205,201,201,215,81,240,202,204,43,81,4,0,123,253,209,10,12,0,0,0";
+
+    private const string Payload = "Hello, Jint!";
+
+    private static Engine StreamEngine()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Compression | WebApiFeatures.Streams | WebApiFeatures.Encoding));
+        engine.Execute("""
+            var log = [];
+
+            // Everything below is byte arrays, so a chunk is reported as its bytes and a stream as one
+            // concatenated array.
+            async function drain(stream, label) {
+              const reader = stream.getReader();
+              const bytes = [];
+              for (;;) {
+                let result;
+                try { result = await reader.read(); }
+                catch (e) { log.push(label + ':error:' + e.name + ':' + e.message); return null; }
+                if (result.done) { return bytes; }
+                if (!(result.value instanceof Uint8Array)) { log.push(label + ':not-a-uint8array'); return null; }
+                for (const b of result.value) { bytes.push(b); }
+              }
+            }
+
+            function feed(writable, bytes, chunkSize) {
+              const writer = writable.getWriter();
+              for (let i = 0; i < bytes.length; i += chunkSize) {
+                writer.write(new Uint8Array(bytes.slice(i, i + chunkSize))).catch(() => {});
+              }
+              writer.close().catch(e => log.push('close:' + e.name));
+            }
+
+            async function decompress(format, bytes, chunkSize) {
+              const ds = new DecompressionStream(format);
+              const output = drain(ds.readable, format);
+              feed(ds.writable, bytes, chunkSize || bytes.length);
+              const result = await output;
+              return result === null ? null : new TextDecoder().decode(new Uint8Array(result));
+            }
+
+            async function compress(format, text) {
+              const cs = new CompressionStream(format);
+              const output = drain(cs.readable, format);
+              feed(cs.writable, Array.from(new TextEncoder().encode(text)), 1024);
+              return await output;
+            }
+
+            // The vectors arrive as the comma-separated text the C# side holds them in, so nothing about
+            // these tests depends on how a CLR array is projected into script.
+            function vector(text) { return text.split(',').map(Number); }
+            """);
+        return engine;
+    }
+
+    private static string Log(Engine engine) => engine.Evaluate("log.join(',')").AsString();
+
+    [Theory]
+    [InlineData("gzip", GzipVector)]
+    [InlineData("deflate", ZlibVector)]
+    [InlineData("deflate-raw", RawDeflateVector)]
+    public void DecompressesAnotherImplementationsBytes(string format, string bytes)
+    {
+        var engine = StreamEngine();
+
+        var text = engine.Evaluate($"decompress('{format}', vector('{bytes}'))").UnwrapIfPromise();
+
+        text.AsString().Should().Be(Payload);
+        Log(engine).Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("gzip")]
+    [InlineData("deflate")]
+    [InlineData("deflate-raw")]
+    public void RoundTripsThroughItsOwnCompressor(string format)
+    {
+        var engine = StreamEngine();
+
+        var text = engine.Evaluate($$"""
+            (async () => {
+              const original = 'the quick brown fox '.repeat(200) + 'é€😀';
+              const compressed = await compress('{{format}}', original);
+              const back = await decompress('{{format}}', compressed);
+              return (back === original) + ':' + (compressed.length < original.length);
+            })()
+            """).UnwrapIfPromise();
+
+        // Round trips, and actually compressed: the payload is repetitive enough that it must shrink.
+        text.AsString().Should().Be("true:true");
+        Log(engine).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ProducesTheFormatsOwnFraming()
+    {
+        var engine = StreamEngine();
+
+        var checks = engine.Evaluate("""
+            (async () => {
+              const gzip = await compress('gzip', 'Hello, Jint!');
+              const zlib = await compress('deflate', 'Hello, Jint!');
+              const raw = await compress('deflate-raw', 'Hello, Jint!');
+              return [
+                // RFC 1952's magic number and "the only valid value of the CM field is 8".
+                'gzip:' + (gzip[0] === 0x1F && gzip[1] === 0x8B && gzip[2] === 8),
+                // RFC 1950's CMF/FLG: the low nibble of CMF is the compression method (8), and the two
+                // bytes read as a big-endian number are a multiple of 31.
+                'cmf:' + ((zlib[0] & 0x0F) === 8),
+                'fcheck:' + (((zlib[0] * 256 + zlib[1]) % 31) === 0),
+                // The whole of the difference between the two deflate formats: zlib is the same bit stream
+                // with a two-byte header and a four-byte ADLER32 around it.
+                'wrapper:' + (zlib.length - raw.length === 6),
+                'body:' + (zlib.slice(2, -4).join(',') === raw.join(','))
+              ].join(' ');
+            })()
+            """).UnwrapIfPromise();
+
+        checks.AsString().Should().Be("gzip:true cmf:true fcheck:true wrapper:true body:true");
+    }
+
+    [Fact]
+    public void DeflateIsTheZlibWrapperNotRawDeflate()
+    {
+        // The classic implementation mistake: mapping "deflate" onto a bare DeflateStream. Each format
+        // refuses the other's bytes, and this is the test that fails the moment the mapping slips.
+        var engine = StreamEngine();
+        engine.Execute($"var zlib = vector('{ZlibVector}'); var raw = vector('{RawDeflateVector}');");
+
+        engine.Evaluate("decompress('deflate-raw', zlib)").UnwrapIfPromise().IsNull().Should().BeTrue();
+        engine.Evaluate("decompress('deflate', raw)").UnwrapIfPromise().IsNull().Should().BeTrue();
+
+        Log(engine).Should().Contain("deflate-raw:error:TypeError").And.Contain("deflate:error:TypeError");
+
+        // ... and each one accepts its own.
+        engine.Execute("log.length = 0;");
+        engine.Evaluate("decompress('deflate', zlib)").UnwrapIfPromise().AsString().Should().Be(Payload);
+        engine.Evaluate("decompress('deflate-raw', raw)").UnwrapIfPromise().AsString().Should().Be(Payload);
+        Log(engine).Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("gzip", GzipVector)]
+    [InlineData("deflate", ZlibVector)]
+    [InlineData("deflate-raw", RawDeflateVector)]
+    public void DecompressesInputSplitOneByteAtATime(string format, string bytes)
+    {
+        var engine = StreamEngine();
+
+        // A member split across as many chunks as it has bytes decodes to exactly what the whole sequence
+        // does: the context is per stream, not per chunk.
+        engine.Evaluate($"decompress('{format}', vector('{bytes}'), 1)").UnwrapIfPromise().AsString().Should().Be(Payload);
+        Log(engine).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CompressedOutputIsSplitIntoUint8ArrayChunks()
+    {
+        var engine = StreamEngine();
+
+        var shapes = engine.Evaluate("""
+            (async () => {
+              const cs = new CompressionStream('gzip');
+              const reader = cs.readable.getReader();
+              const shapes = [];
+              const collect = (async () => {
+                for (;;) {
+                  const r = await reader.read();
+                  if (r.done) { return; }
+                  shapes.push(r.value.constructor.name + '(' + (r.value.byteLength > 0) + ')');
+                }
+              })();
+              const writer = cs.writable.getWriter();
+              writer.write(new Uint8Array(200000));
+              writer.close();
+              await collect;
+              return shapes.length > 1 ? 'many:' + shapes[0] : 'one:' + shapes[0];
+            })()
+            """).UnwrapIfPromise();
+
+        // "Splitting buffer into one or more non-empty pieces": every piece is a non-empty Uint8Array,
+        // whether the compressor hands the output over in one or in several.
+        shapes.AsString().Should().EndWith("Uint8Array(true)");
+    }
+
+    [Fact]
+    public void CorruptInputErrorsBothSides()
+    {
+        var engine = StreamEngine();
+        engine.Execute($"var gzip = vector('{GzipVector}');");
+
+        engine.Execute("""
+            var corrupt = gzip.slice();
+            corrupt[15] = corrupt[15] ^ 0xFF;
+            var ds = new DecompressionStream('gzip');
+            drain(ds.readable, 'out');
+            var writer = ds.writable.getWriter();
+            writer.write(new Uint8Array(corrupt)).catch(e => log.push('write:' + e.name));
+            writer.closed.catch(e => log.push('writable:' + e.name));
+            """);
+
+        Log(engine).Should().StartWith("out:error:TypeError:");
+        Log(engine).Should().Contain("write:TypeError").And.Contain("writable:TypeError");
+    }
+
+    [Fact]
+    public void ClosingADecompressionStreamThatReceivedNothingIsAnError()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var ds = new DecompressionStream('gzip');
+            drain(ds.readable, 'out');
+            ds.writable.getWriter().close().catch(e => log.push('close:' + e.name));
+            """);
+
+        // "If the end of the compressed input has not been reached, then throw a TypeError": no bytes at
+        // all cannot be a complete member in any of the three formats.
+        Log(engine).Should().StartWith("out:error:TypeError:");
+        Log(engine).Should().Contain("close:TypeError");
+    }
+
+    [Fact]
+    public void ClosingACompressionStreamThatReceivedNothingProducesAnEmptyMember()
+    {
+        var engine = StreamEngine();
+
+        // Compressing nothing is not an error — it is a valid, tiny member that decompresses to nothing.
+        // The lengths are each format's empty member: a gzip header and trailer, a zlib header and
+        // ADLER32, and one final empty DEFLATE block.
+        var text = engine.Evaluate("""
+            (async () => {
+              const lengths = [];
+              for (const format of ['gzip', 'deflate', 'deflate-raw']) {
+                const compressed = await compress(format, '');
+                const back = await decompress(format, compressed);
+                lengths.push(format + ':' + compressed.length + ':' + (back === '' ? 'empty' : back));
+              }
+              return lengths.join(' ');
+            })()
+            """).UnwrapIfPromise();
+
+        text.AsString().Should().Be("gzip:20:empty deflate:8:empty deflate-raw:2:empty");
+        Log(engine).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RefusesAChunkThatIsNotABufferSource()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var cs = new CompressionStream('gzip');
+            drain(cs.readable, 'out');
+            cs.writable.getWriter().write('not bytes').catch(e => log.push('write:' + e.name));
+            """);
+
+        Log(engine).Should().Be("out:error:TypeError:CompressionStream: the chunk is not an ArrayBuffer or a view over one,write:TypeError");
+    }
+
+    [Fact]
+    public void ComposesWithPipeThrough()
+    {
+        var engine = StreamEngine();
+
+        var text = engine.Evaluate("""
+            (async () => {
+              const source = new ReadableStream({
+                start(c) { c.enqueue(new TextEncoder().encode('round ')); c.enqueue(new TextEncoder().encode('trip')); c.close(); }
+              });
+              let text = '';
+              const piped = source
+                .pipeThrough(new CompressionStream('deflate'))
+                .pipeThrough(new DecompressionStream('deflate'))
+                .pipeThrough(new TextDecoderStream());
+              for await (const chunk of piped) { text += chunk; }
+              return text;
+            })()
+            """).UnwrapIfPromise();
+
+        text.AsString().Should().Be("round trip");
+    }
+
+    [Theory]
+    [InlineData("brotli")]
+    [InlineData("GZIP")]
+    [InlineData("Deflate")]
+    [InlineData("deflate_raw")]
+    [InlineData("")]
+    public void RefusesAFormatItDoesNotSupport(string format)
+    {
+        var engine = StreamEngine();
+        engine.SetValue("format", format);
+
+        // The WebIDL enumeration is matched exactly; "brotli" is in it but unsupported here, which the
+        // standard also spells as a TypeError.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new CompressionStream(format)"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new DecompressionStream(format)"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void RequiresTheFormatArgumentAndNew()
+    {
+        var engine = StreamEngine();
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new CompressionStream()"))
+            .Error.Get("message").AsString().Should().Contain("1 argument required");
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("CompressionStream('gzip')"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("DecompressionStream('gzip')"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+
+        engine.Evaluate("CompressionStream.length").AsNumber().Should().Be(1);
+        engine.Evaluate("DecompressionStream.length").AsNumber().Should().Be(1);
+    }
+
+    [Fact]
+    public void ExposesNothingButTheGenericTransformStreamMixin()
+    {
+        var engine = StreamEngine();
+        engine.Execute("var cs = new CompressionStream('gzip'); var ds = new DecompressionStream('gzip');");
+
+        engine.Evaluate("cs.readable instanceof ReadableStream").AsBoolean().Should().BeTrue();
+        engine.Evaluate("cs.writable instanceof WritableStream").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.prototype.toString.call(cs)").AsString().Should().Be("[object CompressionStream]");
+        engine.Evaluate("Object.prototype.toString.call(ds)").AsString().Should().Be("[object DecompressionStream]");
+
+        // No format attribute: the standard keeps it internal, and a browser exposes none either.
+        engine.Evaluate("Object.getOwnPropertyNames(CompressionStream.prototype).sort().join(',')")
+            .AsString().Should().Be("constructor,readable,writable");
+
+        foreach (var attribute in new[] { "readable", "writable" })
+        {
+            Assert.Throws<JavaScriptException>(() => engine.Evaluate($"CompressionStream.prototype.{attribute}"))
+                .Error.Get("name").AsString().Should().Be("TypeError", attribute);
+
+            // The two interfaces share the mixin but not their brands.
+            Assert.Throws<JavaScriptException>(() => engine.Evaluate(
+                    $"Object.getOwnPropertyDescriptor(CompressionStream.prototype, '{attribute}').get.call(ds)"))
+                .Error.Get("name").AsString().Should().Be("TypeError", attribute);
+        }
+    }
+
+    [Fact]
+    public void NeedsBothItsFlagAndTheStreamsFlag()
+    {
+        foreach (var name in new[] { "CompressionStream", "DecompressionStream" })
+        {
+            new Engine(options => options.UseWebApis(WebApiFeatures.Compression))
+                .Evaluate($"typeof {name}").AsString().Should().Be("undefined", name);
+            new Engine(options => options.UseWebApis(WebApiFeatures.Streams))
+                .Evaluate($"typeof {name}").AsString().Should().Be("undefined", name);
+            new Engine(options => options.UseWebApis(WebApiFeatures.Streams | WebApiFeatures.Compression))
+                .Evaluate($"typeof {name}").AsString().Should().Be("function", name);
+        }
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/TextDecoderStreamTests.cs
+++ b/Jint.Tests/Runtime/WebApi/TextDecoderStreamTests.cs
@@ -1,0 +1,296 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// <c>TextDecoderStream</c> — https://encoding.spec.whatwg.org/#interface-textdecoderstream.
+/// </summary>
+/// <remarks>
+/// It is the same decoding a <c>TextDecoder</c> does, driven the way a script would drive one: every chunk
+/// is a streaming decode and closing the writable side is the final flush. The tests that matter are
+/// therefore the ones about what happens at a chunk boundary — a split sequence, a split BOM, a sequence
+/// that never completes.
+/// </remarks>
+public class TextDecoderStreamTests
+{
+    private static Engine StreamEngine()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Encoding | WebApiFeatures.Streams));
+        engine.Execute("""
+            var log = [];
+            async function collect(stream, label) {
+              const reader = stream.getReader();
+              for (;;) {
+                let result;
+                try { result = await reader.read(); }
+                catch (e) { log.push(label + ':error:' + e.name); return; }
+                if (result.done) { log.push(label + ':done'); return; }
+                log.push(label + ':' + result.value);
+              }
+            }
+            function bytes() { return new Uint8Array(Array.prototype.slice.call(arguments)); }
+            """);
+        return engine;
+    }
+
+    private static string Log(Engine engine) => engine.Evaluate("log.join(',')").AsString();
+
+    [Fact]
+    public void ExposesTheMixinsAndTheDecoderAttributes()
+    {
+        var engine = StreamEngine();
+        engine.Execute("var s = new TextDecoderStream();");
+
+        engine.Evaluate("s.readable instanceof ReadableStream").AsBoolean().Should().BeTrue();
+        engine.Evaluate("s.writable instanceof WritableStream").AsBoolean().Should().BeTrue();
+        engine.Evaluate("[s.encoding, s.fatal, s.ignoreBOM].join(',')").AsString().Should().Be("utf-8,false,false");
+        engine.Evaluate("Object.prototype.toString.call(s)").AsString().Should().Be("[object TextDecoderStream]");
+        engine.Evaluate("TextDecoderStream.length").AsNumber().Should().Be(0);
+        engine.Evaluate("TextDecoderStream.name").AsString().Should().Be("TextDecoderStream");
+
+        engine.Evaluate("new TextDecoderStream('UTF-16LE', { fatal: true, ignoreBOM: true }).encoding")
+            .AsString().Should().Be("utf-16le");
+        engine.Evaluate("new TextDecoderStream(undefined, { fatal: true }).fatal").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void TakesTheSameConstructorArgumentsAsTextDecoder()
+    {
+        var engine = StreamEngine();
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new TextDecoderStream('windows-1252')"))
+            .Error.Get("name").AsString().Should().Be("RangeError");
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new TextDecoderStream('utf-8', 42)"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+
+        // The options are read before the label is validated, which is what the WebIDL conversion order
+        // requires: a getter on the dictionary runs even when the label is nonsense.
+        engine.Execute("var read = []; var options = { get fatal() { read.push('fatal'); return false; } };");
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new TextDecoderStream('nonsense', options)"));
+        engine.Evaluate("read.join(',')").AsString().Should().Be("fatal");
+    }
+
+    [Fact]
+    public void DecodesEachChunk()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var s = new TextDecoderStream();
+            collect(s.readable, 'out');
+            var writer = s.writable.getWriter();
+            writer.write(bytes(104, 105));
+            writer.write(bytes(226, 130, 172));
+            writer.close();
+            """);
+
+        Log(engine).Should().Be("out:hi,out:€,out:done");
+    }
+
+    [Fact]
+    public void JoinsASequenceSplitAcrossChunks()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var s = new TextDecoderStream();
+            collect(s.readable, 'out');
+            var writer = s.writable.getWriter();
+            writer.write(bytes(226, 130));
+            writer.write(bytes(172));
+            writer.close();
+            """);
+
+        // The first chunk holds an incomplete sequence, so it enqueues nothing at all — "if outputChunk is
+        // not the empty string" — and the euro sign appears once the third byte arrives.
+        Log(engine).Should().Be("out:€,out:done");
+    }
+
+    [Fact]
+    public void ASequenceLeftIncompleteAtTheEndBecomesTheReplacementCharacter()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var s = new TextDecoderStream();
+            collect(s.readable, 'out');
+            var writer = s.writable.getWriter();
+            writer.write(bytes(97, 226, 130));
+            writer.close();
+            """);
+
+        // The flush is what ends the stream, and an incomplete sequence at that point is U+FFFD.
+        Log(engine).Should().Be("out:a,out:�,out:done");
+    }
+
+    [Fact]
+    public void AFatalDecoderErrorsBothSides()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var s = new TextDecoderStream('utf-8', { fatal: true });
+            collect(s.readable, 'out');
+            var writer = s.writable.getWriter();
+            writer.write(bytes(0xC0, 0x80)).catch(e => log.push('write:' + e.name));
+            writer.closed.catch(e => log.push('writable:' + e.name));
+            """);
+
+        // "If the error mode is fatal and the decoder returns error, both readable and writable will be
+        // errored with a TypeError."
+        Log(engine).Should().Be("out:error:TypeError,write:TypeError,writable:TypeError");
+    }
+
+    [Fact]
+    public void AFatalDecoderAlsoRefusesAnIncompleteSequenceAtTheEnd()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var s = new TextDecoderStream('utf-8', { fatal: true });
+            collect(s.readable, 'out');
+            var writer = s.writable.getWriter();
+            writer.write(bytes(226, 130));
+            writer.close().catch(e => log.push('close:' + e.name));
+            """);
+
+        Log(engine).Should().Be("out:error:TypeError,close:TypeError");
+    }
+
+    [Fact]
+    public void DropsALeadingByteOrderMarkUnlessAskedNotTo()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var s = new TextDecoderStream();
+            collect(s.readable, 'first');
+            var writer = s.writable.getWriter();
+            writer.write(bytes(0xEF, 0xBB, 0xBF, 104, 105));
+            writer.close();
+            """);
+
+        Log(engine).Should().Be("first:hi,first:done");
+
+        // With ignoreBOM the mark is part of the output; the code points say so without an invisible
+        // character in the expectation.
+        engine.Evaluate("""
+            (async () => {
+              const s = new TextDecoderStream('utf-8', { ignoreBOM: true });
+              const writer = s.writable.getWriter();
+              writer.write(new Uint8Array([0xEF, 0xBB, 0xBF, 104, 105]));
+              writer.close();
+              let text = '';
+              for await (const chunk of s.readable) { text += chunk; }
+              return Array.from(text).map(c => c.charCodeAt(0)).join(',');
+            })()
+            """).UnwrapIfPromise().AsString().Should().Be("65279,104,105");
+    }
+
+    [Fact]
+    public void DropsAByteOrderMarkSplitAcrossChunks()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var s = new TextDecoderStream();
+            collect(s.readable, 'out');
+            var writer = s.writable.getWriter();
+            writer.write(bytes(0xEF));
+            writer.write(bytes(0xBB));
+            writer.write(bytes(0xBF, 104, 105));
+            writer.close();
+            """);
+
+        // The BOM is one stream's worth of state, not one chunk's: the first two chunks decode to nothing
+        // and the third produces "hi" with the mark already removed.
+        Log(engine).Should().Be("out:hi,out:done");
+    }
+
+    [Fact]
+    public void RefusesAChunkThatIsNotABufferSource()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var s = new TextDecoderStream();
+            collect(s.readable, 'out');
+            var writer = s.writable.getWriter();
+            writer.write('not bytes').catch(e => log.push('write:' + e.name));
+            """);
+
+        Log(engine).Should().Be("out:error:TypeError,write:TypeError");
+    }
+
+    [Fact]
+    public void AcceptsEveryBufferSourceShape()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var s = new TextDecoderStream();
+            collect(s.readable, 'out');
+            var writer = s.writable.getWriter();
+            var buffer = new Uint8Array([104, 105]).buffer;
+            writer.write(buffer);
+            writer.write(new DataView(new Uint8Array([33]).buffer));
+            writer.close();
+            """);
+
+        Log(engine).Should().Be("out:hi,out:!,out:done");
+    }
+
+    [Fact]
+    public void DecodesUtf16LikeTextDecoderDoes()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var s = new TextDecoderStream('utf-16le');
+            collect(s.readable, 'out');
+            var writer = s.writable.getWriter();
+            writer.write(bytes(104, 0, 105));
+            writer.write(bytes(0));
+            writer.close();
+            """);
+
+        // The second code unit's bytes arrive in two chunks, and the pair is still one character.
+        Log(engine).Should().Be("out:h,out:i,out:done");
+    }
+
+    [Fact]
+    public void ComposesWithPipeThrough()
+    {
+        var engine = StreamEngine();
+        var result = engine.Evaluate("""
+            (async () => {
+              const source = new ReadableStream({
+                start(c) {
+                  c.enqueue(new Uint8Array([0xF0, 0x9F]));
+                  c.enqueue(new Uint8Array([0x98, 0x80, 33]));
+                  c.close();
+                }
+              });
+              let text = '';
+              for await (const chunk of source.pipeThrough(new TextDecoderStream())) { text += chunk; }
+              return text;
+            })()
+            """).UnwrapIfPromise();
+
+        result.AsString().Should().Be("😀!");
+    }
+
+    [Fact]
+    public void TheAttributesBrandCheckTheirReceiver()
+    {
+        var engine = StreamEngine();
+
+        foreach (var attribute in new[] { "encoding", "fatal", "ignoreBOM", "readable", "writable" })
+        {
+            Assert.Throws<JavaScriptException>(() => engine.Evaluate($"TextDecoderStream.prototype.{attribute}"))
+                .Error.Get("name").AsString().Should().Be("TypeError", attribute);
+        }
+
+        // A TextDecoder includes the same TextDecoderCommon mixin but is a different interface.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate(
+                "Object.getOwnPropertyDescriptor(TextDecoderStream.prototype, 'encoding').get.call(new TextDecoder())"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("TextDecoderStream()"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/TextEncoderStreamTests.cs
+++ b/Jint.Tests/Runtime/WebApi/TextEncoderStreamTests.cs
@@ -1,0 +1,275 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// <c>TextEncoderStream</c> — https://encoding.spec.whatwg.org/#interface-textencoderstream.
+/// </summary>
+/// <remarks>
+/// The interesting half is the leading-surrogate carry: chunks are <c>DOMString</c>s rather than
+/// <c>USVString</c>s exactly so that a surrogate pair split across two of them still encodes as one scalar
+/// value, and every other lone surrogate is U+FFFD.
+/// </remarks>
+public class TextEncoderStreamTests
+{
+    /// <summary>
+    /// Both flags: the interface is one standard's algorithm running inside another's machinery, so the
+    /// engine needs to have been asked for both.
+    /// </summary>
+    private static Engine StreamEngine()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Encoding | WebApiFeatures.Streams));
+        engine.Execute("""
+            var log = [];
+            async function collect(stream, label) {
+              const reader = stream.getReader();
+              for (;;) {
+                let result;
+                try { result = await reader.read(); }
+                catch (e) { log.push(label + ':error:' + e.name); return; }
+                if (result.done) { log.push(label + ':done'); return; }
+                log.push(label + ':' + Array.from(result.value).join(' '));
+              }
+            }
+            """);
+        return engine;
+    }
+
+    private static string Log(Engine engine) => engine.Evaluate("log.join(',')").AsString();
+
+    [Fact]
+    public void ExposesTheGenericTransformStreamMixin()
+    {
+        var engine = StreamEngine();
+        engine.Execute("var s = new TextEncoderStream();");
+
+        engine.Evaluate("s.readable instanceof ReadableStream").AsBoolean().Should().BeTrue();
+        engine.Evaluate("s.writable instanceof WritableStream").AsBoolean().Should().BeTrue();
+        engine.Evaluate("s.readable === s.readable && s.writable === s.writable").AsBoolean().Should().BeTrue();
+        engine.Evaluate("s.encoding").AsString().Should().Be("utf-8");
+        engine.Evaluate("Object.prototype.toString.call(s)").AsString().Should().Be("[object TextEncoderStream]");
+        engine.Evaluate("TextEncoderStream.length").AsNumber().Should().Be(0);
+        engine.Evaluate("TextEncoderStream.name").AsString().Should().Be("TextEncoderStream");
+
+        // The transform itself is never exposed: the instance owns one, it is not one.
+        engine.Evaluate("s instanceof TransformStream").AsBoolean().Should().BeFalse();
+        engine.Evaluate("Object.getOwnPropertyNames(s).length").AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void EncodesEachChunkAsUtf8()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var s = new TextEncoderStream();
+            collect(s.readable, 'out');
+            var writer = s.writable.getWriter();
+            writer.write('hi');
+            writer.write('€');
+            writer.close();
+            """);
+
+        Log(engine).Should().Be("out:104 105,out:226 130 172,out:done");
+    }
+
+    [Fact]
+    public void EnqueuesNothingForAChunkThatProducesNoBytes()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var s = new TextEncoderStream();
+            collect(s.readable, 'out');
+            var writer = s.writable.getWriter();
+            writer.write('');
+            writer.write('x');
+            writer.close();
+            """);
+
+        // "If output is not empty": the empty chunk enqueues nothing at all rather than an empty array.
+        Log(engine).Should().Be("out:120,out:done");
+    }
+
+    [Fact]
+    public void ReassemblesASurrogatePairSplitAcrossTwoChunks()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var s = new TextEncoderStream();
+            collect(s.readable, 'out');
+            var writer = s.writable.getWriter();
+            writer.write('a\uD83D');
+            writer.write('\uDE00b');
+            writer.close();
+            """);
+
+        // The high surrogate is held back — the first chunk enqueues only 'a', not 'a' plus U+FFFD — and
+        // the pair then encodes as the one scalar value U+1F600. Encoding the two chunks independently
+        // would have produced 97 239 191 189 and 239 191 189 98 instead.
+        Log(engine).Should().Be("out:97,out:240 159 152 128 98,out:done");
+    }
+
+    [Fact]
+    public void AHeldSurrogateThatIsNeverCompletedBecomesTheReplacementCharacter()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var s = new TextEncoderStream();
+            collect(s.readable, 'out');
+            var writer = s.writable.getWriter();
+            writer.write('\uD83D');
+            writer.write('x');
+            writer.close();
+            """);
+
+        // "Restore item to input and return U+FFFD": the code unit that failed to complete the pair is not
+        // consumed, so it is encoded after the replacement character rather than dropped.
+        Log(engine).Should().Be("out:239 191 189 120,out:done");
+    }
+
+    [Fact]
+    public void ASurrogateLeftPendingAtTheEndIsFlushedAsTheReplacementCharacter()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var s = new TextEncoderStream();
+            collect(s.readable, 'out');
+            var writer = s.writable.getWriter();
+            writer.write('a\uD83D');
+            writer.close();
+            """);
+
+        // "Encode and flush": « 0xEF, 0xBF, 0xBD ».
+        Log(engine).Should().Be("out:97,out:239 191 189,out:done");
+    }
+
+    [Fact]
+    public void ALoneTrailingSurrogateIsTheReplacementCharacter()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var s = new TextEncoderStream();
+            collect(s.readable, 'out');
+            var writer = s.writable.getWriter();
+            writer.write('\uDE00a');
+            writer.close();
+            """);
+
+        Log(engine).Should().Be("out:239 191 189 97,out:done");
+    }
+
+    [Fact]
+    public void ChunksAreConvertedToStringsRatherThanRefused()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var s = new TextEncoderStream();
+            collect(s.readable, 'out');
+            var writer = s.writable.getWriter();
+            writer.write(42);
+            writer.write({ toString() { return 'obj'; } });
+            writer.close();
+            """);
+
+        // The chunk is a DOMString, so anything at all is converted rather than rejected.
+        Log(engine).Should().Be("out:52 50,out:111 98 106,out:done");
+    }
+
+    [Fact]
+    public void ProducesUint8ArraysInTheEnginesOwnRealm()
+    {
+        var engine = StreamEngine();
+        var result = engine.Evaluate("""
+            (async () => {
+              const s = new TextEncoderStream();
+              const writer = s.writable.getWriter();
+              writer.write('hi');
+              writer.close();
+              const chunk = (await s.readable.getReader().read()).value;
+              return (chunk instanceof Uint8Array) + ':' + chunk.constructor.name + ':' + chunk.byteLength;
+            })()
+            """).UnwrapIfPromise();
+
+        result.AsString().Should().Be("true:Uint8Array:2");
+    }
+
+    [Fact]
+    public void ComposesWithPipeThrough()
+    {
+        var engine = StreamEngine();
+        var result = engine.Evaluate("""
+            (async () => {
+              const source = new ReadableStream({
+                start(c) { c.enqueue('héllo '); c.enqueue('wörld'); c.close(); }
+              });
+              const bytes = [];
+              for await (const chunk of source.pipeThrough(new TextEncoderStream())) {
+                bytes.push(...chunk);
+              }
+              return bytes.join(',');
+            })()
+            """).UnwrapIfPromise();
+
+        // 104 233 -> "h" plus the two-byte é, and likewise for ö.
+        result.AsString().Should().Be("104,195,169,108,108,111,32,119,195,182,114,108,100");
+    }
+
+    [Fact]
+    public void RoundTripsThroughTextDecoderStream()
+    {
+        var engine = StreamEngine();
+        var result = engine.Evaluate("""
+            (async () => {
+              const source = new ReadableStream({
+                start(c) { c.enqueue('a\uD83D'); c.enqueue('\uDE00b'); c.close(); }
+              });
+              let text = '';
+              for await (const chunk of source.pipeThrough(new TextEncoderStream()).pipeThrough(new TextDecoderStream())) {
+                text += chunk;
+              }
+              return text === 'a😀b';
+            })()
+            """).UnwrapIfPromise();
+
+        result.AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void TheAttributesBrandCheckTheirReceiver()
+    {
+        var engine = StreamEngine();
+
+        foreach (var attribute in new[] { "encoding", "readable", "writable" })
+        {
+            Assert.Throws<JavaScriptException>(() => engine.Evaluate(
+                    $"Object.getOwnPropertyDescriptor(TextEncoderStream.prototype, '{attribute}').get.call({{}})"))
+                .Error.Get("name").AsString().Should().Be("TypeError", attribute);
+
+            // The prototype itself is not an instance either, and neither is the other transform stream.
+            Assert.Throws<JavaScriptException>(() => engine.Evaluate($"TextEncoderStream.prototype.{attribute}"))
+                .Error.Get("name").AsString().Should().Be("TypeError", attribute);
+        }
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate(
+                "Object.getOwnPropertyDescriptor(TextEncoderStream.prototype, 'readable').get.call(new TextDecoderStream())"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void RequiresNewAndBothFeatureFlags()
+    {
+        var engine = StreamEngine();
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("TextEncoderStream()"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+
+        // Either flag on its own installs neither of the two streams: they are useless without the other
+        // half, and an absent global is the honest answer for feature detection.
+        new Engine(options => options.UseWebApis(WebApiFeatures.Encoding))
+            .Evaluate("typeof TextEncoderStream").AsString().Should().Be("undefined");
+        new Engine(options => options.UseWebApis(WebApiFeatures.Streams))
+            .Evaluate("typeof TextEncoderStream").AsString().Should().Be("undefined");
+    }
+}
+#endif

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -437,6 +437,10 @@ public enum WebApiFeatures
     /// <summary>
     /// <c>TextEncoder</c> and <c>TextDecoder</c> — https://encoding.spec.whatwg.org/#api. The encoder is
     /// UTF-8 only, as the standard requires; the decoder reads UTF-8, UTF-16LE and UTF-16BE.
+    /// <para>
+    /// Their streaming counterparts, <c>TextEncoderStream</c> and <c>TextDecoderStream</c>, need
+    /// <see cref="Streams"/> as well and are installed only when both flags are present.
+    /// </para>
     /// </summary>
     Encoding = 1 << 2,
 
@@ -619,14 +623,29 @@ public enum WebApiFeatures
     EventSource = 1 << 17,
 
     /// <summary>
+    /// <c>CompressionStream</c> and <c>DecompressionStream</c> — https://compression.spec.whatwg.org/ — for
+    /// the three formats the standard's <c>CompressionFormat</c> names and this implementation supports:
+    /// <c>gzip</c> (RFC 1952), <c>deflate</c> (the ZLIB wrapper of RFC 1950, as the standard defines that
+    /// name) and <c>deflate-raw</c> (RFC 1951). <c>brotli</c> is not implemented and, like any other
+    /// unsupported value, is a <c>TypeError</c>.
+    /// </summary>
+    /// <remarks>
+    /// <b>Requires <see cref="Streams"/> as well</b>: both are transform streams, so naming this flag on
+    /// its own installs nothing. The bit is 1 &lt;&lt; 20 rather than the next numerically free one — the
+    /// bits below it are spoken for by features landing alongside this one, and the layout is fixed ahead
+    /// of the implementations so that a value a host persisted keeps its meaning as the surface grows.
+    /// </remarks>
+    Compression = 1 << 20,
+
+    /// <summary>
     /// The web APIs a host normally wants: everything except outbound network access and persistent state.
     /// Today that is
     /// <see cref="Console"/>, <see cref="Timers"/>, <see cref="Encoding"/>, <see cref="Base64"/>,
     /// <see cref="StructuredClone"/>, <see cref="Crypto"/>, <see cref="Performance"/>, <see cref="Events"/>,
     /// <see cref="Url"/>, <see cref="Files"/>, <see cref="Navigator"/>, <see cref="Streams"/>,
-    /// <see cref="Scheduler"/>, <see cref="Messaging"/> and <see cref="Reporting"/>; it grows as further
+    /// <see cref="Scheduler"/>, <see cref="Messaging"/> <see cref="Reporting"/> and <see cref="Compression"/>; it grows as further
     /// features land, and never comes to include fetch or <see cref="Storage"/>.
     /// </summary>
-    Default = Console | Timers | Encoding | Base64 | StructuredClone | Crypto | Performance | Events | Url | Files | Navigator | Streams | Scheduler | Messaging | Reporting,
+    Default = Console | Timers | Encoding | Base64 | StructuredClone | Crypto | Performance | Events | Url | Files | Navigator | Streams | Scheduler | Messaging | Reporting | Compression,
 }
 #endif

--- a/Jint/Runtime/Intrinsics.WebApi.cs
+++ b/Jint/Runtime/Intrinsics.WebApi.cs
@@ -1,6 +1,7 @@
 #if NET8_0_OR_GREATER
 using Jint.WebApi.Abort;
 using Jint.WebApi.Base64;
+using Jint.WebApi.Compression;
 using Jint.WebApi.Console;
 using Jint.WebApi.Crypto;
 using Jint.WebApi.DomException;
@@ -322,5 +323,27 @@ public sealed partial class Intrinsics
     /// <inheritdoc cref="LocalStorage" />
     internal JsStorage SessionStorage =>
         _sessionStorage ??= JsStorage.Create(_engine, _realm, Storage, StorageKind.Session);
+
+    private TextEncoderStreamConstructor? _textEncoderStream;
+    private TextDecoderStreamConstructor? _textDecoderStream;
+    private CompressionStreamConstructor? _compressionStream;
+    private DecompressionStreamConstructor? _decompressionStream;
+
+    /// <summary>
+    /// The four transform streams other standards define. Each is an interface of its own rather than a
+    /// <c>TransformStream</c> subclass, so none of them shares a prototype with <see cref="TransformStream"/>
+    /// — but each owns one, which is why reaching any of these builds the streams intrinsics too.
+    /// </summary>
+    internal TextEncoderStreamConstructor TextEncoderStream =>
+        _textEncoderStream ??= new TextEncoderStreamConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
+
+    internal TextDecoderStreamConstructor TextDecoderStream =>
+        _textDecoderStream ??= new TextDecoderStreamConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
+
+    internal CompressionStreamConstructor CompressionStream =>
+        _compressionStream ??= new CompressionStreamConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
+
+    internal DecompressionStreamConstructor DecompressionStream =>
+        _decompressionStream ??= new DecompressionStreamConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
 }
 #endif

--- a/Jint/WebApi/Compression/CompressionCodec.cs
+++ b/Jint/WebApi/Compression/CompressionCodec.cs
@@ -1,0 +1,158 @@
+#if NET8_0_OR_GREATER
+using System.IO;
+using System.IO.Compression;
+
+namespace Jint.WebApi.Compression;
+
+/// <summary>
+/// The <c>CompressionStream</c>'s "compression context" — https://compression.spec.whatwg.org/#compression-context.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The context is the BCL compressing stream for the format plus the buffer it writes into. Input is
+/// written straight through and whatever the compressor has produced so far is taken out; the compressor
+/// is deliberately <b>not</b> flushed per chunk, because a flush emits a sync-flush marker and would bloat
+/// the output for no benefit. The specification anticipates exactly this — "if buffer is empty, return" —
+/// so a chunk that produces nothing yet enqueues nothing, and the bulk of a small stream's output appears
+/// when <see cref="Finish"/> ends the member.
+/// </para>
+/// <para>
+/// Nothing here touches the engine or a thread: the compressor is a synchronous in-memory transform driven
+/// from the transform stream's algorithms, which run on the engine's thread like every other stream
+/// callback.
+/// </para>
+/// </remarks>
+internal sealed class CompressionCodec : IDisposable
+{
+    /// <summary>
+    /// The whole of an RFC 1951 stream whose payload is empty: BFINAL=1, BTYPE=01 (fixed Huffman) and the
+    /// end-of-block symbol, which is ten bits and therefore these two bytes.
+    /// </summary>
+    private static ReadOnlySpan<byte> EmptyDeflateBlock => [0x03, 0x00];
+
+    /// <summary>
+    /// An RFC 1950 stream whose payload is empty: CMF (CM=8, CINFO=7) and FLG, whose FCHECK bits make
+    /// 0x789C a multiple of 31; the empty block; and the ADLER32 of the empty byte sequence, which is 1.
+    /// </summary>
+    private static ReadOnlySpan<byte> EmptyZlibStream => [0x78, 0x9C, 0x03, 0x00, 0x00, 0x00, 0x00, 0x01];
+
+    /// <summary>
+    /// An RFC 1952 member whose payload is empty: the magic number, CM=8, no flags, no MTIME, no extra
+    /// flags, OS = 255 (unknown, rather than this machine's); the empty block; and a CRC32 and ISIZE of
+    /// zero. Every field a <c>DecompressionStream</c> must ignore is at its "nothing to say" value.
+    /// </summary>
+    private static ReadOnlySpan<byte> EmptyGzipMember =>
+    [
+        0x1F, 0x8B, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF,
+        0x03, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+    ];
+
+    private readonly MemoryStream _output = new();
+    private readonly Stream _compressor;
+    private readonly CompressionFormat _format;
+    private bool _wroteBytes;
+    private bool _disposed;
+
+    internal CompressionCodec(CompressionFormat format)
+    {
+        _format = format;
+
+        // See CompressionFormat: "deflate" is the ZLIB wrapper of RFC 1950, and only "deflate-raw" is the
+        // bare RFC 1951 bit stream.
+        _compressor = format switch
+        {
+            CompressionFormat.Gzip => new GZipStream(_output, CompressionMode.Compress, leaveOpen: true),
+            CompressionFormat.Deflate => new ZLibStream(_output, CompressionMode.Compress, leaveOpen: true),
+            _ => new DeflateStream(_output, CompressionMode.Compress, leaveOpen: true),
+        };
+    }
+
+    /// <summary>
+    /// "Compressing <paramref name="input"/> with the format and context", and taking whatever output that
+    /// has made available. Returns <see langword="null"/> for the specification's empty buffer.
+    /// </summary>
+    internal byte[]? Compress(ReadOnlySpan<byte> input)
+    {
+        if (_disposed || input.Length == 0)
+        {
+            // A chunk of no bytes cannot change the compressor's state or produce output, and passing it
+            // on would arm the BCL flag that <see cref="Finish"/> reasons about below.
+            return null;
+        }
+
+        _wroteBytes = true;
+        _compressor.Write(input);
+        return TakeOutput();
+    }
+
+    /// <summary>
+    /// "Compressing an empty input with the format and context, with the finish flag": the compressor is
+    /// closed, which is what writes the format's trailer — a gzip CRC32 and ISIZE, a zlib ADLER32, the
+    /// final DEFLATE block — and then everything left is taken out.
+    /// </summary>
+    /// <remarks>
+    /// The empty case is the constant above rather than the compressor's own output, because the BCL will
+    /// not produce one: a compressing <see cref="DeflateStream"/> that was never handed a byte writes
+    /// <i>nothing at all</i> when it is closed — deliberately, because <c>ZipArchiveEntry</c> depends on
+    /// zero output for zero input. On .NET 8 a zero-length write was enough to arm it and on .NET 10 it is
+    /// not, so relying on that would make the same source produce different bytes per target framework.
+    /// Zero bytes is not a valid stream in any of the three formats — our own <c>DecompressionStream</c>
+    /// rejects it, and so does every other implementation — so the empty member is emitted explicitly.
+    /// </remarks>
+    internal byte[]? Finish()
+    {
+        if (_disposed)
+        {
+            return null;
+        }
+
+        if (!_wroteBytes)
+        {
+            Dispose();
+            return _format switch
+            {
+                CompressionFormat.Gzip => EmptyGzipMember.ToArray(),
+                CompressionFormat.Deflate => EmptyZlibStream.ToArray(),
+                _ => EmptyDeflateBlock.ToArray(),
+            };
+        }
+
+        _compressor.Dispose();
+        var output = TakeOutput();
+        _disposed = true;
+        return output;
+    }
+
+    private byte[]? TakeOutput()
+    {
+        if (_output.Length == 0)
+        {
+            return null;
+        }
+
+        var bytes = _output.ToArray();
+
+        // SetLength(0) also rewinds the position, so the buffer is reused rather than reallocated.
+        _output.SetLength(0);
+        return bytes;
+    }
+
+    /// <summary>
+    /// Releases the native compression context of a stream that will never be finished — one whose
+    /// readable side was cancelled or whose writable side was aborted. Ordinary completion goes through
+    /// <see cref="Finish"/>, which disposes it too.
+    /// </summary>
+    public void Dispose()
+    {
+        if (!_disposed)
+        {
+            _compressor.Dispose();
+            _disposed = true;
+        }
+
+        _output.Dispose();
+    }
+}
+#endif

--- a/Jint/WebApi/Compression/CompressionFormat.cs
+++ b/Jint/WebApi/Compression/CompressionFormat.cs
@@ -1,0 +1,90 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Compression;
+
+/// <summary>
+/// The <c>CompressionFormat</c> enumeration — https://compression.spec.whatwg.org/#supported-formats.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b><c>deflate</c> is ZLIB, not raw DEFLATE.</b> The standard defines <c>"deflate"</c> as the "ZLIB
+/// Compressed Data Format" of [RFC1950] — a two-byte header, the DEFLATE body, and an ADLER32 checksum —
+/// and notes that it is named that way "for consistency with HTTP Content-Encodings". Raw DEFLATE, the
+/// [RFC1951] bit stream with no wrapper at all, is the separate <c>"deflate-raw"</c> value. Mapping
+/// <c>"deflate"</c> onto a bare <see cref="System.IO.Compression.DeflateStream"/> is the classic mistake
+/// here, and it produces bytes no other implementation can read.
+/// </para>
+/// <para>
+/// The standard's fourth value, <c>"brotli"</c> ([RFC7932]), is not implemented. A value the standard
+/// names but an implementation does not support is a <c>TypeError</c> ("If format is unsupported in
+/// CompressionStream, then throw a TypeError"), which is the same failure a value outside the enumeration
+/// gets from the WebIDL conversion — so a script sees one answer either way.
+/// </para>
+/// </remarks>
+internal enum CompressionFormat
+{
+    /// <summary>"GZIP file format" [RFC1952] — <see cref="System.IO.Compression.GZipStream"/>.</summary>
+    Gzip,
+
+    /// <summary>"ZLIB Compressed Data Format" [RFC1950] — <see cref="System.IO.Compression.ZLibStream"/>.</summary>
+    Deflate,
+
+    /// <summary>"The DEFLATE algorithm" [RFC1951] — <see cref="System.IO.Compression.DeflateStream"/>.</summary>
+    DeflateRaw,
+}
+
+/// <summary>
+/// The WebIDL enumeration conversion for <see cref="CompressionFormat"/>.
+/// </summary>
+internal static class CompressionFormats
+{
+    /// <summary>
+    /// The <c>format</c> argument both constructors take: a required <c>CompressionFormat</c>, so a
+    /// missing argument and an unrecognized one are both a <c>TypeError</c> — and so is
+    /// <c>"brotli"</c>, which the enumeration names but this implementation does not support.
+    /// </summary>
+    internal static CompressionFormat ReadFormat(Realm realm, JsCallArguments arguments, string interfaceName)
+    {
+        if (arguments.Length == 0)
+        {
+            Throw.TypeError(realm, "Failed to construct '" + interfaceName + "': 1 argument required, but only 0 present");
+        }
+
+        var value = TypeConverter.ToString(arguments.At(0));
+        if (!TryParse(value, out var format))
+        {
+            Throw.TypeError(
+                realm,
+                "Failed to construct '" + interfaceName + "': the provided value '" + value +
+                "' is not a supported CompressionFormat; use 'gzip', 'deflate' or 'deflate-raw'");
+        }
+
+        return format;
+    }
+
+    /// <summary>
+    /// Matches one of the three identifiers the standard defines, exactly and case-sensitively, as
+    /// https://webidl.spec.whatwg.org/#es-enumeration requires.
+    /// </summary>
+    private static bool TryParse(string value, out CompressionFormat format)
+    {
+        switch (value)
+        {
+            case "gzip":
+                format = CompressionFormat.Gzip;
+                return true;
+            case "deflate":
+                format = CompressionFormat.Deflate;
+                return true;
+            case "deflate-raw":
+                format = CompressionFormat.DeflateRaw;
+                return true;
+            default:
+                format = default;
+                return false;
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/Compression/CompressionStreamConstructor.cs
+++ b/Jint/WebApi/Compression/CompressionStreamConstructor.cs
@@ -1,0 +1,63 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.Streams;
+
+namespace Jint.WebApi.Compression;
+
+/// <summary>
+/// The <c>CompressionStream</c> interface object.
+/// <para>
+/// https://compression.spec.whatwg.org/#compression-stream
+/// </para>
+/// </summary>
+internal sealed class CompressionStreamConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("CompressionStream");
+
+    internal CompressionStreamConstructor(
+        Engine engine,
+        Realm realm,
+        FunctionPrototype functionPrototype,
+        ObjectPrototype objectPrototype)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = functionPrototype;
+        PrototypeObject = new CompressionStreamPrototype(engine, realm, this, objectPrototype);
+        _length = new PropertyDescriptor(JsNumber.PositiveOne, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal CompressionStreamPrototype PrototypeObject { get; }
+
+    /// <summary>
+    /// https://compression.spec.whatwg.org/#dom-compressionstream-compressionstream
+    /// </summary>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        var format = CompressionFormats.ReadFormat(_realm, arguments, "CompressionStream");
+
+        var stream = OrdinaryCreateFromConstructor(
+            newTarget,
+            static intrinsics => intrinsics.CompressionStream.PrototypeObject,
+            static (Engine engine, Realm realm, CompressionFormat state) => new JsCompressionStream(engine, realm, state),
+            format);
+
+        // The algorithms close over the instance, so the transform can only be set up once it exists. The
+        // cancel algorithm is not one the standard gives, and it is unobservable from script: it exists so
+        // that a stream nobody finishes releases its native compression context without waiting for a
+        // finalizer.
+        stream.Transform = TransformStreamOperations.SetUp(
+            _engine,
+            _realm,
+            stream.CompressAndEnqueue,
+            stream.CompressFlushAndEnqueue,
+            stream.Dispose);
+
+        return stream;
+    }
+}
+#endif

--- a/Jint/WebApi/Compression/CompressionStreamPrototype.cs
+++ b/Jint/WebApi/Compression/CompressionStreamPrototype.cs
@@ -1,0 +1,74 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.Streams;
+
+namespace Jint.WebApi.Compression;
+
+/// <summary>
+/// <c>CompressionStream.prototype</c> — the interface prototype object.
+/// <para>
+/// https://compression.spec.whatwg.org/#compression-stream
+/// </para>
+/// </summary>
+/// <remarks>
+/// The interface is nothing but the <c>GenericTransformStream</c> mixin, so the prototype carries its two
+/// attributes and no operations at all. There is deliberately no <c>format</c> attribute: the standard
+/// keeps the format as an internal value, and a browser exposes none either.
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class CompressionStreamPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly CompressionStreamConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString CompressionStreamToStringTag = new("CompressionStream");
+
+    internal CompressionStreamPrototype(
+        Engine engine,
+        Realm realm,
+        CompressionStreamConstructor constructor,
+        ObjectInstance objectPrototype) : base(engine, realm)
+    {
+        _prototype = objectPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#dom-generictransformstream-readable
+    /// </summary>
+    [JsAccessor("readable", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsReadableStream ReadableGet(JsValue thisObject) => Brand(thisObject).Transform.Readable;
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#dom-generictransformstream-writable
+    /// </summary>
+    [JsAccessor("writable", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsWritableStream WritableGet(JsValue thisObject) => Brand(thisObject).Transform.Writable;
+
+    /// <summary>
+    /// The WebIDL brand check every attribute performs: a receiver that is not a platform object
+    /// implementing the interface raises a <c>TypeError</c> — a <c>DecompressionStream</c> included, since
+    /// the two share the mixin but are different interfaces.
+    /// </summary>
+    private JsCompressionStream Brand(JsValue thisObject)
+    {
+        if (thisObject is JsCompressionStream stream)
+        {
+            return stream;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a CompressionStream");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Compression/DecompressionCodec.cs
+++ b/Jint/WebApi/Compression/DecompressionCodec.cs
@@ -1,0 +1,181 @@
+#if NET8_0_OR_GREATER
+using System.IO;
+using System.IO.Compression;
+
+namespace Jint.WebApi.Compression;
+
+/// <summary>
+/// The <c>DecompressionStream</c>'s "compression context" — https://compression.spec.whatwg.org/#compression-context.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The BCL's decompressing streams <i>pull</i> from a source stream, while a transform stream <i>pushes</i>
+/// chunks at them, so the context owns a small push source: a chunk is copied into its queue and the
+/// decompressor is then read until it asks for input the queue does not have. A source read that finds the
+/// queue empty returns 0, which the decompressor treats as "no more for now" and recovers from when the
+/// next chunk arrives — that is what makes a member split across arbitrarily many chunks decode
+/// identically to the whole byte sequence.
+/// </para>
+/// <para>
+/// The copy is deliberate: the queue may still hold the bytes when the algorithm returns to script, and
+/// the specification asks for a synchronous copy of a buffer source precisely so a later mutation of the
+/// caller's <c>ArrayBuffer</c> cannot be observed.
+/// </para>
+/// <para>
+/// <b>Two documented divergences, both in the lenient direction.</b> The standard makes it an error for a
+/// stream to end before its member is complete, and an error for anything to follow the member (a second
+/// gzip "member" included). Detecting either needs to know how many of the bytes handed over the
+/// decompressor actually consumed, and .NET exposes no incremental inflater — only these pull streams,
+/// which buffer input internally and report neither figure. So a truncated stream ends its readable side
+/// cleanly rather than erroring it, trailing bytes after a member are ignored, and a multi-member gzip
+/// stream decodes every member. Everything the decompressor itself rejects — a bad header, a failed
+/// CRC32/ADLER32, a malformed DEFLATE block — is still an error, which is the case that matters for
+/// telling corrupt input from good. The one truncation that <i>is</i> caught here is the empty stream: no
+/// compressed bytes at all cannot be a complete member in any of the three formats.
+/// </para>
+/// </remarks>
+internal sealed class DecompressionCodec : IDisposable
+{
+    private readonly PushSource _source = new();
+    private readonly Stream _decompressor;
+    private readonly byte[] _buffer = new byte[8192];
+    private long _inputBytes;
+    private bool _disposed;
+
+    internal DecompressionCodec(CompressionFormat format)
+    {
+        // See CompressionFormat: "deflate" is the ZLIB wrapper of RFC 1950, and only "deflate-raw" is the
+        // bare RFC 1951 bit stream.
+        _decompressor = format switch
+        {
+            CompressionFormat.Gzip => new GZipStream(_source, CompressionMode.Decompress, leaveOpen: true),
+            CompressionFormat.Deflate => new ZLibStream(_source, CompressionMode.Decompress, leaveOpen: true),
+            _ => new DeflateStream(_source, CompressionMode.Decompress, leaveOpen: true),
+        };
+    }
+
+    /// <summary>
+    /// "Decompressing <paramref name="input"/> with the format and context". Returns
+    /// <see langword="null"/> for the specification's empty buffer, and raises the BCL's
+    /// <see cref="InvalidDataException"/> or <see cref="IOException"/> for input the format rejects — which
+    /// the caller reports as the <c>TypeError</c> the standard asks for.
+    /// </summary>
+    internal byte[]? Decompress(ReadOnlySpan<byte> input)
+    {
+        if (_disposed)
+        {
+            return null;
+        }
+
+        _inputBytes += input.Length;
+        _source.Push(input.ToArray());
+        return Drain();
+    }
+
+    /// <summary>
+    /// "Decompressing an empty input with the format and context, with the finish flag", followed by the
+    /// standard's "if the end of the compressed input has not been reached, then throw a TypeError" — of
+    /// which only the empty-input case is detectable here, as the class remarks explain.
+    /// </summary>
+    internal byte[]? Finish()
+    {
+        if (_disposed)
+        {
+            return null;
+        }
+
+        if (_inputBytes == 0)
+        {
+            throw new InvalidDataException("The compressed input ended before any member began.");
+        }
+
+        var output = Drain();
+        Dispose();
+        return output;
+    }
+
+    /// <summary>
+    /// Reads the decompressor until it has produced everything the input so far allows. A read of 0 means
+    /// it asked the push source for input that has not arrived, not that the stream ended.
+    /// </summary>
+    private byte[]? Drain()
+    {
+        MemoryStream? output = null;
+
+        int read;
+        while ((read = _decompressor.Read(_buffer, 0, _buffer.Length)) > 0)
+        {
+            (output ??= new MemoryStream()).Write(_buffer, 0, read);
+        }
+
+        return output?.ToArray();
+    }
+
+    /// <summary>
+    /// Releases the native decompression context. Ordinary completion goes through <see cref="Finish"/>,
+    /// which calls this; a cancelled or aborted stream calls it directly rather than waiting for a
+    /// finalizer.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _decompressor.Dispose();
+        _source.Dispose();
+    }
+
+    /// <summary>
+    /// The stream the decompressor pulls from: a queue of byte sequences that reports "nothing available"
+    /// rather than a permanent end of stream, since more chunks may follow.
+    /// </summary>
+    private sealed class PushSource : Stream
+    {
+        private readonly Queue<byte[]> _queue = new();
+        private byte[]? _current;
+        private int _offset;
+
+        internal void Push(byte[] bytes)
+        {
+            if (bytes.Length > 0)
+            {
+                _queue.Enqueue(bytes);
+            }
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => Read(buffer.AsSpan(offset, count));
+
+        public override int Read(Span<byte> buffer)
+        {
+            if (_current is null || _offset == _current.Length)
+            {
+                _current = _queue.Count > 0 ? _queue.Dequeue() : null;
+                _offset = 0;
+            }
+
+            if (_current is null || buffer.Length == 0)
+            {
+                return 0;
+            }
+
+            var count = Math.Min(buffer.Length, _current.Length - _offset);
+            _current.AsSpan(_offset, count).CopyTo(buffer);
+            _offset += count;
+            return count;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}
+#endif

--- a/Jint/WebApi/Compression/DecompressionStreamConstructor.cs
+++ b/Jint/WebApi/Compression/DecompressionStreamConstructor.cs
@@ -1,0 +1,62 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.Streams;
+
+namespace Jint.WebApi.Compression;
+
+/// <summary>
+/// The <c>DecompressionStream</c> interface object.
+/// <para>
+/// https://compression.spec.whatwg.org/#decompression-stream
+/// </para>
+/// </summary>
+internal sealed class DecompressionStreamConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("DecompressionStream");
+
+    internal DecompressionStreamConstructor(
+        Engine engine,
+        Realm realm,
+        FunctionPrototype functionPrototype,
+        ObjectPrototype objectPrototype)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = functionPrototype;
+        PrototypeObject = new DecompressionStreamPrototype(engine, realm, this, objectPrototype);
+        _length = new PropertyDescriptor(JsNumber.PositiveOne, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal DecompressionStreamPrototype PrototypeObject { get; }
+
+    /// <summary>
+    /// https://compression.spec.whatwg.org/#dom-decompressionstream-decompressionstream
+    /// </summary>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        var format = CompressionFormats.ReadFormat(_realm, arguments, "DecompressionStream");
+
+        var stream = OrdinaryCreateFromConstructor(
+            newTarget,
+            static intrinsics => intrinsics.DecompressionStream.PrototypeObject,
+            static (Engine engine, Realm realm, CompressionFormat state) => new JsDecompressionStream(engine, realm, state),
+            format);
+
+        // The cancel algorithm is not one the standard gives, and it is unobservable from script: it exists
+        // so that a stream nobody finishes releases its native decompression context without waiting for a
+        // finalizer.
+        stream.Transform = TransformStreamOperations.SetUp(
+            _engine,
+            _realm,
+            stream.DecompressAndEnqueue,
+            stream.DecompressFlushAndEnqueue,
+            stream.Dispose);
+
+        return stream;
+    }
+}
+#endif

--- a/Jint/WebApi/Compression/DecompressionStreamPrototype.cs
+++ b/Jint/WebApi/Compression/DecompressionStreamPrototype.cs
@@ -1,0 +1,69 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.Streams;
+
+namespace Jint.WebApi.Compression;
+
+/// <summary>
+/// <c>DecompressionStream.prototype</c> — the interface prototype object.
+/// <para>
+/// https://compression.spec.whatwg.org/#decompression-stream
+/// </para>
+/// </summary>
+[JsObject(UseShape = true)]
+internal sealed partial class DecompressionStreamPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly DecompressionStreamConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString DecompressionStreamToStringTag = new("DecompressionStream");
+
+    internal DecompressionStreamPrototype(
+        Engine engine,
+        Realm realm,
+        DecompressionStreamConstructor constructor,
+        ObjectInstance objectPrototype) : base(engine, realm)
+    {
+        _prototype = objectPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#dom-generictransformstream-readable
+    /// </summary>
+    [JsAccessor("readable", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsReadableStream ReadableGet(JsValue thisObject) => Brand(thisObject).Transform.Readable;
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#dom-generictransformstream-writable
+    /// </summary>
+    [JsAccessor("writable", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsWritableStream WritableGet(JsValue thisObject) => Brand(thisObject).Transform.Writable;
+
+    /// <summary>
+    /// The WebIDL brand check every attribute performs: a receiver that is not a platform object
+    /// implementing the interface raises a <c>TypeError</c> — a <c>CompressionStream</c> included, since
+    /// the two share the mixin but are different interfaces.
+    /// </summary>
+    private JsDecompressionStream Brand(JsValue thisObject)
+    {
+        if (thisObject is JsDecompressionStream stream)
+        {
+            return stream;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a DecompressionStream");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Compression/JsCompressionStream.cs
+++ b/Jint/WebApi/Compression/JsCompressionStream.cs
@@ -1,0 +1,70 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Runtime;
+using Jint.WebApi.Encoding;
+using Jint.WebApi.Streams;
+
+namespace Jint.WebApi.Compression;
+
+/// <summary>
+/// A <c>CompressionStream</c> instance.
+/// <para>
+/// https://compression.spec.whatwg.org/#compression-stream
+/// </para>
+/// </summary>
+/// <remarks>
+/// The writable side accepts any <c>BufferSource</c> and the readable side produces <c>Uint8Array</c>s, as
+/// the standard's introduction specifies. Compression never fails, so the only error a script can see here
+/// is the <c>TypeError</c> for a chunk that is not a buffer source.
+/// </remarks>
+internal sealed class JsCompressionStream : JsGenericTransformStream, IDisposable
+{
+    private readonly CompressionCodec _codec;
+
+    internal JsCompressionStream(Engine engine, Realm realm, CompressionFormat format) : base(engine, realm)
+    {
+        Format = format;
+        _codec = new CompressionCodec(format);
+    }
+
+    /// <summary>https://compression.spec.whatwg.org/#compressionstream-format</summary>
+    internal CompressionFormat Format { get; }
+
+    /// <summary>
+    /// "Compress and enqueue a chunk" — https://compression.spec.whatwg.org/#compress-and-enqueue-a-chunk.
+    /// </summary>
+    internal void CompressAndEnqueue(JsValue chunk)
+    {
+        if (!BufferSource.TryGetBytes(chunk, out var bytes))
+        {
+            Throw.TypeError(Realm, "CompressionStream: the chunk is not an ArrayBuffer or a view over one");
+        }
+
+        EnqueueBytes(_codec.Compress(bytes));
+    }
+
+    /// <summary>
+    /// "Compress flush and enqueue" — https://compression.spec.whatwg.org/#compress-flush-and-enqueue.
+    /// </summary>
+    internal void CompressFlushAndEnqueue() => EnqueueBytes(_codec.Finish());
+
+    /// <summary>
+    /// Releases the compression context of a stream that will never be finished. This is the transform's
+    /// cancel algorithm — it runs when either side is shut down early, and it is invisible to script. The
+    /// object stays perfectly usable afterwards; there is simply nothing left to compress into.
+    /// </summary>
+    public void Dispose() => _codec.Dispose();
+
+    /// <summary>
+    /// "Splitting buffer into one or more non-empty pieces and converting them into Uint8Arrays": one piece
+    /// is a valid split, and the standard's "if buffer is empty, return" is the null case.
+    /// </summary>
+    private void EnqueueBytes(byte[]? output)
+    {
+        if (output is not null)
+        {
+            Enqueue(Realm.Intrinsics.Uint8Array.Construct(output));
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/Compression/JsDecompressionStream.cs
+++ b/Jint/WebApi/Compression/JsDecompressionStream.cs
@@ -1,0 +1,95 @@
+#if NET8_0_OR_GREATER
+using System.IO;
+using Jint.Native;
+using Jint.Runtime;
+using Jint.WebApi.Encoding;
+using Jint.WebApi.Streams;
+
+namespace Jint.WebApi.Compression;
+
+/// <summary>
+/// A <c>DecompressionStream</c> instance.
+/// <para>
+/// https://compression.spec.whatwg.org/#decompression-stream
+/// </para>
+/// </summary>
+/// <remarks>
+/// The writable side accepts any <c>BufferSource</c> and the readable side produces <c>Uint8Array</c>s.
+/// Input the format rejects errors <b>both</b> sides with a <c>TypeError</c>, which is what the standard's
+/// "throw a TypeError" inside the transform algorithm means for a transform stream; see
+/// <see cref="DecompressionCodec"/> for the two truncation cases the BCL does not let us detect.
+/// </remarks>
+internal sealed class JsDecompressionStream : JsGenericTransformStream, IDisposable
+{
+    private readonly DecompressionCodec _codec;
+
+    internal JsDecompressionStream(Engine engine, Realm realm, CompressionFormat format) : base(engine, realm)
+    {
+        Format = format;
+        _codec = new DecompressionCodec(format);
+    }
+
+    /// <summary>https://compression.spec.whatwg.org/#decompressionstream-format</summary>
+    internal CompressionFormat Format { get; }
+
+    /// <summary>
+    /// "Decompress and enqueue a chunk" — https://compression.spec.whatwg.org/#decompress-and-enqueue-a-chunk.
+    /// </summary>
+    internal void DecompressAndEnqueue(JsValue chunk)
+    {
+        if (!BufferSource.TryGetBytes(chunk, out var bytes))
+        {
+            Throw.TypeError(Realm, "DecompressionStream: the chunk is not an ArrayBuffer or a view over one");
+        }
+
+        try
+        {
+            EnqueueBytes(_codec.Decompress(bytes));
+        }
+        catch (Exception e) when (e is InvalidDataException or IOException)
+        {
+            // "If this results in an error, then throw a TypeError." The BCL's own message names an archive
+            // entry and a compression method, which would be a puzzle in a script's console.
+            Throw.TypeError(Realm, "DecompressionStream: the input is not valid " + Name(Format) + " data");
+        }
+    }
+
+    /// <summary>
+    /// "Decompress flush and enqueue" — https://compression.spec.whatwg.org/#decompress-flush-and-enqueue.
+    /// </summary>
+    internal void DecompressFlushAndEnqueue()
+    {
+        try
+        {
+            EnqueueBytes(_codec.Finish());
+        }
+        catch (Exception e) when (e is InvalidDataException or IOException)
+        {
+            Throw.TypeError(Realm, "DecompressionStream: the " + Name(Format) + " input ended before the compressed data was complete");
+        }
+    }
+
+    /// <summary>
+    /// Releases the decompression context of a stream that will never be finished. This is the transform's
+    /// cancel algorithm — it runs when either side is shut down early, and it is invisible to script. The
+    /// object stays perfectly usable afterwards; there is simply nothing left to decompress into.
+    /// </summary>
+    public void Dispose() => _codec.Dispose();
+
+    private void EnqueueBytes(byte[]? output)
+    {
+        if (output is not null)
+        {
+            Enqueue(Realm.Intrinsics.Uint8Array.Construct(output));
+        }
+    }
+
+    /// <summary>The format's own name, so a failure says which one the input did not match.</summary>
+    private static string Name(CompressionFormat format) => format switch
+    {
+        CompressionFormat.Gzip => "gzip",
+        CompressionFormat.Deflate => "deflate",
+        _ => "deflate-raw",
+    };
+}
+#endif

--- a/Jint/WebApi/Encoding/JsTextDecoder.cs
+++ b/Jint/WebApi/Encoding/JsTextDecoder.cs
@@ -1,143 +1,29 @@
 #if NET8_0_OR_GREATER
-using System.Text;
-using Jint.Native;
 using Jint.Native.Object;
-using Jint.Runtime;
-using SystemEncoding = System.Text.Encoding;
 
 namespace Jint.WebApi.Encoding;
 
 /// <summary>
-/// A <c>TextDecoder</c> instance, and the decoding state it carries between calls.
+/// A <c>TextDecoder</c> instance.
 /// <para>
 /// https://encoding.spec.whatwg.org/#interface-textdecoder
 /// </para>
 /// </summary>
 /// <remarks>
-/// <para>
-/// The specification's decoder state — the encoding's decoder instance, the I/O queue holding the bytes
-/// of an incomplete sequence, the "do not flush" flag and the "BOM seen" flag — maps onto a BCL
-/// <see cref="Decoder"/> plus two booleans. The <see cref="Decoder"/> is what holds the bytes of a
-/// sequence split across two <c>decode(…, { stream: true })</c> calls, which is why it is created once
-/// per stream and kept until a non-streaming call ends it.
-/// </para>
-/// <para>
-/// <c>fatal</c> is the BCL's <see cref="DecoderExceptionFallback"/> and the default error mode is its
-/// <see cref="DecoderReplacementFallback"/>, so the U+FFFD substitution follows the Unicode
-/// "maximal subpart" recommendation that https://encoding.spec.whatwg.org/#error-mode also describes.
-/// </para>
+/// All of its state is the <c>TextDecoderCommon</c> mixin's, so it lives in
+/// <see cref="TextDecoderCommon"/> — the same object a <c>TextDecoderStream</c> carries. What is left here
+/// is the platform object itself, which exists so the prototype has a brand to check: a plain object handed
+/// to <c>TextDecoder.prototype.decode</c> must raise a <c>TypeError</c>, which it cannot if every object
+/// looks like a decoder.
 /// </remarks>
 internal sealed class JsTextDecoder : ObjectInstance
 {
-    // One encoding object per (encoding, error mode). They are immutable and thread-safe; only the
-    // Decoder they hand out is stateful, and that one is per instance.
-    private static readonly SystemEncoding _utf8Replacement = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false);
-    private static readonly SystemEncoding _utf8Fatal = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
-    private static readonly SystemEncoding _utf16LeReplacement = new UnicodeEncoding(bigEndian: false, byteOrderMark: false, throwOnInvalidBytes: false);
-    private static readonly SystemEncoding _utf16LeFatal = new UnicodeEncoding(bigEndian: false, byteOrderMark: false, throwOnInvalidBytes: true);
-    private static readonly SystemEncoding _utf16BeReplacement = new UnicodeEncoding(bigEndian: true, byteOrderMark: false, throwOnInvalidBytes: false);
-    private static readonly SystemEncoding _utf16BeFatal = new UnicodeEncoding(bigEndian: true, byteOrderMark: false, throwOnInvalidBytes: true);
-
-    /// <summary>U+FEFF, the code point "serialize I/O queue" drops when it leads the stream.</summary>
-    private const char ByteOrderMark = '\uFEFF';
-
-    private readonly SystemEncoding _encoding;
-    private readonly string _encodingName;
-
-    private Decoder? _decoder;
-    private bool _doNotFlush;
-    private bool _bomSeen;
-
-    internal JsTextDecoder(Engine engine, string encodingName, bool fatal, bool ignoreBom) : base(engine, ObjectClass.Object)
+    internal JsTextDecoder(Engine engine, TextDecoderCommon common) : base(engine, ObjectClass.Object)
     {
-        Name = JsString.Create(encodingName);
-        Fatal = fatal;
-        IgnoreBom = ignoreBom;
-        _encodingName = encodingName;
-        _encoding = Resolve(encodingName, fatal);
+        Common = common;
     }
 
-    /// <summary>The encoding's name, already ASCII-lowercase — https://encoding.spec.whatwg.org/#dom-textdecoder-encoding.</summary>
-    internal JsString Name { get; }
-
-    /// <summary>https://encoding.spec.whatwg.org/#dom-textdecoder-fatal</summary>
-    internal bool Fatal { get; }
-
-    /// <summary>https://encoding.spec.whatwg.org/#dom-textdecoder-ignorebom</summary>
-    internal bool IgnoreBom { get; }
-
-    /// <summary>
-    /// https://encoding.spec.whatwg.org/#dom-textdecoder-decode, followed by "serialize I/O queue"
-    /// (https://encoding.spec.whatwg.org/#concept-td-serialize) for the BOM handling.
-    /// </summary>
-    /// <param name="realm">The realm a <c>fatal</c> failure's <c>TypeError</c> belongs to.</param>
-    /// <param name="input">The bytes to push onto the queue; empty when the argument was omitted.</param>
-    /// <param name="stream">The <c>stream</c> option, which becomes the new "do not flush" flag.</param>
-    internal JsString Decode(Realm realm, ReadOnlySpan<byte> input, bool stream)
-    {
-        // Step 1: a decode that follows a non-streaming one starts a new stream, which is what discarding
-        // the decoder does — the next call builds a fresh one, holding no bytes over and having seen no BOM.
-        if (!_doNotFlush)
-        {
-            _decoder = null;
-            _bomSeen = false;
-        }
-
-        _doNotFlush = stream;
-
-        var decoder = _decoder ??= _encoding.GetDecoder();
-
-        char[] chars;
-        int charCount;
-        try
-        {
-            // GetCharCount does not advance the decoder, so this is the documented two-pass shape rather
-            // than a double decode.
-            chars = new char[decoder.GetCharCount(input, flush: !stream)];
-            charCount = decoder.GetChars(input, chars, flush: !stream);
-        }
-        catch (DecoderFallbackException)
-        {
-            // The instance is reset rather than left holding a decoder whose state after a fallback
-            // exception the BCL does not define, so the next decode starts a clean stream.
-            _decoder = null;
-            _doNotFlush = false;
-            _bomSeen = false;
-            Throw.TypeError(realm, "The encoded data was not valid for encoding " + _encodingName);
-            return null!;
-        }
-
-        var decoded = chars.AsSpan(0, charCount);
-
-        // "Serialize I/O queue" step 2.3: for utf-8, utf-16le and utf-16be — which is all three we
-        // implement — the very first scalar value of the stream is dropped when it is U+FEFF. BOM seen is
-        // set by looking, not by finding one, so at most one leading BOM is ever removed and only once per
-        // stream, which is what makes a BOM split across two chunks work.
-        if (!IgnoreBom && !_bomSeen && decoded.Length > 0)
-        {
-            _bomSeen = true;
-            if (decoded[0] == ByteOrderMark)
-            {
-                decoded = decoded.Slice(1);
-            }
-        }
-
-        return decoded.Length == 0 ? JsString.Empty : JsString.Create(decoded.ToString());
-    }
-
-    private static SystemEncoding Resolve(string encodingName, bool fatal)
-    {
-        if (string.Equals(encodingName, EncodingLabels.Utf16Le, StringComparison.Ordinal))
-        {
-            return fatal ? _utf16LeFatal : _utf16LeReplacement;
-        }
-
-        if (string.Equals(encodingName, EncodingLabels.Utf16Be, StringComparison.Ordinal))
-        {
-            return fatal ? _utf16BeFatal : _utf16BeReplacement;
-        }
-
-        return fatal ? _utf8Fatal : _utf8Replacement;
-    }
+    /// <summary>https://encoding.spec.whatwg.org/#textdecodercommon</summary>
+    internal TextDecoderCommon Common { get; }
 }
 #endif

--- a/Jint/WebApi/Encoding/JsTextDecoderStream.cs
+++ b/Jint/WebApi/Encoding/JsTextDecoderStream.cs
@@ -1,0 +1,67 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Runtime;
+using Jint.WebApi.Streams;
+
+namespace Jint.WebApi.Encoding;
+
+/// <summary>
+/// A <c>TextDecoderStream</c> instance: the <c>TextDecoderCommon</c> mixin's state plus the transform
+/// stream that runs it.
+/// <para>
+/// https://encoding.spec.whatwg.org/#interface-textdecoderstream
+/// </para>
+/// </summary>
+/// <remarks>
+/// The decoding is the same object a <c>TextDecoder</c> uses, driven the same way a script drives one:
+/// every chunk is a <c>decode(bytes, { stream: true })</c> and the flush is the closing <c>decode()</c>.
+/// That is what makes a sequence split anywhere — mid sequence, mid surrogate pair, mid BOM — decode to
+/// exactly the string the whole byte sequence would have.
+/// </remarks>
+internal sealed class JsTextDecoderStream : JsGenericTransformStream
+{
+    internal JsTextDecoderStream(Engine engine, Realm realm, TextDecoderCommon common) : base(engine, realm)
+    {
+        Common = common;
+    }
+
+    /// <summary>https://encoding.spec.whatwg.org/#textdecodercommon</summary>
+    internal TextDecoderCommon Common { get; }
+
+    /// <summary>
+    /// "Decode and enqueue a chunk" — https://encoding.spec.whatwg.org/#decode-and-enqueue-a-chunk.
+    /// </summary>
+    /// <remarks>
+    /// The chunk is an <c>AllowSharedBufferSource</c>, so anything else is the <c>TypeError</c> the WebIDL
+    /// conversion raises — and a <c>TypeError</c> raised here errors both sides of the stream, which is what
+    /// the interface's description promises for a decoder in <c>fatal</c> mode too.
+    /// </remarks>
+    internal void DecodeAndEnqueue(JsValue chunk)
+    {
+        if (!BufferSource.TryGetBytes(chunk, out var bytes))
+        {
+            Throw.TypeError(Realm, "TextDecoderStream: the chunk is not an ArrayBuffer or a view over one");
+        }
+
+        // The decoder is never flushed here: an incomplete sequence at the end of a chunk waits for the
+        // next one, and only the flush algorithm below ends the stream.
+        EnqueueIfNotEmpty(Common.Decode(Realm, bytes, stream: true));
+    }
+
+    /// <summary>
+    /// "Flush and enqueue" — https://encoding.spec.whatwg.org/#flush-and-enqueue. This is the closing
+    /// non-streaming decode, so a sequence left incomplete becomes U+FFFD, or a <c>TypeError</c> when the
+    /// decoder is <c>fatal</c>.
+    /// </summary>
+    internal void FlushAndEnqueue() => EnqueueIfNotEmpty(Common.Decode(Realm, ReadOnlySpan<byte>.Empty, stream: false));
+
+    /// <summary>"If outputChunk is not the empty string, then enqueue outputChunk".</summary>
+    private void EnqueueIfNotEmpty(JsString outputChunk)
+    {
+        if (outputChunk.Length > 0)
+        {
+            Enqueue(outputChunk);
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/Encoding/JsTextEncoderStream.cs
+++ b/Jint/WebApi/Encoding/JsTextEncoderStream.cs
@@ -1,0 +1,121 @@
+#if NET8_0_OR_GREATER
+using System.Text;
+using Jint.Native;
+using Jint.Runtime;
+using Jint.WebApi.Streams;
+using SystemEncoding = System.Text.Encoding;
+
+namespace Jint.WebApi.Encoding;
+
+/// <summary>
+/// A <c>TextEncoderStream</c> instance: a UTF-8 encoder, the leading surrogate carried between chunks, and
+/// the transform stream that runs them.
+/// <para>
+/// https://encoding.spec.whatwg.org/#interface-textencoderstream
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// The one piece of state is the specification's <c>leading surrogate</c> slot, and it is the whole reason
+/// this is not <c>TextEncoder.encode</c> in a loop. A chunk is a <c>DOMString</c> rather than a
+/// <c>USVString</c> precisely so that a surrogate pair split across two chunks can be reassembled: a high
+/// surrogate at the end of a chunk is held back, and the next chunk either completes it — one astral scalar
+/// value — or does not, in which case the held surrogate becomes U+FFFD and the code unit that failed to
+/// complete it is processed from the start.
+/// </para>
+/// <para>
+/// Every other lone surrogate is U+FFFD, which is what .NET's UTF-8 encoder does with its replacement
+/// fallback, so the conversion and the encoding happen in one pass over the rest of the chunk.
+/// </para>
+/// </remarks>
+internal sealed class JsTextEncoderStream : JsGenericTransformStream
+{
+    /// <summary>U+FFFD REPLACEMENT CHARACTER in UTF-8, the specification's « 0xEF, 0xBF, 0xBD ».</summary>
+    private static ReadOnlySpan<byte> ReplacementCharacterUtf8 => [0xEF, 0xBF, 0xBD];
+
+    /// <summary>
+    /// https://encoding.spec.whatwg.org/#textencoderstream-pending-high-surrogate — null, or the leading
+    /// surrogate the previous chunk ended with.
+    /// </summary>
+    private char? _leadingSurrogate;
+
+    internal JsTextEncoderStream(Engine engine, Realm realm) : base(engine, realm)
+    {
+    }
+
+    /// <summary>
+    /// "Encode and enqueue a chunk" — https://encoding.spec.whatwg.org/#encode-and-enqueue-a-chunk,
+    /// together with "convert code unit to scalar value"
+    /// (https://encoding.spec.whatwg.org/#convert-code-unit-to-scalar-value), which is what the carried
+    /// surrogate below implements.
+    /// </summary>
+    internal void EncodeAndEnqueue(JsValue chunk)
+    {
+        var input = TypeConverter.ToString(chunk);
+        var text = input.AsSpan();
+
+        // At most one scalar value is produced before the chunk's own text: either the pair the carried
+        // surrogate completes (four bytes) or the U+FFFD it becomes (three).
+        Span<byte> carried = stackalloc byte[4];
+        var carriedLength = 0;
+
+        if (_leadingSurrogate is { } leadingSurrogate)
+        {
+            _leadingSurrogate = null;
+
+            if (text.Length > 0 && char.IsLowSurrogate(text[0]))
+            {
+                // "Return a scalar value from surrogates given leadingSurrogate and item": the pair is one
+                // scalar value, and the trailing surrogate is consumed with it.
+                carriedLength = new Rune(leadingSurrogate, text[0]).EncodeToUtf8(carried);
+                text = text.Slice(1);
+            }
+            else
+            {
+                // "Restore item to input" — the code unit is not consumed, so it is encoded below as
+                // whatever it is — "and return U+FFFD".
+                ReplacementCharacterUtf8.CopyTo(carried);
+                carriedLength = ReplacementCharacterUtf8.Length;
+            }
+        }
+
+        // A leading surrogate at the very end of the chunk is held rather than replaced: it may be the
+        // first half of a pair the next chunk completes. Nothing else can be pending, since any earlier
+        // leading surrogate was resolved by the code unit that followed it.
+        if (text.Length > 0 && char.IsHighSurrogate(text[text.Length - 1]))
+        {
+            _leadingSurrogate = text[text.Length - 1];
+            text = text.Slice(0, text.Length - 1);
+        }
+
+        var byteCount = carriedLength + SystemEncoding.UTF8.GetByteCount(text);
+        if (byteCount == 0)
+        {
+            // "If output is not empty" — a chunk that produced nothing enqueues nothing, which is how the
+            // empty string and a chunk that is a lone leading surrogate behave.
+            return;
+        }
+
+        var bytes = new byte[byteCount];
+        carried.Slice(0, carriedLength).CopyTo(bytes);
+        SystemEncoding.UTF8.GetBytes(text, bytes.AsSpan(carriedLength));
+
+        Enqueue(Realm.Intrinsics.Uint8Array.Construct(bytes));
+    }
+
+    /// <summary>
+    /// "Encode and flush" — https://encoding.spec.whatwg.org/#encode-and-flush. A leading surrogate the
+    /// stream ends on has nothing left to complete it, so it is the replacement character.
+    /// </summary>
+    internal void EncodeAndFlush()
+    {
+        if (_leadingSurrogate is null)
+        {
+            return;
+        }
+
+        _leadingSurrogate = null;
+        Enqueue(Realm.Intrinsics.Uint8Array.Construct(ReplacementCharacterUtf8));
+    }
+}
+#endif

--- a/Jint/WebApi/Encoding/TextDecoderCommon.cs
+++ b/Jint/WebApi/Encoding/TextDecoderCommon.cs
@@ -1,0 +1,193 @@
+#if NET8_0_OR_GREATER
+using System.Text;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using SystemEncoding = System.Text.Encoding;
+
+namespace Jint.WebApi.Encoding;
+
+/// <summary>
+/// The <c>TextDecoderCommon</c> mixin: the encoding, the error mode, the ignore-BOM flag, the encoding's
+/// decoder and the I/O queue holding the bytes of an incomplete sequence.
+/// <para>
+/// https://encoding.spec.whatwg.org/#textdecodercommon
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both interfaces that include the mixin — <c>TextDecoder</c> and <c>TextDecoderStream</c> — keep their
+/// state here rather than each carrying a copy, which is what makes the two decode the same bytes to the
+/// same string by construction. The specification's decoder state maps onto a BCL <see cref="Decoder"/>
+/// plus two booleans: the <see cref="Decoder"/> is what holds the bytes of a sequence split across two
+/// calls, which is why it is created once per stream and kept until a non-streaming call ends it.
+/// </para>
+/// <para>
+/// <c>fatal</c> is the BCL's <see cref="DecoderExceptionFallback"/> and the default error mode is its
+/// <see cref="DecoderReplacementFallback"/>, so the U+FFFD substitution follows the Unicode
+/// "maximal subpart" recommendation that https://encoding.spec.whatwg.org/#error-mode also describes.
+/// </para>
+/// </remarks>
+internal sealed class TextDecoderCommon
+{
+    // One encoding object per (encoding, error mode). They are immutable and thread-safe; only the
+    // Decoder they hand out is stateful, and that one is per instance.
+    private static readonly SystemEncoding _utf8Replacement = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false);
+    private static readonly SystemEncoding _utf8Fatal = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+    private static readonly SystemEncoding _utf16LeReplacement = new UnicodeEncoding(bigEndian: false, byteOrderMark: false, throwOnInvalidBytes: false);
+    private static readonly SystemEncoding _utf16LeFatal = new UnicodeEncoding(bigEndian: false, byteOrderMark: false, throwOnInvalidBytes: true);
+    private static readonly SystemEncoding _utf16BeReplacement = new UnicodeEncoding(bigEndian: true, byteOrderMark: false, throwOnInvalidBytes: false);
+    private static readonly SystemEncoding _utf16BeFatal = new UnicodeEncoding(bigEndian: true, byteOrderMark: false, throwOnInvalidBytes: true);
+
+    private static readonly JsString _fatal = new("fatal");
+    private static readonly JsString _ignoreBom = new("ignoreBOM");
+
+    /// <summary>U+FEFF, the code point "serialize I/O queue" drops when it leads the stream.</summary>
+    private const char ByteOrderMark = (char) 0xFEFF;
+
+    private readonly SystemEncoding _encoding;
+    private readonly string _encodingName;
+
+    private Decoder? _decoder;
+    private bool _doNotFlush;
+    private bool _bomSeen;
+
+    internal TextDecoderCommon(string encodingName, bool fatal, bool ignoreBom)
+    {
+        Name = JsString.Create(encodingName);
+        Fatal = fatal;
+        IgnoreBom = ignoreBom;
+        _encodingName = encodingName;
+        _encoding = Resolve(encodingName, fatal);
+    }
+
+    /// <summary>The encoding's name, already ASCII-lowercase — https://encoding.spec.whatwg.org/#dom-textdecoder-encoding.</summary>
+    internal JsString Name { get; }
+
+    /// <summary>https://encoding.spec.whatwg.org/#dom-textdecoder-fatal</summary>
+    internal bool Fatal { get; }
+
+    /// <summary>https://encoding.spec.whatwg.org/#dom-textdecoder-ignorebom</summary>
+    internal bool IgnoreBom { get; }
+
+    /// <summary>
+    /// The <c>(label, options)</c> pair both constructors take:
+    /// <c>constructor(optional DOMString label = "utf-8", optional TextDecoderOptions options = {})</c>.
+    /// </summary>
+    /// <remarks>
+    /// The two arguments are converted first and the constructor steps run after, which is the order WebIDL
+    /// specifies and the reason a bad <c>label</c> raises its <c>RangeError</c> only once <c>options</c> has
+    /// been read — a getter on <c>options</c> runs even when the label is nonsense.
+    /// </remarks>
+    /// <param name="realm">The realm the conversion's exceptions belong to.</param>
+    /// <param name="label">The first argument, an encoding label.</param>
+    /// <param name="options">The second argument, a <c>TextDecoderOptions</c> dictionary.</param>
+    /// <param name="interfaceName">Which of the two interfaces is being constructed, for the messages.</param>
+    internal static TextDecoderCommon Create(Realm realm, JsValue label, JsValue options, string interfaceName)
+    {
+        // `optional DOMString label = "utf-8"`: an omitted argument and an explicitly passed undefined
+        // both take the default.
+        var labelText = label.IsUndefined() ? EncodingLabels.Utf8 : TypeConverter.ToString(label);
+
+        // The dictionary conversion, https://webidl.spec.whatwg.org/#es-dictionary: undefined and null
+        // are the empty dictionary, anything else that is not an object is a TypeError, and the members
+        // are read in lexicographic order — "fatal" before "ignoreBOM".
+        var fatal = false;
+        var ignoreBom = false;
+        if (!options.IsUndefined() && !options.IsNull())
+        {
+            if (options is not ObjectInstance optionsObject)
+            {
+                Throw.TypeError(realm, interfaceName + ": options must be an object");
+                return null!;
+            }
+
+            fatal = TypeConverter.ToBoolean(optionsObject.Get(_fatal));
+            ignoreBom = TypeConverter.ToBoolean(optionsObject.Get(_ignoreBom));
+        }
+
+        // Step 1 and 2: get an encoding from the label, and refuse anything the table does not name.
+        var encoding = EncodingLabels.Lookup(labelText);
+        if (encoding is null)
+        {
+            Throw.RangeError(realm, interfaceName + ": the encoding label provided ('" + labelText + "') is invalid");
+        }
+
+        return new TextDecoderCommon(encoding!, fatal, ignoreBom);
+    }
+
+    /// <summary>
+    /// https://encoding.spec.whatwg.org/#dom-textdecoder-decode, followed by "serialize I/O queue"
+    /// (https://encoding.spec.whatwg.org/#concept-td-serialize) for the BOM handling.
+    /// </summary>
+    /// <param name="realm">The realm a <c>fatal</c> failure's <c>TypeError</c> belongs to.</param>
+    /// <param name="input">The bytes to push onto the queue; empty when the argument was omitted.</param>
+    /// <param name="stream">The <c>stream</c> option, which becomes the new "do not flush" flag.</param>
+    internal JsString Decode(Realm realm, ReadOnlySpan<byte> input, bool stream)
+    {
+        // Step 1: a decode that follows a non-streaming one starts a new stream, which is what discarding
+        // the decoder does — the next call builds a fresh one, holding no bytes over and having seen no BOM.
+        if (!_doNotFlush)
+        {
+            _decoder = null;
+            _bomSeen = false;
+        }
+
+        _doNotFlush = stream;
+
+        var decoder = _decoder ??= _encoding.GetDecoder();
+
+        char[] chars;
+        int charCount;
+        try
+        {
+            // GetCharCount does not advance the decoder, so this is the documented two-pass shape rather
+            // than a double decode.
+            chars = new char[decoder.GetCharCount(input, flush: !stream)];
+            charCount = decoder.GetChars(input, chars, flush: !stream);
+        }
+        catch (DecoderFallbackException)
+        {
+            // The instance is reset rather than left holding a decoder whose state after a fallback
+            // exception the BCL does not define, so the next decode starts a clean stream.
+            _decoder = null;
+            _doNotFlush = false;
+            _bomSeen = false;
+            Throw.TypeError(realm, "The encoded data was not valid for encoding " + _encodingName);
+            return null!;
+        }
+
+        var decoded = chars.AsSpan(0, charCount);
+
+        // "Serialize I/O queue" step 2.3: for utf-8, utf-16le and utf-16be — which is all three we
+        // implement — the very first scalar value of the stream is dropped when it is U+FEFF. BOM seen is
+        // set by looking, not by finding one, so at most one leading BOM is ever removed and only once per
+        // stream, which is what makes a BOM split across two chunks work.
+        if (!IgnoreBom && !_bomSeen && decoded.Length > 0)
+        {
+            _bomSeen = true;
+            if (decoded[0] == ByteOrderMark)
+            {
+                decoded = decoded.Slice(1);
+            }
+        }
+
+        return decoded.Length == 0 ? JsString.Empty : JsString.Create(decoded.ToString());
+    }
+
+    private static SystemEncoding Resolve(string encodingName, bool fatal)
+    {
+        if (string.Equals(encodingName, EncodingLabels.Utf16Le, StringComparison.Ordinal))
+        {
+            return fatal ? _utf16LeFatal : _utf16LeReplacement;
+        }
+
+        if (string.Equals(encodingName, EncodingLabels.Utf16Be, StringComparison.Ordinal))
+        {
+            return fatal ? _utf16BeFatal : _utf16BeReplacement;
+        }
+
+        return fatal ? _utf8Fatal : _utf8Replacement;
+    }
+}
+#endif

--- a/Jint/WebApi/Encoding/TextDecoderConstructor.cs
+++ b/Jint/WebApi/Encoding/TextDecoderConstructor.cs
@@ -16,9 +16,8 @@ namespace Jint.WebApi.Encoding;
 /// <remarks>
 /// <para>
 /// <c>constructor(optional DOMString label = "utf-8", optional TextDecoderOptions options = {})</c>. The
-/// two arguments are converted first and the constructor steps run after, which is the order WebIDL
-/// specifies and the reason a bad <c>label</c> raises its <c>RangeError</c> only once <c>options</c> has
-/// been read — a getter on <c>options</c> runs even when the label is nonsense.
+/// two arguments are converted by <see cref="TextDecoderCommon.Create"/>, which is also what
+/// <c>TextDecoderStream</c>'s identical constructor uses.
 /// </para>
 /// <para>
 /// Called without <c>new</c> it raises a <c>TypeError</c>, which <see cref="Constructor"/> already does
@@ -28,8 +27,6 @@ namespace Jint.WebApi.Encoding;
 internal sealed class TextDecoderConstructor : Constructor
 {
     private static readonly JsString _functionName = new("TextDecoder");
-    private static readonly JsString _fatal = new("fatal");
-    private static readonly JsString _ignoreBom = new("ignoreBOM");
 
     internal TextDecoderConstructor(
         Engine engine,
@@ -51,43 +48,13 @@ internal sealed class TextDecoderConstructor : Constructor
     /// </summary>
     public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
     {
-        var labelArgument = arguments.At(0);
-        var optionsArgument = arguments.At(1);
-
-        // `optional DOMString label = "utf-8"`: an omitted argument and an explicitly passed undefined
-        // both take the default.
-        var label = labelArgument.IsUndefined() ? EncodingLabels.Utf8 : TypeConverter.ToString(labelArgument);
-
-        // The dictionary conversion, https://webidl.spec.whatwg.org/#es-dictionary: undefined and null
-        // are the empty dictionary, anything else that is not an object is a TypeError, and the members
-        // are read in lexicographic order — "fatal" before "ignoreBOM".
-        var fatal = false;
-        var ignoreBom = false;
-        if (!optionsArgument.IsUndefined() && !optionsArgument.IsNull())
-        {
-            if (optionsArgument is not ObjectInstance options)
-            {
-                Throw.TypeError(_realm, "TextDecoder: options must be an object");
-                return null!;
-            }
-
-            fatal = TypeConverter.ToBoolean(options.Get(_fatal));
-            ignoreBom = TypeConverter.ToBoolean(options.Get(_ignoreBom));
-        }
-
-        // Step 1 and 2: get an encoding from the label, and refuse anything the table does not name.
-        var encoding = EncodingLabels.Lookup(label);
-        if (encoding is null)
-        {
-            Throw.RangeError(_realm, "TextDecoder: the encoding label provided ('" + label + "') is invalid");
-        }
+        var common = TextDecoderCommon.Create(_realm, arguments.At(0), arguments.At(1), "TextDecoder");
 
         return OrdinaryCreateFromConstructor(
             newTarget,
             static intrinsics => intrinsics.TextDecoder.PrototypeObject,
-            static (Engine engine, Realm _, (string Encoding, bool Fatal, bool IgnoreBom) state)
-                => new JsTextDecoder(engine, state.Encoding, state.Fatal, state.IgnoreBom),
-            (Encoding: encoding!, Fatal: fatal, IgnoreBom: ignoreBom));
+            static (Engine engine, Realm _, TextDecoderCommon? state) => new JsTextDecoder(engine, state!),
+            common);
     }
 }
 #endif

--- a/Jint/WebApi/Encoding/TextDecoderPrototype.cs
+++ b/Jint/WebApi/Encoding/TextDecoderPrototype.cs
@@ -59,7 +59,7 @@ internal sealed partial class TextDecoderPrototype : Prototype
     [JsAccessor("encoding", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
     private JsString EncodingGet(JsValue thisObject)
     {
-        return Brand(thisObject).Name;
+        return Brand(thisObject).Common.Name;
     }
 
     /// <summary>
@@ -68,7 +68,7 @@ internal sealed partial class TextDecoderPrototype : Prototype
     [JsAccessor("fatal", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
     private JsBoolean FatalGet(JsValue thisObject)
     {
-        return Brand(thisObject).Fatal ? JsBoolean.True : JsBoolean.False;
+        return Brand(thisObject).Common.Fatal ? JsBoolean.True : JsBoolean.False;
     }
 
     /// <summary>
@@ -77,7 +77,7 @@ internal sealed partial class TextDecoderPrototype : Prototype
     [JsAccessor("ignoreBOM", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
     private JsBoolean IgnoreBomGet(JsValue thisObject)
     {
-        return Brand(thisObject).IgnoreBom ? JsBoolean.True : JsBoolean.False;
+        return Brand(thisObject).Common.IgnoreBom ? JsBoolean.True : JsBoolean.False;
     }
 
     /// <summary>
@@ -114,7 +114,7 @@ internal sealed partial class TextDecoderPrototype : Prototype
             stream = TypeConverter.ToBoolean(optionsObject.Get(_stream));
         }
 
-        return decoder.Decode(_realm, bytes, stream);
+        return decoder.Common.Decode(_realm, bytes, stream);
     }
 
     /// <summary>

--- a/Jint/WebApi/Encoding/TextDecoderStreamConstructor.cs
+++ b/Jint/WebApi/Encoding/TextDecoderStreamConstructor.cs
@@ -1,0 +1,67 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.Streams;
+
+namespace Jint.WebApi.Encoding;
+
+/// <summary>
+/// The <c>TextDecoderStream</c> interface object.
+/// <para>
+/// https://encoding.spec.whatwg.org/#interface-textdecoderstream
+/// </para>
+/// </summary>
+/// <remarks>
+/// The constructor takes exactly what <c>TextDecoder</c>'s does — <c>(label, options)</c>, converted by
+/// the same code — and differs only in what it builds: a transform stream whose writable side accepts
+/// buffer sources and whose readable side produces the strings they decode to.
+/// </remarks>
+internal sealed class TextDecoderStreamConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("TextDecoderStream");
+
+    internal TextDecoderStreamConstructor(
+        Engine engine,
+        Realm realm,
+        FunctionPrototype functionPrototype,
+        ObjectPrototype objectPrototype)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = functionPrototype;
+        PrototypeObject = new TextDecoderStreamPrototype(engine, realm, this, objectPrototype);
+        _length = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal TextDecoderStreamPrototype PrototypeObject { get; }
+
+    /// <summary>
+    /// https://encoding.spec.whatwg.org/#dom-textdecoderstream, whose steps are "set up a text decoder
+    /// stream" (https://encoding.spec.whatwg.org/#set-up-a-text-decoder-stream) once the label and the
+    /// options have been converted.
+    /// </summary>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        var common = TextDecoderCommon.Create(_realm, arguments.At(0), arguments.At(1), "TextDecoderStream");
+
+        var stream = OrdinaryCreateFromConstructor(
+            newTarget,
+            static intrinsics => intrinsics.TextDecoderStream.PrototypeObject,
+            static (Engine engine, Realm realm, TextDecoderCommon? state) => new JsTextDecoderStream(engine, realm, state!),
+            common);
+
+        // The algorithms close over the instance, so the transform can only be set up once it exists —
+        // which is why the specification's "set up" operation takes the stream as an argument.
+        stream.Transform = TransformStreamOperations.SetUp(
+            _engine,
+            _realm,
+            stream.DecodeAndEnqueue,
+            stream.FlushAndEnqueue);
+
+        return stream;
+    }
+}
+#endif

--- a/Jint/WebApi/Encoding/TextDecoderStreamPrototype.cs
+++ b/Jint/WebApi/Encoding/TextDecoderStreamPrototype.cs
@@ -1,0 +1,93 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.Streams;
+
+namespace Jint.WebApi.Encoding;
+
+/// <summary>
+/// <c>TextDecoderStream.prototype</c> — the interface prototype object.
+/// <para>
+/// https://encoding.spec.whatwg.org/#interface-textdecoderstream
+/// </para>
+/// </summary>
+/// <remarks>
+/// Five attributes and no operations: <c>encoding</c>, <c>fatal</c> and <c>ignoreBOM</c> from
+/// <c>TextDecoderCommon</c>, and <c>readable</c> and <c>writable</c> from <c>GenericTransformStream</c>.
+/// Each brand-checks its receiver, so <c>TextDecoderStream.prototype</c> itself — which is not a
+/// <c>TextDecoderStream</c> — and a <c>TextDecoder</c>, which includes the same mixin but is a different
+/// interface, both raise a <c>TypeError</c>.
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class TextDecoderStreamPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly TextDecoderStreamConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString TextDecoderStreamToStringTag = new("TextDecoderStream");
+
+    internal TextDecoderStreamPrototype(
+        Engine engine,
+        Realm realm,
+        TextDecoderStreamConstructor constructor,
+        ObjectInstance objectPrototype) : base(engine, realm)
+    {
+        _prototype = objectPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://encoding.spec.whatwg.org/#dom-textdecoder-encoding
+    /// </summary>
+    [JsAccessor("encoding", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsString EncodingGet(JsValue thisObject) => Brand(thisObject).Common.Name;
+
+    /// <summary>
+    /// https://encoding.spec.whatwg.org/#dom-textdecoder-fatal
+    /// </summary>
+    [JsAccessor("fatal", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsBoolean FatalGet(JsValue thisObject) => Brand(thisObject).Common.Fatal ? JsBoolean.True : JsBoolean.False;
+
+    /// <summary>
+    /// https://encoding.spec.whatwg.org/#dom-textdecoder-ignorebom
+    /// </summary>
+    [JsAccessor("ignoreBOM", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsBoolean IgnoreBomGet(JsValue thisObject) => Brand(thisObject).Common.IgnoreBom ? JsBoolean.True : JsBoolean.False;
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#dom-generictransformstream-readable
+    /// </summary>
+    [JsAccessor("readable", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsReadableStream ReadableGet(JsValue thisObject) => Brand(thisObject).Transform.Readable;
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#dom-generictransformstream-writable
+    /// </summary>
+    [JsAccessor("writable", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsWritableStream WritableGet(JsValue thisObject) => Brand(thisObject).Transform.Writable;
+
+    /// <summary>
+    /// The WebIDL brand check every attribute performs: a receiver that is not a platform object
+    /// implementing the interface raises a <c>TypeError</c>.
+    /// </summary>
+    private JsTextDecoderStream Brand(JsValue thisObject)
+    {
+        if (thisObject is JsTextDecoderStream stream)
+        {
+            return stream;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a TextDecoderStream");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Encoding/TextEncoderStreamConstructor.cs
+++ b/Jint/WebApi/Encoding/TextEncoderStreamConstructor.cs
@@ -1,0 +1,60 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.Streams;
+
+namespace Jint.WebApi.Encoding;
+
+/// <summary>
+/// The <c>TextEncoderStream</c> interface object.
+/// <para>
+/// https://encoding.spec.whatwg.org/#interface-textencoderstream
+/// </para>
+/// </summary>
+/// <remarks>
+/// <c>constructor()</c> takes no arguments at all: like <c>TextEncoder</c>, the interface encodes UTF-8 and
+/// nothing else, so there is no label to give it.
+/// </remarks>
+internal sealed class TextEncoderStreamConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("TextEncoderStream");
+
+    internal TextEncoderStreamConstructor(
+        Engine engine,
+        Realm realm,
+        FunctionPrototype functionPrototype,
+        ObjectPrototype objectPrototype)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = functionPrototype;
+        PrototypeObject = new TextEncoderStreamPrototype(engine, realm, this, objectPrototype);
+        _length = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal TextEncoderStreamPrototype PrototypeObject { get; }
+
+    /// <summary>
+    /// https://encoding.spec.whatwg.org/#dom-textencoderstream
+    /// </summary>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        var stream = OrdinaryCreateFromConstructor(
+            newTarget,
+            static intrinsics => intrinsics.TextEncoderStream.PrototypeObject,
+            static (Engine engine, Realm realm, object? _) => new JsTextEncoderStream(engine, realm));
+
+        // The algorithms close over the instance, so the transform can only be set up once it exists.
+        stream.Transform = TransformStreamOperations.SetUp(
+            _engine,
+            _realm,
+            stream.EncodeAndEnqueue,
+            stream.EncodeAndFlush);
+
+        return stream;
+    }
+}
+#endif

--- a/Jint/WebApi/Encoding/TextEncoderStreamPrototype.cs
+++ b/Jint/WebApi/Encoding/TextEncoderStreamPrototype.cs
@@ -1,0 +1,85 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.Streams;
+
+namespace Jint.WebApi.Encoding;
+
+/// <summary>
+/// <c>TextEncoderStream.prototype</c> — the interface prototype object.
+/// <para>
+/// https://encoding.spec.whatwg.org/#interface-textencoderstream
+/// </para>
+/// </summary>
+/// <remarks>
+/// Three attributes and no operations: <c>encoding</c> from <c>TextEncoderCommon</c>, which answers
+/// <c>"utf-8"</c> for every instance, and <c>readable</c> and <c>writable</c> from
+/// <c>GenericTransformStream</c>.
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class TextEncoderStreamPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly TextEncoderStreamConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString TextEncoderStreamToStringTag = new("TextEncoderStream");
+
+    private static readonly JsString _utf8 = new(EncodingLabels.Utf8);
+
+    internal TextEncoderStreamPrototype(
+        Engine engine,
+        Realm realm,
+        TextEncoderStreamConstructor constructor,
+        ObjectInstance objectPrototype) : base(engine, realm)
+    {
+        _prototype = objectPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://encoding.spec.whatwg.org/#dom-textencoder-encoding
+    /// </summary>
+    [JsAccessor("encoding", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsString EncodingGet(JsValue thisObject)
+    {
+        Brand(thisObject);
+        return _utf8;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#dom-generictransformstream-readable
+    /// </summary>
+    [JsAccessor("readable", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsReadableStream ReadableGet(JsValue thisObject) => Brand(thisObject).Transform.Readable;
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#dom-generictransformstream-writable
+    /// </summary>
+    [JsAccessor("writable", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsWritableStream WritableGet(JsValue thisObject) => Brand(thisObject).Transform.Writable;
+
+    /// <summary>
+    /// The WebIDL brand check every attribute performs: a receiver that is not a platform object
+    /// implementing the interface raises a <c>TypeError</c>.
+    /// </summary>
+    private JsTextEncoderStream Brand(JsValue thisObject)
+    {
+        if (thisObject is JsTextEncoderStream stream)
+        {
+            return stream;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a TextEncoderStream");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/JsGenericTransformStream.cs
+++ b/Jint/WebApi/Streams/JsGenericTransformStream.cs
@@ -1,0 +1,52 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// The base of every platform object that includes the <c>GenericTransformStream</c> mixin — a transform
+/// stream defined by another standard rather than constructed by a script.
+/// <para>
+/// https://streams.spec.whatwg.org/#generictransformstream
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// Such an object is <b>not</b> a <c>TransformStream</c>: it owns one (its
+/// <see cref="Transform"/>) and republishes that stream's two sides as its own <c>readable</c> and
+/// <c>writable</c> attributes. The transform itself is never handed to script, which is why the mixin's
+/// implementers do not share a prototype chain — each is its own interface, and each brand-checks for its
+/// own type.
+/// </para>
+/// <para>
+/// The transform is built by <see cref="TransformStreamOperations.SetUp"/>, so the algorithms behind it are
+/// engine code rather than script callbacks. Everything else about it is an ordinary transform stream:
+/// backpressure reaches the producer, the readable side buffers nothing by default, and every promise it
+/// hands out is an ordinary engine promise settled from the job queue.
+/// </para>
+/// </remarks>
+internal abstract class JsGenericTransformStream : ObjectInstance
+{
+    private protected JsGenericTransformStream(Engine engine, Realm realm) : base(engine, ObjectClass.Object)
+    {
+        Realm = realm;
+    }
+
+    /// <summary>The realm the object was created in, which its errors and result objects belong to.</summary>
+    internal Realm Realm { get; }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#generictransformstream-transform — assigned by the constructor
+    /// immediately after the instance exists, because the algorithms it is set up with need the instance.
+    /// </summary>
+    internal JsTransformStream Transform { get; set; } = null!;
+
+    /// <summary>
+    /// "Enqueue <c>chunk</c> into this's transform" —
+    /// https://streams.spec.whatwg.org/#transformstream-enqueue.
+    /// </summary>
+    private protected void Enqueue(JsValue chunk) => TransformStreamOperations.Enqueue(Transform, chunk);
+}
+#endif

--- a/Jint/WebApi/Streams/TransformStreamOperations.cs
+++ b/Jint/WebApi/Streams/TransformStreamOperations.cs
@@ -58,6 +58,98 @@ internal static class TransformStreamOperations
     }
 
     /// <summary>
+    /// https://streams.spec.whatwg.org/#transformstream-set-up — the entry point for the transform streams
+    /// <i>other</i> standards define (<c>TextEncoderStream</c>, <c>CompressionStream</c>, …) rather than ones
+    /// a script constructs. It creates the stream too, which the specification leaves to the one line above
+    /// every call site ("let transformStream be a new TransformStream").
+    /// </summary>
+    /// <remarks>
+    /// The algorithms are engine code, not script callbacks, so they are <see cref="Action"/>s rather than
+    /// functions returning a promise: the specification's wrappers exist to turn a thrown exception into a
+    /// rejected promise and a non-promise return value into a resolved one, which is exactly what the
+    /// <c>RunAlgorithm</c> pair below does. The high water marks are the specification's own defaults — one chunk
+    /// of buffering on the way in, none on the way out — so a chunk is transformed only once the readable
+    /// side is read from.
+    /// </remarks>
+    internal static JsTransformStream SetUp(
+        Engine engine,
+        Realm realm,
+        Action<JsValue> transformAlgorithm,
+        Action? flushAlgorithm = null,
+        Action? cancelAlgorithm = null)
+    {
+        var stream = new JsTransformStream(engine, realm)
+        {
+            _prototype = realm.Intrinsics.TransformStream.PrototypeObject,
+        };
+
+        Initialize(
+            stream,
+            StreamPromises.ResolvedWithUndefined(engine, realm),
+            writableHighWaterMark: 1,
+            SizeOfOne,
+            readableHighWaterMark: 0,
+            SizeOfOne);
+
+        var controller = new JsTransformStreamDefaultController(engine, realm)
+        {
+            _prototype = realm.Intrinsics.TransformStreamDefaultController.PrototypeObject,
+        };
+
+        SetUpController(
+            stream,
+            controller,
+            chunk => RunAlgorithm(engine, realm, transformAlgorithm, chunk),
+            () => RunAlgorithm(engine, realm, flushAlgorithm),
+            _ => RunAlgorithm(engine, realm, cancelAlgorithm));
+
+        return stream;
+    }
+
+    /// <summary>
+    /// "Enqueue <paramref name="chunk"/> into <paramref name="stream"/>" —
+    /// https://streams.spec.whatwg.org/#transformstream-enqueue.
+    /// </summary>
+    internal static void Enqueue(JsTransformStream stream, JsValue chunk)
+        => ControllerEnqueue(stream.Controller, chunk);
+
+    /// <summary>The size algorithm the set-up operation gives both sides: "an algorithm that returns 1".</summary>
+    private static readonly Func<JsValue, double> SizeOfOne = static _ => 1;
+
+    /// <summary>
+    /// The specification's <c>transformAlgorithmWrapper</c>: run the algorithm, and report a JavaScript
+    /// exception it raised as a rejected promise rather than letting it escape into the caller.
+    /// </summary>
+    private static JsPromise RunAlgorithm(Engine engine, Realm realm, Action<JsValue>? algorithm, JsValue chunk)
+    {
+        try
+        {
+            algorithm?.Invoke(chunk);
+        }
+        catch (JavaScriptException e)
+        {
+            return StreamPromises.RejectedWith(engine, realm, e.Error);
+        }
+
+        return StreamPromises.ResolvedWithUndefined(engine, realm);
+    }
+
+    /// <summary>The same wrapper for the two algorithms that take no argument.</summary>
+    private static JsPromise RunAlgorithm(Engine engine, Realm realm, Action? algorithm)
+    {
+        try
+        {
+            algorithm?.Invoke();
+        }
+        catch (JavaScriptException e)
+        {
+            return StreamPromises.RejectedWith(engine, realm, e.Error);
+        }
+
+        return StreamPromises.ResolvedWithUndefined(engine, realm);
+    }
+
+    /// <summary>
     /// https://streams.spec.whatwg.org/#transform-stream-error
     /// </summary>
     /// <remarks>

--- a/Jint/WebApi/WebApiRegistration.cs
+++ b/Jint/WebApi/WebApiRegistration.cs
@@ -213,6 +213,24 @@ internal static class WebApiRegistration
             // both flags gets one object either way.
             Install(global, engine, "MessageEvent", static e => e.Realm.Intrinsics.MessageEvent, PropertyFlag.NonEnumerable);
         }
+
+        // The transform streams other standards define need two flags each, because each of them is one
+        // standard's algorithm running inside the Streams Standard's machinery: an engine that asked for
+        // only one half of the pair gets neither, rather than an interface whose readable and writable
+        // sides it has no way to consume.
+        const WebApiFeatures TextTransforms = WebApiFeatures.Encoding | WebApiFeatures.Streams;
+        if ((features & TextTransforms) == TextTransforms)
+        {
+            Install(global, engine, "TextDecoderStream", static e => e.Realm.Intrinsics.TextDecoderStream, PropertyFlag.NonEnumerable);
+            Install(global, engine, "TextEncoderStream", static e => e.Realm.Intrinsics.TextEncoderStream, PropertyFlag.NonEnumerable);
+        }
+
+        const WebApiFeatures CompressionTransforms = WebApiFeatures.Compression | WebApiFeatures.Streams;
+        if ((features & CompressionTransforms) == CompressionTransforms)
+        {
+            Install(global, engine, "CompressionStream", static e => e.Realm.Intrinsics.CompressionStream, PropertyFlag.NonEnumerable);
+            Install(global, engine, "DecompressionStream", static e => e.Realm.Intrinsics.DecompressionStream, PropertyFlag.NonEnumerable);
+        }
     }
 
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ its own `console` (or any other name in the table below), enabling the feature l
 | `Blob` (incl. `stream()`) / `File` / `FormData` | `Files` | ✔ shipped |
 | `navigator.userAgent` | `Navigator` | ✔ shipped |
 | `ReadableStream` / `WritableStream` / `TransformStream` / `ByteLengthQueuingStrategy` / `CountQueuingStrategy` | `Streams` | ✔ shipped |
+| `TextEncoderStream` / `TextDecoderStream` | `Encoding` **and** `Streams` | ✔ shipped |
+| `CompressionStream` / `DecompressionStream` (`gzip`, `deflate`, `deflate-raw`) | `Compression` **and** `Streams` | ✔ shipped |
 | `scheduler.postTask` / `scheduler.yield` / `TaskController` / `TaskSignal` | `Scheduler` | ✔ shipped |
 | `MessageChannel` / `MessagePort` / `MessageEvent` (incl. cross-engine ports) | `Messaging` | ✔ shipped |
 | `reportError` (and the `DiagnosticsSink` behind it) | `Reporting` | ✔ shipped |
@@ -825,6 +827,36 @@ re-registering. And bound the script: the constraints above are what stand betwe
 handler that decides to loop forever.
 
 </details>
+
+### Text and compression transform streams need two flags
+
+`TextEncoderStream`, `TextDecoderStream`, `CompressionStream` and `DecompressionStream` are each one
+standard's algorithm running inside the Streams Standard's machinery, so each needs **both** flags: the text
+pair wants `Encoding | Streams`, the compression pair `Compression | Streams`. Naming one half installs
+neither global, which is the honest answer for feature detection — and `UseWebApis()` enables all four
+anyway. None of them is a `TransformStream` subclass: like a browser, each is its own interface exposing a
+`readable` and a `writable`, and the transform behind it is never handed to script.
+
+```javascript
+const bytes = textReadable.pipeThrough(new TextEncoderStream()).pipeThrough(new CompressionStream('gzip'));
+const text = bytes.pipeThrough(new DecompressionStream('gzip')).pipeThrough(new TextDecoderStream());
+```
+
+`TextEncoderStream` carries the standard's leading-surrogate slot, so a surrogate pair split across two
+chunks is reassembled into the one scalar value it denotes rather than becoming two U+FFFDs, and
+`TextDecoderStream` is the same decoder `TextDecoder` uses with `stream: true` — a UTF-8 sequence, a UTF-16
+code unit or a byte order mark split across chunks all decode as if the bytes had arrived in one piece. A
+`fatal` decoder errors *both* sides with a `TypeError`, as the standard prescribes.
+
+For compression, note that the standard's `deflate` is **RFC 1950's ZLIB container**, named that way for
+consistency with HTTP `Content-Encoding`; raw RFC 1951 DEFLATE is the separate `deflate-raw`. Jint maps them
+onto `ZLibStream` and `DeflateStream` accordingly (and `gzip` onto `GZipStream`), so bytes produced here are
+the bytes every other implementation expects. `brotli`, which the standard's enumeration also names, is not
+implemented and — like any unsupported value — raises a `TypeError`. Input a format rejects (a bad header, a
+failed CRC32 or ADLER32, a malformed block) errors both sides with a `TypeError`; two truncation cases the
+standard also calls errors are the documented exception, because .NET exposes no incremental inflater that
+could report them: a stream that ends mid-member closes cleanly instead, and bytes following a complete
+member are ignored. A stream that ends with no compressed bytes at all *is* refused.
 
 
 ## Node compatibility (opt-in)


### PR DESCRIPTION
Part of #3082: the four transform streams other standards define — `TextEncoderStream`, `TextDecoderStream` (https://encoding.spec.whatwg.org/), `CompressionStream` and `DecompressionStream` (https://compression.spec.whatwg.org/) — with `WebApiFeatures.Compression = 1 << 20` (part of `Default`; the text pair rides `Encoding`). Each pair needs `Streams` too, since each is one standard's algorithm inside the Streams machinery; an engine with only half the pair gets neither global.

The encoder takes `DOMString` chunks precisely so a surrogate pair split across two chunks reassembles (mutation-pinned: the `IsHighSurrogate` carry); the decoder shares one `TextDecoderCommon` state with `TextDecoder` — one label table, one `fatal`/`ignoreBOM`/streaming implementation, refactored out rather than duplicated. Compression maps the standard's names to the BCL exactly — `deflate` is the RFC 1950 ZLIB wrapper (`ZLibStream`), the classic slip mutation-pinned against CPython-generated vectors, `deflate-raw` RFC 1951, `gzip` RFC 1952; `brotli` is in the enumeration and refused as unsupported per constructor step 1.

Two lenient decompression divergences are documented rather than hidden, both forced by the BCL exposing no incremental inflater (only pull streams that buffer input internally): a stream ending mid-member closes cleanly, and bytes after a complete member are ignored. Everything the format itself rejects is still a `TypeError` on both sides, and an empty stream is refused. Empty-member output is a documented per-format constant, because the BCL's own empty-member bytes measurably differ between net8.0 and net10.0. An abandoned stream releases its zlib context via the transform's cancel algorithm rather than a finalizer.

63 tests including format vectors from an independent implementation; both suites green on net10.0 and net472, with and without `JINT_HOST_CONTRACT_VERIFICATION=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G7Ud48VAs1JicxRZxLDxg
