### PR TITLE
WPT harness shim: the assertion families the WebCrypto suites need

### DIFF
--- a/Jint.Tests/Wpt/Prelude/testharness-shim.js
+++ b/Jint.Tests/Wpt/Prelude/testharness-shim.js
@@ -170,6 +170,66 @@
         }
     }
 
+    // Membership by `indexOf`, deliberately not by `same_value`: upstream documents that this one "doesn't
+    // handle NaN or ±0 correctly", and a shim that quietly handled them would accept a suite a browser fails.
+    function assert_in_array(actual, expected, description) {
+        assert(expected.indexOf(actual) !== -1,
+            'value ' + format_value(actual) + ' not in array ' + format_value(expected) + describe(description));
+    }
+
+    // Deprecated upstream since 2015 (https://github.com/web-platform-tests/wpt/issues/2033) and carrying its
+    // author's own "this needs to be improved a great deal", so it is copied as it is rather than as it ought
+    // to be. Three of its quirks are load-bearing for the suites that still call it: the walk is `for..in`,
+    // which reaches inherited enumerable properties as well as own ones, while the presence check on the other
+    // side is `hasOwnProperty`; a value already on the stack is not descended into again, so a cycle on the
+    // `actual` side terminates and one reachable only from `expected` does not; and the second loop is what
+    // catches a property `expected` has and `actual` does not, which the first loop cannot see.
+    function assert_object_equals(actual, expected, description) {
+        assert(typeof actual === 'object' && actual !== null,
+            'value is ' + format_value(actual) + ', expected object' + describe(description));
+
+        function check_equal(actual, expected, stack) {
+            stack.push(actual);
+            var p;
+            for (p in actual) {
+                // hasOwnProperty through Object.prototype rather than off the object, as everywhere else in
+                // this file: upstream calls it as a method, which a null-prototype object does not have.
+                assert(Object.prototype.hasOwnProperty.call(expected, p),
+                    'unexpected property ' + format_value(p) + describe(description));
+                if (typeof actual[p] === 'object' && actual[p] !== null) {
+                    if (stack.indexOf(actual[p]) === -1) {
+                        check_equal(actual[p], expected[p], stack);
+                    }
+                } else {
+                    assert(same_value(actual[p], expected[p]),
+                        'property ' + format_value(p) + ' expected ' + format_value(expected[p]) +
+                        ' got ' + format_value(actual[p]) + describe(description));
+                }
+            }
+            for (p in expected) {
+                assert(Object.prototype.hasOwnProperty.call(actual, p),
+                    'expected property ' + format_value(p) + ' missing' + describe(description));
+            }
+            stack.pop();
+        }
+
+        check_equal(actual, expected, []);
+    }
+
+    // https://webidl.spec.whatwg.org/#dfn-class-string — the string an interface's `@@toStringTag` makes
+    // `Object.prototype.toString` report, which is how a suite checks what it was handed actually is one.
+    function assert_class_string(object, class_string, description) {
+        var actual = Object.prototype.toString.call(object);
+        var expected = '[object ' + class_string + ']';
+        assert(same_value(actual, expected),
+            'expected ' + format_value(expected) + ' but got ' + format_value(actual) + describe(description));
+    }
+
+    function assert_own_property(object, property_name, description) {
+        assert(Object.prototype.hasOwnProperty.call(object, property_name),
+            'expected property ' + format_value(property_name) + ' missing' + describe(description));
+    }
+
     function assert_unreached(description) {
         throw new AssertionError('reached unreachable code' + describe(description));
     }
@@ -205,7 +265,14 @@
         InvalidNodeTypeError: 24, DataCloneError: 25
     };
 
