### PR TITLE
Web API: BroadcastChannel

### DIFF
--- a/Jint.Tests.PublicInterface/WebApiBroadcastChannelTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiBroadcastChannelTests.cs
@@ -1,0 +1,419 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.Threading;
+using Jint;
+using Jint.Native;
+using Jint.WebApi;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// <c>BroadcastChannel</c> seen from outside the assembly: what a host has to write to get it, and the one
+/// setting it has — <see cref="Options.MessagingOptions.Broker"/>, which decides which engines are in earshot
+/// of one another.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This project has no <c>InternalsVisibleTo</c>, so everything here is reachable by a third party.
+/// </para>
+/// <para>
+/// The cross-engine tests run every engine on the test's own thread and pump them with
+/// <c>Advanced.ProcessTasks()</c>, which is the shape a host with its own loop uses. That is deliberate: two
+/// threads would test the operating system's scheduler as much as the code, whereas pumping in turn tests
+/// exactly the contract — a message serialized on one engine's turn is deserialized and dispatched on the
+/// other engine's turn, and never in between.
+/// </para>
+/// </remarks>
+public class WebApiBroadcastChannelTests
+{
+    private static Engine BroadcastEngine() => new(options => options.UseWebApis(WebApiFeatures.Messaging));
+
+    private static Engine BroadcastEngine(BroadcastChannelBroker broker) =>
+        new(options =>
+        {
+            options.UseWebApis(WebApiFeatures.Messaging);
+            options.WebApi.Messaging.Broker = broker;
+        });
+
+    // ---------------------------------------------------------------- the opt-in
+
+    [Fact]
+    public void ADefaultEngineHasNoBroadcastChannel()
+    {
+        var engine = new Engine();
+
+        engine.Evaluate("typeof BroadcastChannel").AsString().Should().Be("undefined");
+        engine.Evaluate("'BroadcastChannel' in globalThis").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void TheMessagingFlagInstallsIt()
+    {
+        var engine = BroadcastEngine();
+
+        engine.Evaluate("typeof BroadcastChannel").AsString().Should().Be("function");
+        engine.Evaluate("new BroadcastChannel('x').name").AsString().Should().Be("x");
+    }
+
+    [Fact]
+    public void TheDefaultSetIncludesIt()
+    {
+        new Engine(options => options.UseWebApis()).Evaluate("typeof BroadcastChannel").AsString().Should().Be("function");
+    }
+
+    [Fact]
+    public void AHostRegisteredGlobalWins()
+    {
+        var marker = new JsString("host's own BroadcastChannel");
+
+        var engine = new Engine(options => options
+            .AddLazyGlobal("BroadcastChannel", _ => marker)
+            .UseWebApis(WebApiFeatures.Messaging));
+
+        engine.Evaluate("BroadcastChannel").Should().Be(marker);
+
+        // The names the host did not claim are still installed.
+        engine.Evaluate("typeof MessageChannel").AsString().Should().Be("function");
+    }
+
+    [Fact]
+    public void AShadowRealmHasNoBroadcastChannel()
+    {
+        BroadcastEngine().Evaluate("new ShadowRealm().evaluate('typeof BroadcastChannel')").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void EnablingMessagingOnALiveEngineBringsItToo()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Console));
+        engine.Evaluate("typeof BroadcastChannel").AsString().Should().Be("undefined");
+
+        engine.Advanced.EnableWebApis(WebApiFeatures.Messaging);
+
+        engine.Execute("""
+            var log = [];
+            var a = new BroadcastChannel('room');
+            var b = new BroadcastChannel('room');
+            b.onmessage = function (e) { log.push(e.data); };
+            a.postMessage('live');
+            """);
+
+        engine.Evaluate("log.join(',')").AsString().Should().Be("live");
+    }
+
+    [Fact]
+    public void ALiveEnableCanSupplyTheBroker()
+    {
+        var broker = new BroadcastChannelBroker();
+
+        var listener = BroadcastEngine(broker);
+        listener.Execute("var received = []; var c = new BroadcastChannel('room'); c.onmessage = function (e) { received.push(e.data); };");
+
+        var sender = new Engine(options => options.UseWebApis(WebApiFeatures.Console));
+        sender.Advanced.EnableWebApis(WebApiFeatures.Messaging, webApi => webApi.Messaging.Broker = broker);
+
+        sender.Execute("new BroadcastChannel('room').postMessage('from a live enable');");
+        listener.Advanced.ProcessTasks();
+
+        listener.Evaluate("received[0]").AsString().Should().Be("from a live enable");
+    }
+
+    [Fact]
+    public void ALiveEnableCanSupplyTheBrokerToAnEngineThatAlreadyHasWebApiState()
+    {
+        var broker = new BroadcastChannelBroker();
+
+        var listener = BroadcastEngine(broker);
+        listener.Execute("var received = []; var c = new BroadcastChannel('room'); c.onmessage = function (e) { received.push(e.data); };");
+
+        // Timers already gave this engine its web-API state, so enabling messaging has to attach the broker to
+        // the state that exists rather than create one — the other half of the live door.
+        var sender = new Engine(options => options.UseWebApis(WebApiFeatures.Timers));
+        sender.Advanced.EnableWebApis(WebApiFeatures.Messaging, webApi => webApi.Messaging.Broker = broker);
+
+        sender.Execute("new BroadcastChannel('room').postMessage('attached to a live state');");
+        listener.Advanced.ProcessTasks();
+
+        listener.Evaluate("received[0]").AsString().Should().Be("attached to a live state");
+    }
+
+    // ---------------------------------------------------------------- the broker
+
+    [Fact]
+    public void EachEngineGetsAPrivateBrokerWhenTheHostNamesNone()
+    {
+        var first = BroadcastEngine();
+        var second = BroadcastEngine();
+
+        second.Execute("var received = []; var c = new BroadcastChannel('room'); c.onmessage = function (e) { received.push(e.data); };");
+        first.Execute("new BroadcastChannel('room').postMessage('should not cross');");
+
+        second.Advanced.ProcessTasks();
+        ReceivedCount(second).Should().Be(0);
+    }
+
+    [Fact]
+    public void SharingOneBrokerIsWhatPutsTwoEnginesInEarshot()
+    {
+        var broker = new BroadcastChannelBroker();
+        var (sender, listener) = (BroadcastEngine(broker), BroadcastEngine(broker));
+
+        listener.Execute("var received = []; var c = new BroadcastChannel('room'); c.onmessage = function (e) { received.push(e.data); };");
+
+        sender.Execute("var c = new BroadcastChannel('room'); c.postMessage({ ask: 'ping', payload: [1, 2, 3] });");
+
+        // Nothing has been pumped on the listener yet, so nothing has arrived.
+        ReceivedCount(listener).Should().Be(0);
+
+        listener.Advanced.ProcessTasks();
+        listener.Evaluate("received.length").AsNumber().Should().Be(1);
+        listener.Evaluate("received[0].ask").AsString().Should().Be("ping");
+        listener.Evaluate("received[0].payload.join('-')").AsString().Should().Be("1-2-3");
+    }
+
+    [Fact]
+    public void AnEngineWithoutTheSharedBrokerIsIsolated()
+    {
+        var broker = new BroadcastChannelBroker();
+        var sender = BroadcastEngine(broker);
+        var inside = BroadcastEngine(broker);
+        var outside = BroadcastEngine();
+
+        const string Setup = "var received = []; var c = new BroadcastChannel('room'); c.onmessage = function (e) { received.push(e.data); };";
+        inside.Execute(Setup);
+        outside.Execute(Setup);
+
+        sender.Execute("new BroadcastChannel('room').postMessage('members only');");
+
+        inside.Advanced.ProcessTasks();
+        outside.Advanced.ProcessTasks();
+
+        inside.Evaluate("received[0]").AsString().Should().Be("members only");
+        ReceivedCount(outside).Should().Be(0);
+    }
+
+    [Fact]
+    public void OneBrokerReachesEveryEngineThatJoinedIt()
+    {
+        var broker = new BroadcastChannelBroker();
+        var sender = BroadcastEngine(broker);
+        var listeners = new[] { BroadcastEngine(broker), BroadcastEngine(broker), BroadcastEngine(broker) };
+
+        foreach (var listener in listeners)
+        {
+            listener.Execute("var received = []; var c = new BroadcastChannel('room'); c.onmessage = function (e) { received.push(e.data); };");
+        }
+
+        sender.Execute("new BroadcastChannel('room').postMessage('everyone');");
+
+        foreach (var listener in listeners)
+        {
+            listener.Advanced.ProcessTasks();
+            listener.Evaluate("received[0]").AsString().Should().Be("everyone");
+        }
+    }
+
+    [Fact]
+    public void OneOptionsInstanceSharedByTwoEnginesSharesItsBroker()
+    {
+        // The other spelling: not one broker assigned to two Options, but one Options used to build two
+        // engines — which is the shape a host pooling engines from a single configuration has.
+        var options = new Options();
+        options.UseWebApis(WebApiFeatures.Messaging);
+        options.WebApi.Messaging.Broker = new BroadcastChannelBroker();
+
+        var sender = new Engine(options);
+        var listener = new Engine(options);
+
+        listener.Execute("var received = []; var c = new BroadcastChannel('room'); c.onmessage = function (e) { received.push(e.data); };");
+        sender.Execute("new BroadcastChannel('room').postMessage('shared options');");
+
+        listener.Advanced.ProcessTasks();
+        listener.Evaluate("received[0]").AsString().Should().Be("shared options");
+    }
+
+    [Fact]
+    public void TwoEnginesSharingOptionsButNoBrokerStayPrivate()
+    {
+        // The default is deliberately per engine rather than one instance on the options object: two engines
+        // built from one shared Options must not see each other's channels unless the host said so.
+        var options = new Options();
+        options.UseWebApis(WebApiFeatures.Messaging);
+
+        var sender = new Engine(options);
+        var listener = new Engine(options);
+
+        listener.Execute("var received = []; var c = new BroadcastChannel('room'); c.onmessage = function (e) { received.push(e.data); };");
+        sender.Execute("new BroadcastChannel('room').postMessage('should not cross');");
+
+        listener.Advanced.ProcessTasks();
+        ReceivedCount(listener).Should().Be(0);
+    }
+
+    [Fact]
+    public void ACrossEngineMessageIsACloneNotASharedObject()
+    {
+        var broker = new BroadcastChannelBroker();
+        var sender = BroadcastEngine(broker);
+        var listener = BroadcastEngine(broker);
+
+        listener.Execute("var received = []; var c = new BroadcastChannel('room'); c.onmessage = function (e) { received.push(e.data); };");
+        sender.Execute("new BroadcastChannel('room').postMessage(new Map([['k', { n: 1 }]]));");
+        listener.Advanced.ProcessTasks();
+
+        // The receiving engine gets objects of its own realm, which is what makes sharing a JsValue across
+        // engines unnecessary — and it is the only reason this is safe at all.
+        listener.Evaluate("received[0] instanceof Map").AsBoolean().Should().BeTrue();
+        listener.Evaluate("received[0].get('k').n").AsNumber().Should().Be(1);
+        listener.Evaluate("Object.getPrototypeOf(received[0]) === Map.prototype").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void NothingIsDeliveredToAnEngineThatIsNeverPumped()
+    {
+        var broker = new BroadcastChannelBroker();
+        var sender = BroadcastEngine(broker);
+        var listener = BroadcastEngine(broker);
+
+        listener.Execute("var received = []; var c = new BroadcastChannel('room'); c.onmessage = function (e) { received.push(e.data); };");
+        sender.Execute("new BroadcastChannel('room').postMessage('never');");
+
+        // Jint starts no threads, so an engine nobody pumps runs nothing — the same contract the timers and
+        // the message ports have. Note that the observation has to be a non-pumping one: Evaluate drains the
+        // event loop when the script it ran has finished.
+        ReceivedCount(listener).Should().Be(0);
+        Thread.Sleep(50);
+        ReceivedCount(listener).Should().Be(0);
+
+        listener.Advanced.ProcessTasks();
+        listener.Evaluate("received[0]").AsString().Should().Be("never");
+    }
+
+    [Fact]
+    public void TwoEnginesInEarshotEachGetTheirOwnArrayBufferStorage()
+    {
+        var broker = new BroadcastChannelBroker();
+        var sender = BroadcastEngine(broker);
+        var first = BroadcastEngine(broker);
+        var second = BroadcastEngine(broker);
+
+        const string Setup = "var received = []; var c = new BroadcastChannel('room'); c.onmessage = function (e) { received.push(e.data); };";
+        first.Execute(Setup);
+        second.Execute(Setup);
+
+        sender.Execute("new BroadcastChannel('room').postMessage(new Uint8Array([1, 2, 3]));");
+
+        first.Advanced.ProcessTasks();
+        second.Advanced.ProcessTasks();
+
+        // One serialization record, two deserializations, and each has to own its bytes — otherwise a write on
+        // one engine's thread would be visible on another's, which is the one thing a message is never allowed
+        // to be.
+        first.Execute("received[0][0] = 99;");
+        second.Evaluate("received[0][0]").AsNumber().Should().Be(1);
+        first.Evaluate("received[0][0]").AsNumber().Should().Be(99);
+    }
+
+    // ---------------------------------------------------------------- the evaluation cycle
+
+    [Fact]
+    public void AMessageInFlightWhenTheReceiverRestoresIsDropped()
+    {
+        var broker = new BroadcastChannelBroker();
+        var sender = BroadcastEngine(broker);
+        var listener = BroadcastEngine(broker);
+
+        listener.Execute("var received = []; var c = new BroadcastChannel('room'); c.onmessage = function (e) { received.push(e.data); };");
+        var snapshot = listener.Advanced.CaptureGlobalSnapshot();
+
+        // Posted while the listener is in the cycle the channel belongs to, but not yet pumped.
+        sender.Execute("new BroadcastChannel('room').postMessage('from the previous cycle');");
+
+        listener.Advanced.RestoreGlobalSnapshot(snapshot);
+        listener.Advanced.ProcessTasks();
+
+        // A channel's listeners are closures over the cycle it was created in, so running them against the
+        // restored globals is exactly the cross-cycle channel a restore forbids. `received` is part of the
+        // snapshot, so it is back — and still empty.
+        listener.Evaluate("received.length").AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void AMessagePostedAfterTheReceiverRestoresIsDropped()
+    {
+        var broker = new BroadcastChannelBroker();
+        var sender = BroadcastEngine(broker);
+        var listener = BroadcastEngine(broker);
+
+        listener.Execute("var received = []; var c = new BroadcastChannel('room'); c.onmessage = function (e) { received.push(e.data); };");
+        var snapshot = listener.Advanced.CaptureGlobalSnapshot();
+
+        listener.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        // The channel itself is what belonged to the ended cycle, so it does not matter that this message was
+        // posted afterwards: it is no longer a subscriber and it is closed.
+        sender.Execute("new BroadcastChannel('room').postMessage('too late');");
+        listener.Advanced.ProcessTasks();
+
+        // A fresh channel is what a pooled engine wants, and it works immediately.
+        listener.Execute("var received = []; var fresh = new BroadcastChannel('room'); fresh.onmessage = function (e) { received.push(e.data); };");
+        sender.Execute("new BroadcastChannel('room').postMessage('next cycle');");
+        listener.Advanced.ProcessTasks();
+
+        listener.Evaluate("received.join(',')").AsString().Should().Be("next cycle");
+    }
+
+    [Fact]
+    public void ARestoreOnTheSenderDoesNotStopTheReceiver()
+    {
+        var broker = new BroadcastChannelBroker();
+        var sender = BroadcastEngine(broker);
+        var listener = BroadcastEngine(broker);
+
+        listener.Execute("var received = []; var c = new BroadcastChannel('room'); c.onmessage = function (e) { received.push(e.data); };");
+        var snapshot = sender.Advanced.CaptureGlobalSnapshot();
+
+        sender.Execute("new BroadcastChannel('room').postMessage('sent then restored');");
+        sender.Advanced.RestoreGlobalSnapshot(snapshot);
+        listener.Advanced.ProcessTasks();
+
+        // The message was serialized when it was posted and carries nothing of the sender's, so the sender's
+        // cycle ending afterwards has no bearing on it.
+        listener.Evaluate("received[0]").AsString().Should().Be("sent then restored");
+    }
+
+    [Fact]
+    public void DisposingAnEngineTakesItsChannelsOutOfASharedBroker()
+    {
+        var broker = new BroadcastChannelBroker();
+        var sender = BroadcastEngine(broker);
+        var listener = BroadcastEngine(broker);
+        var leaving = BroadcastEngine(broker);
+
+        const string Setup = "var received = []; var c = new BroadcastChannel('room'); c.onmessage = function (e) { received.push(e.data); };";
+        listener.Execute(Setup);
+        leaving.Execute(Setup);
+
+        leaving.Dispose();
+
+        sender.Execute("new BroadcastChannel('room').postMessage('after the dispose');");
+
+        // The engine that is still here is unaffected; the one that left is not asked for a job at all, which
+        // is what keeps a long-lived broker from retaining every engine that ever joined it.
+        listener.Advanced.ProcessTasks();
+        listener.Evaluate("received[0]").AsString().Should().Be("after the dispose");
+
+        leaving.Advanced.ProcessTasks();
+        ReceivedCount(leaving).Should().Be(0);
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    /// <summary>
+    /// How many messages an engine has taken delivery of, read <b>without</b> pumping it — which
+    /// <c>Evaluate</c> would do, since a drain is what it ends with.
+    /// </summary>
+    private static int ReceivedCount(Engine engine) => (int) engine.GetValue("received").Get("length").AsNumber();
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/BroadcastChannelTests.cs
+++ b/Jint.Tests/Runtime/WebApi/BroadcastChannelTests.cs
@@ -1,0 +1,718 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Native;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// <c>BroadcastChannel</c> against the HTML Standard's
+/// https://html.spec.whatwg.org/multipage/web-messaging.html#broadcasting-to-other-browsing-contexts.
+/// </summary>
+/// <remarks>
+/// Everything here is one engine talking to itself: a default engine gets a private
+/// <c>BroadcastChannelBroker</c>, so channels it creates hear each other and nothing leaves the engine. The
+/// cross-engine form — one broker shared through <c>Options.WebApi.Messaging.Broker</c> — is exercised from a
+/// third party's side in <c>Jint.Tests.PublicInterface.WebApiBroadcastChannelTests</c>.
+/// <para>
+/// The other half of every assertion is <i>when</i> delivery happens: each destination gets a task of its own,
+/// and <c>Engine.Execute</c> drains the loop once the script has finished — which is why a message posted by a
+/// script has already been delivered when <c>Execute</c> returns, and is not yet delivered on the line after
+/// the <c>postMessage</c> call.
+/// </para>
+/// </remarks>
+public class BroadcastChannelTests
+{
+    private static Engine BroadcastEngine(WebApiFeatures features = WebApiFeatures.Default)
+    {
+        var engine = new Engine(options => options.UseWebApis(features));
+
+        engine.Execute("var log = [];");
+        engine.Execute("function err(f) { try { f(); return 'no error'; } catch (e) { return e.name; } }");
+        return engine;
+    }
+
+    private static string Log(Engine engine) => engine.Evaluate("log.join(',')").AsString();
+
+    private static string Err(Engine engine, string body) => engine.Evaluate("err(function() { " + body + " })").AsString();
+
+    // ---------------------------------------------------------------- installation
+
+    [Fact]
+    public void IsAbsentUntilTheFeatureIsEnabled()
+    {
+        new Engine().Evaluate("typeof BroadcastChannel").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void RidesTheMessagingFeatureRatherThanOneOfItsOwn()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Messaging));
+
+        engine.Evaluate("typeof BroadcastChannel").AsString().Should().Be("function");
+
+        // ... and the Events globals really are absent, so this is not accidentally testing Default.
+        engine.Evaluate("typeof EventTarget").AsString().Should().Be("undefined");
+
+        // A channel still has the EventTarget operations, because the prototype chain does not need the global.
+        engine.Execute("var c = new BroadcastChannel('x'); c.addEventListener('message', function () {});");
+    }
+
+    [Fact]
+    public void IsPartOfTheDefaultFeatureSet()
+    {
+        new Engine(options => options.UseWebApis()).Evaluate("typeof BroadcastChannel").AsString().Should().Be("function");
+    }
+
+    [Fact]
+    public void GivesTheGlobalTheAttributesWebIdlAsksFor()
+    {
+        var engine = BroadcastEngine();
+
+        // An interface object is writable and configurable but not enumerable —
+        // https://webidl.spec.whatwg.org/#es-interfaces.
+        var descriptor = engine.Realm.GlobalObject.GetOwnProperty("BroadcastChannel");
+        descriptor.Should().NotBe(PropertyDescriptor.Undefined);
+        descriptor.Writable.Should().BeTrue();
+        descriptor.Configurable.Should().BeTrue();
+        descriptor.Enumerable.Should().BeFalse();
+    }
+
+    [Fact]
+    public void InheritsFromEventTarget()
+    {
+        var engine = BroadcastEngine();
+
+        engine.Evaluate("Object.getPrototypeOf(BroadcastChannel) === EventTarget").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.getPrototypeOf(BroadcastChannel.prototype) === EventTarget.prototype").AsBoolean().Should().BeTrue();
+        engine.Evaluate("new BroadcastChannel('x') instanceof EventTarget").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.prototype.toString.call(new BroadcastChannel('x'))").AsString().Should().Be("[object BroadcastChannel]");
+    }
+
+    [Fact]
+    public void HasTheInterfaceShapeTheIdlDeclares()
+    {
+        var engine = BroadcastEngine();
+
+        engine.Evaluate("BroadcastChannel.length").AsNumber().Should().Be(1);
+        engine.Evaluate("BroadcastChannel.name").AsString().Should().Be("BroadcastChannel");
+        engine.Evaluate("BroadcastChannel.prototype.postMessage.length").AsNumber().Should().Be(1);
+        engine.Evaluate("BroadcastChannel.prototype.close.length").AsNumber().Should().Be(0);
+
+        // `name` is a readonly attribute: an accessor with a getter and no setter.
+        engine.Evaluate("typeof Object.getOwnPropertyDescriptor(BroadcastChannel.prototype, 'name').get").AsString().Should().Be("function");
+        engine.Evaluate("Object.getOwnPropertyDescriptor(BroadcastChannel.prototype, 'name').set === undefined").AsBoolean().Should().BeTrue();
+
+        // The two event handlers are accessor pairs.
+        engine.Evaluate("typeof Object.getOwnPropertyDescriptor(BroadcastChannel.prototype, 'onmessage').set").AsString().Should().Be("function");
+        engine.Evaluate("typeof Object.getOwnPropertyDescriptor(BroadcastChannel.prototype, 'onmessageerror').set").AsString().Should().Be("function");
+    }
+
+    // ---------------------------------------------------------------- the constructor
+
+    [Fact]
+    public void RequiresAName()
+    {
+        var engine = BroadcastEngine();
+
+        Err(engine, "new BroadcastChannel();").Should().Be("TypeError");
+
+        // A present argument is converted, so `undefined` is a channel called "undefined" and 42 is one
+        // called "42" — which is what a DOMString parameter with no default means.
+        engine.Evaluate("new BroadcastChannel(undefined).name").AsString().Should().Be("undefined");
+        engine.Evaluate("new BroadcastChannel(42).name").AsString().Should().Be("42");
+        engine.Evaluate("new BroadcastChannel('').name").AsString().Should().Be("");
+    }
+
+    [Fact]
+    public void RefusesToBeCalledWithoutNew()
+    {
+        var engine = BroadcastEngine();
+
+        Err(engine, "BroadcastChannel('x');").Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void EveryOperationIsBranded()
+    {
+        var engine = BroadcastEngine();
+
+        Err(engine, "BroadcastChannel.prototype.postMessage.call({}, 1);").Should().Be("TypeError");
+        Err(engine, "BroadcastChannel.prototype.close.call({});").Should().Be("TypeError");
+        Err(engine, "Object.getOwnPropertyDescriptor(BroadcastChannel.prototype, 'name').get.call({});").Should().Be("TypeError");
+        Err(engine, "Object.getOwnPropertyDescriptor(BroadcastChannel.prototype, 'onmessage').get.call({});").Should().Be("TypeError");
+    }
+
+    // ---------------------------------------------------------------- delivery
+
+    [Fact]
+    public void ReachesEveryOtherChannelOfThatNameAndNotTheSender()
+    {
+        var engine = BroadcastEngine();
+
+        engine.Execute("""
+            var a = new BroadcastChannel('room');
+            var b = new BroadcastChannel('room');
+            a.onmessage = function (e) { log.push('a:' + e.data); };
+            b.onmessage = function (e) { log.push('b:' + e.data); };
+            a.postMessage('hello');
+            """);
+
+        // Step 6: "Remove source from destinations." A channel never hears itself.
+        Log(engine).Should().Be("b:hello");
+    }
+
+    [Fact]
+    public void ReachesTheDestinationsInCreationOrder()
+    {
+        var engine = BroadcastEngine();
+
+        engine.Execute("""
+            var first = new BroadcastChannel('room');
+            var second = new BroadcastChannel('room');
+            var third = new BroadcastChannel('room');
+            var sender = new BroadcastChannel('room');
+            third.onmessage = function () { log.push('third'); };
+            first.onmessage = function () { log.push('first'); };
+            second.onmessage = function () { log.push('second'); };
+            sender.postMessage(1);
+            """);
+
+        // Step 7 sorts the destinations, and within one agent cluster that reduces to creation order — which
+        // is deliberately not the order the listeners happened to be attached in.
+        Log(engine).Should().Be("first,second,third");
+    }
+
+    [Fact]
+    public void ADifferentNameHearsNothing()
+    {
+        var engine = BroadcastEngine();
+
+        engine.Execute("""
+            var a = new BroadcastChannel('room');
+            var b = new BroadcastChannel('room');
+            var other = new BroadcastChannel('other room');
+            b.onmessage = function (e) { log.push('b'); };
+            other.onmessage = function (e) { log.push('other'); };
+            a.postMessage(1);
+            """);
+
+        Log(engine).Should().Be("b");
+    }
+
+    [Fact]
+    public void TheNameIsComparedAsAnExactString()
+    {
+        var engine = BroadcastEngine();
+
+        engine.Execute("""
+            var a = new BroadcastChannel('Room');
+            var b = new BroadcastChannel('room');
+            b.onmessage = function () { log.push('b'); };
+            a.postMessage(1);
+            """);
+
+        Log(engine).Should().Be("");
+    }
+
+    [Fact]
+    public void DeliveryIsATaskAndNotASynchronousCall()
+    {
+        var engine = BroadcastEngine();
+
+        engine.Execute("""
+            var a = new BroadcastChannel('room');
+            var b = new BroadcastChannel('room');
+            b.onmessage = function (e) { log.push(e.data); };
+            a.postMessage('later');
+            log.push('synchronously: ' + log.length);
+            """);
+
+        // The specification queues a global task per destination, so nothing has been dispatched by the time
+        // the next statement runs; the drain at the end of Execute is what delivers it.
+        Log(engine).Should().Be("synchronously: 0,later");
+    }
+
+    [Fact]
+    public void EveryAlreadyQueuedJobRunsBeforeTheMessage()
+    {
+        var engine = BroadcastEngine();
+
+        engine.Execute("""
+            var a = new BroadcastChannel('room');
+            var b = new BroadcastChannel('room');
+            b.onmessage = function () { log.push('message'); };
+            Promise.resolve().then(function () { log.push('microtask'); });
+            a.postMessage(1);
+            Promise.resolve().then(function () { log.push('afterwards'); });
+            """);
+
+        // Step 8 queues one task per destination, and Jint's event loop is a single queue — so a broadcast
+        // takes its place in it when it is posted, exactly as an EventSource's or a WebSocket's message does.
+        // That is deliberately a hop earlier than a MessagePort, whose delivery costs two jobs because its
+        // port message queue can be disabled; the difference is visible only to a job queued between the post
+        // and the delivery, as the third line here is.
+        Log(engine).Should().Be("microtask,message,afterwards");
+    }
+
+    [Fact]
+    public void AddEventListenerAloneIsEnoughToReceive()
+    {
+        var engine = BroadcastEngine();
+
+        engine.Execute("""
+            var a = new BroadcastChannel('room');
+            var b = new BroadcastChannel('room');
+            b.addEventListener('message', function (e) { log.push(e.data); });
+            a.postMessage('heard');
+            """);
+
+        // Unlike a MessagePort there is no port message queue to enable, so there is no start() and nothing
+        // waits for onmessage to be assigned.
+        Log(engine).Should().Be("heard");
+    }
+
+    [Fact]
+    public void TheEventIsATrustedMessageEvent()
+    {
+        var engine = BroadcastEngine();
+
+        engine.Execute("""
+            var a = new BroadcastChannel('room');
+            var b = new BroadcastChannel('room');
+            b.onmessage = function (e) {
+                log.push(e instanceof MessageEvent);
+                log.push(e.type);
+                log.push(e.isTrusted);
+                log.push(e.origin === '');
+                log.push(e.lastEventId === '');
+                log.push(e.source === null);
+                log.push(e.ports.length === 0);
+                log.push(e.target === b);
+            };
+            a.postMessage(1);
+            """);
+
+        Log(engine).Should().Be("true,message,true,true,true,true,true,true");
+    }
+
+    [Fact]
+    public void ManyMessagesArriveInThePostedOrder()
+    {
+        var engine = BroadcastEngine();
+
+        engine.Execute("""
+            var a = new BroadcastChannel('room');
+            var b = new BroadcastChannel('room');
+            b.onmessage = function (e) { log.push(e.data); };
+            for (var i = 0; i < 4; i++) { a.postMessage(i); }
+            """);
+
+        Log(engine).Should().Be("0,1,2,3");
+    }
+
+    // ---------------------------------------------------------------- the event handler attributes
+
+    [Fact]
+    public void OnMessageIsAnOrdinaryEventHandlerAttribute()
+    {
+        var engine = BroadcastEngine();
+
+        engine.Execute("""
+            var c = new BroadcastChannel('room');
+            log.push(c.onmessage === null);
+            var f = function () {};
+            c.onmessage = f;
+            log.push(c.onmessage === f);
+            c.onmessage = 'not an object';
+            log.push(c.onmessage === null);
+            """);
+
+        Log(engine).Should().Be("true,true,true");
+    }
+
+    [Fact]
+    public void OnMessageTakesItsTurnAmongTheOtherListeners()
+    {
+        var engine = BroadcastEngine();
+
+        engine.Execute("""
+            var a = new BroadcastChannel('room');
+            var b = new BroadcastChannel('room');
+            b.addEventListener('message', function () { log.push('first'); });
+            b.onmessage = function () { log.push('handler'); };
+            b.addEventListener('message', function () { log.push('last'); });
+            a.postMessage(1);
+            """);
+
+        Log(engine).Should().Be("first,handler,last");
+    }
+
+    [Fact]
+    public void OnMessageErrorExistsAndNeverFires()
+    {
+        var engine = BroadcastEngine();
+
+        engine.Execute("""
+            var a = new BroadcastChannel('room');
+            var b = new BroadcastChannel('room');
+            log.push(b.onmessageerror === null);
+            b.onmessageerror = function () { log.push('messageerror'); };
+            b.onmessage = function () { log.push('message'); };
+            a.postMessage(new Map([['k', 1]]));
+            """);
+
+        // The only thing that fires one is a deserialization that fails, and a record this engine's own
+        // serializer built always deserializes.
+        Log(engine).Should().Be("true,message");
+    }
+
+    // ---------------------------------------------------------------- close
+
+    [Fact]
+    public void PostingOnAClosedChannelThrowsInvalidStateError()
+    {
+        var engine = BroadcastEngine();
+
+        engine.Execute("var c = new BroadcastChannel('room'); c.close();");
+
+        // Step 1, and deliberately not the MessagePort behaviour: a closed port's postMessage merely goes
+        // nowhere, a closed BroadcastChannel refuses.
+        Err(engine, "c.postMessage(1);").Should().Be("InvalidStateError");
+
+        // The error is a DOMException, which is how every web API reports a refusal to script.
+        engine.Evaluate("(function () { try { c.postMessage(1); } catch (e) { return e instanceof DOMException; } })()")
+            .AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void TheClosedCheckHappensBeforeTheMessageIsSerialized()
+    {
+        var engine = BroadcastEngine();
+
+        engine.Execute("var c = new BroadcastChannel('room'); c.close();");
+
+        // Step 1 precedes step 2, and the order is observable: an uncloneable value on a closed channel is
+        // still an InvalidStateError rather than a DataCloneError.
+        Err(engine, "c.postMessage(function () {});").Should().Be("InvalidStateError");
+    }
+
+    [Fact]
+    public void AClosedChannelReceivesNothing()
+    {
+        var engine = BroadcastEngine();
+
+        engine.Execute("""
+            var a = new BroadcastChannel('room');
+            var b = new BroadcastChannel('room');
+            b.onmessage = function (e) { log.push(e.data); };
+            b.close();
+            a.postMessage('lost');
+            """);
+
+        Log(engine).Should().Be("");
+    }
+
+    [Fact]
+    public void ClosingIsIdempotent()
+    {
+        var engine = BroadcastEngine();
+
+        engine.Execute("var c = new BroadcastChannel('room'); c.close(); c.close(); c.close();");
+
+        // The name survives closing — the attribute is not "the name while open".
+        engine.Evaluate("c.name").AsString().Should().Be("room");
+    }
+
+    [Fact]
+    public void ClosingDuringADispatchStopsTheDestinationsBehindIt()
+    {
+        var engine = BroadcastEngine();
+
+        engine.Execute("""
+            var first = new BroadcastChannel('room');
+            var second = new BroadcastChannel('room');
+            var sender = new BroadcastChannel('room');
+            first.onmessage = function () { log.push('first'); second.close(); };
+            second.onmessage = function () { log.push('second'); };
+            sender.postMessage(1);
+            """);
+
+        // Both tasks were queued when the message was posted, so what stops the second one is step 8.1 —
+        // "if destination's closed flag is true, then abort these steps" — checked when the task runs.
+        Log(engine).Should().Be("first");
+    }
+
+    [Fact]
+    public void AChannelClosedAfterAPostStillDoesNotHearIt()
+    {
+        var engine = BroadcastEngine();
+
+        engine.Execute("""
+            var a = new BroadcastChannel('room');
+            var b = new BroadcastChannel('room');
+            b.onmessage = function (e) { log.push(e.data); };
+            a.postMessage('in flight');
+            b.close();
+            """);
+
+        Log(engine).Should().Be("");
+    }
+
+    // ---------------------------------------------------------------- structured clone
+
+    [Fact]
+    public void AnUncloneableValueIsASynchronousDataCloneError()
+    {
+        var engine = BroadcastEngine();
+
+        engine.Execute("var a = new BroadcastChannel('room'); var b = new BroadcastChannel('room');");
+        engine.Execute("b.onmessage = function () { log.push('delivered'); };");
+
+        // Step 2 runs on the caller, before any destination is looked at, so the error reaches the script that
+        // called postMessage — and nothing is delivered.
+        Err(engine, "a.postMessage(function () {});").Should().Be("DataCloneError");
+        Log(engine).Should().Be("");
+    }
+
+    [Fact]
+    public void ItSerializesEvenWhenNobodyIsListening()
+    {
+        var engine = BroadcastEngine();
+
+        engine.Execute("var lonely = new BroadcastChannel('nobody else');");
+
+        // Step 2 precedes the collection of destinations, so a DataCloneError does not depend on there being
+        // anyone to deliver to.
+        Err(engine, "lonely.postMessage(Symbol('x'));").Should().Be("DataCloneError");
+    }
+
+    [Fact]
+    public void TheMessageIsAStructuredCloneTakenAtThePost()
+    {
+        var engine = BroadcastEngine();
+
+        engine.Execute("""
+            var a = new BroadcastChannel('room');
+            var b = new BroadcastChannel('room');
+            b.onmessage = function (e) {
+                log.push(e.data.when instanceof Date);
+                log.push(e.data.when.getTime() === 86400000);
+                log.push(e.data.map instanceof Map);
+                log.push(e.data.map.get('k'));
+                log.push(e.data.mutated === undefined);
+                log.push(e.data !== sent);
+            };
+            var sent = { when: new Date(86400000), map: new Map([['k', 'v']]) };
+            a.postMessage(sent);
+            sent.mutated = true;
+            """);
+
+        Log(engine).Should().Be("true,true,true,v,true,true");
+    }
+
+    [Fact]
+    public void ThereIsNoTransferListAndNothingIsDetached()
+    {
+        var engine = BroadcastEngine();
+
+        engine.Execute("""
+            var a = new BroadcastChannel('room');
+            var b = new BroadcastChannel('room');
+            b.onmessage = function (e) { log.push(new Uint8Array(e.data)[0]); };
+            var buffer = new ArrayBuffer(2);
+            new Uint8Array(buffer)[0] = 7;
+            a.postMessage(buffer, [buffer]);
+            log.push('sender byteLength: ' + buffer.byteLength);
+            """);
+
+        // postMessage takes one argument; a second one is ignored rather than treated as a transfer list, so
+        // the sender's buffer is untouched — which is the only answer available when a message has many
+        // destinations.
+        Log(engine).Should().Be("sender byteLength: 2,7");
+    }
+
+    [Fact]
+    public void EachDestinationGetsItsOwnCopyOfTheMessage()
+    {
+        var engine = BroadcastEngine();
+
+        engine.Execute("""
+            var sender = new BroadcastChannel('room');
+            var first = new BroadcastChannel('room');
+            var second = new BroadcastChannel('room');
+            var received = [];
+            first.onmessage = function (e) { received.push(e.data); };
+            second.onmessage = function (e) { received.push(e.data); };
+            sender.postMessage({ n: 1 });
+            """);
+
+        engine.Evaluate("received.length").AsNumber().Should().Be(2);
+        engine.Evaluate("received[0] !== received[1]").AsBoolean().Should().BeTrue();
+
+        engine.Execute("received[0].n = 99;");
+        engine.Evaluate("received[1].n").AsNumber().Should().Be(1);
+    }
+
+    [Fact]
+    public void TwoDestinationsDoNotShareOneArrayBuffersStorage()
+    {
+        var engine = BroadcastEngine();
+
+        engine.Execute("""
+            var sender = new BroadcastChannel('room');
+            var first = new BroadcastChannel('room');
+            var second = new BroadcastChannel('room');
+            var received = [];
+            first.onmessage = function (e) { received.push(e.data); };
+            second.onmessage = function (e) { received.push(e.data); };
+            sender.postMessage(new Uint8Array([1, 2, 3]));
+            """);
+
+        // One record, two deserializations: the storage a deserializer would ordinarily adopt has to be
+        // copied here, or a write through one receiver's view would be visible through the other's.
+        engine.Evaluate("received.length").AsNumber().Should().Be(2);
+        engine.Evaluate("received[0].buffer !== received[1].buffer").AsBoolean().Should().BeTrue();
+
+        engine.Execute("received[0][0] = 99;");
+        engine.Evaluate("received[1][0]").AsNumber().Should().Be(1);
+        engine.Evaluate("received[0][0]").AsNumber().Should().Be(99);
+    }
+
+    [Fact]
+    public void ACyclicGraphSurvivesTheRoundTrip()
+    {
+        var engine = BroadcastEngine();
+
+        engine.Execute("""
+            var a = new BroadcastChannel('room');
+            var b = new BroadcastChannel('room');
+            b.onmessage = function (e) {
+                log.push(e.data.self === e.data);
+                log.push(e.data.n);
+            };
+            var cyclic = { n: 5 };
+            cyclic.self = cyclic;
+            a.postMessage(cyclic);
+            """);
+
+        Log(engine).Should().Be("true,5");
+    }
+
+    // ---------------------------------------------------------------- the evaluation cycle
+
+    [Fact]
+    public void ARestoreEndsEveryChannelTheEngineCreated()
+    {
+        var engine = BroadcastEngine();
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+
+        engine.Execute("""
+            var sender = new BroadcastChannel('room');
+            var receiver = new BroadcastChannel('room');
+            receiver.onmessage = function () { log.push('heard'); };
+            """);
+
+        var receiver = engine.GetValue("receiver");
+        var sender = engine.GetValue("sender");
+
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        // The channel objects still exist — the host kept references — but the restore ended them, exactly as
+        // it ends a MessagePort: their listeners are closures over the cycle that has gone.
+        engine.SetValue("oldSender", sender);
+        engine.SetValue("oldReceiver", receiver);
+        engine.Execute("var log = []; function err(f) { try { f(); return 'no error'; } catch (e) { return e.name; } }");
+
+        Err(engine, "oldSender.postMessage('too late');").Should().Be("InvalidStateError");
+        Log(engine).Should().Be("");
+
+        // ... and a fresh pair in the new cycle works immediately, which is what a pooled engine wants.
+        engine.Execute("""
+            var a = new BroadcastChannel('room');
+            var b = new BroadcastChannel('room');
+            b.onmessage = function (e) { log.push(e.data); };
+            a.postMessage('next cycle');
+            """);
+
+        Log(engine).Should().Be("next cycle");
+    }
+
+    [Fact]
+    public void AChannelFromAnEndedCycleIsGoneFromTheBroker()
+    {
+        var engine = BroadcastEngine();
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+
+        engine.Execute("var stale = new BroadcastChannel('room'); stale.onmessage = function () { log.push('stale'); };");
+        var stale = engine.GetValue("stale");
+
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+        engine.SetValue("stale", stale);
+
+        // Exactly one delivery: the surviving object is no longer a subscriber, so a message posted in the new
+        // cycle reaches only the channel created in it.
+        engine.Execute("""
+            var log = [];
+            var sender = new BroadcastChannel('room');
+            var fresh = new BroadcastChannel('room');
+            fresh.onmessage = function () { log.push('fresh'); };
+            sender.postMessage(1);
+            """);
+
+        Log(engine).Should().Be("fresh");
+    }
+
+    // ---------------------------------------------------------------- the broker keeps nothing it need not
+
+    [Fact]
+    public void AClosedChannelLeavesTheBrokerAndAnEmptyNameGoesWithIt()
+    {
+        var broker = new BroadcastChannelBroker();
+        var engine = new Engine(options =>
+        {
+            options.UseWebApis(WebApiFeatures.Messaging);
+            options.WebApi.Messaging.Broker = broker;
+        });
+
+        broker.ActiveNameCount.Should().Be(0);
+
+        engine.Execute("var a = new BroadcastChannel('room'); var b = new BroadcastChannel('room'); var c = new BroadcastChannel('other');");
+        broker.ActiveNameCount.Should().Be(2);
+
+        engine.Execute("a.close();");
+        broker.ActiveNameCount.Should().Be(2);
+
+        // The last subscriber of a name takes the name with it — otherwise a script cycling through channel
+        // names would grow the broker for as long as the process lives.
+        engine.Execute("b.close();");
+        broker.ActiveNameCount.Should().Be(1);
+
+        engine.Execute("c.close();");
+        broker.ActiveNameCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void ARestoreTakesEveryNameWithIt()
+    {
+        var broker = new BroadcastChannelBroker();
+        var engine = new Engine(options =>
+        {
+            options.UseWebApis(WebApiFeatures.Messaging);
+            options.WebApi.Messaging.Broker = broker;
+        });
+
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+        engine.Execute("var a = new BroadcastChannel('room'); var b = new BroadcastChannel('other');");
+        broker.ActiveNameCount.Should().Be(2);
+
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        // A broker the host shares outlives the engine, so a restore that merely stopped delivering would
+        // leave this engine reachable from it for good.
+        broker.ActiveNameCount.Should().Be(0);
+    }
+}
+#endif

--- a/Jint/Engine.WebApi.cs
+++ b/Jint/Engine.WebApi.cs
@@ -7,6 +7,7 @@ using Jint.WebApi.Abort;
 using Jint.WebApi.Fetch;
 using Jint.WebApi.GlobalEvents;
 using Jint.WebApi.Idle;
+using Jint.WebApi.Messaging;
 using Jint.WebApi;
 using Jint.WebApi.Scheduling;
 using Jint.WebApi.ServerSentEvents;
@@ -180,7 +181,22 @@ internal sealed class WebApiEngineState
     /// </summary>
     private GlobalEventTarget? _globalEventTarget;
 
-    internal WebApiEngineState(Engine engine, TimeProvider timeProvider, TimerQueue? timers, Options.FetchOptions? fetchOptions, SchedulerQueue? scheduler, DiagnosticsSink? diagnostics, Options.StorageOptions? storage = null, CacheStorageProvider? cacheProvider = null, IdleCallbackQueue? idleCallbacks = null)
+    /// <summary>
+    /// The <c>BroadcastChannel</c> objects this engine has open, in creation order. Engine-thread-only for the
+    /// same reason the fetch list is: a channel is added by its own constructor and removed by <c>close()</c>,
+    /// both of which run on the engine's thread. It exists so a restore can end every channel this engine
+    /// created — the broker itself is shareable and has no idea which engine anything came from.
+    /// </summary>
+    private List<JsBroadcastChannel>? _broadcastChannels;
+
+    /// <summary>
+    /// Where this engine's <c>BroadcastChannel</c> objects find each other, or <see langword="null"/> until one
+    /// is needed. Seeded from <c>Options.WebApi.Messaging.Broker</c> when the engine was built, and defaulted
+    /// per engine on first use — see <see cref="BroadcastChannels"/>.
+    /// </summary>
+    private BroadcastChannelBroker? _broadcastChannelBroker;
+
+    internal WebApiEngineState(Engine engine, TimeProvider timeProvider, TimerQueue? timers, Options.FetchOptions? fetchOptions, SchedulerQueue? scheduler, DiagnosticsSink? diagnostics, Options.StorageOptions? storage = null, CacheStorageProvider? cacheProvider = null, IdleCallbackQueue? idleCallbacks = null, Options.MessagingOptions? messaging = null)
     {
         _engine = engine;
         _timeProvider = timeProvider;
@@ -196,6 +212,10 @@ internal sealed class WebApiEngineState
         _storageQuotaBytes = storage?.MaxTotalBytes ?? Options.StorageOptions.DefaultMaxTotalBytes;
         CacheProvider = cacheProvider;
         IdleCallbacks = idleCallbacks;
+
+        // Read once, here, exactly as the storage providers above are — and, like them, left null when the
+        // host named none so that an engine which never creates a channel allocates no broker at all.
+        _broadcastChannelBroker = messaging?.Broker;
 
         // Both halves of the time origin, read back to back: the monotonic reading every later now() is a
         // duration from, and the wall-clock moment that reading corresponds to.
@@ -364,6 +384,32 @@ internal sealed class WebApiEngineState
         _sessionStorageProvider ??= new InMemoryStorageProvider(_storageQuotaBytes);
 
     /// <summary>
+    /// The <see cref="BroadcastChannelBroker"/> this engine's <c>BroadcastChannel</c> objects join: the host's,
+    /// when it assigned one to <see cref="Options.MessagingOptions.Broker"/>, and otherwise a private one of
+    /// this engine's own — so channels on one engine always hear each other and nothing crosses an engine
+    /// boundary unless the host deliberately shared a broker.
+    /// </summary>
+    /// <remarks>
+    /// Defaulted on first use rather than at construction, so an engine that enabled messaging and never
+    /// created a channel has still allocated nothing. Deliberately <b>not</b> reset by
+    /// <see cref="ResetTransientState"/>: a host's broker is host state like a storage provider, and the
+    /// private default is the identity of this engine's own cluster, which a restore has no business
+    /// replacing — what a restore ends is the channels, not the cluster they were in.
+    /// </remarks>
+    internal BroadcastChannelBroker BroadcastChannels =>
+        _broadcastChannelBroker ??= new BroadcastChannelBroker();
+
+    /// <summary>
+    /// Records a live <c>BroadcastChannel</c>, so that a restore or a dispose can end it — which is also what
+    /// takes it out of a broker the host may be sharing with engines that outlive this one.
+    /// </summary>
+    internal void RegisterBroadcastChannel(JsBroadcastChannel channel) =>
+        (_broadcastChannels ??= new List<JsBroadcastChannel>()).Add(channel);
+
+    /// <summary>Forgets one channel, which is what <c>close()</c> does to itself.</summary>
+    internal void UnregisterBroadcastChannel(JsBroadcastChannel channel) => _broadcastChannels?.Remove(channel);
+
+    /// <summary>
     /// Gives a state that was built without one the timer queue a feature enabled later needs. Called only by
     /// <c>WebApiRegistration.ExtendEngineState</c>, and only for a slot that is still empty — a queue the
     /// engine has already been scheduling on is never replaced.
@@ -422,6 +468,16 @@ internal sealed class WebApiEngineState
         _sessionStorageProvider ??= storage.SessionStorageProvider;
         _storageQuotaBytes = storage.MaxTotalBytes;
     }
+
+    /// <summary>
+    /// Reads the messaging group into a state that was built without it. Like <see cref="AttachStorage"/> and
+    /// unlike the <c>Debug.Assert</c>-ing siblings above, it has no slot of its own to test: the broker is
+    /// defaulted lazily on first use, so what it must not do is overwrite one that has already been resolved —
+    /// hence the <c>??=</c>. Nothing can have resolved one before the messaging feature was on, since only a
+    /// <c>BroadcastChannel</c> constructor reads it, so the assignment reaches exactly the engines the host is
+    /// enabling messaging for.
+    /// </summary>
+    internal void AttachMessaging(Options.MessagingOptions messaging) => _broadcastChannelBroker ??= messaging.Broker;
 
     /// <summary>
     /// Promotes at most one due timer into an event-loop job, and failing that runs at most one idle callback.
@@ -580,6 +636,11 @@ internal sealed class WebApiEngineState
     /// <c>error</c> fired afterwards must reach none of them. The sink is deliberately not reset: it is
     /// configuration the engine was built with, like the time origin beside it, and a pooled engine
     /// reporting the next cycle's errors nowhere would be a strange thing for a restore to arrange.
+    /// A <c>BroadcastChannel</c> is <b>closed</b> rather than merely forgotten, which is the same rule a
+    /// <c>MessagePort</c> follows for the same reason — its listeners are closures over the cycle that is
+    /// ending — with one addition: the broker it joined may be the host's and may outlive this engine, so
+    /// leaving the subscription there would keep this engine reachable and go on costing every future sender a
+    /// job the generation fence then throws away.
     /// </remarks>
     internal void ResetTransientState()
     {
@@ -589,6 +650,7 @@ internal sealed class WebApiEngineState
         AbandonFetchBodies();
         AbandonEventSources();
         AbandonWebSockets();
+        CloseBroadcastChannels();
         IdleCallbacks?.Clear();
 
         // Dropped whole rather than emptied: the next cycle's first addEventListener builds a fresh target,
@@ -658,6 +720,28 @@ internal sealed class WebApiEngineState
         }
     }
 
+    /// <summary>
+    /// Closes every <c>BroadcastChannel</c> this engine created — which unsubscribes each from its broker, so
+    /// a broker the host shares between engines does not keep a finished one reachable.
+    /// </summary>
+    private void CloseBroadcastChannels()
+    {
+        if (_broadcastChannels is not { Count: > 0 } channels)
+        {
+            return;
+        }
+
+        // Copied before the walk, exactly as the fetches are: Close unregisters the channel, which would
+        // otherwise mutate the list under the enumerator.
+        var open = channels.ToArray();
+        channels.Clear();
+
+        foreach (var channel in open)
+        {
+            channel.Close();
+        }
+    }
+
     private void AbandonFetchBodies()
     {
         if (_fetchBodies is not { Count: > 0 } bodies)
@@ -675,10 +759,15 @@ internal sealed class WebApiEngineState
     }
 
     /// <summary>
-    /// Called from <see cref="Engine.Dispose"/>: releases the state that reaches outside the engine, which
-    /// today is the host token registrations. The queues need nothing — they hold no unmanaged resource and no
-    /// timer, and die with the engine.
+    /// Called from <see cref="Engine.Dispose"/>: releases the state that reaches outside the engine, which is
+    /// the host token registrations and the subscriptions in a <see cref="BroadcastChannelBroker"/> the host
+    /// may share with engines that outlive this one. The queues need nothing — they hold no unmanaged resource
+    /// and no timer, and die with the engine.
     /// </summary>
-    internal void Dispose() => ReleaseHostAbortBridges();
+    internal void Dispose()
+    {
+        ReleaseHostAbortBridges();
+        CloseBroadcastChannels();
+    }
 }
 #endif

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -90,6 +90,46 @@ public partial class Options
         /// <see cref="WebApiFeatures.CacheApi"/> — which <see cref="WebApiFeatures.Default"/> never does.
         /// </summary>
         public CacheOptions Cache { get; } = new();
+
+        /// <summary>
+        /// Settings for channel messaging, installed when <see cref="Features"/> contains
+        /// <see cref="WebApiFeatures.Messaging"/>.
+        /// </summary>
+        public MessagingOptions Messaging { get; } = new();
+    }
+
+    /// <summary>
+    /// Settings for the <c>Messaging</c> feature — today, which <c>BroadcastChannel</c> objects can hear each
+    /// other. Requires .NET 8 or higher.
+    /// </summary>
+    /// <remarks>
+    /// Nothing here is needed for <c>MessageChannel</c>, <c>MessagePort</c> or <c>MessageEvent</c>: a port pair
+    /// is entangled by construction, and the cross-engine form of one is
+    /// <c>Engine.Advanced.CreateMessagePortPair</c> rather than an option. A <c>BroadcastChannel</c> has no
+    /// pair to be entangled with — it addresses a <i>name</i> — so which channels are in earshot of each other
+    /// is the one thing about it a host has to be able to say.
+    /// </remarks>
+    public class MessagingOptions
+    {
+        /// <summary>
+        /// Which <c>BroadcastChannel</c> objects can hear each other: one broker is one agent cluster and one
+        /// origin. <see langword="null"/> — the default — gives each engine a private broker of its own, so
+        /// channels created on one engine hear each other and nothing crosses an engine boundary.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Assign one instance to an <see cref="Options"/> object several engines are built from — or the same
+        /// instance to several <see cref="Options"/> objects — and those engines broadcast to each other. A
+        /// broker is thread-safe, so the engines may run concurrently; what crosses between them is a
+        /// serialization record and never a <c>JsValue</c>, and delivery still happens on the receiving
+        /// engine's own pump. See <see cref="BroadcastChannelBroker"/>, including what it keeps alive.
+        /// </para>
+        /// <para>
+        /// Read once, when the engine is built, so assigning it afterwards does not affect an engine that
+        /// already exists.
+        /// </para>
+        /// </remarks>
+        public BroadcastChannelBroker? Broker { get; set; }
     }
 
     /// <summary>
@@ -643,12 +683,15 @@ public enum WebApiFeatures
     Scheduler = 1 << 13,
 
     /// <summary>
-    /// <c>MessageChannel</c>, <c>MessagePort</c> and <c>MessageEvent</c> — the HTML Standard's channel
-    /// messaging, https://html.spec.whatwg.org/multipage/web-messaging.html. A message is structured-cloned
-    /// when it is posted and delivered as an event-loop task, so a port fires only while the engine is being
-    /// pumped. The same ports can span <b>two</b> engines through
-    /// <c>Engine.Advanced.CreateMessagePortPair</c>, which needs this flag on both of them. Transferring a
-    /// port through a port is not supported.
+    /// <c>MessageChannel</c>, <c>MessagePort</c>, <c>MessageEvent</c> and <c>BroadcastChannel</c> — the HTML
+    /// Standard's web messaging, https://html.spec.whatwg.org/multipage/web-messaging.html. A message is
+    /// structured-cloned when it is posted and delivered as an event-loop task, so nothing fires except while
+    /// the engine is being pumped. The same ports can span <b>two</b> engines through
+    /// <c>Engine.Advanced.CreateMessagePortPair</c>, which needs this flag on both of them; a
+    /// <c>BroadcastChannel</c> spans as many engines as share a
+    /// <see cref="Options.MessagingOptions.Broker"/>, and reaches every other channel of its name rather than
+    /// one peer. Transferring a port through a port is not supported, and a broadcast has no transfer list at
+    /// all.
     /// </summary>
     Messaging = 1 << 14,
 

--- a/Jint/Runtime/Intrinsics.WebApi.cs
+++ b/Jint/Runtime/Intrinsics.WebApi.cs
@@ -179,6 +179,7 @@ public sealed partial class Intrinsics
     private MessagePortConstructor? _messagePort;
     private MessageChannelConstructor? _messageChannel;
     private MessageEventConstructor? _messageEvent;
+    private BroadcastChannelConstructor? _broadcastChannel;
 
     /// <summary><c>MessagePort</c> inherits from <c>EventTarget</c>.</summary>
     internal MessagePortConstructor MessagePort =>
@@ -190,6 +191,10 @@ public sealed partial class Intrinsics
     /// <summary><c>MessageEvent</c> inherits from <c>Event</c>.</summary>
     internal MessageEventConstructor MessageEvent =>
         _messageEvent ??= new MessageEventConstructor(_engine, _realm, Event);
+
+    /// <summary><c>BroadcastChannel</c> inherits from <c>EventTarget</c>.</summary>
+    internal BroadcastChannelConstructor BroadcastChannel =>
+        _broadcastChannel ??= new BroadcastChannelConstructor(_engine, _realm, EventTarget);
 
     private CacheConstructor? _cache;
     private CacheStorageConstructor? _cacheStorage;

--- a/Jint/WebApi/BroadcastChannelBroker.cs
+++ b/Jint/WebApi/BroadcastChannelBroker.cs
@@ -1,0 +1,262 @@
+#if NET8_0_OR_GREATER
+using System.Threading;
+using Jint.WebApi.Messaging;
+using Jint.WebApi.StructuredClone;
+
+namespace Jint.WebApi;
+
+/// <summary>
+/// The set of <c>BroadcastChannel</c> objects that can hear one another — what the HTML Standard reaches
+/// through "the <see href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-broadcastchannel-postmessage">
+/// BroadcastChannel objects whose relevant global object's storage key equals sourceStorageKey and whose
+/// channel name equals source's channel name</see>". Requires .NET 8 or higher.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A browser scopes broadcasting by two things Jint does not have: an <i>agent cluster</i> (which browsing
+/// contexts share one event loop family) and a <i>storage key</i> (an origin). This object is Jint's answer to
+/// both at once — <b>one broker is one agent cluster and one origin</b>. Channels created on engines that share
+/// a broker hear each other; channels on engines that do not, cannot, however equal their names.
+/// </para>
+/// <para>
+/// <b>You only ever construct one and hand it over.</b> It has no members of its own: everything it does
+/// happens through the <c>BroadcastChannel</c> objects scripts create. Assign one to
+/// <see cref="Options.MessagingOptions.Broker"/> on an <see cref="Options"/> instance several engines are built
+/// from — or assign the same instance to several <see cref="Options"/> instances — and those engines broadcast
+/// to each other. Say nothing and each engine gets a private broker of its own, so channels on one engine still
+/// hear each other and nothing crosses an engine boundary.
+/// </para>
+/// <para>
+/// <b>Threading.</b> This type is thread-safe, which is the whole reason it is a class rather than a field on
+/// the engine: a broker shared by engines running on different threads is reached from all of them. What
+/// crosses between them is never a <c>JsValue</c> — a message is serialized on the sending engine's thread into
+/// a record that belongs to no engine, and enqueued onto the receiving engine's event loop, the one part of an
+/// engine any thread may touch. The deserialization, the <c>MessageEvent</c> and the listeners all run on
+/// whichever thread pumps the receiving engine, so an engine nobody pumps never takes delivery, exactly as for
+/// timers and message ports.
+/// </para>
+/// <para>
+/// <b>It holds its subscribers strongly, and that is deliberate.</b> A subscribed channel keeps its engine
+/// reachable for as long as the broker lives, exactly as a browser keeps a <c>BroadcastChannel</c> alive until
+/// it is closed or its context goes away — a channel nobody references is still a live receiver, so collecting
+/// it would silently drop messages. Three things release a subscription: <c>close()</c> from script,
+/// <c>Engine.Advanced.RestoreGlobalSnapshot</c> (which ends every channel that engine created, permanently, the
+/// same rule a <c>MessagePort</c> follows), and <see cref="Engine.Dispose"/>. A host that shares one broker
+/// between long-lived engines and short-lived ones therefore disposes or restores the short-lived ones;
+/// there is no finalizer-driven cleanup and none is planned.
+/// </para>
+/// </remarks>
+public sealed class BroadcastChannelBroker
+{
+    /// <summary>
+    /// Guards <see cref="_channels"/> and every walk of a bucket. Held across the enqueue of a delivery job so
+    /// that the set of destinations a message goes to is the set that existed when it was posted.
+    /// </summary>
+    /// <remarks>
+    /// Enqueuing under a lock is only safe because <c>EventLoop.Enqueue</c> runs no user code: it appends to a
+    /// concurrent queue, sets a <see cref="System.Threading.ManualResetEventSlim"/>, and completes its async
+    /// waiters through task sources created <c>RunContinuationsAsynchronously</c>, so nothing it touches can
+    /// re-enter this type. The delivery job itself runs later, on the receiving engine's own pump.
+    /// </remarks>
+    private readonly Lock _gate = new();
+
+    /// <summary>
+    /// The subscribers of each channel name, in subscription order, or <see langword="null"/> until the first
+    /// channel is created — which is what keeps a broker an engine never broadcasts on to one empty object.
+    /// A name whose last subscriber leaves is removed outright, so a script cycling through channel names
+    /// cannot grow this map.
+    /// </summary>
+    private Dictionary<string, List<BroadcastChannelSubscription>>? _channels;
+
+    /// <summary>
+    /// Creates a broker: one agent cluster's worth of <c>BroadcastChannel</c> objects, empty to begin with.
+    /// </summary>
+    public BroadcastChannelBroker()
+    {
+    }
+
+    /// <summary>
+    /// How many channel names currently have at least one subscriber.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately <see langword="internal"/> and deliberately not a host-facing figure: it exists because the
+    /// leak guard below — a name whose last subscriber leaves is removed from the map outright — is invisible
+    /// from script by construction, so the in-repo tests have no other way to pin it. A host has no business
+    /// branching on it.
+    /// </remarks>
+    internal int ActiveNameCount
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _channels?.Count ?? 0;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Adds a channel to its name's bucket, at the end — which is the order
+    /// <see href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-broadcastchannel-postmessage">step
+    /// 7</see> asks for, "sorted in creation order of their relevant global object", reduced to creation order
+    /// because a broker is one agent cluster and the objects in it are therefore already sorted by nothing else.
+    /// </summary>
+    internal void Subscribe(BroadcastChannelSubscription subscription)
+    {
+        lock (_gate)
+        {
+            var channels = _channels ??= new Dictionary<string, List<BroadcastChannelSubscription>>(StringComparer.Ordinal);
+
+            if (!channels.TryGetValue(subscription.Name, out var bucket))
+            {
+                bucket = new List<BroadcastChannelSubscription>();
+                channels[subscription.Name] = bucket;
+            }
+
+            bucket.Add(subscription);
+        }
+    }
+
+    /// <summary>
+    /// Removes a channel from its bucket, and the bucket itself once it is empty.
+    /// </summary>
+    /// <remarks>
+    /// Idempotent, because everything that can end a channel calls it: <c>close()</c>, the restore that ends
+    /// the evaluation cycle the channel belongs to, and <see cref="Engine.Dispose"/>. A subscription that is
+    /// already gone simply is not found.
+    /// </remarks>
+    internal void Unsubscribe(BroadcastChannelSubscription subscription)
+    {
+        lock (_gate)
+        {
+            if (_channels is not { } channels || !channels.TryGetValue(subscription.Name, out var bucket))
+            {
+                return;
+            }
+
+            bucket.Remove(subscription);
+
+            if (bucket.Count == 0)
+            {
+                channels.Remove(subscription.Name);
+            }
+        }
+    }
+
+    /// <summary>
+    /// <see href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-broadcastchannel-postmessage">Steps
+    /// 5 to 8</see>: the destinations, minus the sender, each given a task of their own.
+    /// </summary>
+    /// <remarks>
+    /// <b>Runs on the sending engine's thread</b>, and does exactly two things per destination: check the
+    /// fences, and enqueue. The record was produced before this was called, so nothing here touches a
+    /// <c>JsValue</c> — see <see cref="BroadcastChannelSubscription"/> for why that is what makes a shared
+    /// broker safe at all.
+    /// </remarks>
+    /// <param name="source">The posting channel, which step 6 removes from the destinations.</param>
+    /// <param name="record">The message, already serialized on the sender.</param>
+    internal void Post(BroadcastChannelSubscription source, in SerializationRecord record)
+    {
+        lock (_gate)
+        {
+            if (_channels is not { } channels || !channels.TryGetValue(source.Name, out var bucket))
+            {
+                return;
+            }
+
+            foreach (var destination in bucket)
+            {
+                // Step 6: "Remove source from destinations." A channel never hears itself, however many
+                // channels of that name the same engine has.
+                if (ReferenceEquals(destination, source))
+                {
+                    continue;
+                }
+
+                destination.Deliver(in record);
+            }
+        }
+    }
+}
+
+/// <summary>
+/// One <c>BroadcastChannel</c>'s entry in a <see cref="BroadcastChannelBroker"/>, as seen from whichever engine
+/// is posting. Every member here may be read by a sending engine's thread, so every member here is immutable or
+/// <see langword="volatile"/> — the same discipline <c>MessagePortEndpoint</c> keeps, and for the same reason.
+/// </summary>
+/// <remarks>
+/// The subscription carries the receiving engine's <see cref="Engine.EventLoopGeneration"/> as it was when the
+/// channel was <b>created</b>, not as it is when a message is posted. A channel's listeners are closures over
+/// the evaluation cycle it was created in, so delivering into it after a <c>RestoreGlobalSnapshot</c> would run
+/// that dead cycle's code against the freshly restored globals — the exact cross-cycle channel the generation
+/// fence exists to forbid. Reading the receiver's <i>current</i> generation from the sender's thread would have
+/// permitted precisely that, as well as being a cross-thread read of a value the receiver is free to change
+/// underneath it. So: <b>a channel belongs to the evaluation cycle its engine was in when it was created, and a
+/// restore on that engine ends it permanently.</b>
+/// </remarks>
+internal sealed class BroadcastChannelSubscription
+{
+    private volatile bool _closed;
+
+    internal BroadcastChannelSubscription(Engine engine, JsBroadcastChannel channel, string name)
+    {
+        Engine = engine;
+        Channel = channel;
+        Name = name;
+        Generation = engine.EventLoopGeneration;
+    }
+
+    /// <summary>The engine that owns <see cref="Channel"/> and on whose pump a delivery job runs.</summary>
+    internal Engine Engine { get; }
+
+    /// <summary>The channel itself. Only ever dereferenced on <see cref="Engine"/>'s own thread.</summary>
+    internal JsBroadcastChannel Channel { get; }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/web-messaging.html#dom-broadcastchannel-name — the channel name,
+    /// which is what a bucket is keyed on. Compared with ordinal equality, since it is an arbitrary
+    /// <c>DOMString</c> and the standard's "equals" is on the string and not on any collation.
+    /// </summary>
+    internal string Name { get; }
+
+    /// <summary>The evaluation cycle this channel belongs to; see the class remarks.</summary>
+    internal int Generation { get; }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/web-messaging.html#dom-broadcastchannel-close — the channel's
+    /// <i>closed flag</i>. Volatile because a sending engine reads it from its own thread to decide whether
+    /// this destination is still worth a job; it is a one-way flag, so a stale read can only cost one job that
+    /// the receiving engine then discards at step 8.1 anyway.
+    /// </summary>
+    internal bool Closed => _closed;
+
+    internal void Close() => _closed = true;
+
+    /// <summary>
+    /// Step 8: "queue a global task … given destination's relevant global object". <b>Runs on the sender's
+    /// thread</b>, so it checks the fences and enqueues, and does nothing else.
+    /// </summary>
+    internal void Deliver(in SerializationRecord record)
+    {
+        if (_closed)
+        {
+            return;
+        }
+
+        var engine = Engine;
+
+        // A cheap early-out for a channel whose engine has since restored a global snapshot, so a sender that
+        // keeps posting into a dead channel does not grow that engine's queue. It is not the fence: the
+        // authoritative check is the one every job gets at dequeue, on the engine's own thread, which is the
+        // only place the comparison is free of races.
+        if (engine.EventLoopGeneration != Generation)
+        {
+            return;
+        }
+
+        var channel = Channel;
+        var message = record;
+        engine.AddToEventLoop(() => channel.Receive(in message), Generation);
+    }
+}
+#endif

--- a/Jint/WebApi/Messaging/BroadcastChannelConstructor.cs
+++ b/Jint/WebApi/Messaging/BroadcastChannelConstructor.cs
@@ -1,0 +1,72 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.Events;
+
+namespace Jint.WebApi.Messaging;
+
+/// <summary>
+/// The <c>BroadcastChannel</c> interface object.
+/// <para>
+/// https://html.spec.whatwg.org/multipage/web-messaging.html#broadcastchannel
+/// </para>
+/// </summary>
+/// <remarks>
+/// <c>BroadcastChannel</c> inherits from <c>EventTarget</c>, so its <c>[[Prototype]]</c> is the
+/// <c>EventTarget</c> interface object and <c>channel instanceof EventTarget</c> holds. Unlike
+/// <c>MessagePort</c> it declares a constructor operation, taking the channel name — the one argument, and a
+/// required one.
+/// </remarks>
+internal sealed class BroadcastChannelConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("BroadcastChannel");
+
+    internal BroadcastChannelConstructor(Engine engine, Realm realm, EventTargetConstructor eventTargetConstructor)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = eventTargetConstructor;
+        PrototypeObject = new BroadcastChannelPrototype(engine, realm, this, eventTargetConstructor.PrototypeObject);
+        _length = new PropertyDescriptor(JsNumber.PositiveOne, PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal BroadcastChannelPrototype PrototypeObject { get; }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/web-messaging.html#dom-broadcastchannel-broadcastchannel — "Set
+    /// this's channel name to name."
+    /// </summary>
+    /// <remarks>
+    /// The name is a <c>DOMString</c> with no default, so a bare <c>new BroadcastChannel()</c> is WebIDL's
+    /// arity <c>TypeError</c> rather than a channel named <c>"undefined"</c> — while
+    /// <c>new BroadcastChannel(undefined)</c> is a channel named <c>"undefined"</c>, which is what converting a
+    /// present argument to a <c>DOMString</c> gives.
+    /// </remarks>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        var state = _engine._webApi;
+        if (state is null)
+        {
+            // Unreachable: the global that reaches this is installed only where the state was created, in the
+            // same block of WebApiRegistration.
+            Throw.InvalidOperationException("The BroadcastChannel global was reached on an engine that has no web API state.");
+        }
+
+        if (arguments.Length == 0)
+        {
+            Throw.TypeError(_realm, "Failed to construct 'BroadcastChannel': 1 argument required, but only 0 present.");
+        }
+
+        var name = TypeConverter.ToString(arguments[0]);
+
+        return OrdinaryCreateFromConstructor(
+            newTarget,
+            static intrinsics => intrinsics.BroadcastChannel.PrototypeObject,
+            static (Engine engine, Realm realm, (string Name, BroadcastChannelBroker Broker) created)
+                => new JsBroadcastChannel(engine, realm, created.Name, created.Broker),
+            (Name: name, Broker: state.BroadcastChannels));
+    }
+}
+#endif

