### PR TITLE
Web API: opt-in WebSocket with CloseEvent and the shared network policy

### DIFF
--- a/Jint.Tests.PublicInterface/WebApiWebSocketTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiWebSocketTests.cs
@@ -1,0 +1,278 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint;
+using Jint.Runtime;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// <c>WebSocket</c> seen from outside the assembly: what a host has to say to get it, what it costs when the
+/// host says nothing, and the policy that decides which sockets may be opened at all.
+/// </summary>
+/// <remarks>
+/// This project has no <c>InternalsVisibleTo</c>, so everything here is reachable by a third party — and
+/// nothing here opens a socket: every test either refuses the URL before a connection exists, or stops at the
+/// synchronous half of the interface. The socket layer itself is exercised against a scripted transport in
+/// <c>Jint.Tests</c>, which is where the seam that makes that possible lives.
+/// </remarks>
+public class WebApiWebSocketTests
+{
+    /// <summary>
+    /// An engine whose policy refuses every URL, so a socket can be constructed and observed without a
+    /// network existing. The refusal is deliberately asynchronous — see
+    /// https://websockets.spec.whatwg.org/#feedback-from-the-protocol.
+    /// </summary>
+    private static Engine RefusingEngine()
+        => new(options => options.UseWebSocket(net => net.UrlFilter = _ => false));
+
+    [Fact]
+    public void ADefaultEngineHasNoWebSocket()
+    {
+        var engine = new Engine();
+
+        engine.Evaluate("typeof WebSocket").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof CloseEvent").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof MessageEvent").AsString().Should().Be("undefined");
+    }
+
+    /// <summary>
+    /// Network egress is never inherited from asking for "the web APIs", which is the same rule
+    /// <c>fetch</c> has.
+    /// </summary>
+    [Fact]
+    public void UseWebApisDoesNotBringWebSocket()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        engine.Evaluate("typeof WebSocket").AsString().Should().Be("undefined");
+        WebApiFeatures.Default.HasFlag(WebApiFeatures.WebSocket).Should().BeFalse();
+    }
+
+    [Fact]
+    public void UseWebSocketInstallsTheInterfacesItsEventsAreMadeOf()
+    {
+        var engine = new Engine(options => options.UseWebSocket());
+
+        engine.Evaluate("typeof WebSocket").AsString().Should().Be("function");
+        engine.Evaluate("typeof CloseEvent").AsString().Should().Be("function");
+        engine.Evaluate("typeof MessageEvent").AsString().Should().Be("function");
+
+        // ... and the two features its own surface is built out of.
+        engine.Evaluate("typeof EventTarget").AsString().Should().Be("function");
+        engine.Evaluate("typeof Blob").AsString().Should().Be("function");
+    }
+
+    [Fact]
+    public void EnablingWebSocketDoesNotEnableFetchAndTheOptionReadsBackWhatWasAsked()
+    {
+        var options = new Options().UseWebSocket();
+        var engine = new Engine(options);
+
+        engine.Evaluate("typeof fetch").AsString().Should().Be("undefined");
+        options.WebApi.Features.Should().Be(WebApiFeatures.WebSocket, "the closure is computed when the engine is built");
+    }
+
+    [Fact]
+    public void EnablingFetchDoesNotEnableWebSocket()
+    {
+        var engine = new Engine(options => options.UseFetch());
+
+        engine.Evaluate("typeof fetch").AsString().Should().Be("function");
+        engine.Evaluate("typeof WebSocket").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void AHostRegisteredGlobalWins()
+    {
+        var marker = new Jint.Native.JsString("the host's own WebSocket");
+
+        var engine = new Engine(options => options
+            .AddLazyGlobal("WebSocket", _ => marker)
+            .UseWebSocket());
+
+        // The host's configuration runs first and the install is non-clobbering, so a host that already
+        // projects its own socket implementation keeps it.
+        engine.Evaluate("WebSocket").Should().BeSameAs(marker);
+    }
+
+    [Fact]
+    public void UseWebSocketConfiguresTheSharedNetworkGroup()
+    {
+        var options = new Options().UseWebSocket(net =>
+        {
+            net.MaxConcurrentRequests = 3;
+            net.AllowedSchemes.Clear();
+            net.AllowedSchemes.Add("wss");
+        });
+
+        options.WebApi.Fetch.MaxConcurrentRequests.Should().Be(3);
+        options.WebApi.Fetch.AllowedSchemes.Should().Equal("wss");
+    }
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#dom-websocket-websocket steps 3 to 7 — the only failures the
+    /// constructor has, and all of them <c>SyntaxError</c> <c>DOMException</c>s.
+    /// </summary>
+    [Theory]
+    [InlineData("ftp://example.org/")]
+    [InlineData("relative/path")]
+    [InlineData("wss://example.org/#fragment")]
+    public void ABadUrlIsASyntaxErrorDomException(string url)
+    {
+        var engine = RefusingEngine();
+
+        var thrown = Assert.Throws<JavaScriptException>(() => engine.Execute($"new WebSocket('{url}');"));
+
+        thrown.Error.Get("name").AsString().Should().Be("SyntaxError");
+        engine.Evaluate($"(() => {{ try {{ new WebSocket('{url}'); }} catch (e) {{ return e instanceof DOMException; }} }})()")
+            .AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ABadSubprotocolIsASyntaxErrorDomException()
+    {
+        var engine = RefusingEngine();
+
+        Assert.Throws<JavaScriptException>(() => engine.Execute("new WebSocket('wss://example.org/', ['a b']);"))
+            .Error.Get("name").AsString().Should().Be("SyntaxError");
+        Assert.Throws<JavaScriptException>(() => engine.Execute("new WebSocket('wss://example.org/', ['x', 'x']);"))
+            .Error.Get("name").AsString().Should().Be("SyntaxError");
+    }
+
+    /// <summary>
+    /// The host's filter is the last word, and refusing is not something a script can tell from a refused
+    /// connection: the socket is born CONNECTING and fails on a later turn.
+    /// </summary>
+    [Fact]
+    public void ARefusedUrlOpensNothingAndFailsAsynchronously()
+    {
+        var engine = RefusingEngine();
+
+        engine.Execute("""
+            var log = [];
+            var ws = new WebSocket('wss://example.org/');
+            log.push('state:' + ws.readyState);
+            ws.onerror = () => log.push('error');
+            ws.onclose = e => log.push('close:' + e.code + ':' + e.wasClean);
+            """);
+
+        // The socket is born CONNECTING — read inside the script, before anything is pumped. Execute then
+        // drains the loop, which is where the failure lands.
+        engine.Evaluate("log.join('|')").AsString().Should().Be("state:0|error|close:1006:false");
+        engine.Evaluate("ws.readyState").AsNumber().Should().Be(3);
+    }
+
+    /// <summary>
+    /// The filter is shown the <c>ws:</c> URL, which is what a host has to write its rules against.
+    /// </summary>
+    [Fact]
+    public void TheFilterIsShownTheWebSocketUrl()
+    {
+        var seen = new List<Uri>();
+        var engine = new Engine(options => options.UseWebSocket(net => net.UrlFilter = uri =>
+        {
+            seen.Add(uri);
+            return false;
+        }));
+
+        engine.Execute("new WebSocket('https://example.org/chat');");
+
+        seen.Should().Equal(new Uri("wss://example.org/chat"));
+    }
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#dom-websocket-send step 1: the one exception the method has.
+    /// </summary>
+    [Fact]
+    public void SendBeforeTheConnectionIsEstablishedIsAnInvalidStateError()
+    {
+        var engine = RefusingEngine();
+
+        engine.Execute("var ws = new WebSocket('wss://example.org/');");
+
+        // The engine has been pumped by Execute, so this socket is CLOSED rather than CONNECTING — the
+        // interesting state is the one before that, which the same statement can still observe.
+        var thrown = Assert.Throws<JavaScriptException>(() => engine.Execute("""
+            var early = new WebSocket('wss://example.org/');
+            early.send('too early');
+            """));
+
+        thrown.Error.Get("name").AsString().Should().Be("InvalidStateError");
+    }
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#dom-websocket-close steps 1 and 2.
+    /// </summary>
+    [Fact]
+    public void CloseValidatesItsArgumentsWhateverTheReadyStateIs()
+    {
+        var engine = RefusingEngine();
+
+        engine.Execute("var ws = new WebSocket('wss://example.org/');");
+        engine.Evaluate("ws.readyState").AsNumber().Should().Be(3, "the refused socket has already failed");
+
+        Assert.Throws<JavaScriptException>(() => engine.Execute("ws.close(1001);"))
+            .Error.Get("name").AsString().Should().Be("InvalidAccessError");
+
+        Assert.Throws<JavaScriptException>(() => engine.Execute("ws.close(1000, 'x'.repeat(124));"))
+            .Error.Get("name").AsString().Should().Be("SyntaxError");
+
+        // A closed socket still accepts a well-formed close, and does nothing with it.
+        engine.Execute("ws.close(3000, 'fine');");
+    }
+
+    /// <summary>
+    /// The attributes a host can read before anything has happened, and the divergence it should know about:
+    /// <c>binaryType</c> starts at <c>"arraybuffer"</c> here, where a browser starts at <c>"blob"</c>.
+    /// </summary>
+    [Fact]
+    public void TheAttributesReadBackBeforeAnythingHasHappened()
+    {
+        var engine = new Engine(options => options.UseWebSocket(net => net.UrlFilter = _ => false));
+
+        engine.Execute("var ws = new WebSocket('wss://example.org/chat?x=1');");
+
+        engine.Evaluate("ws.url").AsString().Should().Be("wss://example.org/chat?x=1");
+        engine.Evaluate("ws.protocol").AsString().Should().BeEmpty();
+        engine.Evaluate("ws.extensions").AsString().Should().BeEmpty();
+        engine.Evaluate("ws.bufferedAmount").AsNumber().Should().Be(0);
+        engine.Evaluate("ws.binaryType").AsString().Should().Be("arraybuffer");
+        engine.Evaluate("ws instanceof EventTarget").AsBoolean().Should().BeTrue();
+    }
+
+    /// <summary>
+    /// One <c>Options</c> instance serves any number of engines, and the socket registry is per engine.
+    /// </summary>
+    [Fact]
+    public void OneOptionsInstanceServesSeveralEnginesIndependently()
+    {
+        var options = new Options().UseWebSocket(net =>
+        {
+            net.UrlFilter = _ => false;
+            net.MaxConcurrentRequests = 1;
+        });
+
+        var first = new Engine(options);
+        var second = new Engine(options);
+
+        first.Execute("var a = new WebSocket('wss://example.org/1');");
+        second.Execute("var b = new WebSocket('wss://example.org/2');");
+
+        first.Evaluate("a.readyState").AsNumber().Should().Be(3);
+        second.Evaluate("b.readyState").AsNumber().Should().Be(3);
+    }
+
+    /// <summary>
+    /// The globals are never reached inside a shadow realm, which is the same conservative choice every other
+    /// web API here makes.
+    /// </summary>
+    [Fact]
+    public void AShadowRealmHasNoWebSocket()
+    {
+        var engine = new Engine(options => options.UseWebSocket());
+
+        engine.Evaluate("new ShadowRealm().evaluate('typeof WebSocket')").AsString().Should().Be("undefined");
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/WebSocketEventTests.cs
+++ b/Jint.Tests/Runtime/WebApi/WebSocketEventTests.cs
@@ -1,0 +1,135 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// The two event interfaces a <c>WebSocket</c> dispatches, as constructible interfaces in their own right:
+/// <c>CloseEvent</c> (https://websockets.spec.whatwg.org/#the-closeevent-interface) and <c>MessageEvent</c>
+/// (https://html.spec.whatwg.org/multipage/comms.html#messageevent).
+/// </summary>
+public class WebSocketEventTests
+{
+    private static Engine WebEngine() => new(options => options.UseWebSocket());
+
+    [Fact]
+    public void CloseEventDefaultsEveryMemberOfItsDictionary()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("var e = new CloseEvent('close');");
+
+        engine.Evaluate("e.type").AsString().Should().Be("close");
+        engine.Evaluate("e.wasClean").AsBoolean().Should().BeFalse();
+        engine.Evaluate("e.code").AsNumber().Should().Be(0);
+        engine.Evaluate("e.reason").AsString().Should().BeEmpty();
+        engine.Evaluate("e.isTrusted").AsBoolean().Should().BeFalse("a script constructed it");
+        engine.Evaluate("e instanceof Event").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.getPrototypeOf(CloseEvent) === Event").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void CloseEventReadsItsDictionary()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("var e = new CloseEvent('close', { code: 3001, reason: 'bye', wasClean: true, bubbles: true });");
+
+        engine.Evaluate("[e.code, e.reason, e.wasClean, e.bubbles].join(',')").AsString().Should().Be("3001,bye,true,true");
+    }
+
+    /// <summary>
+    /// <c>code</c> is a plain <c>unsigned short</c>, so https://webidl.spec.whatwg.org/#js-unsigned-short
+    /// wraps rather than clamping — unlike <c>close()</c>'s own <c>[Clamp]</c> argument.
+    /// </summary>
+    [Theory]
+    [InlineData("65536", 0)]
+    [InlineData("-1", 65535)]
+    [InlineData("NaN", 0)]
+    [InlineData("1000.9", 1000)]
+    public void CloseEventWrapsItsCode(string code, double expected)
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate($"new CloseEvent('close', {{ code: {code} }}).code").AsNumber().Should().Be(expected);
+    }
+
+    [Fact]
+    public void CloseEventRequiresAType()
+    {
+        var engine = WebEngine();
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new CloseEvent()"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void MessageEventDefaultsEveryMemberOfItsDictionary()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("var e = new MessageEvent('message');");
+
+        engine.Evaluate("e.data").IsNull().Should().BeTrue("the IDL default is null, not undefined");
+        engine.Evaluate("e.origin").AsString().Should().BeEmpty();
+        engine.Evaluate("e.lastEventId").AsString().Should().BeEmpty();
+        engine.Evaluate("e instanceof Event").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.getPrototypeOf(MessageEvent) === Event").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.prototype.toString.call(e)").AsString().Should().Be("[object MessageEvent]");
+    }
+
+    [Fact]
+    public void MessageEventCarriesAnyValueAsItsData()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("var payload = { a: 1 }; var e = new MessageEvent('message', { data: payload, origin: 'wss://x', lastEventId: '7' });");
+
+        engine.Evaluate("e.data === payload").AsBoolean().Should().BeTrue();
+        engine.Evaluate("e.origin").AsString().Should().Be("wss://x");
+        engine.Evaluate("e.lastEventId").AsString().Should().Be("7");
+    }
+
+    /// <summary>
+    /// Both interfaces' attributes are accessors that brand-check, as WebIDL specifies.
+    /// </summary>
+    [Fact]
+    public void ThePrototypesAreNotInstances()
+    {
+        var engine = WebEngine();
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("CloseEvent.prototype.code"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("MessageEvent.prototype.data"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+
+        engine.Evaluate("Object.getOwnPropertyNames(new CloseEvent('x')).length").AsNumber().Should().Be(0);
+    }
+
+    /// <summary>
+    /// Both are dispatchable like any other event, which is what makes them usable from script for something
+    /// other than a socket.
+    /// </summary>
+    [Fact]
+    public void BothCanBeDispatchedAtAnyEventTarget()
+    {
+        var engine = WebEngine();
+
+        var result = engine.Evaluate("""
+            (() => {
+                const seen = [];
+                const target = new EventTarget();
+                target.addEventListener('close', e => seen.push(e.code + ':' + e.wasClean));
+                target.addEventListener('message', e => seen.push(e.data));
+                target.dispatchEvent(new CloseEvent('close', { code: 1000, wasClean: true }));
+                target.dispatchEvent(new MessageEvent('message', { data: 'hi' }));
+                return seen.join('|');
+            })()
+            """);
+
+        result.AsString().Should().Be("1000:true|hi");
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/WebSocketTests.cs
+++ b/Jint.Tests/Runtime/WebApi/WebSocketTests.cs
@@ -1,0 +1,1078 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Jint.Runtime;
+using Jint.WebApi.WebSockets;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// <c>WebSocket</c> against the WHATWG WebSockets Standard —
+/// https://websockets.spec.whatwg.org/#the-websocket-interface — driven against a scripted transport so that
+/// nothing here touches a network.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The double replaces <see cref="IWebSocketConnection"/>, which is the seam the whole state machine sits on:
+/// the handshake, the receive loop, the send queue, <c>bufferedAmount</c>, the closing handshake and every
+/// event go through the real code, and only the socket itself is imaginary.
+/// </para>
+/// <para>
+/// <b>Nothing here measures time.</b> Every assertion is structural; <see cref="Pump"/> turns the engine over
+/// until the state a test is waiting for arrives, and its deadline exists only so that a hang fails the run
+/// instead of hanging it.
+/// </para>
+/// </remarks>
+public class WebSocketTests
+{
+    /// <summary>
+    /// A socket the test drives by hand. Its <see cref="ConnectAsync"/> answers a gate the test opens, its
+    /// <see cref="ReceiveAsync"/> answers whatever the test has delivered, and everything it was asked to
+    /// write is recorded.
+    /// </summary>
+    private sealed class FakeConnection : IWebSocketConnection
+    {
+        private readonly object _lock = new();
+        private readonly Queue<object> _inbound = new();
+        private readonly SemaphoreSlim _written = new(0);
+        private TaskCompletionSource<WebSocketReceipt>? _waiting;
+        private bool _aborted;
+
+        internal FakeConnection(Uri url, IReadOnlyList<string> protocols, long maxMessageBytes)
+        {
+            Url = url;
+            Protocols = protocols;
+            MaxMessageBytes = maxMessageBytes;
+        }
+
+        internal Uri Url { get; }
+
+        internal IReadOnlyList<string> Protocols { get; }
+
+        internal long MaxMessageBytes { get; }
+
+        /// <summary>Completed by the test to finish the handshake, or faulted to fail it.</summary>
+        internal TaskCompletionSource Handshake { get; } = new();
+
+        public string SubProtocol { get; set; } = string.Empty;
+
+        internal List<(byte[] Payload, bool IsText)> Sent { get; } = new();
+
+        internal List<(int? Code, string Reason)> CloseFrames { get; } = new();
+
+        /// <summary>Everything written, messages and Close frame alike, in the order it reached the socket.</summary>
+        internal List<string> Writes { get; } = new();
+
+        internal int Aborts { get; private set; }
+
+        public Task ConnectAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.Register(static state => ((TaskCompletionSource) state!).TrySetCanceled(), Handshake);
+            return Handshake.Task;
+        }
+
+        public Task SendAsync(ReadOnlyMemory<byte> payload, bool isText, CancellationToken cancellationToken)
+        {
+            lock (_lock)
+            {
+                if (_aborted)
+                {
+                    return Task.FromException(new IOException("the connection was aborted"));
+                }
+
+                Sent.Add((payload.ToArray(), isText));
+                Writes.Add((isText ? "text:" : "binary:") + System.Text.Encoding.UTF8.GetString(payload.Span));
+            }
+
+            _written.Release();
+            return Task.CompletedTask;
+        }
+
+        public Task<WebSocketReceipt> ReceiveAsync(CancellationToken cancellationToken)
+        {
+            lock (_lock)
+            {
+                if (_inbound.Count > 0)
+                {
+                    var next = _inbound.Dequeue();
+                    return next is Exception failure
+                        ? Task.FromException<WebSocketReceipt>(failure)
+                        : Task.FromResult((WebSocketReceipt) next);
+                }
+
+                if (_aborted)
+                {
+                    return Task.FromCanceled<WebSocketReceipt>(new CancellationToken(canceled: true));
+                }
+
+                _waiting = new TaskCompletionSource<WebSocketReceipt>();
+                cancellationToken.Register(static state => ((TaskCompletionSource<WebSocketReceipt>) state!).TrySetCanceled(), _waiting);
+                return _waiting.Task;
+            }
+        }
+
+        public Task CloseOutputAsync(int? code, string reason, CancellationToken cancellationToken)
+        {
+            lock (_lock)
+            {
+                CloseFrames.Add((code, reason));
+                Writes.Add("close:" + (code?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "none"));
+            }
+
+            _written.Release();
+            return Task.CompletedTask;
+        }
+
+        public void Abort()
+        {
+            TaskCompletionSource<WebSocketReceipt>? waiting;
+            lock (_lock)
+            {
+                Aborts++;
+                _aborted = true;
+                waiting = _waiting;
+                _waiting = null;
+            }
+
+            Handshake.TrySetCanceled();
+            waiting?.TrySetCanceled();
+        }
+
+        public void Dispose()
+        {
+        }
+
+        /// <summary>Hands the socket a message, or the peer's Close frame, from the test's thread.</summary>
+        internal void Deliver(WebSocketReceipt receipt) => Deliver((object) receipt);
+
+        /// <summary>Fails the next receive, which is how a dropped connection looks from in here.</summary>
+        internal void Fail(Exception failure) => Deliver((object) failure);
+
+        private void Deliver(object item)
+        {
+            TaskCompletionSource<WebSocketReceipt>? waiting;
+            lock (_lock)
+            {
+                waiting = _waiting;
+                _waiting = null;
+
+                if (waiting is null)
+                {
+                    _inbound.Enqueue(item);
+                    return;
+                }
+            }
+
+            if (item is Exception failure)
+            {
+                waiting.SetException(failure);
+            }
+            else
+            {
+                waiting.SetResult((WebSocketReceipt) item);
+            }
+        }
+
+        /// <summary>
+        /// Waits for the send loop — which runs on a thread pool thread, deliberately, so that a socket write
+        /// never blocks the engine — to have written <paramref name="count"/> things.
+        /// </summary>
+        internal void WaitForWrites(int count)
+        {
+            for (var i = 0; i < count; i++)
+            {
+                _written.Wait(TimeSpan.FromSeconds(30)).Should().BeTrue("the send loop should have written {0} time(s)", count);
+            }
+        }
+    }
+
+    private sealed class FakeConnections : IWebSocketConnectionFactory
+    {
+        internal List<FakeConnection> Created { get; } = new();
+
+        internal FakeConnection Last => Created[^1];
+
+        public IWebSocketConnection Create(Uri url, IReadOnlyList<string> protocols, long maxMessageBytes)
+        {
+            var connection = new FakeConnection(url, protocols, maxMessageBytes);
+            Created.Add(connection);
+            return connection;
+        }
+    }
+
+    private static (Engine Engine, FakeConnections Sockets) SocketEngine(Action<Options.FetchOptions>? configure = null)
+    {
+        var engine = new Engine(options => options.UseWebApis().UseWebSocket(configure));
+        var sockets = new FakeConnections();
+        engine._webApi!.WebSocketConnections = sockets;
+        engine.Execute("var log = [];");
+        return (engine, sockets);
+    }
+
+    /// <summary>
+    /// Turns the engine over until <paramref name="until"/> holds. Nothing here is a measurement: the
+    /// deadline only turns a hang into a failed assertion.
+    /// </summary>
+    private static void Pump(Engine engine, Func<bool> until)
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        while (true)
+        {
+            engine.Advanced.ProcessTasks();
+
+            if (until())
+            {
+                return;
+            }
+
+            if (stopwatch.Elapsed > TimeSpan.FromSeconds(30))
+            {
+                Assert.Fail("the engine never reached the state the test was waiting for");
+            }
+
+            Thread.Sleep(1);
+        }
+    }
+
+    private static string Log(Engine engine) => engine.Evaluate("log.join('|')").AsString();
+
+    private static void PumpUntilLogged(Engine engine, int entries)
+        => Pump(engine, () => engine.Evaluate("log.length").AsNumber() >= entries);
+
+    /// <summary>
+    /// Opens a socket, finishes its handshake and returns once the <c>open</c> event has been dispatched.
+    /// </summary>
+    private static (Engine Engine, FakeConnections Sockets) OpenSocket(string script = "", string url = "wss://example.org/socket")
+    {
+        var (engine, sockets) = SocketEngine();
+
+        engine.Execute($$"""
+            var ws = new WebSocket('{{url}}');
+            ws.onopen = () => log.push('open:' + ws.readyState + ':' + ws.protocol);
+            {{script}}
+            """);
+
+        sockets.Last.Handshake.SetResult();
+        PumpUntilLogged(engine, 1);
+
+        return (engine, sockets);
+    }
+
+    [Fact]
+    public void TheConstructorOpensTheConnectionItWasGiven()
+    {
+        var (engine, sockets) = SocketEngine();
+
+        engine.Execute("var ws = new WebSocket('wss://example.org/socket?x=1', ['chat', 'v2']);");
+
+        sockets.Created.Should().HaveCount(1);
+        sockets.Last.Url.Should().Be(new Uri("wss://example.org/socket?x=1"));
+        sockets.Last.Protocols.Should().Equal("chat", "v2");
+
+        // Nothing has been pumped, so the socket is still connecting and its url reads back serialized.
+        engine.Evaluate("ws.readyState").AsNumber().Should().Be(0);
+        engine.Evaluate("ws.url").AsString().Should().Be("wss://example.org/socket?x=1");
+        engine.Evaluate("ws.protocol").AsString().Should().BeEmpty();
+        engine.Evaluate("ws.extensions").AsString().Should().BeEmpty();
+        engine.Evaluate("ws.bufferedAmount").AsNumber().Should().Be(0);
+        engine.Evaluate("ws.binaryType").AsString().Should().Be("arraybuffer");
+    }
+
+    [Fact]
+    public void AFinishedHandshakeFiresOpenAndPublishesTheSubprotocol()
+    {
+        var (engine, sockets) = SocketEngine();
+
+        engine.Execute("""
+            var ws = new WebSocket('wss://example.org/socket', 'chat');
+            ws.onopen = e => log.push('open:' + ws.readyState + ':' + ws.protocol + ':' + e.type + ':' + e.isTrusted);
+            """);
+
+        sockets.Last.SubProtocol = "chat";
+        Log(engine).Should().BeEmpty("nothing runs until the engine is pumped");
+
+        sockets.Last.Handshake.SetResult();
+        PumpUntilLogged(engine, 1);
+
+        Log(engine).Should().Be("open:1:chat:open:true");
+    }
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#dom-websocket-websocket steps 4 and 5 — the current text maps the
+    /// two HTTP schemes rather than refusing them.
+    /// </summary>
+    [Theory]
+    [InlineData("http://example.org/s", "ws://example.org/s")]
+    [InlineData("https://example.org/s", "wss://example.org/s")]
+    [InlineData("ws://example.org/s", "ws://example.org/s")]
+    [InlineData("wss://example.org/s", "wss://example.org/s")]
+    public void MapsTheHttpSchemesOntoTheWebSocketOnes(string input, string expected)
+    {
+        var (engine, sockets) = SocketEngine();
+
+        engine.Execute($"var ws = new WebSocket('{input}');");
+
+        engine.Evaluate("ws.url").AsString().Should().Be(expected);
+        sockets.Last.Url.Scheme.Should().Be(new Uri(expected).Scheme);
+    }
+
+    /// <summary>
+    /// Steps 3, 6 and 7: an unparsable URL, a scheme that is not one of the four, and a fragment.
+    /// </summary>
+    [Theory]
+    [InlineData("not a url")]
+    [InlineData("/relative")]
+    [InlineData("ftp://example.org/")]
+    [InlineData("file:///tmp/x")]
+    [InlineData("wss://example.org/s#fragment")]
+    [InlineData("ws://example.org/s#")]
+    public void RefusesAUrlTheStandardRefuses(string url)
+    {
+        var (engine, sockets) = SocketEngine();
+
+        var thrown = Assert.Throws<JavaScriptException>(() => engine.Execute($"new WebSocket('{url}');"));
+
+        thrown.Error.Get("name").AsString().Should().Be("SyntaxError");
+        engine.Evaluate($"(() => {{ try {{ new WebSocket('{url}'); }} catch (e) {{ return e instanceof DOMException; }} }})()")
+            .AsBoolean().Should().BeTrue();
+
+        sockets.Created.Should().BeEmpty("a URL that fails the constructor never reaches a socket");
+    }
+
+    /// <summary>
+    /// Step 10: every element must be a <c>Sec-WebSocket-Protocol</c> token and none may repeat.
+    /// </summary>
+    [Theory]
+    [InlineData("['']")]
+    [InlineData("['a b']")]
+    [InlineData("['a,b']")]
+    [InlineData("['a;b']")]
+    [InlineData("['a\\u00e9']")]
+    [InlineData("['chat', 'chat']")]
+    public void RefusesASubprotocolTheProtocolWouldRefuse(string protocols)
+    {
+        var (engine, sockets) = SocketEngine();
+
+        var thrown = Assert.Throws<JavaScriptException>(() => engine.Execute($"new WebSocket('wss://example.org/', {protocols});"));
+
+        thrown.Error.Get("name").AsString().Should().Be("SyntaxError");
+        sockets.Created.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AcceptsASingleStringProtocolAndAnIterableOfThem()
+    {
+        var (engine, sockets) = SocketEngine();
+
+        engine.Execute("""
+            new WebSocket('wss://example.org/', 'chat');
+            new WebSocket('wss://example.org/', ['chat', 'superchat']);
+            new WebSocket('wss://example.org/', new Set(['a', 'b']));
+            new WebSocket('wss://example.org/');
+            """);
+
+        sockets.Created[0].Protocols.Should().Equal("chat");
+        sockets.Created[1].Protocols.Should().Equal("chat", "superchat");
+        sockets.Created[2].Protocols.Should().Equal("a", "b");
+        sockets.Created[3].Protocols.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ATextMessageArrivesAsAStringOnATrustedMessageEvent()
+    {
+        var (engine, sockets) = OpenSocket("""
+            ws.onmessage = e => log.push([typeof e.data, e.data, e.origin, e.isTrusted, e instanceof MessageEvent, e instanceof Event].join(','));
+            """);
+
+        sockets.Last.Deliver(WebSocketReceipt.Message(isText: true, "héllo"u8.ToArray()));
+        PumpUntilLogged(engine, 2);
+
+        Log(engine).Should().Be("open:1:|string,héllo,wss://example.org,true,true,true");
+    }
+
+    [Fact]
+    public void ABinaryMessageArrivesAsAnArrayBufferByDefault()
+    {
+        var (engine, sockets) = OpenSocket("""
+            ws.onmessage = e => log.push(e.data.constructor.name + ':' + new Uint8Array(e.data).join('-'));
+            """);
+
+        sockets.Last.Deliver(WebSocketReceipt.Message(isText: false, [1, 2, 3]));
+        PumpUntilLogged(engine, 2);
+
+        Log(engine).Should().Be("open:1:|ArrayBuffer:1-2-3");
+    }
+
+    [Fact]
+    public void ABinaryMessageArrivesAsABlobWhenBinaryTypeSaysSo()
+    {
+        var (engine, sockets) = OpenSocket("""
+            ws.binaryType = 'blob';
+            ws.onmessage = e => log.push(e.data.constructor.name + ':' + e.data.size + ':' + JSON.stringify(e.data.type));
+            """);
+
+        sockets.Last.Deliver(WebSocketReceipt.Message(isText: false, [1, 2, 3, 4]));
+        PumpUntilLogged(engine, 2);
+
+        Log(engine).Should().Be("open:1:|Blob:4:\"\"");
+    }
+
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#es-enumeration — assigning something that is not one of the
+    /// enumeration's values to an attribute of enumeration type is ignored, not refused.
+    /// </summary>
+    [Fact]
+    public void BinaryTypeIgnoresAValueThatIsNotOneOfTheTwo()
+    {
+        var (engine, _) = OpenSocket();
+
+        engine.Evaluate("ws.binaryType = 'blob'; ws.binaryType").AsString().Should().Be("blob");
+        engine.Evaluate("ws.binaryType = 'nodebuffer'; ws.binaryType").AsString().Should().Be("blob");
+        engine.Evaluate("ws.binaryType = 'arraybuffer'; ws.binaryType").AsString().Should().Be("arraybuffer");
+    }
+
+    /// <summary>
+    /// A message that arrives once the socket is no longer OPEN is dropped — step 1 of "when a WebSocket
+    /// message has been received".
+    /// </summary>
+    [Fact]
+    public void AMessageThatArrivesAfterTheCloseIsDropped()
+    {
+        var (engine, sockets) = OpenSocket("""
+            ws.onmessage = e => log.push('message:' + e.data);
+            ws.onclose = e => log.push('close:' + e.code);
+            """);
+
+        var socket = sockets.Last;
+
+        // The message is queued as a job while the socket is still OPEN, and close() then moves the ready
+        // state to CLOSING before the engine turns over — Execute drains the loop when the script is done, so
+        // the job runs against a socket that is no longer OPEN and step 1 drops it.
+        socket.Deliver(WebSocketReceipt.Message(isText: true, "late"u8.ToArray()));
+        engine.Execute("ws.close();");
+
+        Log(engine).Should().Be("open:1:");
+
+        socket.WaitForWrites(1);
+        socket.Deliver(WebSocketReceipt.Closed(1000, "done"));
+        PumpUntilLogged(engine, 2);
+
+        Log(engine).Should().Be("open:1:|close:1000");
+    }
+
+    [Fact]
+    public void SendMarshalsOnTheEngineThreadAndBufferedAmountFallsWhenTheBytesGoOut()
+    {
+        var (engine, sockets) = OpenSocket();
+        var socket = sockets.Last;
+
+        engine.Execute("""
+            var bytes = new Uint8Array([7, 8, 9]);
+            ws.send('héllo');
+            ws.send(bytes);
+            bytes[0] = 99;
+
+            // Read inside the script: six UTF-8 bytes for the string plus three for the view, counted by
+            // send() itself. Nothing can have come off the count yet, because the release is an event-loop
+            // job and no job runs while a script is running.
+            log.push('buffered:' + ws.bufferedAmount);
+            """);
+
+        Log(engine).Should().Be("open:1:|buffered:9");
+
+        socket.WaitForWrites(2);
+        Pump(engine, () => engine.Evaluate("ws.bufferedAmount").AsNumber() == 0);
+
+        socket.Sent.Should().HaveCount(2);
+        socket.Sent[0].IsText.Should().BeTrue();
+        socket.Sent[0].Payload.Should().Equal("héllo"u8.ToArray());
+
+        socket.Sent[1].IsText.Should().BeFalse();
+        socket.Sent[1].Payload.Should().Equal([7, 8, 9], "the bytes were copied when send() was called, not when they were written");
+    }
+
+    [Fact]
+    public void SendAcceptsEveryArmOfTheUnion()
+    {
+        var (engine, sockets) = OpenSocket();
+        var socket = sockets.Last;
+
+        engine.Execute("""
+            ws.send('text');
+            ws.send(new Uint8Array([1, 2]).buffer);
+            ws.send(new DataView(new Uint8Array([3, 4, 5]).buffer));
+            ws.send(new Blob(['ab']));
+            ws.send(42);
+            """);
+
+        socket.WaitForWrites(5);
+
+        socket.Sent.Select(s => s.IsText).Should().Equal(true, false, false, false, true);
+        socket.Sent[1].Payload.Should().Equal([1, 2]);
+        socket.Sent[2].Payload.Should().Equal([3, 4, 5]);
+        socket.Sent[3].Payload.Should().Equal("ab"u8.ToArray());
+        socket.Sent[4].Payload.Should().Equal("42"u8.ToArray());
+    }
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#dom-websocket-send step 1.
+    /// </summary>
+    [Fact]
+    public void SendBeforeTheHandshakeFinishesIsAnInvalidStateError()
+    {
+        var (engine, sockets) = SocketEngine();
+
+        engine.Execute("var ws = new WebSocket('wss://example.org/');");
+
+        var thrown = Assert.Throws<JavaScriptException>(() => engine.Execute("ws.send('too early');"));
+        thrown.Error.Get("name").AsString().Should().Be("InvalidStateError");
+        engine.Evaluate("(() => { try { ws.send('x'); } catch (e) { return e instanceof DOMException; } })()")
+            .AsBoolean().Should().BeTrue();
+
+        engine.Evaluate("ws.bufferedAmount").AsNumber().Should().Be(0, "a call that throws queues nothing");
+        sockets.Last.Sent.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// "If the WebSocket connection is closed, this attribute's value will only increase with each call to the
+    /// send() method" — https://websockets.spec.whatwg.org/#dom-websocket-bufferedamount.
+    /// </summary>
+    [Fact]
+    public void SendAfterTheCloseOnlyCountsBytesAndWritesNothing()
+    {
+        var (engine, sockets) = OpenSocket();
+        var socket = sockets.Last;
+
+        engine.Execute("ws.close();");
+        engine.Evaluate("ws.readyState").AsNumber().Should().Be(2);
+
+        engine.Execute("ws.send('abcd');");
+        engine.Evaluate("ws.bufferedAmount").AsNumber().Should().Be(4);
+
+        socket.WaitForWrites(1);
+        socket.CloseFrames.Should().HaveCount(1);
+        socket.Sent.Should().BeEmpty("a socket that is CLOSING transmits nothing");
+
+        // ... and it never comes down again, because nothing will ever write those bytes.
+        engine.Advanced.ProcessTasks();
+        engine.Evaluate("ws.bufferedAmount").AsNumber().Should().Be(4);
+    }
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#dom-websocket-close step 3.3, then the peer's answer.
+    /// </summary>
+    [Fact]
+    public void CloseStartsTheHandshakeAndStaysClosingUntilThePeerAnswers()
+    {
+        var (engine, sockets) = OpenSocket("""
+            ws.onclose = e => log.push(['close', e.code, e.reason, e.wasClean, e.isTrusted, e instanceof CloseEvent].join(','));
+            ws.onerror = () => log.push('error');
+            """);
+
+        var socket = sockets.Last;
+
+        engine.Execute("ws.close(3000, 'bye');");
+        engine.Evaluate("ws.readyState").AsNumber().Should().Be(2, "close() sets CLOSING synchronously");
+
+        socket.WaitForWrites(1);
+        socket.CloseFrames.Should().Equal((3000, "bye"));
+        Log(engine).Should().Be("open:1:", "the socket is not closed until the peer answers");
+
+        socket.Deliver(WebSocketReceipt.Closed(3000, "bye"));
+        PumpUntilLogged(engine, 2);
+
+        Log(engine).Should().Be("open:1:|close,3000,bye,true,true,true");
+        engine.Evaluate("ws.readyState").AsNumber().Should().Be(3);
+    }
+
+    [Fact]
+    public void CloseWithNoArgumentsSendsAFrameWithNoBody()
+    {
+        var (engine, sockets) = OpenSocket();
+
+        engine.Execute("ws.close();");
+        sockets.Last.WaitForWrites(1);
+
+        sockets.Last.CloseFrames.Should().Equal((null, string.Empty));
+    }
+
+    [Fact]
+    public void QueuedMessagesAreWrittenBeforeTheCloseFrame()
+    {
+        var (engine, sockets) = OpenSocket();
+        var socket = sockets.Last;
+
+        engine.Execute("ws.send('first'); ws.send('second'); ws.close(1000);");
+        socket.WaitForWrites(3);
+
+        // The Close frame goes out last, which is what lets a script send and then close without losing the
+        // message it just sent.
+        socket.Writes.Should().Equal("text:first", "text:second", "close:1000");
+    }
+
+    /// <summary>
+    /// The peer's Close frame: "when the WebSocket closing handshake is started" moves the ready state, and
+    /// this endpoint answers with a Close frame of its own before the connection ends.
+    /// </summary>
+    [Fact]
+    public void APeerInitiatedCloseIsEchoedAndReportedAsClean()
+    {
+        var (engine, sockets) = OpenSocket("""
+            ws.onclose = e => log.push(['close', e.code, e.reason, e.wasClean].join(','));
+            ws.onerror = () => log.push('error');
+            """);
+
+        var socket = sockets.Last;
+        socket.Deliver(WebSocketReceipt.Closed(1001, "going away"));
+
+        PumpUntilLogged(engine, 2);
+
+        Log(engine).Should().Be("open:1:|close,1001,going away,true");
+        socket.CloseFrames.Should().Equal((1001, string.Empty));
+    }
+
+    /// <summary>
+    /// A Close frame with no status code is 1005, "no status received" —
+    /// https://www.rfc-editor.org/rfc/rfc6455#section-7.4.1 — and is answered with a body-less frame.
+    /// </summary>
+    [Fact]
+    public void APeerCloseWithNoCodeIsReportedAs1005()
+    {
+        var (engine, sockets) = OpenSocket("ws.onclose = e => log.push('close:' + e.code + ':' + e.wasClean);");
+
+        sockets.Last.Deliver(WebSocketReceipt.Closed(1005, string.Empty));
+        PumpUntilLogged(engine, 2);
+
+        Log(engine).Should().Be("open:1:|close:1005:true");
+        sockets.Last.CloseFrames.Should().Equal((null, string.Empty));
+    }
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#dom-websocket-close step 3.2: closing before the connection is
+    /// established <i>fails</i> it, so the script sees the error and the 1006 every abnormal closure has.
+    /// </summary>
+    [Fact]
+    public void ClosingDuringTheHandshakeFailsTheConnection()
+    {
+        var (engine, sockets) = SocketEngine();
+
+        engine.Execute("""
+            var ws = new WebSocket('wss://example.org/');
+            ws.onopen = () => log.push('open');
+            ws.onerror = e => log.push('error:' + e.type);
+            ws.onclose = e => log.push(['close', e.code, e.wasClean].join(','));
+            ws.close();
+            log.push('closing:' + ws.readyState);
+            """);
+
+        sockets.Last.Aborts.Should().Be(1);
+
+        PumpUntilLogged(engine, 3);
+
+        // The ready state is CLOSING inside close() itself; the failure it started reaches the script only on
+        // a later turn, and never as an open event.
+        Log(engine).Should().Be("closing:2|error:error|close,1006,false");
+        engine.Evaluate("ws.readyState").AsNumber().Should().Be(3);
+    }
+
+    /// <summary>
+    /// The same close, one turn later: the handshake had already finished, so an <c>open</c> event was
+    /// queued — and must not be dispatched into a socket the script has since closed.
+    /// </summary>
+    [Fact]
+    public void AnOpenThatWasAlreadyQueuedIsSuppressedByAClose()
+    {
+        var (engine, sockets) = SocketEngine();
+
+        engine.Execute("""
+            var ws = new WebSocket('wss://example.org/');
+            ws.onopen = () => log.push('open');
+            ws.onerror = () => log.push('error');
+            ws.onclose = e => log.push('close:' + e.code);
+            """);
+
+        // The handshake finishes, which queues the open event; the script then closes the socket before the
+        // engine turns over at all.
+        sockets.Last.Handshake.SetResult();
+        engine.Execute("ws.close();");
+
+        PumpUntilLogged(engine, 2);
+
+        Log(engine).Should().Be("error|close:1006");
+        engine.Evaluate("ws.readyState").AsNumber().Should().Be(3);
+    }
+
+    /// <summary>
+    /// A handshake that never succeeds ends in the same pair, which is what
+    /// https://websockets.spec.whatwg.org/#feedback-from-the-protocol requires: no failure may be told from
+    /// another.
+    /// </summary>
+    [Fact]
+    public void AFailedHandshakeFiresErrorThenClose()
+    {
+        var (engine, sockets) = SocketEngine();
+
+        engine.Execute("""
+            var ws = new WebSocket('wss://example.org/');
+            ws.onopen = () => log.push('open');
+            ws.onerror = () => log.push('error');
+            ws.onclose = e => log.push(['close', e.code, e.reason, e.wasClean].join(','));
+            """);
+
+        sockets.Last.Handshake.SetException(new IOException("connection refused"));
+        PumpUntilLogged(engine, 2);
+
+        Log(engine).Should().Be("error|close,1006,,false");
+    }
+
+    [Fact]
+    public void ADroppedConnectionFiresErrorThenClose()
+    {
+        var (engine, sockets) = OpenSocket("""
+            ws.onerror = () => log.push('error');
+            ws.onclose = e => log.push(['close', e.code, e.wasClean].join(','));
+            """);
+
+        sockets.Last.Fail(new IOException("the connection was reset"));
+        PumpUntilLogged(engine, 3);
+
+        Log(engine).Should().Be("open:1:|error|close,1006,false");
+    }
+
+    /// <summary>
+    /// A message larger than <c>Options.WebApi.Fetch.MaxResponseBytes</c> is the host's own limit rather than
+    /// the network's, so unlike every other failure it names itself with RFC 6455's 1009.
+    /// </summary>
+    [Fact]
+    public void AMessageOverTheCeilingClosesWith1009()
+    {
+        var (engine, sockets) = OpenSocket("""
+            ws.onerror = () => log.push('error');
+            ws.onclose = e => log.push(['close', e.code, e.wasClean].join(','));
+            """);
+
+        sockets.Last.MaxMessageBytes.Should().Be(32 * 1024 * 1024, "the ceiling is the network group's own");
+        sockets.Last.Fail(new WebSocketMessageTooLargeException("too large"));
+        PumpUntilLogged(engine, 3);
+
+        Log(engine).Should().Be("open:1:|error|close,1009,false");
+        sockets.Last.Aborts.Should().Be(1);
+    }
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#dom-websocket-close steps 1 and 2.
+    /// </summary>
+    [Theory]
+    [InlineData("999", "InvalidAccessError")]
+    [InlineData("1001", "InvalidAccessError")]
+    [InlineData("2999", "InvalidAccessError")]
+    [InlineData("5000", "InvalidAccessError")]
+    [InlineData("-1", "InvalidAccessError")]
+    [InlineData("NaN", "InvalidAccessError")]
+    [InlineData("1e10", "InvalidAccessError")]
+    public void CloseRefusesACodeTheProtocolReserves(string code, string expected)
+    {
+        var (engine, sockets) = OpenSocket();
+
+        var thrown = Assert.Throws<JavaScriptException>(() => engine.Execute($"ws.close({code});"));
+        thrown.Error.Get("name").AsString().Should().Be(expected);
+
+        engine.Evaluate("ws.readyState").AsNumber().Should().Be(1, "a refused close leaves the socket open");
+        sockets.Last.CloseFrames.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("1000")]
+    [InlineData("3000")]
+    [InlineData("4999")]
+    public void CloseAcceptsTheCodesAnApplicationMaySend(string code)
+    {
+        var (engine, sockets) = OpenSocket();
+
+        engine.Execute($"ws.close({code});");
+        sockets.Last.WaitForWrites(1);
+
+        sockets.Last.CloseFrames.Should().Equal((int.Parse(code, System.Globalization.CultureInfo.InvariantCulture), string.Empty));
+    }
+
+    [Fact]
+    public void CloseRefusesAReasonLongerThan123Utf8Bytes()
+    {
+        var (engine, _) = OpenSocket();
+
+        engine.Execute("ws.close(1000, 'x'.repeat(123));");
+
+        var (second, _) = OpenSocket();
+        var thrown = Assert.Throws<JavaScriptException>(() => second.Execute("ws.close(1000, 'x'.repeat(124));"));
+        thrown.Error.Get("name").AsString().Should().Be("SyntaxError");
+
+        // Bytes, not characters: 62 two-byte characters are 124 bytes.
+        var (third, _) = OpenSocket();
+        Assert.Throws<JavaScriptException>(() => third.Execute("ws.close(1000, 'é'.repeat(62));"))
+            .Error.Get("name").AsString().Should().Be("SyntaxError");
+    }
+
+    /// <summary>
+    /// Both arguments are converted before either is validated, which is the order
+    /// https://webidl.spec.whatwg.org/#js-operations puts them in.
+    /// </summary>
+    [Fact]
+    public void CloseConvertsBothArgumentsBeforeValidatingEither()
+    {
+        var (engine, _) = OpenSocket();
+
+        Assert.Throws<JavaScriptException>(() => engine.Execute("""
+            ws.close(999, { toString() { log.push('reason converted'); return 'r'; } });
+            """));
+
+        Log(engine).Should().Be("open:1:|reason converted");
+    }
+
+    [Fact]
+    public void CloseIsIdempotentAndSendsOneFrame()
+    {
+        var (engine, sockets) = OpenSocket();
+
+        engine.Execute("ws.close(1000, 'first'); ws.close(3000, 'second');");
+        sockets.Last.WaitForWrites(1);
+
+        sockets.Last.CloseFrames.Should().Equal((1000, "first"));
+    }
+
+    /// <summary>
+    /// A reason with no code has nowhere to live in the protocol's Close frame, so it travels behind a normal
+    /// closure rather than being dropped.
+    /// </summary>
+    [Fact]
+    public void AReasonWithNoCodeTravelsAsANormalClosure()
+    {
+        var (engine, sockets) = OpenSocket();
+
+        engine.Execute("ws.close(undefined, 'bye');");
+        sockets.Last.WaitForWrites(1);
+
+        sockets.Last.CloseFrames.Should().Equal((1000, "bye"));
+    }
+
+    /// <summary>
+    /// The policy refuses the URL, and the script cannot tell that from a refused connection — which
+    /// https://websockets.spec.whatwg.org/#feedback-from-the-protocol requires.
+    /// </summary>
+    [Fact]
+    public void APolicyDenialLooksExactlyLikeARefusedConnection()
+    {
+        var (engine, sockets) = SocketEngine(net => net.UrlFilter = _ => false);
+
+        engine.Execute("""
+            var ws = new WebSocket('wss://example.org/');
+            log.push('state:' + ws.readyState);
+            ws.onerror = () => log.push('error');
+            ws.onclose = e => log.push(['close', e.code, e.wasClean].join(','));
+            """);
+
+        sockets.Created.Should().BeEmpty("nothing is opened at all");
+
+        PumpUntilLogged(engine, 3);
+
+        // The constructor does not throw and the socket is born CONNECTING; only a later turn tells the
+        // script anything, and what it tells it is what a refused connection would have.
+        Log(engine).Should().Be("state:0|error|close,1006,false");
+    }
+
+    /// <summary>
+    /// The scheme list is written in fetch's terms, and read in the socket's: <c>http</c> admits <c>ws</c> and
+    /// <c>https</c> admits <c>wss</c>.
+    /// </summary>
+    [Theory]
+    [InlineData("ws://example.org/", "https", false)]
+    [InlineData("ws://example.org/", "http", true)]
+    [InlineData("ws://example.org/", "ws", true)]
+    [InlineData("wss://example.org/", "http", false)]
+    [InlineData("wss://example.org/", "https", true)]
+    [InlineData("wss://example.org/", "wss", true)]
+    public void TheSchemeListIsTranslatedIntoTheSocketsOwnSchemes(string url, string allowed, bool opens)
+    {
+        var (engine, sockets) = SocketEngine(net =>
+        {
+            net.AllowedSchemes.Clear();
+            net.AllowedSchemes.Add(allowed);
+        });
+
+        engine.Execute($"var ws = new WebSocket('{url}');");
+
+        sockets.Created.Should().HaveCount(opens ? 1 : 0);
+    }
+
+    [Fact]
+    public void TheFilterIsShownTheWebSocketUrl()
+    {
+        var seen = new List<Uri>();
+        var (engine, _) = SocketEngine(net => net.UrlFilter = uri =>
+        {
+            seen.Add(uri);
+            return true;
+        });
+
+        engine.Execute("new WebSocket('https://example.org/chat?x=1');");
+
+        seen.Should().Equal(new Uri("wss://example.org/chat?x=1"));
+    }
+
+    /// <summary>
+    /// <c>Options.WebApi.Fetch.MaxConcurrentRequests</c> bounds sockets too — separately from the requests in
+    /// flight, since a socket is meant to be long-lived.
+    /// </summary>
+    [Fact]
+    public void TooManyOpenSocketsIsAQuotaExceededError()
+    {
+        var (engine, sockets) = SocketEngine(net => net.MaxConcurrentRequests = 2);
+
+        engine.Execute("var a = new WebSocket('wss://example.org/1'); var b = new WebSocket('wss://example.org/2');");
+
+        var thrown = Assert.Throws<JavaScriptException>(() => engine.Execute("new WebSocket('wss://example.org/3');"));
+        thrown.Error.Get("name").AsString().Should().Be("QuotaExceededError");
+
+        // A closed socket frees its slot.
+        sockets.Created[0].Handshake.SetResult();
+        sockets.Created[1].Handshake.SetResult();
+        Pump(engine, () => engine.Evaluate("a.readyState").AsNumber() == 1);
+
+        engine.Execute("a.close();");
+        sockets.Created[0].WaitForWrites(1);
+        sockets.Created[0].Deliver(WebSocketReceipt.Closed(1000, string.Empty));
+        Pump(engine, () => engine.Evaluate("a.readyState").AsNumber() == 3);
+
+        engine.Execute("new WebSocket('wss://example.org/4');");
+        sockets.Created.Should().HaveCount(3);
+    }
+
+    /// <summary>
+    /// A restore ends the evaluation cycle, so the socket is dropped rather than left delivering into globals
+    /// that no longer exist.
+    /// </summary>
+    [Fact]
+    public void ARestoreAbortsTheSocketAndDeliversNothingIntoTheRestoredEngine()
+    {
+        var (engine, sockets) = SocketEngine();
+        var delivered = false;
+        engine.SetValue("mark", new Action(() => delivered = true));
+
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+
+        engine.Execute("""
+            var ws = new WebSocket('wss://example.org/');
+            ws.onopen = mark;
+            ws.onclose = mark;
+            ws.onerror = mark;
+            """);
+
+        var socket = sockets.Last;
+        socket.Handshake.SetResult();
+
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        socket.Aborts.Should().Be(1, "the connection is dropped, not merely forgotten");
+
+        socket.Deliver(WebSocketReceipt.Message(isText: true, "ignored"u8.ToArray()));
+        for (var i = 0; i < 10; i++)
+        {
+            engine.Advanced.ProcessTasks();
+        }
+
+        delivered.Should().BeFalse();
+        engine.Evaluate("typeof ws").AsString().Should().Be("undefined", "the binding belonged to the cycle that ended");
+    }
+
+    [Fact]
+    public void TheReadyStateConstantsAreOnBothTheInterfaceObjectAndThePrototype()
+    {
+        var engine = new Engine(options => options.UseWebSocket());
+
+        engine.Evaluate("[WebSocket.CONNECTING, WebSocket.OPEN, WebSocket.CLOSING, WebSocket.CLOSED].join(',')")
+            .AsString().Should().Be("0,1,2,3");
+        engine.Evaluate("[WebSocket.prototype.CONNECTING, WebSocket.prototype.OPEN, WebSocket.prototype.CLOSING, WebSocket.prototype.CLOSED].join(',')")
+            .AsString().Should().Be("0,1,2,3");
+
+        // https://webidl.spec.whatwg.org/#es-constants — { writable: false, enumerable: true, configurable: false }
+        var descriptor = engine.Evaluate("Object.getOwnPropertyDescriptor(WebSocket, 'OPEN')");
+        descriptor.Get("writable").AsBoolean().Should().BeFalse();
+        descriptor.Get("enumerable").AsBoolean().Should().BeTrue();
+        descriptor.Get("configurable").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void TheInterfaceInheritsFromEventTarget()
+    {
+        var (engine, _) = OpenSocket();
+
+        engine.Evaluate("Object.getPrototypeOf(WebSocket) === EventTarget").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.getPrototypeOf(WebSocket.prototype) === EventTarget.prototype").AsBoolean().Should().BeTrue();
+        engine.Evaluate("ws instanceof EventTarget").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.prototype.toString.call(ws)").AsString().Should().Be("[object WebSocket]");
+        engine.Evaluate("Object.getOwnPropertyNames(ws).length").AsNumber().Should().Be(0, "every attribute is an accessor on the prototype");
+    }
+
+    /// <summary>
+    /// The attributes brand-check their receiver, so the prototype itself answers none of them.
+    /// </summary>
+    [Fact]
+    public void ThePrototypeIsNotASocket()
+    {
+        var engine = new Engine(options => options.UseWebSocket());
+
+        foreach (var member in new[] { "url", "readyState", "bufferedAmount", "protocol", "extensions", "binaryType" })
+        {
+            Assert.Throws<JavaScriptException>(() => engine.Evaluate($"WebSocket.prototype.{member}"))
+                .Error.Get("name").AsString().Should().Be("TypeError");
+        }
+    }
+
+    /// <summary>
+    /// An <c>addEventListener</c> registration and the handler attribute are the same list, in registration
+    /// order — https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes.
+    /// </summary>
+    [Fact]
+    public void ListenersAndHandlerAttributesShareOneList()
+    {
+        var (engine, sockets) = SocketEngine();
+
+        engine.Execute("""
+            var ws = new WebSocket('wss://example.org/');
+            ws.addEventListener('open', () => log.push('listener'));
+            ws.onopen = () => log.push('handler');
+            ws.addEventListener('open', () => log.push('second listener'));
+            """);
+
+        engine.Evaluate("typeof ws.onopen").AsString().Should().Be("function");
+
+        sockets.Last.Handshake.SetResult();
+        PumpUntilLogged(engine, 3);
+
+        Log(engine).Should().Be("listener|handler|second listener");
+    }
+
+    [Fact]
+    public void AHandlerAttributeCanBeClearedAndReassigned()
+    {
+        var (engine, sockets) = SocketEngine();
+
+        engine.Execute("""
+            var ws = new WebSocket('wss://example.org/');
+            ws.onopen = () => log.push('first');
+            ws.onopen = null;
+            ws.onopen = () => log.push('second');
+            """);
+
+        sockets.Last.Handshake.SetResult();
+        PumpUntilLogged(engine, 1);
+
+        Log(engine).Should().Be("second");
+        engine.Execute("ws.onopen = null;");
+        engine.Evaluate("ws.onopen").IsNull().Should().BeTrue();
+    }
+}
+#endif

--- a/Jint/Engine.WebApi.cs
+++ b/Jint/Engine.WebApi.cs
@@ -6,6 +6,7 @@ using Jint.WebApi.Fetch;
 using Jint.WebApi.Scheduling;
 using Jint.WebApi.ServerSentEvents;
 using Jint.WebApi.Timers;
+using Jint.WebApi.WebSockets;
 
 namespace Jint;
 
@@ -95,6 +96,13 @@ internal sealed class WebApiEngineState
     /// </summary>
     private List<FetchBodyStream>? _fetchBodies;
 
+    /// <summary>
+    /// The sockets this engine has open, in the order they were created. Engine-thread-only for the same
+    /// reason the fetch list is: a socket is added by the <c>WebSocket</c> constructor and removed by its own
+    /// close job, both of which run on the engine's thread.
+    /// </summary>
+    private List<JsWebSocket>? _webSockets;
+
     internal WebApiEngineState(Engine engine, TimeProvider timeProvider, TimerQueue? timers, Options.FetchOptions? fetchOptions, SchedulerQueue? scheduler, DiagnosticsSink? diagnostics, Options.StorageOptions? storage = null)
     {
         _engine = engine;
@@ -178,6 +186,29 @@ internal sealed class WebApiEngineState
         => (_eventSources ??= new List<EventSourceConnection>()).Add(connection);
 
     internal void UnregisterEventSource(EventSourceConnection connection) => _eventSources?.Remove(connection);
+
+    /// <summary>
+    /// How many sockets are open, which is what <c>Options.FetchOptions.MaxConcurrentRequests</c> bounds for
+    /// this feature. Counted separately from the requests in flight: a socket is a long-lived thing and a
+    /// fetch is not, so one kind must not exhaust the other's budget.
+    /// </summary>
+    internal int ActiveWebSocketCount => _webSockets?.Count ?? 0;
+
+    /// <summary>
+    /// Where a <c>WebSocket</c>'s transport comes from, or <see langword="null"/> for the in-box
+    /// <c>ClientWebSocket</c> one.
+    /// </summary>
+    /// <remarks>
+    /// The seam the test suite replaces so that the whole state machine — handshake, messages,
+    /// <c>bufferedAmount</c>, the closing handshake, every event — can be driven with no network anywhere. It
+    /// is deliberately not a host-facing option: a transport a host supplied would want headers, proxies,
+    /// certificates and a keep-alive policy with it, which is a larger design than this field.
+    /// </remarks>
+    internal IWebSocketConnectionFactory? WebSocketConnections { get; set; }
+
+    internal void RegisterWebSocket(JsWebSocket socket) => (_webSockets ??= new List<JsWebSocket>()).Add(socket);
+
+    internal void UnregisterWebSocket(JsWebSocket socket) => _webSockets?.Remove(socket);
 
     /// <summary>
     /// <c>performance.timeOrigin</c>: the moment this state was created, as milliseconds since the Unix
@@ -269,8 +300,10 @@ internal sealed class WebApiEngineState
     /// <c>ReadableStream</c>. Its controller is <b>errored</b>, which is the honest answer to a host still
     /// holding the response — a stream that reports failure beats one that silently never produces another
     /// byte — and the reactions that erroring schedules carry the ending cycle's generation, so the fence
-    /// discards them exactly as it discards a chunk still on its way. The sink is deliberately not reset: it
-    /// is configuration the engine was built with, like the time origin beside it, and a pooled engine
+    /// discards them exactly as it discards a chunk still on its way. A <c>WebSocket</c> is abandoned the
+    /// same way and for the same reason, and fires no further event: its connection is dropped, and its
+    /// <c>close</c> event belongs to a cycle that has ended. The sink is deliberately not reset: it is
+    /// configuration the engine was built with, like the time origin beside it, and a pooled engine
     /// reporting the next cycle's errors nowhere would be a strange thing for a restore to arrange.
     /// </remarks>
     internal void ResetTransientState()
@@ -280,6 +313,7 @@ internal sealed class WebApiEngineState
         AbandonFetches();
         AbandonFetchBodies();
         AbandonEventSources();
+        AbandonWebSockets();
     }
 
     private void AbandonFetches()
@@ -289,14 +323,30 @@ internal sealed class WebApiEngineState
             return;
         }
 
-        // Copied before the walk: Abandon cancels a token source, and a synchronous continuation on this very
-        // thread would otherwise reach UnregisterFetch and mutate the list under the enumerator.
+        // Copied before the walk: Abandon cancels a token source, and a synchronous continuation on this
+        // very thread would otherwise reach UnregisterFetch and mutate the list under the enumerator.
         var pending = fetches.ToArray();
         fetches.Clear();
 
         foreach (var fetch in pending)
         {
             fetch.Abandon();
+        }
+    }
+
+    private void AbandonWebSockets()
+    {
+        if (_webSockets is not { Count: > 0 } sockets)
+        {
+            return;
+        }
+
+        var open = sockets.ToArray();
+        sockets.Clear();
+
+        foreach (var socket in open)
+        {
+            socket.Operation?.Abandon();
         }
     }
 

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -154,6 +154,19 @@ public partial class Options
     /// what <see cref="UrlFilter"/> is for, and a deployment exposed to untrusted script wants one.
     /// </para>
     /// <para>
+    /// <b><see cref="WebApiFeatures.WebSocket"/> reads this group too</b>, because a socket is outbound
+    /// access to the same hosts from the same process. <see cref="AllowedSchemes"/> admits <c>ws</c> wherever
+    /// it admits <c>http</c> and <c>wss</c> wherever it admits <c>https</c> (naming <c>ws</c> or <c>wss</c>
+    /// outright works too); <see cref="UrlFilter"/> is shown the <c>ws:</c> URL itself;
+    /// <see cref="MaxResponseBytes"/> is the ceiling on one incoming message and on the bytes <c>send()</c>
+    /// may have unwritten; <see cref="MaxConcurrentRequests"/> is how many sockets one engine may have open,
+    /// counted separately from the requests in flight; and <see cref="Timeout"/> bounds the opening and
+    /// closing handshakes rather than the connection, which is meant to be long-lived. The other three
+    /// members are about HTTP alone and a socket ignores them: <see cref="HttpClient"/>,
+    /// <see cref="HttpClientFactory"/> and <see cref="MaxRedirects"/> — the WebSocket handshake is not
+    /// allowed to be redirected at all.
+    /// </para>
+    /// <para>
     /// Like every other option group this may be shared by any number of engines, including concurrent ones:
     /// nothing on it is engine-affine. Two members carry a thread-safety obligation, because they are called
     /// from whichever thread the HTTP stack happens to be on — see <see cref="UrlFilter"/> and
@@ -622,6 +635,27 @@ public enum WebApiFeatures
     /// </list>
     /// </remarks>
     EventSource = 1 << 17,
+
+    /// <summary>
+    /// <c>WebSocket</c>, and the <c>CloseEvent</c> and <c>MessageEvent</c> interfaces its events are —
+    /// a long-lived two-way connection from script.
+    /// <b>Never part of <see cref="Default"/>:</b> like <see cref="Fetch"/> this is outbound network access,
+    /// so it is only ever set by naming it or by calling <c>options.UseWebSocket()</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Implies <see cref="Events"/> — a <c>WebSocket</c> <i>is</i> an <c>EventTarget</c> — and
+    /// <see cref="Files"/>, because <c>binaryType = "blob"</c> answers a binary message with a <c>Blob</c>.
+    /// </para>
+    /// <para>
+    /// The policy is <see cref="Options.FetchOptions"/>, the same group <see cref="Fetch"/> reads: a socket
+    /// reaches the same hosts from the same process. Read it before enabling this — in particular
+    /// <see cref="Options.FetchOptions.UrlFilter"/>, which is shown the <c>ws:</c> or <c>wss:</c> URL, and
+    /// <see cref="Options.FetchOptions.AllowedSchemes"/>, where <c>http</c> admits <c>ws</c> and
+    /// <c>https</c> admits <c>wss</c>.
+    /// </para>
+    /// </remarks>
+    WebSocket = 1 << 18,
 
     /// <summary>
     /// <c>CompressionStream</c> and <c>DecompressionStream</c> — https://compression.spec.whatwg.org/ — for

--- a/Jint/Runtime/Intrinsics.WebApi.cs
+++ b/Jint/Runtime/Intrinsics.WebApi.cs
@@ -20,6 +20,7 @@ using Jint.WebApi.Storage;
 using Jint.WebApi.Streams;
 using Jint.WebApi.Timers;
 using Jint.WebApi.Url;
+using Jint.WebApi.WebSockets;
 
 namespace Jint.Runtime;
 
@@ -136,6 +137,17 @@ public sealed partial class Intrinsics
     internal EventSourceConstructor EventSource =>
         _eventSource ??= new EventSourceConstructor(_engine, _realm, EventTarget);
 
+
+    private WebSocketConstructor? _webSocket;
+    private CloseEventConstructor? _closeEvent;
+
+    /// <summary><c>CloseEvent</c> inherits from <c>Event</c>.</summary>
+    internal CloseEventConstructor CloseEvent =>
+        _closeEvent ??= new CloseEventConstructor(_engine, _realm, Event);
+
+    /// <summary><c>WebSocket</c> inherits from <c>EventTarget</c>.</summary>
+    internal WebSocketConstructor WebSocket =>
+        _webSocket ??= new WebSocketConstructor(_engine, _realm, EventTarget);
     private HeadersConstructor? _headers;
     private RequestConstructor? _request;
     private ResponseConstructor? _response;

--- a/Jint/WebApi/WebApiOptionsExtensions.cs
+++ b/Jint/WebApi/WebApiOptionsExtensions.cs
@@ -178,6 +178,49 @@ public static class WebApiOptionsExtensions
     }
 
     /// <summary>
+    /// Enables <c>WebSocket</c>, together with the <c>CloseEvent</c> and <c>MessageEvent</c> interfaces its
+    /// events are — and with <see cref="WebApiFeatures.Events"/> and <see cref="WebApiFeatures.Files"/>,
+    /// which its own surface is built out of.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>This grants a script outbound network access</b>, and <see cref="UseWebApis(Options)"/> deliberately
+    /// never does. A socket answers to the same policy a fetch does — the <see cref="Options.FetchOptions"/>
+    /// group, which <paramref name="configure"/> hands over — with the scheme list read in its WebSocket
+    /// sense: <c>http</c> admits <c>ws</c> and <c>https</c> admits <c>wss</c>. The
+    /// <see cref="Options.FetchOptions.UrlFilter"/> is shown the <c>ws:</c> URL, so a filter that tests the
+    /// scheme needs to know about both.
+    /// </para>
+    /// <para>
+    /// Enabling this does <b>not</b> enable <c>fetch</c>, and enabling <c>fetch</c> does not enable this:
+    /// they share their settings, not their permission.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// var engine = new Engine(options => options.UseWebApis().UseWebSocket(net =>
+    /// {
+    ///     net.AllowedSchemes.Remove("http");                   // wss only
+    ///     net.UrlFilter = uri => uri.Host.EndsWith(".example.org", StringComparison.OrdinalIgnoreCase);
+    /// }));
+    /// </code>
+    /// </example>
+    /// <param name="options">Options to modify.</param>
+    /// <param name="configure">Optional configuration of the network settings, run after the feature is enabled.</param>
+    /// <returns>Options instance for fluent syntax.</returns>
+    public static Options UseWebSocket(this Options options, Action<Options.FetchOptions>? configure = null)
+    {
+        if (options is null)
+        {
+            Throw.ArgumentNullException(nameof(options));
+        }
+
+        options.WebApi.Features |= WebApiFeatures.WebSocket;
+        configure?.Invoke(options.WebApi.Fetch);
+        return options;
+    }
+
+    /// <summary>
     /// Enables the <c>console</c> object and sends its output to <paramref name="sink"/>.
     /// </summary>
     /// <param name="options">Options to modify.</param>

--- a/Jint/WebApi/WebApiRegistration.cs
+++ b/Jint/WebApi/WebApiRegistration.cs
@@ -231,6 +231,16 @@ internal static class WebApiRegistration
             Install(global, engine, "CompressionStream", static e => e.Realm.Intrinsics.CompressionStream, PropertyFlag.NonEnumerable);
             Install(global, engine, "DecompressionStream", static e => e.Realm.Intrinsics.DecompressionStream, PropertyFlag.NonEnumerable);
         }
+
+        if ((features & WebApiFeatures.WebSocket) != WebApiFeatures.None)
+        {
+            Install(global, engine, "WebSocket", static e => e.Realm.Intrinsics.WebSocket, PropertyFlag.NonEnumerable);
+            Install(global, engine, "CloseEvent", static e => e.Realm.Intrinsics.CloseEvent, PropertyFlag.NonEnumerable);
+
+            // MessageEvent is the HTML Standard's; the messaging and event-source features install the same
+            // intrinsic, and Install is non-clobbering, so an engine with any combination gets one object.
+            Install(global, engine, "MessageEvent", static e => e.Realm.Intrinsics.MessageEvent, PropertyFlag.NonEnumerable);
+        }
     }
 
     /// <summary>