+    // The synchronous form always means this global's DOMException. `promise_rejects_dom` may be told which
+    // global the exception is expected to come from, so the matching half takes the constructor as an
+    // argument — upstream splits the two the same way and for the same reason.
     function assert_throws_dom(type, func, description) {
+        assert_throws_dom_impl(type, func, description, global.DOMException);
+    }
+
+    function assert_throws_dom_impl(type, func, description, constructor) {
         try {
             func.call(this);
         } catch (e) {
@@ -214,7 +281,7 @@
             }
             assert(typeof e === 'object' && e !== null,
                 'threw ' + format_value(e) + ', not an object' + describe(description));
-            assert(e.constructor === global.DOMException,
+            assert(e.constructor === constructor,
                 'expected a DOMException but got ' + format_value(e) + describe(description));
             if (typeof type === 'number') {
                 assert(e.code === type,
@@ -388,6 +455,64 @@
         return t;
     }
 
+    // ---------------------------------------------------------------- promise rejections
+
+    // Upstream re-wraps the promise it was handed in one built here so that a promise from another realm can
+    // still be awaited. Jint has a single realm, so what this actually buys is thenable adoption — whatever a
+    // suite hands over is driven through its own `then` — and it is kept in that shape because upstream's
+    // contract is written against it.
+    function bring_promise_to_current_realm(promise) {
+        return new Promise(promise.then.bind(promise));
+    }
+
+    // Each of the three waits for the rejection and then hands the reason to the matching `assert_throws_*`
+    // through a thunk that re-throws it, so what counts as the right exception has exactly one implementation
+    // and the synchronous and asynchronous forms of an assertion can never drift apart.
+    //
+    // A promise that *resolves* fails through `test.unreached_func`, which is a step of the test: it records
+    // the failure on the test and returns normally, so the promise this hands back is fulfilled rather than
+    // rejected and the promise_test that returned it still settles.
+    function promise_rejects_js(test, constructor, promise, description) {
+        return bring_promise_to_current_realm(promise)
+            .then(test.unreached_func('Should have rejected: ' + description))
+            .catch(function (e) {
+                assert_throws_js(constructor, function () { throw e; }, description);
+            });
+    }
+
+    // Two ways to call this, exactly as upstream: with the promise third, or — when the DOMException is
+    // expected to come from another global — with that global's DOMException constructor third and the
+    // promise fourth. The two are told apart by the third argument being a function named "DOMException",
+    // which is also why the no-constructor form asserts that nothing was passed in the fifth position: a
+    // suite that spelled the constructor form wrong would otherwise silently lose its description.
+    function promise_rejects_dom(test, type, promiseOrConstructor, descriptionOrPromise, maybeDescription) {
+        var constructor, promise, description;
+        if (typeof promiseOrConstructor === 'function' && promiseOrConstructor.name === 'DOMException') {
+            constructor = promiseOrConstructor;
+            promise = descriptionOrPromise;
+            description = maybeDescription;
+        } else {
+            constructor = global.DOMException;
+            promise = promiseOrConstructor;
+            description = descriptionOrPromise;
+            assert(maybeDescription === undefined,
+                'Too many args passed to no-constructor version of promise_rejects_dom, or accidentally explicitly passed undefined');
+        }
+        return bring_promise_to_current_realm(promise)
+            .then(test.unreached_func('Should have rejected: ' + description))
+            .catch(function (e) {
+                assert_throws_dom_impl(type, function () { throw e; }, description, constructor);
+            });
+    }
+
+    function promise_rejects_exactly(test, exception, promise, description) {
+        return bring_promise_to_current_realm(promise)
+            .then(test.unreached_func('Should have rejected: ' + description))
+            .catch(function (e) {
+                assert_throws_exactly(exception, function () { throw e; }, description);
+            });
+    }
+
     // `setup` exists here for the one shape the corpus uses — a function run for its side effects before the
     // tests are registered. The properties form (`explicit_done`, `single_test`, timeouts) is a browser
     // scheduling concern the driver has no analogue for, so it is accepted and ignored.
@@ -456,10 +581,17 @@
     global.assert_equals = assert_equals;
     global.assert_not_equals = assert_not_equals;
     global.assert_array_equals = assert_array_equals;
+    global.assert_in_array = assert_in_array;
+    global.assert_object_equals = assert_object_equals;
+    global.assert_class_string = assert_class_string;
+    global.assert_own_property = assert_own_property;
     global.assert_unreached = assert_unreached;
     global.assert_throws_js = assert_throws_js;
     global.assert_throws_dom = assert_throws_dom;
     global.assert_throws_exactly = assert_throws_exactly;
+    global.promise_rejects_js = promise_rejects_js;
+    global.promise_rejects_dom = promise_rejects_dom;
+    global.promise_rejects_exactly = promise_rejects_exactly;
 
     // Both of these are the live arrays, and the driver reads them through the object model rather than by
     // evaluating a script. That is not a shortcut: `engine.Evaluate` drains the event loop on its way out,

--- a/Jint.Tests/Wpt/WptExclusions.cs
+++ b/Jint.Tests/Wpt/WptExclusions.cs
@@ -10,14 +10,6 @@ namespace Jint.Tests.Wpt;
 internal enum WptDivergence
 {
     /// <summary>
-    /// The test needs one of the Encoding Standard's legacy single-byte or multi-byte decoders
-    /// (<c>windows-1252</c>, <c>shift_jis</c>, <c>gbk</c>, <c>replacement</c>, …). Jint implements
-    /// <c>utf-8</c>, <c>utf-16le</c> and <c>utf-16be</c> and reports every other label as a failure, which
-    /// is what <c>EncodingLabels</c> documents. Tracked by
-    /// https://github.com/sebastienros/jint/issues/3106; the change that lands those decoders removes these
-    /// entries.
-    /// </summary>
-    /// <summary>
     /// The seven legacy multi-byte encodings (Big5, EUC-JP, EUC-KR, GBK, gb18030, ISO-2022-JP, Shift_JIS)
     /// are named by the label table and refused as unsupported; their suites stay red until someone demands
     /// the tables. The single-byte families these entries used to cover are implemented and green.

--- a/Jint.Tests/Wpt/WptHarnessTests.cs
+++ b/Jint.Tests/Wpt/WptHarnessTests.cs
@@ -52,10 +52,133 @@ public class WptHarnessTests
         "assert_throws_dom('NotFoundError', () => { var e = new Error(); e.name = 'NotFoundError'; e.code = 8; throw e; })")]
     [InlineData("assert_throws_exactly(1, () => { throw 1; })", "assert_throws_exactly(1, () => { throw 2; })")]
     [InlineData("if (false) assert_unreached('x')", "assert_unreached('x')")]
+    [InlineData("assert_in_array(2, [1, 2, 3])", "assert_in_array(4, [1, 2, 3])")]
+    // indexOf rather than same_value, which is upstream's own documented caveat: -0 finds 0, NaN finds nothing.
+    [InlineData("assert_in_array(-0, [0])", "assert_in_array(NaN, [NaN])")]
+    [InlineData("assert_object_equals({ a: 1, b: { c: 2 } }, { a: 1, b: { c: 2 } })", "assert_object_equals({ a: { b: 1 } }, { a: { b: 2 } })")]
+    // A property on one side and not the other, in both directions: the second walk is what catches the second.
+    [InlineData("assert_object_equals({ a: 1 }, { a: 1 })", "assert_object_equals({ a: 1, b: 2 }, { a: 1 })")]
+    [InlineData("assert_object_equals([1, 2], [1, 2])", "assert_object_equals({ a: 1 }, { a: 1, b: 2 })")]
+    // Leaves compare by same_value, exactly as assert_equals does.
+    [InlineData("assert_object_equals({ a: NaN }, { a: NaN })", "assert_object_equals({ a: 0 }, { a: -0 })")]
+    [InlineData("assert_object_equals({}, {})", "assert_object_equals(1, {})")]
+    // What upstream's `for..in` walk plus its `hasOwnProperty` check add up to: an enumerable property has to
+    // be an own property on *both* sides, because the walk reaches an inherited one and the check refuses it.
+    // Both directions, since the two loops are what catch the two of them.
+    [InlineData("assert_object_equals({ a: 'x' }, { a: 'x' })", "assert_object_equals(Object.create({ a: 1 }), { a: 1 })")]
+    [InlineData("assert_object_equals({ a: undefined }, { a: undefined })", "assert_object_equals({ a: 1 }, Object.create({ a: 1 }))")]
+    [InlineData("assert_class_string(new URL('https://example.com/'), 'URL')", "assert_class_string(new URL('https://example.com/'), 'Object')")]
+    [InlineData("assert_class_string(Math, 'Math')", "assert_class_string([], 'Object')")]
+    [InlineData("assert_own_property({ x: 1 }, 'x')", "assert_own_property({}, 'x')")]
+    // Own, so a property reached through the prototype chain does not satisfy it.
+    [InlineData("assert_own_property([], 'length')", "assert_own_property(Object.create({ x: 1 }), 'x')")]
     public void AnAssertionRecordsBothOutcomes(string passing, string failing)
     {
         StatusOf($"test(() => {{ {passing} }}, 'row');").Should().Be("PASS");
         StatusOf($"test(() => {{ {failing} }}, 'row');").Should().Be("FAIL");
+    }
+
+    /// <summary>
+    /// What every <c>promise_rejects_*</c> row runs before its assertion, so a row can name a value by
+    /// identity and can name a <c>DOMException</c> constructor that is not this global's.
+    /// </summary>
+    private const string RejectionPreamble = """
+        var sentinel = new Error('sentinel');
+        // What a cross-realm DOMException looks like to the overload check — a function named DOMException
+        // that is not the one this global exposes — without a second realm to obtain one from.
+        var foreignDOMException = function DOMException() {};
+        """;
+
+    [Theory]
+    // Each row is one rejection assertion inside a promise_test, a body that must be recorded PASS and a body
+    // that must be recorded FAIL. `t` is the test the shim passes the body.
+    [InlineData(
+        "promise_rejects_js(t, TypeError, Promise.reject(new TypeError()))",
+        "promise_rejects_js(t, TypeError, Promise.reject(new RangeError()))")]
+    // A promise that resolves has to fail the assertion rather than satisfy it by not rejecting.
+    [InlineData(
+        "promise_rejects_js(t, RangeError, Promise.reject(new RangeError()))",
+        "promise_rejects_js(t, TypeError, Promise.resolve('resolved'))")]
+    // The same sanity check assert_throws_js makes: a rejection reason that is not an object is not an error.
+    [InlineData(
+        "promise_rejects_js(t, TypeError, Promise.reject(new TypeError()))",
+        "promise_rejects_js(t, TypeError, Promise.reject('not an object'))")]
+    [InlineData(
+        "promise_rejects_dom(t, 'NotFoundError', Promise.reject(new DOMException('x', 'NotFoundError')))",
+        "promise_rejects_dom(t, 'NotFoundError', Promise.reject(new DOMException('x', 'DataCloneError')))")]
+    [InlineData(
+        "promise_rejects_dom(t, 'DataCloneError', Promise.reject(new DOMException('x', 'DataCloneError')))",
+        "promise_rejects_dom(t, 'NotFoundError', Promise.resolve())")]
+    // A plain Error wearing the right name and the right legacy code is still not a DOMException.
+    [InlineData(
+        "promise_rejects_dom(t, 'AbortError', Promise.reject(new DOMException('x', 'AbortError')))",
+        "promise_rejects_dom(t, 'NotFoundError', Promise.reject(Object.assign(new Error(), { name: 'NotFoundError', code: 8 })))")]
+    // The four-argument form names the global the exception must come from: this one satisfies it, and a
+    // DOMException constructor that is not this global's does not, however right the name and code are.
+    [InlineData(
+        "promise_rejects_dom(t, 'NotFoundError', DOMException, Promise.reject(new DOMException('x', 'NotFoundError')))",
+        "promise_rejects_dom(t, 'NotFoundError', foreignDOMException, Promise.reject(new DOMException('x', 'NotFoundError')))")]
+    [InlineData(
+        "promise_rejects_exactly(t, sentinel, Promise.reject(sentinel))",
+        "promise_rejects_exactly(t, sentinel, Promise.reject(new Error('sentinel')))")]
+    [InlineData(
+        "promise_rejects_exactly(t, 1, Promise.reject(1))",
+        "promise_rejects_exactly(t, 1, Promise.resolve(1))")]
+    public void ARejectionAssertionRecordsBothOutcomes(string passing, string failing)
+    {
+        StatusOf($"{RejectionPreamble}\npromise_test(t => {passing}, 'row');").Should().Be("PASS");
+        StatusOf($"{RejectionPreamble}\npromise_test(t => {failing}, 'row');").Should().Be("FAIL");
+    }
+
+    [Fact]
+    public void ARejectionAssertionReportsTheSameMismatchItsSynchronousTwinWould()
+    {
+        // The point of the promise_rejects_* family routing through assert_throws_* rather than repeating the
+        // matching rules: the message is the one assert_throws_js produces, character for character.
+        var rejected = Run("promise_test(t => promise_rejects_js(t, TypeError, Promise.reject(new RangeError()), 'why'), 'row');");
+        var thrown = Run("test(() => assert_throws_js(TypeError, () => { throw new RangeError(); }, 'why'), 'row');");
+
+        rejected.HarnessError.Should().BeNull();
+        rejected.Results[0].Status.Should().Be("FAIL");
+        rejected.Results[0].Message.Should().Be("expected TypeError but got object \"RangeError\" (why)");
+        rejected.Results[0].Message.Should().Be(thrown.Results[0].Message);
+    }
+
+    [Fact]
+    public void APromiseThatResolvesSaysThatIsWhyTheRejectionAssertionFailed()
+    {
+        var outcome = Run("promise_test(t => promise_rejects_exactly(t, 1, Promise.resolve(), 'the operation'), 'row');");
+
+        outcome.HarnessError.Should().BeNull();
+        outcome.Results[0].Status.Should().Be("FAIL");
+        outcome.Results[0].Message.Should().Contain("Should have rejected: the operation");
+    }
+
+    [Fact]
+    public void TheNoConstructorFormOfPromiseRejectsDomRefusesAFifthArgument()
+    {
+        // A suite that meant the constructor form and spelled it wrong would otherwise have its description
+        // silently swallowed and the assertion still pass, which is what upstream's guard is for.
+        var outcome = Run(
+            "promise_test(t => promise_rejects_dom(t, 'NotFoundError', Promise.reject(new DOMException('x', 'NotFoundError')), 'why', 'extra'), 'row');");
+
+        outcome.HarnessError.Should().BeNull();
+        outcome.Results[0].Status.Should().Be("FAIL");
+        outcome.Results[0].Message.Should().Contain("Too many args passed to no-constructor version of promise_rejects_dom");
+    }
+
+    [Fact]
+    public void ARejectionAssertionIsWaitedOnRatherThanFireAndForgotten()
+    {
+        // The assertion has to be part of what settles the test: if the returned promise were dropped, the
+        // test would be recorded before the rejection was ever observed and this row would read PASS.
+        var outcome = Run("""
+            promise_test(t => promise_rejects_js(t, TypeError, new Promise((resolve, reject) => setTimeout(() => reject(new RangeError()), 1))), 'row');
+            """);
+
+        outcome.HarnessError.Should().BeNull();
+        outcome.Results[0].Status.Should().Be("FAIL");
+        outcome.Results[0].Message.Should().Contain("RangeError");
     }
 
     [Fact]
@@ -66,6 +189,22 @@ public class WptHarnessTests
         outcome.Results.Should().HaveCount(1);
         outcome.Results[0].Status.Should().Be("FAIL");
         outcome.Results[0].Message.Should().Be("expected \"want\" but got \"got\" (why)");
+    }
+
+    [Fact]
+    public void TheValueAssertionsSayWhichPropertyDisagreedAndHow()
+    {
+        // Messages are what an exclusion is triaged from, and every one of these is a name the corresponding
+        // upstream assertion produces once its ${p}/${actual} substitutions have gone through format_value.
+        static string? MessageOf(string body) => Run($"test(() => {body}, 'row');").Results[0].Message;
+
+        MessageOf("assert_object_equals({ a: 1 }, { a: 2 }, 'why')").Should().Be("property \"a\" expected 2 got 1 (why)");
+        MessageOf("assert_object_equals({ a: 1, b: 2 }, { a: 1 })").Should().Be("unexpected property \"b\"");
+        MessageOf("assert_object_equals({ a: 1 }, { a: 1, b: 2 })").Should().Be("expected property \"b\" missing");
+        MessageOf("assert_object_equals(1, {})").Should().Be("value is 1, expected object");
+        MessageOf("assert_own_property({}, 'x')").Should().Be("expected property \"x\" missing");
+        MessageOf("assert_class_string([], 'URL')").Should().Be("expected \"[object URL]\" but got \"[object Array]\"");
+        MessageOf("assert_in_array(4, [1, 2, 3])").Should().Be("value 4 not in array [1, 2, 3]");
     }
 
     [Fact]


### PR DESCRIPTION
Extends the WPT testharness shim with the assertion families the WebCryptoAPI suites lean on, ahead of vendoring that corpus for #3162: `promise_rejects_js`, `promise_rejects_dom` (both call forms, including the cross-realm constructor overload), `promise_rejects_exactly`, `assert_in_array`, `assert_object_equals`, `assert_class_string` and `assert_own_property`.

Everything is written against upstream `resources/testharness.js` as it is, not as it ought to be:

- The `promise_rejects_*` family does not re-implement matching: each waits for the rejection and hands the reason to its synchronous twin through a thunk that re-throws it, so what counts as the right exception has exactly one implementation and the two forms can never drift apart. A pin compares the message `promise_rejects_js` produces for a wrong constructor character-for-character with `assert_throws_js`'s for the same mismatch.
- `assert_throws_dom` was split into a signature-preserving wrapper plus an `_impl` taking the expected constructor — the synchronous form always means this global's `DOMException`, while `promise_rejects_dom` may be told which global the exception must come from. Upstream splits the pair the same way and for the same reason.
- `assert_object_equals`'s quirks (own-property requirement on both sides of the `for..in` walk, the one-sided cycle guard, `indexOf` semantics in `assert_in_array`) are deliberately reproduced and pinned from both sides — a shim stricter than the harness it stands in for would turn a suite red for a reason the suite cannot see.
- A promise that *resolves* fails through `test.unreached_func` with upstream's "Should have rejected" message, and the no-constructor form of `promise_rejects_dom` keeps upstream's fifth-argument guard.

Every new assertion is exercised from both sides in `WptHarnessTests` (35 → 62 cases), covering the failure modes that matter: wrong constructor, wrong `DOMException` name, resolved-not-rejected, wrong exact value, differing nested objects in both directions, inherited-not-own properties, a plain `Error` wearing a `DOMException`'s name and code, and — the quiet-green case — a dropped return promise letting a mismatched rejection be observed only after the test was recorded. Six load-bearing invariants were mutation-verified (each break flips specific rows to FAIL and nothing else).

Drive-by: `WptDivergence.NeedsLegacyMultiByteEncodings` carried two consecutive `<summary>` blocks; the stale pre-single-byte one is removed.

Test-only change — no engine code, no new suites, no exclusion entries. Both existing WPT suites stay fully green; full `Jint.Tests` and `Jint.Tests.PublicInterface` green on net10.0 and net472.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014n5uCpi2vvHWBSiewUwBiY
