### PR TITLE
Web API: enable features on a live engine through Engine.Advanced

### DIFF
--- a/Jint.Tests.PublicInterface/WebApiLiveEnableTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiLiveEnableTests.cs
@@ -1,0 +1,533 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Jint;
+using Jint.Native;
+using Jint.WebApi;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// <c>engine.Advanced.EnableWebApis</c> seen from outside the assembly: turning a web API on for an engine
+/// that already exists, which is what a host renting engines from a pool needs when it only learns per
+/// request what the script it is about to run wants.
+/// </summary>
+/// <remarks>
+/// This project has no <c>InternalsVisibleTo</c>, so nothing here can reach the feature record, the timer
+/// queue or the property table directly — every assertion goes through script, through the public options
+/// surface and through the return value, exactly as an embedder's would. Nothing sleeps: the tests that need
+/// time to pass move a host-supplied <see cref="TimeProvider"/> and pump the engine themselves.
+/// </remarks>
+public class WebApiLiveEnableTests
+{
+    /// <summary>
+    /// A host-supplied clock, so that a suite exercising timers need not sleep. Only
+    /// <see cref="TimeProvider.GetTimestamp"/> and <see cref="TimeProvider.GetUtcNow"/> are ever asked for.
+    /// </summary>
+    private sealed class ManualClock : TimeProvider
+    {
+        private long _timestamp;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp() => _timestamp;
+
+        public override DateTimeOffset GetUtcNow() => DateTimeOffset.UnixEpoch.AddTicks(_timestamp);
+
+        internal void Advance(int milliseconds) => _timestamp += milliseconds * TimeSpan.TicksPerMillisecond;
+    }
+
+    /// <summary>Answers every request from memory, so nothing in this file opens a socket.</summary>
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        internal List<string> Urls { get; } = new();
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            lock (Urls)
+            {
+                Urls.Add(request.RequestUri!.ToString());
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") });
+        }
+    }
+
+    [Fact]
+    public void EnablingOnADefaultEngineInstallsTheGlobals()
+    {
+        var engine = new Engine();
+        engine.Evaluate("typeof console").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof TextEncoder").AsString().Should().Be("undefined");
+
+        var added = engine.Advanced.EnableWebApis(WebApiFeatures.Console | WebApiFeatures.Encoding);
+
+        added.Should().Be(WebApiFeatures.Console | WebApiFeatures.Encoding);
+        engine.Evaluate("typeof console").AsString().Should().Be("object");
+        engine.Evaluate("new TextEncoder().encode('ab').length").AsNumber().Should().Be(2);
+
+        // DOMException has no flag of its own and arrives with the first web API, live exactly as at options
+        // time.
+        engine.Evaluate("typeof DOMException").AsString().Should().Be("function");
+    }
+
+    /// <summary>
+    /// The whole promise of the API: an engine enabled live must be the engine options-time enabling would
+    /// have produced. Compared over the whole default surface rather than a sample, including the WebIDL
+    /// property attributes, which differ per global and are the part a second install path is most likely to
+    /// get wrong.
+    /// </summary>
+    [Fact]
+    public void ALiveEnabledEngineHasTheSameSurfaceAsAnOptionsConfiguredOne()
+    {
+        var configured = new Engine(options => options.UseWebApis());
+
+        var live = new Engine();
+        live.Advanced.EnableWebApis();
+
+        const string Survey = """
+            Object.getOwnPropertyNames(globalThis)
+                .map(n => {
+                    const d = Object.getOwnPropertyDescriptor(globalThis, n);
+                    return n + ':' + typeof globalThis[n] + ':' + (d.writable ? 'w' : '') + (d.enumerable ? 'e' : '') + (d.configurable ? 'c' : '');
+                })
+                .sort()
+                .join('|')
+            """;
+
+        live.Evaluate(Survey).AsString().Should().Be(configured.Evaluate(Survey).AsString());
+    }
+
+    [Fact]
+    public void ALiveEnabledTimerFiresOnTheHostsClock()
+    {
+        var clock = new ManualClock();
+        var engine = new Engine();
+
+        engine.Advanced.EnableWebApis(WebApiFeatures.Timers, webApi => webApi.Timers.TimeProvider = clock);
+
+        engine.Execute("var log = []; setTimeout(() => log.push('late'), 50);");
+        engine.Evaluate("log.length").AsNumber().Should().Be(0);
+
+        // Not yet due: the pump must not run it early.
+        clock.Advance(20);
+        engine.Advanced.ProcessTasks();
+        engine.Evaluate("log.length").AsNumber().Should().Be(0);
+
+        clock.Advance(40);
+        engine.Advanced.ProcessTasks();
+        engine.Evaluate("log.join(',')").AsString().Should().Be("late");
+    }
+
+    /// <summary>
+    /// The closure is the options-time closure: fetch's own interfaces are part of its surface, so they arrive
+    /// with it here exactly as they do at construction.
+    /// </summary>
+    [Fact]
+    public void EnablingReportsTheWholeClosureItAdded()
+    {
+        var engine = new Engine();
+
+        var added = engine.Advanced.EnableWebApis(WebApiFeatures.Fetch, webApi => webApi.Fetch.HttpClient = new HttpClient(new StubHandler()));
+
+        added.Should().Be(
+            WebApiFeatures.Fetch | WebApiFeatures.Events | WebApiFeatures.Url | WebApiFeatures.Files | WebApiFeatures.Streams);
+        engine.Advanced.WebApiFeatures.Should().Be(added);
+
+        foreach (var name in new[] { "fetch", "Request", "Response", "Headers", "AbortController", "URL", "Blob", "ReadableStream" })
+        {
+            engine.Evaluate($"typeof {name}").AsString().Should().NotBe("undefined");
+        }
+    }
+
+    /// <summary>
+    /// The counterpart of the closure test, and the security-relevant half: no non-network feature may pull a
+    /// network feature in. Asserted over every feature the enum declares, one engine each, so a closure rule
+    /// added later cannot quietly change the answer.
+    /// </summary>
+    [Fact]
+    public void NoNonNetworkFeatureEverBringsNetworkAccess()
+    {
+        const WebApiFeatures Network = WebApiFeatures.Fetch | WebApiFeatures.EventSource | WebApiFeatures.WebSocket;
+
+        foreach (WebApiFeatures feature in Enum.GetValues<WebApiFeatures>())
+        {
+            if (feature == WebApiFeatures.None || (feature & Network) != WebApiFeatures.None)
+            {
+                continue;
+            }
+
+            var engine = new Engine();
+            engine.Advanced.EnableWebApis(feature);
+
+            engine.Advanced.WebApiFeatures.Should().NotHaveFlag(WebApiFeatures.Fetch, $"{feature} must not grant fetch");
+            engine.Advanced.WebApiFeatures.Should().NotHaveFlag(WebApiFeatures.EventSource, $"{feature} must not grant EventSource");
+            engine.Advanced.WebApiFeatures.Should().NotHaveFlag(WebApiFeatures.WebSocket, $"{feature} must not grant WebSocket");
+
+            engine.Evaluate("typeof fetch").AsString().Should().Be("undefined");
+            engine.Evaluate("typeof EventSource").AsString().Should().Be("undefined");
+            engine.Evaluate("typeof WebSocket").AsString().Should().Be("undefined");
+        }
+    }
+
+    [Fact]
+    public void EnablingWhatIsAlreadyOnIsANoOpRatherThanAnError()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Console));
+
+        // The identity a script can see, captured before the second call.
+        engine.Execute("var saved = console;");
+
+        var configureRan = false;
+        var added = engine.Advanced.EnableWebApis(WebApiFeatures.Console, _ => configureRan = true);
+
+        added.Should().Be(WebApiFeatures.None);
+        configureRan.Should().BeFalse("a call that enables nothing must not even run the configuration delegate");
+        engine.Evaluate("console === saved").AsBoolean().Should().BeTrue("an already-installed global must not be re-installed");
+    }
+
+    [Fact]
+    public void EnablingNothingIsANoOp()
+    {
+        var engine = new Engine();
+
+        var configureRan = false;
+        engine.Advanced.EnableWebApis(WebApiFeatures.None, _ => configureRan = true).Should().Be(WebApiFeatures.None);
+
+        configureRan.Should().BeFalse();
+        engine.Advanced.WebApiFeatures.Should().Be(WebApiFeatures.None);
+        engine.Evaluate("typeof DOMException").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void EnablingUnionsWithWhatTheEngineWasBuiltWith()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Console));
+        engine.Execute("var saved = console;");
+
+        var added = engine.Advanced.EnableWebApis(WebApiFeatures.Console | WebApiFeatures.Base64);
+
+        // Only the part that was missing.
+        added.Should().Be(WebApiFeatures.Base64);
+        engine.Advanced.WebApiFeatures.Should().Be(WebApiFeatures.Console | WebApiFeatures.Base64);
+
+        engine.Evaluate("console === saved").AsBoolean().Should().BeTrue();
+        engine.Evaluate("atob(btoa('hi'))").AsString().Should().Be("hi");
+    }
+
+    /// <summary>
+    /// A global whose value the script has already forced into existence must come through untouched — its
+    /// own expandos included, since re-installing would replace the object rather than the descriptor.
+    /// </summary>
+    [Fact]
+    public void AnAlreadyMaterializedGlobalKeepsItsIdentity()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Encoding));
+
+        engine.Execute("var encoder = new TextEncoder(); TextEncoder.marker = 'mine';");
+
+        engine.Advanced.EnableWebApis(WebApiFeatures.Streams);
+
+        engine.Evaluate("TextEncoder.marker").AsString().Should().Be("mine");
+        engine.Evaluate("encoder instanceof TextEncoder").AsBoolean().Should().BeTrue();
+
+        // And the pair that needs BOTH flags is completed by the second half arriving.
+        engine.Evaluate("typeof TextEncoderStream").AsString().Should().Be("function");
+        engine.Evaluate("typeof TextDecoderStream").AsString().Should().Be("function");
+    }
+
+    [Fact]
+    public void AHostGlobalOfTheSameNameSurvives()
+    {
+        var engine = new Engine();
+        engine.SetValue("console", new { marker = "host" });
+
+        engine.Advanced.EnableWebApis(WebApiFeatures.Console);
+
+        engine.Evaluate("console.marker").AsString().Should().Be("host");
+        engine.Evaluate("typeof console.log").AsString().Should().Be("undefined");
+
+        // Only the name the host owns is left alone; the rest of the feature still arrives.
+        engine.Evaluate("typeof DOMException").AsString().Should().Be("function");
+    }
+
+    /// <summary>
+    /// The non-clobbering check has to <i>probe</i> rather than read, or a host's own lazy global would be
+    /// built by the mere act of enabling a feature that shares its name — which is exactly what a host chose
+    /// laziness to avoid.
+    /// </summary>
+    [Fact]
+    public void AHostLazyGlobalOfTheSameNameIsNotMaterializedByTheCheck()
+    {
+        var built = 0;
+        var engine = new Engine();
+        engine.Advanced.AddLazyGlobal("console", _ =>
+        {
+            built++;
+            return JsValue.FromObject(engine, new { marker = "host" });
+        });
+
+        engine.Advanced.EnableWebApis(WebApiFeatures.Console);
+
+        built.Should().Be(0, "the existence check must probe, not read");
+
+        engine.Evaluate("console.marker").AsString().Should().Be("host");
+        built.Should().Be(1);
+    }
+
+    /// <summary>
+    /// The state-extension half, which is where the real work is: an engine whose web-API state exists but
+    /// carries no timer queue — <see cref="WebApiFeatures.Performance"/> reads the time origin and never
+    /// schedules — has to have one attached when a scheduling feature arrives.
+    /// </summary>
+    [Fact]
+    public void EnablingTimersOnAnEngineWhoseStateHasNoQueueAttachesOne()
+    {
+        var clock = new ManualClock();
+        var engine = new Engine(options =>
+        {
+            options.UseWebApis(WebApiFeatures.Performance);
+            options.WebApi.Timers.TimeProvider = clock;
+        });
+
+        engine.Advanced.EnableWebApis(WebApiFeatures.Timers).Should().Be(WebApiFeatures.Timers);
+
+        engine.Execute("var log = []; setTimeout(() => log.push('fired'), 10);");
+        clock.Advance(20);
+        engine.Advanced.ProcessTasks();
+
+        engine.Evaluate("log.join(',')").AsString().Should().Be("fired");
+
+        // The clock is the state's own, so performance and the timers stayed coherent.
+        engine.Evaluate("performance.now() >= 20").AsBoolean().Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The two-piece attachment: <c>requestIdleCallback</c> needs an idle queue, which needs the timer queue,
+    /// and neither exists on a state built for <see cref="WebApiFeatures.Performance"/> alone.
+    /// </summary>
+    [Fact]
+    public void EnablingIdleCallbacksOnAnEngineWhoseStateHasNoQueuesAttachesBoth()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Performance));
+
+        engine.Advanced.EnableWebApis(WebApiFeatures.IdleCallback).Should().Be(WebApiFeatures.IdleCallback);
+
+        engine.Execute("var log = []; requestIdleCallback(d => log.push(typeof d.timeRemaining));");
+        engine.Advanced.ProcessTasks();
+
+        engine.Evaluate("log.join(',')").AsString().Should().Be("function");
+    }
+
+    [Fact]
+    public void EnablingTheSchedulerOnAnEngineThatAlreadyHadItsQueueAttachesTheTaskQueues()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Events));
+
+        engine.Advanced.EnableWebApis(WebApiFeatures.Scheduler).Should().Be(WebApiFeatures.Scheduler);
+
+        engine.Execute("var log = []; scheduler.postTask(() => log.push('task'));");
+        engine.Advanced.ProcessTasks();
+
+        engine.Evaluate("log.join(',')").AsString().Should().Be("task");
+    }
+
+    /// <summary>
+    /// The network features carry an options group, and the live door has to accept the same configuration the
+    /// options-time extension does — including the policy, which is the setting a host must never be unable to
+    /// supply.
+    /// </summary>
+    [Fact]
+    public void TheConfigureDelegateSuppliesTheNetworkPolicyAtEnableTime()
+    {
+        var handler = new StubHandler();
+        var engine = new Engine();
+
+        engine.Advanced.EnableWebApis(WebApiFeatures.Fetch, webApi =>
+        {
+            webApi.Fetch.HttpClient = new HttpClient(handler);
+            webApi.Fetch.UrlFilter = uri => uri.Host.EndsWith(".example.org", StringComparison.OrdinalIgnoreCase);
+        });
+
+        engine.Evaluate("fetch('https://api.example.org/x').then(r => r.status)").UnwrapIfPromise().AsNumber().Should().Be(200);
+
+        engine.Evaluate("fetch('https://elsewhere.test/x').then(() => 'resolved', e => e.constructor.name)")
+            .UnwrapIfPromise().AsString().Should().Be("TypeError");
+
+        handler.Urls.Should().ContainSingle().Which.Should().Be("https://api.example.org/x");
+    }
+
+    [Fact]
+    public void EnablingStorageLiveUsesTheProviderTheHostSupplies()
+    {
+        var provider = new InMemoryStorageProvider();
+        var engine = new Engine();
+
+        engine.Advanced.EnableWebApis(WebApiFeatures.Storage, webApi => webApi.Storage.LocalStorageProvider = provider);
+
+        engine.Execute("localStorage.setItem('k', 'v');");
+
+        provider.GetItem("k").Should().Be("v");
+        engine.Evaluate("sessionStorage.getItem('k')").Should().Be(JsValue.Null, "the two globals are two stores");
+    }
+
+    /// <summary>
+    /// A restore returns the global bindings to their state at capture, so globals a live enable installed
+    /// afterwards are gone — the same thing that happens to an <c>AddLazyGlobal</c> global and to the ones
+    /// <c>SetFetchHandler</c> installs. The engine-side record is deliberately not part of what a restore
+    /// reverts, which is why the feature still reads as enabled and why re-enabling cannot bring the globals
+    /// back.
+    /// </summary>
+    [Fact]
+    public void ARestoreOfASnapshotTakenBeforeTheEnableRemovesTheGlobalsAgain()
+    {
+        var engine = new Engine();
+        var clean = engine.Advanced.CaptureGlobalSnapshot();
+
+        engine.Advanced.EnableWebApis(WebApiFeatures.Console).Should().Be(WebApiFeatures.Console);
+        engine.Evaluate("typeof console").AsString().Should().Be("object");
+
+        engine.Advanced.RestoreGlobalSnapshot(clean);
+
+        engine.Evaluate("typeof console").AsString().Should().Be("undefined");
+        engine.Evaluate("'console' in globalThis").AsBoolean().Should().BeFalse();
+
+        // The record survives, so the engine knows about an API whose globals script can no longer name — and
+        // asking again is a no-op, not a reinstall.
+        engine.Advanced.WebApiFeatures.Should().Be(WebApiFeatures.Console);
+        engine.Advanced.EnableWebApis(WebApiFeatures.Console).Should().Be(WebApiFeatures.None);
+        engine.Evaluate("typeof console").AsString().Should().Be("undefined");
+    }
+
+    /// <summary>The documented remedy: capture after the enable, and every restore carries the globals.</summary>
+    [Fact]
+    public void ASnapshotTakenAfterTheEnableCarriesTheGlobalsThroughEveryRestore()
+    {
+        var engine = new Engine();
+        engine.Advanced.EnableWebApis(WebApiFeatures.Console | WebApiFeatures.Base64);
+
+        var clean = engine.Advanced.CaptureGlobalSnapshot();
+
+        engine.Execute("globalThis.perRequest = 1; console.marker = 'dirty';");
+        engine.Advanced.RestoreGlobalSnapshot(clean);
+
+        engine.Evaluate("typeof console").AsString().Should().Be("object");
+        engine.Evaluate("atob(btoa('x'))").AsString().Should().Be("x");
+        engine.Evaluate("typeof perRequest").AsString().Should().Be("undefined");
+
+        // ... and the expando on the console object itself does NOT go away, exactly as it does not for an
+        // options-time engine: a restore reverts the global binding table, not the objects behind it, and
+        // `console` is an intrinsic. That is a documented non-guarantee of the snapshot, not something the
+        // live door changes.
+        engine.Evaluate("console.marker").AsString().Should().Be("dirty");
+    }
+
+    /// <summary>
+    /// A global left unread at capture time is still a lazy descriptor, so a restore returns it to that
+    /// unmaterialized state rather than dropping it — the contract <c>AddLazyGlobal</c> already has. What a
+    /// script <i>replaced</i> the binding with is reverted; what it wrote onto the intrinsic behind the
+    /// binding is not, which is the snapshot's documented non-guarantee and is the same for an
+    /// options-time engine.
+    /// </summary>
+    [Fact]
+    public void AGlobalStillUnreadAtCaptureIsRestoredToItsBinding()
+    {
+        var engine = new Engine();
+        engine.Advanced.EnableWebApis(WebApiFeatures.Console);
+
+        // Captured without ever reading `console`, so the descriptor is still unmaterialized.
+        var clean = engine.Advanced.CaptureGlobalSnapshot();
+
+        engine.Execute("globalThis.console = 'replaced';");
+        engine.Evaluate("typeof console").AsString().Should().Be("string");
+
+        engine.Advanced.RestoreGlobalSnapshot(clean);
+
+        engine.Evaluate("typeof console").AsString().Should().Be("object");
+        engine.Evaluate("typeof console.log").AsString().Should().Be("function");
+    }
+
+    [Fact]
+    public void AShadowRealmStillGetsNothing()
+    {
+        var engine = new Engine();
+        engine.Advanced.EnableWebApis();
+
+        engine.Evaluate("typeof console").AsString().Should().Be("object");
+
+        foreach (var name in new[] { "console", "DOMException", "setTimeout", "TextEncoder", "URL", "structuredClone" })
+        {
+            engine.Evaluate($"new ShadowRealm().evaluate('typeof {name}')").AsString().Should().Be("undefined");
+        }
+    }
+
+    /// <summary>
+    /// The invalidation story from the only angle a third party has. A prepared script is the public way to
+    /// keep one handler tree across evaluations, and its per-site caches engage from the second run — so a
+    /// site that has already answered <c>undefined</c> for a name twice must answer with the global once the
+    /// feature installs it. (The install's own half of that, the own-property version bump every one of those
+    /// caches revalidates against, is pinned inside the assembly by
+    /// <c>Jint.Tests.Runtime.WebApi.LiveEnableTests.InstallingBumpsTheOwnPropertyVersion</c>: it is what keeps
+    /// this true if a later change ever makes an install replace a name rather than only add one.)
+    /// </summary>
+    [Fact]
+    public void AWarmedIdentifierSiteReResolvesAfterALiveEnable()
+    {
+        var engine = new Engine();
+        var probe = Engine.PrepareScript("typeof console + '/' + typeof globalThis.console");
+
+        // Twice, because the handler-tree caches engage from the second evaluation of a script on an engine.
+        engine.Evaluate(probe).AsString().Should().Be("undefined/undefined");
+        engine.Evaluate(probe).AsString().Should().Be("undefined/undefined");
+
+        engine.Advanced.EnableWebApis(WebApiFeatures.Console);
+
+        engine.Evaluate(probe).AsString().Should().Be("object/object");
+    }
+
+    /// <summary>
+    /// The same pin for a member read of the global object rather than a bare identifier, on an engine that
+    /// already had web APIs — the shape a pooled host that enables in two stages actually produces.
+    /// </summary>
+    [Fact]
+    public void AWarmedMemberReadSeesAGlobalInstalledAfterIt()
+    {
+        var engine = new Engine();
+        engine.Advanced.EnableWebApis(WebApiFeatures.Console);
+
+        var probe = Engine.PrepareScript("typeof globalThis.btoa");
+        engine.Evaluate(probe).AsString().Should().Be("undefined");
+        engine.Evaluate(probe).AsString().Should().Be("undefined");
+
+        engine.Advanced.EnableWebApis(WebApiFeatures.Base64);
+
+        engine.Evaluate(probe).AsString().Should().Be("function");
+    }
+
+    /// <summary>
+    /// The host APIs that refuse an engine which never opted in have to accept one that opted in late — they
+    /// read the engine's own record, which the live door updates.
+    /// </summary>
+    [Fact]
+    public void TheFeatureGatedHostApisAcceptALiveEnabledEngine()
+    {
+        var engine = new Engine();
+
+        Assert.Throws<InvalidOperationException>(() => engine.Advanced.CreateAbortSignal(CancellationToken.None));
+        Assert.Throws<InvalidOperationException>(() => engine.Advanced.CreateMessagePortPair(engine));
+
+        engine.Advanced.EnableWebApis(WebApiFeatures.Events | WebApiFeatures.Messaging);
+
+        engine.SetValue("hostSignal", engine.Advanced.CreateAbortSignal(CancellationToken.None));
+        engine.Evaluate("hostSignal.aborted").AsBoolean().Should().BeFalse();
+
+        var pair = engine.Advanced.CreateMessagePortPair(engine);
+        pair.Local.Should().NotBeNull();
+        pair.Remote.Should().NotBeNull();
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/LiveEnableTests.cs
+++ b/Jint.Tests/Runtime/WebApi/LiveEnableTests.cs
@@ -1,0 +1,204 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Descriptors.Specialized;
+using Jint.WebApi;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// <c>Engine.Advanced.EnableWebApis</c> from the inside: the parts of a post-construction install the public
+/// surface cannot see. Which descriptor is stored and that it is stored unmaterialized; that the install bumps
+/// the own-property version every global-binding and member-read inline cache validates against; and — the
+/// half the issue calls the real work — that an engine which already had web-API state has that state
+/// <i>extended</i> rather than replaced.
+/// </summary>
+/// <remarks>
+/// The behaviour a third party can observe is pinned in
+/// <c>Jint.Tests.PublicInterface.WebApiLiveEnableTests</c>; everything here needs
+/// <c>InternalsVisibleTo</c> and belongs on this side of it.
+/// </remarks>
+public class LiveEnableTests
+{
+    [Fact]
+    public void InstallsUnmaterializedLazyDescriptors()
+    {
+        var engine = new Engine();
+        engine.Advanced.EnableWebApis(WebApiFeatures.Console);
+
+        var descriptor = engine.Realm.GlobalObject.GetOwnProperty("console");
+
+        descriptor.Should().BeOfType<LazyPropertyDescriptor<Engine>>();
+        // CustomJsValue is what routes the read through the resolver; it is cleared the moment the value
+        // materializes, which is also what admits the descriptor to the global-binding inline cache.
+        (descriptor._flags & PropertyFlag.CustomJsValue).Should().NotBe(PropertyFlag.None);
+        descriptor._value.Should().BeNull("enabling a feature must not build the object a script never reads");
+    }
+
+    /// <summary>
+    /// The design risk of a post-construction install, pinned directly — the same one
+    /// <see cref="LazyGlobalInstallationTests.InstallingBumpsTheOwnPropertyVersionOnEveryStoragePath"/> pins
+    /// for <c>AddLazyGlobal</c>. At construction time no inline cache exists, so an install that skipped the
+    /// bump would still be correct; on a live engine a warmed identifier site holds the previous descriptor by
+    /// reference and revalidates it against <c>_propertiesVersion</c> alone.
+    /// </summary>
+    [Fact]
+    public void InstallingBumpsTheOwnPropertyVersion()
+    {
+        var engine = new Engine();
+        var global = engine.Realm.GlobalObject;
+
+        var before = global._propertiesVersion;
+        engine.Advanced.EnableWebApis(WebApiFeatures.Console);
+        global._propertiesVersion.Should().NotBe(before, "the first install has to invalidate the caches");
+
+        // ... and again for a second, later call, which is the pooled-engine shape.
+        before = global._propertiesVersion;
+        engine.Advanced.EnableWebApis(WebApiFeatures.Base64);
+        global._propertiesVersion.Should().NotBe(before);
+
+        // A call that enables nothing installs nothing, so it must not churn the caches either.
+        before = global._propertiesVersion;
+        engine.Advanced.EnableWebApis(WebApiFeatures.Console).Should().Be(WebApiFeatures.None);
+        global._propertiesVersion.Should().Be(before);
+    }
+
+    /// <summary>
+    /// Installing global object properties creates no lexical binding and injects nothing into an existing
+    /// environment, so the two counters that describe those must NOT move — bumping either would be
+    /// invalidating caches for a change that did not happen.
+    /// </summary>
+    [Fact]
+    public void InstallingDoesNotDisturbTheLexicalCounters()
+    {
+        var engine = new Engine();
+        var globalEnv = engine.Realm.GlobalEnv;
+
+        var lexicalMutations = globalEnv._lexicalMutations;
+        var injectionEpoch = engine._envBindingInjectionEpoch;
+
+        engine.Advanced.EnableWebApis();
+
+        globalEnv._lexicalMutations.Should().Be(lexicalMutations);
+        engine._envBindingInjectionEpoch.Should().Be(injectionEpoch);
+    }
+
+    [Fact]
+    public void TheEngineRecordsTheExpandedClosure()
+    {
+        var engine = new Engine();
+        engine.Advanced.EnableWebApis(WebApiFeatures.CacheApi);
+
+        // The Cache API stores Request/Response pairs, so it brings the three features those are built out of
+        // — and deliberately not the network.
+        engine._webApiFeatures.Should().Be(
+            WebApiFeatures.CacheApi | WebApiFeatures.Events | WebApiFeatures.Url | WebApiFeatures.Files);
+        engine._webApiFeatures.Should().NotHaveFlag(WebApiFeatures.Fetch);
+
+        // Options is untouched: it reads back exactly what the host asked for, at options time and here.
+        engine.Options.WebApi.Features.Should().Be(WebApiFeatures.None);
+    }
+
+    /// <summary>
+    /// The state-extension half. A state built for <see cref="WebApiFeatures.Performance"/> alone carries the
+    /// time origin and no queue at all, so enabling a scheduling feature has to attach one — to that very
+    /// state, because replacing it would move the time origin and lose everything the engine had already put
+    /// in it.
+    /// </summary>
+    [Fact]
+    public void ExtendingAnExistingStateAttachesTheQueuesWithoutReplacingIt()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Performance));
+
+        var state = engine._webApi;
+        state.Should().NotBeNull();
+        state!.Timers.Should().BeNull("a performance-only engine reads the time origin and never schedules");
+        state.Scheduler.Should().BeNull();
+        state.IdleCallbacks.Should().BeNull();
+
+        var timeOrigin = state.TimeOrigin;
+        var clock = state.TimeProvider;
+
+        engine.Advanced.EnableWebApis(WebApiFeatures.Timers | WebApiFeatures.Scheduler | WebApiFeatures.IdleCallback);
+
+        engine._webApi.Should().BeSameAs(state, "the state must be extended, never rebuilt");
+        state.Timers.Should().NotBeNull();
+        state.Scheduler.Should().NotBeNull();
+        state.IdleCallbacks.Should().NotBeNull();
+        state.TimeOrigin.Should().Be(timeOrigin, "performance.now() must not be able to go backwards");
+        state.TimeProvider.Should().BeSameAs(clock, "everything attached later has to share the engine's clock");
+    }
+
+    /// <summary>
+    /// The clock a state was built on is the engine's forever: a <c>TimeProvider</c> assigned to the options
+    /// after construction must not reach an engine that already exists, or the timers and
+    /// <c>performance.now()</c> would be reading two different clocks.
+    /// </summary>
+    [Fact]
+    public void ExtendingAnExistingStateDoesNotAdoptALaterClock()
+    {
+        var options = new Options().UseWebApis(WebApiFeatures.Performance);
+        var engine = new Engine(options);
+        var original = engine._webApi!.TimeProvider;
+
+        options.WebApi.Timers.TimeProvider = new FakeTimeProvider();
+        engine.Advanced.EnableWebApis(WebApiFeatures.Timers);
+
+        engine._webApi!.TimeProvider.Should().BeSameAs(original);
+        engine._webApi.Timers.Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// An engine with no state at all is the other branch: it gets one built exactly as construction would
+    /// have built it, reading the options group at the moment of the call.
+    /// </summary>
+    [Fact]
+    public void AnEngineWithNoStateGetsOneBuiltFromTheOptionsAtEnableTime()
+    {
+        var clock = new FakeTimeProvider();
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Console));
+
+        engine._webApi.Should().BeNull("console keeps no engine state");
+
+        engine.Advanced.EnableWebApis(WebApiFeatures.Timers, webApi =>
+        {
+            webApi.Timers.TimeProvider = clock;
+            webApi.Timers.MaxActiveTimers = 3;
+        });
+
+        engine._webApi.Should().NotBeNull();
+        engine._webApi!.TimeProvider.Should().BeSameAs(clock);
+        engine._webApi.Timers!.MaxActiveTimers.Should().Be(3);
+    }
+
+    /// <summary>
+    /// The storage providers are resolved lazily on first use, so enabling storage live has to fill the slots
+    /// that are still empty and may never overwrite one an engine has already been reading and writing.
+    /// </summary>
+    [Fact]
+    public void EnablingStorageLiveDoesNotDisplaceAProviderAlreadyInUse()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Storage));
+        engine.Execute("localStorage.setItem('k', 'v');");
+
+        var provider = engine._webApi!.LocalStorageProvider;
+
+        // Enabling storage again is a no-op, and so is enabling something else beside it.
+        engine.Advanced.EnableWebApis(WebApiFeatures.Storage | WebApiFeatures.Base64);
+
+        engine._webApi.LocalStorageProvider.Should().BeSameAs(provider);
+        engine.Evaluate("localStorage.getItem('k')").AsString().Should().Be("v");
+    }
+
+    /// <summary>A clock that never moves; only its identity matters to these tests.</summary>
+    private sealed class FakeTimeProvider : TimeProvider
+    {
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp() => 0;
+
+        public override DateTimeOffset GetUtcNow() => DateTimeOffset.UnixEpoch;
+    }
+}
+#endif