@@ -272,6 +282,8 @@ internal static class WebApiRegistration
     /// so installing fetch without them would ship an interface that throws on its own members. An
     /// <c>EventSource</c> is an <c>EventTarget</c> for the same kind of reason, and the reconnect delay it
     /// schedules rides the queue that flag creates.
+    /// A <c>WebSocket</c> <i>is</i> an <c>EventTarget</c> too, and answers a binary message with a
+    /// <c>Blob</c> whenever <c>binaryType</c> says so — the same argument for the same two features.
     /// </para>
     /// </remarks>
     private static WebApiFeatures ExpandFeatures(WebApiFeatures features)
@@ -288,6 +300,11 @@ internal static class WebApiRegistration
         if ((features & WebApiFeatures.EventSource) != WebApiFeatures.None)
         {
             features |= WebApiFeatures.Events;
+        }
+
+        if ((features & WebApiFeatures.WebSocket) != WebApiFeatures.None)
+        {
+            features |= WebApiFeatures.Events | WebApiFeatures.Files;
         }
 
         return features;
@@ -312,7 +329,7 @@ internal static class WebApiRegistration
         // in-flight set here, the scheduler keeps its own task queues here, and storage keeps its providers
         // here, which is why each of them wants the state even without the timers flag.
         const WebApiFeatures NeedsEngineState =
