### PR TITLE
Fix the three WPT-surfaced defects: WebIDL constant order, decode-time detach, UTF-16 end-of-queue

### DIFF
--- a/Jint.SourceGenerators/Attributes.cs
+++ b/Jint.SourceGenerators/Attributes.cs
@@ -31,6 +31,17 @@ internal static class Attributes
             /// BuiltinShapeObject.
             /// </summary>
             public bool UseShape { get; set; } = true;
+
+            /// <summary>
+            /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+            /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+            /// defines them one after another in IDL declaration order, and that order is observable —
+            /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+            /// default because it makes enumeration order a property of the names rather than of how a host
+            /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+            /// symbols and aliases stay sorted.
+            /// </summary>
+            public bool PreserveDeclarationOrder { get; set; }
         }
 
         [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.SourceGenerators/Models.cs
+++ b/Jint.SourceGenerators/Models.cs
@@ -108,6 +108,7 @@ internal sealed record class ObjectDefinition(
         var extraCapacity = 0;
         var useShapeRequested = true;
         var useShapeExplicitlySet = false;
+        var preserveDeclarationOrder = false;
         foreach (var attr in typeSymbol.GetAttributes())
         {
             if (attr.AttributeClass?.Name != "JsObjectAttribute") continue;
@@ -115,6 +116,7 @@ internal sealed record class ObjectDefinition(
             {
                 if (named.Key == "ExtraCapacity" && named.Value.Value is int v) extraCapacity = v;
                 else if (named.Key == "UseShape" && named.Value.Value is bool s) { useShapeRequested = s; useShapeExplicitlySet = true; }
+                else if (named.Key == "PreserveDeclarationOrder" && named.Value.Value is bool d) preserveDeclarationOrder = d;
             }
         }
 
@@ -403,7 +405,16 @@ internal sealed record class ObjectDefinition(
         // and — via Factory slots — [JsIntrinsicReference]s and [JsThrowerAccessor]s.
 
         functions.Sort(static (a, b) => string.CompareOrdinal(a.JsName, b.JsName));
-        properties.Sort(static (a, b) => string.CompareOrdinal(a.JsName, b.JsName));
+
+        // [JsObject(PreserveDeclarationOrder = true)] leaves the properties in the order GetMembers() hands
+        // them back, which for a source type is the order they are declared in — what a WebIDL interface's
+        // constants need, and what nothing ECMAScript defines does. Both emission paths read this list
+        // directly, so skipping the sort here is the whole of it.
+        if (!preserveDeclarationOrder)
+        {
+            properties.Sort(static (a, b) => string.CompareOrdinal(a.JsName, b.JsName));
+        }
+
         symbols.Sort(static (a, b) => string.CompareOrdinal(a.SymbolName, b.SymbolName));
         throwerAccessors.Sort(static (a, b) => string.CompareOrdinal(a.JsName, b.JsName));
         intrinsicReferences.Sort(static (a, b) => string.CompareOrdinal(a.JsName, b.JsName));

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterAndSetter#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterAndSetter#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterOnly#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterOnly#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorWrongArity_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorWrongArity_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ArgCountParameter#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ArgCountParameter#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.CoercedRestSpan#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.CoercedRestSpan#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.CoercedRestSpanTypeMismatch_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.CoercedRestSpanTypeMismatch_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConflictingAccessorFlags_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConflictingAccessorFlags_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConflictingConversionAttrs_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConflictingConversionAttrs_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConversionTypeMismatch_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConversionTypeMismatch_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.DuplicateIntrinsicReference_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.DuplicateIntrinsicReference_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.DuplicateThrower_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.DuplicateThrower_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallDeclaredArgumentGuards#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallDeclaredArgumentGuards#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallKeyedCollectionGuards#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallKeyedCollectionGuards#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallLanes#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallLanes#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallOnArgCount_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallOnArgCount_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallOnOverlongArity_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallOnOverlongArity_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallOnRawArguments_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallOnRawArguments_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallSingleSlot#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallSingleSlot#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallTypedReceiver#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallTypedReceiver#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallVariadicLanes#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallVariadicLanes#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallVariadicSingleSlot#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FastCallVariadicSingleSlot#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FunctionCaptureField#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.FunctionCaptureField#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.InstanceMethod#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.InstanceMethod#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntegerConversions#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntegerConversions#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntrinsicReference#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntrinsicReference#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntrinsicReferenceWithoutRealmField_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntrinsicReferenceWithoutRealmField_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.LeafOnUncoercedRest_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.LeafOnUncoercedRest_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.LeafOnUnguardableHazards_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.LeafOnUnguardableHazards_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.MinimalClass#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.MinimalClass#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.MissingRealmField_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.MissingRealmField_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.NotPartial_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.NotPartial_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.OverloadCollision_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.OverloadCollision_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.PassthroughArguments#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.PassthroughArguments#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.PropertyConstants#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.PropertyConstants#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RestParameter#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RestParameter#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RichConversions#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RichConversions#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ShapeAliasAndInstanceSlot#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ShapeAliasAndInstanceSlot#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ShapeFunctionCaptureField#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ShapeFunctionCaptureField#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ShapeIntrinsicReference#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ShapeIntrinsicReference#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ShapeSymbolAlias#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ShapeSymbolAlias#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ShapeThrowerAccessor#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ShapeThrowerAccessor#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.StringAliasSharesDescriptor#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.StringAliasSharesDescriptor#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolAccessorGetterOnly#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolAccessorGetterOnly#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolAlias#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolAlias#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolFunctionCaptureField#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolFunctionCaptureField#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolFunctionMethod#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolFunctionMethod#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolMember#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolMember#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToCallable#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToCallable#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToObjectInstance#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToObjectInstance#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThrowerAccessor#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThrowerAccessor#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ToNumberConversion#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ToNumberConversion#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.UnsupportedReturnType_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.UnsupportedReturnType_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -27,6 +27,17 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     /// BuiltinShapeObject.
     /// </summary>
     public bool UseShape { get; set; } = true;
+
+    /// <summary>
+    /// Emit the [JsProperty] members in the order they are declared rather than sorted by JS name,
+    /// which a WebIDL interface's constants need: https://webidl.spec.whatwg.org/#es-constants
+    /// defines them one after another in IDL declaration order, and that order is observable —
+    /// a record conversion over the interface object reads [[OwnPropertyKeys]]. Sorting is the
+    /// default because it makes enumeration order a property of the names rather than of how a host
+    /// file happens to be laid out. Covers [JsProperty] and nothing else: [JsFunction]s, accessors,
+    /// symbols and aliases stay sorted.
+    /// </summary>
+    public bool PreserveDeclarationOrder { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests/Runtime/WebApi/DomExceptionTests.cs
+++ b/Jint.Tests/Runtime/WebApi/DomExceptionTests.cs
@@ -89,6 +89,31 @@ public class DomExceptionTests
     }
 
     [Fact]
+    public void EnumeratesTheLegacyConstantsInDeclarationOrder()
+    {
+        var engine = WebEngine();
+
+        // https://webidl.spec.whatwg.org/#es-constants defines the constants one after another in the order
+        // the IDL declares them, so INDEX_SIZE_ERR comes first and DATA_CLONE_ERR last — alphabetical order
+        // would start at ABORT_ERR. web-platform-tests reads exactly this through the record conversion:
+        // `new URLSearchParams(DOMException).toString()` in url/urlsearchparams-constructor.any.js.
+        const string Expected =
+            "INDEX_SIZE_ERR,DOMSTRING_SIZE_ERR,HIERARCHY_REQUEST_ERR,WRONG_DOCUMENT_ERR,INVALID_CHARACTER_ERR," +
+            "NO_DATA_ALLOWED_ERR,NO_MODIFICATION_ALLOWED_ERR,NOT_FOUND_ERR,NOT_SUPPORTED_ERR,INUSE_ATTRIBUTE_ERR," +
+            "INVALID_STATE_ERR,SYNTAX_ERR,INVALID_MODIFICATION_ERR,NAMESPACE_ERR,INVALID_ACCESS_ERR,VALIDATION_ERR," +
+            "TYPE_MISMATCH_ERR,SECURITY_ERR,NETWORK_ERR,ABORT_ERR,URL_MISMATCH_ERR,QUOTA_EXCEEDED_ERR,TIMEOUT_ERR," +
+            "INVALID_NODE_TYPE_ERR,DATA_CLONE_ERR";
+
+        engine.Evaluate("Object.keys(DOMException).join(',')").AsString().Should().Be(Expected);
+        engine.Evaluate("Object.getOwnPropertyNames(DOMException.prototype).filter(function (n) { return /_ERR$/.test(n); }).join(',')")
+            .AsString().Should().Be(Expected);
+
+        // The values track the names, which is what the URLSearchParams row actually asserts.
+        engine.Evaluate("Object.values(DOMException).join(',')").AsString()
+            .Should().Be("1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25");
+    }
+
+    [Fact]
     public void GivesTheConstantsTheAttributesWebIdlGivesConstants()
     {
         var engine = WebEngine();

--- a/Jint.Tests/Runtime/WebApi/EncodingTests.cs
+++ b/Jint.Tests/Runtime/WebApi/EncodingTests.cs
@@ -281,6 +281,37 @@ public class EncodingTests
     }
 
     [Fact]
+    public void CopiesTheInputOnlyOnceTheOptionsDictionaryHasBeenConverted()
+    {
+        var engine = WebEngine();
+
+        // WebIDL converts both arguments before the operation runs, and
+        // https://encoding.spec.whatwg.org/#dom-textdecoder-decode step 3 then pushes "a copy of input" onto
+        // the I/O queue — so a `stream` getter that detaches the buffer during the dictionary conversion
+        // leaves nothing to decode: https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy step 5 makes
+        // a detached buffer source the empty byte sequence. Mirrors "TextDecoder decode() with array buffer
+        // detached during arg conversion" in web-platform-tests encoding/textdecoder-arguments.any.js.
+        engine.Evaluate("""
+            const decoder = new TextDecoder();
+            const arr = new Uint8Array(10000).fill(42);
+            const result = decoder.decode(arr, { get stream() { arr.buffer.transfer(0); return false; } });
+            """);
+
+        engine.Evaluate("result").AsString().Should().Be("");
+
+        // The getter still runs, and its answer is still the `stream` option.
+        engine.Evaluate("""
+            const other = new TextDecoder();
+            const bytes = new Uint8Array([0x61, 0xE2, 0x82]);
+            const streamed = other.decode(bytes, { get stream() { bytes.buffer.transfer(0); return true; } });
+            const flushed = other.decode();
+            """);
+
+        engine.Evaluate("streamed").AsString().Should().Be("");
+        engine.Evaluate("flushed").AsString().Should().Be("");
+    }
+
+    [Fact]
     public void RefusesAnInputThatIsNotABufferSource()
     {
         var engine = WebEngine();
@@ -343,6 +374,27 @@ public class EncodingTests
 
         engine.Evaluate("new TextDecoder('utf-16le').decode(new Uint8Array([0x00, 0xD8, 0x61, 0x00])).charCodeAt(0)")
             .AsNumber().Should().Be(0xFFFD);
+    }
+
+    [Fact]
+    public void EndsAUtf16QueueWithOneReplacementHoweverMuchIsPending()
+    {
+        var engine = WebEngine();
+
+        // https://encoding.spec.whatwg.org/#shared-utf-16-decoder, the end-of-queue step: "If UTF-16 lead
+        // byte is non-null or UTF-16 lead surrogate is non-null, set UTF-16 lead byte and UTF-16 lead
+        // surrogate to null, and return error" — one error however many of the two are pending. Mirrors the
+        // "utf-16{le,be} does not produce more chars than truncated" rows of
+        // web-platform-tests encoding/textdecoder-mistakes.any.js.
+        engine.Evaluate("new TextDecoder('utf-16le').decode(new Uint8Array([0, 0, 0]))").AsString().Should().Be("\0�");
+        engine.Evaluate("new TextDecoder('utf-16le').decode(new Uint8Array([42, 0, 0]))").AsString().Should().Be("*�");
+        engine.Evaluate("new TextDecoder('utf-16le').decode(new Uint8Array([0, 0xd8, 0]))").AsString().Should().Be("�");
+        engine.Evaluate("new TextDecoder('utf-16le').decode(new Uint8Array([0, 0xd8, 0xd8]))").AsString().Should().Be("�");
+
+        engine.Evaluate("new TextDecoder('utf-16be').decode(new Uint8Array([0, 0, 0]))").AsString().Should().Be("\0�");
+        engine.Evaluate("new TextDecoder('utf-16be').decode(new Uint8Array([0, 42, 0]))").AsString().Should().Be("*�");
+        engine.Evaluate("new TextDecoder('utf-16be').decode(new Uint8Array([0xd8, 0, 0]))").AsString().Should().Be("�");
+        engine.Evaluate("new TextDecoder('utf-16be').decode(new Uint8Array([0xd8, 0, 0xd8]))").AsString().Should().Be("�");
     }
 
     #endregion

--- a/Jint.Tests/Runtime/WebApi/EventSourceTests.cs
+++ b/Jint.Tests/Runtime/WebApi/EventSourceTests.cs
@@ -425,6 +425,10 @@ public class EventSourceTests
         engine.Evaluate("[EventSource.CONNECTING, EventSource.OPEN, EventSource.CLOSED].join(',')").AsString().Should().Be("0,1,2");
         engine.Evaluate("[EventSource.prototype.CONNECTING, EventSource.prototype.OPEN, EventSource.prototype.CLOSED].join(',')").AsString().Should().Be("0,1,2");
 
+        // … in the order the IDL declares them, which that section defines them in and which a record
+        // conversion over the interface object reads.
+        engine.Evaluate("Object.keys(EventSource).join(',')").AsString().Should().Be("CONNECTING,OPEN,CLOSED");
+
         var descriptor = engine.Evaluate("Object.getOwnPropertyDescriptor(EventSource, 'OPEN')").AsObject();
         descriptor.Get("writable").AsBoolean().Should().BeFalse();
         descriptor.Get("enumerable").AsBoolean().Should().BeTrue();

--- a/Jint.Tests/Runtime/WebApi/EventTests.cs
+++ b/Jint.Tests/Runtime/WebApi/EventTests.cs
@@ -100,6 +100,11 @@ public class EventTests
         engine.Evaluate("[Event.prototype.NONE, Event.prototype.CAPTURING_PHASE, Event.prototype.AT_TARGET, Event.prototype.BUBBLING_PHASE].join(',')")
             .AsString().Should().Be("0,1,2,3");
 
+        // … and in the order the IDL declares them, which that section defines them in and which the record
+        // conversion behind `new URLSearchParams(Event)` reads through [[OwnPropertyKeys]].
+        engine.Evaluate("Object.keys(Event).join(',')").AsString()
+            .Should().Be("NONE,CAPTURING_PHASE,AT_TARGET,BUBBLING_PHASE");
+
         // https://webidl.spec.whatwg.org/#es-constants: { writable: false, enumerable: true, configurable: false }.
         var descriptor = "Object.getOwnPropertyDescriptor(Event, 'AT_TARGET')";
         engine.Evaluate($"{descriptor}.writable").AsBoolean().Should().BeFalse();

--- a/Jint.Tests/Runtime/WebApi/WebSocketTests.cs
+++ b/Jint.Tests/Runtime/WebApi/WebSocketTests.cs
@@ -997,6 +997,11 @@ public class WebSocketTests
         engine.Evaluate("[WebSocket.prototype.CONNECTING, WebSocket.prototype.OPEN, WebSocket.prototype.CLOSING, WebSocket.prototype.CLOSED].join(',')")
             .AsString().Should().Be("0,1,2,3");
 
+        // … and in the order the IDL declares them, which is the order that section defines them in and the
+        // one a record conversion over the interface object reads.
+        engine.Evaluate("Object.keys(WebSocket).join(',')").AsString()
+            .Should().Be("CONNECTING,OPEN,CLOSING,CLOSED");
+
         // https://webidl.spec.whatwg.org/#es-constants — { writable: false, enumerable: true, configurable: false }
         var descriptor = engine.Evaluate("Object.getOwnPropertyDescriptor(WebSocket, 'OPEN')");
         descriptor.Get("writable").AsBoolean().Should().BeFalse();

--- a/Jint.Tests/Wpt/WptExclusions.cs
+++ b/Jint.Tests/Wpt/WptExclusions.cs
@@ -51,9 +51,13 @@ internal enum WptDivergence
 
     /// <summary>
     /// A genuine failure that is not attributable to a feature Jint has decided not to have. Every entry
-    /// here is a bug or a specification detail to chase, and this phase of the harness work deliberately
-    /// records them rather than fixing them: the point of standing the suites up was to find out what they
-    /// say, and mixing engine fixes into the change that first ran them would hide which of the two moved.
+    /// here is a bug or a specification detail to chase, and the phase of the harness work that stood the
+    /// suites up deliberately recorded them rather than fixing them: the point was to find out what they
+    /// say, and mixing engine fixes into the change that first ran them would have hidden which of the two
+    /// moved. The four it recorded — WebIDL constant order, <c>TextDecoder.decode()</c> reading its input
+    /// before the options dictionary was converted, and the shared UTF-16 decoder's end-of-queue step for
+    /// both endiannesses — were fixed by https://github.com/sebastienros/jint/issues/3121, so nothing is
+    /// filed here today.
     /// </summary>
     NeedsTriage,
 }

--- a/Jint.Tests/Wpt/WptTestRunner.cs
+++ b/Jint.Tests/Wpt/WptTestRunner.cs
@@ -19,9 +19,11 @@ namespace Jint.Tests.Wpt;
 /// </para>
 /// <para>
 /// This is phase 1 of https://github.com/sebastienros/jint/issues/3104: the shim and the first two suites.
-/// Failures were expected and found; the ones that are not a missing feature are parked under
-/// <see cref="WptDivergence.NeedsTriage"/> rather than fixed here, so that the change which first ran these
-/// suites is not also the change that moved the engine.
+/// Failures were expected and found; the ones that were not a missing feature were parked under
+/// <see cref="WptDivergence.NeedsTriage"/> rather than fixed there, so that the change which first ran these
+/// suites was not also the change that moved the engine. All four were fixed by
+/// https://github.com/sebastienros/jint/issues/3121, so the category is currently unused — which is the
+/// state it is meant to be in, and an entry earning it back is a bug to open rather than a line to keep.
 /// </para>
 /// </remarks>
 public class WptTestRunner
@@ -206,13 +208,6 @@ public class WptTestRunner
         new("url/urlencoded-parser.any.js", "request.formData() with input: *", WptDivergence.NeedsFetchObjectModel),
         new("url/urlencoded-parser.any.js", "response.formData() with input: *", WptDivergence.NeedsFetchObjectModel),
 
-        // `new URLSearchParams(DOMException)` reads the interface object's own enumerable properties, which
-        // are its 25 legacy code constants, and the record conversion keeps [[OwnPropertyKeys]] order. The
-        // values are all correct; Jint hands them back in alphabetical order where WebIDL requires the order
-        // the constants are declared in (INDEX_SIZE_ERR first, DATA_CLONE_ERR last).
-        // https://webidl.spec.whatwg.org/#es-constants
-        new("url/urlsearchparams-constructor.any.js", "URLSearchParams constructor, DOMException as argument", WptDivergence.NeedsTriage),
-
         // ---------------------------------------------------------------- encoding
         // common/sab.js takes its SharedArrayBuffer constructor from WebAssembly.Memory. Note that
         // "Invalid encodeInto() destination: SharedArrayBuffer" is *not* here: it asserts a TypeError, and
@@ -222,19 +217,6 @@ public class WptTestRunner
         new("encoding/encodeInto.any.js", "Invalid encodeInto() destination: *, backed by: SharedArrayBuffer", WptDivergence.NeedsWebAssembly),
         new("encoding/textdecoder-copy.any.js", "Modify buffer after passing it in (SharedArrayBuffer)", WptDivergence.NeedsWebAssembly),
         new("encoding/textdecoder-streaming.any.js", "*(SharedArrayBuffer)", WptDivergence.NeedsWebAssembly),
-
-        // https://encoding.spec.whatwg.org/#dom-textdecoder-decode step 1 copies the bytes, and WebIDL
-        // converts the options dictionary before the operation runs — so a getter on the dictionary that
-        // detaches the buffer leaves an empty byte sequence to decode. Jint reads the bytes after the
-        // conversion instead, and decodes the buffer's former contents.
-        new("encoding/textdecoder-arguments.any.js", "TextDecoder decode() with array buffer detached during arg conversion", WptDivergence.NeedsTriage),
-
-        // https://encoding.spec.whatwg.org/#shared-utf-16-decoder, the end-of-queue step: "If UTF-16 lead
-        // byte is non-null or UTF-16 lead surrogate is non-null, set them to null and return error" — one
-        // error however many of the two are pending. Decoding [0x00, 0xd8, 0x00] as utf-16le leaves both
-        // pending and must yield a single U+FFFD; Jint yields two.
-        new("encoding/textdecoder-mistakes.any.js", "utf-16le does not produce more chars than truncated", WptDivergence.NeedsTriage),
-        new("encoding/textdecoder-mistakes.any.js", "utf-16be does not produce more chars than truncated", WptDivergence.NeedsTriage),
 
         // Everything below is one missing feature: the Encoding Standard's legacy single-byte and multi-byte
         // decoders, which EncodingLabels documents as out of scope and issue #3106 implements. Each of these

--- a/Jint/WebApi/DomException/DomExceptionConstructor.cs
+++ b/Jint/WebApi/DomException/DomExceptionConstructor.cs
@@ -25,10 +25,13 @@ namespace Jint.WebApi.DomException;
 /// </para>
 /// <para>
 /// The 25 legacy constants appear here as well as on the prototype, per
-/// https://webidl.spec.whatwg.org/#es-constants.
+/// https://webidl.spec.whatwg.org/#es-constants, which defines them one after another in the order the IDL
+/// declares them. That order is observable — a record conversion over the interface object reads
+/// <c>[[OwnPropertyKeys]]</c> — so the declarations below are in it and
+/// <c>PreserveDeclarationOrder</c> keeps the generator from sorting them by name.
 /// </para>
 /// </remarks>
-[JsObject(UseShape = true)]
+[JsObject(UseShape = true, PreserveDeclarationOrder = true)]
 internal sealed partial class DomExceptionConstructor : Constructor
 {
     private static readonly JsString _functionName = new("DOMException");

--- a/Jint/WebApi/DomException/DomExceptionPrototype.cs
+++ b/Jint/WebApi/DomException/DomExceptionPrototype.cs
@@ -23,10 +23,12 @@ namespace Jint.WebApi.DomException;
 /// <para>
 /// The 25 legacy constants appear on both this object and the interface object, per
 /// https://webidl.spec.whatwg.org/#es-constants, with the attributes constants are given there:
-/// <c>{ writable: false, enumerable: true, configurable: false }</c>.
+/// <c>{ writable: false, enumerable: true, configurable: false }</c>. They are declared — and, thanks to
+/// <c>PreserveDeclarationOrder</c>, enumerate — in the order the IDL declares them, which is the order that
+/// section defines them in and the one the interface object is read in.
 /// </para>
 /// </remarks>
-[JsObject(UseShape = true)]
+[JsObject(UseShape = true, PreserveDeclarationOrder = true)]
 internal sealed partial class DomExceptionPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/WebApi/Encoding/BufferSource.cs
+++ b/Jint/WebApi/Encoding/BufferSource.cs
@@ -25,6 +25,18 @@ namespace Jint.WebApi.Encoding;
 internal static class BufferSource
 {
     /// <summary>
+    /// Whether <paramref name="value"/> is a buffer source at all — the only thing the WebIDL
+    /// <c>AllowSharedBufferSource</c> conversion decides, and it decides it before the operation runs.
+    /// </summary>
+    /// <remarks>
+    /// An operation whose <i>later</i> arguments can detach the buffer has to separate the two: the type
+    /// check belongs to the argument conversion, the bytes to the operation that follows it. Everything else
+    /// converts one buffer source and nothing that could run script, so it goes straight to
+    /// <see cref="TryGetBytes"/>.
+    /// </remarks>
+    internal static bool IsBufferSource(JsValue value) => value is JsTypedArray or JsDataView or JsArrayBuffer;
+
+    /// <summary>
     /// Yields the bytes of <paramref name="value"/>, or <see langword="false"/> when it is not a buffer
     /// source at all — which the caller reports as the <c>TypeError</c> the WebIDL conversion would raise.
     /// </summary>

--- a/Jint/WebApi/Encoding/EncodingLabels.cs
+++ b/Jint/WebApi/Encoding/EncodingLabels.cs
@@ -89,10 +89,10 @@ internal enum EncodingKind
     /// <summary>https://encoding.spec.whatwg.org/#utf-8-decoder, run by the BCL.</summary>
     Utf8,
 
-    /// <summary>https://encoding.spec.whatwg.org/#utf-16le, run by the BCL.</summary>
+    /// <summary>https://encoding.spec.whatwg.org/#utf-16le, run by the shared UTF-16 decoder.</summary>
     Utf16Le,
 
-    /// <summary>https://encoding.spec.whatwg.org/#utf-16be, run by the BCL.</summary>
+    /// <summary>https://encoding.spec.whatwg.org/#utf-16be, run by the shared UTF-16 decoder.</summary>
     Utf16Be,
 
     /// <summary>

--- a/Jint/WebApi/Encoding/TextDecoderHandler.cs
+++ b/Jint/WebApi/Encoding/TextDecoderHandler.cs
@@ -17,7 +17,8 @@ namespace Jint.WebApi.Encoding;
 /// substitutes U+FFFD inside the handler and keeps going.
 /// </para>
 /// <para>
-/// Two implementations sit behind it: <see cref="BclDecoderHandler"/> for the three Unicode encodings, and
+/// Three implementations sit behind it: <see cref="BclDecoderHandler"/> for UTF-8,
+/// <see cref="Utf16DecoderHandler"/> for the two UTF-16 encodings, and
 /// <see cref="SingleByteDecoderHandler"/> / <see cref="XUserDefinedDecoderHandler"/> for the legacy ones,
 /// which are stateless because a byte is a whole code point there. Keeping the seam uniform is what lets
 /// <see cref="JsTextDecoder"/> hold one decoding algorithm and no branches per call.
@@ -33,7 +34,9 @@ internal abstract class TextDecoderHandler
     {
         EncodingKind.SingleByte => new SingleByteDecoderHandler(encoding.Index, fatal),
         EncodingKind.XUserDefined => new XUserDefinedDecoderHandler(),
-        _ => new BclDecoderHandler(encoding.Kind, fatal),
+        EncodingKind.Utf16Le => new Utf16DecoderHandler(bigEndian: false, fatal),
+        EncodingKind.Utf16Be => new Utf16DecoderHandler(bigEndian: true, fatal),
+        _ => new BclDecoderHandler(fatal),
     };
 
     /// <summary>
@@ -56,7 +59,10 @@ internal abstract class TextDecoderHandler
 }
 
 /// <summary>
-/// UTF-8, UTF-16LE and UTF-16BE, decoded by the BCL.
+/// UTF-8, decoded by the BCL.
+/// <para>
+/// https://encoding.spec.whatwg.org/#utf-8-decoder
+/// </para>
 /// </summary>
 /// <remarks>
 /// <para>
@@ -66,24 +72,25 @@ internal abstract class TextDecoderHandler
 /// mode is <see cref="DecoderReplacementFallback"/>, so the U+FFFD substitution follows the Unicode
 /// "maximal subpart" recommendation that https://encoding.spec.whatwg.org/#error-mode also describes.
 /// </para>
+/// <para>
+/// The two UTF-16 encodings used to run through here as well, and no longer do: see
+/// <see cref="Utf16DecoderHandler"/> for the end-of-queue step that made a <see cref="Decoder"/> the wrong
+/// shape for them.
+/// </para>
 /// </remarks>
 internal sealed class BclDecoderHandler : TextDecoderHandler
 {
-    // One encoding object per (encoding, error mode). They are immutable and thread-safe; only the
-    // Decoder they hand out is stateful, and that one is per instance.
+    // One encoding object per error mode. They are immutable and thread-safe; only the Decoder they hand
+    // out is stateful, and that one is per instance.
     private static readonly SystemEncoding _utf8Replacement = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false);
     private static readonly SystemEncoding _utf8Fatal = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
-    private static readonly SystemEncoding _utf16LeReplacement = new UnicodeEncoding(bigEndian: false, byteOrderMark: false, throwOnInvalidBytes: false);
-    private static readonly SystemEncoding _utf16LeFatal = new UnicodeEncoding(bigEndian: false, byteOrderMark: false, throwOnInvalidBytes: true);
-    private static readonly SystemEncoding _utf16BeReplacement = new UnicodeEncoding(bigEndian: true, byteOrderMark: false, throwOnInvalidBytes: false);
-    private static readonly SystemEncoding _utf16BeFatal = new UnicodeEncoding(bigEndian: true, byteOrderMark: false, throwOnInvalidBytes: true);
 
     private readonly SystemEncoding _encoding;
     private Decoder? _decoder;
 
-    internal BclDecoderHandler(EncodingKind kind, bool fatal)
+    internal BclDecoderHandler(bool fatal)
     {
-        _encoding = Resolve(kind, fatal);
+        _encoding = fatal ? _utf8Fatal : _utf8Replacement;
     }
 
     internal override bool TryDecode(ReadOnlySpan<byte> input, bool flush, out ReadOnlySpan<char> output)
@@ -107,12 +114,5 @@ internal sealed class BclDecoderHandler : TextDecoderHandler
     }
 
     internal override void Reset() => _decoder = null;
-
-    private static SystemEncoding Resolve(EncodingKind kind, bool fatal) => kind switch
-    {
-        EncodingKind.Utf16Le => fatal ? _utf16LeFatal : _utf16LeReplacement,
-        EncodingKind.Utf16Be => fatal ? _utf16BeFatal : _utf16BeReplacement,
-        _ => fatal ? _utf8Fatal : _utf8Replacement,
-    };
 }
 #endif

--- a/Jint/WebApi/Encoding/TextDecoderPrototype.cs
+++ b/Jint/WebApi/Encoding/TextDecoderPrototype.cs
@@ -95,8 +95,9 @@ internal sealed partial class TextDecoderPrototype : Prototype
     {
         var decoder = Brand(thisObject);
 
-        var bytes = ReadOnlySpan<byte>.Empty;
-        if (!input.IsUndefined() && !BufferSource.TryGetBytes(input, out bytes))
+        // The WebIDL argument conversion, which runs before any of the operation's own steps: `input` is only
+        // type-checked here, because converting an AllowSharedBufferSource takes no copy.
+        if (!input.IsUndefined() && !BufferSource.IsBufferSource(input))
         {
             Throw.TypeError(_realm, "TextDecoder.decode: input must be an ArrayBuffer or a view over one");
         }
@@ -112,6 +113,16 @@ internal sealed partial class TextDecoderPrototype : Prototype
             }
 
             stream = TypeConverter.ToBoolean(optionsObject.Get(_stream));
+        }
+
+        // Only now — step 3, "push a copy of input to this's I/O queue". A `stream` getter that detached the
+        // buffer during the dictionary conversion above leaves the empty byte sequence to decode, per
+        // https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy step 5, which is what makes reading the
+        // bytes here rather than alongside the type check observable.
+        var bytes = ReadOnlySpan<byte>.Empty;
+        if (!input.IsUndefined())
+        {
+            BufferSource.TryGetBytes(input, out bytes);
         }
 
         return decoder.Common.Decode(_realm, bytes, stream);

--- a/Jint/WebApi/Encoding/Utf16DecoderHandler.cs
+++ b/Jint/WebApi/Encoding/Utf16DecoderHandler.cs
@@ -1,0 +1,147 @@
+#if NET8_0_OR_GREATER
+namespace Jint.WebApi.Encoding;
+
+/// <summary>
+/// The decoder <c>utf-16le</c> and <c>utf-16be</c> share, which is one algorithm parameterised by
+/// endianness.
+/// <para>
+/// https://encoding.spec.whatwg.org/#shared-utf-16-decoder
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// It is written out rather than delegated to <see cref="System.Text.UnicodeEncoding"/> because of the
+/// end-of-queue step, which the BCL has no equivalent of: "If UTF-16 lead byte is non-null <b>or</b> UTF-16
+/// lead surrogate is non-null, set UTF-16 lead byte and UTF-16 lead surrogate to null, and return error" —
+/// <i>one</i> error however many of the two are pending. A <see cref="System.Text.Decoder"/> reports the
+/// dangling byte and the unpaired lead surrogate separately, so <c>[0x00, 0xd8, 0x00]</c> as <c>utf-16le</c>
+/// came back as two U+FFFD where the standard asks for one.
+/// </para>
+/// <para>
+/// The two pieces of state are the specification's own: the first byte of a code unit whose second byte has
+/// not arrived, and a lead surrogate whose trail has not. Both survive a
+/// <c>decode(…, { stream: true })</c> call and are what <see cref="Reset"/> throws away.
+/// </para>
+/// </remarks>
+internal sealed class Utf16DecoderHandler : TextDecoderHandler
+{
+    /// <summary>U+FFFD, what the "replacement" error mode pushes for an error.</summary>
+    private const char ReplacementCharacter = '\uFFFD';
+
+    /// <summary>The specification's <c>null</c> for the two pieces of state, which are byte/code-unit valued.</summary>
+    private const int None = -1;
+
+    private readonly bool _bigEndian;
+    private readonly bool _fatal;
+
+    private int _leadByte = None;
+    private int _leadSurrogate = None;
+
+    internal Utf16DecoderHandler(bool bigEndian, bool fatal)
+    {
+        _bigEndian = bigEndian;
+        _fatal = fatal;
+    }
+
+    internal override bool TryDecode(ReadOnlySpan<byte> input, bool flush, out ReadOnlySpan<char> output)
+    {
+        // Two bytes make one code unit, and a code unit yields at most one character more than the last one
+        // did: the only step that emits two is the one consuming a pending lead surrogate, and the step that
+        // made it pending emitted none. Two spare slots cover a lead surrogate carried in from the previous
+        // chunk and the end-of-queue error, so the buffer is sized once and never grown.
+        var chars = new char[(input.Length + 1) / 2 + 3];
+        var count = 0;
+
+        for (var i = 0; i < input.Length; i++)
+        {
+            // Step 3: the first byte of a code unit is held until its partner arrives.
+            if (_leadByte == None)
+            {
+                _leadByte = input[i];
+                continue;
+            }
+
+            // Step 4, and step 5 sets the lead byte back to null.
+            var codeUnit = _bigEndian ? (_leadByte << 8) + input[i] : (input[i] << 8) + _leadByte;
+            _leadByte = None;
+
+            // Step 6: a lead surrogate is waiting for a trail.
+            if (_leadSurrogate != None)
+            {
+                var leadSurrogate = _leadSurrogate;
+                _leadSurrogate = None;
+
+                if (IsTrailSurrogate(codeUnit))
+                {
+                    // Step 6.3 returns the astral code point, which is these two units in UTF-16.
+                    chars[count++] = (char) leadSurrogate;
+                    chars[count++] = (char) codeUnit;
+                    continue;
+                }
+
+                // Step 6.4 restores this code unit's bytes to the queue and reports the unpaired lead
+                // surrogate. With the lead surrogate now null the restored bytes re-form the very same code
+                // unit, so the steps below take it rather than the loop reading the bytes a second time.
+                if (_fatal)
+                {
+                    output = default;
+                    return false;
+                }
+
+                chars[count++] = ReplacementCharacter;
+            }
+
+            // Step 7: a lead surrogate waits for the next code unit.
+            if (IsLeadSurrogate(codeUnit))
+            {
+                _leadSurrogate = codeUnit;
+                continue;
+            }
+
+            // Step 8: a trail surrogate with nothing leading it is an error.
+            if (IsTrailSurrogate(codeUnit))
+            {
+                if (_fatal)
+                {
+                    output = default;
+                    return false;
+                }
+
+                chars[count++] = ReplacementCharacter;
+                continue;
+            }
+
+            // Step 9.
+            chars[count++] = (char) codeUnit;
+        }
+
+        // Step 1, the end-of-queue step: either piece of state being non-null is one error between them.
+        if (flush && (_leadByte != None || _leadSurrogate != None))
+        {
+            _leadByte = None;
+            _leadSurrogate = None;
+
+            if (_fatal)
+            {
+                output = default;
+                return false;
+            }
+
+            chars[count++] = ReplacementCharacter;
+        }
+
+        output = chars.AsSpan(0, count);
+        return true;
+    }
+
+    internal override void Reset()
+    {
+        _leadByte = None;
+        _leadSurrogate = None;
+    }
+
+    private static bool IsLeadSurrogate(int codeUnit) => codeUnit is >= 0xD800 and <= 0xDBFF;
+
+    private static bool IsTrailSurrogate(int codeUnit) => codeUnit is >= 0xDC00 and <= 0xDFFF;
+}
+#endif

--- a/Jint/WebApi/Events/EventConstructor.cs
+++ b/Jint/WebApi/Events/EventConstructor.cs
@@ -16,9 +16,11 @@ namespace Jint.WebApi.Events;
 /// <remarks>
 /// The four phase constants appear here as well as on the prototype, per
 /// https://webidl.spec.whatwg.org/#es-constants, with the attributes constants are given there:
-/// <c>{ writable: false, enumerable: true, configurable: false }</c>.
+/// <c>{ writable: false, enumerable: true, configurable: false }</c>. That section defines them one
+/// after another in the order the IDL declares them, and that order is observable, so they are declared
+/// below in it and <c>PreserveDeclarationOrder</c> keeps the generator from sorting them by name.
 /// </remarks>
-[JsObject(UseShape = true)]
+[JsObject(UseShape = true, PreserveDeclarationOrder = true)]
 internal sealed partial class EventConstructor : Constructor
 {
     private static readonly JsString _functionName = new("Event");

--- a/Jint/WebApi/Events/EventPrototype.cs
+++ b/Jint/WebApi/Events/EventPrototype.cs
@@ -25,8 +25,13 @@ namespace Jint.WebApi.Events;
 /// the constants <i>are</i> enumerable, as they should be. Nothing but code inspecting property attributes can
 /// observe the difference.
 /// </para>
+/// <para>
+/// https://webidl.spec.whatwg.org/#es-constants defines the constants one after another in the order the IDL
+/// declares them, and that order is observable, so they are declared below in it and
+/// <c>PreserveDeclarationOrder</c> keeps the generator from sorting them by name.
+/// </para>
 /// </remarks>
-[JsObject(UseShape = true)]
+[JsObject(UseShape = true, PreserveDeclarationOrder = true)]
 internal sealed partial class EventPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/WebApi/ServerSentEvents/EventSourceConstructor.cs
+++ b/Jint/WebApi/ServerSentEvents/EventSourceConstructor.cs
@@ -20,9 +20,11 @@ namespace Jint.WebApi.ServerSentEvents;
 /// <c>EventSource</c> inherits from <c>EventTarget</c>, so its <c>[[Prototype]]</c> is the <c>EventTarget</c>
 /// interface object and <c>source instanceof EventTarget</c> holds. The three readyState constants appear
 /// here as well as on the prototype, per https://webidl.spec.whatwg.org/#es-constants, with the attributes
-/// constants are given there: <c>{ writable: false, enumerable: true, configurable: false }</c>.
+/// constants are given there: <c>{ writable: false, enumerable: true, configurable: false }</c>. That section
+/// defines them one after another in the order the IDL declares them, and that order is observable, so they
+/// are declared below in it and <c>PreserveDeclarationOrder</c> keeps the generator from sorting them by name.
 /// </remarks>
-[JsObject(UseShape = true)]
+[JsObject(UseShape = true, PreserveDeclarationOrder = true)]
 internal sealed partial class EventSourceConstructor : Constructor
 {
     private static readonly JsString _functionName = new("EventSource");

--- a/Jint/WebApi/ServerSentEvents/EventSourcePrototype.cs
+++ b/Jint/WebApi/ServerSentEvents/EventSourcePrototype.cs
@@ -16,9 +16,11 @@ namespace Jint.WebApi.ServerSentEvents;
 /// <remarks>
 /// Its <c>[[Prototype]]</c> is <c>EventTarget.prototype</c>, so an event source has <c>addEventListener</c>
 /// and the rest. The three readyState constants appear here as well as on the interface object, per
-/// https://webidl.spec.whatwg.org/#es-constants.
+/// https://webidl.spec.whatwg.org/#es-constants, which defines them one after another in the order the IDL
+/// declares them. That order is observable, so they are declared below in it and
+/// <c>PreserveDeclarationOrder</c> keeps the generator from sorting them by name.
 /// </remarks>
-[JsObject(UseShape = true)]
+[JsObject(UseShape = true, PreserveDeclarationOrder = true)]
 internal sealed partial class EventSourcePrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/WebApi/WebSockets/WebSocketConstructor.cs
+++ b/Jint/WebApi/WebSockets/WebSocketConstructor.cs
@@ -26,10 +26,12 @@ namespace Jint.WebApi.WebSockets;
 /// <para>
 /// The four ready-state constants appear here as well as on the prototype, per
 /// https://webidl.spec.whatwg.org/#es-constants, with the attributes constants are given there:
-/// <c>{ writable: false, enumerable: true, configurable: false }</c>.
+/// <c>{ writable: false, enumerable: true, configurable: false }</c>. That section defines them one
+/// after another in the order the IDL declares them, and that order is observable, so they are declared
+/// below in it and <c>PreserveDeclarationOrder</c> keeps the generator from sorting them by name.
 /// </para>
 /// </remarks>
-[JsObject(UseShape = true)]
+[JsObject(UseShape = true, PreserveDeclarationOrder = true)]
 internal sealed partial class WebSocketConstructor : Constructor
 {
     private static readonly JsString _functionName = new("WebSocket");

--- a/Jint/WebApi/WebSockets/WebSocketPrototype.cs
+++ b/Jint/WebApi/WebSockets/WebSocketPrototype.cs
@@ -21,9 +21,11 @@ namespace Jint.WebApi.WebSockets;
 /// Its <c>[[Prototype]]</c> is <c>EventTarget.prototype</c>, so a socket has <c>addEventListener</c> and the
 /// rest, and <c>socket instanceof EventTarget</c> holds. The attributes are accessors that brand-check their
 /// receiver, as WebIDL specifies, so <c>WebSocket.prototype.readyState</c> is a <c>TypeError</c> rather than
-/// an answer.
+/// an answer. https://webidl.spec.whatwg.org/#es-constants defines the four ready-state constants one after
+/// another in the order the IDL declares them, and that order is observable, so they are declared below in it
+/// and <c>PreserveDeclarationOrder</c> keeps the generator from sorting them by name.
 /// </remarks>
-[JsObject(UseShape = true)]
+[JsObject(UseShape = true, PreserveDeclarationOrder = true)]
 internal sealed partial class WebSocketPrototype : Prototype
 {
     /// <summary>


### PR DESCRIPTION
Closes #3121 — the three genuine defects the WPT harness surfaced, each fixed at the root with its normative citation, all four `NeedsTriage` exclusions removed (the runner fails on stale exclusions, so their removal is itself verified), and a focused unit test per defect so the pins survive without the WPT corpus.

**1. WebIDL constants now enumerate in declaration order** (https://webidl.spec.whatwg.org/#es-constants). The source generator sorted every `[JsProperty]` by name — right for ECMAScript built-ins, observably wrong for WebIDL constants, whose order a record conversion over the interface object reads via `[[OwnPropertyKeys]]`. New opt-in `[JsObject(PreserveDeclarationOrder = true)]` skips exactly the property sort and nothing else, applied to the eight hosts carrying WebIDL constants (`DOMException`, `Event`, `EventSource`, `WebSocket` × constructor/prototype — the sibling six had the identical latent defect, WPT just happened to read DOMException). No `Sample.*` generator snapshot changed, which is the evidence emission is otherwise byte-identical.

**2. `TextDecoder.decode()` no longer copies its input before argument conversion** (https://encoding.spec.whatwg.org/#dom-textdecoder-decode step 3, https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy step 5). The bytes were read in the same statement as the type check, before the options dictionary converted — so a `get stream()` that detaches the buffer saw the buffer's former contents decoded. The type check stays where WebIDL puts it; the copy moves to where the spec's operation takes it. Pre-fix: 10,000 stale bytes decoded where the spec requires `""`.

**3. UTF-16 end-of-queue emits one replacement, not two** (https://encoding.spec.whatwg.org/#shared-utf-16-decoder step 1: lead byte *or* lead surrogate pending → both cleared, one error). `System.Text.Decoder` reports a dangling byte and an unpaired lead surrogate separately, so UTF-16LE/BE now run through a new `Utf16DecoderHandler` implementing the spec's algorithm step for step (including 6.4's restore-and-report); the BCL handler is UTF-8 only.

Gate: solution build 0 errors; Jint.Tests 9064/7046 green including the 1,757-case WPT family with its stale-exclusion check; PublicInterface green; all four host-contract-verification legs green; SourceGenerators 52 green; full test262 green (102,495).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G7Ud48VAs1JicxRZxLDxg
