### PR TITLE
Web API: fetch bodies and Blob.stream() as byte streams, and duplex:'half' streaming uploads

### DIFF
--- a/Jint.Tests/Runtime/WebApi/BlobTests.cs
+++ b/Jint.Tests/Runtime/WebApi/BlobTests.cs
@@ -357,6 +357,48 @@ public class BlobTests
             .UnwrapIfPromise().AsString().Should().Be("true:true");
     }
 
+    /// <summary>
+    /// https://w3c.github.io/FileAPI/#blob-get-stream: "Let stream be a new ReadableStream created in
+    /// realm … set up with byte reading support." So a BYOB reader works on it, and a BYOB read is bounded
+    /// by the caller's buffer rather than by the one chunk a default reader sees.
+    /// </summary>
+    [Fact]
+    public void StreamIsAByteStreamAndCanBeReadByob()
+    {
+        var engine = WebEngine();
+        engine.Execute("var r = new Blob(['hello']).stream().getReader({ mode: 'byob' });");
+
+        engine.Evaluate("Object.getPrototypeOf(r).constructor.name").AsString().Should().Be("ReadableStreamBYOBReader");
+
+        // A buffer smaller than the blob takes what fits; the rest stays queued for the next read.
+        engine.Evaluate("r.read(new Uint8Array(3)).then(x => x.done + ':' + String.fromCharCode.apply(null, Array.from(x.value)))")
+            .UnwrapIfPromise().AsString().Should().Be("false:hel");
+
+        engine.Evaluate("r.read(new Uint8Array(3)).then(x => x.done + ':' + String.fromCharCode.apply(null, Array.from(x.value)))")
+            .UnwrapIfPromise().AsString().Should().Be("false:lo");
+
+        engine.Evaluate("r.read(new Uint8Array(3)).then(x => x.done + ':' + x.value.byteLength)")
+            .UnwrapIfPromise().AsString().Should().Be("true:0");
+    }
+
+    /// <summary>
+    /// A byte source can also serve a BYOB read through <c>respondWithNewView</c>-shaped machinery — but a
+    /// blob's stream has its bytes already, so what this pins is the other half of the ownership rule: the
+    /// caller's buffer is transferred away, and the view handed back owns the memory.
+    /// </summary>
+    [Fact]
+    public void StreamTransfersTheBufferOfAByobRead()
+    {
+        var engine = WebEngine();
+        engine.Execute("var view = new Uint8Array(8); var buffer = view.buffer;");
+
+        engine.Evaluate("new Blob(['ab']).stream().getReader({ mode: 'byob' }).read(view).then(x => x.value.buffer.byteLength)")
+            .UnwrapIfPromise().AsNumber().Should().Be(8);
+
+        engine.Evaluate("buffer.byteLength").AsNumber().Should().Be(0);
+        engine.Evaluate("view.byteLength").AsNumber().Should().Be(0);
+    }
+
     [Fact]
     public void StreamIsAReadableStreamEvenWithoutTheStreamsFeature()
     {

--- a/Jint.Tests/Runtime/WebApi/FetchStreamTests.cs
+++ b/Jint.Tests/Runtime/WebApi/FetchStreamTests.cs
@@ -97,6 +97,109 @@ public class FetchStreamTests
         }
     }
 
+    /// <summary>
+    /// A handler that copies the <i>request</i> body into a recorder, one entry per write the transport
+    /// makes, so a streaming upload is observable as it happens rather than only once it is complete.
+    /// </summary>
+    /// <remarks>
+    /// <c>HttpContent.CopyToAsync</c> is what a real handler's send path does, and it goes straight to
+    /// <c>SerializeToStreamAsync</c> — where <c>ReadAsStreamAsync</c> would buffer the whole body first and
+    /// hide exactly what this is here to see.
+    /// </remarks>
+    private sealed class UploadHandler : HttpMessageHandler
+    {
+        private readonly RecordingStream _recorder = new();
+
+        /// <summary>Set as soon as the transport has the request, before a byte of body is asked for.</summary>
+        internal ManualResetEventSlim RequestStarted { get; } = new(false);
+
+        /// <summary>Set when the upload saw its cancellation token fire — the proof an abort reached it.</summary>
+        internal ManualResetEventSlim Cancelled { get; } = new(false);
+
+        internal IReadOnlyList<string> Chunks => _recorder.Chunks;
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestStarted.Set();
+
+            try
+            {
+                await request.Content!.CopyToAsync(_recorder, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                Cancelled.Set();
+                throw;
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") };
+        }
+
+        private sealed class RecordingStream : Stream
+        {
+            private readonly List<string> _chunks = new();
+
+            internal IReadOnlyList<string> Chunks
+            {
+                get
+                {
+                    lock (_chunks)
+                    {
+                        return _chunks.ToArray();
+                    }
+                }
+            }
+
+            public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                Write(buffer.Span);
+                return default;
+            }
+
+            public override void Write(ReadOnlySpan<byte> buffer)
+            {
+                var text = SystemEncoding.UTF8.GetString(buffer);
+                lock (_chunks)
+                {
+                    _chunks.Add(text);
+                }
+            }
+
+            public override void Write(byte[] buffer, int offset, int count) => Write(buffer.AsSpan(offset, count));
+
+            public override bool CanRead => false;
+            public override bool CanSeek => false;
+            public override bool CanWrite => true;
+            public override long Length => throw new NotSupportedException();
+            public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+            public override void Flush() { }
+            public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+        }
+    }
+
+    /// <summary>
+    /// Runs event-loop turns until <paramref name="condition"/> holds, or fails the test at a deliberately
+    /// generous bound. The bound is not a measurement: what is being waited for is a hand-over between the
+    /// engine's thread and the transport's, which either happens or means the test has found a bug.
+    /// </summary>
+    private static void PumpUntil(Engine engine, Func<bool> condition, string what)
+    {
+        var deadline = Environment.TickCount64 + 15_000;
+
+        while (!condition())
+        {
+            if (Environment.TickCount64 > deadline)
+            {
+                Assert.Fail("Timed out waiting for " + what);
+            }
+
+            engine.Advanced.ProcessTasks();
+            Thread.Sleep(1);
+        }
+    }
+
     private static Engine WebEngine(HttpMessageHandler handler)
     {
         var engine = new Engine(options => options.UseFetch(fetch => fetch.HttpClient = new HttpClient(handler)));
@@ -323,6 +426,115 @@ public class FetchStreamTests
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NoContent));
+    }
+
+    /// <summary>
+    /// The upload half of the same design: a <c>ReadableStream</c> request body sent with
+    /// <c>duplex: 'half'</c> reaches the transport <b>as the script produces it</b>, not after the whole
+    /// stream has been drained into memory.
+    /// <para>
+    /// https://fetch.spec.whatwg.org/#dom-requestinit-duplex
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void AStreamingRequestBodyReachesTheTransportAsTheScriptProducesIt()
+    {
+        var handler = new UploadHandler();
+        var engine = WebEngine(handler);
+
+        engine.Execute("""
+            var t = new TransformStream();
+            var writer = t.writable.getWriter();
+            var state = 'pending';
+            fetch('https://example.org/', { method: 'POST', duplex: 'half', body: t.readable })
+                .then(r => state = 'ok:' + r.status, e => state = 'failed:' + e.message);
+            """);
+
+        // The request is already on its way, with nothing written into it: a buffered upload would not have
+        // opened it at all until the stream had closed.
+        PumpUntil(engine, () => handler.RequestStarted.IsSet, "the request to reach the transport");
+        engine.Advanced.ProcessTasks();
+        handler.Chunks.Should().BeEmpty();
+        engine.Evaluate("state").AsString().Should().Be("pending");
+
+        engine.Execute("writer.write(new Uint8Array([104, 105]));");
+        PumpUntil(engine, () => handler.Chunks.Count == 1, "the first chunk to reach the transport");
+        handler.Chunks[0].Should().Be("hi");
+
+        // The fetch is still open: the body is not finished, so neither is the request.
+        engine.Evaluate("state").AsString().Should().Be("pending");
+
+        engine.Execute("writer.write(new Uint8Array([33])); writer.close();");
+        PumpUntil(engine, () => !string.Equals(engine.Evaluate("state").AsString(), "pending", StringComparison.Ordinal), "the fetch to settle");
+
+        engine.Evaluate("state").AsString().Should().Be("ok:200");
+
+        // Two writes, in order, each carrying exactly what the script enqueued.
+        string.Concat(handler.Chunks).Should().Be("hi!");
+        handler.Chunks.Should().HaveCount(2);
+
+        // The body's stream is disturbed and locked, as a body consumed by a fetch always is.
+        engine.Evaluate("t.readable.locked").AsBoolean().Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A streaming upload is cross-cycle state like any other in-flight request, so
+    /// <c>RestoreGlobalSnapshot</c> ends it: the transport's token fires and the engine half stops reading
+    /// the script's stream. Without that, a request nobody can finish would hold the socket until the
+    /// deadline.
+    /// </summary>
+    [Fact]
+    public void ARestoreEndsAStreamingRequestBody()
+    {
+        var handler = new UploadHandler();
+        var engine = WebEngine(handler);
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+
+        engine.Execute("""
+            var t = new TransformStream();
+            var writer = t.writable.getWriter();
+            fetch('https://example.org/', { method: 'POST', duplex: 'half', body: t.readable });
+            """);
+
+        PumpUntil(engine, () => handler.RequestStarted.IsSet, "the request to reach the transport");
+
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        handler.Cancelled.Wait(TimeSpan.FromSeconds(15)).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A network response body is a byte stream — https://fetch.spec.whatwg.org/#concept-body — so it can be
+    /// read BYOB straight off the socket, into a buffer the consumer recycles. The chunk boundary stays the
+    /// transport's: one BYOB read takes one transport read, however much room the caller offered.
+    /// </summary>
+    [Fact]
+    public void ANetworkResponseBodyCanBeReadByob()
+    {
+        var handler = new GatedHandler();
+        handler.Body.Emit("he");
+        handler.Body.Emit("llo");
+        handler.Body.Complete();
+
+        var engine = WebEngine(handler);
+        engine.Execute("var r; fetch('https://example.org/').then(x => r = x);");
+        engine.Advanced.ProcessTasks();
+
+        // Taking a BYOB reader is as free as taking a default one: nothing is read until read() asks.
+        engine.Execute("var reader = r.body.getReader({ mode: 'byob' });");
+        handler.Body.ReadCount.Should().Be(0);
+
+        engine.Evaluate("reader.read(new Uint8Array(8)).then(x => x.done + ':' + dec(x.value))")
+            .UnwrapIfPromise().AsString().Should().Be("false:he");
+        handler.Body.ReadCount.Should().Be(1);
+
+        engine.Evaluate("reader.read(new Uint8Array(8)).then(x => x.done + ':' + dec(x.value))")
+            .UnwrapIfPromise().AsString().Should().Be("false:llo");
+        handler.Body.ReadCount.Should().Be(2);
+
+        engine.Evaluate("reader.read(new Uint8Array(8)).then(x => x.done + ':' + x.value.byteLength)")
+            .UnwrapIfPromise().AsString().Should().Be("true:0");
+        handler.Body.ReadCount.Should().Be(3);
     }
 }
 #endif

--- a/Jint.Tests/Runtime/WebApi/FetchTests.cs
+++ b/Jint.Tests/Runtime/WebApi/FetchTests.cs
@@ -38,19 +38,23 @@ public class FetchTests
 
         internal Func<RecordedRequest, HttpResponseMessage>? Responder { get; set; }
 
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            var recorded = Record(request);
+            var recorded = await RecordAsync(request, cancellationToken).ConfigureAwait(false);
             Requests.Add(recorded);
 
-            var response = Responder is { } responder
+            return Responder is { } responder
                 ? responder(recorded)
                 : new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") };
-
-            return Task.FromResult(response);
         }
 
