### PR TITLE
Web API: the Cache API over a host CacheStorageProvider

### DIFF
--- a/.github/THREAT_MODEL.md
+++ b/.github/THREAT_MODEL.md
@@ -697,6 +697,50 @@ attacker-controlled endpoint also controls how often the host retries it.
 the engine itself for untrusted script — one worker per request, discarded when the request
 ends — rather than pooling an engine that a script may leave streaming.
 
+### TM-23: The Cache API gives script storage that outlives the evaluation
+
+**Threat.** `WebApiFeatures.CacheApi` is the first feature whose whole point is that data a
+script writes is still there later — for a longer-lived engine, and for anything else the
+host wires to the same `CacheStorageProvider`. Three consequences follow. A script can
+**consume storage**: the entries it `put`s live wherever the provider keeps them, on the
+host's disk or database if that is what the provider is. A script can **poison what a later
+reader trusts**: a stored `Response` replays to whoever `match`es it, so two tenants sharing
+one provider, or a host reading a cache a script could write, turn a cache entry into an
+injection channel. And with `UseFetch` also granted, `cache.add` records what the *network*
+said — a cache filled through a redirect-day DNS answer replays it long after the DNS has
+moved on.
+
+**Existing mitigations.**
+
+- The feature is **off by default and not part of `WebApiFeatures.Default`** — like `Storage`,
+  and for the same reason: a host asking for "the web APIs" has not agreed to durable storage.
+  Enabling it brings the fetch *object model*, never the network; `cache.add`/`addAll` reject
+  with a `TypeError` until `UseFetch` is also granted, and with it they run under fetch's full
+  policy (scheme list, `UrlFilter`, size cap, deadline) exactly as a scripted `fetch` would.
+- The provider seam is **host-supplied and engine-free**: entries cross it as plain CLR
+  records, everything runs on the engine's thread, and a provider's
+  `CacheQuotaExceededException` surfaces as the standard `QuotaExceededError`, so quotas,
+  eviction and per-tenant partitioning have a sanctioned place to live.
+- The defaulted provider is **private to one engine** — nothing is shared between engines, and
+  nothing survives the engine being dropped.
+
+**Missing or residual mitigation.**
+
+- **The default `InMemoryCacheStorageProvider` has no quota.** A script can `put` until the
+  process runs out of memory; nothing in the engine bounds it. It also survives
+  `RestoreGlobalSnapshot` — a restore reverts global bindings, not host storage — so a pooled
+  engine carries one cycle's cache into the next unless the host swaps or clears the provider
+  itself.
+- Nothing validates what a provider returns against what was stored; a provider shared across
+  trust boundaries is itself the boundary, and partitioning is entirely its job.
+
+**Required host action.** For untrusted script, supply the provider: enforce a byte quota and
+an entry cap in it (throwing `CacheQuotaExceededException` when exceeded), partition it per
+tenant, and treat cached responses read outside the engine as script-controlled input. With a
+pooled engine, swap or clear the provider per request the same way `HostDefined` is swapped.
+If the default in-memory store is used at all, bound the engine's lifetime instead — the
+store dies with the engine, which is the only bound it has.
+
 ## Hardened deployment baseline
 
 The numbers below are examples only. Measure normal workloads and choose smaller limits that