-            WebApiFeatures.Timers | WebApiFeatures.Events | WebApiFeatures.Performance | WebApiFeatures.Fetch | WebApiFeatures.Scheduler | WebApiFeatures.Messaging | WebApiFeatures.Storage;
+            WebApiFeatures.Timers | WebApiFeatures.Events | WebApiFeatures.Performance | WebApiFeatures.Fetch | WebApiFeatures.Scheduler | WebApiFeatures.Messaging | WebApiFeatures.Storage | WebApiFeatures.WebSocket;
 
         // The diagnostics sink is the one thing here no feature flag governs: a host that set one gets the
         // channel whatever else it did or did not ask for, which is why it is read before the flags are.
@@ -339,7 +356,7 @@ internal static class WebApiRegistration
         // Options — and so that a host mutating them afterwards does not change an engine that already exists.
         // EventSource reads the same group: it is a second grant of network access over the same transport
         // and the same policy, so either flag is reason enough to keep them.
-        const WebApiFeatures NeedsFetchOptions = WebApiFeatures.Fetch | WebApiFeatures.EventSource;
+        const WebApiFeatures NeedsFetchOptions = WebApiFeatures.Fetch | WebApiFeatures.EventSource | WebApiFeatures.WebSocket;
         var fetch = (features & NeedsFetchOptions) != WebApiFeatures.None ? options.WebApi.Fetch : null;
 
         var scheduler = (features & WebApiFeatures.Scheduler) != WebApiFeatures.None

