### PR TITLE
Web API: ErrorEvent, PromiseRejectionEvent and global error events

### DIFF
--- a/Jint.Tests.PublicInterface/HostGlobalErrorEventTests.cs
+++ b/Jint.Tests.PublicInterface/HostGlobalErrorEventTests.cs
@@ -1,0 +1,214 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Runtime;
+using Jint.WebApi;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// <see cref="WebApiFeatures.GlobalEvents"/> from the outside: what a host has to name to get it, what its
+/// globals are, and — the part a host actually has to be able to rely on — that a script registering an
+/// <c>error</c> listener can neither silence the host's <see cref="DiagnosticsSink"/> nor swallow an execution
+/// constraint.
+/// </summary>
+/// <remarks>
+/// This project has no <c>InternalsVisibleTo</c>, so everything here is reachable by a third party exactly as
+/// written.
+/// </remarks>
+public class HostGlobalErrorEventTests
+{
+    private sealed class RecordingSink : DiagnosticsSink
+    {
+        internal List<DiagnosticEvent> Reports { get; } = new();
+
+        public override void Report(DiagnosticEvent report) => Reports.Add(report);
+    }
+
+    /// <summary>A clock that only moves when the test moves it, so nothing here waits on wall time.</summary>
+    private sealed class ManualClock : TimeProvider
+    {
+        private long _timestamp;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp() => _timestamp;
+
+        public override DateTimeOffset GetUtcNow() => DateTimeOffset.UnixEpoch.AddTicks(_timestamp);
+
+        internal void Advance(int milliseconds) => _timestamp += milliseconds * TimeSpan.TicksPerMillisecond;
+    }
+
+    /// <summary>
+    /// The feature is part of <see cref="WebApiFeatures.Default"/>, so <c>UseWebApis()</c> is enough — it is a
+    /// non-network, non-persistent API and the standing exceptions to <c>Default</c> are exactly the two that
+    /// are not.
+    /// </summary>
+    [Fact]
+    public void UseWebApisEnablesTheFeature()
+    {
+        WebApiFeatures.Default.HasFlag(WebApiFeatures.GlobalEvents).Should().BeTrue();
+
+        using var engine = new Engine(options => options.UseWebApis());
+
+        foreach (var name in new[] { "addEventListener", "removeEventListener", "dispatchEvent", "self", "ErrorEvent", "PromiseRejectionEvent" })
+        {
+            engine.Evaluate($"typeof {name}").AsString().Should().NotBe("undefined");
+        }
+    }
+
+    /// <summary>
+    /// Naming the flag on its own is enough: it brings <see cref="WebApiFeatures.Events"/> with it, because
+    /// what its operations register on is an <c>EventTarget</c> and what they dispatch is an <c>Event</c>.
+    /// </summary>
+    [Fact]
+    public void NamingTheFlagAloneBringsTheEventMachinery()
+    {
+        using var engine = new Engine(options => options.UseWebApis(WebApiFeatures.GlobalEvents));
+
+        engine.Evaluate("typeof Event").AsString().Should().Be("function");
+        engine.Evaluate("typeof EventTarget").AsString().Should().Be("function");
+        engine.Evaluate("new ErrorEvent('error') instanceof Event").AsBoolean().Should().BeTrue();
+
+        // The closure is computed when the engine is built, so the options still read back what was asked for.
+        var options = new Options();
+        options.UseWebApis(WebApiFeatures.GlobalEvents);
+        options.WebApi.Features.Should().Be(WebApiFeatures.GlobalEvents);
+    }
+
+    /// <summary>
+    /// <c>self</c> is the global object, and the global object is deliberately still not an
+    /// <c>EventTarget</c>: the listener list lives beside the engine's timers, not on the object a host has
+    /// been handed through <c>engine.Realm.GlobalObject</c>.
+    /// </summary>
+    [Fact]
+    public void SelfIsGlobalThisAndTheGlobalIsNotAnEventTarget()
+    {
+        using var engine = new Engine(options => options.UseWebApis());
+
+        engine.Evaluate("self === globalThis").AsBoolean().Should().BeTrue();
+        engine.Evaluate("self").Should().BeSameAs(engine.Evaluate("globalThis"));
+        engine.Evaluate("globalThis instanceof EventTarget").AsBoolean().Should().BeFalse();
+
+        // And a host's own global of that name still wins: the install is non-clobbering.
+        using var hosted = new Engine(options => options
+            .Configure(e => e.SetValue("self", "mine"))
+            .UseWebApis());
+
+        hosted.Evaluate("self").AsString().Should().Be("mine");
+    }
+
+    /// <summary>
+    /// The locked rule: the events <b>feed</b> the sink, they never replace it. HTML lets a listener's
+    /// <c>preventDefault()</c> suppress the console report; a host's diagnostics channel is not something the
+    /// script it is running may switch off, so the report happens anyway.
+    /// </summary>
+    [Fact]
+    public void AListenerCannotSilenceTheSink()
+    {
+        var sink = new RecordingSink();
+        var clock = new ManualClock();
+
+        using var engine = new Engine(options => options.UseWebApis(webApi =>
+        {
+            webApi.Timers.TimeProvider = clock;
+            webApi.Diagnostics.Sink = sink;
+        }));
+
+        engine.Execute("""
+            var canceled = 0;
+            addEventListener('error', function (e) { e.preventDefault(); canceled++; });
+            addEventListener('unhandledrejection', function (e) { e.preventDefault(); canceled++; });
+            reportError(new Error('reported'));
+            Promise.reject(new Error('rejected'));
+            setTimeout(function () { throw new Error('timed'); }, 1);
+            """);
+
+        clock.Advance(5);
+        engine.Advanced.ProcessTasks();
+
+        engine.Evaluate("canceled").AsNumber().Should().Be(3);
+
+        sink.Reports.Select(r => r.Kind).Should().Equal(
+            DiagnosticEventKind.ReportedError,
+            DiagnosticEventKind.UnhandledPromiseRejection,
+            DiagnosticEventKind.UncaughtCallbackError);
+    }
+
+    /// <summary>
+    /// A global <c>error</c> listener must not become a way for script to observe — let alone continue past —
+    /// the failures that exist to bound execution. Only a <see cref="JavaScriptException"/> is ever dispatched
+    /// or reported.
+    /// </summary>
+    [Fact]
+    public void AListenerNeverSeesAnExecutionConstraintFailure()
+    {
+        var sink = new RecordingSink();
+        var clock = new ManualClock();
+
+        using var engine = new Engine(options =>
+        {
+            options.UseWebApis(webApi =>
+            {
+                webApi.Timers.TimeProvider = clock;
+                webApi.Diagnostics.Sink = sink;
+            });
+            options.LimitRecursion(8);
+        });
+
+        engine.Execute("""
+            var seen = 0;
+            addEventListener('error', function () { seen++; });
+            function recurse() { return recurse(); }
+            setTimeout(recurse, 1);
+            """);
+
+        clock.Advance(5);
+        Assert.Throws<RecursionDepthOverflowException>(() => engine.Advanced.ProcessTasks());
+
+        engine.Evaluate("seen").AsNumber().Should().Be(0);
+        sink.Reports.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The other half of the sink contract, unchanged by this feature: with no sink an uncaught callback
+    /// failure is not <i>reported</i> at all, it erupts — and since firing the <c>error</c> event is a step of
+    /// reporting, a listener sees nothing either. A host that wants script to observe these installs a sink.
+    /// </summary>
+    [Fact]
+    public void WithoutASinkAnUncaughtCallbackErrorStillErupts()
+    {
+        var clock = new ManualClock();
+        using var engine = new Engine(options => options.UseWebApis(webApi => webApi.Timers.TimeProvider = clock));
+
+        engine.Execute("""
+            var seen = 0;
+            addEventListener('error', function () { seen++; });
+            setTimeout(function () { throw new Error('boom'); }, 1);
+            """);
+
+        clock.Advance(5);
+        Assert.Throws<JavaScriptException>(() => engine.Advanced.ProcessTasks()).Message.Should().Be("boom");
+
+        engine.Evaluate("seen").AsNumber().Should().Be(0);
+
+        // reportError is the exception, because the call itself is the request to report.
+        engine.Execute("reportError(new Error('asked for it'));");
+        engine.Evaluate("seen").AsNumber().Should().Be(1);
+    }
+
+    /// <summary>
+    /// An engine that named no web API is byte-for-byte the engine it was before this feature existed.
+    /// </summary>
+    [Fact]
+    public void ADefaultEngineIsUnchanged()
+    {
+        using var engine = new Engine();
+
+        foreach (var name in new[] { "addEventListener", "removeEventListener", "dispatchEvent", "self", "ErrorEvent", "PromiseRejectionEvent" })
+        {
+            engine.Evaluate($"typeof {name}").AsString().Should().Be("undefined");
+        }
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/ErrorEventTests.cs
+++ b/Jint.Tests/Runtime/WebApi/ErrorEventTests.cs
@@ -1,0 +1,273 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// The two event interfaces the <see cref="WebApiFeatures.GlobalEvents"/> feature adds:
+/// <see href="https://html.spec.whatwg.org/multipage/webappapis.html#the-errorevent-interface">ErrorEvent</see>
+/// and
+/// <see href="https://html.spec.whatwg.org/multipage/webappapis.html#the-promiserejectionevent-interface">PromiseRejectionEvent</see>.
+/// </summary>
+/// <remarks>
+/// What is pinned here is the interface itself — the constructor's WebIDL conversions, the dictionary member
+/// order, the prototype chain and the brand checks. What the engine <i>fires</i> at the global scope is
+/// <c>GlobalErrorEventTests</c>.
+/// </remarks>
+public class ErrorEventTests
+{
+    private static Engine WebEngine()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.GlobalEvents));
+        engine.Execute("var log = [];");
+        return engine;
+    }
+
+    private static string Log(Engine engine) => engine.Evaluate("log.join(',')").AsString();
+
+    // ErrorEvent
+
+    [Fact]
+    public void ErrorEventDefaultsEveryMember()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("var e = new ErrorEvent('error');");
+
+        engine.Evaluate("e.type").AsString().Should().Be("error");
+        engine.Evaluate("e.message").AsString().Should().Be("");
+        engine.Evaluate("e.filename").AsString().Should().Be("");
+        engine.Evaluate("e.lineno").AsNumber().Should().Be(0);
+        engine.Evaluate("e.colno").AsNumber().Should().Be(0);
+
+        // `any error` has no default, so it is undefined rather than null.
+        engine.Evaluate("e.error").IsUndefined().Should().BeTrue();
+
+        // The inherited EventInit members default as they do everywhere else, and a constructed event is
+        // never trusted.
+        engine.Evaluate("e.bubbles").AsBoolean().Should().BeFalse();
+        engine.Evaluate("e.cancelable").AsBoolean().Should().BeFalse();
+        engine.Evaluate("e.isTrusted").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void ErrorEventReadsItsDictionary()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("""
+            var thrown = new TypeError('nope');
+            var e = new ErrorEvent('error', {
+                bubbles: true,
+                cancelable: true,
+                message: 'boom',
+                filename: 'app.js',
+                lineno: 12,
+                colno: 34,
+                error: thrown,
+            });
+            """);
+
+        engine.Evaluate("e.message").AsString().Should().Be("boom");
+        engine.Evaluate("e.filename").AsString().Should().Be("app.js");
+        engine.Evaluate("e.lineno").AsNumber().Should().Be(12);
+        engine.Evaluate("e.colno").AsNumber().Should().Be(34);
+        engine.Evaluate("e.error === thrown").AsBoolean().Should().BeTrue();
+        engine.Evaluate("e.bubbles").AsBoolean().Should().BeTrue();
+        engine.Evaluate("e.cancelable").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ErrorEventCoercesLikeWebIdlDoes()
+    {
+        var engine = WebEngine();
+
+        // `unsigned long` is ToUint32: NaN and the infinities become 0 and anything beyond 32 bits wraps.
+        engine.Execute("var e = new ErrorEvent('error', { lineno: -1, colno: NaN, message: 42, filename: 7 });");
+
+        engine.Evaluate("e.lineno").AsNumber().Should().Be(4294967295d);
+        engine.Evaluate("e.colno").AsNumber().Should().Be(0);
+
+        // DOMString and USVString both stringify.
+        engine.Evaluate("e.message").AsString().Should().Be("42");
+        engine.Evaluate("e.filename").AsString().Should().Be("7");
+    }
+
+    [Fact]
+    public void ErrorEventReadsItsMembersInWebIdlOrder()
+    {
+        var engine = WebEngine();
+
+        // The inherited EventInit members first, then this dictionary's own in lexicographical order —
+        // https://webidl.spec.whatwg.org/#es-dictionary.
+        engine.Execute("""
+            var init = {};
+            for (const name of ['bubbles', 'cancelable', 'composed', 'colno', 'error', 'filename', 'lineno', 'message']) {
+                Object.defineProperty(init, name, { get: function () { log.push(name); return undefined; }, enumerable: true });
+            }
+            new ErrorEvent('error', init);
+            """);
+
+        Log(engine).Should().Be("bubbles,cancelable,composed,colno,error,filename,lineno,message");
+    }
+
+    [Fact]
+    public void ErrorEventRequiresItsType()
+    {
+        var engine = WebEngine();
+
+        Assert.Throws<JavaScriptException>(() => engine.Execute("new ErrorEvent()"))
+            .Message.Should().Contain("1 argument required");
+
+        // The dictionary is optional, and a non-object that is not undefined or null is a TypeError.
+        engine.Evaluate("new ErrorEvent('error', null).message").AsString().Should().Be("");
+        Assert.Throws<JavaScriptException>(() => engine.Execute("new ErrorEvent('error', 5)"));
+    }
+
+    [Fact]
+    public void ErrorEventInheritsFromEvent()
+    {
+        var engine = WebEngine();
+
+        engine.Evaluate("new ErrorEvent('error') instanceof Event").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.getPrototypeOf(ErrorEvent) === Event").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.getPrototypeOf(ErrorEvent.prototype) === Event.prototype").AsBoolean().Should().BeTrue();
+        engine.Evaluate("ErrorEvent.length").AsNumber().Should().Be(1);
+        engine.Evaluate("ErrorEvent.name").AsString().Should().Be("ErrorEvent");
+        engine.Evaluate("Object.prototype.toString.call(new ErrorEvent('error'))").AsString().Should().Be("[object ErrorEvent]");
+    }
+
+    [Fact]
+    public void ErrorEventAccessorsAreBranded()
+    {
+        var engine = WebEngine();
+
+        // Every attribute is an accessor on the prototype reading CLR state through a brand check, so a plain
+        // Event is refused.
+        foreach (var member in new[] { "message", "filename", "lineno", "colno", "error" })
+        {
+            var descriptor = engine.Evaluate($"Object.getOwnPropertyDescriptor(ErrorEvent.prototype, '{member}')");
+            descriptor.IsUndefined().Should().BeFalse();
+
+            engine.Evaluate($"Object.getOwnPropertyDescriptor(ErrorEvent.prototype, '{member}').enumerable").AsBoolean().Should().BeTrue();
+            engine.Evaluate($"Object.getOwnPropertyDescriptor(ErrorEvent.prototype, '{member}').configurable").AsBoolean().Should().BeTrue();
+
+            Assert.Throws<JavaScriptException>(() =>
+                engine.Execute($"Object.getOwnPropertyDescriptor(ErrorEvent.prototype, '{member}').get.call(new Event('x'))"))
+                .Message.Should().Contain("not an ErrorEvent");
+        }
+    }
+
+    // PromiseRejectionEvent
+
+    [Fact]
+    public void PromiseRejectionEventRequiresItsDictionaryAndItsPromise()
+    {
+        var engine = WebEngine();
+
+        // Unlike every other event interface here, eventInitDict is not optional — the dictionary has a
+        // required member — so length is 2 and one argument is an arity error.
+        engine.Evaluate("PromiseRejectionEvent.length").AsNumber().Should().Be(2);
+
+        Assert.Throws<JavaScriptException>(() => engine.Execute("new PromiseRejectionEvent('unhandledrejection')"))
+            .Message.Should().Contain("2 arguments required");
+
+        Assert.Throws<JavaScriptException>(() => engine.Execute("new PromiseRejectionEvent('unhandledrejection', {})"))
+            .Message.Should().Contain("required member promise");
+
+        // WebIDL treats an explicit undefined as absent, so it fails the same way.
+        Assert.Throws<JavaScriptException>(() => engine.Execute("new PromiseRejectionEvent('unhandledrejection', { promise: undefined })"))
+            .Message.Should().Contain("required member promise");
+
+        // And so does a null dictionary, which converts to one with no members at all.
+        Assert.Throws<JavaScriptException>(() => engine.Execute("new PromiseRejectionEvent('unhandledrejection', null)"))
+            .Message.Should().Contain("required member promise");
+    }
+
+    [Fact]
+    public void PromiseRejectionEventKeepsAPromiseAndConvertsAnythingElse()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("""
+            var p = Promise.resolve(1);
+            var kept = new PromiseRejectionEvent('unhandledrejection', { promise: p, reason: 'why' });
+            var converted = new PromiseRejectionEvent('unhandledrejection', { promise: 42 });
+            """);
+
+        // Promise<any> is https://webidl.spec.whatwg.org/#es-promise — PromiseResolve, which hands back a
+        // native promise unchanged and wraps anything else.
+        engine.Evaluate("kept.promise === p").AsBoolean().Should().BeTrue();
+        engine.Evaluate("kept.reason").AsString().Should().Be("why");
+
+        engine.Evaluate("converted.promise instanceof Promise").AsBoolean().Should().BeTrue();
+        engine.Evaluate("converted.promise === 42").AsBoolean().Should().BeFalse();
+
+        // `any reason` has no default.
+        engine.Evaluate("converted.reason").IsUndefined().Should().BeTrue();
+    }
+
+    [Fact]
+    public void PromiseRejectionEventReadsItsMembersInWebIdlOrder()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("""
+            var init = {};
+            for (const name of ['bubbles', 'cancelable', 'composed', 'reason']) {
+                Object.defineProperty(init, name, { get: function () { log.push(name); return undefined; }, enumerable: true });
+            }
+            Object.defineProperty(init, 'promise', { get: function () { log.push('promise'); return Promise.resolve(1); }, enumerable: true });
+            new PromiseRejectionEvent('unhandledrejection', init);
+            """);
+
+        // `promise` before `reason`, and both after the inherited members.
+        Log(engine).Should().Be("bubbles,cancelable,composed,promise,reason");
+    }
+
+    [Fact]
+    public void PromiseRejectionEventInheritsFromEvent()
+    {
+        var engine = WebEngine();
+
+        engine.Execute("var e = new PromiseRejectionEvent('unhandledrejection', { promise: Promise.resolve(1) });");
+
+        engine.Evaluate("e instanceof Event").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.getPrototypeOf(PromiseRejectionEvent) === Event").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.getPrototypeOf(PromiseRejectionEvent.prototype) === Event.prototype").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.prototype.toString.call(e)").AsString().Should().Be("[object PromiseRejectionEvent]");
+
+        Assert.Throws<JavaScriptException>(() =>
+            engine.Execute("Object.getOwnPropertyDescriptor(PromiseRejectionEvent.prototype, 'promise').get.call(new Event('x'))"))
+            .Message.Should().Contain("not a PromiseRejectionEvent");
+    }
+
+    [Fact]
+    public void TheInterfaceObjectsAreWebIdlInterfaceObjects()
+    {
+        var engine = WebEngine();
+
+        foreach (var name in new[] { "ErrorEvent", "PromiseRejectionEvent" })
+        {
+            // Writable and configurable but not enumerable — https://webidl.spec.whatwg.org/#es-interfaces.
+            var descriptor = engine.Realm.GlobalObject.GetOwnProperty(name);
+            descriptor.Writable.Should().BeTrue();
+            descriptor.Configurable.Should().BeTrue();
+            descriptor.Enumerable.Should().BeFalse();
+        }
+    }
+
+    [Fact]
+    public void TheInterfacesAreAbsentWithoutTheFeature()
+    {
+        // The events feature alone brings Event and EventTarget and neither of these two.
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Events));
+
+        engine.Evaluate("typeof Event").AsString().Should().Be("function");
+        engine.Evaluate("typeof ErrorEvent").AsString().Should().Be("undefined");
+        engine.Evaluate("typeof PromiseRejectionEvent").AsString().Should().Be("undefined");
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/GlobalErrorEventTests.cs
+++ b/Jint.Tests/Runtime/WebApi/GlobalErrorEventTests.cs
@@ -1,0 +1,517 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Runtime;
+using Jint.WebApi;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// The global scope's event surface: <c>addEventListener</c>, <c>removeEventListener</c>,
+/// <c>dispatchEvent</c> and <c>self</c>, and the <c>error</c>, <c>unhandledrejection</c> and
+/// <c>rejectionhandled</c> events the engine fires at them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The specifications are HTML's
+/// <see href="https://html.spec.whatwg.org/multipage/webappapis.html#report-an-exception">report an
+/// exception</see> and
+/// <see href="https://html.spec.whatwg.org/multipage/webappapis.html#unhandled-promise-rejections">unhandled
+/// promise rejections</see>.
+/// </para>
+/// <para>
+/// Four things here are load-bearing and are asserted from both sides. The events <b>feed</b> the
+/// <see cref="DiagnosticsSink"/> and never replace it, so <c>preventDefault()</c> cannot starve a host's log.
+/// Only a <see cref="JavaScriptException"/> is ever dispatched, so a listener cannot swallow a budget. A
+/// report does not recurse, so a throwing <c>error</c> listener cannot loop. And an engine without the flag —
+/// or without any web API at all — is exactly the engine it was.
+/// </para>
+/// </remarks>
+public class GlobalErrorEventTests
+{
+    private sealed class RecordingSink : DiagnosticsSink
+    {
+        internal List<DiagnosticEvent> Reports { get; } = new();
+
+        public override void Report(DiagnosticEvent report) => Reports.Add(report);
+    }
+
+    /// <summary>A clock that only moves when a test moves it, so the timer tests are exact and instant.</summary>
+    private sealed class ManualClock : TimeProvider
+    {
+        private long _timestamp;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp() => _timestamp;
+
+        public override DateTimeOffset GetUtcNow() => DateTimeOffset.UnixEpoch.AddTicks(_timestamp);
+
+        internal void Advance(int milliseconds) => _timestamp += milliseconds * TimeSpan.TicksPerMillisecond;
+    }
+
+    private static (Engine Engine, RecordingSink Sink, ManualClock Clock) Reporting(Action<Options>? configure = null)
+    {
+        var sink = new RecordingSink();
+        var clock = new ManualClock();
+        var engine = new Engine(options =>
+        {
+            options.UseWebApis(webApi =>
+            {
+                webApi.Timers.TimeProvider = clock;
+                webApi.Diagnostics.Sink = sink;
+            });
+            configure?.Invoke(options);
+        });
+
+        engine.Execute("var log = [];");
+        return (engine, sink, clock);
+    }
+
+    private static (Engine Engine, ManualClock Clock) Silent(Action<Options>? configure = null)
+    {
+        var clock = new ManualClock();
+        var engine = new Engine(options =>
+        {
+            options.UseWebApis(webApi => webApi.Timers.TimeProvider = clock);
+            configure?.Invoke(options);
+        });
+
+        engine.Execute("var log = [];");
+        return (engine, clock);
+    }
+
+    private static string Log(Engine engine) => engine.Evaluate("log.join(',')").AsString();
+
+    // The globals themselves
+
+    [Fact]
+    public void SelfIsGlobalThis()
+    {
+        var (engine, _) = Silent();
+
+        engine.Evaluate("self === globalThis").AsBoolean().Should().BeTrue();
+
+        // A [Replaceable] readonly attribute, simplified to an ordinary enumerable data property exactly as
+        // console, crypto and navigator are.
+        var descriptor = engine.Realm.GlobalObject.GetOwnProperty("self");
+        descriptor.Writable.Should().BeTrue();
+        descriptor.Enumerable.Should().BeTrue();
+        descriptor.Configurable.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TheThreeOperationsAreWebIdlOperations()
+    {
+        var (engine, _) = Silent();
+
+        foreach (var (name, length) in new[] { ("addEventListener", 2), ("removeEventListener", 2), ("dispatchEvent", 1) })
+        {
+            var descriptor = engine.Realm.GlobalObject.GetOwnProperty(name);
+            descriptor.Writable.Should().BeTrue();
+            descriptor.Enumerable.Should().BeTrue();
+            descriptor.Configurable.Should().BeTrue();
+
+            engine.Evaluate($"{name}.length").AsNumber().Should().Be(length);
+            engine.Evaluate($"{name}.name").AsString().Should().Be(name);
+        }
+    }
+
+    [Fact]
+    public void TheGlobalObjectItselfIsNotAnEventTarget()
+    {
+        var (engine, _) = Silent();
+
+        // The whole point of the synthetic target: the global object gains no prototype and no brand, so
+        // nothing about its own property model changes.
+        engine.Evaluate("globalThis instanceof EventTarget").AsBoolean().Should().BeFalse();
+
+        // And EventTarget.prototype's own methods still refuse it, because it is not one.
+        Assert.Throws<JavaScriptException>(() =>
+            engine.Execute("EventTarget.prototype.addEventListener.call(globalThis, 'x', function () {})"))
+            .Message.Should().Contain("not an EventTarget");
+    }
+
+    [Fact]
+    public void DispatchesToTheGlobalScopeWithTheGlobalObjectAsTarget()
+    {
+        var (engine, _) = Silent();
+
+        engine.Execute("""
+            addEventListener('ping', function (e) {
+                log.push(e.type, e.target === globalThis, e.currentTarget === globalThis, this === globalThis, e.isTrusted);
+            });
+            var result = dispatchEvent(new Event('ping'));
+            """);
+
+        // A script's own dispatch is never trusted, and target/currentTarget/this are the global object —
+        // not the synthetic listener list, which script has no way to name.
+        Log(engine).Should().Be("ping,true,true,true,false");
+        engine.Evaluate("result").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void RemoveEventListenerMatchesOnIdentity()
+    {
+        var (engine, _) = Silent();
+
+        engine.Execute("""
+            function handler() { log.push('ran'); }
+            self.addEventListener('ping', handler);
+            self.removeEventListener('ping', handler);
+            self.dispatchEvent(new Event('ping'));
+            """);
+
+        Log(engine).Should().Be("");
+    }
+
+    [Fact]
+    public void TheOperationsAreReachableThroughSelfAndGlobalThisAlike()
+    {
+        var (engine, _) = Silent();
+
+        engine.Execute("""
+            var seen = 0;
+            globalThis.addEventListener('ping', function () { seen++; });
+            self.dispatchEvent(new Event('ping'));
+            dispatchEvent(new Event('ping'));
+            """);
+
+        engine.Evaluate("seen").AsNumber().Should().Be(2);
+    }
+
+    // error — HTML's report an exception, step 5
+
+    [Fact]
+    public void AnUncaughtTimerErrorFiresATrustedErrorEvent()
+    {
+        var (engine, sink, clock) = Reporting();
+
+        engine.Execute("""
+            var seen = null;
+            addEventListener('error', function (e) { seen = e; log.push(e.type, e.isTrusted, e.cancelable, e.bubbles); });
+            setTimeout(function () { throw new TypeError('boom'); }, 1);
+            """);
+
+        clock.Advance(5);
+        engine.Advanced.ProcessTasks();
+
+        Log(engine).Should().Be("error,true,true,false");
+        engine.Evaluate("seen instanceof ErrorEvent").AsBoolean().Should().BeTrue();
+        engine.Evaluate("seen.message").AsString().Should().Be("boom");
+        engine.Evaluate("seen.error instanceof TypeError").AsBoolean().Should().BeTrue();
+
+        // The location the engine knew at the throw, which for a script executed here is a real line.
+        engine.Evaluate("seen.lineno > 0").AsBoolean().Should().BeTrue();
+        engine.Evaluate("seen.colno > 0").AsBoolean().Should().BeTrue();
+
+        // And the sink still hears it — the event feeds it, it does not replace it.
+        var report = Assert.Single(sink.Reports);
+        report.Kind.Should().Be(DiagnosticEventKind.UncaughtCallbackError);
+        report.CallbackSource.Should().Be(DiagnosticCallbackSource.Timer);
+    }
+
+    [Fact]
+    public void AnUncaughtListenerErrorFiresATrustedErrorEvent()
+    {
+        var (engine, sink, _) = Reporting();
+
+        engine.Execute("""
+            addEventListener('error', function (e) { log.push('global:' + e.message); });
+            var target = new EventTarget();
+            target.addEventListener('ping', function () { throw new Error('inner'); });
+            target.addEventListener('ping', function () { log.push('second'); });
+            target.dispatchEvent(new Event('ping'));
+            """);
+
+        // Inner invoke reports and carries on, and reporting is what fires the global error event.
+        Log(engine).Should().Be("global:inner,second");
+        Assert.Single(sink.Reports).CallbackSource.Should().Be(DiagnosticCallbackSource.EventListener);
+    }
+
+    [Fact]
+    public void ReportErrorFiresTheErrorEventAndStillFeedsTheSink()
+    {
+        var (engine, sink, _) = Reporting();
+
+        engine.Execute("""
+            var seen = null;
+            addEventListener('error', function (e) { seen = e; });
+            var boom = new Error('boom');
+            reportError(boom);
+            """);
+
+        engine.Evaluate("seen instanceof ErrorEvent").AsBoolean().Should().BeTrue();
+        engine.Evaluate("seen.error === boom").AsBoolean().Should().BeTrue();
+        engine.Evaluate("seen.message").AsString().Should().Be("boom");
+        engine.Evaluate("seen.isTrusted").AsBoolean().Should().BeTrue();
+
+        Assert.Single(sink.Reports).Kind.Should().Be(DiagnosticEventKind.ReportedError);
+    }
+
+    [Fact]
+    public void ReportErrorFiresTheErrorEventWithNoSinkAtAll()
+    {
+        // reportError is itself the request to report, so unlike a callback failure it does not need the
+        // sink to be armed before anything happens.
+        var (engine, _) = Silent();
+
+        engine.Execute("""
+            var seen = null;
+            addEventListener('error', function (e) { seen = e; });
+            reportError('a string');
+            """);
+
+        engine.Evaluate("seen.message").AsString().Should().Be("a string");
+        engine.Evaluate("seen.error").AsString().Should().Be("a string");
+    }
+
+    [Fact]
+    public void ReportErrorDescribesAnObjectWithoutRunningScript()
+    {
+        // Rendering an arbitrary object would mean calling its own toString, which is exactly the hazard
+        // Throw.SafeToDisplayString exists for. An in-box Error's own `message` data property is safe to
+        // read; anything else is reported as its shape. event.error carries the value itself either way.
+        var (engine, _) = Silent();
+
+        engine.Execute("""
+            var messages = [];
+            addEventListener('error', function (e) { messages.push(e.message); });
+            reportError({ toString: function () { throw new Error('never called'); } });
+            reportError(new RangeError('real message'));
+            """);
+
+        engine.Evaluate("messages[0]").AsString().Should().Be("[object]");
+        engine.Evaluate("messages[1]").AsString().Should().Be("real message");
+    }
+
+    [Fact]
+    public void PreventDefaultDoesNotStarveTheSink()
+    {
+        var (engine, sink, clock) = Reporting();
+
+        engine.Execute("""
+            addEventListener('error', function (e) { e.preventDefault(); log.push('canceled:' + e.defaultPrevented); });
+            reportError(new Error('reported'));
+            setTimeout(function () { throw new Error('timed'); }, 1);
+            """);
+
+        clock.Advance(5);
+        engine.Advanced.ProcessTasks();
+
+        // The listener really did cancel — this is HTML's notHandled going false — and the host's channel is
+        // told anyway. That is the locked divergence: a script may observe a failure, never hide one.
+        Log(engine).Should().Be("canceled:true,canceled:true");
+        sink.Reports.Should().HaveCount(2);
+        sink.Reports[0].Kind.Should().Be(DiagnosticEventKind.ReportedError);
+        sink.Reports[1].Kind.Should().Be(DiagnosticEventKind.UncaughtCallbackError);
+    }
+
+    [Fact]
+    public void AThrowingErrorListenerDoesNotReDispatch()
+    {
+        var (engine, sink, _) = Reporting();
+
+        engine.Execute("""
+            var errors = 0;
+            addEventListener('error', function () { errors++; throw new Error('from the reporter'); });
+            var target = new EventTarget();
+            target.addEventListener('ping', function () { throw new Error('original'); });
+            target.dispatchEvent(new Event('ping'));
+            """);
+
+        // HTML's re-entrancy rule: an exception thrown while reporting one goes to the sink alone. Without
+        // the guard this would recurse until the stack or the recursion budget gave out.
+        engine.Evaluate("errors").AsNumber().Should().Be(1);
+
+        // Both reach the sink, the nested one first — step 5 (fire the event, inside which the listener's own
+        // failure is reported whole) completes before step 6 reports the original, which is the order a
+        // browser's console shows them in too.
+        sink.Reports.Should().HaveCount(2);
+        sink.Reports[0].Exception!.Message.Should().Be("from the reporter");
+        sink.Reports[1].Exception!.Message.Should().Be("original");
+    }
+
+    [Fact]
+    public void AnErrorListenerNeverSeesAConstraintFailure()
+    {
+        // Only a JavaScriptException is ever dispatched or reported. A budget that a listener could observe
+        // is a budget a listener could be tempted to swallow, so the ones that bound execution keep erupting
+        // past both the event and the sink.
+        var (engine, sink, clock) = Reporting(options => options.LimitRecursion(8));
+
+        engine.Execute("""
+            addEventListener('error', function () { log.push('seen'); });
+            function recurse() { return recurse(); }
+            setTimeout(recurse, 1);
+            """);
+
+        clock.Advance(5);
+        Assert.Throws<RecursionDepthOverflowException>(() => engine.Advanced.ProcessTasks());
+
+        Log(engine).Should().Be("");
+        sink.Reports.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AnUncaughtTimerErrorStillEruptsWithoutASink()
+    {
+        // The sink is what turns an uncaught callback failure into a *report*, and report an exception is the
+        // algorithm that fires the event. With no sink there is no report, so there is no event either and
+        // the exception erupts exactly as it always has.
+        var (engine, clock) = Silent();
+
+        engine.Execute("""
+            addEventListener('error', function () { log.push('seen'); });
+            setTimeout(function () { throw new Error('boom'); }, 1);
+            """);
+
+        clock.Advance(5);
+        Assert.Throws<JavaScriptException>(() => engine.Advanced.ProcessTasks()).Message.Should().Be("boom");
+
+        Log(engine).Should().Be("");
+    }
+
+    // unhandledrejection / rejectionhandled
+
+    [Fact]
+    public void AnUnhandledRejectionFiresAPromiseRejectionEvent()
+    {
+        var (engine, sink, _) = Reporting();
+
+        engine.Execute("""
+            var seen = null;
+            addEventListener('unhandledrejection', function (e) { seen = e; log.push(e.type, e.isTrusted, e.cancelable); });
+            var reason = new Error('nope');
+            var p = Promise.reject(reason);
+            """);
+
+        Log(engine).Should().Be("unhandledrejection,true,true");
+        engine.Evaluate("seen instanceof PromiseRejectionEvent").AsBoolean().Should().BeTrue();
+        engine.Evaluate("seen.promise === p").AsBoolean().Should().BeTrue();
+        engine.Evaluate("seen.reason === reason").AsBoolean().Should().BeTrue();
+
+        Assert.Single(sink.Reports).RejectionHandled.Should().BeFalse();
+    }
+
+    [Fact]
+    public void AHandlerAttachedLaterFiresRejectionHandled()
+    {
+        var (engine, _) = Silent();
+
+        engine.Execute("""
+            addEventListener('unhandledrejection', function (e) { log.push('unhandled'); });
+            addEventListener('rejectionhandled', function (e) { log.push('handled:' + e.cancelable); });
+            var p = Promise.reject(new Error('nope'));
+            p.catch(function () {});
+            """);
+
+        // The tracker's cadence, not HTML's microtask checkpoint: a browser would raise neither of these for
+        // a rejection handled this soon. rejectionhandled is fired without a cancelable initializer.
+        Log(engine).Should().Be("unhandled,handled:false");
+    }
+
+    [Fact]
+    public void CancellingUnhandledRejectionDoesNotStarveTheSink()
+    {
+        var (engine, sink, _) = Reporting();
+
+        engine.Execute("""
+            addEventListener('unhandledrejection', function (e) { e.preventDefault(); });
+            Promise.reject(new Error('nope'));
+            """);
+
+        Assert.Single(sink.Reports).Kind.Should().Be(DiagnosticEventKind.UnhandledPromiseRejection);
+    }
+
+    // Gating and lifetime
+
+    [Fact]
+    public void TheGlobalsAreAbsentWithoutTheFlag()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Events | WebApiFeatures.Timers | WebApiFeatures.Reporting));
+
+        foreach (var name in new[] { "addEventListener", "removeEventListener", "dispatchEvent", "self", "ErrorEvent", "PromiseRejectionEvent" })
+        {
+            engine.Evaluate($"typeof {name}").AsString().Should().Be("undefined");
+        }
+    }
+
+    [Fact]
+    public void AnEngineWithoutTheFlagFiresNothingAndPaysNothing()
+    {
+        // The hook sites are null-guarded on the synthetic target, which only the three global operations can
+        // create — so an engine without them behaves exactly as it did before this feature existed.
+        var sink = new RecordingSink();
+        var clock = new ManualClock();
+        var engine = new Engine(options => options.UseWebApis(webApi =>
+        {
+            webApi.Features = WebApiFeatures.Events | WebApiFeatures.Timers;
+            webApi.Timers.TimeProvider = clock;
+            webApi.Diagnostics.Sink = sink;
+        }));
+
+        engine.Execute("setTimeout(function () { throw new Error('boom'); }, 1);");
+        clock.Advance(5);
+        engine.Advanced.ProcessTasks();
+
+        Assert.Single(sink.Reports).CallbackSource.Should().Be(DiagnosticCallbackSource.Timer);
+    }
+
+    [Fact]
+    public void ADefaultEngineHasNoneOfIt()
+    {
+        var engine = new Engine();
+
+        foreach (var name in new[] { "addEventListener", "self", "ErrorEvent", "PromiseRejectionEvent", "reportError" })
+        {
+            engine.Evaluate($"typeof {name}").AsString().Should().Be("undefined");
+        }
+    }
+
+    [Fact]
+    public void ARestoreDropsTheListeners()
+    {
+        var (engine, _) = Silent();
+
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+
+        // A sloppy-mode assignment to a free identifier, so a listener that survived the restore would write
+        // into the *next* cycle's `seen` and be caught red-handed.
+        engine.Execute("addEventListener('error', function () { seen = 'stale'; });");
+
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        // The listener is a closure over the ended cycle — over globals the restore has just replaced — so a
+        // failure in the next cycle must reach none of them.
+        engine.Execute("var seen = 'none'; reportError(new Error('boom'));");
+        engine.Evaluate("seen").AsString().Should().Be("none");
+
+        // And the next cycle registers its own on a target built fresh.
+        engine.Execute("addEventListener('error', function (e) { seen = e.message; }); reportError(new Error('after'));");
+        engine.Evaluate("seen").AsString().Should().Be("after");
+    }
+
+    [Fact]
+    public void TheFeatureCanBeEnabledOnALiveEngine()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Console));
+
+        engine.Evaluate("typeof addEventListener").AsString().Should().Be("undefined");
+
+        engine.Advanced.EnableWebApis(WebApiFeatures.GlobalEvents | WebApiFeatures.Reporting);
+
+        // GlobalEvents implies Events, so the machinery it needs arrives with it.
+        engine.Evaluate("typeof Event").AsString().Should().Be("function");
+        engine.Evaluate("self === globalThis").AsBoolean().Should().BeTrue();
+
+        engine.Execute("""
+            var seen = null;
+            addEventListener('error', function (e) { seen = e.message; });
+            reportError(new Error('live'));
+            """);
+
+        engine.Evaluate("seen").AsString().Should().Be("live");
+    }
+}
+#endif