-        private static RecordedRequest Record(HttpRequestMessage request)
+        /// <remarks>
+        /// The body is read <b>asynchronously</b>. A streaming request body — the standard's
+        /// <c>duplex: 'half'</c> — is produced by the engine thread as the transport drains it, so a
+        /// synchronous read here would block this thread waiting on turns the engine has not run yet. That
+        /// is why <c>FetchRequestBodyStream</c>'s content refuses synchronous serialization outright.
+        /// </remarks>
+        private static async Task<RecordedRequest> RecordAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             Collect(headers, request.Headers);
@@ -59,8 +63,7 @@ public class FetchTests
             if (request.Content is { } content)
             {
                 Collect(headers, content.Headers);
-                using var reader = new StreamReader(content.ReadAsStream());
-                body = reader.ReadToEnd();
+                body = await content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
             }
 
             return new RecordedRequest(request.Method.Method, request.RequestUri!.ToString(), headers, body);
@@ -125,15 +128,18 @@ public class FetchTests
         request.Body.Should().Be("hi");
     }
 
+    /// <summary>
+    /// A <c>ReadableStream</c> body is streamed to the wire — the standard's <c>duplex: 'half'</c> — and
+    /// arrives as the bytes the stream produced, chunked because nothing can compute its length in advance.
+    /// </summary>
     [Fact]
-    public void AStreamRequestBodyIsReadInFullBeforeAnythingIsSent()
+    public void AStreamRequestBodyReachesTheTransport()
     {
-        // Streaming uploads (the standard's `duplex: "half"`) are out of scope: the stream is drained first
-        // and the request carries the bytes it produced.
         var handler = new StubHandler();
 
         Fetch(handler, @"fetch('https://example.org/a', {
             method: 'POST',
+            duplex: 'half',
             body: new ReadableStream({
                 start(c) { c.enqueue(new Uint8Array([104])); c.enqueue(new Uint8Array([105])); c.close(); },
             }),
@@ -143,22 +149,117 @@ public class FetchTests
         request.Method.Should().Be("POST");
         request.Body.Should().Be("hi");
 
+        // No Content-Length: the length is not known when the headers go out, so the body is chunked.
+        request.Header("content-length").Should().BeNull();
+
         // https://fetch.spec.whatwg.org/#concept-bodyinit-extract — the ReadableStream arm implies no type.
         request.Header("content-type").Should().BeNull();
     }
 
+    /// <summary>
+    /// https://fetch.spec.whatwg.org/#dom-request step 41: a <c>ReadableStream</c> body without
+    /// <c>duplex</c> is a <c>TypeError</c>, which <c>fetch</c> turns into a rejection rather than a throw
+    /// because the whole of its synchronous half does.
+    /// </summary>
     [Fact]
-    public void AStreamRequestBodyThatErrorsRejectsBeforeASocketIsOpened()
+    public void AStreamRequestBodyWithoutDuplexRejects()
     {
         var handler = new StubHandler();
 
         Fetch(handler, @"fetch('https://example.org/a', {
             method: 'POST',
-            body: new ReadableStream({ start(c) { c.error(new TypeError('boom')); } }),
-        }).then(() => 'resolved', e => e.constructor.name + ': ' + e.message)")
-            .AsString().Should().Be("TypeError: boom");
+            body: new ReadableStream({ start(c) { c.close(); } }),
+        }).then(() => 'resolved', e => e.constructor.name)")
+            .AsString().Should().Be("TypeError");
 
         handler.Requests.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// A request body stream that errors fails the fetch. The standard's <c>processBodyError</c> steps
+    /// (https://fetch.spec.whatwg.org/#concept-http-network-fetch) <i>terminate</i> the fetch controller,
+    /// so what the promise rejects with is the one network-error <c>TypeError</c> — not the stream's own
+    /// error, which a buffered upload would have propagated verbatim.
+    /// </summary>
+    [Fact]
+    public void AStreamRequestBodyThatErrorsFailsTheFetch()
+    {
+        var handler = new StubHandler();
+
+        Fetch(handler, @"fetch('https://example.org/a', {
+            method: 'POST',
+            duplex: 'half',
+            body: new ReadableStream({ start(c) { c.error(new TypeError('boom')); } }),
+        }).then(() => 'resolved', e => e.constructor.name + ': ' + e.message)")
+            .AsString().Should().Be("TypeError: Failed to fetch");
+    }
+
+    /// <summary>
+    /// https://fetch.spec.whatwg.org/#http-redirect-fetch step 12: "If internalResponse's status is not 303,
+    /// request's body is non-null, and request's body's source is null, then return a network error." The
+    /// bytes have gone down the first hop's socket and cannot go down a second one.
+    /// </summary>
+    [Fact]
+    public void AStreamRequestBodyCannotSurviveABodyPreservingRedirect()
+    {
+        var handler = new StubHandler
+        {
+            Responder = recorded =>
+            {
+                if (recorded.Url.EndsWith("/a", StringComparison.Ordinal))
+                {
+                    var redirect = new HttpResponseMessage(HttpStatusCode.TemporaryRedirect);
+                    redirect.Headers.Add("location", "https://example.org/b");
+                    return redirect;
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") };
+            },
+        };
+
+        Fetch(handler, @"fetch('https://example.org/a', {
+            method: 'POST',
+            duplex: 'half',
+            body: new ReadableStream({ start(c) { c.enqueue(new Uint8Array([104])); c.close(); } }),
+        }).then(() => 'resolved', e => e.constructor.name + ': ' + e.message)")
+            .AsString().Should().Be("TypeError: Failed to fetch");
+
+        // The first hop was sent; the second never was.
+        handler.Requests.Should().ContainSingle().Which.Url.Should().Be("https://example.org/a");
+    }
+
+    /// <summary>
+    /// A 303 is the exemption the step above carves out: it drops the body along with the method, so there
+    /// is nothing left to re-send and the redirect is followed as it would be for any other body.
+    /// </summary>
+    [Fact]
+    public void AStreamRequestBodyFollowsA303ThatDropsIt()
+    {
+        var handler = new StubHandler
+        {
+            Responder = recorded =>
+            {
+                if (recorded.Url.EndsWith("/a", StringComparison.Ordinal))
+                {
+                    var redirect = new HttpResponseMessage(HttpStatusCode.SeeOther);
+                    redirect.Headers.Add("location", "https://example.org/b");
+                    return redirect;
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") };
+            },
+        };
+
+        Fetch(handler, @"fetch('https://example.org/a', {
+            method: 'POST',
+            duplex: 'half',
+            body: new ReadableStream({ start(c) { c.enqueue(new Uint8Array([104])); c.close(); } }),
+        }).then(r => r.status + ':' + r.redirected)")
+            .AsString().Should().Be("200:true");
+
+        handler.Requests.Should().HaveCount(2);
+        handler.Requests[1].Method.Should().Be("GET");
+        handler.Requests[1].Body.Should().BeNull();
     }
 
     [Fact]

--- a/Jint.Tests/Runtime/WebApi/ReadableByteStreamTests.cs
+++ b/Jint.Tests/Runtime/WebApi/ReadableByteStreamTests.cs
@@ -845,36 +845,131 @@ public class ReadableByteStreamTests
         engine.Evaluate("new Response(byteStream([[65, 66], [67]])).text()")
             .UnwrapIfPromise().AsString().Should().Be("ABC");
 
-        engine.Evaluate("new Request('https://example.org/', { method: 'POST', body: byteStream([[68]]) }).text()")
+        engine.Evaluate("new Request('https://example.org/', { method: 'POST', body: byteStream([[68]]), duplex: 'half' }).text()")
             .UnwrapIfPromise().AsString().Should().Be("D");
     }
 
     /// <summary>
-    /// The streams the <i>engine</i> hands out are not byte streams yet — <c>Response.body</c>,
-    /// <c>Request.body</c> and <c>Blob.stream()</c> carry <c>Uint8Array</c> chunks over a default
-    /// controller. So BYOB reading refuses on them, with the standard's own TypeError for a stream that was
-    /// not constructed with a byte source. This pins the documented gap rather than an implementation
-    /// accident: it is what changes when those bodies are upgraded.
+    /// Every stream the <i>engine</i> hands out over a byte sequence it holds is a byte stream:
+    /// <c>Response.body</c> and <c>Request.body</c> (https://fetch.spec.whatwg.org/#concept-body, whose
+    /// stream is "set up with byte reading support") and <c>Blob.stream()</c>
+    /// (https://w3c.github.io/FileAPI/#blob-get-stream). So BYOB reading works on all three.
     /// </summary>
+    /// <remarks>
+    /// This test replaces the boundary pin that asserted the opposite. It is the observable half of the
+    /// upgrade: nothing about the default-reader path changed, and the next test says so.
+    /// </remarks>
     [Fact]
-    public void RefusesBYOBOnTheBodiesTheEngineHandsOut()
+    public void ServesBYOBOnTheBodiesTheEngineHandsOut()
     {
         var engine = new Engine(options => options.UseFetch());
 
-        foreach (var source in new[]
-                 {
-                     "new Response('xy').body",
-                     "new Request('https://example.org/', { method: 'POST', body: 'xy' }).body",
-                     "new Blob(['xy']).stream()",
-                 })
+        foreach (var source in BodySources)
         {
-            Assert.Throws<JavaScriptException>(() => engine.Evaluate($"({source}).getReader({{ mode: 'byob' }})"))
-                .Error.Get("name").AsString().Should().Be("TypeError", source);
+            engine.Execute($"var reader = ({source}).getReader({{ mode: 'byob' }});");
+            engine.Evaluate("Object.getPrototypeOf(reader).constructor.name").AsString()
+                .Should().Be("ReadableStreamBYOBReader", source);
 
-            // A default reader is what they do serve.
-            engine.Evaluate($"({source}).getReader().read().then(r => r.value.constructor.name)")
-                .UnwrapIfPromise().AsString().Should().Be("Uint8Array", source);
+            // The caller's buffer is filled in place, and the view handed back is a view onto the transfer
+            // of that very buffer — which is the whole point of reading BYOB.
+            engine.Evaluate("""
+                reader.read(new Uint8Array(8)).then(r =>
+                    r.done + ':' + r.value.constructor.name + ':' + r.value.byteLength + ':' +
+                    String.fromCharCode.apply(null, Array.from(r.value)))
+                """)
+                .UnwrapIfPromise().AsString().Should().Be("false:Uint8Array:2:xy", source);
+
+            // A second read sees the end of the body, and gets its buffer back rather than losing it.
+            engine.Evaluate("reader.read(new Uint8Array(8)).then(r => r.done + ':' + r.value.byteLength)")
+                .UnwrapIfPromise().AsString().Should().Be("true:0", source);
         }
     }
