### PR TITLE
Give computed property keys a stable handler identity across replays

### DIFF
--- a/Jint.Tests/Runtime/SuspendedComputedKeyTests.cs
+++ b/Jint.Tests/Runtime/SuspendedComputedKeyTests.cs
@@ -14,6 +14,15 @@ namespace Jint.Tests.Runtime;
 /// Without them <c>o[f()] = await g()</c> and <c>({ [f()]: await g() })</c> call <c>f</c> twice, and
 /// the assignment lands on whatever key the second call produced.
 /// </para>
+/// <para>
+/// The complementary case is a suspension <em>inside</em> the key, <c>({ [f() + await g()]: 1 })</c>,
+/// which nothing above can park because the key never finished producing a value. What the key's own
+/// sub-expressions park — a binary operator's left operand, an addition chain's accumulator, an
+/// argument buffer — is keyed on the handler instance that parked it, so the key expression has to be
+/// the same handler on the replay as it was on the way in. Every key position now takes its handler
+/// from the engine's per-node cache instead of building a throwaway one per evaluation
+/// (<c>Engine.GetOrBuildPropertyKeyExpression</c>).
+/// </para>
 /// </summary>
 public class SuspendedComputedKeyTests
 {
@@ -183,5 +192,202 @@ public class SuspendedComputedKeyTests
             it.next(8);
             calls + '|' + JSON.stringify(r);
             """).Should().Be("2|{\"k1\":1,\"k2\":8}");
+    }
+
+    // ------------------------------------------------- suspension INSIDE the key expression
+
+    [Fact]
+    public void AComputedObjectLiteralKeyThatSuspendsMidwayRunsItsSideEffectsOnce()
+    {
+        RunAsync($$"""
+            {{CountingKey}}
+            (async function () {
+              var r = { [f() + await Promise.resolve('!')]: 1 };
+              return calls + '|' + JSON.stringify(r);
+            })();
+            """).Should().Be("1|{\"k1!\":1}");
+    }
+
+    [Fact]
+    public void AComputedObjectLiteralKeyThatSuspendsMidwayOnAYieldRunsItsSideEffectsOnce()
+    {
+        Run($$"""
+            {{CountingKey}}
+            var r;
+            function* g() { r = { [f() + (yield 1)]: 5 }; }
+            var it = g();
+            it.next();
+            it.next('!');
+            calls + '|' + JSON.stringify(r);
+            """).Should().Be("1|{\"k1!\":5}");
+    }
+
+    [Fact]
+    public void AComputedKeyThatIsItselfTheAwaitRunsOnce()
+    {
+        // Already correct before the handler-identity fix — an await finds its settled value by AST node
+        // — but it is the degenerate case of the shape above, so pin it.
+        RunAsync("""
+            var calls = 0;
+            function g() { calls++; return Promise.resolve('k'); }
+            (async function () {
+              var r = { [await g()]: 1 };
+              return calls + '|' + JSON.stringify(r);
+            })();
+            """).Should().Be("1|{\"k\":1}");
+    }
+
+    [Fact]
+    public void AnEarlierComputedKeySuspendingMidwayDoesNotShiftTheLaterKeys()
+    {
+        // Re-running the first key would consume the counter the second key then reads, so the whole
+        // literal came out keyed one step along: { k2: 1, k3: 2 } instead of { k1: 1, k2: 2 }.
+        RunAsync($$"""
+            {{CountingKey}}
+            (async function () {
+              var r = { [f() + await Promise.resolve('')]: 1, [f()]: 2 };
+              return calls + '|' + JSON.stringify(r);
+            })();
+            """).Should().Be("2|{\"k1\":1,\"k2\":2}");
+    }
+
+    [Fact]
+    public void AComputedMethodKeyThatSuspendsMidwayDefinesOnlyTheKeyItResolvesTo()
+    {
+        // A method is defined from inside MethodDefinitionEvaluation, before the object literal's own
+        // suspension check runs, so the placeholder undefined the suspended key produced used to be
+        // converted and defined as a property literally named "undefined" — on the very object the
+        // resume carries forward, which therefore could never take it back.
+        RunAsync($$"""
+            {{CountingKey}}
+            (async function () {
+              var r = { [f() + await Promise.resolve('!')]() { return 7; } };
+              return calls + '|' + JSON.stringify(Object.keys(r)) + '|' + r['k1!']();
+            })();
+            """).Should().Be("1|[\"k1!\"]|7");
+    }
+
+    [Fact]
+    public void AComputedAccessorKeyThatSuspendsMidwayRunsItsSideEffectsOnce()
+    {
+        RunAsync($$"""
+            {{CountingKey}}
+            (async function () {
+              var r = { get [f() + await Promise.resolve('!')]() { return 7; } };
+              return calls + '|' + JSON.stringify(Object.keys(r)) + '|' + r['k1!'];
+            })();
+            """).Should().Be("1|[\"k1!\"]|7");
+    }
+
+    [Fact]
+    public void TheSameComputedKeySuspendingOnEveryIterationRunsItsSideEffectsOncePerIteration()
+    {
+        // The key handler is now shared by every evaluation of the node, so what one iteration parks
+        // must be consumed and cleared by that same iteration and never inherited by the next.
+        RunAsync($$"""
+            {{CountingKey}}
+            (async function () {
+              var r = [];
+              for (var i = 0; i < 3; i++) {
+                r.push({ [f() + await Promise.resolve(i)]: i });
+              }
+              return calls + '|' + JSON.stringify(r);
+            })();
+            """).Should().Be("3|[{\"k10\":0},{\"k21\":1},{\"k32\":2}]");
+    }
+
+    [Fact]
+    public void TwoGeneratorsSuspendedInsideTheSameComputedKeyKeepTheirOwnParkedState()
+    {
+        // One handler, two suspendables: the parked state lives in each generator's own suspend-data
+        // dictionary, so sharing the handler must not let one instance read the other's.
+        Run($$"""
+            {{CountingKey}}
+            var r = [];
+            function* g(tag) { r.push({ [f() + tag + (yield 1)]: tag }); }
+            var a = g('a'), b = g('b');
+            a.next(); b.next();
+            a.next('1'); b.next('2');
+            calls + '|' + JSON.stringify(r);
+            """).Should().Be("2|[{\"k1a1\":\"a\"},{\"k2b2\":\"b\"}]");
+    }
+
+    // ------------------------------------------------------------------ class bodies
+
+    [Fact]
+    public void AComputedClassMethodKeyThatSuspendsMidwayRunsItsSideEffectsOnce()
+    {
+        RunAsync($$"""
+            {{CountingKey}}
+            (async function () {
+              var C = class { [f() + await Promise.resolve('!')]() { return 7; } };
+              return calls + '|' + JSON.stringify(Object.getOwnPropertyNames(C.prototype));
+            })();
+            """).Should().Be("1|[\"constructor\",\"k1!\"]");
+    }
+
+    [Fact]
+    public void AComputedStaticClassMethodKeyThatSuspendsMidwayRunsItsSideEffectsOnce()
+    {
+        RunAsync($$"""
+            {{CountingKey}}
+            (async function () {
+              var C = class { static [f() + await Promise.resolve('!')]() { return 7; } };
+              return calls + '|' + C['k1!']();
+            })();
+            """).Should().Be("1|7");
+    }
+
+    [Fact]
+    public void AComputedClassFieldKeyThatSuspendsMidwayRunsItsSideEffectsOnce()
+    {
+        RunAsync($$"""
+            {{CountingKey}}
+            (async function () {
+              var C = class { [f() + await Promise.resolve('!')] = 7; };
+              return calls + '|' + JSON.stringify(new C());
+            })();
+            """).Should().Be("1|{\"k1!\":7}");
+    }
+
+    [Fact]
+    public void AComputedClassMethodKeyThatSuspendsMidwayOnAYieldRunsItsSideEffectsOnce()
+    {
+        Run($$"""
+            {{CountingKey}}
+            var C;
+            function* g() { C = class { [f() + (yield 1)]() { return 7; } }; }
+            var it = g();
+            it.next();
+            it.next('!');
+            calls + '|' + JSON.stringify(Object.getOwnPropertyNames(C.prototype));
+            """).Should().Be("1|[\"constructor\",\"k1!\"]");
+    }
+
+    // ------------------------------------------------------------------ destructuring
+
+    [Fact]
+    public void AComputedDestructuringKeyThatSuspendsMidwayRunsItsSideEffectsOnce()
+    {
+        RunAsync($$"""
+            {{CountingKey}}
+            (async function () {
+              var v;
+              ({ [f() + await Promise.resolve('!')]: v } = { 'k1!': 11 });
+              return calls + '|' + v;
+            })();
+            """).Should().Be("1|11");
+    }
+
+    [Fact]
+    public void AComputedKeyInADestructuringDeclarationThatSuspendsMidwayRunsItsSideEffectsOnce()
+    {
+        RunAsync($$"""
+            {{CountingKey}}
+            (async function () {
+              var { [f() + await Promise.resolve('!')]: v } = { 'k1!': 11 };
+              return calls + '|' + v;
+            })();
+            """).Should().Be("1|11");
     }
 }

--- a/Jint/AstExtensions.cs
+++ b/Jint/AstExtensions.cs
@@ -100,8 +100,12 @@ public static class AstExtensions
         // allowlist of node types with a silent JsValue.Undefined fallback, which made keys like
         // `{ [(sideEffect(), "k")]: v }` (SequenceExpression) or `{ [new Key()]: v }` bind the
         // property "undefined" without running the key expression at all.
+        //
+        // The handler comes from the engine's per-node cache rather than being rebuilt here: a suspension
+        // inside the key expression parks its replay state under the handler instance that parked it, so a
+        // fresh instance per evaluation would lose it and re-run the whole key subtree on resume.
         var context = engine._evaluationContext;
-        var result = JintExpression.Build(expression).GetValue(context);
+        var result = engine.GetOrBuildPropertyKeyExpression(expression).GetValue(context);
 
         // If the expression suspended the generator (e.g., yield in computed property name),
         // return the value. The caller should check ExecutionContext.Suspended.

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -162,6 +162,37 @@ public sealed partial class Engine : IDisposable
         return list;
     }
 
+    // Per-engine cache of the interpreter handler built for a property key expression that has to be
+    // evaluated — every computed key (`{ [k]: v }`, `class { [k]() {} }`, `({ [k]: v } = o)`) plus the
+    // literal keys of a destructuring pattern. Keyed on the stable AST node and engine-owned for the same
+    // lifetime reasons as _functionDefinitions above: a handler tree accumulates engine-affine per-node
+    // inline caches, so it must not be published to the AST's UserData and shared across engines.
+    //
+    // Identity is what makes this correct, not merely cheaper. Everything a suspension parks for its
+    // replay — LeftOperandSuspendData, AdditionChainSuspendData, the argument buffers — is keyed on the
+    // handler instance that parked it, so a key expression rebuilt on every evaluation can never find its
+    // own parked state. Building it afresh made `{ [f() + await g()]: 1 }` replay the whole key subtree
+    // and call f twice (issue #3142).
+    private Dictionary<Expression, JintExpression>? _propertyKeyExpressions;
+
+    internal JintExpression GetOrBuildPropertyKeyExpression(Expression expression)
+    {
+        var cache = _propertyKeyExpressions ??= new Dictionary<Expression, JintExpression>();
+        if (!cache.TryGetValue(expression, out var built))
+        {
+            // backstop mirroring CacheFunctionDefinition: bound growth for hosts streaming endless
+            // distinct sources through one long-lived engine.
+            if (cache.Count >= 2048)
+            {
+                cache.Clear();
+            }
+
+            cache[expression] = built = JintExpression.Build(expression);
+        }
+
+        return built;
+    }
+
     internal JintFunctionDefinition GetOrCreateFunctionDefinition(FunctionDeclaration declaration)
     {
         if (!TryGetFunctionDefinition(declaration, out var definition))

--- a/Jint/Native/Function/ClassDefinition.cs
+++ b/Jint/Native/Function/ClassDefinition.cs
@@ -830,6 +830,17 @@ internal sealed class ClassDefinition
         if (method.Kind != PropertyKind.Get && method.Kind != PropertyKind.Set && !function.Generator)
         {
             var methodDef = method.DefineMethod(obj, functionPrototype: null, sourceTextNode: method);
+
+            // A computed key that suspended (`{ [f() + await g()]() {} }`) produced no key at all —
+            // DefineMethod turned the placeholder undefined into the property key "undefined", and an
+            // object literal reuses the same target object across the resume, so defining it would leave
+            // a property the replay can never take back. IsSuspended rather than Suspended: the latter
+            // only sees a generator parked at a yield, and this shape suspends on an await too.
+            if (engine.ExecutionContext.IsSuspended)
+            {
+                return null;
+            }
+
             definedKey = methodDef.Key;
             methodDef.Closure.SetFunctionName(methodDef.Key);
             return DefineMethodProperty(obj, methodDef.Key, methodDef.Closure, enumerable);

--- a/Jint/Runtime/Interpreter/Expressions/DestructuringPatternAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/DestructuringPatternAssignmentExpression.cs
@@ -508,7 +508,11 @@ internal sealed class DestructuringPatternAssignmentExpression : JintExpression
                 var identifier = p.Key as Identifier;
                 if (identifier == null || p.Computed)
                 {
-                    var keyExpression = Build(p.Key);
+                    // Same per-node cache the object-literal and class-body key positions use: this
+                    // method is static and has no handler of its own to hang the key expression on, and a
+                    // freshly built one would lose the replay state a suspension inside the key parked
+                    // under it (`({ [f() + await g()]: v } = o)` called f twice).
+                    var keyExpression = context.Engine.GetOrBuildPropertyKeyExpression(p.Key);
                     var value = keyExpression.GetValue(context);
                     sourceKey = TypeConverter.ToPropertyKey(value);
                 }


### PR DESCRIPTION
Closes #3142.

A suspension **inside** a computed property key lost its replay state, because `AstExtensions.TryGetComputedPropertyKey` called `JintExpression.Build` on every evaluation: all replay suspend data is keyed on the handler *instance* that parked it, so a fresh instance per evaluation could never find its parked state, and the whole key subtree re-ran on resume. This is the complement of #3144's case (there the key had finished and the *value* suspended).

Pre-fix this was worse than a doubled side effect. With `f()` returning a fresh key per call, `{ [f() + await x]: 1, [f()]: 2 }` came out `{k2:1, k3:2}` — the keys shift; and an object-literal **method** with a suspending computed key left behind a real own property literally named `"undefined"` that the resume could never remove, because the literal reuses the same target object across the resume. 13 of the 14 new tests fail on unfixed code with exactly those shapes.

**The fix**: a per-engine cache, `Engine.GetOrBuildPropertyKeyExpression`, gives every evaluated key position a stable handler identity — keyed on the AST node, engine-owned for the same reason `_functionDefinitions` is (a handler tree accumulates engine-affine inline caches, so it must not be published to shared-AST `UserData`), lazily allocated, with the same 2048-entry clear backstop `CacheFunctionDefinition` uses. All six routes to an evaluated key go through it: object-literal computed keys, class methods/fields/auto-accessors via `ClassDefinition`, plain methods via `DefineMethod`, destructuring pattern keys (which reached `Build` directly, same root cause, included with two pinning tests), and function-parameter destructuring (covered incidentally; it cannot suspend — `yield`/`await` in parameters are Early Errors). Plus the adjacent one-liner: `MethodDefinitionEvaluation` now bails before defining the placeholder-`undefined` key when the key suspended, using `IsSuspended` rather than the accessor branch's `Suspended`, which only sees a generator parked at a `yield` and would miss the `await` shape.

**Steady state is cheaper, not just correct**: a computed key used to pay a full recursive handler build — one allocation per node of the key subtree — on *every* evaluation; it now pays one reference-keyed dictionary lookup, and the key's own inline caches stay warm across evaluations instead of being thrown away.

**Tests**: 14 added to `SuspendedComputedKeyTests` — await/yield mid-key for object literals, methods, accessors, class methods (instance and static), class fields, destructuring (expression and declaration), the key-is-itself-the-await pin, loop re-suspension of one key node, and two concurrently suspended generators sharing one key node keeping their parked state apart.

**Gate**: solution build 0 errors; Jint.Tests 8691/7019 green; PublicInterface green; full test262 green (102,495); CommonScripts green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G7Ud48VAs1JicxRZxLDxg
