### PR TITLE
Park an already-resolved computed assignment key across an await or yield

### DIFF
--- a/Jint.Tests/Runtime/SuspendedComputedKeyTests.cs
+++ b/Jint.Tests/Runtime/SuspendedComputedKeyTests.cs
@@ -1,0 +1,187 @@
+#nullable enable
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// A computed key that has already been evaluated must not be evaluated a second time when the
+/// expression it belongs to suspends on an <c>await</c> or a <c>yield</c> and is replayed.
+/// <para>
+/// Both shapes park their already-resolved state in the suspendable's
+/// <c>SuspendDataDictionary</c>: a simple assignment parks the resolved left-hand
+/// <c>Reference</c> (<c>AssignmentSuspendData.Lref</c>, the slot the compound forms
+/// <c>+=</c>/<c>-=</c>/… have always used), and an object literal parks the converted property key
+/// of the property whose <em>value</em> suspended (<c>ObjectExpressionSuspendData.PendingKey</c>).
+/// Without them <c>o[f()] = await g()</c> and <c>({ [f()]: await g() })</c> call <c>f</c> twice, and
+/// the assignment lands on whatever key the second call produced.
+/// </para>
+/// </summary>
+public class SuspendedComputedKeyTests
+{
+    /// <summary>
+    /// The key function returns a different name on every call, so a replay that re-runs it is
+    /// visible in the landing key as well as in the counter.
+    /// </summary>
+    private const string CountingKey = "var calls = 0; function f() { return 'k' + (++calls); }";
+
+    private static string Run(string script) => new Engine().Evaluate(script).AsString();
+
+    private static string RunAsync(string script) => new Engine().Evaluate(script).UnwrapIfPromise().AsString();
+
+    // ------------------------------------------------------------------ simple assignment
+
+    [Fact]
+    public void ComputedAssignmentKeyRunsOnceAcrossAnAwait()
+    {
+        RunAsync($$"""
+            {{CountingKey}}
+            var o = {};
+            (async function () {
+              o[f()] = await Promise.resolve(1);
+              return calls + '|' + JSON.stringify(Object.keys(o)) + '|' + o.k1;
+            })();
+            """).Should().Be("1|[\"k1\"]|1");
+    }
+
+    [Fact]
+    public void ComputedAssignmentKeyRunsOnceAcrossAYield()
+    {
+        Run($$"""
+            {{CountingKey}}
+            var o = {};
+            function* g() { o[f()] = yield 1; }
+            var it = g();
+            it.next();
+            it.next(42);
+            calls + '|' + JSON.stringify(Object.keys(o)) + '|' + o.k1;
+            """).Should().Be("1|[\"k1\"]|42");
+    }
+
+    [Fact]
+    public void ComputedAssignmentBaseRunsOnceAcrossAnAwait()
+    {
+        // The base of the member expression is side-effecting too; the parked Reference holds it,
+        // so neither half of `base()[key()]` is re-run.
+        RunAsync("""
+            var baseCalls = 0, keyCalls = 0;
+            var o = {};
+            function b() { baseCalls++; return o; }
+            function k() { keyCalls++; return 'p'; }
+            (async function () {
+              b()[k()] = await Promise.resolve(3);
+              return baseCalls + '|' + keyCalls + '|' + o.p;
+            })();
+            """).Should().Be("1|1|3");
+    }
+
+    [Fact]
+    public void ComputedAssignmentIndexSideEffectAppliesOnceAcrossAnAwait()
+    {
+        RunAsync("""
+            var i = 0;
+            var a = [0, 0, 0];
+            (async function () {
+              a[i++] = await Promise.resolve(9);
+              return i + '|' + a.join(',');
+            })();
+            """).Should().Be("1|9,0,0");
+    }
+
+    [Fact]
+    public void ComputedAssignmentKeyRunsOnceWhenTheAwaitedPromiseRejects()
+    {
+        RunAsync($$"""
+            {{CountingKey}}
+            var o = {};
+            (async function () {
+              try { o[f()] = await Promise.reject(new Error('x')); }
+              catch (e) { }
+              return calls + '|' + JSON.stringify(Object.keys(o));
+            })();
+            """).Should().Be("1|[]");
+    }
+
+    // ------------------------------------------------------------------ compound assignment (guard)
+
+    [Fact]
+    public void CompoundComputedAssignmentKeyRunsOnceAcrossAnAwait()
+    {
+        RunAsync($$"""
+            {{CountingKey}}
+            var o = { k1: 1 };
+            (async function () {
+              o[f()] += await Promise.resolve(5);
+              return calls + '|' + JSON.stringify(Object.keys(o)) + '|' + o.k1;
+            })();
+            """).Should().Be("1|[\"k1\"]|6");
+    }
+
+    [Fact]
+    public void CompoundComputedAssignmentKeyRunsOnceAcrossAYield()
+    {
+        Run($$"""
+            {{CountingKey}}
+            var o = { k1: 1 };
+            function* g() { o[f()] += yield 1; }
+            var it = g();
+            it.next();
+            it.next(5);
+            calls + '|' + JSON.stringify(Object.keys(o)) + '|' + o.k1;
+            """).Should().Be("1|[\"k1\"]|6");
+    }
+
+    // ------------------------------------------------------------------ object literal
+
+    [Fact]
+    public void ComputedObjectLiteralKeyRunsOnceAcrossAnAwait()
+    {
+        RunAsync($$"""
+            {{CountingKey}}
+            (async function () {
+              var r = { a: 0, [f()]: await Promise.resolve(7) };
+              return calls + '|' + JSON.stringify(r);
+            })();
+            """).Should().Be("1|{\"a\":0,\"k1\":7}");
+    }
+
+    [Fact]
+    public void ComputedObjectLiteralKeyRunsOnceAcrossAYield()
+    {
+        Run($$"""
+            {{CountingKey}}
+            var r;
+            function* g() { r = { a: 0, [f()]: yield 1 }; }
+            var it = g();
+            it.next();
+            it.next(9);
+            calls + '|' + JSON.stringify(r);
+            """).Should().Be("1|{\"a\":0,\"k1\":9}");
+    }
+
+    [Fact]
+    public void EveryComputedObjectLiteralKeyRunsOnceWhenSeveralPropertiesSuspend()
+    {
+        // Each property parks its own key at its own index, so the slot must be consumed by the
+        // property that parked it and never carried into the next one.
+        RunAsync($$"""
+            {{CountingKey}}
+            (async function () {
+              var r = { [f()]: await Promise.resolve(1), [f()]: await Promise.resolve(2), [f()]: 3 };
+              return calls + '|' + JSON.stringify(r);
+            })();
+            """).Should().Be("3|{\"k1\":1,\"k2\":2,\"k3\":3}");
+    }
+
+    [Fact]
+    public void ComputedObjectLiteralKeyAfterANonSuspendingPropertyRunsOnce()
+    {
+        Run($$"""
+            {{CountingKey}}
+            var r;
+            function* g() { r = { [f()]: 1, [f()]: yield 2 }; }
+            var it = g();
+            it.next();
+            it.next(8);
+            calls + '|' + JSON.stringify(r);
+            """).Should().Be("2|{\"k1\":1,\"k2\":8}");
+    }
+}

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -974,29 +974,63 @@ internal sealed class JintAssignmentExpression : JintExpression
                 return fastResult;
             }
 