+
+    /// <summary>
+    /// The regression half of the upgrade above: a default reader on those same bodies still answers with
+    /// one <c>Uint8Array</c> chunk carrying the whole body, and every <c>Body</c>-mixin consumer still works.
+    /// </summary>
+    [Fact]
+    public void StillServesADefaultReaderOnTheBodiesTheEngineHandsOut()
+    {
+        var engine = new Engine(options => options.UseFetch());
+
+        foreach (var source in BodySources)
+        {
+            engine.Evaluate($"({source}).getReader().read().then(r => r.done + ':' + r.value.constructor.name + ':' + Array.from(r.value))")
+                .UnwrapIfPromise().AsString().Should().Be("false:Uint8Array:120,121", source);
+        }
+
+        engine.Evaluate("new Response('xy').text()").UnwrapIfPromise().AsString().Should().Be("xy");
+        engine.Evaluate("new Blob(['xy']).text()").UnwrapIfPromise().AsString().Should().Be("xy");
+        engine.Evaluate("new Response('xy').arrayBuffer().then(b => b.byteLength)").UnwrapIfPromise().AsNumber().Should().Be(2);
+    }
+
+    /// <summary>
+    /// <c>tee()</c> on a body picks the byte-stream algorithm now, so both branches are byte streams and each
+    /// can be read BYOB — https://streams.spec.whatwg.org/#readable-stream-tee dispatches on the controller.
+    /// </summary>
+    [Fact]
+    public void TeesABodyIntoTwoByteStreams()
+    {
+        var engine = new Engine(options => options.UseFetch());
+        engine.Execute("var branches = new Response('xy').body.tee();");
+
+        engine.Evaluate("branches[0].getReader({ mode: 'byob' }).read(new Uint8Array(4)).then(r => Array.from(r.value).join(','))")
+            .UnwrapIfPromise().AsString().Should().Be("120,121");
+
+        // The second branch is independent, and reads the same bytes — through a default reader, which a
+        // byte tee serves by swapping the reader over the original.
+        engine.Evaluate("branches[1].getReader().read().then(r => Array.from(r.value).join(','))")
+            .UnwrapIfPromise().AsString().Should().Be("120,121");
+    }
+
+    /// <summary>
+    /// <c>clone()</c> is the <c>Body</c> mixin's own tee — https://fetch.spec.whatwg.org/#concept-body-clone
+    /// — so a cloned body whose stream had already been materialized is a byte stream on both sides.
+    /// </summary>
+    [Fact]
+    public void ClonesAMaterializedBodyIntoTwoByteStreams()
+    {
+        var engine = new Engine(options => options.UseFetch());
+
+        // Reading `body` first is what forces the clone down the tee path rather than the shared-source one.
+        engine.Execute("var original = new Response('xy'); original.body; var copy = original.clone();");
+
+        foreach (var name in new[] { "original", "copy" })
+        {
+            engine.Evaluate($"{name}.body.getReader({{ mode: 'byob' }}).read(new Uint8Array(4)).then(r => Array.from(r.value).join(','))")
+                .UnwrapIfPromise().AsString().Should().Be("120,121", name);
+        }
+    }
+
+    /// <summary>
+    /// The bodies the engine hands out have no <c>autoAllocateChunkSize</c>, so a BYOB read is served by the
+    /// bytes the source enqueues rather than through a <c>byobRequest</c> — but the buffer the caller
+    /// supplied is still transferred away from it, which is the ownership rule every byte stream keeps.
+    /// </summary>
+    [Fact]
+    public void TransfersTheCallersBufferOnABodyRead()
+    {
+        var engine = new Engine(options => options.UseFetch());
+        engine.Execute("var view = new Uint8Array(8); var buffer = view.buffer;");
+
+        engine.Evaluate("new Blob(['xy']).stream().getReader({ mode: 'byob' }).read(view).then(r => r.value.byteLength)")
+            .UnwrapIfPromise().AsNumber().Should().Be(2);
+
+        engine.Evaluate("buffer.byteLength").AsNumber().Should().Be(0);
+        engine.Evaluate("view.byteLength").AsNumber().Should().Be(0);
+    }
+
+    /// <summary>
+    /// The three streams the engine builds over bytes it already holds — a buffered <c>Response</c> body, a
+    /// buffered <c>Request</c> body and a <c>Blob</c>'s stream. All three carry the two bytes of "xy".
+    /// </summary>
+    private static readonly string[] BodySources =
+    [
+        "new Response('xy').body",
+        "new Request('https://example.org/', { method: 'POST', body: 'xy' }).body",
+        "new Blob(['xy']).stream()",
+    ];
 }
 #endif

--- a/Jint.Tests/Runtime/WebApi/RequestTests.cs
+++ b/Jint.Tests/Runtime/WebApi/RequestTests.cs
@@ -316,7 +316,7 @@ public class RequestTests
         var engine = WebEngine();
         engine.Execute(@"
             var source = new ReadableStream({ start(c) { c.enqueue(new Uint8Array([104, 105])); c.close(); } });
-            var a = new Request('https://example.org', { method: 'POST', body: source });");
+            var a = new Request('https://example.org', { method: 'POST', body: source, duplex: 'half' });");
 
         // https://fetch.spec.whatwg.org/#concept-bodyinit-extract — the ReadableStream arm becomes the
         // body's stream itself, and implies no Content-Type.
@@ -325,6 +325,68 @@ public class RequestTests
 
         engine.Evaluate("a.text()").UnwrapIfPromise().AsString().Should().Be("hi");
         engine.Evaluate("a.bodyUsed").AsBoolean().Should().BeTrue();
+    }
+
+    /// <summary>
+    /// https://fetch.spec.whatwg.org/#dom-request step 41: "If initBody is non-null and init["duplex"] does
+    /// not exist, then throw a TypeError." The member is what makes a script say out loud that it knows the
+    /// whole request is sent before the response is read.
+    /// </summary>
+    /// <remarks>
+    /// The step keys on the body's <i>source</i> being null, which is only true of the <c>ReadableStream</c>
+    /// arm — so every other <c>BodyInit</c> may carry <c>duplex</c> or not as it likes, and neither is
+    /// refused. And it keys on <c>initBody</c>, not on the final body, so a request built <i>from another
+    /// request</i> that has a stream body needs no <c>duplex</c> of its own.
+    /// </remarks>
+    [Fact]
+    public void RequiresDuplexForAStreamBodyAndForNothingElse()
+    {
+        var engine = WebEngine();
+        engine.Execute("function stream() { return new ReadableStream({ start(c) { c.enqueue(new Uint8Array([104])); c.close(); } }); }");
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new Request('https://example.org', { method: 'POST', body: stream() })"))
+            .Message.Should().Contain("duplex");
+
+        engine.Evaluate("new Request('https://example.org', { method: 'POST', body: stream(), duplex: 'half' }).method")
+            .AsString().Should().Be("POST");
+
+        // A body with a source needs nothing, and is not refused for supplying it either.
+        engine.Evaluate("new Request('https://example.org', { method: 'POST', body: 'hi' }).method").AsString().Should().Be("POST");
+        engine.Evaluate("new Request('https://example.org', { method: 'POST', body: 'hi', duplex: 'half' }).method").AsString().Should().Be("POST");
+
+        // Copying a request whose body is a stream: initBody is null, so the step does not apply.
+        engine.Execute("var streamed = new Request('https://example.org', { method: 'POST', body: stream(), duplex: 'half' });");
+        engine.Evaluate("new Request(streamed).method").AsString().Should().Be("POST");
+        engine.Evaluate("streamed.clone().method").AsString().Should().Be("POST");
+    }
+
+    /// <summary>
+    /// <c>enum RequestDuplex { "half" };</c> — WebIDL refuses anything else, including the <c>"full"</c> the
+    /// standard reserves for a duplex fetch nobody has specified. The attribute always reads back
+    /// <c>"half"</c>: https://fetch.spec.whatwg.org/#dom-request-duplex.
+    /// </summary>
+    [Fact]
+    public void HasADuplexAttributeThatOnlyAcceptsHalf()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("new Request('https://example.org').duplex").AsString().Should().Be("half");
+        engine.Evaluate("new Request('https://example.org', { duplex: 'half' }).duplex").AsString().Should().Be("half");
+
+        foreach (var invalid in new[] { "'full'", "'HALF'", "''", "null", "1" })
+        {
+            Assert.Throws<JavaScriptException>(() => engine.Evaluate($"new Request('https://example.org', {{ duplex: {invalid} }})"))
+                .Error.Get("name").AsString().Should().Be("TypeError", invalid);
+        }
+
+        // An explicit undefined means "not present", as for every other member of the dictionary — so it
+        // neither fails the enum conversion nor satisfies the requirement above.
+        engine.Evaluate("new Request('https://example.org', { duplex: undefined }).duplex").AsString().Should().Be("half");
+
+        // The attribute is an accessor on the prototype with a brand check, like every other one.
+        engine.Evaluate("Object.getOwnPropertyDescriptor(Request.prototype, 'duplex').get.name").AsString().Should().Be("get duplex");
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("Object.getOwnPropertyDescriptor(Request.prototype, 'duplex').get.call({})"))
+            .Error.Get("name").AsString().Should().Be("TypeError");
     }
 
     [Fact]

--- a/Jint/WebApi/Fetch/FetchBodyObject.cs
+++ b/Jint/WebApi/Fetch/FetchBodyObject.cs
@@ -399,33 +399,6 @@ internal static class FetchBody
         FullyRead(engine, realm, body.Stream!, bytes => onBytes(bytes.WrittenSpan.ToArray()), onError);
     }
 