--- a/Jint/WebApi/WebSockets/ClientWebSocketConnection.cs
+++ b/Jint/WebApi/WebSockets/ClientWebSocketConnection.cs
@@ -1,0 +1,167 @@
+#if NET8_0_OR_GREATER
+using System.Buffers;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jint.WebApi.WebSockets;
+
+/// <summary>
+/// The in-box transport: one <see cref="ClientWebSocket"/> per <c>WebSocket</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two things the WHATWG handshake asks for are deliberately not offered here, and both show up in the
+/// interface's own attributes. <b>No <c>permessage-deflate</c></b> — the standard has the user agent offer a
+/// compression extension, and .NET only enables one when a host configures it; not offering it means
+/// <c>extensions</c> is always the empty string, which is the honest answer rather than a guess, and a
+/// decompression bomb cannot be built out of a message the size cap measures after inflation. And <b>no
+/// cookies and no credentials</b>: there is no cookie jar in an embedded engine, and the standard's
+/// <c>credentials: "include"</c> would mean sending some other component's.
+/// </para>
+/// <para>
+/// Redirects are not followed, which is what the standard asks for too — "redirect mode is error" — so unlike
+/// <c>fetch</c> there is no per-hop policy re-check to perform: the one URL the host's filter admitted is the
+/// only one a socket ever reaches.
+/// </para>
+/// </remarks>
+internal sealed class ClientWebSocketConnection : IWebSocketConnection
+{
+    /// <summary>
+    /// The read buffer one receive rents. A whole message is reassembled from as many of these as it takes;
+    /// the number only decides how many awaits a large message costs.
+    /// </summary>
+    private const int ReceiveChunkSize = 16 * 1024;
+
+    private readonly ClientWebSocket _socket = new();
+    private readonly Uri _url;
+    private readonly long _maxMessageBytes;
+
+    internal ClientWebSocketConnection(Uri url, IReadOnlyList<string> protocols, long maxMessageBytes)
+    {
+        _url = url;
+        _maxMessageBytes = maxMessageBytes;
+
+        for (var i = 0; i < protocols.Count; i++)
+        {
+            // Already validated against the token grammar by the constructor, which is what keeps this from
+            // being the place a bad subprotocol is discovered.
+            _socket.Options.AddSubProtocol(protocols[i]);
+        }
+
+        _socket.Options.UseDefaultCredentials = false;
+        _socket.Options.Cookies = null;
+    }
+
+    public string SubProtocol => _socket.SubProtocol ?? string.Empty;
+
+    public Task ConnectAsync(CancellationToken cancellationToken) => _socket.ConnectAsync(_url, cancellationToken);
+
+    public Task SendAsync(ReadOnlyMemory<byte> payload, bool isText, CancellationToken cancellationToken)
+    {
+        var type = isText ? WebSocketMessageType.Text : WebSocketMessageType.Binary;
+        return _socket.SendAsync(payload, type, endOfMessage: true, cancellationToken).AsTask();
+    }
+
+    public async Task<WebSocketReceipt> ReceiveAsync(CancellationToken cancellationToken)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(ReceiveChunkSize);
+        ArrayBufferWriter<byte>? pending = null;
+        var isText = false;
+
+        try
+        {
+            while (true)
+            {
+                var result = await _socket.ReceiveAsync(buffer.AsMemory(), cancellationToken).ConfigureAwait(false);
+
+                if (result.MessageType == WebSocketMessageType.Close)
+                {
+                    // A Close frame with no body leaves CloseStatus at Empty, which is 1005 — the code the
+                    // standard has the close event report for "no status code was actually present".
+                    var code = (int?) _socket.CloseStatus ?? WebSocketReceipt.NoStatusReceived;
+                    return WebSocketReceipt.Closed(code, _socket.CloseStatusDescription ?? string.Empty);
+                }
+
+                if (pending is null)
+                {
+                    // The first frame of the message decides whether the whole of it is text.
+                    isText = result.MessageType == WebSocketMessageType.Text;
+
+                    if (result.EndOfMessage)
+                    {
+                        // The common case: one frame, one message, one copy and no writer at all.
+                        Guard(result.Count);
+                        return WebSocketReceipt.Message(isText, buffer.AsSpan(0, result.Count).ToArray());
+                    }
+
+                    pending = new ArrayBufferWriter<byte>(result.Count == 0 ? ReceiveChunkSize : result.Count * 2);
+                }
+
+                Guard(pending.WrittenCount + (long) result.Count);
+                pending.Write(buffer.AsSpan(0, result.Count));
+
+                if (result.EndOfMessage)
+                {
+                    return WebSocketReceipt.Message(isText, pending.WrittenSpan.ToArray());
+                }
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    public Task CloseOutputAsync(int? code, string reason, CancellationToken cancellationToken)
+    {
+        // WebSocketCloseStatus.Empty is 1005, which the framework writes as a Close frame with no body at
+        // all; it refuses to carry a reason, which is exactly the protocol's own rule — a reason has nowhere
+        // to live without a status code in front of it.
+        if (code is not { } status)
+        {
+            return _socket.CloseOutputAsync(WebSocketCloseStatus.Empty, statusDescription: null, cancellationToken);
+        }
+
+        return _socket.CloseOutputAsync((WebSocketCloseStatus) status, reason, cancellationToken);
+    }
+
+    public void Abort()
+    {
+        try
+        {
+            _socket.Abort();
+        }
+        catch (ObjectDisposedException)
+        {
+            // Raced with the run's own disposal; the connection is gone either way.
+        }
+    }
+
+    public void Dispose() => _socket.Dispose();
+
+    private void Guard(long total)
+    {
+        if (total > _maxMessageBytes)
+        {
+            throw new WebSocketMessageTooLargeException(
+                $"The message exceeded the {_maxMessageBytes} byte limit set by Options.WebApi.Fetch.MaxResponseBytes.");
+        }
+    }
+}
+
+/// <summary>
+/// The factory behind every socket a host did not redirect elsewhere.
+/// </summary>
+internal sealed class ClientWebSocketConnectionFactory : IWebSocketConnectionFactory
+{
+    internal static readonly ClientWebSocketConnectionFactory Instance = new();
+
+    private ClientWebSocketConnectionFactory()
+    {
+    }
+
+    public IWebSocketConnection Create(Uri url, IReadOnlyList<string> protocols, long maxMessageBytes)
+        => new ClientWebSocketConnection(url, protocols, maxMessageBytes);
+}
+#endif

--- a/Jint/WebApi/WebSockets/CloseEventConstructor.cs
+++ b/Jint/WebApi/WebSockets/CloseEventConstructor.cs
@@ -1,0 +1,93 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.Events;
+using Jint.WebApi.Url;
+
+namespace Jint.WebApi.WebSockets;
+
+/// <summary>
+/// The <c>CloseEvent</c> interface object.
+/// <para>
+/// https://websockets.spec.whatwg.org/#the-closeevent-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// <c>CloseEvent</c> inherits from <c>Event</c>, so its <c>[[Prototype]]</c> is the <c>Event</c> interface
+/// object — https://webidl.spec.whatwg.org/#interface-object.
+/// </remarks>
+internal sealed class CloseEventConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("CloseEvent");
+    private static readonly JsString _code = new("code");
+    private static readonly JsString _reason = new("reason");
+    private static readonly JsString _wasClean = new("wasClean");
+
+    internal CloseEventConstructor(Engine engine, Realm realm, EventConstructor eventConstructor)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = eventConstructor;
+        PrototypeObject = new CloseEventPrototype(engine, realm, this, eventConstructor.PrototypeObject);
+        _length = new PropertyDescriptor(JsNumber.PositiveOne, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal CloseEventPrototype PrototypeObject { get; }
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#the-closeevent-interface — the ordinary event constructor over
+    /// <c>CloseEventInit</c>, whose members default to <c>false</c>, <c>0</c> and <c>""</c>.
+    /// </summary>
+    /// <remarks>
+    /// The inherited <c>EventInit</c> members are converted first and this dictionary's own in
+    /// lexicographical order — <c>code</c>, <c>reason</c>, <c>wasClean</c> — which is what
+    /// https://webidl.spec.whatwg.org/#es-dictionary asks for and is observable through getters on the
+    /// dictionary.
+    /// </remarks>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        var type = EventConstructor.RequireType(_realm, arguments, "CloseEvent");
+        var initArgument = arguments.At(1);
+
+        var init = EventConstructor.ReadEventInit(_realm, initArgument, "CloseEvent");
+        var dictionary = initArgument as ObjectInstance;
+
+        var code = 0;
+        if (Member(dictionary, _code) is { } codeValue)
+        {
+            code = WebSocketValues.ToUnsignedShort(codeValue);
+        }
+
+        var reason = Member(dictionary, _reason) is { } reasonValue ? UrlValues.ToUsvString(reasonValue) : string.Empty;
+        var wasClean = Member(dictionary, _wasClean) is { } cleanValue && TypeConverter.ToBoolean(cleanValue);
+
+        return OrdinaryCreateFromConstructor(
+            newTarget,
+            static intrinsics => intrinsics.CloseEvent.PrototypeObject,
+            static (Engine engine, Realm _, (JsString Type, EventInit Init, double TimeStamp, bool WasClean, int Code, string Reason) state)
+                => new JsCloseEvent(engine, state.Type, state.Init, state.TimeStamp, state.WasClean, state.Code, state.Reason),
+            (Type: type, Init: init, TimeStamp: EventConstructor.TimeStampNow(_engine), WasClean: wasClean, Code: code, Reason: reason));
+    }
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#concept-event-fire for the <c>close</c> event a connection's end produces:
+    /// created by the engine, so <c>isTrusted</c> is true.
+    /// </summary>
+    internal JsCloseEvent CreateTrustedClose(JsString type, int code, string reason, bool wasClean)
+    {
+        return new JsCloseEvent(_engine, type, default, EventConstructor.TimeStampNow(_engine), wasClean, code, reason)
+        {
+            IsTrusted = true,
+            _prototype = PrototypeObject,
+        };
+    }
+
+    private static JsValue? Member(ObjectInstance? dictionary, JsString name)
+    {
+        var value = dictionary?.Get(name);
+        return value is null || value.IsUndefined() ? null : value;
+    }
+}
+#endif

--- a/Jint/WebApi/WebSockets/CloseEventPrototype.cs
+++ b/Jint/WebApi/WebSockets/CloseEventPrototype.cs
@@ -1,0 +1,73 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.WebSockets;
+
+/// <summary>
+/// <c>CloseEvent.prototype</c> — the interface prototype object.
+/// <para>
+/// https://websockets.spec.whatwg.org/#the-closeevent-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// Its <c>[[Prototype]]</c> is <c>Event.prototype</c>, so a <c>close</c> event has every <c>Event</c> member
+/// and <c>event instanceof Event</c> holds inside the listener.
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class CloseEventPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly CloseEventConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString CloseEventToStringTag = new("CloseEvent");
+
+    internal CloseEventPrototype(
+        Engine engine,
+        Realm realm,
+        CloseEventConstructor constructor,
+        ObjectInstance eventPrototype) : base(engine, realm)
+    {
+        _prototype = eventPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#dom-closeevent-wasclean
+    /// </summary>
+    [JsAccessor("wasClean", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsBoolean WasCleanGet(JsValue thisObject) => JsBoolean.Create(Brand(thisObject).WasClean);
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#dom-closeevent-code
+    /// </summary>
+    [JsAccessor("code", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsNumber CodeGet(JsValue thisObject) => JsNumber.Create(Brand(thisObject).Code);
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#dom-closeevent-reason
+    /// </summary>
+    [JsAccessor("reason", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsString ReasonGet(JsValue thisObject) => JsString.Create(Brand(thisObject).Reason);
+
+    private JsCloseEvent Brand(JsValue thisObject)
+    {
+        if (thisObject is JsCloseEvent close)
+        {
+            return close;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a CloseEvent");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/WebSockets/JsCloseEvent.cs
+++ b/Jint/WebApi/WebSockets/JsCloseEvent.cs
@@ -1,0 +1,47 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.WebApi.Events;
+
+namespace Jint.WebApi.WebSockets;
+
+/// <summary>
+/// A <c>CloseEvent</c> instance: how a <c>WebSocket</c> connection ended.
+/// <para>
+/// https://websockets.spec.whatwg.org/#the-closeevent-interface
+/// </para>
+/// </summary>
+internal sealed class JsCloseEvent : JsEvent
+{
+    internal JsCloseEvent(
+        Engine engine,
+        JsString type,
+        EventInit init,
+        double timeStamp,
+        bool wasClean,
+        int code,
+        string reason)
+        : base(engine, type, init, timeStamp)
+    {
+        WasClean = wasClean;
+        Code = code;
+        Reason = reason;
+    }
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#dom-closeevent-wasclean — whether the connection closed after the
+    /// closing handshake completed, rather than being dropped.
+    /// </summary>
+    internal bool WasClean { get; }
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#dom-closeevent-code — the WebSocket connection close code, which
+    /// is 1006 for every abnormal closure and 1005 when the peer sent no code at all.
+    /// </summary>
+    internal int Code { get; }
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#dom-closeevent-reason — the close reason, UTF-8 decoded.
+    /// </summary>
+    internal string Reason { get; }
+}
+#endif

--- a/Jint/WebApi/WebSockets/JsWebSocket.cs
+++ b/Jint/WebApi/WebSockets/JsWebSocket.cs
@@ -1,0 +1,244 @@
+#if NET8_0_OR_GREATER
+using SystemEncoding = System.Text.Encoding;
+using Jint.Native;
+using Jint.Runtime;
+using Jint.WebApi.Events;
+using Jint.WebApi.Files;
+
+namespace Jint.WebApi.WebSockets;
+
+/// <summary>
+/// A <c>WebSocket</c> instance: the ready state, the attributes the standard exposes, and the four tasks the
+/// protocol feeds back into the event loop.
+/// <para>
+/// https://websockets.spec.whatwg.org/#the-websocket-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Every member here runs on the engine's thread.</b> The socket itself lives in
+/// <see cref="WebSocketOperation"/>, which touches nothing on this object directly — it queues the four
+/// <c>Report</c> methods below as event-loop jobs, so the ready state only ever moves while the engine is
+/// being pumped or inside a <c>close()</c> the script itself called.
+/// </para>
+/// <para>
+/// Two attributes are permanently what an embedded engine can honestly say. <c>extensions</c> is always the
+/// empty string, because the in-box transport offers no <c>permessage-deflate</c> — see
+/// <see cref="ClientWebSocketConnection"/>. And <c>binaryType</c> defaults to <c>"arraybuffer"</c> where the
+/// standard's default is <c>"blob"</c>: this is the one deliberate divergence in the interface, taken because
+/// a <c>Blob</c> is an inert byte holder here whose only consumers are asynchronous, so defaulting to it would
+/// make every binary message cost a promise round-trip to look at. Setting <c>binaryType = "blob"</c> works
+/// and produces real <c>Blob</c>s, which is why enabling this feature also enables <c>Files</c>.
+/// </para>
+/// </remarks>
+internal sealed class JsWebSocket : JsEventTarget
+{
+    /// <summary>https://websockets.spec.whatwg.org/#dom-websocket-connecting.</summary>
+    internal const int Connecting = 0;
+
+    /// <summary>https://websockets.spec.whatwg.org/#dom-websocket-open.</summary>
+    internal const int Open = 1;
+
+    /// <summary>https://websockets.spec.whatwg.org/#dom-websocket-closing.</summary>
+    internal const int Closing = 2;
+
+    /// <summary>https://websockets.spec.whatwg.org/#dom-websocket-closed.</summary>
+    internal const int Closed = 3;
+
+    /// <summary>The <c>BinaryType</c> enumeration, https://websockets.spec.whatwg.org/#binarytype.</summary>
+    internal const string BinaryTypeArrayBuffer = "arraybuffer";
+
+    /// <summary>The <c>BinaryType</c> enumeration, https://websockets.spec.whatwg.org/#binarytype.</summary>
+    internal const string BinaryTypeBlob = "blob";
+
+    internal const string OpenEventType = "open";
+    internal const string MessageEventType = "message";
+    internal const string ErrorEventType = "error";
+    internal const string CloseEventType = "close";
+
+    private static readonly JsString _openEvent = new(OpenEventType);
+    private static readonly JsString _messageEvent = new(MessageEventType);
+    private static readonly JsString _errorEvent = new(ErrorEventType);
+    private static readonly JsString _closeEvent = new(CloseEventType);
+
+    internal JsWebSocket(Engine engine, Realm realm, string url, string origin) : base(engine, realm)
+    {
+        Url = url;
+        Origin = origin;
+    }
+
+    /// <summary>https://websockets.spec.whatwg.org/#dom-websocket-url — this's url, serialized.</summary>
+    internal string Url { get; }
+
+    /// <summary>
+    /// The serialization of the url's origin, which is what every <c>message</c> event carries —
+    /// https://websockets.spec.whatwg.org/#feedback-from-the-protocol.
+    /// </summary>
+    internal string Origin { get; }
+
+    /// <summary>https://websockets.spec.whatwg.org/#dom-websocket-readystate.</summary>
+    internal int ReadyState { get; private set; } = Connecting;
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#dom-websocket-protocol — the subprotocol the handshake settled on,
+    /// which is the empty string until it has.
+    /// </summary>
+    internal string Protocol { get; private set; } = string.Empty;
+
+    /// <summary>https://websockets.spec.whatwg.org/#dom-websocket-binarytype.</summary>
+    internal string BinaryType { get; set; } = BinaryTypeArrayBuffer;
+
+    /// <summary>https://websockets.spec.whatwg.org/#dom-websocket-bufferedamount.</summary>
+    internal long BufferedAmount { get; private set; }
+
+    /// <summary>
+    /// The socket behind this object. Always set once the constructor has returned; it is a property rather
+    /// than a constructor argument only because the operation needs the object it reports to.
+    /// </summary>
+    internal WebSocketOperation? Operation { get; set; }
+
+    /// <summary>
+    /// "Increase the bufferedAmount attribute by the number of bytes needed to express the argument" — every
+    /// <c>send()</c> that does not throw, whether or not the bytes are ever written.
+    /// </summary>
+    internal void AddBufferedAmount(long bytes) => BufferedAmount += bytes;
+
+    /// <summary>
+    /// The other half: the bytes have reached the network, so they are no longer queued. Posted by the send
+    /// loop as its own event-loop job, one per message.
+    /// </summary>
+    internal void ReleaseBufferedAmount(long bytes)
+    {
+        BufferedAmount -= bytes;
+
+        if (BufferedAmount < 0)
+        {
+            // Unreachable — every release answers one queueing — but a negative bufferedAmount would be an
+            // unsigned long long underflow to script, which is a far worse thing to ship than a clamp.
+            BufferedAmount = 0;
+        }
+    }
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#dom-websocket-close steps 3.2 and 3.3, which both set the ready
+    /// state to CLOSING synchronously, inside the <c>close()</c> call itself.
+    /// </summary>
+    internal void EnterClosing()
+    {
+        if (ReadyState is Connecting or Open)
+        {
+            ReadyState = Closing;
+        }
+    }
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#feedback-from-the-protocol — "when the WebSocket connection is
+    /// established".
+    /// </summary>
+    /// <remarks>
+    /// The guard is what makes a <c>close()</c> during the handshake final: it set the ready state to CLOSING
+    /// on the spot, so a connection that had already been established by the time the job runs still fires no
+    /// <c>open</c> event.
+    /// </remarks>
+    internal void ReportOpen(string protocol)
+    {
+        if (ReadyState != Connecting)
+        {
+            return;
+        }
+
+        ReadyState = Open;
+        Protocol = protocol;
+
+        // "Fire an event named open at the WebSocket object" — extensions would be updated here too, and are
+        // always the empty string; see the class remarks.
+        FireEvent(_openEvent);
+    }
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#feedback-from-the-protocol — "when a WebSocket message has been
+    /// received". Step 1 drops anything that arrives once the socket is no longer OPEN.
+    /// </summary>
+    internal void ReportMessage(bool isText, byte[] data)
+    {
+        if (ReadyState != Open)
+        {
+            return;
+        }
+
+        var payload = Package(isText, data);
+        var message = _realm.Intrinsics.MessageEvent.CreateTrustedMessageEvent(_messageEvent, payload, JsString.Create(Origin), JsString.Empty);
+        DispatchEvent(message);
+    }
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#feedback-from-the-protocol — "when the WebSocket closing handshake
+    /// is started", which fires no event and only moves the ready state.
+    /// </summary>
+    internal void ReportClosingHandshake()
+    {
+        if (ReadyState == Open)
+        {
+            ReadyState = Closing;
+        }
+    }
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#feedback-from-the-protocol — "when the WebSocket connection is
+    /// closed".
+    /// </summary>
+    /// <remarks>
+    /// The <c>error</c> event is fired for every closure that is not clean, which covers both cases the
+    /// standard names — a connection the user agent was required to fail, and one closed after being flagged
+    /// as full — and the abrupt drops that amount to the same thing. The socket has already left the engine's
+    /// registry and released its transport by the time either listener runs, so a listener that throws — which
+    /// erupts from the pump, as every web-API callback in Jint does — leaks nothing.
+    /// </remarks>
+    internal void ReportClosed(int code, string reason, bool wasClean)
+    {
+        if (ReadyState == Closed)
+        {
+            return;
+        }
+
+        ReadyState = Closed;
+        _engine._webApi?.UnregisterWebSocket(this);
+        Operation = null;
+
+        if (!wasClean)
+        {
+            FireEvent(_errorEvent);
+        }
+
+        var close = _realm.Intrinsics.CloseEvent.CreateTrustedClose(_closeEvent, code, reason, wasClean);
+        DispatchEvent(close);
+    }
+
+    /// <summary>
+    /// The <c>data</c> attribute the <c>message</c> event carries: a string for a text message, and for a
+    /// binary one whichever of the two <c>binaryType</c> names.
+    /// </summary>
+    private JsValue Package(bool isText, byte[] data)
+    {
+        if (isText)
+        {
+            // A text message is UTF-8 by protocol; decoded leniently, so a peer that lies produces U+FFFD
+            // rather than an exception on the engine's pump.
+            return JsString.Create(SystemEncoding.UTF8.GetString(data));
+        }
+
+        if (string.Equals(BinaryType, BinaryTypeBlob, StringComparison.Ordinal))
+        {
+            return new JsBlob(_engine, data, string.Empty)
+            {
+                _prototype = _realm.Intrinsics.Blob.PrototypeObject,
+            };
+        }
+
+        return new JsArrayBuffer(_engine, data)
+        {
+            _prototype = _realm.Intrinsics.ArrayBuffer.PrototypeObject,
+        };
+    }
+}
+#endif

--- a/Jint/WebApi/WebSockets/WebSocketConnection.cs
+++ b/Jint/WebApi/WebSockets/WebSocketConnection.cs
@@ -1,0 +1,143 @@
+#if NET8_0_OR_GREATER
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jint.WebApi.WebSockets;
+
+/// <summary>
+/// What one <see cref="IWebSocketConnection.ReceiveAsync"/> answered with: a whole message, or the peer's
+/// half of the closing handshake.
+/// </summary>
+internal enum WebSocketReceiptKind
+{
+    /// <summary>A complete text message, still as its UTF-8 bytes.</summary>
+    Text,
+
+    /// <summary>A complete binary message.</summary>
+    Binary,
+
+    /// <summary>The peer sent a Close frame; <see cref="WebSocketReceipt.CloseCode"/> carries its status code.</summary>
+    Close,
+}
+
+/// <summary>
+/// One answer from the transport. Deliberately message-shaped rather than frame-shaped: the reassembly of a
+/// fragmented message, and the ceiling on how large one may grow, belong to the transport, so that everything
+/// above it — <see cref="WebSocketOperation"/> and the event dispatch — deals in whole messages.
+/// </summary>
+/// <param name="Kind">Which of the three shapes this is.</param>
+/// <param name="Data">The message bytes, empty for a close.</param>
+/// <param name="CloseCode">
+/// The status code the peer sent, or 1005 when it sent a Close frame with no body —
+/// https://www.rfc-editor.org/rfc/rfc6455#section-7.4.1, where 1005 is "no status code was actually present".
+/// </param>
+/// <param name="CloseReason">The peer's close reason, UTF-8 decoded, or the empty string.</param>
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct WebSocketReceipt(WebSocketReceiptKind Kind, byte[] Data, int CloseCode, string CloseReason)
+{
+    /// <summary>https://www.rfc-editor.org/rfc/rfc6455#section-7.4.1 — "no status code was actually present".</summary>
+    internal const int NoStatusReceived = 1005;
+
+    internal static WebSocketReceipt Message(bool isText, byte[] data)
+        => new(isText ? WebSocketReceiptKind.Text : WebSocketReceiptKind.Binary, data, 0, string.Empty);
+
+    internal static WebSocketReceipt Closed(int code, string reason)
+        => new(WebSocketReceiptKind.Close, [], code, reason);
+}
+
+/// <summary>
+/// The socket operations <c>WebSocket</c> needs, as an interface rather than a <c>ClientWebSocket</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Nothing here may touch the engine.</b> Every member runs on a thread pool thread while the script that
+/// opened the socket goes on running, exactly as <c>FetchTransport</c> does: the engine is not thread-safe,
+/// so the only way back to it is the generation-stamped event-loop job
+/// <see cref="WebSocketOperation"/> queues.
+/// </para>
+/// <para>
+/// The seam exists so the whole state machine above it — the handshake, the receive loop, the send queue,
+/// <c>bufferedAmount</c>, the close handshake and every event — can be driven by a scripted double with no
+/// network anywhere. It is deliberately <see langword="internal"/>: a host-facing transport seam is a larger
+/// design question (a host supplying its own would want headers, proxies, client certificates and a
+/// keep-alive policy with it) and is left for a follow-up.
+/// </para>
+/// <para>
+/// The concurrency contract is the one <c>ClientWebSocket</c> itself has: at most one
+/// <see cref="SendAsync"/> and at most one <see cref="ReceiveAsync"/> may be outstanding at a time, and those
+/// two may overlap each other. <see cref="Abort"/> may be called from any thread at any time, including from
+/// the engine's.
+/// </para>
+/// </remarks>
+internal interface IWebSocketConnection : IDisposable
+{
+    /// <summary>
+    /// The subprotocol the handshake settled on, or the empty string. Read after <see cref="ConnectAsync"/>
+    /// has completed.
+    /// </summary>
+    string SubProtocol { get; }
+
+    /// <summary>Opens the connection — https://websockets.spec.whatwg.org/#concept-websocket-establish.</summary>
+    Task ConnectAsync(CancellationToken cancellationToken);
+
+    /// <summary>Sends one whole message, as a text frame or a binary one.</summary>
+    Task SendAsync(ReadOnlyMemory<byte> payload, bool isText, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Waits for the next whole message, or for the peer's Close frame.
+    /// </summary>
+    /// <exception cref="WebSocketMessageTooLargeException">
+    /// The message exceeded the ceiling the connection was created with.
+    /// </exception>
+    Task<WebSocketReceipt> ReceiveAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Sends this endpoint's Close frame, which is the whole of "start the WebSocket closing handshake".
+    /// </summary>
+    /// <param name="code">
+    /// The status code, or <see langword="null"/> for a Close frame with no body at all — which is what
+    /// <c>close()</c> with neither argument is specified to send.
+    /// </param>
+    /// <param name="reason">The reason, which is only ever sent alongside a code.</param>
+    /// <param name="cancellationToken">Cancels the write.</param>
+    Task CloseOutputAsync(int? code, string reason, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Drops the connection without a handshake — "fail the WebSocket connection",
+    /// https://www.rfc-editor.org/rfc/rfc6455#section-7.1.7. Safe to call from any thread and more than once.
+    /// </summary>
+    void Abort();
+}
+
+/// <summary>
+/// Where a <see cref="IWebSocketConnection"/> comes from. One instance serves every engine.
+/// </summary>
+internal interface IWebSocketConnectionFactory
+{
+    /// <summary>
+    /// Builds a connection for one <c>WebSocket</c>. Called on the engine's thread, before anything is sent.
+    /// </summary>
+    /// <param name="url">The absolute <c>ws:</c> or <c>wss:</c> URL, already past the host's policy.</param>
+    /// <param name="protocols">The subprotocols to offer, already validated as tokens.</param>
+    /// <param name="maxMessageBytes">
+    /// The largest message the connection may reassemble before it raises
+    /// <see cref="WebSocketMessageTooLargeException"/>, from <c>Options.WebApi.Fetch.MaxResponseBytes</c>.
+    /// </param>
+    IWebSocketConnection Create(Uri url, IReadOnlyList<string> protocols, long maxMessageBytes);
+}
+
+/// <summary>
+/// A peer sent more in one message than <c>Options.WebApi.Fetch.MaxResponseBytes</c> allows.
+/// </summary>
+/// <remarks>
+/// It never reaches script: <see cref="WebSocketOperation"/> turns it into a close with status code 1009,
+/// which is RFC 6455's "message is too big", plus the <c>error</c> event every abnormal closure fires.
+/// </remarks>
+internal sealed class WebSocketMessageTooLargeException : Exception
+{
+    internal WebSocketMessageTooLargeException(string message) : base(message)
+    {
+    }
+}
+#endif

--- a/Jint/WebApi/WebSockets/WebSocketConstructor.cs
+++ b/Jint/WebApi/WebSockets/WebSocketConstructor.cs
@@ -1,0 +1,249 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Native.Symbol;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.DomException;
+using Jint.WebApi.Events;
+using Jint.WebApi.Url;
+using Jint.WebApi.Url.Parsing;
+
+namespace Jint.WebApi.WebSockets;
+
+/// <summary>
+/// The <c>WebSocket</c> interface object.
+/// <para>
+/// https://websockets.spec.whatwg.org/#the-websocket-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>WebSocket</c> inherits from <c>EventTarget</c>, so its <c>[[Prototype]]</c> is the <c>EventTarget</c>
+/// interface object — https://webidl.spec.whatwg.org/#interface-object.
+/// </para>
+/// <para>
+/// The four ready-state constants appear here as well as on the prototype, per
+/// https://webidl.spec.whatwg.org/#es-constants, with the attributes constants are given there:
+/// <c>{ writable: false, enumerable: true, configurable: false }</c>.
+/// </para>
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class WebSocketConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("WebSocket");
+
+    [JsProperty(Name = "CONNECTING", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber Connecting = JsNumber.Create(JsWebSocket.Connecting);
+    [JsProperty(Name = "OPEN", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber Open = JsNumber.Create(JsWebSocket.Open);
+    [JsProperty(Name = "CLOSING", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber Closing = JsNumber.Create(JsWebSocket.Closing);
+    [JsProperty(Name = "CLOSED", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber Closed = JsNumber.Create(JsWebSocket.Closed);
+
+    internal WebSocketConstructor(Engine engine, Realm realm, EventTargetConstructor eventTargetConstructor)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = eventTargetConstructor;
+        PrototypeObject = new WebSocketPrototype(engine, realm, this, eventTargetConstructor.PrototypeObject);
+        _length = new PropertyDescriptor(JsNumber.PositiveOne, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal WebSocketPrototype PrototypeObject { get; }
+
+    protected override void Initialize() => CreateProperties_Generated();
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#dom-websocket-websocket — the constructor steps, followed by
+    /// "establish a WebSocket connection … in parallel".
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>There is no base URL.</b> The specification parses <c>url</c> against "the relevant settings
+    /// object's API base URL", which is a document's URL; an embedded engine has no document, so a relative
+    /// URL simply does not parse and is the <c>SyntaxError</c> step 3 asks for. Pass an absolute URL, or
+    /// resolve it yourself with <c>new URL(relative, base).href</c>.
+    /// </para>
+    /// <para>
+    /// Steps 4 and 5 — <c>http</c> becomes <c>ws</c> and <c>https</c> becomes <c>wss</c> — are the
+    /// specification's current text and are implemented as written, so <c>new WebSocket('https://x/')</c> is
+    /// a <c>wss</c> socket rather than the <c>SyntaxError</c> older text produced.
+    /// </para>
+    /// </remarks>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        if (arguments.Length == 0)
+        {
+            Throw.TypeError(_realm, "Failed to construct 'WebSocket': 1 argument required, but only 0 present.");
+        }
+
+        var href = UrlValues.ToUsvString(arguments[0]);
+
+        // Steps 2 and 3.
+        var url = UrlParser.Parse(href);
+        if (url is null)
+        {
+            ThrowSyntaxError($"Failed to construct 'WebSocket': The URL '{href}' is invalid.");
+        }
+
+        // Steps 4 and 5: the two HTTP schemes name the same endpoints as the two WebSocket ones, and the
+        // handshake is an HTTP request anyway, so the standard maps rather than refuses.
+        if (string.Equals(url!.Scheme, "http", StringComparison.Ordinal))
+        {
+            url.Scheme = "ws";
+        }
+        else if (string.Equals(url.Scheme, "https", StringComparison.Ordinal))
+        {
+            url.Scheme = "wss";
+        }
+
+        // Step 6.
+        if (url.Scheme is not ("ws" or "wss"))
+        {
+            ThrowSyntaxError($"Failed to construct 'WebSocket': The URL's scheme must be either 'http', 'https', 'ws', or 'wss'. '{url.Scheme}' is not allowed.");
+        }
+
+        // Step 7: a fragment is meaningless to a socket, and silently dropping one would make two different
+        // strings name the same connection.
+        if (url.Fragment is not null)
+        {
+            ThrowSyntaxError("Failed to construct 'WebSocket': The URL contains a fragment identifier. Fragment identifiers are not allowed in WebSocket URLs.");
+        }
+
+        // Steps 8 and 9.
+        var protocols = ReadProtocols(arguments.At(1));
+        ValidateProtocols(protocols);
+
+        var socket = OrdinaryCreateFromConstructor(
+            newTarget,
+            static intrinsics => intrinsics.WebSocket.PrototypeObject,
+            static (Engine engine, Realm realm, (string Url, string Origin) state) => new JsWebSocket(engine, realm, state.Url, state.Origin),
+            (Url: url.Serialize(), Origin: url.SerializeOrigin()));
+
+        Connect(socket, url, protocols);
+        return socket;
+    }
+
+    /// <summary>
+    /// The "establish a WebSocket connection" half, https://websockets.spec.whatwg.org/#concept-websocket-establish,
+    /// which the standard runs <i>in parallel</i> — so nothing below blocks and nothing below throws.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A URL the host's policy refuses opens no connection at all and fails on the next event-loop turn, with
+    /// the same <c>error</c> and <c>close(1006)</c> pair a refused connection produces. That is not an
+    /// oversight: https://websockets.spec.whatwg.org/#feedback-from-the-protocol <b>requires</b> that a script
+    /// cannot tell a blocked request from a DNS failure from a refused port, precisely so that it cannot map
+    /// the network it is running in by probing it.
+    /// </para>
+    /// <para>
+    /// The concurrency ceiling is the one exception, and it is a synchronous throw: it is not about the
+    /// network at all but about this engine's own resources, and a script that has hit it has a bug worth
+    /// reporting rather than a host to probe.
+    /// </para>
+    /// </remarks>
+    private void Connect(JsWebSocket socket, UrlRecord url, List<string> protocols)
+    {
+        var state = _engine._webApi;
+        if (state?.FetchOptions is not { } options)
+        {
+            // Unreachable: the global that reaches this constructor is installed only where the state and the
+            // network settings were created, in the same block of WebApiRegistration.
+            Throw.InvalidOperationException("The WebSocket global was reached on an engine that has no network configuration.");
+            return;
+        }
+
+        if (state.ActiveWebSocketCount >= options.MaxConcurrentRequests)
+        {
+            ThrowDomException(
+                DomExceptionNames.QuotaExceeded,
+                $"Failed to construct 'WebSocket': the engine already has {options.MaxConcurrentRequests} sockets open, which is its Options.WebApi.Fetch.MaxConcurrentRequests limit.");
+        }
+
+        IWebSocketConnection? connection = null;
+        if (WebSocketPolicy.Allows(options, url, out var uri))
+        {
+            var factory = state.WebSocketConnections ?? ClientWebSocketConnectionFactory.Instance;
+            connection = factory.Create(uri, protocols, options.MaxResponseBytes);
+        }
+
+        var operation = new WebSocketOperation(_engine, _realm, socket, connection, options.Timeout);
+        socket.Operation = operation;
+        state.RegisterWebSocket(socket);
+        operation.Start();
+    }
+
+    /// <summary>
+    /// The <c>(DOMString or sequence&lt;DOMString&gt;)</c> conversion, https://webidl.spec.whatwg.org/#es-union:
+    /// an object with an iterator is the sequence arm, and everything else — including an object without one —
+    /// is stringified into a one-element list. An omitted argument is the IDL default, the empty sequence.
+    /// </summary>
+    private List<string> ReadProtocols(JsValue protocols)
+    {
+        var result = new List<string>();
+
+        if (protocols.IsUndefined())
+        {
+            return result;
+        }
+
+        if (protocols is not ObjectInstance candidate || candidate.GetMethod(GlobalSymbolRegistry.Iterator) is null)
+        {
+            result.Add(TypeConverter.ToString(protocols));
+            return result;
+        }
+
+        var iterator = protocols.GetIterator(_realm);
+        try
+        {
+            while (iterator.TryIteratorStepValue(out var value))
+            {
+                result.Add(TypeConverter.ToString(value));
+            }
+        }
+        catch
+        {
+            iterator.CloseIfNotDone(CompletionType.Throw);
+            throw;
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Step 10: "If any of the values in protocols occur more than once, or otherwise fail to match the
+    /// requirements for elements that comprise the value of <c>Sec-WebSocket-Protocol</c> fields as defined by
+    /// The WebSocket Protocol, then throw a <c>SyntaxError</c> DOMException."
+    /// </summary>
+    private void ValidateProtocols(List<string> protocols)
+    {
+        for (var i = 0; i < protocols.Count; i++)
+        {
+            var protocol = protocols[i];
+
+            if (!WebSocketValues.IsToken(protocol))
+            {
+                ThrowSyntaxError($"Failed to construct 'WebSocket': The subprotocol '{protocol}' is invalid.");
+            }
+
+            // The list is bounded by what a script wrote out, so the quadratic scan is the cheaper answer
+            // than a set — and it keeps the comparison the byte-for-byte one the protocol asks for.
+            for (var j = 0; j < i; j++)
+            {
+                if (string.Equals(protocols[j], protocol, StringComparison.Ordinal))
+                {
+                    ThrowSyntaxError($"Failed to construct 'WebSocket': The subprotocol '{protocol}' is duplicated.");
+                }
+            }
+        }
+    }
+
+    private void ThrowSyntaxError(string message) => ThrowDomException(DomExceptionNames.Syntax, message);
+
+    private void ThrowDomException(string name, string message)
+    {
+        var exception = _realm.Intrinsics.DomException.CreateException(name, message);
+        var location = _engine._lastSyntaxElement?.Location ?? default;
+        Throw.JavaScriptException(_engine, exception, in location);
+    }
+}
+#endif

--- a/Jint/WebApi/WebSockets/WebSocketOperation.cs
+++ b/Jint/WebApi/WebSockets/WebSocketOperation.cs
@@ -1,0 +1,462 @@
+#if NET8_0_OR_GREATER
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Jint.Constraints;
+using Jint.Runtime;
+
+namespace Jint.WebApi.WebSockets;
+
+/// <summary>
+/// One <c>WebSocket</c>'s life off the engine thread: the handshake, the receive loop, the queue of outgoing
+/// messages and the closing handshake.
+/// <para>
+/// https://websockets.spec.whatwg.org/#feedback-from-the-protocol
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>No JavaScript ever runs here.</b> Every one of the standard's "queue a task" steps is a
+/// generation-stamped event-loop job, so an <c>open</c>, <c>message</c>, <c>error</c> or <c>close</c> listener
+/// runs where every other continuation in Jint runs: inside a blocking <c>UnwrapIfPromise</c>, an
+/// <c>await</c> of <c>EvaluateAsync</c>, or the host's own <c>engine.Advanced.ProcessTasks()</c> loop. Jint
+/// never starts a thread to pump the engine, so an engine nobody pumps sees no events at all — while the
+/// socket itself goes on draining, which is what keeps a peer from being throttled by a script that has
+/// stopped listening.
+/// </para>
+/// <para>
+/// <b>The realm and the event-loop generation are captured at construction</b>, exactly as
+/// <c>FetchOperation</c> captures them, and for the same reason: a message that arrives after
+/// <c>RestoreGlobalSnapshot</c> has ended the evaluation cycle must not reach the restored engine. The
+/// registry in <c>WebApiEngineState</c> additionally aborts the socket at that point, so the connection is
+/// dropped rather than merely ignored.
+/// </para>
+/// <para>
+/// <b>The direction of every hand-over is one-way and lock-free.</b> Engine thread to socket: a
+/// <see cref="Channel{T}"/> of already-marshalled byte payloads, and one <see cref="CloseIntent"/> published
+/// by a compare-and-swap. Socket to engine thread: event-loop jobs. Nothing is shared mutable state, which is
+/// why there is not a lock in the file.
+/// </para>
+/// </remarks>
+internal sealed class WebSocketOperation
+{
+    /// <summary>https://www.rfc-editor.org/rfc/rfc6455#section-7.4.1 — "normal closure".</summary>
+    internal const int NormalClosure = 1000;
+
+    /// <summary>
+    /// https://www.rfc-editor.org/rfc/rfc6455#section-7.4.1 — "the connection was closed abnormally". The one
+    /// code every failure reports, which is what
+    /// https://websockets.spec.whatwg.org/#feedback-from-the-protocol requires so that a script cannot tell a
+    /// refused connection from a DNS failure from a policy refusal.
+    /// </summary>
+    internal const int AbnormalClosure = 1006;
+
+    /// <summary>https://www.rfc-editor.org/rfc/rfc6455#section-7.4.1 — "message is too big".</summary>
+    private const int MessageTooBig = 1009;
+
+    private readonly Engine _engine;
+
+    /// <summary>
+    /// The realm the socket was created in, captured now. A job running on a later event-loop turn would
+    /// otherwise build its <c>MessageEvent</c> — and its <c>ArrayBuffer</c> — against whatever realm happened
+    /// to be ambient then.
+    /// </summary>
+    private readonly Realm _realm;
+
+    private readonly JsWebSocket _socket;
+
+    /// <summary>
+    /// The transport, or <see langword="null"/> when the host's policy refused the URL — in which case the
+    /// only thing this operation ever does is queue the failure the standard's asynchronous "fail the
+    /// WebSocket connection" amounts to.
+    /// </summary>
+    private readonly IWebSocketConnection? _connection;
+
+    private readonly int _generation;
+
+    /// <summary>
+    /// The engine's own cancellation token, from <see cref="CancellationConstraint"/>. A socket torn down
+    /// through it fires no events at all: a constraint that turned into an <c>error</c> event would no longer
+    /// bound anything, since the script would handle it and carry on.
+    /// </summary>
+    private readonly CancellationToken _engineToken;
+
+    private readonly CancellationTokenSource _cancellation;
+
+    /// <summary>
+    /// How long the opening handshake may take, and — once this endpoint has sent its Close frame — how long
+    /// the peer has to answer it. From <c>Options.WebApi.Fetch.Timeout</c>.
+    /// </summary>
+    private readonly TimeSpan _handshakeTimeout;
+
+    /// <summary>
+    /// The messages <c>send()</c> has marshalled on the engine thread and the send loop has not yet written.
+    /// Unbounded because the ceiling is <c>bufferedAmount</c>'s, which <c>send()</c> enforces itself by
+    /// flagging the socket as full — the standard's own escape hatch for a buffer that cannot grow further.
+    /// </summary>
+    private readonly Channel<PendingSend> _outgoing = Channel.CreateUnbounded<PendingSend>(new UnboundedChannelOptions
+    {
+        SingleReader = true,
+
+        // The engine thread writes and both it and the receive loop may complete the writer, so this is not a
+        // single-writer channel however single-threaded the sends themselves are.
+        SingleWriter = false,
+
+        // The send loop must never run on the engine's thread: it does socket I/O.
+        AllowSynchronousContinuations = false,
+    });
+
+    private CloseIntent? _closeIntent;
+    private bool _abandoned;
+
+    internal WebSocketOperation(
+        Engine engine,
+        Realm realm,
+        JsWebSocket socket,
+        IWebSocketConnection? connection,
+        TimeSpan handshakeTimeout)
+    {
+        _engine = engine;
+        _realm = realm;
+        _socket = socket;
+        _connection = connection;
+        _generation = engine.EventLoopGeneration;
+        _handshakeTimeout = handshakeTimeout;
+        _engineToken = engine.Constraints.Find<CancellationConstraint>()?.Token ?? CancellationToken.None;
+        _cancellation = CancellationTokenSource.CreateLinkedTokenSource(_engineToken);
+    }
+
+    /// <summary>
+    /// Starts the run. Called from the constructor, on the engine thread; it returns at the transport's first
+    /// await, so the <c>new WebSocket(...)</c> expression completes without waiting for a socket.
+    /// </summary>
+    internal void Start()
+    {
+        if (_connection is null)
+        {
+            // The policy refused the URL. The standard has no synchronous failure for this — its own
+            // equivalent, a blocked request, is a network error inside "establish a WebSocket connection" —
+            // so the socket is born CONNECTING and fails on the next turn, indistinguishably from a refused
+            // connection. That indistinguishability is required:
+            // https://websockets.spec.whatwg.org/#feedback-from-the-protocol.
+            Finish(Abnormal());
+            return;
+        }
+
+        _ = RunAsync(_connection);
+    }
+
+    /// <summary>
+    /// Queues one marshalled message for the send loop. The bytes were taken on the engine thread, so nothing
+    /// the script does afterwards can change what goes on the wire.
+    /// </summary>
+    /// <returns>Whether the message was queued, i.e. whether it will ever be written.</returns>
+    internal bool Enqueue(ReadOnlyMemory<byte> payload, bool isText)
+        => _outgoing.Writer.TryWrite(new PendingSend(payload, isText));
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#dom-websocket-close step 3.3, "start the WebSocket closing
+    /// handshake". The frame goes out <i>after</i> everything already queued, which is what lets a script
+    /// <c>send()</c> and then <c>close()</c> without losing the message.
+    /// </summary>
+    /// <remarks>
+    /// The first caller wins: a script closing twice, or closing while the peer's own Close frame is being
+    /// echoed, must not put two Close frames on the wire.
+    /// </remarks>
+    internal void RequestClose(int? code, string reason)
+    {
+        if (Interlocked.CompareExchange(ref _closeIntent, new CloseIntent(code, reason), null) is not null)
+        {
+            return;
+        }
+
+        _outgoing.Writer.TryComplete();
+    }
+
+    /// <summary>
+    /// "Fail the WebSocket connection", https://www.rfc-editor.org/rfc/rfc6455#section-7.1.7 — drop it now,
+    /// with no handshake. What <c>close()</c> before the connection is established does, and what a socket
+    /// flagged as full does.
+    /// </summary>
+    internal void Fail()
+    {
+        _connection?.Abort();
+
+        try
+        {
+            _cancellation.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // The run finished first and released it; there is nothing left to cancel.
+        }
+    }
+
+    /// <summary>
+    /// Abandons the socket because the evaluation cycle it belongs to has ended. The generation fence already
+    /// stops a message reaching the restored engine; this is what stops the socket holding a connection open
+    /// to deliver into a queue nobody will read.
+    /// </summary>
+    internal void Abandon()
+    {
+        Volatile.Write(ref _abandoned, true);
+        _outgoing.Writer.TryComplete();
+        Fail();
+    }
+
+    private async Task RunAsync(IWebSocketConnection connection)
+    {
+        try
+        {
+            using (var handshake = CancellationTokenSource.CreateLinkedTokenSource(_cancellation.Token))
+            {
+                if (IsBounded(_handshakeTimeout))
+                {
+                    handshake.CancelAfter(_handshakeTimeout);
+                }
+
+                await connection.ConnectAsync(handshake.Token).ConfigureAwait(false);
+            }
+        }
+        catch
+        {
+            // Every way the handshake can fail is one failure: a refused connection, a name that does not
+            // resolve, a TLS error, a status that is not 101, a subprotocol the server did not accept, the
+            // deadline, or a close() that fell during it. The standard requires exactly that — none of them
+            // may be told apart by a script.
+            Finish(Abnormal());
+            return;
+        }
+
+        EnqueueOpen(connection.SubProtocol);
+
+        var sender = SendLoopAsync(connection);
+        var closure = await ReceiveLoopAsync(connection).ConfigureAwait(false);
+
+        // The receive loop has ended, so nothing more will ever be written: completing the queue is what lets
+        // the send loop finish its own work — including this endpoint's Close frame — and stop.
+        _outgoing.Writer.TryComplete();
+        await sender.ConfigureAwait(false);
+
+        Finish(closure);
+    }
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#feedback-from-the-protocol — "when a WebSocket message has been
+    /// received" and "when the WebSocket closing handshake is started", until the connection ends.
+    /// </summary>
+    private async Task<WebSocketClosure> ReceiveLoopAsync(IWebSocketConnection connection)
+    {
+        while (true)
+        {
+            WebSocketReceipt receipt;
+            try
+            {
+                receipt = await connection.ReceiveAsync(_cancellation.Token).ConfigureAwait(false);
+            }
+            catch (WebSocketMessageTooLargeException)
+            {
+                // The host's own ceiling, not the network's, so unlike every other failure this one names
+                // itself: a script that cannot tell "your peer sent more than this host allows" from "the
+                // connection dropped" cannot react to it. The connection is dropped rather than closed
+                // politely — the peer is already sending more than the host agreed to buffer.
+                connection.Abort();
+                return new WebSocketClosure(MessageTooBig, string.Empty, WasClean: false);
+            }
+            catch
+            {
+                return Abnormal();
+            }
+
+            if (receipt.Kind == WebSocketReceiptKind.Close)
+            {
+                // "When the WebSocket closing handshake is started, queue a task to change the ready state to
+                // CLOSING." Then answer it, unless this endpoint already sent its own Close frame — which is
+                // exactly what RequestClose's compare-and-swap decides.
+                EnqueueClosingHandshake();
+                RequestClose(EchoCode(receipt.CloseCode), string.Empty);
+
+                return new WebSocketClosure(receipt.CloseCode, receipt.CloseReason, WasClean: true);
+            }
+
+            EnqueueMessage(receipt.Kind == WebSocketReceiptKind.Text, receipt.Data);
+        }
+    }
+
+    /// <summary>
+    /// Writes what <c>send()</c> queued, then this endpoint's Close frame if one was asked for.
+    /// </summary>
+    /// <remarks>
+    /// <c>bufferedAmount</c> comes down one message at a time, from an event-loop job posted after the write
+    /// completed — which is the attribute's own definition: bytes "queued using send() but ... not yet
+    /// transmitted to the network". A write that never happened, because the connection died first, therefore
+    /// leaves its bytes counted, which is the truthful answer.
+    /// </remarks>
+    private async Task SendLoopAsync(IWebSocketConnection connection)
+    {
+        try
+        {
+            while (await _outgoing.Reader.WaitToReadAsync(_cancellation.Token).ConfigureAwait(false))
+            {
+                while (_outgoing.Reader.TryRead(out var pending))
+                {
+                    await connection.SendAsync(pending.Payload, pending.IsText, _cancellation.Token).ConfigureAwait(false);
+                    EnqueueBufferedRelease(pending.Payload.Length);
+                }
+            }
+        }
+        catch
+        {
+            // The connection is gone. The receive loop is what reports that, with the one code every failure
+            // gets, so there is nothing to do here but stop.
+            return;
+        }
+
+        if (Volatile.Read(ref _closeIntent) is not { } intent)
+        {
+            return;
+        }
+
+        try
+        {
+            await connection.CloseOutputAsync(intent.Code, intent.Reason, _cancellation.Token).ConfigureAwait(false);
+        }
+        catch
+        {
+            return;
+        }
+
+        // The peer now owes us its half of the handshake. Bounding that wait is what stops a socket the
+        // script has closed from living on because the peer never answered — the close then reports 1006 and
+        // wasClean false, which is precisely what an unfinished handshake is.
+        if (IsBounded(_handshakeTimeout))
+        {
+            try
+            {
+                _cancellation.CancelAfter(_handshakeTimeout);
+            }
+            catch (ObjectDisposedException)
+            {
+                // The run finished between the write and here; the wait is already over.
+            }
+        }
+    }
+
+    /// <summary>
+    /// Releases the transport and queues the standard's "when the WebSocket connection is closed" task.
+    /// </summary>
+    private void Finish(WebSocketClosure closure)
+    {
+        _connection?.Dispose();
+        _cancellation.Dispose();
+        EnqueueClosed(closure);
+    }
+
+    private void EnqueueOpen(string protocol) => Enqueue(() => _socket.ReportOpen(protocol));
+
+    private void EnqueueMessage(bool isText, byte[] data) => Enqueue(() => _socket.ReportMessage(isText, data));
+
+    private void EnqueueClosingHandshake() => Enqueue(_socket.ReportClosingHandshake);
+
+    private void EnqueueClosed(WebSocketClosure closure)
+        => Enqueue(() => _socket.ReportClosed(closure.Code, closure.Reason, closure.WasClean));
+
+    private void EnqueueBufferedRelease(int bytes) => Enqueue(() => _socket.ReleaseBufferedAmount(bytes));
+
+    /// <summary>
+    /// Queues one of the standard's tasks, carrying the generation the socket was opened in.
+    /// </summary>
+    /// <remarks>
+    /// Two things are checked before it is queued rather than after it is dequeued, both because a queued job
+    /// would otherwise keep the socket — and the values it carries — alive for nothing: an abandoned socket,
+    /// and an engine whose cancellation constraint has fired. The generation fence at dequeue is the
+    /// authority either way.
+    /// </remarks>
+    private void Enqueue(Action task)
+    {
+        if (Volatile.Read(ref _abandoned) || _engineToken.IsCancellationRequested)
+        {
+            return;
+        }
+
+        _engine.AddToEventLoop(() => RunTask(task), _generation);
+    }
+
+    /// <summary>
+    /// On the engine thread, in the realm the socket was created in. An exception from a listener erupts out
+    /// of whatever is pumping, which is the contract every other web-API callback in Jint has — see
+    /// <c>JsEventTarget</c>'s remarks. The socket's own state has already been updated by then, so it stays
+    /// usable.
+    /// </summary>
+    private void RunTask(Action task)
+    {
+        var entered = EnterRealm();
+        try
+        {
+            task();
+        }
+        finally
+        {
+            LeaveRealm(entered);
+        }
+    }
+
+    private bool EnterRealm()
+    {
+        if (ReferenceEquals(_engine.Realm, _realm))
+        {
+            return false;
+        }
+
+        _engine.EnterExecutionContext(_realm.GlobalEnv, _realm.GlobalEnv, _realm, privateEnvironment: null, strict: _engine.Options.Strict);
+        return true;
+    }
+
+    private void LeaveRealm(bool entered)
+    {
+        if (entered)
+        {
+            _engine.LeaveExecutionContext();
+        }
+    }
+
+    private static WebSocketClosure Abnormal() => new(AbnormalClosure, string.Empty, WasClean: false);
+
+    private static bool IsBounded(TimeSpan timeout) => timeout > TimeSpan.Zero && timeout != Timeout.InfiniteTimeSpan;
+
+    /// <summary>
+    /// The status code to answer the peer's Close frame with —
+    /// https://www.rfc-editor.org/rfc/rfc6455#section-5.5.1, "may send a Close frame … echoing the status
+    /// code". A frame that carried no code is answered with none, and a code the framework would refuse to
+    /// put on the wire is answered with 1000 rather than turning a clean close into a failure.
+    /// </summary>
+    private static int? EchoCode(int code)
+    {
+        if (code == WebSocketReceipt.NoStatusReceived)
+        {
+            return null;
+        }
+
+        var sendable = code is (>= 1000 and <= 1003) or (>= 1007 and <= 1011) or (>= 3000 and <= 4999);
+        return sendable ? code : NormalClosure;
+    }
+
+    /// <summary>One message the engine thread marshalled and the send loop has yet to write.</summary>
+    [StructLayout(LayoutKind.Auto)]
+    private readonly record struct PendingSend(ReadOnlyMemory<byte> Payload, bool IsText);
+
+    /// <summary>
+    /// The close this endpoint asked for. A class rather than a struct so that it can be published — and read
+    /// back as one whole — with a single interlocked operation.
+    /// </summary>
+    private sealed record CloseIntent(int? Code, string Reason);
+
+    /// <summary>
+    /// How the connection ended, as the <c>close</c> event's three attributes —
+    /// https://websockets.spec.whatwg.org/#eventdef-websocket-close.
+    /// </summary>
+    [StructLayout(LayoutKind.Auto)]
+    private readonly record struct WebSocketClosure(int Code, string Reason, bool WasClean);
+}
+#endif

--- a/Jint/WebApi/WebSockets/WebSocketPolicy.cs
+++ b/Jint/WebApi/WebSockets/WebSocketPolicy.cs
@@ -1,0 +1,75 @@
+#if NET8_0_OR_GREATER
+using Jint.WebApi.Url.Parsing;
+
+namespace Jint.WebApi.WebSockets;
+
+/// <summary>
+/// Whether a socket may be opened at all: the host's network policy, translated from the schemes
+/// <c>fetch</c> speaks to the two a <c>WebSocket</c> speaks.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>There is no separate WebSocket policy group.</b> A socket is outbound network access from the same
+/// process, reaching the same hosts, so it answers to the same settings — <c>Options.WebApi.Fetch</c>. Only
+/// the scheme list needs translating, because a host writes it in terms of <c>http</c> and <c>https</c>:
+/// <c>ws</c> is admitted by <c>http</c> and <c>wss</c> by <c>https</c>, and naming <c>ws</c> or <c>wss</c>
+/// outright works too, for a host that wants sockets and not fetches.
+/// </para>
+/// <para>
+/// <b>The filter sees the <c>ws:</c> URL</b>, not the <c>http:</c> one the handshake is made of. That is the
+/// URL the script asked for and the one an error message would name, and it fails safe: a filter written for
+/// fetch that tests <c>uri.Scheme == "https"</c> refuses every socket rather than admitting one it was never
+/// shown.
+/// </para>
+/// <para>
+/// Unlike <c>fetch</c> there is no per-hop re-check to do, because there are no hops: the WHATWG handshake
+/// sets the request's redirect mode to <c>error</c>, so the one URL the filter admitted is the only one the
+/// socket can reach.
+/// </para>
+/// </remarks>
+internal static class WebSocketPolicy
+{
+    /// <summary>
+    /// Runs the whole check, and yields the <see cref="Uri"/> the transport should open.
+    /// </summary>
+    internal static bool Allows(Options.FetchOptions options, UrlRecord url, out Uri uri)
+    {
+        uri = null!;
+
+        if (!IsSchemeAllowed(options.AllowedSchemes, url.Scheme))
+        {
+            return false;
+        }
+
+        // The WHATWG serialization is always absolute, but Uri has a grammar of its own and a host it cannot
+        // represent must be refused rather than guessed at.
+        if (!Uri.TryCreate(url.Serialize(), UriKind.Absolute, out var parsed))
+        {
+            return false;
+        }
+
+        uri = parsed;
+
+        var filter = options.UrlFilter;
+        return filter is null || filter(uri);
+    }
+
+    private static bool IsSchemeAllowed(List<string> allowed, string scheme)
+    {
+        // The parser has already lowercased the scheme and the constructor has already refused everything
+        // that is not one of these two.
+        var httpEquivalent = string.Equals(scheme, "wss", StringComparison.Ordinal) ? "https" : "http";
+
+        foreach (var candidate in allowed)
+        {
+            if (string.Equals(candidate, scheme, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(candidate, httpEquivalent, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+#endif

--- a/Jint/WebApi/WebSockets/WebSocketPrototype.cs
+++ b/Jint/WebApi/WebSockets/WebSocketPrototype.cs
@@ -1,0 +1,396 @@
+#if NET8_0_OR_GREATER
+using SystemEncoding = System.Text.Encoding;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.DomException;
+using Jint.WebApi.Events;
+using Jint.WebApi.Files;
+using Jint.WebApi.Url;
+
+namespace Jint.WebApi.WebSockets;
+
+/// <summary>
+/// <c>WebSocket.prototype</c> — the interface prototype object.
+/// <para>
+/// https://websockets.spec.whatwg.org/#the-websocket-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// Its <c>[[Prototype]]</c> is <c>EventTarget.prototype</c>, so a socket has <c>addEventListener</c> and the
+/// rest, and <c>socket instanceof EventTarget</c> holds. The attributes are accessors that brand-check their
+/// receiver, as WebIDL specifies, so <c>WebSocket.prototype.readyState</c> is a <c>TypeError</c> rather than
+/// an answer.
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class WebSocketPrototype : Prototype
+{
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#dom-websocket-close step 2: "If reasonBytes is longer than 123
+    /// bytes, then throw a SyntaxError DOMException" — the protocol's 125-byte control frame payload, less
+    /// the two the status code takes.
+    /// </summary>
+    private const int MaxReasonBytes = 123;
+
+    private static readonly JsString _arrayBuffer = new(JsWebSocket.BinaryTypeArrayBuffer);
+    private static readonly JsString _blob = new(JsWebSocket.BinaryTypeBlob);
+
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly WebSocketConstructor _constructor;
+
+    [JsProperty(Name = "CONNECTING", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber Connecting = JsNumber.Create(JsWebSocket.Connecting);
+    [JsProperty(Name = "OPEN", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber Open = JsNumber.Create(JsWebSocket.Open);
+    [JsProperty(Name = "CLOSING", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber Closing = JsNumber.Create(JsWebSocket.Closing);
+    [JsProperty(Name = "CLOSED", Flags = PropertyFlag.OnlyEnumerable)] private static readonly JsNumber Closed = JsNumber.Create(JsWebSocket.Closed);
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString WebSocketToStringTag = new("WebSocket");
+
+    internal WebSocketPrototype(
+        Engine engine,
+        Realm realm,
+        WebSocketConstructor constructor,
+        ObjectInstance eventTargetPrototype) : base(engine, realm)
+    {
+        _prototype = eventTargetPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#dom-websocket-url
+    /// </summary>
+    [JsAccessor("url", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsString UrlGet(JsValue thisObject) => JsString.Create(Brand(thisObject).Url);
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#dom-websocket-readystate
+    /// </summary>
+    [JsAccessor("readyState", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsNumber ReadyStateGet(JsValue thisObject) => JsNumber.Create(Brand(thisObject).ReadyState);
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#dom-websocket-bufferedamount — the bytes <c>send()</c> has queued
+    /// that have not reached the network. It only ever grows once the connection is closed, because a
+    /// <c>send()</c> then queues bytes nothing will ever write; the standard says so explicitly.
+    /// </summary>
+    [JsAccessor("bufferedAmount", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsNumber BufferedAmountGet(JsValue thisObject) => JsNumber.Create(Brand(thisObject).BufferedAmount);
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#dom-websocket-extensions — always the empty string, because the
+    /// in-box transport negotiates no extensions at all; see <see cref="ClientWebSocketConnection"/>.
+    /// </summary>
+    [JsAccessor("extensions", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsString ExtensionsGet(JsValue thisObject)
+    {
+        Brand(thisObject);
+        return JsString.Empty;
+    }
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#dom-websocket-protocol
+    /// </summary>
+    [JsAccessor("protocol", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsString ProtocolGet(JsValue thisObject) => JsString.Create(Brand(thisObject).Protocol);
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#dom-websocket-binarytype
+    /// </summary>
+    /// <remarks>
+    /// Jint's default is <c>"arraybuffer"</c> where the standard's is <c>"blob"</c> — the one deliberate
+    /// divergence in this interface, explained on <see cref="JsWebSocket"/>.
+    /// </remarks>
+    [JsAccessor("binaryType", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsString BinaryTypeGet(JsValue thisObject)
+        => string.Equals(Brand(thisObject).BinaryType, JsWebSocket.BinaryTypeBlob, StringComparison.Ordinal) ? _blob : _arrayBuffer;
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#dom-websocket-binarytype, setter half. Assigning something that is
+    /// not one of the two enumeration values is <i>ignored</i> rather than refused, which is what
+    /// https://webidl.spec.whatwg.org/#es-enumeration says an attribute of enumeration type does.
+    /// </summary>
+    [JsAccessor("binaryType", AccessorKind.Set, Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue BinaryTypeSet(JsValue thisObject, JsValue value)
+    {
+        var socket = Brand(thisObject);
+        var requested = TypeConverter.ToString(value);
+
+        if (requested is JsWebSocket.BinaryTypeArrayBuffer or JsWebSocket.BinaryTypeBlob)
+        {
+            socket.BinaryType = requested;
+        }
+
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#dom-websocket-send
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The union arms are tried in the order the IDL declares them — <c>BufferSource</c>, then <c>Blob</c>,
+    /// then <c>USVString</c> — which is what makes a typed array binary rather than the string
+    /// <c>"[object Uint8Array]"</c>. A <c>SharedArrayBuffer</c> is not a <c>BufferSource</c> and is therefore
+    /// stringified, exactly as in a browser.
+    /// </para>
+    /// <para>
+    /// <c>bufferedAmount</c> grows for every call that does not throw, whether or not the bytes are ever
+    /// written; only a write that reaches the network brings it down again.
+    /// </para>
+    /// </remarks>
+    [JsFunction(Name = "send", Length = 1)]
+    private JsValue Send(JsValue thisObject, JsValue data)
+    {
+        var socket = Brand(thisObject);
+
+        // Step 1: sending before the handshake finished is the script's own bug, and the only exception this
+        // method has.
+        if (socket.ReadyState == JsWebSocket.Connecting)
+        {
+            ThrowDomException(DomExceptionNames.InvalidState, "Failed to execute 'send' on 'WebSocket': Still in CONNECTING state.");
+        }
+
+        var payload = Marshal(data, out var isText);
+        socket.AddBufferedAmount(payload.Length);
+
+        // "If the WebSocket connection is established and the WebSocket closing handshake has not yet
+        // started" — a socket that is CLOSING or CLOSED counts the bytes and writes nothing.
+        if (socket.ReadyState != JsWebSocket.Open || socket.Operation is not { } operation)
+        {
+            return Undefined;
+        }
+
+        if (!operation.Enqueue(payload, isText))
+        {
+            // The closing handshake started underneath us — the peer sent a Close frame the engine has not
+            // dispatched yet. The bytes stay counted, which is what they are: queued and never transmitted.
+            return Undefined;
+        }
+
+        // "If the data cannot be sent, e.g. because it would need to be buffered but the buffer is full, the
+        // user agent must flag the WebSocket as full and then close the WebSocket connection." That ceiling
+        // is the host's, and reaching it drops the connection with the error and close events every abnormal
+        // closure fires — a script that outruns its socket is told so rather than growing the heap.
+        if (socket.BufferedAmount > BufferedAmountLimit())
+        {
+            operation.Fail();
+        }
+
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#dom-websocket-close
+    /// </summary>
+    /// <remarks>
+    /// Both arguments are converted before either is validated, which is the order WebIDL puts them in and is
+    /// observable through a <c>reason</c> whose <c>toString</c> has a side effect.
+    /// </remarks>
+    [JsFunction(Name = "close", Length = 0)]
+    private JsValue Close(JsValue thisObject, JsCallArguments arguments)
+    {
+        var socket = Brand(thisObject);
+
+        var codeArgument = arguments.At(0);
+        var reasonArgument = arguments.At(1);
+
+        // Both arguments are optional with no default, so an explicit undefined is "not present".
+        var hasCode = !codeArgument.IsUndefined();
+        var code = hasCode ? WebSocketValues.ToClampedUnsignedShort(codeArgument) : 0;
+
+        var hasReason = !reasonArgument.IsUndefined();
+        var reason = hasReason ? UrlValues.ToUsvString(reasonArgument) : string.Empty;
+
+        // Step 1: 1000 and the private range are the only codes an application may send; everything else is
+        // reserved to the protocol.
+        if (hasCode && code != WebSocketOperation.NormalClosure && code is < 3000 or > 4999)
+        {
+            ThrowDomException(
+                DomExceptionNames.InvalidAccess,
+                $"Failed to execute 'close' on 'WebSocket': The close code must be either 1000, or between 3000 and 4999. {code} is neither.");
+        }
+
+        // Step 2.
+        if (hasReason && SystemEncoding.UTF8.GetByteCount(reason) > MaxReasonBytes)
+        {
+            ThrowDomException(
+                DomExceptionNames.Syntax,
+                $"Failed to execute 'close' on 'WebSocket': The close reason must not be greater than {MaxReasonBytes} UTF-8 bytes.");
+        }
+
+        // Step 3.1: already closing or closed, so there is nothing to do.
+        if (socket.ReadyState is JsWebSocket.Closing or JsWebSocket.Closed)
+        {
+            return Undefined;
+        }
+
+        var operation = socket.Operation;
+
+        if (socket.ReadyState == JsWebSocket.Connecting)
+        {
+            // Step 3.2: "Fail the WebSocket connection and set this's ready state to CLOSING." Failing rather
+            // than handshaking is why closing during the handshake ends in error and close(1006) rather than
+            // in the code the script passed — there was never a connection to close politely.
+            socket.EnterClosing();
+            operation?.Fail();
+            return Undefined;
+        }
+
+        // Step 3.3: "Start the WebSocket closing handshake and set this's ready state to CLOSING."
+        socket.EnterClosing();
+
+        // "If neither code nor reason is present, the WebSocket Close message must not have a body." A reason
+        // with no code has nowhere to live — the protocol puts the status code in front of it — so it travels
+        // behind a normal closure, which is what the sending endpoint means by it.
+        var sent = hasCode ? code : hasReason ? WebSocketOperation.NormalClosure : (int?) null;
+        operation?.RequestClose(sent, reason);
+
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#handler-websocket-onopen
+    /// </summary>
+    [JsAccessor("onopen", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue OnOpenGet(JsValue thisObject) => HandlerGet(thisObject, JsWebSocket.OpenEventType);
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#handler-websocket-onopen, setter half.
+    /// </summary>
+    [JsAccessor("onopen", AccessorKind.Set, Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue OnOpenSet(JsValue thisObject, JsValue value) => HandlerSet(thisObject, value, JsWebSocket.OpenEventType);
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#handler-websocket-onmessage
+    /// </summary>
+    [JsAccessor("onmessage", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue OnMessageGet(JsValue thisObject) => HandlerGet(thisObject, JsWebSocket.MessageEventType);
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#handler-websocket-onmessage, setter half.
+    /// </summary>
+    [JsAccessor("onmessage", AccessorKind.Set, Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue OnMessageSet(JsValue thisObject, JsValue value) => HandlerSet(thisObject, value, JsWebSocket.MessageEventType);
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#handler-websocket-onerror
+    /// </summary>
+    [JsAccessor("onerror", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue OnErrorGet(JsValue thisObject) => HandlerGet(thisObject, JsWebSocket.ErrorEventType);
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#handler-websocket-onerror, setter half.
+    /// </summary>
+    [JsAccessor("onerror", AccessorKind.Set, Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue OnErrorSet(JsValue thisObject, JsValue value) => HandlerSet(thisObject, value, JsWebSocket.ErrorEventType);
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#handler-websocket-onclose
+    /// </summary>
+    [JsAccessor("onclose", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue OnCloseGet(JsValue thisObject) => HandlerGet(thisObject, JsWebSocket.CloseEventType);
+
+    /// <summary>
+    /// https://websockets.spec.whatwg.org/#handler-websocket-onclose, setter half.
+    /// </summary>
+    [JsAccessor("onclose", AccessorKind.Set, Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue OnCloseSet(JsValue thisObject, JsValue value) => HandlerSet(thisObject, value, JsWebSocket.CloseEventType);
+
+    /// <summary>
+    /// An event handler IDL attribute's getter,
+    /// https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes: whatever was
+    /// assigned, or null.
+    /// </summary>
+    private JsValue HandlerGet(JsValue thisObject, string type)
+        => Brand(thisObject).FindEventHandler(type)?.Callback ?? Null;
+
+    /// <summary>
+    /// An event handler IDL attribute's setter. <c>EventHandler</c> is <c>[LegacyTreatNonObjectAsNull]</c>, so
+    /// assigning anything that is not an object clears the handler instead of raising; an object that is not
+    /// callable is stored and read back but never invoked. Reassigning replaces the value in place, so the
+    /// handler keeps the position it first took among the <c>addEventListener</c> listeners.
+    /// </summary>
+    private JsValue HandlerSet(JsValue thisObject, JsValue value, string type)
+    {
+        var socket = Brand(thisObject);
+        var existing = socket.FindEventHandler(type);
+
+        if (value is not ObjectInstance)
+        {
+            if (existing is not null)
+            {
+                socket.RemoveListener(existing);
+            }
+
+            return Undefined;
+        }
+
+        if (existing is not null)
+        {
+            existing.Callback = value;
+            return Undefined;
+        }
+
+        socket.AddListener(new EventListenerRegistration(type, value) { IsEventHandler = true });
+        return Undefined;
+    }
+
+    /// <summary>
+    /// The bytes to put on the wire, and whether they are a text frame — the
+    /// <c>(BufferSource or Blob or USVString)</c> union, converted on the engine's thread so that nothing the
+    /// script does afterwards can change what is sent.
+    /// </summary>
+    private static ReadOnlyMemory<byte> Marshal(JsValue data, out bool isText)
+    {
+        isText = false;
+
+        if (FileApi.TryGetBufferSourceBytes(data, out var buffered))
+        {
+            // A copy: the buffer stays script-writable, and a frame that changed under the socket after it
+            // was queued would be a message-smuggling primitive rather than a curiosity.
+            return buffered.ToArray();
+        }
+
+        if (data is JsBlob blob)
+        {
+            // A blob is immutable by specification, so its bytes can go on the wire as they are.
+            return blob.Data;
+        }
+
+        isText = true;
+        return SystemEncoding.UTF8.GetBytes(UrlValues.ToUsvString(data));
+    }
+
+    /// <summary>
+    /// The ceiling on unwritten bytes, which is the same number that bounds one incoming message —
+    /// <c>Options.WebApi.Fetch.MaxResponseBytes</c>. Read afresh on the engine's thread, from the settings the
+    /// engine was built with.
+    /// </summary>
+    private long BufferedAmountLimit() => _engine._webApi?.FetchOptions?.MaxResponseBytes ?? long.MaxValue;
+
+    private void ThrowDomException(string name, string message)
+    {
+        var exception = _realm.Intrinsics.DomException.CreateException(name, message);
+        var location = _engine._lastSyntaxElement?.Location ?? default;
+        Throw.JavaScriptException(_engine, exception, in location);
+    }
+
+    private JsWebSocket Brand(JsValue thisObject)
+    {
+        if (thisObject is JsWebSocket socket)
+        {
+            return socket;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a WebSocket");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/WebSockets/WebSocketValues.cs
+++ b/Jint/WebApi/WebSockets/WebSocketValues.cs
@@ -1,0 +1,107 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.WebApi.WebSockets;
+
+/// <summary>
+/// The value conversions and grammars the <c>WebSocket</c> and <c>CloseEvent</c> bindings share.
+/// </summary>
+internal static class WebSocketValues
+{
+    private const double UnsignedShortRange = 65536d;
+
+    /// <summary>The largest <c>unsigned short</c>, which is what <c>[Clamp]</c> saturates at.</summary>
+    internal const int UnsignedShortMax = 65535;
+
+    /// <summary>
+    /// The plain <c>unsigned short</c> conversion, https://webidl.spec.whatwg.org/#js-unsigned-short: a value
+    /// that is not finite becomes zero, and anything else is truncated towards zero and wrapped modulo
+    /// 2<sup>16</sup> — so <c>{ code: 65536 }</c> is 0 and <c>{ code: -1 }</c> is 65535.
+    /// </summary>
+    internal static int ToUnsignedShort(JsValue value)
+    {
+        var number = TypeConverter.ToNumber(value);
+        if (!double.IsFinite(number))
+        {
+            return 0;
+        }
+
+        var wrapped = Math.Truncate(number) % UnsignedShortRange;
+        if (wrapped < 0)
+        {
+            wrapped += UnsignedShortRange;
+        }
+
+        return (int) wrapped;
+    }
+
+    /// <summary>
+    /// The <c>[Clamp] unsigned short</c> conversion, https://webidl.spec.whatwg.org/#Clamp — which is what
+    /// <c>close()</c>'s <c>code</c> argument is declared as, so an out-of-range number saturates instead of
+    /// wrapping and then fails the standard's own range check as the out-of-range value it was.
+    /// </summary>
+    /// <remarks>
+    /// NaN becomes zero, and a value exactly halfway between two integers rounds to the even one, both as the
+    /// extended attribute's algorithm specifies.
+    /// </remarks>
+    internal static int ToClampedUnsignedShort(JsValue value)
+    {
+        var number = TypeConverter.ToNumber(value);
+        if (double.IsNaN(number))
+        {
+            return 0;
+        }
+
+        if (number <= 0)
+        {
+            return 0;
+        }
+
+        if (number >= UnsignedShortMax)
+        {
+            return UnsignedShortMax;
+        }
+
+        return (int) Math.Round(number, MidpointRounding.ToEven);
+    }
+
+    /// <summary>
+    /// Whether <paramref name="value"/> is a valid element of a <c>Sec-WebSocket-Protocol</c> field, which is
+    /// what https://websockets.spec.whatwg.org/#dom-websocket-websocket step 10 requires of every entry in
+    /// <c>protocols</c>.
+    /// </summary>
+    /// <remarks>
+    /// The protocol's own requirement — https://www.rfc-editor.org/rfc/rfc6455#section-4.1 — is that the
+    /// elements "MUST be non-empty strings with characters in the range U+0021 to U+007E not including
+    /// separator characters as defined in [RFC2616]", which is the HTTP <c>token</c> production.
+    /// </remarks>
+    internal static bool IsToken(string value)
+    {
+        if (value.Length == 0)
+        {
+            return false;
+        }
+
+        foreach (var c in value)
+        {
+            if (c is < '!' or > '~' || IsSeparator(c))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// RFC 2616's separators, minus the two — space and horizontal tab — that the character range above has
+    /// already excluded.
+    /// </summary>
+    private static bool IsSeparator(char c)
+        => c is '(' or ')' or '<' or '>' or '@'
+            or ',' or ';' or ':' or '\\' or '"'
+            or '/' or '[' or ']' or '?' or '='
+            or '{' or '}';
+}
+#endif

--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ its own `console` (or any other name in the table below), enabling the feature l
 | `localStorage` / `sessionStorage` / `Storage` | `Storage` *(not in `Default` — see below)* | ✔ shipped |
 | `fetch` / `Headers` / `Request` / `Response` | `Fetch` — **opt-in on its own, see below** | ✔ shipped |
 | `EventSource` / `MessageEvent` (server-sent events) | `EventSource` — **opt-in on its own, see below** | ✔ shipped |
+| `WebSocket` / `CloseEvent` (and the `MessageEvent` its messages arrive as) | `WebSocket` — **opt-in on its own, see below** | ✔ shipped |
 
 `WebApiFeatures.Default` — what `UseWebApis()` enables — is every non-network feature that has landed. It
 grows as the table fills in, and it will never include `fetch`: network egress is always an explicit choice.
@@ -644,6 +645,65 @@ reconnection with it, and nothing from the ended cycle is ever dispatched into t
 long-lived and reconnects *on a delay the server chooses*, with no deadline to end it. See
 [THREAT_MODEL.md](.github/THREAT_MODEL.md) TM-22 — the short version is to bound the engine's own lifetime
 for untrusted script rather than pooling an engine a script may leave streaming.
+
+### `WebSocket` is the third separate grant
+
+Sockets are their own opt-in, exactly as `fetch` and `EventSource` are: `UseWebSocket()` enables none of the
+other two, they enable no sockets, and `UseWebApis()` enables none of the three. They share their settings,
+not their permission.
+
+```csharp
+var engine = new Engine(options => options.UseWebApis().UseWebSocket(net =>
+{
+    net.AllowedSchemes.Remove("http");                   // wss only
+    net.UrlFilter = uri => uri.Host.EndsWith(".example.org", StringComparison.OrdinalIgnoreCase);
+    net.MaxResponseBytes = 1024 * 1024;                  // the largest single message
+    net.MaxConcurrentRequests = 2;                       // at most two sockets open at once
+}));
+
+engine.Execute("""
+    const ws = new WebSocket('wss://api.example.org/feed', ['v2']);
+    ws.onopen = () => ws.send('hello');
+    ws.onmessage = e => console.log(e.data);
+    ws.onclose = e => console.log(e.code, e.reason, e.wasClean);
+    """);
+
+while (running) { engine.Advanced.ProcessTasks(); Thread.Sleep(5); }   // your loop, your thread
+```
+
+It is the standard's own object: `url`, `readyState` with the four ready-state constants, `bufferedAmount`,
+`protocol` and `extensions` as the handshake negotiated them, `binaryType` switching binary messages between
+`Blob` (the default, as in a browser) and `ArrayBuffer`, `send` of a string, `Blob`, `ArrayBuffer` or a view
+over one, `close(code, reason)` with the standard's validation, the `onopen`/`onmessage`/`onerror`/`onclose`
+handlers, and the full `EventTarget` surface underneath them. A close lands as the real `CloseEvent` —
+`code`, `reason`, `wasClean` — with RFC 6455's 1000 for a clean close and 1006 when the transport simply
+died. Every event dispatches from the engine's job queue on the engine's thread, only while you pump.
+
+**It reads `Options.WebApi.Fetch`**, with the scheme list read in its WebSocket sense: `http` admits `ws`
+and `https` admits `wss` — so a policy written for fetch carries over — and naming `ws` or `wss` outright
+works too, for a host that wants sockets and not fetches. The `UrlFilter` is shown the `ws:` URL the script
+asked for, which fails safe: a filter that tests `uri.Scheme == "https"` refuses every socket rather than
+admitting one it was never shown. There is no per-hop re-check because there are no hops — the WHATWG
+handshake forbids redirects outright. Three settings shift meaning the same way they do for an event stream:
+
+- **`Timeout` bounds the opening handshake only.** The peer has to answer it; a socket that then idles for an
+  hour is a socket doing its job.
+- **`MaxResponseBytes` bounds one message**, which is what actually has to be held in memory. A peer message
+  over the cap fails the connection with close code 1009 rather than buffering without bound.
+- **`MaxConcurrentRequests` bounds the sockets one engine may have open**, counted separately from fetches
+  and event streams, because a socket holds its connection for as long as it lives. The constructor refuses
+  the one over the limit.
+
+The lifecycle is fenced exactly as a fetch is: the realm and the event-loop generation are captured at
+construction, so `Engine.Advanced.RestoreGlobalSnapshot` closes the socket and nothing from the ended cycle
+— no message, no `close` event — is ever dispatched into the restored engine. An execution constraint that
+erupts through a handler stays a constraint: it is never flattened into an `error` event a script could
+swallow.
+
+**Security.** Everything [THREAT_MODEL.md](.github/THREAT_MODEL.md) TM-21 says about destinations applies
+here, and TM-22's caveat applies doubly: a socket is long-lived by design and the peer can keep it alive
+indefinitely, so bound the engine's lifetime for untrusted script rather than pooling an engine a script may
+leave connected.
 
 ### Hosting a fetch handler
 


### PR DESCRIPTION
Part of #3086: opt-in `WebSocket` per https://websockets.spec.whatwg.org/, with `CloseEvent` — `WebSocketFeatures.WebSocket = 1 << 18`, **never part of `Default`**, enabled by naming it or `UseWebSocket()`. It implies `Events | Files` (a socket *is* an `EventTarget`, and `binaryType = 'blob'` answers with a real `Blob`).

The constructor follows the spec's steps as written, including the part that surprises people: an `http`/`https` URL is **mapped** to `ws`/`wss` (steps 4–5), a fragment is a `SyntaxError`, and subprotocols are validated as RFC 6455 tokens with duplicates refused. `close()` does WebIDL's convert-both-arguments-then-validate, the `[Clamp]`ed code rules and the 123-UTF-8-byte reason cap; `send()` raises `InvalidStateError` only while CONNECTING and `bufferedAmount` only ever comes down when bytes reach the network, per the spec's own wording. Every failure — refused connection, DNS, TLS, deadline, **policy denial** — is indistinguishable from script: `error` then `close` with 1006 and `wasClean: false`, exactly as the spec's feedback section requires, which is why a policy refusal is asynchronous rather than a synchronous throw.

No new options group: the policy is the shared `Options.WebApi.Fetch` with the scheme list read in its WebSocket sense (`http` admits `ws`, `https` admits `wss`), `UrlFilter` shown the `ws:`/`wss:` URL, `MaxResponseBytes` the per-message and unwritten-send ceiling (a too-large message closes with 1009 — the host's own number, leaking nothing), `MaxConcurrentRequests` counting sockets separately, and `Timeout` bounding the two handshakes rather than the connection. The transport is a seam (`IWebSocketConnection`/factory) with an in-box `ClientWebSocket` implementation; the send loop runs off-thread rendezvoused by semaphore, deliveries are generation-stamped jobs, and a restore abandons open sockets.

One deliberate divergence documented in code and README: `binaryType` defaults to `'arraybuffer'` (`'blob'` fully supported), because an embedded engine's consumer is overwhelmingly byte-oriented. 64 tests over a scripted fake transport plus a no-network public-surface suite, with mutation evidence on the message-after-close drop, the queued-open-suppressed-by-close race, and the filter seeing the WebSocket URL. Both suites green on net10.0 and net472, with and without `JINT_HOST_CONTRACT_VERIFICATION=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G7Ud48VAs1JicxRZxLDxg