-            // slower version
-            var lref = _left.Evaluate(context) as Reference;
-            if (lref is null)
-            {
-                Throw.ReferenceError(engine.Realm, "Invalid left-hand side in assignment");
-            }
+            var suspendable = engine.ExecutionContext.Suspendable;
 
-            lref.AssertValid(engine.Realm);
+            // slower version
+            Reference? lref;
+            if (suspendable is { IsResuming: true }
+                && suspendable.Data.TryGet(this, out AssignmentSuspendData? suspendData))
+            {
+                // Resuming: the left-hand side ran to completion before the suspension and may have
+                // observable side effects in its base or its computed key (`o[f()] = await x`), so
+                // the parked Reference is consumed instead of re-evaluating it. Mirrors the compound
+                // path in JintAssignmentExpression.EvaluateMaterialized.
+                lref = suspendData!.Lref;
+            }
+            else
+            {
+                lref = _left.Evaluate(context) as Reference;
+                if (lref is null)
+                {
+                    Throw.ReferenceError(engine.Realm, "Invalid left-hand side in assignment");
+                }
+
+                lref.AssertValid(engine.Realm);
+            }
 
             // sum-of-products right-hand sides compute on raw doubles and box once
             var rval = _rightSumOfProducts is not null && _rightSumOfProducts.TryEvaluate(context, out var unboxedProductSum)
                 ? JsNumber.Create(unboxedProductSum)
                 : _right.GetValue(context);
 
