### PR TITLE
Web API: URLPattern on the in-tree URL parser

### DIFF
--- a/Jint.Tests.PublicInterface/WebApiUrlTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiUrlTests.cs
@@ -22,8 +22,10 @@ public class WebApiUrlTests
 
         engine.Evaluate("typeof URL").AsString().Should().Be("undefined");
         engine.Evaluate("typeof URLSearchParams").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof URLPattern").AsString().Should().Be("undefined");
         engine.Evaluate("'URL' in globalThis").AsBoolean().Should().BeFalse();
         engine.Evaluate("'URLSearchParams' in globalThis").AsBoolean().Should().BeFalse();
+        engine.Evaluate("'URLPattern' in globalThis").AsBoolean().Should().BeFalse();
 
         // Nor an engine that asked for a different feature.
         var console = new Engine(options => options.UseWebApis(WebApiFeatures.Console));
@@ -31,12 +33,16 @@ public class WebApiUrlTests
     }
 
     [Fact]
-    public void TheUrlFlagInstallsBothInterfaces()
+    public void TheUrlFlagInstallsEveryInterfaceOfTheStandardFamily()
     {
         var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Url));
 
         engine.Evaluate("typeof URL").AsString().Should().Be("function");
         engine.Evaluate("typeof URLSearchParams").AsString().Should().Be("function");
+
+        // URLPattern has no flag of its own: it is defined in terms of the URL parser and matches against URLs,
+        // so it would have no independent meaning on an engine that has no URL.
+        engine.Evaluate("typeof URLPattern").AsString().Should().Be("function");
 
         // ... and nothing else the group could have brought along.
         engine.Evaluate("typeof console").AsString().Should().Be("undefined");
@@ -59,7 +65,7 @@ public class WebApiUrlTests
         var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Url));
 
         // An interface object is writable and configurable but not enumerable.
-        foreach (var name in new[] { "URL", "URLSearchParams" })
+        foreach (var name in new[] { "URL", "URLSearchParams", "URLPattern" })
         {
             var descriptor = engine.Evaluate($"Object.getOwnPropertyDescriptor(globalThis, '{name}')").AsObject();
 
@@ -92,6 +98,7 @@ public class WebApiUrlTests
 
         engine.Evaluate("new ShadowRealm().evaluate('typeof URL')").AsString().Should().Be("undefined");
         engine.Evaluate("new ShadowRealm().evaluate('typeof URLSearchParams')").AsString().Should().Be("undefined");
+        engine.Evaluate("new ShadowRealm().evaluate('typeof URLPattern')").AsString().Should().Be("undefined");
         engine.Evaluate("typeof URL").AsString().Should().Be("function");
     }
 
@@ -175,6 +182,46 @@ public class WebApiUrlTests
         engine.Evaluate("URL.canParse('https://example.com:demo')").AsBoolean().Should().BeFalse();
         engine.Evaluate("URL.canParse('http://[www.example.com]/')").AsBoolean().Should().BeFalse();
         engine.Evaluate("URL.canParse('https://09/')").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void MatchesUrlsWithUrlPatternFromTheHostSide()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Url));
+
+        var pattern = engine.Evaluate("new URLPattern('https://*.example.com/products/:id')").AsObject();
+
+        pattern.Get("hostname").AsString().Should().Be("*.example.com");
+        pattern.Get("pathname").AsString().Should().Be("/products/:id");
+        pattern.Get("hasRegExpGroups").AsBoolean().Should().BeFalse();
+
+        engine.SetValue("pattern", pattern);
+        engine.Evaluate("pattern.test('https://shop.example.com/products/74205')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("pattern.test('https://shop.example.com/orders/74205')").AsBoolean().Should().BeFalse();
+
+        var result = engine.Evaluate("pattern.exec('https://shop.example.com/products/74205')").AsObject();
+        result.Get("pathname").AsObject().Get("groups").AsObject().Get("id").AsString().Should().Be("74205");
+        result.Get("hostname").AsObject().Get("groups").AsObject().Get("0").AsString().Should().Be("shop");
+
+        // A component pattern that will not canonicalize is a TypeError from the constructor, not a silent
+        // never-matching pattern.
+        Assert.Throws<Jint.Runtime.JavaScriptException>(() => engine.Evaluate("new URLPattern({ protocol: 'http{' })"));
+    }
+
+    [Fact]
+    public void UrlPatternSurvivesAGlobalSnapshotRestore()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Url));
+
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+
+        engine.Execute("var p = new URLPattern({ pathname: '/a/:b' });");
+        engine.Evaluate("p.test({ pathname: '/a/c' })").AsBoolean().Should().BeTrue();
+
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        engine.Evaluate("typeof p").AsString().Should().Be("undefined");
+        engine.Evaluate("new URLPattern({ pathname: '/x' }).test({ pathname: '/x' })").AsBoolean().Should().BeTrue();
     }
 }
 #endif

--- a/Jint.Tests/Runtime/WebApi/Resources/README.md
+++ b/Jint.Tests/Runtime/WebApi/Resources/README.md
@@ -1,18 +1,25 @@
 # Web Platform Tests URL corpus
 