--- a/Jint/Engine.WebApi.cs
+++ b/Jint/Engine.WebApi.cs
@@ -2,8 +2,10 @@
 using System.Diagnostics;
 using Jint.Native.Promise;
 using Jint.Native;
+using Jint.Runtime;
 using Jint.WebApi.Abort;
 using Jint.WebApi.Fetch;
+using Jint.WebApi.GlobalEvents;
 using Jint.WebApi.Idle;
 using Jint.WebApi;
 using Jint.WebApi.Scheduling;
@@ -169,6 +171,14 @@ internal sealed class WebApiEngineState
     private List<JsWebSocket>? _webSockets;
 
     private List<HostAbortSignalBridge>? _hostAbortBridges;
+
+    /// <summary>
+    /// The synthetic target the global <c>addEventListener</c> registers on, or <see langword="null"/> — which
+    /// is what every engine carries until the first of those calls, and forever on one that never enabled
+    /// <see cref="WebApiFeatures.GlobalEvents"/>. That null is the whole cost of the four report sites: a
+    /// failure nobody is listening for reaches one field read.
+    /// </summary>
+    private GlobalEventTarget? _globalEventTarget;
 
     internal WebApiEngineState(Engine engine, TimeProvider timeProvider, TimerQueue? timers, Options.FetchOptions? fetchOptions, SchedulerQueue? scheduler, DiagnosticsSink? diagnostics, Options.StorageOptions? storage = null, CacheStorageProvider? cacheProvider = null, IdleCallbackQueue? idleCallbacks = null)
     {
@@ -475,19 +485,75 @@ internal sealed class WebApiEngineState
     internal TimeSpan? TimeUntilNextDueTimer() => Timers?.TimeUntilNextDue();
 
     /// <summary>
-    /// <c>reportError(e)</c>: HTML's <i>report an exception</i> reduced to its last step, since this engine's
-    /// global object is not an <c>EventTarget</c> and so has no <c>error</c> event to fire first. See
+    /// The engine's synthetic global event target, created on first use — which is the first global
+    /// <c>addEventListener</c>, <c>removeEventListener</c> or <c>dispatchEvent</c>, all three of which exist
+    /// only when <see cref="WebApiFeatures.GlobalEvents"/> is on.
+    /// </summary>
+    internal GlobalEventTarget GlobalEventTarget =>
+        _globalEventTarget ??= new GlobalEventTarget(_engine, _engine._mainRealm);
+
+    /// <summary>
+    /// <c>reportError(e)</c>: HTML's <i>report an exception</i> —
+    /// https://html.spec.whatwg.org/multipage/webappapis.html#report-an-exception. See
     /// <c>ReportErrorFunction</c>.
     /// </summary>
-    internal void ReportError(JsValue value) => Diagnostics?.Report(DiagnosticEvent.ForReportedError(value));
+    /// <remarks>
+    /// Step 5 fires an <c>error</c> event at the global scope, which now happens whenever a script registered
+    /// a listener for it; step 6 hands the value to the sink. <b>The two are additive rather than
+    /// alternative:</b> HTML lets a listener's <c>preventDefault()</c> set <i>notHandled</i> false and so
+    /// suppress the console report, and Jint deliberately reports either way — a host's diagnostics channel is
+    /// not something the script it is running may switch off.
+    /// </remarks>
+    internal void ReportError(JsValue value)
+    {
+        if (_globalEventTarget is { } target)
+        {
+            // The location the engine last saw, which for a call from script is the reportError call site —
+            // the same fallback every web API that has to place a failure uses.
+            var location = _engine._lastSyntaxElement?.Location ?? default;
+            target.FireError(ErrorEventDetails.FromReportedValue(value, in location));
+        }
+
+        Diagnostics?.Report(DiagnosticEvent.ForReportedError(value));
+    }
+
+    /// <summary>
+    /// HTML's <i>report an exception</i> for a <see cref="JavaScriptException"/> that escaped a callback the
+    /// engine invoked — a timer handler, an event listener. Step 5 only: the callers own step 6, because the
+    /// sink report they make carries the exception itself and not merely its value.
+    /// </summary>
+    /// <remarks>
+    /// A no-op on an engine that has no global listener, which is every engine until a script registers one.
+    /// It declines to recurse: an exception thrown by a listener <i>while</i> a report is being dispatched
+    /// reaches the sink alone — see <see cref="GlobalEventTarget"/>.
+    /// </remarks>
+    internal void FireGlobalErrorEvent(JavaScriptException exception)
+        => _globalEventTarget?.FireError(ErrorEventDetails.FromException(exception));
 
     /// <summary>
     /// The sink's half of <c>HostPromiseRejectionTracker</c>. Additive to
     /// <see cref="Engine.AdvancedOperations.PromiseRejectionTracker"/>, which has already been raised by the
     /// time this runs: a host with both channels wired sees the pre-existing event behave exactly as it did.
     /// </summary>
+    /// <remarks>
+    /// The <c>unhandledrejection</c> and <c>rejectionhandled</c> events of
+    /// https://html.spec.whatwg.org/multipage/webappapis.html#unhandled-promise-rejections ride here too, and
+    /// therefore at the <i>tracker's</i> cadence rather than HTML's microtask checkpoint — the divergence
+    /// <see cref="DiagnosticEvent.RejectionHandled"/> documents, inherited whole. Cancelling
+    /// <c>unhandledrejection</c> suppresses a browser's console report; the sink is told regardless, for the
+    /// reason <see cref="ReportError"/> gives.
+    /// </remarks>
     internal void ReportPromiseRejection(JsPromise promise, PromiseRejectionOperation operation)
-        => Diagnostics?.Report(DiagnosticEvent.ForPromiseRejection(promise, operation));
+    {
+        if (_globalEventTarget is { } target)
+        {
+            var handled = operation == PromiseRejectionOperation.Handle;
+            var reason = promise.State == PromiseState.Rejected ? promise.Value : JsValue.Undefined;
+            target.FireRejection(handled, promise, reason);
+        }
+
+        Diagnostics?.Report(DiagnosticEvent.ForPromiseRejection(promise, operation));
+    }
 
     /// <summary>
     /// Registered timers that have not fired and have not been cleared, for
@@ -509,7 +575,9 @@ internal sealed class WebApiEngineState
     /// byte — and the reactions that erroring schedules carry the ending cycle's generation, so the fence
     /// discards them exactly as it discards a chunk still on its way. A <c>WebSocket</c> is abandoned the
     /// same way and for the same reason, and fires no further event: its connection is dropped, and its
-    /// <c>close</c> event belongs to a cycle that has ended. The sink is deliberately not reset: it is
+    /// <c>close</c> event belongs to a cycle that has ended. The <b>global event listeners</b> go the same
+    /// way: they are closures over the ended cycle, over globals the restore has just replaced, so an
+    /// <c>error</c> fired afterwards must reach none of them. The sink is deliberately not reset: it is
     /// configuration the engine was built with, like the time origin beside it, and a pooled engine
     /// reporting the next cycle's errors nowhere would be a strange thing for a restore to arrange.
     /// </remarks>
@@ -522,6 +590,11 @@ internal sealed class WebApiEngineState
         AbandonEventSources();
         AbandonWebSockets();
         IdleCallbacks?.Clear();
+
+        // Dropped whole rather than emptied: the next cycle's first addEventListener builds a fresh target,
+        // and nothing outside this class holds a reference to the old one — the three global operations ask
+        // for it by property on every call.
+        _globalEventTarget = null;
 
         // A signal bridged to a host token belongs to the cycle it was created in: its abort job carries that
         // cycle's generation and would be dropped at dequeue anyway, so keeping the registration alive could

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -783,14 +783,42 @@ public enum WebApiFeatures
     IdleCallback = 1 << 21,
 
     /// <summary>
+    /// <c>addEventListener</c>, <c>removeEventListener</c>, <c>dispatchEvent</c> and <c>self</c> on the global
+    /// scope, with the <c>ErrorEvent</c> and <c>PromiseRejectionEvent</c> interfaces and the
+    /// <c>error</c>, <c>unhandledrejection</c> and <c>rejectionhandled</c> events the engine fires at it —
+    /// https://html.spec.whatwg.org/multipage/webappapis.html#the-errorevent-interface.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Implies <see cref="Events"/>: what these three operations register listeners on is an
+    /// <c>EventTarget</c>, and what they dispatch is an <c>Event</c>, so installing them without that
+    /// feature's machinery would ship operations with no types to use them on.
+    /// </para>
+    /// <para>
+    /// The <b>global object itself is untouched</b> — it does not become an <c>EventTarget</c> and gains no
+    /// prototype it did not have. The listener list lives on a synthetic target the engine keeps beside its
+    /// timers, and the three operations are ordinary global functions bound to it; <c>event.target</c> and a
+    /// listener's <c>this</c> are still the global object, which is what a browser reports.
+    /// </para>
+    /// <para>
+    /// <b>The events feed <see cref="Options.DiagnosticsOptions.Sink"/>, they never replace it.</b> A listener
+    /// calling <c>preventDefault()</c> suppresses a browser's console report; here the sink is still told,
+    /// because a host's log is not something script may switch off. A listener can therefore observe an
+    /// uncaught failure, and cannot hide one.
+    /// </para>
+    /// </remarks>
+    GlobalEvents = 1 << 22,
+
+    /// <summary>
     /// The web APIs a host normally wants: everything except outbound network access and persistent state.
     /// Today that is
     /// <see cref="Console"/>, <see cref="Timers"/>, <see cref="Encoding"/>, <see cref="Base64"/>,
     /// <see cref="StructuredClone"/>, <see cref="Crypto"/>, <see cref="Performance"/>, <see cref="Events"/>,
     /// <see cref="Url"/>, <see cref="Files"/>, <see cref="Navigator"/>, <see cref="Streams"/>,
-    /// <see cref="Scheduler"/>, <see cref="Messaging"/> <see cref="Reporting"/> and <see cref="Compression"/>; it grows as further
-    /// features land, and never comes to include fetch or <see cref="Storage"/>.
+    /// <see cref="Scheduler"/>, <see cref="Messaging"/>, <see cref="Reporting"/>, <see cref="Compression"/>,
+    /// <see cref="IdleCallback"/> and <see cref="GlobalEvents"/>; it grows as further features land, and never
+    /// comes to include fetch or <see cref="Storage"/>.
     /// </summary>
-    Default = Console | Timers | Encoding | Base64 | StructuredClone | Crypto | Performance | Events | Url | Files | Navigator | Streams | Scheduler | Messaging | Reporting | Compression | IdleCallback,
+    Default = Console | Timers | Encoding | Base64 | StructuredClone | Crypto | Performance | Events | Url | Files | Navigator | Streams | Scheduler | Messaging | Reporting | Compression | IdleCallback | GlobalEvents,
 }
 #endif