-            // If generator suspended or return requested during right-hand side evaluation, don't assign.
-            // IsSuspended also covers an async function suspending at an `await` in the right-hand side:
-            // the RHS value at that point is the suspension sentinel (undefined), and storing it would
-            // clobber the target's previous value - visible forever if the awaited promise then REJECTS,
-            // because the resumed re-entry throws before it can re-assign.
-            if (context.IsGeneratorAborted() || context.IsSuspended())
+            // Neither state below is reachable without a suspendable frame — ExecutionContext.Generator
+            // is one of the three the Suspendable property folds together — so one null test replaces
+            // the two execution-context reads the checks would otherwise do on every assignment.
+            if (suspendable is not null)
             {
-                engine._referencePool.Return(lref);
-                return rval;
+                // If the right-hand side suspended, don't assign: its value at that point is the
+                // suspension sentinel (undefined), and storing it would clobber the target's previous
+                // value - visible forever if the awaited promise then REJECTS, because the resumed
+                // re-entry throws before it can re-assign. The Reference is parked rather than pooled;
+                // the resume above owns it from here.
+                if (context.IsSuspended())
+                {
+                    suspendable.Data.GetOrCreate<AssignmentSuspendData>(this).Lref = lref;
+                    return rval;
+                }
+
+                // A requested generator return abandons the assignment outright — nothing will resume
+                // into it, so the Reference goes straight back to the pool.
+                if (context.IsGeneratorAborted())
+                {
+                    engine._referencePool.Return(lref);
+                    suspendable.Data.Clear(this);
+                    return rval;
+                }
+
+                // Cleared before the store rather than after it, so a throwing setter cannot leave a
+                // consumed entry behind for a later replay of this node to pick up.
+                suspendable.Data.Clear(this);
             }
 
             // Fast path for dense array element writes: arr[intIndex] = rval. Overwrite of an

--- a/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
@@ -376,11 +376,17 @@ internal sealed class JintObjectExpression : JintExpression
 
         ObjectInstance obj;
         int startIndex;
+
+        // The computed key of the property we are resuming into, if that property's value is what
+        // suspended. Consumed by exactly that property (the resume index names it) and never seen by
+        // any other, since only a computed key is ever parked.
+        JsValue? pendingKey = null;
         if (suspendable is { IsResuming: true }
             && suspendable.Data.TryGet(this, out ObjectExpressionSuspendData? suspendData))
         {
             obj = suspendData!.Target!;
             startIndex = suspendData.NextIndex;
+            pendingKey = suspendData.PendingKey;
         }
         else
         {
@@ -409,7 +415,7 @@ internal sealed class JintObjectExpression : JintExpression
                 // Check for generator suspension
                 if (context.IsSuspended())
                 {
-                    SaveObjectExpressionSuspendState(suspendable, obj, i);
+                    SaveObjectExpressionSuspendState(suspendable, obj, i, pendingKey: null);
                     return JsValue.Undefined;
                 }
 
@@ -440,26 +446,43 @@ internal sealed class JintObjectExpression : JintExpression
                 // properties while the generator is suspended.
                 if (context.IsSuspended())
                 {
-                    SaveObjectExpressionSuspendState(suspendable, obj, i);
+                    SaveObjectExpressionSuspendState(suspendable, obj, i, pendingKey: null);
                     return JsValue.Undefined;
                 }
 
                 continue;
             }
 
