### PR TITLE
Web API: scheduler.postTask, scheduler.yield and the host scheduling surface

### DIFF
--- a/Jint.Tests.PublicInterface/HostScheduledWorkTests.cs
+++ b/Jint.Tests.PublicInterface/HostScheduledWorkTests.cs
@@ -1,0 +1,92 @@
+#nullable enable
+
+using Jint.Native;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// <see cref="Engine.AdvancedOperations.TimeUntilNextScheduledWork"/> — the answer a host driving its own loop
+/// needs before it decides whether to call <see cref="Engine.AdvancedOperations.ProcessTasks"/>.
+///
+/// <para>
+/// This file is deliberately <b>not</b> gated on <c>NET8_0_OR_GREATER</c>: the property is part of the
+/// all-target-framework <c>Advanced</c> surface, and the source it reports on every target framework is a core
+/// one — the deadline of an <c>Atomics.waitAsync</c>, whose settle is produced by a background delay rather
+/// than by anything the engine does, so nothing else can tell a host when to pump for it. The web-API sources
+/// (timers, delayed scheduler tasks, idle callbacks) are covered by
+/// <c>WebApiSchedulingSurfaceTests</c>, which is gated because they only exist on .NET 8 and later.
+/// </para>
+/// </summary>
+public class HostScheduledWorkTests
+{
+    /// <summary>
+    /// An engine with nothing scheduled answers <see langword="null"/> — not zero, which would send a host loop
+    /// into a hot spin, and not some arbitrary poll interval, which would be a number the engine invented.
+    /// </summary>
+    [Fact]
+    public void AnEngineWithNothingScheduledReportsNoWork()
+    {
+        using var engine = new Engine();
+        engine.Execute("var x = 1 + 1;");
+
+        engine.Advanced.TimeUntilNextScheduledWork.Should().BeNull();
+    }
+
+    /// <summary>
+    /// An <c>Atomics.waitAsync</c> with a finite timeout is the one wait in the core engine that ends because a
+    /// clock reached a number rather than because something enqueued: its "timed-out" resolution is produced by
+    /// a background delay. So the engine reports its deadline, and a host loop learns when to pump for it.
+    /// </summary>
+    /// <remarks>
+    /// The bounds are structural rather than timed. The script asks for an hour, so the only assertion is that
+    /// the answer is a positive span no larger than what was asked for — true however long the machine stalls
+    /// between the two statements, which is what keeps this test off the clock. The wait is then woken with
+    /// <c>Atomics.notify</c>, which both proves the deadline stops being reported once the wait has settled and
+    /// stops the background delay outliving the test.
+    /// </remarks>
+    [Fact]
+    public void AnAsynchronousAtomicsWaitReportsItsTimeoutDeadline()
+    {
+        using var engine = new Engine();
+
+        engine.Execute("""
+            globalThis.ta = new Int32Array(new SharedArrayBuffer(8));
+            globalThis.settled = null;
+            Atomics.waitAsync(ta, 0, 0, 3600000).value.then(v => { globalThis.settled = v; });
+            """);
+
+        var untilDeadline = engine.Advanced.TimeUntilNextScheduledWork;
+        untilDeadline.Should().NotBeNull();
+        untilDeadline!.Value.Should().BeGreaterThan(TimeSpan.Zero);
+        untilDeadline.Value.Should().BeLessThanOrEqualTo(TimeSpan.FromHours(1));
+
+        // Woken by the other route. The waiter is settled from here on, so its deadline predicts nothing and
+        // must stop being reported — otherwise a host loop would keep waking for an hour for a wait that has
+        // already finished.
+        engine.Execute("Atomics.notify(ta, 0);");
+
+        engine.Evaluate("settled").Should().Be(new JsString("ok"));
+        engine.Advanced.TimeUntilNextScheduledWork.Should().BeNull();
+    }
+
+    /// <summary>
+    /// An infinite <c>Atomics.waitAsync</c> has no deadline at all — only another agent's <c>Atomics.notify</c>
+    /// can end it, and that arrives as an enqueue, which needs no clock. Reporting a time for it would be
+    /// inventing one.
+    /// </summary>
+    [Fact]
+    public void AnInfiniteAtomicsWaitReportsNoDeadline()
+    {
+        using var engine = new Engine();
+
+        engine.Execute("""
+            globalThis.ta = new Int32Array(new SharedArrayBuffer(8));
+            Atomics.waitAsync(ta, 0, 0).value.then(() => {});
+            """);
+
+        engine.Advanced.TimeUntilNextScheduledWork.Should().BeNull();
+
+        // Leave nothing waiting behind the test.
+        engine.Execute("Atomics.notify(ta, 0);");
+    }
+}

