### PR TITLE
Web API: bridge WHATWG streams to System.IO.Stream for hosts

### DIFF
--- a/Jint.Tests.PublicInterface/HostStreamBridgeTests.cs
+++ b/Jint.Tests.PublicInterface/HostStreamBridgeTests.cs
@@ -1,0 +1,764 @@
+#if NET8_0_OR_GREATER
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Jint;
+using Jint.Native;
+using Jint.Runtime;
+using Jint.WebApi;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// The bridge between the WHATWG streams and <see cref="System.IO.Stream"/>, seen from outside the assembly:
+/// <c>Engine.Advanced.CreateReadableStream</c>, <c>CreateWritableStream</c>,
+/// <c>StartReadableStreamCopy</c> and <c>CopyReadableStreamAsync</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This project has no <c>InternalsVisibleTo</c>, so everything used here is reachable by a third party —
+/// which is the point of putting the tests here rather than in <c>Jint.Tests</c>.
+/// </para>
+/// <para>
+/// <b>Nothing here sleeps, races a clock, or asserts that time passed.</b> Every host stream is one whose
+/// asynchronous methods complete synchronously (see <see cref="RecordingStream"/>), so the whole copy runs on
+/// the engine's own turns and a bounded <c>ProcessTasks</c> loop is enough to drive it to completion. The one
+/// test that deliberately goes off-thread, <see cref="ReadsAStreamWhoseReadsCompleteOnAnotherThread"/>, waits
+/// for the outcome through the engine's own blocking drain rather than for an interval.
+/// </para>
+/// </remarks>
+public class HostStreamBridgeTests
+{
+    private static Engine StreamEngine() => new(options => options.UseWebApis(WebApiFeatures.Streams));
+
+    private static byte[] Utf8(string text) => Encoding.UTF8.GetBytes(text);
+
+    /// <summary>
+    /// A <see cref="MemoryStream"/> that records what the engine did to it, and — crucially — keeps the
+    /// synchronous completion its base class gives the <see cref="Memory{T}"/> overloads.
+    /// </summary>
+    /// <remarks>
+    /// The overrides are the <see cref="Memory{T}"/>-based ones because those are what the bridge calls;
+    /// overriding <c>Read(byte[], int, int)</c> would record nothing, since <see cref="MemoryStream"/>
+    /// implements the newer overloads without going through it.
+    /// </remarks>
+    private sealed class RecordingStream : MemoryStream
+    {
+        internal RecordingStream()
+        {
+        }
+
+        internal RecordingStream(byte[] initial) : base(initial, writable: false)
+        {
+        }
+
+        internal int Reads { get; private set; }
+
+        internal int Writes { get; private set; }
+
+        internal int Flushes { get; private set; }
+
+        internal bool Disposed { get; private set; }
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            Reads++;
+            return base.ReadAsync(buffer, cancellationToken);
+        }
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            Writes++;
+            return base.WriteAsync(buffer, cancellationToken);
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            Flushes++;
+            return base.FlushAsync(cancellationToken);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            Disposed = true;
+            base.Dispose(disposing);
+        }
+    }
+
+    /// <summary>A stream whose reads fail, for the error path.</summary>
+    private sealed class FailingReadStream : Stream
+    {
+        internal bool Disposed { get; private set; }
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            => ValueTask.FromException<int>(new IOException("the disk in question is on fire"));
+
+        public override int Read(byte[] buffer, int offset, int count) => throw new IOException("the disk in question is on fire");
+
+        public override void Flush()
+        {
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            Disposed = true;
+            base.Dispose(disposing);
+        }
+    }
+
+    /// <summary>
+    /// A stream whose reads genuinely leave the calling thread, so that the cross-thread chunk delivery is
+    /// exercised rather than the synchronous window.
+    /// </summary>
+    private sealed class OffThreadStream : Stream
+    {
+        private readonly byte[] _data;
+        private int _position;
+
+        internal OffThreadStream(byte[] data)
+        {
+            _data = data;
+        }
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => _data.Length;
+
+        public override long Position
+        {
+            get => _position;
+            set => throw new NotSupportedException();
+        }
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            // Forces the continuation onto the thread pool, which is what puts the chunk delivery through the
+            // event loop rather than through the synchronous window.
+            await Task.Yield();
+
+            var count = Math.Min(buffer.Length, _data.Length - _position);
+            _data.AsSpan(_position, count).CopyTo(buffer.Span);
+            _position += count;
+            return count;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        public override void Flush()
+        {
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// A destination whose writes and flush genuinely leave the calling thread, so that the copy's own
+    /// cross-thread path is exercised rather than its synchronous window.
+    /// </summary>
+    private sealed class OffThreadWriteStream : MemoryStream
+    {
+        internal bool Disposed { get; private set; }
+
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+            await base.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+        }
+
+        public override async Task FlushAsync(CancellationToken cancellationToken)
+        {
+            await Task.Yield();
+            await base.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            Disposed = true;
+            base.Dispose(disposing);
+        }
+    }
+
+    /// <summary>
+    /// Gives the engine turns until the copy is done. Bounded rather than timed: every stream in this file
+    /// completes its I/O synchronously, so each turn makes progress and the bound is only there so that a
+    /// regression fails the test instead of hanging the suite.
+    /// </summary>
+    private static void Drive(Engine engine, HostStreamCopyOperation operation)
+    {
+        for (var i = 0; i < 10_000 && !operation.IsCompleted; i++)
+        {
+            engine.Advanced.ProcessTasks();
+        }
+
+        operation.IsCompleted.Should().BeTrue("the copy should have finished within 10000 engine turns");
+    }
+
+    [Fact]
+    public void ReadsAHostStreamAsAReadableStreamOfUint8Arrays()
+    {
+        var engine = StreamEngine();
+        engine.SetValue("input", engine.Advanced.CreateReadableStream(new RecordingStream(Utf8("hello world"))));
+
+        var text = engine.Evaluate("""
+            (async () => {
+              const reader = input.getReader();
+              const parts = [];
+              for (;;) {
+                const { value, done } = await reader.read();
+                if (done) break;
+                parts.push(...value);
+              }
+              return String.fromCharCode(...parts);
+            })()
+            """).UnwrapIfPromise();
+
+        text.AsString().Should().Be("hello world");
+    }
+
+    [Fact]
+    public void ChunksAreBoundedByTheChunkSize()
+    {
+        var engine = StreamEngine();
+        var options = new HostReadableStreamOptions { ChunkSize = 4 };
+        engine.SetValue("input", engine.Advanced.CreateReadableStream(new RecordingStream(Utf8("abcdefghij")), options));
+
+        var sizes = engine.Evaluate("""
+            (async () => {
+              const reader = input.getReader();
+              const sizes = [];
+              for (;;) {
+                const { value, done } = await reader.read();
+                if (done) break;
+                sizes.push(value.length);
+              }
+              return sizes.join(',');
+            })()
+            """).UnwrapIfPromise();
+
+        sizes.AsString().Should().Be("4,4,2");
+    }
+
+    [Fact]
+    public void TheChunkIsAUint8ArrayAndAFreshOneEveryTime()
+    {
+        var engine = StreamEngine();
+        engine.SetValue("input", engine.Advanced.CreateReadableStream(
+            new RecordingStream(Utf8("abcd")),
+            new HostReadableStreamOptions { ChunkSize = 2 }));
+
+        var outcome = engine.Evaluate("""
+            (async () => {
+              const reader = input.getReader();
+              const first = (await reader.read()).value;
+              first[0] = 0;                              // the host's buffer must not be reachable through this
+              const second = (await reader.read()).value;
+              return (first instanceof Uint8Array) + ':' + (first === second) + ':' + second[0];
+            })()
+            """).UnwrapIfPromise();
+
+        // 'c' is 99: the second chunk is unaffected by the write into the first, so the bridge is not handing
+        // script a window onto its own reusable read buffer.
+        outcome.AsString().Should().Be("true:false:99");
+    }
+
+    [Fact]
+    public void NothingIsReadUntilTheHighWaterMarkAsksForIt()
+    {
+        // The whole of backpressure, asserted structurally: with a high water mark of zero the queue never
+        // wants a chunk, so not one byte leaves the host's stream until a reader asks. With the default of
+        // one, exactly one chunk is read ahead.
+        var engine = StreamEngine();
+        var source = new RecordingStream(Utf8("abcdefgh"));
+
+        engine.SetValue("input", engine.Advanced.CreateReadableStream(
+            source,
+            new HostReadableStreamOptions { ChunkSize = 2, HighWaterMark = 0 }));
+
+        engine.Advanced.ProcessTasks();
+        source.Reads.Should().Be(0);
+
+        engine.Evaluate("input.getReader().read()").UnwrapIfPromise();
+        source.Reads.Should().Be(1);
+
+        var eager = new RecordingStream(Utf8("abcdefgh"));
+        var other = StreamEngine();
+        other.SetValue("input", other.Advanced.CreateReadableStream(eager, new HostReadableStreamOptions { ChunkSize = 2 }));
+
+        other.Advanced.ProcessTasks();
+        eager.Reads.Should().Be(1);
+    }
+
+    [Fact]
+    public void ReadingToTheEndReleasesTheHostStream()
+    {
+        var engine = StreamEngine();
+        var source = new RecordingStream(Utf8("abc"));
+        engine.SetValue("input", engine.Advanced.CreateReadableStream(source));
+
+        engine.Evaluate("(async () => { const r = input.getReader(); while (!(await r.read()).done); })()").UnwrapIfPromise();
+
+        source.Disposed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void LeaveOpenKeepsTheHostStreamForTheHost()
+    {
+        var engine = StreamEngine();
+        var source = new RecordingStream(Utf8("abc"));
+        engine.SetValue("input", engine.Advanced.CreateReadableStream(source, new HostReadableStreamOptions { LeaveOpen = true }));
+
+        engine.Evaluate("(async () => { const r = input.getReader(); while (!(await r.read()).done); })()").UnwrapIfPromise();
+
+        source.Disposed.Should().BeFalse();
+        source.CanRead.Should().BeTrue();
+    }
+
+    [Fact]
+    public void CancellingTheStreamReleasesTheHostStream()
+    {
+        var engine = StreamEngine();
+        var source = new RecordingStream(Utf8("abcdefgh"));
+        engine.SetValue("input", engine.Advanced.CreateReadableStream(source, new HostReadableStreamOptions { ChunkSize = 2 }));
+
+        engine.Evaluate("input.cancel('bored')").UnwrapIfPromise();
+
+        source.Disposed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AFailedReadErrorsTheStreamAndCarriesTheClrExceptionForTheHostAlone()
+    {
+        var engine = StreamEngine();
+        var source = new FailingReadStream();
+        engine.SetValue("input", engine.Advanced.CreateReadableStream(source));
+
+        var rejection = Assert.Throws<PromiseRejectedException>(() => engine.Evaluate("input.getReader().read()").UnwrapIfPromise());
+
+        var error = rejection.RejectedValue;
+        error.Get("name").AsString().Should().Be("TypeError");
+
+        // The message names the failure's shape but not its text: a path or a permission message would tell a
+        // script things about the host it has no business learning.
+        error.Get("message").AsString().Should().Be("The host stream failed while reading (IOException).");
+        error.Get("message").AsString().Should().NotContain("on fire");
+
+        // The exception itself rides the error value, where only the host can read it.
+        JintException.TryGetClrException(rejection, out var clr).Should().BeTrue();
+        clr!.Message.Should().Be("the disk in question is on fire");
+
+        source.Disposed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReadsAStreamWhoseReadsCompleteOnAnotherThread()
+    {
+        // The cross-thread half: every chunk arrives as a generation-stamped event-loop job rather than
+        // through the synchronous window. UnwrapIfPromise is the engine's own blocking drain, which wakes on
+        // the work-arrived signal rather than on a poll interval.
+        var engine = StreamEngine();
+        engine.SetValue("input", engine.Advanced.CreateReadableStream(
+            new OffThreadStream(Utf8("streamed off-thread")),
+            new HostReadableStreamOptions { ChunkSize = 4 }));
+
+        var text = engine.Evaluate("""
+            (async () => {
+              let out = '';
+              for await (const chunk of input) out += String.fromCharCode(...chunk);
+              return out;
+            })()
+            """).UnwrapIfPromise();
+
+        text.AsString().Should().Be("streamed off-thread");
+    }
+
+    [Fact]
+    public void RestoringTheGlobalsReleasesEveryOpenBridge()
+    {
+        // The restore fence. The generation stamp already stops a chunk reaching the restored engine; what
+        // this pins is the other half, that the host's file handle is closed rather than left to a finalizer.
+        var engine = StreamEngine();
+        var source = new RecordingStream(Utf8("abcdefgh"));
+        var destination = new RecordingStream();
+
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+        engine.SetValue("input", engine.Advanced.CreateReadableStream(source, new HostReadableStreamOptions { HighWaterMark = 0 }));
+        engine.SetValue("output", engine.Advanced.CreateWritableStream(destination));
+
+        source.Disposed.Should().BeFalse();
+        destination.Disposed.Should().BeFalse();
+
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        source.Disposed.Should().BeTrue();
+        destination.Disposed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void WritesAWritableStreamToAHostStream()
+    {
+        var engine = StreamEngine();
+        var destination = new RecordingStream();
+        engine.SetValue("output", engine.Advanced.CreateWritableStream(destination));
+
+        engine.Evaluate("""
+            (async () => {
+              const writer = output.getWriter();
+              await writer.write(new Uint8Array([104, 105, 32]));   // "hi "
+              await writer.write('there');                          // a string is UTF-8 encoded
+              await writer.close();
+            })()
+            """).UnwrapIfPromise();
+
+        // ToArray() still answers after a MemoryStream has been closed, which is what lets the default —
+        // the engine owns and disposes the stream — be asserted at all.
+        Encoding.UTF8.GetString(destination.ToArray()).Should().Be("hi there");
+        destination.Flushes.Should().BeGreaterThan(0);
+        destination.Disposed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AChunkThatIsNotAByteSequenceIsRefusedRatherThanStringified()
+    {
+        var engine = StreamEngine();
+        var destination = new RecordingStream();
+        engine.SetValue("output", engine.Advanced.CreateWritableStream(destination));
+
+        var outcome = engine.Evaluate("""
+            (async () => {
+              const writer = output.getWriter();
+              try { await writer.write({ oops: true }); return 'no throw'; }
+              catch (e) { return e.name + ':' + e.message; }
+            })()
+            """).UnwrapIfPromise();
+
+        outcome.AsString().Should().StartWith("TypeError:A host stream can only be written a BufferSource, a Blob or a string");
+
+        // Nothing was written, so an object mistaken for a buffer cannot land in the host's file as
+        // "[object Object]".
+        destination.ToArray().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TheWriterIsBackpressuredByTheHighWaterMark()
+    {
+        // desiredSize is the standard's own arithmetic — highWaterMark minus the queue — so this is an exact
+        // structural statement about backpressure rather than a timing one.
+        var engine = StreamEngine();
+        engine.SetValue("output", engine.Advanced.CreateWritableStream(new RecordingStream()));
+
+        var sizes = engine.Evaluate("""
+            (() => {
+              const writer = output.getWriter();
+              const before = writer.desiredSize;
+              writer.write(new Uint8Array([1]));
+              writer.write(new Uint8Array([2]));
+              return before + ',' + writer.desiredSize;
+            })()
+            """);
+
+        sizes.AsString().Should().Be("1,-1");
+    }
+
+    [Fact]
+    public void AbortingTheWritableStreamReleasesTheHostStreamWithoutFlushing()
+    {
+        var engine = StreamEngine();
+        var destination = new RecordingStream();
+        engine.SetValue("output", engine.Advanced.CreateWritableStream(destination));
+
+        engine.Evaluate("output.abort('nope')").UnwrapIfPromise();
+
+        destination.Disposed.Should().BeTrue();
+        destination.Flushes.Should().Be(0);
+    }
+
+    [Fact]
+    public void CopiesAScriptStreamThroughATransformIntoAHostStream()
+    {
+        // The recipe: a host stream in, a script TransformStream in the middle, a host stream out, and the
+        // host driving every turn itself.
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Streams | WebApiFeatures.Encoding));
+        var destination = new RecordingStream();
+
+        engine.SetValue("input", engine.Advanced.CreateReadableStream(new RecordingStream(Utf8("shout this")), new HostReadableStreamOptions { ChunkSize = 3 }));
+
+        var transformed = engine.Evaluate("""
+            input.pipeThrough(new TransformStream({
+              transform(chunk, controller) {
+                const text = new TextDecoder().decode(chunk);
+                controller.enqueue(new TextEncoder().encode(text.toUpperCase()));
+              }
+            }))
+            """);
+
+        var copy = engine.Advanced.StartReadableStreamCopy(transformed, destination);
+        Drive(engine, copy);
+
+        copy.IsFaulted.Should().BeFalse();
+        copy.GetResult().Should().Be(10);
+        Encoding.UTF8.GetString(destination.ToArray()).Should().Be("SHOUT THIS");
+        destination.Disposed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void CopiesABlobsStreamIntoAHostStream()
+    {
+        // `Blob.stream()` is a ReadableStream the engine built itself, not one a script constructed, so this
+        // is the copy taking a stream from somewhere other than its own tests.
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Streams | WebApiFeatures.Files));
+        var destination = new RecordingStream();
+
+        var body = engine.Evaluate("new Blob(['part one, ', 'part two']).stream()");
+
+        var copy = engine.Advanced.StartReadableStreamCopy(body, destination);
+        Drive(engine, copy);
+
+        copy.IsFaulted.Should().BeFalse();
+        Encoding.UTF8.GetString(destination.ToArray()).Should().Be("part one, part two");
+    }
+
+    [Fact]
+    public void PipesAHostStreamThroughADecompressionStreamIntoAHostStream()
+    {
+        // Both halves of the bridge with an engine-supplied transform between them: a compressed host stream
+        // in, `DecompressionStream` in the middle, a host stream out, and the host owning every turn.
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Streams | WebApiFeatures.Compression));
+        var destination = new RecordingStream();
+
+        var compressed = new MemoryStream();
+        using (var gzip = new System.IO.Compression.GZipStream(compressed, System.IO.Compression.CompressionMode.Compress, leaveOpen: true))
+        {
+            gzip.Write(Utf8("the bytes that made the round trip"));
+        }
+
+        compressed.Position = 0;
+        engine.SetValue("input", engine.Advanced.CreateReadableStream(compressed));
+
+        var plain = engine.Evaluate("input.pipeThrough(new DecompressionStream('gzip'))");
+
+        var copy = engine.Advanced.StartReadableStreamCopy(plain, destination);
+        Drive(engine, copy);
+
+        copy.IsFaulted.Should().BeFalse();
+        Encoding.UTF8.GetString(destination.ToArray()).Should().Be("the bytes that made the round trip");
+    }
+
+    [Fact]
+    public async Task CopyReadableStreamAsyncDrivesTheEngineWhileItWaits()
+    {
+        var engine = StreamEngine();
+        var destination = new RecordingStream();
+        var source = engine.Evaluate("new ReadableStream({ start(c) { c.enqueue(new Uint8Array([97, 98])); c.enqueue('c'); c.close(); } })");
+
+        var written = await engine.Advanced.CopyReadableStreamAsync(source, destination);
+
+        written.Should().Be(3);
+        Encoding.UTF8.GetString(destination.ToArray()).Should().Be("abc");
+    }
+
+    [Fact]
+    public async Task CopiesToADestinationWhoseWritesCompleteOnAnotherThread()
+    {
+        // The copy's own cross-thread half: each write settles on a thread-pool thread and comes back as a
+        // generation-stamped event-loop job. CopyReadableStreamAsync is what drives those turns, so nothing
+        // here waits for an interval.
+        var engine = StreamEngine();
+        var destination = new OffThreadWriteStream();
+        var source = engine.Evaluate("""
+            new ReadableStream({
+              start(c) { c.enqueue('one '); c.enqueue('two '); c.enqueue('three'); c.close(); }
+            })
+            """);
+
+        var written = await engine.Advanced.CopyReadableStreamAsync(source, destination);
+
+        written.Should().Be(13);
+        Encoding.UTF8.GetString(destination.ToArray()).Should().Be("one two three");
+        destination.Disposed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ACopyOfALockedStreamFailsTheOperationRatherThanTheStartCall()
+    {
+        var engine = StreamEngine();
+        var source = engine.Evaluate("new ReadableStream()");
+        engine.SetValue("source", source);
+        engine.Evaluate("source.getReader()");
+
+        var copy = engine.Advanced.StartReadableStreamCopy(source, new RecordingStream());
+
+        copy.IsCompleted.Should().BeTrue();
+        copy.IsFaulted.Should().BeTrue();
+        copy.Error!.Get("name").AsString().Should().Be("TypeError");
+        Assert.Throws<PromiseRejectedException>(() => copy.GetResult());
+    }
+
+    [Fact]
+    public void ACopyOfSomethingThatIsNotAReadableStreamIsAnArgumentException()
+    {
+        var engine = StreamEngine();
+
+        Assert.Throws<ArgumentException>(() => engine.Advanced.StartReadableStreamCopy(JsValue.Undefined, new RecordingStream()));
+        Assert.Throws<ArgumentException>(() => engine.Advanced.StartReadableStreamCopy(engine.Evaluate("({})"), new RecordingStream()));
+        Assert.Throws<ArgumentNullException>(() => engine.Advanced.StartReadableStreamCopy(engine.Evaluate("new ReadableStream()"), null!));
+    }
+
+    [Fact]
+    public void ACopyThatFailsCancelsTheSourceUnlessToldNotTo()
+    {
+        var engine = StreamEngine();
+        engine.Execute("var cancelled = [];");
+
+        // A source that records its own cancel(), which is how the piping rules are observable from script.
+        var source = engine.Evaluate("new ReadableStream({ start(c) { c.enqueue({}); }, cancel(r) { cancelled.push('yes'); } })");
+        var copy = engine.Advanced.StartReadableStreamCopy(source, new RecordingStream());
+        Drive(engine, copy);
+
+        copy.IsFaulted.Should().BeTrue();
+        engine.Evaluate("cancelled.join(',')").AsString().Should().Be("yes");
+
+        engine.Execute("cancelled = [];");
+        var kept = engine.Evaluate("new ReadableStream({ start(c) { c.enqueue({}); }, cancel(r) { cancelled.push('yes'); } })");
+        var preventing = engine.Advanced.StartReadableStreamCopy(kept, new RecordingStream(), new HostStreamCopyOptions { PreventCancel = true });
+        Drive(engine, preventing);
+
+        preventing.IsFaulted.Should().BeTrue();
+        engine.Evaluate("cancelled.join(',')").AsString().Should().Be("");
+    }
+
+    [Fact]
+    public void ACopyOfAnErroredStreamFailsWithTheScriptsOwnError()
+    {
+        var engine = StreamEngine();
+        var source = engine.Evaluate("new ReadableStream({ start(c) { c.error(new RangeError('nope')); } })");
+
+        var copy = engine.Advanced.StartReadableStreamCopy(source, new RecordingStream());
+        Drive(engine, copy);
+
+        copy.IsFaulted.Should().BeTrue();
+        copy.Error!.Get("name").AsString().Should().Be("RangeError");
+        copy.Error!.Get("message").AsString().Should().Be("nope");
+    }
+
+    [Fact]
+    public void ACancelledCopyEndsWithAnAbortErrorAndReleasesTheDestination()
+    {
+        var engine = StreamEngine();
+        var destination = new RecordingStream();
+
+        using var cancellation = new CancellationTokenSource();
+        var source = engine.Evaluate("new ReadableStream({ pull(c) { /* never produces a chunk */ } })");
+
+        var copy = engine.Advanced.StartReadableStreamCopy(source, destination, options: null, cancellation.Token);
+        engine.Advanced.ProcessTasks();
+        copy.IsCompleted.Should().BeFalse();
+
+        cancellation.Cancel();
+        Drive(engine, copy);
+
+        copy.IsFaulted.Should().BeTrue();
+        copy.Error!.Get("name").AsString().Should().Be("AbortError");
+        destination.Disposed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ACopyCancelledBeforeItStartsNeverLocksTheSource()
+    {
+        var engine = StreamEngine();
+        var destination = new RecordingStream();
+
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        var source = engine.Evaluate("new ReadableStream()");
+        engine.SetValue("source", source);
+
+        var copy = engine.Advanced.StartReadableStreamCopy(source, destination, options: null, cancellation.Token);
+
+        copy.IsFaulted.Should().BeTrue();
+        copy.Error!.Get("name").AsString().Should().Be("AbortError");
+        destination.Disposed.Should().BeTrue();
+        engine.Evaluate("source.locked").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void ACopyAbandonedByARestoreReportsItselfCompletedRatherThanPollingForever()
+    {
+        var engine = StreamEngine();
+        var destination = new RecordingStream();
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+
+        var source = engine.Evaluate("new ReadableStream({ pull(c) { } })");
+        var copy = engine.Advanced.StartReadableStreamCopy(source, destination);
+        copy.IsCompleted.Should().BeFalse();
+
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        copy.IsCompleted.Should().BeTrue();
+        copy.IsFaulted.Should().BeTrue();
+        copy.Error!.Get("message").AsString().Should().Contain("abandoned");
+        destination.Disposed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TheOptionsRefuseValuesThatWouldMeanNothing()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new HostReadableStreamOptions { ChunkSize = 0 });
+        Assert.Throws<ArgumentOutOfRangeException>(() => new HostReadableStreamOptions { HighWaterMark = -1 });
+        Assert.Throws<ArgumentOutOfRangeException>(() => new HostWritableStreamOptions { HighWaterMark = double.NaN });
+    }
+
+    [Fact]
+    public void ANonReadableOrNonWritableStreamIsRefusedAtTheBoundary()
+    {
+        var engine = StreamEngine();
+
+        Assert.Throws<ArgumentNullException>(() => engine.Advanced.CreateReadableStream(null!));
+        Assert.Throws<ArgumentNullException>(() => engine.Advanced.CreateWritableStream(null!));
+
+        var readOnly = new RecordingStream(Utf8("abc"));
+        Assert.Throws<ArgumentException>(() => engine.Advanced.CreateWritableStream(readOnly));
+    }
+
+    [Fact]
+    public void AStreamCreatedWithoutTheFeatureFlagStillWorksButIsNotInstanceOfAnything()
+    {
+        // The bridge installs no global and needs none: what the Streams flag buys a script is the
+        // constructor's name, not the object's behaviour.
+        var engine = new Engine();
+        engine.SetValue("input", engine.Advanced.CreateReadableStream(new RecordingStream(Utf8("ok"))));
+
+        engine.Evaluate("typeof ReadableStream").AsString().Should().Be("undefined");
+        engine.Evaluate("(async () => String.fromCharCode(...(await input.getReader().read()).value))()")
+            .UnwrapIfPromise().AsString().Should().Be("ok");
+    }
+}
+#endif

--- a/Jint/Engine.Advanced.WebApi.cs
+++ b/Jint/Engine.Advanced.WebApi.cs
@@ -4,6 +4,7 @@ using Jint.Runtime;
 using Jint.WebApi.Abort;
 using Jint.WebApi.Fetch;
 using Jint.WebApi.Messaging;
+using Jint.WebApi.Streams;
 using Jint.WebApi;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -484,6 +485,233 @@ public partial class Engine
             }
 
             return signal;
+        }
+
+        /// <summary>
+        /// Wraps a readable <see cref="Stream"/> as a <c>ReadableStream</c> a script can read, cancel, tee
+        /// and pipe. Requires .NET 8 or higher.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>Threading.</b> Call this on the engine's thread, like every other engine API, and hand the
+        /// result to script from that thread. From then on the split is fixed: the host's stream is read by
+        /// the BCL's asynchronous I/O, on whichever thread that completes on, and each chunk is delivered to
+        /// the engine as an event-loop job. <b>The engine must be given turns for the stream to make
+        /// progress</b> — an <c>await</c> in script, <c>Engine.EvaluateAsync</c>, a blocking
+        /// <c>UnwrapIfPromise</c>, or the host's own <c>engine.Advanced.ProcessTasks()</c> loop. An engine
+        /// nobody pumps never reads a byte, which is the same contract the timers have.
+        /// </para>
+        /// <para>
+        /// <b>The host must not touch the stream once it has handed it over</b> — not read it, not seek it,
+        /// not dispose it — until the bridge is done with it, because a read is in flight whenever the script
+        /// is asking for a chunk. Ownership comes back only when
+        /// <see cref="HostReadableStreamOptions.LeaveOpen"/> says the host kept it, and even then only after
+        /// the stream has been read to the end or cancelled.
+        /// </para>
+        /// <para>
+        /// <b>Backpressure is the standard's.</b> Nothing is read until the stream's queue has room for it —
+        /// see <see cref="HostReadableStreamOptions.HighWaterMark"/> — so a script that stops reading stops
+        /// the host's stream being read too.
+        /// </para>
+        /// <para>
+        /// <b>Failures.</b> A read that throws errors the stream with a <c>TypeError</c> whose message names
+        /// the exception's type but not its text; the exception itself rides the error value and the host
+        /// reads it with <see cref="JintException.TryGetClrException"/>. <c>stream.cancel()</c> stops reading
+        /// and releases the host's stream. <c>Engine.Advanced.RestoreGlobalSnapshot</c> releases it too, and
+        /// leaves the script's outstanding <c>read()</c> pending forever, which is the contract every
+        /// completion registered before a restore has.
+        /// </para>
+        /// <para>
+        /// The result carries the engine's own <c>ReadableStream</c> prototype whether or not
+        /// <see cref="WebApiFeatures.Streams"/> installed the global, so all of its methods work either way;
+        /// what needs the flag is a script saying <c>x instanceof ReadableStream</c>.
+        /// </para>
+        /// </remarks>
+        /// <param name="source">The stream to read. Must be readable.</param>
+        /// <param name="options">How to read it, or <see langword="null"/> for the defaults.</param>
+        /// <returns>A <c>ReadableStream</c> whose chunks are <c>Uint8Array</c>s.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="source"/> cannot be read.</exception>
+        public JsValue CreateReadableStream(Stream source, HostReadableStreamOptions? options = null)
+        {
+            if (source is null)
+            {
+                Throw.ArgumentNullException(nameof(source));
+            }
+
+            if (!source.CanRead)
+            {
+                Throw.ArgumentException("The stream cannot be read.", nameof(source));
+            }
+
+            return HostReadableStreamSource.Create(_engine, _engine.Realm, source, options ?? new HostReadableStreamOptions());
+        }
+
+        /// <summary>
+        /// Wraps a writable <see cref="Stream"/> as a <c>WritableStream</c> a script can write, close, abort
+        /// and pipe into. Requires .NET 8 or higher.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>Threading.</b> Call this on the engine's thread and hand the result to script from that thread.
+        /// Each chunk is copied out of script's memory on the engine's thread and written by the BCL's
+        /// asynchronous I/O; the write's completion comes back as an event-loop job, so <b>the engine must be
+        /// given turns</b> for a write's promise — and therefore <c>writer.ready</c> and
+        /// <c>writer.close()</c> — ever to settle.
+        /// </para>
+        /// <para>
+        /// <b>The host must not touch the stream once it has handed it over</b>, for the same reason as the
+        /// readable direction: a write may be in flight whenever the script has written a chunk.
+        /// </para>
+        /// <para>
+        /// <b>What a script may write</b> is a <c>BufferSource</c>, a <c>Blob</c> or a string, which is UTF-8
+        /// encoded. Anything else is a <c>TypeError</c> that errors the stream rather than being coerced —
+        /// <c>[object Object]</c> silently appended to a host file is not a failure mode worth having.
+        /// </para>
+        /// <para>
+        /// <b>Backpressure</b> is <c>writer.ready</c>, which stops being resolved once
+        /// <see cref="HostWritableStreamOptions.HighWaterMark"/> chunks are queued.
+        /// </para>
+        /// <para>
+        /// <b>Closing.</b> <c>await writer.close()</c> settles only once the host's stream has been flushed
+        /// and — unless <see cref="HostWritableStreamOptions.LeaveOpen"/> says the host kept it — disposed,
+        /// and rejects with whatever the flush failed with. So a script can prove its output landed.
+        /// <c>abort()</c> and <c>Engine.Advanced.RestoreGlobalSnapshot</c> both release the stream without
+        /// flushing.
+        /// </para>
+        /// </remarks>
+        /// <param name="destination">The stream to write. Must be writable.</param>
+        /// <param name="options">How to write it, or <see langword="null"/> for the defaults.</param>
+        /// <returns>A <c>WritableStream</c> over <paramref name="destination"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="destination"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="destination"/> cannot be written.</exception>
+        public JsValue CreateWritableStream(Stream destination, HostWritableStreamOptions? options = null)
+        {
+            if (destination is null)
+            {
+                Throw.ArgumentNullException(nameof(destination));
+            }
+
+            if (!destination.CanWrite)
+            {
+                Throw.ArgumentException("The stream cannot be written.", nameof(destination));
+            }
+
+            return HostWritableStreamSink.Create(_engine, _engine.Realm, destination, options ?? new HostWritableStreamOptions());
+        }
+
+        /// <summary>
+        /// Starts reading a script's <c>ReadableStream</c> into a host <see cref="Stream"/> and returns at
+        /// once, without blocking and without a thread of its own. Requires .NET 8 or higher.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>The host pumps.</b> Every chunk comes out of the engine, so the copy advances only when the
+        /// engine is given turns: call <c>engine.Advanced.ProcessTasks()</c> and watch
+        /// <see cref="HostStreamCopyOperation.IsCompleted"/>. This is the one entry point of the three where
+        /// every turn provably runs where the host wants it, which is what a game loop or a UI thread needs;
+        /// <see cref="CopyReadableStreamAsync"/> is the same operation with the pumping done inside an
+        /// <c>await</c>. Neither may be called from inside an event-loop job.
+        /// </para>
+        /// <para>
+        /// <b>The source is locked</b> for the copy's duration, exactly as <c>pipeTo</c> locks it, and the
+        /// reader is released however the copy ends. A copy that ends early also cancels the source unless
+        /// <see cref="HostStreamCopyOptions.PreventCancel"/> says otherwise.
+        /// </para>
+        /// <para>
+        /// <b>Backpressure</b> is one chunk in flight: the next <c>read()</c> is issued only once the
+        /// previous chunk has reached the host's stream, so a script producing faster than the disk accepts
+        /// feels it through its own stream's queue.
+        /// </para>
+        /// <para>
+        /// <b>Failures</b> all arrive as <see cref="HostStreamCopyOperation.IsFaulted"/> and
+        /// <see cref="HostStreamCopyOperation.Error"/> rather than as exceptions from this call: the source
+        /// already being locked, the source erroring, a chunk that is not a byte sequence, a write that threw,
+        /// a cancelled token (an <c>AbortError</c> <c>DOMException</c>), and a
+        /// <c>RestoreGlobalSnapshot</c> that abandoned the cycle. The destination is released in every one of
+        /// those cases, and flushed only in the successful one.
+        /// </para>
+        /// </remarks>
+        /// <param name="readableStream">A <c>ReadableStream</c> this engine created.</param>
+        /// <param name="destination">The stream to write it to. Must be writable.</param>
+        /// <param name="options">How to copy, or <see langword="null"/> for the defaults.</param>
+        /// <param name="cancellationToken">
+        /// Stops the copy. May be cancelled from any thread; the copy ends on a later turn of the event loop,
+        /// with an <c>AbortError</c> <c>DOMException</c>.
+        /// </param>
+        /// <exception cref="ArgumentNullException">An argument is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="readableStream"/> is not a <c>ReadableStream</c>, or
+        /// <paramref name="destination"/> cannot be written.
+        /// </exception>
+        public HostStreamCopyOperation StartReadableStreamCopy(
+            JsValue readableStream,
+            Stream destination,
+            HostStreamCopyOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            if (readableStream is null)
+            {
+                Throw.ArgumentNullException(nameof(readableStream));
+            }
+
+            if (destination is null)
+            {
+                Throw.ArgumentNullException(nameof(destination));
+            }
+
+            if (readableStream is not JsReadableStream source)
+            {
+                Throw.ArgumentException("The value is not a ReadableStream.", nameof(readableStream));
+                return null!;
+            }
+
+            if (!destination.CanWrite)
+            {
+                Throw.ArgumentException("The stream cannot be written.", nameof(destination));
+            }
+
+            return HostStreamCopy.Start(
+                _engine,
+                _engine.Realm,
+                source,
+                destination,
+                options ?? new HostStreamCopyOptions(),
+                cancellationToken);
+        }
+
+        /// <summary>
+        /// Reads a script's <c>ReadableStream</c> into a host <see cref="Stream"/>, driving the engine while
+        /// it waits. Requires .NET 8 or higher.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The engine is single-threaded and this does not change that: turns run one at a time, on whichever
+        /// thread resumes the await. A host with a thread affinity — a game loop, a UI thread — wants
+        /// <see cref="StartReadableStreamCopy"/> and its own pump instead, so that every turn runs where the
+        /// host needs it to. Everything else about the copy is identical; see that method.
+        /// </para>
+        /// <para>
+        /// <b>The wait is bounded by <c>Options.Constraints.PromiseTimeout</c></b>, which defaults to ten
+        /// seconds — the same bound <c>Engine.EvaluateAsync</c> and <c>Engine.Modules.ImportAsync</c> carry.
+        /// A copy that can legitimately take longer than that needs the host to raise it, or to poll
+        /// <see cref="StartReadableStreamCopy"/> instead. The copy itself keeps running when the wait gives
+        /// up.
+        /// </para>
+        /// </remarks>
+        /// <returns>How many bytes reached <paramref name="destination"/>.</returns>
+        /// <exception cref="PromiseRejectedException">
+        /// The copy failed; see <see cref="HostStreamCopyOperation.Error"/> for what the value can be.
+        /// </exception>
+        public async Task<long> CopyReadableStreamAsync(
+            JsValue readableStream,
+            Stream destination,
+            HostStreamCopyOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            var operation = StartReadableStreamCopy(readableStream, destination, options, cancellationToken);
+            await _engine.UnwrapResultAsync(operation.Promise, CancellationToken.None).ConfigureAwait(false);
+            return operation.BytesWritten;
         }
     }
 }