+            // Non-null only for a computed key, which is the one a suspension inside the property's
+            // value has to park — a static key costs nothing to re-derive from the node.
+            JsValue? computedKey = null;
+
             JsValue? propName = objectProperty.KeyJsString;
             if (propName is null)
             {
-                var value = property.TryGetKey(engine);
-
-                // Check for generator suspension after evaluating computed property key
-                if (context.IsSuspended())
+                if (pendingKey is not null)
                 {
-                    SaveObjectExpressionSuspendState(suspendable, obj, i);
-                    return value;
+                    // Resuming into the property whose value suspended: its key expression already
+                    // ran, and running it again would double its side effects (`{ [f()]: await x }`)
+                    // and rerun the ToPropertyKey conversion, which reaches user code too.
+                    propName = pendingKey;
+                    pendingKey = null;
+                }
+                else
+                {
+                    var value = property.TryGetKey(engine);
+
+                    // Check for generator suspension after evaluating computed property key
+                    if (context.IsSuspended())
+                    {
+                        SaveObjectExpressionSuspendState(suspendable, obj, i, pendingKey: null);
+                        return value;
+                    }
+
+                    propName = TypeConverter.ToPropertyKey(value);
                 }
 
-                propName = TypeConverter.ToPropertyKey(value);
+                computedKey = propName;
             }
 
             if (property.Kind == PropertyKind.Init)
@@ -473,7 +496,7 @@ internal sealed class JintObjectExpression : JintExpression
                 // Check for generator suspension
                 if (context.IsSuspended())
                 {
-                    SaveObjectExpressionSuspendState(suspendable, obj, i);
+                    SaveObjectExpressionSuspendState(suspendable, obj, i, computedKey);
                     return JsValue.Undefined;
                 }
 
@@ -520,13 +543,16 @@ internal sealed class JintObjectExpression : JintExpression
         return obj;
     }
 
-    private void SaveObjectExpressionSuspendState(ISuspendable? suspendable, ObjectInstance obj, int nextIndex)
+    private void SaveObjectExpressionSuspendState(ISuspendable? suspendable, ObjectInstance obj, int nextIndex, JsValue? pendingKey)
     {
         if (suspendable is not null)
         {
             var data = suspendable.Data.GetOrCreate<ObjectExpressionSuspendData>(this);
             data.Target = obj;
             data.NextIndex = nextIndex;
+            // Written on every save, never left over from an earlier one: a suspension at a
+            // different index, or before this index's key was resolved, must not inherit it.
+            data.PendingKey = pendingKey;
         }
     }
 

--- a/Jint/Runtime/SuspendData.cs
+++ b/Jint/Runtime/SuspendData.cs
@@ -217,15 +217,23 @@ internal sealed class TrySuspendData : SuspendData
 }
 
 /// <summary>
-/// Stores the resolved LHS Reference and pre-mutation value of a compound assignment
-/// (e.g. obj[++i] += await y) when evaluation suspends inside the right-hand side.
-/// Reused on resume so the LHS — which may have observable side effects in its index
-/// or property accessor — is not re-evaluated.
+/// Stores the resolved LHS Reference of an assignment (e.g. <c>obj[++i] = await y</c>) and, for a
+/// compound one (<c>obj[++i] += await y</c>), its pre-mutation value, when evaluation suspends
+/// inside the right-hand side. Reused on resume so the LHS — which may have observable side effects
+/// in its base or its computed key — is not re-evaluated.
+/// <para>
+/// The parked Reference is owned by the suspendable until the resume consumes it, so the
+/// suspension site deliberately does <em>not</em> return it to <c>Engine._referencePool</c>; the
+/// completing resume does, alongside clearing this entry.
+/// </para>
 /// </summary>
 internal sealed class AssignmentSuspendData : SuspendData
 {
     public Reference Lref { get; set; } = null!;
 
+    /// <summary>
+    /// Unused by the simple assignment form, which reads no value from its target.
+    /// </summary>
     public JsValue OriginalLeftValue { get; set; } = JsValue.Undefined;
 }
 