-`urltestdata.json` and `setters_tests.json` are vendored verbatim from the
+`urltestdata.json`, `setters_tests.json` and `urlpatterntestdata.json` are vendored verbatim from the
 [web-platform-tests](https://github.com/web-platform-tests/wpt) repository, at commit
 
     6745634413e4153144e23bc3e866d6b14d3e55e6
 
-from `url/resources/urltestdata.json` and `url/resources/setters_tests.json`. `wpt-LICENSE.md` is that
-commit's `LICENSE.md`; the corpus is redistributed here under the 3-Clause BSD License it carries.
+from `url/resources/urltestdata.json`, `url/resources/setters_tests.json` and
+`urlpattern/resources/urlpatterntestdata.json`. `wpt-LICENSE.md` is that commit's `LICENSE.md`; the corpus is
+redistributed here under the 3-Clause BSD License it carries.
 
-`UrlCorpusTests` runs every row of both files directly against `Jint.WebApi.Url.Parsing`, without building an
-engine — the parser is deliberately engine-free, so a conformance row costs a parse and nothing else. Rows
-that do not pass are listed in that file's exclusion table, each with the divergence category it belongs to,
-and the driver **fails on a stale exclusion**: a row that starts passing has to be removed from the table in
-the same change that fixed it.
+`UrlCorpusTests` runs every row of the first two files directly against `Jint.WebApi.Url.Parsing`, without
+building an engine — the parser is deliberately engine-free, so a conformance row costs a parse and nothing else.
 
-To update the corpus, resolve `master` to a concrete commit, fetch both files at that commit, replace them
-here, update the SHA above and re-run the driver.
+`UrlPatternCorpusTests` runs every row of `urlpatterntestdata.json` through one engine, driven by a port of the
+WPT runner (`urlpattern/resources/urlpatterntests.js`) written in JavaScript, because what those rows assert is
+the behaviour of the `URLPattern` object itself — the pattern strings its accessors return and the shape of its
+`exec()` result — rather than of a parser underneath it.
+
+Both drivers list the rows that do not pass in an exclusion table in the driver file, each with the divergence
+category it belongs to, and **fail on a stale exclusion**: a row that starts passing has to be removed from the
+table in the same change that fixed it.
+
+To update the corpus, resolve `master` to a concrete commit, fetch the three files at that commit, replace them
+here, update the SHA above and re-run the drivers.

--- a/Jint.Tests/Runtime/WebApi/Resources/urlpatterntestdata.json
+++ b/Jint.Tests/Runtime/WebApi/Resources/urlpatterntestdata.json
@@ -1,0 +1,3181 @@
+[
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "/foo/ba" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "/foo/bar/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [ "https://example.com/foo/bar" ],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" } },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": { "0": "https" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [ "https://example.com/foo/bar/baz" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "hostname": "example.com", "pathname": "/foo/bar" }],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" } },
+      "pathname": { "input": "/foo/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "hostname": "example.com", "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "/foo/bar", "baseURL": "https://example.com" }],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" } },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": { "0": "https" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "/foo/bar/baz",
+                 "baseURL": "https://example.com" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "hostname": "example.com", "pathname": "/foo/bar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "protocol": "https", "hostname": "example.com",
+                 "pathname": "/foo/bar" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com" }],
+    "inputs": [{ "protocol": "https", "hostname": "example.com",
+                 "pathname": "/foo/bar" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com" }],
+    "inputs": [{ "protocol": "https", "hostname": "example.com",
+                 "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "protocol": "https", "hostname": "example.com",
+                 "pathname": "/foo/bar", "search": "otherquery",
+                 "hash": "otherhash" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hash": { "input": "otherhash", "groups": { "0": "otherhash" } },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "otherquery", "groups": { "0": "otherquery" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com" }],
+    "inputs": [{ "protocol": "https", "hostname": "example.com",
+                 "pathname": "/foo/bar", "search": "otherquery",
+                 "hash": "otherhash" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hash": { "input": "otherhash", "groups": { "0": "otherhash" } },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "otherquery", "groups": { "0": "otherquery" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?otherquery#otherhash" }],
+    "inputs": [{ "protocol": "https", "hostname": "example.com",
+                 "pathname": "/foo/bar", "search": "otherquery",
+                 "hash": "otherhash" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hash": { "input": "otherhash", "groups": { "0": "otherhash" } },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "otherquery", "groups": { "0": "otherquery" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [ "https://example.com/foo/bar" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [ "https://example.com/foo/bar?otherquery#otherhash" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hash": { "input": "otherhash", "groups": { "0": "otherhash" } },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "otherquery", "groups": { "0": "otherquery" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [ "https://example.com/foo/bar?query#hash" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hash": { "input": "hash", "groups": { "0": "hash" } },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "query", "groups": { "0": "query" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [ "https://example.com/foo/bar/baz" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [ "https://other.com/foo/bar" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [ "http://other.com/foo/bar" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "pathname": "/foo/bar", "baseURL": "https://example.com" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "pathname": "/foo/bar/baz",
+                 "baseURL": "https://example.com" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "pathname": "/foo/bar", "baseURL": "https://other.com" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "pathname": "/foo/bar", "baseURL": "http://example.com" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "bar": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/([^\\/]+?)" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar" }],
+    "inputs": [{ "pathname": "/foo/index.html" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/index.html", "groups": { "bar": "index.html" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar" }],
+    "inputs": [{ "pathname": "/foo/bar/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_obj": {
+      "pathname": "/foo/*"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_obj": {
+      "pathname": "/foo/*"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_obj": {
+      "pathname": "/foo/*"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_obj": {
+      "pathname": "/foo/*"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar(.*)" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "bar": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar(.*)" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "bar": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar(.*)" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "bar": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar(.*)" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar?" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "bar": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar?" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "bar": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar?" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar?" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar?" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar+" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "bar": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar+" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "bar": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar+" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar+" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar+" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar*" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "bar": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar*" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "bar": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar*" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "bar": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar*" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar*" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)?" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_obj": {
+      "pathname": "/foo/*?"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*?" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)?" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_obj": {
+      "pathname": "/foo/*?"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*?" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)?" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_obj": {
+      "pathname": "/foo/*?"
+    },
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "0": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*?" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "0": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)?" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_obj": {
+      "pathname": "/foo/*?"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*?" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)?" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_obj": {
+      "pathname": "/foo/*?"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*?" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)?" }],
+    "inputs": [{ "pathname": "/fo" }],
+    "expected_obj": {
+      "pathname": "/foo/*?"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*?" }],
+    "inputs": [{ "pathname": "/fo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)+" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_obj": {
+      "pathname": "/foo/*+"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*+" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)+" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_obj": {
+      "pathname": "/foo/*+"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*+" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)+" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_obj": {
+      "pathname": "/foo/*+"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*+" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)+" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_obj": {
+      "pathname": "/foo/*+"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*+" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)+" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_obj": {
+      "pathname": "/foo/*+"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*+" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)+" }],
+    "inputs": [{ "pathname": "/fo" }],
+    "expected_obj": {
+      "pathname": "/foo/*+"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*+" }],
+    "inputs": [{ "pathname": "/fo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)*" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_obj": {
+      "pathname": "/foo/**"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/**" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)*" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_obj": {
+      "pathname": "/foo/**"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/**" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)*" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_obj": {
+      "pathname": "/foo/**"
+    },
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "0": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/**" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "0": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)*" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_obj": {
+      "pathname": "/foo/**"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/**" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)*" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_obj": {
+      "pathname": "/foo/**"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/**" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)*" }],
+    "inputs": [{ "pathname": "/fo" }],
+    "expected_obj": {
+      "pathname": "/foo/**"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/**" }],
+    "inputs": [{ "pathname": "/fo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_obj": {
+      "pathname": "/foo/bar"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_obj": {
+      "pathname": "/foo/bar"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_obj": {
+      "pathname": "/foo/bar"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_obj": {
+      "pathname": "/foo/bar"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}?" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}?" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}?" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}?" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}+" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}+" }],
+    "inputs": [{ "pathname": "/foo/bar/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}+" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}+" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}+" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}*" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}*" }],
+    "inputs": [{ "pathname": "/foo/bar/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}*" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}*" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}*" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "(café)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "username": "(café)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "password": "(café)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "(café)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "pathname": "(café)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "search": "(café)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hash": "(café)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "protocol": ":café" }],
+    "inputs": [{ "protocol": "foo" }],
+    "expected_match": {
+      "protocol": { "input": "foo", "groups": { "café": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "username": ":café" }],
+    "inputs": [{ "username": "foo" }],
+    "expected_match": {
+      "username": { "input": "foo", "groups": { "café": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "password": ":café" }],
+    "inputs": [{ "password": "foo" }],
+    "expected_match": {
+      "password": { "input": "foo", "groups": { "café": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "hostname": ":café" }],
+    "inputs": [{ "hostname": "foo" }],
+    "expected_match": {
+      "hostname": { "input": "foo", "groups": { "café": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/:café" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "café": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "search": ":café" }],
+    "inputs": [{ "search": "foo" }],
+    "expected_match": {
+      "search": { "input": "foo", "groups": { "café": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "hash": ":café" }],
+    "inputs": [{ "hash": "foo" }],
+    "expected_match": {
+      "hash": { "input": "foo", "groups": { "café": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "protocol": ":\u2118" }],
+    "inputs": [{ "protocol": "foo" }],
+    "expected_match": {
+      "protocol": { "input": "foo", "groups": { "\u2118": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "username": ":\u2118" }],
+    "inputs": [{ "username": "foo" }],
+    "expected_match": {
+      "username": { "input": "foo", "groups": { "\u2118": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "password": ":\u2118" }],
+    "inputs": [{ "password": "foo" }],
+    "expected_match": {
+      "password": { "input": "foo", "groups": { "\u2118": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "hostname": ":\u2118" }],
+    "inputs": [{ "hostname": "foo" }],
+    "expected_match": {
+      "hostname": { "input": "foo", "groups": { "\u2118": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/:\u2118" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "\u2118": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "search": ":\u2118" }],
+    "inputs": [{ "search": "foo" }],
+    "expected_match": {
+      "search": { "input": "foo", "groups": { "\u2118": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "hash": ":\u2118" }],
+    "inputs": [{ "hash": "foo" }],
+    "expected_match": {
+      "hash": { "input": "foo", "groups": { "\u2118": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "protocol": ":\u3400" }],
+    "inputs": [{ "protocol": "foo" }],
+    "expected_match": {
+      "protocol": { "input": "foo", "groups": { "\u3400": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "username": ":\u3400" }],
+    "inputs": [{ "username": "foo" }],
+    "expected_match": {
+      "username": { "input": "foo", "groups": { "\u3400": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "password": ":\u3400" }],
+    "inputs": [{ "password": "foo" }],
+    "expected_match": {
+      "password": { "input": "foo", "groups": { "\u3400": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "hostname": ":\u3400" }],
+    "inputs": [{ "hostname": "foo" }],
+    "expected_match": {
+      "hostname": { "input": "foo", "groups": { "\u3400": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/:\u3400" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "\u3400": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "search": ":\u3400" }],
+    "inputs": [{ "search": "foo" }],
+    "expected_match": {
+      "search": { "input": "foo", "groups": { "\u3400": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "hash": ":\u3400" }],
+    "inputs": [{ "hash": "foo" }],
+    "expected_match": {
+      "hash": { "input": "foo", "groups": { "\u3400": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "protocol": "(.*)" }],
+    "inputs": [{ "protocol" : "café" }],
+    "expected_obj": {
+      "protocol": "*"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "(.*)" }],
+    "inputs": [{ "protocol": "cafe" }],
+    "expected_obj": {
+      "protocol": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "cafe", "groups": { "0": "cafe" }}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "foo-bar" }],
+    "inputs": [{ "protocol": "foo-bar" }],
+    "expected_match": {
+      "protocol": { "input": "foo-bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "username": "caf%C3%A9" }],
+    "inputs": [{ "username" : "café" }],
+    "expected_match": {
+      "username": { "input": "caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "username": "café" }],
+    "inputs": [{ "username" : "café" }],
+    "expected_obj": {
+      "username": "caf%C3%A9"
+    },
+    "expected_match": {
+      "username": { "input": "caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "username": "caf%c3%a9" }],
+    "inputs": [{ "username" : "café" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "password": "caf%C3%A9" }],
+    "inputs": [{ "password" : "café" }],
+    "expected_match": {
+      "password": { "input": "caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "password": "café" }],
+    "inputs": [{ "password" : "café" }],
+    "expected_obj": {
+      "password": "caf%C3%A9"
+    },
+    "expected_match": {
+      "password": { "input": "caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "password": "caf%c3%a9" }],
+    "inputs": [{ "password" : "café" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "hostname": "xn--caf-dma.com" }],
+    "inputs": [{ "hostname" : "café.com" }],
+    "expected_match": {
+      "hostname": { "input": "xn--caf-dma.com", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "hostname": "café.com" }],
+    "inputs": [{ "hostname" : "café.com" }],
+    "expected_obj": {
+      "hostname": "xn--caf-dma.com"
+    },
+    "expected_match": {
+      "hostname": { "input": "xn--caf-dma.com", "groups": {}}
+    }
+  },
+  {
+    "pattern": ["http://\uD83D\uDEB2.com/"],
+    "inputs": ["http://\uD83D\uDEB2.com/"],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "xn--h78h.com",
+      "pathname": "/"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {}},
+      "hostname": { "input": "xn--h78h.com", "groups": {}},
+      "pathname": { "input": "/", "groups": {}}
+    }
+  },
+  {
+    "pattern": ["http://\uD83D \uDEB2"],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{"hostname":"\uD83D \uDEB2"}],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{"pathname":"\uD83D \uDEB2"}],
+    "inputs": [],
+    "expected_obj": {
+      "pathname": "%EF%BF%BD%20%EF%BF%BD"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{"pathname":":\uD83D \uDEB2"}],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{"pathname":":a\uDB40\uDD00b"}],
+    "inputs": [],
+    "expected_obj": {
+      "pathname": ":a\uDB40\uDD00b"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{"pathname":"test/:a\uD801\uDC50b"}],
+    "inputs": [{"pathname":"test/foo"}],
+    "expected_obj": {
+      "pathname": "test/:a\uD801\uDC50b"
+    },
+    "expected_match": {
+      "pathname": { "input": "test/foo", "groups": { "a\uD801\uDC50b": "foo" }}
+    }
+  },
+  {
+    "pattern": [{"pathname":":\uD83D\uDEB2"}],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "port": "" }],
+    "inputs": [{ "protocol": "http", "port": "80" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "protocol": { "input": "http", "groups": { "0": "http" }}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "http", "port": "80" }],
+    "inputs": [{ "protocol": "http", "port": "80" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "http", "port": "80{20}?" }],
+    "inputs": [{ "protocol": "http", "port": "80" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "http", "port": "80 " }],
+    "inputs": [{ "protocol": "http", "port": "80" }],
+    "expected_obj": {
+      "protocol": "http",
+      "port": "80"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "http", "port": "100000" }],
+    "inputs": [{ "protocol": "http", "port": "100000" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "port": "80" }],
+    "inputs": [{ "protocol": "http", "port": "80" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "http{s}?", "port": "80" }],
+    "inputs": [{ "protocol": "http", "port": "80" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "port": "80" }],
+    "inputs": [{ "port": "80" }],
+    "expected_match": {
+      "port": { "input": "80", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "port": "80" }],
+    "inputs": [{ "port": "8\t0" }],
+    "expected_match": {
+      "port": { "input": "80", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "port": "80" }],
+    "inputs": [{ "port": "80x" }],
+    "expected_match": {
+      "port": { "input": "80", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "port": "80" }],
+    "inputs": [{ "port": "80?x" }],
+    "expected_match": {
+      "port": { "input": "80", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "port": "80" }],
+    "inputs": [{ "port": "80\\x" }],
+    "expected_match": {
+      "port": { "input": "80", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "port": "(.*)" }],
+    "inputs": [{ "port": "invalid80" }],
+    "expected_obj": {
+      "port": "*"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "https", "port": "443*" }],
+    "inputs": [{ "protocol": "https", "port": "4430" }],
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "port": { "input": "4430", "groups": { "0": "0" }}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "https", "port": "*443" }],
+    "inputs": [{ "protocol": "https", "port": "1443" }],
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "port": { "input": "1443", "groups": { "0": "1" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "/foo/./bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/baz" }],
+    "inputs": [{ "pathname": "/foo/bar/../baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/baz", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/caf%C3%A9" }],
+    "inputs": [{ "pathname": "/café" }],
+    "expected_match": {
+      "pathname": { "input": "/caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/café" }],
+    "inputs": [{ "pathname": "/café" }],
+    "expected_obj": {
+      "pathname": "/caf%C3%A9"
+    },
+    "expected_match": {
+      "pathname": { "input": "/caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/caf%c3%a9" }],
+    "inputs": [{ "pathname": "/café" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "foo/bar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "foo/bar", "baseURL": "https://example.com" }],
+    "expected_match": {
+      "protocol": { "input": "https", "groups": { "0": "https" }},
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" }},
+      "pathname": { "input": "/foo/bar", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/../bar" }],
+    "inputs": [{ "pathname": "/bar" }],
+    "expected_obj": {
+      "pathname": "/bar"
+    },
+    "expected_match": {
+      "pathname": { "input": "/bar", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "./foo/bar", "baseURL": "https://example.com" }],
+    "inputs": [{ "pathname": "foo/bar", "baseURL": "https://example.com" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/foo/bar"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {}},
+      "hostname": { "input": "example.com", "groups": {}},
+      "pathname": { "input": "/foo/bar", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "", "baseURL": "https://example.com" }],
+    "inputs": [{ "pathname": "/", "baseURL": "https://example.com" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {}},
+      "hostname": { "input": "example.com", "groups": {}},
+      "pathname": { "input": "/", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{/bar}", "baseURL": "https://example.com/foo/" }],
+    "inputs": [{ "pathname": "./bar", "baseURL": "https://example.com/foo/" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/bar"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "\\/bar", "baseURL": "https://example.com/foo/" }],
+    "inputs": [{ "pathname": "./bar", "baseURL": "https://example.com/foo/" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/bar"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "b", "baseURL": "https://example.com/foo/" }],
+    "inputs": [{ "pathname": "./b", "baseURL": "https://example.com/foo/" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/foo/b"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {}},
+      "hostname": { "input": "example.com", "groups": {}},
+      "pathname": { "input": "/foo/b", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "foo/bar" }],
+    "inputs": [ "https://example.com/foo/bar" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "foo/bar", "baseURL": "https://example.com" }],
+    "inputs": [ "https://example.com/foo/bar" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/foo/bar"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {}},
+      "hostname": { "input": "example.com", "groups": {}},
+      "pathname": { "input": "/foo/bar", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":name.html", "baseURL": "https://example.com" }],
+    "inputs": [ "https://example.com/foo.html"] ,
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/:name.html"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {}},
+      "hostname": { "input": "example.com", "groups": {}},
+      "pathname": { "input": "/foo.html", "groups": { "name": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "search": "q=caf%C3%A9" }],
+    "inputs": [{ "search": "q=café" }],
+    "expected_match": {
+      "search": { "input": "q=caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "search": "q=café" }],
+    "inputs": [{ "search": "q=café" }],
+    "expected_obj": {
+      "search": "q=caf%C3%A9"
+    },
+    "expected_match": {
+      "search": { "input": "q=caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "search": "q=caf%c3%a9" }],
+    "inputs": [{ "search": "q=café" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "hash": "caf%C3%A9" }],
+    "inputs": [{ "hash": "café" }],
+    "expected_match": {
+      "hash": { "input": "caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "hash": "café" }],
+    "inputs": [{ "hash": "café" }],
+    "expected_obj": {
+      "hash": "caf%C3%A9"
+    },
+    "expected_match": {
+      "hash": { "input": "caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "hash": "caf%c3%a9" }],
+    "inputs": [{ "hash": "café" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "about", "pathname": "(blank|sourcedoc)" }],
+    "inputs": [ "about:blank" ],
+    "expected_match": {
+      "protocol": { "input": "about", "groups": {}},
+      "pathname": { "input": "blank", "groups": { "0": "blank" }}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "data", "pathname": ":number([0-9]+)" }],
+    "inputs": [ "data:8675309" ],
+    "expected_match": {
+      "protocol": { "input": "data", "groups": {}},
+      "pathname": { "input": "8675309", "groups": { "number": "8675309" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/(\\m)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "pathname": "/foo!" }],
+    "inputs": [{ "pathname": "/foo!" }],
+    "expected_match": {
+      "pathname": { "input": "/foo!", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo\\:" }],
+    "inputs": [{ "pathname": "/foo:" }],
+    "expected_match": {
+      "pathname": { "input": "/foo:", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo\\{" }],
+    "inputs": [{ "pathname": "/foo{" }],
+    "expected_obj": {
+      "pathname": "/foo%7B"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo%7B", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo\\(" }],
+    "inputs": [{ "pathname": "/foo(" }],
+    "expected_match": {
+      "pathname": { "input": "/foo(", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "javascript", "pathname": "var x = 1;" }],
+    "inputs": [{ "protocol": "javascript", "pathname": "var x = 1;" }],
+    "expected_match": {
+      "protocol": { "input": "javascript", "groups": {}},
+      "pathname": { "input": "var x = 1;", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "var x = 1;" }],
+    "inputs": [{ "protocol": "javascript", "pathname": "var x = 1;" }],
+    "expected_obj": {
+      "pathname": "var%20x%20=%201;"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "javascript", "pathname": "var x = 1;" }],
+    "inputs": [{ "baseURL": "javascript:var x = 1;" }],
+    "expected_match": {
+      "protocol": { "input": "javascript", "groups": {}},
+      "pathname": { "input": "var x = 1;", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "(data|javascript)", "pathname": "var x = 1;" }],
+    "inputs": [{ "protocol": "javascript", "pathname": "var x = 1;" }],
+    "expected_match": {
+      "protocol": { "input": "javascript", "groups": {"0": "javascript"}},
+      "pathname": { "input": "var x = 1;", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "(https|javascript)", "pathname": "var x = 1;" }],
+    "inputs": [{ "protocol": "javascript", "pathname": "var x = 1;" }],
+    "expected_obj": {
+      "pathname": "var%20x%20=%201;"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "var x = 1;" }],
+    "inputs": [{ "pathname": "var x = 1;" }],
+    "expected_obj": {
+      "pathname": "var%20x%20=%201;"
+    },
+    "expected_match": {
+      "pathname": { "input": "var%20x%20=%201;", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [ "./foo/bar", "https://example.com" ],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" } },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": { "0": "https" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [ { "pathname": "/foo/bar" }, "https://example.com" ],
+    "expected_match": "error"
+  },
+  {
+    "pattern": [ "https://example.com:8080/foo?bar#baz" ],
+    "inputs": [{ "pathname": "/foo", "search": "bar", "hash": "baz",
+                 "baseURL": "https://example.com:8080" }],
+    "expected_obj": {
+      "protocol": "https",
+      "username": "*",
+      "password": "*",
+      "hostname": "example.com",
+      "port": "8080",
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "port": { "input": "8080", "groups": {} },
+      "pathname": { "input": "/foo", "groups": {} },
+      "search": { "input": "bar", "groups": {} },
+      "hash": { "input": "baz", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "/foo?bar#baz", "https://example.com:8080" ],
+    "inputs": [{ "pathname": "/foo", "search": "bar", "hash": "baz",
+                 "baseURL": "https://example.com:8080" }],
+    "expected_obj": {
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "port": { "input": "8080", "groups": {} },
+      "pathname": { "input": "/foo", "groups": {} },
+      "search": { "input": "bar", "groups": {} },
+      "hash": { "input": "baz", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "/foo" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "example.com/foo" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "http{s}?://{*.}?example.com/:product/:endpoint" ],
+    "inputs": [ "https://sub.example.com/foo/bar" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "http{s}?",
+      "hostname": "{*.}?example.com",
+      "pathname": "/:product/:endpoint"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "sub.example.com", "groups": { "0": "sub" } },
+      "pathname": { "input": "/foo/bar", "groups": { "product": "foo",
+                                                     "endpoint": "bar" } }
+    }
+  },
+  {
+    "pattern": [ "https://example.com?foo" ],
+    "inputs": [ "https://example.com/?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/",
+      "search": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com#foo" ],
+    "inputs": [ "https://example.com/#foo" ],
+    "exactly_empty_components": [ "port", "search" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/",
+      "hash": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "hash": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com:8080?foo" ],
+    "inputs": [ "https://example.com:8080/?foo" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "port": "8080",
+      "pathname": "/",
+      "search": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "port": { "input": "8080", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com:8080#foo" ],
+    "inputs": [ "https://example.com:8080/#foo" ],
+    "exactly_empty_components": [ "search" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "port": "8080",
+      "pathname": "/",
+      "hash": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "port": { "input": "8080", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "hash": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com/?foo" ],
+    "inputs": [ "https://example.com/?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/",
+      "search": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com/#foo" ],
+    "inputs": [ "https://example.com/#foo" ],
+    "exactly_empty_components": [ "port", "search" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/",
+      "hash": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "hash": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com/*?foo" ],
+    "inputs": [ "https://example.com/?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/*?foo"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "https://example.com/*\\?foo" ],
+    "inputs": [ "https://example.com/?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/*",
+      "search": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "" } },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com/:name?foo" ],
+    "inputs": [ "https://example.com/bar?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/:name?foo"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "https://example.com/:name\\?foo" ],
+    "inputs": [ "https://example.com/bar?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/:name",
+      "search": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/bar", "groups": { "name": "bar" } },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com/(bar)?foo" ],
+    "inputs": [ "https://example.com/bar?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/(bar)?foo"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "https://example.com/(bar)\\?foo" ],
+    "inputs": [ "https://example.com/bar?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/(bar)",
+      "search": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/bar", "groups": { "0": "bar" } },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com/{bar}?foo" ],
+    "inputs": [ "https://example.com/bar?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/{bar}?foo"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "https://example.com/{bar}\\?foo" ],
+    "inputs": [ "https://example.com/bar?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/bar",
+      "search": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/bar", "groups": {} },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com/" ],
+    "inputs": [ "https://example.com:8080/" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "port": "",
+      "pathname": "/"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "data:foobar" ],
+    "inputs": [ "data:foobar" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "data\\:foobar" ],
+    "inputs": [ "data:foobar" ],
+    "exactly_empty_components": [ "hostname", "port" ],
+    "expected_obj": {
+      "protocol": "data",
+      "pathname": "foobar"
+    },
+    "expected_match": {
+      "protocol": { "input": "data", "groups": {} },
+      "pathname": { "input": "foobar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://{sub.}?example.com/foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "{sub.}?example.com",
+      "pathname": "/foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://{sub.}?example{.com/}foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "{sub.}?example.com",
+      "pathname": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo", "groups": { "0": "/foo" } }
+    }
+  },
+  {
+    "pattern": [ "{https://}example.com/foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "https://(sub.)?example.com/foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "(sub.)?example.com",
+      "pathname": "/foo"
+    },
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": { "0": null } },
+      "pathname": { "input": "/foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://(sub.)?example(.com/)foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "(sub.)?example(.com/)foo",
+      "pathname": "*"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "(https://)example.com/foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "https://{sub{.}}example.com/foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "https://(sub(?:.))?example.com/foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "(sub(?:.))?example.com",
+      "pathname": "/foo"
+    },
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": { "0": null } },
+      "pathname": { "input": "/foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "file:///foo/bar" ],
+    "inputs": [ "file:///foo/bar" ],
+    "exactly_empty_components": [ "hostname", "port" ],
+    "expected_obj": {
+      "protocol": "file",
+      "pathname": "/foo/bar"
+    },
+    "expected_match": {
+      "protocol": { "input": "file", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "data:" ],
+    "inputs": [ "data:" ],
+    "exactly_empty_components": [ "hostname", "port", "pathname" ],
+    "expected_obj": {
+      "protocol": "data"
+    },
+    "expected_match": {
+      "protocol": { "input": "data", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "foo://bar" ],
+    "inputs": [ "foo://bad_url_browser_interop" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "foo",
+      "hostname": "bar"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "(café)://foo" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "https://example.com/foo?bar#baz" ],
+    "inputs": [{ "protocol": "https:",
+                 "search": "?bar",
+                 "hash": "#baz",
+                 "baseURL": "http://example.com/foo" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "http{s}?:",
+                  "search": "?bar",
+                  "hash": "#baz" }],
+    "inputs": [ "http://example.com/foo?bar#baz" ],
+    "expected_obj": {
+      "protocol": "http{s}?",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" }},
+      "pathname": { "input": "/foo", "groups": { "0": "/foo" }},
+      "search": { "input": "bar", "groups": {} },
+      "hash": { "input": "baz", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "?bar#baz", "https://example.com/foo" ],
+    "inputs": [ "?bar#baz", "https://example.com/foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo", "groups": {} },
+      "search": { "input": "bar", "groups": {} },
+      "hash": { "input": "baz", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "?bar", "https://example.com/foo#baz" ],
+    "inputs": [ "?bar", "https://example.com/foo#snafu" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo", "groups": {} },
+      "search": { "input": "bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "#baz", "https://example.com/foo?bar" ],
+    "inputs": [ "#baz", "https://example.com/foo?bar" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo", "groups": {} },
+      "search": { "input": "bar", "groups": {} },
+      "hash": { "input": "baz", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "#baz", "https://example.com/foo" ],
+    "inputs": [ "#baz", "https://example.com/foo" ],
+    "exactly_empty_components": [ "port", "search" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/foo",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo", "groups": {} },
+      "hash": { "input": "baz", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "*" }],
+    "inputs": [ "foo", "data:data-urls-cannot-be-base-urls" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "*" }],
+    "inputs": [ "foo", "not|a|valid|url" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [ "https://foo\\:bar@example.com" ],
+    "inputs": [ "https://foo:bar@example.com" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "username": "foo",
+      "password": "bar",
+      "hostname": "example.com",
+      "pathname": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "username": { "input": "foo", "groups": {} },
+      "password": { "input": "bar", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": [ "https://foo@example.com" ],
+    "inputs": [ "https://foo@example.com" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "username": "foo",
+      "hostname": "example.com",
+      "pathname": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "username": { "input": "foo", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": [ "https://\\:bar@example.com" ],
+    "inputs": [ "https://:bar@example.com" ],
+    "exactly_empty_components": [ "username", "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "password": "bar",
+      "hostname": "example.com",
+      "pathname": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "password": { "input": "bar", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": [ "https://:user::pass@example.com" ],
+    "inputs": [ "https://foo:bar@example.com" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "username": ":user",
+      "password": ":pass",
+      "hostname": "example.com",
+      "pathname": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "username": { "input": "foo", "groups": { "user": "foo" } },
+      "password": { "input": "bar", "groups": { "pass": "bar" } },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": [ "https\\:foo\\:bar@example.com" ],
+    "inputs": [ "https:foo:bar@example.com" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "username": "foo",
+      "password": "bar",
+      "hostname": "example.com",
+      "pathname": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "username": { "input": "foo", "groups": {} },
+      "password": { "input": "bar", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": [ "data\\:foo\\:bar@example.com" ],
+    "inputs": [ "data:foo:bar@example.com" ],
+    "exactly_empty_components": [ "hostname", "port" ],
+    "expected_obj": {
+      "protocol": "data",
+      "pathname": "foo\\:bar@example.com"
+    },
+    "expected_match": {
+      "protocol": { "input": "data", "groups": {} },
+      "pathname": { "input": "foo:bar@example.com", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://foo{\\:}bar@example.com" ],
+    "inputs": [ "https://foo:bar@example.com" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "username": "foo%3Abar",
+      "hostname": "example.com"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "data{\\:}channel.html", "https://example.com" ],
+    "inputs": [ "https://example.com/data:channel.html" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/data\\:channel.html",
+      "search": "*",
+      "hash": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/data:channel.html", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "http://[\\:\\:1]/" ],
+    "inputs": [ "http://[::1]/" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "[\\:\\:1]",
+      "pathname": "/"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "[::1]", "groups": {} },
+      "pathname": { "input": "/", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "http://[\\:\\:1]:8080/" ],
+    "inputs": [ "http://[::1]:8080/" ],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "[\\:\\:1]",
+      "port": "8080",
+      "pathname": "/"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "[::1]", "groups": {} },
+      "port": { "input": "8080", "groups": {} },
+      "pathname": { "input": "/", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "http://[\\:\\:a]/" ],
+    "inputs": [ "http://[::a]/" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "[\\:\\:a]",
+      "pathname": "/"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "[::a]", "groups": {} },
+      "pathname": { "input": "/", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "http://[:address]/" ],
+    "inputs": [ "http://[::1]/" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "[:address]",
+      "pathname": "/"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "[::1]", "groups": { "address": "::1" }},
+      "pathname": { "input": "/", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "http://[\\:\\:AB\\::num]/" ],
+    "inputs": [ "http://[::ab:1]/" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "[\\:\\:ab\\::num]",
+      "pathname": "/"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "[::ab:1]", "groups": { "num": "1" }},
+      "pathname": { "input": "/", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "hostname": "[\\:\\:AB\\::num]" }],
+    "inputs": [{ "hostname": "[::ab:1]" }],
+    "expected_obj": {
+      "hostname": "[\\:\\:ab\\::num]"
+    },
+    "expected_match": {
+      "hostname": { "input": "[::ab:1]", "groups": { "num": "1" }}
+    }
+  },
+  {
+    "pattern": [{ "hostname": "[\\:\\:xY\\::num]" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "{[\\:\\:ab\\::num]}" }],
+    "inputs": [{ "hostname": "[::ab:1]" }],
+    "expected_match": {
+      "hostname": { "input": "[::ab:1]", "groups": { "num": "1" }}
+    }
+  },
+  {
+    "pattern": [{ "hostname": "{[\\:\\:fé\\::num]}" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "{[\\:\\::num\\:1]}" }],
+    "inputs": [{ "hostname": "[::ab:1]" }],
+    "expected_match": {
+      "hostname": { "input": "[::ab:1]", "groups": { "num": "ab" }}
+    }
+  },
+  {
+    "pattern": [{ "hostname": "{[\\:\\::num\\:fé]}" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "[*\\:1]" }],
+    "inputs": [{ "hostname": "[::ab:1]" }],
+    "expected_match": {
+      "hostname": { "input": "[::ab:1]", "groups": { "0": "::ab" }}
+    }
+  },
+  {
+    "pattern": [{ "hostname": "*\\:1]" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "https://foo{{@}}example.com" ],
+    "inputs": [ "https://foo@example.com" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "https://foo{@example.com" ],
+    "inputs": [ "https://foo@example.com" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "data\\:text/javascript,let x = 100/:tens?5;" ],
+    "inputs": [ "data:text/javascript,let x = 100/5;" ],
+    "exactly_empty_components": [ "hostname", "port" ],
+    "expected_obj": {
+      "protocol": "data",
+      "pathname": "text/javascript,let x = 100/:tens?5;"
+    },
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "protocol": { "input": "data", "groups": {} },
+      "pathname": { "input": "text/javascript,let x = 100/5;", "groups": { "tens": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/:id/:id" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "pathname": "/foo", "baseURL": "" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "/foo", "" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "pathname": "/foo" }, "https://example.com" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "pathname": ":name*" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "name": "foobar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":name+" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "name": "foobar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":name" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "name": "foobar" }}
+    }
+  },
+  {
+    "pattern": [{ "protocol": ":name*" }],
+    "inputs": [{ "protocol": "foobar" }],
+    "expected_match": {
+      "protocol": { "input": "foobar", "groups": { "name": "foobar" }}
+    }
+  },
+  {
+    "pattern": [{ "protocol": ":name+" }],
+    "inputs": [{ "protocol": "foobar" }],
+    "expected_match": {
+      "protocol": { "input": "foobar", "groups": { "name": "foobar" }}
+    }
+  },
+  {
+    "pattern": [{ "protocol": ":name" }],
+    "inputs": [{ "protocol": "foobar" }],
+    "expected_match": {
+      "protocol": { "input": "foobar", "groups": { "name": "foobar" }}
+    }
+  },
+  {
+    "pattern": [{ "hostname": "bad hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad#hostname" }],
+    "inputs": [{ "hostname":  "bad" }],
+    "expected_obj": {
+      "hostname": "bad"
+    },
+    "expected_match": {
+      "hostname": { "input": "bad", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "hostname": "bad%hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad/hostname" }],
+    "inputs": [{ "hostname": "bad" }],
+    "expected_obj": {
+      "hostname": "bad"
+    },
+    "expected_match": {
+      "hostname": { "input": "bad", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "hostname": "bad\\:hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad<hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad>hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad?hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad@hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad[hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad]hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad\\\\hostname" }],
+    "inputs": [{ "hostname": "badhostname" }],
+    "expected_obj": {
+      "hostname": "bad"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "hostname": "bad^hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad|hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad\nhostname" }],
+    "inputs": [{ "hostname": "badhostname" }],
+    "expected_obj": {
+      "hostname": "badhostname"
+    },
+    "expected_match": {
+      "hostname": { "input": "badhostname", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "hostname": "bad\rhostname" }],
+    "inputs": [{ "hostname": "badhostname" }],
+    "expected_obj": {
+      "hostname": "badhostname"
+    },
+    "expected_match": {
+      "hostname": { "input": "badhostname", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "hostname": "bad\thostname" }],
+    "inputs": [{ "hostname": "badhostname" }],
+    "expected_obj": {
+      "hostname": "badhostname"
+    },
+    "expected_match": {
+      "hostname": { "input": "badhostname", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{}],
+    "inputs": ["https://example.com/"],
+    "expected_match": {
+      "protocol": { "input": "https", "groups": { "0": "https" }},
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" }},
+      "pathname": { "input": "/", "groups": { "0": "/" }}
+    }
+  },
+  {
+    "pattern": [],
+    "inputs": ["https://example.com/"],
+    "expected_match": {
+      "protocol": { "input": "https", "groups": { "0": "https" }},
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" }},
+      "pathname": { "input": "/", "groups": { "0": "/" }}
+    }
+  },
+  {
+    "pattern": [],
+    "inputs": [{}],
+    "expected_match": {}
+  },
+  {
+    "pattern": [],
+    "inputs": [],
+    "expected_match": { "inputs": [{}] }
+  },
+  {
+    "pattern": [{ "pathname": "(foo)(.*)" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "0": "foo", "1": "barbaz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{(foo)bar}(.*)" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "0": "foo", "1": "baz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "(foo)?(.*)" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_obj": {
+      "pathname": "(foo)?*"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "0": "foo", "1": "barbaz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}(.*)" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "foo": "f", "0": "oobarbaz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}(barbaz)" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "foo": "foo", "0": "barbaz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}{(.*)}" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_obj": {
+      "pathname": "{:foo}(.*)"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "foo": "f", "0": "oobarbaz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}{(.*)bar}" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_obj": {
+      "pathname": ":foo{*bar}"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}{bar(.*)}" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_obj": {
+      "pathname": ":foo{bar*}"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "foo": "foo", "0": "baz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}:bar(.*)" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_obj": {
+      "pathname": ":foo:bar(.*)"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "foo": "f", "bar": "oobarbaz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}?(.*)" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_obj": {
+      "pathname": ":foo?*"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "foo": "f", "0": "oobarbaz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo\\bar}" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "foo": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo\\.bar}" }],
+    "inputs": [{ "pathname": "foo.bar" }],
+    "expected_obj": {
+      "pathname": "{:foo.bar}"
+    },
+    "expected_match": {
+      "pathname": { "input": "foo.bar", "groups": { "foo": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo(foo)bar}" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "foo": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}bar" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "foo": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo\\bar" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_obj": {
+      "pathname": "{:foo}bar"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "foo": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo{}(.*)" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_obj": {
+      "pathname": "{:foo}(.*)"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "foo": "f", "0": "oobar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo{}bar" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_obj": {
+      "pathname": "{:foo}bar"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "foo": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo{}?bar" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_obj": {
+      "pathname": "{:foo}bar"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "foo": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "*{}**?" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_obj": {
+      "pathname": "*(.*)?"
+    },
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "0": "foobar", "1": null }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo(baz)(.*)" }],
+    "inputs": [{ "pathname": "bazbar" }],
+    "expected_match": {
+      "pathname": { "input": "bazbar", "groups": { "foo": "baz", "0": "bar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo(baz)bar" }],
+    "inputs": [{ "pathname": "bazbar" }],
+    "expected_match": {
+      "pathname": { "input": "bazbar", "groups": { "foo": "baz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "*/*" }],
+    "inputs": [{ "pathname": "foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "foo/bar", "groups": { "0": "foo", "1": "bar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "*\\/*" }],
+    "inputs": [{ "pathname": "foo/bar" }],
+    "expected_obj": {
+      "pathname": "*/{*}"
+    },
+    "expected_match": {
+      "pathname": { "input": "foo/bar", "groups": { "0": "foo", "1": "bar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "*/{*}" }],
+    "inputs": [{ "pathname": "foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "foo/bar", "groups": { "0": "foo", "1": "bar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "*//*" }],
+    "inputs": [{ "pathname": "foo/bar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/:foo." }],
+    "inputs": [{ "pathname": "/bar." }],
+    "expected_match": {
+      "pathname": { "input": "/bar.", "groups": { "foo": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/:foo.." }],
+    "inputs": [{ "pathname": "/bar.." }],
+    "expected_match": {
+      "pathname": { "input": "/bar..", "groups": { "foo": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "./foo" }],
+    "inputs": [{ "pathname": "./foo" }],
+    "expected_match": {
+      "pathname": { "input": "./foo", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "../foo" }],
+    "inputs": [{ "pathname": "../foo" }],
+    "expected_match": {
+      "pathname": { "input": "../foo", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo./" }],
+    "inputs": [{ "pathname": "bar./" }],
+    "expected_match": {
+      "pathname": { "input": "bar./", "groups": { "foo": "bar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo../" }],
+    "inputs": [{ "pathname": "bar../" }],
+    "expected_match": {
+      "pathname": { "input": "bar../", "groups": { "foo": "bar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/:foo\\bar" }],
+    "inputs": [{ "pathname": "/bazbar" }],
+    "expected_obj": {
+      "pathname": "{/:foo}bar"
+    },
+    "expected_match": {
+      "pathname": { "input": "/bazbar", "groups": { "foo": "baz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }, { "ignoreCase": true }],
+    "inputs": [{ "pathname": "/FOO/BAR" }],
+    "expected_match": {
+      "pathname": { "input": "/FOO/BAR", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "ignoreCase": true }],
+    "inputs": [{ "pathname": "/FOO/BAR" }],
+    "expected_match": {
+      "pathname": { "input": "/FOO/BAR", "groups": { "0": "/FOO/BAR" } }
+    }
+  },
+  {
+    "pattern": [ "https://example.com:8080/foo?bar#baz",
+                 { "ignoreCase": true }],
+    "inputs": [{ "pathname": "/FOO", "search": "BAR", "hash": "BAZ",
+                 "baseURL": "https://example.com:8080" }],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "port": "8080",
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "port": { "input": "8080", "groups": {} },
+      "pathname": { "input": "/FOO", "groups": {} },
+      "search": { "input": "BAR", "groups": {} },
+      "hash": { "input": "BAZ", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "/foo?bar#baz", "https://example.com:8080",
+                 { "ignoreCase": true }],
+    "inputs": [{ "pathname": "/FOO", "search": "BAR", "hash": "BAZ",
+                 "baseURL": "https://example.com:8080" }],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "port": "8080",
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "port": { "input": "8080", "groups": {} },
+      "pathname": { "input": "/FOO", "groups": {} },
+      "search": { "input": "BAR", "groups": {} },
+      "hash": { "input": "BAZ", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "/foo?bar#baz", { "ignoreCase": true },
+                 "https://example.com:8080" ],
+    "inputs": [{ "pathname": "/FOO", "search": "BAR", "hash": "BAZ",
+                 "baseURL": "https://example.com:8080" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "search": "foo", "baseURL": "https://example.com/a/+/b" }],
+    "inputs": [{ "search": "foo", "baseURL": "https://example.com/a/+/b" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/a/\\+/b"
+    },
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/a/+/b", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "hash": "foo", "baseURL": "https://example.com/?q=*&v=?&hmm={}&umm=()" }],
+    "inputs": [{ "hash": "foo", "baseURL": "https://example.com/?q=*&v=?&hmm={}&umm=()" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "search": "q=\\*&v=\\?&hmm=\\{\\}&umm=\\(\\)"
+    },
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "q=*&v=?&hmm={}&umm=()", "groups": {} },
+      "hash": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "#foo", "https://example.com/?q=*&v=?&hmm={}&umm=()" ],
+    "inputs": [ "https://example.com/?q=*&v=?&hmm={}&umm=()#foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "search": "q=\\*&v=\\?&hmm=\\{\\}&umm=\\(\\)",
+      "hash": "foo"
+    },
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "q=*&v=?&hmm={}&umm=()", "groups": {} },
+      "hash": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/([[a-z]--a])" }],
+    "inputs": [{ "pathname": "/a" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/([[a-z]--a])" }],
+    "inputs": [{ "pathname": "/z" }],
+    "expected_match": {
+      "pathname": { "input": "/z", "groups": { "0": "z" } }
+    }
+  },
+    {
+    "pattern": [{ "pathname": "/([\\d&&[0-1]])" }],
+    "inputs": [{ "pathname": "/0" }],
+    "expected_match": {
+      "pathname": { "input": "/0", "groups": { "0": "0" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/([\\d&&[0-1]])" }],
+    "inputs": [{ "pathname": "/3" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "http", "hostname": "example.com/ignoredpath" }],
+    "inputs": ["http://example.com/"],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "example.com",
+      "pathname": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": [{ "protocol": "http", "hostname": "example.com\\?ignoredsearch" }],
+    "inputs": ["http://example.com/"],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "example.com",
+      "search": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": [{ "protocol": "http", "hostname": "example.com#ignoredhash" }],
+    "inputs": ["http://example.com/"],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "example.com",
+      "hash": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": ["https://www.example.com/*"],
+    "inputs": ["https://www.example.com/x"],
+    "exactly_empty_components": ["port"],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "www.example.com",
+      "pathname": "/*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "www.example.com", "groups": {} },
+      "pathname": { "input": "/x", "groups": { "0": "x" } }
+    }
+  },
+  {
+    "pattern": ["https://www.example.com/*"],
+    "inputs": ["https://www.example.com/xyz"],
+    "exactly_empty_components": ["port"],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "www.example.com",
+      "pathname": "/*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "www.example.com", "groups": {} },
+      "pathname": { "input": "/xyz", "groups": { "0": "xyz" } }
+    }
+  },
+  {
+    "pattern": ["https://www.example.com/*"],
+    "inputs": ["https://www.example.com/example"],
+    "exactly_empty_components": ["port"],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "www.example.com",
+      "pathname": "/*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "www.example.com", "groups": {} },
+      "pathname": { "input": "/example", "groups": { "0": "example" } }
+    }
+  },
+  {
+    "pattern": ["https://www.example.com/*"],
+    "inputs": ["https://www.example.com/text"],
+    "exactly_empty_components": ["port"],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "www.example.com",
+      "pathname": "/*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "www.example.com", "groups": {} },
+      "pathname": { "input": "/text", "groups": { "0": "text" } }
+    }
+  },
+  {
+    "pattern": ["https://www.example.com/*"],
+    "inputs": ["https://www.example.com/path/with/x"],
+    "exactly_empty_components": ["port"],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "www.example.com",
+      "pathname": "/*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "www.example.com", "groups": {} },
+      "pathname": { "input": "/path/with/x", "groups": { "0": "path/with/x" } }
+    }
+  },
+  {
+    "pattern": [{ "hostname": ":domain(.*)" }],
+    "inputs": [{ "hostname": "localhost" }],
+    "expected_obj": {
+      "hostname": ":domain(.*)"
+    },
+    "expected_match": {
+      "hostname": { "input": "localhost", "groups": { "domain" : "localhost"} }
+    }
+  },
+  {
+    "pattern": ["((?R)):"],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": ["(\\H):"],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [
+      {"pathname": "/:foo((?<x>a))"}
+    ],
+    "inputs": [
+      {"pathname": "/a"}
+    ],
+    "expected_match": {
+      "pathname": {
+        "input": "/a",
+        "groups": {"foo": "a"}
+      }
+    }
+  },
+  {
+    "pattern": [
+      {"pathname": "/foo/(bar(?<x>baz))"}
+    ],
+    "inputs": [
+      {"pathname": "/foo/barbaz"}
+    ],
+    "expected_match": {
+      "pathname": {
+        "input": "/foo/barbaz",
+        "groups": {"0": "barbaz"}
+      }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/:𠀀" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "𠀀": "foo" } }
+    }
+  }
+]

--- a/Jint.Tests/Runtime/WebApi/UrlPatternCorpusTests.cs
+++ b/Jint.Tests/Runtime/WebApi/UrlPatternCorpusTests.cs
@@ -1,0 +1,324 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.IO;
+using System.Text;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// The Web Platform Tests <c>URLPattern</c> corpus, run through the JavaScript surface.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Unlike <see cref="UrlCorpusTests"/>, which drives the engine-free URL parser directly, these rows assert
+/// things only the <c>URLPattern</c> <i>object</i> has: the normalized pattern string each of its eight
+/// accessors returns, the truthiness of <c>test()</c>, and the exact shape of the <c>exec()</c> result down to
+/// which group names exist and which of them are <c>undefined</c>. So the driver is a port of WPT's own
+/// <c>urlpattern/resources/urlpatterntests.js</c>, written in JavaScript and run on one engine for the whole
+/// corpus — including its rule for deriving an expected pattern string when a row does not spell one out, which
+/// is where most of its coverage of the constructor-string shorthand lives.
+/// </para>
+/// <para>
+/// <b>The exclusion table is the whole point of the driver.</b> A row that does not pass has to be named in it
+/// with the divergence category it belongs to, and a row that <i>does</i> pass while named there fails the run
+/// as a stale exclusion — the same discipline the test262 harness and the URL corpus use, so a fix cannot
+/// silently leave a permanent exemption behind.
+/// </para>
+/// </remarks>
+public class UrlPatternCorpusTests
+{
+    /// <summary>
+    /// The divergence categories a failing row may be filed under. The enum is deliberately declared even while
+    /// the table below is empty: a row that starts failing after a corpus bump has to be classified, not merely
+    /// listed.
+    /// </summary>
+    private enum Divergence
+    {
+        /// <summary>
+        /// The outcome depends on the platform's Unicode tables — the IDNA mapping behind a hostname pattern, or
+        /// the general categories behind a group name's <c>ID_Start</c> / <c>ID_Continue</c> derivation.
+        /// </summary>
+        UnicodeVersion,
+
+        /// <summary>
+        /// The row exercises a corner of the "<c>v</c>"-flag regular expression grammar the engine's own
+        /// <c>RegExp</c> implementation does not reach.
+        /// </summary>
+        RegExpEngine,
+    }
+
+    /// <summary>
+    /// Rows that do not pass, keyed by the WPT test name — <c>Pattern: &lt;json&gt; Inputs: &lt;json&gt;</c>,
+    /// exactly as the upstream runner builds it.
+    /// </summary>
+    /// <remarks>
+    /// Empty, and meant to stay that way: every row of the corpus passes.
+    /// </remarks>
+    private static readonly Dictionary<string, Divergence> _exclusions = new(StringComparer.Ordinal);
+
+    [Fact]
+    public void MatchesEveryRowOfTheWebPlatformTestsCorpus()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Url));
+        engine.SetValue("__corpus", LoadCorpus());
+
+        var report = engine.Evaluate(Driver).AsObject();
+
+        var checkedRows = (int) report.Get("total").AsNumber();
+
+        // The corpus was actually run: a resource that silently stopped being embedded, or a driver that threw
+        // its rows away, would otherwise be an empty green test.
+        checkedRows.Should().BeGreaterThan(350);
+
+        var failures = new List<string>();
+        var failedNames = new HashSet<string>(StringComparer.Ordinal);
+        var reported = report.Get("failures").AsArray();
+
+        for (uint i = 0; i < reported.Length; i++)
+        {
+            var failure = reported[i].AsObject();
+            var name = failure.Get("name").AsString();
+            failedNames.Add(name);
+
+            if (!_exclusions.ContainsKey(name))
+            {
+                failures.Add(name + ": " + failure.Get("message").AsString());
+            }
+        }
+
+        var stale = new List<string>();
+        foreach (var excluded in _exclusions.Keys)
+        {
+            if (!failedNames.Contains(excluded))
+            {
+                stale.Add(excluded);
+            }
+        }
+
+        var message = new StringBuilder();
+
+        if (stale.Count > 0)
+        {
+            message.Append(stale.Count).AppendLine(" stale exclusion(s) — these rows pass and must be removed from the exclusion table:");
+            foreach (var row in stale)
+            {
+                message.Append("  ").AppendLine(row);
+            }
+        }
+
+        if (failures.Count > 0)
+        {
+            message.Append(failures.Count).AppendLine(" failing row(s):");
+            foreach (var row in failures)
+            {
+                message.Append("  ").AppendLine(row);
+            }
+        }
+
+        message.ToString().Should().BeEmpty();
+    }
+
+    private static string LoadCorpus()
+    {
+        var assembly = typeof(UrlPatternCorpusTests).Assembly;
+        var name = Array.Find(assembly.GetManifestResourceNames(), n => n.EndsWith("urlpatterntestdata.json", StringComparison.Ordinal));
+        name.Should().NotBeNull("the urlpatterntestdata.json corpus must be embedded");
+
+        using var stream = assembly.GetManifestResourceStream(name!)!;
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        return reader.ReadToEnd();
+    }
+
+    /// <summary>
+    /// A port of <c>urlpattern/resources/urlpatterntests.js</c> at the pinned commit. The assertions report into
+    /// a failure list instead of throwing, so one run reports every failing row rather than only the first, and
+    /// the test names it builds are the ones the exclusion table is keyed on.
+    /// </summary>
+    private const string Driver = """
+        (function () {
+          const kComponents = [
+            'protocol', 'username', 'password', 'hostname',
+            'port', 'pathname', 'search', 'hash',
+          ];
+
+          const data = JSON.parse(__corpus);
+          const failures = [];
+          let total = 0;
+
+          function describe(value) {
+            if (value === undefined) return 'undefined';
+            return JSON.stringify(value);
+          }
+
+          function threw(fn) {
+            try {
+              fn();
+              return null;
+            } catch (e) {
+              return e;
+            }
+          }
+
+          for (const entry of data) {
+            if (typeof entry !== 'object' || entry === null || !('pattern' in entry)) continue;
+
+            total++;
+            const name = `Pattern: ${JSON.stringify(entry.pattern)} Inputs: ${JSON.stringify(entry.inputs)}`;
+            const problems = [];
+
+            const check = (actual, expected, what) => {
+              if (!Object.is(actual, expected)) {
+                problems.push(`${what}: expected ${describe(expected)} but was ${describe(actual)}`);
+              }
+            };
+
+            const checkObject = (actual, expected, what) => {
+              if (actual === null || typeof actual !== 'object') {
+                problems.push(`${what}: expected an object but was ${describe(actual)}`);
+                return;
+              }
+              const actualKeys = Object.keys(actual).sort();
+              const expectedKeys = Object.keys(expected).sort();
+              check(actualKeys.join(','), expectedKeys.join(','), `${what} keys`);
+              for (const key of expectedKeys) {
+                const a = actual[key];
+                const e = expected[key];
+                if (e !== null && typeof e === 'object') {
+                  checkObject(a, e, `${what}.${key}`);
+                } else {
+                  check(a, e, `${what}.${key}`);
+                }
+              }
+            };
+
+            let pattern = null;
+            const constructionError = threw(() => { pattern = new URLPattern(...entry.pattern); });
+
+            if (entry.expected_obj === 'error') {
+              if (!(constructionError instanceof TypeError)) {
+                problems.push(`constructor: expected a TypeError but got ${describe(String(constructionError))}`);
+              }
+              if (problems.length > 0) failures.push({ name, message: problems.join('; ') });
+              continue;
+            }
+
+            if (constructionError !== null) {
+              failures.push({ name, message: `constructor threw ${String(constructionError)}` });
+              continue;
+            }
+
+            const expectedObj = entry.expected_obj || {};
+
+            for (const component of kComponents) {
+              let expected = expectedObj[component];
+
+              if (expected === undefined) {
+                let baseURL = null;
+                if (entry.pattern.length > 0 && entry.pattern[0].baseURL) {
+                  baseURL = new URL(entry.pattern[0].baseURL);
+                } else if (entry.pattern.length > 1 && typeof entry.pattern[1] === 'string') {
+                  baseURL = new URL(entry.pattern[1]);
+                }
+
+                const EARLIER_COMPONENTS = {
+                  protocol: [],
+                  hostname: ['protocol'],
+                  port: ['protocol', 'hostname'],
+                  username: [],
+                  password: [],
+                  pathname: ['protocol', 'hostname', 'port'],
+                  search: ['protocol', 'hostname', 'port', 'pathname'],
+                  hash: ['protocol', 'hostname', 'port', 'pathname', 'search'],
+                };
+
+                if (entry.exactly_empty_components && entry.exactly_empty_components.includes(component)) {
+                  expected = '';
+                } else if (typeof entry.pattern[0] === 'object' && entry.pattern[0][component]) {
+                  expected = entry.pattern[0][component];
+                } else if (typeof entry.pattern[0] === 'object' &&
+                           EARLIER_COMPONENTS[component].some(c => c in entry.pattern[0])) {
+                  expected = '*';
+                } else if (baseURL && component !== 'username' && component !== 'password') {
+                  let baseValue = baseURL[component];
+                  if (component === 'protocol') baseValue = baseValue.substring(0, baseValue.length - 1);
+                  else if (component === 'search' || component === 'hash') baseValue = baseValue.substring(1);
+                  expected = baseValue;
+                } else {
+                  expected = '*';
+                }
+              }
+
+              check(pattern[component], expected, `compiled pattern property '${component}'`);
+            }
+
+            if (entry.expected_match === 'error') {
+              const testError = threw(() => pattern.test(...entry.inputs));
+              if (!(testError instanceof TypeError)) {
+                problems.push(`test(): expected a TypeError but got ${describe(String(testError))}`);
+              }
+              const execError = threw(() => pattern.exec(...entry.inputs));
+              if (!(execError instanceof TypeError)) {
+                problems.push(`exec(): expected a TypeError but got ${describe(String(execError))}`);
+              }
+              if (problems.length > 0) failures.push({ name, message: problems.join('; ') });
+              continue;
+            }
+
+            check(pattern.test(...entry.inputs), !!entry.expected_match, 'test() result');
+
+            const execResult = pattern.exec(...entry.inputs);
+
+            if (!entry.expected_match || typeof entry.expected_match !== 'object') {
+              check(execResult, entry.expected_match, 'exec() failed match result');
+              if (problems.length > 0) failures.push({ name, message: problems.join('; ') });
+              continue;
+            }
+
+            if (execResult === null) {
+              failures.push({ name, message: 'exec() returned null but a match was expected' });
+              continue;
+            }
+
+            const expectedInputs = entry.expected_match.inputs || entry.inputs;
+            check(execResult.inputs.length, expectedInputs.length, 'exec() result.inputs.length');
+            for (let i = 0; i < execResult.inputs.length; ++i) {
+              const input = execResult.inputs[i];
+              const expectedInput = expectedInputs[i];
+              if (typeof input === 'string') {
+                check(input, expectedInput, `exec() result.inputs[${i}]`);
+                continue;
+              }
+              for (const component of kComponents) {
+                check(input[component], expectedInput[component], `exec() result.inputs[${i}][${component}]`);
+              }
+            }
+
+            for (const component of kComponents) {
+              let expectedComponent = entry.expected_match[component];
+
+              if (!expectedComponent) {
+                expectedComponent = { input: '', groups: {} };
+                if (!entry.exactly_empty_components || !entry.exactly_empty_components.includes(component)) {
+                  expectedComponent.groups['0'] = '';
+                }
+              }
+
+              // JSON cannot carry undefined, so the data file writes null where a group did not participate.
+              for (const key in expectedComponent.groups) {
+                if (expectedComponent.groups[key] === null) {
+                  expectedComponent.groups[key] = undefined;
+                }
+              }
+
+              checkObject(execResult[component], expectedComponent, `exec() result for ${component}`);
+            }
+
+            if (problems.length > 0) failures.push({ name, message: problems.join('; ') });
+          }
+
+          return { total, failures };
+        })();
+        """;
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/UrlPatternTests.cs
+++ b/Jint.Tests/Runtime/WebApi/UrlPatternTests.cs
@@ -1,0 +1,441 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.Text.RegularExpressions;
+using Jint.Runtime;
+using Jint.WebApi.Url.Pattern;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// The <c>URLPattern</c> class as the URL Pattern Standard specifies it —
+/// https://urlpattern.spec.whatwg.org/#urlpattern-class.
+/// </summary>
+/// <remarks>
+/// The pattern syntax, the constructor-string shorthand and the match results are covered exhaustively by
+/// <see cref="UrlPatternCorpusTests"/>, which runs the Web Platform Tests corpus through the same script surface.
+/// What is tested here is what no corpus row reaches: the WebIDL skin and its overload resolution, the property
+/// attributes, the brand checks, the shape of the object the two operations hand back, and the two properties
+/// that follow from building on the engine's own <c>RegExp</c> — that a patched <c>RegExp.prototype.exec</c>
+/// cannot be observed, and that a hostile author regexp ends in the engine's regex timeout rather than a hang.
+/// </remarks>
+public class UrlPatternTests
+{
+    private static Engine WebEngine() => new(options => options.UseWebApis(WebApiFeatures.Url));
+
+    [Fact]
+    public void IsInstalledOnlyWithTheUrlFeature()
+    {
+        new Engine().Evaluate("typeof URLPattern").AsString().Should().Be("undefined");
+        new Engine(options => options.UseWebApis(WebApiFeatures.Console))
+            .Evaluate("typeof URLPattern").AsString().Should().Be("undefined");
+
+        WebEngine().Evaluate("typeof URLPattern").AsString().Should().Be("function");
+
+        // It rides the URL flag rather than one of its own, so asking for URL is what brings it.
+        new Engine(options => options.UseWebApis()).Evaluate("typeof URLPattern").AsString().Should().Be("function");
+    }
+
+    [Fact]
+    public void IsAWebIdlInterfaceObject()
+    {
+        var engine = WebEngine();
+
+        var descriptor = engine.Evaluate("Object.getOwnPropertyDescriptor(globalThis, 'URLPattern')").AsObject();
+        descriptor.Get("writable").AsBoolean().Should().BeTrue();
+        descriptor.Get("configurable").AsBoolean().Should().BeTrue();
+        descriptor.Get("enumerable").AsBoolean().Should().BeFalse();
+
+        engine.Evaluate("URLPattern.name").AsString().Should().Be("URLPattern");
+
+        // The smallest number of required arguments across the two constructor overloads is zero.
+        engine.Evaluate("URLPattern.length").AsNumber().Should().Be(0);
+
+        engine.Evaluate("Object.getPrototypeOf(URLPattern) === Function.prototype").AsBoolean().Should().BeTrue();
+        engine.Evaluate("URLPattern.prototype[Symbol.toStringTag]").AsString().Should().Be("URLPattern");
+        engine.Evaluate("URLPattern.prototype.constructor === URLPattern").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.prototype.toString.call(new URLPattern({}))").AsString().Should().Be("[object URLPattern]");
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("URLPattern({})"))
+            .Error.ToString().Should().Contain("TypeError");
+    }
+
+    [Fact]
+    public void EveryAttributeIsAReadOnlyAccessorOnThePrototype()
+    {
+        var engine = WebEngine();
+
+        foreach (var name in new[] { "protocol", "username", "password", "hostname", "port", "pathname", "search", "hash", "hasRegExpGroups" })
+        {
+            var descriptor = engine.Evaluate($"Object.getOwnPropertyDescriptor(URLPattern.prototype, '{name}')").AsObject();
+
+            descriptor.Get("configurable").AsBoolean().Should().BeTrue($"{name} is a WebIDL attribute");
+            descriptor.Get("enumerable").AsBoolean().Should().BeTrue($"{name} is a WebIDL attribute");
+            descriptor.Get("set").IsUndefined().Should().BeTrue($"{name} is readonly");
+            descriptor.Get("get").IsUndefined().Should().BeFalse($"{name} is an accessor");
+        }
+
+        // An instance therefore has no own property of its own.
+        engine.Evaluate("Object.getOwnPropertyNames(new URLPattern({})).length").AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void ParsesTheStandardsIntroductoryConstructorString()
+    {
+        // https://urlpattern.spec.whatwg.org/#example-intro
+        var engine = WebEngine();
+        engine.Execute("const p = new URLPattern('https://example.com/:category/*');");
+
+        engine.Evaluate("p.protocol").AsString().Should().Be("https");
+        engine.Evaluate("p.username").AsString().Should().Be("*");
+        engine.Evaluate("p.password").AsString().Should().Be("*");
+        engine.Evaluate("p.hostname").AsString().Should().Be("example.com");
+        engine.Evaluate("p.port").AsString().Should().Be("");
+        engine.Evaluate("p.pathname").AsString().Should().Be("/:category/*");
+        engine.Evaluate("p.search").AsString().Should().Be("*");
+        engine.Evaluate("p.hash").AsString().Should().Be("*");
+
+        engine.Evaluate("p.test('https://example.com/products/')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("p.test('https://example.com/blog/our-greatest-product-ever')").AsBoolean().Should().BeTrue();
+
+        engine.Evaluate("p.test('https://example.com/')").AsBoolean().Should().BeFalse();
+        engine.Evaluate("p.test('http://example.com/products/')").AsBoolean().Should().BeFalse();
+        engine.Evaluate("p.test('https://example.com:8443/blog/our-greatest-product-ever')").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void ParsesTheStandardsModifierAndRegexpConstructorString()
+    {
+        // https://urlpattern.spec.whatwg.org/#example-intro-2
+        var engine = WebEngine();
+        engine.Execute("const p = new URLPattern('http{s}?://{:subdomain.}?shop.example/products/:id([0-9]+)#reviews');");
+
+        engine.Evaluate("p.protocol").AsString().Should().Be("http{s}?");
+        engine.Evaluate("p.hostname").AsString().Should().Be("{:subdomain.}?shop.example");
+        engine.Evaluate("p.pathname").AsString().Should().Be("/products/:id([0-9]+)");
+        engine.Evaluate("p.search").AsString().Should().Be("");
+        engine.Evaluate("p.hash").AsString().Should().Be("reviews");
+
+        engine.Evaluate("p.test('https://shop.example/products/74205#reviews')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("p.test('https://kathryn@voyager.shop.example/products/74656#reviews')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("p.test('http://insecure.shop.example/products/1701#reviews')").AsBoolean().Should().BeTrue();
+
+        engine.Evaluate("p.test('https://shop.example/products/2000')").AsBoolean().Should().BeFalse();
+        engine.Evaluate("p.test('http://shop.example:8080/products/0#reviews')").AsBoolean().Should().BeFalse();
+        engine.Evaluate("p.test('https://nx.shop.example/products/01?speed=5#reviews')").AsBoolean().Should().BeFalse();
+        engine.Evaluate("p.test('https://shop.example/products/chair#reviews')").AsBoolean().Should().BeFalse();
+
+        engine.Evaluate("p.exec('https://kathryn@voyager.shop.example/products/74656#reviews').hostname.groups.subdomain")
+            .AsString().Should().Be("voyager");
+    }
+
+    [Fact]
+    public void ResolvesARelativeConstructorStringAgainstItsBaseUrl()
+    {
+        // https://urlpattern.spec.whatwg.org/#example-intro-3
+        var engine = WebEngine();
+        engine.Execute("const p = new URLPattern('../admin/*', 'https://discussion.example/forum/?page=2');");
+
+        engine.Evaluate("p.protocol").AsString().Should().Be("https");
+        engine.Evaluate("p.hostname").AsString().Should().Be("discussion.example");
+        engine.Evaluate("p.port").AsString().Should().Be("");
+        engine.Evaluate("p.pathname").AsString().Should().Be("/admin/*");
+        engine.Evaluate("p.search").AsString().Should().Be("*");
+        engine.Evaluate("p.hash").AsString().Should().Be("*");
+
+        engine.Evaluate("p.test('https://discussion.example/admin/')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("p.test('https://edd:librarian@discussion.example/admin/update?id=1')").AsBoolean().Should().BeTrue();
+
+        engine.Evaluate("p.test('https://discussion.example/forum/admin/')").AsBoolean().Should().BeFalse();
+        engine.Evaluate("p.test('http://discussion.example:8080/admin/update?id=1')").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void ResolvesTheTwoArgumentOverloadByTheSecondArgumentsType()
+    {
+        var engine = WebEngine();
+
+        // An object at the distinguishing position selects the options overload, so this is not a base URL.
+        engine.Execute("const opts = new URLPattern({ pathname: '/FOO' }, { ignoreCase: true });");
+        engine.Evaluate("opts.test({ pathname: '/foo' })").AsBoolean().Should().BeTrue();
+
+        // undefined and null go the same way, because the overload with a dictionary at that position wins.
+        engine.Evaluate("new URLPattern({ pathname: '/foo' }, undefined).pathname").AsString().Should().Be("/foo");
+        engine.Evaluate("new URLPattern({ pathname: '/foo' }, null).pathname").AsString().Should().Be("/foo");
+
+        // Anything else is a USVString base URL.
+        engine.Evaluate("new URLPattern('/foo', 'https://example.com').hostname").AsString().Should().Be("example.com");
+
+        // A third argument forces the base URL overload whatever the second argument looks like.
+        Assert.Throws<JavaScriptException>(
+            () => engine.Evaluate("new URLPattern('/foo', { ignoreCase: true }, 'https://example.com')"));
+    }
+
+    [Fact]
+    public void IgnoreCaseReachesOnlyThePathnameSearchAndHash()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("new URLPattern({ pathname: '/FOO' }).test({ pathname: '/foo' })").AsBoolean().Should().BeFalse();
+        engine.Evaluate("new URLPattern({ pathname: '/FOO' }, { ignoreCase: true }).test({ pathname: '/foo' })").AsBoolean().Should().BeTrue();
+        engine.Evaluate("new URLPattern({ search: 'A=B' }, { ignoreCase: true }).test({ search: 'a=b' })").AsBoolean().Should().BeTrue();
+        engine.Evaluate("new URLPattern({ hash: 'FRAG' }, { ignoreCase: true }).test({ hash: 'frag' })").AsBoolean().Should().BeTrue();
+
+        // The credentials are not among the components the flag is threaded into: the specification builds the
+        // pathname, search and hash components from a copy of the options carrying ignore case, and leaves the
+        // protocol, username, password, hostname and port components on the plain default and hostname options.
+        engine.Evaluate("new URLPattern({ username: 'ABC' }, { ignoreCase: true }).test({ username: 'abc' })").AsBoolean().Should().BeFalse();
+        engine.Evaluate("new URLPattern({ password: 'ABC' }, { ignoreCase: true }).test({ password: 'abc' })").AsBoolean().Should().BeFalse();
+
+        // A non-object options argument is a TypeError; undefined and null give the member its default.
+        engine.Evaluate("new URLPattern({ pathname: '/FOO' }, { }).test({ pathname: '/foo' })").AsBoolean().Should().BeFalse();
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new URLPattern({ pathname: '/f' }, 1, 2)"));
+    }
+
+    [Fact]
+    public void HasRegExpGroupsReportsOnlyCustomRegularExpressions()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("new URLPattern({ pathname: '/foo' }).hasRegExpGroups").AsBoolean().Should().BeFalse();
+        engine.Evaluate("new URLPattern({ pathname: '/:id' }).hasRegExpGroups").AsBoolean().Should().BeFalse();
+        engine.Evaluate("new URLPattern({ pathname: '/*' }).hasRegExpGroups").AsBoolean().Should().BeFalse();
+        engine.Evaluate("new URLPattern({ pathname: '/:id([0-9]+)' }).hasRegExpGroups").AsBoolean().Should().BeTrue();
+
+        // Any component counts, not only the pathname.
+        engine.Evaluate("new URLPattern({ hostname: '(sub|www).example.com' }).hasRegExpGroups").AsBoolean().Should().BeTrue();
+
+        // A written-out regexp that is exactly the segment wildcard is folded back into a segment wildcard, so it
+        // is not a regexp group at all.
+        engine.Evaluate("new URLPattern({ pathname: '/:id([^\\\\/]+?)' }).hasRegExpGroups").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasRegExpGroupsAnswersForEveryComponent()
+    {
+        // A port of WPT's urlpattern/resources/urlpattern-hasregexpgroups-tests.js at the pinned commit, which is
+        // a separate file from the corpus and so is not covered by UrlPatternCorpusTests.
+        var engine = WebEngine();
+
+        var failures = engine.Evaluate(
+            """
+            (function () {
+              const problems = [];
+              const check = (actual, expected, what) => {
+                if (actual !== expected) problems.push(`${what}: expected ${expected} but was ${actual}`);
+              };
+
+              check('hasRegExpGroups' in URLPattern.prototype, true, 'hasRegExpGroups is implemented');
+              check(new URLPattern({}).hasRegExpGroups, false, 'match-everything pattern');
+
+              for (const c of ['protocol', 'username', 'password', 'hostname', 'port', 'pathname', 'search', 'hash']) {
+                check(new URLPattern({ [c]: '*' }).hasRegExpGroups, false, `wildcard in ${c}`);
+                check(new URLPattern({ [c]: ':foo' }).hasRegExpGroups, false, `segment wildcard in ${c}`);
+                check(new URLPattern({ [c]: ':foo?' }).hasRegExpGroups, false, `optional segment wildcard in ${c}`);
+                check(new URLPattern({ [c]: ':foo(hi)' }).hasRegExpGroups, true, `named regexp group in ${c}`);
+                check(new URLPattern({ [c]: '(hi)' }).hasRegExpGroups, true, `anonymous regexp group in ${c}`);
+
+                // The protocol and the port accept far less than the other six in any case.
+                if (c !== 'protocol' && c !== 'port') {
+                  check(new URLPattern({ [c]: 'a-{:hello}-z-*-a' }).hasRegExpGroups, false, `wildcards and fixed text in ${c}`);
+                  check(new URLPattern({ [c]: 'a-(hi)-z-(lo)-a' }).hasRegExpGroups, true, `regexp groups and fixed text in ${c}`);
+                }
+              }
+
+              check(new URLPattern({ pathname: '/a/:foo/:baz?/b/*' }).hasRegExpGroups, false, 'complex pathname with no regexp');
+              check(new URLPattern({ pathname: '/a/:foo/:baz([a-z]+)?/b/*' }).hasRegExpGroups, true, 'complex pathname with regexp');
+
+              return problems.join('; ');
+            })();
+            """).AsString();
+
+        failures.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ExecReturnsTheDictionaryTheStandardDeclares()
+    {
+        var engine = WebEngine();
+        engine.Execute("const p = new URLPattern({ pathname: '/blog/:year(\\\\d+)/:slug' });");
+        engine.Execute("const r = p.exec({ pathname: '/blog/2012/hello' });");
+
+        // URLPatternResult's members, in declaration order.
+        engine.Evaluate("Object.keys(r).join(',')").AsString()
+            .Should().Be("inputs,protocol,username,password,hostname,port,pathname,search,hash");
+
+        // URLPatternComponentResult's members, in declaration order.
+        engine.Evaluate("Object.keys(r.pathname).join(',')").AsString().Should().Be("input,groups");
+
+        engine.Evaluate("r.pathname.input").AsString().Should().Be("/blog/2012/hello");
+        engine.Evaluate("r.pathname.groups.year").AsString().Should().Be("2012");
+        engine.Evaluate("r.pathname.groups.slug").AsString().Should().Be("hello");
+        engine.Evaluate("Object.keys(r.pathname.groups).join(',')").AsString().Should().Be("year,slug");
+
+        // The groups record is an ordinary object, not a null-prototype one.
+        engine.Evaluate("Object.getPrototypeOf(r.pathname.groups) === Object.prototype").AsBoolean().Should().BeTrue();
+
+        // inputs echoes what was passed in, as a fresh dictionary carrying only the members that were present.
+        engine.Evaluate("Array.isArray(r.inputs)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("r.inputs.length").AsNumber().Should().Be(1);
+        engine.Evaluate("Object.keys(r.inputs[0]).join(',')").AsString().Should().Be("pathname");
+
+        // A string input with a base URL puts both in the list.
+        engine.Execute("const r2 = new URLPattern({ pathname: '/a' }).exec('/a', 'https://example.com');");
+        engine.Evaluate("r2.inputs.join('|')").AsString().Should().Be("/a|https://example.com");
+
+        // A group that did not participate is present and undefined.
+        engine.Execute("const r3 = new URLPattern({ pathname: '/a{/:b}?' }).exec({ pathname: '/a' });");
+        engine.Evaluate("'b' in r3.pathname.groups").AsBoolean().Should().BeTrue();
+        engine.Evaluate("r3.pathname.groups.b === undefined").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void TestIsExecReducedToABoolean()
+    {
+        var engine = WebEngine();
+        engine.Execute("const p = new URLPattern({ pathname: '/foo' });");
+
+        engine.Evaluate("p.test({ pathname: '/foo' })").AsBoolean().Should().BeTrue();
+        engine.Evaluate("p.test({ pathname: '/bar' })").AsBoolean().Should().BeFalse();
+        engine.Evaluate("p.exec({ pathname: '/bar' })").IsNull().Should().BeTrue();
+
+        // An input that is not a URL at all is a non-match, not an error.
+        engine.Evaluate("p.exec('not a url')").IsNull().Should().BeTrue();
+        engine.Evaluate("p.test('not a url')").AsBoolean().Should().BeFalse();
+
+        // Both default their input to an empty dictionary.
+        engine.Evaluate("new URLPattern({}).test()").AsBoolean().Should().BeTrue();
+        engine.Evaluate("new URLPattern({ pathname: '/foo' }).test()").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void RejectsThePatternsTheStandardRejects()
+    {
+        var engine = WebEngine();
+
+        // A constructor string that is relative and has no base URL.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new URLPattern('/foo')"));
+
+        // A dictionary input cannot also take a base URL argument.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new URLPattern({ pathname: '/foo' }, 'https://example.com')"));
+
+        // Two groups cannot share a name.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new URLPattern({ pathname: '/:id/:id' })"));
+
+        // A grouping has to be closed, and a regexp group cannot be empty or contain a capturing group.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new URLPattern({ pathname: '/{foo' })"));
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new URLPattern({ pathname: '/()' })"));
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new URLPattern({ pathname: '/((a))' })"));
+
+        // A regexp group whose source is not a valid regular expression.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new URLPattern({ pathname: '/(a[)' })"));
+
+        // ... and an exec whose input dictionary does not canonicalize is a non-match rather than a throw.
+        engine.Evaluate("new URLPattern({}).exec({ port: 'invalid80' })").IsNull().Should().BeTrue();
+    }
+
+    [Fact]
+    public void MembersBrandCheckTheirReceiver()
+    {
+        var engine = WebEngine();
+
+        foreach (var expression in new[]
+                 {
+                     "Object.getOwnPropertyDescriptor(URLPattern.prototype, 'pathname').get.call({})",
+                     "Object.getOwnPropertyDescriptor(URLPattern.prototype, 'hasRegExpGroups').get.call({})",
+                     "URLPattern.prototype.test.call({}, {})",
+                     "URLPattern.prototype.exec.call({}, {})",
+                 })
+        {
+            Assert.Throws<JavaScriptException>(() => engine.Evaluate(expression))
+                .Error.ToString().Should().Contain("TypeError");
+        }
+
+        // URLPattern.prototype itself is not a URLPattern.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("URLPattern.prototype.pathname"));
+    }
+
+    [Fact]
+    public void SubclassingUsesTheNewTargetsPrototype()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("class MyPattern extends URLPattern { }");
+        engine.Execute("const p = new MyPattern({ pathname: '/foo' });");
+
+        engine.Evaluate("p instanceof MyPattern").AsBoolean().Should().BeTrue();
+        engine.Evaluate("p instanceof URLPattern").AsBoolean().Should().BeTrue();
+        engine.Evaluate("p.pathname").AsString().Should().Be("/foo");
+    }
+
+    [Fact]
+    public void IsAbsentFromAShadowRealm()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("new ShadowRealm().evaluate('typeof URLPattern')").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof URLPattern").AsString().Should().Be("function");
+    }
+
+    [Fact]
+    public void MatchingIsUnaffectedByAPatchedRegExpPrototypeExec()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("const p = new URLPattern({ pathname: '/:id' });");
+        engine.Execute("RegExp.prototype.exec = function () { throw new Error('exec was called'); };");
+
+        // The specification runs RegExpBuiltinExec, not RegExpExec, so nothing here reaches the replacement.
+        engine.Evaluate("p.test({ pathname: '/42' })").AsBoolean().Should().BeTrue();
+        engine.Evaluate("p.exec({ pathname: '/42' }).pathname.groups.id").AsString().Should().Be("42");
+    }
+
+    [Fact]
+    public void ComponentRegularExpressionsAreBuiltByTheEnginesOwnRegExpMachinery()
+    {
+        // A structural pin on the claim the timeout test below rests on: each component's regular expression is a
+        // real JsRegExp of this realm carrying the flags the standard names, so it is matched by the same code —
+        // and under the same Options.Constraints.RegexTimeout — as any RegExp a script builds.
+        var engine = WebEngine();
+
+        var pattern = (JsUrlPattern) engine.Evaluate("new URLPattern({ pathname: '/:id' }, { ignoreCase: true })").AsObject();
+
+        pattern.Pattern.Pathname.RegularExpression.Flags.Should().Be("vi");
+        pattern.Pattern.Search.RegularExpression.Flags.Should().Be("vi");
+        pattern.Pattern.Hash.RegularExpression.Flags.Should().Be("vi");
+
+        // ... and only those three: the other five are compiled from the plain default or hostname options.
+        pattern.Pattern.Protocol.RegularExpression.Flags.Should().Be("v");
+        pattern.Pattern.Username.RegularExpression.Flags.Should().Be("v");
+        pattern.Pattern.Password.RegularExpression.Flags.Should().Be("v");
+        pattern.Pattern.Hostname.RegularExpression.Flags.Should().Be("v");
+        pattern.Pattern.Port.RegularExpression.Flags.Should().Be("v");
+
+        pattern.Pattern.Pathname.RegularExpression.Engine.Should().BeSameAs(engine);
+
+        // The "v" flag takes every one of them onto the engine's own regexp interpreter, which is the path that
+        // enforces the deadline; a .NET Regex would enforce Regex.MatchTimeout instead, and either way the source
+        // of the timeout is the engine's configured constraint.
+        pattern.Pattern.Pathname.RegularExpression.UsesDotNetEngine.Should().BeFalse();
+    }
+
+    [Fact]
+    public void AHostileRegExpGroupEndsInTheEnginesRegexTimeout()
+    {
+        // The pattern below backtracks exponentially: the group has to partition a run of "a"s that can never be
+        // followed by the "!" the anchored expression demands. The assertion is that the attempt is bounded, not
+        // that it is fast — no machine finishes 2^40 backtracking steps, so nothing here can flake on timing.
+        var engine = new Engine(options => options
+            .UseWebApis(WebApiFeatures.Url)
+            .RegexTimeoutInterval(TimeSpan.FromMilliseconds(50)));
+
+        engine.Execute("const p = new URLPattern({ pathname: '/:x((?:a+)+)' });");
+        engine.SetValue("hostileInput", "/" + new string('a', 40) + "!");
+
+        var timeout = Assert.Throws<RegexMatchTimeoutException>(() => engine.Evaluate("p.test({ pathname: hostileInput })"));
+
+        // The deadline is the engine's own regex constraint, not a constant of this feature's own.
+        timeout.MatchTimeout.Should().Be(TimeSpan.FromMilliseconds(50));
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/UrlTests.cs
+++ b/Jint.Tests/Runtime/WebApi/UrlTests.cs
@@ -317,12 +317,11 @@ public class UrlTests
     }
 
     [Fact]
-    public void HasNeitherUrlPatternNorTheBlobUrlStore()
+    public void HasNoBlobUrlStore()
     {
         var engine = WebEngine();
 
         // Absent, not present and throwing: feature detection has to be able to see they are missing.
-        engine.Evaluate("typeof URLPattern").AsString().Should().Be("undefined");
         engine.Evaluate("typeof URL.createObjectURL").AsString().Should().Be("undefined");
         engine.Evaluate("typeof URL.revokeObjectURL").AsString().Should().Be("undefined");
     }

--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -1346,7 +1346,13 @@ internal sealed partial class RegExpPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-regexpbuiltinexec
     /// </summary>
-    private static JsValue RegExpBuiltinExec(JsRegExp R, string s)
+    /// <remarks>
+    /// Internal rather than private because the specification of a host API can name it directly:
+    /// <c>URLPattern</c>'s match algorithm runs <c>RegExpBuiltinExec</c> on each component's regular expression,
+    /// deliberately not <c>RegExpExec</c>, so a script that replaced <c>RegExp.prototype.exec</c> cannot observe
+    /// or alter a <c>URLPattern</c> match.
+    /// </remarks>
+    internal static JsValue RegExpBuiltinExec(JsRegExp R, string s)
     {
         var length = (ulong) s.Length;
         var lastIndex = TypeConverter.ToLength(R.Get(JsRegExp.PropertyLastIndex));

--- a/Jint/Runtime/Intrinsics.WebApi.cs
+++ b/Jint/Runtime/Intrinsics.WebApi.cs
@@ -22,6 +22,7 @@ using Jint.WebApi.Storage;
 using Jint.WebApi.Streams;
 using Jint.WebApi.Timers;
 using Jint.WebApi.Url;
+using Jint.WebApi.Url.Pattern;
 using Jint.WebApi.WebSockets;
 
 namespace Jint.Runtime;
@@ -48,6 +49,7 @@ public sealed partial class Intrinsics
     private StructuredCloneFunction? _structuredClone;
     private UrlConstructor? _webApiUrl;
     private UrlSearchParamsConstructor? _webApiUrlSearchParams;
+    private UrlPatternConstructor? _webApiUrlPattern;
     private CryptoInstance? _crypto;
     private SubtleCryptoInstance? _subtleCrypto;
     private CryptoKeyConstructor? _cryptoKey;
@@ -106,6 +108,9 @@ public sealed partial class Intrinsics
 
     internal UrlSearchParamsConstructor WebApiUrlSearchParams =>
         _webApiUrlSearchParams ??= new UrlSearchParamsConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
+
+    internal UrlPatternConstructor WebApiUrlPattern =>
+        _webApiUrlPattern ??= new UrlPatternConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
 
     private EventConstructor? _event;
     private CustomEventConstructor? _customEvent;

--- a/Jint/WebApi/Url/Parsing/UrlParser.cs
+++ b/Jint/WebApi/Url/Parsing/UrlParser.cs
@@ -677,11 +677,19 @@ internal ref struct UrlParser : IDisposable
 
                 _url.Port = port == UrlRecord.DefaultPort(_url.Scheme) ? null : port;
                 _buffer.Length = 0;
-            }
 
-            if (_stateOverride is not null)
+                if (_stateOverride is not null)
+                {
+                    return StepResult.Return;
+                }
+            }
+            else if (_stateOverride is not null)
             {
-                return StepResult.Return;
+                // A state-override run that reached here with nothing buffered was handed something that is not
+                // a port at all — "abc", or the empty string. The spec's "return failure" is inside this branch
+                // and the success "return" is inside the one above, which the URL port setter cannot tell apart
+                // because it discards the result either way; URLPattern's canonicalize a port does not.
+                return StepResult.Failure;
             }
 
             _state = UrlParserState.PathStart;

--- a/Jint/WebApi/Url/Pattern/JsUrlPattern.cs
+++ b/Jint/WebApi/Url/Pattern/JsUrlPattern.cs
@@ -1,0 +1,29 @@
+#if NET8_0_OR_GREATER
+using Jint.Native.Object;
+
+namespace Jint.WebApi.Url.Pattern;
+
+/// <summary>
+/// A <c>URLPattern</c> instance.
+/// <para>
+/// https://urlpattern.spec.whatwg.org/#urlpattern-class
+/// </para>
+/// </summary>
+/// <remarks>
+/// The object's only associated value is its
+/// <a href="https://urlpattern.spec.whatwg.org/#urlpattern-associated-url-pattern">associated URL pattern</a>, and
+/// every member is an accessor or method on <see cref="UrlPatternPrototype"/> that brand-checks its receiver — so
+/// an instance has no own property at all, which is what a browser reports for
+/// <c>Object.getOwnPropertyNames(new URLPattern("https://example.com/*"))</c>.
+/// </remarks>
+internal sealed class JsUrlPattern : ObjectInstance
+{
+    internal JsUrlPattern(Engine engine, UrlPatternRecord pattern) : base(engine, ObjectClass.Object)
+    {
+        Pattern = pattern;
+    }
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#urlpattern-associated-url-pattern</summary>
+    internal UrlPatternRecord Pattern { get; }
+}
+#endif

--- a/Jint/WebApi/Url/Pattern/UrlPatternCanonicalization.cs
+++ b/Jint/WebApi/Url/Pattern/UrlPatternCanonicalization.cs
@@ -1,0 +1,219 @@
+#if NET8_0_OR_GREATER
+using System.Text;
+using Jint.Runtime;
+using Jint.WebApi.Url.Parsing;
+
+namespace Jint.WebApi.Url.Pattern;
+
+/// <summary>
+/// The encoding callbacks of https://urlpattern.spec.whatwg.org/#canon-encoding-callbacks — one per URL
+/// component, each canonicalizing a piece of fixed text the way the URL parser would canonicalize that component.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every one of them is defined in terms of the URL Standard's own parser, run over a throwaway
+/// "<c>https://dummy.invalid/</c>" record, so this is a thin skin over <see cref="UrlParser"/> and
+/// <see cref="UrlSetters"/> rather than a second canonicalizer. Applying them only to the <i>fixed text</i> of a
+/// pattern is the whole point: "<c>:name</c>", "<c>*</c>" and "<c>(regexp)</c>" must survive verbatim, which is
+/// why the constructor string parser cannot simply run the URL parser over the input.
+/// </para>
+/// <para>
+/// A failure here is a <c>TypeError</c> from the <c>URLPattern</c> constructor. Where the spec runs the parser
+/// without checking for failure — the pathname, search and hash callbacks — so does this, because those three
+/// states cannot fail.
+/// </para>
+/// </remarks>
+internal static class UrlPatternCanonicalization
+{
+    /// <summary>https://urlpattern.spec.whatwg.org/#url-pattern-create-a-dummy-url</summary>
+    private static UrlRecord CreateDummyUrl() => UrlParser.Parse("https://dummy.invalid/")!;
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#canonicalize-a-protocol</summary>
+    internal static string CanonicalizeProtocol(Realm realm, string value)
+    {
+        if (value.Length == 0)
+        {
+            return value;
+        }
+
+        // A state override is deliberately not used: its extra restrictions belong to the URL protocol setter,
+        // not to a scheme being canonicalized on its own.
+        var parseResult = UrlParser.Parse(value + "://dummy.invalid/");
+        if (parseResult is null)
+        {
+            Throw.TypeError(realm, $"Invalid URLPattern protocol: {value}");
+        }
+
+        return parseResult.Scheme;
+    }
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#canonicalize-a-username</summary>
+    internal static string CanonicalizeUsername(Realm realm, string value)
+    {
+        if (value.Length == 0)
+        {
+            return value;
+        }
+
+        var dummyUrl = CreateDummyUrl();
+        UrlSetters.SetUsername(dummyUrl, value);
+        return dummyUrl.Username;
+    }
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#canonicalize-a-password</summary>
+    internal static string CanonicalizePassword(Realm realm, string value)
+    {
+        if (value.Length == 0)
+        {
+            return value;
+        }
+
+        var dummyUrl = CreateDummyUrl();
+        UrlSetters.SetPassword(dummyUrl, value);
+        return dummyUrl.Password;
+    }
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#canonicalize-a-hostname</summary>
+    internal static string CanonicalizeHostname(Realm realm, string value)
+    {
+        if (value.Length == 0)
+        {
+            return value;
+        }
+
+        var dummyUrl = CreateDummyUrl();
+        if (!UrlParser.ParseInto(value, dummyUrl, UrlParserState.Hostname))
+        {
+            Throw.TypeError(realm, $"Invalid URLPattern hostname: {value}");
+        }
+
+        return dummyUrl.SerializeHost();
+    }
+
+    /// <summary>
+    /// https://urlpattern.spec.whatwg.org/#canonicalize-an-ipv6-hostname — an IPv6 literal is lowercased and
+    /// otherwise left alone, because the host parser would collapse a pattern such as "<c>[::*]</c>" that is not
+    /// a valid address in the first place.
+    /// </summary>
+    internal static string CanonicalizeIpv6Hostname(Realm realm, string value)
+    {
+        var result = new ValueStringBuilder(stackalloc char[48]);
+        try
+        {
+            foreach (var c in value)
+            {
+                if (!UrlCharacters.IsAsciiHexDigit(c) && c != '[' && c != ']' && c != ':')
+                {
+                    Throw.TypeError(realm, $"Invalid URLPattern IPv6 hostname: {value}");
+                }
+
+                result.Append(c is >= 'A' and <= 'Z' ? (char) (c | 0x20) : c);
+            }
+
+            return result.AsSpan().ToString();
+        }
+        finally
+        {
+            result.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// https://urlpattern.spec.whatwg.org/#canonicalize-a-port, in the form the pattern parser uses it as an
+    /// encoding callback — with no protocol to normalize a default port against.
+    /// </summary>
+    internal static string CanonicalizePort(Realm realm, string value) => CanonicalizePort(realm, value, protocolValue: null);
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#canonicalize-a-port</summary>
+    internal static string CanonicalizePort(Realm realm, string portValue, string? protocolValue)
+    {
+        if (portValue.Length == 0)
+        {
+            return portValue;
+        }
+
+        var dummyUrl = CreateDummyUrl();
+
+        // The scheme is set so that the port state recognizes a default port and drops it.
+        dummyUrl.Scheme = protocolValue ?? string.Empty;
+        dummyUrl.Port = null;
+
+        if (!UrlParser.ParseInto(portValue, dummyUrl, UrlParserState.Port))
+        {
+            Throw.TypeError(realm, $"Invalid URLPattern port: {portValue}");
+        }
+
+        return dummyUrl.SerializePort();
+    }
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#canonicalize-a-pathname</summary>
+    internal static string CanonicalizePathname(Realm realm, string value)
+    {
+        if (value.Length == 0)
+        {
+            return value;
+        }
+
+        // The URL parser prepends a leading slash to a path, which is wrong here because this runs on pieces of a
+        // pathname rather than on a whole one. Supplying "/-" disables the prepending; the "-" keeps a leading dot
+        // in the value from being read as the "/." single-dot segment. Both are cut off again below.
+        var leadingSlash = value[0] == '/';
+        var modifiedValue = leadingSlash ? value : "/-" + value;
+
+        var dummyUrl = CreateDummyUrl();
+        dummyUrl.Path.Clear();
+        UrlParser.ParseInto(modifiedValue, dummyUrl, UrlParserState.PathStart);
+
+        var result = dummyUrl.SerializePath();
+        return leadingSlash ? result : result.Substring(2);
+    }
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#canonicalize-an-opaque-pathname</summary>
+    internal static string CanonicalizeOpaquePathname(Realm realm, string value)
+    {
+        if (value.Length == 0)
+        {
+            return value;
+        }
+
+        var dummyUrl = CreateDummyUrl();
+        dummyUrl.Path.Clear();
+        dummyUrl.OpaquePath = string.Empty;
+
+        if (!UrlParser.ParseInto(value, dummyUrl, UrlParserState.OpaquePath))
+        {
+            Throw.TypeError(realm, $"Invalid URLPattern pathname: {value}");
+        }
+
+        return dummyUrl.SerializePath();
+    }
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#canonicalize-a-search</summary>
+    internal static string CanonicalizeSearch(Realm realm, string value)
+    {
+        if (value.Length == 0)
+        {
+            return value;
+        }
+
+        var dummyUrl = CreateDummyUrl();
+        dummyUrl.Query = string.Empty;
+        UrlParser.ParseInto(value, dummyUrl, UrlParserState.Query);
+        return dummyUrl.Query ?? string.Empty;
+    }
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#canonicalize-a-hash</summary>
+    internal static string CanonicalizeHash(Realm realm, string value)
+    {
+        if (value.Length == 0)
+        {
+            return value;
+        }
+
+        var dummyUrl = CreateDummyUrl();
+        dummyUrl.Fragment = string.Empty;
+        UrlParser.ParseInto(value, dummyUrl, UrlParserState.Fragment);
+        return dummyUrl.Fragment ?? string.Empty;
+    }
+}
+#endif

--- a/Jint/WebApi/Url/Pattern/UrlPatternComponent.cs
+++ b/Jint/WebApi/Url/Pattern/UrlPatternComponent.cs
@@ -1,0 +1,166 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Native.RegExp;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Url.Pattern;
+
+/// <summary>
+/// https://urlpattern.spec.whatwg.org/#component — one compiled URL component of a pattern: its normalized
+/// pattern string, the regular expression that matches it, and the names of that expression's capture groups.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The regular expression is a real JavaScript <c>RegExp</c> built through the engine's own
+/// <c>RegExpCreate</c> with the "<c>v</c>" flag the specification names, and matching goes through
+/// <c>RegExpBuiltinExec</c>. That is not incidental: a "<c>(regexp)</c>" group holds arbitrary JavaScript
+/// regular expression source, which only the engine's own regexp machinery can be trusted to read. It also means
+/// a component inherits that machinery's guards unchanged — in particular <c>Options.Constraints.RegexTimeout</c>,
+/// so a pattern written to backtrack catastrophically ends in the same <c>RegexMatchTimeoutException</c> a
+/// hostile <c>RegExp</c> literal would, rather than hanging the host.
+/// </para>
+/// <para>
+/// The specification notes that using regular expressions for matching is not mandated and that an implementation
+/// may match a part list directly. This one does not: correctness for author-supplied regexp groups is worth more
+/// here than avoiding the <c>RegExp</c> object, and the "<c>v</c>" flag's semantics — code-point-wise
+/// <c>[^/]</c>, a "<c>.</c>" that excludes every line terminator — are exactly what the engine already implements
+/// and a hand-rolled matcher would have to reproduce.
+/// </para>
+/// </remarks>
+internal sealed class UrlPatternComponent
+{
+    /// <summary>https://url.spec.whatwg.org/#special-scheme</summary>
+    private static readonly string[] _specialSchemes = ["ftp", "file", "http", "https", "ws", "wss"];
+
+    private UrlPatternComponent(string patternString, JsRegExp regularExpression, string[] groupNameList, bool hasRegexpGroups)
+    {
+        PatternString = patternString;
+        RegularExpression = regularExpression;
+        GroupNameList = groupNameList;
+        HasRegexpGroups = hasRegexpGroups;
+    }
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#component-pattern-string</summary>
+    internal string PatternString { get; }
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#component-regular-expression</summary>
+    internal JsRegExp RegularExpression { get; }
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#component-group-name-list</summary>
+    internal string[] GroupNameList { get; }
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#component-has-regexp-groups</summary>
+    internal bool HasRegexpGroups { get; }
+
+    /// <summary>
+    /// https://urlpattern.spec.whatwg.org/#compile-a-component
+    /// </summary>
+    internal static UrlPatternComponent Compile(
+        Engine engine,
+        string input,
+        UrlPatternEncodingCallback encodingCallback,
+        UrlPatternCompileOptions options)
+    {
+        var realm = engine.Realm;
+        var partList = UrlPatternStringParser.Parse(realm, input, options, encodingCallback);
+        var (source, nameList) = UrlPatternGenerator.GenerateRegularExpressionAndNameList(partList, options);
+
+        // An author-supplied "(regexp)" group is compiled here rather than lazily, so that an invalid one is a
+        // TypeError from the constructor instead of a surprise on a later match.
+        JsRegExp regularExpression;
+        try
+        {
+            regularExpression = realm.Intrinsics.RegExp.RegExpCreate(JsString.Create(source), options.IgnoreCase ? "vi" : "v");
+        }
+        catch (JavaScriptException)
+        {
+            Throw.TypeError(realm, $"Invalid regular expression in URLPattern component: {input}");
+            return null!;
+        }
+
+        var hasRegexpGroups = false;
+        foreach (var part in partList)
+        {
+            if (part.Type == UrlPatternPartType.Regexp)
+            {
+                hasRegexpGroups = true;
+                break;
+            }
+        }
+
+        return new UrlPatternComponent(
+            UrlPatternGenerator.GeneratePatternString(partList, options),
+            regularExpression,
+            nameList,
+            hasRegexpGroups);
+    }
+
+    /// <summary>
+    /// <c>RegExpBuiltinExec</c> against this component's regular expression, which is what
+    /// https://urlpattern.spec.whatwg.org/#url-pattern-match runs for every component. The built-in is called
+    /// directly rather than through <c>RegExpExec</c>, so a script that replaced
+    /// <c>RegExp.prototype.exec</c> cannot observe or alter a <c>URLPattern</c> match.
+    /// </summary>
+    internal JsValue Exec(string input) => RegExpPrototype.RegExpBuiltinExec(RegularExpression, input);
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#protocol-component-matches-a-special-scheme</summary>
+    internal bool MatchesSpecialScheme()
+    {
+        foreach (var scheme in _specialSchemes)
+        {
+            if (!Exec(scheme).IsNull())
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// https://urlpattern.spec.whatwg.org/#create-a-component-match-result — the
+    /// <c>URLPatternComponentResult</c> for one component: the string that was matched, and a record from group
+    /// name to the value that group captured, <see langword="undefined"/> where it did not participate.
+    /// </summary>
+    internal ObjectInstance CreateComponentMatchResult(Engine engine, string input, JsValue execResult)
+    {
+        var groups = ObjectInstance.OrdinaryObjectCreate(engine, engine.Realm.Intrinsics.Object.PrototypeObject);
+        var match = (ObjectInstance) execResult;
+
+        for (var index = 1; index <= GroupNameList.Length; index++)
+        {
+            groups.CreateDataPropertyOrThrow(JsString.Create(GroupNameList[index - 1]), match.Get(JsString.Create(index)));
+        }
+
+        return JsObject.Create(engine, UrlPatternResultLayouts.ComponentResult, [JsString.Create(input), groups]);
+    }
+}
+
+/// <summary>
+/// The two WebIDL dictionaries a match produces. Declaring them as layouts means every result object in an engine
+/// shares one hidden class, so a caller reading <c>.pathname.groups</c> off many results keeps a monomorphic
+/// inline cache.
+/// </summary>
+internal static class UrlPatternResultLayouts
+{
+    /// <summary>https://urlpattern.spec.whatwg.org/#dictdef-urlpatterncomponentresult</summary>
+    internal static readonly JsObjectLayout ComponentResult = JsObjectLayout.CreateBuilder()
+        .Add("input")
+        .Add("groups")
+        .Build();
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#dictdef-urlpatternresult</summary>
+    internal static readonly JsObjectLayout Result = JsObjectLayout.CreateBuilder()
+        .Add("inputs")
+        .Add("protocol")
+        .Add("username")
+        .Add("password")
+        .Add("hostname")
+        .Add("port")
+        .Add("pathname")
+        .Add("search")
+        .Add("hash")
+        .Build();
+}
+#endif

--- a/Jint/WebApi/Url/Pattern/UrlPatternConstructor.cs
+++ b/Jint/WebApi/Url/Pattern/UrlPatternConstructor.cs
@@ -1,0 +1,149 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Url.Pattern;
+
+/// <summary>
+/// The <c>URLPattern</c> interface object.
+/// <para>
+/// https://urlpattern.spec.whatwg.org/#urlpattern-class
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// The interface declares two constructors —
+/// <c>(URLPatternInput input, USVString baseURL, optional URLPatternOptions options)</c> and
+/// <c>(optional URLPatternInput input, optional URLPatternOptions options)</c> — which
+/// <a href="https://webidl.spec.whatwg.org/#es-overloads">WebIDL overload resolution</a> tells apart by the second
+/// argument alone: <see langword="undefined"/>, <see langword="null"/> or any object selects the options
+/// overload, anything else is a base URL string. The interface object's <c>length</c> is 0 because that is the
+/// smallest number of required arguments across the two.
+/// </para>
+/// <para>
+/// The interface object's <c>length</c> notwithstanding, a pattern built from a plain string is not the same as
+/// one built from a <c>URLPatternInit</c>: the string form is a whole-URL shorthand parsed by
+/// <see cref="UrlPatternConstructorString"/>, and it refuses to be relative unless it is given a base URL.
+/// </para>
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class UrlPatternConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("URLPattern");
+
+    internal UrlPatternConstructor(
+        Engine engine,
+        Realm realm,
+        FunctionPrototype functionPrototype,
+        ObjectPrototype objectPrototype)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = functionPrototype;
+        PrototypeObject = new UrlPatternPrototype(engine, realm, this, objectPrototype);
+        _length = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal UrlPatternPrototype PrototypeObject { get; }
+
+    protected override void Initialize() => CreateProperties_Generated();
+
+    /// <summary>
+    /// https://urlpattern.spec.whatwg.org/#dom-urlpattern-urlpattern-input-baseurl-options and its sibling
+    /// overload, both of which are the single step "run initialize".
+    /// </summary>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        // Overload resolution inspects the second argument's type before anything is converted, so this decision
+        // comes first and the conversions below then run left to right as WebIDL requires.
+        var takesBaseUrl = arguments.Length switch
+        {
+            0 or 1 => false,
+            2 => !(arguments[1].IsUndefined() || arguments[1].IsNull() || arguments[1].IsObject()),
+            _ => true,
+        };
+
+        var input = ReadInput(arguments.At(0));
+        var baseUrl = takesBaseUrl ? UrlValues.ToUsvString(arguments[1]) : null;
+        var ignoreCase = ReadIgnoreCase(_realm, takesBaseUrl ? arguments.At(2) : arguments.At(1));
+
+        var pattern = UrlPatternRecord.Create(_engine, input.StringInput, input.Init, baseUrl, ignoreCase);
+
+        return OrdinaryCreateFromConstructor(
+            newTarget,
+            static intrinsics => intrinsics.WebApiUrlPattern.PrototypeObject,
+            static (Engine engine, Realm _, UrlPatternRecord? state) => new JsUrlPattern(engine, state!),
+            pattern);
+    }
+
+    /// <summary>
+    /// The <c>URLPatternInput</c> union, https://urlpattern.spec.whatwg.org/#typedefdef-urlpatterninput: an object
+    /// — and <see langword="null"/> or <see langword="undefined"/>, which the union sends to the dictionary — is a
+    /// <c>URLPatternInit</c>, and anything else is a <c>USVString</c>.
+    /// </summary>
+    internal static (string? StringInput, UrlPatternInit? Init) ReadInput(JsValue input)
+    {
+        if (input.IsUndefined() || input.IsNull() || input.IsObject())
+        {
+            return (null, ReadInit(input));
+        }
+
+        return (UrlValues.ToUsvString(input), null);
+    }
+
+    /// <summary>
+    /// https://urlpattern.spec.whatwg.org/#dictdef-urlpatterninit read per
+    /// https://webidl.spec.whatwg.org/#es-dictionary: the members are read in declaration order, and a member
+    /// whose value is <see langword="undefined"/> — including one that is simply absent — does not exist.
+    /// </summary>
+    private static UrlPatternInit ReadInit(JsValue value)
+    {
+        var init = new UrlPatternInit();
+        if (value is not ObjectInstance dictionary)
+        {
+            return init;
+        }
+
+        init.Protocol = ReadMember(dictionary, UrlPatternProperties.Protocol);
+        init.Username = ReadMember(dictionary, UrlPatternProperties.Username);
+        init.Password = ReadMember(dictionary, UrlPatternProperties.Password);
+        init.Hostname = ReadMember(dictionary, UrlPatternProperties.Hostname);
+        init.Port = ReadMember(dictionary, UrlPatternProperties.Port);
+        init.Pathname = ReadMember(dictionary, UrlPatternProperties.Pathname);
+        init.Search = ReadMember(dictionary, UrlPatternProperties.Search);
+        init.Hash = ReadMember(dictionary, UrlPatternProperties.Hash);
+        init.BaseUrl = ReadMember(dictionary, UrlPatternProperties.BaseUrl);
+        return init;
+    }
+
+    private static string? ReadMember(ObjectInstance dictionary, JsString name)
+    {
+        var value = dictionary.Get(name);
+        return value.IsUndefined() ? null : UrlValues.ToUsvString(value);
+    }
+
+    /// <summary>
+    /// https://urlpattern.spec.whatwg.org/#dictdef-urlpatternoptions — one member, defaulting to false, so a
+    /// pattern is case-sensitive unless it is told otherwise.
+    /// </summary>
+    private static bool ReadIgnoreCase(Realm realm, JsValue options)
+    {
+        if (options.IsUndefined() || options.IsNull())
+        {
+            return false;
+        }
+
+        if (options is not ObjectInstance dictionary)
+        {
+            Throw.TypeError(realm, "Failed to construct 'URLPattern': the provided value is not of type 'URLPatternOptions'.");
+            return false;
+        }
+
+        var value = dictionary.Get(UrlPatternProperties.IgnoreCase);
+        return !value.IsUndefined() && TypeConverter.ToBoolean(value);
+    }
+}
+#endif

--- a/Jint/WebApi/Url/Pattern/UrlPatternConstructorString.cs
+++ b/Jint/WebApi/Url/Pattern/UrlPatternConstructorString.cs
@@ -1,0 +1,465 @@
+#if NET8_0_OR_GREATER
+using Jint.Runtime;
+
+namespace Jint.WebApi.Url.Pattern;
+
+/// <summary>
+/// The constructor string parser of https://urlpattern.spec.whatwg.org/#constructor-string-parsing — splits a
+/// URL-shaped pattern such as "<c>https://*.example.com/:page?</c>" into per-component pattern strings.
+/// </summary>
+/// <remarks>
+/// <para>
+/// It resembles the basic URL parser and deliberately is not one. It runs over <see cref="UrlPatternToken"/>s
+/// produced with the lenient policy rather than over code points, so a "<c>:hmm</c>" name cannot be mistaken for
+/// a port; it applies no canonicalization, because which code points are fixed text is not known until each
+/// component is compiled; and it handles no backslash escaping or file-URL host quirks, since a pattern that
+/// needs those is better written as a <c>URLPatternInit</c>.
+/// </para>
+/// <para>
+/// Two shorthands fall out of it. Components after the last one written are wildcards — "<c>https://example.com</c>"
+/// matches any path, search and hash on that origin — while a hostname written without a port pins the port to
+/// the scheme's default, so matching any port takes an explicit "<c>:*</c>".
+/// </para>
+/// </remarks>
+internal static class UrlPatternConstructorString
+{
+    /// <summary>https://urlpattern.spec.whatwg.org/#constructor-string-parser</summary>
+    private enum ParserState
+    {
+        Init,
+        Protocol,
+        Authority,
+        Username,
+        Password,
+        Hostname,
+        Port,
+        Pathname,
+        Search,
+        Hash,
+        Done,
+    }
+
+    /// <summary>
+    /// https://urlpattern.spec.whatwg.org/#parse-a-constructor-string
+    /// </summary>
+    internal static UrlPatternInit Parse(Engine engine, string input)
+    {
+        var parser = new ConstructorStringParser(engine, input);
+        parser.Run();
+        return parser.Result;
+    }
+
+    private sealed class ConstructorStringParser(Engine engine, string input)
+    {
+        private readonly Engine _engine = engine;
+        private readonly string _input = input;
+        private readonly List<UrlPatternToken> _tokenList = UrlPatternTokenizer.Tokenize(engine.Realm, input, strict: false);
+        private ParserState _state = ParserState.Init;
+        private int _componentStart;
+        private int _tokenIndex;
+        private int _tokenIncrement = 1;
+        private int _groupDepth;
+        private int _hostnameIpv6BracketDepth;
+        private bool _protocolMatchesSpecialScheme;
+
+        internal UrlPatternInit Result { get; } = new();
+
+        internal void Run()
+        {
+            while (_tokenIndex < _tokenList.Count)
+            {
+                _tokenIncrement = 1;
+
+                if (_tokenList[_tokenIndex].Type == UrlPatternTokenType.End)
+                {
+                    if (_state == ParserState.Init)
+                    {
+                        // No protocol terminator was found, so this is a relative pattern; where it begins is
+                        // decided by whether it starts with a hash or a search prefix.
+                        Rewind();
+
+                        if (IsHashPrefix())
+                        {
+                            ChangeState(ParserState.Hash, 1);
+                        }
+                        else if (IsSearchPrefix())
+                        {
+                            ChangeState(ParserState.Search, 1);
+                        }
+                        else
+                        {
+                            ChangeState(ParserState.Pathname, 0);
+                        }
+
+                        _tokenIndex += _tokenIncrement;
+                        continue;
+                    }
+
+                    if (_state == ParserState.Authority)
+                    {
+                        // No "@" was found, so there is no username or password after all.
+                        RewindAndSetState(ParserState.Hostname);
+                        _tokenIndex += _tokenIncrement;
+                        continue;
+                    }
+
+                    ChangeState(ParserState.Done, 0);
+                    break;
+                }
+
+                if (_tokenList[_tokenIndex].Type == UrlPatternTokenType.Open)
+                {
+                    // Everything inside "{ ... }" is one grouping, so a component boundary cannot lie within it.
+                    _groupDepth++;
+                    _tokenIndex += _tokenIncrement;
+                    continue;
+                }
+
+                if (_groupDepth > 0)
+                {
+                    if (_tokenList[_tokenIndex].Type == UrlPatternTokenType.Close)
+                    {
+                        _groupDepth--;
+                    }
+                    else
+                    {
+                        _tokenIndex += _tokenIncrement;
+                        continue;
+                    }
+                }
+
+                Step();
+                _tokenIndex += _tokenIncrement;
+            }
+
+            if (Result.Hostname is not null && Result.Port is null)
+            {
+                // An author who named a host and no port meant the default port; "any port" is written ":*".
+                Result.Port = string.Empty;
+            }
+        }
+
+        private void Step()
+        {
+            switch (_state)
+            {
+                case ParserState.Init:
+                    if (IsProtocolSuffix())
+                    {
+                        RewindAndSetState(ParserState.Protocol);
+                    }
+
+                    break;
+
+                case ParserState.Protocol:
+                    if (IsProtocolSuffix())
+                    {
+                        // The protocol has to be compiled here and now: whether it matches a special scheme
+                        // decides both the default pathname and whether an authority is looked for at all.
+                        ComputeProtocolMatchesSpecialScheme();
+
+                        var nextState = ParserState.Pathname;
+                        var skip = 1;
+
+                        if (NextIsAuthoritySlashes())
+                        {
+                            nextState = ParserState.Authority;
+                            skip = 3;
+                        }
+                        else if (_protocolMatchesSpecialScheme)
+                        {
+                            nextState = ParserState.Authority;
+                        }
+
+                        ChangeState(nextState, skip);
+                    }
+
+                    break;
+
+                case ParserState.Authority:
+                    if (IsIdentityTerminator())
+                    {
+                        RewindAndSetState(ParserState.Username);
+                    }
+                    else if (IsPathnameStart() || IsSearchPrefix() || IsHashPrefix())
+                    {
+                        RewindAndSetState(ParserState.Hostname);
+                    }
+
+                    break;
+
+                case ParserState.Username:
+                    if (IsPasswordPrefix())
+                    {
+                        ChangeState(ParserState.Password, 1);
+                    }
+                    else if (IsIdentityTerminator())
+                    {
+                        ChangeState(ParserState.Hostname, 1);
+                    }
+
+                    break;
+
+                case ParserState.Password:
+                    if (IsIdentityTerminator())
+                    {
+                        ChangeState(ParserState.Hostname, 1);
+                    }
+
+                    break;
+
+                case ParserState.Hostname:
+                    if (IsIpv6Open())
+                    {
+                        _hostnameIpv6BracketDepth++;
+                    }
+                    else if (IsIpv6Close())
+                    {
+                        _hostnameIpv6BracketDepth--;
+                    }
+                    else if (IsPortPrefix() && _hostnameIpv6BracketDepth == 0)
+                    {
+                        ChangeState(ParserState.Port, 1);
+                    }
+                    else if (IsPathnameStart())
+                    {
+                        ChangeState(ParserState.Pathname, 0);
+                    }
+                    else if (IsSearchPrefix())
+                    {
+                        ChangeState(ParserState.Search, 1);
+                    }
+                    else if (IsHashPrefix())
+                    {
+                        ChangeState(ParserState.Hash, 1);
+                    }
+
+                    break;
+
+                case ParserState.Port:
+                    if (IsPathnameStart())
+                    {
+                        ChangeState(ParserState.Pathname, 0);
+                    }
+                    else if (IsSearchPrefix())
+                    {
+                        ChangeState(ParserState.Search, 1);
+                    }
+                    else if (IsHashPrefix())
+                    {
+                        ChangeState(ParserState.Hash, 1);
+                    }
+
+                    break;
+
+                case ParserState.Pathname:
+                    if (IsSearchPrefix())
+                    {
+                        ChangeState(ParserState.Search, 1);
+                    }
+                    else if (IsHashPrefix())
+                    {
+                        ChangeState(ParserState.Hash, 1);
+                    }
+
+                    break;
+
+                case ParserState.Search:
+                    if (IsHashPrefix())
+                    {
+                        ChangeState(ParserState.Hash, 1);
+                    }
+
+                    break;
+
+                default:
+                    // The hash state consumes everything that is left, and the done state is never stepped.
+                    break;
+            }
+        }
+
+        /// <summary>https://urlpattern.spec.whatwg.org/#change-state</summary>
+        private void ChangeState(ParserState newState, int skip)
+        {
+            if (_state is not (ParserState.Init or ParserState.Authority or ParserState.Done))
+            {
+                SetResult(_state, MakeComponentString());
+            }
+
+            if (_state != ParserState.Init && newState != ParserState.Done)
+            {
+                // Leaving the authority behind without having written a hostname means there was none; the same
+                // reasoning gives an empty pathname and search to a pattern that stops before reaching them, which
+                // is what makes "https://example.com/foo" match any search and any hash but only that path.
+                if (_state is ParserState.Protocol or ParserState.Authority or ParserState.Username or ParserState.Password
+                    && newState is ParserState.Port or ParserState.Pathname or ParserState.Search or ParserState.Hash
+                    && Result.Hostname is null)
+                {
+                    Result.Hostname = string.Empty;
+                }
+
+                if (_state is ParserState.Protocol or ParserState.Authority or ParserState.Username or ParserState.Password
+                        or ParserState.Hostname or ParserState.Port
+                    && newState is ParserState.Search or ParserState.Hash
+                    && Result.Pathname is null)
+                {
+                    Result.Pathname = _protocolMatchesSpecialScheme ? "/" : string.Empty;
+                }
+
+                if (_state is ParserState.Protocol or ParserState.Authority or ParserState.Username or ParserState.Password
+                        or ParserState.Hostname or ParserState.Port or ParserState.Pathname
+                    && newState == ParserState.Hash
+                    && Result.Search is null)
+                {
+                    Result.Search = string.Empty;
+                }
+            }
+
+            _state = newState;
+            _tokenIndex += skip;
+            _componentStart = _tokenIndex;
+            _tokenIncrement = 0;
+        }
+
+        private void SetResult(ParserState state, string value)
+        {
+            switch (state)
+            {
+                case ParserState.Protocol:
+                    Result.Protocol = value;
+                    break;
+                case ParserState.Username:
+                    Result.Username = value;
+                    break;
+                case ParserState.Password:
+                    Result.Password = value;
+                    break;
+                case ParserState.Hostname:
+                    Result.Hostname = value;
+                    break;
+                case ParserState.Port:
+                    Result.Port = value;
+                    break;
+                case ParserState.Pathname:
+                    Result.Pathname = value;
+                    break;
+                case ParserState.Search:
+                    Result.Search = value;
+                    break;
+                default:
+                    Result.Hash = value;
+                    break;
+            }
+        }
+
+        /// <summary>https://urlpattern.spec.whatwg.org/#rewind</summary>
+        private void Rewind()
+        {
+            _tokenIndex = _componentStart;
+            _tokenIncrement = 0;
+        }
+
+        /// <summary>https://urlpattern.spec.whatwg.org/#rewind-and-set-state</summary>
+        private void RewindAndSetState(ParserState state)
+        {
+            Rewind();
+            _state = state;
+        }
+
+        /// <summary>https://urlpattern.spec.whatwg.org/#get-a-safe-token</summary>
+        private UrlPatternToken GetSafeToken(int index)
+            => index < _tokenList.Count ? _tokenList[index] : _tokenList[_tokenList.Count - 1];
+
+        /// <summary>https://urlpattern.spec.whatwg.org/#is-a-non-special-pattern-char</summary>
+        private bool IsNonSpecialPatternChar(int index, char value)
+        {
+            var token = GetSafeToken(index);
+            if (token.Value.Length != 1 || token.Value[0] != value)
+            {
+                return false;
+            }
+
+            return token.Type is UrlPatternTokenType.Char or UrlPatternTokenType.EscapedChar or UrlPatternTokenType.InvalidChar;
+        }
+
+        /// <summary>https://urlpattern.spec.whatwg.org/#is-a-protocol-suffix</summary>
+        private bool IsProtocolSuffix() => IsNonSpecialPatternChar(_tokenIndex, ':');
+
+        /// <summary>https://urlpattern.spec.whatwg.org/#next-is-authority-slashes</summary>
+        private bool NextIsAuthoritySlashes()
+            => IsNonSpecialPatternChar(_tokenIndex + 1, '/') && IsNonSpecialPatternChar(_tokenIndex + 2, '/');
+
+        /// <summary>https://urlpattern.spec.whatwg.org/#is-an-identity-terminator</summary>
+        private bool IsIdentityTerminator() => IsNonSpecialPatternChar(_tokenIndex, '@');
+
+        /// <summary>https://urlpattern.spec.whatwg.org/#is-a-password-prefix</summary>
+        private bool IsPasswordPrefix() => IsNonSpecialPatternChar(_tokenIndex, ':');
+
+        /// <summary>https://urlpattern.spec.whatwg.org/#is-a-port-prefix</summary>
+        private bool IsPortPrefix() => IsNonSpecialPatternChar(_tokenIndex, ':');
+
+        /// <summary>https://urlpattern.spec.whatwg.org/#is-a-pathname-start</summary>
+        private bool IsPathnameStart() => IsNonSpecialPatternChar(_tokenIndex, '/');
+
+        /// <summary>https://urlpattern.spec.whatwg.org/#is-a-hash-prefix</summary>
+        private bool IsHashPrefix() => IsNonSpecialPatternChar(_tokenIndex, '#');
+
+        /// <summary>https://urlpattern.spec.whatwg.org/#is-an-ipv6-open</summary>
+        private bool IsIpv6Open() => IsNonSpecialPatternChar(_tokenIndex, '[');
+
+        /// <summary>https://urlpattern.spec.whatwg.org/#is-an-ipv6-close</summary>
+        private bool IsIpv6Close() => IsNonSpecialPatternChar(_tokenIndex, ']');
+
+        /// <summary>
+        /// https://urlpattern.spec.whatwg.org/#is-a-search-prefix — a "<c>?</c>" only starts the search when it is
+        /// not the modifier of the group in front of it.
+        /// </summary>
+        private bool IsSearchPrefix()
+        {
+            if (IsNonSpecialPatternChar(_tokenIndex, '?'))
+            {
+                return true;
+            }
+
+            var token = _tokenList[_tokenIndex];
+            if (token.Value.Length != 1 || token.Value[0] != '?')
+            {
+                return false;
+            }
+
+            var previousIndex = _tokenIndex - 1;
+            if (previousIndex < 0)
+            {
+                return true;
+            }
+
+            return GetSafeToken(previousIndex).Type
+                is not (UrlPatternTokenType.Name or UrlPatternTokenType.Regexp
+                    or UrlPatternTokenType.Close or UrlPatternTokenType.Asterisk);
+        }
+
+        /// <summary>https://urlpattern.spec.whatwg.org/#make-a-component-string</summary>
+        private string MakeComponentString()
+        {
+            var token = _tokenList[_tokenIndex];
+            var componentStartInputIndex = GetSafeToken(_componentStart).Index;
+            return _input.Substring(componentStartInputIndex, token.Index - componentStartInputIndex);
+        }
+
+        /// <summary>https://urlpattern.spec.whatwg.org/#compute-protocol-matches-a-special-scheme-flag</summary>
+        private void ComputeProtocolMatchesSpecialScheme()
+        {
+            var protocolComponent = UrlPatternComponent.Compile(
+                _engine,
+                MakeComponentString(),
+                UrlPatternCanonicalization.CanonicalizeProtocol,
+                UrlPatternCompileOptions.Default());
+
+            if (protocolComponent.MatchesSpecialScheme())
+            {
+                _protocolMatchesSpecialScheme = true;
+            }
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/Url/Pattern/UrlPatternGenerator.cs
+++ b/Jint/WebApi/Url/Pattern/UrlPatternGenerator.cs
@@ -1,0 +1,349 @@
+#if NET8_0_OR_GREATER
+using System.Text;
+
+namespace Jint.WebApi.Url.Pattern;
+
+/// <summary>
+/// Converts a part list back into the two strings a component keeps: the regular expression source of
+/// https://urlpattern.spec.whatwg.org/#converting-part-lists-to-regular-expressions, and the normalized pattern
+/// string of https://urlpattern.spec.whatwg.org/#converting-part-lists-to-pattern-strings that the eight
+/// <c>URLPattern</c> accessors return.
+/// </summary>
+internal static class UrlPatternGenerator
+{
+    /// <summary>https://urlpattern.spec.whatwg.org/#full-wildcard-regexp-value</summary>
+    internal const string FullWildcardRegexpValue = ".*";
+
+    /// <summary>
+    /// https://urlpattern.spec.whatwg.org/#generate-a-segment-wildcard-regexp — what an unadorned "<c>:foo</c>"
+    /// matches, which is everything up to the component's own delimiter.
+    /// </summary>
+    internal static string GenerateSegmentWildcardRegexp(UrlPatternCompileOptions options)
+    {
+        var result = new ValueStringBuilder(stackalloc char[8]);
+        try
+        {
+            result.Append("[^");
+            AppendEscapedRegexpString(ref result, options.Delimiter);
+            result.Append("]+?");
+            return result.AsSpan().ToString();
+        }
+        finally
+        {
+            result.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// https://urlpattern.spec.whatwg.org/#generate-a-regular-expression-and-name-list — the anchored regular
+    /// expression source, plus the capture group names in the order the groups appear in it.
+    /// </summary>
+    /// <remarks>
+    /// The names ride alongside rather than becoming named capture groups: that is what path-to-regexp does, and
+    /// the spec keeps it deliberately, so a group named "<c>0</c>" (the automatic name of an unnamed group) stays
+    /// expressible.
+    /// </remarks>
+    internal static (string Source, string[] NameList) GenerateRegularExpressionAndNameList(
+        List<UrlPatternPart> partList,
+        UrlPatternCompileOptions options)
+    {
+        var nameList = new List<string>();
+        var result = new ValueStringBuilder(stackalloc char[128]);
+        try
+        {
+            result.Append('^');
+
+            foreach (var part in partList)
+            {
+                if (part.Type == UrlPatternPartType.FixedText)
+                {
+                    if (part.Modifier == UrlPatternModifier.None)
+                    {
+                        AppendEscapedRegexpString(ref result, part.Value);
+                    }
+                    else
+                    {
+                        // "(?:<fixed text>)<modifier>"
+                        result.Append("(?:");
+                        AppendEscapedRegexpString(ref result, part.Value);
+                        result.Append(')');
+                        result.Append(ConvertModifierToString(part.Modifier));
+                    }
+
+                    continue;
+                }
+
+                nameList.Add(part.Name);
+
+                var regexpValue = part.Type switch
+                {
+                    UrlPatternPartType.SegmentWildcard => GenerateSegmentWildcardRegexp(options),
+                    UrlPatternPartType.FullWildcard => FullWildcardRegexpValue,
+                    _ => part.Value,
+                };
+
+                if (part.Prefix.Length == 0 && part.Suffix.Length == 0)
+                {
+                    if (part.Modifier is UrlPatternModifier.None or UrlPatternModifier.Optional)
+                    {
+                        // "(<regexp value>)<modifier>"
+                        result.Append('(');
+                        result.Append(regexpValue);
+                        result.Append(')');
+                        result.Append(ConvertModifierToString(part.Modifier));
+                    }
+                    else
+                    {
+                        // "((?:<regexp value>)<modifier>)"
+                        result.Append("((?:");
+                        result.Append(regexpValue);
+                        result.Append(')');
+                        result.Append(ConvertModifierToString(part.Modifier));
+                        result.Append(')');
+                    }
+
+                    continue;
+                }
+
+                if (part.Modifier is UrlPatternModifier.None or UrlPatternModifier.Optional)
+                {
+                    // "(?:<prefix>(<regexp value>)<suffix>)<modifier>"
+                    result.Append("(?:");
+                    AppendEscapedRegexpString(ref result, part.Prefix);
+                    result.Append('(');
+                    result.Append(regexpValue);
+                    result.Append(')');
+                    AppendEscapedRegexpString(ref result, part.Suffix);
+                    result.Append(')');
+                    result.Append(ConvertModifierToString(part.Modifier));
+                    continue;
+                }
+
+                // A repeating part with a prefix or suffix excludes the first prefix and the last suffix but keeps
+                // both between repetitions, so the body appears twice:
+                // "(?:<prefix>((?:<regexp value>)(?:<suffix><prefix>(?:<regexp value>))*)<suffix>)?"
+                result.Append("(?:");
+                AppendEscapedRegexpString(ref result, part.Prefix);
+                result.Append("((?:");
+                result.Append(regexpValue);
+                result.Append(")(?:");
+                AppendEscapedRegexpString(ref result, part.Suffix);
+                AppendEscapedRegexpString(ref result, part.Prefix);
+                result.Append("(?:");
+                result.Append(regexpValue);
+                result.Append("))*)");
+                AppendEscapedRegexpString(ref result, part.Suffix);
+                result.Append(')');
+
+                if (part.Modifier == UrlPatternModifier.ZeroOrMore)
+                {
+                    result.Append('?');
+                }
+            }
+
+            result.Append('$');
+            return (result.AsSpan().ToString(), nameList.ToArray());
+        }
+        finally
+        {
+            result.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// https://urlpattern.spec.whatwg.org/#generate-a-pattern-string — the normalized pattern string, which is
+    /// what every one of the eight component accessors returns and is itself a well formed pattern string.
+    /// </summary>
+    internal static string GeneratePatternString(List<UrlPatternPart> partList, UrlPatternCompileOptions options)
+    {
+        var result = new ValueStringBuilder(stackalloc char[128]);
+        try
+        {
+            for (var index = 0; index < partList.Count; index++)
+            {
+                var part = partList[index];
+                var previousPart = index > 0 ? partList[index - 1] : (UrlPatternPart?) null;
+                var nextPart = index < partList.Count - 1 ? partList[index + 1] : (UrlPatternPart?) null;
+
+                if (part.Type == UrlPatternPartType.FixedText)
+                {
+                    if (part.Modifier == UrlPatternModifier.None)
+                    {
+                        AppendEscapedPatternString(ref result, part.Value);
+                        continue;
+                    }
+
+                    result.Append('{');
+                    AppendEscapedPatternString(ref result, part.Value);
+                    result.Append('}');
+                    result.Append(ConvertModifierToString(part.Modifier));
+                    continue;
+                }
+
+                var customName = !IsAsciiDigit(part.Name[0]);
+                var needsGrouping = part.Suffix.Length != 0
+                    || (part.Prefix.Length != 0 && !options.IsPrefix(part.Prefix));
+
+                if (!needsGrouping
+                    && customName
+                    && part.Type == UrlPatternPartType.SegmentWildcard
+                    && part.Modifier == UrlPatternModifier.None
+                    && nextPart is { } following
+                    && following.Prefix.Length == 0
+                    && following.Suffix.Length == 0)
+                {
+                    // Without braces, whatever follows would be read as more of this group's name.
+                    needsGrouping = following.Type == UrlPatternPartType.FixedText
+                        ? following.Value.Length != 0
+                            && UrlPatternTokenizer.IsValidNameCodePoint(FirstCodePoint(following.Value), first: false)
+                        : IsAsciiDigit(following.Name[0]);
+                }
+
+                if (!needsGrouping
+                    && part.Prefix.Length == 0
+                    && previousPart is { Type: UrlPatternPartType.FixedText } preceding
+                    && preceding.Value.Length != 0
+                    && options.PrefixCodePoint != '\0'
+                    && preceding.Value[preceding.Value.Length - 1] == options.PrefixCodePoint)
+                {
+                    // The preceding fixed text ends with the prefix code point, which would otherwise be read as
+                    // this group's automatic prefix.
+                    needsGrouping = true;
+                }
+
+                if (needsGrouping)
+                {
+                    result.Append('{');
+                }
+
+                AppendEscapedPatternString(ref result, part.Prefix);
+
+                if (customName)
+                {
+                    result.Append(':');
+                    result.Append(part.Name);
+                }
+
+                if (part.Type == UrlPatternPartType.Regexp)
+                {
+                    result.Append('(');
+                    result.Append(part.Value);
+                    result.Append(')');
+                }
+                else if (part.Type == UrlPatternPartType.SegmentWildcard && !customName)
+                {
+                    result.Append('(');
+                    result.Append(GenerateSegmentWildcardRegexp(options));
+                    result.Append(')');
+                }
+                else if (part.Type == UrlPatternPartType.FullWildcard)
+                {
+                    if (!customName
+                        && (previousPart is null
+                            || previousPart.Value.Type == UrlPatternPartType.FixedText
+                            || previousPart.Value.Modifier != UrlPatternModifier.None
+                            || needsGrouping
+                            || part.Prefix.Length != 0))
+                    {
+                        result.Append('*');
+                    }
+                    else
+                    {
+                        result.Append('(');
+                        result.Append(FullWildcardRegexpValue);
+                        result.Append(')');
+                    }
+                }
+
+                if (part.Type == UrlPatternPartType.SegmentWildcard
+                    && customName
+                    && part.Suffix.Length != 0
+                    && UrlPatternTokenizer.IsValidNameCodePoint(FirstCodePoint(part.Suffix), first: false))
+                {
+                    // The suffix would otherwise extend the name.
+                    result.Append('\\');
+                }
+
+                AppendEscapedPatternString(ref result, part.Suffix);
+
+                if (needsGrouping)
+                {
+                    result.Append('}');
+                }
+
+                result.Append(ConvertModifierToString(part.Modifier));
+            }
+
+            return result.AsSpan().ToString();
+        }
+        finally
+        {
+            result.Dispose();
+        }
+    }
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#convert-a-modifier-to-a-string</summary>
+    private static string ConvertModifierToString(UrlPatternModifier modifier) => modifier switch
+    {
+        UrlPatternModifier.ZeroOrMore => "*",
+        UrlPatternModifier.Optional => "?",
+        UrlPatternModifier.OneOrMore => "+",
+        _ => string.Empty,
+    };
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#escape-a-regexp-string</summary>
+    private static void AppendEscapedRegexpString(ref ValueStringBuilder builder, string input)
+    {
+        foreach (var c in input)
+        {
+            if (c is '.' or '+' or '*' or '?' or '^' or '$' or '{' or '}' or '(' or ')' or '[' or ']' or '|' or '/' or '\\')
+            {
+                builder.Append('\\');
+            }
+
+            builder.Append(c);
+        }
+    }
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#escape-a-pattern-string</summary>
+    internal static string EscapePatternString(string input)
+    {
+        var builder = new ValueStringBuilder(stackalloc char[64]);
+        try
+        {
+            AppendEscapedPatternString(ref builder, input);
+            return builder.AsSpan().ToString();
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    private static void AppendEscapedPatternString(ref ValueStringBuilder builder, string input)
+    {
+        foreach (var c in input)
+        {
+            if (c is '+' or '*' or '?' or ':' or '{' or '}' or '(' or ')' or '\\')
+            {
+                builder.Append('\\');
+            }
+
+            builder.Append(c);
+        }
+    }
+
+    private static bool IsAsciiDigit(char c) => c is >= '0' and <= '9';
+
+    private static int FirstCodePoint(string value)
+    {
+        var c = value[0];
+        if (char.IsHighSurrogate(c) && value.Length > 1 && char.IsLowSurrogate(value[1]))
+        {
+            return char.ConvertToUtf32(c, value[1]);
+        }
+
+        return c;
+    }
+}
+#endif

--- a/Jint/WebApi/Url/Pattern/UrlPatternInit.cs
+++ b/Jint/WebApi/Url/Pattern/UrlPatternInit.cs
@@ -1,0 +1,267 @@
+#if NET8_0_OR_GREATER
+using System.Globalization;
+using Jint.Runtime;
+using Jint.WebApi.Url.Parsing;
+
+namespace Jint.WebApi.Url.Pattern;
+
+/// <summary>
+/// Which of the two jobs https://urlpattern.spec.whatwg.org/#process-a-urlpatterninit is doing.
+/// </summary>
+internal enum UrlPatternProcessType
+{
+    /// <summary>
+    /// The values are pattern strings being compiled, so they are left alone — canonicalization happens later,
+    /// per piece of fixed text, inside the pattern parser.
+    /// </summary>
+    Pattern,
+
+    /// <summary>
+    /// The values are the components of a URL being matched, so each is canonicalized whole, right here.
+    /// </summary>
+    Url,
+}
+
+/// <summary>
+/// https://urlpattern.spec.whatwg.org/#dictdef-urlpatterninit — a component-by-component pattern or URL, with
+/// every member independently present or absent.
+/// </summary>
+/// <remarks>
+/// <see langword="null"/> is how "does not exist" is spelled; the difference matters throughout
+/// <see cref="Process"/>, where a member that exists suppresses inheritance of every less specific component
+/// from the base URL.
+/// </remarks>
+internal sealed class UrlPatternInit
+{
+    internal string? Protocol;
+    internal string? Username;
+    internal string? Password;
+    internal string? Hostname;
+    internal string? Port;
+    internal string? Pathname;
+    internal string? Search;
+    internal string? Hash;
+    internal string? BaseUrl;
+
+    /// <summary>
+    /// https://urlpattern.spec.whatwg.org/#process-a-urlpatterninit — fills in whatever the init leaves out from
+    /// the base URL, then canonicalizes what the init did supply.
+    /// </summary>
+    /// <remarks>
+    /// The inheritance rules are the note in the specification made mechanical: a component is inherited only
+    /// when the init specifies nothing at least as specific as it, along "protocol, hostname, port, pathname,
+    /// search, hash" and "protocol, hostname, port, username, password". So an init carrying only a pathname
+    /// keeps the base URL's protocol, hostname and port but not its search or hash, and username and password
+    /// are never inherited while compiling a pattern.
+    /// </remarks>
+    internal static UrlPatternInit Process(
+        Realm realm,
+        UrlPatternInit init,
+        UrlPatternProcessType type,
+        string? protocol,
+        string? username,
+        string? password,
+        string? hostname,
+        string? port,
+        string? pathname,
+        string? search,
+        string? hash)
+    {
+        var result = new UrlPatternInit
+        {
+            Protocol = protocol,
+            Username = username,
+            Password = password,
+            Hostname = hostname,
+            Port = port,
+            Pathname = pathname,
+            Search = search,
+            Hash = hash,
+        };
+
+        UrlRecord? baseUrl = null;
+        if (init.BaseUrl is { } baseUrlString)
+        {
+            baseUrl = UrlParser.Parse(baseUrlString);
+            if (baseUrl is null)
+            {
+                Throw.TypeError(realm, $"Invalid URLPattern baseURL: {baseUrlString}");
+            }
+
+            if (init.Protocol is null)
+            {
+                result.Protocol = ProcessBaseUrlString(baseUrl.Scheme, type);
+            }
+
+            if (type != UrlPatternProcessType.Pattern
+                && init.Protocol is null && init.Hostname is null && init.Port is null && init.Username is null)
+            {
+                result.Username = ProcessBaseUrlString(baseUrl.Username, type);
+            }
+
+            if (type != UrlPatternProcessType.Pattern
+                && init.Protocol is null && init.Hostname is null && init.Port is null && init.Username is null && init.Password is null)
+            {
+                result.Password = ProcessBaseUrlString(baseUrl.Password, type);
+            }
+
+            if (init.Protocol is null && init.Hostname is null)
+            {
+                result.Hostname = ProcessBaseUrlString(baseUrl.SerializeHost(), type);
+            }
+
+            if (init.Protocol is null && init.Hostname is null && init.Port is null)
+            {
+                // A port is ASCII digits or nothing, so it is the one inherited component that never needs
+                // escaping into a pattern string.
+                result.Port = baseUrl.Port is { } basePort ? basePort.ToString(CultureInfo.InvariantCulture) : string.Empty;
+            }
+
+            if (init.Protocol is null && init.Hostname is null && init.Port is null && init.Pathname is null)
+            {
+                result.Pathname = ProcessBaseUrlString(baseUrl.SerializePath(), type);
+            }
+
+            if (init.Protocol is null && init.Hostname is null && init.Port is null && init.Pathname is null && init.Search is null)
+            {
+                result.Search = ProcessBaseUrlString(baseUrl.Query ?? string.Empty, type);
+            }
+
+            if (init.Protocol is null && init.Hostname is null && init.Port is null && init.Pathname is null
+                && init.Search is null && init.Hash is null)
+            {
+                result.Hash = ProcessBaseUrlString(baseUrl.Fragment ?? string.Empty, type);
+            }
+        }
+
+        if (init.Protocol is { } initProtocol)
+        {
+            result.Protocol = ProcessProtocolForInit(realm, initProtocol, type);
+        }
+
+        if (init.Username is { } initUsername)
+        {
+            result.Username = type == UrlPatternProcessType.Pattern
+                ? initUsername
+                : UrlPatternCanonicalization.CanonicalizeUsername(realm, initUsername);
+        }
+
+        if (init.Password is { } initPassword)
+        {
+            result.Password = type == UrlPatternProcessType.Pattern
+                ? initPassword
+                : UrlPatternCanonicalization.CanonicalizePassword(realm, initPassword);
+        }
+
+        if (init.Hostname is { } initHostname)
+        {
+            result.Hostname = type == UrlPatternProcessType.Pattern
+                ? initHostname
+                : UrlPatternCanonicalization.CanonicalizeHostname(realm, initHostname);
+        }
+
+        var resultProtocolString = result.Protocol ?? string.Empty;
+
+        if (init.Port is { } initPort)
+        {
+            result.Port = type == UrlPatternProcessType.Pattern
+                ? initPort
+                : UrlPatternCanonicalization.CanonicalizePort(realm, initPort, resultProtocolString);
+        }
+
+        if (init.Pathname is { } initPathname)
+        {
+            result.Pathname = initPathname;
+
+            if (baseUrl is not null && !baseUrl.HasOpaquePath && !IsAbsolutePathname(result.Pathname, type))
+            {
+                // A relative pathname resolves against the base URL's directory, exactly as a relative URL does.
+                var baseUrlPath = ProcessBaseUrlString(baseUrl.SerializePath(), type);
+                var slashIndex = baseUrlPath.LastIndexOf('/');
+                if (slashIndex >= 0)
+                {
+                    result.Pathname = string.Concat(baseUrlPath.AsSpan(0, slashIndex + 1), result.Pathname);
+                }
+            }
+
+            result.Pathname = ProcessPathnameForInit(realm, result.Pathname, resultProtocolString, type);
+        }
+
+        if (init.Search is { } initSearch)
+        {
+            var strippedValue = initSearch.Length != 0 && initSearch[0] == '?' ? initSearch.Substring(1) : initSearch;
+            result.Search = type == UrlPatternProcessType.Pattern
+                ? strippedValue
+                : UrlPatternCanonicalization.CanonicalizeSearch(realm, strippedValue);
+        }
+
+        if (init.Hash is { } initHash)
+        {
+            var strippedValue = initHash.Length != 0 && initHash[0] == '#' ? initHash.Substring(1) : initHash;
+            result.Hash = type == UrlPatternProcessType.Pattern
+                ? strippedValue
+                : UrlPatternCanonicalization.CanonicalizeHash(realm, strippedValue);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// https://urlpattern.spec.whatwg.org/#process-a-base-url-string — a value inherited from the base URL is
+    /// fixed text, so when it is going to be compiled as a pattern every syntax code point in it is escaped.
+    /// </summary>
+    private static string ProcessBaseUrlString(string input, UrlPatternProcessType type)
+        => type == UrlPatternProcessType.Pattern ? UrlPatternGenerator.EscapePatternString(input) : input;
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#process-protocol-for-init</summary>
+    private static string ProcessProtocolForInit(Realm realm, string value, UrlPatternProcessType type)
+    {
+        var strippedValue = value.Length != 0 && value[value.Length - 1] == ':' ? value.Substring(0, value.Length - 1) : value;
+        return type == UrlPatternProcessType.Pattern
+            ? strippedValue
+            : UrlPatternCanonicalization.CanonicalizeProtocol(realm, strippedValue);
+    }
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#process-pathname-for-init</summary>
+    private static string ProcessPathnameForInit(Realm realm, string pathnameValue, string protocolValue, UrlPatternProcessType type)
+    {
+        if (type == UrlPatternProcessType.Pattern)
+        {
+            return pathnameValue;
+        }
+
+        // An empty protocol means the init supplied none, and the common case by far is a hierarchical path, so
+        // it is treated like a special scheme rather than like an opaque one.
+        if (protocolValue.Length == 0 || UrlRecord.IsSpecialScheme(protocolValue))
+        {
+            return UrlPatternCanonicalization.CanonicalizePathname(realm, pathnameValue);
+        }
+
+        return UrlPatternCanonicalization.CanonicalizeOpaquePathname(realm, pathnameValue);
+    }
+
+    /// <summary>
+    /// https://urlpattern.spec.whatwg.org/#is-an-absolute-pathname — a pattern may start its absolute path with an
+    /// escaped or braced slash, which a plain URL pathname cannot.
+    /// </summary>
+    private static bool IsAbsolutePathname(string input, UrlPatternProcessType type)
+    {
+        if (input.Length == 0)
+        {
+            return false;
+        }
+
+        if (input[0] == '/')
+        {
+            return true;
+        }
+
+        if (type == UrlPatternProcessType.Url || input.Length < 2)
+        {
+            return false;
+        }
+
+        return (input[0] == '\\' && input[1] == '/') || (input[0] == '{' && input[1] == '/');
+    }
+}
+#endif

--- a/Jint/WebApi/Url/Pattern/UrlPatternPart.cs
+++ b/Jint/WebApi/Url/Pattern/UrlPatternPart.cs
@@ -1,0 +1,92 @@
+#if NET8_0_OR_GREATER
+using System.Runtime.InteropServices;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Url.Pattern;
+
+/// <summary>https://urlpattern.spec.whatwg.org/#part-type</summary>
+internal enum UrlPatternPartType
+{
+    /// <summary>A simple fixed text string.</summary>
+    FixedText,
+
+    /// <summary>A matching group with a custom regular expression.</summary>
+    Regexp,
+
+    /// <summary>A matching group that matches up to the next delimiter code point, such as "<c>:foo</c>".</summary>
+    SegmentWildcard,
+
+    /// <summary>A matching group that greedily matches everything, such as "<c>*</c>".</summary>
+    FullWildcard,
+}
+
+/// <summary>https://urlpattern.spec.whatwg.org/#part-modifier</summary>
+internal enum UrlPatternModifier
+{
+    /// <summary>No modifier.</summary>
+    None,
+
+    /// <summary>U+003F (<c>?</c>).</summary>
+    Optional,
+
+    /// <summary>U+002A (<c>*</c>).</summary>
+    ZeroOrMore,
+
+    /// <summary>U+002B (<c>+</c>).</summary>
+    OneOrMore,
+}
+
+/// <summary>
+/// https://urlpattern.spec.whatwg.org/#part — one piece of a parsed pattern string: at most one matching group,
+/// with fixed text before and after it and a modifier.
+/// </summary>
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct UrlPatternPart(
+    UrlPatternPartType Type,
+    string Value,
+    UrlPatternModifier Modifier,
+    string Name,
+    string Prefix,
+    string Suffix);
+
+/// <summary>
+/// https://urlpattern.spec.whatwg.org/#options-header — the per-component settings that decide how a pattern
+/// string behaves.
+/// </summary>
+/// <remarks>
+/// Both code points are "one ASCII code point or the empty string"; <c>'\0'</c> is how the empty string is spelled
+/// here, and <see cref="Delimiter"/> / <see cref="IsPrefix"/> are the two places that difference is observable.
+/// The three named sets are the spec's
+/// <a href="https://urlpattern.spec.whatwg.org/#default-options">default</a>,
+/// <a href="https://urlpattern.spec.whatwg.org/#hostname-options">hostname</a> and
+/// <a href="https://urlpattern.spec.whatwg.org/#pathname-options">pathname</a> options.
+/// </remarks>
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct UrlPatternCompileOptions(char DelimiterCodePoint, char PrefixCodePoint, bool IgnoreCase)
+{
+    /// <summary>https://urlpattern.spec.whatwg.org/#default-options</summary>
+    internal static UrlPatternCompileOptions Default(bool ignoreCase = false) => new('\0', '\0', ignoreCase);
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#hostname-options</summary>
+    internal static UrlPatternCompileOptions Hostname(bool ignoreCase = false) => new('.', '\0', ignoreCase);
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#pathname-options</summary>
+    internal static UrlPatternCompileOptions Pathname(bool ignoreCase = false) => new('/', '/', ignoreCase);
+
+    /// <summary>The delimiter as a string, empty when there is none.</summary>
+    internal string Delimiter => DelimiterCodePoint == '\0' ? string.Empty : DelimiterCodePoint.ToString();
+
+    /// <summary>
+    /// Whether <paramref name="value"/> is exactly the prefix code point — the spec's "is <i>options</i>'s prefix
+    /// code point" comparison, which an empty prefix code point can never satisfy.
+    /// </summary>
+    internal bool IsPrefix(string value)
+        => PrefixCodePoint != '\0' && value.Length == 1 && value[0] == PrefixCodePoint;
+}
+
+/// <summary>
+/// https://urlpattern.spec.whatwg.org/#encoding-callback — validates and encodes one piece of fixed text of a
+/// pattern string, or throws a <c>TypeError</c>.
+/// </summary>
+internal delegate string UrlPatternEncodingCallback(Realm realm, string input);
+#endif

--- a/Jint/WebApi/Url/Pattern/UrlPatternPrototype.cs
+++ b/Jint/WebApi/Url/Pattern/UrlPatternPrototype.cs
@@ -1,0 +1,124 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Url.Pattern;
+
+/// <summary>
+/// <c>URLPattern.prototype</c> — the interface prototype object.
+/// <para>
+/// https://urlpattern.spec.whatwg.org/#urlpattern-class
+/// </para>
+/// </summary>
+/// <remarks>
+/// The nine attributes are read-only, so each is an accessor pair with no setter, and each brand-checks its
+/// receiver as WebIDL requires. The two operations carry the same documented simplification the rest of this
+/// subtree carries: they are non-enumerable, where https://webidl.spec.whatwg.org/#es-operations makes an
+/// interface's operations enumerable.
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class UrlPatternPrototype : Prototype
+{
+    private const PropertyFlag AttributeFlags = PropertyFlag.Configurable | PropertyFlag.Enumerable;
+
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly UrlPatternConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString UrlPatternToStringTag = new("URLPattern");
+
+    internal UrlPatternPrototype(
+        Engine engine,
+        Realm realm,
+        UrlPatternConstructor constructor,
+        ObjectPrototype objectPrototype) : base(engine, realm)
+    {
+        _prototype = objectPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#dom-urlpattern-protocol</summary>
+    [JsAccessor("protocol", Flags = AttributeFlags)]
+    private JsString ProtocolGet(JsValue thisObject) => JsString.Create(Brand(thisObject).Pattern.Protocol.PatternString);
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#dom-urlpattern-username</summary>
+    [JsAccessor("username", Flags = AttributeFlags)]
+    private JsString UsernameGet(JsValue thisObject) => JsString.Create(Brand(thisObject).Pattern.Username.PatternString);
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#dom-urlpattern-password</summary>
+    [JsAccessor("password", Flags = AttributeFlags)]
+    private JsString PasswordGet(JsValue thisObject) => JsString.Create(Brand(thisObject).Pattern.Password.PatternString);
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#dom-urlpattern-hostname</summary>
+    [JsAccessor("hostname", Flags = AttributeFlags)]
+    private JsString HostnameGet(JsValue thisObject) => JsString.Create(Brand(thisObject).Pattern.Hostname.PatternString);
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#dom-urlpattern-port</summary>
+    [JsAccessor("port", Flags = AttributeFlags)]
+    private JsString PortGet(JsValue thisObject) => JsString.Create(Brand(thisObject).Pattern.Port.PatternString);
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#dom-urlpattern-pathname</summary>
+    [JsAccessor("pathname", Flags = AttributeFlags)]
+    private JsString PathnameGet(JsValue thisObject) => JsString.Create(Brand(thisObject).Pattern.Pathname.PatternString);
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#dom-urlpattern-search</summary>
+    [JsAccessor("search", Flags = AttributeFlags)]
+    private JsString SearchGet(JsValue thisObject) => JsString.Create(Brand(thisObject).Pattern.Search.PatternString);
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#dom-urlpattern-hash</summary>
+    [JsAccessor("hash", Flags = AttributeFlags)]
+    private JsString HashGet(JsValue thisObject) => JsString.Create(Brand(thisObject).Pattern.Hash.PatternString);
+
+    /// <summary>
+    /// https://urlpattern.spec.whatwg.org/#dom-urlpattern-hasregexpgroups — whether any component uses a
+    /// "<c>(regexp)</c>" group, which is the question an API that will not evaluate author regular expressions
+    /// asks before accepting a pattern.
+    /// </summary>
+    [JsAccessor("hasRegExpGroups", Flags = AttributeFlags)]
+    private JsBoolean HasRegExpGroupsGet(JsValue thisObject) => JsBoolean.Create(Brand(thisObject).Pattern.HasRegexpGroups);
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#dom-urlpattern-test</summary>
+    [JsFunction(Name = "test", Length = 0)]
+    private JsBoolean Test(JsValue thisObject, JsValue input, JsValue baseUrl)
+    {
+        var pattern = Brand(thisObject);
+        var readInput = UrlPatternConstructor.ReadInput(input);
+        var baseUrlString = UrlValues.ToOptionalUsvString(baseUrl);
+        var result = pattern.Pattern.Match(_engine, readInput.StringInput, readInput.Init, baseUrlString);
+        return JsBoolean.Create(!result.IsNull());
+    }
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#dom-urlpattern-exec</summary>
+    [JsFunction(Name = "exec", Length = 0)]
+    private JsValue Exec(JsValue thisObject, JsValue input, JsValue baseUrl)
+    {
+        var pattern = Brand(thisObject);
+        var readInput = UrlPatternConstructor.ReadInput(input);
+        var baseUrlString = UrlValues.ToOptionalUsvString(baseUrl);
+        return pattern.Pattern.Match(_engine, readInput.StringInput, readInput.Init, baseUrlString);
+    }
+
+    /// <summary>
+    /// The WebIDL brand check every member performs: a receiver that is not a platform object implementing the
+    /// interface raises a <c>TypeError</c>.
+    /// </summary>
+    private JsUrlPattern Brand(JsValue thisObject)
+    {
+        if (thisObject is JsUrlPattern pattern)
+        {
+            return pattern;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a URLPattern");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Url/Pattern/UrlPatternRecord.cs
+++ b/Jint/WebApi/Url/Pattern/UrlPatternRecord.cs
@@ -1,0 +1,325 @@
+#if NET8_0_OR_GREATER
+using System.Globalization;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.WebApi.Url.Parsing;
+
+namespace Jint.WebApi.Url.Pattern;
+
+/// <summary>
+/// https://urlpattern.spec.whatwg.org/#url-pattern — a compiled pattern: one <see cref="UrlPatternComponent"/>
+/// per URL component, matched independently and all of which must match.
+/// </summary>
+/// <remarks>
+/// This is the specification's <i>URL pattern</i> struct rather than the <c>URLPattern</c> object, and it holds
+/// no JavaScript state beyond the eight compiled regular expressions — which is what lets
+/// <see cref="Match"/> be the whole of <c>test()</c> and <c>exec()</c>.
+/// </remarks>
+internal sealed class UrlPatternRecord
+{
+    private UrlPatternRecord(
+        UrlPatternComponent protocol,
+        UrlPatternComponent username,
+        UrlPatternComponent password,
+        UrlPatternComponent hostname,
+        UrlPatternComponent port,
+        UrlPatternComponent pathname,
+        UrlPatternComponent search,
+        UrlPatternComponent hash)
+    {
+        Protocol = protocol;
+        Username = username;
+        Password = password;
+        Hostname = hostname;
+        Port = port;
+        Pathname = pathname;
+        Search = search;
+        Hash = hash;
+    }
+
+    internal UrlPatternComponent Protocol { get; }
+    internal UrlPatternComponent Username { get; }
+    internal UrlPatternComponent Password { get; }
+    internal UrlPatternComponent Hostname { get; }
+    internal UrlPatternComponent Port { get; }
+    internal UrlPatternComponent Pathname { get; }
+    internal UrlPatternComponent Search { get; }
+    internal UrlPatternComponent Hash { get; }
+
+    /// <summary>https://urlpattern.spec.whatwg.org/#url-pattern-has-regexp-groups</summary>
+    internal bool HasRegexpGroups
+        => Protocol.HasRegexpGroups || Username.HasRegexpGroups || Password.HasRegexpGroups || Hostname.HasRegexpGroups
+            || Port.HasRegexpGroups || Pathname.HasRegexpGroups || Search.HasRegexpGroups || Hash.HasRegexpGroups;
+
+    /// <summary>
+    /// https://urlpattern.spec.whatwg.org/#url-pattern-create — exactly one of <paramref name="stringInput"/> and
+    /// <paramref name="initInput"/> is given, which is the two constructor overloads after WebIDL has resolved
+    /// them.
+    /// </summary>
+    internal static UrlPatternRecord Create(
+        Engine engine,
+        string? stringInput,
+        UrlPatternInit? initInput,
+        string? baseUrl,
+        bool ignoreCase)
+    {
+        var realm = engine.Realm;
+        UrlPatternInit init;
+
+        if (stringInput is not null)
+        {
+            init = UrlPatternConstructorString.Parse(engine, stringInput);
+
+            if (baseUrl is null && init.Protocol is null)
+            {
+                Throw.TypeError(realm, $"Relative URLPattern constructor string requires a base URL: {stringInput}");
+            }
+
+            if (baseUrl is not null)
+            {
+                init.BaseUrl = baseUrl;
+            }
+        }
+        else
+        {
+            if (baseUrl is not null)
+            {
+                Throw.TypeError(realm, "A URLPattern built from a URLPatternInit cannot also take a base URL argument");
+            }
+
+            init = initInput!;
+        }
+
+        var processedInit = UrlPatternInit.Process(
+            realm, init, UrlPatternProcessType.Pattern, null, null, null, null, null, null, null, null);
+
+        // A component the author said nothing about matches anything.
+        processedInit.Protocol ??= "*";
+        processedInit.Username ??= "*";
+        processedInit.Password ??= "*";
+        processedInit.Hostname ??= "*";
+        processedInit.Port ??= "*";
+        processedInit.Pathname ??= "*";
+        processedInit.Search ??= "*";
+        processedInit.Hash ??= "*";
+
+        if (UrlRecord.DefaultPort(processedInit.Protocol) is { } defaultPort
+            && string.Equals(processedInit.Port, defaultPort.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal))
+        {
+            // "https://example.com:443" is the same origin as "https://example.com", so the port pattern is the
+            // empty string a URL record would have serialized.
+            processedInit.Port = string.Empty;
+        }
+
+        var protocol = UrlPatternComponent.Compile(
+            engine, processedInit.Protocol, UrlPatternCanonicalization.CanonicalizeProtocol, UrlPatternCompileOptions.Default());
+        var username = UrlPatternComponent.Compile(
+            engine, processedInit.Username, UrlPatternCanonicalization.CanonicalizeUsername, UrlPatternCompileOptions.Default());
+        var password = UrlPatternComponent.Compile(
+            engine, processedInit.Password, UrlPatternCanonicalization.CanonicalizePassword, UrlPatternCompileOptions.Default());
+
+        var hostname = UrlPatternComponent.Compile(
+            engine,
+            processedInit.Hostname,
+            HostnamePatternIsIpv6Address(processedInit.Hostname)
+                ? UrlPatternCanonicalization.CanonicalizeIpv6Hostname
+                : UrlPatternCanonicalization.CanonicalizeHostname,
+            UrlPatternCompileOptions.Hostname());
+
+        var port = UrlPatternComponent.Compile(
+            engine, processedInit.Port, UrlPatternCanonicalization.CanonicalizePort, UrlPatternCompileOptions.Default());
+
+        // Only the last three components honour ignoreCase; protocol, hostname and port are already lowercased by
+        // their own canonicalization, and username and password are case-sensitive by the URL Standard.
+        var compileOptions = UrlPatternCompileOptions.Default(ignoreCase);
+
+        var pathname = protocol.MatchesSpecialScheme()
+            ? UrlPatternComponent.Compile(
+                engine, processedInit.Pathname, UrlPatternCanonicalization.CanonicalizePathname, UrlPatternCompileOptions.Pathname(ignoreCase))
+            : UrlPatternComponent.Compile(
+                engine, processedInit.Pathname, UrlPatternCanonicalization.CanonicalizeOpaquePathname, compileOptions);
+
+        var search = UrlPatternComponent.Compile(
+            engine, processedInit.Search, UrlPatternCanonicalization.CanonicalizeSearch, compileOptions);
+        var hash = UrlPatternComponent.Compile(
+            engine, processedInit.Hash, UrlPatternCanonicalization.CanonicalizeHash, compileOptions);
+
+        return new UrlPatternRecord(protocol, username, password, hostname, port, pathname, search, hash);
+    }
+
+    /// <summary>
+    /// https://urlpattern.spec.whatwg.org/#url-pattern-match — the whole of <c>test()</c> and <c>exec()</c>.
+    /// Returns <see cref="JsValue.Null"/> for the specification's null, and a <c>URLPatternResult</c> otherwise.
+    /// </summary>
+    internal JsValue Match(Engine engine, string? stringInput, UrlPatternInit? initInput, string? baseUrlString)
+    {
+        var realm = engine.Realm;
+
+        string protocol, username, password, hostname, port, pathname, search, hash;
+        JsValue firstInput;
+        JsValue? secondInput = null;
+
+        if (initInput is not null)
+        {
+            firstInput = CreateInitObject(engine, initInput);
+
+            if (baseUrlString is not null)
+            {
+                Throw.TypeError(realm, "A URLPatternInit input cannot also take a base URL argument");
+            }
+
+            UrlPatternInit applyResult;
+            try
+            {
+                applyResult = UrlPatternInit.Process(
+                    realm, initInput, UrlPatternProcessType.Url, "", "", "", "", "", "", "", "");
+            }
+            catch (JavaScriptException)
+            {
+                // A component that does not canonicalize — a port that is not a number, a hostname the host
+                // parser rejects — is not a failure of the call, only a non-match. The catch is narrow on
+                // purpose: everything this can raise is one of this file's own TypeErrors (the values are
+                // already-coerced strings, so nothing user-written runs inside), and the sibling JintExceptions
+                // that bound execution must never become a quiet null.
+                return JsValue.Null;
+            }
+
+            protocol = applyResult.Protocol!;
+            username = applyResult.Username!;
+            password = applyResult.Password!;
+            hostname = applyResult.Hostname!;
+            port = applyResult.Port!;
+            pathname = applyResult.Pathname!;
+            search = applyResult.Search!;
+            hash = applyResult.Hash!;
+        }
+        else
+        {
+            firstInput = JsString.Create(stringInput!);
+
+            UrlRecord? baseUrl = null;
+            if (baseUrlString is not null)
+            {
+                baseUrl = UrlParser.Parse(baseUrlString);
+                if (baseUrl is null)
+                {
+                    return JsValue.Null;
+                }
+
+                secondInput = JsString.Create(baseUrlString);
+            }
+
+            var url = UrlParser.Parse(stringInput!, baseUrl);
+            if (url is null)
+            {
+                return JsValue.Null;
+            }
+
+            protocol = url.Scheme;
+            username = url.Username;
+            password = url.Password;
+            hostname = url.SerializeHost();
+            port = url.SerializePort();
+            pathname = url.SerializePath();
+            search = url.Query ?? string.Empty;
+            hash = url.Fragment ?? string.Empty;
+        }
+
+        var protocolExecResult = Protocol.Exec(protocol);
+        var usernameExecResult = Username.Exec(username);
+        var passwordExecResult = Password.Exec(password);
+        var hostnameExecResult = Hostname.Exec(hostname);
+        var portExecResult = Port.Exec(port);
+        var pathnameExecResult = Pathname.Exec(pathname);
+        var searchExecResult = Search.Exec(search);
+        var hashExecResult = Hash.Exec(hash);
+
+        if (protocolExecResult.IsNull() || usernameExecResult.IsNull() || passwordExecResult.IsNull()
+            || hostnameExecResult.IsNull() || portExecResult.IsNull() || pathnameExecResult.IsNull()
+            || searchExecResult.IsNull() || hashExecResult.IsNull())
+        {
+            return JsValue.Null;
+        }
+
+        var inputs = realm.Intrinsics.Array.ConstructFast(
+            secondInput is null ? new[] { firstInput } : new[] { firstInput, secondInput });
+
+        return JsObject.Create(engine, UrlPatternResultLayouts.Result,
+        [
+            inputs,
+            Protocol.CreateComponentMatchResult(engine, protocol, protocolExecResult),
+            Username.CreateComponentMatchResult(engine, username, usernameExecResult),
+            Password.CreateComponentMatchResult(engine, password, passwordExecResult),
+            Hostname.CreateComponentMatchResult(engine, hostname, hostnameExecResult),
+            Port.CreateComponentMatchResult(engine, port, portExecResult),
+            Pathname.CreateComponentMatchResult(engine, pathname, pathnameExecResult),
+            Search.CreateComponentMatchResult(engine, search, searchExecResult),
+            Hash.CreateComponentMatchResult(engine, hash, hashExecResult),
+        ]);
+    }
+
+    /// <summary>
+    /// https://urlpattern.spec.whatwg.org/#hostname-pattern-is-an-ipv6-address — a cheap syntactic test for a
+    /// bracketed IPv6 literal, which is canonicalized by lowercasing rather than by the host parser.
+    /// </summary>
+    private static bool HostnamePatternIsIpv6Address(string input)
+    {
+        if (input.Length < 2)
+        {
+            return false;
+        }
+
+        return input[0] == '['
+            || (input[0] == '{' && input[1] == '[')
+            || (input[0] == '\\' && input[1] == '[');
+    }
+
+    /// <summary>
+    /// The <c>URLPatternInit</c> that went into a match, converted back to a JavaScript object for
+    /// <c>URLPatternResult</c>'s <c>inputs</c>: a WebIDL dictionary becomes an ordinary object carrying exactly
+    /// the members that are present, in declaration order.
+    /// </summary>
+    private static JsObject CreateInitObject(Engine engine, UrlPatternInit init)
+    {
+        var result = ObjectInstance.OrdinaryObjectCreate(engine, engine.Realm.Intrinsics.Object.PrototypeObject);
+
+        AddIfPresent(result, UrlPatternProperties.Protocol, init.Protocol);
+        AddIfPresent(result, UrlPatternProperties.Username, init.Username);
+        AddIfPresent(result, UrlPatternProperties.Password, init.Password);
+        AddIfPresent(result, UrlPatternProperties.Hostname, init.Hostname);
+        AddIfPresent(result, UrlPatternProperties.Port, init.Port);
+        AddIfPresent(result, UrlPatternProperties.Pathname, init.Pathname);
+        AddIfPresent(result, UrlPatternProperties.Search, init.Search);
+        AddIfPresent(result, UrlPatternProperties.Hash, init.Hash);
+        AddIfPresent(result, UrlPatternProperties.BaseUrl, init.BaseUrl);
+
+        return result;
+    }
+
+    private static void AddIfPresent(ObjectInstance target, JsString name, string? value)
+    {
+        if (value is not null)
+        {
+            target.CreateDataPropertyOrThrow(name, JsString.Create(value));
+        }
+    }
+}
+
+/// <summary>
+/// The <c>URLPatternInit</c> and <c>URLPatternOptions</c> member names, interned once.
+/// </summary>
+internal static class UrlPatternProperties
+{
+    internal static readonly JsString Protocol = new("protocol");
+    internal static readonly JsString Username = new("username");
+    internal static readonly JsString Password = new("password");
+    internal static readonly JsString Hostname = new("hostname");
+    internal static readonly JsString Port = new("port");
+    internal static readonly JsString Pathname = new("pathname");
+    internal static readonly JsString Search = new("search");
+    internal static readonly JsString Hash = new("hash");
+    internal static readonly JsString BaseUrl = new("baseURL");
+    internal static readonly JsString IgnoreCase = new("ignoreCase");
+}
+#endif

--- a/Jint/WebApi/Url/Pattern/UrlPatternStringParser.cs
+++ b/Jint/WebApi/Url/Pattern/UrlPatternStringParser.cs
@@ -1,0 +1,303 @@
+#if NET8_0_OR_GREATER
+using System.Globalization;
+using System.Text;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Url.Pattern;
+
+/// <summary>
+/// The pattern parser of https://urlpattern.spec.whatwg.org/#parsing — turns a pattern string into a part list.
+/// </summary>
+/// <remarks>
+/// The pattern syntax is path-to-regexp's, so a part is "an optional prefix, at most one matching group, an
+/// optional suffix, and a modifier". The parser reads the two shapes that can produce one: the bare sequence
+/// <c>&lt;prefix char&gt;&lt;name&gt;&lt;regexp&gt;&lt;modifier&gt;</c>, and the braced
+/// <c>{&lt;prefix&gt;&lt;name&gt;&lt;regexp&gt;&lt;suffix&gt;}&lt;modifier&gt;</c>. Anything else is fixed text,
+/// buffered in <c>pending fixed value</c> so that a run of it becomes one part rather than one part per code
+/// point — and run through the encoding callback, which is where a component's own URL canonicalization applies.
+/// </remarks>
+internal static class UrlPatternStringParser
+{
+    /// <summary>
+    /// https://urlpattern.spec.whatwg.org/#parse-a-pattern-string
+    /// </summary>
+    internal static List<UrlPatternPart> Parse(
+        Realm realm,
+        string input,
+        UrlPatternCompileOptions options,
+        UrlPatternEncodingCallback encodingCallback)
+    {
+        var parser = new PatternParser(realm, UrlPatternTokenizer.Tokenize(realm, input, strict: true), options, encodingCallback);
+        parser.Run();
+        return parser.PartList;
+    }
+
+    private sealed class PatternParser(
+        Realm realm,
+        List<UrlPatternToken> tokenList,
+        UrlPatternCompileOptions options,
+        UrlPatternEncodingCallback encodingCallback)
+    {
+        private readonly Realm _realm = realm;
+        private readonly List<UrlPatternToken> _tokenList = tokenList;
+        private readonly UrlPatternCompileOptions _options = options;
+        private readonly UrlPatternEncodingCallback _encodingCallback = encodingCallback;
+        private readonly string _segmentWildcardRegexp = UrlPatternGenerator.GenerateSegmentWildcardRegexp(options);
+        private string _pendingFixedValue = string.Empty;
+        private int _index;
+        private int _nextNumericName;
+
+        internal List<UrlPatternPart> PartList { get; } = [];
+
+        internal void Run()
+        {
+            while (_index < _tokenList.Count)
+            {
+                // The first shape: <prefix char><name><regexp><modifier>, any of which may be absent.
+                var charToken = TryConsume(UrlPatternTokenType.Char);
+                var nameToken = TryConsume(UrlPatternTokenType.Name);
+                var regexpOrWildcardToken = TryConsumeRegexpOrWildcard(nameToken.HasValue);
+
+                if (nameToken.HasValue || regexpOrWildcardToken.HasValue)
+                {
+                    var prefix = charToken?.Value ?? string.Empty;
+                    if (prefix.Length != 0 && !_options.IsPrefix(prefix))
+                    {
+                        // Only the component's own prefix code point is an automatic prefix; anything else is
+                        // fixed text that happens to sit in front of the group.
+                        _pendingFixedValue += prefix;
+                        prefix = string.Empty;
+                    }
+
+                    MaybeAddPartFromPendingFixedValue();
+                    AddPart(prefix, nameToken, regexpOrWildcardToken, string.Empty, TryConsumeModifier());
+                    continue;
+                }
+
+                var fixedToken = charToken ?? TryConsume(UrlPatternTokenType.EscapedChar);
+                if (fixedToken is { } fixedText)
+                {
+                    _pendingFixedValue += fixedText.Value;
+                    continue;
+                }
+
+                // The second shape: {<prefix><name><regexp><suffix>}<modifier>.
+                if (TryConsume(UrlPatternTokenType.Open).HasValue)
+                {
+                    var prefix = ConsumeText();
+                    nameToken = TryConsume(UrlPatternTokenType.Name);
+                    regexpOrWildcardToken = TryConsumeRegexpOrWildcard(nameToken.HasValue);
+                    var suffix = ConsumeText();
+                    ConsumeRequired(UrlPatternTokenType.Close);
+                    AddPart(prefix, nameToken, regexpOrWildcardToken, suffix, TryConsumeModifier());
+                    continue;
+                }
+
+                MaybeAddPartFromPendingFixedValue();
+                ConsumeRequired(UrlPatternTokenType.End);
+            }
+        }
+
+        /// <summary>https://urlpattern.spec.whatwg.org/#try-to-consume-a-token</summary>
+        private UrlPatternToken? TryConsume(UrlPatternTokenType type)
+        {
+            var next = _tokenList[_index];
+            if (next.Type != type)
+            {
+                return null;
+            }
+
+            _index++;
+            return next;
+        }
+
+        /// <summary>https://urlpattern.spec.whatwg.org/#try-to-consume-a-modifier-token</summary>
+        private UrlPatternToken? TryConsumeModifier()
+            => TryConsume(UrlPatternTokenType.OtherModifier) ?? TryConsume(UrlPatternTokenType.Asterisk);
+
+        /// <summary>https://urlpattern.spec.whatwg.org/#try-to-consume-a-regexp-or-wildcard-token</summary>
+        private UrlPatternToken? TryConsumeRegexpOrWildcard(bool hasNameToken)
+        {
+            var token = TryConsume(UrlPatternTokenType.Regexp);
+            if (!hasNameToken && token is null)
+            {
+                // A "*" right after a name is the name's modifier, not a wildcard of its own.
+                token = TryConsume(UrlPatternTokenType.Asterisk);
+            }
+
+            return token;
+        }
+
+        /// <summary>https://urlpattern.spec.whatwg.org/#consume-a-required-token</summary>
+        private void ConsumeRequired(UrlPatternTokenType type)
+        {
+            if (TryConsume(type) is null)
+            {
+                Throw.TypeError(_realm, $"Invalid URLPattern syntax at index {_tokenList[_index].Index}");
+            }
+        }
+
+        /// <summary>https://urlpattern.spec.whatwg.org/#consume-text</summary>
+        private string ConsumeText()
+        {
+            var result = new ValueStringBuilder(stackalloc char[32]);
+            try
+            {
+                while (true)
+                {
+                    var token = TryConsume(UrlPatternTokenType.Char) ?? TryConsume(UrlPatternTokenType.EscapedChar);
+                    if (token is not { } consumed)
+                    {
+                        break;
+                    }
+
+                    result.Append(consumed.Value);
+                }
+
+                return result.AsSpan().ToString();
+            }
+            finally
+            {
+                result.Dispose();
+            }
+        }
+
+        /// <summary>https://urlpattern.spec.whatwg.org/#maybe-add-a-part-from-the-pending-fixed-value</summary>
+        private void MaybeAddPartFromPendingFixedValue()
+        {
+            if (_pendingFixedValue.Length == 0)
+            {
+                return;
+            }
+
+            var encodedValue = _encodingCallback(_realm, _pendingFixedValue);
+            _pendingFixedValue = string.Empty;
+            PartList.Add(new UrlPatternPart(
+                UrlPatternPartType.FixedText,
+                encodedValue,
+                UrlPatternModifier.None,
+                string.Empty,
+                string.Empty,
+                string.Empty));
+        }
+
+        /// <summary>https://urlpattern.spec.whatwg.org/#add-a-part</summary>
+        private void AddPart(
+            string prefix,
+            UrlPatternToken? nameToken,
+            UrlPatternToken? regexpOrWildcardToken,
+            string suffix,
+            UrlPatternToken? modifierToken)
+        {
+            var modifier = UrlPatternModifier.None;
+            if (modifierToken is { } modifierValue)
+            {
+                modifier = modifierValue.Value switch
+                {
+                    "?" => UrlPatternModifier.Optional,
+                    "*" => UrlPatternModifier.ZeroOrMore,
+                    "+" => UrlPatternModifier.OneOrMore,
+                    _ => UrlPatternModifier.None,
+                };
+            }
+
+            if (nameToken is null && regexpOrWildcardToken is null && modifier == UrlPatternModifier.None)
+            {
+                // A "{foo}" grouping: it can be merged with the text on either side of it.
+                _pendingFixedValue += prefix;
+                return;
+            }
+
+            MaybeAddPartFromPendingFixedValue();
+
+            if (nameToken is null && regexpOrWildcardToken is null)
+            {
+                // A "{foo}?" grouping: the modifier makes it a part of its own.
+                if (prefix.Length == 0)
+                {
+                    return;
+                }
+
+                PartList.Add(new UrlPatternPart(
+                    UrlPatternPartType.FixedText,
+                    _encodingCallback(_realm, prefix),
+                    modifier,
+                    string.Empty,
+                    string.Empty,
+                    string.Empty));
+                return;
+            }
+
+            // Everything becomes a regular expression first, so that an explicitly written "([^/]+?)" is treated
+            // exactly like the ":foo" that would have generated it.
+            string regexpValue;
+            if (regexpOrWildcardToken is not { } token)
+            {
+                regexpValue = _segmentWildcardRegexp;
+            }
+            else if (token.Type == UrlPatternTokenType.Asterisk)
+            {
+                regexpValue = UrlPatternGenerator.FullWildcardRegexpValue;
+            }
+            else
+            {
+                regexpValue = token.Value;
+            }
+
+            var type = UrlPatternPartType.Regexp;
+            if (string.Equals(regexpValue, _segmentWildcardRegexp, StringComparison.Ordinal))
+            {
+                type = UrlPatternPartType.SegmentWildcard;
+                regexpValue = string.Empty;
+            }
+            else if (string.Equals(regexpValue, UrlPatternGenerator.FullWildcardRegexpValue, StringComparison.Ordinal))
+            {
+                type = UrlPatternPartType.FullWildcard;
+                regexpValue = string.Empty;
+            }
+
+            string name;
+            if (nameToken is { } named)
+            {
+                name = named.Value;
+            }
+            else if (regexpOrWildcardToken is not null)
+            {
+                name = _nextNumericName.ToString(CultureInfo.InvariantCulture);
+                _nextNumericName++;
+            }
+            else
+            {
+                name = string.Empty;
+            }
+
+            if (IsDuplicateName(name))
+            {
+                Throw.TypeError(_realm, $"Duplicate URLPattern group name \"{name}\"");
+            }
+
+            PartList.Add(new UrlPatternPart(
+                type,
+                regexpValue,
+                modifier,
+                name,
+                _encodingCallback(_realm, prefix),
+                _encodingCallback(_realm, suffix)));
+        }
+
+        /// <summary>https://urlpattern.spec.whatwg.org/#is-a-duplicate-name</summary>
+        private bool IsDuplicateName(string name)
+        {
+            foreach (var part in PartList)
+            {
+                if (string.Equals(part.Name, name, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/Url/Pattern/UrlPatternTokenizer.cs
+++ b/Jint/WebApi/Url/Pattern/UrlPatternTokenizer.cs
@@ -1,0 +1,397 @@
+#if NET8_0_OR_GREATER
+using System.Globalization;
+using System.Runtime.InteropServices;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Url.Pattern;
+
+/// <summary>
+/// https://urlpattern.spec.whatwg.org/#tokens — the lexical token kinds of a pattern string.
+/// </summary>
+internal enum UrlPatternTokenType
+{
+    /// <summary>A U+007B (<c>{</c>) code point.</summary>
+    Open,
+
+    /// <summary>A U+007D (<c>}</c>) code point.</summary>
+    Close,
+
+    /// <summary>A "<c>(&lt;regular expression&gt;)</c>" string, whose value excludes the parentheses.</summary>
+    Regexp,
+
+    /// <summary>A "<c>:&lt;name&gt;</c>" string, whose value excludes the colon.</summary>
+    Name,
+
+    /// <summary>A valid pattern code point with no special syntactical meaning.</summary>
+    Char,
+
+    /// <summary>A code point escaped with a backslash; the value is the escaped code point alone.</summary>
+    EscapedChar,
+
+    /// <summary>A U+003F (<c>?</c>) or U+002B (<c>+</c>) modifier.</summary>
+    OtherModifier,
+
+    /// <summary>A U+002A (<c>*</c>), which is either a wildcard group or a modifier.</summary>
+    Asterisk,
+
+    /// <summary>The end of the pattern string.</summary>
+    End,
+
+    /// <summary>A code point that is invalid in the pattern, either in itself or in this position.</summary>
+    InvalidChar,
+}
+
+/// <summary>
+/// https://urlpattern.spec.whatwg.org/#token — one lexical token, its position in the pattern string and the
+/// code points it covers.
+/// </summary>
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct UrlPatternToken(UrlPatternTokenType Type, int Index, string Value);
+
+/// <summary>
+/// The tokenizer of https://urlpattern.spec.whatwg.org/#tokenizing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The spec's tokenizer walks <i>code points</i> and this one walks UTF-16 code units, which is a difference of
+/// bookkeeping only: "get the next code point" consumes both halves of a surrogate pair, so every position
+/// this type records is the start of a code point and every "code point substring" is an ordinary substring.
+/// The spec's recurring test "index is equal to input's code point length minus 1" — read as "the code point
+/// just read is the last one" — becomes <c>_nextIndex == _input.Length</c>, which holds for an astral code point
+/// as well.
+/// </para>
+/// <para>
+/// The two policies differ only in what an error does. Under
+/// "<a href="https://urlpattern.spec.whatwg.org/#tokenize-policy">strict</a>" it throws a <c>TypeError</c>, which
+/// is how a malformed component pattern is rejected; under "lenient" it produces an
+/// <see cref="UrlPatternTokenType.InvalidChar"/> token, which is what lets the constructor string parser see a
+/// code point that is not valid pattern syntax and still treat it as a component separator.
+/// </para>
+/// </remarks>
+internal static class UrlPatternTokenizer
+{
+    /// <summary>
+    /// https://urlpattern.spec.whatwg.org/#tokenize
+    /// </summary>
+    internal static List<UrlPatternToken> Tokenize(Realm realm, string input, bool strict)
+    {
+        var tokenizer = new Tokenizer(realm, input, strict);
+        tokenizer.Run();
+        return tokenizer.Tokens;
+    }
+
+    /// <summary>
+    /// https://urlpattern.spec.whatwg.org/#is-a-valid-name-code-point — whether <paramref name="codePoint"/> may
+    /// appear in a "<c>:name</c>" group name, in the first position or a later one.
+    /// </summary>
+    /// <remarks>
+    /// The spec defers to ECMAScript's <c>IdentifierStart</c> and <c>IdentifierPart</c>. Outside ASCII those are
+    /// Unicode's <c>ID_Start</c> and <c>ID_Continue</c>, which the BCL does not expose as properties, so they are
+    /// derived here from the general category plus the <c>Other_ID_Start</c> and <c>Other_ID_Continue</c> lists —
+    /// the derivation the properties themselves are defined by. It agrees with the real properties up to the
+    /// Unicode version of the platform's category table, the same version skew
+    /// <see cref="Jint.WebApi.Url.Parsing.Idna"/> documents for IDNA.
+    /// </remarks>
+    internal static bool IsValidNameCodePoint(int codePoint, bool first)
+    {
+        if (codePoint < 0x80)
+        {
+            if (codePoint == '$' || codePoint == '_'
+                || (codePoint >= 'a' && codePoint <= 'z')
+                || (codePoint >= 'A' && codePoint <= 'Z'))
+            {
+                // U+005F (_) is IdentifierStartChar in its own right and is in ID_Continue.
+                return true;
+            }
+
+            return !first && codePoint >= '0' && codePoint <= '9';
+        }
+
+        return first ? IsUnicodeIdStart(codePoint) : IsUnicodeIdContinue(codePoint);
+    }
+
+    private static bool IsUnicodeIdStart(int codePoint)
+    {
+        // Other_ID_Start: code points kept in ID_Start for stability although their category no longer implies it.
+        if (codePoint is 0x1885 or 0x1886 or 0x2118 or 0x212E or 0x309B or 0x309C)
+        {
+            return true;
+        }
+
+        return CharUnicodeInfo.GetUnicodeCategory(codePoint) is UnicodeCategory.UppercaseLetter
+            or UnicodeCategory.LowercaseLetter
+            or UnicodeCategory.TitlecaseLetter
+            or UnicodeCategory.ModifierLetter
+            or UnicodeCategory.OtherLetter
+            or UnicodeCategory.LetterNumber;
+    }
+
+    private static bool IsUnicodeIdContinue(int codePoint)
+    {
+        // IdentifierPartChar adds the two joiners on top of ID_Continue.
+        if (codePoint is 0x200C or 0x200D)
+        {
+            return true;
+        }
+
+        // Other_ID_Continue.
+        if (codePoint is 0x00B7 or 0x0387 or 0x19DA || (codePoint >= 0x1369 && codePoint <= 0x1371))
+        {
+            return true;
+        }
+
+        if (IsUnicodeIdStart(codePoint))
+        {
+            return true;
+        }
+
+        return CharUnicodeInfo.GetUnicodeCategory(codePoint) is UnicodeCategory.NonSpacingMark
+            or UnicodeCategory.SpacingCombiningMark
+            or UnicodeCategory.DecimalDigitNumber
+            or UnicodeCategory.ConnectorPunctuation;
+    }
+
+    private sealed class Tokenizer(Realm realm, string input, bool strict)
+    {
+        private readonly Realm _realm = realm;
+        private readonly string _input = input;
+        private readonly bool _strict = strict;
+        private int _index;
+        private int _nextIndex;
+        private int _codePoint = -1;
+
+        internal List<UrlPatternToken> Tokens { get; } = [];
+
+        internal void Run()
+        {
+            while (_index < _input.Length)
+            {
+                SeekAndGetNextCodePoint(_index);
+
+                switch (_codePoint)
+                {
+                    case '*':
+                        AddTokenWithDefaultPositionAndLength(UrlPatternTokenType.Asterisk);
+                        continue;
+                    case '+':
+                    case '?':
+                        AddTokenWithDefaultPositionAndLength(UrlPatternTokenType.OtherModifier);
+                        continue;
+                    case '\\':
+                        ReadEscapedChar();
+                        continue;
+                    case '{':
+                        AddTokenWithDefaultPositionAndLength(UrlPatternTokenType.Open);
+                        continue;
+                    case '}':
+                        AddTokenWithDefaultPositionAndLength(UrlPatternTokenType.Close);
+                        continue;
+                    case ':':
+                        ReadName();
+                        continue;
+                    case '(':
+                        ReadRegexp();
+                        continue;
+                    default:
+                        AddTokenWithDefaultPositionAndLength(UrlPatternTokenType.Char);
+                        continue;
+                }
+            }
+
+            AddTokenWithDefaultLength(UrlPatternTokenType.End, _index, _index);
+        }
+
+        private void ReadEscapedChar()
+        {
+            if (_nextIndex == _input.Length)
+            {
+                // A trailing backslash escapes nothing.
+                ProcessTokenizingError(_nextIndex, _index);
+                return;
+            }
+
+            var escapedIndex = _nextIndex;
+            GetNextCodePoint();
+            AddTokenWithDefaultLength(UrlPatternTokenType.EscapedChar, _nextIndex, escapedIndex);
+        }
+
+        private void ReadName()
+        {
+            var namePosition = _nextIndex;
+            var nameStart = namePosition;
+
+            while (namePosition < _input.Length)
+            {
+                SeekAndGetNextCodePoint(namePosition);
+                if (!IsValidNameCodePoint(_codePoint, first: namePosition == nameStart))
+                {
+                    break;
+                }
+
+                namePosition = _nextIndex;
+            }
+
+            if (namePosition <= nameStart)
+            {
+                // A colon that names nothing.
+                ProcessTokenizingError(nameStart, _index);
+                return;
+            }
+
+            AddTokenWithDefaultLength(UrlPatternTokenType.Name, namePosition, nameStart);
+        }
+
+        private void ReadRegexp()
+        {
+            var depth = 1;
+            var regexpPosition = _nextIndex;
+            var regexpStart = regexpPosition;
+            var error = false;
+
+            while (regexpPosition < _input.Length)
+            {
+                SeekAndGetNextCodePoint(regexpPosition);
+
+                if (_codePoint > 0x7F)
+                {
+                    // "The regular expression is required to consist of only ASCII code points."
+                    error = FailRegexp(regexpStart);
+                    break;
+                }
+
+                if (regexpPosition == regexpStart && _codePoint == '?')
+                {
+                    // A leading "?" would make the group non-capturing or a lookaround.
+                    error = FailRegexp(regexpStart);
+                    break;
+                }
+
+                if (_codePoint == '\\')
+                {
+                    if (_nextIndex == _input.Length)
+                    {
+                        error = FailRegexp(regexpStart);
+                        break;
+                    }
+
+                    GetNextCodePoint();
+                    if (_codePoint > 0x7F)
+                    {
+                        error = FailRegexp(regexpStart);
+                        break;
+                    }
+
+                    regexpPosition = _nextIndex;
+                    continue;
+                }
+
+                if (_codePoint == ')')
+                {
+                    depth--;
+                    if (depth == 0)
+                    {
+                        regexpPosition = _nextIndex;
+                        break;
+                    }
+                }
+                else if (_codePoint == '(')
+                {
+                    depth++;
+                    if (_nextIndex == _input.Length)
+                    {
+                        error = FailRegexp(regexpStart);
+                        break;
+                    }
+
+                    var temporaryPosition = _nextIndex;
+                    GetNextCodePoint();
+                    if (_codePoint != '?')
+                    {
+                        // Only non-capturing groups and assertions may nest inside a regexp group.
+                        error = FailRegexp(regexpStart);
+                        break;
+                    }
+
+                    _nextIndex = temporaryPosition;
+                }
+
+                regexpPosition = _nextIndex;
+            }
+
+            if (error)
+            {
+                return;
+            }
+
+            if (depth != 0)
+            {
+                ProcessTokenizingError(regexpStart, _index);
+                return;
+            }
+
+            var regexpLength = regexpPosition - regexpStart - 1;
+            if (regexpLength == 0)
+            {
+                ProcessTokenizingError(regexpStart, _index);
+                return;
+            }
+
+            AddToken(UrlPatternTokenType.Regexp, regexpPosition, regexpStart, regexpLength);
+        }
+
+        private bool FailRegexp(int regexpStart)
+        {
+            ProcessTokenizingError(regexpStart, _index);
+            return true;
+        }
+
+        /// <summary>https://urlpattern.spec.whatwg.org/#get-the-next-code-point</summary>
+        private void GetNextCodePoint()
+        {
+            var c = _input[_nextIndex];
+            if (char.IsHighSurrogate(c) && _nextIndex + 1 < _input.Length && char.IsLowSurrogate(_input[_nextIndex + 1]))
+            {
+                _codePoint = char.ConvertToUtf32(c, _input[_nextIndex + 1]);
+                _nextIndex += 2;
+                return;
+            }
+
+            _codePoint = c;
+            _nextIndex++;
+        }
+
+        /// <summary>https://urlpattern.spec.whatwg.org/#seek-and-get-the-next-code-point</summary>
+        private void SeekAndGetNextCodePoint(int index)
+        {
+            _nextIndex = index;
+            GetNextCodePoint();
+        }
+
+        /// <summary>https://urlpattern.spec.whatwg.org/#add-a-token</summary>
+        private void AddToken(UrlPatternTokenType type, int nextPosition, int valuePosition, int valueLength)
+        {
+            Tokens.Add(new UrlPatternToken(type, _index, _input.Substring(valuePosition, valueLength)));
+            _index = nextPosition;
+        }
+
+        /// <summary>https://urlpattern.spec.whatwg.org/#add-a-token-with-default-length</summary>
+        private void AddTokenWithDefaultLength(UrlPatternTokenType type, int nextPosition, int valuePosition)
+            => AddToken(type, nextPosition, valuePosition, nextPosition - valuePosition);
+
+        /// <summary>https://urlpattern.spec.whatwg.org/#add-a-token-with-default-position-and-length</summary>
+        private void AddTokenWithDefaultPositionAndLength(UrlPatternTokenType type)
+            => AddTokenWithDefaultLength(type, _nextIndex, _index);
+
+        /// <summary>https://urlpattern.spec.whatwg.org/#process-a-tokenizing-error</summary>
+        private void ProcessTokenizingError(int nextPosition, int valuePosition)
+        {
+            if (_strict)
+            {
+                Throw.TypeError(_realm, $"Invalid URLPattern syntax at index {valuePosition}");
+            }
+
+            AddTokenWithDefaultLength(UrlPatternTokenType.InvalidChar, nextPosition, valuePosition);
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/WebApiRegistration.cs
+++ b/Jint/WebApi/WebApiRegistration.cs
@@ -105,6 +105,11 @@ internal static class WebApiRegistration
         {
             Install(global, engine, "URL", static e => e.Realm.Intrinsics.WebApiUrl, PropertyFlag.NonEnumerable);
             Install(global, engine, "URLSearchParams", static e => e.Realm.Intrinsics.WebApiUrlSearchParams, PropertyFlag.NonEnumerable);
+
+            // URLPattern rides this flag rather than carrying one of its own: it is the same standard family, it
+            // is defined entirely in terms of the URL parser and its component canonicalization, and a pattern is
+            // matched against a URL — so an engine that has no URL has nothing for it to be useful on.
+            Install(global, engine, "URLPattern", static e => e.Realm.Intrinsics.WebApiUrlPattern, PropertyFlag.NonEnumerable);
         }
 
         if ((features & WebApiFeatures.Events) != WebApiFeatures.None)

--- a/README.md
+++ b/README.md
@@ -223,13 +223,14 @@ its own `console` (or any other name in the table below), enabling the feature l
 | `crypto.getRandomValues` / `crypto.randomUUID` / `crypto.subtle` (SHA digests, HMAC, AES-GCM, `CryptoKey`) | `WebApiFeatures.Crypto` | ✔ shipped |
 | `performance.now` / `timeOrigin` / `mark` / `measure` / `getEntries*` / `clearMarks` / `clearMeasures` | `WebApiFeatures.Performance` | ✔ shipped |
 | `Event` / `EventTarget` / `CustomEvent` / `AbortController` / `AbortSignal` | `Events` | ✔ shipped |
-| `URL` / `URLSearchParams` | `Url` | ✔ shipped |
+| `URL` / `URLSearchParams` / `URLPattern` | `Url` | ✔ shipped |
 | `Blob` (incl. `stream()`) / `File` / `FormData` | `Files` | ✔ shipped |
 | `navigator.userAgent` | `Navigator` | ✔ shipped |
 | `ReadableStream` / `WritableStream` / `TransformStream` / `ByteLengthQueuingStrategy` / `CountQueuingStrategy` | `Streams` | ✔ shipped |
 | `TextEncoderStream` / `TextDecoderStream` | `Encoding` **and** `Streams` | ✔ shipped |
 | `CompressionStream` / `DecompressionStream` (`gzip`, `deflate`, `deflate-raw`) | `Compression` **and** `Streams` | ✔ shipped |
 | `scheduler.postTask` / `scheduler.yield` / `TaskController` / `TaskSignal` | `Scheduler` | ✔ shipped |
+| `requestIdleCallback` / `cancelIdleCallback` / `IdleDeadline` | `IdleCallback` | ✔ shipped |
 | `MessageChannel` / `MessagePort` / `MessageEvent` (incl. cross-engine ports) | `Messaging` | ✔ shipped |
 | `reportError` (and the `DiagnosticsSink` behind it) | `Reporting` | ✔ shipped |
 | `localStorage` / `sessionStorage` / `Storage` | `Storage` *(not in `Default` — see below)* | ✔ shipped |
@@ -237,9 +238,6 @@ its own `console` (or any other name in the table below), enabling the feature l
 | `EventSource` / `MessageEvent` (server-sent events) | `EventSource` — **opt-in on its own, see below** | ✔ shipped |
 | `WebSocket` / `CloseEvent` (and the `MessageEvent` its messages arrive as) | `WebSocket` — **opt-in on its own, see below** | ✔ shipped |
 | `caches` / `Cache` / `CacheStorage` | `CacheApi` — **opt-in on its own, see below** | ✔ shipped |
-
-| `requestIdleCallback` / `cancelIdleCallback` / `IdleDeadline` | `IdleCallback` | ✔ shipped |
-| `fetch` / `Headers` / `Request` / `Response` | `Fetch` | in progress |
 
 `WebApiFeatures.Default` — what `UseWebApis()` enables — is every non-network feature that has landed. It
 grows as the table fills in, and it will never include `fetch`: network egress is always an explicit choice.


### PR DESCRIPTION
`URLPattern` per https://urlpattern.spec.whatwg.org/ on the in-tree URL parser, riding `WebApiFeatures.Url`: the tokenizer, pattern parser, canonicalization and generator as the spec writes them, with the WPT `urlpatterntestdata.json` corpus (369 rows, pinned to the same wpt commit as the URL corpus) as the acceptance net.

The load-bearing decision: **components compile to the engine's own JS `RegExp`, not `System.Text.RegularExpressions`.** A `(regexp)` group is arbitrary author regexp source, and .NET is not merely a dialect away — the spec's own default wildcard `[^]+?` is not even valid .NET regex. The spec's `v`/`vi` flags route every component to Jint's own regex engine, so there is no second dialect to document and the engine's `Options.Constraints.RegexTimeout` bounds a hostile group exactly as it bounds script regex (pinned with a catastrophic-backtracking pattern). Matching calls `RegExpBuiltinExec` — the built-in the spec names — so a patched `RegExp.prototype.exec` cannot observe or alter a match (mutation-pinned). `ignoreCase` reaches only pathname/search/hash, which is what the spec's create steps actually say (mutation-pinned, because nobody believes it).

The corpus caught a real conformance bug in the URL parser on its first run — port-state's "if state override is given, return" belongs *inside* the non-empty-buffer block, so a state-override parse of a non-numeric port now reports failure — invisible through the `port` setter (which discards the result), visible to `canonicalize a port`, and both URL corpora stay green. The corpus driver enforces the test262-style stale-exclusion discipline (a bogus exclusion fails the run, quoted in the report).

Both suites green on net10.0 and net472, with and without `JINT_HOST_CONTRACT_VERIFICATION=1`.

Closes #3102

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G7Ud48VAs1JicxRZxLDxg