-    /// <summary>
-    /// Reads a request body that only exists as a stream into the bytes the transport has to send.
-    /// </summary>
-    /// <remarks>
-    /// <b>A request body is uploaded buffered.</b> The standard allows a <c>ReadableStream</c> to be streamed
-    /// to the server (<c>duplex: "half"</c>), which needs a request-side <c>HttpContent</c> the transport can
-    /// pull from and a server willing to read it before answering; that is deliberately out of scope, and
-    /// <c>duplex</c> is absent rather than accepted and ignored. What is supported is the shape a script
-    /// actually writes — a stream that produces the bytes, which are collected here and then sent as one
-    /// body. The stream is disturbed by this, exactly as it would be by a streaming upload.
-    /// </remarks>
-    internal static void ReadRequestBody(
-        Engine engine,
-        Realm realm,
-        FetchBodyObject request,
-        Action<ReadOnlyMemory<byte>> onBytes,
-        Action<JsValue> onError)
-    {
-        if (request.IsUnusable)
-        {
-            onError(realm.Intrinsics.TypeError.Construct("Body has already been consumed"));
-            return;
-        }
-
-        FullyRead(engine, realm, request.Stream!, bytes => onBytes(bytes.WrittenSpan.ToArray()), onError);
-    }
-
     private static void Settle(
         Engine engine,
         Realm realm,

--- a/Jint/WebApi/Fetch/FetchBodyObject.cs
+++ b/Jint/WebApi/Fetch/FetchBodyObject.cs
@@ -304,6 +304,12 @@ internal static class FetchBody
     /// used the moment a stream exists — for a network response, or for a body a script has already asked
     /// <c>body</c> for — because from then on the two objects' streams have to be different objects with
     /// independent queues.
+    /// <para>
+    /// The tee goes through <see cref="ReadableStreamOperations.Tee"/> rather than straight to the default
+    /// algorithm, because https://streams.spec.whatwg.org/#readable-stream-tee dispatches on the kind of
+    /// controller the stream has: a body's own stream is a byte stream, and its two branches have to be byte
+    /// streams too or a clone would quietly lose BYOB reading.
+    /// </para>
     /// </remarks>
     internal static void CloneBody(FetchBodyObject source, FetchBodyObject target)
     {
@@ -318,7 +324,7 @@ internal static class FetchBody
             return;
         }
 
-        var (branch1, branch2) = ReadableStreamTee.Tee(stream);
+        var (branch1, branch2) = ReadableStreamOperations.Tee(stream);
         source.ReplaceStream(branch1);
         target.SetStreamBody(branch2);
     }

--- a/Jint/WebApi/Fetch/FetchBodyStream.cs
+++ b/Jint/WebApi/Fetch/FetchBodyStream.cs
@@ -11,13 +11,21 @@ using Jint.WebApi.Streams;
 namespace Jint.WebApi.Fetch;
 
 /// <summary>
-/// A network response body, streamed: the HTTP content on one side and a <c>ReadableStream</c> on the other,
-/// joined by demand rather than by a buffer.
+/// A network response body, streamed: the HTTP content on one side and a readable <i>byte</i> stream on the
+/// other, joined by demand rather than by a buffer.
 /// <para>
 /// https://fetch.spec.whatwg.org/#concept-response-body
 /// </para>
 /// </summary>
 /// <remarks>
+/// <para>
+/// <b>The stream is a byte stream</b>, as https://fetch.spec.whatwg.org/#concept-body requires of every
+/// body ("set up with byte reading support"), so a consumer may read it BYOB and recycle one buffer across
+/// the whole download. No <c>autoAllocateChunkSize</c> is set: the transport reads into a pooled array on
+/// its own thread and cannot write into a script's buffer across that boundary, so a BYOB read is served
+/// out of the controller's queue like any other. What a default reader sees is unchanged — one
+/// <c>Uint8Array</c> per chunk the transport produced.
+/// </para>
 /// <para>
 /// <b>The two halves never touch each other's state directly.</b> The engine half — the underlying source's
 /// <c>pull</c> and <c>cancel</c>, and everything that reaches the controller — runs on the engine thread and
@@ -134,9 +142,10 @@ internal sealed class FetchBodyStream : IDisposable
         }
 
         // A high water mark of zero means the transport is only asked for bytes once a consumer wants them:
-        // nothing is read ahead into a queue the script may never drain.
-        _stream = ReadableStreamOperations.CreateReadableStream(
-            engine, realm, static () => JsValue.Undefined, PullAlgorithm, CancelAlgorithm, highWaterMark: 0);
+        // nothing is read ahead into a queue the script may never drain. CreateReadableByteStream fixes that
+        // mark at zero, which is what the default-controller predecessor asked for explicitly.
+        _stream = ReadableStreamOperations.CreateReadableByteStream(
+            engine, realm, static () => JsValue.Undefined, PullAlgorithm, CancelAlgorithm);
 
         engine._webApi?.RegisterBodyStream(this);
 
@@ -168,8 +177,8 @@ internal sealed class FetchBodyStream : IDisposable
         _finished = true;
         CancelTransport();
 