@@ -319,6 +327,19 @@ internal sealed class ObjectExpressionSuspendData : SuspendData
     public PropertyDictionary? FastProperties { get; set; }
 
     public int NextIndex { get; set; }
+
+    /// <summary>
+    /// The already-converted property key of the property at <see cref="NextIndex"/>, parked when
+    /// that property's <em>value</em> suspended (<c>{ [f()]: await x }</c>). Without it the resume
+    /// re-runs the computed key expression, doubling its side effects and — when the key differs
+    /// between calls — binding the value under the second call's name.
+    /// <para>
+    /// Null whenever the key of the property being resumed into has not been resolved yet: a static
+    /// key (re-derived for free from the node), or a computed key whose own expression is what
+    /// suspended.
+    /// </para>
+    /// </summary>
+    public JsValue? PendingKey { get; set; }
 }
 
 /// <summary>


### PR DESCRIPTION
Closes #3133.

The replay interpreter re-ran an already-evaluated computed assignment key across an `await` or `yield` suspension, in the two shapes the #3133 analysis isolated (everything else was already covered by the existing `SuspendData` classes):

- **`o[f()] = await g()`** — `SimpleAssignmentExpression.SetValue` resolved the left `Reference`, then on suspension returned it to the pool and discarded it, so the whole left-hand side re-ran on resume. Worse than a doubled side effect: with a key that differs per call, the value lands under the *second* key and the write is lost from the caller's point of view — pre-fix, `o[f()] = await Promise.resolve(1)` produced `{"k2": 1}` with `o.k1 === undefined` and `f` called twice. The fix parks `Lref` in `AssignmentSuspendData` exactly as the compound (`+=`) path already did, with the same ownership rule: the suspension site does *not* pool the parked reference, the completing resume consumes and pools it, and a requested generator return pools it immediately since nothing will resume. The entry is cleared *before* the store so a throwing setter cannot leave a consumed entry for a later replay. The suspend checks also got cheaper on the way: both now sit behind the single `Suspendable` null test they imply, so a plain assignment reads the execution context once less.
- **`{ [f()]: await g() }`** — `ObjectExpressionSuspendData` parked `Target`/`FastProperties`/`NextIndex` but not the already-converted key of the property whose *value* suspended, so the key expression **and** its `ToPropertyKey` conversion (which reaches user code too) re-ran. A new `PendingKey` slot carries it; `SaveObjectExpressionSuspendState` now takes the key as a required parameter so every save site states it explicitly and a suspension at a different index can never inherit a stale one. Only the Init-value site parks a key — the one place a computed key precedes a suspending value.

Both fixes cover `yield` identically (same replay machinery). Nothing is parked unless a suspension happens, so the non-suspending hot path allocates nothing new.

**Tests**: `Jint.Tests/Runtime/SuspendedComputedKeyTests.cs`, 11 facts — the four issue variants, base/index-side-effect/rejection assignments, multi-property and mixed object literals, plus two compound-assignment guards for the already-correct path. Against unfixed code: 10 of 12 fail with `calls == 2` and the value under the wrong key (the 2 passers are the compound guards).

**Gate**: solution build 0 errors; Jint.Tests 8474/7005 green (net10.0/net472); PublicInterface 1837/1544 green; full test262 green; CommonScripts and the host-contract-verification leg green.

Found along the way and deliberately out of scope: a suspension *inside* a computed key still loses its replay state because the key handler is rebuilt per evaluation — filed as #3142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G7Ud48VAs1JicxRZxLDxg