--- a/Jint.Tests.PublicInterface/WebApiSchedulingSurfaceTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiSchedulingSurfaceTests.cs
@@ -1,0 +1,296 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.Threading;
+using Jint.Native;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// The scheduling surface a host driving its own loop actually touches:
+/// <see cref="Engine.AdvancedOperations.TimeUntilNextScheduledWork"/> over the web-API sources,
+/// <see cref="Engine.AdvancedOperations.CreateAbortSignal"/> as the way its own cancellation reaches script,
+/// and the <c>requestIdleCallback</c> globals.
+/// </summary>
+/// <remarks>
+/// This project has no <c>InternalsVisibleTo</c>, so everything here is asserted through the public options
+/// surface and through script, exactly as an embedder would have to. Nothing waits on the wall clock: the
+/// timer-driven tests hand the engine a <see cref="ManualClock"/>, and the cross-thread test synchronises on a
+/// thread's completion rather than on an interval.
+/// </remarks>
+public class WebApiSchedulingSurfaceTests
+{
+    /// <summary>A host-supplied clock, so that a suite exercising timed work need not sleep.</summary>
+    private sealed class ManualClock : TimeProvider
+    {
+        private long _timestamp;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp() => _timestamp;
+
+        public override DateTimeOffset GetUtcNow() => DateTimeOffset.UnixEpoch.AddTicks(_timestamp);
+
+        internal void Advance(int milliseconds) => _timestamp += milliseconds * TimeSpan.TicksPerMillisecond;
+    }
+
+    private static (Engine Engine, ManualClock Clock) WebEngine(TimeSpan? idleBudget = null)
+    {
+        var clock = new ManualClock();
+        var engine = new Engine(options => options.UseWebApis(webApi =>
+        {
+            webApi.Timers.TimeProvider = clock;
+            if (idleBudget is { } budget)
+            {
+                webApi.Timers.IdleBudget = budget;
+            }
+        }));
+
+        return (engine, clock);
+    }
+
+    /// <summary>
+    /// A web-API engine with nothing outstanding answers <see langword="null"/>, so a host loop can tell "there
+    /// is nothing for me to do" from "there is something, in a while".
+    /// </summary>
+    [Fact]
+    public void NothingScheduledIsReportedAsNothingScheduled()
+    {
+        var (engine, _) = WebEngine();
+
+        engine.Execute("var x = 1;");
+
+        engine.Advanced.TimeUntilNextScheduledWork.Should().BeNull();
+    }
+
+    /// <summary>
+    /// A pending timer reports exactly how long is left, which is what lets a host sleep rather than poll. The
+    /// clock is the host's own, so the answer is a number this test can name.
+    /// </summary>
+    [Fact]
+    public void APendingTimerReportsItsRemainingDelay()
+    {
+        var (engine, clock) = WebEngine();
+
+        engine.Execute("setTimeout(() => {}, 100);");
+
+        engine.Advanced.TimeUntilNextScheduledWork.Should().Be(TimeSpan.FromMilliseconds(100));
+
+        clock.Advance(40);
+        engine.Advanced.TimeUntilNextScheduledWork.Should().Be(TimeSpan.FromMilliseconds(60));
+    }
+
+    /// <summary>
+    /// A timer that came due while nobody was pumping reports zero rather than a negative span: the host is
+    /// being told to pump, and "how late am I" is not something it could act on.
+    /// </summary>
+    [Fact]
+    public void ATimerThatIsAlreadyDueReportsZero()
+    {
+        var (engine, clock) = WebEngine();
+
+        engine.Execute("globalThis.fired = false; setTimeout(() => { globalThis.fired = true; }, 100);");
+
+        clock.Advance(250);
+
+        engine.Advanced.TimeUntilNextScheduledWork.Should().Be(TimeSpan.Zero);
+
+        engine.Advanced.ProcessTasks();
+
+        engine.Evaluate("fired").Should().Be(JsBoolean.True);
+        engine.Advanced.TimeUntilNextScheduledWork.Should().BeNull();
+    }
+
+    /// <summary>
+    /// A delayed <c>scheduler.postTask</c> rides the timer queue, so it is reported exactly as a
+    /// <c>setTimeout</c> is — a host does not have to know which of the two a script used.
+    /// </summary>
+    [Fact]
+    public void ADelayedSchedulerTaskIsReportedLikeATimer()
+    {
+        var (engine, clock) = WebEngine();
+
+        engine.Execute("globalThis.ran = false; scheduler.postTask(() => { globalThis.ran = true; }, { delay: 250 });");
+
+        engine.Advanced.TimeUntilNextScheduledWork.Should().Be(TimeSpan.FromMilliseconds(250));
+
+        clock.Advance(250);
+        engine.Advanced.ProcessTasks();
+
+        engine.Evaluate("ran").Should().Be(JsBoolean.True);
+    }
+
+    /// <summary>
+    /// An idle callback becomes runnable the moment a pump drains, so it is work for <i>now</i> — a host that
+    /// slept on a positive answer would be sleeping through work it could already be doing.
+    /// </summary>
+    /// <remarks>
+    /// The outer callback runs during <c>Execute</c>'s own drain and requests the inner one, which — the
+    /// pending list being what the <i>next</i> idle period picks up — is left waiting for the next pump. That
+    /// is the state this property has to describe.
+    /// </remarks>
+    [Fact]
+    public void APendingIdleCallbackIsWorkForNow()
+    {
+        var (engine, _) = WebEngine();
+
+        engine.Execute("""
+            globalThis.inner = false;
+            requestIdleCallback(() => { requestIdleCallback(() => { globalThis.inner = true; }); });
+            """);
+
+        engine.Advanced.TimeUntilNextScheduledWork.Should().Be(TimeSpan.Zero);
+
+        engine.Advanced.ProcessTasks();
+
+        engine.Evaluate("inner").Should().Be(JsBoolean.True);
+        engine.Advanced.TimeUntilNextScheduledWork.Should().BeNull();
+    }
+
+    /// <summary>
+    /// A host that declares it has no idle time is not told there is idle work to do: with a zero budget no
+    /// idle period can ever start, so reporting zero would spin the host's loop over a callback that can never
+    /// run.
+    /// </summary>
+    [Fact]
+    public void AZeroIdleBudgetMeansAnIdleCallbackIsNotWorkAtAll()
+    {
+        var (engine, _) = WebEngine(idleBudget: TimeSpan.Zero);
+
+        engine.Execute("globalThis.ran = false; requestIdleCallback(() => { globalThis.ran = true; });");
+
+        engine.Advanced.TimeUntilNextScheduledWork.Should().BeNull();
+
+        engine.Advanced.ProcessTasks();
+        engine.Evaluate("ran").Should().Be(JsBoolean.False);
+    }
+
+    /// <summary>
+    /// <c>Options.WebApi.Timers.IdleBudget</c> is reachable from outside the assembly and is what an idle
+    /// callback's <c>timeRemaining()</c> counts down from.
+    /// </summary>
+    [Fact]
+    public void TheIdleBudgetIsTheHostsToChoose()
+    {
+        var (engine, _) = WebEngine(idleBudget: TimeSpan.FromMilliseconds(12));
+
+        engine.Execute("globalThis.remaining = null; requestIdleCallback(d => { globalThis.remaining = d.timeRemaining(); });");
+
+        engine.Evaluate("remaining").Should().Be(JsNumber.Create(12));
+
+        // The default, for a host that says nothing.
+        new Options().WebApi.Timers.IdleBudget.Should().Be(TimeSpan.FromMilliseconds(50));
+    }
+
+    /// <summary>
+    /// The whole point of the bridge, and the one thing that must never be true of it: cancelling the host's
+    /// token does not run a single line of script on the cancelling thread. It enqueues, and the abort happens
+    /// on the thread that pumps.
+    /// </summary>
+    /// <remarks>
+    /// A dedicated <see cref="Thread"/> rather than <c>Task.Run</c>, because a task can be inlined onto the
+    /// waiting thread and the test would then be asserting nothing. The waits are liveness guards, not
+    /// intervals: nothing here is measured against a clock.
+    /// </remarks>
+    [Fact]
+    public void CancellingTheTokenNeverRunsScriptOnTheCancellingThread()
+    {
+        var (engine, _) = WebEngine();
+        using var cts = new CancellationTokenSource();
+
+        engine.SetValue("hostSignal", engine.Advanced.CreateAbortSignal(cts.Token));
+
+        var abortThread = 0;
+        engine.SetValue("recordAbortThread", new Action(() => abortThread = Environment.CurrentManagedThreadId));
+        engine.Execute("hostSignal.addEventListener('abort', () => recordAbortThread());");
+
+        var engineThread = Environment.CurrentManagedThreadId;
+        var cancellingThread = 0;
+
+        var canceller = new Thread(() =>
+        {
+            cancellingThread = Environment.CurrentManagedThreadId;
+            cts.Cancel();
+        })
+        {
+            IsBackground = true,
+            Name = "host-cancellation",
+        };
+
+        canceller.Start();
+        canceller.Join(TimeSpan.FromSeconds(30)).Should().BeTrue("the cancelling thread must not block");
+
+        // Cancel() has returned, so every registration it runs has run. Nothing observed the abort, because
+        // the registration only enqueued.
+        cancellingThread.Should().NotBe(engineThread);
+        abortThread.Should().Be(0);
+
+        // ... and the engine has work waiting, which is what a host loop is told to look for.
+        engine.Advanced.TimeUntilNextScheduledWork.Should().Be(TimeSpan.Zero);
+
+        engine.Advanced.ProcessTasks();
+
+        abortThread.Should().Be(engineThread);
+        engine.Evaluate("hostSignal.aborted").Should().Be(JsBoolean.True);
+    }
+
+    /// <summary>
+    /// An engine that has been disposed lets go of the host's token, so an application-lifetime token cancelled
+    /// long afterwards reaches nothing.
+    /// </summary>
+    /// <remarks>
+    /// Observable from outside through the property: had the registration survived, the cancellation would have
+    /// enqueued a job and the engine would report work to do.
+    /// </remarks>
+    [Fact]
+    public void DisposingTheEngineReleasesTheHostToken()
+    {
+        var (engine, _) = WebEngine();
+        using var cts = new CancellationTokenSource();
+
+        engine.SetValue("hostSignal", engine.Advanced.CreateAbortSignal(cts.Token));
+
+        engine.Dispose();
+
+        cts.Cancel();
+
+        engine.Advanced.TimeUntilNextScheduledWork.Should().BeNull();
+    }
+
+    /// <summary>
+    /// The idle-callback globals are behind their own flag, and a default engine has none of them.
+    /// </summary>
+    [Fact]
+    public void TheIdleCallbackGlobalsAreOptIn()
+    {
+        var names = new[] { "requestIdleCallback", "cancelIdleCallback", "IdleDeadline" };
+
+        using var untouched = new Engine();
+        using var consoleOnly = new Engine(options => options.UseWebApis(WebApiFeatures.Console));
+        using var idle = new Engine(options => options.UseWebApis(WebApiFeatures.IdleCallback));
+
+        foreach (var name in names)
+        {
+            untouched.Evaluate($"typeof {name}").Should().Be(new JsString("undefined"));
+            consoleOnly.Evaluate($"typeof {name}").Should().Be(new JsString("undefined"));
+            idle.Evaluate($"typeof {name}").Should().Be(new JsString("function"));
+
+            // Deliberately more conservative than a browser, where these are [Exposed=*].
+            idle.Evaluate($"new ShadowRealm().evaluate('typeof {name}')").Should().Be(new JsString("undefined"));
+        }
+    }
+
+    /// <summary>
+    /// <see cref="WebApiFeatures.Default"/> — what <c>UseWebApis()</c> enables — includes the idle callbacks,
+    /// since they need no network and no host decision beyond the budget.
+    /// </summary>
+    [Fact]
+    public void TheDefaultFeatureSetIncludesTheIdleCallbacks()
+    {
+        WebApiFeatures.Default.Should().HaveFlag(WebApiFeatures.IdleCallback);
+
+        var (engine, _) = WebEngine();
+        engine.Evaluate("typeof requestIdleCallback").Should().Be(new JsString("function"));
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/HostAbortSignalTests.cs
+++ b/Jint.Tests/Runtime/WebApi/HostAbortSignalTests.cs
@@ -1,0 +1,160 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.Threading;
+using Jint.Native;
+using Jint.WebApi.Abort;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// <c>Engine.Advanced.CreateAbortSignal(CancellationToken)</c> — the bridge from the host's own cancellation to
+/// the <c>AbortSignal</c> script consumes.
+/// </summary>
+/// <remarks>
+/// This file is inside the assembly, so it can check the half a host cannot see: the signal's internal
+/// <see cref="CancellationToken"/>, which is what a CLR-side operation such as <c>fetch</c> links its HTTP
+/// request against. The host-visible half — that nothing ever runs on the cancelling thread — is pinned from
+/// outside in <c>Jint.Tests.PublicInterface.WebApiSchedulingSurfaceTests</c>.
+/// </remarks>
+public class HostAbortSignalTests
+{
+    private static Engine EventsEngine() => new(options => options.UseWebApis(WebApiFeatures.Events));
+
+    /// <summary>
+    /// A token that is already cancelled produces an already-aborted signal, right here and with no pump — the
+    /// creation runs on the engine's thread, which is the only thread that may abort a signal, so there is
+    /// nothing to defer.
+    /// </summary>
+    [Fact]
+    public void AnAlreadyCancelledTokenYieldsAnAlreadyAbortedSignal()
+    {
+        using var engine = EventsEngine();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var signal = (JsAbortSignal) engine.Advanced.CreateAbortSignal(cts.Token);
+
+        signal.Aborted.Should().BeTrue();
+
+        // The standard's default reason, exactly as AbortSignal.abort() with no argument produces.
+        engine.SetValue("s", signal);
+        engine.Evaluate("s.reason.constructor.name").Should().Be(new JsString("DOMException"));
+        engine.Evaluate("s.reason.name").Should().Be(new JsString("AbortError"));
+
+        // And the handle a fetch would link against is already cancelled, so such an operation refuses without
+        // ever issuing a request.
+        signal.CancellationToken.IsCancellationRequested.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A live token aborts nothing until the engine is pumped, and then aborts everything at once: the abort
+    /// algorithms — the engine's own CLR-side cancellation among them — run before the <c>abort</c> event, so
+    /// an in-flight CLR operation is stopped before any script observes the abort.
+    /// </summary>
+    [Fact]
+    public void CancellationAbortsTheSignalAndItsClrTokenOnTheNextPump()
+    {
+        using var engine = EventsEngine();
+        using var cts = new CancellationTokenSource();
+
+        var signal = (JsAbortSignal) engine.Advanced.CreateAbortSignal(cts.Token);
+
+        // Taken before the abort, which is what a fetch does when it starts a request.
+        var clrToken = signal.CancellationToken;
+
+        engine.SetValue("s", signal);
+        engine.Execute("var seen = null; s.addEventListener('abort', () => { seen = s.reason.name; });");
+
+        cts.Cancel();
+
+        // Nothing has run: cancelling only enqueued a job.
+        signal.Aborted.Should().BeFalse();
+        clrToken.IsCancellationRequested.Should().BeFalse();
+
+        engine.Advanced.ProcessTasks();
+
+        signal.Aborted.Should().BeTrue();
+        clrToken.IsCancellationRequested.Should().BeTrue();
+        engine.Evaluate("seen").Should().Be(new JsString("AbortError"));
+    }
+
+    /// <summary>
+    /// A token that can never be cancelled — <see cref="CancellationToken.None"/>, or a struct default — still
+    /// produces a usable signal; it simply never aborts, and nothing is registered on the host's side.
+    /// </summary>
+    [Fact]
+    public void ATokenThatCanNeverBeCancelledYieldsASignalThatNeverAborts()
+    {
+        using var engine = EventsEngine();
+
+        var signal = (JsAbortSignal) engine.Advanced.CreateAbortSignal(CancellationToken.None);
+
+        signal.Aborted.Should().BeFalse();
+
+        engine.SetValue("s", signal);
+        engine.Evaluate("s instanceof AbortSignal").Should().Be(JsBoolean.True);
+
+        engine.Advanced.ProcessTasks();
+        signal.Aborted.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// The signal belongs to the principal realm's <c>AbortSignal</c>, so everything script does with it — the
+    /// <c>instanceof</c>, the listeners, handing it to an API that takes a signal — works.
+    /// </summary>
+    [Fact]
+    public void TheSignalIsAnOrdinaryAbortSignalOfThePrincipalRealm()
+    {
+        using var engine = EventsEngine();
+        using var cts = new CancellationTokenSource();
+
+        engine.SetValue("s", engine.Advanced.CreateAbortSignal(cts.Token));
+
+        engine.Evaluate("Object.getPrototypeOf(s) === AbortSignal.prototype").Should().Be(JsBoolean.True);
+        engine.Evaluate("s instanceof EventTarget").Should().Be(JsBoolean.True);
+        engine.Evaluate("s.aborted").Should().Be(JsBoolean.False);
+        engine.Evaluate("typeof s.throwIfAborted").Should().Be(new JsString("function"));
+    }
+
+    /// <summary>
+    /// A signal bridged in one evaluation cycle must not abort into the next: a
+    /// <c>RestoreGlobalSnapshot</c> ends the cycle, and the bridge is released with everything else that cycle
+    /// registered.
+    /// </summary>
+    [Fact]
+    public void ARestoreReleasesTheBridge()
+    {
+        using var engine = EventsEngine();
+        using var cts = new CancellationTokenSource();
+
+        var signal = (JsAbortSignal) engine.Advanced.CreateAbortSignal(cts.Token);
+
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        cts.Cancel();
+        engine.Advanced.ProcessTasks();
+
+        signal.Aborted.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// The feature gate: <c>AbortSignal</c> belongs to <see cref="WebApiFeatures.Events"/>, and an engine that
+    /// did not ask for it is told which feature to enable rather than silently handed an object whose interface
+    /// object no script can name.
+    /// </summary>
+    [Fact]
+    public void AnEngineWithoutTheEventsFeatureIsRefused()
+    {
+        using var engine = new Engine();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => engine.Advanced.CreateAbortSignal(CancellationToken.None));
+        exception.Message.Should().Contain("WebApiFeatures.Events");
+
+        // Enabling some other feature is not enough either.
+        using var consoleOnly = new Engine(options => options.UseWebApis(WebApiFeatures.Console));
+        Assert.Throws<InvalidOperationException>(() => consoleOnly.Advanced.CreateAbortSignal(CancellationToken.None));
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/IdleCallbackTests.cs
+++ b/Jint.Tests/Runtime/WebApi/IdleCallbackTests.cs
@@ -1,0 +1,507 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Native;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Descriptors.Specialized;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// <c>requestIdleCallback</c> / <c>cancelIdleCallback</c> against https://w3c.github.io/requestidlecallback/,
+/// and against the embedding mapping Jint documents for them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The standard is written for a browser, where an idle period is the slack before the next frame is due.
+/// Jint has no frames, so an idle period is a pump that has run out of everything else and its deadline is
+/// <c>Options.WebApi.Timers.IdleBudget</c>. The tests that matter are therefore about <i>position</i> — a
+/// callback runs after every job, every scheduler task at every priority, and every due timer — and about the
+/// budget being a real boundary rather than decoration.
+/// </para>
+/// <para>
+/// Every test drives a <see cref="ManualClock"/>, so nothing here waits on the wall clock: an idle deadline is
+/// a number this suite chooses, and a <c>timeout</c> elapses exactly when a test says it does.
+/// </para>
+/// </remarks>
+public class IdleCallbackTests
+{
+    /// <summary>
+    /// A <see cref="TimeProvider"/> whose clock only moves when a test moves it.
+    /// </summary>
+    private sealed class ManualClock : TimeProvider
+    {
+        private long _timestamp;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp() => _timestamp;
+
+        public override DateTimeOffset GetUtcNow() => DateTimeOffset.UnixEpoch.AddTicks(_timestamp);
+
+        internal void Advance(int milliseconds) => _timestamp += milliseconds * TimeSpan.TicksPerMillisecond;
+    }
+
+    private static (Engine Engine, ManualClock Clock) IdleEngine(
+        TimeSpan? idleBudget = null,
+        int? maxActiveTimers = null)
+    {
+        var clock = new ManualClock();
+        var engine = new Engine(options => options.UseWebApis(webApi =>
+        {
+            webApi.Timers.TimeProvider = clock;
+            if (idleBudget is { } budget)
+            {
+                webApi.Timers.IdleBudget = budget;
+            }
+
+            if (maxActiveTimers is { } max)
+            {
+                webApi.Timers.MaxActiveTimers = max;
+            }
+        }));
+
+        engine.Execute("var log = [];");
+        return (engine, clock);
+    }
+
+    private static string Log(Engine engine) => engine.Evaluate("log.join(',')").AsString();
+
+    /// <summary>
+    /// The happy path: a pump that has run out of everything else starts an idle period and runs the callback,
+    /// handing it an <c>IdleDeadline</c> that says it is not a timeout and that the whole budget is left.
+    /// </summary>
+    /// <remarks>
+    /// The clock does not move while the callback runs, so <c>timeRemaining()</c> is the budget exactly — which
+    /// is what makes this assertable at all. Against a real clock it would be "50 minus however long the pump
+    /// took", i.e. a number no test could name.
+    /// </remarks>
+    [Fact]
+    public void ARequestedCallbackRunsOnTheNextPumpWithTheWholeBudgetLeft()
+    {
+        var (engine, _) = IdleEngine();
+
+        engine.Execute("requestIdleCallback(d => log.push(d.didTimeout, d.timeRemaining()));");
+
+        Log(engine).Should().Be("false,50");
+    }
+
+    /// <summary>
+    /// <c>Options.WebApi.Timers.IdleBudget</c> is what <c>timeRemaining()</c> counts down from, so a host that
+    /// narrows it narrows what a callback believes it may do.
+    /// </summary>
+    [Fact]
+    public void TheDeadlineIsTheHostsIdleBudget()
+    {
+        var (engine, _) = IdleEngine(idleBudget: TimeSpan.FromMilliseconds(7));
+
+        engine.Execute("requestIdleCallback(d => log.push(d.timeRemaining()));");
+
+        Log(engine).Should().Be("7");
+    }
+
+    /// <summary>
+    /// The idle period is a real budget: once the clock has passed the deadline, the period ends and whatever
+    /// is left waits for the next pump rather than running the engine's idle list to exhaustion in one go.
+    /// </summary>
+    /// <remarks>
+    /// The first callback moves the clock past the deadline itself — through the host callback the test
+    /// installs — which is the only way a manual clock can model a callback that overruns. That is exactly the
+    /// case the budget exists for.
+    /// </remarks>
+    [Fact]
+    public void ACallbackThatOverrunsTheBudgetEndsTheIdlePeriod()
+    {
+        var (engine, clock) = IdleEngine(idleBudget: TimeSpan.FromMilliseconds(50));
+        engine.SetValue("burnTheBudget", new Action(() => clock.Advance(60)));
+
+        engine.Execute("""
+            requestIdleCallback(() => { log.push('first'); burnTheBudget(); });
+            requestIdleCallback(() => log.push('second'));
+            """);
+
+        // The first ran and then spent the whole budget, so the pump returned to the host with the second
+        // callback still waiting.
+        Log(engine).Should().Be("first");
+
+        engine.Advanced.ProcessTasks();
+        Log(engine).Should().Be("first,second");
+    }
+
+    /// <summary>
+    /// "Start an idle period" is what moves the pending list into the runnable list, so a callback requested
+    /// from inside a callback belongs to the <i>next</i> period — which is what stops a self-re-arming
+    /// <c>requestIdleCallback</c> monopolising the pump it was started from.
+    /// </summary>
+    [Fact]
+    public void ACallbackRequestedDuringAnIdlePeriodWaitsForTheNextPump()
+    {
+        var (engine, _) = IdleEngine();
+
+        engine.Execute("""
+            requestIdleCallback(() => {
+                log.push('outer');
+                requestIdleCallback(() => log.push('inner'));
+            });
+            """);
+
+        Log(engine).Should().Be("outer");
+
+        engine.Advanced.ProcessTasks();
+        Log(engine).Should().Be("outer,inner");
+    }
+
+    /// <summary>
+    /// The position the whole design turns on: idle callbacks are the lowest band the engine has. A microtask,
+    /// a <c>background</c> scheduler task — the lowest priority the scheduler offers — and a due timer all run
+    /// first, in that order.
+    /// </summary>
+    [Fact]
+    public void EveryOtherKindOfWorkRunsBeforeAnIdleCallback()
+    {
+        var (engine, _) = IdleEngine();
+
+        engine.Execute("""
+            requestIdleCallback(() => log.push('idle'));
+            setTimeout(() => log.push('timer'), 0);
+            scheduler.postTask(() => log.push('background'), { priority: 'background' });
+            Promise.resolve().then(() => log.push('microtask'));
+            """);
+
+        Log(engine).Should().Be("microtask,background,timer,idle");
+    }
+
+    /// <summary>
+    /// A timer that is not yet due does not hold an idle callback back — idleness is about having nothing to
+    /// run <i>now</i>, not about having nothing scheduled at all.
+    /// </summary>
+    [Fact]
+    public void ATimerThatIsNotYetDueDoesNotHoldAnIdleCallbackBack()
+    {
+        var (engine, clock) = IdleEngine();
+
+        engine.Execute("""
+            setTimeout(() => log.push('timer'), 100);
+            requestIdleCallback(() => log.push('idle'));
+            """);
+
+        Log(engine).Should().Be("idle");
+
+        clock.Advance(100);
+        engine.Advanced.ProcessTasks();
+        Log(engine).Should().Be("idle,timer");
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/requestidlecallback/#the-cancelidlecallback-method — the entry is removed from
+    /// both lists, so the callback never runs.
+    /// </summary>
+    [Fact]
+    public void CancelIdleCallbackStopsTheCallbackRunning()
+    {
+        var (engine, _) = IdleEngine();
+
+        engine.Execute("""
+            const handle = requestIdleCallback(() => log.push('never'));
+            cancelIdleCallback(handle);
+            """);
+
+        Log(engine).Should().BeEmpty();
+
+        engine.Advanced.ProcessTasks();
+        Log(engine).Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// An unknown handle is not an error — "if there is such an entry" simply does not hold.
+    /// </summary>
+    [Fact]
+    public void CancellingAnUnknownHandleIsSilent()
+    {
+        var (engine, _) = IdleEngine();
+
+        engine.Execute("cancelIdleCallback(9999); cancelIdleCallback(); cancelIdleCallback('nope');");
+
+        Log(engine).Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The invoke idle callback timeout algorithm,
+    /// https://w3c.github.io/requestidlecallback/#invoke-idle-callback-timeout-algorithm: when the timeout
+    /// elapses the callback runs whether or not the engine is idle, with <c>didTimeout</c> true and a
+    /// <c>timeRemaining()</c> of zero — its deadline is <i>now</i>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A budget of zero is what makes this observable: it tells the engine the host never has idle time, so
+    /// nothing but the timeout can reach the callback. Without it the very first pump would run the callback as
+    /// an ordinary idle one and the timeout would be cancelled before it could ever fire.
+    /// </para>
+    /// <para>
+    /// The timeout rides the timer queue, so the manual clock drives it and this test touches no wall clock.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void ATimeoutRunsTheCallbackOutsideAnyIdlePeriod()
+    {
+        var (engine, clock) = IdleEngine(idleBudget: TimeSpan.Zero);
+
+        engine.Execute("requestIdleCallback(d => log.push(d.didTimeout, d.timeRemaining()), { timeout: 100 });");
+
+        // A host with no idle time runs nothing idle, however often it pumps.
+        Log(engine).Should().BeEmpty();
+        engine.Advanced.ProcessTasks();
+        Log(engine).Should().BeEmpty();
+
+        clock.Advance(99);
+        engine.Advanced.ProcessTasks();
+        Log(engine).Should().BeEmpty();
+
+        clock.Advance(1);
+        engine.Advanced.ProcessTasks();
+        Log(engine).Should().Be("true,0");
+    }
+
+    /// <summary>
+    /// A callback that an idle period reached first must not run a second time when its timeout comes due —
+    /// the idle path removes the entry from both lists, which is what the timeout algorithm looks for.
+    /// </summary>
+    [Fact]
+    public void ACallbackThatAlreadyRanDoesNotRunAgainWhenItsTimeoutElapses()
+    {
+        var (engine, clock) = IdleEngine();
+
+        engine.Execute("requestIdleCallback(d => log.push('ran:' + d.didTimeout), { timeout: 10 });");
+
+        Log(engine).Should().Be("ran:false");
+
+        clock.Advance(1000);
+        engine.Advanced.ProcessTasks();
+        Log(engine).Should().Be("ran:false");
+    }
+
+    /// <summary>
+    /// A callback with no <c>timeout</c> occupies no timer slot: it waits in a list for the next pump, exactly
+    /// as a queued job does, so it is not something a script can exhaust the timer quota with.
+    /// </summary>
+    [Fact]
+    public void ACallbackWithoutATimeoutCostsNoTimerSlot()
+    {
+        var (engine, _) = IdleEngine(maxActiveTimers: 0);
+
+        engine.Execute("requestIdleCallback(() => log.push('idle'));");
+
+        Log(engine).Should().Be("idle");
+    }
+
+    /// <summary>
+    /// A <c>timeout</c> is a timer, so it does count against <c>MaxActiveTimers</c> — a script that can request
+    /// idle callbacks must not be able to register timers without bound through the back door.
+    /// </summary>
+    [Fact]
+    public void ATimeoutCountsAgainstTheTimerQuota()
+    {
+        var (engine, _) = IdleEngine(idleBudget: TimeSpan.Zero, maxActiveTimers: 1);
+
+        engine.Execute("""
+            requestIdleCallback(() => {}, { timeout: 100 });
+            try {
+                requestIdleCallback(() => {}, { timeout: 100 });
+            } catch (e) {
+                log.push(e.constructor.name, e.name);
+            }
+            """);
+
+        Log(engine).Should().Be("DOMException,QuotaExceededError");
+    }
+
+    /// <summary>
+    /// Cancelling a callback frees the timer slot its timeout held, rather than leaving it to expire into
+    /// nothing.
+    /// </summary>
+    [Fact]
+    public void CancellingACallbackFreesItsTimeoutSlot()
+    {
+        var (engine, _) = IdleEngine(idleBudget: TimeSpan.Zero, maxActiveTimers: 1);
+
+        engine.Execute("""
+            const first = requestIdleCallback(() => {}, { timeout: 100 });
+            cancelIdleCallback(first);
+            requestIdleCallback(() => log.push('second scheduled'), { timeout: 100 });
+            log.push('no quota error');
+            """);
+
+        Log(engine).Should().Be("no quota error");
+    }
+
+    /// <summary>
+    /// A callback that is not callable is a <c>TypeError</c>, per the WebIDL <c>IdleRequestCallback</c>
+    /// conversion.
+    /// </summary>
+    [Fact]
+    public void ANonCallableCallbackIsATypeError()
+    {
+        var (engine, _) = IdleEngine();
+
+        var exception = Assert.Throws<JavaScriptException>(() => engine.Execute("requestIdleCallback(42);"));
+        exception.Error.Get("name").Should().Be(new JsString("TypeError"));
+    }
+
+    /// <summary>
+    /// The <c>IdleRequestOptions</c> dictionary's <c>timeout</c> member is a plain <c>unsigned long</c>, so the
+    /// conversion is <c>ToUint32</c>'s and not <c>[EnforceRange]</c>'s refusal: a non-number becomes 0 rather
+    /// than an exception.
+    /// </summary>
+    [Fact]
+    public void AnUnparsableTimeoutIsZeroRatherThanAnError()
+    {
+        var (engine, _) = IdleEngine(idleBudget: TimeSpan.Zero);
+
+        // Zero means "no timeout", so nothing is ever scheduled and — the budget being zero — nothing runs.
+        engine.Execute("log.push(typeof requestIdleCallback(() => {}, { timeout: NaN }));");
+
+        Log(engine).Should().Be("number");
+    }
+
+    /// <summary>
+    /// The WebIDL shape of the two operations: <c>length</c> counts the required arguments only, and both are
+    /// writable, enumerable and configurable properties of the global, as operations of a global interface
+    /// mixin are — https://webidl.spec.whatwg.org/#es-operations.
+    /// </summary>
+    [Fact]
+    public void TheOperationsHaveTheirWebIdlShape()
+    {
+        var (engine, _) = IdleEngine();
+
+        engine.Evaluate("typeof requestIdleCallback").Should().Be(new JsString("function"));
+        engine.Evaluate("requestIdleCallback.length").Should().Be(JsNumber.Create(1));
+        engine.Evaluate("requestIdleCallback.name").Should().Be(new JsString("requestIdleCallback"));
+        engine.Evaluate("cancelIdleCallback.length").Should().Be(JsNumber.Create(1));
+
+        var descriptor = engine.Realm.GlobalObject.GetOwnProperty("requestIdleCallback");
+        descriptor.Enumerable.Should().BeTrue();
+        descriptor.Writable.Should().BeTrue();
+        descriptor.Configurable.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// <c>IdleDeadline</c> is exposed even though nothing but the engine can create one — that is what makes
+    /// <c>deadline instanceof IdleDeadline</c> and feature detection work — and, being an interface object, it
+    /// is non-enumerable and refuses to construct.
+    /// </summary>
+    [Fact]
+    public void TheIdleDeadlineInterfaceObjectIsExposedButNotConstructible()
+    {
+        var (engine, _) = IdleEngine();
+
+        engine.Execute("""
+            requestIdleCallback(d => {
+                log.push(d instanceof IdleDeadline);
+                log.push(Object.prototype.toString.call(d));
+                log.push(Object.getPrototypeOf(d) === IdleDeadline.prototype);
+                try { new IdleDeadline(); } catch (e) { log.push(e.constructor.name); }
+            });
+            """);
+
+        Log(engine).Should().Be("true,[object IdleDeadline],true,TypeError");
+
+        var descriptor = engine.Realm.GlobalObject.GetOwnProperty("IdleDeadline");
+        descriptor.Enumerable.Should().BeFalse();
+        descriptor.Writable.Should().BeTrue();
+        descriptor.Configurable.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Both members brand-check their receiver, as WebIDL requires: <c>IdleDeadline.prototype</c> is not an
+    /// <c>IdleDeadline</c>, and neither is a plain object borrowed into the receiver position.
+    /// </summary>
+    [Fact]
+    public void TheMembersBrandCheckTheirReceiver()
+    {
+        var (engine, _) = IdleEngine();
+
+        engine.Execute("""
+            try { IdleDeadline.prototype.timeRemaining(); } catch (e) { log.push(e.constructor.name); }
+            const getter = Object.getOwnPropertyDescriptor(IdleDeadline.prototype, 'didTimeout').get;
+            try { getter.call({}); } catch (e) { log.push(e.constructor.name); }
+            """);
+
+        Log(engine).Should().Be("TypeError,TypeError");
+    }
+
+    /// <summary>
+    /// The globals are installed lazily, exactly as every other web-API global is: the property exists for
+    /// enumeration and existence checks from the start, and the function object behind it is built only when
+    /// something reads it.
+    /// </summary>
+    [Fact]
+    public void TheGlobalsAreInstalledLazily()
+    {
+        var (engine, _) = IdleEngine();
+
+        var descriptor = engine.Realm.GlobalObject.GetOwnProperty("requestIdleCallback");
+        descriptor.Should().BeOfType<LazyPropertyDescriptor<Engine>>();
+
+        // Still flagged CustomJsValue means the factory has not run: enabling the feature costs one descriptor
+        // per global and nothing else.
+        (descriptor._flags & PropertyFlag.CustomJsValue).Should().NotBe(PropertyFlag.None);
+        descriptor._value.Should().BeNull();
+
+        engine.Evaluate("typeof requestIdleCallback");
+
+        // Materialized once and then an ordinary data property, so later reads rejoin the caching lanes.
+        descriptor._value.Should().NotBeNull();
+        (descriptor._flags & PropertyFlag.CustomJsValue).Should().Be(PropertyFlag.None);
+    }
+
+    /// <summary>
+    /// A callback requested by the evaluation cycle a <c>RestoreGlobalSnapshot</c> ends must never run against
+    /// the globals that restore put back — the same fence a timer and a scheduler task sit behind.
+    /// </summary>
+    [Fact]
+    public void ARestoreForgetsPendingIdleCallbacks()
+    {
+        var (engine, _) = IdleEngine();
+
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+
+        // The outer callback runs during this Execute's own drain; the inner one it requests belongs to the
+        // next idle period and is still waiting when the restore lands, which is the state under test.
+        engine.Execute("""
+            requestIdleCallback(() => {
+                requestIdleCallback(() => { globalThis.ranAfterRestore = true; });
+            });
+            """);
+
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        engine.Execute("globalThis.ranAfterRestore = false;");
+        engine.Advanced.ProcessTasks();
+
+        engine.Evaluate("ranAfterRestore").Should().Be(JsBoolean.False);
+    }
+
+    /// <summary>
+    /// A callback that throws erupts from whatever was pumping — the contract a timer callback and a promise
+    /// reaction already have — and the callbacks behind it still run on the next pump.
+    /// </summary>
+    [Fact]
+    public void AThrowingCallbackEruptsFromThePump()
+    {
+        var (engine, _) = IdleEngine();
+
+        var exception = Assert.Throws<JavaScriptException>(() => engine.Execute("""
+            requestIdleCallback(() => { throw new Error('boom'); });
+            requestIdleCallback(() => log.push('after'));
+            """));
+
+        exception.Message.Should().Be("boom");
+
+        // The throw does not wedge the queue: the callback behind it still runs on the next pump, and the one
+        // that threw does not run twice.
+        engine.Advanced.ProcessTasks();
+        Log(engine).Should().Be("after");
+    }
+}
+#endif

--- a/Jint/Engine.Advanced.WebApi.cs
+++ b/Jint/Engine.Advanced.WebApi.cs
@@ -1,12 +1,13 @@
 #if NET8_0_OR_GREATER
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
 using Jint.Native;
 using Jint.Runtime;
-using Jint.WebApi;
+using Jint.WebApi.Abort;
 using Jint.WebApi.Fetch;
 using Jint.WebApi.Messaging;
+using Jint.WebApi;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Threading;
 
 namespace Jint;
 
@@ -382,6 +383,107 @@ public partial class Engine
             }
 
             return state;
+        }
+
+        /// <summary>
+        /// Creates an <c>AbortSignal</c> that aborts when <paramref name="cancellationToken"/> is cancelled, so
+        /// that a host's own cancellation reaches the script's <c>fetch</c>, <c>scheduler.postTask</c>,
+        /// <c>addEventListener('abort', …)</c> and anything else that takes a signal.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The bridge is one-way. Cancelling the token aborts the signal; nothing a script does to the signal
+        /// can cancel the host's token, and there is deliberately no controller for it — a signal produced here
+        /// is the host's to abort, and script's only to observe.
+        /// </para>
+        /// <para>
+        /// <b>The abort is observed only while the engine is pumped.</b> Cancelling a
+        /// <see cref="CancellationTokenSource"/> runs its registrations on the cancelling thread, and aborting
+        /// a signal dispatches a JavaScript <c>abort</c> event — which is script, and Jint runs script on the
+        /// thread that calls into it and on no other. So the registration this method installs never aborts
+        /// anything itself: it enqueues an event-loop job, and the abort happens when that job runs. That is
+        /// the same contract <c>setTimeout</c> and <c>AbortSignal.timeout()</c> have, and it means a host that
+        /// cancels a token and never pumps again has a signal that stays unaborted. Pump — through
+        /// <see cref="ProcessTasks"/>, a blocking <c>UnwrapIfPromise</c>, or an <c>EvaluateAsync</c> that is
+        /// still running — for the cancellation to land.
+        /// </para>
+        /// <para>
+        /// <b>A token that is already cancelled produces an already-aborted signal, synchronously.</b> There is
+        /// no job and no pump involved: this method runs on the engine's own thread, which is the only thread
+        /// that may abort a signal, and doing it here is what lets
+        /// <c>fetch(url, { signal })</c> reject immediately instead of issuing a request it would have to
+        /// cancel. The reason is the standard's default, a <c>DOMException</c> named <c>AbortError</c>, in both
+        /// cases.
+        /// </para>
+        /// <para>
+        /// <b>Lifetime.</b> The registration is released as soon as the abort lands, when
+        /// <see cref="RestoreGlobalSnapshot"/> ends the evaluation cycle the signal was created in, and when
+        /// the engine is disposed — so a long-lived host token (a web request's, an application lifetime's)
+        /// does not accumulate registrations, and does not retain a finished engine. A signal created before a
+        /// restore therefore never aborts into the restored engine, exactly as a timer scheduled before one
+        /// never fires: it belongs to a cycle that has ended.
+        /// </para>
+        /// <para>
+        /// The signal belongs to the engine's <b>principal</b> realm, like every other web API Jint installs; a
+        /// <c>ShadowRealm</c> has none of them.
+        /// </para>
+        /// </remarks>
+        /// <example>
+        /// <code>
+        /// var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Events));
+        ///
+        /// using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        /// engine.SetValue("hostSignal", engine.Advanced.CreateAbortSignal(cts.Token));
+        ///
+        /// engine.Execute("hostSignal.addEventListener('abort', () => cleanUp())");
+        /// </code>
+        /// </example>
+        /// <param name="cancellationToken">
+        /// The host's token. <see cref="CancellationToken.None"/> — and any other token that can never be
+        /// cancelled — yields a signal that can never abort, and registers nothing.
+        /// </param>
+        /// <returns>The <c>AbortSignal</c>, ready to hand to script.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// This engine did not enable <see cref="WebApiFeatures.Events"/>, which is the feature
+        /// <c>AbortSignal</c> belongs to.
+        /// </exception>
+        public JsValue CreateAbortSignal(CancellationToken cancellationToken)
+        {
+            var engine = _engine;
+
+            // The state is built for every feature that keeps any, Events among them, so a null field settles
+            // the question without asking the options — which matters because Options may be shared by other
+            // engines being built right now, and its web-API group is allocated on first touch.
+            if (engine._webApi is null || (engine.Options.WebApi.Features & WebApiFeatures.Events) == WebApiFeatures.None)
+            {
+                Throw.InvalidOperationException(
+                    "Engine.Advanced.CreateAbortSignal requires the WebApiFeatures.Events web API, which this engine did not enable. Build the engine with options.UseWebApis(WebApiFeatures.Events) — or any feature set that includes it, such as WebApiFeatures.Default.");
+            }
+
+            // The principal realm, deliberately, and not Engine.Realm: that one follows the running execution
+            // context and would hand back a ShadowRealm's intrinsics when called from inside one. A host
+            // bridging its own cancellation means the engine's own realm, which is the only one these APIs are
+            // installed in.
+            var constructor = engine._mainRealm.Intrinsics.AbortSignal;
+            var signal = constructor.CreateSignal();
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                // Safe without a job: this runs on the engine's thread, because a host calling into the engine
+                // is the engine's thread by definition.
+                signal.SignalAbort(constructor.DefaultedReason(JsValue.Undefined));
+                return signal;
+            }
+
+            if (cancellationToken.CanBeCanceled)
+            {
+                // The state exists because the Events feature was checked above, and that is one of the
+                // features WebApiRegistration builds it for.
+                var bridge = new HostAbortSignalBridge(engine, constructor, signal, cancellationToken);
+                engine._webApi!.AddHostAbortBridge(bridge);
+            }
+
+            return signal;
         }
     }
 }

--- a/Jint/Engine.Pump.cs
+++ b/Jint/Engine.Pump.cs
@@ -85,7 +85,7 @@ public partial class Engine
     {
 #if NET8_0_OR_GREATER
         var webApi = _webApi;
-        return webApi is not null && webApi.TryPromoteDueTimerJob();
+        return webApi is not null && webApi.TryPromoteDeferredWork();
 #else
         // Timers are the one web API that needs engine infrastructure, and every line of them is net8.0 and
         // later; downlevel there is nothing to promote and the JIT folds this call away to nothing.
@@ -111,5 +111,123 @@ public partial class Engine
 #endif
 
         return untilWaiter;
+    }
+
+    public partial class AdvancedOperations
+    {
+        /// <summary>
+        /// How long this engine may be left alone before <see cref="ProcessTasks"/> has something to run, or
+        /// <see langword="null"/> when it has nothing scheduled at all.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>The canonical host loop is this property plus <see cref="ProcessTasks"/>, and there is
+        /// deliberately no third method that drains for a budget.</b> Jint never starts a thread to run script:
+        /// a <c>setTimeout</c> callback, a <c>scheduler.postTask</c> task, a settled <c>Atomics.waitAsync</c>
+        /// all run on whichever thread calls into the engine, and nowhere else. What a host driving its own
+        /// loop was missing is not another way to pump but the answer to <i>when</i> to pump, which is this.
+        /// </para>
+        /// <para>
+        /// The three answers:
+        /// <list type="bullet">
+        /// <item><description>
+        /// <see cref="TimeSpan.Zero"/> — there is work to run <em>now</em>: an event-loop job is queued (a
+        /// promise reaction, a scheduler task, a completion that arrived from a background thread), a timer is
+        /// already due, or an idle callback is waiting for a pump. Call <see cref="ProcessTasks"/>.
+        /// </description></item>
+        /// <item><description>
+        /// A positive <see cref="TimeSpan"/> — nothing to run yet, and this is how long until the earliest
+        /// <em>timed</em> work comes due. That covers <c>setTimeout</c> and <c>setInterval</c>,
+        /// <c>AbortSignal.timeout()</c>, a delayed <c>scheduler.postTask</c>, a <c>requestIdleCallback</c>
+        /// timeout, and the deadline of an <c>Atomics.waitAsync</c>.
+        /// </description></item>
+        /// <item><description>
+        /// <see langword="null"/> — nothing is scheduled. The engine will produce no work by itself; only
+        /// something the host does, or a background completion it is already waiting for, can change that.
+        /// </description></item>
+        /// </list>
+        /// </para>
+        /// <para>
+        /// <b>It is a hint about the engine's own schedule, never a substitute for waiting on external work.</b>
+        /// A <see cref="System.Threading.Tasks.Task"/> a script is awaiting through interop settles when it
+        /// settles, and an <c>Atomics.waitAsync</c> woken by another agent's <c>Atomics.notify</c> settles when
+        /// that happens; both simply enqueue, and neither has a due time to report. A <see langword="null"/>
+        /// therefore means "I have nothing timed pending", not "nothing will ever happen" — which is why the
+        /// loop below still has a frame cadence of its own rather than sleeping on this value alone.
+        /// </para>
+        /// <para>
+        /// The answer is a snapshot taken on the calling thread and can be stale the instant it is returned:
+        /// a background completion may enqueue a job right after a <see langword="null"/> is handed back. That
+        /// is harmless for the loop shape below — the job is simply seen by the next
+        /// <see cref="ProcessTasks"/> — and it is another reason not to sleep on the value indefinitely. For
+        /// the same reason it may occasionally report <see cref="TimeSpan.Zero"/> for a job that turns out to
+        /// belong to an evaluation cycle <see cref="RestoreGlobalSnapshot"/> has ended, which
+        /// <see cref="ProcessTasks"/> then discards without running.
+        /// </para>
+        /// <para>
+        /// Reading it is cheap and allocation-free, and an engine with no web APIs and no asynchronous atomics
+        /// wait answers from one queue check.
+        /// </para>
+        /// </remarks>
+        /// <example>
+        /// A game loop — the shape this exists for. The engine is pumped once per frame, and the pump is
+        /// skipped entirely on the frames where it provably has nothing to do:
+        /// <code>
+        /// while (running)
+        /// {
+        ///     var until = engine.Advanced.TimeUntilNextScheduledWork;
+        ///     if (until is null || until &lt;= frameBudget)
+        ///     {
+        ///         // Either nothing is scheduled — in which case a job may still have arrived from a
+        ///         // background completion — or it comes due within this frame. Either way, pump.
+        ///         engine.Advanced.ProcessTasks();
+        ///     }
+        ///
+        ///     RenderFrame();
+        ///     SleepUntilNextFrame();
+        /// }
+        /// </code>
+        /// A message pump with no frame of its own can sleep on the value instead, keeping a ceiling so that
+        /// work arriving from a background thread is still picked up:
+        /// <code>
+        /// var until = engine.Advanced.TimeUntilNextScheduledWork ?? TimeSpan.FromMilliseconds(50);
+        /// if (until > TimeSpan.Zero)
+        /// {
+        ///     Thread.Sleep(until &lt; TimeSpan.FromMilliseconds(50) ? until : TimeSpan.FromMilliseconds(50));
+        /// }
+        ///
+        /// engine.Advanced.ProcessTasks();
+        /// </code>
+        /// </example>
+        public TimeSpan? TimeUntilNextScheduledWork
+        {
+            get
+            {
+                // Anything already queued is work the pump can run now, so no clock can improve on the
+                // answer. This check lives here rather than in the internal aggregate below, because the
+                // engine's own wait loops clamp on that aggregate while the queue may be unrunnable from
+                // where they stand — a zero there would spin them hot for their caller's whole timeout.
+                if (_engine._eventLoop.HasPendingJobs)
+                {
+                    return TimeSpan.Zero;
+                }
+
+#if NET8_0_OR_GREATER
+                // An idle callback becomes runnable the moment the job queue drains, so it is work for now
+                // rather than work for later.
+                if (_engine._webApi is { } webApi && webApi.HasPendingIdleWork)
+                {
+                    return TimeSpan.Zero;
+                }
+#endif
+
+                var next = _engine.TimeUntilNextPumpScheduledWork();
+
+                // A timer that came due while nobody was pumping reports a negative remainder; the contract
+                // above says zero means "run it now", and there is nothing a host could do with "how late am
+                // I".
+                return next is { } value && value < TimeSpan.Zero ? TimeSpan.Zero : next;
+            }
+        }
     }
 }

--- a/Jint/Engine.WebApi.cs
+++ b/Jint/Engine.WebApi.cs
@@ -1,8 +1,10 @@
 #if NET8_0_OR_GREATER
-using Jint.Native;
 using Jint.Native.Promise;
-using Jint.WebApi;
+using Jint.Native;
+using Jint.WebApi.Abort;
 using Jint.WebApi.Fetch;
+using Jint.WebApi.Idle;
+using Jint.WebApi;
 using Jint.WebApi.Scheduling;
 using Jint.WebApi.ServerSentEvents;
 using Jint.WebApi.Timers;
@@ -103,7 +105,9 @@ internal sealed class WebApiEngineState
     /// </summary>
     private List<JsWebSocket>? _webSockets;
 
-    internal WebApiEngineState(Engine engine, TimeProvider timeProvider, TimerQueue? timers, Options.FetchOptions? fetchOptions, SchedulerQueue? scheduler, DiagnosticsSink? diagnostics, Options.StorageOptions? storage = null, CacheStorageProvider? cacheProvider = null)
+    private List<HostAbortSignalBridge>? _hostAbortBridges;
+
+    internal WebApiEngineState(Engine engine, TimeProvider timeProvider, TimerQueue? timers, Options.FetchOptions? fetchOptions, SchedulerQueue? scheduler, DiagnosticsSink? diagnostics, Options.StorageOptions? storage = null, CacheStorageProvider? cacheProvider = null, IdleCallbackQueue? idleCallbacks = null)
     {
         _engine = engine;
         _timeProvider = timeProvider;
@@ -118,6 +122,7 @@ internal sealed class WebApiEngineState
         _sessionStorageProvider = storage?.SessionStorageProvider;
         _storageQuotaBytes = storage?.MaxTotalBytes ?? Options.StorageOptions.DefaultMaxTotalBytes;
         CacheProvider = cacheProvider;
+        IdleCallbacks = idleCallbacks;
 
         // Both halves of the time origin, read back to back: the monotonic reading every later now() is a
         // duration from, and the wall-clock moment that reading corresponds to.
@@ -225,6 +230,21 @@ internal sealed class WebApiEngineState
     internal void UnregisterWebSocket(JsWebSocket socket) => _webSockets?.Remove(socket);
 
     /// <summary>
+    /// The engine's <c>requestIdleCallback</c> queue, or <see langword="null"/> when that feature is off. It
+    /// is drained from the same pump exhaustion point the timers are promoted at, one callback at a time and
+    /// only once no timer is due — see <see cref="IdleCallbackQueue"/> for what "idle" means for an engine
+    /// that has no frames.
+    /// </summary>
+    internal IdleCallbackQueue? IdleCallbacks { get; }
+
+    /// <summary>
+    /// Whether an idle callback is waiting for a pump. Read only by
+    /// <see cref="Engine.AdvancedOperations.TimeUntilNextScheduledWork"/>, which reports such a callback as
+    /// work available now.
+    /// </summary>
+    internal bool HasPendingIdleWork => IdleCallbacks is { HasPendingWork: true };
+
+    /// <summary>
     /// <c>performance.timeOrigin</c>: the moment this state was created, as milliseconds since the Unix
     /// epoch, https://w3c.github.io/hr-time/#dom-performance-timeorigin.
     /// </summary>
@@ -263,22 +283,58 @@ internal sealed class WebApiEngineState
         _sessionStorageProvider ??= new InMemoryStorageProvider(_storageQuotaBytes);
 
     /// <summary>
-    /// Promotes at most one due timer into an event-loop job. One per call rather than all of them, so that
-    /// the reactions a timer's callback queues are run before the next timer is even looked at.
+    /// Promotes at most one due timer into an event-loop job, and failing that runs at most one idle callback.
+    /// One per call rather than all of them, so that the reactions a callback queues are run before the next
+    /// one is even looked at.
     /// </summary>
-    internal bool TryPromoteDueTimerJob()
+    /// <remarks>
+    /// The order is the priority: a due timer is a task, and idle callbacks are what a browser runs in the
+    /// slack after the tasks are done, so nothing idle may overtake a timer that is already due.
+    /// </remarks>
+    internal bool TryPromoteDeferredWork()
     {
         var timers = Timers;
-        if (timers is null || !timers.TryTakeDue(out var entry))
+        if (timers is not null && timers.TryTakeDue(out var entry))
         {
-            return false;
+            // Enqueued with the timer's own registration generation rather than the current one: a timer
+            // registered before a RestoreGlobalSnapshot is already gone from the queue that restore cleared,
+            // and this is the belt to that braces.
+            _engine.AddToEventLoop(entry.Job, entry.Generation);
+            return true;
         }
 
-        // Enqueued with the timer's own registration generation rather than the current one: a timer
-        // registered before a RestoreGlobalSnapshot is already gone from the queue that restore cleared, and
-        // this is the belt to that braces.
-        _engine.AddToEventLoop(entry.Job, entry.Generation);
-        return true;
+        return IdleCallbacks is { } idle && idle.TryRunIdleCallback();
+    }
+
+    /// <summary>
+    /// Records a host <c>CancellationToken</c> bridged to an <c>AbortSignal</c> by
+    /// <see cref="Engine.AdvancedOperations.CreateAbortSignal"/>, so the token registration can be released
+    /// again when the cycle ends or the engine is disposed.
+    /// </summary>
+    internal void AddHostAbortBridge(HostAbortSignalBridge bridge) =>
+        (_hostAbortBridges ??= new List<HostAbortSignalBridge>()).Add(bridge);
+
+    /// <summary>Forgets one bridge, which is what a bridge does to itself once its abort has landed.</summary>
+    internal void RemoveHostAbortBridge(HostAbortSignalBridge bridge) => _hostAbortBridges?.Remove(bridge);
+
+    /// <summary>
+    /// Releases every host token registration. A long-lived host token — a request's, an application
+    /// lifetime's — would otherwise keep a finished engine reachable through its registration list.
+    /// </summary>
+    internal void ReleaseHostAbortBridges()
+    {
+        if (_hostAbortBridges is not { } bridges)
+        {
+            return;
+        }
+
+        foreach (var bridge in bridges)
+        {
+            // Detach deliberately does not touch this list, so walking it here is safe.
+            bridge.Detach();
+        }
+
+        bridges.Clear();
     }
 
     /// <summary>
@@ -328,6 +384,12 @@ internal sealed class WebApiEngineState
         AbandonFetchBodies();
         AbandonEventSources();
         AbandonWebSockets();
+        IdleCallbacks?.Clear();
+
+        // A signal bridged to a host token belongs to the cycle it was created in: its abort job carries that
+        // cycle's generation and would be dropped at dequeue anyway, so keeping the registration alive could
+        // only accumulate one per cycle on a pooled engine.
+        ReleaseHostAbortBridges();
     }
 
     private void AbandonFetches()
@@ -401,5 +463,12 @@ internal sealed class WebApiEngineState
             body.Abandon();
         }
     }
+
+    /// <summary>
+    /// Called from <see cref="Engine.Dispose"/>: releases the state that reaches outside the engine, which
+    /// today is the host token registrations. The queues need nothing — they hold no unmanaged resource and no
+    /// timer, and die with the engine.
+    /// </summary>
+    internal void Dispose() => ReleaseHostAbortBridges();
 }
 #endif

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -2823,6 +2823,13 @@ public sealed partial class Engine : IDisposable
         _recentObjectWrapperCache?.Clear();
         _recentObjectWrapperCache = null;
 
+#if NET8_0_OR_GREATER
+        // A host CancellationToken bridged to an AbortSignal holds a registration that reaches this engine, and
+        // the token may well outlive it — an application-lifetime token would otherwise keep every engine it
+        // was ever handed to reachable.
+        _webApi?.Dispose();
+#endif
+
         if (_objectWrapperCache is null)
         {
             return;

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -412,6 +412,31 @@ public partial class Options
         /// effectively unbounded, and a value of zero or less refuses every timer.
         /// </remarks>
         public int MaxActiveTimers { get; set; } = 1000;
+
+        /// <summary>
+        /// How much of a pump an engine may spend running <c>requestIdleCallback</c> callbacks. Defaults to
+        /// 50 milliseconds, which is the ceiling the standard itself recommends for an idle deadline.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// It lives beside the timer settings because it is measured on the same
+        /// <see cref="TimeProvider"/>, and because the <c>timeout</c> option of an idle callback rides the
+        /// same queue and counts against the same <see cref="MaxActiveTimers"/> cap.
+        /// </para>
+        /// <para>
+        /// An idle period begins when a pump has run out of everything else — every queued job, every
+        /// scheduler task, every due timer — and ends when this budget elapses or the callbacks run out,
+        /// whichever comes first; whatever is left waits for the next pump. It is what
+        /// <c>IdleDeadline.timeRemaining()</c> counts down from, so a callback that chunks its work against
+        /// that value is really being told how much of this budget is left.
+        /// </para>
+        /// <para>
+        /// <b>Zero or less means the host has no idle time</b>, and then an idle callback runs only if it was
+        /// requested with a <c>timeout</c> — which is the honest setting for a host that pumps the engine on a
+        /// hard deadline it does not want script to eat into. Read once, when the engine is built.
+        /// </para>
+        /// </remarks>
+        public TimeSpan IdleBudget { get; set; } = TimeSpan.FromMilliseconds(50);
     }
 
     /// <summary>
@@ -740,6 +765,15 @@ public enum WebApiFeatures
     Compression = 1 << 20,
 
     /// <summary>
+    /// <c>requestIdleCallback</c> and <c>cancelIdleCallback</c>, with <c>IdleDeadline</c> —
+    /// https://w3c.github.io/requestidlecallback/. An engine has no frames, so an idle period is a pump that
+    /// has run out of everything else and its deadline is
+    /// <see cref="Options.TimerOptions.IdleBudget"/>; the <c>timeout</c> option rides the timer queue and
+    /// counts against <see cref="Options.TimerOptions.MaxActiveTimers"/>.
+    /// </summary>
+    IdleCallback = 1 << 21,
+
+    /// <summary>
     /// The web APIs a host normally wants: everything except outbound network access and persistent state.
     /// Today that is
     /// <see cref="Console"/>, <see cref="Timers"/>, <see cref="Encoding"/>, <see cref="Base64"/>,
@@ -748,6 +782,6 @@ public enum WebApiFeatures
     /// <see cref="Scheduler"/>, <see cref="Messaging"/> <see cref="Reporting"/> and <see cref="Compression"/>; it grows as further
     /// features land, and never comes to include fetch or <see cref="Storage"/>.
     /// </summary>
-    Default = Console | Timers | Encoding | Base64 | StructuredClone | Crypto | Performance | Events | Url | Files | Navigator | Streams | Scheduler | Messaging | Reporting | Compression,
+    Default = Console | Timers | Encoding | Base64 | StructuredClone | Crypto | Performance | Events | Url | Files | Navigator | Streams | Scheduler | Messaging | Reporting | Compression | IdleCallback,
 }
 #endif

--- a/Jint/Runtime/EventLoop.cs
+++ b/Jint/Runtime/EventLoop.cs
@@ -341,13 +341,14 @@ internal sealed record EventLoop
 
                 if (!_events.TryDequeue(out var job))
                 {
-                    // The queue is empty, so this is the moment — and the only moment — a timer may join it.
-                    // Promoting exactly one due timer per exhaustion is what makes this single queue behave as
-                    // the microtask queue HTML specifies: everything a job queues, transitively, runs before
-                    // the next timer is even looked at, so Promise.resolve().then(f) beats setTimeout(g, 0)
-                    // and a chain of reactions can never be starved by a due interval. The check costs one
-                    // predictable null test per drain on an engine without timers, and on a target framework
-                    // that has no timers at all the call folds away to nothing.
+                    // The queue is empty, so this is the moment — and the only moment — a timer may join it,
+                    // and failing that an idle callback may run. Promoting exactly one due timer per
+                    // exhaustion is what makes this single queue behave as the microtask queue HTML
+                    // specifies: everything a job queues, transitively, runs before the next timer is even
+                    // looked at, so Promise.resolve().then(f) beats setTimeout(g, 0) and a chain of reactions
+                    // can never be starved by a due interval. The check costs one predictable null test per
+                    // drain on an engine without timers, and on a target framework that has no timers at all
+                    // the call folds away to nothing.
                     if (engine.TryPromoteDueTimerJob())
                     {
                         continue;

--- a/Jint/Runtime/Intrinsics.WebApi.cs
+++ b/Jint/Runtime/Intrinsics.WebApi.cs
@@ -10,6 +10,7 @@ using Jint.WebApi.Encoding;
 using Jint.WebApi.Events;
 using Jint.WebApi.Fetch;
 using Jint.WebApi.Files;
+using Jint.WebApi.Idle;
 using Jint.WebApi.Messaging;
 using Jint.WebApi.Navigator;
 using Jint.WebApi.ServerSentEvents;
@@ -375,5 +376,18 @@ public sealed partial class Intrinsics
 
     internal DecompressionStreamConstructor DecompressionStream =>
         _decompressionStream ??= new DecompressionStreamConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
+
+    private IdleCallbackFunctions? _idleCallbacks;
+    private IdleDeadlineConstructor? _idleDeadline;
+
+    /// <summary>
+    /// The two idle-callback globals, which are ordinary functions rather than one object — this holder exists
+    /// only so that a realm builds one of each, and each of the two is itself built on first access.
+    /// </summary>
+    internal IdleCallbackFunctions IdleCallbacks =>
+        _idleCallbacks ??= IdleCallbackFunctions.Create(_engine, _realm);
+
+    internal IdleDeadlineConstructor IdleDeadline =>
+        _idleDeadline ??= new IdleDeadlineConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
 }
 #endif

--- a/Jint/WebApi/Abort/HostAbortSignalBridge.cs
+++ b/Jint/WebApi/Abort/HostAbortSignalBridge.cs
@@ -1,0 +1,94 @@
+#if NET8_0_OR_GREATER
+using System.Threading;
+using Jint.Native;
+
+namespace Jint.WebApi.Abort;
+
+/// <summary>
+/// The link between a host <see cref="CancellationToken"/> and the <c>AbortSignal</c> handed to script by
+/// <see cref="Engine.AdvancedOperations.CreateAbortSignal"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The token's registration never aborts the signal itself.</b> Cancelling a
+/// <see cref="CancellationTokenSource"/> runs its registrations synchronously on the cancelling thread, and
+/// aborting an <c>AbortSignal</c> runs abort algorithms and then dispatches a JavaScript <c>abort</c> event —
+/// which is script, and script runs on the engine's thread and nowhere else. So the registration does exactly
+/// one thing: enqueue a generation-stamped event-loop job. The abort happens when that job runs, i.e. on the
+/// next pump, on the pumping thread. It is the same contract <c>AbortSignal.timeout()</c> has, and it is why
+/// an engine nobody pumps never observes the cancellation.
+/// </para>
+/// <para>
+/// The generation is read when the bridge is built — on the engine thread — and carried by the job, so a
+/// cancellation arriving after a <see cref="Engine.AdvancedOperations.RestoreGlobalSnapshot"/> is discarded at
+/// dequeue rather than aborting a signal that belongs to a cycle the engine has ended.
+/// </para>
+/// </remarks>
+internal sealed class HostAbortSignalBridge
+{
+    private readonly Engine _engine;
+    private readonly AbortSignalConstructor _constructor;
+    private readonly JsAbortSignal _signal;
+    private readonly int _generation;
+
+    /// <summary>Allocated once, in the constructor, because the cancelling thread must not race to create it.</summary>
+    private readonly Action _job;
+
+    private readonly CancellationTokenRegistration _registration;
+
+    internal HostAbortSignalBridge(Engine engine, AbortSignalConstructor constructor, JsAbortSignal signal, CancellationToken cancellationToken)
+    {
+        _engine = engine;
+        _constructor = constructor;
+        _signal = signal;
+        _generation = engine.EventLoopGeneration;
+        _job = Abort;
+
+        // UnsafeRegister rather than Register: the callback touches nothing that an ExecutionContext carries —
+        // no AsyncLocal, no culture, no impersonation — and flowing the host's context into a callback whose
+        // whole body is an enqueue would only cost an allocation per bridge.
+        //
+        // A token cancelled between the caller's already-cancelled check and this line runs the callback right
+        // here, on the engine thread. That is still only an enqueue, so the abort lands on the pump like every
+        // other one rather than reentering the engine from inside a constructor.
+        _registration = cancellationToken.UnsafeRegister(
+            static state => ((HostAbortSignalBridge) state!).OnCancellationRequested(),
+            this);
+    }
+
+    /// <summary>
+    /// Runs on whichever thread cancelled the token — a thread-pool thread, a UI thread, anything. The only
+    /// engine member it may touch is the event loop's queue, which is the one part of an <see cref="Engine"/>
+    /// that is thread-safe by design.
+    /// </summary>
+    private void OnCancellationRequested() => _engine.AddToEventLoop(_job, _generation);
+
+    /// <summary>
+    /// The engine-thread half: build the reason in this realm and abort. Reached only through the event loop,
+    /// so it is as safe a point to run script from as a timer callback is.
+    /// </summary>
+    private void Abort()
+    {
+        Detach();
+        _engine._webApi?.RemoveHostAbortBridge(this);
+
+        // Aborting is one-shot and the signal has no controller, so this is the only route to it — but a
+        // second cancellation of a linked token could still enqueue twice, and SignalAbort is idempotent.
+        _signal.SignalAbort(_constructor.DefaultedReason(JsValue.Undefined));
+    }
+
+    /// <summary>
+    /// Releases the token registration, so a long-lived host token stops retaining this engine. Called when the
+    /// abort lands, when the engine's evaluation cycle ends, and when the engine is disposed. It deliberately
+    /// does not touch the engine's bridge list, so the bulk paths can call it while walking that list.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="CancellationTokenRegistration.Unregister"/> rather than <c>Dispose</c>: <c>Dispose</c> blocks
+    /// until a callback that is already running on another thread has finished, and there is no reason for the
+    /// engine's thread to wait on a callback whose entire body is an enqueue. <c>Unregister</c> reports
+    /// <see langword="false"/> in that case and returns immediately; the job it enqueued is then dropped by the
+    /// generation fence, or aborts a signal nobody is listening to any more.
+    /// </remarks>
+    internal void Detach() => _registration.Unregister();
+}
+#endif

--- a/Jint/WebApi/Idle/IdleCallbackFunctions.cs
+++ b/Jint/WebApi/Idle/IdleCallbackFunctions.cs
@@ -1,0 +1,156 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Interop;
+using Jint.WebApi.DomException;
+using Jint.WebApi.Timers;
+
+namespace Jint.WebApi.Idle;
+
+/// <summary>
+/// The two idle-callback globals: <c>requestIdleCallback</c> and <c>cancelIdleCallback</c>.
+/// <para>
+/// https://w3c.github.io/requestidlecallback/
+/// </para>
+/// </summary>
+/// <remarks>
+/// They are global <i>operations</i> rather than members of a namespace object, so this class only owns them
+/// so that one realm builds one of each; each is built on first access. What "idle" means for an engine with
+/// no frames is documented on <see cref="IdleCallbackQueue"/>, and it is the part a host has to know.
+/// </remarks>
+internal sealed class IdleCallbackFunctions
+{
+    private static readonly JsString _timeoutProperty = new("timeout");
+
+    private readonly Engine _engine;
+    private readonly Realm _realm;
+    private readonly IdleCallbackQueue _callbacks;
+    private readonly TimerQueue _timers;
+
+    private ClrFunction? _requestIdleCallback;
+    private ClrFunction? _cancelIdleCallback;
+
+    private IdleCallbackFunctions(Engine engine, Realm realm, IdleCallbackQueue callbacks, TimerQueue timers)
+    {
+        _engine = engine;
+        _realm = realm;
+        _callbacks = callbacks;
+        _timers = timers;
+    }
+
+    internal static IdleCallbackFunctions Create(Engine engine, Realm realm)
+    {
+        var state = engine._webApi;
+        if (state?.IdleCallbacks is not { } callbacks || state.Timers is not { } timers)
+        {
+            // Unreachable: the globals that reach this property are installed only where both queues were
+            // created, in the same block of WebApiRegistration.
+            Throw.InvalidOperationException("The idle callback globals were reached on an engine that has no idle callback queue.");
+            return null!;
+        }
+
+        return new IdleCallbackFunctions(engine, realm, callbacks, timers);
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/requestidlecallback/#dom-window-requestidlecallback
+    /// </summary>
+    internal ClrFunction RequestIdleCallback =>
+        _requestIdleCallback ??= Operation("requestIdleCallback", 1, (_, arguments) => Request(arguments));
+
+    /// <summary>
+    /// https://w3c.github.io/requestidlecallback/#dom-window-cancelidlecallback
+    /// </summary>
+    internal ClrFunction CancelIdleCallback =>
+        _cancelIdleCallback ??= Operation("cancelIdleCallback", 1, (_, arguments) => Cancel(arguments));
+
+    /// <summary>
+    /// A WebIDL operation: <c>length</c> counts the required arguments only and is configurable but neither
+    /// writable nor enumerable — https://webidl.spec.whatwg.org/#dfn-create-operation-function.
+    /// </summary>
+    private ClrFunction Operation(string name, int length, JsCallDelegate body)
+        => new(_engine, _realm, name, body, length, PropertyFlag.Configurable);
+
+    private JsValue Request(JsCallArguments arguments)
+    {
+        if (arguments.At(0) is not ICallable callback)
+        {
+            Throw.TypeError(
+                _realm,
+                "Failed to execute 'requestIdleCallback': the callback provided as parameter 1 is not a function.");
+            return JsValue.Undefined;
+        }
+
+        var timeout = ReadTimeout(arguments.At(1));
+
+        if (timeout > 0 && _timers.Count >= _timers.MaxActiveTimers)
+        {
+            // Not a specified failure mode — the specification assumes a browser's resources — but a timeout
+            // is a timer, and a script must not be able to register them without bound. Only the timeout half
+            // is capped: a callback with no timeout occupies no schedule slot, it simply waits in a list for
+            // the next idle period exactly as a queued job waits for the next pump.
+            var quotaExceeded = _realm.Intrinsics.DomException.CreateException(
+                DomExceptionNames.QuotaExceeded,
+                $"Failed to execute 'requestIdleCallback': the engine already has {_timers.MaxActiveTimers} active timers, which is its Options.WebApi.Timers.MaxActiveTimers limit.");
+
+            var location = _engine._lastSyntaxElement?.Location ?? default;
+            Throw.JavaScriptException(_engine, quotaExceeded, in location);
+        }
+
+        return JsNumber.Create(_callbacks.Request(callback, timeout));
+    }
+
+    /// <summary>
+    /// The <c>IdleRequestOptions</c> dictionary,
+    /// https://w3c.github.io/requestidlecallback/#dictdef-idlerequestoptions — one member, <c>timeout</c>,
+    /// typed plain <c>unsigned long</c>.
+    /// </summary>
+    /// <remarks>
+    /// Plain, so the conversion is ECMAScript's <c>ToUint32</c> and not <c>[EnforceRange]</c>'s refusal:
+    /// <c>NaN</c> and the infinities become 0, and a negative value wraps to a very large one — which a
+    /// browser does too, and which then clamps to the same <see cref="int.MaxValue"/> millisecond ceiling
+    /// <c>setTimeout</c> has, about 24.8 days.
+    /// </remarks>
+    private long ReadTimeout(JsValue options)
+    {
+        if (options.IsUndefined() || options.IsNull())
+        {
+            return 0;
+        }
+
+        if (options is not ObjectInstance dictionary)
+        {
+            Throw.TypeError(_realm, "Failed to execute 'requestIdleCallback': the provided value is not of type 'IdleRequestOptions'.");
+            return 0;
+        }
+
+        var value = dictionary.Get(_timeoutProperty);
+        if (value.IsUndefined())
+        {
+            return 0;
+        }
+
+        var timeout = (long) TypeConverter.ToUint32(value);
+        return timeout > int.MaxValue ? int.MaxValue : timeout;
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/requestidlecallback/#dom-window-cancelidlecallback — a handle that is not there
+    /// is simply not an error.
+    /// </summary>
+    private JsValue Cancel(JsCallArguments arguments)
+    {
+        var handle = TypeConverter.ToUint32(arguments.At(0));
+        if (handle <= int.MaxValue)
+        {
+            // Handles are handed out from 1 upwards and never exceed int.MaxValue, so anything above it names
+            // no callback at all and the lookup is skipped rather than wrapped into a handle that does exist.
+            _callbacks.Cancel((int) handle);
+        }
+
+        return JsValue.Undefined;
+    }
+}
+#endif

--- a/Jint/WebApi/Idle/IdleCallbackQueue.cs
+++ b/Jint/WebApi/Idle/IdleCallbackQueue.cs
@@ -1,0 +1,364 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Runtime;
+using Jint.WebApi.Timers;
+
+namespace Jint.WebApi.Idle;
+
+/// <summary>
+/// One engine's idle callbacks: the specification's <i>list of idle request callbacks</i> and <i>list of
+/// runnable idle callbacks</i>, plus the idle period they are run in.
+/// <para>
+/// https://w3c.github.io/requestidlecallback/
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Engine-thread only, and deliberately lock-free</b>, like the timer and scheduler queues beside it.
+/// </para>
+/// <para>
+/// <b>What "idle" means here, stated honestly.</b> The specification is written for a browser, where an idle
+/// period is the slack between finishing a frame and having to start the next one, and the deadline is when
+/// the next frame is due. Jint has no frames and no display; the only thing that resembles one is the host's
+/// own pump. So the mapping is:
+/// </para>
+/// <list type="bullet">
+/// <item><description>
+/// <b>An idle period starts when a pump runs out of everything else.</b> A callback is promoted only at the
+/// moment the event-loop job queue has drained <i>and</i> no timer is due — the same exhaustion point a timer
+/// is promoted at, taken after it. Every promise reaction, every <c>scheduler.postTask</c> task (whose drain
+/// job keeps the job queue non-empty while any remain, at every priority including <c>background</c>) and
+/// every due timer therefore runs first. That is the lowest band the engine has, which is where the standard
+/// puts these callbacks.
+/// </description></item>
+/// <item><description>
+/// <b>The deadline is a fixed budget from the start of the period</b>, <c>Options.WebApi.Timers.IdleBudget</c>,
+/// 50 ms by default — the ceiling the standard itself recommends ("capping idle deadlines to 50ms"). When the
+/// budget runs out the period ends and the pump returns to the host, so one pump spends at most one budget on
+/// idle work however many callbacks are waiting; the rest run on the next pump. A budget of zero or less says
+/// the host has no idle time at all, and then <i>only</i> the <c>timeout</c> option ever runs a callback.
+/// </description></item>
+/// <item><description>
+/// <b>A callback requested while a period is running waits for the next one</b>, because starting a period is
+/// what moves the pending list into the runnable list — the specification's own arrangement, and what stops
+/// <c>requestIdleCallback</c> re-arming itself from monopolising the engine.
+/// </description></item>
+/// </list>
+/// <para>
+/// <b>Callbacks run only while the engine is being pumped</b>, exactly as timers and scheduler tasks do. An
+/// engine nobody pumps runs none of them, and a callback that throws erupts out of whatever was pumping — the
+/// same contract a timer callback has. The standard says to <i>report</i> such an exception, which presumes
+/// the <c>reportError</c> channel Jint does not have yet.
+/// </para>
+/// </remarks>
+internal sealed class IdleCallbackQueue
+{
+    private readonly Engine _engine;
+    private readonly Realm _realm;
+    private readonly TimeProvider _timeProvider;
+    private readonly TimerQueue _timers;
+
+    /// <summary>
+    /// The idle budget in <see cref="TimeProvider.GetTimestamp"/> ticks. Zero means the host declared that it
+    /// has no idle time, and no idle period is ever started.
+    /// </summary>
+    private readonly long _budgetTicks;
+
+    /// <summary>https://w3c.github.io/requestidlecallback/#dfn-list-of-idle-request-callbacks.</summary>
+    private readonly Queue<IdleCallbackEntry> _pending = new();
+
+    /// <summary>https://w3c.github.io/requestidlecallback/#dfn-list-of-runnable-idle-callbacks.</summary>
+    private readonly Queue<IdleCallbackEntry> _runnable = new();
+
+    /// <summary>
+    /// Every live callback by handle — the thing <c>cancelIdleCallback</c> looks in, and the exact count of
+    /// callbacks that still have to run. A cancelled or already-run entry is removed from here at once and
+    /// discarded from whichever queue holds it when it next surfaces, which is what makes cancellation O(1).
+    /// </summary>
+    private readonly Dictionary<int, IdleCallbackEntry> _byHandle = new();
+
+    /// <summary>https://w3c.github.io/requestidlecallback/#dfn-idle-callback-identifier, monotonic from 1.</summary>
+    private int _nextHandle = 1;
+
+    private bool _periodActive;
+    private long _periodDeadline;
+
+    internal IdleCallbackQueue(Engine engine, Realm realm, TimeProvider timeProvider, TimerQueue timers, TimeSpan idleBudget)
+    {
+        _engine = engine;
+        _realm = realm;
+        _timeProvider = timeProvider;
+        _timers = timers;
+        _budgetTicks = idleBudget > TimeSpan.Zero
+            ? (long) (idleBudget.TotalSeconds * timeProvider.TimestampFrequency)
+            : 0;
+    }
+
+    /// <summary>
+    /// Whether any callback is still waiting to run <i>and</i> could ever run in an idle period. False when the
+    /// budget is non-positive, because then nothing but a <c>timeout</c> can reach a callback and reporting
+    /// "work is available now" would spin a host loop that believes it.
+    /// </summary>
+    internal bool HasPendingWork => _budgetTicks > 0 && _byHandle.Count > 0;
+
+    /// <summary>
+    /// The request idle callback algorithm,
+    /// https://w3c.github.io/requestidlecallback/#the-requestidlecallback-method: take the next identifier,
+    /// append the callback to the list, and — when a positive <c>timeout</c> was given — arrange for the
+    /// timeout algorithm to run it if no idle period reaches it first.
+    /// </summary>
+    /// <returns>The handle, which is what <c>requestIdleCallback</c> returns.</returns>
+    internal int Request(ICallable callback, long timeout)
+    {
+        var handle = _nextHandle;
+        _nextHandle = handle == int.MaxValue ? 1 : handle + 1;
+
+        var entry = new IdleCallbackEntry(handle, callback);
+        _byHandle[handle] = entry;
+        _pending.Enqueue(entry);
+
+        if (timeout > 0)
+        {
+            // "Wait for timeout milliseconds … queue a task on the queue associated with the idle-task task
+            // source … to run the invoke idle callback timeout algorithm". The wait is an entry on the
+            // engine's own timer queue, so it elapses only while the engine is being pumped and occupies one
+            // of the engine's timer slots until then.
+            var timerEntry = new TimerEntry(
+                _timers,
+                new IdleTimeoutAlgorithm(this, entry),
+                [],
+                timeout,
+                repeat: false,
+                _engine.EventLoopGeneration);
+
+            entry.TimeoutTimerId = _timers.Schedule(timerEntry);
+        }
+
+        return handle;
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/requestidlecallback/#the-cancelidlecallback-method: remove the entry with this
+    /// handle from both lists. An unknown handle is silently ignored, as the algorithm's "if there is such an
+    /// entry" implies.
+    /// </summary>
+    internal void Cancel(int handle)
+    {
+        if (_byHandle.Remove(handle, out var entry))
+        {
+            Retire(entry);
+        }
+    }
+
+    /// <summary>
+    /// The one thing the pump asks of this queue: run a single idle callback if there is one and the budget
+    /// allows, otherwise report that there is nothing to do. Called from <c>Engine.TryPromoteDeferredWork</c>
+    /// once the job queue has drained and no timer is due.
+    /// </summary>
+    /// <remarks>
+    /// One callback per call, like the timers, so that everything a callback queues — promise reactions,
+    /// <c>queueMicrotask</c>, another task — runs before the next callback is even looked at, and so that a
+    /// timer that came due meanwhile still wins the next round.
+    /// <para>
+    /// Returning <see langword="false"/> ends the pump, which is precisely what makes the budget mean
+    /// something: it is the boundary between one host pump and the next, and the only pump boundary the engine
+    /// has.
+    /// </para>
+    /// </remarks>
+    /// <returns>Whether a callback was run, i.e. whether the pump has more work to do.</returns>
+    internal bool TryRunIdleCallback()
+    {
+        if (_byHandle.Count == 0)
+        {
+            _periodActive = false;
+            return false;
+        }
+
+        if (_budgetTicks <= 0)
+        {
+            // The host declared that it never has idle time; only the timeout option reaches a callback.
+            return false;
+        }
+
+        var now = _timeProvider.GetTimestamp();
+
+        if (!_periodActive)
+        {
+            // The start an idle period algorithm, https://w3c.github.io/requestidlecallback/#start-an-idle-period-algorithm:
+            // "for each entry in window's list of idle request callbacks, append entry to window's list of
+            // runnable idle callbacks; clear window's list of idle request callbacks".
+            while (_pending.TryDequeue(out var moved))
+            {
+                _runnable.Enqueue(moved);
+            }
+
+            _periodDeadline = now + _budgetTicks;
+            _periodActive = true;
+        }
+        else if (now >= _periodDeadline)
+        {
+            // "While now is less than deadline" no longer holds: the period is over, and whatever is left
+            // runs in the next one.
+            _periodActive = false;
+            return false;
+        }
+
+        var entry = TakeRunnable();
+        if (entry is null)
+        {
+            // Everything runnable has run. Anything requested during this period is in the pending list and
+            // deliberately waits for the next one.
+            _periodActive = false;
+            return false;
+        }
+
+        Invoke(entry, _periodDeadline, didTimeout: false);
+        return true;
+    }
+
+    /// <summary>
+    /// Forgets every callback. Called from <c>Engine.ResetTransientEvaluationState</c>, so a callback requested
+    /// by one evaluation cycle can never run against the globals a <c>RestoreGlobalSnapshot</c> put back.
+    /// </summary>
+    internal void Clear()
+    {
+        foreach (var entry in _byHandle.Values)
+        {
+            // The timers are cleared by the same reset, so cancelling here is belt to that braces — and it is
+            // what keeps a timeout from being charged against the next cycle's timer quota.
+            entry.Cancelled = true;
+            CancelTimeoutTimer(entry);
+        }
+
+        _byHandle.Clear();
+        _pending.Clear();
+        _runnable.Clear();
+        _periodActive = false;
+    }
+
+    /// <summary>
+    /// The invoke idle callback timeout algorithm,
+    /// https://w3c.github.io/requestidlecallback/#invoke-idle-callback-timeout-algorithm: remove the entry from
+    /// both lists and run it with a deadline of <i>now</i> — so its <c>timeRemaining()</c> is zero — and
+    /// <c>didTimeout</c> true.
+    /// </summary>
+    private void RunTimedOut(IdleCallbackEntry entry)
+    {
+        if (entry.Cancelled)
+        {
+            // Cancelled, or already run by an idle period that reached it first.
+            return;
+        }
+
+        _byHandle.Remove(entry.Handle);
+        entry.Cancelled = true;
+
+        // The timer that brought us here has already fired, so there is nothing to cancel; clearing the id
+        // keeps Retire from asking the queue about an id it no longer owns.
+        entry.TimeoutTimerId = 0;
+
+        Invoke(entry, _timeProvider.GetTimestamp(), didTimeout: true);
+    }
+
+    /// <summary>
+    /// The queue's first entry that has not been cancelled, discarding the marked ones on the way — the other
+    /// half of <see cref="Cancel"/> being O(1).
+    /// </summary>
+    private IdleCallbackEntry? TakeRunnable()
+    {
+        while (_runnable.TryDequeue(out var candidate))
+        {
+            if (candidate.Cancelled)
+            {
+                continue;
+            }
+
+            // Taken out of the live set before it runs, so a callback that cancels its own handle from inside
+            // itself is the no-op it should be.
+            _byHandle.Remove(candidate.Handle);
+            candidate.Cancelled = true;
+            CancelTimeoutTimer(candidate);
+            return candidate;
+        }
+
+        return null;
+    }
+
+    private void Invoke(IdleCallbackEntry entry, long deadlineTimestamp, bool didTimeout)
+    {
+        var deadline = new JsIdleDeadline(
+            _engine,
+            _realm.Intrinsics.IdleDeadline.PrototypeObject,
+            _timeProvider,
+            deadlineTimestamp,
+            didTimeout);
+
+        entry.Callback.Call(JsValue.Undefined, [deadline]);
+    }
+
+    private void Retire(IdleCallbackEntry entry)
+    {
+        entry.Cancelled = true;
+        CancelTimeoutTimer(entry);
+    }
+
+    private void CancelTimeoutTimer(IdleCallbackEntry entry)
+    {
+        if (entry.TimeoutTimerId != 0)
+        {
+            _timers.Cancel(entry.TimeoutTimerId);
+            entry.TimeoutTimerId = 0;
+        }
+    }
+
+    /// <summary>
+    /// What a <c>timeout</c> option's timer runs. An <see cref="ICallable"/> rather than a <c>ClrFunction</c>
+    /// so that a timeout creates no JavaScript function object for something no script can reach — the timer
+    /// queue only ever calls it.
+    /// </summary>
+    private sealed class IdleTimeoutAlgorithm : ICallable
+    {
+        private readonly IdleCallbackQueue _queue;
+        private readonly IdleCallbackEntry _entry;
+
+        internal IdleTimeoutAlgorithm(IdleCallbackQueue queue, IdleCallbackEntry entry)
+        {
+            _queue = queue;
+            _entry = entry;
+        }
+
+        public JsValue Call(JsValue thisObject, params JsCallArguments arguments)
+        {
+            _queue.RunTimedOut(_entry);
+            return JsValue.Undefined;
+        }
+    }
+}
+
+/// <summary>
+/// One entry of https://w3c.github.io/requestidlecallback/#dfn-list-of-idle-request-callbacks: a handle, the
+/// callback, and the timer a <c>timeout</c> option armed.
+/// </summary>
+internal sealed class IdleCallbackEntry
+{
+    internal IdleCallbackEntry(int handle, ICallable callback)
+    {
+        Handle = handle;
+        Callback = callback;
+    }
+
+    /// <summary>The value <c>requestIdleCallback</c> returned, and what <c>cancelIdleCallback</c> names.</summary>
+    internal int Handle { get; }
+
+    internal ICallable Callback { get; }
+
+    /// <summary>
+    /// Set once the entry has left the live set, whether because it was cancelled, because it ran, or because
+    /// the evaluation cycle ended. The two queues discard a marked entry when it surfaces.
+    /// </summary>
+    internal bool Cancelled { get; set; }
+
+    /// <summary>The timer id of the <c>timeout</c> option, or zero when none was given.</summary>
+    internal int TimeoutTimerId { get; set; }
+}
+#endif

--- a/Jint/WebApi/Idle/IdleDeadlineConstructor.cs
+++ b/Jint/WebApi/Idle/IdleDeadlineConstructor.cs
@@ -1,0 +1,50 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Idle;
+
+/// <summary>
+/// The <c>IdleDeadline</c> interface object.
+/// <para>
+/// https://w3c.github.io/requestidlecallback/#idledeadline
+/// </para>
+/// </summary>
+/// <remarks>
+/// The interface declares no constructor operation, which in WebIDL means the interface object exists and is a
+/// function but refuses to construct anything — https://webidl.spec.whatwg.org/#es-interface-call. A deadline
+/// only ever comes from the engine, as the argument to an idle callback. The object is exposed all the same,
+/// because that is what makes <c>deadline instanceof IdleDeadline</c> and feature detection work.
+/// </remarks>
+internal sealed class IdleDeadlineConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("IdleDeadline");
+
+    internal IdleDeadlineConstructor(
+        Engine engine,
+        Realm realm,
+        FunctionPrototype functionPrototype,
+        ObjectPrototype objectPrototype)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = functionPrototype;
+        PrototypeObject = new IdleDeadlinePrototype(engine, realm, this, objectPrototype);
+        _length = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal IdleDeadlinePrototype PrototypeObject { get; }
+
+    /// <summary>
+    /// An interface without a constructor operation is not constructible.
+    /// </summary>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        Throw.TypeError(_realm, "Illegal constructor");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Idle/IdleDeadlinePrototype.cs
+++ b/Jint/WebApi/Idle/IdleDeadlinePrototype.cs
@@ -1,0 +1,70 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Idle;
+
+/// <summary>
+/// <c>IdleDeadline.prototype</c> — the interface prototype object.
+/// <para>
+/// https://w3c.github.io/requestidlecallback/#idledeadline
+/// </para>
+/// </summary>
+/// <remarks>
+/// Both members brand-check their receiver, so <c>IdleDeadline.prototype.timeRemaining()</c> and a plain
+/// object borrowed into the receiver position raise a <c>TypeError</c> rather than answering something
+/// meaningless. The same documented simplification the other web-API prototypes carry applies here: the
+/// operation is non-enumerable where WebIDL makes an interface prototype object's operations enumerable, while
+/// the attribute is enumerable as it should be.
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class IdleDeadlinePrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly IdleDeadlineConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString IdleDeadlineToStringTag = new("IdleDeadline");
+
+    internal IdleDeadlinePrototype(
+        Engine engine,
+        Realm realm,
+        IdleDeadlineConstructor constructor,
+        ObjectInstance objectPrototype) : base(engine, realm)
+    {
+        _prototype = objectPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/requestidlecallback/#dom-idledeadline-timeremaining
+    /// </summary>
+    [JsFunction(Name = "timeRemaining", Length = 0)]
+    private JsNumber TimeRemaining(JsValue thisObject) => JsNumber.Create(Brand(thisObject).TimeRemaining());
+
+    /// <summary>
+    /// https://w3c.github.io/requestidlecallback/#dom-idledeadline-didtimeout
+    /// </summary>
+    [JsAccessor("didTimeout", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsBoolean DidTimeoutGet(JsValue thisObject) => JsBoolean.Create(Brand(thisObject).DidTimeout);
+
+    private JsIdleDeadline Brand(JsValue thisObject)
+    {
+        if (thisObject is JsIdleDeadline deadline)
+        {
+            return deadline;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not an IdleDeadline");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Idle/JsIdleDeadline.cs
+++ b/Jint/WebApi/Idle/JsIdleDeadline.cs
@@ -1,0 +1,67 @@
+#if NET8_0_OR_GREATER
+using Jint.Native.Object;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Idle;
+
+/// <summary>
+/// An <c>IdleDeadline</c> instance — the object an idle callback is handed, telling it how much of the
+/// engine's idle budget is left and whether it is running because that budget arrived or because its timeout
+/// ran out.
+/// <para>
+/// https://w3c.github.io/requestidlecallback/#dom-idledeadline
+/// </para>
+/// </summary>
+/// <remarks>
+/// One per invocation, as the specification says ("let deadlineArg be a new IdleDeadline"): the deadline it
+/// carries belongs to the idle period the callback is running in, and a callback that stores the object and
+/// consults it later gets a <c>timeRemaining()</c> of zero rather than a stale positive number, because the
+/// instant it names is in the past.
+/// </remarks>
+internal sealed class JsIdleDeadline : ObjectInstance
+{
+    private readonly TimeProvider _timeProvider;
+
+    /// <summary>
+    /// The instant the idle period ends, on <see cref="TimeProvider.GetTimestamp"/>'s scale — the same clock
+    /// the timers are scheduled against, so a fake one drives both coherently.
+    /// </summary>
+    private readonly long _deadlineTimestamp;
+
+    internal JsIdleDeadline(
+        Engine engine,
+        ObjectInstance prototype,
+        TimeProvider timeProvider,
+        long deadlineTimestamp,
+        bool didTimeout) : base(engine, ObjectClass.Object)
+    {
+        _prototype = prototype;
+        _timeProvider = timeProvider;
+        _deadlineTimestamp = deadlineTimestamp;
+        DidTimeout = didTimeout;
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/requestidlecallback/#dom-idledeadline-didtimeout — "each IdleDeadline has an
+    /// associated timeout, which is initially false", true only for a callback the timeout algorithm ran.
+    /// </summary>
+    internal bool DidTimeout { get; }
+
+    /// <summary>
+    /// https://w3c.github.io/requestidlecallback/#dom-idledeadline-timeremaining, whose steps this is exactly:
+    /// let <i>now</i> be the current high resolution time, let <i>deadline</i> be the result of the get
+    /// deadline time algorithm, let <i>timeRemaining</i> be <i>deadline</i> − <i>now</i>, and if it is negative
+    /// set it to 0.
+    /// </summary>
+    /// <remarks>
+    /// A timed-out callback's deadline is the moment it was invoked, so this answers zero for it — which is
+    /// what the specification produces too, and what tells such a callback that it is running on borrowed time
+    /// and should do the minimum.
+    /// </remarks>
+    internal double TimeRemaining()
+    {
+        var remaining = _timeProvider.GetElapsedTime(_timeProvider.GetTimestamp(), _deadlineTimestamp).TotalMilliseconds;
+        return remaining > 0 ? remaining : 0;
+    }
+}
+#endif

--- a/Jint/WebApi/WebApiRegistration.cs
+++ b/Jint/WebApi/WebApiRegistration.cs
@@ -3,6 +3,7 @@ using Jint.Native;
 using Jint.Native.Object;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Descriptors.Specialized;
+using Jint.WebApi.Idle;
 using Jint.WebApi.Scheduling;
 using Jint.WebApi.Timers;
 
@@ -259,6 +260,16 @@ internal static class WebApiRegistration
             // property is the same simplification console, crypto and performance are installed with.
             Install(global, engine, "caches", static e => e.Realm.Intrinsics.Caches, PropertyFlag.ConfigurableEnumerableWritable);
         }
+
+        if ((features & WebApiFeatures.IdleCallback) != WebApiFeatures.None)
+        {
+            Install(global, engine, "requestIdleCallback", static e => e.Realm.Intrinsics.IdleCallbacks.RequestIdleCallback, PropertyFlag.ConfigurableEnumerableWritable);
+            Install(global, engine, "cancelIdleCallback", static e => e.Realm.Intrinsics.IdleCallbacks.CancelIdleCallback, PropertyFlag.ConfigurableEnumerableWritable);
+
+            // Exposed even though nothing but the engine can create one: it is what makes
+            // `deadline instanceof IdleDeadline` and feature detection work.
+            Install(global, engine, "IdleDeadline", static e => e.Realm.Intrinsics.IdleDeadline, PropertyFlag.NonEnumerable);
+        }
     }
 
     /// <summary>
@@ -355,7 +366,7 @@ internal static class WebApiRegistration
         // in-flight set here, the scheduler keeps its own task queues here, and storage keeps its providers
         // here, which is why each of them wants the state even without the timers flag.
         const WebApiFeatures NeedsEngineState =
-            WebApiFeatures.Timers | WebApiFeatures.Events | WebApiFeatures.Performance | WebApiFeatures.Fetch | WebApiFeatures.Scheduler | WebApiFeatures.Messaging | WebApiFeatures.Storage | WebApiFeatures.WebSocket | WebApiFeatures.CacheApi;
+            WebApiFeatures.Timers | WebApiFeatures.Events | WebApiFeatures.Performance | WebApiFeatures.Fetch | WebApiFeatures.Scheduler | WebApiFeatures.Messaging | WebApiFeatures.Storage | WebApiFeatures.WebSocket | WebApiFeatures.CacheApi | WebApiFeatures.IdleCallback;
 
         // The diagnostics sink is the one thing here no feature flag governs: a host that set one gets the
         // channel whatever else it did or did not ask for, which is why it is read before the flags are.
@@ -373,7 +384,8 @@ internal static class WebApiRegistration
         // scheduler.postTask(), each of which needs it whether or not the host also asked for setTimeout; a
         // performance-only engine reads just the time origin and never schedules, so it carries no queue at
         // all.
-        const WebApiFeatures NeedsTimerQueue = WebApiFeatures.Timers | WebApiFeatures.Events | WebApiFeatures.Scheduler;
+        const WebApiFeatures NeedsTimerQueue =
+            WebApiFeatures.Timers | WebApiFeatures.Events | WebApiFeatures.Scheduler | WebApiFeatures.IdleCallback;
         var timers = (features & NeedsTimerQueue) != WebApiFeatures.None
             ? new TimerQueue(timeProvider, timerOptions.MaxActiveTimers, diagnostics)
             : null;
@@ -399,7 +411,15 @@ internal static class WebApiRegistration
             ? options.WebApi.Cache.Provider ?? new InMemoryCacheStorageProvider()
             : null;
 
-        engine._webApi = new WebApiEngineState(engine, timeProvider, timers, fetch, scheduler, diagnostics, storage, cache);
+        // The idle queue needs the timer queue for the `timeout` option, and the realm so it can build an
+        // IdleDeadline for each invocation. Engine.Realm is the principal realm here — Options.Apply runs
+        // during construction, long before any ShadowRealm can exist — and the principal realm is the only
+        // one these globals are installed in.
+        var idleCallbacks = (features & WebApiFeatures.IdleCallback) != WebApiFeatures.None
+            ? new IdleCallbackQueue(engine, engine.Realm, timeProvider, timers!, timerOptions.IdleBudget)
+            : null;
+
+        engine._webApi = new WebApiEngineState(engine, timeProvider, timers, fetch, scheduler, diagnostics, storage, cache, idleCallbacks);
     }
 
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -238,6 +238,9 @@ its own `console` (or any other name in the table below), enabling the feature l
 | `WebSocket` / `CloseEvent` (and the `MessageEvent` its messages arrive as) | `WebSocket` — **opt-in on its own, see below** | ✔ shipped |
 | `caches` / `Cache` / `CacheStorage` | `CacheApi` — **opt-in on its own, see below** | ✔ shipped |
 
+| `requestIdleCallback` / `cancelIdleCallback` / `IdleDeadline` | `IdleCallback` | ✔ shipped |
+| `fetch` / `Headers` / `Request` / `Response` | `Fetch` | in progress |
+
 `WebApiFeatures.Default` — what `UseWebApis()` enables — is every non-network feature that has landed. It
 grows as the table fills in, and it will never include `fetch`: network egress is always an explicit choice.
 `Storage` is one standing exception, for the reason in its own section below, and `CacheApi` is the
@@ -449,6 +452,62 @@ A sink alone is enough; the `Reporting` feature flag only decides whether script
 built. It is called synchronously, on the engine's thread, and must be thread-safe if the same `Options` builds
 engines that run concurrently. The `JsValue`s on a report belong to the reporting engine: read them inside the
 call rather than stashing them.
+
+### Idle callbacks: `requestIdleCallback`
+
+`requestIdleCallback(callback, { timeout })` runs a callback when the engine has nothing better to do, handing
+it an `IdleDeadline` with `didTimeout` and `timeRemaining()`. A browser means "the slack before the next frame
+is due"; Jint has no frames, so the mapping is stated plainly:
+
+- **An idle period starts when a pump has run out of everything else** — every queued job, every
+  `scheduler.postTask` task at every priority including `background`, every *due* timer. It is the lowest band
+  the engine has.
+- **Its deadline is `Options.WebApi.Timers.IdleBudget`**, 50 ms by default, which is the ceiling the standard
+  itself recommends. One pump spends at most one budget on idle work, however many callbacks are waiting; the
+  rest run on the next pump. Set it to `TimeSpan.Zero` if your host has no idle time to give, and then only a
+  callback requested *with* a `timeout` ever runs.
+- **A callback requested from inside a callback belongs to the next period**, so a self-re-arming
+  `requestIdleCallback` cannot monopolise the pump it started in.
+- **A `timeout` rides the timer queue**, so it counts against `MaxActiveTimers` and — like every timer — only
+  elapses while the engine is being pumped. A callback it reaches runs with `didTimeout === true` and a
+  `timeRemaining()` of zero. A callback with no `timeout` costs no timer slot at all.
+
+### Driving the engine from your own loop
+
+`engine.Advanced.TimeUntilNextScheduledWork` answers the question a host loop actually has — *when should I
+pump?* — and `engine.Advanced.ProcessTasks()` is the pump. There is deliberately no third method that drains
+for a budget: Jint never starts a thread, so the work always runs on your thread anyway; what was missing was
+the timing, not another way to run it.
+
+```csharp
+while (running)
+{
+    var until = engine.Advanced.TimeUntilNextScheduledWork;
+    if (until is null || until <= frameBudget)
+    {
+        engine.Advanced.ProcessTasks();
+    }
+
+    RenderFrame();
+}
+```
+
+`TimeSpan.Zero` means there is work to run right now (a queued job, a due timer, a waiting idle callback); a
+positive span is how long until the earliest *timed* work — a `setTimeout`, an `AbortSignal.timeout()`, a
+delayed `postTask`, a `requestIdleCallback` timeout, an `Atomics.waitAsync` deadline — comes due; `null` means
+nothing is scheduled. It is available on **every** target framework, not just .NET 8: the atomics deadline it
+reports is a core-engine one. It describes the engine's own schedule and not the outside world, so a `null` is
+"nothing timed is pending" rather than "nothing will ever happen" — keep a cadence of your own for the work
+that arrives from a background thread.
+
+**`engine.Advanced.CreateAbortSignal(cancellationToken)`** bridges your cancellation into script: hand the
+returned `AbortSignal` to `fetch`, to `scheduler.postTask`, or to a listener the script adds itself. Requires
+the `Events` feature. Cancelling the token **never runs script on the cancelling thread** — it enqueues, and
+the abort happens on the next pump, the same contract `setTimeout` has — so an engine nobody pumps never
+observes it. A token that is *already* cancelled yields an already-aborted signal on the spot, so
+`fetch(url, { signal })` rejects without issuing a request. The registration is released when the abort lands,
+when `RestoreGlobalSnapshot` ends the cycle, and when the engine is disposed, so a long-lived host token does
+not retain a finished engine.
 
 **A `ShadowRealm` does not get these globals.** Only the principal realm's global object is touched, which is
 deliberately more conservative than a browser (where these APIs are `[Exposed=*]`); a host that wants them


### PR DESCRIPTION
Completes #3084's host scheduling surface, and part of #3089: three pieces for hosts that drive the engine from their own loop.

**`Engine.Advanced.TimeUntilNextScheduledWork`** — the answer to *when* to pump, on every target framework. `TimeSpan.Zero` means work is runnable now (a queued job, a due timer, a waiting idle callback); a positive value is the time until the earliest timed work (timers, `AbortSignal.timeout()`, delayed `postTask`, an idle-callback timeout, an `Atomics.waitAsync` deadline); `null` means nothing is scheduled. The XML docs carry the worked game-loop and message-pump examples and the honest caveat that the value is a snapshot, never a substitute for waiting on external work. The queued-jobs and idle checks deliberately live in this public property rather than in the internal aggregate the engine's own wait loops clamp on — a zero there while the queue is unrunnable from a nested drain would spin that wait hot.

**`Engine.Advanced.CreateAbortSignal(CancellationToken)`** — the one-way host-cancellation bridge. Cancelling the token aborts the signal through a generation-stamped job (never on the cancelling thread — mutation-pinned with a dedicated-thread test), the registration is released on restore and on `Engine.Dispose`, and a signal built inside a `ShadowRealm` callback still belongs to the principal realm.

**`requestIdleCallback` / `cancelIdleCallback` / `IdleDeadline`** per https://w3c.github.io/requestidlecallback/ (`WebApiFeatures.IdleCallback = 1 << 21`, in `Default`): an idle period is a pump that ran out of everything else — genuinely the lowest band the engine has, after microtasks, scheduler tasks and due timers (pinned as `microtask,background,timer,idle`) — with the deadline from `TimerOptions.IdleBudget` (default the standard's own 50 ms cap), the pending/runnable two-list discipline so a self-re-arming callback cannot monopolize a pump, and the `timeout` option riding the timer queue.

All timer/idle tests drive a manual `TimeProvider`; the atomics deadline reporting rides the engine's existing waiter-deadline heap. Both suites green on all TFMs, with and without `JINT_HOST_CONTRACT_VERIFICATION=1`.

Closes #3084

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G7Ud48VAs1JicxRZxLDxg