--- a/Jint.Tests.PublicInterface/WebApiCacheTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiCacheTests.cs
@@ -1,0 +1,459 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Jint;
+using Jint.Runtime;
+using Jint.WebApi;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// The Cache API seen from outside the assembly: the host seam a third party implements to decide where a
+/// script's cached data goes, and what the engine promises about how it is called.
+/// </summary>
+/// <remarks>
+/// This project has no <c>InternalsVisibleTo</c>, so everything here — <see cref="CacheStorageProvider"/>,
+/// <see cref="CacheStore"/>, the record types, <see cref="CacheQuotaExceededException"/> — is reachable by a
+/// real embedder.
+/// </remarks>
+public class WebApiCacheTests
+{
+    /// <summary>
+    /// A provider that records what the engine asked it for and lets a test decide how a write ends.
+    /// </summary>
+    private sealed class RecordingProvider : CacheStorageProvider
+    {
+        private readonly List<string> _names = new();
+        private readonly Dictionary<string, RecordingStore> _stores = new(StringComparer.Ordinal);
+
+        internal List<string> Calls { get; } = new();
+
+        /// <summary>Returns an exception to fail the write with, or null to let it through.</summary>
+        internal Func<CacheWrite, Exception?>? OnWrite { get; set; }
+
+        public override IReadOnlyList<string> Names
+        {
+            get
+            {
+                Calls.Add("names");
+                return _names;
+            }
+        }
+
+        public override bool Contains(string cacheName)
+        {
+            Calls.Add("contains:" + cacheName);
+            return _stores.ContainsKey(cacheName);
+        }
+
+        public override CacheStore Open(string cacheName)
+        {
+            Calls.Add("open:" + cacheName);
+
+            if (_stores.TryGetValue(cacheName, out var existing))
+            {
+                return existing;
+            }
+
+            var store = new RecordingStore(this);
+            _stores.Add(cacheName, store);
+            _names.Add(cacheName);
+            return store;
+        }
+
+        public override bool Delete(string cacheName)
+        {
+            Calls.Add("delete:" + cacheName);
+
+            if (!_stores.Remove(cacheName))
+            {
+                return false;
+            }
+
+            _names.Remove(cacheName);
+            return true;
+        }
+
+        internal RecordingStore Store(string cacheName) => _stores[cacheName];
+
+        internal Exception? FailWrite(CacheWrite write) => OnWrite?.Invoke(write);
+    }
+
+    private sealed class RecordingStore : CacheStore
+    {
+        private readonly RecordingProvider _owner;
+        private List<CacheEntry> _entries = new();
+
+        internal RecordingStore(RecordingProvider owner)
+        {
+            _owner = owner;
+        }
+
+        internal List<CacheWrite> Writes { get; } = new();
+
+        public override IReadOnlyList<CacheEntry> Entries => _entries;
+
+        public override void Write(in CacheWrite write)
+        {
+            Writes.Add(write);
+
+            if (_owner.FailWrite(write) is { } failure)
+            {
+                throw failure;
+            }
+
+            var next = new List<CacheEntry>();
+            var removed = 0;
+            for (var i = 0; i < _entries.Count; i++)
+            {
+                if (removed < write.RemovedIndexes.Count && write.RemovedIndexes[removed] == i)
+                {
+                    removed++;
+                    continue;
+                }
+
+                next.Add(_entries[i]);
+            }
+
+            next.AddRange(write.Added);
+            _entries = next;
+        }
+
+        /// <summary>Puts an entry there without the engine having asked, as a host restoring a cache does.</summary>
+        internal void Seed(CacheEntry entry) => _entries.Add(entry);
+    }
+
+    private static Engine CacheEngine(CacheStorageProvider provider)
+        => new(options => options.UseCacheApi(cache => cache.Provider = provider));
+
+    private static string Run(Engine engine, string body)
+        => engine.Evaluate("(async () => {" + body + "})()").UnwrapIfPromise().AsString();
+
+    [Fact]
+    public void ADefaultEngineHasNoCaches()
+    {
+        new Engine().Evaluate("typeof caches").AsString().Should().Be("undefined");
+
+        // Not even the default set, which never carries a feature whose data outlives the evaluation.
+        new Engine(options => options.UseWebApis()).Evaluate("typeof caches").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void UseCacheApiRecordsOnlyItsOwnFlag()
+    {
+        var options = new Options().UseCacheApi();
+
+        // The features its model needs are added when the engine is built, so the option still reads back
+        // exactly what the host asked for.
+        options.WebApi.Features.Should().Be(WebApiFeatures.CacheApi);
+        options.WebApi.Cache.Provider.Should().BeNull();
+
+        var engine = new Engine(options);
+        engine.Evaluate("typeof caches").AsString().Should().Be("object");
+        engine.Evaluate("typeof Response").AsString().Should().Be("function");
+
+        // ... and it is not a way to get network access.
+        engine.Evaluate("typeof fetch").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void PutIssuesOneWriteCarryingTheFlattenedPair()
+    {
+        var provider = new RecordingProvider();
+        var engine = CacheEngine(provider);
+
+        Run(engine, """
+            const cache = await caches.open('v1');
+            await cache.put(new Request('https://example.org/a?q=1', { headers: { 'x-req': 'r' } }),
+                new Response('hi', { status: 201, statusText: 'Created', headers: { 'x-res': '1' } }));
+            return 'done';
+            """);
+
+        var store = provider.Store("v1");
+        var write = store.Writes.Should().ContainSingle().Subject;
+
+        write.RemovedIndexes.Should().BeEmpty();
+        var entry = write.Added.Should().ContainSingle().Subject;
+
+        entry.Request.Url.Should().Be("https://example.org/a?q=1");
+        entry.Request.Method.Should().Be("GET");
+        entry.Request.Headers.Should().Contain(header => header.Name == "x-req" && header.Value == "r");
+
+        entry.Response.Status.Should().Be(201);
+        entry.Response.StatusText.Should().Be("Created");
+        entry.Response.Url.Should().BeEmpty();
+        entry.Response.Redirected.Should().BeFalse();
+        entry.Response.Headers.Should().Contain(header => header.Name == "x-res" && header.Value == "1");
+
+        entry.Response.Body.Should().NotBeNull();
+        Encoding.UTF8.GetString(entry.Response.Body!.Value.ToArray()).Should().Be("hi");
+    }
+
+    [Fact]
+    public void ASecondPutForOneUrlRemovesTheEntryItReplaces()
+    {
+        var provider = new RecordingProvider();
+        var engine = CacheEngine(provider);
+
+        Run(engine, """
+            const cache = await caches.open('v1');
+            await cache.put('https://example.org/a', new Response('first'));
+            await cache.put('https://example.org/a', new Response('second'));
+            return 'done';
+            """);
+
+        var store = provider.Store("v1");
+        store.Writes.Should().HaveCount(2);
+
+        // The second write names the entry it evicts by its index in the list the store had just handed out.
+        store.Writes[1].RemovedIndexes.Should().Equal(0);
+        store.Writes[1].Added.Should().ContainSingle();
+        store.Entries.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void ADeleteThatMatchesNothingWritesNothing()
+    {
+        var provider = new RecordingProvider();
+        var engine = CacheEngine(provider);
+
+        Run(engine, """
+            const cache = await caches.open('v1');
+            await cache.put('https://example.org/a', new Response('a'));
+            const missing = await cache.delete('https://example.org/b');
+            const hit = await cache.delete('https://example.org/a');
+            return missing + ':' + hit;
+            """).Should().Be("false:true");
+
+        var store = provider.Store("v1");
+
+        // One write for the put and one for the delete that matched; the delete that matched nothing does
+        // not open a transaction only to be told there was nothing to do.
+        store.Writes.Should().HaveCount(2);
+        store.Writes[1].Added.Should().BeEmpty();
+        store.Writes[1].RemovedIndexes.Should().Equal(0);
+    }
+
+    [Fact]
+    public void AHostCanSeedACacheAndTheScriptReadsItBack()
+    {
+        var provider = new RecordingProvider();
+        var store = (RecordingStore) provider.Open("v1");
+
+        store.Seed(new CacheEntry(
+            new CachedRequest("https://example.org/seeded", "GET", [new CachedHeader("x-req", "r")]),
+            new CachedResponse(
+                Status: 203,
+                StatusText: "Non-Authoritative Information",
+                Headers: [new CachedHeader("x-res", "s")],
+                Body: Encoding.UTF8.GetBytes("from the host"),
+                Url: "https://example.org/seeded",
+                Redirected: true)));
+
+        var engine = CacheEngine(provider);
+
+        Run(engine, """
+            const cache = await caches.open('v1');
+            const r = await cache.match('https://example.org/seeded');
+            const keys = await cache.keys();
+            return [r.status, r.statusText, r.url, r.redirected, r.headers.get('x-res'), await r.text(), keys[0].url, keys[0].headers.get('x-req')].join('|');
+            """).Should().Be("203|Non-Authoritative Information|https://example.org/seeded|true|s|from the host|https://example.org/seeded|r");
+    }
+
+    [Fact]
+    public void AnEntryWhoseStoredUrlDoesNotParseIsInvisible()
+    {
+        var provider = new RecordingProvider();
+        var store = (RecordingStore) provider.Open("v1");
+
+        store.Seed(new CacheEntry(
+            new CachedRequest("not a url", "GET", []),
+            new CachedResponse(200, string.Empty, [], Encoding.UTF8.GetBytes("x"), string.Empty, false)));
+        store.Seed(new CacheEntry(
+            new CachedRequest("https://example.org/ok", "GET", []),
+            new CachedResponse(200, string.Empty, [], Encoding.UTF8.GetBytes("y"), string.Empty, false)));
+
+        var engine = CacheEngine(provider);
+
+        // A row a provider hydrated badly can never match and never appears among the keys, rather than
+        // failing every read of the cache it is in.
+        Run(engine, """
+            const cache = await caches.open('v1');
+            const keys = await cache.keys();
+            const all = await cache.matchAll();
+            return keys.length + '|' + keys[0].url + '|' + all.length;
+            """).Should().Be("1|https://example.org/ok|1");
+    }
+
+    [Fact]
+    public void AQuotaExceededExceptionBecomesTheDomExceptionABrowserRaises()
+    {
+        var provider = new RecordingProvider { OnWrite = _ => new CacheQuotaExceededException("no room left") };
+        var engine = CacheEngine(provider);
+
+        Run(engine, """
+            const cache = await caches.open('v1');
+            try {
+                await cache.put('https://example.org/a', new Response('x'));
+                return 'stored';
+            } catch (e) {
+                return [e.name, e.code, e.message, e instanceof DOMException].join('|');
+            }
+            """).Should().Be("QuotaExceededError|22|no room left|true");
+    }
+
+    [Fact]
+    public void AnyOtherProviderFailureBecomesATypeErrorTheHostCanReadTheCauseOf()
+    {
+        var provider = new RecordingProvider { OnWrite = _ => new InvalidOperationException("the disk is on fire") };
+        var engine = CacheEngine(provider);
+
+        // The script sees a plain TypeError …
+        Run(engine, """
+            const cache = await caches.open('v1');
+            try { await cache.put('https://example.org/a', new Response('x')); return 'stored'; }
+            catch (e) { return e.constructor.name + '|' + (e.message.indexOf('disk') >= 0); }
+            """).Should().Be("TypeError|false");
+
+        // … and the host gets the original exception off the error value, which the script cannot reach.
+        var rejected = Assert.Throws<PromiseRejectedException>(() => engine
+            .Evaluate("(async () => { const c = await caches.open('v1'); await c.put('https://example.org/a', new Response('x')); })()")
+            .UnwrapIfPromise());
+
+        JintException.TryGetClrException(rejected, out var clrException).Should().BeTrue();
+        clrException.Should().BeOfType<InvalidOperationException>().Which.Message.Should().Be("the disk is on fire");
+    }
+
+    [Fact]
+    public void TheDefaultProviderIsPrivateToEachEngineAndAnAssignedOneIsNot()
+    {
+        var shared = new Options().UseCacheApi();
+
+        var writer = new Engine(shared);
+        var reader = new Engine(shared);
+
+        Run(writer, "const c = await caches.open('v1'); await c.put('https://example.org/a', new Response('x')); return 'done';");
+
+        // Two engines built from one Options do not share a cache unless the host said so.
+        Run(reader, "const c = await caches.open('v1'); return typeof (await c.match('https://example.org/a'));")
+            .Should().Be("undefined");
+
+        var provider = new RecordingProvider();
+        var explicitly = new Options().UseCacheApi(cache => cache.Provider = provider);
+
+        Run(new Engine(explicitly), "const c = await caches.open('v1'); await c.put('https://example.org/a', new Response('x')); return 'done';");
+        Run(new Engine(explicitly), "const c = await caches.open('v1'); return await (await c.match('https://example.org/a')).text();")
+            .Should().Be("x");
+    }
+
+    [Fact]
+    public void CachedDataSurvivesAGlobalSnapshotRestore()
+    {
+        var engine = new Engine(options => options.UseCacheApi());
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+
+        Run(engine, "const c = await caches.open('v1'); await c.put('https://example.org/a', new Response('x')); return 'done';");
+
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        // A restore reverts the engine's global bindings, not host storage — the same answer the module
+        // registry gets. A host that wants each cycle to start empty gives the engine a fresh provider.
+        Run(engine, "const c = await caches.open('v1'); return await (await c.match('https://example.org/a')).text();")
+            .Should().Be("x");
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        internal int Requests { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("body of " + request.RequestUri),
+            });
+        }
+    }
+
+    [Fact]
+    public void AddAllCommitsTheWholeBatchAsOneWrite()
+    {
+        var provider = new RecordingProvider();
+        var handler = new StubHandler();
+
+        var engine = new Engine(options => options
+            .UseCacheApi(cache => cache.Provider = provider)
+            .UseFetch(fetch => fetch.HttpClient = new HttpClient(handler)));
+
+        Run(engine, """
+            const cache = await caches.open('v1');
+            await cache.addAll(['https://example.org/a', 'https://example.org/b']);
+            return 'done';
+            """);
+
+        handler.Requests.Should().Be(2);
+
+        // One write for two requests: what makes the standard's all-or-nothing true here is that nothing is
+        // written until every fetch has come back, so a provider only ever has one transaction to honour.
+        var store = provider.Store("v1");
+        store.Writes.Should().ContainSingle();
+        store.Writes[0].Added.Should().HaveCount(2);
+        store.Entries.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void AFailedAddAllNeverReachesTheProvider()
+    {
+        var provider = new RecordingProvider();
+        var handler = new StubHandler();
+
+        var engine = new Engine(options => options
+            .UseCacheApi(cache => cache.Provider = provider)
+            .UseFetch(fetch =>
+            {
+                fetch.UrlFilter = uri => uri.Host.Equals("allowed.example", StringComparison.Ordinal);
+                fetch.HttpClient = new HttpClient(handler);
+            }));
+
+        Run(engine, """
+            const cache = await caches.open('v1');
+            try { await cache.addAll(['https://example.org/a', 'https://example.org/b']); return 'stored'; }
+            catch (e) { return e.constructor.name; }
+            """).Should().Be("TypeError");
+
+        handler.Requests.Should().Be(0);
+        provider.Store("v1").Writes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TheEngineAsksTheProviderForNamesInTheOrderItSearchesThem()
+    {
+        var provider = new RecordingProvider();
+        var engine = CacheEngine(provider);
+
+        Run(engine, """
+            await caches.open('v1');
+            await caches.open('v2');
+            return (await caches.keys()).join(',');
+            """).Should().Be("v1,v2");
+
+        provider.Calls.Should().Contain("open:v1");
+        provider.Calls.Should().Contain("open:v2");
+        provider.Calls.Should().Contain("names");
+
+        // caches.match with a cacheName asks whether it exists rather than opening it, so a name nobody
+        // created is not created by looking for it.
+        Run(engine, "return typeof (await caches.match('https://example.org/a', { cacheName: 'v3' }));")
+            .Should().Be("undefined");
+
+        provider.Calls.Should().Contain("contains:v3");
+        provider.Calls.Should().NotContain("open:v3");
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/CacheTests.cs
+++ b/Jint.Tests/Runtime/WebApi/CacheTests.cs
@@ -1,0 +1,812 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Jint.Native;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// The Cache API as https://w3c.github.io/ServiceWorker/#cache-interface specifies it — the object model, the
+/// request-matching algorithm and the batch semantics, over the in-box in-memory provider.
+/// </summary>
+public class CacheTests
+{
+    private static Engine CacheEngine() => new(options => options.UseCacheApi());
+
+    private static JsValue Run(Engine engine, string source) => engine.Evaluate(source).UnwrapIfPromise();
+
+    private static JsValue Run(string source) => Run(CacheEngine(), source);
+
+    /// <summary>
+    /// Wraps a body in an immediately-invoked async function, which is how every one of these tests reads the
+    /// promises the whole interface is made of.
+    /// </summary>
+    private static string Async(string body) => "(async () => {" + body + "})()";
+
+    [Fact]
+    public void PutAndMatchRoundTripTheWholeResponse()
+    {
+        var result = Run(Async("""
+            const cache = await caches.open('v1');
+            await cache.put('https://example.org/a', new Response('hello', {
+                status: 201,
+                statusText: 'Created',
+                headers: { 'x-a': '1', 'content-type': 'text/plain' },
+            }));
+
+            const r = await cache.match('https://example.org/a');
+            return [r.status, r.statusText, r.ok, r.headers.get('x-a'), r.headers.get('content-type'), await r.text()].join('|');
+            """));
+
+        result.AsString().Should().Be("201|Created|true|1|text/plain|hello");
+    }
+
+    [Fact]
+    public void MatchAnswersUndefinedWhenNothingMatches()
+    {
+        Run(Async("""
+            const cache = await caches.open('v1');
+            await cache.put('https://example.org/a', new Response('hello'));
+            return typeof (await cache.match('https://example.org/b'));
+            """)).AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void AMatchedResponseCarriesImmutableHeaders()
+    {
+        // "Add a new Response object associated with response and a new Headers object whose guard is
+        // 'immutable'" — a script must not be able to edit the answer and mistake it for editing the cache.
+        Run(Async("""
+            const cache = await caches.open('v1');
+            await cache.put('https://example.org/a', new Response('hello', { headers: { 'x-a': '1' } }));
+
+            const r = await cache.match('https://example.org/a');
+            try {
+                r.headers.set('x-a', '2');
+                return 'mutated';
+            } catch (e) {
+                return e.constructor.name;
+            }
+            """)).AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void PutReplacesAnEntryWithTheSameUrl()
+    {
+        // Batch Cache Operations' put arm: "set requestResponses to the result of running Query Cache with
+        // operation's request … remove the item … append", so a second put for one URL leaves one entry.
+        Run(Async("""
+            const cache = await caches.open('v1');
+            await cache.put('https://example.org/a', new Response('first'));
+            await cache.put('https://example.org/a', new Response('second'));
+
+            const all = await cache.matchAll('https://example.org/a');
+            return all.length + ':' + (await all[0].text());
+            """)).AsString().Should().Be("1:second");
+    }
+
+    [Fact]
+    public void PutConsumesTheResponseItWasGiven()
+    {
+        // "Let bodyReadPromise be the result of reading all bytes from reader" — the original is disturbed,
+        // and the copy the cache keeps is not.
+        Run(Async("""
+            const cache = await caches.open('v1');
+            const response = new Response('hello');
+            await cache.put('https://example.org/a', response);
+
+            let second = 'read';
+            try { await response.text(); } catch (e) { second = e.constructor.name; }
+
+            const cached = await cache.match('https://example.org/a');
+            return response.bodyUsed + '|' + second + '|' + (await cached.text());
+            """)).AsString().Should().Be("true|TypeError|hello");
+    }
+
+    [Fact]
+    public void MatchAllAnswersEveryEntryInCacheOrder()
+    {
+        Run(Async("""
+            const cache = await caches.open('v1');
+            await cache.put('https://example.org/a', new Response('a'));
+            await cache.put('https://example.org/b', new Response('b'));
+            await cache.put('https://example.org/c', new Response('c'));
+
+            const all = await cache.matchAll();
+            const bodies = [];
+            for (const r of all) { bodies.push(await r.text()); }
+            return bodies.join(',');
+            """)).AsString().Should().Be("a,b,c");
+    }
+
+    [Fact]
+    public void MatchAllKeepsVaryingEntriesApartAndInOrder()
+    {
+        // Two entries may share a URL when the cached responses vary by a header the two requests differ in;
+        // ignoreVary then collapses them, and the order is the order they were put in.
+        var engine = CacheEngine();
+        engine.Execute("""
+            var setup = (async () => {
+                const cache = await caches.open('v1');
+                await cache.put(new Request('https://example.org/a', { headers: { accept: 'x' } }),
+                    new Response('first', { headers: { vary: 'accept' } }));
+                await cache.put(new Request('https://example.org/a', { headers: { accept: 'y' } }),
+                    new Response('second', { headers: { vary: 'accept' } }));
+                return cache;
+            })();
+            """);
+
+        Run(engine, Async("""
+            const cache = await setup;
+            const all = await cache.matchAll('https://example.org/a', { ignoreVary: true });
+            const bodies = [];
+            for (const r of all) { bodies.push(await r.text()); }
+            return bodies.join(',');
+            """)).AsString().Should().Be("first,second");
+
+        // Without ignoreVary each request finds only its own entry, and a query carrying no `accept` at all
+        // finds neither: an absent value does not match a present one.
+        Run(engine, Async("""
+            const cache = await setup;
+            const x = await cache.match(new Request('https://example.org/a', { headers: { accept: 'x' } }));
+            const y = await cache.match(new Request('https://example.org/a', { headers: { accept: 'y' } }));
+            const none = await cache.match('https://example.org/a');
+            return (await x.text()) + '|' + (await y.text()) + '|' + typeof none;
+            """)).AsString().Should().Be("first|second|undefined");
+    }
+
+    [Fact]
+    public void MatchAllAndKeysAnswerFrozenArrays()
+    {
+        Run(Async("""
+            const cache = await caches.open('v1');
+            await cache.put('https://example.org/a', new Response('a'));
+            return Object.isFrozen(await cache.matchAll()) + ':' + Object.isFrozen(await cache.keys());
+            """)).AsString().Should().Be("true:true");
+    }
+
+    [Fact]
+    public void IgnoreSearchComparesUrlsWithoutTheirQuery()
+    {
+        var engine = CacheEngine();
+        engine.Execute("""
+            var setup = (async () => {
+                const cache = await caches.open('v1');
+                await cache.put('https://example.org/a?q=1', new Response('stored'));
+                return cache;
+            })();
+            """);
+
+        // Exact by default …
+        Run(engine, Async("const c = await setup; return typeof (await c.match('https://example.org/a'));"))
+            .AsString().Should().Be("undefined");
+
+        // … and with the queries removed from both sides, a bare URL and a different query both match.
+        Run(engine, Async("""
+            const c = await setup;
+            const bare = await c.match('https://example.org/a', { ignoreSearch: true });
+            const other = await c.match('https://example.org/a?q=2', { ignoreSearch: true });
+            return (await bare.text()) + '|' + (await other.text());
+            """)).AsString().Should().Be("stored|stored");
+
+        // A different path still does not match, so ignoreSearch is not simply ignoring the tail.
+        Run(engine, Async("const c = await setup; return typeof (await c.match('https://example.org/b', { ignoreSearch: true }));"))
+            .AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void AFragmentIsExcludedFromTheComparisonButKeptOnTheStoredRequest()
+    {
+        // "If queryURL does not equal cachedURL with the exclude fragment flag set" — matching ignores the
+        // fragment, while keys() reports the request's URL as the script wrote it.
+        Run(Async("""
+            const cache = await caches.open('v1');
+            await cache.put('https://example.org/a#one', new Response('stored'));
+
+            const matched = await cache.match('https://example.org/a#two');
+            const keys = await cache.keys();
+            return (await matched.text()) + '|' + keys[0].url;
+            """)).AsString().Should().Be("stored|https://example.org/a#one");
+    }
+
+    [Fact]
+    public void IgnoreMethodDecidesWhetherANonGetQueryMatchesAnything()
+    {
+        var engine = CacheEngine();
+        engine.Execute("""
+            var setup = (async () => {
+                const cache = await caches.open('v1');
+                await cache.put('https://example.org/a', new Response('stored'));
+                return cache;
+            })();
+            var post = () => new Request('https://example.org/a', { method: 'POST', body: 'x' });
+            """);
+
+        // "If r's method is not `GET` and options.ignoreMethod is false, return a promise resolved with an
+        // empty array" — a successful empty answer, not a rejection.
+        Run(engine, Async("""
+            const c = await setup;
+            const all = await c.matchAll(post());
+            const one = await c.match(post());
+            const keys = await c.keys(post());
+            return all.length + '|' + typeof one + '|' + keys.length;
+            """)).AsString().Should().Be("0|undefined|0");
+
+        Run(engine, Async("""
+            const c = await setup;
+            const one = await c.match(post(), { ignoreMethod: true });
+            const keys = await c.keys(post(), { ignoreMethod: true });
+            return (await one.text()) + '|' + keys.length;
+            """)).AsString().Should().Be("stored|1");
+    }
+
+    [Fact]
+    public void DeleteHonoursIgnoreMethodAndReportsWhetherAnythingWent()
+    {
+        var engine = CacheEngine();
+        engine.Execute("""
+            var open = () => caches.open('v1');
+            var post = () => new Request('https://example.org/a', { method: 'POST', body: 'x' });
+            """);
+
+        Run(engine, Async("""
+            const cache = await open();
+            await cache.put('https://example.org/a', new Response('stored'));
+
+            // A non-GET query deletes nothing and says so …
+            const refused = await cache.delete(post());
+            const stillThere = (await cache.keys()).length;
+
+            // … until ignoreMethod lets it through.
+            const deleted = await cache.delete(post(), { ignoreMethod: true });
+            const afterwards = (await cache.keys()).length;
+
+            // A second delete finds nothing left.
+            const again = await cache.delete('https://example.org/a');
+
+            return [refused, stillThere, deleted, afterwards, again].join('|');
+            """)).AsString().Should().Be("false|1|true|0|false");
+    }
+
+    [Fact]
+    public void PutRefusesANonGetRequest()
+    {
+        // "If innerRequest's url's scheme is not one of `http` and `https`, or innerRequest's method is not
+        // `GET`, return a promise rejected with a TypeError."
+        Run(Async("""
+            const cache = await caches.open('v1');
+            try {
+                await cache.put(new Request('https://example.org/a', { method: 'POST', body: 'x' }), new Response('y'));
+                return 'stored';
+            } catch (e) {
+                return e.constructor.name + ':' + (await cache.keys()).length;
+            }
+            """)).AsString().Should().Be("TypeError:0");
+    }
+
+    [Fact]
+    public void PutRefusesANonHttpScheme()
+    {
+        Run(Async("""
+            const cache = await caches.open('v1');
+            try {
+                await cache.put('data:,hello', new Response('y'));
+                return 'stored';
+            } catch (e) {
+                return e.constructor.name;
+            }
+            """)).AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void PutRefusesAPartialResponseAndAVaryWildcard()
+    {
+        // Both refusals exist so that what a cache answers with later can be trusted: a 206 is a fragment of
+        // a body, and a response varying by everything could never be matched again.
+        Run(Async("""
+            const cache = await caches.open('v1');
+            const failures = [];
+
+            try { await cache.put('https://example.org/a', new Response('x', { status: 206 })); failures.push('206 stored'); }
+            catch (e) { failures.push(e.constructor.name); }
+
+            try { await cache.put('https://example.org/a', new Response('x', { headers: { vary: '*' } })); failures.push('vary stored'); }
+            catch (e) { failures.push(e.constructor.name); }
+
+            try { await cache.put('https://example.org/a', new Response('x', { headers: { vary: 'accept, *' } })); failures.push('list stored'); }
+            catch (e) { failures.push(e.constructor.name); }
+
+            return failures.join(',') + ':' + (await cache.keys()).length;
+            """)).AsString().Should().Be("TypeError,TypeError,TypeError:0");
+    }
+
+    [Fact]
+    public void PutRefusesAnAlreadyConsumedBody()
+    {
+        Run(Async("""
+            const cache = await caches.open('v1');
+            const response = new Response('hello');
+            await response.text();
+
+            try {
+                await cache.put('https://example.org/a', response);
+                return 'stored';
+            } catch (e) {
+                return e.constructor.name;
+            }
+            """)).AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void PutRefusesASecondArgumentThatIsNotAResponse()
+    {
+        Run(Async("""
+            const cache = await caches.open('v1');
+            try { await cache.put('https://example.org/a', 'not a response'); return 'stored'; }
+            catch (e) { return e.constructor.name; }
+            """)).AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void KeysAnswersTheStoredRequestsInCacheOrder()
+    {
+        Run(Async("""
+            const cache = await caches.open('v1');
+            await cache.put('https://example.org/b', new Response('b'));
+            await cache.put('https://example.org/a', new Response('a'));
+            await cache.put('https://example.org/c', new Response('c'));
+
+            const keys = await cache.keys();
+            return keys.map(r => r.url + ':' + r.method).join(',');
+            """)).AsString().Should().Be("https://example.org/b:GET,https://example.org/a:GET,https://example.org/c:GET");
+    }
+
+    [Fact]
+    public void KeysNarrowsToOneRequestWhenGivenOne()
+    {
+        Run(Async("""
+            const cache = await caches.open('v1');
+            await cache.put('https://example.org/a', new Response('a'));
+            await cache.put('https://example.org/b', new Response('b'));
+
+            const keys = await cache.keys('https://example.org/b');
+            return keys.length + ':' + keys[0].url;
+            """)).AsString().Should().Be("1:https://example.org/b");
+    }
+
+    [Fact]
+    public void ARequestsHeadersSurviveTheRoundTrip()
+    {
+        Run(Async("""
+            const cache = await caches.open('v1');
+            await cache.put(new Request('https://example.org/a', { headers: { 'x-a': '1', 'x-b': '2' } }), new Response('a'));
+
+            const keys = await cache.keys();
+            return keys[0].headers.get('x-a') + '|' + keys[0].headers.get('x-b');
+            """)).AsString().Should().Be("1|2");
+    }
+
+    [Fact]
+    public void CachesAreListedInCreationOrderAndDeletedByName()
+    {
+        Run(Async("""
+            const before = await caches.keys();
+            await caches.open('v2');
+            await caches.open('v1');
+
+            const listed = await caches.keys();
+            const has = await caches.has('v1');
+            const missing = await caches.has('nope');
+            const deleted = await caches.delete('v2');
+            const again = await caches.delete('v2');
+
+            return before.length + '|' + listed.join(',') + '|' + has + '|' + missing + '|' + deleted + '|' + again + '|' + (await caches.keys()).join(',');
+            """)).AsString().Should().Be("0|v2,v1|true|false|true|false|v1");
+    }
+
+    [Fact]
+    public void OpeningTheSameNameTwiceGivesTwoObjectsOverOneCache()
+    {
+        // "Resolve promise with a new Cache object that represents value" — a new object every time, over the
+        // storage the name already had.
+        Run(Async("""
+            const first = await caches.open('v1');
+            await first.put('https://example.org/a', new Response('stored'));
+
+            const second = await caches.open('v1');
+            return (first === second) + ':' + (await (await second.match('https://example.org/a')).text());
+            """)).AsString().Should().Be("false:stored");
+    }
+
+    [Fact]
+    public void ACacheKeepsWorkingAfterItsNameIsDeleted()
+    {
+        // The standard's own note: "the existing DOM objects … should remain functional".
+        Run(Async("""
+            const cache = await caches.open('v1');
+            await cache.put('https://example.org/a', new Response('stored'));
+            await caches.delete('v1');
+
+            const matched = await cache.match('https://example.org/a');
+            return (await caches.has('v1')) + ':' + (await matched.text());
+            """)).AsString().Should().Be("false:stored");
+    }
+
+    [Fact]
+    public void CachesMatchSearchesEveryCacheInCreationOrder()
+    {
+        Run(Async("""
+            const v1 = await caches.open('v1');
+            const v2 = await caches.open('v2');
+            await v2.put('https://example.org/a', new Response('from v2'));
+            await v2.put('https://example.org/b', new Response('only in v2'));
+            await v1.put('https://example.org/a', new Response('from v1'));
+
+            // v1 was opened first, so it answers first even though v2 was filled first.
+            const first = await caches.match('https://example.org/a');
+
+            // A cache further down the list still answers for a URL nothing above it holds.
+            const later = await caches.match('https://example.org/b');
+
+            return (await first.text()) + '|' + (await later.text());
+            """)).AsString().Should().Be("from v1|only in v2");
+    }
+
+    [Fact]
+    public void CachesMatchNarrowsToOneCacheByName()
+    {
+        Run(Async("""
+            const v1 = await caches.open('v1');
+            const v2 = await caches.open('v2');
+            await v1.put('https://example.org/a', new Response('from v1'));
+            await v2.put('https://example.org/a', new Response('from v2'));
+
+            const named = await caches.match('https://example.org/a', { cacheName: 'v2' });
+            const missing = await caches.match('https://example.org/a', { cacheName: 'nope' });
+
+            // Naming a cache that does not exist answers undefined rather than creating it.
+            return (await named.text()) + '|' + typeof missing + '|' + (await caches.keys()).join(',');
+            """)).AsString().Should().Be("from v2|undefined|v1,v2");
+    }
+
+    [Fact]
+    public void CachesMatchAnswersUndefinedWhenNoCacheHoldsIt()
+    {
+        Run(Async("""
+            await caches.open('v1');
+            return typeof (await caches.match('https://example.org/nothing'));
+            """)).AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void EveryOperationRejectsRatherThanThrows()
+    {
+        // Both interfaces are promise-returning throughout, so a brand-check failure and an argument that
+        // cannot be converted are rejections — which is what lets a caches chain be written without a try.
+        Run(Async("""
+            const cache = await caches.open('v1');
+            const results = [];
+
+            try { results.push(await Cache.prototype.match.call({}, 'https://example.org/a')); }
+            catch (e) { results.push('brand:' + e.constructor.name); }
+
+            try { results.push(await CacheStorage.prototype.keys.call({})); }
+            catch (e) { results.push('storageBrand:' + e.constructor.name); }
+
+            try { results.push(await cache.match('not a url')); }
+            catch (e) { results.push('url:' + e.constructor.name); }
+
+            try { results.push(await cache.match('https://example.org/a', 5)); }
+            catch (e) { results.push('options:' + e.constructor.name); }
+
+            try { results.push(await caches.open()); }
+            catch (e) { results.push('missing:' + e.constructor.name); }
+
+            return results.join(',');
+            """)).AsString().Should().Be("brand:TypeError,storageBrand:TypeError,url:TypeError,options:TypeError,missing:TypeError");
+    }
+
+    [Fact]
+    public void NeitherInterfaceIsConstructible()
+    {
+        var engine = CacheEngine();
+
+        // WebIDL: an interface with no constructor operation has an interface object that refuses to build
+        // anything — https://webidl.spec.whatwg.org/#es-interface-call.
+        engine.Evaluate("(() => { try { new Cache(); return 'built'; } catch (e) { return e.constructor.name; } })()")
+            .AsString().Should().Be("TypeError");
+        engine.Evaluate("(() => { try { new CacheStorage(); return 'built'; } catch (e) { return e.constructor.name; } })()")
+            .AsString().Should().Be("TypeError");
+
+        engine.Evaluate("caches instanceof CacheStorage").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.prototype.toString.call(caches)").AsString().Should().Be("[object CacheStorage]");
+    }
+
+    [Fact]
+    public void ACacheObjectHasTheShapeWebIdlDescribes()
+    {
+        var engine = CacheEngine();
+
+        Run(engine, Async("globalThis.cache = await caches.open('v1'); return 0;"));
+
+        engine.Evaluate("Object.getOwnPropertyNames(cache).length").AsNumber().Should().Be(0);
+        engine.Evaluate("Object.getPrototypeOf(cache) === Cache.prototype").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.prototype.toString.call(cache)").AsString().Should().Be("[object Cache]");
+        engine.Evaluate("[Cache.prototype.match.length, Cache.prototype.matchAll.length, Cache.prototype.add.length, Cache.prototype.addAll.length, Cache.prototype.put.length, Cache.prototype.delete.length, Cache.prototype.keys.length].join(',')")
+            .AsString().Should().Be("1,0,1,1,2,1,0");
+        engine.Evaluate("[CacheStorage.prototype.match.length, CacheStorage.prototype.has.length, CacheStorage.prototype.open.length, CacheStorage.prototype.delete.length, CacheStorage.prototype.keys.length].join(',')")
+            .AsString().Should().Be("1,1,1,1,0");
+    }
+
+    [Fact]
+    public void InstallsTheCacheGlobalsBehindTheirOwnFlagOnly()
+    {
+        var engine = CacheEngine();
+
+        foreach (var name in new[] { "Cache", "CacheStorage" })
+        {
+            engine.Evaluate($"typeof {name}").AsString().Should().Be("function");
+
+            // Interface objects: writable and configurable, but not enumerable.
+            var descriptor = engine.Realm.GlobalObject.GetOwnProperty(name);
+            descriptor.Enumerable.Should().BeFalse();
+            descriptor.Writable.Should().BeTrue();
+            descriptor.Configurable.Should().BeTrue();
+        }
+
+        engine.Evaluate("typeof caches").AsString().Should().Be("object");
+        engine.Realm.GlobalObject.GetOwnProperty("caches").Enumerable.Should().BeTrue();
+
+        // The default set never carries it, and neither does a default engine.
+        new Engine(options => options.UseWebApis()).Evaluate("typeof caches").AsString().Should().Be("undefined");
+        new Engine().Evaluate("typeof caches").AsString().Should().Be("undefined");
+
+        // ... and never inside a shadow realm.
+        engine.Evaluate("new ShadowRealm().evaluate('typeof caches')").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void BringsTheObjectModelACacheIsMadeOfButNotFetch()
+    {
+        var engine = CacheEngine();
+
+        foreach (var name in new[] { "Headers", "Request", "Response", "AbortController", "URL", "Blob" })
+        {
+            engine.Evaluate($"typeof {name}").AsString().Should().Be("function");
+        }
+
+        // Caching is not network access: the flag brings the classes and deliberately not the function.
+        engine.Evaluate("typeof fetch").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void AddAndAddAllRejectWithoutTheFetchFeature()
+    {
+        var result = Run(Async("""
+            const cache = await caches.open('v1');
+            const messages = [];
+
+            try { await cache.add('https://example.org/a'); messages.push('added'); }
+            catch (e) { messages.push(e.constructor.name + ':' + e.message); }
+
+            try { await cache.addAll(['https://example.org/a']); messages.push('added'); }
+            catch (e) { messages.push(e.constructor.name); }
+
+            return messages.join('|');
+            """)).AsString();
+
+        // The message has to name what to turn on — an absent capability that says nothing is a support
+        // ticket rather than a diagnosis.
+        result.Should().StartWith("TypeError:");
+        result.Should().Contain("WebApiFeatures.Fetch");
+        result.Should().Contain("UseFetch");
+        result.Should().EndWith("|TypeError");
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        internal List<string> Requests { get; } = new();
+
+        internal Func<string, HttpResponseMessage>? Responder { get; set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var url = request.RequestUri!.ToString();
+            Requests.Add(url);
+
+            var response = Responder is { } responder
+                ? responder(url)
+                : new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("body of " + url) };
+
+            return Task.FromResult(response);
+        }
+    }
+
+    private static Engine FetchingCacheEngine(HttpMessageHandler handler, Action<Options.FetchOptions>? configure = null)
+    {
+        return new Engine(options => options
+            .UseCacheApi()
+            .UseFetch(fetch =>
+            {
+                fetch.HttpClient = new HttpClient(handler);
+                configure?.Invoke(fetch);
+            }));
+    }
+
+    [Fact]
+    public void AddAllFetchesEveryRequestAndStoresThemAll()
+    {
+        var handler = new StubHandler();
+
+        Run(FetchingCacheEngine(handler), Async("""
+            const cache = await caches.open('v1');
+            const result = await cache.addAll(['https://example.org/a', 'https://example.org/b']);
+
+            const keys = await cache.keys();
+            const first = await cache.match('https://example.org/a');
+            return typeof result + '|' + keys.map(r => r.url).join(',') + '|' + (await first.text());
+            """)).AsString().Should().Be("undefined|https://example.org/a,https://example.org/b|body of https://example.org/a");
+
+        handler.Requests.Should().BeEquivalentTo(["https://example.org/a", "https://example.org/b"]);
+    }
+
+    [Fact]
+    public void AddStoresTheOneResponseItFetched()
+    {
+        var handler = new StubHandler();
+
+        Run(FetchingCacheEngine(handler), Async("""
+            const cache = await caches.open('v1');
+            await cache.add('https://example.org/a');
+            return await (await cache.match('https://example.org/a')).text();
+            """)).AsString().Should().Be("body of https://example.org/a");
+    }
+
+    [Fact]
+    public void AddAllStoresNothingWhenAnyResponseIsNotOk()
+    {
+        var handler = new StubHandler
+        {
+            Responder = url => url.EndsWith("/b", StringComparison.Ordinal)
+                ? new HttpResponseMessage(HttpStatusCode.NotFound) { Content = new StringContent("nope") }
+                : new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") },
+        };
+
+        // "If response's … status is not an ok status … reject responsePromise with a TypeError" — and
+        // because nothing is committed until every response has passed, the first one is not stored either.
+        Run(FetchingCacheEngine(handler), Async("""
+            const cache = await caches.open('v1');
+            let outcome = 'stored';
+            try { await cache.addAll(['https://example.org/a', 'https://example.org/b']); }
+            catch (e) { outcome = e.constructor.name; }
+
+            return outcome + ':' + (await cache.keys()).length;
+            """)).AsString().Should().Be("TypeError:0");
+    }
+
+    [Fact]
+    public void AddAllStoresNothingWhenAResponseVariesByEverything()
+    {
+        var handler = new StubHandler
+        {
+            Responder = _ =>
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") };
+                response.Headers.Add("vary", "*");
+                return response;
+            },
+        };
+
+        Run(FetchingCacheEngine(handler), Async("""
+            const cache = await caches.open('v1');
+            let outcome = 'stored';
+            try { await cache.addAll(['https://example.org/a']); }
+            catch (e) { outcome = e.constructor.name; }
+
+            return outcome + ':' + (await cache.keys()).length;
+            """)).AsString().Should().Be("TypeError:0");
+    }
+
+    [Fact]
+    public void AddAllRefusesTwoRequestsThatMatchEachOther()
+    {
+        var handler = new StubHandler();
+
+        // Batch Cache Operations step 4.3: "if the result of running Query Cache with operation's request …
+        // and addedItems is not empty, throw an InvalidStateError" — and the rollback leaves nothing behind.
+        Run(FetchingCacheEngine(handler), Async("""
+            const cache = await caches.open('v1');
+            let outcome = 'stored';
+            try { await cache.addAll(['https://example.org/a', 'https://example.org/a']); }
+            catch (e) { outcome = e.name; }
+
+            return outcome + ':' + (await cache.keys()).length;
+            """)).AsString().Should().Be("InvalidStateError:0");
+    }
+
+    [Fact]
+    public void AddAllRefusesANonHttpSchemeBeforeFetchingAnything()
+    {
+        var handler = new StubHandler();
+
+        Run(FetchingCacheEngine(handler), Async("""
+            const cache = await caches.open('v1');
+            let outcome = 'stored';
+            try { await cache.addAll(['https://example.org/a', 'data:,hello']); }
+            catch (e) { outcome = e.constructor.name; }
+
+            return outcome + ':' + (await cache.keys()).length;
+            """)).AsString().Should().Be("TypeError:0");
+
+        // The refusal is made before a socket is opened, so the sibling request is never sent either.
+        handler.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AddAllRefusesANonGetRequestObject()
+    {
+        var handler = new StubHandler();
+
+        Run(FetchingCacheEngine(handler), Async("""
+            const cache = await caches.open('v1');
+            try { await cache.addAll([new Request('https://example.org/a', { method: 'POST', body: 'x' })]); return 'stored'; }
+            catch (e) { return e.constructor.name; }
+            """)).AsString().Should().Be("TypeError");
+
+        handler.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AddGoesThroughTheEnginesOwnFetchPolicy()
+    {
+        var handler = new StubHandler();
+
+        // The whole point of routing add/addAll through the engine's fetch: the host's URL filter, scheme
+        // list, size cap and deadline bound them exactly as they bound a fetch the script wrote itself.
+        var engine = FetchingCacheEngine(handler, fetch => fetch.UrlFilter = uri => uri.Host.Equals("allowed.example", StringComparison.Ordinal));
+
+        Run(engine, Async("""
+            const cache = await caches.open('v1');
+            let outcome = 'stored';
+            try { await cache.add('https://denied.example/a'); }
+            catch (e) { outcome = e.constructor.name; }
+
+            return outcome + ':' + (await cache.keys()).length;
+            """)).AsString().Should().Be("TypeError:0");
+
+        handler.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AddAllWithNoRequestsResolvesWithoutFetchingAnything()
+    {
+        var handler = new StubHandler();
+
+        Run(FetchingCacheEngine(handler), Async("""
+            const cache = await caches.open('v1');
+            const result = await cache.addAll([]);
+            return typeof result + ':' + (await cache.keys()).length;
+            """)).AsString().Should().Be("undefined:0");
+
+        handler.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AddAllRejectsForSomethingThatIsNotIterable()
+    {
+        var handler = new StubHandler();
+
+        // The sequence<RequestInfo> conversion is an argument conversion, so its failure is a rejection like
+        // every other — https://webidl.spec.whatwg.org/#es-sequence.
+        Run(FetchingCacheEngine(handler), Async("""
+            const cache = await caches.open('v1');
+            try { await cache.addAll(5); return 'accepted'; }
+            catch (e) { return e.constructor.name; }
+            """)).AsString().Should().Be("TypeError");
+    }
+}
+#endif

--- a/Jint/Engine.WebApi.cs
+++ b/Jint/Engine.WebApi.cs
@@ -103,7 +103,7 @@ internal sealed class WebApiEngineState
     /// </summary>
     private List<JsWebSocket>? _webSockets;
 
-    internal WebApiEngineState(Engine engine, TimeProvider timeProvider, TimerQueue? timers, Options.FetchOptions? fetchOptions, SchedulerQueue? scheduler, DiagnosticsSink? diagnostics, Options.StorageOptions? storage = null)
+    internal WebApiEngineState(Engine engine, TimeProvider timeProvider, TimerQueue? timers, Options.FetchOptions? fetchOptions, SchedulerQueue? scheduler, DiagnosticsSink? diagnostics, Options.StorageOptions? storage = null, CacheStorageProvider? cacheProvider = null)
     {
         _engine = engine;
         _timeProvider = timeProvider;
@@ -117,6 +117,7 @@ internal sealed class WebApiEngineState
         _localStorageProvider = storage?.LocalStorageProvider;
         _sessionStorageProvider = storage?.SessionStorageProvider;
         _storageQuotaBytes = storage?.MaxTotalBytes ?? Options.StorageOptions.DefaultMaxTotalBytes;
+        CacheProvider = cacheProvider;
 
         // Both halves of the time origin, read back to back: the monotonic reading every later now() is a
         // duration from, and the wall-clock moment that reading corresponds to.
@@ -146,6 +147,19 @@ internal sealed class WebApiEngineState
     /// engine is built, so that no background thread ever reaches into <see cref="Options"/>.
     /// </summary>
     internal Options.FetchOptions? FetchOptions { get; }
+
+    /// <summary>
+    /// Where the <c>caches</c> object keeps what a script stored, or <see langword="null"/> when the Cache
+    /// API is off. Resolved once, when the engine is built — either the host's provider or a private
+    /// in-memory one — so two engines built from one shared <see cref="Options"/> do not share a cache
+    /// unless the host deliberately gave them one provider.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately untouched by <see cref="ResetTransientState"/>: the provider is host storage, not engine
+    /// state, so a pooled engine's next cycle finds what the previous one cached — the same answer the module
+    /// registry gets from a restore.
+    /// </remarks>
+    internal CacheStorageProvider? CacheProvider { get; }
 
     /// <summary>
     /// How many requests are in flight, which is what <c>Options.FetchOptions.MaxConcurrentRequests</c>

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -77,6 +77,12 @@ public partial class Options
         /// contains <see cref="WebApiFeatures.Storage"/>.
         /// </summary>
         public StorageOptions Storage { get; } = new();
+
+        /// <summary>
+        /// Settings for the <c>caches</c> object, installed when <see cref="Features"/> contains
+        /// <see cref="WebApiFeatures.CacheApi"/> — which <see cref="WebApiFeatures.Default"/> never does.
+        /// </summary>
+        public CacheOptions Cache { get; } = new();
     }
 
     /// <summary>
@@ -139,6 +145,43 @@ public partial class Options
         /// no "unlimited" sentinel — <see cref="long.MaxValue"/> is how that is spelled.
         /// </remarks>
         public long MaxTotalBytes { get; set; } = DefaultMaxTotalBytes;
+    }
+
+    /// <summary>
+    /// Settings for the Cache API: where a script's cached request/response pairs are kept. Requires .NET 8
+    /// or higher.
+    /// </summary>
+    /// <remarks>
+    /// Like every other option group this may be shared by any number of engines, including concurrent ones.
+    /// Sharing one <see cref="Provider"/> between them is what makes them share a cache, and such a provider
+    /// must be thread-safe — see <see cref="CacheStorageProvider"/>.
+    /// </remarks>
+    public class CacheOptions
+    {
+        /// <summary>
+        /// Where the caches live, or <see langword="null"/> to give each engine a private
+        /// <see cref="InMemoryCacheStorageProvider"/> of its own.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The default is deliberately per engine rather than one instance on this options object: two
+        /// engines built from one shared <see cref="Options"/> would otherwise see each other's cached data,
+        /// which is not something a host asking for a web API should inherit. Sharing is what assigning a
+        /// provider here is <i>for</i>, and it is then an explicit act.
+        /// </para>
+        /// <para>
+        /// <b>The default has no quota</b>, so a script can go on caching until the process runs out of
+        /// memory; a host running untrusted script implements <see cref="CacheStorageProvider"/> and throws
+        /// <see cref="CacheQuotaExceededException"/> to impose one. Cached data also survives
+        /// <c>Engine.Advanced.RestoreGlobalSnapshot</c>, which reverts the engine's global bindings and not
+        /// host storage.
+        /// </para>
+        /// <para>
+        /// Read once, when the engine is built, so assigning it afterwards does not affect an engine that
+        /// already exists.
+        /// </para>
+        /// </remarks>
+        public CacheStorageProvider? Provider { get; set; }
     }
 
     /// <summary>
@@ -656,6 +699,30 @@ public enum WebApiFeatures
     /// </para>
     /// </remarks>
     WebSocket = 1 << 18,
+
+    /// <summary>
+    /// The <c>caches</c> object and the <c>Cache</c> and <c>CacheStorage</c> interfaces —
+    /// https://w3c.github.io/ServiceWorker/#cache-interface. <b>Never part of
+    /// <see cref="Default"/>:</b> a cache outlives the evaluation that filled it, so where the data goes and
+    /// what bounds it are decisions a host makes rather than inherits — see
+    /// <see cref="Options.CacheOptions"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Implies <see cref="Events"/>, <see cref="Url"/> and <see cref="Files"/> for the same reason
+    /// <see cref="Fetch"/> does, and additionally installs <c>Headers</c>, <c>Request</c> and
+    /// <c>Response</c>: a cache <i>is</i> a list of request/response pairs, so a script that cannot build one
+    /// has nothing to put in it. What this flag does not bring is the network — <c>fetch</c> itself stays
+    /// behind <see cref="Fetch"/>, and the two <c>Cache</c> methods that reach the network,
+    /// <c>add</c> and <c>addAll</c>, reject with a <c>TypeError</c> naming the flag until it is enabled.
+    /// Everything else works: a host can populate a cache from its own data and a script can read it back.
+    /// </para>
+    /// <para>
+    /// Storage is delegated to <see cref="Options.CacheOptions.Provider"/>, which defaults to an in-memory
+    /// store per engine with no quota at all.
+    /// </para>
+    /// </remarks>
+    CacheApi = 1 << 19,
 
     /// <summary>
     /// <c>CompressionStream</c> and <c>DecompressionStream</c> — https://compression.spec.whatwg.org/ — for

--- a/Jint/Runtime/Intrinsics.WebApi.cs
+++ b/Jint/Runtime/Intrinsics.WebApi.cs
@@ -2,6 +2,7 @@
 using Jint.WebApi.Abort;
 using Jint.WebApi.Base64;
 using Jint.WebApi.Compression;
+using Jint.WebApi.Caches;
 using Jint.WebApi.Console;
 using Jint.WebApi.Crypto;
 using Jint.WebApi.DomException;
@@ -182,6 +183,23 @@ public sealed partial class Intrinsics
     /// <summary><c>MessageEvent</c> inherits from <c>Event</c>.</summary>
     internal MessageEventConstructor MessageEvent =>
         _messageEvent ??= new MessageEventConstructor(_engine, _realm, Event);
+
+    private CacheConstructor? _cache;
+    private CacheStorageConstructor? _cacheStorage;
+    private JsCacheStorage? _caches;
+
+    internal CacheConstructor Cache =>
+        _cache ??= new CacheConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
+
+    internal CacheStorageConstructor CacheStorage =>
+        _cacheStorage ??= new CacheStorageConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
+
+    /// <summary>
+    /// The <c>caches</c> object, which reads the engine's cache storage provider and therefore needs the
+    /// web-API state <c>WebApiRegistration</c> created alongside the global.
+    /// </summary>
+    internal JsCacheStorage Caches =>
+        _caches ??= JsCacheStorage.Create(_engine, _realm);
 
     internal CryptoInstance Crypto =>
         _crypto ??= new CryptoInstance(_engine, _realm, Object.PrototypeObject);

--- a/Jint/WebApi/CacheStorageProvider.cs
+++ b/Jint/WebApi/CacheStorageProvider.cs
@@ -1,0 +1,248 @@
+#if NET8_0_OR_GREATER
+using System.Runtime.InteropServices;
+
+namespace Jint.WebApi;
+
+/// <summary>
+/// Where the engine's <c>caches</c> object keeps what a script stored. Requires .NET 8 or higher.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Jint implements the <see href="https://w3c.github.io/ServiceWorker/#cache-interface">Service Workers
+/// Standard</see>'s object model — the <c>Cache</c> and <c>CacheStorage</c> classes, the request-matching
+/// algorithm, the <c>Vary</c> rules, the batch semantics — and delegates the storage itself to a provider.
+/// A <c>Request</c>/<c>Response</c> pair is flattened into <see cref="CacheEntry"/>, a plain CLR record with
+/// no engine reference in it, so a provider may put it in a dictionary, a file, a database or a distributed
+/// cache without knowing anything about JavaScript.
+/// </para>
+/// <para>
+/// <b>Threading.</b> Every member here is called on the engine's own thread, synchronously, from inside the
+/// <c>Cache</c> method the script called. Nothing is ever called from a thread pool thread, and no member is
+/// called while another one is in progress on the same engine. A provider must not block — the script that
+/// called it is suspended — and one that is shared by engines running concurrently must be thread-safe, the
+/// same obligation <see cref="ConsoleSink"/> carries. A provider must not touch the <see cref="Engine"/>.
+/// </para>
+/// <para>
+/// <b>Failure.</b> Any exception a provider throws becomes a rejection of the promise the script is holding:
+/// <see cref="CacheQuotaExceededException"/> becomes a <c>QuotaExceededError</c> <c>DOMException</c>, which is
+/// what the standard's storage steps raise, and anything else becomes a <c>TypeError</c> carrying the original
+/// exception on the error value for the host to read with <c>JintException.TryGetClrException</c>. The engine
+/// never swallows one.
+/// </para>
+/// <para>
+/// The default is <see cref="InMemoryCacheStorageProvider"/>, one per engine, which is why the caches of two
+/// engines are unrelated unless a host deliberately hands them the same provider.
+/// </para>
+/// </remarks>
+public abstract class CacheStorageProvider
+{
+    /// <summary>
+    /// The names of the caches that exist, in the order they were first opened.
+    /// </summary>
+    /// <remarks>
+    /// This is what <c>caches.keys()</c> answers and the order <c>caches.match()</c> searches in, so the
+    /// creation order is observable and a provider that cannot preserve it changes which response a script
+    /// gets. The engine never mutates the returned list and reads it once per call.
+    /// </remarks>
+    public abstract IReadOnlyList<string> Names { get; }
+
+    /// <summary>
+    /// Whether a cache with this name exists — <c>caches.has(name)</c>.
+    /// </summary>
+    /// <param name="cacheName">The name, compared exactly as the script wrote it.</param>
+    public abstract bool Contains(string cacheName);
+
+    /// <summary>
+    /// The cache with this name, <b>creating it when it does not exist</b> — <c>caches.open(name)</c>.
+    /// </summary>
+    /// <remarks>
+    /// Never returns <see langword="null"/>. Opening the same name twice may hand back the same
+    /// <see cref="CacheStore"/> or two objects over one store; the script sees a new <c>Cache</c> object
+    /// either way, as the standard requires.
+    /// </remarks>
+    /// <param name="cacheName">The name, taken verbatim from the script.</param>
+    public abstract CacheStore Open(string cacheName);
+
+    /// <summary>
+    /// Forgets the cache with this name — <c>caches.delete(name)</c>. Returns whether it existed.
+    /// </summary>
+    /// <remarks>
+    /// A <see cref="CacheStore"/> a script is still holding a <c>Cache</c> object for goes on working after
+    /// this, which is what the standard's own note asks for; it is simply no longer reachable by name.
+    /// </remarks>
+    /// <param name="cacheName">The name, taken verbatim from the script.</param>
+    public abstract bool Delete(string cacheName);
+}
+
+/// <summary>
+/// One named cache: an ordered list of request/response pairs. Requires .NET 8 or higher.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The engine performs every algorithm the standard defines — matching, <c>Vary</c>, the duplicate check —
+/// against the snapshot <see cref="Entries"/> returns, and expresses the whole outcome as one
+/// <see cref="Write"/>. That is what makes a <c>put</c>, a <c>delete</c> or a whole <c>addAll</c> atomic:
+/// there is one call, and a provider that applies it in a transaction gives the script the all-or-nothing
+/// behaviour the standard's rollback step describes.
+/// </para>
+/// <para>
+/// <b>The two calls are a pair.</b> A <see cref="Write"/> names entries by their index in the list the
+/// immediately preceding <see cref="Entries"/> read returned, and no engine code — and therefore no script —
+/// runs between the two, so the list a provider hands out only has to stay stable across that window.
+/// </para>
+/// </remarks>
+public abstract class CacheStore
+{
+    /// <summary>
+    /// The pairs this cache holds, oldest first.
+    /// </summary>
+    /// <remarks>
+    /// The order is observable: it is the order <c>matchAll()</c> and <c>keys()</c> answer in, and therefore
+    /// decides which response a bare <c>match()</c> picks. The engine never mutates the returned list.
+    /// </remarks>
+    public abstract IReadOnlyList<CacheEntry> Entries { get; }
+
+    /// <summary>
+    /// Applies one atomic change: removes the named entries, then appends the new ones.
+    /// </summary>
+    /// <remarks>
+    /// Either the whole write happens or none of it does — a provider that cannot honour that turns a failed
+    /// <c>addAll</c> into a half-populated cache, which is exactly what the standard's rollback step forbids.
+    /// Throw to refuse the write; see <see cref="CacheStorageProvider"/> for what the script then sees.
+    /// </remarks>
+    /// <param name="write">The removals and additions, both possibly empty.</param>
+    public abstract void Write(in CacheWrite write);
+}
+
+/// <summary>
+/// One atomic change to a <see cref="CacheStore"/>. Requires .NET 8 or higher.
+/// </summary>
+/// <param name="RemovedIndexes">
+/// Ascending indexes into the list the immediately preceding <see cref="CacheStore.Entries"/> read returned.
+/// Empty for a write that only adds.
+/// </param>
+/// <param name="Added">
+/// The entries to append, in order, <i>after</i> the removals have been applied. Empty for a write that only
+/// removes.
+/// </param>
+[StructLayout(LayoutKind.Auto)]
+public readonly record struct CacheWrite(IReadOnlyList<int> RemovedIndexes, IReadOnlyList<CacheEntry> Added);
+
+/// <summary>
+/// One cached request/response pair — https://w3c.github.io/ServiceWorker/#dfn-request-response-list.
+/// Requires .NET 8 or higher.
+/// </summary>
+/// <param name="Request">The request the pair is keyed by.</param>
+/// <param name="Response">The response that was stored for it.</param>
+public sealed record CacheEntry(CachedRequest Request, CachedResponse Response);
+
+/// <summary>
+/// A cached request, flattened out of a <c>Request</c> object. Requires .NET 8 or higher.
+/// </summary>
+/// <param name="Url">
+/// The absolute URL, serialized. Written by the engine as the WHATWG URL serialization <i>including</i> any
+/// fragment, because that is what <c>request.url</c> answers; matching excludes the fragment either way. An
+/// entry whose URL a provider hands back does not parse is invisible to the script — it can never match and
+/// never appears in <c>keys()</c>.
+/// </param>
+/// <param name="Method">
+/// The HTTP method. Always <c>GET</c> for anything the engine stored, because
+/// <see href="https://w3c.github.io/ServiceWorker/#dom-cache-put">put</see> refuses every other method; a
+/// provider may still hand back another one, and such an entry then matches only a query that passed
+/// <c>ignoreMethod</c>.
+/// </param>
+/// <param name="Headers">
+/// The request's headers, in order, with repeated names kept apart. They are what the <c>Vary</c> rules
+/// compare, so dropping them changes which entry a query matches.
+/// </param>
+public sealed record CachedRequest(string Url, string Method, IReadOnlyList<CachedHeader> Headers);
+
+/// <summary>
+/// A cached response, flattened out of a <c>Response</c> object. Requires .NET 8 or higher.
+/// </summary>
+/// <param name="Status">The HTTP status code.</param>
+/// <param name="StatusText">The reason phrase, possibly empty.</param>
+/// <param name="Headers">
+/// The response's headers, in order, with repeated names kept apart — <c>Set-Cookie</c> in particular.
+/// A <c>Vary</c> header among them is honoured by the matching algorithm.
+/// </param>
+/// <param name="Body">
+/// The body's bytes, or <see langword="null"/> for the standard's <i>null body</i>, which is not the same as
+/// an empty one: a null body can be consumed any number of times and never flips <c>bodyUsed</c>.
+/// </param>
+/// <param name="Url">
+/// What <c>response.url</c> answers — the URL the response came from, or the empty string for one a script
+/// built itself.
+/// </param>
+/// <param name="Redirected">What <c>response.redirected</c> answers.</param>
+/// <remarks>
+/// The response's <i>type</i> is deliberately not part of the record. It describes how a browser filtered a
+/// cross-origin response, and this engine has no origins to filter across, so a response handed back from a
+/// cache is a plain one — its status, headers and body are the whole of what a script here can act on.
+/// </remarks>
+public sealed record CachedResponse(
+    int Status,
+    string StatusText,
+    IReadOnlyList<CachedHeader> Headers,
+    ReadOnlyMemory<byte>? Body,
+    string Url,
+    bool Redirected);
+
+/// <summary>
+/// One header of a cached request or response. Requires .NET 8 or higher.
+/// </summary>
+/// <param name="Name">
+/// The header's name. The engine writes it already lowercased, and reads every name back
+/// ASCII-case-insensitively, so a provider that round-trips through a store which corrects casing loses
+/// nothing.
+/// </param>
+/// <param name="Value">The header's value, already normalized.</param>
+[StructLayout(LayoutKind.Auto)]
+public readonly record struct CachedHeader(string Name, string Value);
+
+/// <summary>
+/// Thrown by a <see cref="CacheStore"/> or a <see cref="CacheStorageProvider"/> to refuse a write for want of
+/// room. Requires .NET 8 or higher.
+/// </summary>
+/// <remarks>
+/// This is the one provider failure with a specified meaning: the engine turns it into the
+/// <c>QuotaExceededError</c> <c>DOMException</c> the storage steps of
+/// <see href="https://w3c.github.io/ServiceWorker/#batch-cache-operations">Batch Cache Operations</see> and
+/// <see href="https://w3c.github.io/ServiceWorker/#cache-storage-open">open</see> raise, so a script sees the
+/// failure it would see in a browser and can handle it by name. Every other exception becomes a
+/// <c>TypeError</c>.
+/// <para>
+/// Nothing in Jint throws it: the built-in <see cref="InMemoryCacheStorageProvider"/> has no quota at all,
+/// and imposing one is a host decision.
+/// </para>
+/// </remarks>
+public sealed class CacheQuotaExceededException : Exception
+{
+    /// <summary>
+    /// Creates the exception with a default message.
+    /// </summary>
+    public CacheQuotaExceededException() : this("The cache storage quota has been exceeded.")
+    {
+    }
+
+    /// <summary>
+    /// Creates the exception with a message of the host's own.
+    /// </summary>
+    /// <param name="message">
+    /// What went wrong. It reaches the script as the <c>DOMException</c>'s message, so it must not name
+    /// anything the script should not learn.
+    /// </param>
+    public CacheQuotaExceededException(string message) : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Creates the exception with a message and the failure underneath it.
+    /// </summary>
+    /// <param name="message">What went wrong; it reaches the script as the <c>DOMException</c>'s message.</param>
+    /// <param name="innerException">The underlying failure, which the script never sees.</param>
+    public CacheQuotaExceededException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}
+#endif

--- a/Jint/WebApi/Caches/CacheAddAll.cs
+++ b/Jint/WebApi/Caches/CacheAddAll.cs
@@ -1,0 +1,320 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Promise;
+using Jint.Runtime;
+using Jint.WebApi.DomException;
+using Jint.WebApi.Fetch;
+
+namespace Jint.WebApi.Caches;
+
+/// <summary>
+/// <c>Cache.add</c> and <c>Cache.addAll</c>: fetch every request, and store the lot or store none of it.
+/// <para>
+/// https://w3c.github.io/ServiceWorker/#dom-cache-addall
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// These are the only two <c>Cache</c> methods that reach the network, which is why they are the only two
+/// that need <c>fetch</c> enabled. Every other method works on an engine that has the Cache API and nothing
+/// else — a script can build its own <c>Request</c> and <c>Response</c> objects and populate the cache from
+/// host data — so requiring the network feature for the whole surface would be far too coarse. The refusal
+/// is a <c>TypeError</c> naming the flag rather than an absent method, because the method <i>is</i> there in
+/// a browser and a script feature-detecting on <c>caches</c> alone would otherwise get no answer at all.
+/// </para>
+/// <para>
+/// <b>All or nothing.</b> The standard's own atomicity comes from Batch Cache Operations' rollback; here it
+/// comes from ordering: not one byte is written until every fetch has fulfilled and every response has
+/// passed its checks, and the whole run is then committed as one <see cref="CacheStore.Write"/>. A failed
+/// fetch, a 404, a <c>Vary: *</c> or a duplicate request therefore leaves the cache exactly as it was.
+/// </para>
+/// <para>
+/// The fetches all start at once, so a list longer than
+/// <c>Options.WebApi.Fetch.MaxConcurrentRequests</c> rejects on the requests that exceed it — and, being
+/// all-or-nothing, stores nothing. That is the honest failure for a bound the host chose; a script wanting
+/// more than the engine allows at once can <c>await</c> its way through <c>cache.add</c> instead.
+/// </para>
+/// </remarks>
+internal static class CacheAddAll
+{
+    /// <summary>
+    /// https://w3c.github.io/ServiceWorker/#dom-cache-add — "let requests be an array containing only
+    /// request", then the algorithm below. The fulfillment value is already <c>undefined</c>, so the
+    /// standard's mapping handler has nothing left to do.
+    /// </summary>
+    internal static JsValue Add(Engine engine, Realm realm, JsCache cache, JsValue request)
+    {
+        var info = CacheOperations.ResolveRequestInfo(request, optional: false)!;
+        return Start(engine, realm, cache, [info], "add");
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/ServiceWorker/#dom-cache-addall
+    /// </summary>
+    internal static JsValue AddAll(Engine engine, Realm realm, JsCache cache, JsValue requests)
+    {
+        return Start(engine, realm, cache, ReadSequence(realm, requests), "addAll");
+    }
+
+    private static JsValue Start(Engine engine, Realm realm, JsCache cache, List<JsValue> infos, string operation)
+    {
+        var state = engine._webApi;
+        if (state?.FetchOptions is null)
+        {
+            Throw.TypeError(
+                realm,
+                $"Failed to execute '{operation}' on 'Cache': this engine cannot fetch. Enable WebApiFeatures.Fetch (options.UseFetch()) to use Cache.add and Cache.addAll; every other Cache method works without it.");
+        }
+
+        // Step 3: a Request the script handed over is checked before anything is fetched — both its scheme
+        // and its method. A string input cannot fail the method check, which is why the algorithm makes this
+        // pass over the Request-typed elements alone.
+        for (var i = 0; i < infos.Count; i++)
+        {
+            if (infos[i] is JsRequest request && (!CacheOperations.IsHttpScheme(request.Url) || !string.Equals(request.Method, "GET", StringComparison.Ordinal)))
+            {
+                Throw.TypeError(realm, $"Failed to execute '{operation}' on 'Cache': Request method '{request.Method}' is unsupported");
+            }
+        }
+
+        // Step 5: every element becomes a request, and a scheme that is not HTTP(S) ends the whole call —
+        // the standard aborts the fetches already started, which here means simply never starting one.
+        var requests = new List<JsRequest>(infos.Count);
+        for (var i = 0; i < infos.Count; i++)
+        {
+            var info = infos[i];
+            var request = info as JsRequest ?? CacheOperations.ConstructRequest(realm, info);
+            if (!CacheOperations.IsHttpScheme(request.Url))
+            {
+                Throw.TypeError(realm, $"Failed to execute '{operation}' on 'Cache': Add/AddAll does not support schemes other than \"http\" or \"https\"");
+            }
+
+            requests.Add(request);
+        }
+
+        var capability = PromiseConstructor.NewPromiseCapability(engine, realm.Intrinsics.Promise);
+        new Join(engine, realm, cache, capability, requests, operation).Start(state!);
+        return capability.PromiseInstance;
+    }
+
+    /// <summary>
+    /// The <c>sequence&lt;RequestInfo&gt;</c> conversion, https://webidl.spec.whatwg.org/#es-sequence: the
+    /// argument is iterated and every element is converted to the <c>RequestInfo</c> union as it arrives.
+    /// </summary>
+    private static List<JsValue> ReadSequence(Realm realm, JsValue requests)
+    {
+        var infos = new List<JsValue>();
+        var iterator = requests.GetIterator(realm);
+
+        try
+        {
+            while (iterator.TryIteratorStepValue(out var value))
+            {
+                infos.Add(CacheOperations.ResolveRequestInfo(value, optional: false)!);
+            }
+        }
+        catch
+        {
+            iterator.CloseIfNotDone(CompletionType.Throw);
+            throw;
+        }
+
+        return infos;
+    }
+
+    /// <summary>
+    /// Waits for every fetch, checks each response, and commits once — the "get a promise to wait for all"
+    /// step and the fulfillment handler after it.
+    /// </summary>
+    /// <remarks>
+    /// The reactions are engine-internal continuations rather than JavaScript functions, so no function
+    /// object is materialized per request and nothing a script could reach observes the join. Everything
+    /// here runs on the engine's thread, inside a promise reaction job — which is why every failure has to
+    /// become a rejection: an exception escaping a queued job erupts out of whatever is pumping and leaves
+    /// the script's promise pending forever.
+    /// </remarks>
+    private sealed class Join
+    {
+        private readonly Engine _engine;
+        private readonly Realm _realm;
+        private readonly JsCache _cache;
+        private readonly PromiseCapability _capability;
+        private readonly List<JsRequest> _requests;
+        private readonly JsResponse?[] _responses;
+        private readonly ReadOnlyMemory<byte>?[] _bodies;
+        private readonly string _operation;
+
+        private int _pending;
+        private bool _settled;
+
+        internal Join(Engine engine, Realm realm, JsCache cache, PromiseCapability capability, List<JsRequest> requests, string operation)
+        {
+            _engine = engine;
+            _realm = realm;
+            _cache = cache;
+            _capability = capability;
+            _requests = requests;
+            _responses = new JsResponse?[requests.Count];
+            _bodies = new ReadOnlyMemory<byte>?[requests.Count];
+            _operation = operation;
+        }
+
+        internal void Start(WebApiEngineState state)
+        {
+            _pending = _requests.Count;
+
+            // `addAll([])` waits for nothing and has nothing to store, so the commit below reaches the
+            // provider with an empty batch — which CacheOperations.Put declines to write at all.
+            if (_pending == 0)
+            {
+                Guarded(Commit);
+                return;
+            }
+
+            for (var i = 0; i < _requests.Count; i++)
+            {
+                // Through the engine's own fetch, so the host's scheme list, URL filter, size cap, deadline
+                // and concurrency bound all apply exactly as they do to a fetch the script wrote itself.
+                var promise = FetchOperation.Start(_engine, _realm, state, [_requests[i]]);
+                PromiseOperations.PerformPromiseThen(_engine, (JsPromise) promise, new Reaction(this, i));
+            }
+        }
+
+        internal void Settle(int index, JsValue value, ReactionType type)
+        {
+            if (_settled)
+            {
+                return;
+            }
+
+            if (type == ReactionType.Reject)
+            {
+                // A fetch that failed — a network error, a refused URL, a blown deadline — is the whole
+                // call's failure, with the reason the script would have seen from the fetch itself.
+                _settled = true;
+                _capability.Reject(value);
+                return;
+            }
+
+            Guarded(() => Fulfilled(index, value));
+        }
+
+        private void Fulfilled(int index, JsValue value)
+        {
+            var response = (JsResponse) value;
+
+            // processResponse: "if response's type is error, or response's status is not an ok status or is
+            // 206, reject with a TypeError". A network error is already a rejection here, so what is left is
+            // the status — and 206, which is an ok status but a partial one, so caching it would answer a
+            // later request with a fragment of a body.
+            if (!response.Ok || response.Status == 206)
+            {
+                Fail(_realm.Intrinsics.TypeError.Construct(
+                    $"Failed to execute '{_operation}' on 'Cache': Request failed with status {response.Status}"));
+                return;
+            }
+
+            if (CacheQuery.VaryContainsWildcard(response.Headers.List.Get("vary")))
+            {
+                Fail(_realm.Intrinsics.TypeError.Construct(
+                    $"Failed to execute '{_operation}' on 'Cache': Response with Vary: * cannot be cached"));
+                return;
+            }
+
+            // A network response's body is a stream now, so the standard's read-all-bytes is a second
+            // asynchronous stage per slot: the slot only counts as arrived once its bytes have too, and a
+            // body that errors mid-read fails the whole call exactly as the fetch itself failing would.
+            FetchBody.ReadBodyBytes(
+                _engine,
+                _realm,
+                response,
+                bytes => Guarded(() => BodyRead(index, response, bytes)),
+                reason =>
+                {
+                    if (!_settled)
+                    {
+                        Fail(reason);
+                    }
+                });
+        }
+
+        private void BodyRead(int index, JsResponse response, ReadOnlyMemory<byte>? bytes)
+        {
+            if (_settled)
+            {
+                return;
+            }
+
+            _responses[index] = response;
+            _bodies[index] = bytes;
+
+            if (--_pending == 0)
+            {
+                Commit();
+            }
+        }
+
+        private void Commit()
+        {
+            _settled = true;
+
+            var responses = new List<JsResponse>(_responses.Length);
+            var bodies = new List<ReadOnlyMemory<byte>?>(_responses.Length);
+            for (var i = 0; i < _responses.Length; i++)
+            {
+                responses.Add(_responses[i]!);
+                bodies.Add(_bodies[i]);
+            }
+
+            CacheOperations.Put(_realm, _cache.Store, _requests, responses, bodies);
+            _capability.Resolve(JsValue.Undefined);
+        }
+
+        private void Fail(JsValue reason)
+        {
+            _settled = true;
+            _capability.Reject(reason);
+        }
+
+        /// <summary>
+        /// Runs one step of the join on an event-loop turn, where nothing may escape.
+        /// </summary>
+        private void Guarded(Action step)
+        {
+            try
+            {
+                step();
+            }
+            catch (JavaScriptException ex)
+            {
+                Fail(ex.Error);
+            }
+            catch (CacheQuotaExceededException ex)
+            {
+                Fail(_realm.Intrinsics.DomException.CreateException(DomExceptionNames.QuotaExceeded, ex.Message));
+            }
+            catch (Exception ex) when (!ConstraintFailure.MustPropagate(ex))
+            {
+                Fail(CacheOperations.ProviderFailure(_realm, ex));
+            }
+        }
+
+        /// <summary>
+        /// One request's reaction, carrying the index the response belongs at.
+        /// </summary>
+        private sealed class Reaction : IPromiseContinuation
+        {
+            private readonly Join _join;
+            private readonly int _index;
+
+            internal Reaction(Join join, int index)
+            {
+                _join = join;
+                _index = index;
+            }
+
+            public void Invoke(Engine engine, JsValue value, ReactionType type) => _join.Settle(_index, value, type);
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/Caches/CacheConstructor.cs
+++ b/Jint/WebApi/Caches/CacheConstructor.cs
@@ -1,0 +1,57 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Caches;
+
+/// <summary>
+/// The <c>Cache</c> interface object.
+/// <para>
+/// https://w3c.github.io/ServiceWorker/#cache-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// The interface declares no constructor operation, which in WebIDL means the interface object exists and is
+/// a function but refuses to construct anything — https://webidl.spec.whatwg.org/#es-interface-call. A
+/// <c>Cache</c> comes from <c>caches.open(name)</c> and from nowhere else, which is what keeps every cache a
+/// script can reach one the host's provider knows about.
+/// </remarks>
+internal sealed class CacheConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("Cache");
+
+    internal CacheConstructor(
+        Engine engine,
+        Realm realm,
+        FunctionPrototype functionPrototype,
+        ObjectPrototype objectPrototype)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = functionPrototype;
+        PrototypeObject = new CachePrototype(engine, realm, this, objectPrototype);
+        _length = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal CachePrototype PrototypeObject { get; }
+
+    /// <summary>
+    /// An interface without a constructor operation is not constructible.
+    /// </summary>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        Throw.TypeError(_realm, "Illegal constructor");
+        return null!;
+    }
+
+    /// <summary>
+    /// Builds the <c>Cache</c> object <c>caches.open</c> hands out — a new one per call, as the standard
+    /// says, over whichever store the provider answered with.
+    /// </summary>
+    internal JsCache CreateInstance(string name, CacheStore store)
+        => new(_engine, name, store) { _prototype = PrototypeObject };
+}
+#endif

--- a/Jint/WebApi/Caches/CacheOperations.cs
+++ b/Jint/WebApi/Caches/CacheOperations.cs
@@ -1,0 +1,400 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Promise;
+using Jint.Runtime;
+using Jint.WebApi.Abort;
+using Jint.WebApi.DomException;
+using Jint.WebApi.Fetch;
+using Jint.WebApi.Url;
+using Jint.WebApi.Url.Parsing;
+
+namespace Jint.WebApi.Caches;
+
+/// <summary>
+/// The bridge between the engine's <c>Request</c>/<c>Response</c> objects and the plain CLR records a
+/// <see cref="CacheStorageProvider"/> stores, plus
+/// <see href="https://w3c.github.io/ServiceWorker/#batch-cache-operations">Batch Cache Operations</see>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The standard models every mutation as a list of typed operations run atomically with a rollback if any of
+/// them throws. Only three shapes of that list can occur — one <c>delete</c>, one <c>put</c>, and the run of
+/// <c>put</c>s an <c>addAll</c> commits — so each is written out here instead, and each reads the store's
+/// entries once and issues exactly one <see cref="CacheStore.Write"/>. The rollback then needs no backup
+/// copy: nothing is written until every step has succeeded, which is a stronger guarantee than undoing
+/// afterwards and is what makes a failed <c>addAll</c> leave the cache untouched.
+/// </para>
+/// <para>
+/// Everything here runs on the engine's thread, inside the <c>Cache</c> method the script called.
+/// </para>
+/// </remarks>
+internal static class CacheOperations
+{
+    /// <summary>
+    /// Flattens a request/response pair into the record a provider stores.
+    /// </summary>
+    internal static CacheEntry Dehydrate(JsRequest request, JsResponse response, ReadOnlyMemory<byte>? body)
+    {
+        return new CacheEntry(
+            new CachedRequest(request.Url.Serialize(), request.Method, Dehydrate(request.Headers.List)),
+            new CachedResponse(
+                response.Status,
+                response.StatusText,
+                Dehydrate(response.Headers.List),
+                body,
+                response.Url,
+                response.Redirected));
+    }
+
+    private static CachedHeader[] Dehydrate(HeaderList headers)
+    {
+        var entries = headers.Entries;
+        if (entries.Count == 0)
+        {
+            return [];
+        }
+
+        var flattened = new CachedHeader[entries.Count];
+        for (var i = 0; i < entries.Count; i++)
+        {
+            flattened[i] = new CachedHeader(entries[i].LowerName, entries[i].Value);
+        }
+
+        return flattened;
+    }
+
+    /// <summary>
+    /// The <c>Response</c> a <c>match</c> or a <c>matchAll</c> answers with. Its headers are immutable, which
+    /// is what "a new Headers object whose guard is <c>immutable</c>" asks for — a cached response handed to
+    /// a script must not be editable in place, because the edit would not reach the cache.
+    /// </summary>
+    internal static JsResponse HydrateResponse(Engine engine, Realm realm, CachedResponse cached)
+    {
+        var headers = realm.Intrinsics.Headers.CreateInstance(Hydrate(cached.Headers));
+        headers.List.Guard = HeadersGuard.Immutable;
+
+        var response = new JsResponse(engine, headers)
+        {
+            _prototype = realm.Intrinsics.Response.PrototypeObject,
+            Status = cached.Status,
+            StatusText = cached.StatusText,
+            Url = cached.Url,
+            Redirected = cached.Redirected,
+        };
+
+        if (cached.Body is { } body)
+        {
+            response.SetBufferedBody(body);
+        }
+
+        return response;
+    }
+
+    /// <summary>
+    /// The <c>Request</c> a <c>keys</c> answers with, or <see langword="null"/> when the stored URL does not
+    /// parse — an entry a provider hydrated badly is invisible rather than fatal, the same rule
+    /// <see cref="CacheQuery.Matches"/> applies.
+    /// </summary>
+    internal static JsRequest? HydrateRequest(Engine engine, Realm realm, CachedRequest cached)
+    {
+        var url = UrlParser.Parse(cached.Url);
+        if (url is null)
+        {
+            return null;
+        }
+
+        var headers = realm.Intrinsics.Headers.CreateInstance(Hydrate(cached.Headers));
+        headers.List.Guard = HeadersGuard.Immutable;
+
+        return new JsRequest(engine, headers)
+        {
+            _prototype = realm.Intrinsics.Request.PrototypeObject,
+            Method = cached.Method,
+            Url = url,
+
+            // A request's signal is never null. A cached one was never in flight, so it gets a fresh signal
+            // nothing can abort rather than the one the request that filled the cache carried.
+            Signal = new JsAbortSignal(engine, realm) { _prototype = realm.Intrinsics.AbortSignal.PrototypeObject },
+        };
+    }
+
+    /// <summary>
+    /// Rebuilds a header list from a provider's records.
+    /// </summary>
+    /// <remarks>
+    /// A header a provider hands back that is not a well-formed HTTP header — a name that is not a token, a
+    /// value carrying NUL, CR or LF — is dropped rather than admitted, because everything downstream of a
+    /// <c>Headers</c> object assumes those invariants. It is dropped only from the JavaScript object: the
+    /// stored record is what the matching algorithm reads, so a dropped header still varies what it varies.
+    /// </remarks>
+    private static HeaderList Hydrate(IReadOnlyList<CachedHeader> headers)
+    {
+        var list = new HeaderList();
+        for (var i = 0; i < headers.Count; i++)
+        {
+            var header = headers[i];
+            if (HeaderList.IsName(header.Name) && HeaderList.IsValue(header.Value))
+            {
+                list.Append(header.Name, header.Value);
+            }
+        }
+
+        return list;
+    }
+
+    /// <summary>
+    /// The <c>put</c> half of Batch Cache Operations for one or more pairs: each new request evicts whatever
+    /// it matches, then is appended, and the whole run is committed as one write.
+    /// </summary>
+    /// <remarks>
+    /// The duplicate check is the algorithm's step 4.3 — "if the result of running Query Cache with
+    /// operation's request, operation's options, and addedItems is not empty, throw an InvalidStateError" —
+    /// and it is the reason <c>cache.addAll(['/a', '/a'])</c> rejects and stores nothing rather than quietly
+    /// keeping one of the two. Matching is run without options, exactly as a <c>put</c> operation carries
+    /// none, so a cached response's <c>Vary</c> still decides what a new one evicts.
+    /// </remarks>
+    internal static void Put(Realm realm, CacheStore store, List<JsRequest> requests, List<JsResponse> responses, List<ReadOnlyMemory<byte>?> bodies)
+    {
+        var snapshot = store.Entries;
+        var evicted = new bool[snapshot.Count];
+        var added = new List<CacheEntry>(requests.Count);
+
+        for (var i = 0; i < requests.Count; i++)
+        {
+            var request = requests[i];
+
+            for (var j = 0; j < added.Count; j++)
+            {
+                if (CacheQuery.Matches(request, added[j], default))
+                {
+                    throw new JavaScriptException(realm.Intrinsics.DomException.CreateException(
+                        DomExceptionNames.InvalidState,
+                        "Failed to execute 'addAll' on 'Cache': duplicate requests"));
+                }
+            }
+
+            for (var k = 0; k < snapshot.Count; k++)
+            {
+                if (!evicted[k] && CacheQuery.Matches(request, snapshot[k], default))
+                {
+                    evicted[k] = true;
+                }
+            }
+
+            added.Add(Dehydrate(request, responses[i], bodies[i]));
+        }
+
+        var removed = new List<int>();
+        for (var k = 0; k < evicted.Length; k++)
+        {
+            if (evicted[k])
+            {
+                removed.Add(k);
+            }
+        }
+
+        if (removed.Count == 0 && added.Count == 0)
+        {
+            // `addAll([])` is the only way here: nothing was fetched and nothing is evicted, so there is
+            // nothing for a provider to open a transaction for. Same rule as a delete that matched nothing.
+            return;
+        }
+
+        store.Write(new CacheWrite(removed, added));
+    }
+
+    /// <summary>
+    /// The <c>delete</c> half of Batch Cache Operations: whether anything matched, and it is gone if so.
+    /// </summary>
+    /// <remarks>
+    /// A delete that matches nothing issues no write at all, which is the rule both operations follow: the
+    /// standard's batch still "runs", but a batch that changes nothing is not worth a provider's
+    /// transaction.
+    /// </remarks>
+    internal static bool Delete(CacheStore store, JsRequest request, CacheQueryOptions options)
+    {
+        var snapshot = store.Entries;
+        var matches = CacheQuery.Run(snapshot, request, options);
+        if (matches.Count == 0)
+        {
+            return false;
+        }
+
+        store.Write(new CacheWrite(matches, []));
+        return true;
+    }
+
+    /// <summary>
+    /// The responses a query selects, hydrated in list order —
+    /// https://w3c.github.io/ServiceWorker/#dom-cache-matchall steps 5.2 and 5.3.
+    /// </summary>
+    /// <param name="engine">The engine the responses are built in.</param>
+    /// <param name="realm">The realm whose <c>Response</c> prototype they get.</param>
+    /// <param name="store">The cache to search.</param>
+    /// <param name="query">
+    /// The request to match, or <see langword="null"/> for the omitted-argument case, which selects every
+    /// entry the cache holds.
+    /// </param>
+    /// <param name="options">The query options the matching algorithm honours.</param>
+    /// <param name="stopAtFirst">
+    /// Whether to stop once one response has been produced — what <c>match</c> is defined as, and what
+    /// keeps <c>caches.match</c> from hydrating a whole cache to discard all but its first entry.
+    /// </param>
+    internal static List<JsValue> MatchAll(
+        Engine engine,
+        Realm realm,
+        CacheStore store,
+        JsRequest? query,
+        CacheQueryOptions options,
+        bool stopAtFirst)
+    {
+        var entries = store.Entries;
+        var responses = new List<JsValue>();
+
+        for (var i = 0; i < entries.Count; i++)
+        {
+            var entry = entries[i];
+            var selected = query is null ? CacheQuery.IsAddressable(entry) : CacheQuery.Matches(query, entry, options);
+            if (!selected)
+            {
+                continue;
+            }
+
+            responses.Add(HydrateResponse(engine, realm, entry.Response));
+            if (stopAtFirst)
+            {
+                break;
+            }
+        }
+
+        return responses;
+    }
+
+    /// <summary>
+    /// The <c>RequestInfo</c> union conversion, https://webidl.spec.whatwg.org/#es-union: a <c>Request</c>
+    /// stays itself and everything else becomes a <c>USVString</c>.
+    /// </summary>
+    /// <remarks>
+    /// Performed where WebIDL performs it — before the method's own steps — so an argument whose
+    /// <c>toString</c> runs script does so before an options bag's getters, exactly as in a browser. The
+    /// <c>Request</c> constructor is <i>not</i> invoked here: that is a method step, and it runs after the
+    /// options have been read.
+    /// </remarks>
+    /// <param name="value">The argument as the script passed it.</param>
+    /// <param name="optional">
+    /// Whether an omitted argument is meaningful. For <c>matchAll</c> and <c>keys</c> it is, and answers
+    /// <see langword="null"/>; for the required arguments <c>undefined</c> is stringified like anything else,
+    /// which ends in the <c>TypeError</c> a missing argument owes the script.
+    /// </param>
+    internal static JsValue? ResolveRequestInfo(JsValue value, bool optional)
+    {
+        if (optional && value.IsUndefined())
+        {
+            return null;
+        }
+
+        return value is JsRequest ? value : JsString.Create(UrlValues.ToUsvString(value));
+    }
+
+    /// <summary>
+    /// The "let r be …" prologue <c>matchAll</c>, <c>delete</c> and <c>keys</c> share.
+    /// </summary>
+    /// <returns>
+    /// <see langword="false"/> when the query is a <c>Request</c> whose method is not <c>GET</c> and
+    /// <c>ignoreMethod</c> was not asked for — the callers' "return a promise resolved with an empty array"
+    /// and "…with false" step, which is a successful answer rather than a failure.
+    /// </returns>
+    internal static bool TryQueryRequest(Realm realm, JsValue? info, CacheQueryOptions options, out JsRequest? query)
+    {
+        query = null;
+
+        if (info is null)
+        {
+            return true;
+        }
+
+        if (info is JsRequest request)
+        {
+            if (!options.IgnoreMethod && !string.Equals(request.Method, "GET", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            query = request;
+            return true;
+        }
+
+        query = ConstructRequest(realm, info);
+        return true;
+    }
+
+    /// <summary>
+    /// "The result of invoking the initial value of <c>Request</c> as constructor" — so a URL that does not
+    /// parse fails here, with the constructor's own <c>TypeError</c>.
+    /// </summary>
+    internal static JsRequest ConstructRequest(Realm realm, JsValue info)
+        => (JsRequest) realm.Intrinsics.Request.Construct([info], realm.Intrinsics.Request);
+
+    /// <summary>
+    /// The scheme restriction <c>put</c> and <c>addAll</c> impose: a cache holds HTTP(S) responses and
+    /// nothing else.
+    /// </summary>
+    internal static bool IsHttpScheme(UrlRecord url)
+        => string.Equals(url.Scheme, "http", StringComparison.Ordinal)
+        || string.Equals(url.Scheme, "https", StringComparison.Ordinal);
+
+    /// <summary>
+    /// Runs one <c>Cache</c> or <c>CacheStorage</c> method's steps and turns the outcome into the promise the
+    /// method returns.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every operation on both interfaces returns a promise, which under WebIDL means <b>none of them ever
+    /// throws</b>: an argument conversion failure, a brand-check failure and a step that raises are all
+    /// rejections of the promise the script is holding —
+    /// https://webidl.spec.whatwg.org/#dfn-create-operation-function.
+    /// </para>
+    /// <para>
+    /// A body that answers with a promise of its own — which is what <c>add</c> and <c>addAll</c> do — has it
+    /// adopted, so the script sees one promise settling once.
+    /// </para>
+    /// <para>
+    /// The two provider failures are told apart here, and only here:
+    /// <see cref="CacheQuotaExceededException"/> is the storage steps' <c>QuotaExceededError</c>, and every
+    /// other CLR exception becomes a <c>TypeError</c> carrying the original on the error value for
+    /// <c>JintException.TryGetClrException</c>. The failures that bound execution still escape — a constraint
+    /// that became a promise rejection would no longer bound anything.
+    /// </para>
+    /// </remarks>
+    internal static JsValue Promised(Engine engine, Realm realm, Func<JsValue> body)
+    {
+        var capability = PromiseConstructor.NewPromiseCapability(engine, realm.Intrinsics.Promise);
+
+        try
+        {
+            capability.Resolve(body());
+        }
+        catch (JavaScriptException ex)
+        {
+            capability.Reject(ex.Error);
+        }
+        catch (CacheQuotaExceededException ex)
+        {
+            capability.Reject(realm.Intrinsics.DomException.CreateException(DomExceptionNames.QuotaExceeded, ex.Message));
+        }
+        catch (Exception ex) when (!ConstraintFailure.MustPropagate(ex))
+        {
+            capability.Reject(ProviderFailure(realm, ex));
+        }
+
+        return capability.PromiseInstance;
+    }
+
+    /// <summary>
+    /// The error value a provider's own failure becomes: a <c>TypeError</c>, with the CLR exception on the
+    /// error value where the host can read it and the script cannot.
+    /// </summary>
+    internal static JsValue ProviderFailure(Realm realm, Exception failure)
+        => new JavaScriptException(realm.Intrinsics.TypeError, "The cache storage provider failed", failure).Error;
+}
+#endif

--- a/Jint/WebApi/Caches/CachePrototype.cs
+++ b/Jint/WebApi/Caches/CachePrototype.cs
@@ -1,0 +1,297 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Array;
+using Jint.Native.Object;
+using Jint.Native.Promise;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.DomException;
+using Jint.WebApi.Fetch;
+
+namespace Jint.WebApi.Caches;
+
+/// <summary>
+/// <c>Cache.prototype</c> — the interface prototype object.
+/// <para>
+/// https://w3c.github.io/ServiceWorker/#cache-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every operation returns a promise, so none of them throws: a brand-check failure, an argument conversion
+/// failure and a failing step all reject instead — see <see cref="CacheOperations.Promised"/>.
+/// </para>
+/// <para>
+/// The standard runs the storage half "in parallel" and queues a task to settle. The host storage here is
+/// synchronous, so the work is done on the calling turn and only the settle is deferred, which the promise
+/// does anyway: a <c>.then</c> never runs before the current job finishes. What that reduction costs is the
+/// number of microtask turns between the call and the settle — nothing a script can observe about
+/// <i>this</i> promise, only about how it interleaves with others.
+/// </para>
+/// <para>
+/// One documented simplification, the same one <c>Headers.prototype</c>, <c>URL.prototype</c> and
+/// <c>Blob.prototype</c> carry: the operations are non-enumerable, where
+/// https://webidl.spec.whatwg.org/#es-operations makes an interface's operations enumerable.
+/// </para>
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class CachePrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly CacheConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString CacheToStringTag = new("Cache");
+
+    internal CachePrototype(
+        Engine engine,
+        Realm realm,
+        CacheConstructor constructor,
+        ObjectPrototype objectPrototype) : base(engine, realm)
+    {
+        _prototype = objectPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/ServiceWorker/#dom-cache-match — <c>matchAll</c>, then its first element or
+    /// <c>undefined</c>.
+    /// </summary>
+    [JsFunction(Name = "match", Length = 1)]
+    private JsValue Match(JsValue thisObject, JsValue request, JsValue options)
+        => CacheOperations.Promised(_engine, _realm, () => MatchAllCore(thisObject, request, options, "match", single: true));
+
+    /// <summary>
+    /// https://w3c.github.io/ServiceWorker/#dom-cache-matchall — a frozen array, in cache order, of every
+    /// response the query selects. With the request omitted that is every response the cache holds.
+    /// </summary>
+    [JsFunction(Name = "matchAll", Length = 0)]
+    private JsValue MatchAll(JsValue thisObject, JsValue request, JsValue options)
+        => CacheOperations.Promised(_engine, _realm, () => MatchAllCore(thisObject, request, options, "matchAll", single: false));
+
+    /// <summary>
+    /// https://w3c.github.io/ServiceWorker/#dom-cache-add — fetch one request and store what comes back.
+    /// <b>Needs <c>fetch</c> enabled</b>; see <see cref="CacheAddAll"/>.
+    /// </summary>
+    [JsFunction(Name = "add", Length = 1)]
+    private JsValue Add(JsValue thisObject, JsValue request)
+        => CacheOperations.Promised(_engine, _realm, () => CacheAddAll.Add(_engine, _realm, Brand(thisObject), request));
+
+    /// <summary>
+    /// https://w3c.github.io/ServiceWorker/#dom-cache-addall — fetch every request and store all of them or
+    /// none. <b>Needs <c>fetch</c> enabled</b>; see <see cref="CacheAddAll"/>.
+    /// </summary>
+    [JsFunction(Name = "addAll", Length = 1)]
+    private JsValue AddAll(JsValue thisObject, JsValue requests)
+        => CacheOperations.Promised(_engine, _realm, () => CacheAddAll.AddAll(_engine, _realm, Brand(thisObject), requests));
+
+    /// <summary>
+    /// https://w3c.github.io/ServiceWorker/#dom-cache-put — store a pair the script already has, with no
+    /// network involved.
+    /// </summary>
+    [JsFunction(Name = "put", Length = 2)]
+    private JsValue Put(JsValue thisObject, JsValue request, JsValue response)
+        => CacheOperations.Promised(_engine, _realm, () => PutCore(thisObject, request, response));
+
+    /// <summary>
+    /// https://w3c.github.io/ServiceWorker/#dom-cache-delete — whether anything matched, and it is gone if
+    /// so.
+    /// </summary>
+    [JsFunction(Name = "delete", Length = 1)]
+    private JsValue Delete(JsValue thisObject, JsValue request, JsValue options)
+        => CacheOperations.Promised(_engine, _realm, () => DeleteCore(thisObject, request, options));
+
+    /// <summary>
+    /// https://w3c.github.io/ServiceWorker/#dom-cache-keys — a frozen array, in cache order, of the requests
+    /// the query selects. With the request omitted that is every request the cache holds.
+    /// </summary>
+    [JsFunction(Name = "keys", Length = 0)]
+    private JsValue Keys(JsValue thisObject, JsValue request, JsValue options)
+        => CacheOperations.Promised(_engine, _realm, () => KeysCore(thisObject, request, options));
+
+    private JsValue MatchAllCore(JsValue thisObject, JsValue request, JsValue options, string operation, bool single)
+    {
+        var cache = Brand(thisObject);
+
+        // The union conversion first, then the dictionary's members, then the steps — the order WebIDL
+        // performs them in, which an argument whose toString runs script can observe.
+        var info = CacheOperations.ResolveRequestInfo(request, optional: !single);
+        var query = CacheQuery.ReadOptions(_realm, options, operation, "Cache");
+
+        if (!CacheOperations.TryQueryRequest(_realm, info, query, out var target))
+        {
+            // A non-GET Request without ignoreMethod selects nothing, which is a successful empty answer.
+            return single ? Undefined : Frozen([]);
+        }
+
+        var responses = CacheOperations.MatchAll(_engine, _realm, cache.Store, target, query, stopAtFirst: single);
+
+        if (!single)
+        {
+            return Frozen(responses);
+        }
+
+        return responses.Count == 0 ? Undefined : responses[0];
+    }
+
+    private JsArray KeysCore(JsValue thisObject, JsValue request, JsValue options)
+    {
+        var cache = Brand(thisObject);
+
+        var info = CacheOperations.ResolveRequestInfo(request, optional: true);
+        var query = CacheQuery.ReadOptions(_realm, options, "keys", "Cache");
+
+        var requests = new List<JsValue>();
+        if (CacheOperations.TryQueryRequest(_realm, info, query, out var target))
+        {
+            var entries = cache.Store.Entries;
+            for (var i = 0; i < entries.Count; i++)
+            {
+                var entry = entries[i];
+                if (target is not null && !CacheQuery.Matches(target, entry, query))
+                {
+                    continue;
+                }
+
+                // An entry whose stored URL does not parse is invisible rather than fatal — the same rule
+                // the matching algorithm applies, so keys() and match() agree about which entries exist.
+                var hydrated = CacheOperations.HydrateRequest(_engine, _realm, entry.Request);
+                if (hydrated is not null)
+                {
+                    requests.Add(hydrated);
+                }
+            }
+        }
+
+        return Frozen(requests);
+    }
+
+    private JsBoolean DeleteCore(JsValue thisObject, JsValue request, JsValue options)
+    {
+        var cache = Brand(thisObject);
+
+        var info = CacheOperations.ResolveRequestInfo(request, optional: false);
+        var query = CacheQuery.ReadOptions(_realm, options, "delete", "Cache");
+
+        if (!CacheOperations.TryQueryRequest(_realm, info, query, out var target))
+        {
+            return JsBoolean.False;
+        }
+
+        return JsBoolean.Create(CacheOperations.Delete(cache.Store, target!, query));
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/ServiceWorker/#dom-cache-put, whose refusals are the whole of what makes a cache
+    /// answerable later.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Only <c>GET</c>, only HTTP(S), never a 206 and never <c>Vary: *</c>.</b> A non-GET has a method the
+    /// matching algorithm would refuse to match on the way out; a 206 is a fragment of a body, so serving it
+    /// as a whole one would corrupt the answer; and a response varying by everything can never be matched
+    /// again, so storing it only wastes room.
+    /// </para>
+    /// <para>
+    /// The response's body is <b>consumed</b> here, as it is in a browser: the standard reads all its bytes
+    /// while keeping a clone for the cache, so <c>bodyUsed</c> flips and a later <c>text()</c> on the very
+    /// object that was cached rejects. The cached copy carries its own flag and reads fine.
+    /// </para>
+    /// </remarks>
+    private JsValue PutCore(JsValue thisObject, JsValue requestValue, JsValue responseValue)
+    {
+        var cache = Brand(thisObject);
+
+        var info = CacheOperations.ResolveRequestInfo(requestValue, optional: false)!;
+        if (responseValue is not JsResponse response)
+        {
+            Throw.TypeError(_realm, "Failed to execute 'put' on 'Cache': parameter 2 is not of type 'Response'.");
+            return Undefined;
+        }
+
+        var request = info as JsRequest ?? CacheOperations.ConstructRequest(_realm, info);
+
+        if (!CacheOperations.IsHttpScheme(request.Url) || !string.Equals(request.Method, "GET", StringComparison.Ordinal))
+        {
+            Throw.TypeError(_realm, "Failed to execute 'put' on 'Cache': Request scheme must be 'http' or 'https' and its method must be 'GET'");
+        }
+
+        if (response.Status == 206)
+        {
+            Throw.TypeError(_realm, "Failed to execute 'put' on 'Cache': Partial response (status code 206) is unsupported");
+        }
+
+        if (CacheQuery.VaryContainsWildcard(response.Headers.List.Get("vary")))
+        {
+            Throw.TypeError(_realm, "Failed to execute 'put' on 'Cache': Vary header contains *");
+        }
+
+        if (response.IsUnusable)
+        {
+            Throw.TypeError(_realm, "Failed to execute 'put' on 'Cache': Response body is already used");
+        }
+
+        // "Read all bytes from reader" — the clone the cache keeps is the record built below, and the
+        // original is disturbed by having been read. A buffered body answers synchronously, so the common
+        // put settles on this very turn; a stream-backed body — a network response — settles when its last
+        // chunk has arrived, exactly as the standard's read-all-bytes does. The outer promise adopts the
+        // capability either way.
+        var capability = PromiseConstructor.NewPromiseCapability(_engine, _realm.Intrinsics.Promise);
+        var store = cache.Store;
+        FetchBody.ReadBodyBytes(
+            _engine,
+            _realm,
+            response,
+            bytes =>
+            {
+                try
+                {
+                    CacheOperations.Put(_realm, store, [request], [response], [bytes]);
+                    capability.Resolve(Undefined);
+                }
+                catch (JavaScriptException ex)
+                {
+                    capability.Reject(ex.Error);
+                }
+                catch (CacheQuotaExceededException ex)
+                {
+                    capability.Reject(_realm.Intrinsics.DomException.CreateException(DomExceptionNames.QuotaExceeded, ex.Message));
+                }
+            },
+            capability.Reject);
+        return capability.PromiseInstance;
+    }
+
+    /// <summary>
+    /// The <c>FrozenArray</c> both list-returning operations answer with,
+    /// https://webidl.spec.whatwg.org/#dfn-create-frozen-array — an ordinary array that has been frozen, so a
+    /// script cannot edit the answer it was handed and mistake it for having edited the cache.
+    /// </summary>
+    private JsArray Frozen(List<JsValue> items)
+    {
+        var array = new JsArray(_engine, items.ToArray());
+        array.SetIntegrityLevel(IntegrityLevel.Frozen);
+        return array;
+    }
+
+    /// <summary>
+    /// The WebIDL brand check every member performs.
+    /// </summary>
+    private JsCache Brand(JsValue thisObject)
+    {
+        if (thisObject is JsCache cache)
+        {
+            return cache;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a Cache");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Caches/CacheQuery.cs
+++ b/Jint/WebApi/Caches/CacheQuery.cs
@@ -1,0 +1,311 @@
+#if NET8_0_OR_GREATER
+using System.Runtime.InteropServices;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.WebApi.Fetch;
+using Jint.WebApi.Url.Parsing;
+
+namespace Jint.WebApi.Caches;
+
+/// <summary>
+/// The <c>CacheQueryOptions</c> dictionary, https://w3c.github.io/ServiceWorker/#dictdef-cachequeryoptions —
+/// three booleans, each defaulting to false.
+/// </summary>
+/// <param name="IgnoreSearch">Compare URLs with their query strings removed.</param>
+/// <param name="IgnoreMethod">Do not refuse a query whose method is not <c>GET</c>.</param>
+/// <param name="IgnoreVary">Do not honour a cached response's <c>Vary</c> header.</param>
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct CacheQueryOptions(bool IgnoreSearch, bool IgnoreMethod, bool IgnoreVary);
+
+/// <summary>
+/// The two matching algorithms every <c>Cache</c> method is defined in terms of:
+/// <see href="https://w3c.github.io/ServiceWorker/#query-cache-algorithm">Query Cache</see> and
+/// <see href="https://w3c.github.io/ServiceWorker/#request-matches-cached-item-algorithm">Request Matches
+/// Cached Item</see>.
+/// </summary>
+/// <remarks>
+/// A query runs against the snapshot a <see cref="CacheStore.Entries"/> read returned, and answers with
+/// <i>indexes</i> into that snapshot rather than with the entries themselves — because that is what a
+/// <see cref="CacheWrite"/> names, so the same result serves both a read (<c>matchAll</c>, <c>keys</c>) and a
+/// write (<c>put</c>, <c>delete</c>) with nothing recomputed in between.
+/// </remarks>
+internal static class CacheQuery
+{
+    private const string VaryName = "vary";
+    private const string GetMethod = "GET";
+
+    /// <summary>
+    /// Query Cache: the indexes of every entry in <paramref name="entries"/> the query matches, in list
+    /// order.
+    /// </summary>
+    internal static List<int> Run(IReadOnlyList<CacheEntry> entries, JsRequest query, CacheQueryOptions options)
+    {
+        var matches = new List<int>();
+        for (var i = 0; i < entries.Count; i++)
+        {
+            if (Matches(query, entries[i], options))
+            {
+                matches.Add(i);
+            }
+        }
+
+        return matches;
+    }
+
+    /// <summary>
+    /// Request Matches Cached Item, with the cached item's response always present — an entry the engine
+    /// stored, or one a provider hydrated, always carries one.
+    /// </summary>
+    /// <remarks>
+    /// The cached URL is re-parsed here rather than compared as text, because the two have to be compared as
+    /// <i>URLs</i>: the fragment is excluded and, under <c>ignoreSearch</c>, so is the query. A stored URL
+    /// that does not parse can never match, which is the documented fate of an entry a provider hydrated
+    /// badly.
+    /// </remarks>
+    internal static bool Matches(JsRequest query, CacheEntry entry, CacheQueryOptions options)
+    {
+        // Step 1. The cached request is the one whose method is inspected, not the query's — the caller has
+        // already refused a non-GET query where the algorithm above it says to. Everything the engine stores
+        // is a GET, so this only ever fires for an entry a provider hydrated itself.
+        if (!options.IgnoreMethod && !string.Equals(entry.Request.Method, GetMethod, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        // Steps 2-6.
+        var cachedUrl = UrlParser.Parse(entry.Request.Url);
+        if (cachedUrl is null)
+        {
+            return false;
+        }
+
+        var queryText = SerializeForComparison(query.Url, options.IgnoreSearch);
+        var cachedText = SerializeForComparison(cachedUrl, options.IgnoreSearch);
+        if (!string.Equals(queryText, cachedText, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        // Step 7.
+        if (options.IgnoreVary)
+        {
+            return true;
+        }
+
+        var vary = CombinedValue(entry.Response.Headers, VaryName);
+        if (vary is null)
+        {
+            return true;
+        }
+
+        // Steps 8-9: every field the response varies by must have the same combined value in the cached
+        // request as in the query, "same" including both being absent.
+        var fields = new List<string>();
+        AppendFieldValues(vary, fields);
+
+        foreach (var field in fields)
+        {
+            if (IsWildcard(field))
+            {
+                return false;
+            }
+
+            var cachedValue = CombinedValue(entry.Request.Headers, field);
+            var queryValue = query.Headers.List.Get(field);
+            if (!string.Equals(cachedValue, queryValue, StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Whether an entry is reachable at all.
+    /// </summary>
+    /// <remarks>
+    /// An entry whose stored URL does not parse can never match a query, so it would otherwise be visible to
+    /// the request-less forms of <c>matchAll</c> and invisible to everything else — including <c>keys</c>,
+    /// which cannot build a <c>Request</c> for it at all. One rule instead: such an entry does not exist as
+    /// far as the script is concerned. It cannot be deleted or replaced either, which is the honest
+    /// consequence of a provider handing back a URL nothing can address.
+    /// </remarks>
+    internal static bool IsAddressable(CacheEntry entry) => UrlParser.Parse(entry.Request.Url) is not null;
+
+    /// <summary>
+    /// The text two URLs are compared as: the serialization with the fragment excluded, and — under
+    /// <c>ignoreSearch</c> — without the query either.
+    /// </summary>
+    /// <remarks>
+    /// The algorithm sets both URLs' queries to the empty string, which appends a bare <c>?</c> to both
+    /// serializations; dropping the query from both instead is the same comparison with one fewer allocation.
+    /// The first <c>?</c> in a fragment-excluded serialization always begins the query, because <c>?</c> is in
+    /// the path percent-encode set and a host may not contain one.
+    /// </remarks>
+    private static string SerializeForComparison(UrlRecord url, bool ignoreSearch)
+    {
+        var serialized = url.Serialize(excludeFragment: true);
+        if (!ignoreSearch)
+        {
+            return serialized;
+        }
+
+        var query = serialized.IndexOf('?');
+        return query < 0 ? serialized : serialized.Substring(0, query);
+    }
+
+    /// <summary>
+    /// https://fetch.spec.whatwg.org/#concept-header-list-get over the flattened headers of a cached request
+    /// or response: every value with that name joined by <c>", "</c>, or <see langword="null"/> when there is
+    /// none.
+    /// </summary>
+    /// <remarks>
+    /// Names are compared ASCII-case-insensitively rather than ordinally, unlike
+    /// <see cref="HeaderList.Get"/>: the engine writes them lowercased, but a provider that round-tripped
+    /// them through a store which corrects casing must not thereby lose a header.
+    /// </remarks>
+    internal static string? CombinedValue(IReadOnlyList<CachedHeader> headers, string name)
+    {
+        string? first = null;
+        List<string>? all = null;
+
+        for (var i = 0; i < headers.Count; i++)
+        {
+            var header = headers[i];
+            if (!string.Equals(header.Name, name, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (first is null)
+            {
+                first = header.Value;
+                continue;
+            }
+
+            all ??= new List<string> { first };
+            all.Add(header.Value);
+        }
+
+        return all is null ? first : string.Join(", ", all);
+    }
+
+    /// <summary>
+    /// Whether a <c>Vary</c> value names <c>*</c>, which is what <c>put</c> and <c>addAll</c> refuse:
+    /// a response that varies by everything can never be matched again, so storing one is always a mistake.
+    /// </summary>
+    internal static bool VaryContainsWildcard(string? vary)
+    {
+        if (vary is null)
+        {
+            return false;
+        }
+
+        var fields = new List<string>();
+        AppendFieldValues(vary, fields);
+
+        foreach (var field in fields)
+        {
+            if (IsWildcard(field))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The field-values of a <c>Vary</c> header: comma-separated, each stripped of the surrounding HTTP
+    /// whitespace — https://www.rfc-editor.org/rfc/rfc9110#name-vary.
+    /// </summary>
+    private static void AppendFieldValues(string value, List<string> into)
+    {
+        var start = 0;
+        while (start <= value.Length)
+        {
+            var comma = value.IndexOf(',', start);
+            var end = comma < 0 ? value.Length : comma;
+
+            var field = value.Substring(start, end - start).Trim('\t', '\n', '\r', ' ');
+            if (field.Length != 0)
+            {
+                into.Add(field);
+            }
+
+            if (comma < 0)
+            {
+                return;
+            }
+
+            start = comma + 1;
+        }
+    }
+
+    private static bool IsWildcard(string field) => string.Equals(field, "*", StringComparison.Ordinal);
+
+    /// <summary>
+    /// The <c>CacheQueryOptions</c> conversion, https://webidl.spec.whatwg.org/#es-dictionary: the members
+    /// are read in lexicographical order of their identifiers, and an explicitly passed <c>undefined</c> takes
+    /// the declared default.
+    /// </summary>
+    internal static CacheQueryOptions ReadOptions(Realm realm, JsValue value, string operation, string target)
+    {
+        var dictionary = ToDictionary(realm, value, operation, target);
+
+        return new CacheQueryOptions(
+            IgnoreSearch: ReadFlag(dictionary, "ignoreSearch"),
+            IgnoreMethod: ReadFlag(dictionary, "ignoreMethod"),
+            IgnoreVary: ReadFlag(dictionary, "ignoreVary"));
+    }
+
+    /// <summary>
+    /// The <c>MultiCacheQueryOptions</c> conversion,
+    /// https://w3c.github.io/ServiceWorker/#dictdef-multicachequeryoptions — <c>CacheQueryOptions</c> plus an
+    /// optional <c>cacheName</c>, which has no default, so an absent one is a different thing from an empty
+    /// one.
+    /// </summary>
+    /// <remarks>
+    /// An inherited dictionary's members are converted before the deriving one's, so the read order is
+    /// <c>ignoreMethod</c>, <c>ignoreSearch</c>, <c>ignoreVary</c>, then <c>cacheName</c> — observable
+    /// through an options bag whose members are getters.
+    /// </remarks>
+    internal static CacheQueryOptions ReadMultiOptions(Realm realm, JsValue value, string operation, string target, out string? cacheName)
+    {
+        var dictionary = ToDictionary(realm, value, operation, target);
+
+        var ignoreMethod = ReadFlag(dictionary, "ignoreMethod");
+        var ignoreSearch = ReadFlag(dictionary, "ignoreSearch");
+        var ignoreVary = ReadFlag(dictionary, "ignoreVary");
+
+        var name = RequestConstructor.Member(dictionary, "cacheName");
+        cacheName = name is null ? null : TypeConverter.ToString(name);
+
+        return new CacheQueryOptions(ignoreSearch, ignoreMethod, ignoreVary);
+    }
+
+    private static bool ReadFlag(ObjectInstance? dictionary, string name)
+    {
+        var member = RequestConstructor.Member(dictionary, name);
+        return member is not null && TypeConverter.ToBoolean(member);
+    }
+
+    private static ObjectInstance? ToDictionary(Realm realm, JsValue value, string operation, string target)
+    {
+        if (value.IsNullOrUndefined())
+        {
+            return null;
+        }
+
+        if (value is not ObjectInstance dictionary)
+        {
+            Throw.TypeError(realm, $"Failed to execute '{operation}' on '{target}': The provided value is not of type 'CacheQueryOptions'");
+            return null;
+        }
+
+        return dictionary;
+    }
+}
+#endif

--- a/Jint/WebApi/Caches/CacheStorageConstructor.cs
+++ b/Jint/WebApi/Caches/CacheStorageConstructor.cs
@@ -1,0 +1,50 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Caches;
+
+/// <summary>
+/// The <c>CacheStorage</c> interface object.
+/// <para>
+/// https://w3c.github.io/ServiceWorker/#cachestorage-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// Like <c>Cache</c>, the interface declares no constructor operation, so the interface object exists and is a
+/// function but refuses to construct anything — https://webidl.spec.whatwg.org/#es-interface-call. The one
+/// instance is the <c>caches</c> global, which is what
+/// <c>caches instanceof CacheStorage</c> is written against.
+/// </remarks>
+internal sealed class CacheStorageConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("CacheStorage");
+
+    internal CacheStorageConstructor(
+        Engine engine,
+        Realm realm,
+        FunctionPrototype functionPrototype,
+        ObjectPrototype objectPrototype)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = functionPrototype;
+        PrototypeObject = new CacheStoragePrototype(engine, realm, this, objectPrototype);
+        _length = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal CacheStoragePrototype PrototypeObject { get; }
+
+    /// <summary>
+    /// An interface without a constructor operation is not constructible.
+    /// </summary>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        Throw.TypeError(_realm, "Illegal constructor");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Caches/CacheStoragePrototype.cs
+++ b/Jint/WebApi/Caches/CacheStoragePrototype.cs
@@ -1,0 +1,204 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Array;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.Fetch;
+
+namespace Jint.WebApi.Caches;
+
+/// <summary>
+/// <c>CacheStorage.prototype</c> — the interface prototype object.
+/// <para>
+/// https://w3c.github.io/ServiceWorker/#cachestorage-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// The standard's own note describes this interface as "largely conform[ing] to ECMAScript 6 Map objects but
+/// entirely async": <c>has</c>, <c>delete</c> and <c>keys</c> mean what they do on a map, <c>open</c> is the
+/// get-or-create, and <c>match</c> is the convenience that searches every cache.
+/// </para>
+/// <para>
+/// Every operation returns a promise and therefore never throws — see
+/// <see cref="CacheOperations.Promised"/>. The operations are non-enumerable, the same documented
+/// simplification the other prototypes in this assembly carry.
+/// </para>
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class CacheStoragePrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly CacheStorageConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString CacheStorageToStringTag = new("CacheStorage");
+
+    internal CacheStoragePrototype(
+        Engine engine,
+        Realm realm,
+        CacheStorageConstructor constructor,
+        ObjectPrototype objectPrototype) : base(engine, realm)
+    {
+        _prototype = objectPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/ServiceWorker/#cache-storage-match — the first response any cache can answer
+    /// with, or <c>undefined</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The caches are searched <b>in creation order</b>, which is the order the provider's
+    /// <see cref="CacheStorageProvider.Names"/> reports; the first cache with a match wins, and the rest are
+    /// not consulted. An <c>options.cacheName</c> narrows the search to that one cache, and naming a cache
+    /// that does not exist answers <c>undefined</c> rather than creating it.
+    /// </para>
+    /// <para>
+    /// The standard chains one promise per cache, so a browser takes a microtask turn per cache searched;
+    /// the search here is synchronous. The answer is identical — only the interleaving with other pending
+    /// jobs differs.
+    /// </para>
+    /// </remarks>
+    [JsFunction(Name = "match", Length = 1)]
+    private JsValue Match(JsValue thisObject, JsValue request, JsValue options)
+        => CacheOperations.Promised(_engine, _realm, () => MatchCore(thisObject, request, options));
+
+    /// <summary>
+    /// https://w3c.github.io/ServiceWorker/#cache-storage-has
+    /// </summary>
+    [JsFunction(Name = "has", Length = 1)]
+    private JsValue Has(JsValue thisObject, JsValue cacheName, [ArgCount] int argumentCount)
+        => CacheOperations.Promised(_engine, _realm, () =>
+        {
+            var storage = Brand(thisObject);
+            var name = ToCacheName(cacheName, argumentCount, "has");
+            return JsBoolean.Create(storage.Provider.Contains(name));
+        });
+
+    /// <summary>
+    /// https://w3c.github.io/ServiceWorker/#cache-storage-open — the cache with that name, created if it did
+    /// not exist. A new <c>Cache</c> object every time, over the same storage.
+    /// </summary>
+    [JsFunction(Name = "open", Length = 1)]
+    private JsValue Open(JsValue thisObject, JsValue cacheName, [ArgCount] int argumentCount)
+        => CacheOperations.Promised(_engine, _realm, () =>
+        {
+            var storage = Brand(thisObject);
+            var name = ToCacheName(cacheName, argumentCount, "open");
+            return _realm.Intrinsics.Cache.CreateInstance(name, storage.Provider.Open(name));
+        });
+
+    /// <summary>
+    /// https://w3c.github.io/ServiceWorker/#cache-storage-delete — whether the cache existed.
+    /// </summary>
+    /// <remarks>
+    /// A <c>Cache</c> object a script is still holding goes on working afterwards, which is what the
+    /// standard's own note asks for: what is deleted is the name, not the storage behind an object somebody
+    /// already has.
+    /// </remarks>
+    [JsFunction(Name = "delete", Length = 1)]
+    private JsValue Delete(JsValue thisObject, JsValue cacheName, [ArgCount] int argumentCount)
+        => CacheOperations.Promised(_engine, _realm, () =>
+        {
+            var storage = Brand(thisObject);
+            var name = ToCacheName(cacheName, argumentCount, "delete");
+            return JsBoolean.Create(storage.Provider.Delete(name));
+        });
+
+    /// <summary>
+    /// https://w3c.github.io/ServiceWorker/#cache-storage-keys — the cache names, in the order they were
+    /// first opened.
+    /// </summary>
+    [JsFunction(Name = "keys", Length = 0)]
+    private JsValue Keys(JsValue thisObject)
+        => CacheOperations.Promised(_engine, _realm, () =>
+        {
+            var storage = Brand(thisObject);
+            var names = storage.Provider.Names;
+
+            var items = new JsValue[names.Count];
+            for (var i = 0; i < names.Count; i++)
+            {
+                items[i] = JsString.Create(names[i]);
+            }
+
+            return new JsArray(_engine, items);
+        });
+
+    private JsValue MatchCore(JsValue thisObject, JsValue request, JsValue options)
+    {
+        var storage = Brand(thisObject);
+
+        var info = CacheOperations.ResolveRequestInfo(request, optional: false);
+        var query = CacheQuery.ReadMultiOptions(_realm, options, "match", "CacheStorage", out var cacheName);
+
+        if (!CacheOperations.TryQueryRequest(_realm, info, query, out var target))
+        {
+            return Undefined;
+        }
+
+        if (cacheName is not null)
+        {
+            return storage.Provider.Contains(cacheName)
+                ? MatchIn(storage.Provider.Open(cacheName), target, query)
+                : Undefined;
+        }
+
+        var names = storage.Provider.Names;
+        for (var i = 0; i < names.Count; i++)
+        {
+            var response = MatchIn(storage.Provider.Open(names[i]), target, query);
+            if (!response.IsUndefined())
+            {
+                return response;
+            }
+        }
+
+        return Undefined;
+    }
+
+    private JsValue MatchIn(CacheStore store, JsRequest? target, CacheQueryOptions query)
+    {
+        var responses = CacheOperations.MatchAll(_engine, _realm, store, target, query, stopAtFirst: true);
+        return responses.Count == 0 ? Undefined : responses[0];
+    }
+
+    /// <summary>
+    /// The <c>DOMString</c> argument, https://webidl.spec.whatwg.org/#es-DOMString — with the missing-argument
+    /// check WebIDL performs before any conversion, so <c>caches.open()</c> is a <c>TypeError</c> rather than
+    /// a cache named <c>"undefined"</c>.
+    /// </summary>
+    private string ToCacheName(JsValue value, int argumentCount, string operation)
+    {
+        if (argumentCount < 1)
+        {
+            Throw.TypeError(_realm, $"Failed to execute '{operation}' on 'CacheStorage': 1 argument required, but only 0 present.");
+        }
+
+        return TypeConverter.ToString(value);
+    }
+
+    /// <summary>
+    /// The WebIDL brand check every member performs.
+    /// </summary>
+    private JsCacheStorage Brand(JsValue thisObject)
+    {
+        if (thisObject is JsCacheStorage storage)
+        {
+            return storage;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a CacheStorage");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Caches/JsCache.cs
+++ b/Jint/WebApi/Caches/JsCache.cs
@@ -1,0 +1,43 @@
+#if NET8_0_OR_GREATER
+using Jint.Native.Object;
+
+namespace Jint.WebApi.Caches;
+
+/// <summary>
+/// A <c>Cache</c> instance.
+/// <para>
+/// https://w3c.github.io/ServiceWorker/#cache-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// "A <c>Cache</c> object represents a request response list. Multiple separate objects implementing the
+/// <c>Cache</c> interface … can all be associated with the same request response list simultaneously" — which
+/// is exactly the shape here: the state is the <see cref="Store"/>, which belongs to the host's
+/// <see cref="CacheStorageProvider"/>, and every <c>caches.open(name)</c> hands out a new JavaScript object in
+/// front of the same one.
+/// </para>
+/// <para>
+/// The instance carries no own property; <see cref="CachePrototype"/> reaches the store through a brand
+/// check.
+/// </para>
+/// </remarks>
+internal sealed class JsCache : ObjectInstance
+{
+    internal JsCache(Engine engine, string name, CacheStore store) : base(engine, ObjectClass.Object)
+    {
+        Name = name;
+        Store = store;
+    }
+
+    /// <summary>
+    /// The name this cache was opened under. Kept for diagnostics only — the standard gives a <c>Cache</c>
+    /// object no way to report it, and a cache deleted by name goes on working through an object a script
+    /// still holds.
+    /// </summary>
+    internal string Name { get; }
+
+    /// <summary>The host storage behind this object.</summary>
+    internal CacheStore Store { get; }
+}
+#endif

--- a/Jint/WebApi/Caches/JsCacheStorage.cs
+++ b/Jint/WebApi/Caches/JsCacheStorage.cs
@@ -1,0 +1,44 @@
+#if NET8_0_OR_GREATER
+using Jint.Native.Object;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Caches;
+
+/// <summary>
+/// The <c>caches</c> object — an instance of the <c>CacheStorage</c> interface.
+/// <para>
+/// https://w3c.github.io/ServiceWorker/#cachestorage-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// One per realm, holding the host's <see cref="CacheStorageProvider"/> and nothing else: the name-to-cache
+/// map the standard talks about is the provider's, so two engines sharing a provider share the map and an
+/// engine with the default provider has one of its own.
+/// </remarks>
+internal sealed class JsCacheStorage : ObjectInstance
+{
+    private JsCacheStorage(Engine engine, CacheStorageProvider provider) : base(engine, ObjectClass.Object)
+    {
+        Provider = provider;
+    }
+
+    /// <summary>Where the caches live.</summary>
+    internal CacheStorageProvider Provider { get; }
+
+    internal static JsCacheStorage Create(Engine engine, Realm realm)
+    {
+        var provider = engine._webApi?.CacheProvider;
+        if (provider is null)
+        {
+            // Unreachable: the global that reaches this is installed only where the provider was resolved, in
+            // the same block of WebApiRegistration.
+            Throw.InvalidOperationException("The caches global was reached on an engine that has no cache storage provider.");
+        }
+
+        return new JsCacheStorage(engine, provider)
+        {
+            _prototype = realm.Intrinsics.CacheStorage.PrototypeObject,
+        };
+    }
+}
+#endif

--- a/Jint/WebApi/Fetch/FetchBodyObject.cs
+++ b/Jint/WebApi/Fetch/FetchBodyObject.cs
@@ -365,6 +365,35 @@ internal static class FetchBody
     }
 
     /// <summary>
+    /// Hands over a body's bytes for a consumer outside the <c>Body</c> mixin — the Cache API's "read all
+    /// bytes from reader". A null body answers <see langword="null"/> synchronously; a buffered body is
+    /// disturbed and answered synchronously; a stream body is fully read, disturbing it, and answers on the
+    /// engine's thread when the read settles.
+    /// </summary>
+    internal static void ReadBodyBytes(
+        Engine engine,
+        Realm realm,
+        FetchBodyObject body,
+        Action<ReadOnlyMemory<byte>?> onBytes,
+        Action<JsValue> onError)
+    {
+        if (!body.HasBody)
+        {
+            onBytes(null);
+            return;
+        }
+
+        if (body.Stream is null)
+        {
+            body.MarkSourceDisturbed();
+            onBytes(body.Source!.Value);
+            return;
+        }
+
+        FullyRead(engine, realm, body.Stream!, bytes => onBytes(bytes.WrittenSpan.ToArray()), onError);
+    }
+
+    /// <summary>
     /// Reads a request body that only exists as a stream into the bytes the transport has to send.
     /// </summary>
     /// <remarks>

--- a/Jint/WebApi/InMemoryCacheStorageProvider.cs
+++ b/Jint/WebApi/InMemoryCacheStorageProvider.cs
@@ -1,0 +1,153 @@
+#if NET8_0_OR_GREATER
+using System.Threading;
+
+namespace Jint.WebApi;
+
+/// <summary>
+/// The <see cref="CacheStorageProvider"/> an engine uses when the host names none: the caches live in this
+/// object's own memory and die with it. Requires .NET 8 or higher.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>There is no quota.</b> A script with the Cache API can go on storing until the process runs out of
+/// memory, and nothing here will stop it — the same shape of exposure a script that keeps appending to an
+/// array already has, except that this store outlives the evaluation that filled it. A host running untrusted
+/// script that wants a ceiling implements <see cref="CacheStorageProvider"/> itself and throws
+/// <see cref="CacheQuotaExceededException"/>, which the script sees as the <c>QuotaExceededError</c> a browser
+/// would raise.
+/// </para>
+/// <para>
+/// One instance is created per engine when <c>Options.WebApi.Cache.Provider</c> is left unset, so two engines
+/// never see each other's caches. Assigning one instance to a shared <see cref="Options"/> is how a host
+/// deliberately shares them; this class is thread-safe for that, guarding every read and write with a lock.
+/// </para>
+/// <para>
+/// The contents survive <c>Engine.Advanced.RestoreGlobalSnapshot</c>. A restore reverts the engine's global
+/// bindings, not host storage — the same answer the module registry gets — so a pooled engine's next cycle
+/// finds whatever the previous one cached. A host that wants each cycle to start empty gives the engine a
+/// fresh provider, which means a fresh engine or a provider of its own.
+/// </para>
+/// </remarks>
+public sealed class InMemoryCacheStorageProvider : CacheStorageProvider
+{
+    private readonly Lock _lock = new();
+
+    /// <summary>
+    /// The caches, in the order they were first opened — which is the order
+    /// <see cref="CacheStorageProvider.Names"/> has to answer in.
+    /// </summary>
+    private readonly List<string> _names = new();
+
+    private readonly Dictionary<string, InMemoryCacheStore> _stores = new(StringComparer.Ordinal);
+
+    /// <inheritdoc />
+    public override IReadOnlyList<string> Names
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _names.ToArray();
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public override bool Contains(string cacheName)
+    {
+        lock (_lock)
+        {
+            return _stores.ContainsKey(cacheName);
+        }
+    }
+
+    /// <inheritdoc />
+    public override CacheStore Open(string cacheName)
+    {
+        lock (_lock)
+        {
+            if (_stores.TryGetValue(cacheName, out var existing))
+            {
+                return existing;
+            }
+
+            var store = new InMemoryCacheStore();
+            _stores.Add(cacheName, store);
+            _names.Add(cacheName);
+            return store;
+        }
+    }
+
+    /// <inheritdoc />
+    public override bool Delete(string cacheName)
+    {
+        lock (_lock)
+        {
+            if (!_stores.Remove(cacheName))
+            {
+                return false;
+            }
+
+            _names.Remove(cacheName);
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// One in-memory cache: a list of entries a write replaces wholesale, which is what makes the write
+    /// atomic without a transaction log.
+    /// </summary>
+    private sealed class InMemoryCacheStore : CacheStore
+    {
+        private readonly Lock _lock = new();
+
+        /// <summary>
+        /// Immutable once published, so <see cref="Entries"/> can hand it out without copying and a write in
+        /// progress can never be observed half-applied.
+        /// </summary>
+        private CacheEntry[] _entries = [];
+
+        public override IReadOnlyList<CacheEntry> Entries
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _entries;
+                }
+            }
+        }
+
+        public override void Write(in CacheWrite write)
+        {
+            var removed = write.RemovedIndexes;
+            var added = write.Added;
+
+            lock (_lock)
+            {
+                var current = _entries;
+                var result = new List<CacheEntry>(current.Length - removed.Count + added.Count);
+
+                var next = 0;
+                for (var i = 0; i < current.Length; i++)
+                {
+                    if (next < removed.Count && removed[next] == i)
+                    {
+                        next++;
+                        continue;
+                    }
+
+                    result.Add(current[i]);
+                }
+
+                for (var i = 0; i < added.Count; i++)
+                {
+                    result.Add(added[i]);
+                }
+
+                _entries = result.ToArray();
+            }
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/WebApiOptionsExtensions.cs
+++ b/Jint/WebApi/WebApiOptionsExtensions.cs
@@ -221,6 +221,48 @@ public static class WebApiOptionsExtensions
     }
 
     /// <summary>
+    /// Enables the <c>caches</c> object and the <c>Cache</c> and <c>CacheStorage</c> interfaces — and with
+    /// them <see cref="WebApiFeatures.Events"/>, <see cref="WebApiFeatures.Url"/> and
+    /// <see cref="WebApiFeatures.Files"/>, plus the <c>Headers</c>, <c>Request</c> and <c>Response</c>
+    /// classes a cache is made of.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="UseWebApis(Options)"/> deliberately never does this: a cache outlives the evaluation that
+    /// filled it, so where the data goes and what bounds it are decisions a host makes rather than inherits.
+    /// Left unconfigured, each engine gets a private in-memory store <b>with no quota</b> — see
+    /// <see cref="Options.CacheOptions.Provider"/>.
+    /// </para>
+    /// <para>
+    /// This grants no network access. <c>cache.add</c> and <c>cache.addAll</c> fetch, so they additionally
+    /// need <see cref="UseFetch"/>, and reject with a <c>TypeError</c> naming it until they have it; every
+    /// other <c>Cache</c> method works without it.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// var engine = new Engine(options => options.UseWebApis().UseCacheApi(cache =>
+    /// {
+    ///     cache.Provider = myRedisBackedProvider;
+    /// }));
+    /// </code>
+    /// </example>
+    /// <param name="options">Options to modify.</param>
+    /// <param name="configure">Optional configuration of the cache settings, run after the feature is enabled.</param>
+    /// <returns>Options instance for fluent syntax.</returns>
+    public static Options UseCacheApi(this Options options, Action<Options.CacheOptions>? configure = null)
+    {
+        if (options is null)
+        {
+            Throw.ArgumentNullException(nameof(options));
+        }
+
+        options.WebApi.Features |= WebApiFeatures.CacheApi;
+        configure?.Invoke(options.WebApi.Cache);
+        return options;
+    }
+
+    /// <summary>
     /// Enables the <c>console</c> object and sends its output to <paramref name="sink"/>.
     /// </summary>
     /// <param name="options">Options to modify.</param>

--- a/Jint/WebApi/WebApiRegistration.cs
+++ b/Jint/WebApi/WebApiRegistration.cs
@@ -241,6 +241,24 @@ internal static class WebApiRegistration
             // intrinsic, and Install is non-clobbering, so an engine with any combination gets one object.
             Install(global, engine, "MessageEvent", static e => e.Realm.Intrinsics.MessageEvent, PropertyFlag.NonEnumerable);
         }
+
+        if ((features & WebApiFeatures.CacheApi) != WebApiFeatures.None)
+        {
+            // A cache is a list of request/response pairs, so the fetch object model is the Cache API's model
+            // too — without it a script has nothing it could put in a cache. The network function is not part
+            // of that and stays behind its own flag; these three are installed by the block above as well
+            // when it ran, and Install leaves a name that already exists alone.
+            Install(global, engine, "Headers", static e => e.Realm.Intrinsics.Headers, PropertyFlag.NonEnumerable);
+            Install(global, engine, "Request", static e => e.Realm.Intrinsics.Request, PropertyFlag.NonEnumerable);
+            Install(global, engine, "Response", static e => e.Realm.Intrinsics.Response, PropertyFlag.NonEnumerable);
+
+            Install(global, engine, "Cache", static e => e.Realm.Intrinsics.Cache, PropertyFlag.NonEnumerable);
+            Install(global, engine, "CacheStorage", static e => e.Realm.Intrinsics.CacheStorage, PropertyFlag.NonEnumerable);
+
+            // WebIDL exposes caches through a [SameObject] accessor pair; an ordinary enumerable data
+            // property is the same simplification console, crypto and performance are installed with.
+            Install(global, engine, "caches", static e => e.Realm.Intrinsics.Caches, PropertyFlag.ConfigurableEnumerableWritable);
+        }
     }
 
     /// <summary>
@@ -307,6 +325,14 @@ internal static class WebApiRegistration
             features |= WebApiFeatures.Events | WebApiFeatures.Files;
         }
 
+        // The Cache API stores Request/Response pairs, so it needs the same three for the same reasons — and
+        // the fetch interface objects, which the install block adds. It deliberately does not bring
+        // WebApiFeatures.Fetch: caching is not network access, and only Cache.add/addAll need one.
+        if ((features & WebApiFeatures.CacheApi) != WebApiFeatures.None)
+        {
+            features |= WebApiFeatures.Events | WebApiFeatures.Url | WebApiFeatures.Files;
+        }
+
         return features;
     }
 
@@ -329,7 +355,7 @@ internal static class WebApiRegistration
         // in-flight set here, the scheduler keeps its own task queues here, and storage keeps its providers
         // here, which is why each of them wants the state even without the timers flag.
         const WebApiFeatures NeedsEngineState =
-            WebApiFeatures.Timers | WebApiFeatures.Events | WebApiFeatures.Performance | WebApiFeatures.Fetch | WebApiFeatures.Scheduler | WebApiFeatures.Messaging | WebApiFeatures.Storage | WebApiFeatures.WebSocket;
+            WebApiFeatures.Timers | WebApiFeatures.Events | WebApiFeatures.Performance | WebApiFeatures.Fetch | WebApiFeatures.Scheduler | WebApiFeatures.Messaging | WebApiFeatures.Storage | WebApiFeatures.WebSocket | WebApiFeatures.CacheApi;
 
         // The diagnostics sink is the one thing here no feature flag governs: a host that set one gets the
         // channel whatever else it did or did not ask for, which is why it is read before the flags are.
@@ -367,7 +393,13 @@ internal static class WebApiRegistration
         // needs is decided by the global a script touches, so defaulting one costs nothing until then.
         var storage = (features & WebApiFeatures.Storage) != WebApiFeatures.None ? options.WebApi.Storage : null;
 
-        engine._webApi = new WebApiEngineState(engine, timeProvider, timers, fetch, scheduler, diagnostics, storage);
+        // The provider is resolved here, once, and a host that named none gets one of its own rather than
+        // one shared by every engine built from this Options instance — see Options.CacheOptions.Provider.
+        var cache = (features & WebApiFeatures.CacheApi) != WebApiFeatures.None
+            ? options.WebApi.Cache.Provider ?? new InMemoryCacheStorageProvider()
+            : null;
+
+        engine._webApi = new WebApiEngineState(engine, timeProvider, timers, fetch, scheduler, diagnostics, storage, cache);
     }
 
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -236,10 +236,13 @@ its own `console` (or any other name in the table below), enabling the feature l
 | `fetch` / `Headers` / `Request` / `Response` | `Fetch` — **opt-in on its own, see below** | ✔ shipped |
 | `EventSource` / `MessageEvent` (server-sent events) | `EventSource` — **opt-in on its own, see below** | ✔ shipped |
 | `WebSocket` / `CloseEvent` (and the `MessageEvent` its messages arrive as) | `WebSocket` — **opt-in on its own, see below** | ✔ shipped |
+| `caches` / `Cache` / `CacheStorage` | `CacheApi` — **opt-in on its own, see below** | ✔ shipped |
 
 `WebApiFeatures.Default` — what `UseWebApis()` enables — is every non-network feature that has landed. It
 grows as the table fills in, and it will never include `fetch`: network egress is always an explicit choice.
-`Storage` is the other standing exception, for the reason in its own section below.
+`Storage` is one standing exception, for the reason in its own section below, and `CacheApi` is the
+other, for the neighbouring one — a cache outlives the evaluation that filled it, so where its data goes,
+and what bounds it, is a decision you make rather than inherit.
 
 `crypto.subtle` carries **`digest`, `sign`, `verify`, `encrypt`, `decrypt`, `generateKey`, `importKey` and
 `exportKey`**, over SHA-1/256/384/512 (for `digest` and as HMAC's inner hash), **HMAC**, and **AES-GCM** at
@@ -1011,6 +1014,53 @@ platform you are on, the same answer `process.platform` gives. `WorkingDirectory
 
 `node:querystring` and `node:url` need .NET 8 or newer, because both build on the engine's WHATWG URL
 implementation. `node:path` is available on every target framework Jint has.
+
+
+### The Cache API stores through a provider you supply
+
+`caches` is the Service Workers Standard's [`CacheStorage`](https://w3c.github.io/ServiceWorker/#cache-interface)
+— `open`, `has`, `delete`, `keys`, `match` — with the full `Cache` behind it: `match` / `matchAll` with
+`ignoreSearch`, `ignoreMethod` and `ignoreVary`, `put`, `add`, `addAll`, `delete`, `keys`, the request-matching
+algorithm including `Vary`, and the batch semantics that make a failed `addAll` store nothing at all.
+
+Jint implements the object model and delegates the storage:
+
+```csharp
+var engine = new Engine(options => options.UseCacheApi(cache =>
+{
+    cache.Provider = myProvider;   // omit for a private in-memory store per engine
+}));
+
+var body = engine.Evaluate(
+    "(async () => {" +
+    "  const cache = await caches.open('v1');" +
+    "  await cache.put('https://example.org/a', new Response('hi'));" +
+    "  return (await cache.match('https://example.org/a')).text();" +
+    "})()").UnwrapIfPromise();
+```
+
+A `CacheStorageProvider` opens, lists and deletes named caches; each `CacheStore` lists its entries and applies
+one `CacheWrite` — the removals and the additions of a whole operation together, so a provider that writes it
+in a transaction gets the standard's all-or-nothing behaviour for free. A request/response pair crosses that
+seam as `CacheEntry`, a plain CLR record with no engine reference in it, so it can go into a dictionary, a
+file, SQL or Redis. Everything is called on the engine's thread, synchronously, and any exception becomes a
+rejection: `CacheQuotaExceededException` as the `QuotaExceededError` a browser raises, anything else as a
+`TypeError` whose cause your host can read with `JintException.TryGetClrException`.
+
+Enabling it also brings `Headers`, `Request` and `Response` (and `Events`, `Url`, `Files` under them), because
+a cache *is* a list of request/response pairs. It does **not** bring the network: `cache.add` and
+`cache.addAll` fetch, so they additionally need `UseFetch` and reject with a `TypeError` naming it until they
+have it — and when they do have it, they go through the very same policy, so your `UrlFilter`, scheme list,
+size cap and deadline bound them exactly as they bound a `fetch` the script wrote itself. Every other `Cache`
+method works with no network at all, which is what lets a host populate a cache from its own data and a script
+read it back.
+
+**The default store has no quota.** Left unconfigured, each engine gets a private `InMemoryCacheStorageProvider`
+that grows until the process runs out of memory, and its contents survive `RestoreGlobalSnapshot` — a restore
+reverts global bindings, not host storage. A deployment running untrusted script implements the provider
+itself: that is where a size limit, an eviction policy and a per-tenant partition belong. See
+[THREAT_MODEL.md](.github/THREAT_MODEL.md) TM-23 for the full analysis.
+
 
 
 ## Performance


### PR DESCRIPTION
The last slice of #3086: the Cache API — `caches`, `Cache` and `CacheStorage` per https://w3c.github.io/ServiceWorker/ §5.4/§5.5 and its Appendix A algorithms — over a host-implementable `CacheStorageProvider`. `WebApiFeatures.CacheApi = 1 << 19`, **not in `Default`**: a cache outlives the evaluation that filled it, so where the data goes is a decision a host makes rather than inherits.

The query algorithms are the spec's: URL matching with the exclude-fragment flag, `ignoreSearch`/`ignoreMethod`/`ignoreVary` per Query Cache, `Vary` compared by combined value with absent==absent, and `CacheStorage.match` searching caches in creation order. `put` implements each refusal step (non-GET, non-http(s), 206, `Vary: *`, disturbed body) and **consumes** the response it was given; with streamed bodies that consumption is the standard's read-all-bytes — a buffered body settles on the calling turn, a network response's `put` settles when its last chunk arrives. `addAll` is all-or-nothing by ordering (nothing written until every fetch, every check and every body read has succeeded — strictly stronger than a rollback), fetches through the engine's own `fetch` so every host policy applies, and rejects with a `TypeError` naming `UseFetch()` when the network function is absent — caching itself grants no network access.

The host seam is small and atomic: `Entries` plus one `Write(removed, added)` batch, with `CacheQuotaExceededException` mapping to the catchable `QuotaExceededError`. The in-box default is per-engine, in-memory and quota-less — documented loudly, with the provider as the answer. Cached data survives `RestoreGlobalSnapshot` like the module registry (pinned). One real bug was found by the tests during development and fixed: an entry whose stored URL does not parse is now invisible to *every* operation, not just some.

56 tests with mutation evidence on Vary separation, addAll atomicity, cache search order, and put's consumption; both suites green on net10.0 and net472, with and without `JINT_HOST_CONTRACT_VERIFICATION=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G7Ud48VAs1JicxRZxLDxg