--- a/Jint/Runtime/Intrinsics.WebApi.cs
+++ b/Jint/Runtime/Intrinsics.WebApi.cs
@@ -10,6 +10,7 @@ using Jint.WebApi.Encoding;
 using Jint.WebApi.Events;
 using Jint.WebApi.Fetch;
 using Jint.WebApi.Files;
+using Jint.WebApi.GlobalEvents;
 using Jint.WebApi.Idle;
 using Jint.WebApi.Messaging;
 using Jint.WebApi.Navigator;
@@ -358,6 +359,26 @@ public sealed partial class Intrinsics
 
     internal ReportErrorFunction ReportError =>
         _reportError ??= new ReportErrorFunction(_engine, _realm, Function.PrototypeObject);
+
+    private ErrorEventConstructor? _errorEvent;
+    private PromiseRejectionEventConstructor? _promiseRejectionEvent;
+    private GlobalEventFunctions? _globalEventFunctions;
+
+    /// <summary><c>ErrorEvent</c> inherits from <c>Event</c>.</summary>
+    internal ErrorEventConstructor ErrorEvent =>
+        _errorEvent ??= new ErrorEventConstructor(_engine, _realm, Event);
+
+    /// <summary><c>PromiseRejectionEvent</c> inherits from <c>Event</c>.</summary>
+    internal PromiseRejectionEventConstructor PromiseRejectionEvent =>
+        _promiseRejectionEvent ??= new PromiseRejectionEventConstructor(_engine, _realm, Event);
+
+    /// <summary>
+    /// The three global event-target operations, which are ordinary functions rather than one object — this
+    /// holder exists only so that a realm builds one of each, and each of the three is itself built on first
+    /// access.
+    /// </summary>
+    internal GlobalEventFunctions GlobalEventFunctions =>
+        _globalEventFunctions ??= Jint.WebApi.GlobalEvents.GlobalEventFunctions.Create(_engine, _realm);
 
     private StorageConstructor? _storage;
     private JsStorage? _localStorage;