-        ReadableStreamDefaultControllerOperations.Error(
-            _stream.DefaultController,
+        ReadableByteStreamControllerOperations.Error(
+            _stream.ByteController,
             _realm.Intrinsics.TypeError.Construct("Failed to fetch: the engine's globals were restored while the response body was still streaming"));
 
         ResolvePull();
@@ -292,7 +301,7 @@ internal sealed class FetchBodyStream : IDisposable
         {
             _finished = true;
             _engine._webApi?.UnregisterBodyStream(this);
-            ReadableStreamDefaultControllerOperations.Error(_stream.DefaultController, FetchOperation.NetworkError(_realm, failure));
+            ReadableByteStreamControllerOperations.Error(_stream.ByteController, FetchOperation.NetworkError(_realm, failure));
             ResolvePull();
             return;
         }
@@ -301,12 +310,14 @@ internal sealed class FetchBodyStream : IDisposable
         {
             _finished = true;
             _engine._webApi?.UnregisterBodyStream(this);
-            ReadableStreamDefaultControllerOperations.Close(_stream.DefaultController);
+            ByteStreams.CloseAndReleasePendingByob(_stream.ByteController);
             ResolvePull();
             return;
         }
 
-        ReadableStreamDefaultControllerOperations.Enqueue(_stream.DefaultController, ByteStreams.NewUint8Array(_engine, _realm, chunk));
+        // The array is the transport's own copy, taken out of the pooled buffer before it was posted, so
+        // nothing else will ever read it and the byte controller can take it as it stands.
+        ByteStreams.EnqueueOwnedBytes(_stream.ByteController, chunk);
 
         // Resolved after the enqueue, so the reaction that lets the controller pull again observes the chunk
         // already in the queue.

--- a/Jint/WebApi/Fetch/FetchOperation.cs
+++ b/Jint/WebApi/Fetch/FetchOperation.cs
@@ -88,6 +88,12 @@ internal sealed class FetchOperation
     /// </summary>
     private FetchBodyStream? _pendingBody;
 
+    /// <summary>
+    /// The engine half of a streaming request body, or <see langword="null"/> for every other body shape.
+    /// Touched only on the engine thread: the transport sees its <see cref="HttpContent"/> and nothing else.
+    /// </summary>
+    private FetchRequestBodyStream? _requestBody;
+
     private FetchOperation(Engine engine, Realm realm, PromiseCapability capability, JsAbortSignal signal, TimeSpan timeout)
     {
         _engine = engine;
@@ -201,39 +207,36 @@ internal sealed class FetchOperation
         var operation = new FetchOperation(engine, realm, capability, request.Signal, options.Timeout);
         state.RegisterFetch(operation);
 
-        FetchRequestSnapshot Snapshot(ReadOnlyMemory<byte>? body) => new()
+        FetchRequestSnapshot Snapshot(ReadOnlyMemory<byte>? body, HttpContent? content = null) => new()
         {
             Method = request.Method,
             Url = request.Url,
             Headers = new List<HeaderEntry>(request.Headers.List.Entries),
             Body = body,
+            BodyContent = content,
             Redirect = request.Redirect,
         };
 
-        // A request body given as a ReadableStream is read in full before anything is sent: a streaming
-        // upload is the standard's `duplex: "half"`, which needs a request-side body the transport can pull
-        // from and is deliberately out of scope. Everything else already holds its bytes.
+        // A request body given as a ReadableStream has no bytes to snapshot: it is streamed to the wire as
+        // the socket drains it, which is the standard's `duplex: "half"` and is why the Request constructor
+        // makes that member compulsory for such a body. Everything else already holds its bytes.
         if (request is { HasBody: true, Source: null })
         {
-            // Reading the stream can take any number of event-loop turns, so both callbacks have to allow for
-            // the operation having been abandoned in between — which is what Abandoned() answers.
-            FetchBody.ReadRequestBody(
-                engine,
-                realm,
-                request,
-                bytes =>
-                {
-                    if (!operation.Abandoned)
-                    {
-                        operation.Run(client, Snapshot(bytes), policy);
-                    }
-                },
-                error =>
-                {
-                    state.UnregisterFetch(operation);
-                    operation.RejectBeforeSending(error);
-                });
+            if (request.IsUnusable)
+            {
+                state.UnregisterFetch(operation);
+                operation.RejectBeforeSending(realm.Intrinsics.TypeError.Construct("Body has already been consumed"));
+                return capability.PromiseInstance;
+            }
 
+            var requestBody = new FetchRequestBodyStream(engine, request.Stream!);
+            operation._requestBody = requestBody;
+
+            // Started before the transport, so the first chunk is usually already waiting when the socket
+            // asks for it — and so that a stream which errors immediately does so before a byte is sent.
+            requestBody.Start();
+
+            operation.Run(client, Snapshot(null, requestBody.Content), policy);
             return capability.PromiseInstance;
         }
 
@@ -242,22 +245,16 @@ internal sealed class FetchOperation
     }
 
     /// <summary>
-    /// Whether the operation has already been settled or abandoned, which is the only thing a callback
-    /// arriving on a later event-loop turn can safely act on.
-    /// </summary>
-    private bool Abandoned => Volatile.Read(ref _settled) != 0;
-
-    /// <summary>
-    /// Fails the fetch before a socket was ever opened, which is what a request body stream that errored
-    /// leaves. The token source has nothing to cancel and is released here rather than by a settle job that
-    /// will never run.
+    /// Fails the fetch before a socket was ever opened — a request whose body turned out to be unusable.
+    /// The token source has nothing to cancel and is released here rather than by a settle job that will
+    /// never run.
     /// </summary>
     private void RejectBeforeSending(JsValue error)
     {
         if (Interlocked.Exchange(ref _settled, 1) != 0)
         {
-            // Abandoned while the request body was still being read: the restore's generation fence is what
-            // this promise is behind now, and settling it is exactly what that forbids.
+            // Already abandoned, which the restore's generation fence now stands behind: settling this
+            // promise is exactly what that forbids.
             return;
         }
 
@@ -513,6 +510,11 @@ internal sealed class FetchOperation
     private void Release()
     {
         _engine._webApi?.UnregisterFetch(this);
+
+        // Whatever the outcome, nothing will consume another byte of a streaming request body: the transport
+        // disposes its content on the way out of a successful send, and a failed or cancelled one has
+        // nothing left to send it to.
+        _requestBody?.StopProducing();
         _cancellation.Dispose();
     }
 
@@ -539,6 +541,10 @@ internal sealed class FetchOperation
         // A response whose headers arrived but whose settle job the fence will discard: nothing will ever
         // read the body, so the connection is let go here rather than waiting for a finalizer.
         Interlocked.Exchange(ref _pendingBody, null)?.Dispose();
+
+        // Runs on the engine thread, from the restore, so the engine half of a streaming request body can be
+        // stopped here directly rather than through a job the fence would discard.
+        _requestBody?.Abandon();
     }
 
     private bool EnterFetchRealm()

--- a/Jint/WebApi/Fetch/FetchRequestBodyStream.cs
+++ b/Jint/WebApi/Fetch/FetchRequestBodyStream.cs
@@ -1,0 +1,358 @@
+#if NET8_0_OR_GREATER
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Jint.Native;
+using Jint.Native.TypedArray;
+using Jint.Runtime;
+using Jint.WebApi.Files;
+using Jint.WebApi.Streams;
+
+namespace Jint.WebApi.Fetch;
+
+/// <summary>
+/// A request body that only exists as a <c>ReadableStream</c>, streamed to the wire rather than collected
+/// first: the standard's <c>duplex: "half"</c>.
+/// <para>
+/// https://fetch.spec.whatwg.org/#dom-requestinit-duplex — "the user agent sends the entire request before
+/// processing the response" — and https://fetch.spec.whatwg.org/#concept-request-body, whose transmission
+/// steps are <c>processBodyChunk</c> / <c>processEndOfBody</c> / <c>processBodyError</c>.
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// It is <see cref="FetchBodyStream"/> pointing the other way, and obeys the same rule: <b>the two halves
+/// never touch each other's state directly</b>. The engine half reads the script's stream on the engine
+/// thread, one chunk per read, through an ordinary read request — nothing else may read a
+/// <c>ReadableStream</c>. The transport half is an <see cref="HttpContent"/> whose
+/// <c>SerializeToStreamAsync</c> runs on whichever thread <see cref="HttpClient"/> gives it. Between them
+/// sits a <see cref="Channel{T}"/> of <b>capacity one</b>, which is the whole of the synchronization: a
+/// plain CLR object both threads may touch, carrying nothing but byte arrays.
+/// </para>
+/// <para>
+/// <b>Backpressure falls out of that capacity.</b> The engine's write does not complete until the transport
+/// has taken the previous chunk, and the next read of the script's stream is not issued until the write
+/// completes — so a script writing into a <c>TransformStream</c> faster than the socket drains is stopped by
+/// its own <c>desiredSize</c>, and a slow server slows the script rather than filling memory. The engine
+/// never blocks waiting for that: the write's continuation comes back as a <b>generation-stamped event-loop
+/// job</b>, the same fence every other cross-thread completion in Jint sits behind.
+/// </para>
+/// <para>
+/// <b>Three reductions against a browser, all of them consequences of the transport being
+/// <see cref="HttpClient"/>.</b>
+/// </para>
+/// <list type="number">
+/// <item>
+/// A body-preserving redirect fails the fetch. That is what the standard itself prescribes —
+/// https://fetch.spec.whatwg.org/#http-redirect-fetch step 12: "If internalResponse's status is not 303,
+/// request's body is non-null, and request's body's source is null, then return a network error" — because
+/// the bytes are gone once sent and cannot be sent again. A 303 is fine: it drops the body with the method.
+/// </item>
+/// <item>
+/// Nothing checks the negotiated HTTP version, where https://fetch.spec.whatwg.org/#concept-http-network-fetch
+/// makes an HTTP/1.x connection carrying a null-source body a network error and browsers therefore require
+/// HTTP/2. This streams over HTTP/1.1 as <c>Transfer-Encoding: chunked</c>, which is what every server-side
+/// HTTP client does and what a server-side embedder wants; the browser rule exists to protect a shared
+/// connection pool from a request that occupies it indefinitely, and is deliberately not mirrored.
+/// </item>
+/// <item>
+/// The content can be serialized <b>once</b>. <see cref="HttpClient"/> resends a request in a few situations
+/// of its own — a connection closed at exactly the wrong moment, an authentication challenge — and a second
+/// serialization is refused rather than silently sending a truncated body. The standard anticipates this too
+/// ("if the user agent needs to resend request, then instead return a network error"); a browser's 64 KiB
+/// replay buffer is not reproduced.
+/// </item>
+/// </list>
+/// <para>
+/// A host handler that reads the content <i>synchronously</i> — <c>HttpContent.ReadAsStream()</c>,
+/// <c>ReadAsByteArrayAsync()</c>'s synchronous cousins — gets a <see cref="NotSupportedException"/>, because
+/// producing the bytes needs the engine thread to run event-loop turns and blocking the caller for them
+/// would deadlock whenever the caller <i>is</i> that thread. The asynchronous members all work.
+/// </para>
+/// </remarks>
+internal sealed class FetchRequestBodyStream : ReadRequest
+{
+    private readonly Engine _engine;
+    private readonly int _generation;
+    private readonly JsReadableStreamDefaultReader _reader;
+
+    /// <summary>
+    /// One chunk in flight, which is what makes the socket's pace the script's pace. Single reader and
+    /// single writer: exactly one thread is ever on each end.
+    /// </summary>
+    private readonly Channel<byte[]> _chunks = Channel.CreateBounded<byte[]>(new BoundedChannelOptions(1)
+    {
+        SingleReader = true,
+        SingleWriter = true,
+        FullMode = BoundedChannelFullMode.Wait,
+    });
+
+    /// <summary>
+    /// Set by the transport half when it will take no more bytes — the request finished, failed, was
+    /// aborted, or its message was disposed. Written from the transport's thread and read from the engine's,
+    /// hence <c>volatile</c>; it is a hint that the engine half checks at its own next safe point, never a
+    /// handshake.
+    /// </summary>
+    private volatile bool _stopped;
+
+    private bool _reading;
+    private bool _readAgain;
+    private bool _finished;
+
+    internal FetchRequestBodyStream(Engine engine, JsReadableStream stream)
+    {
+        _engine = engine;
+        _generation = engine.EventLoopGeneration;
+
+        // The fetch takes the body: the stream is locked and disturbed from here on, exactly as a buffered
+        // upload's full read left it. The caller has already ruled out an unusable body.
+        _reader = ReadableStreamOperations.AcquireDefaultReader(stream);
+
+        Content = new RequestBodyContent(this);
+    }
+
+    /// <summary>
+    /// What goes on the <see cref="HttpRequestMessage"/>. Plain CLR state: the transport touches this and
+    /// the channel behind it, and no part of the engine.
+    /// </summary>
+    internal HttpContent Content { get; }
+
+    /// <summary>
+    /// Starts reading the script's stream. Called on the engine thread, before the request is handed to the
+    /// transport, so that the first chunk is usually already waiting when the socket asks for it.
+    /// </summary>
+    internal void Start() => Run();
+
+    /// <summary>
+    /// Ends the body because the evaluation cycle it belongs to has ended — see
+    /// <c>WebApiEngineState.ResetTransientState</c> — or because the fetch settled without the transport
+    /// having consumed the body. Runs on the engine thread.
+    /// </summary>
+    internal void Abandon()
+    {
+        _finished = true;
+        _chunks.Writer.TryComplete(new FetchFailureException(
+            FetchFailureKind.Network,
+            "The request body stream ended because the fetch was abandoned."));
+
+        StopProducing();
+    }
+
+    /// <summary>
+    /// Tells the engine half that nothing will read another byte. Safe from any thread and any number of
+    /// times.
+    /// </summary>
+    /// <remarks>
+    /// The flag alone is not enough: the engine half may be parked on a write into a channel that is full,
+    /// and only a read makes room. So the queue is drained here — the chunk it holds is going nowhere — and
+    /// the write that was waiting for that space completes, sees the flag, and lets the read loop end. The
+    /// two orders are both fine: a write that arrives after the drain finds the channel empty and completes
+    /// at once.
+    /// </remarks>
+    internal void StopProducing()
+    {
+        _stopped = true;
+
+        while (_chunks.Reader.TryRead(out _))
+        {
+            // Discarded: there is no longer anything to send it to.
+        }
+    }
+
+    /// <summary>
+    /// The read loop. The standard writes it as recursion — each chunk's steps read again — which for a
+    /// stream whose queue is already full would recurse once per queued chunk. This is
+    /// <c>FetchBody.FullyReadRequest</c>'s loop with the same reentrancy pair: a chunk delivered
+    /// <i>inside</i> the read sets <c>readAgain</c> and the loop goes round, while one delivered later
+    /// starts a fresh loop of its own.
+    /// </summary>
+    private void Run()
+    {
+        do
+        {
+            _readAgain = false;
+            _reading = true;
+            try
+            {
+                ReadableStreamOperations.DefaultReaderRead(_reader, this);
+            }
+            finally
+            {
+                _reading = false;
+            }
+        }
+        while (_readAgain && !_finished);
+    }
+
+    internal override void ChunkSteps(JsValue chunk)
+    {
+        if (_finished || _stopped)
+        {
+            _finished = true;
+            return;
+        }
+
+        // "If chunk is not a Uint8Array object, terminate" — a stream carrying strings or plain objects is
+        // not a body, and saying so beats coercing it into one.
+        if (chunk is not JsTypedArray { _arrayElementType: TypedArrayElementType.Uint8 })
+        {
+            Fail("The request body stream produced a chunk that is not a Uint8Array.", releaseReader: true);
+            return;
+        }
+
+        if (!FileApi.TryGetBufferSourceBytes(chunk, out var bytes) || bytes.IsEmpty)
+        {
+            // A zero-length chunk transmits nothing; reading on is the whole of its handling.
+            ReadAgain();
+            return;
+        }
+
+        // The array leaves the engine thread, so it is the engine's copy and nothing script holds.
+        var write = _chunks.Writer.WriteAsync(bytes.ToArray());
+
+        if (write.IsCompletedSuccessfully)
+        {
+            // The transport was already waiting, so the whole hand-over happened on this stack.
+            OnWriteCompleted(succeeded: true);
+            return;
+        }
+
+        _ = write.AsTask().ContinueWith(
+            static (task, state) =>
+            {
+                var self = (FetchRequestBodyStream) state!;
+
+                // The generation stamp is what stops a chunk written before Engine.Advanced
+                // .RestoreGlobalSnapshot from resuming a read against the restored engine.
+                self._engine.AddToEventLoop(() => self.OnWriteCompleted(task.IsCompletedSuccessfully), self._generation);
+            },
+            this,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
+    internal override void CloseSteps()
+    {
+        // processEndOfBody: the body is complete, so the transport's loop ends and the request finishes.
+        _finished = true;
+        _chunks.Writer.TryComplete();
+    }
+
+    internal override void ErrorSteps(JsValue error)
+    {
+        // processBodyError: "terminate fetchParams's controller", which surfaces as a network error rather
+        // than as the stream's own error — the fetch promise has the standard's one TypeError either way.
+        // The error value itself is deliberately not stringified: doing that can run script.
+        Fail("The request body stream errored.", releaseReader: false);
+    }
+
+    /// <summary>
+    /// Called on the engine thread when the write the loop was parked on has settled. A cancelled or failed
+    /// write means the transport has gone; there is nothing left to read the stream for.
+    /// </summary>
+    private void OnWriteCompleted(bool succeeded)
+    {
+        if (_finished)
+        {
+            return;
+        }
+
+        if (!succeeded || _stopped)
+        {
+            _finished = true;
+            return;
+        }
+
+        ReadAgain();
+    }
+
+    private void ReadAgain()
+    {
+        if (_reading)
+        {
+            _readAgain = true;
+            return;
+        }
+
+        Run();
+    }
+
+    private void Fail(string message, bool releaseReader)
+    {
+        _finished = true;
+
+        if (releaseReader)
+        {
+            // The standard's failure steps for a non-Uint8Array chunk release the reader's lock before
+            // reporting, so the stream is left usable rather than pinned by a reader nobody holds.
+            ReadableStreamOperations.DefaultReaderRelease(_reader);
+        }
+
+        _chunks.Writer.TryComplete(new FetchFailureException(FetchFailureKind.Network, message));
+    }
+
+    /// <summary>
+    /// The transport half: an <see cref="HttpContent"/> of unknown length whose bytes arrive from the
+    /// channel. Unknown length is what makes <see cref="HttpClient"/> send
+    /// <c>Transfer-Encoding: chunked</c> rather than wait for a <c>Content-Length</c> nobody can compute.
+    /// </summary>
+    private sealed class RequestBodyContent : HttpContent
+    {
+        private readonly FetchRequestBodyStream _owner;
+        private int _serialized;
+
+        internal RequestBodyContent(FetchRequestBodyStream owner)
+        {
+            _owner = owner;
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return false;
+        }
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+            => WriteAsync(stream, CancellationToken.None);
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken)
+            => WriteAsync(stream, cancellationToken);
+
+        private async Task WriteAsync(Stream stream, CancellationToken cancellationToken)
+        {
+            if (Interlocked.Exchange(ref _serialized, 1) != 0)
+            {
+                // A resend. The bytes are gone, and half a body is worse than none.
+                throw new FetchFailureException(
+                    FetchFailureKind.Network,
+                    "The request body is a ReadableStream and has already been sent, so the request cannot be sent again.");
+            }
+
+            var reader = _owner._chunks.Reader;
+
+            // A channel the engine half completed with a reason raises it from here as the inner exception
+            // of a ChannelClosedException, which the transport turns into a network error like any other
+            // send failure — and which the host can still read off the error value.
+            while (await reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                while (reader.TryRead(out var chunk))
+                {
+                    await stream.WriteAsync(chunk, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            // Every hop disposes its request message, so this runs once the body has been sent — and also
+            // when the send failed, or when a handler answered without reading the body at all. In all three
+            // the engine half has nothing left to produce for.
+            _owner.StopProducing();
+            base.Dispose(disposing);
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/Fetch/FetchTransport.cs
+++ b/Jint/WebApi/Fetch/FetchTransport.cs
@@ -50,8 +50,9 @@ internal sealed class FetchFailureException : Exception
 /// </summary>
 /// <remarks>
 /// Nothing here is engine state: the URL record and the header list are both from the deliberately
-/// engine-free layers, and the body is a byte window. That is what lets the whole of
-/// <see cref="FetchTransport"/> run on a thread pool thread while the engine goes on running script.
+/// engine-free layers, the body is a byte window, and a streaming body is an <see cref="HttpContent"/> whose
+/// engine half the transport never reaches. That is what lets the whole of <see cref="FetchTransport"/> run
+/// on a thread pool thread while the engine goes on running script.
 /// </remarks>
 internal sealed class FetchRequestSnapshot
 {
@@ -62,6 +63,15 @@ internal sealed class FetchRequestSnapshot
     internal required List<HeaderEntry> Headers { get; init; }
 
     internal required ReadOnlyMemory<byte>? Body { get; init; }
+
+    /// <summary>
+    /// The body as a live <see cref="HttpContent"/> rather than as bytes, for the one shape that has no
+    /// bytes to give: a <c>ReadableStream</c> body sent with <c>duplex: "half"</c>. Exactly one of this and
+    /// <see cref="Body"/> is ever non-null, and this one being non-null is the transport's way of knowing
+    /// the body has no <i>source</i> in the standard's sense — which is what decides whether a redirect can
+    /// be followed. See <see cref="FetchRequestBodyStream"/>.
+    /// </summary>
+    internal HttpContent? BodyContent { get; init; }
 
     /// <summary>One of <c>follow</c>, <c>error</c> or <c>manual</c>.</summary>
     internal required string Redirect { get; init; }
@@ -313,6 +323,7 @@ internal static class FetchTransport
         var url = request.Url;
         var method = request.Method;
         var body = request.Body;
+        var content = request.BodyContent;
         var headers = new List<HeaderEntry>(request.Headers);
         var redirectCount = 0;
 
@@ -330,7 +341,7 @@ internal static class FetchTransport
             HttpResponseMessage response;
             try
             {
-                using var message = BuildRequest(method, uri, headers, body);
+                using var message = BuildRequest(method, uri, headers, body, content);
                 response = await client.SendAsync(message, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex) when (ex is not OperationCanceledException and not FetchFailureException)
@@ -369,6 +380,17 @@ internal static class FetchTransport
                     return new FetchExchange { Response = response, Url = url, Redirected = redirectCount > 0 };
                 }
 
+                // https://fetch.spec.whatwg.org/#http-redirect-fetch step 12: "If internalResponse's status
+                // is not 303, request's body is non-null, and request's body's source is null, then return a
+                // network error." A streamed body has already gone down the wire and cannot go again; a 303
+                // is exempt because it drops the body along with the method.
+                if (content is not null && status != 303)
+                {
+                    throw new FetchFailureException(
+                        FetchFailureKind.Network,
+                        $"'{uri}' answered a {status} redirect, which would have to re-send a request body that is a ReadableStream.");
+                }
+
                 if (++redirectCount > policy.MaxRedirects)
                 {
                     throw new FetchFailureException(
@@ -376,7 +398,7 @@ internal static class FetchTransport
                         $"The request to '{request.Url.Serialize()}' exceeded the limit of {policy.MaxRedirects} redirects.");
                 }
 
-                Rewrite(status, ref method, ref body, headers, url, location);
+                Rewrite(status, ref method, ref body, ref content, headers, url, location);
                 url = location;
             }
             finally
@@ -431,7 +453,14 @@ internal static class FetchTransport
     /// The method and header rewrites a redirect performs —
     /// https://fetch.spec.whatwg.org/#http-redirect-fetch steps 11 to 13.
     /// </summary>
-    private static void Rewrite(int status, ref string method, ref ReadOnlyMemory<byte>? body, List<HeaderEntry> headers, UrlRecord from, UrlRecord to)
+    private static void Rewrite(
+        int status,
+        ref string method,
+        ref ReadOnlyMemory<byte>? body,
+        ref HttpContent? content,
+        List<HeaderEntry> headers,
+        UrlRecord from,
+        UrlRecord to)
     {
         var dropsBody = (status is 301 or 302 && string.Equals(method, "POST", StringComparison.Ordinal))
             || (status == 303 && method is not ("GET" or "HEAD"));
@@ -440,6 +469,10 @@ internal static class FetchTransport
         {
             method = "GET";
             body = null;
+
+            // The hop's request message has already been disposed, and with it this content — the check
+            // above is what guarantees only a 303 ever reaches here with one.
+            content = null;
             Remove(headers, _bodyHeaderNames);
         }
 
@@ -474,11 +507,22 @@ internal static class FetchTransport
         && string.Equals(a.SerializeHost(), b.SerializeHost(), StringComparison.Ordinal)
         && a.Port == b.Port;
 
-    private static HttpRequestMessage BuildRequest(string method, Uri uri, List<HeaderEntry> headers, ReadOnlyMemory<byte>? body)
+    private static HttpRequestMessage BuildRequest(
+        string method,
+        Uri uri,
+        List<HeaderEntry> headers,
+        ReadOnlyMemory<byte>? body,
+        HttpContent? content)
     {
         var message = new HttpRequestMessage(new HttpMethod(method), uri);
 
-        if (body is { } bytes)
+        if (content is not null)
+        {
+            // A streaming body: the content pulls from the engine as the socket drains it, and computes no
+            // length, so this goes out chunked.
+            message.Content = content;
+        }
+        else if (body is { } bytes)
         {
             message.Content = new ReadOnlyMemoryContent(bytes);
 

--- a/Jint/WebApi/Fetch/JsRequest.cs
+++ b/Jint/WebApi/Fetch/JsRequest.cs
@@ -19,10 +19,15 @@ namespace Jint.WebApi.Fetch;
 /// <para>
 /// This is the <b>minimal</b> request of the plan's surface v1: the members <c>fetch</c> actually acts on.
 /// <c>destination</c>, <c>referrer</c>, <c>referrerPolicy</c>, <c>mode</c>, <c>credentials</c>, <c>cache</c>,
-/// <c>integrity</c>, <c>keepalive</c>, <c>isReloadNavigation</c>, <c>isHistoryNavigation</c> and
-/// <c>duplex</c> are deliberately absent rather than present and lying: every one of them describes a browser
-/// concept — an origin, a cookie jar, an HTTP cache, a navigation — that this engine does not have, and an
-/// absent member is what feature detection is written against.
+/// <c>integrity</c>, <c>keepalive</c>, <c>isReloadNavigation</c> and <c>isHistoryNavigation</c> are
+/// deliberately absent rather than present and lying: every one of them describes a browser concept — an
+/// origin, a cookie jar, an HTTP cache, a navigation — that this engine does not have, and an absent member
+/// is what feature detection is written against.
+/// </para>
+/// <para>
+/// <c>duplex</c> is the one that moved the other way. It describes no browser concept — it says whether the
+/// request is sent before the response is read — and it is the member a script must set for a
+/// <c>ReadableStream</c> body, so it is both read from <c>RequestInit</c> and exposed as an attribute.
 /// </para>
 /// </remarks>
 internal sealed class JsRequest : FetchBodyObject
@@ -59,5 +64,11 @@ internal sealed class JsRequest : FetchBodyObject
     internal const string RedirectFollow = "follow";
     internal const string RedirectError = "error";
     internal const string RedirectManual = "manual";
+
+    /// <summary>
+    /// https://fetch.spec.whatwg.org/#dom-request-duplex — <c>enum RequestDuplex { "half" };</c> has exactly
+    /// one value, and the attribute's getter steps are to return it, so no request carries any state for it.
+    /// </summary>
+    internal const string DuplexHalf = "half";
 }
 #endif

--- a/Jint/WebApi/Fetch/RequestConstructor.cs
+++ b/Jint/WebApi/Fetch/RequestConstructor.cs
@@ -103,9 +103,10 @@ internal sealed class RequestConstructor : Constructor
         }
 
         // WebIDL converts a dictionary's members in lexicographical order of their identifiers, so a bag whose
-        // members are getters observes body, headers, method, redirect, signal in that order.
+        // members are getters observes body, duplex, headers, method, redirect, signal in that order.
         var initObject = ToInit(init);
         var bodyInit = Member(initObject, "body");
+        var duplexInit = Member(initObject, "duplex");
         var headersInit = Member(initObject, "headers");
         var methodInit = Member(initObject, "method");
         var redirectInit = Member(initObject, "redirect");
@@ -129,6 +130,15 @@ internal sealed class RequestConstructor : Constructor
             {
                 Throw.TypeError(_realm, $"Failed to construct 'Request': The provided value '{redirect}' is not a valid enum value of type RequestRedirect.");
             }
+        }
+
+        // `enum RequestDuplex { "half" };` — "half" is the only value, and "full" is reserved for a
+        // full-duplex fetch nobody has specified yet. WebIDL performs this conversion while the dictionary
+        // is being read rather than as a step of the algorithm; doing it here instead only changes which
+        // TypeError a bag carrying two invalid members reports, and keeps it beside the other enum member.
+        if (duplexInit is not null && !string.Equals(FetchValues.ToByteString(_realm, duplexInit), JsRequest.DuplexHalf, StringComparison.Ordinal))
+        {
+            Throw.TypeError(_realm, "Failed to construct 'Request': The provided value is not a valid enum value of type RequestDuplex.");
         }
 
         if (signalInit is not null && !signalInit.IsNull())
@@ -179,6 +189,17 @@ internal sealed class RequestConstructor : Constructor
             // Steps 38-40: extract, then append the implied Content-Type unless the header list — which the
             // step above has already filled — carries one of its own.
             var extracted = FetchBody.Extract(_realm, bodyInit!);
+
+            // Step 41: "If initBody is non-null and init["duplex"] does not exist, then throw a TypeError."
+            // Only a body whose source is null — the ReadableStream arm — reaches it, which is why a string
+            // or a Blob body may carry duplex or not as it likes and neither is refused. The member is what
+            // makes a script say out loud that it knows the request will be sent before the response is
+            // read; there is no "full" to ask for.
+            if (extracted.Stream is not null && duplexInit is null)
+            {
+                Throw.TypeError(_realm, "Failed to construct 'Request': The `duplex` member must be set to 'half' for a request with a ReadableStream body.");
+            }
+
             FetchBody.SetBody(request, in extracted);
         }
         else if (hasInputBody)

--- a/Jint/WebApi/Fetch/RequestPrototype.cs
+++ b/Jint/WebApi/Fetch/RequestPrototype.cs
@@ -88,14 +88,26 @@ internal sealed partial class RequestPrototype : Prototype
     private JsAbortSignal SignalGet(JsValue thisObject) => Brand(thisObject).Signal;
 
     /// <summary>
+    /// https://fetch.spec.whatwg.org/#dom-request-duplex — "the getter steps are to return
+    /// <c>"half"</c>", which is what every request is: the whole request body reaches the wire before the
+    /// response body is read. <c>"full"</c> is reserved and nothing implements it.
+    /// </summary>
+    [JsAccessor("duplex", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsString DuplexGet(JsValue thisObject)
+    {
+        Brand(thisObject);
+        return JsString.Create(JsRequest.DuplexHalf);
+    }
+
+    /// <summary>
     /// https://fetch.spec.whatwg.org/#dom-body-body — the body's <c>ReadableStream</c>, or <c>null</c> when
     /// the request has no body, which every <c>GET</c> and <c>HEAD</c> necessarily has not.
     /// </summary>
     /// <remarks>
-    /// A body given as bytes materializes its stream here, on first ask. <b>A request body is still uploaded
-    /// buffered:</b> a <c>ReadableStream</c> handed to the constructor is read in full before the request is
-    /// sent, so a streaming upload — the standard's <c>duplex: 'half'</c> — is out of scope, and
-    /// <c>duplex</c> is absent rather than present and ignored.
+    /// A body given as bytes materializes its stream here, on first ask, as a readable <i>byte</i> stream —
+    /// so a BYOB reader works on it, exactly as https://fetch.spec.whatwg.org/#concept-body requires. A body
+    /// given as a <c>ReadableStream</c> is that stream, whatever kind it is, and <c>fetch</c> streams it to
+    /// the wire rather than collecting it first: see <see cref="FetchRequestBodyStream"/>.
     /// </remarks>
     [JsAccessor("body", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
     private JsValue BodyGet(JsValue thisObject)

--- a/Jint/WebApi/Files/BlobPrototype.cs
+++ b/Jint/WebApi/Files/BlobPrototype.cs
@@ -164,19 +164,20 @@ internal sealed partial class BlobPrototype : Prototype
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Two reductions against the algorithm as written. The stream is an ordinary (non-byte)
-    /// <c>ReadableStream</c> rather than one "set up with byte reading support", so
-    /// <c>getReader({ mode: "byob" })</c> on it raises the standard's TypeError for a stream that was not
-    /// constructed with a byte source. That is a gap in <i>this caller</i> rather than in the engine —
-    /// readable byte streams are implemented, and a script can build one with
-    /// <c>new ReadableStream({ type: "bytes" })</c> — so moving a blob onto one is a change here alone. And
-    /// the blob's bytes are one chunk rather than the implementation-defined slices the algorithm's loop
-    /// reads: the bytes are already in memory, so slicing them would manufacture event-loop turns rather
-    /// than model any I/O. An empty blob enqueues nothing and closes, so its first <c>read()</c> is done.
+    /// The stream is "set up with byte reading support" as the algorithm says — a readable <i>byte</i>
+    /// stream — so <c>getReader({ mode: "byob" })</c> works on it and a consumer can read a blob into a
+    /// buffer it recycles.
     /// </para>
     /// <para>
-    /// The chunk is a <c>Uint8Array</c> over a fresh copy, like every other way a blob's bytes cross into
-    /// script: a blob is immutable and what script is handed is writable.
+    /// One reduction against the algorithm as written: the blob's bytes are one chunk rather than the
+    /// implementation-defined slices the algorithm's loop reads. The bytes are already in memory, so
+    /// slicing them would manufacture event-loop turns rather than model any I/O — and it is only a
+    /// <i>default</i> reader that can tell, since a BYOB read is bounded by the caller's own buffer either
+    /// way. An empty blob enqueues nothing and closes, so its first <c>read()</c> is done.
+    /// </para>
+    /// <para>
+    /// The bytes are copied on the way out, like every other way a blob's bytes cross into script: a blob is
+    /// immutable and what script is handed is writable.
     /// </para>
     /// </remarks>
     [JsFunction(Name = "stream", Length = 0)]

--- a/Jint/WebApi/Streams/ByteStreams.cs
+++ b/Jint/WebApi/Streams/ByteStreams.cs
@@ -6,19 +6,19 @@ using Jint.Runtime;
 namespace Jint.WebApi.Streams;
 
 /// <summary>
-/// The two pieces every specification that hands bytes to a stream needs: a chunk, which is always a
-/// <c>Uint8Array</c>, and a stream over a byte sequence that already exists in full.
+/// The three pieces every specification that hands bytes to a stream needs: a chunk, which is always a
+/// <c>Uint8Array</c>; a way to push raw bytes into a byte stream's controller; and a stream over a byte
+/// sequence that already exists in full.
 /// </summary>
 /// <remarks>
 /// Used by <c>Blob.stream()</c> (https://w3c.github.io/FileAPI/#blob-get-stream) and by the <c>Body</c>
 /// mixin's <c>body</c> attribute for a body that was extracted from bytes
 /// (https://fetch.spec.whatwg.org/#concept-bodyinit-extract). Both specifications ask for a stream "set up
-/// with byte reading support" — a readable <i>byte</i> stream, which
-/// <see cref="ReadableByteStreamControllerOperations"/> now implements — but neither caller has been moved
-/// onto one yet, so what they get is still an ordinary stream carrying <c>Uint8Array</c> chunks. That is
-/// what those algorithms reduce to once BYOB readers are out of the picture, and it is what every consumer
-/// in this implementation reads; the difference a script can see is that <c>getReader({ mode: "byob" })</c>
-/// on such a body refuses, where in a browser it would not.
+/// with byte reading support" — a readable <i>byte</i> stream — and both get one:
+/// <see cref="CreateFromBytes"/> builds a <see cref="JsReadableByteStreamController"/>, so
+/// <c>getReader({ mode: "byob" })</c> works on a blob's stream and on either kind of body, exactly as it
+/// does in a browser. A default reader sees no difference at all: the chunk it takes out of the queue is
+/// still one <c>Uint8Array</c>.
 /// </remarks>
 internal static class ByteStreams
 {
@@ -35,23 +35,89 @@ internal static class ByteStreams
     }
 
     /// <summary>
-    /// A <c>ReadableStream</c> over a byte sequence that is already in memory: one chunk, then close.
+    /// Enqueues a byte sequence the engine holds into a byte stream's controller —
+    /// https://streams.spec.whatwg.org/#readable-byte-stream-controller-enqueue, whose argument is an
+    /// <c>ArrayBufferView</c> rather than a chunk of any type.
+    /// </summary>
+    /// <remarks>
+    /// The buffer is built here and handed straight over, so the transfer <c>enqueue</c> performs on it
+    /// costs nothing: the data block moves to the new buffer and the one made here is detached without ever
+    /// having been reachable from script. The copy of <paramref name="bytes"/> is the same one
+    /// <see cref="NewUint8Array"/> makes and for the same reason — a blob, a body source or a pooled
+    /// transport buffer must not be what a script ends up owning.
+    /// </remarks>
+    internal static void EnqueueBytes(JsReadableByteStreamController controller, ReadOnlySpan<byte> bytes)
+        => EnqueueOwnedBytes(controller, bytes.ToArray());
+
+    /// <summary>
+    /// <see cref="EnqueueBytes"/> for a caller that already holds an array nothing else will read —
+    /// a transport chunk copied out of a pooled buffer, say — and so needs no copy of its own.
+    /// </summary>
+    internal static void EnqueueOwnedBytes(JsReadableByteStreamController controller, byte[] bytes)
+    {
+        var realm = controller.Realm;
+
+        var buffer = new JsArrayBuffer(controller.Engine, bytes)
+        {
+            _prototype = realm.Intrinsics.ArrayBuffer.PrototypeObject,
+        };
+
+        var view = new StreamBufferOperations.ArrayBufferViewInfo(
+            buffer, ByteOffset: 0, bytes.Length, bytes.Length, ElementSize: 1, TypedArrayElementType.Uint8);
+
+        ReadableByteStreamControllerOperations.Enqueue(controller, in view);
+    }
+
+    /// <summary>
+    /// Ends a byte stream whose bytes arrive from outside the engine, the way
+    /// https://streams.spec.whatwg.org/#example-rbs-pull ends one: close the controller, and then answer any
+    /// outstanding BYOB request with zero bytes.
+    /// </summary>
+    /// <remarks>
+    /// The second half is not optional and is easy to miss.
+    /// <c>ReadableByteStreamControllerClose</c> closes the <i>stream</i>, and
+    /// https://streams.spec.whatwg.org/#readable-stream-close resolves a default reader's pending
+    /// <c>read()</c>s — but deliberately not a BYOB reader's pending read-<i>into</i> requests, which are
+    /// still holding a buffer only the controller can hand back. A source that closes without responding
+    /// leaves a <c>read(view)</c> pending for ever. Responding zero into a closed stream is exactly the
+    /// "the source has no more bytes, here is your buffer" answer, and produces <c>{ done: true }</c> with
+    /// an empty view onto the caller's own memory.
+    /// </remarks>
+    internal static void CloseAndReleasePendingByob(JsReadableByteStreamController controller)
+    {
+        ReadableByteStreamControllerOperations.Close(controller);
+
+        // Close only *requests* a close while the queue still holds bytes, and a stream that is not closed
+        // has nothing to hand back yet — the drain of those bytes will close it and answer the read.
+        if (controller.Stream.State == ReadableStreamState.Closed && controller.PendingPullIntos.Count > 0)
+        {
+            ReadableByteStreamControllerOperations.Respond(controller, 0);
+        }
+    }
+
+    /// <summary>
+    /// A readable <i>byte</i> stream over a byte sequence that is already in memory: one chunk, then close.
     /// </summary>
     /// <remarks>
     /// <para>
     /// The whole sequence is one chunk rather than the implementation-defined slices a browser hands out.
-    /// That is observable — a reader sees one <c>read()</c> resolve with everything — and it is the honest
-    /// shape here, because there is no I/O to interleave: the bytes exist, and slicing them would only
-    /// manufacture event-loop turns.
+    /// That is observable to a default reader — one <c>read()</c> resolves with everything — and it is the
+    /// honest shape here, because there is no I/O to interleave: the bytes exist, and slicing them would
+    /// only manufacture event-loop turns. A BYOB reader is unaffected either way, since it is the
+    /// <i>caller's</i> buffer that decides how much one read takes.
     /// </para>
     /// <para>
     /// An empty sequence enqueues nothing and closes immediately, so the first <c>read()</c> answers
     /// <c>{ value: undefined, done: true }</c>.
     /// </para>
+    /// <para>
+    /// No <c>autoAllocateChunkSize</c>: the bytes are already here, so there is nothing for the controller
+    /// to allocate a buffer for. A BYOB read is served out of the queue instead.
+    /// </para>
     /// </remarks>
     internal static JsReadableStream CreateFromBytes(Engine engine, Realm realm, ReadOnlyMemory<byte> bytes)
     {
-        var stream = ReadableStreamOperations.CreateReadableStream(
+        var stream = ReadableStreamOperations.CreateReadableByteStream(
             engine,
             realm,
             static () => JsValue.Undefined,
@@ -60,13 +126,13 @@ internal static class ByteStreams
 
         // Filled after the stream exists rather than from its start algorithm, which runs while the
         // controller is still being wired up and has no way to reach it.
-        var controller = stream.DefaultController;
+        var controller = stream.ByteController;
         if (!bytes.IsEmpty)
         {
-            ReadableStreamDefaultControllerOperations.Enqueue(controller, NewUint8Array(engine, realm, bytes.Span));
+            EnqueueBytes(controller, bytes.Span);
         }
 
-        ReadableStreamDefaultControllerOperations.Close(controller);
+        ReadableByteStreamControllerOperations.Close(controller);
         return stream;
     }
 }

--- a/Jint/WebApi/Streams/JsReadableStream.cs
+++ b/Jint/WebApi/Streams/JsReadableStream.cs
@@ -89,5 +89,13 @@ internal sealed class JsReadableStream : ObjectInstance
     /// <see cref="JsReadableStreamController"/> instead.
     /// </summary>
     internal JsReadableStreamDefaultController DefaultController => (JsReadableStreamDefaultController) Controller;
+
+    /// <summary>
+    /// The controller of a stream the engine built itself through
+    /// <see cref="ReadableStreamOperations.CreateReadableByteStream"/> — a byte tee's branch, a body's
+    /// stream, a blob's stream. Those are byte controllers by construction, which is what makes the cast
+    /// safe; the same rule as <see cref="DefaultController"/>, on the other side of the pair.
+    /// </summary>
+    internal JsReadableByteStreamController ByteController => (JsReadableByteStreamController) Controller;
 }
 #endif

--- a/README.md
+++ b/README.md
@@ -597,11 +597,12 @@ them: a `Request` always has an `AbortSignal`, its URL is a WHATWG URL, `respons
 iteration, `getSetCookie`), method normalization, `redirect` modes, `clone()`, `Response.error()`,
 `Response.redirect()`, `Response.json()`. A `FormData` body is serialized as `multipart/form-data` with a
 cryptographically random boundary, and `formData()` reads one back — as well as an
-`application/x-www-form-urlencoded` body — rejecting with a `TypeError` for anything else. `credentials`,
-`cache`, `mode`, `referrer` and `integrity` are accepted and ignored, the same convention Node and workerd
-follow, because there is no origin, cookie jar or HTTP cache here to honour them with.
+`application/x-www-form-urlencoded` body — rejecting with a `TypeError` for anything else. `duplex` is read
+and validated, because it decides whether a body may be a stream at all (see below). `credentials`, `cache`,
+`mode`, `referrer` and `integrity` are accepted and ignored, the same convention Node and workerd follow,
+because there is no origin, cookie jar or HTTP cache here to honour them with.
 
-### Response bodies stream
+### Bodies stream, in both directions
 
 `response.body` is a real `ReadableStream`, and a network response is read **on demand**: the promise
 resolves as soon as the headers are in, and the socket is only read when a consumer asks for the next chunk.
@@ -628,10 +629,41 @@ the stream, so each half has its own queue and its own flags. A body built from 
 a `Blob`, a `BufferSource` — keeps its bytes and only materializes a stream if something reads `body`, so the
 common `new Response(x).text()` costs no stream at all.
 
-`Blob.stream()` is there too, and a `ReadableStream` is accepted as a `BodyInit` for both `Request` and
-`Response`. **Uploads are still buffered:** a request body given as a stream is read in full before anything
-is sent, so the standard's `duplex: 'half'` streaming upload is out of scope and `duplex` is absent rather
-than accepted and ignored.
+Every body the engine hands out is a **byte stream** — `response.body`, `request.body` and `Blob.stream()`
+alike, as [Fetch](https://fetch.spec.whatwg.org/#concept-body) and
+[File API](https://w3c.github.io/FileAPI/#blob-get-stream) both require — so `getReader({ mode: 'byob' })`
+works on all three and a download loop can recycle one buffer instead of allocating per chunk. A default
+reader sees exactly what it always did: one `Uint8Array` per chunk.
+
+**Uploads stream too.** A request body given as a `ReadableStream` goes to the wire as the script produces
+it, which is the standard's `duplex: 'half'` — and, as the standard says, that member is **compulsory** for
+such a body:
+
+```js
+const { readable, writable } = new TransformStream();
+const done = fetch('https://api.example.org/ingest', {
+    method: 'POST',
+    duplex: 'half',           // required whenever body is a ReadableStream; omitting it is a TypeError
+    body: readable,
+});
+
+const writer = writable.getWriter();
+for (const row of rows) { await writer.write(encode(row)); }   // each write reaches the socket
+await writer.close();
+await done;
+```
+
+Backpressure runs the whole way through: the next chunk is not read from your stream until the previous one
+has been handed to the transport, so a slow server slows the script rather than filling memory. The request
+goes out chunked, because nothing can compute a `Content-Length` in advance.
+
+Three honest reductions, all of them consequences of the transport being `HttpClient`. A **body-preserving
+redirect fails the fetch** — which is what
+[the standard itself prescribes](https://fetch.spec.whatwg.org/#http-redirect-fetch) for a body with no
+source, since the bytes are gone once sent; a `303`, which drops the body with the method, is followed
+normally. **Nothing checks the negotiated HTTP version**, where a browser refuses a streaming upload over
+HTTP/1.1; this sends it chunked, as every server-side HTTP client does. And the body can be sent **once** —
+if `HttpClient` needs to resend the request, the fetch fails rather than sending a truncated body.
 
 Like every other web API, `fetch` settles only while the engine is being pumped: the promise resolves inside a
 blocking `UnwrapIfPromise`, an `await` of `EvaluateAsync`, or your own `engine.Advanced.ProcessTasks()` loop.
@@ -675,10 +707,12 @@ while the one you get back owns the memory — so a read loop recycles one alloc
 chunk. `tee()` on a byte stream produces two byte streams, and swaps between a default and a BYOB reader on
 the original depending on how each branch is being read.
 
-The streams the *engine* hands out are not byte streams yet: `response.body`, `request.body` and
-`Blob.stream()` are ordinary streams carrying `Uint8Array` chunks, so `getReader({ mode: 'byob' })` on one of
-them raises the `TypeError` the standard gives for a stream that was not constructed with a byte source. A
-byte stream is something script builds today.
+The streams the *engine* hands out are byte streams too: `response.body`, `request.body` and `Blob.stream()`
+each give a `ReadableByteStreamController` behind the scenes, so `getReader({ mode: 'byob' })` works on a
+network response, on a buffered body and on a blob — and `tee()` on any of them produces two byte streams.
+`Engine.Advanced.CreateReadableStream(Stream)` is the one that is still an ordinary stream: it wraps a host
+`Stream` you already own, whose reads go into a buffer the bridge owns rather than into one a script
+supplied.
 
 One deliberate reduction: **only the five interfaces a script constructs by name are globals.**
 `ReadableStreamDefaultReader`, `ReadableStreamBYOBReader`, `WritableStreamDefaultWriter`, the four


### PR DESCRIPTION
Closes #3105 — the remainder after #3158.

**Fetch bodies and `Blob.stream()` are byte streams now.** `Response.body`, `Request.body` and `Blob.stream()` are constructed with the byte controller, so `getReader({ mode: 'byob' })` works on all three (https://fetch.spec.whatwg.org/#concept-body, https://w3c.github.io/FileAPI/#blob-get-stream), `read(view)` transfers the caller's buffer, and a tee or a `clone()` keeps BYOB (`CloneBody` dispatches on controller kind). The former boundary pin flipped into `ServesBYOBOnTheBodiesTheEngineHandsOut`, with a default-reader regression pin beside it. The integration surfaced a real gap worth naming: `ReadableStreamClose` deliberately does not resolve a BYOB reader's pending read-into requests — they hold a buffer only the controller can hand back — so a source that closes without answering leaves `read(view)` pending forever; `CloseAndReleasePendingByob` is the standard's own byte-source close-then-`respond(0)` sequence, and the network body uses it.

**`duplex: 'half'` streams a request body to the wire.** The `RequestInit` member is read in its lexicographic position, refuses everything but `"half"`, and its absence on a stream body is the spec's `TypeError` (https://fetch.spec.whatwg.org/#dom-requestinit-duplex). The upload is a real stream: the engine half reads the script's `ReadableStream` chunk by chunk; the transport half is an `HttpContent` draining a **capacity-one channel**, which is both the synchronization and the backpressure — the script's next `pull` runs only when the wire took the previous chunk, and write continuations come back as generation-stamped event-loop jobs so `RestoreGlobalSnapshot` ends the upload (pinned). Incremental delivery is pinned against a recording handler.

The documented reductions are each anchored: a body-preserving redirect fails the fetch (that is the spec's own step 12 for a null-source body; a 303 that drops the body follows normally), the browser's HTTP/2 requirement is not reproduced (it protects a shared connection pool an embedded engine does not have), the content serializes once and a resend fails rather than truncating (the spec anticipates exactly this), a body stream that errors rejects with the standard's single network-error `TypeError`, and synchronous `HttpContent` serialization is unsupported because blocking the transport thread for engine turns deadlocks when the caller is the engine thread.

14 new/flipped/rewritten tests; streaming tests re-run 8× for stability. Gate: solution build 0 errors; Jint.Tests 9086/7046 green including the WPT family; PublicInterface 1962/1556; all four host-contract-verification legs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G7Ud48VAs1JicxRZxLDxg