--- a/Jint/Engine.Advanced.WebApi.cs
+++ b/Jint/Engine.Advanced.WebApi.cs
@@ -17,6 +17,145 @@ public partial class Engine
     public partial class AdvancedOperations
     {
         /// <summary>
+        /// The opt-in web APIs this engine carries, after the feature closure has been expanded. Requires
+        /// .NET 8 or higher.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This is what the engine actually has, which is deliberately not the same thing as
+        /// <c>options.WebApi.Features</c>: that one reads back exactly what the host asked for, while a
+        /// feature whose surface is built out of another's interfaces brings that one with it. An engine built
+        /// with <c>options.UseFetch()</c> answers <c>Fetch | Events | Url | Files | Streams</c> here and
+        /// <c>Fetch</c> there.
+        /// </para>
+        /// <para>
+        /// Reading it is what makes <see cref="EnableWebApis(WebApiFeatures, Action{Options.WebApiOptions})"/>
+        /// unnecessary to guard: that method is additive and a feature already present is a no-op, so a host
+        /// only needs this to decide whether a call is <i>worth</i> making, or to assert what a pooled engine
+        /// came back with.
+        /// </para>
+        /// </remarks>
+        public WebApiFeatures WebApiFeatures => _engine._webApiFeatures;
+
+        /// <summary>
+        /// Turns on the web APIs a host normally wants — <see cref="WebApiFeatures.Default"/> — on an engine
+        /// that already exists. The per-engine counterpart of
+        /// <see cref="WebApiOptionsExtensions.UseWebApis(Options)"/>. Requires .NET 8 or higher.
+        /// </summary>
+        /// <returns>The features this call added; see the main overload.</returns>
+        public WebApiFeatures EnableWebApis() => EnableWebApis(Jint.WebApiFeatures.Default, configure: null);
+
+        /// <summary>
+        /// Turns the named web APIs on for <em>this</em> engine, after it has been constructed. The per-engine
+        /// counterpart of <see cref="WebApiOptionsExtensions.UseWebApis(Options, WebApiFeatures)"/>, for the
+        /// host that only discovers per request which APIs the script it is about to run needs — a pooled
+        /// engine in a tenant host, a plugin runner — and would otherwise have to over-provision every engine
+        /// or build a fresh one. Requires .NET 8 or higher.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>Additive only.</b> There is no way to turn a web API off again: a script that has already
+        /// captured <c>fetch</c> keeps it whatever a later call says, so an API promising removal could not
+        /// keep the promise. Naming a feature the engine already carries is a plain no-op — not an error, and
+        /// not a re-install: the globals it owns keep their identity, an unread one stays unread, and
+        /// <paramref name="configure"/> does not even run. The return value says what actually changed.
+        /// </para>
+        /// <para>
+        /// <b>It runs the same code construction runs.</b> The feature closure is expanded by the one function
+        /// that expands it at options time, so <see cref="WebApiFeatures.Fetch"/> brings
+        /// <see cref="WebApiFeatures.Events"/>, <see cref="WebApiFeatures.Url"/>,
+        /// <see cref="WebApiFeatures.Files"/> and <see cref="WebApiFeatures.Streams"/> here exactly as it does
+        /// there; the per-engine state is created, or extended with the queues the new features need; and each
+        /// global is installed as the same lazy, <b>non-clobbering</b> property — a name the host already owns
+        /// is left exactly as the host left it, and the check probes rather than reads, so a host's own lazy
+        /// global is not materialized merely by our looking. No closure ever pulls in a network feature:
+        /// <see cref="WebApiFeatures.Fetch"/>, <see cref="WebApiFeatures.EventSource"/> and
+        /// <see cref="WebApiFeatures.WebSocket"/> are only ever enabled by being named.
+        /// </para>
+        /// <para>
+        /// <b>Warmed inline caches are invalidated.</b> Unlike a registration applied during construction this
+        /// one lands on an engine whose handler trees may already hold a resolved binding for one of these
+        /// names — a script that ran <c>typeof fetch</c> before the call. Every global goes in through the
+        /// storage path that bumps the global object's own-property version, which is the sole thing the
+        /// global-identifier and member-read inline caches revalidate against, so the next read of that name
+        /// re-resolves. This is the same mechanism, and the same guarantee,
+        /// <see cref="AddLazyGlobal(string, Func{Engine, JsValue}, Runtime.Descriptors.PropertyFlag)"/> rests on.
+        /// </para>
+        /// <para>
+        /// <b>What the settings come from.</b> The per-feature options are read from this engine's own
+        /// <see cref="Options"/> — <c>options.WebApi.Fetch</c>, <c>.Storage</c>, <c>.Cache</c>,
+        /// <c>.Timers</c> — at the moment of this call, with the same read-once semantics they have at
+        /// construction, and <paramref name="configure"/> is handed that same group so a host can supply what
+        /// it could not know earlier. Two settings are deliberately <b>not</b> re-read for an engine that
+        /// already has web-API state: <c>Timers.TimeProvider</c>, because the timers,
+        /// <c>performance.now()</c> and the time origin must stay on one clock for the engine's whole life;
+        /// and <c>Diagnostics.Sink</c>, whose contract is that it holds still for an engine's lifetime because
+        /// it also decides whether a callback's exception erupts. An engine that had no web-API state at all
+        /// gets both read here, exactly as construction would have read them — including a time origin that is
+        /// therefore <em>now</em> rather than the engine's birth.
+        /// </para>
+        /// <para>
+        /// <b>Interaction with <see cref="CaptureGlobalSnapshot"/>.</b> A restore returns the global bindings
+        /// to their state at capture, so globals installed by a call made <em>after</em> a capture are gone
+        /// after the restore — the same thing that happens to an
+        /// <see cref="AddLazyGlobal(string, Func{Engine, JsValue}, Runtime.Descriptors.PropertyFlag)"/> global and to the ones
+        /// <see cref="SetFetchHandler"/> installs. What a restore does not revert is the engine-side record:
+        /// <see cref="WebApiFeatures"/> still reports the feature, and the state behind it (the timer queue,
+        /// the cache provider) is still there, so the engine is left knowing about an API whose globals script
+        /// can no longer name. <b>Enable after the restore, or enable on the options</b> so the globals are
+        /// part of the engine's initial state and every snapshot carries them. Re-calling this method after a
+        /// restore does not put them back either — the feature is already on, so the call is a no-op; a host
+        /// that must reinstate them captures its snapshot after the enable.
+        /// </para>
+        /// <para>
+        /// <b>The principal realm only</b>, exactly as at options time: a <c>ShadowRealm</c> carries none of
+        /// these globals, and this method does not change that however it is reached.
+        /// </para>
+        /// <para>
+        /// <b>When to call it.</b> Between evaluations, under the engine's usual single-thread contract; this
+        /// is an ordinary mutation of the engine's global object. Calling it during an evaluation is not
+        /// prevented, but a read already in flight may have resolved the old binding.
+        /// </para>
+        /// </remarks>
+        /// <example>
+        /// A pooled engine that learns per request what the script needs:
+        /// <code>
+        /// var engine = pool.Rent();                       // built with WebApiFeatures.Console only
+        /// if (script.NeedsTimers)
+        /// {
+        ///     engine.Advanced.EnableWebApis(WebApiFeatures.Timers | WebApiFeatures.Events);
+        /// }
+        ///
+        /// if (tenant.MayReachTheNetwork)
+        /// {
+        ///     engine.Advanced.EnableWebApis(WebApiFeatures.Fetch, w =>
+        ///         w.Fetch.UrlFilter = uri => tenant.Allows(uri));
+        /// }
+        /// </code>
+        /// </example>
+        /// <param name="features">
+        /// The features to turn on, in addition to those already present.
+        /// <see cref="WebApiFeatures.None"/> does nothing and, in particular, disables nothing.
+        /// </param>
+        /// <param name="configure">
+        /// Optional configuration of the per-feature settings, run once — before anything is installed, and
+        /// only when this call is actually enabling something. It is handed this engine's own
+        /// <c>Options.WebApi</c> group, which is the group the engine reads its settings from; <b>an
+        /// <see cref="Options"/> instance shared with other engines is shared here too</b>, exactly as it
+        /// already is at options time, so give an engine its own <see cref="Options"/> when its network policy
+        /// has to be its own. Assigning <c>Features</c> inside the delegate does not enable anything for this
+        /// call — <paramref name="features"/> is what this call enables — and only affects engines built from
+        /// those options later.
+        /// </param>
+        /// <returns>
+        /// The features this call actually added, after closure expansion, or
+        /// <see cref="WebApiFeatures.None"/> when everything asked for was already present. A host granting
+        /// network access can assert on it; a host that only wants the globals can ignore it.
+        /// </returns>
+        public WebApiFeatures EnableWebApis(WebApiFeatures features, Action<Options.WebApiOptions>? configure = null)
+            => WebApiRegistration.ApplyLive(_engine, features, configure);
+
+        /// <summary>
         /// Creates a pair of entangled <c>MessagePort</c> objects spanning this engine and
         /// <paramref name="other"/>, so a script on one can <c>postMessage</c> to a script on the other.
         /// Requires .NET 8 or higher, and <see cref="WebApiFeatures.Messaging"/> on <b>both</b> engines.
@@ -452,10 +591,12 @@ public partial class Engine
         {
             var engine = _engine;
 
-            // The state is built for every feature that keeps any, Events among them, so a null field settles
-            // the question without asking the options — which matters because Options may be shared by other
-            // engines being built right now, and its web-API group is allocated on first touch.
-            if (engine._webApi is null || (engine.Options.WebApi.Features & WebApiFeatures.Events) == WebApiFeatures.None)
+            // The engine's own record rather than the options': Options is shareable and mutable, so the set
+            // an engine was actually built with is only knowable from the engine — and it is the set AFTER the
+            // feature closure, so an engine built with options.UseFetch() (which implies Events) and one that
+            // enabled Events through EnableWebApis are both recognized. The state is built for every feature
+            // that keeps any, Events among them, so the null check is the belt to that brace.
+            if (engine._webApi is null || (engine._webApiFeatures & WebApiFeatures.Events) == WebApiFeatures.None)
             {
                 Throw.InvalidOperationException(
                     "Engine.Advanced.CreateAbortSignal requires the WebApiFeatures.Events web API, which this engine did not enable. Build the engine with options.UseWebApis(WebApiFeatures.Events) — or any feature set that includes it, such as WebApiFeatures.Default.");

--- a/Jint/Engine.WebApi.cs
+++ b/Jint/Engine.WebApi.cs
@@ -1,4 +1,5 @@
 #if NET8_0_OR_GREATER
+using System.Diagnostics;
 using Jint.Native.Promise;
 using Jint.Native;
 using Jint.WebApi.Abort;
@@ -79,18 +80,23 @@ public partial class Engine
     /// loop nor the wait loops need a conditional-compilation directive of their own. It is created by
     /// <c>WebApiRegistration.Apply</c> for the features that keep state in it — the timers and the events, the
     /// latter for the time origin <c>Event.timeStamp</c> is measured against and for the queue
-    /// <c>AbortSignal.timeout()</c> schedules on.
+    /// <c>AbortSignal.timeout()</c> schedules on — or, for a feature enabled through
+    /// <see cref="AdvancedOperations.EnableWebApis(WebApiFeatures, Action{Options.WebApiOptions})"/>, created
+    /// or extended by that call.
     /// </summary>
     internal WebApiEngineState? _webApi;
 
     /// <summary>
-    /// Which opt-in web APIs this engine was built with, as <c>WebApiRegistration.Apply</c> recorded them
-    /// after computing the feature closure, or <see cref="WebApiFeatures.None"/> for an engine that asked for
-    /// nothing. Read by the host APIs that have to refuse an engine which never opted in —
-    /// <see cref="AdvancedOperations.CreateMessagePortPair"/> and
-    /// <see cref="AdvancedOperations.SetFetchHandler"/> — and by nothing on any hot path. It lives here rather
-    /// than being read back from <c>Options</c> because an <c>Options</c> instance is shareable and mutable,
-    /// so the set an engine was actually built with is only knowable at build time.
+    /// Which opt-in web APIs this engine carries, as <c>WebApiRegistration</c> recorded them after computing
+    /// the feature closure, or <see cref="WebApiFeatures.None"/> for an engine that asked for nothing. Read by
+    /// the host APIs that have to refuse an engine which never opted in —
+    /// <see cref="AdvancedOperations.CreateMessagePortPair"/>,
+    /// <see cref="AdvancedOperations.SetFetchHandler"/> and
+    /// <see cref="AdvancedOperations.CreateAbortSignal"/> — by
+    /// <see cref="AdvancedOperations.EnableWebApis(WebApiFeatures, Action{Options.WebApiOptions})"/>, which
+    /// adds to it, and by nothing on any hot path. It lives here rather than being read back from
+    /// <c>Options</c> because an <c>Options</c> instance is shareable and mutable, so the set an engine
+    /// actually has is only knowable from the engine.
     /// </summary>
     internal WebApiFeatures _webApiFeatures;
 
@@ -129,9 +135,11 @@ internal sealed class WebApiEngineState
 
     /// <summary>
     /// The quota a defaulted <see cref="InMemoryStorageProvider"/> is built with, captured when the engine
-    /// was, so that mutating the options afterwards cannot change an engine that already exists.
+    /// was — or, for an engine that enabled storage through <c>Engine.Advanced.EnableWebApis</c>, when that
+    /// call ran. Either way it is read once and never again, so mutating the options afterwards cannot change
+    /// an engine that already has it.
     /// </summary>
-    private readonly long _storageQuotaBytes;
+    private long _storageQuotaBytes;
 
     private StorageProvider? _localStorageProvider;
     private StorageProvider? _sessionStorageProvider;
@@ -198,15 +206,23 @@ internal sealed class WebApiEngineState
     internal FetchHandler? FetchHandler { get; set; }
 
     /// <summary>
-    /// The engine's active timers, or <see langword="null"/> when nothing that schedules one is enabled.
+    /// The clock this state was built on, which every later piece attached to it has to share: the timers,
+    /// <c>performance.now()</c> and the time origin all read it, so a feature enabled later must schedule
+    /// against the same one rather than against whatever the options say by then.
     /// </summary>
-    internal TimerQueue? Timers { get; }
+    internal TimeProvider TimeProvider => _timeProvider;
 
     /// <summary>
-    /// The host's fetch settings, or <see langword="null"/> when the feature is off. Read once, when the
-    /// engine is built, so that no background thread ever reaches into <see cref="Options"/>.
+    /// The engine's active timers, or <see langword="null"/> when nothing that schedules one is enabled.
     /// </summary>
-    internal Options.FetchOptions? FetchOptions { get; }
+    internal TimerQueue? Timers { get; private set; }
+
+    /// <summary>
+    /// The host's fetch settings, or <see langword="null"/> when the feature is off. Read once — when the
+    /// engine is built, or when <c>Engine.Advanced.EnableWebApis</c> turned the feature on — so that no
+    /// background thread ever reaches into <see cref="Options"/>.
+    /// </summary>
+    internal Options.FetchOptions? FetchOptions { get; private set; }
 
     /// <summary>
     /// Where the <c>caches</c> object keeps what a script stored, or <see langword="null"/> when the Cache
@@ -219,7 +235,7 @@ internal sealed class WebApiEngineState
     /// state, so a pooled engine's next cycle finds what the previous one cached — the same answer the module
     /// registry gets from a restore.
     /// </remarks>
-    internal CacheStorageProvider? CacheProvider { get; }
+    internal CacheStorageProvider? CacheProvider { get; private set; }
 
     /// <summary>
     /// How many requests are in flight, which is what <c>Options.FetchOptions.MaxConcurrentRequests</c>
@@ -240,7 +256,7 @@ internal sealed class WebApiEngineState
     /// Nothing else consults it: the scheduler drains itself through an ordinary event-loop job, so unlike the
     /// timers it needs no hook in the pump.
     /// </summary>
-    internal SchedulerQueue? Scheduler { get; }
+    internal SchedulerQueue? Scheduler { get; private set; }
 
     /// <summary>
     /// Where uncaught script errors are reported, or <see langword="null"/> when the host set no sink — which
@@ -290,7 +306,7 @@ internal sealed class WebApiEngineState
     /// only once no timer is due — see <see cref="IdleCallbackQueue"/> for what "idle" means for an engine
     /// that has no frames.
     /// </summary>
-    internal IdleCallbackQueue? IdleCallbacks { get; }
+    internal IdleCallbackQueue? IdleCallbacks { get; private set; }
 
     /// <summary>
     /// Whether an idle callback is waiting for a pump. Read only by
@@ -336,6 +352,66 @@ internal sealed class WebApiEngineState
     /// <inheritdoc cref="LocalStorageProvider" />
     internal StorageProvider SessionStorageProvider =>
         _sessionStorageProvider ??= new InMemoryStorageProvider(_storageQuotaBytes);
+
+    /// <summary>
+    /// Gives a state that was built without one the timer queue a feature enabled later needs. Called only by
+    /// <c>WebApiRegistration.ExtendEngineState</c>, and only for a slot that is still empty — a queue the
+    /// engine has already been scheduling on is never replaced.
+    /// </summary>
+    /// <remarks>
+    /// The whole late-attachment family exists for <c>Engine.Advanced.EnableWebApis</c>: the state is created
+    /// once, with exactly the queues the features named at that moment, so turning a feature on afterwards has
+    /// to be able to add the one piece it brought with it. Each of these asserts the slot is empty rather than
+    /// tolerating a second call, because a second call could only mean the caller lost track of which features
+    /// were already on — which is precisely the question <c>Engine._webApiFeatures</c> answers.
+    /// </remarks>
+    internal void AttachTimers(TimerQueue timers)
+    {
+        Debug.Assert(Timers is null, "the timer queue must never be replaced on a live engine");
+        Timers = timers;
+    }
+
+    /// <inheritdoc cref="AttachTimers" />
+    internal void AttachFetchOptions(Options.FetchOptions fetchOptions)
+    {
+        Debug.Assert(FetchOptions is null, "the network settings must never be replaced on a live engine");
+        FetchOptions = fetchOptions;
+    }
+
+    /// <inheritdoc cref="AttachTimers" />
+    internal void AttachScheduler(SchedulerQueue scheduler)
+    {
+        Debug.Assert(Scheduler is null, "the scheduler queues must never be replaced on a live engine");
+        Scheduler = scheduler;
+    }
+
+    /// <inheritdoc cref="AttachTimers" />
+    internal void AttachCacheProvider(CacheStorageProvider cacheProvider)
+    {
+        Debug.Assert(CacheProvider is null, "the cache provider must never be replaced on a live engine");
+        CacheProvider = cacheProvider;
+    }
+
+    /// <inheritdoc cref="AttachTimers" />
+    internal void AttachIdleCallbacks(IdleCallbackQueue idleCallbacks)
+    {
+        Debug.Assert(IdleCallbacks is null, "the idle-callback queue must never be replaced on a live engine");
+        IdleCallbacks = idleCallbacks;
+    }
+
+    /// <summary>
+    /// Reads the storage group into a state that was built without it. Unlike its siblings this one has no
+    /// slot of its own to test: the two providers are defaulted lazily on first use, so what it must not do is
+    /// overwrite a provider that has already been resolved — hence the <c>??=</c>. The quota is only ever
+    /// consulted while defaulting a provider, so assigning it here reaches exactly the providers that do not
+    /// exist yet, which is the same set the host is enabling storage for.
+    /// </summary>
+    internal void AttachStorage(Options.StorageOptions storage)
+    {
+        _localStorageProvider ??= storage.LocalStorageProvider;
+        _sessionStorageProvider ??= storage.SessionStorageProvider;
+        _storageQuotaBytes = storage.MaxTotalBytes;
+    }
 
     /// <summary>
     /// Promotes at most one due timer into an event-loop job, and failing that runs at most one idle callback.

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -44,6 +44,13 @@ public partial class Options
         /// Which web APIs this engine exposes. Defaults to <see cref="WebApiFeatures.None"/>, which installs
         /// nothing at all — not even <c>DOMException</c>.
         /// </summary>
+        /// <remarks>
+        /// Read once, when an engine is built, so this is the set an engine <i>starts</i> with rather than the
+        /// set it has: it always reads back exactly what the host asked for, while the engine additionally
+        /// carries the feature closure, and a host may turn further features on afterwards with
+        /// <c>Engine.Advanced.EnableWebApis</c>. What a given engine actually has is
+        /// <c>engine.Advanced.WebApiFeatures</c>.
+        /// </remarks>
         public WebApiFeatures Features { get; set; }
 
         /// <summary>

--- a/Jint/WebApi/WebApiRegistration.cs
+++ b/Jint/WebApi/WebApiRegistration.cs
@@ -12,7 +12,8 @@ namespace Jint.WebApi;
 /// <summary>
 /// Installs the globals for the web APIs an engine opted into. Invoked from <c>Options.Apply</c>, which is
 /// the sanctioned conditional-install site — the same one <c>Interop.Enabled</c> and
-/// <c>Modules.RegisterRequire</c> use.
+/// <c>Modules.RegisterRequire</c> use — and from <c>Engine.Advanced.EnableWebApis</c>, which is the same
+/// work applied to an engine that already exists.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -33,19 +34,89 @@ internal static class WebApiRegistration
 {
     internal static void Apply(Options options, Engine engine)
     {
-        var global = engine.Realm.GlobalObject;
         var features = ExpandFeatures(options.WebApi.Features);
 
-        // Recorded on the engine because one host API — Engine.Advanced.CreateMessagePortPair — has to be
-        // able to refuse an engine that never opted in, and Options is shareable so it cannot be asked later.
+        // Recorded on the engine because two host APIs — Engine.Advanced.CreateMessagePortPair and
+        // Engine.Advanced.EnableWebApis — have to be able to ask what an engine already carries, and Options
+        // is shareable so it cannot be asked later.
         engine._webApiFeatures = features;
 
         CreateEngineState(options, engine, features);
+        InstallGlobals(engine, features);
+    }
+
+    /// <summary>
+    /// The post-construction door: <c>Engine.Advanced.EnableWebApis</c>. Additive only, and deliberately the
+    /// very same closure, state-creation and install code <see cref="Apply"/> runs — the only differences are
+    /// that the state may have to be <i>extended</i> rather than created, and that the install lands on an
+    /// engine whose inline caches may already hold a resolved binding for one of these names.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The whole feature set is re-installed rather than only the newly added flags, because several globals
+    /// are conditioned on a <i>pair</i> of features — <c>TextDecoderStream</c> needs both
+    /// <see cref="WebApiFeatures.Encoding"/> and <see cref="WebApiFeatures.Streams"/> — so adding one half
+    /// completes a pair the other half could not install on its own. <see cref="Install"/> leaves every name
+    /// the global already owns alone, and does so with a probe, so re-running it neither replaces an
+    /// already-installed global nor materializes an unread one.
+    /// </para>
+    /// <para>
+    /// <paramref name="configure"/> runs only when something is actually being enabled, so that a call naming
+    /// nothing new is a no-op in every sense rather than one that still mutates the options.
+    /// </para>
+    /// </remarks>
+    /// <returns>The features this call added, after closure expansion; <see cref="WebApiFeatures.None"/> when
+    /// everything asked for was already present.</returns>
+    internal static WebApiFeatures ApplyLive(Engine engine, WebApiFeatures requested, Action<Options.WebApiOptions>? configure)
+    {
+        var existing = engine._webApiFeatures;
+
+        // The closure is monotone and `existing` has already been through it, so expanding the request alone
+        // gives the same answer as expanding the union — and this is the one place the rules live.
+        var added = ExpandFeatures(requested) & ~existing;
+        if (added == WebApiFeatures.None)
+        {
+            return WebApiFeatures.None;
+        }
+
+        // Touching the WebApi property allocates the group if the engine was built from options that never
+        // named a web API — a host-thread act, like every other option mutation, and the only place engine
+        // code ever does it. That is exactly what this call is: the host asking, on the engine's own thread,
+        // for something the options never said.
+        var options = engine.Options;
+        configure?.Invoke(options.WebApi);
+
+        var combined = existing | added;
+        engine._webApiFeatures = combined;
+
+        var state = engine._webApi;
+        if (state is null)
+        {
+            CreateEngineState(options, engine, combined);
+        }
+        else
+        {
+            // `added` rather than `combined`: the options group belonging to a feature that was already on has
+            // been read once already, and reading it again is exactly the "read once, when the engine is
+            // built" promise every one of those settings makes.
+            ExtendEngineState(options, engine, state, added);
+        }
+
+        InstallGlobals(engine, combined);
+        return added;
+    }
+
+    private static void InstallGlobals(Engine engine, WebApiFeatures features)
+    {
+        // The PRINCIPAL realm, deliberately, and not Engine.Realm: during construction the two are the same,
+        // but the live door can be called from anywhere — including a host callback running inside a
+        // ShadowRealm — and these globals belong to the engine's own realm and to no other.
+        var global = engine._mainRealm.GlobalObject;
 
         if (features == WebApiFeatures.None)
         {
             // Reachable only for an engine whose host set a diagnostics sink and named no feature: it gets the
-            // reporting channel the state above carries and no globals whatever — not even DOMException, which
+            // reporting channel the state carries and no globals whatever — not even DOMException, which
             // exists to let a web API report a failure to script and here there is no web API to have one.
             return;
         }
@@ -292,7 +363,7 @@ internal static class WebApiRegistration
     /// </remarks>
     internal static void InstallFetchModel(Engine engine)
     {
-        var global = engine.Realm.GlobalObject;
+        var global = engine._mainRealm.GlobalObject;
         Install(global, engine, "Headers", static e => e.Realm.Intrinsics.Headers, PropertyFlag.NonEnumerable);
         Install(global, engine, "Request", static e => e.Realm.Intrinsics.Request, PropertyFlag.NonEnumerable);
         Install(global, engine, "Response", static e => e.Realm.Intrinsics.Response, PropertyFlag.NonEnumerable);
@@ -355,6 +426,32 @@ internal static class WebApiRegistration
     }
 
     /// <summary>
+    /// The features that keep something in <c>Engine._webApi</c>. The timer globals are the obvious reason for
+    /// a queue; AbortSignal.timeout() and a delayed scheduler.postTask() are the others, and they need one
+    /// whether or not the host also asked for setTimeout. The events, messaging and performance features
+    /// additionally read the time origin (Event.timeStamp, MessageEvent.timeStamp, performance.now), fetch
+    /// keeps its settings and its in-flight set here, the scheduler keeps its own task queues here, and storage
+    /// keeps its providers here, which is why each of them wants the state even without the timers flag.
+    /// </summary>
+    private const WebApiFeatures NeedsEngineState =
+        WebApiFeatures.Timers | WebApiFeatures.Events | WebApiFeatures.Performance | WebApiFeatures.Fetch | WebApiFeatures.Scheduler | WebApiFeatures.Messaging | WebApiFeatures.Storage | WebApiFeatures.WebSocket | WebApiFeatures.CacheApi | WebApiFeatures.IdleCallback;
+
+    /// <summary>
+    /// The queue exists for the timer globals, for AbortSignal.timeout() and for a delayed
+    /// scheduler.postTask(), each of which needs it whether or not the host also asked for setTimeout; a
+    /// performance-only engine reads just the time origin and never schedules, so it carries no queue at all.
+    /// </summary>
+    private const WebApiFeatures NeedsTimerQueue =
+        WebApiFeatures.Timers | WebApiFeatures.Events | WebApiFeatures.Scheduler | WebApiFeatures.IdleCallback;
+
+    /// <summary>
+    /// The features that take their transport and their policy from <c>Options.WebApi.Fetch</c>. EventSource
+    /// and WebSocket read the same group as fetch: they are further grants of network access over the same
+    /// transport and the same policy, so any of the three is reason enough to keep the settings.
+    /// </summary>
+    private const WebApiFeatures NeedsFetchOptions = WebApiFeatures.Fetch | WebApiFeatures.EventSource | WebApiFeatures.WebSocket;
+
+    /// <summary>
     /// Creates <c>Engine._webApi</c> — once, and before any feature block, because more than one feature keeps
     /// state in it now. A feature that needs none leaves the field null, which is what every hot path that
     /// consults it starts by checking, so a <c>console</c>-only engine is still the engine it was.
@@ -366,15 +463,6 @@ internal static class WebApiRegistration
     /// </remarks>
     private static void CreateEngineState(Options options, Engine engine, WebApiFeatures features)
     {
-        // The timer globals are the obvious reason for a queue; AbortSignal.timeout() and a delayed
-        // scheduler.postTask() are the others, and they need one whether or not the host also asked for
-        // setTimeout. The events, messaging and performance features additionally read the time origin
-        // (Event.timeStamp, MessageEvent.timeStamp, performance.now), fetch keeps its settings and its
-        // in-flight set here, the scheduler keeps its own task queues here, and storage keeps its providers
-        // here, which is why each of them wants the state even without the timers flag.
-        const WebApiFeatures NeedsEngineState =
-            WebApiFeatures.Timers | WebApiFeatures.Events | WebApiFeatures.Performance | WebApiFeatures.Fetch | WebApiFeatures.Scheduler | WebApiFeatures.Messaging | WebApiFeatures.Storage | WebApiFeatures.WebSocket | WebApiFeatures.CacheApi | WebApiFeatures.IdleCallback;
-
         // The diagnostics sink is the one thing here no feature flag governs: a host that set one gets the
         // channel whatever else it did or did not ask for, which is why it is read before the flags are.
         var diagnostics = options.WebApi.Diagnostics.Sink;
@@ -387,21 +475,12 @@ internal static class WebApiRegistration
         var timerOptions = options.WebApi.Timers;
         var timeProvider = timerOptions.TimeProvider ?? TimeProvider.System;
 
-        // The queue exists for the timer globals, for AbortSignal.timeout() and for a delayed
-        // scheduler.postTask(), each of which needs it whether or not the host also asked for setTimeout; a
-        // performance-only engine reads just the time origin and never schedules, so it carries no queue at
-        // all.
-        const WebApiFeatures NeedsTimerQueue =
-            WebApiFeatures.Timers | WebApiFeatures.Events | WebApiFeatures.Scheduler | WebApiFeatures.IdleCallback;
         var timers = (features & NeedsTimerQueue) != WebApiFeatures.None
             ? new TimerQueue(timeProvider, timerOptions.MaxActiveTimers, diagnostics)
             : null;
 
         // The fetch settings are read here, once, so that nothing on a background thread ever reaches into
         // Options — and so that a host mutating them afterwards does not change an engine that already exists.
-        // EventSource reads the same group: it is a second grant of network access over the same transport
-        // and the same policy, so either flag is reason enough to keep them.
-        const WebApiFeatures NeedsFetchOptions = WebApiFeatures.Fetch | WebApiFeatures.EventSource | WebApiFeatures.WebSocket;
         var fetch = (features & NeedsFetchOptions) != WebApiFeatures.None ? options.WebApi.Fetch : null;
 
         var scheduler = (features & WebApiFeatures.Scheduler) != WebApiFeatures.None
@@ -419,14 +498,72 @@ internal static class WebApiRegistration
             : null;
 
         // The idle queue needs the timer queue for the `timeout` option, and the realm so it can build an
-        // IdleDeadline for each invocation. Engine.Realm is the principal realm here — Options.Apply runs
-        // during construction, long before any ShadowRealm can exist — and the principal realm is the only
-        // one these globals are installed in.
+        // IdleDeadline for each invocation. The PRINCIPAL realm, which is the only one these globals are
+        // installed in — and the only one this can mean when the live door is called from inside a
+        // ShadowRealm callback.
         var idleCallbacks = (features & WebApiFeatures.IdleCallback) != WebApiFeatures.None
-            ? new IdleCallbackQueue(engine, engine.Realm, timeProvider, timers!, timerOptions.IdleBudget)
+            ? new IdleCallbackQueue(engine, engine._mainRealm, timeProvider, timers!, timerOptions.IdleBudget)
             : null;
 
         engine._webApi = new WebApiEngineState(engine, timeProvider, timers, fetch, scheduler, diagnostics, storage, cache, idleCallbacks);
+    }
+
+    /// <summary>
+    /// Attaches to an existing <c>Engine._webApi</c> whatever the features being enabled <i>now</i> need and it
+    /// does not already carry. The other half of <see cref="ApplyLive"/>, and the reason
+    /// <see cref="WebApiEngineState"/>'s slots are settable at all.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every attachment fills a null slot and never replaces a live one, so a queue the engine has been
+    /// scheduling on cannot be swapped underneath it. <paramref name="added"/> is the newly enabled set rather
+    /// than the union, which is what keeps the "read once, when the engine is built" promise every one of these
+    /// settings makes: a group belonging to a feature that was already on is not read a second time.
+    /// </para>
+    /// <para>
+    /// Two things are deliberately <b>not</b> re-read. The <b>clock</b> is the state's own — the timers,
+    /// <c>performance.now()</c> and the time origin have to stay on one clock for the engine's whole life, so a
+    /// <c>TimeProvider</c> assigned to the options after construction never reaches an engine that already
+    /// exists. And the <b>diagnostics sink</b>, whose contract is that it holds still for an engine's lifetime
+    /// because it also decides whether a callback's exception erupts.
+    /// </para>
+    /// </remarks>
+    private static void ExtendEngineState(Options options, Engine engine, WebApiEngineState state, WebApiFeatures added)
+    {
+        var timerOptions = options.WebApi.Timers;
+
+        if ((added & NeedsTimerQueue) != WebApiFeatures.None && state.Timers is null)
+        {
+            state.AttachTimers(new TimerQueue(state.TimeProvider, timerOptions.MaxActiveTimers, state.Diagnostics));
+        }
+
+        if ((added & NeedsFetchOptions) != WebApiFeatures.None && state.FetchOptions is null)
+        {
+            state.AttachFetchOptions(options.WebApi.Fetch);
+        }
+
+        if ((added & WebApiFeatures.Scheduler) != WebApiFeatures.None && state.Scheduler is null)
+        {
+            state.AttachScheduler(new SchedulerQueue(engine));
+        }
+
+        if ((added & WebApiFeatures.Storage) != WebApiFeatures.None)
+        {
+            state.AttachStorage(options.WebApi.Storage);
+        }
+
+        if ((added & WebApiFeatures.CacheApi) != WebApiFeatures.None && state.CacheProvider is null)
+        {
+            state.AttachCacheProvider(options.WebApi.Cache.Provider ?? new InMemoryCacheStorageProvider());
+        }
+
+        if ((added & WebApiFeatures.IdleCallback) != WebApiFeatures.None && state.IdleCallbacks is null)
+        {
+            // The timer queue is there: IdleCallback is in NeedsTimerQueue, so either the state already had
+            // one or the block above has just attached it.
+            state.AttachIdleCallbacks(
+                new IdleCallbackQueue(engine, engine._mainRealm, state.TimeProvider, state.Timers!, timerOptions.IdleBudget));
+        }
     }
 
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -274,6 +274,59 @@ encoding, never decoded as something else. The label table and the single-byte i
 from the standard's own data files; `TextEncoder` is UTF-8 only, as the standard requires.
 
 
+### Enabling web APIs on an engine that already exists
+
+`options.WebApi.Features` is read once, when the engine is built, so a pooled engine's feature set is fixed at
+construction — which is awkward for a host that only discovers *per request* what the script it is about to
+run needs. `engine.Advanced.EnableWebApis(...)` is the per-engine counterpart of `options.UseWebApis(...)`,
+for exactly that case:
+
+```csharp
+var engine = pool.Rent();                       // built with WebApiFeatures.Console only
+
+if (script.NeedsTimers)
+{
+    engine.Advanced.EnableWebApis(WebApiFeatures.Timers | WebApiFeatures.Events);
+}
+
+if (tenant.MayReachTheNetwork)
+{
+    // The optional delegate is handed this engine's own options group, so a feature that carries settings
+    // can be configured at the moment it is enabled.
+    engine.Advanced.EnableWebApis(WebApiFeatures.Fetch, w =>
+        w.Fetch.UrlFilter = uri => tenant.Allows(uri));
+}
+
+// What the engine actually carries, after the feature closure has been expanded.
+WebApiFeatures live = engine.Advanced.WebApiFeatures;   // Console | Timers | Events | Fetch | Url | Files | Streams
+```
+
+It runs the same code construction runs — the same feature closure, the same per-engine state, the same lazy,
+non-clobbering globals — so an engine enabled this way is the engine `options.UseWebApis(...)` would have
+built. Four things are worth knowing:
+
+* **It is additive only.** There is no way to turn a web API off again; a script that already captured
+  `fetch` would keep it whatever a later call said. Naming a feature the engine already has is a plain no-op —
+  not an error, not a re-install — and the return value tells you what actually changed. A global you
+  registered yourself still wins, and the existence check *probes*, so your own lazy global is not built
+  merely by our looking.
+* **Network access is still only ever granted by name.** No feature closure pulls in `Fetch`, `EventSource`
+  or `WebSocket`; asking for `WebApiFeatures.Default` here grants exactly what it grants on the options.
+* **Settings come from this engine's `Options`, read at the moment of the call**, with the same read-once
+  semantics they have at construction. The delegate is handed that same group — which, exactly as at options
+  time, is shared with every other engine built from the same `Options` instance, so give an engine its own
+  `Options` when its network policy has to be its own. Two settings are deliberately *not* re-read for an
+  engine that already has web-API state: `Timers.TimeProvider`, because the timers, `performance.now()` and
+  the time origin have to stay on one clock for the engine's life, and `Diagnostics.Sink`, which also decides
+  whether a callback's exception erupts.
+* **`RestoreGlobalSnapshot` removes globals installed after the capture**, exactly as it does for
+  `AddLazyGlobal` and `SetFetchHandler` — and it does *not* revert the engine's feature record, so the engine
+  is left knowing about an API whose globals script can no longer name, and re-calling `EnableWebApis` is a
+  no-op that cannot bring them back. Enable **before** you capture the snapshot you reuse, or enable on the
+  `Options` so the globals are part of the engine's initial state.
+
+As at options time, only the principal realm is touched: a `ShadowRealm` still gets none of it.
+
 ### Timers fire only while the engine is being pumped
 
 **Jint never starts a thread, and never a `System.Threading.Timer`, to run your script.** A `setTimeout`


### PR DESCRIPTION
Closes #3126.

A host can now enable Web API features on an engine that already exists:

```csharp
engine.Advanced.EnableWebApis();                                       // WebApiFeatures.Default
engine.Advanced.EnableWebApis(WebApiFeatures.Fetch, o => { o.Fetch.UrlFilter = ...; });
engine.Advanced.WebApiFeatures                                          // the post-closure set the engine carries
```

**Additive-only, and one code path.** `WebApiRegistration.Apply` split into `ExpandFeatures` / `CreateEngineState` / `InstallGlobals`, and the live door (`ApplyLive`) runs the very same three — the closure rules exist in exactly one function, and the monotone-closure property (`existing` is always already-expanded) is what makes the delta computation exact. Enabling something already present is an observable no-op: the method returns the closure-expanded set it actually added, `None` included, so a host granting network access can assert on what happened. No non-network feature ever pulls in a network one — pinned for every enum member.

**State extends, never replaces.** An engine with no `WebApiEngineState` gets one built exactly as construction would have; one that has state gets only its null slots filled (`AttachTimers`/`AttachScheduler`/…, each asserting emptiness), so the time origin cannot move and a clock configured later is deliberately not adopted. The `configure` delegate runs only when something is actually being enabled, and hands over the engine's own `Options.WebApi` — the group the state holds by reference, which is what keeps `UrlFilter`/`AllowedSchemes` live per request; the sharing consequence for a host that shares one `Options` across engines is documented on the method and in the README.

**Installs behave exactly as at options time**: non-clobbering lazy descriptors through `GlobalObject.SetProperty` (the `AddLazyGlobal` body — the version bump per the AGENTS.md invariant), the union re-installed rather than the delta because pair-gated globals (`TextDecoderStream` = `Encoding`+`Streams`) can be completed by the second half, a host's own global of the same name survives unmaterialized, and only the principal realm is touched — `InstallGlobals` now names `engine._mainRealm` explicitly so the live door is correct even when reached from inside a ShadowRealm callback. Two drive-by corrections rode along: `CreateAbortSignal` gated on the raw `Options.WebApi.Features` instead of the engine's recorded closure (so `UseFetch()`, which implies `Events`, was wrongly refused) and reached into shareable `Options` from engine code.

**Snapshot interaction pinned, not invented**: restoring a snapshot captured *before* a live enable removes the installed globals (as it does for every post-construction install), while the engine-side feature record and queues survive — so a later `EnableWebApis` of the same feature is a no-op that cannot bring the globals back; the remedy (capture after enabling, or enable via `Options`) is documented. A snapshot captured *after* carries them through every restore.

31 tests (23 PublicInterface — third-party-reachable surface including a whole-`globalThis` parity survey against an options-configured engine, ManualClock-driven timer firing, warmed-site re-resolution, ShadowRealm exclusion; 8 internals — version bump, closure recording, state extension). Each fix-relevant pin was shown failing against deliberately broken code (four breakages, each reverted).

Gate: solution build 0 errors (all five TFMs — the net462/netstandard legs prove the `#if` hygiene); Jint.Tests 9069/7046; PublicInterface 1962/1556; both host-contract-verification legs green. Rebased over #3157 and #3158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G7Ud48VAs1JicxRZxLDxg