--- a/Jint/Engine.GlobalSnapshot.cs
+++ b/Jint/Engine.GlobalSnapshot.cs
@@ -282,6 +282,11 @@ public partial class Engine
         // queue is the engine's, not the event loop's, so clearing the loop above does not reach it; the
         // generation each entry carries is the second line of defence for one already promoted into a job.
         _webApi?.ResetTransientState();
+
+        // A bridge to a host System.IO.Stream holds an operating-system handle, so the cycle ending has to
+        // close it rather than merely stop delivering its chunks: the generation fence already does the
+        // latter.
+        AbandonHostStreamBridges();
 #endif
 
         _error = null;

--- a/Jint/Engine.WebApi.cs
+++ b/Jint/Engine.WebApi.cs
@@ -7,6 +7,7 @@ using Jint.WebApi.Idle;
 using Jint.WebApi;
 using Jint.WebApi.Scheduling;
 using Jint.WebApi.ServerSentEvents;
+using Jint.WebApi.Streams;
 using Jint.WebApi.Timers;
 using Jint.WebApi.WebSockets;
 
@@ -14,6 +15,60 @@ namespace Jint;
 
 public partial class Engine
 {
+    /// <summary>
+    /// The bridges between a WHATWG stream and a host <see cref="System.IO.Stream"/> this engine has open,
+    /// or <see langword="null"/> — which is what every engine carries until the first
+    /// <c>Engine.Advanced.CreateReadableStream</c> and friends.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately its own field rather than a member of <see cref="WebApiEngineState"/>, which the streams
+    /// feature does not otherwise need: putting it there would mean building that state — and reading a clock
+    /// — for every engine that merely enables <see cref="WebApiFeatures.Streams"/>, and adding a live
+    /// null check to the pump for a feature that never schedules anything. Here, an engine that never bridges
+    /// a stream pays one null field.
+    /// </remarks>
+    private List<HostStreamBridge>? _hostStreamBridges;
+
+    /// <summary>
+    /// Adds a live bridge, so that a <c>RestoreGlobalSnapshot</c> can close the host stream behind it rather
+    /// than leave the handle to a finalizer. Engine thread, from the bridge's own creation.
+    /// </summary>
+    /// <remarks>
+    /// The list is pruned here rather than on release, because a release can happen on whichever thread the
+    /// I/O completed on and this list is engine-thread state. Pruning on every registration bounds it at the
+    /// number of bridges alive at the last one, so a host that opens one stream per request does not
+    /// accumulate.
+    /// </remarks>
+    internal void RegisterHostStreamBridge(HostStreamBridge bridge)
+    {
+        var bridges = _hostStreamBridges ??= new List<HostStreamBridge>();
+        bridges.RemoveAll(static candidate => candidate.IsReleased);
+        bridges.Add(bridge);
+    }
+
+    /// <summary>
+    /// Abandons every live bridge because the evaluation cycle they belong to has ended. Engine thread, from
+    /// <see cref="ResetTransientEvaluationState"/>.
+    /// </summary>
+    internal void AbandonHostStreamBridges()
+    {
+        if (_hostStreamBridges is not { Count: > 0 } bridges)
+        {
+            return;
+        }
+
+        // Copied before the walk, exactly as the in-flight fetches are: abandoning cancels a token source,
+        // and a continuation running synchronously on this very thread must not find the list being
+        // enumerated.
+        var pending = bridges.ToArray();
+        bridges.Clear();
+
+        foreach (var bridge in pending)
+        {
+            bridge.Abandon();
+        }
+    }
+
     /// <summary>
     /// The per-engine state behind the opt-in web APIs, or <see langword="null"/> — which is what a default
     /// engine, and an engine that enabled only stateless features such as <c>console</c>, carries. Every hot

--- a/Jint/WebApi/HostStreamCopyOperation.cs
+++ b/Jint/WebApi/HostStreamCopyOperation.cs
@@ -1,0 +1,201 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.WebApi;
+
+/// <summary>
+/// A copy of a script's <c>ReadableStream</c> into a host <see cref="Stream"/> in progress, handed back by
+/// <c>Engine.Advanced.StartReadableStreamCopy</c>. Requires .NET 8 or higher.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The engine makes progress on the copy only when it is given turns.</b> Every chunk comes out of the
+/// engine, so the copy advances on the event loop and nowhere else: a host with a thread it must not block —
+/// a game loop, a UI thread — drives it by calling <c>engine.Advanced.ProcessTasks()</c> and watching
+/// <see cref="IsCompleted"/>. A host that would rather await something has
+/// <c>Engine.Advanced.CopyReadableStreamAsync</c>, which drives the same operation while it waits. This is
+/// the contract <c>Engine.Modules.StartImport</c> and <c>ImportAsync</c> already have, and it is deliberately
+/// the same one.
+/// </para>
+/// <para>
+/// <b>Every member here is engine-thread-only</b>, including the plain property reads: they are read against
+/// engine state and one of them can complete the operation (see <see cref="IsCompleted"/>).
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// // once
+/// _copy = engine.Advanced.StartReadableStreamCopy(stream, File.Create(path));
+///
+/// // every frame
+/// engine.Advanced.ProcessTasks();
+/// if (_copy.IsCompleted)
+/// {
+///     var written = _copy.GetResult();   // throws PromiseRejectedException if the copy failed
+///     _copy = null;
+/// }
+/// </code>
+/// </example>
+public sealed class HostStreamCopyOperation
+{
+    private readonly Engine _engine;
+
+    /// <summary>
+    /// The evaluation cycle the copy was started in. Once the engine has moved past it, no turn of the event
+    /// loop can finish this copy; see <see cref="ObserveAbandonment"/>.
+    /// </summary>
+    private readonly int _generation;
+
+    private bool _completed;
+    private bool _faulted;
+    private long _bytesWritten;
+    private JsValue? _error;
+
+    internal HostStreamCopyOperation(Engine engine, JsValue promise)
+    {
+        _engine = engine;
+        _generation = engine.EventLoopGeneration;
+        Promise = promise;
+    }
+
+    /// <summary>
+    /// The promise the copy settles into: fulfilled with <c>undefined</c>, or rejected with the error the
+    /// copy failed with. Useful for handing the copy to script; a host tracking it from .NET wants
+    /// <see cref="IsCompleted"/>.
+    /// </summary>
+    /// <remarks>
+    /// The promise is marked as handled when the copy starts, because this operation — not the promise — is
+    /// the channel a host reads the outcome from, and a copy nobody attached a handler to must not read as an
+    /// unhandled rejection. A copy abandoned by <c>Engine.Advanced.RestoreGlobalSnapshot</c> leaves it
+    /// pending forever: settling it would run the ended cycle's reactions against the restored globals, which
+    /// is the very thing the restore fenced off.
+    /// </remarks>
+    public JsValue Promise { get; }
+
+    /// <summary>
+    /// Whether the copy has finished, successfully or not. Becomes true during a turn of the event loop, so
+    /// it is only worth re-reading after the engine has been given one.
+    /// </summary>
+    /// <remarks>
+    /// There is one way for a copy to end without a turn: <c>Engine.Advanced.RestoreGlobalSnapshot</c> ends
+    /// the evaluation cycle the copy was started in, and nothing fenced off that way can settle into the
+    /// engine again. Such a copy is reported here as completed and <see cref="IsFaulted"/>, so a host polling
+    /// this cannot poll forever. Its destination has already been released.
+    /// </remarks>
+    public bool IsCompleted
+    {
+        get
+        {
+            ObserveAbandonment();
+            return _completed;
+        }
+    }
+
+    /// <summary>Whether the copy finished by failing.</summary>
+    public bool IsFaulted
+    {
+        get
+        {
+            ObserveAbandonment();
+            return _faulted;
+        }
+    }
+
+    /// <summary>
+    /// How many bytes have reached the host's stream so far. Final once <see cref="IsCompleted"/> is true;
+    /// for a failed copy it is how far the copy got before it failed.
+    /// </summary>
+    public long BytesWritten
+    {
+        get
+        {
+            ObserveAbandonment();
+            return _bytesWritten;
+        }
+    }
+
+    /// <summary>
+    /// The error the copy failed with once it has failed, otherwise null. The script's own stream error, a
+    /// <c>TypeError</c> carrying the host stream's <see cref="Exception"/> (readable with
+    /// <c>JintException.TryGetClrException</c>), or an <c>AbortError</c> <c>DOMException</c> for a cancelled
+    /// copy.
+    /// </summary>
+    public JsValue? Error
+    {
+        get
+        {
+            ObserveAbandonment();
+            return _error;
+        }
+    }
+
+    /// <summary>
+    /// How many bytes the copy wrote.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">The copy has not finished yet.</exception>
+    /// <exception cref="PromiseRejectedException">The copy failed.</exception>
+    public long GetResult()
+    {
+        if (!IsCompleted)
+        {
+            Throw.InvalidOperationException("The stream copy has not completed. Give the engine turns with engine.Advanced.ProcessTasks() until IsCompleted is true, or await Engine.Advanced.CopyReadableStreamAsync instead.");
+        }
+
+        if (IsFaulted)
+        {
+            throw new PromiseRejectedException(_error!);
+        }
+
+        return _bytesWritten;
+    }
+
+    /// <summary>
+    /// Fails a copy the engine has fenced off, deriving the fact from the engine's generation on read.
+    /// </summary>
+    /// <remarks>
+    /// <c>Engine.Advanced.RestoreGlobalSnapshot</c> ends the evaluation cycle, and every job registered in it
+    /// is discarded at dequeue rather than run — so the reads and writes that would finish this copy are
+    /// exactly the ones that can no longer happen. Nothing pushes that news: the documented contract is that
+    /// the host polls, and deriving it on read is what keeps that poll from being a poll forever. It is the
+    /// same reasoning, and the same shape, as <c>ModuleImportOperation</c>'s.
+    /// </remarks>
+    private void ObserveAbandonment()
+    {
+        if (_completed || _engine.EventLoopGeneration == _generation)
+        {
+            return;
+        }
+
+        Fail(_engine.Realm.Intrinsics.Error.Construct(
+            "The stream copy was abandoned: Engine.Advanced.RestoreGlobalSnapshot ended the evaluation cycle it was started in, so nothing it is waiting for can reach this engine any more. The destination stream has been released. Start the copy again on the restored engine."));
+    }
+
+    internal void Fulfil()
+    {
+        if (_completed)
+        {
+            return;
+        }
+
+        _completed = true;
+    }
+
+    internal void Fail(JsValue error)
+    {
+        if (_completed)
+        {
+            return;
+        }
+
+        _completed = true;
+        _faulted = true;
+        _error = error;
+    }
+
+    /// <summary>
+    /// Records progress as the copy runs, so <see cref="BytesWritten"/> is meaningful before the end.
+    /// </summary>
+    internal void Advance(long bytes) => _bytesWritten += bytes;
+}
+#endif

--- a/Jint/WebApi/HostStreamOptions.cs
+++ b/Jint/WebApi/HostStreamOptions.cs
@@ -1,0 +1,165 @@
+#if NET8_0_OR_GREATER
+using Jint.Runtime;
+
+namespace Jint.WebApi;
+
+/// <summary>
+/// How <c>Engine.Advanced.CreateReadableStream</c> reads a host <see cref="Stream"/>. Requires .NET 8 or
+/// higher.
+/// </summary>
+/// <remarks>
+/// An options instance is read once, when the stream is created, and never held: one instance may be reused
+/// for any number of streams and any number of engines.
+/// </remarks>
+public sealed class HostReadableStreamOptions
+{
+    private int _chunkSize = 64 * 1024;
+    private double _highWaterMark = 1;
+
+    /// <summary>
+    /// The most bytes one read takes from the host's stream, and therefore the largest <c>Uint8Array</c> a
+    /// chunk can be. Defaults to 64 KiB.
+    /// </summary>
+    /// <remarks>
+    /// One buffer of this size is allocated per stream and reused for its whole life, because only one read
+    /// is ever in flight. A chunk may be <i>smaller</i> than this whenever the host's stream answers a short
+    /// read, which most of them are allowed to do; a script must not assume a fixed chunk size.
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">The value is not positive.</exception>
+    public int ChunkSize
+    {
+        get => _chunkSize;
+        set
+        {
+            if (value <= 0)
+            {
+                Throw.ArgumentOutOfRangeException(nameof(value), "The chunk size must be positive.");
+            }
+
+            _chunkSize = value;
+        }
+    }
+
+    /// <summary>
+    /// How many chunks the stream reads ahead of its consumer. Defaults to 1, which reads one chunk at a
+    /// time and is what a script's own <c>new ReadableStream(source)</c> defaults to.
+    /// </summary>
+    /// <remarks>
+    /// This is the standard's high water mark under a chunk-counting queuing strategy —
+    /// https://streams.spec.whatwg.org/#qs-api. Raising it trades memory (<see cref="ChunkSize"/> bytes per
+    /// chunk buffered) for fewer stalls on a slow source; zero reads nothing at all until a consumer asks,
+    /// which is the tightest backpressure the standard can express.
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">The value is negative or not a number.</exception>
+    public double HighWaterMark
+    {
+        get => _highWaterMark;
+        set
+        {
+            if (double.IsNaN(value) || value < 0)
+            {
+                Throw.ArgumentOutOfRangeException(nameof(value), "The high water mark must be a non-negative number.");
+            }
+
+            _highWaterMark = value;
+        }
+    }
+
+    /// <summary>
+    /// Whether the host keeps ownership of the stream. Defaults to <see langword="false"/>: the engine
+    /// disposes it once the script has read it to the end, cancelled it, or the engine's globals were
+    /// restored.
+    /// </summary>
+    /// <remarks>
+    /// Disposing is the useful default because the <i>script</i> decides when it is done reading, and the
+    /// host has no other moment at which it could. Set this when the stream is one the host still needs — a
+    /// request body it goes on reading, a <see cref="MemoryStream"/> it means to inspect afterwards.
+    /// </remarks>
+    public bool LeaveOpen { get; set; }
+}
+
+/// <summary>
+/// How <c>Engine.Advanced.CreateWritableStream</c> writes to a host <see cref="Stream"/>. Requires .NET 8 or
+/// higher.
+/// </summary>
+/// <remarks>
+/// An options instance is read once, when the stream is created, and never held: one instance may be reused
+/// for any number of streams and any number of engines.
+/// </remarks>
+public sealed class HostWritableStreamOptions
+{
+    private double _highWaterMark = 1;
+
+    /// <summary>
+    /// How many chunks the stream accepts before <c>writer.ready</c> stops being resolved. Defaults to 1.
+    /// </summary>
+    /// <remarks>
+    /// This is the standard's high water mark under a chunk-counting queuing strategy —
+    /// https://streams.spec.whatwg.org/#qs-api — and it is the whole of the backpressure a script feels: a
+    /// script that awaits <c>writer.ready</c> before each write never gets further ahead of the host's disk
+    /// than this many chunks. A script that does not await it is not blocked, but the queue it builds is the
+    /// engine's memory, so raising this raises what one runaway script can cost.
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">The value is negative or not a number.</exception>
+    public double HighWaterMark
+    {
+        get => _highWaterMark;
+        set
+        {
+            if (double.IsNaN(value) || value < 0)
+            {
+                Throw.ArgumentOutOfRangeException(nameof(value), "The high water mark must be a non-negative number.");
+            }
+
+            _highWaterMark = value;
+        }
+    }
+
+    /// <summary>
+    /// Whether the host keeps ownership of the stream. Defaults to <see langword="false"/>: the engine
+    /// flushes and disposes it when the script closes the writable stream, and disposes it without flushing
+    /// when the script aborts one or the engine's globals are restored.
+    /// </summary>
+    /// <remarks>
+    /// With the default, <c>await writer.close()</c> is the script's proof that every byte reached the host's
+    /// stream and that the stream is closed — a failure to flush rejects that promise. With this set, the
+    /// close still flushes and still reports a failure, but the host is left holding an open stream.
+    /// </remarks>
+    public bool LeaveOpen { get; set; }
+}
+
+/// <summary>
+/// How <c>Engine.Advanced.StartReadableStreamCopy</c> writes a script's <c>ReadableStream</c> to a host
+/// <see cref="Stream"/>. Requires .NET 8 or higher.
+/// </summary>
+/// <remarks>
+/// An options instance is read once, when the copy is started, and never held.
+/// </remarks>
+public sealed class HostStreamCopyOptions
+{
+    /// <summary>
+    /// Whether the host keeps ownership of the destination. Defaults to <see langword="false"/>: the copy
+    /// flushes and disposes it when the source stream ends, so a completed operation means the file is
+    /// written and closed.
+    /// </summary>
+    /// <remarks>
+    /// A copy that fails — the script's stream errored, the destination refused a write, the operation was
+    /// cancelled or abandoned — disposes the destination too, without flushing. Set this to keep a
+    /// destination the host writes more to afterwards.
+    /// </remarks>
+    public bool LeaveOpen { get; set; }
+
+    /// <summary>
+    /// Whether a copy that ends early leaves the script's stream alone. Defaults to <see langword="false"/>:
+    /// a failed or cancelled copy cancels the source, which is what
+    /// <c>pipeTo</c>'s own <c>preventCancel</c> defaults to
+    /// (https://streams.spec.whatwg.org/#dom-streampipeoptions-preventcancel).
+    /// </summary>
+    /// <remarks>
+    /// Cancelling the source is what lets a host stream behind it — a socket, a subprocess — find out that
+    /// nobody is reading any more. Set this when the script means to go on reading the same stream after the
+    /// copy stops, which it can, because the copy releases its reader either way.
+    /// </remarks>
+    public bool PreventCancel { get; set; }
+}
+#endif

--- a/Jint/WebApi/Streams/HostReadableStreamSource.cs
+++ b/Jint/WebApi/Streams/HostReadableStreamSource.cs
@@ -1,0 +1,249 @@
+#if NET8_0_OR_GREATER
+using System.Threading;
+using System.Threading.Tasks;
+using Jint.Native;
+using Jint.Native.Promise;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// A <c>ReadableStream</c> whose underlying source is a host <see cref="Stream"/>: the engine's side of
+/// <c>Engine.Advanced.CreateReadableStream</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Pull-driven, one read at a time.</b> The specification's own reentrancy guard —
+/// <c>[[pulling]]</c>/<c>[[pullAgain]]</c>, https://streams.spec.whatwg.org/#readable-stream-default-controller-call-pull-if-needed
+/// — already promises that <c>pull()</c> is never re-entered while a previous call's promise is outstanding,
+/// so one <see cref="Stream.ReadAsync(Memory{byte}, CancellationToken)"/> is in flight at a time and the
+/// bridge needs a single buffer for its whole life rather than one per chunk. Backpressure is therefore the
+/// standard's, not a second mechanism layered on top: the queue's desired size decides whether a pull
+/// happens, and no byte leaves the host's stream until it does.
+/// </para>
+/// <para>
+/// <b>A read that completes synchronously is delivered synchronously.</b> A <see cref="MemoryStream"/>, or a
+/// file whose bytes are already in the page cache, answers <c>ReadAsync</c> without ever leaving the calling
+/// thread — which here is the engine's, inside <c>pull()</c>, the one place the Streams Standard explicitly
+/// allows an enqueue from. So such a stream costs no thread hop, no event-loop job and no pump: reading it
+/// from script behaves exactly as a stream built by script does. It is the same window
+/// <c>ModuleLoadCompletion</c> opens for a warm module cache, and for the same reason — the engine asked for
+/// this answer and is at a known-safe point waiting for it.
+/// </para>
+/// <para>
+/// Everything else goes the long way round: the read completes on a thread-pool thread, is classified there
+/// into a byte count or an exception, and a generation-stamped job turns it into a chunk on the engine's
+/// thread. <b>The engine must be pumped for that job to run</b> — a stream whose reads do not complete
+/// synchronously makes no progress in an engine nobody is giving turns to.
+/// </para>
+/// </remarks>
+internal sealed class HostReadableStreamSource : HostStreamBridge
+{
+    private readonly byte[] _buffer;
+
+    private JsReadableStreamDefaultController _controller = null!;
+
+    private HostReadableStreamSource(Engine engine, Realm realm, Stream source, HostReadableStreamOptions options)
+        : base(engine, realm, source, options.LeaveOpen, CancellationToken.None)
+    {
+        // One buffer for the bridge's whole life rather than one per chunk: only one read is ever in flight,
+        // and the bytes are copied into a fresh Uint8Array before the next read can start. Below the large
+        // object heap's threshold at the default size, and the host's own choice above it.
+        _buffer = new byte[options.ChunkSize];
+    }
+
+    /// <summary>
+    /// Builds the stream. Runs on the engine thread, and returns before a single byte has been read: the
+    /// first read is the first <c>pull()</c>, which the controller makes once <c>start()</c> has settled.
+    /// </summary>
+    internal static JsReadableStream Create(Engine engine, Realm realm, Stream source, HostReadableStreamOptions options)
+    {
+        var bridge = new HostReadableStreamSource(engine, realm, source, options);
+
+        // The stream and its controller are built here rather than through
+        // ReadableStreamOperations.CreateReadableStream so that the bridge holds the controller before
+        // anything can pull. The controller is reachable from the stream the moment setup returns, but
+        // reading it back afterwards would make this code depend on the fact that the first pull happens on
+        // a later turn — true today, and not an invariant worth resting on.
+        var stream = new JsReadableStream(engine, realm)
+        {
+            _prototype = realm.Intrinsics.ReadableStream.PrototypeObject,
+        };
+
+        var controller = new JsReadableStreamDefaultController(engine, realm)
+        {
+            _prototype = realm.Intrinsics.ReadableStreamDefaultController.PrototypeObject,
+        };
+
+        bridge._controller = controller;
+
+        ReadableStreamOperations.SetUpDefaultController(
+            stream,
+            controller,
+            static () => JsValue.Undefined,
+            bridge.Pull,
+            _ => bridge.Cancel(),
+            options.HighWaterMark,
+            static _ => 1);
+
+        engine.RegisterHostStreamBridge(bridge);
+        return stream;
+    }
+
+    /// <summary>
+    /// The underlying source's <c>pull()</c>: read the next chunk, and settle when it has been enqueued.
+    /// https://streams.spec.whatwg.org/#dom-underlyingsource-pull
+    /// </summary>
+    /// <remarks>
+    /// The promise is resolved <i>after</i> the chunk is enqueued rather than when the read starts, which is
+    /// what makes the standard's guard mean what it says: a pull that resolved early would let the controller
+    /// start another one against a buffer the previous read still owns.
+    /// </remarks>
+    private JsPromise Pull()
+    {
+        var capability = StreamPromises.NewPromise(Engine, Realm);
+        var promise = StreamPromises.PromiseOf(capability);
+
+        if (!TryBeginOperation())
+        {
+            // Only reachable for a bridge a restore has abandoned: a cancelled or closed stream is no longer
+            // readable, and the controller does not pull one. The cycle this promise belongs to has ended,
+            // so nothing will observe how it settles.
+            capability.Resolve(JsValue.Undefined);
+            return promise;
+        }
+
+        ValueTask<int> read;
+        try
+        {
+            read = HostStream.ReadAsync(_buffer, Cancellation.Token);
+        }
+        catch (Exception exception) when (!ConstraintFailure.MustPropagate(exception))
+        {
+            // A stream that refuses synchronously — disposed, opened write-only, a host implementation that
+            // validates before returning a task.
+            Deliver(count: 0, exception, capability);
+            return promise;
+        }
+
+        if (read.IsCompleted)
+        {
+            int count;
+            try
+            {
+                count = read.GetAwaiter().GetResult();
+            }
+            catch (Exception exception) when (!ConstraintFailure.MustPropagate(exception))
+            {
+                Deliver(count: 0, exception, capability);
+                return promise;
+            }
+
+            Deliver(count, failure: null, capability);
+            return promise;
+        }
+
+        var task = read.AsTask();
+        _ = task.ContinueWith(
+            completed => Complete(completed, capability),
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+
+        return promise;
+    }
+
+    /// <summary>
+    /// Off the engine thread: classify the read into plain CLR data and queue the engine-thread half.
+    /// </summary>
+    private void Complete(Task<int> task, PromiseCapability capability)
+    {
+        var failure = ClassifyFailure(task);
+        var count = failure is null ? task.Result : 0;
+
+        Enqueue(() => Deliver(count, failure, capability));
+    }
+
+    /// <summary>
+    /// On the engine thread: turn one finished read into a chunk, a close, or an error, and settle the pull.
+    /// </summary>
+    /// <remarks>
+    /// The order matters. The in-flight operation is ended <i>before</i> the JavaScript work, so that the
+    /// release the standard's close path owes is taken by <see cref="HostStreamBridge.FinishBridge"/> here
+    /// rather than left to an operation that has already finished. The pull promise is resolved last, because
+    /// resolving it is what lets the controller ask for the next chunk.
+    /// </remarks>
+    private void Deliver(int count, Exception? failure, PromiseCapability capability)
+    {
+        var owesRelease = EndOperation();
+
+        if (failure is not null)
+        {
+            if (FinishBridge())
+            {
+                owesRelease = true;
+            }
+
+            if (owesRelease)
+            {
+                ReleaseHostStream();
+            }
+
+            // A rejected pull() errors the stream, which is the standard's own reaction —
+            // https://streams.spec.whatwg.org/#readable-stream-default-controller-call-pull-if-needed. Doing
+            // it that way rather than erroring the controller directly keeps one path for every failure.
+            capability.Reject(HostStreamError("reading", failure));
+            return;
+        }
+
+        if (count == 0)
+        {
+            if (FinishBridge())
+            {
+                owesRelease = true;
+            }
+
+            if (owesRelease)
+            {
+                ReleaseHostStream();
+            }
+
+            ReadableStreamDefaultControllerOperations.Close(_controller);
+            capability.Resolve(JsValue.Undefined);
+            return;
+        }
+
+        if (owesRelease)
+        {
+            // Abandoned while this read ran. The chunk is dropped: the cycle it belongs to is over, and the
+            // job that carried it here only ran at all because it was enqueued before the fence went up.
+            ReleaseHostStream();
+            capability.Resolve(JsValue.Undefined);
+            return;
+        }
+
+        ReadableStreamDefaultControllerOperations.Enqueue(_controller, CreateChunk(_buffer.AsSpan(0, count)));
+        capability.Resolve(JsValue.Undefined);
+    }
+
+    /// <summary>
+    /// The underlying source's <c>cancel()</c>: stop reading and let go of the host's stream.
+    /// https://streams.spec.whatwg.org/#dom-underlyingsource-cancel
+    /// </summary>
+    /// <remarks>
+    /// Answers a resolved promise without waiting for the close, so <c>await stream.cancel()</c> does not
+    /// depend on how long a file handle takes to release. A read still in flight is cancelled and releases
+    /// the stream itself when it unwinds; the reason script gave is not passed on, because a host
+    /// <see cref="Stream"/> has nowhere to put it.
+    /// </remarks>
+    private JsPromise Cancel()
+    {
+        if (FinishBridge())
+        {
+            ReleaseHostStream();
+        }
+
+        return StreamPromises.ResolvedWithUndefined(Engine, Realm);
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/HostStreamBridge.cs
+++ b/Jint/WebApi/Streams/HostStreamBridge.cs
@@ -1,0 +1,312 @@
+#if NET8_0_OR_GREATER
+using System.Threading;
+using System.Threading.Tasks;
+using Jint.Native;
+using Jint.Native.TypedArray;
+using Jint.Runtime;
+using Jint.WebApi.Files;
+using SystemEncoding = System.Text.Encoding;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// The machinery every bridge between a WHATWG stream and a <see cref="Stream"/> shares: the cycle the
+/// bridge belongs to, the cancellation source its I/O runs under, the one-shot release of the host's stream,
+/// and the two conversions between a chunk and a byte sequence.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Two threads meet here and the split is always the same one.</b> Everything that touches the engine —
+/// a controller, a promise, a typed array — happens on the engine's thread, from a generation-stamped
+/// event-loop job. Everything that touches the host's <see cref="Stream"/> happens wherever the BCL's
+/// asynchronous I/O completes, and produces nothing but plain CLR data. That is the same division
+/// <c>FetchOperation</c> and <c>ModuleLoadCompletion</c> are built on, and for the same reason: the engine
+/// is not thread-safe, and a stream chunk arriving on a thread-pool thread is exactly the shape that would
+/// otherwise corrupt it.
+/// </para>
+/// <para>
+/// <b>The generation is captured when the bridge is created, never read at completion time.</b> A chunk
+/// whose read finished after <c>Engine.Advanced.RestoreGlobalSnapshot</c> ended the cycle is discarded at
+/// dequeue rather than delivered into the restored engine — the fence every other cross-thread completion in
+/// Jint sits behind. The restore additionally calls <see cref="Abandon"/>, so the host's stream is closed at
+/// once instead of being held until a garbage collection notices.
+/// </para>
+/// <para>
+/// <b>The host's stream is released exactly once.</b> A release must never happen while an asynchronous read
+/// or write is still writing into a buffer, so the release is owed to whichever of the two racers observes
+/// the other: <see cref="FinishBridge"/> takes it when nothing is in flight, and <see cref="EndOperation"/>
+/// takes it when the bridge was finished while an operation ran.
+/// </para>
+/// </remarks>
+internal abstract class HostStreamBridge
+{
+    /// <summary>No I/O is in flight and the bridge may start more.</summary>
+    private const int Idle = 0;
+
+    /// <summary>One read or write is in flight.</summary>
+    private const int Busy = 1;
+
+    /// <summary>The bridge was finished while an operation was in flight; that operation owes the release.</summary>
+    private const int Releasing = 2;
+
+    /// <summary>The host's stream has been released, or is being released by the caller that took it.</summary>
+    private const int Released = 3;
+
+    private int _state;
+
+    protected HostStreamBridge(Engine engine, Realm realm, Stream stream, bool leaveOpen, CancellationToken hostCancellation)
+    {
+        Engine = engine;
+        Realm = realm;
+        HostStream = stream;
+        LeaveOpen = leaveOpen;
+        Generation = engine.EventLoopGeneration;
+        Cancellation = CancellationTokenSource.CreateLinkedTokenSource(hostCancellation);
+    }
+
+    protected Engine Engine { get; }
+
+    /// <summary>
+    /// The realm the bridge was created in, captured rather than read back from the engine: every promise,
+    /// every chunk and every error it mints belongs to that realm, and a job running on a later turn would
+    /// otherwise build them against whichever realm happens to be ambient then.
+    /// </summary>
+    protected Realm Realm { get; }
+
+    /// <summary>The host's stream. Touched only from asynchronous I/O and from the one release.</summary>
+    protected Stream HostStream { get; }
+
+    /// <summary>Whether the host keeps ownership of <see cref="HostStream"/> — see the options types.</summary>
+    protected bool LeaveOpen { get; }
+
+    /// <summary>The evaluation cycle this bridge belongs to. See the remarks on the class.</summary>
+    protected int Generation { get; }
+
+    /// <summary>
+    /// The token every read and write runs under. Cancelled by <see cref="FinishBridge"/>, so a stream that
+    /// is blocked in a read stops being blocked when the script cancels or the engine is restored.
+    /// </summary>
+    protected CancellationTokenSource Cancellation { get; }
+
+    /// <summary>
+    /// Whether the bridge is done with the host's stream. Read on the engine thread only, to prune the
+    /// engine's registry.
+    /// </summary>
+    internal bool IsReleased => Volatile.Read(ref _state) == Released;
+
+    /// <summary>
+    /// Claims the right to start one read or write. <see langword="false"/> means the bridge has been
+    /// finished — cancelled, closed, or abandoned by a restore — and no further I/O may be started.
+    /// </summary>
+    protected bool TryBeginOperation() => Interlocked.CompareExchange(ref _state, Busy, Idle) == Idle;
+
+    /// <summary>
+    /// Ends the in-flight read or write. Called on whichever thread the I/O completed on, <b>before</b> its
+    /// result is enqueued for the engine: a job may be discarded by the generation fence, so a release owed
+    /// to it would never be paid.
+    /// </summary>
+    /// <returns>Whether this call owes <see cref="ReleaseHostStream"/>.</returns>
+    protected bool EndOperation()
+    {
+        if (Interlocked.CompareExchange(ref _state, Idle, Busy) == Busy)
+        {
+            return false;
+        }
+
+        // Only Releasing can be observed here: the bridge was finished while this operation ran, and the
+        // finisher deliberately left the release to whoever was using the buffer.
+        Volatile.Write(ref _state, Released);
+        return true;
+    }
+
+    /// <summary>
+    /// Refuses every later read and write and cancels any in flight.
+    /// </summary>
+    /// <returns>
+    /// Whether this call owes <see cref="ReleaseHostStream"/>. <see langword="false"/> either because an
+    /// operation is in flight — <see cref="EndOperation"/> will take it — or because the bridge was already
+    /// finished.
+    /// </returns>
+    protected bool FinishBridge()
+    {
+        while (true)
+        {
+            var state = Volatile.Read(ref _state);
+            if (state is Releasing or Released)
+            {
+                return false;
+            }
+
+            var next = state == Busy ? Releasing : Released;
+            if (Interlocked.CompareExchange(ref _state, next, state) != state)
+            {
+                continue;
+            }
+
+            // Reached at most once per bridge, and always before the cancellation source is disposed: every
+            // later FinishBridge returns above.
+            Cancellation.Cancel();
+            return next == Released;
+        }
+    }
+
+    /// <summary>
+    /// Releases what the bridge owns. Called exactly once, by whichever of the two racers
+    /// <see cref="FinishBridge"/> and <see cref="EndOperation"/> was told it owes it, and therefore never
+    /// while a read or write is still using the stream.
+    /// </summary>
+    /// <remarks>
+    /// A failure to close is swallowed, deliberately: this is the path a cancellation, an error and an
+    /// abandonment take, all of which already have their own outcome, and none of which has anywhere left to
+    /// report a second one. The path where closing the stream <i>is</i> the outcome — a writable stream's
+    /// <c>close()</c>, whose promise is the script's proof that the bytes reached the disk — does not come
+    /// through here: <see cref="HostWritableStreamSink"/> flushes and disposes itself and settles that
+    /// promise with whatever happened.
+    /// </remarks>
+    protected void ReleaseHostStream()
+    {
+        Cancellation.Dispose();
+
+        if (LeaveOpen)
+        {
+            return;
+        }
+
+        try
+        {
+            HostStream.Dispose();
+        }
+        catch (Exception exception) when (!ConstraintFailure.MustPropagate(exception))
+        {
+            // Nothing to report it to. See the remarks.
+        }
+    }
+
+    /// <summary>
+    /// Abandons the bridge because the evaluation cycle it belongs to has ended. Runs on the engine thread,
+    /// from <c>Engine.ResetTransientEvaluationState</c>.
+    /// </summary>
+    /// <remarks>
+    /// The host's stream is closed at once rather than merely forgotten — the generation fence already stops
+    /// a chunk reaching the restored engine, but forgetting the bridge would hold a file handle open until a
+    /// finalizer noticed. Whatever promise the stream had outstanding stays pending forever, which is the
+    /// contract every completion registered before a restore has.
+    /// </remarks>
+    internal virtual void Abandon()
+    {
+        if (FinishBridge())
+        {
+            ReleaseHostStream();
+        }
+    }
+
+    /// <summary>
+    /// Queues the engine-thread half of an I/O completion, carrying the cycle the bridge was created in.
+    /// </summary>
+    protected void Enqueue(Action job) => Engine.AddToEventLoop(job, Generation);
+
+    /// <summary>
+    /// The chunk a host stream's bytes are delivered to script as: a fresh <c>Uint8Array</c> over a copy,
+    /// which is what every WHATWG byte-producing stream hands a default reader.
+    /// </summary>
+    protected JsTypedArray CreateChunk(ReadOnlySpan<byte> bytes) => ByteStreams.NewUint8Array(Engine, Realm, bytes);
+
+    /// <summary>
+    /// The bytes a chunk written by script carries, or <see langword="false"/> when it is not something a
+    /// byte sink can write at all.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The Streams Standard says nothing about what a chunk is — <c>chunk</c> is <c>any</c>, and what a sink
+    /// accepts is the sink's business (https://streams.spec.whatwg.org/#underlying-sink-write). This one
+    /// accepts the three things that already <i>are</i> a byte sequence: a <c>BufferSource</c>, a
+    /// <c>Blob</c>, and a string, which is UTF-8 encoded. That is the same union
+    /// <c>FileSystemWritableFileStream</c> takes
+    /// (https://fs.spec.whatwg.org/#typedefdef-filesystemwritechunktype).
+    /// </para>
+    /// <para>
+    /// Everything else is refused rather than coerced. <c>ToString</c> on an arbitrary object would turn a
+    /// programming mistake — writing the object instead of its <c>buffer</c> — into
+    /// <c>[object Object]</c> silently appended to the host's file.
+    /// </para>
+    /// <para>
+    /// A <c>SharedArrayBuffer</c> is refused with everything else, because
+    /// <see cref="FileApi.TryGetBufferSourceBytes"/> implements the plain <c>BufferSource</c> typedef rather
+    /// than <c>[AllowShared]</c>: another agent may write to it while this one is copying, and the bytes that
+    /// reach the host would then be neither of the two states script could observe.
+    /// </para>
+    /// <para>
+    /// The span is a window onto storage script still owns, so the caller must copy out of it before
+    /// returning to the event loop. Every caller here does, into a pooled buffer.
+    /// </para>
+    /// </remarks>
+    protected static bool TryGetChunkBytes(JsValue chunk, out ReadOnlySpan<byte> bytes)
+    {
+        if (FileApi.TryGetBufferSourceBytes(chunk, out bytes))
+        {
+            return true;
+        }
+
+        if (chunk is JsBlob blob)
+        {
+            bytes = blob.Data.Span;
+            return true;
+        }
+
+        if (chunk is JsString text)
+        {
+            // Every unpaired surrogate becomes U+FFFD, which is what a UTF-8 encode of a USVString does.
+            bytes = SystemEncoding.UTF8.GetBytes(text.ToString());
+            return true;
+        }
+
+        bytes = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Off the engine thread: what a finished I/O task failed with, or <see langword="null"/> for one that
+    /// succeeded. Plain CLR data, because nothing here may touch the engine.
+    /// </summary>
+    protected static Exception? ClassifyFailure(Task task)
+    {
+        if (task.IsCanceled)
+        {
+            // The token is only ever cancelled by FinishBridge, so this is a stream the script cancelled or a
+            // restore abandoned. The outcome is not wanted either way.
+            return new OperationCanceledException();
+        }
+
+        if (!task.IsFaulted)
+        {
+            return null;
+        }
+
+        var exception = task.Exception;
+        if (exception is null)
+        {
+            return new IOException("The host stream operation failed.");
+        }
+
+        // The AggregateException wrapper says nothing a host can use; the I/O failure itself is the single
+        // inner exception in every ordinary case.
+        return exception.InnerExceptions.Count == 1 ? exception.InnerExceptions[0] : exception;
+    }
+
+    /// <summary>
+    /// The error value a CLR failure on the host's stream becomes: a <c>TypeError</c> whose message names the
+    /// exception's type but not its text.
+    /// </summary>
+    /// <remarks>
+    /// The message is deliberately thin for the same reason <c>fetch</c>'s network error is: a path, a
+    /// share name or a permission message in an <see cref="IOException"/> tells a script things about the
+    /// host it has no business learning. The originating exception rides the error <i>value</i>, so the host
+    /// reads it with <c>JintException.TryGetClrException</c> while the script cannot see it at all.
+    /// </remarks>
+    protected JsValue HostStreamError(string operation, Exception failure)
+    {
+        var message = $"The host stream failed while {operation} ({failure.GetType().Name}).";
+        return new JavaScriptException(Realm.Intrinsics.TypeError, message, failure).Error;
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/HostStreamCopy.cs
+++ b/Jint/WebApi/Streams/HostStreamCopy.cs
@@ -1,0 +1,429 @@
+#if NET8_0_OR_GREATER
+using System.Buffers;
+using System.Threading;
+using System.Threading.Tasks;
+using Jint.Native;
+using Jint.Native.Promise;
+using Jint.Runtime;
+using Jint.WebApi.DomException;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// Reads a script's <c>ReadableStream</c> to its end and writes every chunk to a host <see cref="Stream"/>:
+/// the engine's side of <c>Engine.Advanced.StartReadableStreamCopy</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>This is the direction with the awkward half</b>, and the awkwardness is who runs the turns. The chunks
+/// come out of the engine, so every read is an engine-thread act driven by the event loop, while every write
+/// leaves the engine entirely. The copy therefore never blocks and never pumps: it makes progress exactly
+/// when the engine is given a turn, and the host either gives it turns itself
+/// (<c>engine.Advanced.ProcessTasks()</c> plus <see cref="HostStreamCopyOperation.IsCompleted"/>) or lets
+/// <c>Engine.Advanced.CopyReadableStreamAsync</c> do it while it awaits. That is the same contract, and the
+/// same pair of entry points, as <c>Engine.Modules.StartImport</c> and <c>ImportAsync</c>.
+/// </para>
+/// <para>
+/// <b>Exactly one read and one write are outstanding at a time</b>, and the next read is issued only once the
+/// previous write has landed, which is the whole of the backpressure: a script producing faster than the disk
+/// accepts sees its own stream's queue fill and its <c>pull()</c> stop being called. The next read is always
+/// issued from a fresh event-loop job rather than from the write's completion, so a source whose chunks are
+/// already queued and a destination that writes synchronously — a <see cref="MemoryStream"/> on both ends —
+/// cannot turn the copy into unbounded recursion.
+/// </para>
+/// <para>
+/// <b>The source is locked for the copy's duration</b>, exactly as <c>pipeTo</c> locks it, and the reader is
+/// released however the copy ends. A copy that ends early also cancels the source unless
+/// <c>HostStreamCopyOptions.PreventCancel</c> says otherwise.
+/// </para>
+/// </remarks>
+internal sealed class HostStreamCopy : HostStreamBridge
+{
+    private readonly HostStreamCopyOperation _operation;
+    private readonly PromiseCapability _capability;
+    private readonly bool _preventCancel;
+
+    private JsReadableStreamDefaultReader? _reader;
+    private CancellationTokenRegistration _cancellationRegistration;
+    private bool _settled;
+
+    private HostStreamCopy(
+        Engine engine,
+        Realm realm,
+        Stream destination,
+        HostStreamCopyOptions options,
+        PromiseCapability capability,
+        HostStreamCopyOperation operation,
+        CancellationToken cancellationToken)
+        : base(engine, realm, destination, options.LeaveOpen, cancellationToken)
+    {
+        _preventCancel = options.PreventCancel;
+        _capability = capability;
+        _operation = operation;
+    }
+
+    /// <summary>
+    /// Starts the copy. Runs on the engine thread and returns before the first chunk has been read.
+    /// </summary>
+    internal static HostStreamCopyOperation Start(
+        Engine engine,
+        Realm realm,
+        JsReadableStream source,
+        Stream destination,
+        HostStreamCopyOptions options,
+        CancellationToken cancellationToken)
+    {
+        var capability = StreamPromises.NewPromise(engine, realm);
+        var promise = StreamPromises.PromiseOf(capability);
+
+        // The operation object is the channel a host reads the outcome from, so an unobserved promise
+        // rejection here is not a lost failure and must not be reported as one.
+        StreamPromises.MarkHandled(promise);
+
+        var operation = new HostStreamCopyOperation(engine, promise);
+        var copy = new HostStreamCopy(engine, realm, destination, options, capability, operation, cancellationToken);
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            // Nothing is started at all: no reader is acquired, so the script's stream is not even locked,
+            // and the destination is released exactly as it would be for a copy cancelled later.
+            copy.FailWith(copy.AbortError("The stream copy was cancelled before it started."));
+            return operation;
+        }
+
+        try
+        {
+            copy._reader = ReadableStreamOperations.AcquireDefaultReader(source);
+        }
+        catch (JavaScriptException exception)
+        {
+            // The stream is already locked — by another copy, by a `getReader()` the script still holds, or
+            // by a `pipeTo` in progress. A rejection rather than a throw, so that host code written to the
+            // poll-then-GetResult pattern does not have to guard the start call as well.
+            copy.FailWith(exception.Error);
+            return operation;
+        }
+
+        engine.RegisterHostStreamBridge(copy);
+
+        // Registered after the reader, so the callback can never run against a half-built copy. It fires on
+        // whichever thread cancels, and does nothing there but queue the engine-thread half.
+        copy._cancellationRegistration = cancellationToken.Register(static state =>
+        {
+            var pending = (HostStreamCopy) state!;
+            pending.Enqueue(pending.CancelFromToken);
+        }, copy);
+
+        copy.ReadNext();
+        return operation;
+    }
+
+    /// <summary>
+    /// Asks the source for one chunk. Engine thread.
+    /// </summary>
+    private void ReadNext()
+    {
+        if (_settled)
+        {
+            return;
+        }
+
+        ReadableStreamOperations.DefaultReaderRead(_reader!, new CopyReadRequest(this));
+    }
+
+    /// <summary>
+    /// One chunk arrived. Engine thread.
+    /// </summary>
+    private void OnChunk(JsValue chunk)
+    {
+        if (_settled)
+        {
+            return;
+        }
+
+        if (!TryGetChunkBytes(chunk, out var bytes))
+        {
+            FailWith(Realm.Intrinsics.TypeError.Construct(
+                $"A host stream can only be written a BufferSource, a Blob or a string, and this chunk is of type '{chunk.Type}'."));
+            return;
+        }
+
+        if (bytes.IsEmpty)
+        {
+            // Nothing to write, and the loop still has to go round through the event loop: a stream of empty
+            // chunks must not become recursion.
+            Enqueue(ReadNext);
+            return;
+        }
+
+        if (!TryBeginOperation())
+        {
+            // Abandoned by a restore between the read and here.
+            return;
+        }
+
+        // Copied out of script-visible storage before the write can start; see HostWritableStreamSink.Write.
+        var count = bytes.Length;
+        var buffer = ArrayPool<byte>.Shared.Rent(count);
+        bytes.CopyTo(buffer);
+
+        ValueTask write;
+        try
+        {
+            write = HostStream.WriteAsync(buffer.AsMemory(0, count), Cancellation.Token);
+        }
+        catch (Exception exception) when (!ConstraintFailure.MustPropagate(exception))
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+            OnWriteSettled(exception, count);
+            return;
+        }
+
+        if (write.IsCompleted)
+        {
+            Exception? failure = null;
+            try
+            {
+                write.GetAwaiter().GetResult();
+            }
+            catch (Exception exception) when (!ConstraintFailure.MustPropagate(exception))
+            {
+                failure = exception;
+            }
+
+            ArrayPool<byte>.Shared.Return(buffer);
+            OnWriteSettled(failure, count);
+            return;
+        }
+
+        _ = write.AsTask().ContinueWith(
+            completed =>
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+                var failure = ClassifyFailure(completed);
+                Enqueue(() => OnWriteSettled(failure, count));
+            },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
+    /// <summary>
+    /// One write finished. Engine thread.
+    /// </summary>
+    private void OnWriteSettled(Exception? failure, int count)
+    {
+        if (EndOperation())
+        {
+            // Abandoned while the write ran.
+            ReleaseHostStream();
+            return;
+        }
+
+        if (failure is not null)
+        {
+            FailWith(HostStreamError("writing", failure));
+            return;
+        }
+
+        _operation.Advance(count);
+
+        // Always a fresh job rather than a direct call: see the class remarks on recursion.
+        Enqueue(ReadNext);
+    }
+
+    /// <summary>
+    /// The source ran out of chunks. Engine thread: flush the destination and settle.
+    /// </summary>
+    private void OnSourceClosed()
+    {
+        if (_settled)
+        {
+            return;
+        }
+
+        if (!TryBeginOperation())
+        {
+            return;
+        }
+
+        var task = FlushAndDisposeAsync();
+
+        if (task.IsCompleted)
+        {
+            Exception? failure = null;
+            try
+            {
+                task.GetAwaiter().GetResult();
+            }
+            catch (Exception exception) when (!ConstraintFailure.MustPropagate(exception))
+            {
+                failure = exception;
+            }
+
+            OnFlushSettled(failure);
+            return;
+        }
+
+        _ = task.AsTask().ContinueWith(
+            completed =>
+            {
+                var failure = ClassifyFailure(completed);
+                Enqueue(() => OnFlushSettled(failure));
+            },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
+    private async ValueTask FlushAndDisposeAsync()
+    {
+        await HostStream.FlushAsync(Cancellation.Token).ConfigureAwait(false);
+
+        if (!LeaveOpen)
+        {
+            await HostStream.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    private void OnFlushSettled(Exception? failure)
+    {
+        var owesRelease = EndOperation();
+
+        if (FinishBridge())
+        {
+            owesRelease = true;
+        }
+
+        if (owesRelease)
+        {
+            ReleaseHostStream();
+        }
+
+        if (failure is not null)
+        {
+            FailWith(HostStreamError("closing", failure), releaseDestination: false);
+            return;
+        }
+
+        // The source is already closed, so there is nothing to cancel — only the lock to give back.
+        Settle();
+        ReleaseReader();
+        _capability.Resolve(JsValue.Undefined);
+        _operation.Fulfil();
+    }
+
+    /// <summary>
+    /// The source errored. Engine thread.
+    /// </summary>
+    private void OnSourceErrored(JsValue error)
+    {
+        // The source cannot be cancelled: it is already errored, and ReadableStreamCancel on an errored
+        // stream answers its stored error rather than running the underlying source's cancel.
+        FailWith(error);
+    }
+
+    /// <summary>
+    /// The host's cancellation token fired. Engine thread, from a generation-stamped job.
+    /// </summary>
+    private void CancelFromToken() => FailWith(AbortError("The stream copy was cancelled."));
+
+    private JsDomException AbortError(string message)
+        => Realm.Intrinsics.DomException.CreateException(DomExceptionNames.Abort, message);
+
+    /// <summary>
+    /// Ends the copy with a failure. Engine thread.
+    /// </summary>
+    private void FailWith(JsValue error, bool releaseDestination = true)
+    {
+        if (_settled)
+        {
+            return;
+        }
+
+        // Marked settled first, because cancelling the source below closes it, and closing a stream with an
+        // outstanding read request runs that request's close steps — which are this copy's own, and would
+        // otherwise try to finish the copy successfully on the way out of failing it.
+        Settle();
+
+        if (releaseDestination && FinishBridge())
+        {
+            // No flush: a copy that failed has no business pushing a partial buffer at the host.
+            ReleaseHostStream();
+        }
+
+        CancelSource(error);
+        ReleaseReader();
+
+        _capability.Reject(error);
+        _operation.Fail(error);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rs-pipeTo — the <c>preventCancel</c> half of the piping rules: a
+    /// destination that stopped reading tells the source so, unless the caller asked it not to.
+    /// </summary>
+    private void CancelSource(JsValue reason)
+    {
+        // Only a still-readable stream is worth cancelling. ReadableStreamCancel on a closed one is a no-op
+        // and on an errored one answers a rejected promise nobody asked for — neither is a cancellation, and
+        // the standard's own piping does not attempt them either.
+        if (_preventCancel || _reader?.Stream is not { State: ReadableStreamState.Readable })
+        {
+            return;
+        }
+
+        var cancelled = ReadableStreamOperations.ReaderGenericCancel(_reader, reason);
+
+        // Whatever the underlying source's cancel() answers is nobody's business here, and a rejection it
+        // produces is not this copy's failure — the copy already has one.
+        StreamPromises.MarkHandled(cancelled);
+    }
+
+    private void ReleaseReader()
+    {
+        if (_reader?.Stream is null)
+        {
+            return;
+        }
+
+        ReadableStreamOperations.DefaultReaderRelease(_reader);
+    }
+
+    private void Settle()
+    {
+        _settled = true;
+        _cancellationRegistration.Dispose();
+    }
+
+    /// <inheritdoc />
+    internal override void Abandon()
+    {
+        base.Abandon();
+
+        // The operation reports itself completed-and-faulted from the engine's generation, so nothing has to
+        // be pushed here; what does have to happen is that the token registration lets go, and that a job
+        // enqueued before the fence went up cannot start another read if it somehow runs.
+        Settle();
+    }
+
+    /// <summary>
+    /// The read request the copy loop makes, one per chunk.
+    /// </summary>
+    private sealed class CopyReadRequest : ReadRequest
+    {
+        private readonly HostStreamCopy _copy;
+
+        internal CopyReadRequest(HostStreamCopy copy)
+        {
+            _copy = copy;
+        }
+
+        internal override void ChunkSteps(JsValue chunk) => _copy.OnChunk(chunk);
+
+        internal override void CloseSteps() => _copy.OnSourceClosed();
+
+        internal override void ErrorSteps(JsValue error) => _copy.OnSourceErrored(error);
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/HostWritableStreamSink.cs
+++ b/Jint/WebApi/Streams/HostWritableStreamSink.cs
@@ -1,0 +1,296 @@
+#if NET8_0_OR_GREATER
+using System.Buffers;
+using System.Threading;
+using System.Threading.Tasks;
+using Jint.Native;
+using Jint.Native.Promise;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// A <c>WritableStream</c> whose underlying sink is a host <see cref="Stream"/>: the engine's side of
+/// <c>Engine.Advanced.CreateWritableStream</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Backpressure is the write promise.</b> The standard's writable queue only advances when the sink's
+/// <c>write()</c> promise settles (https://streams.spec.whatwg.org/#writable-stream-default-controller-advance-queue-if-needed),
+/// and <c>writer.ready</c> is what a script awaits to feel it. So a script writing faster than the host's
+/// disk simply waits on <c>ready</c>, and the queue never grows past
+/// <c>HostWritableStreamOptions.HighWaterMark</c> chunks.
+/// </para>
+/// <para>
+/// <b>The three sink algorithms never overlap</b> — the standard marks a write or a close in flight and
+/// refuses to start anything else until it settles, and it will not run <c>abort()</c> while either is in
+/// flight (https://streams.spec.whatwg.org/#writable-stream-finish-erroring). The one thing that <i>can</i>
+/// arrive mid-write is a restore's <c>Abandon</c>, which is what the bridge's state machine is for.
+/// </para>
+/// <para>
+/// <b><c>close()</c> is the script's proof the bytes landed.</b> Its promise settles only once the host's
+/// stream has been flushed and — unless the host kept ownership — disposed, and a failure in either is what
+/// the promise rejects with. That is the one path where a failure to close is reported rather than swallowed.
+/// </para>
+/// </remarks>
+internal sealed class HostWritableStreamSink : HostStreamBridge
+{
+    private HostWritableStreamSink(Engine engine, Realm realm, Stream destination, HostWritableStreamOptions options)
+        : base(engine, realm, destination, options.LeaveOpen, CancellationToken.None)
+    {
+    }
+
+    /// <summary>
+    /// Builds the stream. Runs on the engine thread; nothing is written until script writes.
+    /// </summary>
+    internal static JsWritableStream Create(Engine engine, Realm realm, Stream destination, HostWritableStreamOptions options)
+    {
+        var bridge = new HostWritableStreamSink(engine, realm, destination, options);
+
+        var stream = WritableStreamOperations.CreateWritableStream(
+            engine,
+            realm,
+            static () => JsValue.Undefined,
+            bridge.Write,
+            bridge.Close,
+            _ => bridge.Abort(),
+            options.HighWaterMark,
+            static _ => 1);
+
+        engine.RegisterHostStreamBridge(bridge);
+        return stream;
+    }
+
+    /// <summary>
+    /// The underlying sink's <c>write()</c>: https://streams.spec.whatwg.org/#dom-underlyingsink-write.
+    /// </summary>
+    private JsPromise Write(JsValue chunk)
+    {
+        var capability = StreamPromises.NewPromise(Engine, Realm);
+        var promise = StreamPromises.PromiseOf(capability);
+
+        if (!TryGetChunkBytes(chunk, out var bytes))
+        {
+            capability.Reject(Realm.Intrinsics.TypeError.Construct(
+                $"A host stream can only be written a BufferSource, a Blob or a string, and this chunk is of type '{chunk.Type}'."));
+            return promise;
+        }
+
+        if (!TryBeginOperation())
+        {
+            // Only reachable for a bridge a restore has abandoned — the standard's own machinery stops a
+            // write to a closed, closing or errored stream long before it reaches the sink.
+            capability.Reject(Realm.Intrinsics.TypeError.Construct(
+                "The host stream was released: Engine.Advanced.RestoreGlobalSnapshot ended the evaluation cycle it was created in."));
+            return promise;
+        }
+
+        if (bytes.IsEmpty)
+        {
+            // Nothing to hand the host, and an empty WriteAsync is not free — it still costs a task and, for
+            // a network stream, potentially a zero-length frame.
+            EndOperationAndReleaseIfOwed();
+            capability.Resolve(JsValue.Undefined);
+            return promise;
+        }
+
+        // The chunk is copied out of script-visible storage here, on the engine thread, before anything can
+        // observe the write. A buffer script keeps writing to while the host reads it would put bytes on the
+        // disk that were never any state the script could see.
+        var count = bytes.Length;
+        var buffer = ArrayPool<byte>.Shared.Rent(count);
+        bytes.CopyTo(buffer);
+
+        ValueTask write;
+        try
+        {
+            write = HostStream.WriteAsync(buffer.AsMemory(0, count), Cancellation.Token);
+        }
+        catch (Exception exception) when (!ConstraintFailure.MustPropagate(exception))
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+            SettleWrite(exception, capability);
+            return promise;
+        }
+
+        if (write.IsCompleted)
+        {
+            Exception? failure = null;
+            try
+            {
+                write.GetAwaiter().GetResult();
+            }
+            catch (Exception exception) when (!ConstraintFailure.MustPropagate(exception))
+            {
+                failure = exception;
+            }
+
+            ArrayPool<byte>.Shared.Return(buffer);
+            SettleWrite(failure, capability);
+            return promise;
+        }
+
+        var task = write.AsTask();
+        _ = task.ContinueWith(
+            completed =>
+            {
+                // Returned here rather than from the engine-thread job: the job may be discarded by the
+                // generation fence, and a buffer returned to the pool by nobody is a buffer the pool has
+                // permanently lost.
+                ArrayPool<byte>.Shared.Return(buffer);
+                var failure = ClassifyFailure(completed);
+                Enqueue(() => SettleWrite(failure, capability));
+            },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+
+        return promise;
+    }
+
+    /// <summary>
+    /// On the engine thread: end the in-flight write and settle its promise. A rejection is what errors the
+    /// writable stream, which is the standard's own reaction to a sink whose <c>write()</c> failed.
+    /// </summary>
+    private void SettleWrite(Exception? failure, PromiseCapability capability)
+    {
+        var owesRelease = EndOperation();
+
+        if (failure is not null && FinishBridge())
+        {
+            owesRelease = true;
+        }
+
+        if (owesRelease)
+        {
+            ReleaseHostStream();
+        }
+
+        if (failure is null)
+        {
+            capability.Resolve(JsValue.Undefined);
+            return;
+        }
+
+        capability.Reject(HostStreamError("writing", failure));
+    }
+
+    /// <summary>
+    /// The underlying sink's <c>close()</c>: https://streams.spec.whatwg.org/#dom-underlyingsink-close.
+    /// Flushes the host's stream and, unless the host kept ownership, disposes it — and the promise it
+    /// answers with is what makes <c>await writer.close()</c> mean the bytes are on the disk.
+    /// </summary>
+    private JsPromise Close()
+    {
+        var capability = StreamPromises.NewPromise(Engine, Realm);
+        var promise = StreamPromises.PromiseOf(capability);
+
+        if (!TryBeginOperation())
+        {
+            // Abandoned by a restore. Nothing is left to close, and nothing will observe this promise.
+            capability.Resolve(JsValue.Undefined);
+            return promise;
+        }
+
+        var task = FlushAndDisposeAsync();
+
+        if (task.IsCompleted)
+        {
+            Exception? failure = null;
+            try
+            {
+                task.GetAwaiter().GetResult();
+            }
+            catch (Exception exception) when (!ConstraintFailure.MustPropagate(exception))
+            {
+                failure = exception;
+            }
+
+            SettleClose(failure, capability);
+            return promise;
+        }
+
+        _ = task.AsTask().ContinueWith(
+            completed =>
+            {
+                var failure = ClassifyFailure(completed);
+                Enqueue(() => SettleClose(failure, capability));
+            },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+
+        return promise;
+    }
+
+    /// <summary>
+    /// The underlying sink's <c>abort()</c>: https://streams.spec.whatwg.org/#dom-underlyingsink-abort.
+    /// </summary>
+    /// <remarks>
+    /// An abort flushes nothing — the script has said the output is not wanted, and pushing a partial buffer
+    /// to the disk on the way out is the opposite of what it asked for. The stream is still disposed unless
+    /// the host kept ownership, because the handle has to go somewhere, and a failure to dispose is
+    /// swallowed: the abort's own reason is the outcome the script is waiting on.
+    /// </remarks>
+    private JsPromise Abort()
+    {
+        if (FinishBridge())
+        {
+            ReleaseHostStream();
+        }
+
+        return StreamPromises.ResolvedWithUndefined(Engine, Realm);
+    }
+
+    /// <summary>
+    /// Flushes and, unless the host kept ownership, disposes. Both asynchronously, so that a slow disk stalls
+    /// the script's promise rather than the engine's thread.
+    /// </summary>
+    private async ValueTask FlushAndDisposeAsync()
+    {
+        await HostStream.FlushAsync(Cancellation.Token).ConfigureAwait(false);
+
+        if (!LeaveOpen)
+        {
+            await HostStream.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// On the engine thread: the close is over, one way or the other, and the bridge is done with the host's
+    /// stream whichever way it went.
+    /// </summary>
+    private void SettleClose(Exception? failure, PromiseCapability capability)
+    {
+        var owesRelease = EndOperation();
+
+        if (FinishBridge())
+        {
+            owesRelease = true;
+        }
+
+        if (owesRelease)
+        {
+            // Disposing twice is a no-op every Stream guarantees, so a close that already disposed and a
+            // release that disposes again cannot collide; what this call is really for is the cancellation
+            // source, and the LeaveOpen case where nothing was disposed at all.
+            ReleaseHostStream();
+        }
+
+        if (failure is null)
+        {
+            capability.Resolve(JsValue.Undefined);
+            return;
+        }
+
+        capability.Reject(HostStreamError("closing", failure));
+    }
+
+    private void EndOperationAndReleaseIfOwed()
+    {
+        if (EndOperation())
+        {
+            ReleaseHostStream();
+        }
+    }
+}
+#endif

--- a/README.md
+++ b/README.md
@@ -987,6 +987,70 @@ standard also calls errors are the documented exception, because .NET exposes no
 could report them: a stream that ends mid-member closes cleanly instead, and bytes following a complete
 member are ignored. A stream that ends with no compressed bytes at all *is* refused.
 
+### Bridging a stream to `System.IO.Stream`
+
+`Engine.Advanced` connects the two worlds in both directions, so a host never has to write the pump itself:
+
+```csharp
+var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Streams | WebApiFeatures.Encoding));
+
+// A .NET stream the script can read, with backpressure: nothing is read until the queue wants a chunk.
+engine.SetValue("input", engine.Advanced.CreateReadableStream(File.OpenRead("in.txt")));
+
+// A .NET stream the script can write; `await writer.close()` is its proof the bytes were flushed.
+engine.SetValue("output", engine.Advanced.CreateWritableStream(File.Create("out.txt")));
+
+// And a script stream read back into .NET — here, a file transformed through a script TransformStream.
+var upperCased = engine.Evaluate("""
+    input.pipeThrough(new TransformStream({
+      transform(chunk, controller) {
+        const text = new TextDecoder().decode(chunk);
+        controller.enqueue(new TextEncoder().encode(text.toUpperCase()));
+      }
+    }))
+    """);
+
+var copy = engine.Advanced.StartReadableStreamCopy(upperCased, File.Create("shouted.txt"));
+while (!copy.IsCompleted)
+{
+    engine.Advanced.ProcessTasks();   // the host owns the turns
+}
+
+Console.WriteLine($"{copy.GetResult()} bytes");   // throws PromiseRejectedException if the copy failed
+```
+
+**The threading contract is the whole design, and it is the same one the timers have.** Everything that
+touches the engine happens on the engine's thread, from an event-loop job stamped with the cycle it was
+registered in; everything that touches your `Stream` happens on whichever thread the BCL's asynchronous I/O
+completes on, and produces nothing but bytes and exceptions. Three consequences:
+
+- **The engine must be given turns or nothing moves.** An `await` in script, `EvaluateAsync`, a blocking
+  `UnwrapIfPromise`, or your own `engine.Advanced.ProcessTasks()` loop. An engine nobody pumps never reads a
+  byte. A read that completes synchronously — a `MemoryStream`, a warm page cache — is delivered on the spot
+  instead, so such a stream costs no thread hop at all.
+- **Hand the stream over and stop touching it.** A read or a write may be in flight whenever the script is
+  asking for a chunk. By default the engine closes it for you: when the script reads to the end or cancels,
+  when it closes or aborts a writable stream, when a copy finishes, or when `RestoreGlobalSnapshot` ends the
+  cycle. `LeaveOpen` keeps ownership with you.
+- **Pick the copy entry point by who owns the thread.** `StartReadableStreamCopy` returns a polling handle and
+  runs nothing on its own, which is what a game loop or a UI thread needs; `CopyReadableStreamAsync` awaits
+  instead and runs its turns on whichever thread resumes the await. This is exactly the
+  `Engine.Modules.StartImport` / `ImportAsync` split, and for the same reason.
+
+Backpressure is the standard's own, in both directions: `HighWaterMark` chunks are read ahead, `writer.ready`
+stops being resolved once that many are queued, and a copy has one chunk in flight at a time. A failure on
+your stream errors the script's stream with a `TypeError` whose message names the exception's *type* but not
+its text — the exception itself rides the error value, where
+[`JintException.TryGetClrException`](#getting-the-original-exception-back) can read it and the script cannot.
+
+What a script may write to a host stream is a `BufferSource`, a `Blob` or a string (UTF-8 encoded). Anything
+else is a `TypeError` rather than a stringification, because `[object Object]` silently appended to your file
+is not a failure mode worth having.
+
+There is deliberately **no adapter presenting a script's `ReadableStream` as a `System.IO.Stream`**. Its
+`Read` would have to drive the engine from whichever thread called it, which is the one thing a single-threaded
+engine cannot allow; the copy operation above is the same capability with the thread question answered.
+
 
 ## Node compatibility (opt-in)
 


### PR DESCRIPTION
Closes #3103.

Bridges WHATWG streams to `System.IO.Stream` for hosts, through `Engine.Advanced`: wrap a host readable stream as a `ReadableStream` a script can consume, a host writable stream as a `WritableStream` a script can fill, and copy a script's `ReadableStream` (including a `Response.body` or a `Blob.stream()`) into a host stream — with backpressure honored in both directions, every JS-side callback on the engine's thread from the job queue, and the host owning every turn through `ProcessTasks`. The deliberate design decision from review stands: there is **no synchronous `Stream` adapter** — a WHATWG stream's chunks arrive only while the engine is pumped, so a blocking `Stream.Read` over one would deadlock the very thread that has to pump; the rationale is in the XML docs and the README section.

Lifecycle: a bridge holds an operating-system handle, so `RestoreGlobalSnapshot` **closes** it (`AbandonHostStreamBridges` in `ResetTransientEvaluationState`) rather than merely generation-fencing its chunks; the registration list is pruned on the engine thread only, and abandonment copies before walking so a synchronously-running continuation cannot observe the list mid-enumeration. An engine that never bridges a stream pays one null field — deliberately not `WebApiEngineState`, which would cost that state's construction and a pump null-check for a feature that never schedules anything.

Landed on top of the completed streams surface, with two integration tests that did not exist when the branch was authored: copying a `Blob.stream()` into a host stream, and piping a host gzip stream through `DecompressionStream('gzip')` into a host stream. 764 lines of `Jint.Tests.PublicInterface/HostStreamBridgeTests.cs` prove the whole surface third-party-reachable; 2,768 insertions, **zero deletions**.

Full gate green: solution build, Jint.Tests (9020/7046), PublicInterface (1939/1556), and both host-contract-verification legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G7Ud48VAs1JicxRZxLDxg
