### PR TITLE
Web API: byte streams — ReadableByteStreamController, BYOB readers and byte tee

### DIFF
--- a/Jint.Tests.PublicInterface/WebApiStreamsTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiStreamsTests.cs
@@ -66,6 +66,7 @@ public class WebApiStreamsTests
                  {
                      "ReadableStreamDefaultReader", "ReadableStreamDefaultController", "WritableStreamDefaultWriter",
                      "WritableStreamDefaultController", "TransformStreamDefaultController",
+                     "ReadableStreamBYOBReader", "ReadableByteStreamController", "ReadableStreamBYOBRequest",
                  })
         {
             engine.Evaluate($"typeof {name}").AsString().Should().Be("undefined", name);
@@ -78,17 +79,27 @@ public class WebApiStreamsTests
     }
 
     [Fact]
-    public void ByteStreamsAreAbsentRatherThanBroken()
+    public void ByteStreamsWorkFromOutsideTheAssembly()
     {
         var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Streams));
 
-        engine.Evaluate("typeof ReadableByteStreamController").AsString().Should().Be("undefined");
-        engine.Evaluate("typeof ReadableStreamBYOBReader").AsString().Should().Be("undefined");
-        engine.Evaluate("typeof ReadableStreamBYOBRequest").AsString().Should().Be("undefined");
+        // A host reads a byte stream the way a browser script does: supply the buffer, get it back filled,
+        // and keep using the view the read handed over — the one it passed in has been transferred away.
+        engine.Execute("""
+            globalThis.log = [];
+            const stream = new ReadableStream({
+                type: 'bytes',
+                autoAllocateChunkSize: 8,
+                pull(c) { c.byobRequest.view.set([1, 2, 3]); c.byobRequest.respond(3); c.close(); }
+            });
 
-        // Asking for one is refused rather than quietly downgraded.
-        engine.Evaluate("(() => { try { new ReadableStream({ type: 'bytes' }); return 'no throw'; } catch (e) { return e.name; } })()")
-            .AsString().Should().Be("TypeError");
+            const reader = stream.getReader({ mode: 'byob' });
+            reader.read(new Uint8Array(4)).then(r => log.push(Array.from(r.value).join('-') + ':' + r.value.buffer.byteLength));
+            """);
+
+        engine.Evaluate("log.join(',')").AsString().Should().Be("1-2-3:4");
+
+        // Asking for a BYOB reader from a stream that is not a byte stream is still the TypeError it was.
         engine.Evaluate("(() => { try { new ReadableStream().getReader({ mode: 'byob' }); return 'no throw'; } catch (e) { return e.name; } })()")
             .AsString().Should().Be("TypeError");
     }