--- a/Jint/WebApi/DiagnosticsSink.cs
+++ b/Jint/WebApi/DiagnosticsSink.cs
@@ -15,9 +15,17 @@ namespace Jint.WebApi;
 /// This is the channel HTML calls <i>reporting an exception</i> —
 /// <see href="https://html.spec.whatwg.org/multipage/webappapis.html#report-an-exception">report an
 /// exception</see>. In a browser that algorithm fires an <c>error</c> event at the global object and, if
-/// nothing cancels it, lets "the user agent … report exception to a developer console". Jint's global object
-/// is not an <c>EventTarget</c>, so the event half never applies and the sink <i>is</i> the developer
-/// console: whatever would have been reported arrives here, once, with no way for script to intercept it.
+/// nothing cancels it, lets "the user agent … report exception to a developer console". The sink <i>is</i>
+/// that console.
+/// </para>
+/// <para>
+/// The event half applies too, on an engine that enabled <see cref="WebApiFeatures.GlobalEvents"/>: Jint's
+/// global object is still not an <c>EventTarget</c>, but the feature gives the engine a synthetic global
+/// target that a script registers <c>error</c>, <c>unhandledrejection</c> and <c>rejectionhandled</c>
+/// listeners on. <b>Those events feed this sink, they never replace it.</b> A listener calling
+/// <c>preventDefault()</c> suppresses a browser's console report and deliberately does not suppress this one:
+/// a host's diagnostics channel is not something the script it is running may switch off. So a script can
+/// observe its own failures, and a host still hears every one of them.
 /// </para>
 /// <para>
 /// <b>Setting a sink changes what happens to an exception that escapes an engine-invoked callback.</b> With
@@ -165,6 +173,14 @@ public sealed class DiagnosticEvent
     /// channels telling one story — so the same code produces a report with this
     /// <see langword="false"/> followed by one with it <see langword="true"/>. A host that wants the browser's
     /// shape correlates the pair by <see cref="Promise"/> identity.
+    /// </para>
+    /// <para>
+    /// <b>The <c>unhandledrejection</c> and <c>rejectionhandled</c> events of
+    /// <see cref="WebApiFeatures.GlobalEvents"/> inherit that cadence whole</b>, being fired from this very
+    /// call. A script that registers those listeners therefore sees the same pair a sink does, in the same
+    /// order and at the same moment, rather than the single deferred event a browser would raise; and
+    /// cancelling <c>unhandledrejection</c> suppresses nothing here, for the reason
+    /// <see cref="DiagnosticsSink"/> gives.
     /// </para>
     /// </remarks>
     public bool RejectionHandled { get; }

--- a/Jint/WebApi/Events/EventTargetPrototype.cs
+++ b/Jint/WebApi/Events/EventTargetPrototype.cs
@@ -51,20 +51,7 @@ internal sealed partial class EventTargetPrototype : Prototype
     private JsValue AddEventListener(JsValue thisObject, JsCallArguments arguments)
     {
         var target = Brand(thisObject);
-        RequireArguments(arguments, 2, "addEventListener");
-
-        var type = TypeConverter.ToString(arguments.At(0));
-        var callback = ReadCallback(arguments.At(1), "addEventListener");
-        var options = FlattenMoreOptions(arguments.At(2));
-
-        target.AddListener(new EventListenerRegistration(type, callback)
-        {
-            Capture = options.Capture,
-            Passive = options.Passive,
-            Once = options.Once,
-            Signal = options.Signal,
-        });
-
+        EventTargetArguments.AddListener(_realm, target, arguments);
         return Undefined;
     }
 
@@ -75,13 +62,7 @@ internal sealed partial class EventTargetPrototype : Prototype
     private JsValue RemoveEventListener(JsValue thisObject, JsCallArguments arguments)
     {
         var target = Brand(thisObject);
-        RequireArguments(arguments, 2, "removeEventListener");
-
-        var type = TypeConverter.ToString(arguments.At(0));
-        var callback = ReadCallback(arguments.At(1), "removeEventListener");
-        var capture = FlattenOptions(arguments.At(2));
-
-        target.RemoveListener(type, callback, capture);
+        EventTargetArguments.RemoveListener(_realm, target, arguments);
         return Undefined;
     }
 
@@ -92,29 +73,97 @@ internal sealed partial class EventTargetPrototype : Prototype
     private JsBoolean DispatchEvent(JsValue thisObject, JsValue eventArgument)
     {
         var target = Brand(thisObject);
+        return JsBoolean.Create(EventTargetArguments.DispatchEvent(_engine, _realm, target, eventArgument));
+    }
 