--- a/Jint/WebApi/Messaging/BroadcastChannelPrototype.cs
+++ b/Jint/WebApi/Messaging/BroadcastChannelPrototype.cs
@@ -1,0 +1,176 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.Events;
+
+namespace Jint.WebApi.Messaging;
+
+/// <summary>
+/// <c>BroadcastChannel.prototype</c> — the interface prototype object.
+/// <para>
+/// https://html.spec.whatwg.org/multipage/web-messaging.html#broadcastchannel
+/// </para>
+/// </summary>
+/// <remarks>
+/// Its <c>[[Prototype]]</c> is <c>EventTarget.prototype</c>, so a channel has <c>addEventListener</c> and the
+/// rest, and <c>channel instanceof EventTarget</c> holds.
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class BroadcastChannelPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly BroadcastChannelConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString BroadcastChannelToStringTag = new("BroadcastChannel");
+
+    internal BroadcastChannelPrototype(
+        Engine engine,
+        Realm realm,
+        BroadcastChannelConstructor constructor,
+        ObjectInstance eventTargetPrototype) : base(engine, realm)
+    {
+        _prototype = eventTargetPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/web-messaging.html#dom-broadcastchannel-name — the channel name,
+    /// which is fixed at construction and has no setter.
+    /// </summary>
+    [JsAccessor("name", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsString NameGet(JsValue thisObject) => JsString.Create(Brand(thisObject).Name);
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/web-messaging.html#dom-broadcastchannel-postmessage
+    /// </summary>
+    /// <remarks>
+    /// One argument, and no <c>transfer</c> overload: the specification calls StructuredSerialize rather than
+    /// StructuredSerializeWithTransfer, so there is no second parameter to resolve — see
+    /// <see cref="JsBroadcastChannel"/>.
+    /// </remarks>
+    [JsFunction(Name = "postMessage", Length = 1)]
+    private JsValue PostMessage(JsValue thisObject, JsCallArguments arguments)
+    {
+        var channel = Brand(thisObject);
+
+        if (arguments.Length == 0)
+        {
+            Throw.TypeError(_realm, "Failed to execute 'postMessage' on 'BroadcastChannel': 1 argument required, but only 0 present.");
+        }
+
+        channel.PostMessage(arguments[0]);
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/web-messaging.html#dom-broadcastchannel-close
+    /// </summary>
+    [JsFunction(Name = "close", Length = 0)]
+    private JsValue Close(JsValue thisObject)
+    {
+        Brand(thisObject).Close();
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/web-messaging.html#handler-broadcastchannel-onmessage — the
+    /// <c>onmessage</c> event handler IDL attribute,
+    /// https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <c>MessagePort</c>'s, assigning this starts nothing: a <c>BroadcastChannel</c> has no port
+    /// message queue to enable, so <c>addEventListener('message', …)</c> on its own is enough to receive. The
+    /// handler is one entry of the channel's own event listener list, so it takes its turn in registration
+    /// order among those listeners rather than running before or after all of them.
+    /// </remarks>
+    [JsAccessor("onmessage", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue OnMessageGet(JsValue thisObject)
+    {
+        return Brand(thisObject).FindEventHandler(JsBroadcastChannel.MessageEventType)?.Callback ?? Null;
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/web-messaging.html#handler-broadcastchannel-onmessage, setter
+    /// half.
+    /// </summary>
+    [JsAccessor("onmessage", AccessorKind.Set, Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue OnMessageSet(JsValue thisObject, JsValue value)
+    {
+        SetEventHandler(Brand(thisObject), JsBroadcastChannel.MessageEventType, value);
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/web-messaging.html#handler-broadcastchannel-onmessageerror.
+    /// </summary>
+    /// <remarks>
+    /// Nothing in Jint ever fires a <c>messageerror</c>; see <see cref="JsBroadcastChannel"/> for why.
+    /// </remarks>
+    [JsAccessor("onmessageerror", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue OnMessageErrorGet(JsValue thisObject)
+    {
+        return Brand(thisObject).FindEventHandler(JsBroadcastChannel.MessageErrorEventType)?.Callback ?? Null;
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/web-messaging.html#handler-broadcastchannel-onmessageerror,
+    /// setter half.
+    /// </summary>
+    [JsAccessor("onmessageerror", AccessorKind.Set, Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsValue OnMessageErrorSet(JsValue thisObject, JsValue value)
+    {
+        SetEventHandler(Brand(thisObject), JsBroadcastChannel.MessageErrorEventType, value);
+        return Undefined;
+    }
+
+    /// <summary>
+    /// HTML's "set the current value of the event handler". <c>EventHandler</c> is a nullable callback
+    /// function annotated <c>[LegacyTreatNonObjectAsNull]</c>, so assigning anything that is not an object
+    /// clears the handler rather than raising a <c>TypeError</c>. Reassigning replaces the value in place, so
+    /// the listener keeps the position it was first given.
+    /// </summary>
+    private static void SetEventHandler(JsBroadcastChannel channel, string type, JsValue value)
+    {
+        var existing = channel.FindEventHandler(type);
+
+        if (value is not ObjectInstance)
+        {
+            // "Deactivate an event handler": the listener goes away entirely.
+            if (existing is not null)
+            {
+                channel.RemoveListener(existing);
+            }
+
+            return;
+        }
+
+        if (existing is not null)
+        {
+            existing.Callback = value;
+            return;
+        }
+
+        channel.AddListener(new EventListenerRegistration(type, value) { IsEventHandler = true });
+    }
+
+    private JsBroadcastChannel Brand(JsValue thisObject)
+    {
+        if (thisObject is JsBroadcastChannel channel)
+        {
+            return channel;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a BroadcastChannel");
+        return null!;
+    }
+}
+#endif

--- a/Jint/WebApi/Messaging/JsBroadcastChannel.cs
+++ b/Jint/WebApi/Messaging/JsBroadcastChannel.cs
@@ -1,0 +1,174 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Runtime;
+using Jint.WebApi.DomException;
+using Jint.WebApi.Events;
+using Jint.WebApi.StructuredClone;
+
+namespace Jint.WebApi.Messaging;
+
+/// <summary>
+/// A <c>BroadcastChannel</c> instance: a name, a subscription to the engine's
+/// <see cref="BroadcastChannelBroker"/>, and an <see cref="JsEventTarget"/> so a script can listen for the
+/// <c>message</c> event.
+/// <para>
+/// https://html.spec.whatwg.org/multipage/web-messaging.html#broadcasting-to-other-browsing-contexts
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>It is a message port without the port.</b> Everything about the message itself is what
+/// <see cref="JsMessagePort"/> does — serialization on the sender, deserialization on the receiver, the record
+/// in between belonging to neither, delivery as an event-loop task — and the differences are all about
+/// <i>who</i> a message reaches. There is no entanglement and no pair: a channel names a string, and every
+/// other channel of that name in the same <see cref="BroadcastChannelBroker"/> hears it. The sender does not
+/// hear itself, and neither does any other channel with a different name.
+/// </para>
+/// <para>
+/// <b>There is no message queue and no <c>start()</c>.</b> A <c>MessagePort</c> holds messages until its queue
+/// is enabled; a <c>BroadcastChannel</c> has no such flag at all, so <c>addEventListener('message', …)</c>
+/// alone is enough to receive and a message that arrives with no listener is simply dispatched to nobody.
+/// Delivery is still a task rather than a synchronous call — the specification queues one global task per
+/// destination — so a same-engine broadcast is observed only after the current script has finished and the
+/// event loop has been pumped.
+/// </para>
+/// <para>
+/// <b>One job per destination, not two.</b> A <see cref="JsMessagePort"/> spends two event-loop jobs on a
+/// message because its port message queue can be disabled and the head has to be taken off separately; a
+/// channel has no queue, so its delivery is the single job step 8 describes — which is also what
+/// <c>EventSource</c> and <c>WebSocket</c> do for the <c>MessageEvent</c>s they fire. Jint's event loop is one
+/// queue rather than a task queue plus a microtask queue, so the observable consequence is that a job queued
+/// <i>between</i> the <c>postMessage</c> and the delivery — a promise reaction, say — runs after the message
+/// where a port's would have run before it. Everything queued before the post still runs before the message.
+/// </para>
+/// <para>
+/// <b>There is no transfer list.</b> <c>postMessage(message)</c> takes one argument: the specification calls
+/// StructuredSerialize, not StructuredSerializeWithTransfer, and there is nowhere for a transfer to move a
+/// buffer <i>to</i> when the message has many destinations. A <c>DataCloneError</c> for an uncloneable value is
+/// therefore still raised synchronously at the call, and no <c>ArrayBuffer</c> is ever detached by one.
+/// </para>
+/// <para>
+/// <b>One record, several destinations.</b> The message is serialized once — step 2, before the destinations
+/// are even collected — and each destination deserializes that one record in its own realm, which is exactly
+/// what steps 2 and 8.3 say. That makes the record the one thing in the engine deserialized more than once, so
+/// the deserializer is asked to copy the storage it would otherwise adopt; without it, two receivers would come
+/// away with two <c>ArrayBuffer</c>s over one <c>byte[]</c> and each could see the other's writes. See
+/// <see cref="StructuredDeserializer"/>'s <c>sharedRecord</c> parameter.
+/// </para>
+/// <para>
+/// <b><c>messageerror</c> is never fired.</b> The event and the <c>onmessageerror</c> attribute exist because
+/// the interface has them and a script may register for them, but the only thing that fires one is step 8.3's
+/// deserialization failing, and a record built by this engine's own serializer always deserializes. An
+/// execution-constraint failure during deserialization is not a candidate: a timeout or a cancellation must
+/// erupt from the pump, never be flattened into an event. This is the same answer <see cref="JsMessagePort"/>
+/// gives, for the same reason.
+/// </para>
+/// </remarks>
+internal sealed class JsBroadcastChannel : JsEventTarget
+{
+    /// <summary>https://html.spec.whatwg.org/multipage/indices.html#event-message.</summary>
+    internal const string MessageEventType = "message";
+
+    /// <summary>https://html.spec.whatwg.org/multipage/indices.html#event-messageerror.</summary>
+    internal const string MessageErrorEventType = "messageerror";
+
+    private static readonly JsString _messageEventName = new(MessageEventType);
+
+    private readonly BroadcastChannelBroker _broker;
+
+    internal JsBroadcastChannel(Engine engine, Realm realm, string name, BroadcastChannelBroker broker)
+        : base(engine, realm)
+    {
+        _prototype = realm.Intrinsics.BroadcastChannel.PrototypeObject;
+        _broker = broker;
+        Name = name;
+        Subscription = new BroadcastChannelSubscription(engine, this, name);
+
+        // The channel is live from the moment it is constructed — there is no start() — so it joins the
+        // broker here, and the engine's own list here, which is what lets a restore end every channel it
+        // created without the broker having to know which engine anything came from.
+        broker.Subscribe(Subscription);
+        engine._webApi!.RegisterBroadcastChannel(this);
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/web-messaging.html#dom-broadcastchannel-name — the name the
+    /// constructor was given, as a CLR string because the broker keys its buckets on it.
+    /// </summary>
+    internal string Name { get; }
+
+    /// <summary>This channel's entry in the broker; see <see cref="BroadcastChannelSubscription"/>.</summary>
+    internal BroadcastChannelSubscription Subscription { get; }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/web-messaging.html#dom-broadcastchannel-postmessage
+    /// </summary>
+    internal void PostMessage(JsValue message)
+    {
+        // Step 1: "If this is closed flag is true, then throw an InvalidStateError DOMException." Unlike a
+        // closed MessagePort, whose postMessage merely goes nowhere, a closed BroadcastChannel refuses.
+        if (Subscription.Closed)
+        {
+            ThrowDomException(
+                DomExceptionNames.InvalidState,
+                "Failed to execute 'postMessage' on 'BroadcastChannel': Channel is closed.");
+        }
+
+        // Step 2: "Let serialized be StructuredSerialize(message). Rethrow any exceptions." Once, on this
+        // thread, before any destination is looked at — so a DataCloneError reaches the caller synchronously
+        // whether or not anybody was listening, and a later mutation of the graph cannot reach the message.
+        var record = new StructuredSerializer(_engine, _realm).Serialize(message, transferList: null);
+
+        // Steps 5 to 8.
+        _broker.Post(Subscription, in record);
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/web-messaging.html#dom-broadcastchannel-close — "Set this's
+    /// closed flag to true", plus the standard's note that closing is what lets the object be collected.
+    /// Calling it again does nothing.
+    /// </summary>
+    internal void Close()
+    {
+        if (Subscription.Closed)
+        {
+            return;
+        }
+
+        Subscription.Close();
+        _broker.Unsubscribe(Subscription);
+        _engine._webApi!.UnregisterBroadcastChannel(this);
+    }
+
+    /// <summary>
+    /// Step 8's task: the message, deserialized into this channel's realm and dispatched as a trusted
+    /// <c>MessageEvent</c>. <b>Runs on this channel's own engine's thread</b>, inside a generation-fenced
+    /// event-loop job, which is what makes touching this object safe however far away the sender was.
+    /// </summary>
+    internal void Receive(in SerializationRecord record)
+    {
+        // Step 8.1: "If destination's closed flag is true, then abort these steps." The channel may have been
+        // closed between the post and this job running.
+        if (Subscription.Closed)
+        {
+            return;
+        }
+
+        // Step 8.3. The record is shared with this broadcast's other destinations, so its storage is copied
+        // rather than adopted — see the class remarks.
+        var data = new StructuredDeserializer(_engine, _realm, sharedRecord: true).Deserialize(in record);
+
+        // Step 8.4. `origin` is the empty string: it is the serialization of the destination's origin, and an
+        // engine has none — the same answer a port-delivered event gives.
+        var messageEvent = _realm.Intrinsics.MessageEvent.CreateTrustedMessageEvent(_messageEventName, data);
+        DispatchEvent(messageEvent);
+    }
+
+    private void ThrowDomException(string name, string message)
+    {
+        var exception = _realm.Intrinsics.DomException.CreateException(name, message);
+        var location = _engine._lastSyntaxElement?.Location ?? default;
+        Throw.JavaScriptException(_engine, exception, in location);
+    }
+}
+#endif

--- a/Jint/WebApi/StructuredClone/SerializationRecord.cs
+++ b/Jint/WebApi/StructuredClone/SerializationRecord.cs
@@ -26,10 +26,15 @@ namespace Jint.WebApi.StructuredClone;
 /// declarations and from a walk of an actual graph.
 /// </para>
 /// <para>
-/// <b>A record is consumed once.</b> Deserializing takes ownership of the byte arrays it finds — a
-/// transferred <c>ArrayBuffer</c>'s storage is moved rather than copied, which is the whole point of
-/// transferring — so deserializing one record twice would hand two engines one mutable buffer. Every producer
-/// here hands each record to exactly one <see cref="StructuredDeserializer"/>.
+/// <b>A record is consumed once, unless the reader is told otherwise.</b> Deserializing takes ownership of the
+/// byte arrays it finds — a transferred <c>ArrayBuffer</c>'s storage is moved rather than copied, which is the
+/// whole point of transferring — so deserializing one record twice would hand two engines one mutable buffer.
+/// <c>structuredClone</c> and <c>MessagePort</c> therefore hand each record to exactly one
+/// <see cref="StructuredDeserializer"/>. <c>BroadcastChannel</c> is the one thing that cannot: its
+/// <c>postMessage</c> serializes once and every destination deserializes that same record, which is what the
+/// standard's steps say, so it asks the deserializer to copy the storage instead
+/// (<see cref="StructuredDeserializer"/>'s <c>sharedRecord</c>). It has no transfer list, so there is never
+/// storage there that had to be moved rather than copied.
 /// </para>
 /// <para>
 /// Sharing and cycles are carried by CLR reference identity: two references to one source object serialize to

--- a/Jint/WebApi/StructuredClone/StructuredDeserializer.cs
+++ b/Jint/WebApi/StructuredClone/StructuredDeserializer.cs
@@ -49,12 +49,29 @@ internal sealed class StructuredDeserializer
 
     private readonly Stack<DeserializeFrame> _pending = new();
 
+    /// <summary>
+    /// Whether the record being read is delivered to more than one destination; see the constructor.
+    /// </summary>
+    private readonly bool _sharedRecord;
+
     private int _visited;
 
-    internal StructuredDeserializer(Engine engine, Realm realm)
+    /// <param name="engine">The engine that will own the result.</param>
+    /// <param name="realm">The realm the specification's "in targetRealm" names.</param>
+    /// <param name="sharedRecord">
+    /// Whether this record is deserialized more than once — which is <c>BroadcastChannel</c> and nothing else,
+    /// because its <c>postMessage</c> serializes once (step 2) and every destination deserializes that one
+    /// record (step 8.3). Set, the byte storage a record carries is <b>copied</b> rather than adopted, so two
+    /// receivers do not come away with two <c>ArrayBuffer</c>s over one <c>byte[]</c> and see each other's
+    /// writes. Left at its default the storage is adopted, which is the move a <i>transfer</i> promised and is
+    /// what <see cref="SerializationRecord"/>'s "a record is consumed once" describes; a broadcast has no
+    /// transfer list at all, so there is never storage that must be moved rather than copied.
+    /// </param>
+    internal StructuredDeserializer(Engine engine, Realm realm, bool sharedRecord = false)
     {
         _engine = engine;
         _realm = realm;
+        _sharedRecord = sharedRecord;
     }
 
     /// <summary>
@@ -244,11 +261,14 @@ internal sealed class StructuredDeserializer
     /// <summary>
     /// Step 13's deserialization counterpart. The record's storage is adopted rather than copied — for a
     /// transferred buffer that is the move the transfer promised, and for a copied one the copy already
-    /// happened during serialization.
+    /// happened during serialization. The one exception is a record with several destinations, where adopting
+    /// would hand every one of them the same mutable array; see the constructor's <c>sharedRecord</c>.
     /// </summary>
     private JsArrayBuffer DeserializeArrayBuffer(SerializedArrayBuffer record)
     {
-        return new JsArrayBuffer(_engine, record.Bytes, record.MaxByteLength)
+        var bytes = _sharedRecord ? record.Bytes.AsSpan().ToArray() : record.Bytes;
+
+        return new JsArrayBuffer(_engine, bytes, record.MaxByteLength)
         {
             _prototype = _realm.Intrinsics.ArrayBuffer.PrototypeObject,
             _isImmutable = record.Immutable,

--- a/Jint/WebApi/WebApiRegistration.cs
+++ b/Jint/WebApi/WebApiRegistration.cs
@@ -286,6 +286,11 @@ internal static class WebApiRegistration
             Install(global, engine, "MessageChannel", static e => e.Realm.Intrinsics.MessageChannel, PropertyFlag.NonEnumerable);
             Install(global, engine, "MessagePort", static e => e.Realm.Intrinsics.MessagePort, PropertyFlag.NonEnumerable);
             Install(global, engine, "MessageEvent", static e => e.Realm.Intrinsics.MessageEvent, PropertyFlag.NonEnumerable);
+
+            // BroadcastChannel rides this flag rather than carrying one of its own: it is the same section of
+            // the same standard, it delivers the same MessageEvent, and it is the same structured clone across
+            // the same event loop — the only difference is that it addresses a name instead of a peer.
+            Install(global, engine, "BroadcastChannel", static e => e.Realm.Intrinsics.BroadcastChannel, PropertyFlag.NonEnumerable);
         }
 
         if ((features & WebApiFeatures.Reporting) != WebApiFeatures.None)
@@ -539,7 +544,11 @@ internal static class WebApiRegistration
             ? new IdleCallbackQueue(engine, engine._mainRealm, timeProvider, timers!, timerOptions.IdleBudget)
             : null;
 
-        engine._webApi = new WebApiEngineState(engine, timeProvider, timers, fetch, scheduler, diagnostics, storage, cache, idleCallbacks);
+        // The messaging group is passed whole rather than resolved here, exactly as the storage group is: a
+        // host that named no BroadcastChannelBroker gets one of its own, and only once a channel asks for it.
+        var messaging = (features & WebApiFeatures.Messaging) != WebApiFeatures.None ? options.WebApi.Messaging : null;
+
+        engine._webApi = new WebApiEngineState(engine, timeProvider, timers, fetch, scheduler, diagnostics, storage, cache, idleCallbacks, messaging);
     }
 
     /// <summary>
@@ -584,6 +593,11 @@ internal static class WebApiRegistration
         if ((added & WebApiFeatures.Storage) != WebApiFeatures.None)
         {
             state.AttachStorage(options.WebApi.Storage);
+        }
+
+        if ((added & WebApiFeatures.Messaging) != WebApiFeatures.None)
+        {
+            state.AttachMessaging(options.WebApi.Messaging);
         }
 
         if ((added & WebApiFeatures.CacheApi) != WebApiFeatures.None && state.CacheProvider is null)

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ its own `console` (or any other name in the table below), enabling the feature l
 | `CompressionStream` / `DecompressionStream` (`gzip`, `deflate`, `deflate-raw`) | `Compression` **and** `Streams` | ✔ shipped |
 | `scheduler.postTask` / `scheduler.yield` / `TaskController` / `TaskSignal` | `Scheduler` | ✔ shipped |
 | `requestIdleCallback` / `cancelIdleCallback` / `IdleDeadline` | `IdleCallback` | ✔ shipped |
-| `MessageChannel` / `MessagePort` / `MessageEvent` (incl. cross-engine ports) | `Messaging` | ✔ shipped |
+| `MessageChannel` / `MessagePort` / `MessageEvent` (incl. cross-engine ports) / `BroadcastChannel` | `Messaging` | ✔ shipped |
 | `reportError` (and the `DiagnosticsSink` behind it) | `Reporting` | ✔ shipped |
 | `addEventListener` / `removeEventListener` / `dispatchEvent` / `self` on the global scope, with `ErrorEvent` / `PromiseRejectionEvent` and the `error` / `unhandledrejection` / `rejectionhandled` events | `GlobalEvents` | ✔ shipped |
 | `localStorage` / `sessionStorage` / `Storage` | `Storage` *(not in `Default` — see below)* | ✔ shipped |
@@ -477,6 +477,37 @@ and the listeners all run on whichever thread pumps that engine, so nothing on t
 its own pump. The receiver must actually be pumped, exactly as for timers: an engine nobody pumps never
 delivers a message. And a `RestoreGlobalSnapshot` on either engine ends that channel permanently — a port's
 listeners are closures over the cycle it was created in — so a pooled engine wants a fresh pair per cycle.
+
+`BroadcastChannel` rides the same `Messaging` flag and is the same machinery addressed by *name* instead of by
+peer. `new BroadcastChannel('room')` joins a name; `postMessage(value)` reaches every **other** channel of that
+name — never the sender itself — as one event-loop task each, in the order the channels were created. There is
+no `start()` and no message queue, so `addEventListener('message', …)` alone is enough to receive; there is no
+transfer list either, since a message with several destinations has nowhere to move a buffer *to*. A
+`postMessage` on a closed channel is an `InvalidStateError` `DOMException`, which is where it differs from a
+closed port's, and `close()` is what takes the channel out of earshot.
+
+Which channels are in earshot of each other is one object — a browser scopes it by agent cluster and origin,
+and `BroadcastChannelBroker` is Jint's answer to both:
+
+```csharp
+var cluster = new BroadcastChannelBroker();
+
+var producer = new Engine(o => { o.UseWebApis(); o.WebApi.Messaging.Broker = cluster; });
+var consumer = new Engine(o => { o.UseWebApis(); o.WebApi.Messaging.Broker = cluster; });
+
+consumer.Execute("new BroadcastChannel('jobs').onmessage = e => log(e.data);");
+producer.Execute("new BroadcastChannel('jobs').postMessage({ id: 7 });");
+
+consumer.Advanced.ProcessTasks();   // the consumer's turn: it receives { id: 7 }
+```
+
+Say nothing and each engine gets a private broker, so channels on one engine hear each other and nothing
+crosses an engine boundary — including between two engines built from one shared `Options`, which has to be an
+explicit act. A broker is thread-safe, and as with ports **no `JsValue` ever crosses**: one serialization record
+is produced on the sender and each destination deserializes its own copy on its own pump. It holds its
+subscribers strongly, exactly as a browser keeps a channel alive until it is closed, so a broker shared between
+long-lived and short-lived engines wants the short-lived ones closed, restored or `Dispose()`d — a
+`RestoreGlobalSnapshot` and an `Engine.Dispose` each end every channel that engine created.
 
 ### Uncaught script errors go to a `DiagnosticsSink`
 


### PR DESCRIPTION
Adds `BroadcastChannel` per the HTML Standard's web-messaging section, riding the existing `Messaging` flag — same section of the same standard, same `MessageEvent`, same structured clone across the same event loop; the only difference is that it addresses a name instead of a peer.

Closes #3165.

**Which channels are in earshot is the one thing a host has to be able to say**, so that is the whole options surface: `Options.WebApi.Messaging.Broker`. One `BroadcastChannelBroker` is one agent cluster and one origin collapsed into a single opaque token — assign the same instance to the options several engines are built from and those engines broadcast to each other; say nothing and each engine gets a private broker, so same-engine channels always work and nothing crosses an engine boundary. The broker is thread-safe and follows the `MessagePortEndpoint` discipline exactly: a message is serialized once on the sender's thread (step 2 — so `DataCloneError` is synchronous and getters run once, whoever is listening), and each destination gets one generation-fenced job on its own engine's pump, in subscription order, sender excluded.

**The catch worth reading first**: the standard's serialize-once/deserialize-per-destination shape makes the broadcast record the one thing in the engine deserialized more than once — and the deserializer's existing contract *adopts* the byte storage it finds. Followed blindly, N receivers would have come away with N `ArrayBuffer`s over one mutable `byte[]`, writes visible across engines and potentially across threads. The deserializer therefore gained a `sharedRecord` flag that copies storage instead of adopting it; the default is unchanged, so `structuredClone` and `MessagePort` are byte-for-byte what they were, and a broadcast has no transfer list at all, so the flag can never turn a promised move into a copy. Pinned from both test projects.

Other behavior worth noting, each pinned:

- `postMessage` on a closed channel is `InvalidStateError` *before* serialization (observable order, unlike a closed `MessagePort`'s silent drop).
- Delivery is the single global task step 8 describes — `EventSource`/`WebSocket` parity rather than `MessagePort`'s two-hop shape; the ordering consequence is documented on the class.
- `messageerror` never fires, for the same documented reason ports give: a record built by this engine's serializer always deserializes, and a constraint failure must erupt, never flatten into an event.
- `RestoreGlobalSnapshot` **closes** every channel the engine created (its listeners are closures over the ended cycle), and `Engine.Dispose` does too — without the latter, a host pooling short-lived engines against a long-lived shared broker would leak an engine per dispose.
- A name's bucket is removed when its last subscriber leaves, so cycling channel names cannot grow a shared broker.

59 new tests (38 in `Jint.Tests`, 21 host-facing in `Jint.Tests.PublicInterface`), nine invariants mutation-verified — including the honest result on the generation fence: the restore's unsubscribe and the dequeue-time fence are each independently sufficient on a single-threaded test surface, so the mutations demonstrate each is load-bearing with the other removed, and the belt-and-braces is kept for the cross-thread window tests cannot reach. Full matrix green: solution build all TFMs, both test projects on net10.0 + net472, and the host-contract-verification legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014n5uCpi2vvHWBSiewUwBiY