--- a/Jint.Tests/Runtime/WebApi/ReadableByteStreamTests.cs
+++ b/Jint.Tests/Runtime/WebApi/ReadableByteStreamTests.cs
@@ -1,0 +1,880 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// Readable byte streams — <c>new ReadableStream({ type: "bytes" })</c>,
+/// <c>ReadableByteStreamController</c>, <c>ReadableStreamBYOBRequest</c> and BYOB reading — against the
+/// Streams Standard, https://streams.spec.whatwg.org/#rbs-controller-class.
+/// </summary>
+/// <remarks>
+/// The thing every one of these tests is really about is buffer ownership: a byte stream transfers the
+/// <c>ArrayBuffer</c> behind every view that crosses it, so the side that handed a view over is left with a
+/// detached one and the side that received it owns the memory. Several tests assert the detachment
+/// directly, because it is the observable half of the zero-copy design.
+/// </remarks>
+public class ReadableByteStreamTests
+{
+    private static Engine StreamEngine()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Streams));
+        engine.Execute("var log = [];");
+        return engine;
+    }
+
+    private static string Log(Engine engine) => engine.Evaluate("log.join(',')").AsString();
+
+    [Fact]
+    public void ConstructsAByteStream()
+    {
+        var engine = StreamEngine();
+        engine.Execute("var stream = new ReadableStream({ type: 'bytes' });");
+
+        engine.Evaluate("stream instanceof ReadableStream").AsBoolean().Should().BeTrue();
+        engine.Evaluate("stream.locked").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void GivesTheUnderlyingSourceAByteController()
+    {
+        var engine = StreamEngine();
+        engine.Execute("var seen; new ReadableStream({ type: 'bytes', start(c) { seen = c; } });");
+
+        engine.Evaluate("Object.getPrototypeOf(seen).constructor.name").AsString().Should().Be("ReadableByteStreamController");
+        engine.Evaluate("seen[Symbol.toStringTag]").AsString().Should().Be("ReadableByteStreamController");
+
+        // A byte stream's default high water mark is 0, not 1: it pulls only once a consumer asks.
+        engine.Evaluate("seen.desiredSize").AsNumber().Should().Be(0);
+        engine.Evaluate("seen.byobRequest").Should().Be(JsValue.Null);
+    }
+
+    [Fact]
+    public void RefusesAQueuingStrategyWithASizeFunction()
+    {
+        // "If strategy["size"] exists, throw a RangeError exception" — a byte stream's chunk size is its
+        // byte length, so a size() would have nothing to mean.
+        var engine = StreamEngine();
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new ReadableStream({ type: 'bytes' }, { size: () => 1 })"))
+            .Error.Get("name").AsString().Should().Be("RangeError");
+
+        // A high water mark on its own is fine, and is in bytes.
+        engine.Execute("var c; new ReadableStream({ type: 'bytes', start(controller) { c = controller; } }, { highWaterMark: 64 });");
+        engine.Evaluate("c.desiredSize").AsNumber().Should().Be(64);
+    }
+
+    [Fact]
+    public void ReadsAnEnqueuedChunkWithADefaultReader()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({
+                type: 'bytes',
+                start(c) { c.enqueue(new Uint8Array([1, 2, 3])); c.close(); }
+            });
+            var reader = stream.getReader();
+            reader.read().then(r => log.push(r.done + ':' + r.value.constructor.name + ':' + Array.from(r.value)));
+            reader.read().then(r => log.push(r.done + ':' + r.value));
+            """);
+
+        // A default read of a byte stream always yields a Uint8Array, whatever view was enqueued.
+        Log(engine).Should().Be("false:Uint8Array:1,2,3,true:undefined");
+    }
+
+    [Fact]
+    public void TransfersTheBufferOfAnEnqueuedChunk()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var source = new Uint8Array([7, 8]);
+            var c;
+            var stream = new ReadableStream({ type: 'bytes', start(controller) { c = controller; } });
+            c.enqueue(source);
+            """);
+
+        // The chunk's buffer belongs to the stream now, so the caller's view is detached.
+        engine.Evaluate("source.byteLength").AsNumber().Should().Be(0);
+        engine.Evaluate("source.buffer.byteLength").AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void RefusesAnEmptyOrNonViewChunk()
+    {
+        var engine = StreamEngine();
+        engine.Execute("var c; new ReadableStream({ type: 'bytes', start(controller) { c = controller; } });");
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("c.enqueue('nope')"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("c.enqueue(new Uint8Array(0))"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+
+        // A view over a detached buffer has a byte length of 0 and is refused by the same check.
+        engine.Execute("var detached = new Uint8Array([1]); c.enqueue(detached);");
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("c.enqueue(detached)"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void AcquiresABYOBReader()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({ type: 'bytes' });
+            var reader = stream.getReader({ mode: 'byob' });
+            """);
+
+        engine.Evaluate("Object.getPrototypeOf(reader).constructor.name").AsString().Should().Be("ReadableStreamBYOBReader");
+        engine.Evaluate("stream.locked").AsBoolean().Should().BeTrue();
+
+        // The constructor is equivalent to getReader({ mode: 'byob' }), and refuses a locked stream.
+        var byobReaderConstructor = "Object.getPrototypeOf(reader).constructor";
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate($"new ({byobReaderConstructor})(stream)"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+
+        engine.Execute("reader.releaseLock();");
+        engine.Evaluate($"new ({byobReaderConstructor})(stream) instanceof Object").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void RefusesABYOBReaderForANonByteStream()
+    {
+        var engine = StreamEngine();
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new ReadableStream().getReader({ mode: 'byob' })"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+
+        // And the stream is not left locked by the attempt.
+        engine.Evaluate("(() => { const s = new ReadableStream(); try { s.getReader({ mode: 'byob' }); } catch (e) {} return s.locked; })()")
+            .AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void FillsABYOBReadFromTheQueue()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({
+                type: 'bytes',
+                start(c) { c.enqueue(new Uint8Array([1, 2, 3, 4])); }
+            });
+            var reader = stream.getReader({ mode: 'byob' });
+            var view = new Uint8Array(2);
+            reader.read(view).then(r => log.push(r.done + ':' + Array.from(r.value) + ':' + r.value.byteOffset));
+            reader.read(new Uint8Array(4)).then(r => log.push(r.done + ':' + Array.from(r.value)));
+            """);
+
+        // The second read is served from what is left of the queued chunk: a BYOB read fulfils as soon as
+        // its minimum fill (one element, by default) is met, not once the whole view is full.
+        Log(engine).Should().Be("false:1,2:0,false:3,4");
+    }
+
+    [Fact]
+    public void TransfersTheViewPassedToABYOBRead()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({ type: 'bytes', start(c) { c.enqueue(new Uint8Array([9])); } });
+            var reader = stream.getReader({ mode: 'byob' });
+            var view = new Uint8Array(1);
+            var buffer = view.buffer;
+            var returned;
+            reader.read(view).then(r => { returned = r.value; });
+            """);
+
+        // The caller's view and its buffer are detached; the value handed back is a new view of the same
+        // type onto the same memory, which is what makes a BYOB read loop recycle one allocation.
+        engine.Evaluate("view.byteLength").AsNumber().Should().Be(0);
+        engine.Evaluate("buffer.byteLength").AsNumber().Should().Be(0);
+        engine.Evaluate("returned.constructor.name").AsString().Should().Be("Uint8Array");
+        engine.Evaluate("Array.from(returned).join()").AsString().Should().Be("9");
+        engine.Evaluate("returned.buffer === buffer").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void KeepsTheViewTypeOfABYOBRead()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var c;
+            var stream = new ReadableStream({ type: 'bytes', start(controller) { c = controller; } });
+            var reader = stream.getReader({ mode: 'byob' });
+            reader.read(new Uint16Array(2)).then(r => log.push(r.value.constructor.name + ':' + r.value.length + ':' + Array.from(r.value)));
+            c.enqueue(new Uint8Array([1, 0, 2, 0]));
+            """);
+
+        // The view constructor comes from the typed array constructors table, and the element size is what
+        // makes four bytes two Uint16 elements.
+        Log(engine).Should().Be("Uint16Array:2:1,2");
+    }
+
+    [Fact]
+    public void ReadsIntoADataView()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var c;
+            var stream = new ReadableStream({ type: 'bytes', start(controller) { c = controller; } });
+            var reader = stream.getReader({ mode: 'byob' });
+            reader.read(new DataView(new ArrayBuffer(2))).then(r => log.push(r.value.constructor.name + ':' + r.value.getUint8(0) + ',' + r.value.getUint8(1)));
+            c.enqueue(new Uint8Array([5, 6]));
+            """);
+
+        Log(engine).Should().Be("DataView:5,6");
+    }
+
+    [Fact]
+    public void HonoursTheMinimumFill()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var c;
+            var stream = new ReadableStream({ type: 'bytes', start(controller) { c = controller; } });
+            var reader = stream.getReader({ mode: 'byob' });
+            reader.read(new Uint8Array(4), { min: 3 }).then(r => log.push('read:' + Array.from(r.value)));
+            c.enqueue(new Uint8Array([1]));
+            log.push('one');
+            c.enqueue(new Uint8Array([2]));
+            log.push('two');
+            c.enqueue(new Uint8Array([3]));
+            log.push('three');
+            """);
+
+        // The read only fulfils once three bytes have arrived, and it takes a microtask to do so.
+        Log(engine).Should().Be("one,two,three,read:1,2,3");
+    }
+
+    [Fact]
+    public void ValidatesTheArgumentsOfABYOBRead()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({ type: 'bytes' });
+            var reader = stream.getReader({ mode: 'byob' });
+            function reason(source) { return eval(source).then(() => 'resolved', e => e.name); }
+            """);
+
+        // Everything about read() rejects rather than throws: the operation returns a promise type.
+        engine.Execute("""
+            reason("reader.read('nope')").then(n => log.push('nonView:' + n));
+            reason("reader.read(new Uint8Array(0))").then(n => log.push('empty:' + n));
+            reason("reader.read(new Uint8Array(2), { min: 0 })").then(n => log.push('minZero:' + n));
+            reason("reader.read(new Uint8Array(2), { min: 3 })").then(n => log.push('minTooBig:' + n));
+            """);
+
+        engine.Execute("reader.releaseLock(); reason('reader.read(new Uint8Array(2))').then(n => log.push('released:' + n));");
+
+        Log(engine).Should().Be("nonView:TypeError,empty:TypeError,minZero:TypeError,minTooBig:RangeError,released:TypeError");
+    }
+
+    [Fact]
+    public void OffersABYOBRequestToTheUnderlyingSource()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({
+                type: 'bytes',
+                pull(c) {
+                    log.push('pull:' + c.byobRequest.view.byteLength);
+                    c.byobRequest.view[0] = 42;
+                    c.byobRequest.respond(1);
+                }
+            });
+            var reader = stream.getReader({ mode: 'byob' });
+            reader.read(new Uint8Array(8)).then(r => log.push('read:' + r.value.byteLength + ':' + r.value[0]));
+            """);
+
+        // The request's view is a window onto the caller's own buffer: the source writes straight into it.
+        Log(engine).Should().Be("pull:8,read:1:42");
+    }
+
+    [Fact]
+    public void InvalidatesTheBYOBRequestOnceRespondedTo()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var kept;
+            var stream = new ReadableStream({
+                type: 'bytes',
+                pull(c) { kept = c.byobRequest; kept.view[0] = 1; kept.respond(1); }
+            });
+            var reader = stream.getReader({ mode: 'byob' });
+            reader.read(new Uint8Array(1)).then(() => log.push('read'));
+            """);
+
+        Log(engine).Should().Be("read");
+        engine.Evaluate("kept.view").Should().Be(JsValue.Null);
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("kept.respond(1)"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void ValidatesRespond()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var request;
+            var stream = new ReadableStream({ type: 'bytes', pull(c) { request = c.byobRequest; } });
+            var reader = stream.getReader({ mode: 'byob' });
+            reader.read(new Uint8Array(2));
+            """);
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("request.respond(3)"))
+            .Error.Get("name").AsString().Should().Be("RangeError");
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("request.respond(0)"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("request.respond(-1)"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void RespondsWithANewView()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var replacement;
+            var stream = new ReadableStream({
+                type: 'bytes',
+                pull(c) {
+                    const request = c.byobRequest;
+                    replacement = new Uint8Array(request.view.buffer, request.view.byteOffset, 2);
+                    replacement[0] = 3;
+                    replacement[1] = 4;
+                    c.byobRequest.respondWithNewView(replacement);
+                }
+            });
+            var reader = stream.getReader({ mode: 'byob' });
+            reader.read(new Uint8Array(4)).then(r => log.push('read:' + Array.from(r.value)));
+            """);
+
+        Log(engine).Should().Be("read:3,4");
+
+        // The source's own view is transferred away as the chunk is handed over, so it cannot go on writing
+        // into memory the consumer now owns.
+        engine.Evaluate("replacement.byteLength").AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void ValidatesRespondWithANewView()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var request;
+            var stream = new ReadableStream({ type: 'bytes', pull(c) { request = c.byobRequest; } });
+            var reader = stream.getReader({ mode: 'byob' });
+            reader.read(new Uint8Array(4));
+            """);
+
+        // The new view has to describe the very region the request named: the same start, a buffer of the
+        // same capacity, and no more bytes than were asked for. Note what is *not* checked — the buffer
+        // need not be the request's own, since it is transferred in either way.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("request.respondWithNewView(new Uint8Array(8))"))
+            .Error.Get("name").AsString().Should().Be("RangeError");
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate(
+            "request.respondWithNewView(new Uint8Array(request.view.buffer, request.view.byteOffset + 1, 1))"))
+            .Error.Get("name").AsString().Should().Be("RangeError");
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("request.respondWithNewView('nope')"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void AutomaticallyAllocatesABufferForADefaultRead()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({
+                type: 'bytes',
+                autoAllocateChunkSize: 16,
+                pull(c) {
+                    log.push('request:' + c.byobRequest.view.byteLength);
+                    c.byobRequest.view.set([1, 2]);
+                    c.byobRequest.respond(2);
+                }
+            });
+            stream.getReader().read().then(r => log.push('read:' + r.value.byteLength + ':' + Array.from(r.value)));
+            """);
+
+        // autoAllocateChunkSize is what lets a source written for BYOB serve an ordinary read() as well.
+        Log(engine).Should().Be("request:16,read:2:1,2");
+    }
+
+    [Fact]
+    public void LetsTheSourceEnqueueInsteadOfRespondingToAnAutomaticAllocation()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var kept;
+            var stream = new ReadableStream({
+                type: 'bytes',
+                autoAllocateChunkSize: 8,
+                pull(c) { kept = c.byobRequest; c.enqueue(new Uint8Array([9, 9])); }
+            });
+            stream.getReader().read().then(r => log.push('read:' + Array.from(r.value)));
+            """);
+
+        // The allocated buffer is simply dropped: an enqueue past a pending pull-into invalidates its BYOB
+        // request first, so the source cannot respond into a buffer whose bytes nobody is waiting for.
+        Log(engine).Should().Be("read:9,9");
+        engine.Evaluate("kept.view").Should().Be(JsValue.Null);
+    }
+
+    [Fact]
+    public void RefusesAZeroAutoAllocateChunkSize()
+    {
+        var engine = StreamEngine();
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new ReadableStream({ type: 'bytes', autoAllocateChunkSize: 0 })"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+
+        // The member is an [EnforceRange] unsigned long long, so it is converted — and rejected — even for a
+        // stream that is not a byte stream.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new ReadableStream({ autoAllocateChunkSize: -1 })"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void HandsBackTheMemoryOfAClosedStream()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({ type: 'bytes', start(c) { c.close(); } });
+            var reader = stream.getReader({ mode: 'byob' });
+            var view = new Uint8Array(4);
+            reader.read(view).then(r => log.push(r.done + ':' + r.value.constructor.name + ':' + r.value.byteLength + ':' + r.value.buffer.byteLength));
+            """);
+
+        // "byobReader.read(chunk) will fulfill with { value: newViewOnSameMemory, done: true } for closed
+        // streams" — the memory comes back, as an empty view onto a buffer of the original size.
+        Log(engine).Should().Be("true:Uint8Array:0:4");
+    }
+
+    [Fact]
+    public void DiscardsTheMemoryOfACancelledStream()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({ type: 'bytes' });
+            var reader = stream.getReader({ mode: 'byob' });
+            reader.read(new Uint8Array(4)).then(r => log.push(r.done + ':' + r.value));
+            reader.cancel('bored');
+            """);
+
+        // "If the stream is canceled, the backing memory is discarded and byobReader.read(chunk) fulfills
+        // with the more traditional { value: undefined, done: true } instead."
+        Log(engine).Should().Be("true:undefined");
+    }
+
+    [Fact]
+    public void RefusesToCloseWithAPartialElement()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var c;
+            var stream = new ReadableStream({ type: 'bytes', start(controller) { c = controller; } });
+            var reader = stream.getReader({ mode: 'byob' });
+            reader.read(new Uint16Array(2)).then(() => log.push('resolved'), e => log.push('rejected:' + e.name));
+            c.byobRequest.view[0] = 1;
+            c.byobRequest.respond(1);
+            """);
+
+        // One byte of a two-byte element has been written, so there is nothing that can be handed back.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("c.close()"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+
+        engine.Execute("");
+        Log(engine).Should().Be("rejected:TypeError");
+    }
+
+    [Fact]
+    public void EndsAPartlyFilledReadWithAZeroByteResponse()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var pulls = 0;
+            var stream = new ReadableStream({
+                type: 'bytes',
+                pull(c) {
+                    if (pulls === 0) { c.byobRequest.view[0] = 1; c.byobRequest.respond(1); }
+                    else { c.close(); c.byobRequest.respond(0); }
+                    pulls++;
+                }
+            });
+            var reader = stream.getReader({ mode: 'byob' });
+            reader.read(new Uint8Array(3), { min: 3 }).then(r => log.push(r.done + ':' + Array.from(r.value)));
+            reader.closed.then(() => log.push('closed'));
+            """);
+
+        // Closing does not settle a pending BYOB read on its own — ReadableStreamClose touches only a
+        // default reader's read requests. The source ends it by responding with zero bytes, which commits
+        // whatever was filled: "the promise is fulfilled with the remaining elements in the stream, which
+        // might be fewer than the initially requested amount".
+        // The closed promise settles first: close() resolves it, and only the respond() after it commits
+        // the descriptor that fulfils the read.
+        Log(engine).Should().Be("closed,true:1");
+        engine.Evaluate("pulls").AsNumber().Should().Be(2);
+    }
+
+    [Fact]
+    public void RefusesAReadThatCanNeverBeFilled()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({
+                type: 'bytes',
+                start(c) { c.enqueue(new Uint8Array([1, 2, 3])); c.close(); }
+            });
+            var reader = stream.getReader({ mode: 'byob' });
+            reader.read(new Uint16Array(2), { min: 2 }).then(() => log.push('resolved'), e => log.push('read:' + e.name));
+            reader.closed.then(() => log.push('closed'), e => log.push('closed:' + e.name));
+            """);
+
+        // Three bytes cannot fill two Uint16 elements and the stream has been closed, so no more are
+        // coming: the read is refused and the stream errors rather than hanging.
+        Log(engine).Should().Be("read:TypeError,closed:TypeError");
+    }
+
+    [Fact]
+    public void ErrorsAPendingBYOBReadWhenTheStreamErrors()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var c;
+            var stream = new ReadableStream({ type: 'bytes', start(controller) { c = controller; } });
+            var reader = stream.getReader({ mode: 'byob' });
+            reader.read(new Uint8Array(2)).then(() => log.push('resolved'), e => log.push('rejected:' + e.message));
+            reader.closed.catch(e => log.push('closed:' + e.message));
+            c.error(new Error('boom'));
+            """);
+
+        // The closed promise is rejected before the pending read is: ReadableStreamError settles the
+        // reader's closedness first and only then errors its read-into requests.
+        Log(engine).Should().Be("closed:boom,rejected:boom");
+    }
+
+    [Fact]
+    public void RejectsPendingBYOBReadsWhenTheLockIsReleased()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var c;
+            var stream = new ReadableStream({ type: 'bytes', start(controller) { c = controller; } });
+            var reader = stream.getReader({ mode: 'byob' });
+            reader.read(new Uint8Array(2)).then(() => log.push('resolved'), e => log.push('rejected:' + e.name));
+            reader.releaseLock();
+            log.push('released:' + stream.locked);
+            """);
+
+        Log(engine).Should().Be("released:false,rejected:TypeError");
+    }
+
+    [Fact]
+    public void KeepsTheBytesWrittenIntoAnAbandonedBuffer()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var c;
+            var stream = new ReadableStream({ type: 'bytes', start(controller) { c = controller; } });
+            var reader = stream.getReader({ mode: 'byob' });
+            reader.read(new Uint8Array(4)).catch(() => log.push('abandoned'));
+            reader.releaseLock();
+
+            // The underlying source is still filling the buffer it was given, and may still respond into it.
+            c.byobRequest.view[0] = 11;
+            c.byobRequest.view[1] = 12;
+            c.byobRequest.respond(2);
+
+            stream.getReader().read().then(r => log.push('recovered:' + Array.from(r.value)));
+            """);
+
+        // [[ReleaseSteps]] downgrades the descriptor to reader type "none" rather than dropping it, so the
+        // bytes the source wrote end up in the stream's queue instead of being lost.
+        Log(engine).Should().Be("abandoned,recovered:11,12");
+    }
+
+    [Fact]
+    public void ServesAWaitingDefaultReadDirectlyFromAnEnqueue()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var c;
+            var stream = new ReadableStream({ type: 'bytes', start(controller) { c = controller; } });
+            var reader = stream.getReader();
+            reader.read().then(r => log.push('read:' + Array.from(r.value)));
+            c.enqueue(new Uint8Array([1, 2]));
+            log.push('enqueued:' + c.desiredSize);
+            """);
+
+        // The waiting read takes the chunk directly, so nothing is left in the queue.
+        Log(engine).Should().Be("enqueued:0,read:1,2");
+    }
+
+    [Fact]
+    public void SplitsOneEnqueueAcrossSeveralBYOBReads()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var c;
+            var stream = new ReadableStream({ type: 'bytes', start(controller) { c = controller; } });
+            var reader = stream.getReader({ mode: 'byob' });
+            reader.read(new Uint8Array(2)).then(r => log.push('a:' + Array.from(r.value)));
+            reader.read(new Uint8Array(2)).then(r => log.push('b:' + Array.from(r.value)));
+            c.enqueue(new Uint8Array([1, 2, 3, 4]));
+            """);
+
+        Log(engine).Should().Be("a:1,2,b:3,4");
+    }
+
+    [Fact]
+    public void TeesAByteStreamIntoTwoByteStreams()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({
+                type: 'bytes',
+                start(c) { c.enqueue(new Uint8Array([1, 2])); c.close(); }
+            });
+            var [a, b] = stream.tee();
+            log.push('byob:' + (typeof a.getReader({ mode: 'byob' }).read === 'function'));
+            b.getReader().read().then(r => log.push('b:' + Array.from(r.value)));
+            """);
+
+        // Both branches are byte streams, so both can be read BYOB — and the second branch's chunk is a
+        // copy, since a byte stream transfers the buffer of everything enqueued into it.
+        Log(engine).Should().Be("byob:true,b:1,2");
+    }
+
+    [Fact]
+    public void TeeReadsTheOriginalThroughABranchesOwnBuffer()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({
+                type: 'bytes',
+                pull(c) { c.byobRequest.view.set([1, 2]); c.byobRequest.respond(2); },
+                autoAllocateChunkSize: 8
+            });
+            var [a, b] = stream.tee();
+            a.getReader({ mode: 'byob' }).read(new Uint8Array(2)).then(r => log.push('a:' + Array.from(r.value)));
+            b.getReader().read().then(r => log.push('b:' + Array.from(r.value)));
+            """);
+
+        Log(engine).Should().Be("a:1,2,b:1,2");
+    }
+
+    [Fact]
+    public void PipesAndIteratesAByteStream()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var stream = new ReadableStream({
+                type: 'bytes',
+                start(c) { c.enqueue(new Uint8Array([1])); c.enqueue(new Uint8Array([2])); c.close(); }
+            });
+            (async () => { for await (const chunk of stream) { log.push('chunk:' + Array.from(chunk)); } log.push('done'); })();
+            """);
+
+        Log(engine).Should().Be("chunk:1,chunk:2,done");
+
+        var piped = StreamEngine();
+        piped.Execute("""
+            var stream = new ReadableStream({
+                type: 'bytes',
+                start(c) { c.enqueue(new Uint8Array([3, 4])); c.close(); }
+            });
+            var sink = new WritableStream({ write(chunk) { log.push('write:' + Array.from(chunk)); } });
+            stream.pipeTo(sink).then(() => log.push('piped'));
+            """);
+
+        Log(piped).Should().Be("write:3,4,piped");
+    }
+
+    [Fact]
+    public void KeepsTheInterfaceObjectsOffTheGlobal()
+    {
+        var engine = StreamEngine();
+
+        // The same documented narrowing the other stream interfaces get: reachable, but not named globally.
+        engine.Evaluate("typeof ReadableByteStreamController").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof ReadableStreamBYOBReader").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof ReadableStreamBYOBRequest").AsString().Should().Be("undefined");
+
+        engine.Execute("""
+            var request;
+            var stream = new ReadableStream({ type: 'bytes', pull(c) { request = c.byobRequest; } });
+            stream.getReader({ mode: 'byob' }).read(new Uint8Array(1));
+            """);
+
+        engine.Evaluate("Object.getPrototypeOf(request).constructor.name").AsString().Should().Be("ReadableStreamBYOBRequest");
+        engine.Evaluate("request[Symbol.toStringTag]").AsString().Should().Be("ReadableStreamBYOBRequest");
+    }
+
+    [Fact]
+    public void RefusesToConstructTheControllerAndTheRequest()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var controller, request;
+            var stream = new ReadableStream({ type: 'bytes', pull(c) { controller = c; request = c.byobRequest; } });
+            stream.getReader({ mode: 'byob' }).read(new Uint8Array(1));
+            """);
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new (Object.getPrototypeOf(controller).constructor)()"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new (Object.getPrototypeOf(request).constructor)()"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void RefusesAForeignReceiver()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var controller, request;
+            var stream = new ReadableStream({ type: 'bytes', pull(c) { controller = c; request = c.byobRequest; } });
+            var reader = stream.getReader({ mode: 'byob' });
+            reader.read(new Uint8Array(1));
+            """);
+
+        // pull() runs on a microtask, so the controller and its BYOB request only exist once the first
+        // script has been executed and the event loop drained.
+        engine.Execute("""
+            var controllerProto = Object.getPrototypeOf(controller);
+            var requestProto = Object.getPrototypeOf(request);
+            var readerProto = Object.getPrototypeOf(reader);
+            """);
+
+        foreach (var source in new[]
+                 {
+                     "Object.getOwnPropertyDescriptor(controllerProto, 'desiredSize').get.call({})",
+                     "controllerProto.enqueue.call({}, new Uint8Array(1))",
+                     "Object.getOwnPropertyDescriptor(requestProto, 'view').get.call({})",
+                     "requestProto.respond.call({}, 1)",
+                     "readerProto.releaseLock.call({})",
+                 })
+        {
+            Assert.Throws<JavaScriptException>(() => engine.Evaluate(source))
+                .Error.Get("name").AsString().Should().Be("TypeError", source);
+        }
+
+        // The two promise-returning members reject instead of throwing.
+        engine.Execute("""
+            readerProto.read.call({}, new Uint8Array(1)).catch(e => log.push('read:' + e.name));
+            Object.getOwnPropertyDescriptor(readerProto, 'closed').get.call({}).catch(e => log.push('closed:' + e.name));
+            """);
+
+        Log(engine).Should().Be("read:TypeError,closed:TypeError");
+    }
+
+    /// <summary>
+    /// The source every composition test below reads from: a byte stream that hands out the chunks it was
+    /// given and then closes.
+    /// </summary>
+    private const string ByteStreamSource = """
+        function byteStream(chunks) {
+            let i = 0;
+            return new ReadableStream({
+                type: 'bytes',
+                pull(c) {
+                    if (i < chunks.length) { c.enqueue(new Uint8Array(chunks[i++])); } else { c.close(); }
+                }
+            });
+        }
+        """;
+
+    /// <summary>
+    /// A byte stream is a readable stream like any other on the producing side, so it pipes through the
+    /// transform streams other standards define. Those were written against the default machinery and know
+    /// nothing about byte streams; that they need to know nothing is the point of extending the default
+    /// controller rather than forking it.
+    /// </summary>
+    [Fact]
+    public void PipesThroughATransformStreamDefinedByAnotherStandard()
+    {
+        var engine = new Engine(options => options.UseWebApis(
+            WebApiFeatures.Streams | WebApiFeatures.Encoding | WebApiFeatures.Compression));
+        engine.Execute(ByteStreamSource);
+
+        // The bytes of "hi!", split across two chunks, decoded by a TextDecoderStream — which emits one
+        // string per input chunk, so the whole stream has to be drained to see all of it.
+        engine.Evaluate("""
+            (async () => {
+                let out = '';
+                for await (const s of byteStream([[104, 105], [33]]).pipeThrough(new TextDecoderStream())) { out += s; }
+                return out;
+            })()
+            """)
+            .UnwrapIfPromise().AsString().Should().Be("hi!");
+
+        // And through a pair that has to see every byte: gzip and back.
+        engine.Evaluate("""
+            byteStream([[1, 2, 3, 4, 5]])
+                .pipeThrough(new CompressionStream('gzip'))
+                .pipeThrough(new DecompressionStream('gzip'))
+                .getReader().read().then(r => Array.from(r.value).join(','))
+            """)
+            .UnwrapIfPromise().AsString().Should().Be("1,2,3,4,5");
+
+        // A script's own TransformStream sees ordinary Uint8Array chunks too.
+        engine.Evaluate("""
+            byteStream([[10, 20, 30]])
+                .pipeThrough(new TransformStream({ transform(c, ctrl) { ctrl.enqueue(c.length); } }))
+                .getReader().read().then(r => r.value)
+            """)
+            .UnwrapIfPromise().AsNumber().Should().Be(3);
+    }
+
+    /// <summary>
+    /// A byte stream is accepted as a <c>BodyInit</c>, which reads it with a <i>default</i> reader — the one
+    /// path through a byte controller that an ordinary consumer takes without knowing it is one.
+    /// </summary>
+    [Fact]
+    public void IsAcceptedAsAFetchBody()
+    {
+        var engine = new Engine(options => options.UseFetch());
+        engine.Execute(ByteStreamSource);
+
+        engine.Evaluate("new Response(byteStream([[65, 66], [67]])).text()")
+            .UnwrapIfPromise().AsString().Should().Be("ABC");
+
+        engine.Evaluate("new Request('https://example.org/', { method: 'POST', body: byteStream([[68]]) }).text()")
+            .UnwrapIfPromise().AsString().Should().Be("D");
+    }
+
+    /// <summary>
+    /// The streams the <i>engine</i> hands out are not byte streams yet — <c>Response.body</c>,
+    /// <c>Request.body</c> and <c>Blob.stream()</c> carry <c>Uint8Array</c> chunks over a default
+    /// controller. So BYOB reading refuses on them, with the standard's own TypeError for a stream that was
+    /// not constructed with a byte source. This pins the documented gap rather than an implementation
+    /// accident: it is what changes when those bodies are upgraded.
+    /// </summary>
+    [Fact]
+    public void RefusesBYOBOnTheBodiesTheEngineHandsOut()
+    {
+        var engine = new Engine(options => options.UseFetch());
+
+        foreach (var source in new[]
+                 {
+                     "new Response('xy').body",
+                     "new Request('https://example.org/', { method: 'POST', body: 'xy' }).body",
+                     "new Blob(['xy']).stream()",
+                 })
+        {
+            Assert.Throws<JavaScriptException>(() => engine.Evaluate($"({source}).getReader({{ mode: 'byob' }})"))
+                .Error.Get("name").AsString().Should().Be("TypeError", source);
+
+            // A default reader is what they do serve.
+            engine.Evaluate($"({source}).getReader().read().then(r => r.value.constructor.name)")
+                .UnwrapIfPromise().AsString().Should().Be("Uint8Array", source);
+        }
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/ReadableStreamTests.cs
+++ b/Jint.Tests/Runtime/WebApi/ReadableStreamTests.cs
@@ -63,17 +63,16 @@ public class ReadableStreamTests
     }
 
     [Fact]
-    public void RefusesAByteStream()
+    public void RefusesAnInvalidStreamType()
     {
-        // Byte streams are not implemented, and `type: "bytes"` is refused rather than quietly ignored, so
-        // feature detection sees the truth.
+        // "bytes" is the only value of the ReadableStreamType enumeration, and it builds a readable byte
+        // stream (see ReadableByteStreamTests); anything else is the TypeError the enumeration conversion
+        // raises — https://webidl.spec.whatwg.org/#es-enumeration.
         var engine = StreamEngine();
-        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new ReadableStream({ type: 'bytes' })"))
-            .Error.Get("name").AsString().Should().Be("TypeError");
-
-        // An invalid enumeration value is the same TypeError.
         Assert.Throws<JavaScriptException>(() => engine.Evaluate("new ReadableStream({ type: 'nonsense' })"))
             .Error.Get("name").AsString().Should().Be("TypeError");
+
+        engine.Evaluate("new ReadableStream({ type: 'bytes' }) instanceof ReadableStream").AsBoolean().Should().BeTrue();
 
         // And a BYOB reader cannot be acquired from a stream that is not a byte stream.
         Assert.Throws<JavaScriptException>(() => engine.Evaluate("new ReadableStream().getReader({ mode: 'byob' })"))

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -618,10 +618,12 @@ public enum WebApiFeatures
 
     /// <summary>
     /// <c>ReadableStream</c>, <c>WritableStream</c>, <c>TransformStream</c> and the two queuing strategies
-    /// — the whole of the WHATWG Streams Standard's default (non-byte) surface, including <c>tee()</c>,
-    /// <c>pipeTo()</c>/<c>pipeThrough()</c> with <c>AbortSignal</c> support, and asynchronous iteration of a
-    /// readable stream. Byte streams (<c>type: "bytes"</c>, <c>ReadableByteStreamController</c>, BYOB
-    /// readers) are not implemented and are absent rather than present-and-broken.
+    /// — the WHATWG Streams Standard, including <c>tee()</c>, <c>pipeTo()</c>/<c>pipeThrough()</c> with
+    /// <c>AbortSignal</c> support, asynchronous iteration of a readable stream, and readable byte streams:
+    /// <c>new ReadableStream({ type: "bytes" })</c>, <c>ReadableByteStreamController</c> with
+    /// <c>autoAllocateChunkSize</c> and <c>byobRequest</c>, and BYOB reading through
+    /// <c>getReader({ mode: "byob" })</c>. Transferring a stream through <c>postMessage()</c> is the one
+    /// part that is absent, there being nothing to transfer it to.
     /// </summary>
     Streams = 1 << 12,
 

--- a/Jint/Runtime/Intrinsics.WebApi.cs
+++ b/Jint/Runtime/Intrinsics.WebApi.cs
@@ -255,6 +255,9 @@ public sealed partial class Intrinsics
     private ReadableStreamConstructor? _readableStream;
     private ReadableStreamDefaultReaderConstructor? _readableStreamDefaultReader;
     private ReadableStreamDefaultControllerConstructor? _readableStreamDefaultController;
+    private ReadableStreamBYOBReaderConstructor? _readableStreamBYOBReader;
+    private ReadableByteStreamControllerConstructor? _readableByteStreamController;
+    private ReadableStreamBYOBRequestConstructor? _readableStreamBYOBRequest;
     private ReadableStreamAsyncIteratorPrototype? _readableStreamAsyncIteratorPrototype;
     private WritableStreamConstructor? _writableStream;
     private WritableStreamDefaultWriterConstructor? _writableStreamDefaultWriter;
@@ -279,6 +282,21 @@ public sealed partial class Intrinsics
 
     internal ReadableStreamDefaultControllerConstructor ReadableStreamDefaultController =>
         _readableStreamDefaultController ??= new ReadableStreamDefaultControllerConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
+
+    /// <summary>
+    /// The three byte-stream interfaces, which follow the same rule: not globals, reachable through their
+    /// instances' prototypes. A byte stream is asked for with <c>new ReadableStream({ type: "bytes" })</c>
+    /// and a BYOB reader with <c>stream.getReader({ mode: "byob" })</c>, so nothing but feature detection
+    /// ever names them.
+    /// </summary>
+    internal ReadableStreamBYOBReaderConstructor ReadableStreamBYOBReader =>
+        _readableStreamBYOBReader ??= new ReadableStreamBYOBReaderConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
+
+    internal ReadableByteStreamControllerConstructor ReadableByteStreamController =>
+        _readableByteStreamController ??= new ReadableByteStreamControllerConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
+
+    internal ReadableStreamBYOBRequestConstructor ReadableStreamBYOBRequest =>
+        _readableStreamBYOBRequest ??= new ReadableStreamBYOBRequestConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
 
     /// <summary>
     /// <c>%ReadableStreamAsyncIteratorPrototype%</c>, whose <c>[[Prototype]]</c> is

--- a/Jint/WebApi/Fetch/FetchBodyStream.cs
+++ b/Jint/WebApi/Fetch/FetchBodyStream.cs
@@ -169,7 +169,7 @@ internal sealed class FetchBodyStream : IDisposable
         CancelTransport();
 
         ReadableStreamDefaultControllerOperations.Error(
-            _stream.Controller,
+            _stream.DefaultController,
             _realm.Intrinsics.TypeError.Construct("Failed to fetch: the engine's globals were restored while the response body was still streaming"));
 
         ResolvePull();
@@ -292,7 +292,7 @@ internal sealed class FetchBodyStream : IDisposable
         {
             _finished = true;
             _engine._webApi?.UnregisterBodyStream(this);
-            ReadableStreamDefaultControllerOperations.Error(_stream.Controller, FetchOperation.NetworkError(_realm, failure));
+            ReadableStreamDefaultControllerOperations.Error(_stream.DefaultController, FetchOperation.NetworkError(_realm, failure));
             ResolvePull();
             return;
         }
@@ -301,12 +301,12 @@ internal sealed class FetchBodyStream : IDisposable
         {
             _finished = true;
             _engine._webApi?.UnregisterBodyStream(this);
-            ReadableStreamDefaultControllerOperations.Close(_stream.Controller);
+            ReadableStreamDefaultControllerOperations.Close(_stream.DefaultController);
             ResolvePull();
             return;
         }
 
-        ReadableStreamDefaultControllerOperations.Enqueue(_stream.Controller, ByteStreams.NewUint8Array(_engine, _realm, chunk));
+        ReadableStreamDefaultControllerOperations.Enqueue(_stream.DefaultController, ByteStreams.NewUint8Array(_engine, _realm, chunk));
 
         // Resolved after the enqueue, so the reaction that lets the controller pull again observes the chunk
         // already in the queue.

--- a/Jint/WebApi/Files/BlobPrototype.cs
+++ b/Jint/WebApi/Files/BlobPrototype.cs
@@ -164,13 +164,15 @@ internal sealed partial class BlobPrototype : Prototype
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Two reductions against the algorithm as written, both forced by there being no byte streams here.
-    /// The stream is an ordinary (non-byte) <c>ReadableStream</c> rather than one "set up with byte reading
-    /// support", so it has no BYOB reader — which is exactly what <c>getReader()</c> already answers for
-    /// every other stream in this implementation. And the blob's bytes are one chunk rather than the
-    /// implementation-defined slices the algorithm's loop reads: the bytes are already in memory, so
-    /// slicing them would manufacture event-loop turns rather than model any I/O. An empty blob enqueues
-    /// nothing and closes, so its first <c>read()</c> is done.
+    /// Two reductions against the algorithm as written. The stream is an ordinary (non-byte)
+    /// <c>ReadableStream</c> rather than one "set up with byte reading support", so
+    /// <c>getReader({ mode: "byob" })</c> on it raises the standard's TypeError for a stream that was not
+    /// constructed with a byte source. That is a gap in <i>this caller</i> rather than in the engine —
+    /// readable byte streams are implemented, and a script can build one with
+    /// <c>new ReadableStream({ type: "bytes" })</c> — so moving a blob onto one is a change here alone. And
+    /// the blob's bytes are one chunk rather than the implementation-defined slices the algorithm's loop
+    /// reads: the bytes are already in memory, so slicing them would manufacture event-loop turns rather
+    /// than model any I/O. An empty blob enqueues nothing and closes, so its first <c>read()</c> is done.
     /// </para>
     /// <para>
     /// The chunk is a <c>Uint8Array</c> over a fresh copy, like every other way a blob's bytes cross into

--- a/Jint/WebApi/Streams/ByteStreams.cs
+++ b/Jint/WebApi/Streams/ByteStreams.cs
@@ -13,9 +13,12 @@ namespace Jint.WebApi.Streams;
 /// Used by <c>Blob.stream()</c> (https://w3c.github.io/FileAPI/#blob-get-stream) and by the <c>Body</c>
 /// mixin's <c>body</c> attribute for a body that was extracted from bytes
 /// (https://fetch.spec.whatwg.org/#concept-bodyinit-extract). Both specifications ask for a stream "set up
-/// with byte reading support" — a readable <i>byte</i> stream — which is not implemented here; an ordinary
-/// stream carrying <c>Uint8Array</c> chunks is what those algorithms reduce to once BYOB readers are out of
-/// the picture, and it is what every consumer in this implementation reads.
+/// with byte reading support" — a readable <i>byte</i> stream, which
+/// <see cref="ReadableByteStreamControllerOperations"/> now implements — but neither caller has been moved
+/// onto one yet, so what they get is still an ordinary stream carrying <c>Uint8Array</c> chunks. That is
+/// what those algorithms reduce to once BYOB readers are out of the picture, and it is what every consumer
+/// in this implementation reads; the difference a script can see is that <c>getReader({ mode: "byob" })</c>
+/// on such a body refuses, where in a browser it would not.
 /// </remarks>
 internal static class ByteStreams
 {
@@ -57,7 +60,7 @@ internal static class ByteStreams
 
         // Filled after the stream exists rather than from its start algorithm, which runs while the
         // controller is still being wired up and has no way to reach it.
-        var controller = stream.Controller;
+        var controller = stream.DefaultController;
         if (!bytes.IsEmpty)
         {
             ReadableStreamDefaultControllerOperations.Enqueue(controller, NewUint8Array(engine, realm, bytes.Span));

--- a/Jint/WebApi/Streams/JsReadableByteStreamController.cs
+++ b/Jint/WebApi/Streams/JsReadableByteStreamController.cs
@@ -1,0 +1,259 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.TypedArray;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// Which kind of reader a pull-into descriptor was created for, or "<c>none</c>" once that reader has
+/// released its lock and the bytes have nowhere to go but the stream's own queue.
+/// <para>
+/// https://streams.spec.whatwg.org/#pull-into-descriptor-reader-type
+/// </para>
+/// </summary>
+internal enum PullIntoReaderType
+{
+    Default,
+    Byob,
+    None,
+}
+
+/// <summary>
+/// A pull-into descriptor: one pending "fill this buffer" request, whether it came from a BYOB
+/// <c>read(view)</c>, from a default <c>read()</c> against a controller with an
+/// <c>autoAllocateChunkSize</c>, or from a reader that has since been released.
+/// <para>
+/// https://streams.spec.whatwg.org/#pull-into-descriptor
+/// </para>
+/// </summary>
+/// <remarks>
+/// A mutable class rather than a struct because the algorithms hold on to the head descriptor across
+/// several steps and mutate it in place — <c>bytesFilled</c> grows as data arrives, and <c>buffer</c> is
+/// replaced every time the buffer is transferred back and forth between the controller and the underlying
+/// source.
+/// </remarks>
+internal sealed class PullIntoDescriptor
+{
+    /// <summary>https://streams.spec.whatwg.org/#pull-into-descriptor-buffer</summary>
+    internal JsArrayBuffer Buffer { get; set; } = null!;
+
+    /// <summary>https://streams.spec.whatwg.org/#pull-into-descriptor-buffer-byte-length</summary>
+    internal int BufferByteLength { get; init; }
+
+    /// <summary>https://streams.spec.whatwg.org/#pull-into-descriptor-byte-offset</summary>
+    internal int ByteOffset { get; init; }
+
+    /// <summary>https://streams.spec.whatwg.org/#pull-into-descriptor-byte-length</summary>
+    internal int ByteLength { get; init; }
+
+    /// <summary>https://streams.spec.whatwg.org/#pull-into-descriptor-bytes-filled</summary>
+    internal int BytesFilled { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#pull-into-descriptor-minimum-fill</summary>
+    internal int MinimumFill { get; init; }
+
+    /// <summary>https://streams.spec.whatwg.org/#pull-into-descriptor-element-size</summary>
+    internal int ElementSize { get; init; }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#pull-into-descriptor-view-constructor, as the element type it names
+    /// — <see langword="null"/> for <c>%DataView%</c>.
+    /// </summary>
+    internal TypedArrayElementType? ViewElementType { get; init; }
+
+    /// <summary>https://streams.spec.whatwg.org/#pull-into-descriptor-reader-type</summary>
+    internal PullIntoReaderType ReaderType { get; set; }
+}
+
+/// <summary>
+/// One entry of a byte stream's internal queue.
+/// <para>
+/// https://streams.spec.whatwg.org/#readable-byte-stream-queue-entry
+/// </para>
+/// </summary>
+/// <remarks>
+/// Mutable, because the head entry is consumed a slice at a time as pull-into descriptors are filled from
+/// it: the standard adjusts the entry's byte offset and byte length in place rather than re-queuing a
+/// remainder.
+/// </remarks>
+internal sealed class ReadableByteStreamQueueEntry
+{
+    internal ReadableByteStreamQueueEntry(JsArrayBuffer buffer, int byteOffset, int byteLength)
+    {
+        Buffer = buffer;
+        ByteOffset = byteOffset;
+        ByteLength = byteLength;
+    }
+
+    /// <summary>https://streams.spec.whatwg.org/#readable-byte-stream-queue-entry-buffer</summary>
+    internal JsArrayBuffer Buffer { get; }
+
+    /// <summary>https://streams.spec.whatwg.org/#readable-byte-stream-queue-entry-byte-offset</summary>
+    internal int ByteOffset { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#readable-byte-stream-queue-entry-byte-length</summary>
+    internal int ByteLength { get; set; }
+}
+
+/// <summary>
+/// A byte stream's <c>[[queue]]</c> and <c>[[queueTotalSize]]</c>, which the standard keeps as a pair and
+/// updates by hand rather than through the queue-with-sizes operations
+/// (<see cref="StreamQueue"/>) the other controllers use.
+/// <para>
+/// https://streams.spec.whatwg.org/#rbs-controller-internal-slots
+/// </para>
+/// </summary>
+/// <remarks>
+/// The total is a byte count, so it is exact in a <see cref="long"/> where the default controller's is a
+/// <see cref="double"/> a queuing strategy produced. There is no <c>size()</c> callback to run and nothing
+/// to range-check: a byte stream's chunk size is its byte length.
+/// </remarks>
+internal sealed class ReadableByteStreamQueue
+{
+    private readonly Queue<ReadableByteStreamQueueEntry> _entries = new();
+
+    /// <summary>The specification's <c>[[queueTotalSize]]</c>, in bytes.</summary>
+    internal long TotalSize { get; private set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#readable-byte-stream-controller-enqueue-chunk-to-queue</summary>
+    internal void Enqueue(JsArrayBuffer buffer, int byteOffset, int byteLength)
+    {
+        _entries.Enqueue(new ReadableByteStreamQueueEntry(buffer, byteOffset, byteLength));
+        TotalSize += byteLength;
+    }
+
+    /// <summary>The head entry, which the fill algorithms copy out of before consuming it.</summary>
+    internal ReadableByteStreamQueueEntry Peek() => _entries.Peek();
+
+    /// <summary>
+    /// Takes the head entry out whole — what
+    /// <c>ReadableByteStreamControllerFillReadRequestFromQueue</c> does before handing it to a default
+    /// reader's read request.
+    /// </summary>
+    internal ReadableByteStreamQueueEntry Dequeue()
+    {
+        var entry = _entries.Dequeue();
+        TotalSize -= entry.ByteLength;
+        return entry;
+    }
+
+    /// <summary>
+    /// Consumes <paramref name="count"/> bytes from the head entry, dropping it once nothing is left. The
+    /// in-place adjustment of the head is the standard's own, and is why a queue entry is mutable.
+    /// </summary>
+    internal void ConsumeFromHead(int count)
+    {
+        var head = _entries.Peek();
+        if (head.ByteLength == count)
+        {
+            _entries.Dequeue();
+        }
+        else
+        {
+            head.ByteOffset += count;
+            head.ByteLength -= count;
+        }
+
+        TotalSize -= count;
+    }
+
+    /// <summary>https://streams.spec.whatwg.org/#reset-queue</summary>
+    internal void Reset()
+    {
+        _entries.Clear();
+        TotalSize = 0;
+    }
+}
+
+/// <summary>
+/// A <c>ReadableByteStreamController</c> instance — the controller of a stream constructed with
+/// <c>type: "bytes"</c>.
+/// <para>
+/// https://streams.spec.whatwg.org/#rbs-controller-class
+/// </para>
+/// </summary>
+/// <remarks>
+/// There is no <c>[[strategySizeAlgorithm]]</c>: a byte stream's queuing strategy may not carry a
+/// <c>size()</c> at all (the constructor raises a <c>RangeError</c> for one), because a chunk's size is its
+/// byte length by definition.
+/// </remarks>
+internal sealed class JsReadableByteStreamController : JsReadableStreamController
+{
+    internal JsReadableByteStreamController(Engine engine, Realm realm) : base(engine, realm)
+    {
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readablebytestreamcontroller-queue and
+    /// <c>[[queueTotalSize]]</c>, which the standard keeps synchronized as one structure.
+    /// </summary>
+    internal ReadableByteStreamQueue Queue { get; } = new();
+
+    /// <summary>https://streams.spec.whatwg.org/#readablebytestreamcontroller-pendingpullintos</summary>
+    internal Queue<PullIntoDescriptor> PendingPullIntos { get; } = new();
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readablebytestreamcontroller-autoallocatechunksize — a positive
+    /// integer when the underlying source asked for automatic buffer allocation, <see langword="null"/>
+    /// otherwise.
+    /// </summary>
+    internal ulong? AutoAllocateChunkSize { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#readablebytestreamcontroller-byobrequest</summary>
+    internal JsReadableStreamBYOBRequest? ByobRequest { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#readablebytestreamcontroller-started</summary>
+    internal bool Started { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#readablebytestreamcontroller-closerequested</summary>
+    internal bool CloseRequested { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#readablebytestreamcontroller-pullagain</summary>
+    internal bool PullAgain { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#readablebytestreamcontroller-pulling</summary>
+    internal bool Pulling { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#readablebytestreamcontroller-strategyhwm</summary>
+    internal double StrategyHighWaterMark { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#readablebytestreamcontroller-pullalgorithm</summary>
+    internal Func<JsPromise>? PullAlgorithm { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#readablebytestreamcontroller-cancelalgorithm</summary>
+    internal Func<JsValue, JsPromise>? CancelAlgorithm { get; set; }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rbs-controller-private-pull
+    /// </summary>
+    internal override void PullSteps(ReadRequest readRequest)
+        => ReadableByteStreamControllerOperations.PullSteps(this, readRequest);
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rbs-controller-private-cancel
+    /// </summary>
+    internal override JsPromise CancelSteps(JsValue reason)
+        => ReadableByteStreamControllerOperations.CancelSteps(this, reason);
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#abstract-opdef-readablebytestreamcontroller-releasesteps — the head
+    /// pull-into descriptor is kept, with its reader type downgraded to "none", and the rest are dropped:
+    /// the buffer the underlying source is currently filling has to stay valid for it to respond into, but
+    /// nothing is waiting for what lands in it any more, so those bytes go to the stream's queue instead.
+    /// </summary>
+    internal override void ReleaseSteps()
+    {
+        if (PendingPullIntos.Count == 0)
+        {
+            return;
+        }
+
+        var firstPendingPullInto = PendingPullIntos.Dequeue();
+        firstPendingPullInto.ReaderType = PullIntoReaderType.None;
+
+        PendingPullIntos.Clear();
+        PendingPullIntos.Enqueue(firstPendingPullInto);
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/JsReadableStream.cs
+++ b/Jint/WebApi/Streams/JsReadableStream.cs
@@ -32,11 +32,10 @@ internal enum ReadableStreamState
 /// <c>Object.getOwnPropertyNames(new ReadableStream())</c> is empty, exactly as in a browser.
 /// </para>
 /// <para>
-/// The <c>[[controller]]</c> slot is always a <see cref="JsReadableStreamDefaultController"/>: byte streams
-/// (<c>type: "bytes"</c>, <c>ReadableByteStreamController</c>, BYOB readers) are not implemented, and the
-/// constructor refuses <c>type: "bytes"</c> rather than pretending. <c>[[Detached]]</c> has no counterpart
-/// either, because a stream can only become detached by being transferred through <c>postMessage()</c>, and
-/// there is nothing to transfer it to.
+/// The <c>[[controller]]</c> slot is a <see cref="JsReadableStreamDefaultController"/> or, for a stream
+/// constructed with <c>type: "bytes"</c>, a <see cref="JsReadableByteStreamController"/>. <c>[[Detached]]</c>
+/// has no counterpart, because a stream can only become detached by being transferred through
+/// <c>postMessage()</c>, and there is nothing to transfer it to.
 /// </para>
 /// </remarks>
 internal sealed class JsReadableStream : ObjectInstance
@@ -72,13 +71,23 @@ internal sealed class JsReadableStream : ObjectInstance
     /// https://streams.spec.whatwg.org/#readablestream-reader — the reader the stream is locked to, or
     /// <see langword="null"/> when it is not locked.
     /// </summary>
-    internal JsReadableStreamDefaultReader? Reader { get; set; }
+    internal JsReadableStreamReader? Reader { get; set; }
 
     /// <summary>
     /// https://streams.spec.whatwg.org/#readablestream-controller. Assigned by
-    /// <see cref="ReadableStreamOperations.SetUpDefaultController"/> before the stream can be reached by
+    /// <see cref="ReadableStreamOperations.SetUpDefaultController"/> or
+    /// <see cref="ReadableByteStreamControllerOperations.SetUp"/> before the stream can be reached by
     /// anything, which is what makes the non-nullable declaration honest.
     /// </summary>
-    internal JsReadableStreamDefaultController Controller { get; set; } = null!;
+    internal JsReadableStreamController Controller { get; set; } = null!;
+
+    /// <summary>
+    /// The controller of a stream the engine built itself through
+    /// <see cref="ReadableStreamOperations.CreateReadableStream"/> — a tee branch, a transform stream's
+    /// readable side, <c>ReadableStream.from</c>. Those are default controllers by construction, which is
+    /// what makes the cast safe; a stream reached from script goes through the polymorphic members on
+    /// <see cref="JsReadableStreamController"/> instead.
+    /// </summary>
+    internal JsReadableStreamDefaultController DefaultController => (JsReadableStreamDefaultController) Controller;
 }
 #endif

--- a/Jint/WebApi/Streams/JsReadableStreamBYOBReader.cs
+++ b/Jint/WebApi/Streams/JsReadableStreamBYOBReader.cs
@@ -1,0 +1,53 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// A read-into request: the three algorithms a BYOB consumer supplies to react to its buffer being filled or
+/// the stream's state changing.
+/// <para>
+/// https://streams.spec.whatwg.org/#read-into-request
+/// </para>
+/// </summary>
+/// <remarks>
+/// The close steps take a chunk where <see cref="ReadRequest.CloseSteps"/> takes nothing, so that the
+/// backing memory can be returned to the caller: a BYOB <c>read(view)</c> against a closed stream fulfils
+/// with a fresh, empty view onto the same memory. A <i>cancelled</i> stream discards the memory instead and
+/// the close steps receive <see cref="JsValue.Undefined"/>, which is the whole reason for the parameter.
+/// </remarks>
+internal abstract class ReadIntoRequest
+{
+    /// <summary>Called when the buffer has been filled to at least its minimum.</summary>
+    internal abstract void ChunkSteps(JsValue chunk);
+
+    /// <summary>Called when no chunk is available because the stream is closed.</summary>
+    internal abstract void CloseSteps(JsValue chunk);
+
+    /// <summary>Called when no chunk is available because the stream is errored.</summary>
+    internal abstract void ErrorSteps(JsValue error);
+}
+
+/// <summary>
+/// A <c>ReadableStreamBYOBReader</c> instance.
+/// <para>
+/// https://streams.spec.whatwg.org/#byob-reader-class
+/// </para>
+/// </summary>
+/// <remarks>
+/// The <c>ReadableStreamGenericReader</c> mixin's <c>[[stream]]</c> and <c>[[closedPromise]]</c> slots live
+/// on <see cref="JsReadableStreamReader"/>; this class adds only its own <c>[[readIntoRequests]]</c>. A BYOB
+/// reader can only be acquired from a stream whose controller is a
+/// <see cref="JsReadableByteStreamController"/>.
+/// </remarks>
+internal sealed class JsReadableStreamBYOBReader : JsReadableStreamReader
+{
+    internal JsReadableStreamBYOBReader(Engine engine, Realm realm) : base(engine, realm)
+    {
+    }
+
+    /// <summary>https://streams.spec.whatwg.org/#readablestreambyobreader-readintorequests</summary>
+    internal Queue<ReadIntoRequest> ReadIntoRequests { get; } = new();
+}
+#endif

--- a/Jint/WebApi/Streams/JsReadableStreamBYOBRequest.cs
+++ b/Jint/WebApi/Streams/JsReadableStreamBYOBRequest.cs
@@ -1,0 +1,44 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// A <c>ReadableStreamBYOBRequest</c> instance: the view a byte stream's underlying source is being asked to
+/// write into, and the two ways of reporting that it has.
+/// <para>
+/// https://streams.spec.whatwg.org/#rs-byob-request-class
+/// </para>
+/// </summary>
+/// <remarks>
+/// Both slots are cleared together when the request is invalidated — which happens the moment the buffer
+/// behind it moves, whether because it was responded to, because a chunk was enqueued past it, or because
+/// the stream errored. A request script kept hold of therefore keeps working as an object while answering
+/// <c>null</c> for <c>view</c> and refusing <c>respond()</c> with a <c>TypeError</c>, exactly as the
+/// standard prescribes.
+/// </remarks>
+internal sealed class JsReadableStreamBYOBRequest : ObjectInstance
+{
+    internal JsReadableStreamBYOBRequest(Engine engine, Realm realm) : base(engine, ObjectClass.Object)
+    {
+        Realm = realm;
+    }
+
+    /// <summary>The realm the request was created in.</summary>
+    internal Realm Realm { get; }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readablestreambyobrequest-controller — <see langword="null"/> once
+    /// the request has been invalidated, which is the specification's "undefined".
+    /// </summary>
+    internal JsReadableByteStreamController? Controller { get; set; }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readablestreambyobrequest-view — the destination region, or
+    /// <see langword="null"/> once the request has been invalidated.
+    /// </summary>
+    internal JsTypedArray? View { get; set; }
+}
+#endif

--- a/Jint/WebApi/Streams/JsReadableStreamController.cs
+++ b/Jint/WebApi/Streams/JsReadableStreamController.cs
@@ -1,0 +1,52 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// The controller of a <c>ReadableStream</c>: either a <see cref="JsReadableStreamDefaultController"/> or a
+/// <see cref="JsReadableByteStreamController"/>.
+/// <para>
+/// https://streams.spec.whatwg.org/#rs-abstract-ops-used-by-controllers
+/// </para>
+/// </summary>
+/// <remarks>
+/// The three abstract members are the standard's own polymorphic internal methods: "the readable stream
+/// implementation will polymorphically call to either these, or to their counterparts for default
+/// controllers". Keeping them as virtual methods rather than as a type test at every call site is what lets
+/// the stream algorithms in <see cref="ReadableStreamOperations"/> stay written the way the specification
+/// writes them.
+/// </remarks>
+internal abstract class JsReadableStreamController : ObjectInstance
+{
+    private protected JsReadableStreamController(Engine engine, Realm realm) : base(engine, ObjectClass.Object)
+    {
+        Realm = realm;
+    }
+
+    /// <summary>The realm the controller was created in.</summary>
+    internal Realm Realm { get; }
+
+    /// <summary>The stream this controller controls.</summary>
+    internal JsReadableStream Stream { get; set; } = null!;
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rs-controller-private-pull — the steps a default reader's
+    /// <c>read()</c> runs once the stream is known to be readable.
+    /// </summary>
+    internal abstract void PullSteps(ReadRequest readRequest);
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rs-controller-private-cancel
+    /// </summary>
+    internal abstract JsPromise CancelSteps(JsValue reason);
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#abstract-opdef-readablestreamcontroller-releasesteps — what a
+    /// controller has to do when its stream's reader releases the lock.
+    /// </summary>
+    internal abstract void ReleaseSteps();
+}
+#endif

--- a/Jint/WebApi/Streams/JsReadableStreamDefaultController.cs
+++ b/Jint/WebApi/Streams/JsReadableStreamDefaultController.cs
@@ -1,6 +1,5 @@
 #if NET8_0_OR_GREATER
 using Jint.Native;
-using Jint.Native.Object;
 using Jint.Runtime;
 
 namespace Jint.WebApi.Streams;
@@ -17,18 +16,11 @@ namespace Jint.WebApi.Streams;
 /// specifically so that a stream stops retaining the underlying source's closures once it is closed or
 /// errored.
 /// </remarks>
-internal sealed class JsReadableStreamDefaultController : ObjectInstance
+internal sealed class JsReadableStreamDefaultController : JsReadableStreamController
 {
-    internal JsReadableStreamDefaultController(Engine engine, Realm realm) : base(engine, ObjectClass.Object)
+    internal JsReadableStreamDefaultController(Engine engine, Realm realm) : base(engine, realm)
     {
-        Realm = realm;
     }
-
-    /// <summary>The realm the controller was created in.</summary>
-    internal Realm Realm { get; }
-
-    /// <summary>https://streams.spec.whatwg.org/#readablestreamdefaultcontroller-stream</summary>
-    internal JsReadableStream Stream { get; set; } = null!;
 
     /// <summary>
     /// https://streams.spec.whatwg.org/#readablestreamdefaultcontroller-queue and
@@ -59,5 +51,26 @@ internal sealed class JsReadableStreamDefaultController : ObjectInstance
 
     /// <summary>https://streams.spec.whatwg.org/#readablestreamdefaultcontroller-cancelalgorithm</summary>
     internal Func<JsValue, JsPromise>? CancelAlgorithm { get; set; }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rs-default-controller-private-pull
+    /// </summary>
+    internal override void PullSteps(ReadRequest readRequest)
+        => ReadableStreamDefaultControllerOperations.PullSteps(this, readRequest);
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rs-default-controller-private-cancel
+    /// </summary>
+    internal override JsPromise CancelSteps(JsValue reason)
+        => ReadableStreamDefaultControllerOperations.CancelSteps(this, reason);
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#abstract-opdef-readablestreamdefaultcontroller-releasesteps — the
+    /// default controller has nothing to do when a reader releases the lock. The byte controller's
+    /// counterpart, which downgrades its head pull-into descriptor, is what this member exists for.
+    /// </summary>
+    internal override void ReleaseSteps()
+    {
+    }
 }
 #endif

--- a/Jint/WebApi/Streams/JsReadableStreamDefaultReader.cs
+++ b/Jint/WebApi/Streams/JsReadableStreamDefaultReader.cs
@@ -1,7 +1,5 @@
 #if NET8_0_OR_GREATER
 using Jint.Native;
-using Jint.Native.Object;
-using Jint.Native.Promise;
 using Jint.Runtime;
 
 namespace Jint.WebApi.Streams;
@@ -37,35 +35,16 @@ internal abstract class ReadRequest
 /// </para>
 /// </summary>
 /// <remarks>
-/// Carries the <c>ReadableStreamGenericReader</c> mixin's <c>[[stream]]</c> and <c>[[closedPromise]]</c>
-/// slots as well as its own <c>[[readRequests]]</c>. The closed promise is held as a capability rather than
-/// as a bare promise because releasing a lock on a non-readable stream <i>replaces</i> it with a freshly
-/// rejected one rather than rejecting the existing one — the specification distinguishes the two, and so
-/// does this.
+/// The <c>ReadableStreamGenericReader</c> mixin's <c>[[stream]]</c> and <c>[[closedPromise]]</c> slots live
+/// on <see cref="JsReadableStreamReader"/>; this class adds only its own <c>[[readRequests]]</c>.
 /// </remarks>
-internal sealed class JsReadableStreamDefaultReader : ObjectInstance
+internal sealed class JsReadableStreamDefaultReader : JsReadableStreamReader
 {
-    internal JsReadableStreamDefaultReader(Engine engine, Realm realm) : base(engine, ObjectClass.Object)
+    internal JsReadableStreamDefaultReader(Engine engine, Realm realm) : base(engine, realm)
     {
-        Realm = realm;
     }
-
-    /// <summary>The realm the reader was created in, which owns its <c>closed</c> and <c>read()</c> promises.</summary>
-    internal Realm Realm { get; }
-
-    /// <summary>
-    /// https://streams.spec.whatwg.org/#readablestreamgenericreader-stream — the stream the reader is
-    /// active for, or <see langword="null"/> once its lock has been released.
-    /// </summary>
-    internal JsReadableStream? Stream { get; set; }
-
-    /// <summary>https://streams.spec.whatwg.org/#readablestreamgenericreader-closedpromise</summary>
-    internal PromiseCapability ClosedCapability { get; set; } = null!;
 
     /// <summary>https://streams.spec.whatwg.org/#readablestreamdefaultreader-readrequests</summary>
     internal Queue<ReadRequest> ReadRequests { get; } = new();
-
-    /// <summary>The promise the <c>closed</c> getter answers with.</summary>
-    internal JsPromise ClosedPromise => StreamPromises.PromiseOf(ClosedCapability);
 }
 #endif

--- a/Jint/WebApi/Streams/JsReadableStreamReader.cs
+++ b/Jint/WebApi/Streams/JsReadableStreamReader.cs
@@ -1,0 +1,51 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Native.Promise;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// The <c>ReadableStreamGenericReader</c> mixin: the state and behaviour a default reader and a BYOB reader
+/// share.
+/// <para>
+/// https://streams.spec.whatwg.org/#generic-reader-mixin
+/// </para>
+/// </summary>
+/// <remarks>
+/// The mixin exists in the standard as a WebIDL <c>includes</c> statement rather than as an interface, so
+/// nothing script-visible corresponds to this class: <c>closed</c> and <c>cancel</c> are own members of both
+/// reader prototypes, and there is no shared prototype between them. It is a CLR base class purely so that
+/// a stream's <c>[[reader]]</c> slot has one type, which is what lets
+/// <see cref="ReadableStreamOperations.ReaderGenericRelease"/> and the closed-promise handling be written
+/// once.
+/// </remarks>
+internal abstract class JsReadableStreamReader : ObjectInstance
+{
+    private protected JsReadableStreamReader(Engine engine, Realm realm) : base(engine, ObjectClass.Object)
+    {
+        Realm = realm;
+    }
+
+    /// <summary>The realm the reader was created in, which owns its <c>closed</c> and read promises.</summary>
+    internal Realm Realm { get; }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readablestreamgenericreader-stream — the stream the reader is
+    /// active for, or <see langword="null"/> once its lock has been released.
+    /// </summary>
+    internal JsReadableStream? Stream { get; set; }
+
+    /// <summary>https://streams.spec.whatwg.org/#readablestreamgenericreader-closedpromise</summary>
+    /// <remarks>
+    /// Held as a capability rather than as a bare promise because releasing a lock on a non-readable stream
+    /// <i>replaces</i> it with a freshly rejected one rather than rejecting the existing one — the
+    /// specification distinguishes the two, and so does this.
+    /// </remarks>
+    internal PromiseCapability ClosedCapability { get; set; } = null!;
+
+    /// <summary>The promise the <c>closed</c> getter answers with.</summary>
+    internal JsPromise ClosedPromise => StreamPromises.PromiseOf(ClosedCapability);
+}
+#endif

--- a/Jint/WebApi/Streams/ReadableByteStreamControllerConstructor.cs
+++ b/Jint/WebApi/Streams/ReadableByteStreamControllerConstructor.cs
@@ -1,0 +1,48 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// The <c>ReadableByteStreamController</c> interface object.
+/// <para>
+/// https://streams.spec.whatwg.org/#rbs-controller-class
+/// </para>
+/// </summary>
+/// <remarks>
+/// Like <c>ReadableStreamDefaultController</c> it declares no constructor operation, so the interface object
+/// exists and is a function but refuses to construct anything —
+/// https://webidl.spec.whatwg.org/#es-interface-call. A byte controller can only come from a stream handing
+/// one to its underlying byte source. It is not installed as a global either, and is reached through
+/// <c>Object.getPrototypeOf(controller).constructor</c>.
+/// </remarks>
+internal sealed class ReadableByteStreamControllerConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("ReadableByteStreamController");
+
+    internal ReadableByteStreamControllerConstructor(
+        Engine engine,
+        Realm realm,
+        FunctionPrototype functionPrototype,
+        ObjectPrototype objectPrototype)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = functionPrototype;
+        PrototypeObject = new ReadableByteStreamControllerPrototype(engine, realm, this, objectPrototype);
+        _length = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal ReadableByteStreamControllerPrototype PrototypeObject { get; }
+
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        Throw.TypeError(_realm, "Illegal constructor");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/ReadableByteStreamControllerOperations.cs
+++ b/Jint/WebApi/Streams/ReadableByteStreamControllerOperations.cs
@@ -1,0 +1,910 @@
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Native.TypedArray;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// The <c>ReadableByteStreamController</c> abstract operations, plus its three internal methods
+/// <c>[[PullSteps]]</c>, <c>[[CancelSteps]]</c> and <c>[[ReleaseSteps]]</c>.
+/// <para>
+/// https://streams.spec.whatwg.org/#rbs-controller-abstract-ops
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// The one thing to hold on to while reading this file is that <b>every buffer that crosses the boundary is
+/// transferred, not shared</b>: a view handed to <c>enqueue()</c>, to a BYOB <c>read()</c> or to
+/// <c>respondWithNewView()</c> has its <c>ArrayBuffer</c> detached and its bytes re-exposed through a new
+/// buffer the other side owns. That is what makes a byte stream's zero-copy promise safe, and it is why the
+/// caller's view is unusable the moment it is handed over.
+/// </para>
+/// <para>
+/// The other is that a byte stream's queue and its pending pull-into descriptors are two halves of one
+/// picture: bytes arrive into whichever is appropriate and are then moved between them —
+/// <see cref="FillPullIntoDescriptorFromQueue"/> drains the queue into a waiting BYOB buffer, and
+/// <see cref="EnqueueDetachedPullIntoToQueue"/> pushes an abandoned buffer's bytes back the other way.
+/// </para>
+/// </remarks>
+internal static class ReadableByteStreamControllerOperations
+{
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-byte-stream-controller-call-pull-if-needed
+    /// </summary>
+    internal static void CallPullIfNeeded(JsReadableByteStreamController controller)
+    {
+        if (!ShouldCallPull(controller))
+        {
+            return;
+        }
+
+        if (controller.Pulling)
+        {
+            controller.PullAgain = true;
+            return;
+        }
+
+        controller.Pulling = true;
+
+        var pullPromise = controller.PullAlgorithm!();
+
+        StreamPromises.UponPromise(
+            controller.Engine,
+            pullPromise,
+            _ =>
+            {
+                controller.Pulling = false;
+                if (controller.PullAgain)
+                {
+                    controller.PullAgain = false;
+                    CallPullIfNeeded(controller);
+                }
+            },
+            error => Error(controller, error));
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-byte-stream-controller-should-call-pull
+    /// </summary>
+    private static bool ShouldCallPull(JsReadableByteStreamController controller)
+    {
+        var stream = controller.Stream;
+
+        if (stream.State != ReadableStreamState.Readable || controller.CloseRequested || !controller.Started)
+        {
+            return false;
+        }
+
+        // A waiting consumer of either kind outranks the high water mark.
+        if (ReadableStreamOperations.HasDefaultReader(stream) && ReadableStreamOperations.GetNumReadRequests(stream) > 0)
+        {
+            return true;
+        }
+
+        if (ReadableStreamOperations.HasBYOBReader(stream) && ReadableStreamOperations.GetNumReadIntoRequests(stream) > 0)
+        {
+            return true;
+        }
+
+        return GetDesiredSize(controller) > 0;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-byte-stream-controller-clear-algorithms
+    /// </summary>
+    internal static void ClearAlgorithms(JsReadableByteStreamController controller)
+    {
+        controller.PullAlgorithm = null;
+        controller.CancelAlgorithm = null;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-byte-stream-controller-clear-pending-pull-intos
+    /// </summary>
+    internal static void ClearPendingPullIntos(JsReadableByteStreamController controller)
+    {
+        InvalidateByobRequest(controller);
+        controller.PendingPullIntos.Clear();
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-byte-stream-controller-close. Raises a <c>TypeError</c> —
+    /// and errors the stream with it — when the head pull-into descriptor holds a partial element, because
+    /// there is no way to hand back half of one.
+    /// </summary>
+    internal static void Close(JsReadableByteStreamController controller)
+    {
+        var stream = controller.Stream;
+
+        if (controller.CloseRequested || stream.State != ReadableStreamState.Readable)
+        {
+            return;
+        }
+
+        // Already-enqueued bytes stay readable; the stream only becomes closed once they have been read.
+        if (controller.Queue.TotalSize > 0)
+        {
+            controller.CloseRequested = true;
+            return;
+        }
+
+        if (controller.PendingPullIntos.Count > 0)
+        {
+            var firstPendingPullInto = controller.PendingPullIntos.Peek();
+            if (firstPendingPullInto.BytesFilled % firstPendingPullInto.ElementSize != 0)
+            {
+                var error = controller.Realm.Intrinsics.TypeError.Construct("Insufficient bytes to fill elements in the given buffer");
+                Error(controller, error);
+                ThrowValue(controller.Engine, error);
+            }
+        }
+
+        ClearAlgorithms(controller);
+        ReadableStreamOperations.Close(stream);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-byte-stream-controller-commit-pull-into-descriptor
+    /// </summary>
+    private static void CommitPullIntoDescriptor(JsReadableStream stream, PullIntoDescriptor pullIntoDescriptor)
+    {
+        var done = stream.State == ReadableStreamState.Closed;
+        var filledView = ConvertPullIntoDescriptor(stream.Realm, pullIntoDescriptor);
+
+        if (pullIntoDescriptor.ReaderType == PullIntoReaderType.Default)
+        {
+            ReadableStreamOperations.FulfillReadRequest(stream, filledView, done);
+        }
+        else
+        {
+            ReadableStreamOperations.FulfillReadIntoRequest(stream, filledView, done);
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-byte-stream-controller-convert-pull-into-descriptor — the
+    /// buffer is transferred one last time, so the view the consumer receives owns it and the controller
+    /// can no longer write into it.
+    /// </summary>
+    private static ObjectInstance ConvertPullIntoDescriptor(Realm realm, PullIntoDescriptor pullIntoDescriptor)
+    {
+        var bytesFilled = pullIntoDescriptor.BytesFilled;
+        var elementSize = pullIntoDescriptor.ElementSize;
+
+        var buffer = StreamBufferOperations.TransferArrayBuffer(realm, pullIntoDescriptor.Buffer);
+
+        return StreamBufferOperations.ConstructView(
+            realm, pullIntoDescriptor.ViewElementType, buffer, pullIntoDescriptor.ByteOffset, bytesFilled / elementSize);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-byte-stream-controller-enqueue
+    /// </summary>
+    internal static void Enqueue(JsReadableByteStreamController controller, in StreamBufferOperations.ArrayBufferViewInfo chunk)
+    {
+        var stream = controller.Stream;
+        var realm = controller.Realm;
+
+        if (controller.CloseRequested || stream.State != ReadableStreamState.Readable)
+        {
+            return;
+        }
+
+        if (chunk.Buffer.IsDetachedBuffer)
+        {
+            Throw.TypeError(realm, "The chunk's buffer is detached and so cannot be enqueued");
+        }
+
+        var byteOffset = chunk.ByteOffset;
+        var byteLength = chunk.ByteLength;
+        var transferredBuffer = StreamBufferOperations.TransferArrayBuffer(realm, chunk.Buffer);
+
+        if (controller.PendingPullIntos.Count > 0)
+        {
+            var firstPendingPullInto = controller.PendingPullIntos.Peek();
+            if (firstPendingPullInto.Buffer.IsDetachedBuffer)
+            {
+                Throw.TypeError(realm, "The BYOB request's buffer has been detached and so cannot be filled with an enqueued chunk");
+            }
+
+            InvalidateByobRequest(controller);
+            firstPendingPullInto.Buffer = StreamBufferOperations.TransferArrayBuffer(realm, firstPendingPullInto.Buffer);
+
+            if (firstPendingPullInto.ReaderType == PullIntoReaderType.None)
+            {
+                EnqueueDetachedPullIntoToQueue(controller, firstPendingPullInto);
+            }
+        }
+
+        if (ReadableStreamOperations.HasDefaultReader(stream))
+        {
+            ProcessReadRequestsUsingQueue(controller);
+
+            if (ReadableStreamOperations.GetNumReadRequests(stream) == 0)
+            {
+                controller.Queue.Enqueue(transferredBuffer, byteOffset, byteLength);
+            }
+            else
+            {
+                // A pull-into descriptor for a default reader (automatic allocation) is discarded: the
+                // waiting read request is about to be served from this chunk instead.
+                if (controller.PendingPullIntos.Count > 0)
+                {
+                    ShiftPendingPullInto(controller);
+                }
+
+                var transferredView = StreamBufferOperations.ConstructUint8Array(realm, transferredBuffer, byteOffset, byteLength);
+                ReadableStreamOperations.FulfillReadRequest(stream, transferredView, done: false);
+            }
+        }
+        else if (ReadableStreamOperations.HasBYOBReader(stream))
+        {
+            controller.Queue.Enqueue(transferredBuffer, byteOffset, byteLength);
+
+            var filledPullIntos = ProcessPullIntoDescriptorsUsingQueue(controller);
+            foreach (var filledPullInto in filledPullIntos)
+            {
+                CommitPullIntoDescriptor(stream, filledPullInto);
+            }
+        }
+        else
+        {
+            controller.Queue.Enqueue(transferredBuffer, byteOffset, byteLength);
+        }
+
+        CallPullIfNeeded(controller);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-byte-stream-controller-enqueue-cloned-chunk-to-queue — a
+    /// copy rather than a transfer, because the bytes being re-queued are in a buffer somebody else still
+    /// owns.
+    /// </summary>
+    private static void EnqueueClonedChunkToQueue(JsReadableByteStreamController controller, JsArrayBuffer buffer, int byteOffset, int byteLength)
+    {
+        JsArrayBuffer clonedChunk;
+        try
+        {
+            clonedChunk = StreamBufferOperations.CloneArrayBufferRegion(controller.Realm, buffer, byteOffset, byteLength);
+        }
+        catch (JavaScriptException e)
+        {
+            Error(controller, e.Error);
+            throw;
+        }
+
+        controller.Queue.Enqueue(clonedChunk, 0, byteLength);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-byte-stream-controller-enqueue-detached-pull-into-to-queue
+    /// — what happens to the bytes already written into a buffer whose reader has gone away.
+    /// </summary>
+    private static void EnqueueDetachedPullIntoToQueue(JsReadableByteStreamController controller, PullIntoDescriptor firstDescriptor)
+    {
+        if (firstDescriptor.BytesFilled > 0)
+        {
+            EnqueueClonedChunkToQueue(controller, firstDescriptor.Buffer, firstDescriptor.ByteOffset, firstDescriptor.BytesFilled);
+        }
+
+        ShiftPendingPullInto(controller);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-byte-stream-controller-error
+    /// </summary>
+    internal static void Error(JsReadableByteStreamController controller, JsValue error)
+    {
+        var stream = controller.Stream;
+        if (stream.State != ReadableStreamState.Readable)
+        {
+            return;
+        }
+
+        ClearPendingPullIntos(controller);
+        controller.Queue.Reset();
+        ClearAlgorithms(controller);
+        ReadableStreamOperations.Error(stream, error);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-byte-stream-controller-fill-pull-into-descriptor-from-queue
+    /// </summary>
+    /// <returns>Whether the descriptor is now filled to at least its minimum fill, and so ready to commit.</returns>
+    private static bool FillPullIntoDescriptorFromQueue(JsReadableByteStreamController controller, PullIntoDescriptor pullIntoDescriptor)
+    {
+        var queue = controller.Queue;
+
+        var maxBytesToCopy = (int) System.Math.Min(queue.TotalSize, pullIntoDescriptor.ByteLength - pullIntoDescriptor.BytesFilled);
+        var maxBytesFilled = pullIntoDescriptor.BytesFilled + maxBytesToCopy;
+
+        var totalBytesToCopyRemaining = maxBytesToCopy;
+        var ready = false;
+
+        var remainderBytes = maxBytesFilled % pullIntoDescriptor.ElementSize;
+        var maxAlignedBytes = maxBytesFilled - remainderBytes;
+
+        // A descriptor that cannot yet reach its minimum fill stays at the head of the queue, so the
+        // underlying source can keep filling it — that is what makes read(view, { min }) wait.
+        if (maxAlignedBytes >= pullIntoDescriptor.MinimumFill)
+        {
+            totalBytesToCopyRemaining = maxAlignedBytes - pullIntoDescriptor.BytesFilled;
+            ready = true;
+        }
+
+        while (totalBytesToCopyRemaining > 0)
+        {
+            var headOfQueue = queue.Peek();
+            var bytesToCopy = System.Math.Min(totalBytesToCopyRemaining, headOfQueue.ByteLength);
+            var destStart = pullIntoDescriptor.ByteOffset + pullIntoDescriptor.BytesFilled;
+
+            StreamBufferOperations.CopyDataBlockBytes(
+                pullIntoDescriptor.Buffer, destStart, headOfQueue.Buffer, headOfQueue.ByteOffset, bytesToCopy);
+
+            queue.ConsumeFromHead(bytesToCopy);
+            pullIntoDescriptor.BytesFilled += bytesToCopy;
+            totalBytesToCopyRemaining -= bytesToCopy;
+        }
+
+        return ready;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-byte-stream-controller-fill-read-request-from-queue
+    /// </summary>
+    private static void FillReadRequestFromQueue(JsReadableByteStreamController controller, ReadRequest readRequest)
+    {
+        var entry = controller.Queue.Dequeue();
+        HandleQueueDrain(controller);
+
+        var view = StreamBufferOperations.ConstructUint8Array(controller.Realm, entry.Buffer, entry.ByteOffset, entry.ByteLength);
+        readRequest.ChunkSteps(view);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-byte-stream-controller-get-byob-request — the request is
+    /// created lazily, on the first read of <c>controller.byobRequest</c>, and invalidated the moment the
+    /// buffer behind it moves.
+    /// </summary>
+    internal static JsReadableStreamBYOBRequest? GetByobRequest(JsReadableByteStreamController controller)
+    {
+        if (controller.ByobRequest is null && controller.PendingPullIntos.Count > 0)
+        {
+            var firstDescriptor = controller.PendingPullIntos.Peek();
+            var realm = controller.Realm;
+
+            var view = StreamBufferOperations.ConstructUint8Array(
+                realm,
+                firstDescriptor.Buffer,
+                firstDescriptor.ByteOffset + firstDescriptor.BytesFilled,
+                firstDescriptor.ByteLength - firstDescriptor.BytesFilled);
+
+            controller.ByobRequest = new JsReadableStreamBYOBRequest(controller.Engine, realm)
+            {
+                _prototype = realm.Intrinsics.ReadableStreamBYOBRequest.PrototypeObject,
+                Controller = controller,
+                View = view,
+            };
+        }
+
+        return controller.ByobRequest;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-byte-stream-controller-get-desired-size
+    /// </summary>
+    internal static double? GetDesiredSize(JsReadableByteStreamController controller)
+    {
+        return controller.Stream.State switch
+        {
+            ReadableStreamState.Errored => null,
+            ReadableStreamState.Closed => 0,
+            _ => controller.StrategyHighWaterMark - controller.Queue.TotalSize,
+        };
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-byte-stream-controller-handle-queue-drain
+    /// </summary>
+    private static void HandleQueueDrain(JsReadableByteStreamController controller)
+    {
+        if (controller.Queue.TotalSize == 0 && controller.CloseRequested)
+        {
+            ClearAlgorithms(controller);
+            ReadableStreamOperations.Close(controller.Stream);
+        }
+        else
+        {
+            CallPullIfNeeded(controller);
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-byte-stream-controller-invalidate-byob-request — the
+    /// request object survives in whatever script kept it, with a null <c>view</c> and a <c>respond()</c>
+    /// that raises a <c>TypeError</c>.
+    /// </summary>
+    internal static void InvalidateByobRequest(JsReadableByteStreamController controller)
+    {
+        var byobRequest = controller.ByobRequest;
+        if (byobRequest is null)
+        {
+            return;
+        }
+
+        byobRequest.Controller = null;
+        byobRequest.View = null;
+        controller.ByobRequest = null;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-byte-stream-controller-process-pull-into-descriptors-using-queue
+    /// </summary>
+    private static List<PullIntoDescriptor> ProcessPullIntoDescriptorsUsingQueue(JsReadableByteStreamController controller)
+    {
+        var filledPullIntos = new List<PullIntoDescriptor>();
+
+        while (controller.PendingPullIntos.Count > 0)
+        {
+            if (controller.Queue.TotalSize == 0)
+            {
+                break;
+            }
+
+            var pullIntoDescriptor = controller.PendingPullIntos.Peek();
+            if (FillPullIntoDescriptorFromQueue(controller, pullIntoDescriptor))
+            {
+                ShiftPendingPullInto(controller);
+                filledPullIntos.Add(pullIntoDescriptor);
+            }
+        }
+
+        return filledPullIntos;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-byte-stream-controller-process-read-requests-using-queue
+    /// </summary>
+    private static void ProcessReadRequestsUsingQueue(JsReadableByteStreamController controller)
+    {
+        var reader = (JsReadableStreamDefaultReader) controller.Stream.Reader!;
+
+        while (reader.ReadRequests.Count > 0)
+        {
+            if (controller.Queue.TotalSize == 0)
+            {
+                return;
+            }
+
+            var readRequest = reader.ReadRequests.Dequeue();
+            FillReadRequestFromQueue(controller, readRequest);
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-byte-stream-controller-pull-into — a BYOB read's whole
+    /// journey: transfer the caller's buffer in, then either fill it from the queue right away or park it
+    /// as a pull-into descriptor for the underlying source to write into.
+    /// </summary>
+    internal static void PullInto(
+        JsReadableByteStreamController controller,
+        in StreamBufferOperations.ArrayBufferViewInfo view,
+        int min,
+        ReadIntoRequest readIntoRequest)
+    {
+        var stream = controller.Stream;
+        var realm = controller.Realm;
+
+        var elementSize = view.ElementSize;
+        var minimumFill = min * elementSize;
+
+        JsArrayBuffer buffer;
+        try
+        {
+            buffer = StreamBufferOperations.TransferArrayBuffer(realm, view.Buffer);
+        }
+        catch (JavaScriptException e)
+        {
+            readIntoRequest.ErrorSteps(e.Error);
+            return;
+        }
+
+        var pullIntoDescriptor = new PullIntoDescriptor
+        {
+            Buffer = buffer,
+            BufferByteLength = buffer.ArrayBufferByteLength,
+            ByteOffset = view.ByteOffset,
+            ByteLength = view.ByteLength,
+            BytesFilled = 0,
+            MinimumFill = minimumFill,
+            ElementSize = elementSize,
+            ViewElementType = view.ElementType,
+            ReaderType = PullIntoReaderType.Byob,
+        };
+
+        if (controller.PendingPullIntos.Count > 0)
+        {
+            // No CallPullIfNeeded: the desired size has not changed, and the source already knows there is
+            // at least one pending read(view).
+            controller.PendingPullIntos.Enqueue(pullIntoDescriptor);
+            ReadableStreamOperations.AddReadIntoRequest(stream, readIntoRequest);
+            return;
+        }
+
+        if (stream.State == ReadableStreamState.Closed)
+        {
+            // The memory is handed back rather than discarded: an empty view onto the very same buffer.
+            var emptyView = StreamBufferOperations.ConstructView(realm, view.ElementType, buffer, view.ByteOffset, 0);
+            readIntoRequest.CloseSteps(emptyView);
+            return;
+        }
+
+        if (controller.Queue.TotalSize > 0)
+        {
+            if (FillPullIntoDescriptorFromQueue(controller, pullIntoDescriptor))
+            {
+                var filledView = ConvertPullIntoDescriptor(realm, pullIntoDescriptor);
+                HandleQueueDrain(controller);
+                readIntoRequest.ChunkSteps(filledView);
+                return;
+            }
+
+            if (controller.CloseRequested)
+            {
+                var error = realm.Intrinsics.TypeError.Construct("Insufficient bytes to fill elements in the given buffer");
+                Error(controller, error);
+                readIntoRequest.ErrorSteps(error);
+                return;
+            }
+        }
+
+        controller.PendingPullIntos.Enqueue(pullIntoDescriptor);
+        ReadableStreamOperations.AddReadIntoRequest(stream, readIntoRequest);
+        CallPullIfNeeded(controller);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-byte-stream-controller-respond
+    /// </summary>
+    internal static void Respond(JsReadableByteStreamController controller, ulong bytesWritten)
+    {
+        var realm = controller.Realm;
+        var firstDescriptor = controller.PendingPullIntos.Peek();
+        var state = controller.Stream.State;
+
+        if (state == ReadableStreamState.Closed)
+        {
+            if (bytesWritten != 0)
+            {
+                Throw.TypeError(realm, "bytesWritten must be 0 when calling respond() on a closed stream");
+            }
+        }
+        else
+        {
+            if (bytesWritten == 0)
+            {
+                Throw.TypeError(realm, "bytesWritten must be greater than 0 when calling respond() on a readable stream");
+            }
+
+            if (bytesWritten > (ulong) (firstDescriptor.ByteLength - firstDescriptor.BytesFilled))
+            {
+                Throw.RangeError(realm, "bytesWritten out of range");
+            }
+        }
+
+        firstDescriptor.Buffer = StreamBufferOperations.TransferArrayBuffer(realm, firstDescriptor.Buffer);
+
+        RespondInternal(controller, (int) bytesWritten);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-byte-stream-controller-respond-in-closed-state
+    /// </summary>
+    private static void RespondInClosedState(JsReadableByteStreamController controller, PullIntoDescriptor firstDescriptor)
+    {
+        if (firstDescriptor.ReaderType == PullIntoReaderType.None)
+        {
+            ShiftPendingPullInto(controller);
+        }
+
+        var stream = controller.Stream;
+        if (!ReadableStreamOperations.HasBYOBReader(stream))
+        {
+            return;
+        }
+
+        var filledPullIntos = new List<PullIntoDescriptor>();
+        while (filledPullIntos.Count < ReadableStreamOperations.GetNumReadIntoRequests(stream))
+        {
+            filledPullIntos.Add(ShiftPendingPullInto(controller));
+        }
+
+        foreach (var filledPullInto in filledPullIntos)
+        {
+            CommitPullIntoDescriptor(stream, filledPullInto);
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-byte-stream-controller-respond-in-readable-state
+    /// </summary>
+    private static void RespondInReadableState(JsReadableByteStreamController controller, int bytesWritten, PullIntoDescriptor pullIntoDescriptor)
+    {
+        pullIntoDescriptor.BytesFilled += bytesWritten;
+
+        if (pullIntoDescriptor.ReaderType == PullIntoReaderType.None)
+        {
+            EnqueueDetachedPullIntoToQueue(controller, pullIntoDescriptor);
+
+            foreach (var filledPullInto in ProcessPullIntoDescriptorsUsingQueue(controller))
+            {
+                CommitPullIntoDescriptor(controller.Stream, filledPullInto);
+            }
+
+            return;
+        }
+
+        // Not yet enough for the read to be answered: the descriptor stays at the head of the queue so the
+        // underlying source can keep filling it.
+        if (pullIntoDescriptor.BytesFilled < pullIntoDescriptor.MinimumFill)
+        {
+            return;
+        }
+
+        ShiftPendingPullInto(controller);
+
+        // A trailing partial element cannot be handed over, so it is copied back into the stream's queue
+        // and becomes the first bytes of the next chunk.
+        var remainderSize = pullIntoDescriptor.BytesFilled % pullIntoDescriptor.ElementSize;
+        if (remainderSize > 0)
+        {
+            var end = pullIntoDescriptor.ByteOffset + pullIntoDescriptor.BytesFilled;
+            EnqueueClonedChunkToQueue(controller, pullIntoDescriptor.Buffer, end - remainderSize, remainderSize);
+        }
+
+        pullIntoDescriptor.BytesFilled -= remainderSize;
+        var filledPullIntos = ProcessPullIntoDescriptorsUsingQueue(controller);
+
+        CommitPullIntoDescriptor(controller.Stream, pullIntoDescriptor);
+        foreach (var filledPullInto in filledPullIntos)
+        {
+            CommitPullIntoDescriptor(controller.Stream, filledPullInto);
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-byte-stream-controller-respond-internal
+    /// </summary>
+    private static void RespondInternal(JsReadableByteStreamController controller, int bytesWritten)
+    {
+        var firstDescriptor = controller.PendingPullIntos.Peek();
+
+        InvalidateByobRequest(controller);
+
+        if (controller.Stream.State == ReadableStreamState.Closed)
+        {
+            RespondInClosedState(controller, firstDescriptor);
+        }
+        else
+        {
+            RespondInReadableState(controller, bytesWritten, firstDescriptor);
+        }
+
+        CallPullIfNeeded(controller);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-byte-stream-controller-respond-with-new-view — the
+    /// underlying source hands back a different view of the same memory, which is how a source that had to
+    /// write elsewhere and copy still avoids a second copy.
+    /// </summary>
+    internal static void RespondWithNewView(JsReadableByteStreamController controller, in StreamBufferOperations.ArrayBufferViewInfo view)
+    {
+        var realm = controller.Realm;
+        var firstDescriptor = controller.PendingPullIntos.Peek();
+        var state = controller.Stream.State;
+
+        if (state == ReadableStreamState.Closed)
+        {
+            if (view.ByteLength != 0)
+            {
+                Throw.TypeError(realm, "The view's length must be 0 when calling respondWithNewView() on a closed stream");
+            }
+        }
+        else if (view.ByteLength == 0)
+        {
+            Throw.TypeError(realm, "The view's length must be greater than 0 when calling respondWithNewView() on a readable stream");
+        }
+
+        if (firstDescriptor.ByteOffset + firstDescriptor.BytesFilled != view.ByteOffset)
+        {
+            Throw.RangeError(realm, "The region specified by view does not match byobRequest");
+        }
+
+        if (firstDescriptor.BufferByteLength != view.Buffer.ArrayBufferByteLength)
+        {
+            Throw.RangeError(realm, "The buffer of view has different capacity than byobRequest");
+        }
+
+        if (firstDescriptor.BytesFilled + view.ByteLength > firstDescriptor.ByteLength)
+        {
+            Throw.RangeError(realm, "The region specified by view is larger than byobRequest");
+        }
+
+        var viewByteLength = view.ByteLength;
+        firstDescriptor.Buffer = StreamBufferOperations.TransferArrayBuffer(realm, view.Buffer);
+
+        RespondInternal(controller, viewByteLength);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-byte-stream-controller-shift-pending-pull-into
+    /// </summary>
+    private static PullIntoDescriptor ShiftPendingPullInto(JsReadableByteStreamController controller)
+        => controller.PendingPullIntos.Dequeue();
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#set-up-readable-byte-stream-controller
+    /// </summary>
+    internal static void SetUp(
+        JsReadableStream stream,
+        JsReadableByteStreamController controller,
+        Func<JsValue> startAlgorithm,
+        Func<JsPromise> pullAlgorithm,
+        Func<JsValue, JsPromise> cancelAlgorithm,
+        double highWaterMark,
+        ulong? autoAllocateChunkSize)
+    {
+        var engine = stream.Engine;
+        var realm = stream.Realm;
+
+        controller.Stream = stream;
+        controller.PullAgain = false;
+        controller.Pulling = false;
+        controller.ByobRequest = null;
+        controller.Queue.Reset();
+        controller.CloseRequested = false;
+        controller.Started = false;
+        controller.StrategyHighWaterMark = highWaterMark;
+        controller.PullAlgorithm = pullAlgorithm;
+        controller.CancelAlgorithm = cancelAlgorithm;
+        controller.AutoAllocateChunkSize = autoAllocateChunkSize;
+        controller.PendingPullIntos.Clear();
+        stream.Controller = controller;
+
+        // As for a default controller: start()'s return type is `any`, so an exception it raises propagates
+        // out of the ReadableStream constructor rather than becoming a rejection.
+        var startResult = startAlgorithm();
+        var startPromise = StreamPromises.ResolvedWith(realm, startResult);
+
+        StreamPromises.UponPromise(
+            engine,
+            startPromise,
+            _ =>
+            {
+                controller.Started = true;
+                CallPullIfNeeded(controller);
+            },
+            reason => Error(controller, reason));
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#set-up-readable-byte-stream-controller-from-underlying-source
+    /// </summary>
+    internal static void SetUpFromUnderlyingSource(
+        JsReadableStream stream,
+        JsValue underlyingSource,
+        in StreamDictionaries.UnderlyingSourceRecord source,
+        double highWaterMark)
+    {
+        var engine = stream.Engine;
+        var realm = stream.Realm;
+
+        var controller = new JsReadableByteStreamController(engine, realm)
+        {
+            _prototype = realm.Intrinsics.ReadableByteStreamController.PrototypeObject,
+        };
+
+        var start = source.Start;
+        var pull = source.Pull;
+        var cancel = source.Cancel;
+
+        Func<JsValue> startAlgorithm = start is null
+            ? static () => JsValue.Undefined
+            : () => start.Call(underlyingSource, controller);
+
+        Func<JsPromise> pullAlgorithm = pull is null
+            ? () => StreamPromises.ResolvedWithUndefined(engine, realm)
+            : () => StreamPromises.PromiseCall(engine, realm, pull, underlyingSource, [controller]);
+
+        Func<JsValue, JsPromise> cancelAlgorithm = cancel is null
+            ? _ => StreamPromises.ResolvedWithUndefined(engine, realm)
+            : reason => StreamPromises.PromiseCall(engine, realm, cancel, underlyingSource, [reason]);
+
+        var autoAllocateChunkSize = source.AutoAllocateChunkSize;
+        if (autoAllocateChunkSize == 0)
+        {
+            Throw.TypeError(realm, "The underlying source's autoAllocateChunkSize must be greater than 0");
+        }
+
+        SetUp(stream, controller, startAlgorithm, pullAlgorithm, cancelAlgorithm, highWaterMark, autoAllocateChunkSize);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rbs-controller-private-pull — a default <c>read()</c> against a byte
+    /// stream, which either takes a chunk out of the queue or, with automatic allocation configured, parks a
+    /// controller-owned buffer for the underlying source to fill.
+    /// </summary>
+    internal static void PullSteps(JsReadableByteStreamController controller, ReadRequest readRequest)
+    {
+        var stream = controller.Stream;
+        var realm = controller.Realm;
+
+        if (controller.Queue.TotalSize > 0)
+        {
+            FillReadRequestFromQueue(controller, readRequest);
+            return;
+        }
+
+        if (controller.AutoAllocateChunkSize is { } autoAllocateChunkSize)
+        {
+            JsArrayBuffer buffer;
+            try
+            {
+                // "Let buffer be Construct(%ArrayBuffer%, « autoAllocateChunkSize »)" — a size no
+                // ArrayBuffer can have fails here, as a RangeError this read reports, rather than having
+                // been rejected by the constructor that never allocated anything.
+                buffer = realm.Intrinsics.ArrayBuffer.AllocateArrayBuffer(realm.Intrinsics.ArrayBuffer, autoAllocateChunkSize);
+            }
+            catch (JavaScriptException e)
+            {
+                readRequest.ErrorSteps(e.Error);
+                return;
+            }
+
+            // The allocation succeeded, so the size is a length an ArrayBuffer can have.
+            var chunkSize = (int) autoAllocateChunkSize;
+
+            controller.PendingPullIntos.Enqueue(new PullIntoDescriptor
+            {
+                Buffer = buffer,
+                BufferByteLength = chunkSize,
+                ByteOffset = 0,
+                ByteLength = chunkSize,
+                BytesFilled = 0,
+                MinimumFill = 1,
+                ElementSize = 1,
+                ViewElementType = TypedArrayElementType.Uint8,
+                ReaderType = PullIntoReaderType.Default,
+            });
+        }
+
+        ReadableStreamOperations.AddReadRequest(stream, readRequest);
+        CallPullIfNeeded(controller);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rbs-controller-private-cancel
+    /// </summary>
+    internal static JsPromise CancelSteps(JsReadableByteStreamController controller, JsValue reason)
+    {
+        ClearPendingPullIntos(controller);
+        controller.Queue.Reset();
+
+        // Reachable only while the stream is readable, so the algorithm has not been cleared yet.
+        var result = controller.CancelAlgorithm!(reason);
+        ClearAlgorithms(controller);
+        return result;
+    }
+
+    [DoesNotReturn]
+    private static void ThrowValue(Engine engine, JsValue error)
+    {
+        var location = engine._lastSyntaxElement?.Location ?? default;
+        Throw.JavaScriptException(engine, error, in location);
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/ReadableByteStreamControllerPrototype.cs
+++ b/Jint/WebApi/Streams/ReadableByteStreamControllerPrototype.cs
@@ -1,0 +1,141 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// <c>ReadableByteStreamController.prototype</c> — the interface prototype object.
+/// <para>
+/// https://streams.spec.whatwg.org/#rbs-controller-prototype
+/// </para>
+/// </summary>
+[JsObject(UseShape = true)]
+internal sealed partial class ReadableByteStreamControllerPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly ReadableByteStreamControllerConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString ControllerToStringTag = new("ReadableByteStreamController");
+
+    internal ReadableByteStreamControllerPrototype(
+        Engine engine,
+        Realm realm,
+        ReadableByteStreamControllerConstructor constructor,
+        ObjectInstance objectPrototype) : base(engine, realm)
+    {
+        _prototype = objectPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rbs-controller-byob-request — the buffer the stream is currently
+    /// waiting to have filled, or <c>null</c> when there is no pending BYOB pull.
+    /// </summary>
+    [JsAccessor("byobRequest", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue ByobRequestGet(JsValue thisObject)
+    {
+        var byobRequest = ReadableByteStreamControllerOperations.GetByobRequest(Brand(thisObject));
+        return byobRequest is null ? Null : byobRequest;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rbs-controller-desired-size — in bytes, since a byte stream's chunk
+    /// size is its byte length.
+    /// </summary>
+    [JsAccessor("desiredSize", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue DesiredSizeGet(JsValue thisObject)
+    {
+        var desiredSize = ReadableByteStreamControllerOperations.GetDesiredSize(Brand(thisObject));
+        return desiredSize is { } value ? JsNumber.Create(value) : Null;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rbs-controller-close
+    /// </summary>
+    [JsFunction(Name = "close", Length = 0)]
+    private JsValue Close(JsValue thisObject)
+    {
+        var controller = Brand(thisObject);
+
+        if (controller.CloseRequested)
+        {
+            Throw.TypeError(_realm, "The stream has already been closed");
+        }
+
+        if (controller.Stream.State != ReadableStreamState.Readable)
+        {
+            Throw.TypeError(_realm, "The stream is not in a state that permits close");
+        }
+
+        ReadableByteStreamControllerOperations.Close(controller);
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rbs-controller-enqueue. The chunk is an <c>ArrayBufferView</c>, and
+    /// an empty one — or one over a detached buffer, whose byte length is therefore also zero — is refused:
+    /// a zero-length chunk would be indistinguishable from end-of-stream to a BYOB consumer.
+    /// </summary>
+    [JsFunction(Name = "enqueue", Length = 1)]
+    private JsValue Enqueue(JsValue thisObject, JsValue chunk)
+    {
+        var controller = Brand(thisObject);
+        var view = StreamBufferOperations.ReadArrayBufferView(_realm, chunk, "The chunk");
+
+        if (view.ByteLength == 0)
+        {
+            Throw.TypeError(_realm, "The chunk has a byte length of 0");
+        }
+
+        if (view.Buffer.ArrayBufferByteLength == 0)
+        {
+            Throw.TypeError(_realm, "The chunk's buffer has a byte length of 0");
+        }
+
+        if (controller.CloseRequested)
+        {
+            Throw.TypeError(_realm, "The stream has already been closed");
+        }
+
+        if (controller.Stream.State != ReadableStreamState.Readable)
+        {
+            Throw.TypeError(_realm, "The stream is not in a state that permits enqueue");
+        }
+
+        ReadableByteStreamControllerOperations.Enqueue(controller, in view);
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rbs-controller-error — silently does nothing for a stream that has
+    /// already stopped being readable, exactly as the default controller's does.
+    /// </summary>
+    [JsFunction(Name = "error", Length = 0)]
+    private JsValue Error(JsValue thisObject, JsValue error)
+    {
+        ReadableByteStreamControllerOperations.Error(Brand(thisObject), error);
+        return Undefined;
+    }
+
+    private JsReadableByteStreamController Brand(JsValue thisObject)
+    {
+        if (thisObject is JsReadableByteStreamController controller)
+        {
+            return controller;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a ReadableByteStreamController");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/ReadableByteStreamTee.cs
+++ b/Jint/WebApi/Streams/ReadableByteStreamTee.cs
@@ -1,0 +1,433 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Promise;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// https://streams.spec.whatwg.org/#abstract-opdef-readablebytestreamtee — the algorithm behind
+/// <c>ReadableStream.prototype.tee()</c> for a stream whose controller is a byte controller.
+/// </summary>
+/// <remarks>
+/// <para>
+/// It differs from the default tee in three ways, all of them consequences of the branches being byte
+/// streams themselves. Both branches are byte streams, so each can be read BYOB. The chunk handed to the
+/// second branch is a <b>copy</b>, not the same view — it has to be, because a byte stream transfers the
+/// buffer of everything enqueued into it, so one branch's chunk cannot also be the other's. And the reader
+/// over the original stream is <b>swapped</b> at run time: a branch pulled through a BYOB request reads
+/// into that request's own buffer, which needs a BYOB reader, while a branch pulled ordinarily needs a
+/// default one — so whichever kind is needed is acquired, after releasing the other.
+/// </para>
+/// <para>
+/// The reader swap is why every reader-error forwarding closes over the reader it was registered for: a
+/// rejection arriving from a reader that has since been replaced belongs to the old lock and is ignored.
+/// </para>
+/// </remarks>
+internal sealed class ReadableByteStreamTee
+{
+    private readonly Engine _engine;
+    private readonly Realm _realm;
+    private readonly JsReadableStream _stream;
+    private readonly PromiseCapability _cancelCapability;
+
+    private JsReadableStreamReader _reader;
+    private bool _reading;
+    private bool _readAgainForBranch1;
+    private bool _readAgainForBranch2;
+    private bool _canceled1;
+    private bool _canceled2;
+    private JsValue _reason1 = JsValue.Undefined;
+    private JsValue _reason2 = JsValue.Undefined;
+    private JsReadableStream _branch1 = null!;
+    private JsReadableStream _branch2 = null!;
+    private JsReadableByteStreamController _controller1 = null!;
+    private JsReadableByteStreamController _controller2 = null!;
+
+    private ReadableByteStreamTee(JsReadableStream stream)
+    {
+        _engine = stream.Engine;
+        _realm = stream.Realm;
+        _stream = stream;
+        _reader = ReadableStreamOperations.AcquireDefaultReader(stream);
+        _cancelCapability = StreamPromises.NewPromise(_engine, _realm);
+    }
+
+    /// <summary>
+    /// Tees <paramref name="stream"/> and returns its two branches, in order.
+    /// </summary>
+    internal static (JsReadableStream Branch1, JsReadableStream Branch2) Tee(JsReadableStream stream)
+    {
+        var tee = new ReadableByteStreamTee(stream);
+
+        tee._branch1 = ReadableStreamOperations.CreateReadableByteStream(
+            tee._engine, tee._realm, static () => JsValue.Undefined, tee.Pull1Algorithm, tee.Cancel1Algorithm);
+
+        tee._branch2 = ReadableStreamOperations.CreateReadableByteStream(
+            tee._engine, tee._realm, static () => JsValue.Undefined, tee.Pull2Algorithm, tee.Cancel2Algorithm);
+
+        tee._controller1 = (JsReadableByteStreamController) tee._branch1.Controller;
+        tee._controller2 = (JsReadableByteStreamController) tee._branch2.Controller;
+
+        tee.ForwardReaderError(tee._reader);
+
+        return (tee._branch1, tee._branch2);
+    }
+
+    /// <summary>
+    /// An error in the original reaches both branches through the reader's closed promise, which is the only
+    /// channel that reports an error arriving while no read is outstanding.
+    /// </summary>
+    private void ForwardReaderError(JsReadableStreamReader thisReader)
+    {
+        StreamPromises.UponRejection(_engine, thisReader.ClosedPromise, error =>
+        {
+            // A rejection from a reader that has since been swapped out belongs to a lock nobody holds any
+            // more, and says nothing about the stream.
+            if (thisReader != _reader)
+            {
+                return;
+            }
+
+            ReadableByteStreamControllerOperations.Error(_controller1, error);
+            ReadableByteStreamControllerOperations.Error(_controller2, error);
+
+            if (!_canceled1 || !_canceled2)
+            {
+                _cancelCapability.Resolve(JsValue.Undefined);
+            }
+        });
+    }
+
+    private void PullWithDefaultReader()
+    {
+        if (_reader is JsReadableStreamBYOBReader byobReader)
+        {
+            ReadableStreamOperations.BYOBReaderRelease(byobReader);
+            _reader = ReadableStreamOperations.AcquireDefaultReader(_stream);
+            ForwardReaderError(_reader);
+        }
+
+        ReadableStreamOperations.DefaultReaderRead((JsReadableStreamDefaultReader) _reader, new TeeReadRequest(this));
+    }
+
+    private void PullWithBYOBReader(JsTypedArray view, bool forBranch2)
+    {
+        if (_reader is JsReadableStreamDefaultReader defaultReader)
+        {
+            ReadableStreamOperations.DefaultReaderRelease(defaultReader);
+            _reader = ReadableStreamOperations.AcquireBYOBReader(_stream);
+            ForwardReaderError(_reader);
+        }
+
+        var viewInfo = StreamBufferOperations.ReadArrayBufferView(_realm, view, "The view");
+
+        ReadableStreamOperations.BYOBReaderRead(
+            (JsReadableStreamBYOBReader) _reader, in viewInfo, min: 1, new TeeReadIntoRequest(this, forBranch2));
+    }
+
+    private JsPromise Pull1Algorithm() => PullAlgorithm(forBranch2: false);
+
+    private JsPromise Pull2Algorithm() => PullAlgorithm(forBranch2: true);
+
+    /// <summary>
+    /// A branch pulls with whichever kind of read its own consumer asked for: a pending BYOB request on the
+    /// branch means its consumer supplied a buffer, and the original is read straight into it.
+    /// </summary>
+    private JsPromise PullAlgorithm(bool forBranch2)
+    {
+        if (_reading)
+        {
+            if (forBranch2)
+            {
+                _readAgainForBranch2 = true;
+            }
+            else
+            {
+                _readAgainForBranch1 = true;
+            }
+
+            return StreamPromises.ResolvedWithUndefined(_engine, _realm);
+        }
+
+        _reading = true;
+
+        var controller = forBranch2 ? _controller2 : _controller1;
+        var byobRequest = ReadableByteStreamControllerOperations.GetByobRequest(controller);
+
+        if (byobRequest is null)
+        {
+            PullWithDefaultReader();
+        }
+        else
+        {
+            PullWithBYOBReader(byobRequest.View!, forBranch2);
+        }
+
+        return StreamPromises.ResolvedWithUndefined(_engine, _realm);
+    }
+
+    private JsPromise Cancel1Algorithm(JsValue reason)
+    {
+        _canceled1 = true;
+        _reason1 = reason;
+
+        if (_canceled2)
+        {
+            ResolveCancelPromiseWithComposite();
+        }
+
+        return StreamPromises.PromiseOf(_cancelCapability);
+    }
+
+    private JsPromise Cancel2Algorithm(JsValue reason)
+    {
+        _canceled2 = true;
+        _reason2 = reason;
+
+        if (_canceled1)
+        {
+            ResolveCancelPromiseWithComposite();
+        }
+
+        return StreamPromises.PromiseOf(_cancelCapability);
+    }
+
+    private void ResolveCancelPromiseWithComposite()
+    {
+        var compositeReason = new JsArray(_engine, [_reason1, _reason2]);
+        _cancelCapability.Resolve(ReadableStreamOperations.Cancel(_stream, compositeReason));
+    }
+
+    /// <summary>
+    /// The one read whose result both branches share, once whichever branch asked for it has been served.
+    /// A failure to copy the chunk for the second branch errors both and cancels the original.
+    /// </summary>
+    private bool TryCloneChunk(JsTypedArray chunk, JsReadableByteStreamController first, JsReadableByteStreamController second, out JsTypedArray clone)
+    {
+        try
+        {
+            var view = StreamBufferOperations.ReadArrayBufferView(_realm, chunk, "The chunk");
+            var buffer = StreamBufferOperations.CloneArrayBufferRegion(_realm, view.Buffer, view.ByteOffset, view.ByteLength);
+            clone = StreamBufferOperations.ConstructUint8Array(_realm, buffer, 0, view.ByteLength);
+            return true;
+        }
+        catch (JavaScriptException e)
+        {
+            ReadableByteStreamControllerOperations.Error(first, e.Error);
+            ReadableByteStreamControllerOperations.Error(second, e.Error);
+            _cancelCapability.Resolve(ReadableStreamOperations.Cancel(_stream, e.Error));
+            clone = null!;
+            return false;
+        }
+    }
+
+    private void EnqueueToBranch(JsReadableByteStreamController controller, JsTypedArray chunk)
+    {
+        var view = StreamBufferOperations.ReadArrayBufferView(_realm, chunk, "The chunk");
+        ReadableByteStreamControllerOperations.Enqueue(controller, in view);
+    }
+
+    private void RespondToBranch(JsReadableByteStreamController controller, JsTypedArray chunk)
+    {
+        var view = StreamBufferOperations.ReadArrayBufferView(_realm, chunk, "The chunk");
+        ReadableByteStreamControllerOperations.RespondWithNewView(controller, in view);
+    }
+
+    /// <summary>Continues whichever branch asked for more while the shared read was outstanding.</summary>
+    private void ReadAgainIfRequested()
+    {
+        _reading = false;
+
+        if (_readAgainForBranch1)
+        {
+            PullAlgorithm(forBranch2: false);
+        }
+        else if (_readAgainForBranch2)
+        {
+            PullAlgorithm(forBranch2: true);
+        }
+    }
+
+    /// <summary>
+    /// The read request used when a branch pulls ordinarily. Its chunk steps are deferred by one microtask
+    /// for the same reason the default tee's are: an error in the original is only observable through the
+    /// reader's closed promise, and a synchronously available chunk must not overtake it.
+    /// </summary>
+    private sealed class TeeReadRequest : ReadRequest
+    {
+        private readonly ReadableByteStreamTee _tee;
+
+        internal TeeReadRequest(ReadableByteStreamTee tee)
+        {
+            _tee = tee;
+        }
+
+        internal override void ChunkSteps(JsValue chunk)
+        {
+            _tee._engine.AddToEventLoop(() =>
+            {
+                _tee._readAgainForBranch1 = false;
+                _tee._readAgainForBranch2 = false;
+
+                var chunk1 = (JsTypedArray) chunk;
+                var chunk2 = chunk1;
+
+                if (!_tee._canceled1 && !_tee._canceled2)
+                {
+                    if (!_tee.TryCloneChunk(chunk1, _tee._controller1, _tee._controller2, out chunk2))
+                    {
+                        return;
+                    }
+                }
+
+                if (!_tee._canceled1)
+                {
+                    _tee.EnqueueToBranch(_tee._controller1, chunk1);
+                }
+
+                if (!_tee._canceled2)
+                {
+                    _tee.EnqueueToBranch(_tee._controller2, chunk2);
+                }
+
+                _tee.ReadAgainIfRequested();
+            });
+        }
+
+        internal override void CloseSteps()
+        {
+            _tee._reading = false;
+
+            if (!_tee._canceled1)
+            {
+                ReadableByteStreamControllerOperations.Close(_tee._controller1);
+            }
+
+            if (!_tee._canceled2)
+            {
+                ReadableByteStreamControllerOperations.Close(_tee._controller2);
+            }
+
+            // A branch left holding a BYOB request has to be told that nothing more is coming, which for a
+            // closed byte stream is a zero-byte response.
+            if (_tee._controller1.PendingPullIntos.Count > 0)
+            {
+                ReadableByteStreamControllerOperations.Respond(_tee._controller1, 0);
+            }
+
+            if (_tee._controller2.PendingPullIntos.Count > 0)
+            {
+                ReadableByteStreamControllerOperations.Respond(_tee._controller2, 0);
+            }
+
+            if (!_tee._canceled1 || !_tee._canceled2)
+            {
+                _tee._cancelCapability.Resolve(JsValue.Undefined);
+            }
+        }
+
+        internal override void ErrorSteps(JsValue error)
+        {
+            // Nothing else: the branches are errored through the reader's closed promise instead.
+            _tee._reading = false;
+        }
+    }
+
+    /// <summary>
+    /// The read-into request used when a branch pulls through its own BYOB request: the original is read
+    /// directly into that branch's consumer's buffer, and the other branch gets a copy.
+    /// </summary>
+    private sealed class TeeReadIntoRequest : ReadIntoRequest
+    {
+        private readonly ReadableByteStreamTee _tee;
+        private readonly bool _forBranch2;
+
+        internal TeeReadIntoRequest(ReadableByteStreamTee tee, bool forBranch2)
+        {
+            _tee = tee;
+            _forBranch2 = forBranch2;
+        }
+
+        private JsReadableByteStreamController ByobBranch => _forBranch2 ? _tee._controller2 : _tee._controller1;
+
+        private JsReadableByteStreamController OtherBranch => _forBranch2 ? _tee._controller1 : _tee._controller2;
+
+        private bool ByobCanceled => _forBranch2 ? _tee._canceled2 : _tee._canceled1;
+
+        private bool OtherCanceled => _forBranch2 ? _tee._canceled1 : _tee._canceled2;
+
+        internal override void ChunkSteps(JsValue chunk)
+        {
+            _tee._engine.AddToEventLoop(() =>
+            {
+                _tee._readAgainForBranch1 = false;
+                _tee._readAgainForBranch2 = false;
+
+                var view = (JsTypedArray) chunk;
+
+                if (!OtherCanceled)
+                {
+                    if (!_tee.TryCloneChunk(view, ByobBranch, OtherBranch, out var clonedChunk))
+                    {
+                        return;
+                    }
+
+                    if (!ByobCanceled)
+                    {
+                        _tee.RespondToBranch(ByobBranch, view);
+                    }
+
+                    _tee.EnqueueToBranch(OtherBranch, clonedChunk);
+                }
+                else if (!ByobCanceled)
+                {
+                    _tee.RespondToBranch(ByobBranch, view);
+                }
+
+                _tee.ReadAgainIfRequested();
+            });
+        }
+
+        internal override void CloseSteps(JsValue chunk)
+        {
+            _tee._reading = false;
+
+            if (!ByobCanceled)
+            {
+                ReadableByteStreamControllerOperations.Close(ByobBranch);
+            }
+
+            if (!OtherCanceled)
+            {
+                ReadableByteStreamControllerOperations.Close(OtherBranch);
+            }
+
+            // The chunk is the (empty) view the closed original handed back, and it is the branch's own
+            // consumer's buffer: giving it back is what lets that read fulfil with { done: true }.
+            if (!chunk.IsUndefined())
+            {
+                if (!ByobCanceled)
+                {
+                    _tee.RespondToBranch(ByobBranch, (JsTypedArray) chunk);
+                }
+
+                if (!OtherCanceled && OtherBranch.PendingPullIntos.Count > 0)
+                {
+                    ReadableByteStreamControllerOperations.Respond(OtherBranch, 0);
+                }
+            }
+
+            if (!ByobCanceled || !OtherCanceled)
+            {
+                _tee._cancelCapability.Resolve(JsValue.Undefined);
+            }
+        }
+
+        internal override void ErrorSteps(JsValue error)
+        {
+            _tee._reading = false;
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/ReadableStreamBYOBReaderConstructor.cs
+++ b/Jint/WebApi/Streams/ReadableStreamBYOBReaderConstructor.cs
@@ -1,0 +1,70 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// The <c>ReadableStreamBYOBReader</c> interface object.
+/// <para>
+/// https://streams.spec.whatwg.org/#byob-reader-class
+/// </para>
+/// </summary>
+/// <remarks>
+/// The interface declares <c>constructor(ReadableStream stream)</c>, so this <i>is</i> constructible, and
+/// <c>new ReadableStreamBYOBReader(stream)</c> is equivalent to
+/// <c>stream.getReader({ mode: "byob" })</c> — including raising a <c>TypeError</c> for a stream that is
+/// already locked, and for one that is not a byte stream.
+/// <para>
+/// Like <c>ReadableStreamDefaultReader</c> it is deliberately not installed as a global; it is reachable as
+/// <c>Object.getPrototypeOf(stream.getReader({ mode: "byob" })).constructor</c>.
+/// </para>
+/// </remarks>
+internal sealed class ReadableStreamBYOBReaderConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("ReadableStreamBYOBReader");
+
+    internal ReadableStreamBYOBReaderConstructor(
+        Engine engine,
+        Realm realm,
+        FunctionPrototype functionPrototype,
+        ObjectPrototype objectPrototype)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = functionPrototype;
+        PrototypeObject = new ReadableStreamBYOBReaderPrototype(engine, realm, this, objectPrototype);
+        _length = new PropertyDescriptor(JsNumber.PositiveOne, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal ReadableStreamBYOBReaderPrototype PrototypeObject { get; }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#byob-reader-constructor
+    /// </summary>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        if (newTarget.IsUndefined())
+        {
+            Throw.TypeError(_realm, $"Constructor {GetOwnFunctionNameForMessage()} requires 'new'");
+        }
+
+        if (arguments.At(0) is not JsReadableStream stream)
+        {
+            Throw.TypeError(_realm, "Failed to construct 'ReadableStreamBYOBReader': the argument is not a ReadableStream");
+            return null!;
+        }
+
+        var reader = OrdinaryCreateFromConstructor(
+            newTarget,
+            static intrinsics => intrinsics.ReadableStreamBYOBReader.PrototypeObject,
+            static (Engine engine, Realm realm, object? _) => new JsReadableStreamBYOBReader(engine, realm));
+
+        ReadableStreamOperations.SetUpBYOBReader(reader, stream);
+        return reader;
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/ReadableStreamBYOBReaderPrototype.cs
+++ b/Jint/WebApi/Streams/ReadableStreamBYOBReaderPrototype.cs
@@ -1,0 +1,213 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Iterator;
+using Jint.Native.Object;
+using Jint.Native.Promise;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// <c>ReadableStreamBYOBReader.prototype</c> — the interface prototype object, carrying both the interface's
+/// own members and the <c>ReadableStreamGenericReader</c> mixin's.
+/// <para>
+/// https://streams.spec.whatwg.org/#byob-reader-prototype and
+/// https://streams.spec.whatwg.org/#generic-reader-prototype
+/// </para>
+/// </summary>
+/// <remarks>
+/// The mixin's two members are duplicated here rather than shared with
+/// <see cref="ReadableStreamDefaultReaderPrototype"/>, because that is what a WebIDL <c>includes</c>
+/// statement produces: each interface prototype object gets its own function objects, and
+/// <c>ReadableStreamBYOBReader.prototype.cancel !== ReadableStreamDefaultReader.prototype.cancel</c>.
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class ReadableStreamBYOBReaderPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly ReadableStreamBYOBReaderConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString ReaderToStringTag = new("ReadableStreamBYOBReader");
+
+    internal ReadableStreamBYOBReaderPrototype(
+        Engine engine,
+        Realm realm,
+        ReadableStreamBYOBReaderConstructor constructor,
+        ObjectInstance objectPrototype) : base(engine, realm)
+    {
+        _prototype = objectPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#generic-reader-closed
+    /// </summary>
+    [JsAccessor("closed", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsPromise ClosedGet(JsValue thisObject)
+    {
+        if (thisObject is not JsReadableStreamBYOBReader reader)
+        {
+            // The attribute's type is a promise type, so a failed brand check answers with a rejected
+            // promise rather than throwing — https://webidl.spec.whatwg.org/#dfn-attribute-getter.
+            return RejectedTypeError("Illegal invocation: receiver is not a ReadableStreamBYOBReader");
+        }
+
+        return reader.ClosedPromise;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#generic-reader-cancel
+    /// </summary>
+    [JsFunction(Name = "cancel", Length = 0)]
+    private JsPromise Cancel(JsValue thisObject, JsValue reason)
+    {
+        try
+        {
+            var reader = Brand(thisObject);
+
+            if (reader.Stream is null)
+            {
+                Throw.TypeError(_realm, "Cannot cancel a stream using a released reader");
+            }
+
+            return ReadableStreamOperations.ReaderGenericCancel(reader, reason);
+        }
+        catch (JavaScriptException e)
+        {
+            return StreamPromises.RejectedWith(_engine, _realm, e.Error);
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#byob-reader-read — the read that fills the caller's own buffer.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The view is <b>transferred</b>, so <paramref name="viewArgument"/> is detached and unusable the
+    /// moment this returns; the promise fulfils with a new view of the same type onto the same memory. That
+    /// is the whole point of a BYOB read — the buffer travels down to the source and back rather than being
+    /// copied — and it is why a read loop has to keep using the view it was <i>given</i> rather than the one
+    /// it passed in.
+    /// </para>
+    /// <para>
+    /// Every failure here is a rejection rather than a throw, including the brand check and the argument
+    /// conversions, because the operation's return type is a promise type —
+    /// https://webidl.spec.whatwg.org/#js-operations.
+    /// </para>
+    /// </remarks>
+    [JsFunction(Name = "read", Length = 1)]
+    private JsPromise Read(JsValue thisObject, JsValue viewArgument, JsValue options)
+    {
+        JsReadableStreamBYOBReader reader;
+        StreamBufferOperations.ArrayBufferViewInfo view;
+        int min;
+
+        try
+        {
+            reader = Brand(thisObject);
+            view = StreamBufferOperations.ReadArrayBufferView(_realm, viewArgument, "The view");
+            var minimum = StreamDictionaries.ReadMinimumFill(_realm, options);
+
+            if (view.ByteLength == 0)
+            {
+                Throw.TypeError(_realm, "The view has a byte length of 0");
+            }
+
+            if (view.Buffer.ArrayBufferByteLength == 0)
+            {
+                // Which is also how a detached buffer is caught: it has no byte length left.
+                Throw.TypeError(_realm, "The view's buffer has a byte length of 0");
+            }
+
+            if (minimum == 0)
+            {
+                Throw.TypeError(_realm, "The read options' min must be greater than 0");
+            }
+
+            if (minimum > (ulong) view.ArrayLength)
+            {
+                Throw.RangeError(_realm, "The read options' min is larger than the view");
+            }
+
+            if (reader.Stream is null)
+            {
+                Throw.TypeError(_realm, "Cannot read from a released reader");
+            }
+
+            min = (int) minimum;
+        }
+        catch (JavaScriptException e)
+        {
+            return StreamPromises.RejectedWith(_engine, _realm, e.Error);
+        }
+
+        var capability = StreamPromises.NewPromise(_engine, _realm);
+        ReadableStreamOperations.BYOBReaderRead(reader, in view, min, new ReaderReadIntoRequest(_engine, capability));
+        return StreamPromises.PromiseOf(capability);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#byob-reader-release-lock
+    /// </summary>
+    [JsFunction(Name = "releaseLock", Length = 0)]
+    private JsValue ReleaseLock(JsValue thisObject)
+    {
+        var reader = Brand(thisObject);
+
+        if (reader.Stream is null)
+        {
+            return Undefined;
+        }
+
+        ReadableStreamOperations.BYOBReaderRelease(reader);
+        return Undefined;
+    }
+
+    private JsPromise RejectedTypeError(string message)
+        => StreamPromises.RejectedWith(_engine, _realm, _realm.Intrinsics.TypeError.Construct(message));
+
+    private JsReadableStreamBYOBReader Brand(JsValue thisObject)
+    {
+        if (thisObject is JsReadableStreamBYOBReader reader)
+        {
+            return reader;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a ReadableStreamBYOBReader");
+        return null!;
+    }
+
+    /// <summary>
+    /// The read-into request behind <c>read()</c>. Its close steps carry the chunk, so a read of a closed
+    /// stream fulfils with <c>{ value: emptyViewOntoTheSameMemory, done: true }</c> — and a read of a
+    /// <i>cancelled</i> one with <c>{ value: undefined, done: true }</c>, the memory having been discarded.
+    /// </summary>
+    private sealed class ReaderReadIntoRequest : ReadIntoRequest
+    {
+        private readonly Engine _engine;
+        private readonly PromiseCapability _capability;
+
+        internal ReaderReadIntoRequest(Engine engine, PromiseCapability capability)
+        {
+            _engine = engine;
+            _capability = capability;
+        }
+
+        internal override void ChunkSteps(JsValue chunk)
+            => _capability.Resolve(IteratorResult.CreateValueIteratorPosition(_engine, chunk, JsBoolean.False));
+
+        internal override void CloseSteps(JsValue chunk)
+            => _capability.Resolve(IteratorResult.CreateValueIteratorPosition(_engine, chunk, JsBoolean.True));
+
+        internal override void ErrorSteps(JsValue error) => _capability.Reject(error);
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/ReadableStreamBYOBRequestConstructor.cs
+++ b/Jint/WebApi/Streams/ReadableStreamBYOBRequestConstructor.cs
@@ -1,0 +1,46 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// The <c>ReadableStreamBYOBRequest</c> interface object.
+/// <para>
+/// https://streams.spec.whatwg.org/#rs-byob-request-class
+/// </para>
+/// </summary>
+/// <remarks>
+/// It declares no constructor operation: a BYOB request only ever comes from
+/// <c>controller.byobRequest</c>. Like the controllers it is not installed as a global, and is reached
+/// through <c>Object.getPrototypeOf(controller.byobRequest).constructor</c>.
+/// </remarks>
+internal sealed class ReadableStreamBYOBRequestConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("ReadableStreamBYOBRequest");
+
+    internal ReadableStreamBYOBRequestConstructor(
+        Engine engine,
+        Realm realm,
+        FunctionPrototype functionPrototype,
+        ObjectPrototype objectPrototype)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = functionPrototype;
+        PrototypeObject = new ReadableStreamBYOBRequestPrototype(engine, realm, this, objectPrototype);
+        _length = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal ReadableStreamBYOBRequestPrototype PrototypeObject { get; }
+
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        Throw.TypeError(_realm, "Illegal constructor");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/ReadableStreamBYOBRequestPrototype.cs
+++ b/Jint/WebApi/Streams/ReadableStreamBYOBRequestPrototype.cs
@@ -1,0 +1,117 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// <c>ReadableStreamBYOBRequest.prototype</c> — the interface prototype object.
+/// <para>
+/// https://streams.spec.whatwg.org/#rs-byob-request-prototype
+/// </para>
+/// </summary>
+[JsObject(UseShape = true)]
+internal sealed partial class ReadableStreamBYOBRequestPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly ReadableStreamBYOBRequestConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString RequestToStringTag = new("ReadableStreamBYOBRequest");
+
+    internal ReadableStreamBYOBRequestPrototype(
+        Engine engine,
+        Realm realm,
+        ReadableStreamBYOBRequestConstructor constructor,
+        ObjectInstance objectPrototype) : base(engine, realm)
+    {
+        _prototype = objectPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rs-byob-request-view — <c>null</c> once the request has been
+    /// responded to or otherwise invalidated.
+    /// </summary>
+    [JsAccessor("view", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue ViewGet(JsValue thisObject)
+    {
+        var view = Brand(thisObject).View;
+        return view is null ? Null : view;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rs-byob-request-respond — "I wrote this many bytes into
+    /// <c>view</c>". The view is transferred by this call, so the underlying source must not write into it
+    /// afterwards.
+    /// </summary>
+    [JsFunction(Name = "respond", Length = 1)]
+    private JsValue Respond(JsValue thisObject, JsValue bytesWritten)
+    {
+        var request = Brand(thisObject);
+
+        // The argument is converted at the WebIDL layer, before the method's own steps — so a bytesWritten
+        // that is not a non-negative integer is reported even for an invalidated request.
+        var written = StreamDictionaries.ToEnforcedUnsignedLongLong(_realm, bytesWritten, "The bytesWritten");
+
+        if (request.Controller is not { } controller)
+        {
+            Throw.TypeError(_realm, "This BYOB request has been invalidated");
+            return Undefined;
+        }
+
+        if (request.View!._viewedArrayBuffer.IsDetachedBuffer)
+        {
+            Throw.TypeError(_realm, "The BYOB request's view has a detached buffer");
+        }
+
+        ReadableByteStreamControllerOperations.Respond(controller, written);
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rs-byob-request-respond-with-new-view — "I wrote into this other
+    /// view of the same memory instead", which is how a source that had to hand its buffer to something else
+    /// still avoids a copy.
+    /// </summary>
+    [JsFunction(Name = "respondWithNewView", Length = 1)]
+    private JsValue RespondWithNewView(JsValue thisObject, JsValue viewArgument)
+    {
+        var request = Brand(thisObject);
+        var view = StreamBufferOperations.ReadArrayBufferView(_realm, viewArgument, "The view");
+
+        if (request.Controller is not { } controller)
+        {
+            Throw.TypeError(_realm, "This BYOB request has been invalidated");
+            return Undefined;
+        }
+
+        if (view.Buffer.IsDetachedBuffer)
+        {
+            Throw.TypeError(_realm, "The view's buffer is detached");
+        }
+
+        ReadableByteStreamControllerOperations.RespondWithNewView(controller, in view);
+        return Undefined;
+    }
+
+    private JsReadableStreamBYOBRequest Brand(JsValue thisObject)
+    {
+        if (thisObject is JsReadableStreamBYOBRequest request)
+        {
+            return request;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a ReadableStreamBYOBRequest");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Streams/ReadableStreamConstructor.cs
+++ b/Jint/WebApi/Streams/ReadableStreamConstructor.cs
@@ -75,11 +75,20 @@ internal sealed partial class ReadableStreamConstructor : Constructor
 
         if (source.TypeExists)
         {
-            // `type: "bytes"` asks for a readable byte stream, which is not implemented: there is no
-            // ReadableByteStreamController and no BYOB reader. Refusing is the honest answer — the same
-            // TypeError an invalid enumeration value would produce — rather than handing back a stream that
-            // silently is not a byte stream.
-            Throw.TypeError(_realm, "Failed to construct 'ReadableStream': readable byte streams are not supported");
+            // `type: "bytes"` asks for a readable byte stream. Its queuing strategy may not carry a size()
+            // at all — a chunk's size is its byte length — and its default high water mark is 0 rather
+            // than 1, so a byte stream pulls only when a consumer asks.
+            if (strategy.Size is not null)
+            {
+                Throw.RangeError(_realm, "A readable byte stream cannot have a queuing strategy with a size function");
+            }
+
+            var byteHighWaterMark = StreamDictionaries.ExtractHighWaterMark(_realm, in strategy, 0);
+
+            ReadableByteStreamControllerOperations.SetUpFromUnderlyingSource(
+                stream, underlyingSource, in source, byteHighWaterMark);
+
+            return stream;
         }
 
         var sizeAlgorithm = StreamDictionaries.ExtractSizeAlgorithm(in strategy);
@@ -125,7 +134,7 @@ internal sealed partial class ReadableStreamConstructor : Constructor
                         return Undefined;
                     }
 
-                    var controller = stream.Controller;
+                    var controller = stream.DefaultController;
                     if (TypeConverter.ToBoolean(iterationObject.Get(CommonProperties.Done)))
                     {
                         ReadableStreamDefaultControllerOperations.Close(controller);

--- a/Jint/WebApi/Streams/ReadableStreamOperations.cs
+++ b/Jint/WebApi/Streams/ReadableStreamOperations.cs
@@ -55,6 +55,49 @@ internal static class ReadableStreamOperations
     }
 
     /// <summary>
+    /// https://streams.spec.whatwg.org/#create-readable-byte-stream — the byte-stream counterpart of
+    /// <see cref="CreateReadableStream"/>, for the streams the engine builds itself. The standard fixes its
+    /// high water mark at 0 and gives it no automatic allocation: a stream created this way pulls only when
+    /// a consumer asks.
+    /// </summary>
+    internal static JsReadableStream CreateReadableByteStream(
+        Engine engine,
+        Realm realm,
+        Func<JsValue> startAlgorithm,
+        Func<JsPromise> pullAlgorithm,
+        Func<JsValue, JsPromise> cancelAlgorithm)
+    {
+        var stream = new JsReadableStream(engine, realm)
+        {
+            _prototype = realm.Intrinsics.ReadableStream.PrototypeObject,
+        };
+
+        var controller = new JsReadableByteStreamController(engine, realm)
+        {
+            _prototype = realm.Intrinsics.ReadableByteStreamController.PrototypeObject,
+        };
+
+        ReadableByteStreamControllerOperations.SetUp(
+            stream, controller, startAlgorithm, pullAlgorithm, cancelAlgorithm, highWaterMark: 0, autoAllocateChunkSize: null);
+
+        return stream;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-stream-tee — which of the two tee algorithms applies is
+    /// decided by the kind of controller the stream has, and only here.
+    /// </summary>
+    internal static (JsReadableStream Branch1, JsReadableStream Branch2) Tee(JsReadableStream stream)
+    {
+        if (stream.Controller is JsReadableByteStreamController)
+        {
+            return ReadableByteStreamTee.Tee(stream);
+        }
+
+        return ReadableStreamTee.Tee(stream);
+    }
+
+    /// <summary>
     /// https://streams.spec.whatwg.org/#readable-stream-cancel
     /// </summary>
     internal static JsPromise Cancel(JsReadableStream stream, JsValue reason)
@@ -76,9 +119,18 @@ internal static class ReadableStreamOperations
 
         Close(stream);
 
-        // The BYOB half of this step ("if reader implements ReadableStreamBYOBReader, close its pending
-        // read-into requests") has no counterpart: there are no BYOB readers.
-        var sourceCancelPromise = ReadableStreamDefaultControllerOperations.CancelSteps(stream.Controller, reason);
+        // A cancelled BYOB read does not get its memory back — its close steps receive undefined rather
+        // than an empty view — which is the one place the two close paths differ.
+        if (stream.Reader is JsReadableStreamBYOBReader byobReader)
+        {
+            var readIntoRequests = byobReader.ReadIntoRequests;
+            while (readIntoRequests.Count > 0)
+            {
+                readIntoRequests.Dequeue().CloseSteps(JsValue.Undefined);
+            }
+        }
+
+        var sourceCancelPromise = stream.Controller.CancelSteps(reason);
 
         // "Return the result of reacting to sourceCancelPromise with a fulfillment step that returns
         // undefined" — the underlying source's own fulfillment value is deliberately discarded, so
@@ -102,8 +154,15 @@ internal static class ReadableStreamOperations
         reader.ClosedCapability.Resolve(JsValue.Undefined);
 
         // Every outstanding read() resolves with { value: undefined, done: true }. The list is emptied
-        // before the steps run, because a close step may start a fresh read.
-        var readRequests = reader.ReadRequests;
+        // before the steps run, because a close step may start a fresh read. A BYOB reader's pending
+        // read-into requests are deliberately not touched here: they are answered by the byte controller,
+        // which has a buffer to hand back, or by ReadableStreamCancel, which has not.
+        if (reader is not JsReadableStreamDefaultReader defaultReader)
+        {
+            return;
+        }
+
+        var readRequests = defaultReader.ReadRequests;
         while (readRequests.Count > 0)
         {
             readRequests.Dequeue().CloseSteps();
@@ -127,21 +186,34 @@ internal static class ReadableStreamOperations
         reader.ClosedCapability.Reject(error);
         StreamPromises.MarkHandled(reader.ClosedPromise);
 
-        DefaultReaderErrorReadRequests(reader, error);
+        if (reader is JsReadableStreamDefaultReader defaultReader)
+        {
+            DefaultReaderErrorReadRequests(defaultReader, error);
+        }
+        else
+        {
+            BYOBReaderErrorReadIntoRequests((JsReadableStreamBYOBReader) reader, error);
+        }
     }
 
     /// <summary>
     /// https://streams.spec.whatwg.org/#readable-stream-add-read-request
     /// </summary>
     internal static void AddReadRequest(JsReadableStream stream, ReadRequest readRequest)
-        => stream.Reader!.ReadRequests.Enqueue(readRequest);
+        => ((JsReadableStreamDefaultReader) stream.Reader!).ReadRequests.Enqueue(readRequest);
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-stream-add-read-into-request
+    /// </summary>
+    internal static void AddReadIntoRequest(JsReadableStream stream, ReadIntoRequest readIntoRequest)
+        => ((JsReadableStreamBYOBReader) stream.Reader!).ReadIntoRequests.Enqueue(readIntoRequest);
 
     /// <summary>
     /// https://streams.spec.whatwg.org/#readable-stream-fulfill-read-request
     /// </summary>
     internal static void FulfillReadRequest(JsReadableStream stream, JsValue chunk, bool done)
     {
-        var readRequest = stream.Reader!.ReadRequests.Dequeue();
+        var readRequest = ((JsReadableStreamDefaultReader) stream.Reader!).ReadRequests.Dequeue();
         if (done)
         {
             readRequest.CloseSteps();
@@ -153,15 +225,43 @@ internal static class ReadableStreamOperations
     }
 
     /// <summary>
-    /// https://streams.spec.whatwg.org/#readable-stream-get-num-read-requests
+    /// https://streams.spec.whatwg.org/#readable-stream-fulfill-read-into-request — the close steps take the
+    /// chunk, so a BYOB read of a closing stream still gets its buffer back.
     /// </summary>
-    internal static int GetNumReadRequests(JsReadableStream stream) => stream.Reader!.ReadRequests.Count;
+    internal static void FulfillReadIntoRequest(JsReadableStream stream, JsValue chunk, bool done)
+    {
+        var readIntoRequest = ((JsReadableStreamBYOBReader) stream.Reader!).ReadIntoRequests.Dequeue();
+        if (done)
+        {
+            readIntoRequest.CloseSteps(chunk);
+        }
+        else
+        {
+            readIntoRequest.ChunkSteps(chunk);
+        }
+    }
 
     /// <summary>
-    /// https://streams.spec.whatwg.org/#readable-stream-has-default-reader. Always equivalent to being
-    /// locked here, since a default reader is the only kind of reader there is.
+    /// https://streams.spec.whatwg.org/#readable-stream-get-num-read-requests
     /// </summary>
-    internal static bool HasDefaultReader(JsReadableStream stream) => stream.Reader is not null;
+    internal static int GetNumReadRequests(JsReadableStream stream)
+        => ((JsReadableStreamDefaultReader) stream.Reader!).ReadRequests.Count;
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-stream-get-num-read-into-requests
+    /// </summary>
+    internal static int GetNumReadIntoRequests(JsReadableStream stream)
+        => ((JsReadableStreamBYOBReader) stream.Reader!).ReadIntoRequests.Count;
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-stream-has-default-reader
+    /// </summary>
+    internal static bool HasDefaultReader(JsReadableStream stream) => stream.Reader is JsReadableStreamDefaultReader;
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-stream-has-byob-reader
+    /// </summary>
+    internal static bool HasBYOBReader(JsReadableStream stream) => stream.Reader is JsReadableStreamBYOBReader;
 
     /// <summary>
     /// https://streams.spec.whatwg.org/#acquire-readable-stream-reader
@@ -174,6 +274,20 @@ internal static class ReadableStreamOperations
         };
 
         SetUpDefaultReader(reader, stream);
+        return reader;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#acquire-readable-stream-byob-reader
+    /// </summary>
+    internal static JsReadableStreamBYOBReader AcquireBYOBReader(JsReadableStream stream)
+    {
+        var reader = new JsReadableStreamBYOBReader(stream.Engine, stream.Realm)
+        {
+            _prototype = stream.Realm.Intrinsics.ReadableStreamBYOBReader.PrototypeObject,
+        };
+
+        SetUpBYOBReader(reader, stream);
         return reader;
     }
 
@@ -191,9 +305,29 @@ internal static class ReadableStreamOperations
     }
 
     /// <summary>
+    /// https://streams.spec.whatwg.org/#set-up-readable-stream-byob-reader — a BYOB reader can only be
+    /// acquired from a stream whose controller is a byte controller, which is the whole of what makes
+    /// getReader({ mode: "byob" }) refuse an ordinary stream.
+    /// </summary>
+    internal static void SetUpBYOBReader(JsReadableStreamBYOBReader reader, JsReadableStream stream)
+    {
+        if (IsLocked(stream))
+        {
+            Throw.TypeError(reader.Realm, "This readable stream is already locked for exclusive reading by another reader");
+        }
+
+        if (stream.Controller is not JsReadableByteStreamController)
+        {
+            Throw.TypeError(reader.Realm, "Cannot construct a ReadableStreamBYOBReader for a stream not constructed with a byte source");
+        }
+
+        ReaderGenericInitialize(reader, stream);
+    }
+
+    /// <summary>
     /// https://streams.spec.whatwg.org/#readable-stream-reader-generic-initialize
     /// </summary>
-    private static void ReaderGenericInitialize(JsReadableStreamDefaultReader reader, JsReadableStream stream)
+    private static void ReaderGenericInitialize(JsReadableStreamReader reader, JsReadableStream stream)
     {
         var engine = reader.Engine;
         var realm = reader.Realm;
@@ -223,13 +357,13 @@ internal static class ReadableStreamOperations
     /// <summary>
     /// https://streams.spec.whatwg.org/#readable-stream-reader-generic-cancel
     /// </summary>
-    internal static JsPromise ReaderGenericCancel(JsReadableStreamDefaultReader reader, JsValue reason)
+    internal static JsPromise ReaderGenericCancel(JsReadableStreamReader reader, JsValue reason)
         => Cancel(reader.Stream!, reason);
 
     /// <summary>
     /// https://streams.spec.whatwg.org/#readable-stream-reader-generic-release
     /// </summary>
-    private static void ReaderGenericRelease(JsReadableStreamDefaultReader reader)
+    private static void ReaderGenericRelease(JsReadableStreamReader reader)
     {
         var engine = reader.Engine;
         var realm = reader.Realm;
@@ -253,8 +387,10 @@ internal static class ReadableStreamOperations
 
         StreamPromises.MarkHandled(reader.ClosedPromise);
 
-        // The default controller's [[ReleaseSteps]] do nothing; the byte controller's, which discards
-        // pending pull-intos, has no counterpart here.
+        // The default controller's [[ReleaseSteps]] do nothing; the byte controller's downgrades the
+        // pull-into descriptor the underlying source may be writing into right now.
+        stream.Controller.ReleaseSteps();
+
         stream.Reader = null;
         reader.Stream = null;
     }
@@ -278,9 +414,33 @@ internal static class ReadableStreamOperations
                 break;
 
             default:
-                ReadableStreamDefaultControllerOperations.PullSteps(stream.Controller, readRequest);
+                stream.Controller.PullSteps(readRequest);
                 break;
         }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#readable-stream-byob-reader-read
+    /// </summary>
+    internal static void BYOBReaderRead(
+        JsReadableStreamBYOBReader reader,
+        in StreamBufferOperations.ArrayBufferViewInfo view,
+        int min,
+        ReadIntoRequest readIntoRequest)
+    {
+        var stream = reader.Stream!;
+        stream.Disturbed = true;
+
+        if (stream.State == ReadableStreamState.Errored)
+        {
+            readIntoRequest.ErrorSteps(stream.StoredError);
+            return;
+        }
+
+        // Unlike a default read, a closed stream is not short-circuited here: the byte controller answers
+        // it, because it is the one that can hand the caller's memory back as an empty view.
+        ReadableByteStreamControllerOperations.PullInto(
+            (JsReadableByteStreamController) stream.Controller, in view, min, readIntoRequest);
     }
 
     /// <summary>
@@ -302,6 +462,28 @@ internal static class ReadableStreamOperations
         while (readRequests.Count > 0)
         {
             readRequests.Dequeue().ErrorSteps(error);
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#abstract-opdef-readablestreambyobreaderrelease
+    /// </summary>
+    internal static void BYOBReaderRelease(JsReadableStreamBYOBReader reader)
+    {
+        var realm = reader.Realm;
+        ReaderGenericRelease(reader);
+        BYOBReaderErrorReadIntoRequests(reader, realm.Intrinsics.TypeError.Construct("Reader was released"));
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#abstract-opdef-readablestreambyobreadererrorreadintorequests
+    /// </summary>
+    private static void BYOBReaderErrorReadIntoRequests(JsReadableStreamBYOBReader reader, JsValue error)
+    {
+        var readIntoRequests = reader.ReadIntoRequests;
+        while (readIntoRequests.Count > 0)
+        {
+            readIntoRequests.Dequeue().ErrorSteps(error);
         }
     }
 

--- a/Jint/WebApi/Streams/ReadableStreamPrototype.cs
+++ b/Jint/WebApi/Streams/ReadableStreamPrototype.cs
@@ -87,15 +87,15 @@ internal sealed partial class ReadableStreamPrototype : Prototype
     /// https://streams.spec.whatwg.org/#rs-get-reader
     /// </summary>
     [JsFunction(Name = "getReader", Length = 0)]
-    private JsReadableStreamDefaultReader GetReader(JsValue thisObject, JsValue options)
+    private JsReadableStreamReader GetReader(JsValue thisObject, JsValue options)
     {
         var stream = Brand(thisObject);
 
+        // A BYOB reader can only be acquired from a readable byte stream; asking for one from an ordinary
+        // stream is the TypeError SetUpReadableStreamBYOBReader raises.
         if (StreamDictionaries.ReadByobModeRequested(_realm, options))
         {
-            // A BYOB reader can only be acquired from a readable byte stream, and there are none here — so
-            // the specification's own TypeError for that case is the right and only answer.
-            Throw.TypeError(_realm, "Cannot construct a ReadableStreamBYOBReader for a stream not constructed with a byte source");
+            return ReadableStreamOperations.AcquireBYOBReader(stream);
         }
 
         return ReadableStreamOperations.AcquireDefaultReader(stream);
@@ -174,7 +174,7 @@ internal sealed partial class ReadableStreamPrototype : Prototype
     [JsFunction(Name = "tee", Length = 0)]
     private JsArray Tee(JsValue thisObject)
     {
-        var (branch1, branch2) = ReadableStreamTee.Tee(Brand(thisObject));
+        var (branch1, branch2) = ReadableStreamOperations.Tee(Brand(thisObject));
         return new JsArray(_engine, [branch1, branch2]);
     }
 

--- a/Jint/WebApi/Streams/ReadableStreamTee.cs
+++ b/Jint/WebApi/Streams/ReadableStreamTee.cs
@@ -65,8 +65,8 @@ internal sealed class ReadableStreamTee
         // only channel that reports an error arriving while no read is outstanding.
         StreamPromises.UponRejection(tee._engine, tee._reader.ClosedPromise, error =>
         {
-            ReadableStreamDefaultControllerOperations.Error(tee._branch1.Controller, error);
-            ReadableStreamDefaultControllerOperations.Error(tee._branch2.Controller, error);
+            ReadableStreamDefaultControllerOperations.Error(tee._branch1.DefaultController, error);
+            ReadableStreamDefaultControllerOperations.Error(tee._branch2.DefaultController, error);
             if (!tee._canceled1 || !tee._canceled2)
             {
                 tee._cancelCapability.Resolve(JsValue.Undefined);
@@ -157,12 +157,12 @@ internal sealed class ReadableStreamTee
                 // Both branches receive the very same chunk: this tee never clones.
                 if (!_tee._canceled1)
                 {
-                    ReadableStreamDefaultControllerOperations.Enqueue(_tee._branch1.Controller, chunk);
+                    ReadableStreamDefaultControllerOperations.Enqueue(_tee._branch1.DefaultController, chunk);
                 }
 
                 if (!_tee._canceled2)
                 {
-                    ReadableStreamDefaultControllerOperations.Enqueue(_tee._branch2.Controller, chunk);
+                    ReadableStreamDefaultControllerOperations.Enqueue(_tee._branch2.DefaultController, chunk);
                 }
 
                 _tee._reading = false;
@@ -179,12 +179,12 @@ internal sealed class ReadableStreamTee
 
             if (!_tee._canceled1)
             {
-                ReadableStreamDefaultControllerOperations.Close(_tee._branch1.Controller);
+                ReadableStreamDefaultControllerOperations.Close(_tee._branch1.DefaultController);
             }
 
             if (!_tee._canceled2)
             {
-                ReadableStreamDefaultControllerOperations.Close(_tee._branch2.Controller);
+                ReadableStreamDefaultControllerOperations.Close(_tee._branch2.DefaultController);
             }
 
             if (!_tee._canceled1 || !_tee._canceled2)

--- a/Jint/WebApi/Streams/StreamBufferOperations.cs
+++ b/Jint/WebApi/Streams/StreamBufferOperations.cs
@@ -1,0 +1,180 @@
+#if NET8_0_OR_GREATER
+using System.Runtime.InteropServices;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Native.TypedArray;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// The <c>ArrayBuffer</c> plumbing a readable byte stream is built on: the standard's
+/// <c>TransferArrayBuffer</c>, <c>CloneAsUint8Array</c> and the data-block copy behind
+/// <c>ReadableByteStreamControllerFillPullIntoDescriptorFromQueue</c>, plus the WebIDL
+/// <c>ArrayBufferView</c> conversion every byte-stream entry point starts with.
+/// <para>
+/// https://streams.spec.whatwg.org/#misc-abstract-ops
+/// </para>
+/// </summary>
+internal static class StreamBufferOperations
+{
+    /// <summary>
+    /// What a byte stream needs to know about a view it was handed:
+    /// https://webidl.spec.whatwg.org/#ArrayBufferView.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="ElementType"/> is <see langword="null"/> for a <c>DataView</c>, which is exactly the
+    /// standard's "if view has a [[TypedArrayName]] internal slot" test, and it is also what a pull-into
+    /// descriptor records as its view constructor: the specification takes the constructor from the typed
+    /// array constructors table rather than from the view's own <c>constructor</c> property, so a subclass
+    /// instance is filled and handed back as a plain view of its element type.
+    /// </remarks>
+    [StructLayout(LayoutKind.Auto)]
+    internal readonly record struct ArrayBufferViewInfo(
+        JsArrayBuffer Buffer,
+        int ByteOffset,
+        int ByteLength,
+        int ArrayLength,
+        int ElementSize,
+        TypedArrayElementType? ElementType);
+
+    /// <summary>
+    /// The WebIDL <c>ArrayBufferView</c> conversion. A value that is not a view — or is a view onto a
+    /// <c>SharedArrayBuffer</c>, which only an <c>[AllowShared]</c> declaration would accept and none of the
+    /// stream declarations carries — raises a <c>TypeError</c>.
+    /// </summary>
+    internal static ArrayBufferViewInfo ReadArrayBufferView(Realm realm, JsValue value, string what)
+    {
+        if (value is JsTypedArray typedArray)
+        {
+            var buffer = typedArray._viewedArrayBuffer;
+            AssertNotShared(realm, buffer, what);
+
+            var elementSize = typedArray._arrayElementType.GetElementSize();
+
+            // Length is the buffer-witness answer, so a length-tracking view over a resizable buffer
+            // reports what it currently covers and a detached one reports zero — which is what
+            // [[ArrayLength]] and [[ByteLength]] evaluate to in the same situations.
+            var arrayLength = (int) typedArray.Length;
+
+            return new ArrayBufferViewInfo(
+                buffer,
+                typedArray._byteOffset,
+                arrayLength * elementSize,
+                arrayLength,
+                elementSize,
+                typedArray._arrayElementType);
+        }
+
+        if (value is JsDataView dataView)
+        {
+            var buffer = dataView._viewedArrayBuffer;
+            if (buffer is null)
+            {
+                Throw.TypeError(realm, $"{what} is not an ArrayBufferView");
+                return default;
+            }
+
+            AssertNotShared(realm, buffer, what);
+
+            var byteOffset = (int) dataView._byteOffset;
+            var byteLength = dataView._byteLength == JsTypedArray.LengthAuto
+                ? System.Math.Max(buffer.ArrayBufferByteLength - byteOffset, 0)
+                : (int) dataView._byteLength;
+
+            // A DataView's "number of elements" is its byte length: the element size the standard gives a
+            // DataView pull-into descriptor is 1.
+            return new ArrayBufferViewInfo(buffer, byteOffset, byteLength, byteLength, 1, ElementType: null);
+        }
+
+        Throw.TypeError(realm, $"{what} is not an ArrayBufferView");
+        return default;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#transfer-array-buffer — a move, not a copy: the new buffer takes the
+    /// very same data block and the old one is detached, which is what makes every buffer a byte stream
+    /// touches unusable by the code that handed it over.
+    /// </summary>
+    internal static JsArrayBuffer TransferArrayBuffer(Realm realm, JsArrayBuffer buffer)
+    {
+        // "Perform ? DetachArrayBuffer(O). This will throw an exception if O has an [[ArrayBufferDetachKey]]
+        // that is not undefined" — and, per https://tc39.es/proposal-immutable-arraybuffer/, an immutable
+        // buffer cannot be detached at all. The Streams Standard predates that proposal and so does not
+        // mention it; refusing is the only answer that keeps an immutable buffer immutable.
+        buffer.AssertNotImmutable();
+
+        var data = buffer.ArrayBufferData!;
+        buffer.DetachArrayBuffer();
+
+        return new JsArrayBuffer(buffer.Engine, data)
+        {
+            _prototype = realm.Intrinsics.ArrayBuffer.PrototypeObject,
+        };
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#abstract-opdef-cloneasuint8array, generalized to the region a
+    /// caller names — which is also the <c>CloneArrayBuffer</c> behind
+    /// <c>ReadableByteStreamControllerEnqueueClonedChunkToQueue</c>.
+    /// </summary>
+    internal static JsArrayBuffer CloneArrayBufferRegion(Realm realm, JsArrayBuffer buffer, int byteOffset, int byteLength)
+        => buffer.CloneArrayBuffer(realm.Intrinsics.ArrayBuffer, byteOffset, (uint) byteLength);
+
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-copydatablockbytes, on the two buffers' data blocks.
+    /// </summary>
+    internal static void CopyDataBlockBytes(JsArrayBuffer to, int toIndex, JsArrayBuffer from, int fromIndex, int count)
+        => System.Array.Copy(from.ArrayBufferData!, fromIndex, to.ArrayBufferData!, toIndex, count);
+
+    /// <summary>
+    /// Builds the view a filled pull-into descriptor is handed back as, or the empty one a closed stream
+    /// answers a BYOB read with: <c>Construct(ctor, « buffer, byteOffset, length »)</c> where <c>ctor</c>
+    /// comes from the typed array constructors table, or is <c>%DataView%</c>.
+    /// </summary>
+    internal static ObjectInstance ConstructView(Realm realm, TypedArrayElementType? elementType, JsArrayBuffer buffer, int byteOffset, int length)
+    {
+        if (elementType is not { } type)
+        {
+            var dataView = realm.Intrinsics.DataView;
+            return dataView.Construct([buffer, JsNumber.Create(byteOffset), JsNumber.Create(length)], dataView);
+        }
+
+        return ConstructorFor(realm, type).Construct(buffer, byteOffset, length);
+    }
+
+    /// <summary>
+    /// <c>Construct(%Uint8Array%, « buffer, byteOffset, byteLength »)</c> — the view every chunk a default
+    /// reader takes out of a byte stream's queue is handed over as.
+    /// </summary>
+    internal static JsTypedArray ConstructUint8Array(Realm realm, JsArrayBuffer buffer, int byteOffset, int byteLength)
+        => realm.Intrinsics.Uint8Array.Construct(buffer, byteOffset, byteLength);
+
+    private static void AssertNotShared(Realm realm, JsArrayBuffer buffer, string what)
+    {
+        if (buffer.IsSharedArrayBuffer)
+        {
+            // Only an [AllowShared] declaration accepts a view onto shared memory, and no member of the
+            // Streams Standard carries one — https://webidl.spec.whatwg.org/#AllowSharedBufferSource.
+            Throw.TypeError(realm, $"{what} is backed by a SharedArrayBuffer");
+        }
+    }
+
+    private static Native.TypedArray.TypedArrayConstructor ConstructorFor(Realm realm, TypedArrayElementType type) => type switch
+    {
+        TypedArrayElementType.Int8 => realm.Intrinsics.Int8Array,
+        TypedArrayElementType.Uint8 => realm.Intrinsics.Uint8Array,
+        TypedArrayElementType.Uint8C => realm.Intrinsics.Uint8ClampedArray,
+        TypedArrayElementType.Int16 => realm.Intrinsics.Int16Array,
+        TypedArrayElementType.Uint16 => realm.Intrinsics.Uint16Array,
+        TypedArrayElementType.Int32 => realm.Intrinsics.Int32Array,
+        TypedArrayElementType.Uint32 => realm.Intrinsics.Uint32Array,
+        TypedArrayElementType.BigInt64 => realm.Intrinsics.BigInt64Array,
+        TypedArrayElementType.BigUint64 => realm.Intrinsics.BigUint64Array,
+        TypedArrayElementType.Float16 => realm.Intrinsics.Float16Array,
+        TypedArrayElementType.Float32 => realm.Intrinsics.Float32Array,
+        TypedArrayElementType.Float64 => realm.Intrinsics.Float64Array,
+        _ => throw new InvalidOperationException("Unknown typed array element type " + type),
+    };
+}
+#endif

--- a/Jint/WebApi/Streams/StreamDictionaries.cs
+++ b/Jint/WebApi/Streams/StreamDictionaries.cs
@@ -38,8 +38,18 @@ internal static class StreamDictionaries
     /// <summary>
     /// The <c>UnderlyingSource</c> dictionary — https://streams.spec.whatwg.org/#dictdef-underlyingsource.
     /// </summary>
+    /// <remarks>
+    /// <c>TypeExists</c> is the whole of the <c>type</c> member: the <c>ReadableStreamType</c> enumeration
+    /// has exactly one value, so a member that exists is <c>"bytes"</c> and anything else has already been
+    /// refused by the enumeration conversion.
+    /// </remarks>
     [StructLayout(LayoutKind.Auto)]
-    internal readonly record struct UnderlyingSourceRecord(ICallable? Start, ICallable? Pull, ICallable? Cancel, bool TypeExists);
+    internal readonly record struct UnderlyingSourceRecord(
+        ICallable? Start,
+        ICallable? Pull,
+        ICallable? Cancel,
+        bool TypeExists,
+        ulong? AutoAllocateChunkSize);
 
     /// <summary>
     /// The <c>UnderlyingSink</c> dictionary — https://streams.spec.whatwg.org/#dictdef-underlyingsink.
@@ -141,10 +151,10 @@ internal static class StreamDictionaries
     /// <c>autoAllocateChunkSize</c>, <c>cancel</c>, <c>pull</c>, <c>start</c>, <c>type</c>.
     /// </summary>
     /// <remarks>
-    /// <c>autoAllocateChunkSize</c> is read and converted even though it is meaningless without
-    /// <c>type: "bytes"</c>: the conversion is observable — it is an <c>[EnforceRange] unsigned long long</c>,
-    /// so a getter that throws, or a value out of range, is reported from here — and the specification
-    /// simply ignores the converted value for a non-byte stream.
+    /// <c>autoAllocateChunkSize</c> is read and converted even for a stream that is not a byte stream: the
+    /// conversion is observable — it is an <c>[EnforceRange] unsigned long long</c>, so a getter that
+    /// throws, or a value out of range, is reported from here — and the specification simply ignores the
+    /// converted value in that case.
     /// </remarks>
     internal static UnderlyingSourceRecord ReadUnderlyingSource(Realm realm, JsValue value)
     {
@@ -155,13 +165,13 @@ internal static class StreamDictionaries
             return default;
         }
 
-        ReadEnforcedUnsignedLongLong(realm, dictionary, "autoAllocateChunkSize", What);
+        var autoAllocateChunkSize = ReadEnforcedUnsignedLongLong(realm, dictionary, "autoAllocateChunkSize", What);
         var cancel = ReadCallback(realm, dictionary, "cancel", What);
         var pull = ReadCallback(realm, dictionary, "pull", What);
         var start = ReadCallback(realm, dictionary, "start", What);
         var typeExists = ReadReadableStreamType(realm, dictionary);
 
-        return new UnderlyingSourceRecord(start, pull, cancel, typeExists);
+        return new UnderlyingSourceRecord(start, pull, cancel, typeExists, autoAllocateChunkSize);
     }
 
     /// <summary>
@@ -321,6 +331,24 @@ internal static class StreamDictionaries
     }
 
     /// <summary>
+    /// The <c>ReadableStreamBYOBReaderReadOptions</c> conversion —
+    /// https://streams.spec.whatwg.org/#dictdef-readablestreambyobreaderreadoptions. Its single member
+    /// <c>min</c> is an <c>[EnforceRange] unsigned long long</c> with a default of 1, so an absent member
+    /// and an explicit <see langword="undefined"/> both mean "as soon as one element is available".
+    /// </summary>
+    internal static ulong ReadMinimumFill(Realm realm, JsValue value)
+    {
+        const string What = "The read options";
+        var dictionary = AsDictionary(realm, value, What);
+        if (dictionary is null)
+        {
+            return 1;
+        }
+
+        return ReadEnforcedUnsignedLongLong(realm, dictionary, "min", What) ?? 1;
+    }
+
+    /// <summary>
     /// The <c>ReadableStreamIteratorOptions</c> conversion —
     /// https://streams.spec.whatwg.org/#dictdef-readablestreamiteratoroptions. <c>preventCancel</c> has a
     /// default of false, so an absent member and an explicit <see langword="undefined"/> both mean false.
@@ -389,25 +417,36 @@ internal static class StreamDictionaries
     /// https://webidl.spec.whatwg.org/#js-unsigned-long-long: a value that is not a finite number, or whose
     /// integer part falls outside the type, is a <c>TypeError</c> rather than a wrap.
     /// </summary>
-    private static void ReadEnforcedUnsignedLongLong(Realm realm, ObjectInstance dictionary, string name, string what)
+    private static ulong? ReadEnforcedUnsignedLongLong(Realm realm, ObjectInstance dictionary, string name, string what)
     {
         var value = dictionary.Get(name);
         if (value.IsUndefined())
         {
-            return;
+            return null;
         }
 
+        return ToEnforcedUnsignedLongLong(realm, value, $"{what}.{name}");
+    }
+
+    /// <summary>
+    /// The <c>[EnforceRange] unsigned long long</c> conversion of an argument rather than of a dictionary
+    /// member, https://webidl.spec.whatwg.org/#js-unsigned-long-long.
+    /// </summary>
+    internal static ulong ToEnforcedUnsignedLongLong(Realm realm, JsValue value, string what)
+    {
         var number = TypeConverter.ToNumber(value);
         if (!double.IsFinite(number))
         {
-            Throw.TypeError(realm, $"{what}.{name} is not a finite number");
+            Throw.TypeError(realm, $"{what} is not a finite number");
         }
 
         var integer = Math.Truncate(number);
         if (integer < 0 || integer > 18446744073709551615d)
         {
-            Throw.TypeError(realm, $"{what}.{name} is outside the range of an unsigned long long");
+            Throw.TypeError(realm, $"{what} is outside the range of an unsigned long long");
         }
+
+        return (ulong) integer;
     }
 }
 #endif

--- a/Jint/WebApi/Streams/TransformStreamDefaultControllerPrototype.cs
+++ b/Jint/WebApi/Streams/TransformStreamDefaultControllerPrototype.cs
@@ -44,7 +44,7 @@ internal sealed partial class TransformStreamDefaultControllerPrototype : Protot
     [JsAccessor("desiredSize", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
     private JsValue DesiredSizeGet(JsValue thisObject)
     {
-        var readableController = Brand(thisObject).Stream.Readable.Controller;
+        var readableController = Brand(thisObject).Stream.Readable.DefaultController;
         var desiredSize = ReadableStreamDefaultControllerOperations.GetDesiredSize(readableController);
         return desiredSize is { } value ? JsNumber.Create(value) : Null;
     }

--- a/Jint/WebApi/Streams/TransformStreamOperations.cs
+++ b/Jint/WebApi/Streams/TransformStreamOperations.cs
@@ -157,7 +157,7 @@ internal static class TransformStreamOperations
     /// </remarks>
     internal static void Error(JsTransformStream stream, JsValue error)
     {
-        ReadableStreamDefaultControllerOperations.Error(stream.Readable.Controller, error);
+        ReadableStreamDefaultControllerOperations.Error(stream.Readable.DefaultController, error);
         ErrorWritableAndUnblockWrite(stream, error);
     }
 
@@ -280,7 +280,7 @@ internal static class TransformStreamOperations
     internal static void ControllerEnqueue(JsTransformStreamDefaultController controller, JsValue chunk)
     {
         var stream = controller.Stream;
-        var readableController = stream.Readable.Controller;
+        var readableController = stream.Readable.DefaultController;
 
         if (!ReadableStreamDefaultControllerOperations.CanCloseOrEnqueue(readableController))
         {
@@ -346,7 +346,7 @@ internal static class TransformStreamOperations
     {
         var stream = controller.Stream;
 
-        ReadableStreamDefaultControllerOperations.Close(stream.Readable.Controller);
+        ReadableStreamDefaultControllerOperations.Close(stream.Readable.DefaultController);
 
         // The writable side is errored rather than closed: a producer still writing has to be told that its
         // chunks will never be transformed.
@@ -428,13 +428,13 @@ internal static class TransformStreamOperations
                 }
                 else
                 {
-                    ReadableStreamDefaultControllerOperations.Error(readable.Controller, reason);
+                    ReadableStreamDefaultControllerOperations.Error(readable.DefaultController, reason);
                     finish.Resolve(JsValue.Undefined);
                 }
             },
             error =>
             {
-                ReadableStreamDefaultControllerOperations.Error(readable.Controller, error);
+                ReadableStreamDefaultControllerOperations.Error(readable.DefaultController, error);
                 finish.Reject(error);
             });
 
@@ -474,13 +474,13 @@ internal static class TransformStreamOperations
                 }
                 else
                 {
-                    ReadableStreamDefaultControllerOperations.Close(readable.Controller);
+                    ReadableStreamDefaultControllerOperations.Close(readable.DefaultController);
                     finish.Resolve(JsValue.Undefined);
                 }
             },
             error =>
             {
-                ReadableStreamDefaultControllerOperations.Error(readable.Controller, error);
+                ReadableStreamDefaultControllerOperations.Error(readable.DefaultController, error);
                 finish.Reject(error);
             });
 

--- a/Jint/WebApi/WebApiRegistration.cs
+++ b/Jint/WebApi/WebApiRegistration.cs
@@ -162,10 +162,12 @@ internal static class WebApiRegistration
 
         if ((features & WebApiFeatures.Streams) != WebApiFeatures.None)
         {
-            // Only the five interfaces a script constructs directly are globals. ReadableStreamDefaultReader,
-            // the three controllers and WritableStreamDefaultWriter exist as ordinary interface objects and
-            // are reached through their instances' prototypes — a deliberate, documented narrowing of the
-            // browser surface, since nothing but feature detection ever names them.
+            // Only the five interfaces a script constructs directly are globals. The readers, the four
+            // controllers and ReadableStreamBYOBRequest exist as ordinary interface objects and are reached
+            // through their instances' prototypes — a deliberate, documented narrowing of the browser
+            // surface, since nothing but feature detection ever names them. That includes the byte-stream
+            // interfaces: a byte stream is asked for as new ReadableStream({ type: "bytes" }) and a BYOB
+            // reader as stream.getReader({ mode: "byob" }), never by naming the interface.
             Install(global, engine, "ReadableStream", static e => e.Realm.Intrinsics.ReadableStream, PropertyFlag.NonEnumerable);
             Install(global, engine, "WritableStream", static e => e.Realm.Intrinsics.WritableStream, PropertyFlag.NonEnumerable);
             Install(global, engine, "TransformStream", static e => e.Realm.Intrinsics.TransformStream, PropertyFlag.NonEnumerable);

--- a/README.md
+++ b/README.md
@@ -602,7 +602,7 @@ failures apart; the real cause rides the error value and is readable by the host
 `JintException.TryGetClrException`. See [THREAT_MODEL.md](.github/THREAT_MODEL.md) TM-21 for the full
 analysis, including what these controls do *not* cover.
 
-### Streams are the default (non-byte) half of the standard
+### Streams, including byte streams
 
 `ReadableStream`, `WritableStream` and `TransformStream` implement the WHATWG Streams Standard operation by
 operation: queuing strategies and `desiredSize`, the `pull` reentrancy rules, `tee()` with its composite
@@ -613,16 +613,26 @@ promise and every callback you supply — `start`, `pull`, `cancel`, `write`, `c
 `flush`, `size` — runs on the engine's thread from the same job queue that runs promise reactions, so the
 microtask ordering the standard prescribes is the ordering you get, and nothing here ever starts a thread.
 
-Two deliberate reductions:
+**Byte streams are there too.** `new ReadableStream({ type: 'bytes' })` gives its underlying source a
+`ReadableByteStreamController`, with `byobRequest`, `autoAllocateChunkSize` and a `desiredSize` counted in
+bytes; `stream.getReader({ mode: 'byob' })` gives the consumer a `ReadableStreamBYOBReader` whose
+`read(view, { min })` fills the buffer the caller supplied. Buffers are *transferred* across every crossing,
+exactly as the standard requires — hand a view to `enqueue()` or to a BYOB `read()` and yours is detached,
+while the one you get back owns the memory — so a read loop recycles one allocation instead of allocating per
+chunk. `tee()` on a byte stream produces two byte streams, and swaps between a default and a BYOB reader on
+the original depending on how each branch is being read.
 
-- **Byte streams are absent, not broken.** There is no `ReadableByteStreamController`, no BYOB reader and no
-  `ReadableStreamBYOBRequest`, and `new ReadableStream({ type: 'bytes' })` raises a `TypeError` rather than
-  handing back something that is not a byte stream. `getReader({ mode: 'byob' })` raises the same `TypeError`
-  the standard gives for a stream that was not constructed with a byte source.
-- **Only the five interfaces a script constructs by name are globals.** `ReadableStreamDefaultReader`,
-  `WritableStreamDefaultWriter` and the three controllers exist as ordinary interface objects — a reader's
-  `constructor` is the real thing, and `new` on it behaves as the standard says — but they are not installed
-  on `globalThis`, where a browser would expose them.
+The streams the *engine* hands out are not byte streams yet: `response.body`, `request.body` and
+`Blob.stream()` are ordinary streams carrying `Uint8Array` chunks, so `getReader({ mode: 'byob' })` on one of
+them raises the `TypeError` the standard gives for a stream that was not constructed with a byte source. A
+byte stream is something script builds today.
+
+One deliberate reduction: **only the five interfaces a script constructs by name are globals.**
+`ReadableStreamDefaultReader`, `ReadableStreamBYOBReader`, `WritableStreamDefaultWriter`, the four
+controllers and `ReadableStreamBYOBRequest` exist as ordinary interface objects — a reader's `constructor` is
+the real thing, and `new` on it behaves as the standard says — but they are not installed on `globalThis`,
+where a browser would expose them. Transferring a stream through `postMessage()` is the one part of the
+standard that is absent, there being nothing to transfer it to.
 
 ### Storage is opt-in on its own, and you decide where the data lives
 


### PR DESCRIPTION
Part of #3105 — the byte-stream half. What stays open there afterwards is listed at the end.

`new ReadableStream({ type: 'bytes' })` is now a real byte stream instead of a `TypeError`: `ReadableByteStreamController` with its `byobRequest`, `getReader({ mode: 'byob' })` returning a `ReadableStreamBYOBReader`, `read(view)` with `min`, autoAllocateChunkSize, respond/respondWithNewView, and the spec's separate `ReadableByteStreamTee` algorithm (deliberately not a fork of the default tee). The implementation **extends** the landed streams machinery rather than forking it — `JsReadableStream.Controller` widens to the base `JsReadableStreamController`, and every engine-built stream (tee branches, transform readable sides, `ReadableStream.from`, fetch bodies) keeps its guarantees through the documented `DefaultController` safe-cast accessor, which is what made the merge with the landed fetch-streams/transform-streams surface semantic rather than textual.

The cross-product with the landed features is pinned by new tests: a byte stream pipes through `TextDecoderStream`, `CompressionStream`→`DecompressionStream` and a script `TransformStream`; a byte stream is accepted as a fetch `BodyInit`; and — the boundary this PR deliberately keeps — `Response.body`, `Request.body` and `Blob.stream()` still serve default readers and refuse `mode: 'byob'`, pinned by a test that flips when the remaining #3105 work lands. 880 lines of `ReadableByteStreamTests`, 3,920 insertions.

Regated on top of #3157 (stream-bridge): the two suites are green together — solution build 0 errors, Jint.Tests 9061/7046, PublicInterface 1939/1556, both host-contract-verification legs green, WPT family green with no stale exclusions.

Still open on #3105 after this: fetch bodies *as* byte streams, `Blob.stream()` upgraded to a byte source, `duplex: 'half'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G7Ud48VAs1JicxRZxLDxg