+    private JsEventTarget Brand(JsValue thisObject)
+    {
+        if (thisObject is JsEventTarget target)
+        {
+            return target;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not an EventTarget");
+        return null!;
+    }
+}
+
+/// <summary>
+/// The WebIDL argument conversions of <c>EventTarget</c>'s three operations, and the operations themselves
+/// once a receiver has been established.
+/// </summary>
+/// <remarks>
+/// Lifted out of <see cref="EventTargetPrototype"/> because the global <c>addEventListener</c>,
+/// <c>removeEventListener</c> and <c>dispatchEvent</c> — which are not methods of this prototype at all, being
+/// bound to the engine's synthetic global target — have to convert their arguments <i>identically</i>, down to
+/// the message a <c>TypeError</c> carries. A browser reaches the same conclusion by a different route: its
+/// <c>Window</c> inherits these very functions from <c>EventTarget.prototype</c>, which is why its arity error
+/// also says "on 'EventTarget'" rather than "on 'Window'".
+/// </remarks>
+internal static class EventTargetArguments
+{
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener over an already-branded target.
+    /// </summary>
+    internal static void AddListener(Realm realm, JsEventTarget target, JsCallArguments arguments)
+    {
+        RequireArguments(realm, arguments, 2, "addEventListener");
+
+        var type = TypeConverter.ToString(arguments.At(0));
+        var callback = ReadCallback(realm, arguments.At(1), "addEventListener");
+        var options = FlattenMoreOptions(realm, arguments.At(2));
+
+        target.AddListener(new EventListenerRegistration(type, callback)
+        {
+            Capture = options.Capture,
+            Passive = options.Passive,
+            Once = options.Once,
+            Signal = options.Signal,
+        });
+    }
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#dom-eventtarget-removeeventlistener over an already-branded target.
+    /// </summary>
+    internal static void RemoveListener(Realm realm, JsEventTarget target, JsCallArguments arguments)
+    {
+        RequireArguments(realm, arguments, 2, "removeEventListener");
+
+        var type = TypeConverter.ToString(arguments.At(0));
+        var callback = ReadCallback(realm, arguments.At(1), "removeEventListener");
+        var capture = FlattenOptions(arguments.At(2));
+
+        target.RemoveListener(type, callback, capture);
+    }
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#dom-eventtarget-dispatchevent over an already-branded target.
+    /// </summary>
+    /// <returns>False when the event was canceled, which is what <c>dispatchEvent</c> returns.</returns>
+    internal static bool DispatchEvent(Engine engine, Realm realm, JsEventTarget target, JsValue eventArgument)
+    {
         if (eventArgument is not JsEvent ev)
         {
-            Throw.TypeError(_realm, "Failed to execute 'dispatchEvent' on 'EventTarget': parameter 1 is not of type 'Event'.");
-            return null!;
+            Throw.TypeError(realm, "Failed to execute 'dispatchEvent' on 'EventTarget': parameter 1 is not of type 'Event'.");
+            return false;
         }
 
         // Step 1. Every event this engine can produce has its initialized flag set from construction, so the
         // only way here is a re-entrant dispatch of an event that is already being dispatched.
         if (ev.DispatchFlag)
         {
-            var invalidState = _realm.Intrinsics.DomException.CreateException(
+            var invalidState = realm.Intrinsics.DomException.CreateException(
                 DomExceptionNames.InvalidState,
                 "Failed to execute 'dispatchEvent' on 'EventTarget': the event is already being dispatched.");
 
-            var location = _engine._lastSyntaxElement?.Location ?? default;
-            Throw.JavaScriptException(_engine, invalidState, in location);
+            var location = engine._lastSyntaxElement?.Location ?? default;
+            Throw.JavaScriptException(engine, invalidState, in location);
         }
 
         // Step 2: an event a script dispatches is never trusted, whoever created it.
         ev.IsTrusted = false;
 
-        return JsBoolean.Create(target.DispatchEvent(ev));
+        return target.DispatchEvent(ev);
     }
 
     /// <summary>
@@ -138,7 +187,7 @@ internal sealed partial class EventTargetPrototype : Prototype
     /// inherited dictionary's members in: <c>capture</c> first, then <c>once</c>, <c>passive</c>,
     /// <c>signal</c>.
     /// </summary>
-    private ListenerOptions FlattenMoreOptions(JsValue options)
+    private static ListenerOptions FlattenMoreOptions(Realm realm, JsValue options)
     {
         var capture = FlattenOptions(options);
 
@@ -162,7 +211,7 @@ internal sealed partial class EventTargetPrototype : Prototype
             signal = signalValue as JsAbortSignal;
             if (signal is null)
             {
-                Throw.TypeError(_realm, "Failed to execute 'addEventListener' on 'EventTarget': member signal is not of type 'AbortSignal'.");
+                Throw.TypeError(realm, "Failed to execute 'addEventListener' on 'EventTarget': member signal is not of type 'AbortSignal'.");
             }
         }
 
@@ -175,16 +224,16 @@ internal sealed partial class EventTargetPrototype : Prototype
     /// <see langword="undefined"/> give the null callback, an object is taken as it is, and anything else is a
     /// <c>TypeError</c>.
     /// </summary>
-    private JsValue ReadCallback(JsValue callback, string operationName)
+    private static JsValue ReadCallback(Realm realm, JsValue callback, string operationName)
     {
         if (callback.IsUndefined() || callback.IsNull())
         {
-            return Null;
+            return JsValue.Null;
         }
 
         if (callback is not ObjectInstance)
         {
-            Throw.TypeError(_realm, $"Failed to execute '{operationName}' on 'EventTarget': parameter 2 is not of type 'EventListener'.");
+            Throw.TypeError(realm, $"Failed to execute '{operationName}' on 'EventTarget': parameter 2 is not of type 'EventListener'.");
         }
 
         return callback;
@@ -194,25 +243,14 @@ internal sealed partial class EventTargetPrototype : Prototype
     /// WebIDL's arity check: an operation whose required arguments were not all supplied raises a
     /// <c>TypeError</c> before anything else is converted.
     /// </summary>
-    private void RequireArguments(JsCallArguments arguments, int required, string operationName)
+    private static void RequireArguments(Realm realm, JsCallArguments arguments, int required, string operationName)
     {
         if (arguments.Length < required)
         {
             Throw.TypeError(
-                _realm,
+                realm,
                 $"Failed to execute '{operationName}' on 'EventTarget': {required} arguments required, but only {arguments.Length} present.");
         }
-    }
-
-    private JsEventTarget Brand(JsValue thisObject)
-    {
-        if (thisObject is JsEventTarget target)
-        {
-            return target;
-        }
-
-        Throw.TypeError(_realm, "Illegal invocation: receiver is not an EventTarget");
-        return null!;
     }
 
     /// <summary>

--- a/Jint/WebApi/Events/JsEventTarget.cs
+++ b/Jint/WebApi/Events/JsEventTarget.cs
@@ -53,6 +53,12 @@ namespace Jint.WebApi.Events;
 /// a <c>JintException</c> but not one of those, so it erupts whatever the host configured. The dispatch state
 /// is unwound in every case, so the event and the target stay usable.
 /// </para>
+/// <para>
+/// Reporting it is HTML's <i>report an exception</i>, so on an engine with
+/// <see cref="WebApiFeatures.GlobalEvents"/> it also fires an <c>error</c> event at the global scope — which
+/// is where the re-entrancy rule bites, because the listener that just threw may itself have been running as
+/// part of a report. <c>Jint.WebApi.GlobalEvents.GlobalEventTarget</c> is what declines the second dispatch.
+/// </para>
 /// </remarks>
 internal class JsEventTarget : ObjectInstance
 {
@@ -69,6 +75,43 @@ internal class JsEventTarget : ObjectInstance
     internal JsEventTarget(Engine engine, Realm realm) : base(engine, ObjectClass.Object)
     {
         _realm = realm;
+    }
+
+    /// <summary>
+    /// What a dispatch reports as https://dom.spec.whatwg.org/#dom-event-target and
+    /// https://dom.spec.whatwg.org/#dom-event-currenttarget, and therefore the <c>this</c> a listener is
+    /// invoked with.
+    /// </summary>
+    /// <remarks>
+    /// The target itself for every <c>EventTarget</c> a script can reach, which is what the specification
+    /// says. The one override is the engine's synthetic global target, whose listener list is not reachable
+    /// as an object at all: it answers with the global object, so a global <c>error</c> listener sees the
+    /// <c>event.target</c> and the <c>this</c> a browser gives it rather than an object script has no other
+    /// way to name.
+    /// </remarks>
+    internal virtual JsValue EventTargetValue => this;
+
+    /// <summary>
+    /// Whether one dispatch of <paramref name="type"/> could invoke anything at all. The engine asks before
+    /// <i>building</i> a trusted event, so a target nobody listens to costs a walk of an empty list rather
+    /// than an object nothing would have read.
+    /// </summary>
+    internal bool HasListenerOfType(string type)
+    {
+        if (_listeners is not { } listeners)
+        {
+            return false;
+        }
+
+        foreach (var listener in listeners)
+        {
+            if (!listener.Removed && string.Equals(listener.Type, type, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>
@@ -179,9 +222,11 @@ internal class JsEventTarget : ObjectInstance
     /// <returns>False when the event was canceled, which is what <c>dispatchEvent</c> returns.</returns>
     internal bool DispatchEvent(JsEvent ev)
     {
+        var targetValue = EventTargetValue;
+
         ev.DispatchFlag = true;
-        ev.Target = this;
-        ev.CurrentTarget = this;
+        ev.Target = targetValue;
+        ev.CurrentTarget = targetValue;
         ev.EventPhase = JsEvent.PhaseAtTarget;
 
         try
@@ -277,6 +322,12 @@ internal class JsEventTarget : ObjectInstance
                 // there is somewhere for the report to go. Only a JavaScriptException: everything that bounds
                 // execution is a JintException but not one of these, so a constraint still stops the dispatch
                 // dead. With no sink there is no catch at all — see the class remarks.
+                //
+                // Reporting it is HTML's report an exception, whose step 5 fires an `error` event at the
+                // global scope before step 6's console report. That is a no-op unless the GlobalEvents
+                // feature is on and something is listening, and it declines to recurse when the listener that
+                // just threw was itself running as part of a report.
+                _engine._webApi?.FireGlobalErrorEvent(exception);
                 diagnostics.Report(DiagnosticEvent.ForUncaughtCallbackError(exception, DiagnosticCallbackSource.EventListener));
             }
             finally

--- a/Jint/WebApi/GlobalEvents/ErrorEventConstructor.cs
+++ b/Jint/WebApi/GlobalEvents/ErrorEventConstructor.cs
@@ -1,0 +1,97 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.Events;
+using Jint.WebApi.Url;
+
+namespace Jint.WebApi.GlobalEvents;
+
+/// <summary>
+/// The <c>ErrorEvent</c> interface object.
+/// <para>
+/// https://html.spec.whatwg.org/multipage/webappapis.html#the-errorevent-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// <c>ErrorEvent</c> inherits from <c>Event</c>, so its <c>[[Prototype]]</c> is the <c>Event</c> interface
+/// object — https://webidl.spec.whatwg.org/#interface-object.
+/// </remarks>
+internal sealed class ErrorEventConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("ErrorEvent");
+    private static readonly JsString _colno = new("colno");
+    private static readonly JsString _error = new("error");
+    private static readonly JsString _filename = new("filename");
+    private static readonly JsString _lineno = new("lineno");
+    private static readonly JsString _message = new("message");
+
+    internal ErrorEventConstructor(Engine engine, Realm realm, EventConstructor eventConstructor)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = eventConstructor;
+        PrototypeObject = new ErrorEventPrototype(engine, realm, this, eventConstructor.PrototypeObject);
+        _length = new PropertyDescriptor(JsNumber.PositiveOne, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal ErrorEventPrototype PrototypeObject { get; }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/webappapis.html#the-errorevent-interface — the ordinary event
+    /// constructor over <c>ErrorEventInit</c>, whose members default to <c>""</c>, <c>""</c>, <c>0</c>,
+    /// <c>0</c> and — <c>error</c> being an <c>any</c> with no default — <c>undefined</c>.
+    /// </summary>
+    /// <remarks>
+    /// The inherited <c>EventInit</c> members are converted first and this dictionary's own in
+    /// lexicographical order — <c>colno</c>, <c>error</c>, <c>filename</c>, <c>lineno</c>, <c>message</c> —
+    /// which is what https://webidl.spec.whatwg.org/#es-dictionary asks for and is observable through getters
+    /// on the dictionary.
+    /// </remarks>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        var type = EventConstructor.RequireType(_realm, arguments, "ErrorEvent");
+        var initArgument = arguments.At(1);
+
+        var init = EventConstructor.ReadEventInit(_realm, initArgument, "ErrorEvent");
+        var dictionary = initArgument as ObjectInstance;
+
+        var colno = Member(dictionary, _colno) is { } colnoValue ? TypeConverter.ToUint32(colnoValue) : 0u;
+        var error = Member(dictionary, _error) ?? Undefined;
+        var filename = Member(dictionary, _filename) is { } filenameValue ? UrlValues.ToUsvString(filenameValue) : string.Empty;
+        var lineno = Member(dictionary, _lineno) is { } linenoValue ? TypeConverter.ToUint32(linenoValue) : 0u;
+        var message = Member(dictionary, _message) is { } messageValue ? TypeConverter.ToString(messageValue) : string.Empty;
+
+        var details = new ErrorEventDetails(message, filename, lineno, colno, error);
+
+        return OrdinaryCreateFromConstructor(
+            newTarget,
+            static intrinsics => intrinsics.ErrorEvent.PrototypeObject,
+            static (Engine engine, Realm _, (JsString Type, EventInit Init, double TimeStamp, ErrorEventDetails Details) state)
+                => new JsErrorEvent(engine, state.Type, state.Init, state.TimeStamp, in state.Details),
+            (Type: type, Init: init, TimeStamp: EventConstructor.TimeStampNow(_engine), Details: details));
+    }
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#concept-event-fire for the <c>error</c> event HTML's <i>report an
+    /// exception</i> fires at the global scope: created by the engine, so <c>isTrusted</c> is true, and
+    /// cancelable because step 5 initializes it that way — a listener calling <c>preventDefault()</c> is what
+    /// makes <i>notHandled</i> false.
+    /// </summary>
+    internal JsErrorEvent CreateTrustedError(JsString type, in ErrorEventDetails details)
+    {
+        return new JsErrorEvent(_engine, type, new EventInit(Bubbles: false, Cancelable: true, Composed: false), EventConstructor.TimeStampNow(_engine), in details)
+        {
+            IsTrusted = true,
+            _prototype = PrototypeObject,
+        };
+    }
+
+    private static JsValue? Member(ObjectInstance? dictionary, JsString name)
+    {
+        var value = dictionary?.Get(name);
+        return value is null || value.IsUndefined() ? null : value;
+    }
+}
+#endif

--- a/Jint/WebApi/GlobalEvents/ErrorEventPrototype.cs
+++ b/Jint/WebApi/GlobalEvents/ErrorEventPrototype.cs
@@ -1,0 +1,85 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.GlobalEvents;
+
+/// <summary>
+/// <c>ErrorEvent.prototype</c> — the interface prototype object.
+/// <para>
+/// https://html.spec.whatwg.org/multipage/webappapis.html#the-errorevent-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// Its <c>[[Prototype]]</c> is <c>Event.prototype</c>, so an <c>error</c> event has every <c>Event</c> member
+/// and <c>event instanceof Event</c> holds inside the listener.
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class ErrorEventPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly ErrorEventConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString ErrorEventToStringTag = new("ErrorEvent");
+
+    internal ErrorEventPrototype(
+        Engine engine,
+        Realm realm,
+        ErrorEventConstructor constructor,
+        ObjectInstance eventPrototype) : base(engine, realm)
+    {
+        _prototype = eventPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-message
+    /// </summary>
+    [JsAccessor("message", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsString MessageGet(JsValue thisObject) => JsString.Create(Brand(thisObject).Message);
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-filename
+    /// </summary>
+    [JsAccessor("filename", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsString FilenameGet(JsValue thisObject) => JsString.Create(Brand(thisObject).Filename);
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-lineno
+    /// </summary>
+    [JsAccessor("lineno", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsNumber LinenoGet(JsValue thisObject) => JsNumber.Create((long) Brand(thisObject).Lineno);
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-colno
+    /// </summary>
+    [JsAccessor("colno", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsNumber ColnoGet(JsValue thisObject) => JsNumber.Create((long) Brand(thisObject).Colno);
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-error
+    /// </summary>
+    [JsAccessor("error", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue ErrorGet(JsValue thisObject) => Brand(thisObject).Error;
+
+    private JsErrorEvent Brand(JsValue thisObject)
+    {
+        if (thisObject is JsErrorEvent errorEvent)
+        {
+            return errorEvent;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not an ErrorEvent");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/GlobalEvents/GlobalEventFunctions.cs
+++ b/Jint/WebApi/GlobalEvents/GlobalEventFunctions.cs
@@ -1,0 +1,100 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Interop;
+using Jint.WebApi.Events;
+
+namespace Jint.WebApi.GlobalEvents;
+
+/// <summary>
+/// The three event-target operations on the global scope: <c>addEventListener</c>,
+/// <c>removeEventListener</c> and <c>dispatchEvent</c>.
+/// <para>
+/// https://dom.spec.whatwg.org/#interface-eventtarget
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// A browser's <c>Window</c> <i>implements</i> <c>EventTarget</c> and inherits these three from
+/// <c>EventTarget.prototype</c>. Jint's global object deliberately does not (see
+/// <see cref="GlobalEventTarget"/>), so they are installed as ordinary global operations bound to the
+/// engine's synthetic target — this class only owns them so that one realm builds one of each, exactly as
+/// <c>TimerFunctions</c> does for the timer globals.
+/// </para>
+/// <para>
+/// The one consequence a script could notice: <b>they ignore their <c>this</c></b>. A browser brand-checks the
+/// receiver, so <c>const f = addEventListener; f('error', h)</c> raises "Illegal invocation" there and works
+/// here. The three shapes that matter — <c>addEventListener(…)</c>, <c>self.addEventListener(…)</c> and
+/// <c>globalThis.addEventListener(…)</c> — behave the same either way, and the argument conversions are
+/// literally <c>EventTarget</c>'s, down to the message a <c>TypeError</c> carries.
+/// </para>
+/// </remarks>
+internal sealed class GlobalEventFunctions
+{
+    private readonly Engine _engine;
+    private readonly Realm _realm;
+
+    private ClrFunction? _addEventListener;
+    private ClrFunction? _removeEventListener;
+    private ClrFunction? _dispatchEvent;
+
+    private GlobalEventFunctions(Engine engine, Realm realm)
+    {
+        _engine = engine;
+        _realm = realm;
+    }
+
+    internal static GlobalEventFunctions Create(Engine engine, Realm realm)
+    {
+        if (engine._webApi is null)
+        {
+            // Unreachable: the globals that reach this property are installed only where the web-API state
+            // was created, in the same block of WebApiRegistration.
+            Throw.InvalidOperationException("The global event operations were reached on an engine that has no web-API state.");
+        }
+
+        return new GlobalEventFunctions(engine, realm);
+    }
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener
+    /// </summary>
+    internal ClrFunction AddEventListener =>
+        _addEventListener ??= Operation("addEventListener", 2, (_, arguments) =>
+        {
+            EventTargetArguments.AddListener(_realm, Target, arguments);
+            return JsValue.Undefined;
+        });
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#dom-eventtarget-removeeventlistener
+    /// </summary>
+    internal ClrFunction RemoveEventListener =>
+        _removeEventListener ??= Operation("removeEventListener", 2, (_, arguments) =>
+        {
+            EventTargetArguments.RemoveListener(_realm, Target, arguments);
+            return JsValue.Undefined;
+        });
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#dom-eventtarget-dispatchevent
+    /// </summary>
+    internal ClrFunction DispatchEvent =>
+        _dispatchEvent ??= Operation("dispatchEvent", 1, (_, arguments) =>
+            JsBoolean.Create(EventTargetArguments.DispatchEvent(_engine, _realm, Target, arguments.At(0))));
+
+    /// <summary>
+    /// The engine's synthetic global target, created on the first of these calls — so an engine that enabled
+    /// the feature and never registered a listener has still allocated nothing.
+    /// </summary>
+    private GlobalEventTarget Target => _engine._webApi!.GlobalEventTarget;
+
+    /// <summary>
+    /// A WebIDL operation: <c>length</c> counts the required arguments only and is configurable but neither
+    /// writable nor enumerable — https://webidl.spec.whatwg.org/#dfn-create-operation-function.
+    /// </summary>
+    private ClrFunction Operation(string name, int length, JsCallDelegate body)
+        => new(_engine, _realm, name, body, length, PropertyFlag.Configurable);
+}
+#endif

--- a/Jint/WebApi/GlobalEvents/GlobalEventTarget.cs
+++ b/Jint/WebApi/GlobalEvents/GlobalEventTarget.cs
@@ -1,0 +1,132 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Runtime;
+using Jint.WebApi.Events;
+
+namespace Jint.WebApi.GlobalEvents;
+
+/// <summary>
+/// The engine's <b>synthetic global event target</b>: the listener list behind the global
+/// <c>addEventListener</c>, <c>removeEventListener</c> and <c>dispatchEvent</c>, and what the engine fires
+/// <c>error</c>, <c>unhandledrejection</c> and <c>rejectionhandled</c> at.
+/// <para>
+/// https://html.spec.whatwg.org/multipage/webappapis.html#report-an-exception
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The global object itself is untouched.</b> Making it an <c>EventTarget</c> would mean giving it a
+/// prototype chain it does not have, and every own-property and inline-cache promise the global object makes
+/// to the engine and to a host would have to be re-argued. Nothing is gained by it: what a script needs is the
+/// three operations and the events, and both are reachable with the list kept beside the timers instead.
+/// This object is never handed to script — <see cref="EventTargetValue"/> answers with the global object, so
+/// <c>event.target</c>, <c>event.currentTarget</c> and a listener's <c>this</c> are what a browser reports.
+/// </para>
+/// <para>
+/// <b>Reporting does not recurse.</b> HTML's <i>report an exception</i> is reached from inside the dispatch it
+/// may itself start — a global <c>error</c> listener that throws is an exception escaping an event listener,
+/// which DOM's <i>inner invoke</i> step 2.10 says to report, which fires an <c>error</c> event. Neither
+/// specification closes that loop, and every browser does with a re-entrancy guard;
+/// <see cref="FireReport"/> is Jint's. While a report is being dispatched the next one fires nothing and goes
+/// to the <see cref="DiagnosticsSink"/> alone. Without it the recursion is unbounded and, on an engine with
+/// no recursion constraint, ends in a process-killing stack overflow rather than in a JavaScript error.
+/// </para>
+/// </remarks>
+internal sealed class GlobalEventTarget : JsEventTarget
+{
+    internal GlobalEventTarget(Engine engine, Realm realm) : base(engine, realm)
+    {
+    }
+
+    /// <summary>
+    /// Whether a report is already being dispatched at this target, which is what stops one report starting
+    /// another. Engine-thread state like everything else here, so no synchronization.
+    /// </summary>
+    private bool _reporting;
+
+    /// <inheritdoc />
+    internal override JsValue EventTargetValue => _realm.GlobalObject;
+
+    /// <summary>
+    /// Fires one trusted event at the global scope, unless nothing is listening for it or a report is already
+    /// in flight.
+    /// </summary>
+    /// <returns>
+    /// False when a listener canceled the event, which is HTML's <i>notHandled</i>; true when it did not, when
+    /// nothing was listening, and when the dispatch was declined as re-entrant.
+    /// </returns>
+    private bool FireReport(JsEvent ev)
+    {
+        if (_reporting)
+        {
+            return true;
+        }
+
+        _reporting = true;
+        try
+        {
+            return DispatchEvent(ev);
+        }
+        finally
+        {
+            _reporting = false;
+        }
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/webappapis.html#report-an-exception step 5: "fire an event named
+    /// <c>error</c> at global, using <c>ErrorEvent</c>, with the cancelable attribute initialized to true …".
+    /// </summary>
+    /// <returns>HTML's <i>notHandled</i> — false exactly when a listener called <c>preventDefault()</c>.</returns>
+    internal bool FireError(in ErrorEventDetails details)
+    {
+        if (!HasListenerOfType(GlobalEventNames.ErrorName))
+        {
+            return true;
+        }
+
+        var ev = _realm.Intrinsics.ErrorEvent.CreateTrustedError(GlobalEventNames.Error, in details);
+        return FireReport(ev);
+    }
+
+    /// <summary>
+    /// The two events of
+    /// https://html.spec.whatwg.org/multipage/webappapis.html#unhandled-promise-rejections.
+    /// </summary>
+    /// <param name="handled">
+    /// False for <c>unhandledrejection</c> — a rejection nobody handled, which a listener may cancel — and
+    /// true for <c>rejectionhandled</c>, which reports that one already announced has since been handled and
+    /// which HTML fires without a cancelable initializer.
+    /// </param>
+    /// <param name="promise">The promise the tracker reported.</param>
+    /// <param name="reason">Its rejection reason, or <c>undefined</c> when it is somehow no longer rejected.</param>
+    internal void FireRejection(bool handled, JsValue promise, JsValue reason)
+    {
+        var (type, typeName) = handled
+            ? (GlobalEventNames.RejectionHandled, GlobalEventNames.RejectionHandledName)
+            : (GlobalEventNames.UnhandledRejection, GlobalEventNames.UnhandledRejectionName);
+
+        if (!HasListenerOfType(typeName))
+        {
+            return;
+        }
+
+        var ev = _realm.Intrinsics.PromiseRejectionEvent.CreateTrustedRejection(type, promise, reason, cancelable: !handled);
+        FireReport(ev);
+    }
+}
+
+/// <summary>
+/// The three event types the engine fires at the global scope, interned once.
+/// </summary>
+internal static class GlobalEventNames
+{
+    internal const string ErrorName = "error";
+    internal const string UnhandledRejectionName = "unhandledrejection";
+    internal const string RejectionHandledName = "rejectionhandled";
+
+    internal static readonly JsString Error = new(ErrorName);
+    internal static readonly JsString UnhandledRejection = new(UnhandledRejectionName);
+    internal static readonly JsString RejectionHandled = new(RejectionHandledName);
+}
+#endif

--- a/Jint/WebApi/GlobalEvents/JsErrorEvent.cs
+++ b/Jint/WebApi/GlobalEvents/JsErrorEvent.cs
@@ -1,0 +1,139 @@
+#if NET8_0_OR_GREATER
+using System.Runtime.InteropServices;
+using Jint.Native;
+using Jint.Native.Error;
+using Jint.Runtime;
+using Jint.WebApi.Events;
+
+namespace Jint.WebApi.GlobalEvents;
+
+/// <summary>
+/// An <c>ErrorEvent</c> instance: the event HTML's <i>report an exception</i> fires at the global scope.
+/// <para>
+/// https://html.spec.whatwg.org/multipage/webappapis.html#the-errorevent-interface
+/// </para>
+/// </summary>
+internal sealed class JsErrorEvent : JsEvent
+{
+    internal JsErrorEvent(Engine engine, JsString type, EventInit init, double timeStamp, in ErrorEventDetails details)
+        : base(engine, type, init, timeStamp)
+    {
+        Message = details.Message;
+        Filename = details.Filename;
+        Lineno = details.Lineno;
+        Colno = details.Colno;
+        Error = details.Error;
+    }
+
+    /// <summary>https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-message</summary>
+    internal string Message { get; }
+
+    /// <summary>https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-filename</summary>
+    internal string Filename { get; }
+
+    /// <summary>https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-lineno</summary>
+    internal uint Lineno { get; }
+
+    /// <summary>https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-colno</summary>
+    internal uint Colno { get; }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-error — the value that was
+    /// thrown, or that <c>reportError</c> was handed. <c>any</c>, so it defaults to <c>undefined</c> rather
+    /// than to null.
+    /// </summary>
+    internal JsValue Error { get; }
+}
+
+/// <summary>
+/// The five members of <c>ErrorEventInit</c> that describe the failure, after conversion —
+/// https://html.spec.whatwg.org/multipage/webappapis.html#erroreventinit. Also what the engine fills in for
+/// the trusted <c>error</c> event it fires itself.
+/// </summary>
+/// <param name="Message">A description of the failure; see <see cref="FromException"/> for where it comes from.</param>
+/// <param name="Filename">The script the failure came from, or the empty string when nothing named one.</param>
+/// <param name="Lineno">The 1-based line, or 0 when the location is unknown.</param>
+/// <param name="Colno">The 1-based column, or 0 when the location is unknown.</param>
+/// <param name="Error">The thrown or reported value itself.</param>
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct ErrorEventDetails(string Message, string Filename, uint Lineno, uint Colno, JsValue Error)
+{
+    /// <summary>
+    /// What HTML's <i>report an exception</i> knows about an exception that escaped a callback the engine
+    /// invoked.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Nothing here runs a line of script.</b> <see cref="Exception.Message"/> on a
+    /// <see cref="JavaScriptException"/> is a CLR string materialized when the exception was <i>constructed</i>
+    /// — at the throw, long before this — so reading it now cannot reach a <c>message</c> getter or a
+    /// <c>toString</c>, which is the hazard <see cref="Throw.SafeToDisplayString"/> exists for. A listener that
+    /// wants the error itself has <c>event.error</c>.
+    /// </para>
+    /// <para>
+    /// The message is the error's own <c>message</c> rather than a browser's rendering of it: Chrome reports
+    /// "Uncaught TypeError: …" where this reports "…", because prefixing it would mean deciding what the
+    /// error's <i>name</i> is, and asking an arbitrary thrown object for its <c>name</c> is exactly the script
+    /// call that must not happen here.
+    /// </para>
+    /// </remarks>
+    internal static ErrorEventDetails FromException(JavaScriptException exception)
+    {
+        var (filename, lineno, colno) = ReadLocation(exception.Location);
+        return new ErrorEventDetails(exception.Message ?? string.Empty, filename, lineno, colno, exception.Error);
+    }
+
+    /// <summary>
+    /// The same for a value handed to <c>reportError</c>, where there is no exception to read a message or a
+    /// location from — so the location is the call site the engine last saw, and the message is derived from
+    /// the value without running script.
+    /// </summary>
+    /// <remarks>
+    /// An in-box <c>Error</c> keeps its <c>message</c> as an ordinary own data property, so reading the
+    /// descriptor is a dictionary lookup and cannot run a getter. Anything else — a plain object, a proxy, a
+    /// host object — is rendered by <see cref="Throw.SafeToDisplayString"/>, which reports an object as its
+    /// shape rather than its contents for precisely that reason. This is a divergence from a browser, which
+    /// stringifies the value; <c>event.error</c> carries the value itself either way.
+    /// </remarks>
+    internal static ErrorEventDetails FromReportedValue(JsValue value, in SourceLocation location)
+    {
+        var (filename, lineno, colno) = ReadLocation(in location);
+        return new ErrorEventDetails(Describe(value), filename, lineno, colno, value);
+    }
+
+    private static string Describe(JsValue value)
+    {
+        if (value is ErrorInstance error
+            && error.GetOwnProperty(CommonProperties.Message) is { } descriptor
+            && descriptor.IsDataDescriptor()
+            && descriptor.Value is JsString message)
+        {
+            return message.ToString();
+        }
+
+        return Throw.SafeToDisplayString(value);
+    }
+
+    /// <summary>
+    /// <c>filename</c>, <c>lineno</c> and <c>colno</c> out of one <see cref="SourceLocation"/>.
+    /// </summary>
+    /// <remarks>
+    /// A default <see cref="SourceLocation"/> — what an exception the engine could not place carries — reports
+    /// line 0, and 0 is exactly the "unknown" a browser reports for all three. So the line decides: without
+    /// one there is no column either, which is why the 1-based conversion is not applied to a column that
+    /// names nothing. Acornima counts columns from zero and HTML's <c>colno</c> from one, the same conversion
+    /// the call-stack renderer makes.
+    /// </remarks>
+    private static (string Filename, uint Lineno, uint Colno) ReadLocation(in SourceLocation location)
+    {
+        var line = location.Start.Line;
+        if (line <= 0)
+        {
+            return (location.SourceFile ?? string.Empty, 0u, 0u);
+        }
+
+        var column = location.Start.Column;
+        return (location.SourceFile ?? string.Empty, (uint) line, column >= 0 ? (uint) column + 1u : 0u);
+    }
+}
+#endif

--- a/Jint/WebApi/GlobalEvents/JsPromiseRejectionEvent.cs
+++ b/Jint/WebApi/GlobalEvents/JsPromiseRejectionEvent.cs
@@ -1,0 +1,36 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.WebApi.Events;
+
+namespace Jint.WebApi.GlobalEvents;
+
+/// <summary>
+/// A <c>PromiseRejectionEvent</c> instance: the event behind <c>unhandledrejection</c> and
+/// <c>rejectionhandled</c>.
+/// <para>
+/// https://html.spec.whatwg.org/multipage/webappapis.html#the-promiserejectionevent-interface
+/// </para>
+/// </summary>
+internal sealed class JsPromiseRejectionEvent : JsEvent
+{
+    internal JsPromiseRejectionEvent(Engine engine, JsString type, EventInit init, double timeStamp, JsValue promise, JsValue reason)
+        : base(engine, type, init, timeStamp)
+    {
+        Promise = promise;
+        Reason = reason;
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/webappapis.html#dom-promiserejectionevent-promise — the promise
+    /// itself for an event the engine fired, and for a constructed one whatever WebIDL's <c>Promise&lt;any&gt;</c>
+    /// conversion made of the dictionary member.
+    /// </summary>
+    internal JsValue Promise { get; }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/webappapis.html#dom-promiserejectionevent-reason — the rejection
+    /// reason. <c>any</c>, so it defaults to <c>undefined</c>.
+    /// </summary>
+    internal JsValue Reason { get; }
+}
+#endif

--- a/Jint/WebApi/GlobalEvents/PromiseRejectionEventConstructor.cs
+++ b/Jint/WebApi/GlobalEvents/PromiseRejectionEventConstructor.cs
@@ -1,0 +1,121 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.Events;
+
+namespace Jint.WebApi.GlobalEvents;
+
+/// <summary>
+/// The <c>PromiseRejectionEvent</c> interface object.
+/// <para>
+/// https://html.spec.whatwg.org/multipage/webappapis.html#the-promiserejectionevent-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// <c>PromiseRejectionEvent</c> inherits from <c>Event</c>, so its <c>[[Prototype]]</c> is the <c>Event</c>
+/// interface object — https://webidl.spec.whatwg.org/#interface-object. Unlike every other event interface
+/// here its <c>eventInitDict</c> argument is <b>not</b> optional, because the dictionary has a
+/// <c>required</c> member; that is why <c>length</c> is 2 rather than 1.
+/// </remarks>
+internal sealed class PromiseRejectionEventConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("PromiseRejectionEvent");
+    private static readonly JsString _promise = new("promise");
+    private static readonly JsString _reason = new("reason");
+
+    internal PromiseRejectionEventConstructor(Engine engine, Realm realm, EventConstructor eventConstructor)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = eventConstructor;
+        PrototypeObject = new PromiseRejectionEventPrototype(engine, realm, this, eventConstructor.PrototypeObject);
+        _length = new PropertyDescriptor(JsNumber.Create(2), PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal PromiseRejectionEventPrototype PrototypeObject { get; }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/webappapis.html#the-promiserejectionevent-interface — the
+    /// ordinary event constructor over <c>PromiseRejectionEventInit</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The inherited <c>EventInit</c> members are converted first and this dictionary's own in
+    /// lexicographical order — <c>promise</c>, then <c>reason</c> —
+    /// https://webidl.spec.whatwg.org/#es-dictionary.
+    /// </para>
+    /// <para>
+    /// <c>promise</c> is a <c>required</c> member, so an absent one (and an explicit <c>undefined</c>, which
+    /// WebIDL treats as absent) is a <c>TypeError</c>. Its declared type is <c>Promise&lt;any&gt;</c>, whose
+    /// conversion is https://webidl.spec.whatwg.org/#es-promise: <i>any</i> value becomes a promise, so
+    /// <c>new PromiseRejectionEvent('x', { promise: 42 })</c> has an already-resolved promise of 42 rather
+    /// than the number.
+    /// </para>
+    /// </remarks>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        var type = EventConstructor.RequireType(_realm, arguments, "PromiseRejectionEvent");
+
+        if (arguments.Length < 2)
+        {
+            Throw.TypeError(_realm, "Failed to construct 'PromiseRejectionEvent': 2 arguments required, but only 1 present.");
+        }
+
+        var initArgument = arguments[1];
+
+        // The inherited members first, which is also what refuses anything that is neither an object nor
+        // undefined nor null.
+        var init = EventConstructor.ReadEventInit(_realm, initArgument, "PromiseRejectionEvent");
+
+        // So what is left here is undefined or null, both of which convert to a dictionary with no members at
+        // all — and a dictionary with no members is missing a required one.
+        if (initArgument is not ObjectInstance dictionary)
+        {
+            Throw.TypeError(_realm, "Failed to construct 'PromiseRejectionEvent': required member promise is undefined.");
+            return null!;
+        }
+
+        // `promise` before `reason`, and its required-member check and its Promise<any> conversion both before
+        // `reason` is even read — the order is observable through getters on the dictionary.
+        var promiseValue = dictionary.Get(_promise);
+        if (promiseValue.IsUndefined())
+        {
+            Throw.TypeError(_realm, "Failed to construct 'PromiseRejectionEvent': required member promise is undefined.");
+        }
+
+        var promise = _realm.Intrinsics.Promise.PromiseResolve(promiseValue);
+        var reasonValue = dictionary.Get(_reason);
+
+        return OrdinaryCreateFromConstructor(
+            newTarget,
+            static intrinsics => intrinsics.PromiseRejectionEvent.PrototypeObject,
+            static (Engine engine, Realm _, (JsString Type, EventInit Init, double TimeStamp, JsValue Promise, JsValue Reason) state)
+                => new JsPromiseRejectionEvent(engine, state.Type, state.Init, state.TimeStamp, state.Promise, state.Reason),
+            (Type: type, Init: init, TimeStamp: EventConstructor.TimeStampNow(_engine), Promise: promise, Reason: reasonValue));
+    }
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#concept-event-fire for the two events HTML's <i>unhandled promise
+    /// rejections</i> section fires: created by the engine, so <c>isTrusted</c> is true, and carrying the
+    /// promise object itself rather than a conversion of it.
+    /// </summary>
+    /// <param name="type"><c>unhandledrejection</c> or <c>rejectionhandled</c>.</param>
+    /// <param name="promise">The promise the tracker reported.</param>
+    /// <param name="reason">Its rejection reason.</param>
+    /// <param name="cancelable">
+    /// True for <c>unhandledrejection</c>, whose <i>notHandled</i> a listener may cancel; false for
+    /// <c>rejectionhandled</c>, which HTML fires with no cancelable initializer at all.
+    /// </param>
+    internal JsPromiseRejectionEvent CreateTrustedRejection(JsString type, JsValue promise, JsValue reason, bool cancelable)
+    {
+        var init = new EventInit(Bubbles: false, Cancelable: cancelable, Composed: false);
+        return new JsPromiseRejectionEvent(_engine, type, init, EventConstructor.TimeStampNow(_engine), promise, reason)
+        {
+            IsTrusted = true,
+            _prototype = PrototypeObject,
+        };
+    }
+}
+#endif

--- a/Jint/WebApi/GlobalEvents/PromiseRejectionEventPrototype.cs
+++ b/Jint/WebApi/GlobalEvents/PromiseRejectionEventPrototype.cs
@@ -1,0 +1,67 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.WebApi.GlobalEvents;
+
+/// <summary>
+/// <c>PromiseRejectionEvent.prototype</c> — the interface prototype object.
+/// <para>
+/// https://html.spec.whatwg.org/multipage/webappapis.html#the-promiserejectionevent-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// Its <c>[[Prototype]]</c> is <c>Event.prototype</c>, so an <c>unhandledrejection</c> event has every
+/// <c>Event</c> member and <c>event instanceof Event</c> holds inside the listener.
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class PromiseRejectionEventPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly PromiseRejectionEventConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString PromiseRejectionEventToStringTag = new("PromiseRejectionEvent");
+
+    internal PromiseRejectionEventPrototype(
+        Engine engine,
+        Realm realm,
+        PromiseRejectionEventConstructor constructor,
+        ObjectInstance eventPrototype) : base(engine, realm)
+    {
+        _prototype = eventPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/webappapis.html#dom-promiserejectionevent-promise
+    /// </summary>
+    [JsAccessor("promise", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue PromiseGet(JsValue thisObject) => Brand(thisObject).Promise;
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/webappapis.html#dom-promiserejectionevent-reason
+    /// </summary>
+    [JsAccessor("reason", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue ReasonGet(JsValue thisObject) => Brand(thisObject).Reason;
+
+    private JsPromiseRejectionEvent Brand(JsValue thisObject)
+    {
+        if (thisObject is JsPromiseRejectionEvent rejectionEvent)
+        {
+            return rejectionEvent;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a PromiseRejectionEvent");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Reporting/ReportErrorFunction.cs
+++ b/Jint/WebApi/Reporting/ReportErrorFunction.cs
@@ -17,17 +17,24 @@ namespace Jint.WebApi.Reporting;
 /// "The <c>reportError(e)</c> method steps are to report an exception <c>e</c> for <b>this</b>." The whole of
 /// the operation is therefore
 /// <see href="https://html.spec.whatwg.org/multipage/webappapis.html#report-an-exception">report an
-/// exception</see>, which for this engine reduces to one step. Its step 5 fires an <c>error</c> event at the
-/// global object "if global implements <c>EventTarget</c>" — Jint's global object does not, so nothing is
-/// fired, nothing can cancel it, <i>notHandled</i> stays true, and step 6's "the user agent may report
-/// exception to a developer console" is what actually happens: the value goes to
-/// <see cref="DiagnosticsSink"/>. Script cannot observe or intercept the report.
+/// exception</see>, and both of its observable steps happen. Step 5 fires an <c>error</c> event "if global
+/// implements <c>EventTarget</c>": Jint's global object is not one, but
+/// <see cref="WebApiFeatures.GlobalEvents"/> gives the engine a synthetic target standing in for it, so a
+/// script that registered an <c>error</c> listener sees an <c>ErrorEvent</c> carrying the value. Step 6's "the
+/// user agent may report exception to a developer console" is the <see cref="DiagnosticsSink"/>.
 /// </para>
 /// <para>
-/// <b>Without a sink this does nothing at all</b>, and it never throws for any value it is given — the report
-/// simply has nowhere to go. The one failure it can produce is WebIDL's arity error: <c>e</c> is a required
-/// <c>any</c> argument, so <c>reportError()</c> with no arguments is a <c>TypeError</c>, exactly as it is in a
-/// browser. https://webidl.spec.whatwg.org/#dfn-create-operation-function
+/// <b>The two are additive, and that is a deliberate divergence.</b> HTML lets a listener's
+/// <c>preventDefault()</c> make <i>notHandled</i> false and so suppress the console report; here the sink is
+/// told either way, because a host's diagnostics channel is not something the script it is running may switch
+/// off. A listener can observe an uncaught failure; it cannot hide one.
+/// </para>
+/// <para>
+/// <b>With neither a sink nor a listener this does nothing at all</b>, and it never throws for any value it is
+/// given — the report simply has nowhere to go. The one failure it can produce is WebIDL's arity error:
+/// <c>e</c> is a required <c>any</c> argument, so <c>reportError()</c> with no arguments is a
+/// <c>TypeError</c>, exactly as it is in a browser.
+/// https://webidl.spec.whatwg.org/#dfn-create-operation-function
 /// </para>
 /// </remarks>
 internal sealed class ReportErrorFunction : Jint.Native.Function.Function
@@ -48,8 +55,9 @@ internal sealed class ReportErrorFunction : Jint.Native.Function.Function
             Throw.TypeError(_realm, "Failed to execute 'reportError': 1 argument required, but only 0 present.");
         }
 
-        // The state is null on an engine that enabled the feature but set no sink, which is precisely the
-        // documented no-op: the value was reported, and the report was heard by nobody.
+        // The state is null on an engine that enabled the feature alone — no sink, and none of the features
+        // that keep something here — which is precisely the documented no-op: the value was reported, and the
+        // report was heard by nobody.
         _engine._webApi?.ReportError(arguments[0]);
         return JsValue.Undefined;
     }

--- a/Jint/WebApi/Timers/TimerQueue.cs
+++ b/Jint/WebApi/Timers/TimerQueue.cs
@@ -43,12 +43,20 @@ internal sealed class TimerQueue
     /// <summary>Breaks ties between timers due at the same instant, so equal due times fire FIFO.</summary>
     private long _nextSequence;
 
-    internal TimerQueue(TimeProvider timeProvider, int maxActiveTimers, DiagnosticsSink? diagnostics)
+    internal TimerQueue(Engine engine, TimeProvider timeProvider, int maxActiveTimers, DiagnosticsSink? diagnostics)
     {
+        Engine = engine;
         _timeProvider = timeProvider;
         MaxActiveTimers = maxActiveTimers;
         Diagnostics = diagnostics;
     }
+
+    /// <summary>
+    /// The engine these timers belong to. Reached from <see cref="TimerEntry.Fire"/> alone, and only on the
+    /// path where a callback threw — the web-API state it leads to is where HTML's <i>report an exception</i>
+    /// finds a global <c>error</c> listener, if there is one.
+    /// </summary>
+    internal Engine Engine { get; }
 
     /// <summary>
     /// The most timers that may be registered at once, from <c>Options.WebApi.Timers.MaxActiveTimers</c>,
@@ -332,6 +340,11 @@ internal sealed class TimerEntry
         }
         catch (JavaScriptException exception) when (_queue.Diagnostics is { } diagnostics)
         {
+            // WebIDL's "report" behavior is HTML's report an exception, whose step 5 fires an `error` event at
+            // the global scope before step 6 reaches the console. A no-op unless the GlobalEvents feature is on
+            // and a script is listening; see WebApiEngineState.FireGlobalErrorEvent.
+            _queue.Engine._webApi?.FireGlobalErrorEvent(exception);
+
             // Only a JavaScriptException, which is exactly the class of failure a script could have caught
             // itself. Everything that exists to bound execution — ExecutionCanceledException,
             // TimeoutException, the statement, memory and recursion budgets — is a JintException but not a

--- a/Jint/WebApi/WebApiRegistration.cs
+++ b/Jint/WebApi/WebApiRegistration.cs
@@ -192,6 +192,29 @@ internal static class WebApiRegistration
             Install(global, engine, "AbortSignal", static e => e.Realm.Intrinsics.AbortSignal, PropertyFlag.NonEnumerable);
         }
 
+        if ((features & WebApiFeatures.GlobalEvents) != WebApiFeatures.None)
+        {
+            // WebIDL operations on the global: writable, enumerable and configurable —
+            // https://webidl.spec.whatwg.org/#es-operations. A browser's Window inherits these three from
+            // EventTarget.prototype instead, because its global implements EventTarget; ours does not, and
+            // GlobalEventTarget says why.
+            Install(global, engine, "addEventListener", static e => e.Realm.Intrinsics.GlobalEventFunctions.AddEventListener, PropertyFlag.ConfigurableEnumerableWritable);
+            Install(global, engine, "removeEventListener", static e => e.Realm.Intrinsics.GlobalEventFunctions.RemoveEventListener, PropertyFlag.ConfigurableEnumerableWritable);
+            Install(global, engine, "dispatchEvent", static e => e.Realm.Intrinsics.GlobalEventFunctions.DispatchEvent, PropertyFlag.ConfigurableEnumerableWritable);
+
+            // HTML exposes `self` through a [Replaceable] accessor pair on Window; an ordinary enumerable data
+            // property is the same simplification console, crypto and navigator are installed with. The
+            // PRINCIPAL realm's global object, deliberately: the property lives on that object, so answering
+            // with whichever realm happens to be current when it is first read could make `self === globalThis`
+            // false. https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-self
+            Install(global, engine, "self", static e => e._mainRealm.GlobalObject, PropertyFlag.ConfigurableEnumerableWritable);
+
+            // The two event interfaces the engine fires at that target. Ordinary WebIDL interface objects:
+            // writable and configurable but not enumerable — https://webidl.spec.whatwg.org/#es-interfaces.
+            Install(global, engine, "ErrorEvent", static e => e.Realm.Intrinsics.ErrorEvent, PropertyFlag.NonEnumerable);
+            Install(global, engine, "PromiseRejectionEvent", static e => e.Realm.Intrinsics.PromiseRejectionEvent, PropertyFlag.NonEnumerable);
+        }
+
         if ((features & WebApiFeatures.Crypto) != WebApiFeatures.None)
         {
             // WebIDL exposes crypto through a [Replaceable] accessor pair; an ordinary enumerable data
@@ -402,6 +425,14 @@ internal static class WebApiRegistration
             features |= WebApiFeatures.Events | WebApiFeatures.Url | WebApiFeatures.Files | WebApiFeatures.Streams;
         }
 
+        // The three global operations register listeners on an EventTarget and dispatch an Event, and the two
+        // interface objects the feature adds are Event subclasses — so without the events feature it would
+        // install operations with nothing to use them on.
+        if ((features & WebApiFeatures.GlobalEvents) != WebApiFeatures.None)
+        {
+            features |= WebApiFeatures.Events;
+        }
+
         // Deliberately not the other way round: fetch does not bring server-sent events and server-sent
         // events do not bring fetch. They are two separate grants of outbound network access.
         if ((features & WebApiFeatures.EventSource) != WebApiFeatures.None)
@@ -432,9 +463,12 @@ internal static class WebApiRegistration
     /// additionally read the time origin (Event.timeStamp, MessageEvent.timeStamp, performance.now), fetch
     /// keeps its settings and its in-flight set here, the scheduler keeps its own task queues here, and storage
     /// keeps its providers here, which is why each of them wants the state even without the timers flag.
+    /// The global events keep their synthetic listener target here. That flag is named explicitly rather than
+    /// left to the closure that already brings <see cref="WebApiFeatures.Events"/> with it, because the reason
+    /// it needs the state is its own — a target to fire at, not the time origin the events feature wants.
     /// </summary>
     private const WebApiFeatures NeedsEngineState =
-        WebApiFeatures.Timers | WebApiFeatures.Events | WebApiFeatures.Performance | WebApiFeatures.Fetch | WebApiFeatures.Scheduler | WebApiFeatures.Messaging | WebApiFeatures.Storage | WebApiFeatures.WebSocket | WebApiFeatures.CacheApi | WebApiFeatures.IdleCallback;
+        WebApiFeatures.Timers | WebApiFeatures.Events | WebApiFeatures.Performance | WebApiFeatures.Fetch | WebApiFeatures.Scheduler | WebApiFeatures.Messaging | WebApiFeatures.Storage | WebApiFeatures.WebSocket | WebApiFeatures.CacheApi | WebApiFeatures.IdleCallback | WebApiFeatures.GlobalEvents;
 
     /// <summary>
     /// The queue exists for the timer globals, for AbortSignal.timeout() and for a delayed
@@ -476,7 +510,7 @@ internal static class WebApiRegistration
         var timeProvider = timerOptions.TimeProvider ?? TimeProvider.System;
 
         var timers = (features & NeedsTimerQueue) != WebApiFeatures.None
-            ? new TimerQueue(timeProvider, timerOptions.MaxActiveTimers, diagnostics)
+            ? new TimerQueue(engine, timeProvider, timerOptions.MaxActiveTimers, diagnostics)
             : null;
 
         // The fetch settings are read here, once, so that nothing on a background thread ever reaches into
@@ -534,7 +568,7 @@ internal static class WebApiRegistration
 
         if ((added & NeedsTimerQueue) != WebApiFeatures.None && state.Timers is null)
         {
-            state.AttachTimers(new TimerQueue(state.TimeProvider, timerOptions.MaxActiveTimers, state.Diagnostics));
+            state.AttachTimers(new TimerQueue(engine, state.TimeProvider, timerOptions.MaxActiveTimers, state.Diagnostics));
         }
 
         if ((added & NeedsFetchOptions) != WebApiFeatures.None && state.FetchOptions is null)

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ its own `console` (or any other name in the table below), enabling the feature l
 | `requestIdleCallback` / `cancelIdleCallback` / `IdleDeadline` | `IdleCallback` | ✔ shipped |
 | `MessageChannel` / `MessagePort` / `MessageEvent` (incl. cross-engine ports) | `Messaging` | ✔ shipped |
 | `reportError` (and the `DiagnosticsSink` behind it) | `Reporting` | ✔ shipped |
+| `addEventListener` / `removeEventListener` / `dispatchEvent` / `self` on the global scope, with `ErrorEvent` / `PromiseRejectionEvent` and the `error` / `unhandledrejection` / `rejectionhandled` events | `GlobalEvents` | ✔ shipped |
 | `localStorage` / `sessionStorage` / `Storage` | `Storage` *(not in `Default` — see below)* | ✔ shipped |
 | `fetch` / `Headers` / `Request` / `Response` | `Fetch` — **opt-in on its own, see below** | ✔ shipped |
 | `EventSource` / `MessageEvent` (server-sent events) | `EventSource` — **opt-in on its own, see below** | ✔ shipped |
@@ -399,6 +400,9 @@ Install a sink and that is exactly what happens; without one, swallowing the exc
 entirely, so it propagates instead — the same contract a timer callback has. The dispatch state is unwound
 either way, so the event and the target stay usable.
 
+The global scope has its own listener list, behind `WebApiFeatures.GlobalEvents` — see [global `error`
+events](#and-script-can-watch-them-too-global-error-events) below.
+
 `AbortSignal.timeout(ms)` schedules on the same queue the timers use, so it aborts only while the engine is
 being pumped and it counts against `MaxActiveTimers`; that queue exists whenever the `Events` feature does,
 whether or not you also asked for `setTimeout`. `AbortSignal.any(signals)` builds a composite that is
@@ -510,6 +514,50 @@ A sink alone is enough; the `Reporting` feature flag only decides whether script
 built. It is called synchronously, on the engine's thread, and must be thread-safe if the same `Options` builds
 engines that run concurrently. The `JsValue`s on a report belong to the reporting engine: read them inside the
 call rather than stashing them.
+
+### …and script can watch them too: global `error` events
+
+`WebApiFeatures.GlobalEvents` gives the global scope `addEventListener`, `removeEventListener`,
+`dispatchEvent` and `self` (`=== globalThis`), plus the `ErrorEvent` and `PromiseRejectionEvent` interfaces,
+so a script written for a browser or a worker can watch its own failures:
+
+```js
+self.addEventListener('error', e => {
+    // e.message, e.filename, e.lineno, e.colno, e.error
+});
+self.addEventListener('unhandledrejection', e => { /* e.promise, e.reason */ });
+```
+
+`error` is fired for a `reportError(e)` call, for an exception that escaped a timer callback, and for one that
+escaped an event listener — HTML's [report an
+exception](https://html.spec.whatwg.org/multipage/webappapis.html#report-an-exception), whose step 5 this is.
+`unhandledrejection` and `rejectionhandled` are fired for the two operations of `HostPromiseRejectionTracker`.
+
+**The global object itself is not an `EventTarget`,** and this feature does not make it one — nothing about
+its prototype, its own properties or the inline caches over them changes. The listener list lives on a
+synthetic target the engine keeps beside its timers; the three operations are ordinary global functions bound
+to it, and `event.target`, `event.currentTarget` and a listener's `this` are the global object, which is what
+a browser reports. The one thing a script could notice is that they ignore their `this`, so
+`const f = addEventListener; f('error', h)` works where a browser raises *Illegal invocation*.
+
+Four rules are worth knowing before you rely on it:
+
+- **The events feed the `DiagnosticsSink`, they never replace it.** `preventDefault()` really does cancel the
+  event — that is HTML's *notHandled* going false — and the sink is told anyway. A script can observe an
+  uncaught failure; it cannot hide one from your log.
+- **Only a `JavaScriptException` is ever dispatched.** A timeout, a cancellation, the statement, memory and
+  recursion budgets keep erupting past both the event and the sink, exactly as they always have. An `error`
+  listener is not a way to swallow a constraint.
+- **A sink is still what turns a callback failure into a *report*.** Firing the event is a step of reporting,
+  so with no sink a throwing timer callback or event listener erupts as before and no listener sees it.
+  `reportError` is the exception, being itself a request to report: it fires the event with or without a sink.
+- **Rejection events arrive at the tracker's cadence, not HTML's microtask checkpoint** — the same documented
+  divergence `DiagnosticEvent.RejectionHandled` carries, so `Promise.reject(e).catch(f)` raises
+  `unhandledrejection` and then `rejectionhandled` where a browser would raise neither.
+
+An exception thrown *while* a report is being dispatched goes to the sink alone and starts no second dispatch,
+which is HTML's re-entrancy rule. And a `RestoreGlobalSnapshot` drops the listeners: they are closures over
+the cycle that just ended, over globals the restore has replaced.
 
 ### Idle callbacks: `requestIdleCallback`
 


### PR DESCRIPTION
Adds `WebApiFeatures.GlobalEvents` (part of `Default`): `addEventListener` / `removeEventListener` / `dispatchEvent` and `self` on the global scope, the `ErrorEvent` and `PromiseRejectionEvent` interfaces, and the `error` / `unhandledrejection` / `rejectionhandled` events HTML fires at the global scope — so a script written for a browser or a worker can watch its own failures.

Closes #3163.

**The global object itself is untouched.** The listener list lives on a synthetic target kept beside the engine's timers; the three operations are ordinary global functions bound to it, sharing `EventTarget`'s WebIDL argument conversions (lifted to a co-located static class rather than duplicated, down to the `TypeError` messages). A dispatch answers `event.target`, `event.currentTarget` and the listener's `this` with the global object — via one new internal virtual on `JsEventTarget` whose default is unchanged for every other target — so a listener sees what a browser reports, and `globalThis instanceof EventTarget` stays `false`.

The dispatch wiring follows HTML's *report an exception* at the four existing report sites (uncaught timer callbacks, uncaught event listeners, `reportError`, and the promise-rejection tracker), with the invariants stated and pinned:

- **The events feed the `DiagnosticsSink`, they never replace it** — `preventDefault()` really cancels the event (HTML's *notHandled*) and the sink is told anyway; script can observe an uncaught failure, never hide one.
- **Only a `JavaScriptException` is ever dispatched** — constraint failures keep erupting past both the event and the sink; the hooks live inside the existing exception filters.
- **A sink is still what turns a callback failure into a report**: with no sink a throwing timer callback or listener erupts as before and fires no event; `reportError` is the documented exception, being itself the request to report.
- **Rejection events arrive at the tracker's cadence**, inheriting the divergence `DiagnosticEvent.RejectionHandled` documents.
- **Reporting does not recurse** — an exception thrown while a report is dispatching goes to the sink alone (HTML's re-entrancy rule; without the guard, the mutation run demonstrated a process-killing CLR stack overflow).
- `ErrorEvent.message` and the `reportError` description are produced **without running script** (the exception's materialized message, or an in-box `Error`'s own `message` data descriptor, else `SafeToDisplayString`); `event.error` carries the value itself.
- `RestoreGlobalSnapshot` drops the listeners — closures over the ended cycle — and a default engine without the feature is byte-for-byte unchanged.

`ErrorEvent` and `PromiseRejectionEvent` follow the established event-subclass recipe (dictionary conversion order inherited-then-lexicographic and observable through getters; `PromiseRejectionEvent.length === 2` because `promise` is a required member; `Promise<any>` conversion per WebIDL). `self` answers the principal realm's global object deliberately, so `self === globalThis` cannot be broken by a first read from inside a `ShadowRealm`.

43 new tests (13 `ErrorEventTests`, 23 `GlobalErrorEventTests`, 7 host-facing `HostGlobalErrorEventTests` in `Jint.Tests.PublicInterface`), with seven load-bearing invariants mutation-verified — including the re-entrancy guard, whose removal kills the test process outright. Full matrix green: solution build all TFMs, both test projects on net10.0 + net472, and the host-contract-verification legs. README gains the feature row and a section stating the four rules above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014n5uCpi2vvHWBSiewUwBiY
