### PR TITLE
Web API: the complete RSA family for crypto.subtle, and the asymmetric foundation under it

### DIFF
--- a/Jint.Tests.PublicInterface/WebApiCryptoTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiCryptoTests.cs
@@ -117,6 +117,108 @@ public class WebApiCryptoTests
     }
 
     [Fact]
+    public void VerifiesAnRs256SignatureAHostCanHandTheScript()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Crypto));
+
+        // The shape an embedder actually reaches for: an RS256 JWT verified inside script from a public key
+        // the host supplies as a JSON Web Key. The key, the signing input and the signature are the example
+        // of https://www.rfc-editor.org/rfc/rfc7515#appendix-A.2, so the answer is a known one.
+        engine.SetValue("jwk", Rs256PublicJwk);
+        engine.SetValue("signingInput", Rs256SigningInput);
+        engine.SetValue("signatureHex", Convert.ToHexString(Convert.FromBase64String(Rs256SignatureBase64)));
+
+        var result = engine.Evaluate("""
+            (async () => {
+                const key = await crypto.subtle.importKey(
+                    'jwk', JSON.parse(jwk), { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, ['verify']);
+
+                const signature = Uint8Array.from(signatureHex.match(/../g), x => parseInt(x, 16));
+                const data = Uint8Array.from(signingInput, c => c.charCodeAt(0));
+                const good = await crypto.subtle.verify('RSASSA-PKCS1-v1_5', key, signature, data);
+
+                const tampered = Uint8Array.from(signingInput + 'x', c => c.charCodeAt(0));
+                const bad = await crypto.subtle.verify('RSASSA-PKCS1-v1_5', key, signature, tampered);
+
+                return [good, bad, key.type, key.algorithm.modulusLength, key.algorithm.hash.name].join('|');
+            })()
+            """).UnwrapIfPromise();
+
+        result.AsString().Should().Be("true|false|public|2048|SHA-256");
+    }
+
+    [Fact]
+    public void GeneratesAKeyPairAsThePlainDictionaryTheSpecificationDefines()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Crypto));
+
+        // CryptoKeyPair is a dictionary rather than an interface, so there is no CryptoKeyPair on the global
+        // to brand-check against — what generateKey resolves with is an ordinary object carrying two keys.
+        var result = engine.Evaluate("""
+            (async () => {
+                const pair = await crypto.subtle.generateKey(
+                    { name: 'RSA-PSS', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' },
+                    true,
+                    ['sign', 'verify']);
+
+                const message = Uint8Array.from('signed by the script', c => c.charCodeAt(0));
+                const params = { name: 'RSA-PSS', saltLength: 32 };
+                const signature = await crypto.subtle.sign(params, pair.privateKey, message);
+
+                const spki = await crypto.subtle.exportKey('spki', pair.publicKey);
+
+                return [
+                    typeof CryptoKeyPair,
+                    Object.keys(pair).join(','),
+                    await crypto.subtle.verify(params, pair.publicKey, signature, message),
+                    spki.byteLength > 250,
+                ].join('|');
+            })()
+            """).UnwrapIfPromise();
+
+        result.AsString().Should().Be("undefined|privateKey,publicKey|true|true");
+    }
+
+    [Fact]
+    public void ReportsARestrictionOfThePlatformAsACatchableDomException()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Crypto));
+
+        // The three restrictions .NET's own RSA imposes are reported as OperationError DOMExceptions a
+        // script can catch and branch on, never as CLR exceptions erupting through the host.
+        engine.SetValue("jwk", Rs256PublicJwk);
+
+        var result = engine.Evaluate("""
+            (async () => {
+                const seen = [];
+
+                const key = await crypto.subtle.importKey(
+                    'jwk', JSON.parse(jwk), { name: 'RSA-OAEP', hash: 'SHA-256' }, false, ['encrypt']);
+
+                try { await crypto.subtle.encrypt({ name: 'RSA-OAEP', label: new Uint8Array([1]) }, key, new Uint8Array(4)); }
+                catch (e) { seen.push(e.name + ':' + (e instanceof DOMException)); }
+
+                try {
+                    await crypto.subtle.generateKey(
+                        { name: 'RSA-PSS', modulusLength: 2048, publicExponent: new Uint8Array([3]), hash: 'SHA-256' },
+                        false, ['sign', 'verify']);
+                }
+                catch (e) { seen.push(e.name + ':' + (e instanceof DOMException)); }
+
+                const pss = await crypto.subtle.importKey(
+                    'jwk', JSON.parse(jwk), { name: 'RSA-PSS', hash: 'SHA-256' }, false, ['verify']);
+
+                try { await crypto.subtle.verify({ name: 'RSA-PSS', saltLength: 0 }, pss, new Uint8Array(256), new Uint8Array(4)); }
+                catch (e) { seen.push(e.name + ':' + (e instanceof DOMException)); }
+
+                return seen.join(',');
+            })()
+            """).UnwrapIfPromise();
+
+        result.AsString().Should().Be("OperationError:true,OperationError:true,OperationError:true");
+    }
+
+    [Fact]
     public void AHostRegisteredCryptoGlobalWins()
     {
         var marker = new JsString("the host's own crypto");
@@ -162,5 +264,20 @@ public class WebApiCryptoTests
         first.Evaluate("crypto === crypto").AsBoolean().Should().BeTrue();
         first.Evaluate("crypto.randomUUID()").AsString().Should().NotBe(second.Evaluate("crypto.randomUUID()").AsString());
     }
+
+    /// <summary>
+    /// The RSA key, the JWS Signing Input and the RSASSA-PKCS1-v1_5 SHA-256 signature of
+    /// https://www.rfc-editor.org/rfc/rfc7515#appendix-A.2 — an example produced by an implementation
+    /// that is not this one, which is what makes verifying it a real check rather than a round trip.
+    /// </summary>
+    private const string Rs256PublicJwk =
+        "{\"kty\":\"RSA\",\"n\":\"ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddxHmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMsD1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSHSXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdVMTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ\",\"e\":\"AQAB\"}";
+
+    private const string Rs256SigningInput =
+        "eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ";
+
+    private const string Rs256SignatureBase64 =
+        "cC4hiUPoj9Eetdgtv3hF80EGrhuB//dzERat0XF9g2VtQgr9PJbu3XOiZj5RZmh7AAuHIm4Bh+0Qc/lF5YKt/O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjbKBYNX4BAynRFdiuB++f/nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHlb1L07Qe7K0GarZRmB/eSN9383LcOLn6/dO++xi12jzDwusC+eOkHWEsqtFZESc6BfI7noOPqvhJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AXLIhWkWywlVmtVrBp0igcN/IoypGlUPQGe77Rw==";
+
 }
 #endif

--- a/Jint.Tests/Runtime/WebApi/SubtleCryptoKeyTests.cs
+++ b/Jint.Tests/Runtime/WebApi/SubtleCryptoKeyTests.cs
@@ -673,7 +673,7 @@ public class SubtleCryptoKeyTests
 
             let failure;
             try {
-                await crypto.subtle.importKey('jwk', jwk, 'RSA-OAEP', true, ['sign']);
+                await crypto.subtle.importKey('jwk', jwk, 'PBKDF2', true, ['sign']);
             } catch (e) {
                 failure = e.name;
             }
@@ -862,12 +862,16 @@ public class SubtleCryptoKeyTests
     }
 
     [Theory]
-    [InlineData("sign", "'RSASSA-PKCS1-v1_5'")]
-    [InlineData("verify", "'ECDSA'")]
+    [InlineData("sign", "'ECDSA'")]
+    [InlineData("verify", "'Ed25519'")]
     [InlineData("encrypt", "'AES-CBC'")]
     [InlineData("decrypt", "{ name: 'AES-CTR' }")]
-    [InlineData("generateKey", "'RSA-OAEP'")]
+    [InlineData("generateKey", "'ECDH'")]
     [InlineData("importKey", "'PBKDF2'")]
+    // An algorithm that is registered, but not for this operation: RSA-OAEP encrypts and never signs, and
+    // RSASSA-PKCS1-v1_5 signs and never encrypts.
+    [InlineData("sign", "'RSA-OAEP'")]
+    [InlineData("encrypt", "'RSASSA-PKCS1-v1_5'")]
     public void RefusesAnUnregisteredAlgorithmWithANotSupportedError(string operation, string algorithm)
     {
         var engine = WebEngine();

--- a/Jint.Tests/Runtime/WebApi/SubtleCryptoRsaTests.cs
+++ b/Jint.Tests/Runtime/WebApi/SubtleCryptoRsaTests.cs
@@ -1145,15 +1145,26 @@ public class SubtleCryptoRsaTests
             })()
             """).AsString().Should().Be("true:function,true:function,true:function,true:function");
 
-        // ... and each of them settles as a rejection carrying a DOMException.
-        Settle(engine, """
+        // ... and each of them settles as a rejection carrying a DOMException. The JWK probe is the one row
+        // whose outcome is the platform's to decide: its 17-bit modulus is refused at *import* by an
+        // implementation that validates there (Windows CNG, a DataError) and accepted by one that validates
+        // at *use* (OpenSSL) — where encrypting with it is then refused, still as the wrapped OperationError.
+        // Either way, no CryptographicException reaches script, which is what this test exists to prove.
+        var settled = Settle(engine, """
             Promise.all([
                 crypto.subtle.importKey('spki', new Uint8Array([9, 9, 9]), { name: 'RSA-PSS', hash: 'SHA-256' }, false, ['verify']).catch(e => e.name),
                 crypto.subtle.importKey('pkcs8', new Uint8Array([9, 9, 9]), { name: 'RSA-OAEP', hash: 'SHA-256' }, false, ['decrypt']).catch(e => e.name),
-                crypto.subtle.importKey('jwk', { kty: 'RSA', n: 'AQAB', e: 'AQAB' }, { name: 'RSA-OAEP', hash: 'SHA-256' }, false, ['encrypt']).catch(e => e.name),
+                crypto.subtle.importKey('jwk', { kty: 'RSA', n: 'AQAB', e: 'AQAB' }, { name: 'RSA-OAEP', hash: 'SHA-256' }, false, ['encrypt'])
+                    .then(
+                        key => crypto.subtle.encrypt({ name: 'RSA-OAEP' }, key, new Uint8Array(1)).then(() => 'encrypted', e => 'imported+' + e.name),
+                        e => e.name),
                 crypto.subtle.generateKey({ name: 'RSA-PSS', modulusLength: 7, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' }, false, ['sign']).catch(e => e.name),
             ]).then(names => names.join(','))
-            """).AsString().Should().Be("DataError,DataError,DataError,OperationError");
+            """).AsString();
+
+        settled.Should().BeOneOf(
+            "DataError,DataError,DataError,OperationError",
+            "DataError,DataError,imported+OperationError,OperationError");
     }
 
     [Fact]

--- a/Jint.Tests/Runtime/WebApi/SubtleCryptoRsaTests.cs
+++ b/Jint.Tests/Runtime/WebApi/SubtleCryptoRsaTests.cs
@@ -1,0 +1,1237 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Native;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// The RSA family of <c>crypto.subtle</c> — RSASSA-PKCS1-v1_5
+/// (https://w3c.github.io/webcrypto/#rsassa-pkcs1), RSA-PSS (https://w3c.github.io/webcrypto/#rsa-pss) and
+/// RSA-OAEP (https://w3c.github.io/webcrypto/#rsa-oaep), together with the <c>spki</c> and <c>pkcs8</c> key
+/// formats and the asymmetric half of JSON Web Key that arrived with them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The cryptography is checked against published vectors, which is the only way to check it. The keys and
+/// the expected outputs come from the JOSE RFCs, whose examples were produced by implementations that are
+/// not this one: RFC 7515 Appendix A.2 for RSASSA-PKCS1-v1_5 with SHA-256 (key, signing input and
+/// signature), RFC 7520 Section 4.2 for RSA-PSS with SHA-384 (key from Section 3.4, signing input and
+/// signature), and RFC 7520 Section 5.2 for RSA-OAEP with SHA-1 (4096-bit key, and a fixed ciphertext whose
+/// plaintext the RFC also gives). RSA-PSS and RSA-OAEP are randomized, so only their <i>verify</i> and
+/// <i>decrypt</i> directions can be known-answer tested; their signing and encrypting directions are checked
+/// by round trip against the same key.
+/// </para>
+/// <para>
+/// The <c>pkcs8</c> and <c>spki</c> bytes for the RFC 7515 key were DER-encoded from that JWK's own
+/// integers, by hand, outside this engine — so a test that imports them and reproduces the RFC's signature
+/// is checking this engine's parsing against an encoding it did not produce. The other keys are imported as
+/// JWK and re-exported, which checks the two directions against each other.
+/// </para>
+/// <para>
+/// Key <b>generation</b> appears three times and always at 2048 bits: an RSA key pair is a prime search, and
+/// the cost of one is several orders of magnitude above every other operation here. Everything that does not
+/// need a fresh key uses one of the fixed ones.
+/// </para>
+/// </remarks>
+public class SubtleCryptoRsaTests
+{
+    /// <summary>
+    /// The same helpers <see cref="SubtleCryptoKeyTests"/> uses, for the same reason: bytes are built from
+    /// hex or from character codes rather than through <c>TextEncoder</c> or <c>atob</c>, so that crypto is
+    /// the only feature the engine carries and nothing can be passing because of a neighbour.
+    /// </summary>
+    private const string Prelude = """
+        const hex = b => Array.from(new Uint8Array(b)).map(x => x.toString(16).padStart(2, '0')).join('');
+        const bytes = h => Uint8Array.from(h.match(/../g) || [], x => parseInt(x, 16));
+        const ascii = s => Uint8Array.from(s, c => c.charCodeAt(0));
+        """;
+
+    /// <summary>
+    /// An engine with the crypto feature and the helpers above already declared — unlike
+    /// <see cref="SubtleCryptoKeyTests"/>, whose prelude rides along with each script, because several tests
+    /// here settle more than one expression on one engine and a second <c>const</c> declaration of the same
+    /// name is a redeclaration.
+    /// </summary>
+    private static Engine WebEngine()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Crypto));
+        engine.Evaluate(Prelude);
+        return engine;
+    }
+
+    /// <summary>Runs an async body to completion and answers what it returned.</summary>
+    private static JsValue Run(string body, Engine? engine = null)
+    {
+        engine ??= WebEngine();
+        return engine.Evaluate("(async () => {\n" + body + "\n})()").UnwrapIfPromise();
+    }
+
+    /// <summary>Settles one expression's promise and answers whatever it resolved or rejected to.</summary>
+    private static JsValue Settle(Engine engine, string source) => engine.Evaluate(source).UnwrapIfPromise();
+
+    // ---------------------------------------------------------------------------------------------------
+    // RSASSA-PKCS1-v1_5: the published vector
+    // ---------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void SignsTheRfc7515Rs256Vector()
+    {
+        // https://www.rfc-editor.org/rfc/rfc7515#appendix-A.2 — the RSASSA-PKCS1-v1_5 SHA-256 signature over
+        // that appendix's JWS Signing Input, with the private key of its Figure. PKCS#1 v1.5 is
+        // deterministic, so the signature is a byte-for-byte known answer.
+        Run($$"""
+            const key = await crypto.subtle.importKey(
+                'pkcs8', bytes('{{Rs256Pkcs8Hex}}'), { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, ['sign']);
+
+            return hex(await crypto.subtle.sign('RSASSA-PKCS1-v1_5', key, ascii('{{Rs256SigningInput}}')));
+            """).AsString().Should().Be(Rs256SignatureHex);
+    }
+
+    [Fact]
+    public void VerifiesTheRfc7515Rs256VectorFromEveryPublicFormat()
+    {
+        // The same public key, described three ways, must reach the same answer — and a message that is one
+        // character different must not.
+        Run($$"""
+            const spki = await crypto.subtle.importKey(
+                'spki', bytes('{{Rs256SpkiHex}}'), { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, ['verify']);
+            const jwk = await crypto.subtle.importKey(
+                'jwk', { {{Rs256PublicJwk}} }, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, ['verify']);
+
+            const signature = bytes('{{Rs256SignatureHex}}');
+            const message = ascii('{{Rs256SigningInput}}');
+
+            return [
+                await crypto.subtle.verify('RSASSA-PKCS1-v1_5', spki, signature, message),
+                await crypto.subtle.verify('RSASSA-PKCS1-v1_5', jwk, signature, message),
+                await crypto.subtle.verify('RSASSA-PKCS1-v1_5', spki, signature, ascii('{{Rs256SigningInput}}x')),
+                await crypto.subtle.verify('RSASSA-PKCS1-v1_5', spki, new Uint8Array(256), message),
+                await crypto.subtle.verify('RSASSA-PKCS1-v1_5', spki, new Uint8Array(0), message),
+            ].join(',');
+            """).AsString().Should().Be("true,true,false,false,false");
+    }
+
+    [Theory]
+    [InlineData("SHA-1")]
+    [InlineData("SHA-256")]
+    [InlineData("SHA-384")]
+    [InlineData("SHA-512")]
+    public void SignsAndVerifiesWithEveryRegisteredHash(string hash)
+    {
+        Run($$"""
+            const priv = await crypto.subtle.importKey(
+                'jwk', { {{Rs256PrivateJwk}} }, { name: 'RSASSA-PKCS1-v1_5', hash: '{{hash}}' }, false, ['sign']);
+            const pub = await crypto.subtle.importKey(
+                'jwk', { {{Rs256PublicJwk}} }, { name: 'RSASSA-PKCS1-v1_5', hash: '{{hash}}' }, false, ['verify']);
+
+            const message = ascii('the message');
+            const signature = await crypto.subtle.sign('RSASSA-PKCS1-v1_5', priv, message);
+
+            return [
+                signature.byteLength,
+                await crypto.subtle.verify('RSASSA-PKCS1-v1_5', pub, signature, message),
+                priv.algorithm.hash.name,
+            ].join('|');
+            """).AsString().Should().Be("256|true|" + hash);
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // RSA-PSS: the published vector, and the salt-length restriction
+    // ---------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void VerifiesTheRfc7520Ps384Vector()
+    {
+        // https://www.rfc-editor.org/rfc/rfc7520#section-4.2 — a PS384 signature produced by another
+        // implementation over that section's JWS Signing Input, with the 2048-bit key of Section 3.4. PSS is
+        // randomized, so this direction is the one that can be a known answer at all.
+        Run($$"""
+            const key = await crypto.subtle.importKey(
+                'jwk', { {{PssPublicJwk}} }, { name: 'RSA-PSS', hash: 'SHA-384' }, false, ['verify']);
+
+            const params = { name: 'RSA-PSS', saltLength: 48 };
+            const signature = bytes('{{Ps384SignatureHex}}');
+
+            return [
+                await crypto.subtle.verify(params, key, signature, ascii('{{Ps384SigningInput}}')),
+                await crypto.subtle.verify(params, key, signature, ascii('{{Ps384SigningInput}}x')),
+            ].join(',');
+            """).AsString().Should().Be("true,false");
+    }
+
+    [Theory]
+    [InlineData("SHA-1", 20)]
+    [InlineData("SHA-256", 32)]
+    [InlineData("SHA-384", 48)]
+    [InlineData("SHA-512", 64)]
+    public void RoundTripsAPssSignatureAtTheSaltLengthThePlatformProduces(string hash, int saltLength)
+    {
+        Run($$"""
+            const priv = await crypto.subtle.importKey(
+                'jwk', { {{PssPrivateJwk}} }, { name: 'RSA-PSS', hash: '{{hash}}' }, false, ['sign']);
+            const pub = await crypto.subtle.importKey(
+                'jwk', { {{PssPublicJwk}} }, { name: 'RSA-PSS', hash: '{{hash}}' }, false, ['verify']);
+
+            const params = { name: 'RSA-PSS', saltLength: {{saltLength}} };
+            const message = ascii('the message');
+
+            const first = await crypto.subtle.sign(params, priv, message);
+            const second = await crypto.subtle.sign(params, priv, message);
+
+            return [
+                await crypto.subtle.verify(params, pub, first, message),
+                // PSS draws a fresh salt each time, so two signatures over the same message differ.
+                hex(first) === hex(second),
+            ].join(',');
+            """).AsString().Should().Be("true,false");
+    }
+
+    [Theory]
+    [InlineData("SHA-256", 0)]
+    [InlineData("SHA-256", 20)]
+    [InlineData("SHA-256", 31)]
+    [InlineData("SHA-256", 33)]
+    [InlineData("SHA-512", 32)]
+    public void RefusesAPssSaltLengthThePlatformCannotProduce(string hash, int saltLength)
+    {
+        var engine = WebEngine();
+
+        // A documented divergence: .NET's RSASignaturePadding.Pss carries no salt-length parameter and always
+        // uses the hash's own output length, so every other length the caller may ask for is an
+        // OperationError naming the restriction rather than a signature made with a salt nobody asked for.
+        Settle(engine, $$"""
+            crypto.subtle.importKey('jwk', { {{PssPrivateJwk}} }, { name: 'RSA-PSS', hash: '{{hash}}' }, false, ['sign'])
+                .then(key => crypto.subtle.sign({ name: 'RSA-PSS', saltLength: {{saltLength}} }, key, new Uint8Array(4)))
+                .then(() => 'signed', e => e.name + '/' + (e instanceof DOMException))
+            """).AsString().Should().Be("OperationError/true");
+
+        Settle(engine, $$"""
+            crypto.subtle.importKey('jwk', { {{PssPublicJwk}} }, { name: 'RSA-PSS', hash: '{{hash}}' }, false, ['verify'])
+                .then(key => crypto.subtle.verify({ name: 'RSA-PSS', saltLength: {{saltLength}} }, key, new Uint8Array(256), new Uint8Array(4)))
+                .then(() => 'verified', e => e.name)
+            """).AsString().Should().Be("OperationError");
+    }
+
+    [Fact]
+    public void TheSaltLengthIsARequiredMemberOfRsaPssParams()
+    {
+        var engine = WebEngine();
+
+        // `required [EnforceRange] unsigned long saltLength` — an absent required member is the TypeError
+        // WebIDL raises for it, which is a different failure from a length the platform cannot produce.
+        foreach (var algorithm in new[] { "'RSA-PSS'", "{ name: 'RSA-PSS' }", "{ name: 'RSA-PSS', saltLength: undefined }" })
+        {
+            Settle(engine, $$"""
+                crypto.subtle.importKey('jwk', { {{PssPrivateJwk}} }, { name: 'RSA-PSS', hash: 'SHA-256' }, false, ['sign'])
+                    .then(key => crypto.subtle.sign({{algorithm}}, key, new Uint8Array(4)))
+                    .then(() => 'signed', e => e.constructor.name)
+                """).AsString().Should().Be("TypeError");
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // RSA-OAEP: the published vector, and the label restriction
+    // ---------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void DecryptsTheRfc7520RsaOaepVector()
+    {
+        // https://www.rfc-editor.org/rfc/rfc7520#section-5.2 — the Encrypted Key of Figure 87, produced by
+        // another implementation with the 4096-bit key of Figure 84, whose plaintext is the Content
+        // Encryption Key of Figure 85. The JOSE algorithm named "RSA-OAEP" is OAEP with SHA-1.
+        Run($$"""
+            const key = await crypto.subtle.importKey(
+                'jwk', { {{OaepPrivateJwk}} }, { name: 'RSA-OAEP', hash: 'SHA-1' }, false, ['decrypt']);
+
+            return hex(await crypto.subtle.decrypt({ name: 'RSA-OAEP' }, key, bytes('{{OaepCiphertextHex}}')));
+            """).AsString().Should().Be(OaepPlaintextHex);
+    }
+
+    [Theory]
+    [InlineData("SHA-1")]
+    [InlineData("SHA-256")]
+    [InlineData("SHA-384")]
+    [InlineData("SHA-512")]
+    public void RoundTripsAnOaepMessageWithEveryRegisteredHash(string hash)
+    {
+        Run($$"""
+            const pub = await crypto.subtle.importKey(
+                'jwk', { {{OaepPublicJwk}} }, { name: 'RSA-OAEP', hash: '{{hash}}' }, false, ['encrypt']);
+            const priv = await crypto.subtle.importKey(
+                'jwk', { {{OaepPrivateJwk}} }, { name: 'RSA-OAEP', hash: '{{hash}}' }, false, ['decrypt']);
+
+            const plaintext = ascii('a short secret');
+            const first = await crypto.subtle.encrypt({ name: 'RSA-OAEP' }, pub, plaintext);
+            const second = await crypto.subtle.encrypt({ name: 'RSA-OAEP' }, pub, plaintext);
+
+            return [
+                first.byteLength,
+                hex(await crypto.subtle.decrypt({ name: 'RSA-OAEP' }, priv, first)) === hex(plaintext),
+                // OAEP draws fresh padding each time, so two ciphertexts of one message differ.
+                hex(first) === hex(second),
+            ].join('|');
+            """).AsString().Should().Be("512|true|false");
+    }
+
+    [Fact]
+    public void AnAbsentOrEmptyOaepLabelWorksAndANonEmptyOneDoesNot()
+    {
+        // A documented divergence: RSAEncryptionPadding carries a hash and no label, so the empty label is
+        // the only one this engine can honour. Encrypting with the empty label instead of the caller's would
+        // produce a ciphertext the intended recipient cannot decrypt, so it is refused.
+        Run($$"""
+            const pub = await crypto.subtle.importKey(
+                'jwk', { {{OaepPublicJwk}} }, { name: 'RSA-OAEP', hash: 'SHA-256' }, false, ['encrypt']);
+            const priv = await crypto.subtle.importKey(
+                'jwk', { {{OaepPrivateJwk}} }, { name: 'RSA-OAEP', hash: 'SHA-256' }, false, ['decrypt']);
+
+            const plaintext = ascii('labelled');
+            const outcomes = [];
+
+            for (const params of [{ name: 'RSA-OAEP' }, { name: 'RSA-OAEP', label: new Uint8Array(0) }, { name: 'RSA-OAEP', label: undefined }]) {
+                const ciphertext = await crypto.subtle.encrypt(params, pub, plaintext);
+                outcomes.push(hex(await crypto.subtle.decrypt(params, priv, ciphertext)) === hex(plaintext));
+            }
+
+            for (const params of [{ name: 'RSA-OAEP', label: ascii('x') }, { name: 'RSA-OAEP', label: new Uint8Array(32) }]) {
+                try { await crypto.subtle.encrypt(params, pub, plaintext); outcomes.push('encrypted'); }
+                catch (e) { outcomes.push(e.name); }
+                try { await crypto.subtle.decrypt(params, priv, new Uint8Array(512)); outcomes.push('decrypted'); }
+                catch (e) { outcomes.push(e.name); }
+            }
+
+            return outcomes.join(',');
+            """).AsString().Should().Be(
+                "true,true,true,OperationError,OperationError,OperationError,OperationError");
+    }
+
+    [Fact]
+    public void EveryWayAnOaepDecryptionCanFailIsTheSameOperationError()
+    {
+        // OAEP's padding check is exactly what a chosen-ciphertext attack probes, so a ciphertext that is
+        // corrupt, that was made for another key, or that is simply the wrong length must all be one answer.
+        Run($$"""
+            const pub = await crypto.subtle.importKey(
+                'jwk', { {{OaepPublicJwk}} }, { name: 'RSA-OAEP', hash: 'SHA-256' }, false, ['encrypt']);
+            const priv = await crypto.subtle.importKey(
+                'jwk', { {{OaepPrivateJwk}} }, { name: 'RSA-OAEP', hash: 'SHA-256' }, false, ['decrypt']);
+
+            const good = new Uint8Array(await crypto.subtle.encrypt({ name: 'RSA-OAEP' }, pub, ascii('secret')));
+
+            const corrupt = good.slice();
+            corrupt[100] ^= 1;
+
+            const truncated = good.slice(0, 511);
+            const wrongHash = await crypto.subtle.importKey(
+                'jwk', { {{OaepPrivateJwk}} }, { name: 'RSA-OAEP', hash: 'SHA-384' }, false, ['decrypt']);
+
+            const outcomes = [];
+            for (const [key, data] of [[priv, corrupt], [priv, truncated], [priv, new Uint8Array(512)], [wrongHash, good]]) {
+                try { await crypto.subtle.decrypt({ name: 'RSA-OAEP' }, key, data); outcomes.push('decrypted'); }
+                catch (e) { outcomes.push(e.name + '/' + (e instanceof DOMException) + '/' + (e.message.indexOf('could not be decrypted') >= 0)); }
+            }
+
+            return outcomes.join(',');
+            """).AsString().Should().Be(
+                "OperationError/true/true,OperationError/true/true,OperationError/true/true,OperationError/true/true");
+    }
+
+    [Fact]
+    public void RefusesAPlaintextTooLongForTheModulusWithAnOperationError()
+    {
+        var engine = WebEngine();
+
+        // "If performing the operation results in an error, then throw an OperationError." A 4096-bit
+        // modulus with SHA-512 OAEP padding carries at most 512 - 2*64 - 2 = 382 bytes.
+        Settle(engine, $$"""
+            crypto.subtle.importKey('jwk', { {{OaepPublicJwk}} }, { name: 'RSA-OAEP', hash: 'SHA-512' }, false, ['encrypt'])
+                .then(key => crypto.subtle.encrypt({ name: 'RSA-OAEP' }, key, new Uint8Array(383)))
+                .then(() => 'encrypted', e => e.name + '/' + (e instanceof DOMException))
+            """).AsString().Should().Be("OperationError/true");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // Key formats
+    // ---------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void RoundTripsAnRsaKeyThroughEveryFormatItHas()
+    {
+        // The shape a script actually writes: import once, export, import somewhere else, and get the same
+        // deterministic signature out of each.
+        Run($$"""
+            const original = await crypto.subtle.importKey(
+                'jwk', { {{Rs256PrivateJwk}} }, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, true, ['sign']);
+
+            const message = ascii('{{Rs256SigningInput}}');
+            const expected = '{{Rs256SignatureHex}}';
+
+            const pkcs8 = await crypto.subtle.exportKey('pkcs8', original);
+            const fromPkcs8 = await crypto.subtle.importKey(
+                'pkcs8', pkcs8, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, ['sign']);
+
+            const jwk = await crypto.subtle.exportKey('jwk', original);
+            const fromJwk = await crypto.subtle.importKey(
+                'jwk', jwk, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, ['sign']);
+
+            const publicKey = await crypto.subtle.importKey(
+                'spki', bytes('{{Rs256SpkiHex}}'), { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, true, ['verify']);
+            const spki = await crypto.subtle.exportKey('spki', publicKey);
+            const fromSpki = await crypto.subtle.importKey(
+                'spki', spki, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, ['verify']);
+
+            return [
+                hex(await crypto.subtle.sign('RSASSA-PKCS1-v1_5', fromPkcs8, message)) === expected,
+                hex(await crypto.subtle.sign('RSASSA-PKCS1-v1_5', fromJwk, message)) === expected,
+                await crypto.subtle.verify('RSASSA-PKCS1-v1_5', fromSpki, bytes(expected), message),
+                // The DER a key exports is the DER it was imported from, byte for byte: both are the
+                // platform's canonical encoding of the same key.
+                hex(spki) === '{{Rs256SpkiHex}}',
+                hex(pkcs8) === '{{Rs256Pkcs8Hex}}',
+            ].join('|');
+            """).AsString().Should().Be("true|true|true|true|true");
+    }
+
+    [Fact]
+    public void TheSameKeyImportedFromJwkAndFromPkcs8IsTheSameKey()
+    {
+        // Cross-format consistency: the two import paths reach the same key material, so they export the
+        // same DER, describe themselves the same way, and produce the same deterministic signature.
+        Run($$"""
+            const fromJwk = await crypto.subtle.importKey(
+                'jwk', { {{Rs256PrivateJwk}} }, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, true, ['sign']);
+            const fromPkcs8 = await crypto.subtle.importKey(
+                'pkcs8', bytes('{{Rs256Pkcs8Hex}}'), { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, true, ['sign']);
+
+            const message = ascii('{{Rs256SigningInput}}');
+
+            return [
+                hex(await crypto.subtle.exportKey('pkcs8', fromJwk)) === hex(await crypto.subtle.exportKey('pkcs8', fromPkcs8)),
+                JSON.stringify(await crypto.subtle.exportKey('jwk', fromJwk)) === JSON.stringify(await crypto.subtle.exportKey('jwk', fromPkcs8)),
+                hex(await crypto.subtle.sign('RSASSA-PKCS1-v1_5', fromJwk, message)) === hex(await crypto.subtle.sign('RSASSA-PKCS1-v1_5', fromPkcs8, message)),
+                fromJwk.algorithm.modulusLength === fromPkcs8.algorithm.modulusLength,
+            ].join('|');
+            """).AsString().Should().Be("true|true|true|true");
+    }
+
+    [Fact]
+    public void AJwkWhoseIntegersCarryLeadingZeroBytesStillImports()
+    {
+        // JSON Web Algorithms asks for "the minimum number of octets needed to represent the value", but a
+        // producer that pads is describing the same integer — a big-endian magnitude with leading zeros. The
+        // proof that nothing was lost is the RFC's own signature.
+        Run($$"""
+            const jwk = { {{Rs256PrivateJwk}} };
+            jwk.p = '{{Rs256PaddedP}}';
+            jwk.qi = '{{Rs256PaddedQi}}';
+
+            const key = await crypto.subtle.importKey(
+                'jwk', jwk, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, ['sign']);
+
+            return hex(await crypto.subtle.sign('RSASSA-PKCS1-v1_5', key, ascii('{{Rs256SigningInput}}')));
+            """).AsString().Should().Be(Rs256SignatureHex);
+    }
+
+    [Theory]
+    [InlineData("RSASSA-PKCS1-v1_5", "verify")]
+    [InlineData("RSA-PSS", "verify")]
+    [InlineData("RSA-OAEP", "encrypt")]
+    public void RefusesTheRawFormatWithANotSupportedError(string algorithm, string usage)
+    {
+        var engine = WebEngine();
+
+        // "Otherwise: throw a NotSupportedError" — raw describes a symmetric key, which no RSA algorithm has.
+        Settle(engine, $$"""
+            crypto.subtle.importKey('raw', new Uint8Array(256), { name: '{{algorithm}}', hash: 'SHA-256' }, false, ['{{usage}}'])
+                .then(() => 'imported', e => e.name)
+            """).AsString().Should().Be("NotSupportedError");
+
+        Settle(engine, $$"""
+            crypto.subtle.importKey('jwk', { {{Rs256PublicJwk}} }, { name: '{{algorithm}}', hash: 'SHA-256' }, true, ['{{usage}}'])
+                .then(key => crypto.subtle.exportKey('raw', key))
+                .then(() => 'exported', e => e.name)
+            """).AsString().Should().Be("NotSupportedError");
+    }
+
+    [Fact]
+    public void EachDerFormatBelongsToOneKeyType()
+    {
+        // "If the [[type]] internal slot of key is not 'public', then throw an InvalidAccessError" — spki
+        // describes a public key and pkcs8 a private one, and neither can stand in for the other.
+        Run($$"""
+            const priv = await crypto.subtle.importKey(
+                'jwk', { {{Rs256PrivateJwk}} }, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, true, ['sign']);
+            const pub = await crypto.subtle.importKey(
+                'jwk', { {{Rs256PublicJwk}} }, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, true, ['verify']);
+
+            const outcomes = [];
+            for (const [key, format] of [[priv, 'spki'], [pub, 'pkcs8']]) {
+                try { await crypto.subtle.exportKey(format, key); outcomes.push('exported'); }
+                catch (e) { outcomes.push(e.name + '/' + (e instanceof DOMException)); }
+            }
+
+            return outcomes.join(',');
+            """).AsString().Should().Be("InvalidAccessError/true,InvalidAccessError/true");
+    }
+
+    [Fact]
+    public void ANonExtractableRsaKeyCannotBeExportedInAnyFormat()
+    {
+        Run($$"""
+            const key = await crypto.subtle.importKey(
+                'jwk', { {{Rs256PrivateJwk}} }, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, ['sign']);
+
+            const outcomes = [];
+            for (const format of ['pkcs8', 'jwk']) {
+                try { await crypto.subtle.exportKey(format, key); outcomes.push('exported'); }
+                catch (e) { outcomes.push(e.name); }
+            }
+
+            // ... and it still signs: extractable is about the material, not about the key's use.
+            outcomes.push((await crypto.subtle.sign('RSASSA-PKCS1-v1_5', key, ascii('x'))).byteLength);
+            return outcomes.join('|');
+            """).AsString().Should().Be("InvalidAccessError|InvalidAccessError|256");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // JSON Web Key
+    // ---------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void ExportsAnRsaJwkWithTheFieldsAndTheOrderWebIdlGivesIt()
+    {
+        // A dictionary is converted to an object member by member in lexicographical order —
+        // https://webidl.spec.whatwg.org/#es-dictionary. A public key carries n and e (Section 6.3.1 of JSON
+        // Web Algorithms) and a private key those plus d, p, q, dp, dq and qi (Section 6.3.2).
+        Run($$"""
+            const priv = await crypto.subtle.importKey(
+                'jwk', { {{Rs256PrivateJwk}} }, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, true, ['sign']);
+            const pub = await crypto.subtle.importKey(
+                'jwk', { {{Rs256PublicJwk}} }, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, true, ['verify']);
+
+            const privJwk = await crypto.subtle.exportKey('jwk', priv);
+            const pubJwk = await crypto.subtle.exportKey('jwk', pub);
+
+            return [
+                Object.keys(privJwk).join(','),
+                Object.keys(pubJwk).join(','),
+                privJwk.kty + '/' + privJwk.alg + '/' + privJwk.ext + '/' + privJwk.key_ops.join('+'),
+                pubJwk.e,
+                privJwk.n === pubJwk.n,
+            ].join('|');
+            """).AsString().Should().Be(
+                "alg,d,dp,dq,e,ext,key_ops,kty,n,p,q,qi|alg,e,ext,key_ops,kty,n|RSA/RS256/true/sign|AQAB|true");
+    }
+
+    [Theory]
+    [InlineData("RSASSA-PKCS1-v1_5", "SHA-1", "RS1")]
+    [InlineData("RSASSA-PKCS1-v1_5", "SHA-256", "RS256")]
+    [InlineData("RSASSA-PKCS1-v1_5", "SHA-384", "RS384")]
+    [InlineData("RSASSA-PKCS1-v1_5", "SHA-512", "RS512")]
+    [InlineData("RSA-PSS", "SHA-1", "PS1")]
+    [InlineData("RSA-PSS", "SHA-256", "PS256")]
+    [InlineData("RSA-PSS", "SHA-384", "PS384")]
+    [InlineData("RSA-PSS", "SHA-512", "PS512")]
+    [InlineData("RSA-OAEP", "SHA-1", "RSA-OAEP")]
+    [InlineData("RSA-OAEP", "SHA-256", "RSA-OAEP-256")]
+    [InlineData("RSA-OAEP", "SHA-384", "RSA-OAEP-384")]
+    [InlineData("RSA-OAEP", "SHA-512", "RSA-OAEP-512")]
+    public void TheJwkAlgorithmNamesTheAlgorithmAndItsHash(string algorithm, string hash, string alg)
+    {
+        // https://www.rfc-editor.org/rfc/rfc7518#section-3.1 and #section-4.3, plus RS1 and PS1, which the
+        // Web Cryptography API names for SHA-1. The round trip proves the table is read the same way it is
+        // written: an exported alg must import again.
+        var usage = string.Equals(algorithm, "RSA-OAEP", StringComparison.Ordinal) ? "encrypt" : "verify";
+
+        Run($$"""
+            const key = await crypto.subtle.importKey(
+                'jwk', { {{Rs256PublicJwk}} }, { name: '{{algorithm}}', hash: '{{hash}}' }, true, ['{{usage}}']);
+            const jwk = await crypto.subtle.exportKey('jwk', key);
+
+            const reimported = await crypto.subtle.importKey(
+                'jwk', jwk, { name: '{{algorithm}}', hash: '{{hash}}' }, true, ['{{usage}}']);
+
+            return jwk.alg + '|' + reimported.algorithm.hash.name + '|' + reimported.algorithm.name;
+            """).AsString().Should().Be(alg + "|" + hash + "|" + algorithm);
+    }
+
+    [Theory]
+    // "If the kty field of jwk is not a case-sensitive string match to 'RSA', then throw a DataError."
+    [InlineData("delete jwk.kty", "DataError")]
+    [InlineData("jwk.kty = 'rsa'", "DataError")]
+    [InlineData("jwk.kty = 'oct'", "DataError")]
+    // Section 6.3.1 of JSON Web Algorithms: n and e are what an RSA public key is.
+    [InlineData("delete jwk.n", "DataError")]
+    [InlineData("delete jwk.e", "DataError")]
+    [InlineData("jwk.n = ''", "DataError")]
+    [InlineData("jwk.n = 'not+base64url'", "DataError")]
+    [InlineData("jwk.n = 'AAAA'", "DataError")]
+    // "If the alg field is equal to the string 'RS256' … otherwise throw a DataError", and an alg that names
+    // a hash the import did not ask for is a DataError too.
+    [InlineData("jwk.alg = 'RS384'", "DataError")]
+    [InlineData("jwk.alg = 'PS256'", "DataError")]
+    [InlineData("jwk.alg = 'HS256'", "DataError")]
+    // The three fields every JWK import checks.
+    [InlineData("jwk.use = 'enc'", "DataError")]
+    [InlineData("jwk.key_ops = ['sign']", "DataError")]
+    [InlineData("jwk.key_ops = ['verify', 'verify']", "DataError")]
+    [InlineData("jwk.ext = false", "DataError")]
+    public void RefusesAMalformedRsaJwkWithADataError(string mutation, string expected)
+    {
+        var engine = WebEngine();
+
+        // Every row is imported as an extractable verifying key, so the `ext` and `key_ops` rows are about
+        // the JWK rather than about the request.
+        Settle(engine, $$"""
+            (() => {
+                const jwk = { {{Rs256PublicJwk}} };
+                {{mutation}};
+                return crypto.subtle.importKey('jwk', jwk, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, true, ['verify'])
+                    .then(() => 'imported', e => e.name + '/' + (e instanceof DOMException));
+            })()
+            """).AsString().Should().Be(expected + "/true");
+    }
+
+    [Fact]
+    public void RefusesAPrivateJwkDescribedByDAloneWithADataError()
+    {
+        var engine = WebEngine();
+
+        // A documented divergence: Section 6.3.2 of JSON Web Algorithms permits a private key described by
+        // n, e and d without the CRT parameters, and .NET's RSAParameters describes a private key by its CRT
+        // form. Recovering the primes from (n, e, d) is a factoring routine, which is not something to write
+        // here, so such a key is refused rather than half-imported.
+        Settle(engine, $$"""
+            (() => {
+                const jwk = { {{Rs256PrivateJwk}} };
+                for (const field of ['p', 'q', 'dp', 'dq', 'qi']) { delete jwk[field]; }
+                return crypto.subtle.importKey('jwk', jwk, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, ['sign'])
+                    .then(() => 'imported', e => e.name + '/' + (e.message.indexOf('CRT parameters') >= 0));
+            })()
+            """).AsString().Should().Be("DataError/true");
+
+        // A partial CRT set is refused too — Section 6.3.2 requires all of them or none.
+        Settle(engine, $$"""
+            (() => {
+                const jwk = { {{Rs256PrivateJwk}} };
+                delete jwk.qi;
+                return crypto.subtle.importKey('jwk', jwk, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, ['sign'])
+                    .then(() => 'imported', e => e.name);
+            })()
+            """).AsString().Should().Be("DataError");
+    }
+
+    [Fact]
+    public void ReadsEveryRsaJwkFieldInWebIdlsOwnOrderAndOnlyOnce()
+    {
+        // A dictionary's members are converted in lexicographical order, each read exactly once. A second
+        // read would be a second chance for a getter to change the answer between the check and the import.
+        Run($$"""
+            const reads = [];
+            const source = { {{Rs256PrivateJwk}} };
+            const jwk = {};
+            for (const name of ['qi', 'q', 'p', 'n', 'kty', 'e', 'd', 'dq', 'dp']) {
+                Object.defineProperty(jwk, name, { enumerable: true, get() { reads.push(name); return source[name]; } });
+            }
+            Object.defineProperty(jwk, 'alg', { enumerable: true, get() { reads.push('alg'); return 'RS256'; } });
+            Object.defineProperty(jwk, 'ext', { enumerable: true, get() { reads.push('ext'); return true; } });
+            Object.defineProperty(jwk, 'key_ops', { enumerable: true, get() { reads.push('key_ops'); return ['sign']; } });
+            Object.defineProperty(jwk, 'use', { enumerable: true, get() { reads.push('use'); return 'sig'; } });
+
+            await crypto.subtle.importKey('jwk', jwk, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, true, ['sign']);
+            return reads.join(',');
+            """).AsString().Should().Be("alg,d,dp,dq,e,ext,key_ops,kty,n,p,q,qi,use");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // The key-type and usage matrices
+    // ---------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void AnOperationRefusesTheWrongHalfOfTheKeyPair()
+    {
+        // Step 1 of every RSA operation: sign and decrypt need a private key, verify and encrypt a public
+        // one. It is an InvalidAccessError, and it comes from the algorithm rather than from the usages —
+        // which is why each key here carries the usage the operation asks for.
+        Run($$"""
+            const signPub = await crypto.subtle.importKey(
+                'jwk', { {{Rs256PublicJwk}} }, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, ['verify']);
+            const signPriv = await crypto.subtle.importKey(
+                'jwk', { {{Rs256PrivateJwk}} }, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, ['sign']);
+            const oaepPub = await crypto.subtle.importKey(
+                'jwk', { {{OaepPublicJwk}} }, { name: 'RSA-OAEP', hash: 'SHA-256' }, false, ['encrypt']);
+            const oaepPriv = await crypto.subtle.importKey(
+                'jwk', { {{OaepPrivateJwk}} }, { name: 'RSA-OAEP', hash: 'SHA-256' }, false, ['decrypt']);
+
+            const outcomes = [];
+            const attempt = async fn => { try { await fn(); outcomes.push('ok'); } catch (e) { outcomes.push(e.name); } };
+
+            // A public key cannot sign, and a private key cannot verify.
+            await attempt(() => crypto.subtle.sign('RSASSA-PKCS1-v1_5', signPub, ascii('m')));
+            await attempt(() => crypto.subtle.verify('RSASSA-PKCS1-v1_5', signPriv, new Uint8Array(256), ascii('m')));
+            // A private key cannot encrypt, and a public key cannot decrypt.
+            await attempt(() => crypto.subtle.encrypt({ name: 'RSA-OAEP' }, oaepPriv, ascii('m')));
+            await attempt(() => crypto.subtle.decrypt({ name: 'RSA-OAEP' }, oaepPub, new Uint8Array(512)));
+
+            return outcomes.join(',');
+            """).AsString().Should().Be(
+                "InvalidAccessError,InvalidAccessError,InvalidAccessError,InvalidAccessError");
+    }
+
+    [Theory]
+    // Each format's first step names the usages that format's key may carry, and anything else is a
+    // SyntaxError — which is a different failure from the InvalidAccessError a usable key used wrongly gets.
+    [InlineData("spki", "RSASSA-PKCS1-v1_5", "['sign']")]
+    [InlineData("spki", "RSASSA-PKCS1-v1_5", "['verify', 'sign']")]
+    [InlineData("spki", "RSA-OAEP", "['decrypt']")]
+    [InlineData("spki", "RSA-OAEP", "['encrypt', 'unwrapKey']")]
+    [InlineData("pkcs8", "RSASSA-PKCS1-v1_5", "['verify']")]
+    [InlineData("pkcs8", "RSA-OAEP", "['encrypt']")]
+    [InlineData("pkcs8", "RSA-PSS", "['sign', 'verify']")]
+    public void RefusesAUsageTheFormatDoesNotAllowWithASyntaxError(string format, string algorithm, string usages)
+    {
+        var engine = WebEngine();
+
+        var data = string.Equals(format, "spki", StringComparison.Ordinal) ? Rs256SpkiHex : Rs256Pkcs8Hex;
+
+        Settle(engine, $$"""
+            crypto.subtle.importKey('{{format}}', bytes('{{data}}'), { name: '{{algorithm}}', hash: 'SHA-256' }, false, {{usages}})
+                .then(() => 'imported', e => e.name + '/' + (e instanceof DOMException))
+            """).AsString().Should().Be("SyntaxError/true");
+    }
+
+    [Fact]
+    public void TheUsagesAreCheckedBeforeTheKeyDataIsParsed()
+    {
+        var engine = WebEngine();
+
+        // "If usages contains an entry which is not 'verify', then throw a SyntaxError" is step 1 of the
+        // spki branch and the parse is step 2, so bytes that are not a SubjectPublicKeyInfo at all still
+        // produce the SyntaxError the usages earn.
+        Settle(engine, """
+            crypto.subtle.importKey('spki', new Uint8Array([1, 2, 3]), { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, ['sign'])
+                .then(() => 'imported', e => e.name)
+            """).AsString().Should().Be("SyntaxError");
+
+        // With usages the format does allow, the same bytes reach the parse and fail there instead.
+        Settle(engine, """
+            crypto.subtle.importKey('spki', new Uint8Array([1, 2, 3]), { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, ['verify'])
+                .then(() => 'imported', e => e.name)
+            """).AsString().Should().Be("DataError");
+    }
+
+    [Theory]
+    // A key must permit the operation being asked of it, or the answer is an InvalidAccessError. For a
+    // signature algorithm the check can never fire — each key type's permitted usage set is exactly the one
+    // operation it can perform, so a key carrying the wrong usage cannot be built in the first place. It is
+    // RSA-OAEP, whose key types carry two usages each, where the check has something to do.
+    [InlineData("encrypt", "public", "['wrapKey']", "InvalidAccessError")]
+    [InlineData("encrypt", "public", "['encrypt']", "ok")]
+    [InlineData("encrypt", "public", "['encrypt', 'wrapKey']", "ok")]
+    [InlineData("decrypt", "private", "['unwrapKey']", "InvalidAccessError")]
+    [InlineData("decrypt", "private", "['decrypt']", "ok")]
+    [InlineData("decrypt", "private", "['decrypt', 'unwrapKey']", "ok")]
+    public void EnforcesTheRsaOaepUsageMatrix(string operation, string keyType, string usages, string expected)
+    {
+        var jwk = string.Equals(keyType, "public", StringComparison.Ordinal) ? OaepPublicJwk : OaepPrivateJwk;
+
+        // The decrypt rows need something their own key made, so an encryptor is imported alongside.
+        Run($$"""
+            const encryptor = await crypto.subtle.importKey(
+                'jwk', { {{OaepPublicJwk}} }, { name: 'RSA-OAEP', hash: 'SHA-256' }, false, ['encrypt']);
+            const sample = await crypto.subtle.encrypt({ name: 'RSA-OAEP' }, encryptor, ascii('m'));
+
+            const key = await crypto.subtle.importKey(
+                'jwk', { {{jwk}} }, { name: 'RSA-OAEP', hash: 'SHA-256' }, false, {{usages}});
+            try {
+                await crypto.subtle.{{operation}}({ name: 'RSA-OAEP' }, key, {{(string.Equals(operation, "encrypt", StringComparison.Ordinal) ? "ascii('m')" : "sample")}});
+                return 'ok';
+            } catch (e) {
+                return e.name;
+            }
+            """).AsString().Should().Be(expected);
+    }
+
+    [Fact]
+    public void ASignatureKeyTypeCarriesExactlyTheOneUsageItCanPerform()
+    {
+        var engine = WebEngine();
+
+        // The reason the matrix above is about RSA-OAEP: for RSASSA-PKCS1-v1_5 and RSA-PSS, a private key
+        // may carry only 'sign' and a public key only 'verify', so the mismatch is caught at import as the
+        // SyntaxError the format's first step raises — a key carrying the wrong usage never exists.
+        foreach (var (jwk, usages) in new[] { (Rs256PrivateJwk, "['verify']"), (Rs256PublicJwk, "['sign']") })
+        {
+            Settle(engine, $$"""
+                crypto.subtle.importKey('jwk', { {{jwk}} }, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, {{usages}})
+                    .then(() => 'imported', e => e.name + '/' + (e instanceof DOMException))
+                """).AsString().Should().Be("SyntaxError/true");
+        }
+    }
+
+    [Fact]
+    public void APublicKeyMayBeImportedWithNoUsagesAtAllAndAPrivateKeyMayNot()
+    {
+        var engine = WebEngine();
+
+        // "If the [[type]] internal slot of result is 'secret' or 'private' and usages is empty, then throw
+        // a SyntaxError" — a public key is deliberately outside that step, so importing a certificate's key
+        // to read its algorithm without granting it a use is an ordinary thing to do.
+        Settle(engine, $$"""
+            crypto.subtle.importKey('spki', bytes('{{Rs256SpkiHex}}'), { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, [])
+                .then(key => key.type + '/' + key.usages.length + '/' + key.algorithm.modulusLength, e => e.name)
+            """).AsString().Should().Be("public/0/2048");
+
+        Settle(engine, $$"""
+            crypto.subtle.importKey('pkcs8', bytes('{{Rs256Pkcs8Hex}}'), { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, [])
+                .then(() => 'imported', e => e.name + '/' + (e instanceof DOMException))
+            """).AsString().Should().Be("SyntaxError/true");
+
+        // The same asymmetry through jwk, where the type is decided by whether `d` is present.
+        Settle(engine, $$"""
+            crypto.subtle.importKey('jwk', { {{Rs256PublicJwk}} }, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, [])
+                .then(key => key.type, e => e.name)
+            """).AsString().Should().Be("public");
+
+        Settle(engine, $$"""
+            crypto.subtle.importKey('jwk', { {{Rs256PrivateJwk}} }, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, [])
+                .then(() => 'imported', e => e.name)
+            """).AsString().Should().Be("SyntaxError");
+    }
+
+    [Fact]
+    public void AKeyRemembersTheAlgorithmItWasMadeForAndRefusesAnother()
+    {
+        Run($$"""
+            const rsassa = await crypto.subtle.importKey(
+                'jwk', { {{Rs256PrivateJwk}} }, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, ['sign']);
+            const pss = await crypto.subtle.importKey(
+                'jwk', { {{Rs256PrivateJwk}} }, { name: 'RSA-PSS', hash: 'SHA-256' }, false, ['sign']);
+
+            const outcomes = [];
+            const attempt = async fn => { try { await fn(); outcomes.push('ok'); } catch (e) { outcomes.push(e.name); } };
+
+            // The name check comes before everything the algorithm itself does, and it is an
+            // InvalidAccessError — the same key material described two ways is two keys.
+            await attempt(() => crypto.subtle.sign({ name: 'RSA-PSS', saltLength: 32 }, rsassa, ascii('m')));
+            await attempt(() => crypto.subtle.sign('RSASSA-PKCS1-v1_5', pss, ascii('m')));
+            // An algorithm not registered for the operation at all is a different failure, decided before
+            // any key is looked at.
+            await attempt(() => crypto.subtle.encrypt({ name: 'RSASSA-PKCS1-v1_5' }, rsassa, ascii('m')));
+            await attempt(() => crypto.subtle.sign('RSA-OAEP', rsassa, ascii('m')));
+
+            return outcomes.join(',');
+            """).AsString().Should().Be(
+                "InvalidAccessError,InvalidAccessError,NotSupportedError,NotSupportedError");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // generateKey and CryptoKeyPair
+    // ---------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void GeneratesASigningPairWithTheShapeTheSpecificationDescribes()
+    {
+        // The one place an RSA key pair is generated in this file at all, and the only place the
+        // CryptoKeyPair dictionary is examined in full. 2048 bits: a prime search is the most expensive
+        // thing in this API by orders of magnitude.
+        Run("""
+            const pair = await crypto.subtle.generateKey(
+                { name: 'RSASSA-PKCS1-v1_5', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' },
+                false,
+                ['sign', 'verify']);
+
+            const message = ascii('generated');
+            const signature = await crypto.subtle.sign('RSASSA-PKCS1-v1_5', pair.privateKey, message);
+
+            return [
+                // CryptoKeyPair is a dictionary, not an interface: an ordinary object with two own data
+                // properties, no interface object on the global, and Object.prototype behind it.
+                Object.keys(pair).join(','),
+                Object.getPrototypeOf(pair) === Object.prototype,
+                typeof CryptoKeyPair,
+                pair.publicKey instanceof CryptoKey && pair.privateKey instanceof CryptoKey,
+
+                pair.privateKey.type + '/' + pair.publicKey.type,
+                // "Set the [[extractable]] internal slot of publicKey to true" — whatever was asked for.
+                pair.privateKey.extractable + '/' + pair.publicKey.extractable,
+                // The usages are split by the usage intersection each half's steps name.
+                pair.privateKey.usages.join('+') + '/' + pair.publicKey.usages.join('+'),
+
+                // One RsaHashedKeyAlgorithm, shared by both halves.
+                Object.keys(pair.privateKey.algorithm).join(','),
+                pair.privateKey.algorithm.name + '/' + pair.privateKey.algorithm.modulusLength + '/' + pair.privateKey.algorithm.hash.name,
+                // publicExponent is a BigInteger, which is a Uint8Array holding a big-endian magnitude.
+                Object.prototype.toString.call(pair.publicKey.algorithm.publicExponent) + '/' + hex(pair.publicKey.algorithm.publicExponent),
+
+                signature.byteLength,
+                await crypto.subtle.verify('RSASSA-PKCS1-v1_5', pair.publicKey, signature, message),
+            ].join('|');
+            """).AsString().Should().Be(
+                "privateKey,publicKey|true|undefined|true|"
+                + "private/public|false/true|sign/verify|"
+                + "name,modulusLength,publicExponent,hash|RSASSA-PKCS1-v1_5/2048/SHA-256|[object Uint8Array]/010001|"
+                + "256|true");
+    }
+
+    [Fact]
+    public void GeneratesAnOaepPairThatSplitsTheWrappingUsagesToo()
+    {
+        Run("""
+            const pair = await crypto.subtle.generateKey(
+                { name: 'RSA-OAEP', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' },
+                true,
+                ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey']);
+
+            const plaintext = ascii('round trip');
+            const ciphertext = await crypto.subtle.encrypt({ name: 'RSA-OAEP' }, pair.publicKey, plaintext);
+            const back = await crypto.subtle.decrypt({ name: 'RSA-OAEP' }, pair.privateKey, ciphertext);
+
+            return [
+                pair.publicKey.usages.join('+'),
+                pair.privateKey.usages.join('+'),
+                pair.privateKey.algorithm.name,
+                hex(back) === hex(plaintext),
+            ].join('|');
+            """).AsString().Should().Be("encrypt+wrapKey|decrypt+unwrapKey|RSA-OAEP|true");
+    }
+
+    [Fact]
+    public void RefusesAPairWhosePrivateHalfWouldHaveNoUsages()
+    {
+        var engine = WebEngine();
+
+        // "If result is a CryptoKeyPair object: If the [[usages]] internal slot of the privateKey attribute
+        // of result is the empty sequence, then throw a SyntaxError." A pair nobody can sign with is the
+        // mistake this catches; a pair whose *public* half carries nothing is perfectly ordinary.
+        Settle(engine, """
+            crypto.subtle.generateKey(
+                { name: 'RSASSA-PKCS1-v1_5', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' },
+                false, ['verify'])
+                .then(() => 'generated', e => e.name + '/' + (e instanceof DOMException))
+            """).AsString().Should().Be("SyntaxError/true");
+
+        Settle(engine, """
+            crypto.subtle.generateKey(
+                { name: 'RSASSA-PKCS1-v1_5', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' },
+                false, ['sign'])
+                .then(pair => pair.privateKey.usages.join('+') + '/' + pair.publicKey.usages.length, e => e.name)
+            """).AsString().Should().Be("sign/0");
+    }
+
+    [Theory]
+    [InlineData("['encrypt']")]
+    [InlineData("['sign', 'deriveKey']")]
+    [InlineData("['sign', 'wrapKey']")]
+    public void RefusesAUsageASignatureAlgorithmDoesNotSupportWithASyntaxError(string usages)
+    {
+        var engine = WebEngine();
+
+        // Step 1 of generateKey, which runs before the prime search — so this test generates nothing.
+        Settle(engine, $$"""
+            crypto.subtle.generateKey(
+                { name: 'RSASSA-PKCS1-v1_5', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' },
+                false, {{usages}})
+                .then(() => 'generated', e => e.name)
+            """).AsString().Should().Be("SyntaxError");
+    }
+
+    [Theory]
+    [InlineData("new Uint8Array([3])")]
+    [InlineData("new Uint8Array([1, 0, 0, 1])")]
+    [InlineData("new Uint8Array([0, 1, 0, 1, 0, 1])")]
+    public void RefusesAPublicExponentOtherThan65537(string exponent)
+    {
+        var engine = WebEngine();
+
+        // A documented divergence: RSA.Create takes a key size and nothing else, so 65537 is the only
+        // exponent .NET's key generation can be asked for. Each of these is a *valid* exponent by the
+        // specification's own validation, so the failure is the platform's rather than the caller's.
+        Settle(engine, $$"""
+            crypto.subtle.generateKey(
+                { name: 'RSASSA-PKCS1-v1_5', modulusLength: 2048, publicExponent: {{exponent}}, hash: 'SHA-256' },
+                false, ['sign', 'verify'])
+                .then(() => 'generated', e => e.name + '/' + (e.message.indexOf('65537') >= 0))
+            """).AsString().Should().Be("OperationError/true");
+    }
+
+    [Theory]
+    // "If publicExponent is less than 3, is even, or is greater than or equal to 2^modulusLength - 1, then
+    // throw an OperationError" — the specification's own validation, which runs before the platform's.
+    [InlineData("2048", "new Uint8Array([])")]
+    [InlineData("2048", "new Uint8Array([0])")]
+    [InlineData("2048", "new Uint8Array([1])")]
+    [InlineData("2048", "new Uint8Array([2])")]
+    [InlineData("2048", "new Uint8Array([4])")]
+    [InlineData("8", "new Uint8Array([1, 0, 1])")]
+    // "If modulusLength is less than 4".
+    [InlineData("3", "new Uint8Array([1, 0, 1])")]
+    [InlineData("0", "new Uint8Array([1, 0, 1])")]
+    public void RefusesKeyGenerationParametersTheSpecificationRejects(string modulusLength, string exponent)
+    {
+        var engine = WebEngine();
+
+        Settle(engine, $$"""
+            crypto.subtle.generateKey(
+                { name: 'RSA-PSS', modulusLength: {{modulusLength}}, publicExponent: {{exponent}}, hash: 'SHA-256' },
+                false, ['sign', 'verify'])
+                .then(() => 'generated', e => e.name + '/' + (e instanceof DOMException))
+            """).AsString().Should().Be("OperationError/true");
+    }
+
+    [Theory]
+    // Below what any RSA implementation .NET can reach will generate, not a multiple of the platform's
+    // stride, and above this engine's own ceiling.
+    [InlineData("256")]
+    [InlineData("511")]
+    [InlineData("2049")]
+    [InlineData("16384")]
+    [InlineData("65536")]
+    public void RefusesAModulusLengthThisEngineWillNotGenerate(string modulusLength)
+    {
+        var engine = WebEngine();
+
+        // None of these reaches a prime search: every one is refused before RSA.Create is called at all.
+        Settle(engine, $$"""
+            crypto.subtle.generateKey(
+                { name: 'RSA-OAEP', modulusLength: {{modulusLength}}, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' },
+                false, ['encrypt', 'decrypt'])
+                .then(() => 'generated', e => e.name + '/' + (e instanceof DOMException))
+            """).AsString().Should().Be("OperationError/true");
+    }
+
+    [Fact]
+    public void TheKeyGenerationMembersAreRequiredAndRangeChecked()
+    {
+        var engine = WebEngine();
+
+        // `required [EnforceRange] unsigned long modulusLength`, `required BigInteger publicExponent` and
+        // `required HashAlgorithmIdentifier hash` — an absent one is the TypeError WebIDL raises.
+        foreach (var algorithm in new[]
+        {
+            "'RSASSA-PKCS1-v1_5'",
+            "{ name: 'RSASSA-PKCS1-v1_5' }",
+            "{ name: 'RSASSA-PKCS1-v1_5', modulusLength: 2048 }",
+            "{ name: 'RSASSA-PKCS1-v1_5', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]) }",
+            "{ name: 'RSASSA-PKCS1-v1_5', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: undefined }",
+            // BigInteger is `typedef Uint8Array`, and WebIDL's conversion for a named typed array type
+            // accepts that type alone — an ArrayBuffer, a DataView and an Int8Array are all TypeErrors.
+            "{ name: 'RSASSA-PKCS1-v1_5', modulusLength: 2048, publicExponent: new ArrayBuffer(3), hash: 'SHA-256' }",
+            "{ name: 'RSASSA-PKCS1-v1_5', modulusLength: 2048, publicExponent: new DataView(new ArrayBuffer(3)), hash: 'SHA-256' }",
+            "{ name: 'RSASSA-PKCS1-v1_5', modulusLength: 2048, publicExponent: new Int8Array(3), hash: 'SHA-256' }",
+            "{ name: 'RSASSA-PKCS1-v1_5', modulusLength: 2048, publicExponent: [1, 0, 1], hash: 'SHA-256' }",
+            // [EnforceRange]: a value outside the type is a TypeError rather than a wrap or a clamp.
+            "{ name: 'RSASSA-PKCS1-v1_5', modulusLength: -1, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' }",
+            "{ name: 'RSASSA-PKCS1-v1_5', modulusLength: Infinity, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' }",
+        })
+        {
+            Settle(engine, $$"""
+                crypto.subtle.generateKey({{algorithm}}, false, ['sign', 'verify'])
+                    .then(() => 'generated', e => e.constructor.name)
+                """).AsString().Should().Be("TypeError");
+        }
+
+        // The hash is normalized as a digest algorithm, so a name that is not a registered one is a
+        // NotSupportedError rather than a TypeError.
+        Settle(engine, """
+            crypto.subtle.generateKey(
+                { name: 'RSASSA-PKCS1-v1_5', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'MD5' },
+                false, ['sign', 'verify'])
+                .then(() => 'generated', e => e.name)
+            """).AsString().Should().Be("NotSupportedError");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // Normalization and argument conversion
+    // ---------------------------------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("'rsassa-pkcs1-v1_5'")]
+    [InlineData("'RSASSA-PKCS1-V1_5'")]
+    [InlineData("{ name: 'rSaSsA-pKcS1-V1_5' }")]
+    public void MatchesTheRegisteredRsaNameCaseInsensitively(string algorithm)
+    {
+        // "Case-insensitive" is ASCII case-insensitive, and the key remembers the registered spelling rather
+        // than the caller's — which is what makes the name check on the next operation work at all.
+        Run($$"""
+            const key = await crypto.subtle.importKey(
+                'jwk', { {{Rs256PrivateJwk}} }, { name: 'rsassa-pkcs1-v1_5', hash: 'sha-256' }, false, ['sign']);
+
+            return hex(await crypto.subtle.sign({{algorithm}}, key, ascii('{{Rs256SigningInput}}')))
+                + '|' + key.algorithm.name + '|' + key.algorithm.hash.name;
+            """).AsString().Should().Be(Rs256SignatureHex + "|RSASSA-PKCS1-v1_5|SHA-256");
+    }
+
+    [Fact]
+    public void TheHashIsARequiredMemberOfRsaHashedImportParams()
+    {
+        var engine = WebEngine();
+
+        foreach (var algorithm in new[] { "'RSA-PSS'", "{ name: 'RSA-PSS' }", "{ name: 'RSA-PSS', hash: undefined }" })
+        {
+            Settle(engine, $$"""
+                crypto.subtle.importKey('spki', bytes('{{Rs256SpkiHex}}'), {{algorithm}}, false, ['verify'])
+                    .then(() => 'imported', e => e.constructor.name)
+                """).AsString().Should().Be("TypeError");
+        }
+    }
+
+    [Fact]
+    public void RefusesDerThatIsNotTheStructureTheFormatNames()
+    {
+        var engine = WebEngine();
+
+        // "If an error occurred while parsing, then throw a DataError" — including an spki that is really a
+        // pkcs8 and the other way round, which parse cleanly as themselves and not at all as each other.
+        Settle(engine, $$"""
+            crypto.subtle.importKey('spki', bytes('{{Rs256Pkcs8Hex}}'), { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, ['verify'])
+                .then(() => 'imported', e => e.name + '/' + (e instanceof DOMException))
+            """).AsString().Should().Be("DataError/true");
+
+        Settle(engine, $$"""
+            crypto.subtle.importKey('pkcs8', bytes('{{Rs256SpkiHex}}'), { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, ['sign'])
+                .then(() => 'imported', e => e.name)
+            """).AsString().Should().Be("DataError");
+
+        foreach (var data in new[] { "new Uint8Array(0)", "new Uint8Array(16)", "new Uint8Array([0x30, 0x03, 0x02, 0x01, 0x00])" })
+        {
+            Settle(engine, $$"""
+                crypto.subtle.importKey('spki', {{data}}, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, ['verify'])
+                    .then(() => 'imported', e => e.name)
+                """).AsString().Should().Be("DataError");
+        }
+    }
+
+    [Fact]
+    public void RefusesTrailingBytesAfterAWellFormedStructure()
+    {
+        var engine = WebEngine();
+
+        // "parse an ASN.1 structure … with exactData set to true": a structure that is followed by anything
+        // is not the structure that was asked for, however well-formed its prefix is.
+        Settle(engine, $$"""
+            (() => {
+                const der = bytes('{{Rs256SpkiHex}}');
+                const padded = new Uint8Array(der.length + 1);
+                padded.set(der);
+                return crypto.subtle.importKey('spki', padded, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, ['verify'])
+                    .then(() => 'imported', e => e.name + '/' + (e.message.indexOf('trailing') >= 0));
+            })()
+            """).AsString().Should().Be("DataError/true");
+    }
+
+    [Fact]
+    public void NoRsaOperationEverThrowsSynchronouslyOrLeaksACryptographicException()
+    {
+        var engine = WebEngine();
+
+        // A promise-returning WebIDL operation reports every failure as a rejection, and the failures the
+        // platform's own cryptography raises are no exception: a CryptographicException reaching the host
+        // would be a CLR exception erupting out of a promise-returning API.
+        engine.Evaluate($$"""
+            (() => {
+                const calls = [
+                    () => crypto.subtle.importKey('spki', new Uint8Array([9, 9, 9]), { name: 'RSA-PSS', hash: 'SHA-256' }, false, ['verify']),
+                    () => crypto.subtle.importKey('pkcs8', new Uint8Array([9, 9, 9]), { name: 'RSA-OAEP', hash: 'SHA-256' }, false, ['decrypt']),
+                    () => crypto.subtle.importKey('jwk', { kty: 'RSA', n: 'AQAB', e: 'AQAB' }, { name: 'RSA-OAEP', hash: 'SHA-256' }, false, ['encrypt']),
+                    () => crypto.subtle.generateKey({ name: 'RSA-PSS', modulusLength: 7, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' }, false, ['sign']),
+                ];
+
+                return calls.map(call => {
+                    const promise = call();
+                    return (promise instanceof Promise) + ':' + typeof promise.then;
+                }).join(',');
+            })()
+            """).AsString().Should().Be("true:function,true:function,true:function,true:function");
+
+        // ... and each of them settles as a rejection carrying a DOMException.
+        Settle(engine, """
+            Promise.all([
+                crypto.subtle.importKey('spki', new Uint8Array([9, 9, 9]), { name: 'RSA-PSS', hash: 'SHA-256' }, false, ['verify']).catch(e => e.name),
+                crypto.subtle.importKey('pkcs8', new Uint8Array([9, 9, 9]), { name: 'RSA-OAEP', hash: 'SHA-256' }, false, ['decrypt']).catch(e => e.name),
+                crypto.subtle.importKey('jwk', { kty: 'RSA', n: 'AQAB', e: 'AQAB' }, { name: 'RSA-OAEP', hash: 'SHA-256' }, false, ['encrypt']).catch(e => e.name),
+                crypto.subtle.generateKey({ name: 'RSA-PSS', modulusLength: 7, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' }, false, ['sign']).catch(e => e.name),
+            ]).then(names => names.join(','))
+            """).AsString().Should().Be("DataError,DataError,DataError,OperationError");
+    }
+
+    [Fact]
+    public void TheRsaAlgorithmsAreRegisteredForExactlyTheOperationsTheSpecificationGivesThem()
+    {
+        var engine = WebEngine();
+
+        // The registry decides which algorithm reaches which operation, and an algorithm that is not
+        // registered for one is a NotSupportedError — a signature algorithm cannot encrypt, and a cipher
+        // cannot sign.
+        Settle(engine, $$"""
+            (async () => {
+                const outcomes = [];
+                const attempt = async fn => { try { await fn(); outcomes.push('ok'); } catch (e) { outcomes.push(e.name); } };
+
+                await attempt(() => crypto.subtle.digest('RSA-OAEP', new Uint8Array(0)));
+                await attempt(() => crypto.subtle.importKey('jwk', { {{Rs256PublicJwk}} }, { name: 'RSA-OAEP', hash: 'SHA-256' }, false, ['encrypt']));
+                await attempt(() => crypto.subtle.importKey('jwk', { {{Rs256PublicJwk}} }, { name: 'RSA-PSS', hash: 'SHA-256' }, false, ['verify']));
+                await attempt(() => crypto.subtle.importKey('jwk', { {{Rs256PublicJwk}} }, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, ['verify']));
+
+                return outcomes.join(',');
+            })()
+            """).AsString().Should().Be("NotSupportedError,ok,ok,ok");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // Test vectors
+    //
+    // The JWKs and the expected outputs are transcribed from the RFCs named in this class's remarks. The
+    // pkcs8 and spki bytes were DER-encoded from the RFC 7515 JWK's own integers outside this engine.
+    // ---------------------------------------------------------------------------------------------------
+
+    private const string Rs256PrivateJwk =
+        "kty: 'RSA', n: 'ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddxHmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMsD1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSHSXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdVMTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ', e: 'AQAB', d: 'Eq5xpGnNCivDflJsRQBXHx1hdR1k6Ulwe2JZD50LpXyWPEAeP88vLNO97IjlA7_GQ5sLKMgvfTeXZx9SE-7YwVol2NXOoAJe46sui395IW_GO-pWJ1O0BkTGoVEn2bKVRUCgu-GjBVaYLU6f3l9kJfFNS3E0QbVdxzubSu3Mkqzjkn439X0M_V51gfpRLI9JYanrC4D4qAdGcopV_0ZHHzQlBjudU2QvXt4ehNYTCBr6XCLQUShb1juUO1ZdiYoFaFQT5Tw8bGUl_x_jTj3ccPDVZFD9pIuhLhBOneufuBiB4cS98l2SR_RQyGWSeWjnczT0QU91p1DhOVRuOopznQ', p: '4BzEEOtIpmVdVEZNCqS7baC4crd0pqnRH_5IB3jw3bcxGn6QLvnEtfdUdiYrqBdss1l58BQ3KhooKeQTa9AB0Hw_Py5PJdTJNPY8cQn7ouZ2KKDcmnPGBY5t7yLc1QlQ5xHdwW1VhvKn-nXqhJTBgIPgtldC-KDV5z-y2XDwGUc', q: 'uQPEfgmVtjL0Uyyx88GZFF1fOunH3-7cepKmtH4pxhtCoHqpWmT8YAmZxaewHgHAjLYsp1ZSe7zFYHj7C6ul7TjeLQeZD_YwD66t62wDmpe_HlB-TnBA-njbglfIsRLtXlnDzQkv5dTltRJ11BKBBypeeF6689rjcJIDEz9RWdc', dp: 'BwKfV3Akq5_MFZDFZCnW-wzl-CCo83WoZvnLQwCTeDv8uzluRSnm71I3QCLdhrqE2e9YkxvuxdBfpT_PI7Yz-FOKnu1R6HsJeDCjn12Sk3vmAktV2zb34MCdy7cpdTh_YVr7tss2u6vneTwrA86rZtu5Mbr1C1XsmvkxHQAdYo0', dq: 'h_96-mK1R_7glhsum81dZxjTnYynPbZpHziZjeeHcXYsXaaMwkOlODsWa7I9xXDoRwbKgB719rrmI2oKr6N3Do9U0ajaHF-NKJnwgjMd2w9cjz3_-kyNlxAr2v4IKhGNpmM5iIgOS1VZnOZ68m6_pbLBSp3nssTdlqvd0tIiTHU', qi: 'IYd7DHOhrWvxkwPQsRM2tOgrjbcrfvtQJipd-DlcxyVuuM9sQLdgjVk2oy26F0EmpScGLq2MowX7fhd_QJQ3ydy5cY7YIBi87w93IKLEdfnbJtoOPLUW0ITrJReOgo1cq9SbsxYawBgfp_gh6A5603k2-ZQwVK0JKSHuLFkuQ3U'";
+
+    private const string Rs256PublicJwk =
+        "kty: 'RSA', n: 'ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddxHmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMsD1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSHSXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdVMTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ', e: 'AQAB'";
+
+    private const string Rs256Pkcs8Hex =
+        "308204bd020100300d06092a864886f70d0101010500048204a7308204a30201000282010100a1f8160ae2e3c9b465ce8d2d656263362b927dbe29e1f02477fc1625cc90a136e38bd93497c5b6ea63dd7711e67c7429f956b0fb8a8f089adc4b69893cc1333f53edd019b87784252fec914fe4857769594bea4280d32c0f55bf62944f130396bc6e9bdf6ebdd2bda3678eeca0c668f701b38dbffb38c8342ce2fe6d27fade4a5a4874979dd4b9cf9adec4c75b05852c2c0f5ef8a5c1750392f944e8ed64c110c6b647609aa4783aeb9c6c9ad755313050638b83665c6f6f7a82a396702a1f641b82d3ebf2392219491fb686872c5716f50af8358d9a8b9d17c340728f7f87d89a18d8fcab67ad84590c2ecf759339363c07034d6f606f9e21e05456cae5e9a102030100010282010012ae71a469cd0a2bc37e526c4500571f1d61751d64e949707b62590f9d0ba57c963c401e3fcf2f2cd3bdec88e503bfc6439b0b28c82f7d3797671f5213eed8c15a25d8d5cea0025ee3ab2e8b7f79216fc63bea562753b40644c6a15127d9b2954540a0bbe1a30556982d4e9fde5f6425f14d4b713441b55dc73b9b4aedcc92ace3927e37f57d0cfd5e7581fa512c8f4961a9eb0b80f8a80746728a55ff46471f3425063b9d53642f5ede1e84d613081afa5c22d051285bd63b943b565d898a05685413e53c3c6c6525ff1fe34e3ddc70f0d56450fda48ba12e104e9deb9fb81881e1c4bdf25d9247f450c865927968e77334f4414f75a750e139546e3a8a739d02818100e01cc410eb48a6655d54464d0aa4bb6da0b872b774a6a9d11ffe480778f0ddb7311a7e902ef9c4b5f75476262ba8176cb35979f014372a1a2829e4136bd001d07c3f3f2e4f25d4c934f63c7109fba2e67628a0dc9a73c6058e6def22dcd50950e711ddc16d5586f2a7fa75ea8494c18083e0b65742f8a0d5e73fb2d970f0194702818100b903c47e0995b632f4532cb1f3c199145d5f3ae9c7dfeedc7a92a6b47e29c61b42a07aa95a64fc600999c5a7b01e01c08cb62ca756527bbcc56078fb0baba5ed38de2d07990ff6300faeadeb6c039a97bf1e507e4e7040fa78db8257c8b112ed5e59c3cd092fe5d4e5b51275d41281072a5e785ebaf3dae3709203133f5159d702818007029f577024ab9fcc1590c56429d6fb0ce5f820a8f375a866f9cb430093783bfcbb396e4529e6ef52374022dd86ba84d9ef58931beec5d05fa53fcf23b633f8538a9eed51e87b097830a39f5d92937be6024b55db36f7e0c09dcbb72975387f615afbb6cb36bbabe7793c2b03ceab66dbb931baf50b55ec9af9311d001d628d0281810087ff7afa62b547fee0961b2e9bcd5d6718d39d8ca73db6691f38998de78771762c5da68cc243a5383b166bb23dc570e84706ca801ef5f6bae6236a0aafa3770e8f54d1a8da1c5f8d2899f082331ddb0f5c8f3dfffa4c8d97102bdafe082a118da6633988880e4b55599ce67af26ebfa5b2c14a9de7b2c4dd96abddd2d2224c7502818021877b0c73a1ad6bf19303d0b11336b4e82b8db72b7efb50262a5df8395cc7256eb8cf6c40b7608d5936a32dba174126a527062ead8ca305fb7e177f409437c9dcb9718ed82018bcef0f7720a2c475f9db26da0e3cb516d084eb25178e828d5cabd49bb3161ac0181fa7f821e80e7ad37936f9943054ad092921ee2c592e4375";
+
+    private const string Rs256SpkiHex =
+        "30820122300d06092a864886f70d01010105000382010f003082010a0282010100a1f8160ae2e3c9b465ce8d2d656263362b927dbe29e1f02477fc1625cc90a136e38bd93497c5b6ea63dd7711e67c7429f956b0fb8a8f089adc4b69893cc1333f53edd019b87784252fec914fe4857769594bea4280d32c0f55bf62944f130396bc6e9bdf6ebdd2bda3678eeca0c668f701b38dbffb38c8342ce2fe6d27fade4a5a4874979dd4b9cf9adec4c75b05852c2c0f5ef8a5c1750392f944e8ed64c110c6b647609aa4783aeb9c6c9ad755313050638b83665c6f6f7a82a396702a1f641b82d3ebf2392219491fb686872c5716f50af8358d9a8b9d17c340728f7f87d89a18d8fcab67ad84590c2ecf759339363c07034d6f606f9e21e05456cae5e9a10203010001";
+
+    private const string Rs256SigningInput =
+        "eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ";
+
+    private const string Rs256SignatureHex =
+        "702e218943e88fd11eb5d82dbf7845f34106ae1b81fff7731116add1717d83656d420afd3c96eedd73a2663e5166687b000b87226e0187ed1073f945e582adfcef16d85a798ee8c66ddb3db8975b17d09402beedd5d9d97007108db28160d5f8040ca7445762b81fbe7ff9d92e0ae76f24f25b33bbe6f44ae61eb1040acb20044d3ef9128ed40130795bd4bd3b41eecad066ab651981fde48df77f372dc38b9fafdd3befb18b5da3cc3c2eb02f9e3a41d612caad15911273a05f23b9e838faaf849d698429ef5a1e88798236c3d40e604522a544c8f27a7a2db80663d16cf7caea56de405cb2215a45b2c25566b55ac1a748a070dfc8a32a469543d019eefb47";
+
+    private const string PssPrivateJwk =
+        "kty: 'RSA', n: 'n4EPtAOCc9AlkeQHPzHStgAbgs7bTZLwUBZdR8_KuKPEHLd4rHVTeT-O-XV2jRojdNhxJWTDvNd7nqQ0VEiZQHz_AJmSCpMaJMRBSFKrKb2wqVwGU_NsYOYL-QtiWN2lbzcEe6XC0dApr5ydQLrHqkHHig3RBordaZ6Aj-oBHqFEHYpPe7Tpe-OfVfHd1E6cS6M1FZcD1NNLYD5lFHpPI9bTwJlsde3uhGqC0ZCuEHg8lhzwOHrtIQbS0FVbb9k3-tVTU4fg_3L_vniUFAKwuCLqKnS2BYwdq_mzSnbLY7h_qixoR7jig3__kRhuaxwUkRz5iaiQkqgc5gHdrNP5zw', e: 'AQAB', d: 'bWUC9B-EFRIo8kpGfh0ZuyGPvMNKvYWNtB_ikiH9k20eT-O1q_I78eiZkpXxXQ0UTEs2LsNRS-8uJbvQ-A1irkwMSMkK1J3XTGgdrhCku9gRldY7sNA_AKZGh-Q661_42rINLRCe8W-nZ34ui_qOfkLnK9QWDDqpaIsA-bMwWWSDFu2MUBYwkHTMEzLYGqOe04noqeq1hExBTHBOBdkMXiuFhUq1BU6l-DqEiWxqg82sXt2h-LMnT3046AOYJoRioz75tSUQfGCshWTBnP5uDjd18kKhyv07lhfSJdrPdM5Plyl21hsFf4L_mHCuoFau7gdsPfHPxxjVOcOpBrQzwQ', p: '3Slxg_DwTXJcb6095RoXygQCAZ5RnAvZlno1yhHtnUex_fp7AZ_9nRaO7HX_-SFfGQeutao2TDjDAWU4Vupk8rw9JR0AzZ0N2fvuIAmr_WCsmGpeNqQnev1T7IyEsnh8UMt-n5CafhkikzhEsrmndH6LxOrvRJlsPp6Zv8bUq0k', q: 'uKE2dh-cTf6ERF4k4e_jy78GfPYUIaUyoSSJuBzp3Cubk3OCqs6grT8bR_cu0Dm1MZwWmtdqDyI95HrUeq3MP15vMMON8lHTeZu2lmKvwqW7anV5UzhM1iZ7z4yMkuUwFWoBvyY898EXvRD-hdqRxHlSqAZ192zB3pVFJ0s7pFc', dp: 'B8PVvXkvJrj2L-GYQ7v3y9r6Kw5g9SahXBwsWUzp19TVlgI-YV85q1NIb1rxQtD-IsXXR3-TanevuRPRt5OBOdiMGQp8pbt26gljYfKU_E9xn-RULHz0-ed9E9gXLKD4VGngpz-PfQ_q29pk5xWHoJp009Qf1HvChixRX59ehik', dq: 'CLDmDGduhylc9o7r84rEUVn7pzQ6PF83Y-iBZx5NT-TpnOZKF1pErAMVeKzFEl41DlHHqqBLSM0W1sOFbwTxYWZDm6sI6og5iTbwQGIC3gnJKbi_7k_vJgGHwHxgPaX2PnvP-zyEkDERuf-ry4c_Z11Cq9AqC2yeL6kdKT1cYF8', qi: '3PiqvXQN0zwMeE-sBvZgi289XP9XCQF3VWqPzMKnIgQp7_Tugo6-NZBKCQsMf3HaEGBjTVJs_jcK8-TRXvaKe-7ZMaQj8VfBdYkssbu0NKDDhjJ-GtiseaDVWt7dcH0cfwxgFUHpQh7FoCrjFJ6h6ZEpMF6xmujs4qMpPz8aaI4'";
+
+    private const string PssPublicJwk =
+        "kty: 'RSA', n: 'n4EPtAOCc9AlkeQHPzHStgAbgs7bTZLwUBZdR8_KuKPEHLd4rHVTeT-O-XV2jRojdNhxJWTDvNd7nqQ0VEiZQHz_AJmSCpMaJMRBSFKrKb2wqVwGU_NsYOYL-QtiWN2lbzcEe6XC0dApr5ydQLrHqkHHig3RBordaZ6Aj-oBHqFEHYpPe7Tpe-OfVfHd1E6cS6M1FZcD1NNLYD5lFHpPI9bTwJlsde3uhGqC0ZCuEHg8lhzwOHrtIQbS0FVbb9k3-tVTU4fg_3L_vniUFAKwuCLqKnS2BYwdq_mzSnbLY7h_qixoR7jig3__kRhuaxwUkRz5iaiQkqgc5gHdrNP5zw', e: 'AQAB'";
+
+    private const string Ps384SigningInput =
+        "eyJhbGciOiJQUzM4NCIsImtpZCI6ImJpbGJvLmJhZ2dpbnNAaG9iYml0b24uZXhhbXBsZSJ9.SXTigJlzIGEgZGFuZ2Vyb3VzIGJ1c2luZXNzLCBGcm9kbywgZ29pbmcgb3V0IHlvdXIgZG9vci4gWW91IHN0ZXAgb250byB0aGUgcm9hZCwgYW5kIGlmIHlvdSBkb24ndCBrZWVwIHlvdXIgZmVldCwgdGhlcmXigJlzIG5vIGtub3dpbmcgd2hlcmUgeW91IG1pZ2h0IGJlIHN3ZXB0IG9mZiB0by4";
+
+    private const string Ps384SignatureHex =
+        "72edb6781aa46032a02254e9cc35c6bda15fcfa586a33edf50371f4f49243b2e369a2021daac81ce4d7112c9e4d88a4debeb4f89de95ae494792ab06a83a8709d3fa3bc4d30797430c8b65955a3aff538b3e971b52b8625123316db5d4bddbd65f383e503f1b8a245e40595fcf6f3319656c76234051ff199f23c4815167e38d9974daa254946606aad84577bc3ff8a343ba7c55dcf44d3af151e4f7966f1df6c867af695f253f089948ef000d977b3d8c969f1c044e5ac03cd3d2a2349faba23f568237fdbf8cb01e41396a447b5f6bae1041252614002354a3db0728bbc61a34b9339c6c7e75d1ae8662625401f9968f067aa03e227caa3c0d833e5fbd846b";
+
+    private const string OaepPrivateJwk =
+        "kty: 'RSA', n: 'wbdxI55VaanZXPY29Lg5hdmv2XhvqAhoxUkanfzf2-5zVUxa6prHRrI4pP1AhoqJRlZfYtWWd5mmHRG2pAHIlh0ySJ9wi0BioZBl1XP2e-C-FyXJGcTy0HdKQWlrfhTm42EW7Vv04r4gfao6uxjLGwfpGrZLarohiWCPnkNrg71S2CuNZSQBIPGjXfkmIy2tl_VWgGnL22GplyXj5YlBLdxXp3XeStsqo571utNfoUTU8E4qdzJ3U1DItoVkPGsMwlmmnJiwA7sXRItBCivR4M5qnZtdw-7v4WuR4779ubDuJ5nalMv2S66-RPcnFAzWSKxtBDnFJJDGIUe7Tzizjg1nms0Xq_yPub_UOlWn0ec85FCft1hACpWG8schrOBeNqHBODFskYpUc2LC5JA2TaPF2dA67dg1TTsC_FupfQ2kNGcE1LgprxKHcVWYQb86B-HozjHZcqtauBzFNV5tbTuB-TpkcvJfNcFLlH3b8mb-H_ox35FjqBSAjLKyoeqfKTpVjvXhd09knwgJf6VKq6UC418_TOljMVfFTWXUxlnfhOOnzW6HSSzD1c9WrCuVzsUMv54szidQ9wf1cYWf3g5qFDxDQKis99gcDaiCAwM3yEBIzuNeeCa5dartHDb1xEB_HcHSeYbghbMjGfasvKn0aZRsnTyC0xhWBlsolZE', e: 'AQAB', d: 'n7fzJc3_WG59VEOBTkayzuSMM780OJQuZjN_KbH8lOZG25ZoA7T4Bxcc0xQn5oZE5uSCIwg91oCt0JvxPcpmqzaJZg1nirjcWZ-oBtVk7gCAWq-B3qhfF3izlbkosrzjHajIcY33HBhsy4_WerrXg4MDNE4HYojy68TcxT2LYQRxUOCf5TtJXvM8olexlSGtVnQnDRutxEUCwiewfmmrfveEogLx9EA-KMgAjTiISXxqIXQhWUQX1G7v_mV_Hr2YuImYcNcHkRvp9E7ook0876DhkO8v4UOZLwA1OlUX98mkoqwc58A_Y2lBYbVx1_s5lpPsEqbbH-nqIjh1fL0gdNfihLxnclWtW7pCztLnImZAyeCWAG7ZIfv-Rn9fLIv9jZ6r7r-MSH9sqbuziHN2grGjD_jfRluMHa0l84fFKl6bcqN1JWxPVhzNZo01yDF-1LiQnqUYSepPf6X3a2SOdkqBRiquE6EvLuSYIDpJq3jDIsgoL8Mo1LoomgiJxUwL_GWEOGu28gplyzm-9Q0U0nyhEf1uhSR8aJAQWAiFImWH5W_IQT9I7-yrindr_2fWQ_i1UgMsGzA7aOGzZfPljRy6z-tY_KuBG00-28S_aWvjyUc-Alp8AUyKjBZ-7CWH32fGWK48j1t-zomrwjL_mnhsPbGs0c9WsWgRzI-K8gE', p: '7_2v3OQZzlPFcHyYfLABQ3XP85Es4hCdwCkbDeltaUXgVy9l9etKghvM4hRkOvbb01kYVuLFmxIkCDtpi-zLCYAdXKrAK3PtSbtzld_XZ9nlsYa_QZWpXB_IrtFjVfdKUdMz94pHUhFGFj7nr6NNxfpiHSHWFE1zD_AC3mY46J961Y2LRnreVwAGNw53p07Db8yD_92pDa97vqcZOdgtybH9q6uma-RFNhO1AoiJhYZj69hjmMRXx-x56HO9cnXNbmzNSCFCKnQmn4GQLmRj9sfbZRqL94bbtE4_e0Zrpo8RNo8vxRLqQNwIy85fc6BRgBJomt8QdQvIgPgWCv5HoQ', q: 'zqOHk1P6WN_rHuM7ZF1cXH0x6RuOHq67WuHiSknqQeefGBA9PWs6ZyKQCO-O6mKXtcgE8_Q_hA2kMRcKOcvHil1hqMCNSXlflM7WPRPZu2qCDcqssd_uMbP-DqYthH_EzwL9KnYoH7JQFxxmcv5An8oXUtTwk4knKjkIYGRuUwfQTus0w1NfjFAyxOOiAQ37ussIcE6C6ZSsM3n41UlbJ7TCqewzVJaPJN5cxjySPZPD3Vp01a9YgAD6a3IIaKJdIxJS1ImnfPevSJQBE79-EXe2kSwVgOzvt-gsmM29QQ8veHy4uAqca5dZzMs7hkkHtw1z0jHV90epQJJlXXnH8Q', dp: '19oDkBh1AXelMIxQFm2zZTqUhAzCIr4xNIGEPNoDt1jK83_FJA-xnx5kA7-1erdHdms_Ef67HsONNv5A60JaR7w8LHnDiBGnjdaUmmuO8XAxQJ_ia5mxjxNjS6E2yD44USo2JmHvzeeNczq25elqbTPLhUpGo1IZuG72FZQ5gTjXoTXC2-xtCDEUZfaUNh4IeAipfLugbpe0JAFlFfrTDAMUFpC3iXjxqzbEanflwPvj6V9iDSgjj8SozSM0dLtxvu0LIeIQAeEgT_yXcrKGmpKdSO08kLBx8VUjkbv_3Pn20Gyu2YEuwpFlM_H1NikuxJNKFGmnAq9LcnwwT0jvoQ', dq: 'S6p59KrlmzGzaQYQM3o0XfHCGvfqHLYjCO557HYQf72O9kLMCfd_1VBEqeD-1jjwELKDjck8kOBl5UvohK1oDfSP1DleAy-cnmL29DqWmhgwM1ip0CCNmkmsmDSlqkUXDi6sAaZuntyukyflI-qSQ3C_BafPyFaKrt1fgdyEwYa08pESKwwWisy7KnmoUvaJ3SaHmohFS78TJ25cfc10wZ9hQNOrIChZlkiOdFCtxDqdmCqNacnhgE3bZQjGp3n83ODSz9zwJcSUvODlXBPc2AycH6Ci5yjbxt4Ppox_5pjm6xnQkiPgj01GpsUssMmBN7iHVsrE7N2iznBNCeOUIQ', qi: 'FZhClBMywVVjnuUud-05qd5CYU0dK79akAgy9oX6RX6I3IIIPckCciRrokxglZn-omAY5CnCe4KdrnjFOT5YUZE7G_Pg44XgCXaarLQf4hl80oPEf6-jJ5Iy6wPRx7G2e8qLxnh9cOdf-kRqgOS3F48Ucvw3ma5V6KGMwQqWFeV31XtZ8l5cVI-I3NzBS7qltpUVgz2Ju021eyc7IlqgzR98qKONl27DuEES0aK0WE97jnsyO27Yp88Wa2RiBrEocM89QZI1seJiGDizHRUP4UZxw9zsXww46wy0P6f9grnYp7t8LkyDDk8eoI4KX6SNMNVcyVS9IWjlq8EzqZEKIA'";
+
+    private const string OaepPublicJwk =
+        "kty: 'RSA', n: 'wbdxI55VaanZXPY29Lg5hdmv2XhvqAhoxUkanfzf2-5zVUxa6prHRrI4pP1AhoqJRlZfYtWWd5mmHRG2pAHIlh0ySJ9wi0BioZBl1XP2e-C-FyXJGcTy0HdKQWlrfhTm42EW7Vv04r4gfao6uxjLGwfpGrZLarohiWCPnkNrg71S2CuNZSQBIPGjXfkmIy2tl_VWgGnL22GplyXj5YlBLdxXp3XeStsqo571utNfoUTU8E4qdzJ3U1DItoVkPGsMwlmmnJiwA7sXRItBCivR4M5qnZtdw-7v4WuR4779ubDuJ5nalMv2S66-RPcnFAzWSKxtBDnFJJDGIUe7Tzizjg1nms0Xq_yPub_UOlWn0ec85FCft1hACpWG8schrOBeNqHBODFskYpUc2LC5JA2TaPF2dA67dg1TTsC_FupfQ2kNGcE1LgprxKHcVWYQb86B-HozjHZcqtauBzFNV5tbTuB-TpkcvJfNcFLlH3b8mb-H_ox35FjqBSAjLKyoeqfKTpVjvXhd09knwgJf6VKq6UC418_TOljMVfFTWXUxlnfhOOnzW6HSSzD1c9WrCuVzsUMv54szidQ9wf1cYWf3g5qFDxDQKis99gcDaiCAwM3yEBIzuNeeCa5dartHDb1xEB_HcHSeYbghbMjGfasvKn0aZRsnTyC0xhWBlsolZE', e: 'AQAB'";
+
+    private const string OaepCiphertextHex =
+        "ad3f7daf0ac14db4c8ec824cf1f5371258bbdb6e87101ec87210b136e87b9428ae778f0bc5ea2545db451789f34226de60e9794bf3c9b005d9c125ed0de3f3f6193e05bb6c4c1a82d94b0f39dc230bd36136ea4d36ef6e1c855fb43cae72f23a86f00b799e8e1a784d578bf5cf1da4eced43f3d980cdfc3efe44f7b64ba8ae90d4f82a4110d7c81d7d50e7cf8069ddc5cccba8dc59fd6ee10fdb25da90b5d86b5e4151742cba9338035183e3f1f805ded5deef61f06920f01a7129d515f5271f2504dc626e9e244073dda4b021a2b84f7f9dc16a6e04e8513905c1a2c2734b56ac9ee1ed54cb76a4a2087eec79042ea1b88be663b93357b5bb68852ba589bfdc7e3362fc8c7aae691aa1665b693cce93bcefc4d1959c7ba597cf6034976724b409f28a90ca334ffaa20b06534b3e1db989edf214b867db06b615e7f6e0ea77ac3270c6a09d07ce4ecfe5c9c4d6998f9aa965432a18d83517f4dcd8b046d6f9044fad39d1700804908f7bae0203c6aced805817b7f148d06f496f5e7d52a72bd867758573b58e2586936bb03c0d19fa302e93fb10e632ec42d06ed2dabb1cc39950414d3a32f6539453add14bdfb8a05ad3773103f9c804884b32363690e4f140c9a90cf4ebe826e8f1a29a3a7c7a012139271f69681a6736638e287df98ff425ad084359437a0361a0f2215ac89ebdc4311d1c0542191ccddf0a04236a330d1b";
+
+    private const string OaepPlaintextHex =
+        "99831fb208244c09b44dbbed945876872a179db1332508ccc6680b37777cc570";
+
+    private const string Rs256PaddedP =
+        "AADgHMQQ60imZV1URk0KpLttoLhyt3SmqdEf_kgHePDdtzEafpAu-cS191R2JiuoF2yzWXnwFDcqGigp5BNr0AHQfD8_Lk8l1Mk09jxxCfui5nYooNyac8YFjm3vItzVCVDnEd3BbVWG8qf6deqElMGAg-C2V0L4oNXnP7LZcPAZRw";
+
+    private const string Rs256PaddedQi =
+        "ACGHewxzoa1r8ZMD0LETNrToK423K377UCYqXfg5XMclbrjPbEC3YI1ZNqMtuhdBJqUnBi6tjKMF-34Xf0CUN8ncuXGO2CAYvO8PdyCixHX52ybaDjy1FtCE6yUXjoKNXKvUm7MWGsAYH6f4IegOetN5NvmUMFStCSkh7ixZLkN1";
+}
+#endif

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -549,12 +549,12 @@ public enum WebApiFeatures
     /// cryptographically secure generator, plus <c>crypto.subtle</c> and the <c>CryptoKey</c> interface
     /// object. <c>subtle</c> carries <c>digest</c> (SHA-1, SHA-256, SHA-384, SHA-512), <c>sign</c>,
     /// <c>verify</c>, <c>encrypt</c>, <c>decrypt</c>, <c>generateKey</c>, <c>importKey</c> and
-    /// <c>exportKey</c> over HMAC and AES-GCM, with <c>raw</c> and <c>jwk</c> key formats. Key derivation,
-    /// key wrapping and the asymmetric algorithms are not implemented and are absent rather than
-    /// present-and-throwing, so feature detection sees the truth. Neither <c>subtle</c> nor
-    /// <c>CryptoKey</c> has a flag of its own: <c>subtle</c> is a readonly attribute of the very same
-    /// <c>Crypto</c> interface and <c>CryptoKey</c> is the type of what it hands out, so asking for one is
-    /// asking for all three.
+    /// <c>exportKey</c> over HMAC, AES-GCM, RSASSA-PKCS1-v1_5, RSA-PSS and RSA-OAEP, with the <c>raw</c>,
+    /// <c>spki</c>, <c>pkcs8</c> and <c>jwk</c> key formats. Key derivation and key wrapping are not
+    /// implemented and are absent rather than present-and-throwing, so feature detection sees the truth, and
+    /// neither is any elliptic-curve algorithm. Neither <c>subtle</c> nor <c>CryptoKey</c> has a flag of its
+    /// own: <c>subtle</c> is a readonly attribute of the very same <c>Crypto</c> interface and
+    /// <c>CryptoKey</c> is the type of what it hands out, so asking for one is asking for all three.
     /// </summary>
     Crypto = 1 << 5,
 

--- a/Jint/WebApi/Crypto/AesGcmAlgorithm.cs
+++ b/Jint/WebApi/Crypto/AesGcmAlgorithm.cs
@@ -1,6 +1,7 @@
 #if NET8_0_OR_GREATER
 using System.Security.Cryptography;
 using Jint.Native;
+using Jint.Runtime;
 
 namespace Jint.WebApi.Crypto;
 
@@ -153,7 +154,7 @@ internal static class AesGcmAlgorithm
                 return context.CreateArrayBuffer(key.Handle.ToArray());
 
             case KeyFormat.Jwk:
-                return JsonWebKeyData.CreateExport(
+                return JsonWebKeyData.CreateOctExport(
                     context.Engine,
                     key.Handle,
                     JwkAlgorithm(key.Algorithm.Length),
@@ -317,11 +318,25 @@ internal static class AesGcmAlgorithm
     /// The JWK <c>alg</c> field naming an AES-GCM key of a given length —
     /// https://www.rfc-editor.org/rfc/rfc7518#section-4.7.
     /// </summary>
-    private static string JwkAlgorithm(uint bits) => bits switch
+    /// <remarks>
+    /// The three lengths AES has are spelled out and the default throws rather than one of them standing in
+    /// as the fallback: a key of another length labelled <c>A256GCM</c> would be a JWK naming an algorithm
+    /// it is not. The lengths have all been checked before a key exists, so the arm is unreachable.
+    /// </remarks>
+    private static string JwkAlgorithm(uint bits)
     {
-        128 => "A128GCM",
-        192 => "A192GCM",
-        _ => "A256GCM",
-    };
+        switch (bits)
+        {
+            case 128:
+                return "A128GCM";
+            case 192:
+                return "A192GCM";
+            case 256:
+                return "A256GCM";
+            default:
+                Throw.InvalidOperationException("Unhandled AES key length of " + bits + " bits.");
+                return null!;
+        }
+    }
 }
 #endif

--- a/Jint/WebApi/Crypto/AlgorithmNormalization.cs
+++ b/Jint/WebApi/Crypto/AlgorithmNormalization.cs
@@ -32,10 +32,11 @@ internal enum CryptoOperation
 /// </summary>
 /// <remarks>
 /// All four values are recognized by the WebIDL conversion, and a fifth spelling is a <c>TypeError</c>
-/// because the argument's IDL type is an enumeration. <c>spki</c> and <c>pkcs8</c> then reach the
-/// algorithm's own import steps and earn the <c>NotSupportedError</c> those steps specify for a format they
-/// do not handle — which for a symmetric key is every format but <c>raw</c> and <c>jwk</c>, in a browser as
-/// much as here.
+/// because the argument's IDL type is an enumeration. Which of them an algorithm accepts is then the
+/// algorithm's own business, and a format it does not handle earns the <c>NotSupportedError</c> its steps
+/// specify — <c>spki</c> and <c>pkcs8</c> describe an asymmetric key, so a symmetric algorithm refuses both,
+/// and <c>raw</c> describes a symmetric one, so an RSA algorithm refuses it. That is what a browser answers
+/// too.
 /// </remarks>
 internal enum KeyFormat
 {
@@ -56,13 +57,31 @@ internal static class KeyFormats
     internal const string Pkcs8 = "pkcs8";
     internal const string Jwk = "jwk";
 
-    internal static string NameOf(KeyFormat format) => format switch
+    /// <summary>
+    /// Every value is spelled out and the default throws, rather than one of them standing in as the
+    /// fallback: this string reaches a script in an error message naming the format it asked for, so a value
+    /// added to <see cref="KeyFormat"/> without a case here must fail loudly rather than call itself
+    /// <c>"jwk"</c>.
+    /// </summary>
+    internal static string NameOf(KeyFormat format)
     {
-        KeyFormat.Raw => Raw,
-        KeyFormat.Spki => Spki,
-        KeyFormat.Pkcs8 => Pkcs8,
-        _ => Jwk,
-    };
+        switch (format)
+        {
+            case KeyFormat.Raw:
+                return Raw;
+            case KeyFormat.Spki:
+                return Spki;
+            case KeyFormat.Pkcs8:
+                return Pkcs8;
+            case KeyFormat.Jwk:
+                return Jwk;
+            default:
+                // Unreachable: every KeyFormat is above, and the only producer of one is the WebIDL
+                // enumeration conversion, which recognizes exactly those four.
+                Throw.InvalidOperationException("Unhandled key format '" + format + "'.");
+                return null!;
+        }
+    }
 }
 
 /// <summary>
@@ -71,10 +90,11 @@ internal static class KeyFormats
 /// </summary>
 /// <remarks>
 /// One class rather than a dictionary type per pair, because the union of the members across the pairs this
-/// engine registers is six fields and nothing reads a field its own operation did not fill in. A member that
+/// engine registers is ten fields and nothing reads a field its own operation did not fill in. A member that
 /// the specification calls "not present" is <see langword="null"/> here, which is the distinction several
 /// steps turn on — <c>HmacKeyGenParams</c>'s absent <c>length</c> means the hash's block size, where a
-/// present zero is an <c>OperationError</c>.
+/// present zero is an <c>OperationError</c>, and <c>RsaOaepParams</c>'s absent <c>label</c> means the empty
+/// byte sequence.
 /// </remarks>
 internal sealed class NormalizedAlgorithm
 {
@@ -100,6 +120,24 @@ internal sealed class NormalizedAlgorithm
 
     /// <summary>The <c>tagLength</c> member of <c>AesGcmParams</c>, in bits.</summary>
     internal int? TagLength { get; set; }
+
+    /// <summary>The <c>modulusLength</c> member of <c>RsaHashedKeyGenParams</c>, in bits.</summary>
+    internal uint? ModulusLength { get; set; }
+
+    /// <summary>
+    /// The <c>publicExponent</c> member of <c>RsaHashedKeyGenParams</c> — a <c>BigInteger</c>, which is the
+    /// big-endian magnitude of an unsigned integer.
+    /// </summary>
+    internal byte[]? PublicExponent { get; set; }
+
+    /// <summary>The <c>saltLength</c> member of <c>RsaPssParams</c>, in <i>bytes</i>.</summary>
+    internal uint? SaltLength { get; set; }
+
+    /// <summary>
+    /// The <c>label</c> member of <c>RsaOaepParams</c>, copied at normalization time, or
+    /// <see langword="null"/> when it is not present — which the operation reads as the empty byte sequence.
+    /// </summary>
+    internal byte[]? Label { get; set; }
 }
 
 /// <summary>
@@ -138,11 +176,19 @@ internal static class AlgorithmNormalization
     /// <summary>https://w3c.github.io/webcrypto/#aes-gcm-registration</summary>
     internal const string AesGcm = "AES-GCM";
 
+    /// <summary>https://w3c.github.io/webcrypto/#rsassa-pkcs1-registration</summary>
+    internal const string RsassaPkcs1V15 = "RSASSA-PKCS1-v1_5";
+
+    /// <summary>https://w3c.github.io/webcrypto/#rsa-pss-registration</summary>
+    internal const string RsaPss = "RSA-PSS";
+
+    /// <summary>https://w3c.github.io/webcrypto/#rsa-oaep-registration</summary>
+    internal const string RsaOaep = "RSA-OAEP";
+
     private static readonly string[] _digestAlgorithms = [Sha1, Sha256, Sha384, Sha512];
-    private static readonly string[] _hmacOnly = [Hmac];
-    private static readonly string[] _aesGcmOnly = [AesGcm];
-    private static readonly string[] _keyAlgorithms = [Hmac, AesGcm];
-    private static readonly string[] _none = [];
+    private static readonly string[] _signatureAlgorithms = [Hmac, RsassaPkcs1V15, RsaPss];
+    private static readonly string[] _cipherAlgorithms = [AesGcm, RsaOaep];
+    private static readonly string[] _keyAlgorithms = [Hmac, AesGcm, RsassaPkcs1V15, RsaPss, RsaOaep];
 
     private static readonly JsString _nameKey = new("name");
     private static readonly JsString _hashKey = new("hash");
@@ -150,31 +196,73 @@ internal static class AlgorithmNormalization
     private static readonly JsString _ivKey = new("iv");
     private static readonly JsString _additionalDataKey = new("additionalData");
     private static readonly JsString _tagLengthKey = new("tagLength");
+    private static readonly JsString _modulusLengthKey = new("modulusLength");
+    private static readonly JsString _publicExponentKey = new("publicExponent");
+    private static readonly JsString _saltLengthKey = new("saltLength");
+    private static readonly JsString _labelKey = new("label");
 
     /// <summary>
     /// The associative container "stored at the <c>op</c> key of <c>supportedAlgorithms</c>".
     /// </summary>
-    internal static string[] RegisteredFor(CryptoOperation operation) => operation switch
+    /// <remarks>
+    /// Every operation is spelled out and the default throws rather than answering the empty registry: an
+    /// operation added to <see cref="CryptoOperation"/> without an entry here would silently register nothing
+    /// for it, so every algorithm name would be a <c>NotSupportedError</c> and the new operation would look
+    /// implemented while doing nothing.
+    /// </remarks>
+    internal static string[] RegisteredFor(CryptoOperation operation)
     {
-        CryptoOperation.Digest => _digestAlgorithms,
-        CryptoOperation.Encrypt or CryptoOperation.Decrypt => _aesGcmOnly,
-        CryptoOperation.Sign or CryptoOperation.Verify => _hmacOnly,
-        CryptoOperation.GenerateKey or CryptoOperation.ImportKey or CryptoOperation.ExportKey => _keyAlgorithms,
-        _ => _none,
-    };
+        switch (operation)
+        {
+            case CryptoOperation.Digest:
+                return _digestAlgorithms;
+            case CryptoOperation.Encrypt:
+            case CryptoOperation.Decrypt:
+                return _cipherAlgorithms;
+            case CryptoOperation.Sign:
+            case CryptoOperation.Verify:
+                return _signatureAlgorithms;
+            case CryptoOperation.GenerateKey:
+            case CryptoOperation.ImportKey:
+            case CryptoOperation.ExportKey:
+                return _keyAlgorithms;
+            default:
+                Throw.InvalidOperationException("Unhandled crypto operation '" + operation + "'.");
+                return null!;
+        }
+    }
 
     /// <summary>The name an error message calls the operation, which is also the method's own name.</summary>
-    internal static string NameOf(CryptoOperation operation) => operation switch
+    /// <remarks>
+    /// Every operation is spelled out and the default throws, for the reason <see cref="RegisteredFor"/>
+    /// gives: an operation without a case here would call itself <c>"exportKey"</c> in every message it
+    /// produced.
+    /// </remarks>
+    internal static string NameOf(CryptoOperation operation)
     {
-        CryptoOperation.Digest => "digest",
-        CryptoOperation.Encrypt => "encrypt",
-        CryptoOperation.Decrypt => "decrypt",
-        CryptoOperation.Sign => "sign",
-        CryptoOperation.Verify => "verify",
-        CryptoOperation.GenerateKey => "generateKey",
-        CryptoOperation.ImportKey => "importKey",
-        _ => "exportKey",
-    };
+        switch (operation)
+        {
+            case CryptoOperation.Digest:
+                return "digest";
+            case CryptoOperation.Encrypt:
+                return "encrypt";
+            case CryptoOperation.Decrypt:
+                return "decrypt";
+            case CryptoOperation.Sign:
+                return "sign";
+            case CryptoOperation.Verify:
+                return "verify";
+            case CryptoOperation.GenerateKey:
+                return "generateKey";
+            case CryptoOperation.ImportKey:
+                return "importKey";
+            case CryptoOperation.ExportKey:
+                return "exportKey";
+            default:
+                Throw.InvalidOperationException("Unhandled crypto operation '" + operation + "'.");
+                return null!;
+        }
+    }
 
     /// <summary>
     /// The <c>AlgorithmIdentifier</c> conversion alone — <c>typedef (object or DOMString)</c>, so an object
@@ -305,8 +393,39 @@ internal static class AlgorithmNormalization
                 normalized.TagLength = ReadOptionalOctet(context, algorithm, _tagLengthKey, what);
                 break;
 
+            // RsaHashedKeyGenParams, which all three RSA algorithms register for generateKey. The members are
+            // read in WebIDL's own order — RsaKeyGenParams' `modulusLength` and `publicExponent` first
+            // because it is the less derived dictionary, then RsaHashedKeyGenParams' own `hash`.
+            case (RsassaPkcs1V15, CryptoOperation.GenerateKey):
+            case (RsaPss, CryptoOperation.GenerateKey):
+            case (RsaOaep, CryptoOperation.GenerateKey):
+                normalized.ModulusLength = ReadRequiredUnsignedLong(context, algorithm, _modulusLengthKey, what);
+                normalized.PublicExponent = ReadRequiredBigInteger(context, algorithm, _publicExponentKey, what);
+                normalized.HashName = ReadRequiredHash(context, algorithm, what);
+                break;
+
+            // RsaHashedImportParams, whose one member is the hash.
+            case (RsassaPkcs1V15, CryptoOperation.ImportKey):
+            case (RsaPss, CryptoOperation.ImportKey):
+            case (RsaOaep, CryptoOperation.ImportKey):
+                normalized.HashName = ReadRequiredHash(context, algorithm, what);
+                break;
+
+            // RsaPssParams: `required [EnforceRange] unsigned long saltLength`, in bytes.
+            case (RsaPss, CryptoOperation.Sign):
+            case (RsaPss, CryptoOperation.Verify):
+                normalized.SaltLength = ReadRequiredUnsignedLong(context, algorithm, _saltLengthKey, what);
+                break;
+
+            // RsaOaepParams: `BufferSource label`, which is optional and has no default.
+            case (RsaOaep, CryptoOperation.Encrypt):
+            case (RsaOaep, CryptoOperation.Decrypt):
+                normalized.Label = ReadOptionalBufferSource(context, algorithm, _labelKey, what);
+                break;
+
             // Every remaining pair registers `None` as its parameters, so the Algorithm dictionary — the one
-            // member of which has already been read — is the whole of it.
+            // member of which has already been read — is the whole of it. RSASSA-PKCS1-v1_5's sign and
+            // verify are in that set, as is every algorithm's exportKey.
             default:
                 break;
         }
@@ -400,6 +519,53 @@ internal static class AlgorithmNormalization
         }
 
         return (uint) EnforceRange(context, value, key, what, uint.MaxValue);
+    }
+
+    private static uint ReadRequiredUnsignedLong(CryptoContext context, ObjectInstance? algorithm, JsString key, string what)
+    {
+        var value = algorithm?.Get(key) ?? JsValue.Undefined;
+        if (value.IsUndefined())
+        {
+            context.ThrowTypeError(what + ": required member " + key + " is undefined.");
+        }
+
+        return (uint) EnforceRange(context, value, key, what, uint.MaxValue);
+    }
+
+    /// <summary>
+    /// A <c>required BigInteger</c> member, which is <c>typedef Uint8Array BigInteger</c> —
+    /// https://w3c.github.io/webcrypto/#big-integer. WebIDL's conversion for a specific typed array type
+    /// accepts that type and nothing else (https://webidl.spec.whatwg.org/#es-buffer-source-types), so an
+    /// <c>ArrayBuffer</c>, a <c>DataView</c> or an <c>Int8Array</c> is a <c>TypeError</c> here where a
+    /// <c>BufferSource</c> member would have taken all three.
+    /// </summary>
+    /// <remarks>
+    /// The copy is this engine's own rather than the normalization step's: that step names members "of the
+    /// type BufferSource", which a <c>Uint8Array</c> typedef is not, so nothing in the specification requires
+    /// one here. The hazard it exists for is the same one, though — normalization goes on to read a
+    /// <c>hash</c> member, which may run a script's getter with this very array in scope — so the bytes are
+    /// taken now.
+    /// </remarks>
+    private static byte[] ReadRequiredBigInteger(CryptoContext context, ObjectInstance? algorithm, JsString key, string what)
+    {
+        var value = algorithm?.Get(key) ?? JsValue.Undefined;
+        if (value.IsUndefined())
+        {
+            context.ThrowTypeError(what + ": required member " + key + " is undefined.");
+        }
+
+        if (value is not JsTypedArray { _arrayElementType: TypedArrayElementType.Uint8 })
+        {
+            context.ThrowTypeError(what + ": member " + key + " is not of type 'Uint8Array'.");
+        }
+
+        if (IsSharedBufferSource(value))
+        {
+            context.ThrowTypeError(what + ": member " + key + " is backed by a SharedArrayBuffer, which this operation does not accept.");
+        }
+
+        BufferSource.TryGetBytes(value, out var bytes);
+        return bytes.ToArray();
     }
 
     private static uint ReadRequiredUnsignedShort(CryptoContext context, ObjectInstance? algorithm, JsString key, string what)

--- a/Jint/WebApi/Crypto/CryptoInstance.cs
+++ b/Jint/WebApi/Crypto/CryptoInstance.cs
@@ -26,10 +26,11 @@ namespace Jint.WebApi.Crypto;
 /// nowhere near this file.
 /// </para>
 /// <para>
-/// <c>crypto.subtle</c> exists and carries <b><c>digest</c> alone</b>. The rest of the <c>SubtleCrypto</c>
-/// interface — every operation that needs key material — is absent rather than present-and-throwing, so the
-/// feature detection a library performing cryptography starts with gets the truthful answer about each
-/// operation it means to use. See <see cref="SubtleCryptoInstance"/>.
+/// <c>crypto.subtle</c> exists and carries <b>eight of the twelve operations</b>: <c>digest</c>,
+/// <c>sign</c>, <c>verify</c>, <c>encrypt</c>, <c>decrypt</c>, <c>generateKey</c>, <c>importKey</c> and
+/// <c>exportKey</c>. <c>deriveKey</c>, <c>deriveBits</c>, <c>wrapKey</c> and <c>unwrapKey</c> are absent
+/// rather than present-and-throwing, so the feature detection a library performing cryptography starts with
+/// gets the truthful answer about each operation it means to use. See <see cref="SubtleCryptoInstance"/>.
 /// </para>
 /// <para>
 /// Three documented simplifications against WebIDL, the first pair of which <c>console</c> carries too. There

--- a/Jint/WebApi/Crypto/CryptoKeyConstructor.cs
+++ b/Jint/WebApi/Crypto/CryptoKeyConstructor.cs
@@ -51,9 +51,14 @@ internal sealed class CryptoKeyConstructor : Constructor
     /// Builds a key in this realm. The one place a <see cref="JsCryptoKey"/> is created, so the prototype
     /// cannot be forgotten on some path.
     /// </summary>
-    internal JsCryptoKey CreateKey(byte[] handle, CryptoKeyAlgorithm algorithm, bool extractable, KeyUsage usages)
+    internal JsCryptoKey CreateKey(
+        byte[] handle,
+        string keyType,
+        CryptoKeyAlgorithm algorithm,
+        bool extractable,
+        KeyUsage usages)
     {
-        return new JsCryptoKey(_engine, handle, algorithm, extractable, usages)
+        return new JsCryptoKey(_engine, handle, keyType, algorithm, extractable, usages)
         {
             _prototype = PrototypeObject,
         };

--- a/Jint/WebApi/Crypto/HmacAlgorithm.cs
+++ b/Jint/WebApi/Crypto/HmacAlgorithm.cs
@@ -30,24 +30,52 @@ internal static class HmacAlgorithm
     /// 1024 for SHA-384 and SHA-512. It is the "recommended length" an <c>HmacKeyGenParams</c> without a
     /// <c>length</c> member asks for.
     /// </summary>
-    internal static uint BlockSizeInBits(string hashName) => hashName switch
+    /// <remarks>
+    /// Every registered hash is spelled out and the default throws rather than one of them standing in as
+    /// the fallback: a hash registered later would otherwise be silently given SHA-512's block size.
+    /// </remarks>
+    internal static uint BlockSizeInBits(string hashName)
     {
-        AlgorithmNormalization.Sha1 or AlgorithmNormalization.Sha256 => 512,
-        _ => 1024,
-    };
+        switch (hashName)
+        {
+            case AlgorithmNormalization.Sha1:
+            case AlgorithmNormalization.Sha256:
+                return 512;
+            case AlgorithmNormalization.Sha384:
+            case AlgorithmNormalization.Sha512:
+                return 1024;
+            default:
+                Throw.InvalidOperationException("Unhandled HMAC hash algorithm '" + hashName + "'.");
+                return 0;
+        }
+    }
 
     /// <summary>
     /// The JWK <c>alg</c> field naming an HMAC key with a given inner hash —
     /// https://www.rfc-editor.org/rfc/rfc7518#section-3.1, plus <c>HS1</c>, which the Web Cryptography API
     /// names for SHA-1.
     /// </summary>
-    internal static string JwkAlgorithm(string hashName) => hashName switch
+    /// <remarks>
+    /// The default throws for the reason <see cref="BlockSizeInBits"/> gives, and here the consequence is
+    /// worse: a hash silently labelled <c>HS512</c> would produce a JWK that names the wrong algorithm.
+    /// </remarks>
+    internal static string JwkAlgorithm(string hashName)
     {
-        AlgorithmNormalization.Sha1 => "HS1",
-        AlgorithmNormalization.Sha256 => "HS256",
-        AlgorithmNormalization.Sha384 => "HS384",
-        _ => "HS512",
-    };
+        switch (hashName)
+        {
+            case AlgorithmNormalization.Sha1:
+                return "HS1";
+            case AlgorithmNormalization.Sha256:
+                return "HS256";
+            case AlgorithmNormalization.Sha384:
+                return "HS384";
+            case AlgorithmNormalization.Sha512:
+                return "HS512";
+            default:
+                Throw.InvalidOperationException("Unhandled HMAC hash algorithm '" + hashName + "'.");
+                return null!;
+        }
+    }
 
     /// <summary>The usages an HMAC key may carry: "sign" and "verify".</summary>
     private const KeyUsage AllowedUsages = KeyUsage.Sign | KeyUsage.Verify;
@@ -214,7 +242,7 @@ internal static class HmacAlgorithm
                 return context.CreateArrayBuffer(key.Handle.ToArray());
 
             case KeyFormat.Jwk:
-                return JsonWebKeyData.CreateExport(
+                return JsonWebKeyData.CreateOctExport(
                     context.Engine,
                     key.Handle,
                     JwkAlgorithm(key.Algorithm.HashName!),

--- a/Jint/WebApi/Crypto/JsCryptoKey.cs
+++ b/Jint/WebApi/Crypto/JsCryptoKey.cs
@@ -3,24 +3,63 @@ using System.Runtime.InteropServices;
 using Jint.Native;
 using Jint.Native.Array;
 using Jint.Native.Object;
+using Jint.Native.TypedArray;
 
 namespace Jint.WebApi.Crypto;
 
 /// <summary>
+/// The <c>[[type]]</c> internal slot's three values — https://w3c.github.io/webcrypto/#dfn-KeyType. They are
+/// the strings the <c>type</c> attribute answers with, so they are spelled once here rather than at each
+/// algorithm that decides one.
+/// </summary>
+internal static class CryptoKeyTypes
+{
+    internal const string Secret = "secret";
+    internal const string Public = "public";
+    internal const string Private = "private";
+}
+
+/// <summary>
 /// The <c>[[algorithm]]</c> internal slot of a <see cref="JsCryptoKey"/>: a <c>KeyAlgorithm</c>, or one of
-/// the two dictionaries derived from it that the algorithms here produce.
+/// the dictionaries derived from it that the algorithms here produce.
 /// <para>
 /// https://w3c.github.io/webcrypto/#key-algorithm-dictionary
 /// </para>
 /// </summary>
-/// <param name="Name">The recognized algorithm name — <c>HMAC</c> or <c>AES-GCM</c>.</param>
-/// <param name="Length">The length of the key in bits, which both dictionaries carry.</param>
+/// <remarks>
+/// One struct rather than a type per dictionary, for the reason <see cref="NormalizedAlgorithm"/> is one
+/// class: the union of the members across the dictionaries this engine produces is five fields, and which
+/// dictionary a value describes is decided by which of them are filled in. <see cref="PublicExponent"/> is
+/// the discriminator — an <c>RsaHashedKeyAlgorithm</c> is the only one that has one, so a non-null value
+/// there means <see cref="Length"/> is meaningless and <see cref="ModulusLength"/> is what describes the key.
+/// </remarks>
+/// <param name="Name">
+/// The recognized algorithm name — <c>HMAC</c>, <c>AES-GCM</c>, <c>RSASSA-PKCS1-v1_5</c>, <c>RSA-PSS</c> or
+/// <c>RSA-OAEP</c>.
+/// </param>
+/// <param name="Length">
+/// The length of a symmetric key in bits, which <c>HmacKeyAlgorithm</c> and <c>AesKeyAlgorithm</c> both
+/// carry. It is zero and unused for an <c>RsaHashedKeyAlgorithm</c>, which has no such member.
+/// </param>
 /// <param name="HashName">
-/// The <c>hash</c> member of an <c>HmacKeyAlgorithm</c>, or <see langword="null"/> for an
-/// <c>AesKeyAlgorithm</c>, which has none.
+/// The <c>hash</c> member of an <c>HmacKeyAlgorithm</c> or an <c>RsaHashedKeyAlgorithm</c>, or
+/// <see langword="null"/> for an <c>AesKeyAlgorithm</c>, which has none.
+/// </param>
+/// <param name="ModulusLength">
+/// The <c>modulusLength</c> member of an <c>RsaKeyAlgorithm</c>, in bits.
+/// </param>
+/// <param name="PublicExponent">
+/// The <c>publicExponent</c> member of an <c>RsaKeyAlgorithm</c>, held as the big-endian magnitude a
+/// <c>BigInteger</c> is (https://w3c.github.io/webcrypto/#big-integer) and surfaced to script as a
+/// <c>Uint8Array</c>. <see langword="null"/> for every symmetric algorithm.
 /// </param>
 [StructLayout(LayoutKind.Auto)]
-internal readonly record struct CryptoKeyAlgorithm(string Name, uint Length, string? HashName);
+internal readonly record struct CryptoKeyAlgorithm(
+    string Name,
+    uint Length,
+    string? HashName,
+    uint ModulusLength = 0,
+    byte[]? PublicExponent = null);
 
 /// <summary>
 /// A <c>CryptoKey</c> — "an opaque reference to keying material".
@@ -78,6 +117,20 @@ internal sealed class JsCryptoKey : ObjectInstance
         .Add("length")
         .Build();
 
+    /// <summary>
+    /// <c>RsaHashedKeyAlgorithm</c>, https://w3c.github.io/webcrypto/#RsaHashedKeyAlgorithm-dictionary. The
+    /// member order is the one WebIDL converts a dictionary in — the inherited dictionaries from least to
+    /// most derived, each one's own members lexicographically — so <c>name</c> comes from
+    /// <c>KeyAlgorithm</c>, then <c>modulusLength</c> and <c>publicExponent</c> from <c>RsaKeyAlgorithm</c>,
+    /// and <c>hash</c> last because it is the derived dictionary's own.
+    /// </summary>
+    private static readonly JsObjectLayout _rsaHashedKeyAlgorithmLayout = JsObjectLayout.CreateBuilder()
+        .Add("name")
+        .Add("modulusLength")
+        .Add("publicExponent")
+        .Add("hash")
+        .Build();
+
     private readonly byte[] _handle;
 
     private ObjectInstance? _algorithmCached;
@@ -86,30 +139,42 @@ internal sealed class JsCryptoKey : ObjectInstance
     internal JsCryptoKey(
         Engine engine,
         byte[] handle,
+        string keyType,
         CryptoKeyAlgorithm algorithm,
         bool extractable,
         KeyUsage usages) : base(engine, ObjectClass.Object)
     {
         _handle = handle;
+        KeyType = keyType;
         Algorithm = algorithm;
         Extractable = extractable;
         Usages = usages;
     }
 
     /// <summary>
-    /// The <c>[[handle]]</c> internal slot. Never handed out: the two callers that need the bytes —
+    /// The <c>[[handle]]</c> internal slot. Never handed out: the callers that need the bytes —
     /// <c>sign</c>/<c>verify</c> and <c>encrypt</c>/<c>decrypt</c> — read them and produce something else,
     /// and <c>exportKey</c> copies.
     /// </summary>
+    /// <remarks>
+    /// What the bytes <i>are</i> is the algorithm's business: for a symmetric key they are the key material
+    /// itself, and for an RSA key they are the DER encoding of a <c>SubjectPublicKeyInfo</c> or of a
+    /// <c>PrivateKeyInfo</c>. Holding a serialized form rather than a live
+    /// <see cref="System.Security.Cryptography.RSA"/> is deliberate: an <c>RSA</c> is
+    /// <see cref="IDisposable"/> and would give a script-reachable object a native lifetime the garbage
+    /// collector decides, where a byte array has none. Each operation rehydrates one, uses it and disposes it
+    /// inside a single <c>using</c>, which costs a key import per call and buys a <c>CryptoKey</c> that is
+    /// exactly as ordinary an object as an HMAC key is.
+    /// </remarks>
     internal ReadOnlySpan<byte> Handle => _handle;
 
     /// <summary>
-    /// The <c>[[type]]</c> internal slot. Every key this engine can build is a symmetric one, so it is always
-    /// <c>"secret"</c>; the attribute is nevertheless read from here rather than hard-coded at the accessor,
-    /// so that a public or private key added later cannot silently answer wrongly. It is not called
-    /// <c>Type</c> because <see cref="JsValue.Type"/> already is.
+    /// The <c>[[type]]</c> internal slot — <c>"secret"</c>, <c>"public"</c> or <c>"private"</c>, one of
+    /// <see cref="CryptoKeyTypes"/>. It is supplied by whichever algorithm made the key, because that is
+    /// where the specification decides it: every step that sets it names the type it is setting. It is not
+    /// called <c>Type</c> because <see cref="JsValue.Type"/> already is.
     /// </summary>
-    internal string KeyType { get; } = "secret";
+    internal string KeyType { get; }
 
     /// <summary>The <c>[[extractable]]</c> internal slot.</summary>
     internal bool Extractable { get; }
@@ -134,19 +199,45 @@ internal sealed class JsCryptoKey : ObjectInstance
         }
 
         var name = JsString.Create(Algorithm.Name);
-        var length = JsNumber.Create(Algorithm.Length);
 
-        if (Algorithm.HashName is null)
+        if (Algorithm.PublicExponent is { } publicExponent)
         {
-            _algorithmCached = JsObject.Create(_engine, _aesKeyAlgorithmLayout, [name, length]);
+            var rsaHash = JsObject.Create(_engine, _keyAlgorithmLayout, [JsString.Create(Algorithm.HashName!)]);
+            _algorithmCached = JsObject.Create(
+                _engine,
+                _rsaHashedKeyAlgorithmLayout,
+                [name, JsNumber.Create(Algorithm.ModulusLength), CreateBigInteger(publicExponent), rsaHash]);
+        }
+        else if (Algorithm.HashName is null)
+        {
+            _algorithmCached = JsObject.Create(_engine, _aesKeyAlgorithmLayout, [name, JsNumber.Create(Algorithm.Length)]);
         }
         else
         {
             var hash = JsObject.Create(_engine, _keyAlgorithmLayout, [JsString.Create(Algorithm.HashName)]);
-            _algorithmCached = JsObject.Create(_engine, _hmacKeyAlgorithmLayout, [name, hash, length]);
+            _algorithmCached = JsObject.Create(_engine, _hmacKeyAlgorithmLayout, [name, hash, JsNumber.Create(Algorithm.Length)]);
         }
 
         return _algorithmCached;
+    }
+
+    /// <summary>
+    /// A <c>BigInteger</c> — https://w3c.github.io/webcrypto/#big-integer, which is
+    /// <c>typedef Uint8Array BigInteger</c> holding "an arbitrary magnitude unsigned integer in big-endian
+    /// order".
+    /// </summary>
+    /// <remarks>
+    /// The bytes are copied into the array rather than shared with the key's own: the algorithm object is an
+    /// ordinary object a script may write into, and what the engine decides is decided from
+    /// <see cref="Algorithm"/> alone. The realm is the engine's active one, which is the very realm
+    /// <c>JsObject.Create</c> anchors the surrounding object to.
+    /// </remarks>
+    private JsTypedArray CreateBigInteger(ReadOnlySpan<byte> magnitude)
+    {
+        var uint8Array = _engine.Realm.Intrinsics.Uint8Array;
+        var array = uint8Array.AllocateTypedArray(uint8Array, (uint) magnitude.Length);
+        TypedArrayConstructor.FillTypedArrayInstance(array, magnitude);
+        return array;
     }
 
     /// <summary>

--- a/Jint/WebApi/Crypto/JsonWebKeyData.cs
+++ b/Jint/WebApi/Crypto/JsonWebKeyData.cs
@@ -1,4 +1,5 @@
 #if NET8_0_OR_GREATER
+using System.Runtime.InteropServices;
 using Jint.Extensions;
 using Jint.Native;
 using Jint.Native.Object;
@@ -7,41 +8,73 @@ using Jint.Runtime;
 namespace Jint.WebApi.Crypto;
 
 /// <summary>
-/// The members of a <c>JsonWebKey</c> dictionary that a symmetric key uses —
+/// The eight fields a JSON Web Key describes an RSA private key by —
+/// https://www.rfc-editor.org/rfc/rfc7518#section-6.3.2 and, for the first two, #section-6.3.1 — each one
+/// the big-endian magnitude of the value, which is what base64url is applied to.
+/// </summary>
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct RsaJwkPrivateFields(
+    byte[] N,
+    byte[] E,
+    byte[] D,
+    byte[] P,
+    byte[] Q,
+    byte[] Dp,
+    byte[] Dq,
+    byte[] Qi);
+
+/// <summary>
+/// The members of a <c>JsonWebKey</c> dictionary that this engine's algorithms use —
 /// https://w3c.github.io/webcrypto/#JsonWebKey-dictionary, whose fields are those of
 /// https://www.rfc-editor.org/rfc/rfc7517 and https://www.rfc-editor.org/rfc/rfc7518.
 /// </summary>
 /// <remarks>
 /// <para>
-/// A documented simplification: the dictionary declares eighteen members and this reads the six an
-/// <c>oct</c> key can be described by (<c>alg</c>, <c>ext</c>, <c>k</c>, <c>key_ops</c>, <c>kty</c>,
-/// <c>use</c>). A getter on one of the twelve asymmetric-key members — <c>crv</c>, <c>n</c>, <c>d</c> and the
-/// rest — is therefore not invoked, where a browser's WebIDL conversion would invoke it and could raise a
-/// <c>TypeError</c> from converting its value. Nothing else can observe the difference: the specification's
-/// own note says that "fields that are not explicitly referred to in the key import procedures for an
-/// algorithm are ignored".
+/// A documented simplification: the dictionary declares eighteen members and this reads the fourteen an
+/// <c>oct</c> key or an <c>RSA</c> key can be described by — <c>alg</c>, <c>d</c>, <c>dp</c>, <c>dq</c>,
+/// <c>e</c>, <c>ext</c>, <c>k</c>, <c>key_ops</c>, <c>kty</c>, <c>n</c>, <c>p</c>, <c>q</c>, <c>qi</c> and
+/// <c>use</c>. A getter on one of the four elliptic-curve or multi-prime members — <c>crv</c>, <c>x</c>,
+/// <c>y</c> and <c>oth</c> — is therefore not invoked, where a browser's WebIDL conversion would invoke it
+/// and could raise a <c>TypeError</c> from converting its value. The specification's own note covers the
+/// difference: "fields that are not explicitly referred to in the key import procedures for an algorithm are
+/// ignored".
 /// </para>
 /// <para>
-/// The six that <i>are</i> read are read in lexicographical order, which is the order WebIDL converts a
+/// <c>oth</c> is the one whose absence is worth naming, because a JWK carrying it describes a key with more
+/// than two prime factors and the five CRT fields read here then describe only the first two. Nothing
+/// silently succeeds: the parameters are handed to the platform's own RSA importer, which validates them
+/// against <c>n</c> and refuses the mismatch, so such a key is a <c>DataError</c> rather than a key that is
+/// quietly wrong.
+/// </para>
+/// <para>
+/// The fourteen that <i>are</i> read are read in lexicographical order, which is the order WebIDL converts a
 /// dictionary's members in, so a JWK built out of getters sees them run in the order a browser runs them.
 /// </para>
 /// </remarks>
 internal sealed class JsonWebKeyData
 {
     private static readonly JsString _algKey = new("alg");
+    private static readonly JsString _dKey = new("d");
+    private static readonly JsString _dpKey = new("dp");
+    private static readonly JsString _dqKey = new("dq");
+    private static readonly JsString _eKey = new("e");
     private static readonly JsString _extKey = new("ext");
     private static readonly JsString _kKey = new("k");
     private static readonly JsString _keyOpsKey = new("key_ops");
     private static readonly JsString _ktyKey = new("kty");
+    private static readonly JsString _nKey = new("n");
+    private static readonly JsString _pKey = new("p");
+    private static readonly JsString _qKey = new("q");
+    private static readonly JsString _qiKey = new("qi");
     private static readonly JsString _useKey = new("use");
 
     /// <summary>
-    /// The shape <c>exportKey("jwk")</c> answers with. Both algorithms set every one of the five, and WebIDL
-    /// converts a dictionary to an object in lexicographical order of its members —
+    /// The shape <c>exportKey("jwk")</c> answers with for a symmetric key. Both algorithms set every one of
+    /// the five, and WebIDL converts a dictionary to an object in lexicographical order of its members —
     /// https://webidl.spec.whatwg.org/#es-dictionary — so one layout describes both and
     /// <c>Object.keys(jwk)</c> is stable.
     /// </summary>
-    private static readonly JsObjectLayout _exportLayout = JsObjectLayout.CreateBuilder()
+    private static readonly JsObjectLayout _octExportLayout = JsObjectLayout.CreateBuilder()
         .Add("alg")
         .Add("ext")
         .Add("k")
@@ -49,8 +82,52 @@ internal sealed class JsonWebKeyData
         .Add("kty")
         .Build();
 
+    /// <summary>
+    /// The shape <c>exportKey("jwk")</c> answers with for an RSA <i>public</i> key: the two members Section
+    /// 6.3.1 of JSON Web Algorithms defines, plus the four every export carries, in lexicographical order.
+    /// </summary>
+    private static readonly JsObjectLayout _rsaPublicExportLayout = JsObjectLayout.CreateBuilder()
+        .Add("alg")
+        .Add("e")
+        .Add("ext")
+        .Add("key_ops")
+        .Add("kty")
+        .Add("n")
+        .Build();
+
+    /// <summary>
+    /// The shape <c>exportKey("jwk")</c> answers with for an RSA <i>private</i> key: the public members plus
+    /// the six of Section 6.3.2, again in lexicographical order.
+    /// </summary>
+    private static readonly JsObjectLayout _rsaPrivateExportLayout = JsObjectLayout.CreateBuilder()
+        .Add("alg")
+        .Add("d")
+        .Add("dp")
+        .Add("dq")
+        .Add("e")
+        .Add("ext")
+        .Add("key_ops")
+        .Add("kty")
+        .Add("n")
+        .Add("p")
+        .Add("q")
+        .Add("qi")
+        .Build();
+
     /// <summary>The <c>alg</c> field, or <see langword="null"/> when it is not present.</summary>
     internal string? Alg { get; private set; }
+
+    /// <summary>The <c>d</c> field, or <see langword="null"/> when it is not present.</summary>
+    internal string? D { get; private set; }
+
+    /// <summary>The <c>dp</c> field, or <see langword="null"/> when it is not present.</summary>
+    internal string? Dp { get; private set; }
+
+    /// <summary>The <c>dq</c> field, or <see langword="null"/> when it is not present.</summary>
+    internal string? Dq { get; private set; }
+
+    /// <summary>The <c>e</c> field, or <see langword="null"/> when it is not present.</summary>
+    internal string? E { get; private set; }
 
     /// <summary>The <c>ext</c> field, or <see langword="null"/> when it is not present.</summary>
     internal bool? Ext { get; private set; }
@@ -64,6 +141,18 @@ internal sealed class JsonWebKeyData
     /// <summary>The <c>kty</c> field, or <see langword="null"/> when it is not present.</summary>
     internal string? Kty { get; private set; }
 
+    /// <summary>The <c>n</c> field, or <see langword="null"/> when it is not present.</summary>
+    internal string? N { get; private set; }
+
+    /// <summary>The <c>p</c> field, or <see langword="null"/> when it is not present.</summary>
+    internal string? P { get; private set; }
+
+    /// <summary>The <c>q</c> field, or <see langword="null"/> when it is not present.</summary>
+    internal string? Q { get; private set; }
+
+    /// <summary>The <c>qi</c> field, or <see langword="null"/> when it is not present.</summary>
+    internal string? Qi { get; private set; }
+
     /// <summary>The <c>use</c> field, or <see langword="null"/> when it is not present.</summary>
     internal string? Use { get; private set; }
 
@@ -75,10 +164,18 @@ internal sealed class JsonWebKeyData
         var jwk = new JsonWebKeyData
         {
             Alg = ReadString(source, _algKey),
+            D = ReadString(source, _dKey),
+            Dp = ReadString(source, _dpKey),
+            Dq = ReadString(source, _dqKey),
+            E = ReadString(source, _eKey),
             Ext = ReadBoolean(source, _extKey),
             K = ReadString(source, _kKey),
             KeyOps = ReadStringSequence(context, source, what),
             Kty = ReadString(source, _ktyKey),
+            N = ReadString(source, _nKey),
+            P = ReadString(source, _pKey),
+            Q = ReadString(source, _qKey),
+            Qi = ReadString(source, _qiKey),
             Use = ReadString(source, _useKey),
         };
 
@@ -129,24 +226,48 @@ internal sealed class JsonWebKeyData
     }
 
     /// <summary>
-    /// The first three JWK steps both algorithms share: the key type must be <c>oct</c>, the key must meet
-    /// "the requirements of Section 6.4 of JSON Web Algorithms" — which for an <c>oct</c> key is that
-    /// <c>k</c> is present, https://www.rfc-editor.org/rfc/rfc7518#section-6.4.1 saying "This member MUST be
-    /// present" — and <c>k</c> is then decoded.
+    /// The first three JWK steps both symmetric algorithms share: the key type must be <c>oct</c>, the key
+    /// must meet "the requirements of Section 6.4 of JSON Web Algorithms" — which for an <c>oct</c> key is
+    /// that <c>k</c> is present, https://www.rfc-editor.org/rfc/rfc7518#section-6.4.1 saying "This member
+    /// MUST be present" — and <c>k</c> is then decoded.
     /// </summary>
     internal byte[] RequireOctAndDecodeKey(CryptoContext context, string what)
     {
-        if (!string.Equals(Kty, "oct", StringComparison.Ordinal))
-        {
-            context.ThrowDataError(what + ": the kty field of the JSON Web Key is " + Describe(Kty) + " rather than 'oct'.");
-        }
+        RequireKeyType(context, "oct", what);
 
         if (K is null)
         {
             context.ThrowDataError(what + ": the JSON Web Key has no k field, which Section 6.4.1 of JSON Web Algorithms requires for a key of type 'oct'.");
         }
 
-        return DecodeBase64Url(context, K, what);
+        return DecodeBase64Url(context, K, "k", what);
+    }
+
+    /// <summary>
+    /// "If the kty field of jwk is not a case-sensitive string match to <c>expected</c>, then throw a
+    /// DataError" — the step every algorithm's JWK branch makes, differing only in the type it names.
+    /// </summary>
+    internal void RequireKeyType(CryptoContext context, string expected, string what)
+    {
+        if (!string.Equals(Kty, expected, StringComparison.Ordinal))
+        {
+            context.ThrowDataError(
+                what + ": the kty field of the JSON Web Key is " + Describe(Kty) + " rather than '" + expected + "'.");
+        }
+    }
+
+    /// <summary>
+    /// A JWK field that must be present and must decode as base64url — the shape every RSA parameter has.
+    /// </summary>
+    internal static byte[] RequireBase64UrlField(CryptoContext context, string? value, string field, string what)
+    {
+        if (value is null)
+        {
+            context.ThrowDataError(
+                what + ": the JSON Web Key has no " + field + " field, which JSON Web Algorithms requires for a key of this type.");
+        }
+
+        return DecodeBase64Url(context, value, field, what);
     }
 
     /// <summary>
@@ -161,38 +282,38 @@ internal sealed class JsonWebKeyData
     /// exactly what a base64url string may not contain. Accepting them would mean importing a key from a
     /// document that no other implementation would read.
     /// </remarks>
-    private static byte[] DecodeBase64Url(CryptoContext context, string k, string what)
+    private static byte[] DecodeBase64Url(CryptoContext context, string value, string field, string what)
     {
-        foreach (var c in k)
+        foreach (var c in value)
         {
             var valid = char.IsAsciiLetterOrDigit(c) || c == '-' || c == '_';
             if (!valid)
             {
-                context.ThrowDataError(what + ": the k field of the JSON Web Key contains '" + c + "', which is not a base64url character.");
+                context.ThrowDataError(what + ": the " + field + " field of the JSON Web Key contains '" + c + "', which is not a base64url character.");
             }
         }
 
         // A base64url string of length 4n+1 encodes a fractional byte and cannot be decoded at all.
-        if (k.Length % 4 == 1)
+        if (value.Length % 4 == 1)
         {
-            context.ThrowDataError(what + ": the k field of the JSON Web Key has a length of " + k.Length + ", which no base64url encoding has.");
+            context.ThrowDataError(what + ": the " + field + " field of the JSON Web Key has a length of " + value.Length + ", which no base64url encoding has.");
         }
 
         try
         {
-            return WebEncoders.Base64UrlDecode(k.AsSpan());
+            return WebEncoders.Base64UrlDecode(value.AsSpan());
         }
         catch (FormatException)
         {
-            context.ThrowDataError(what + ": the k field of the JSON Web Key is not a valid base64url encoding.");
+            context.ThrowDataError(what + ": the " + field + " field of the JSON Web Key is not a valid base64url encoding.");
             return null!;
         }
     }
 
     /// <summary>
-    /// The last three JWK steps both algorithms share, in the order they appear in both: <c>use</c>,
+    /// The last three JWK steps every algorithm shares, in the order they appear in all of them: <c>use</c>,
     /// <c>key_ops</c> and <c>ext</c>. <c>expectedUse</c> is "sig" for a signing key and "enc" for an
-    /// encryption key, which is the only part of these three steps that differs between the two.
+    /// encryption key, which is the only part of these three steps that differs between them.
     /// </summary>
     internal void ValidateUseKeyOpsAndExt(
         CryptoContext context,
@@ -261,11 +382,11 @@ internal sealed class JsonWebKeyData
     }
 
     /// <summary>
-    /// The object <c>exportKey("jwk")</c> resolves with: the five fields both algorithms set, with <c>k</c>
-    /// carrying the key material "encoded according to Section 6.4 of JSON Web Algorithms" — base64url with
-    /// no padding.
+    /// The object <c>exportKey("jwk")</c> resolves with for a symmetric key: the five fields both algorithms
+    /// set, with <c>k</c> carrying the key material "encoded according to Section 6.4 of JSON Web Algorithms"
+    /// — base64url with no padding.
     /// </summary>
-    internal static JsObject CreateExport(
+    internal static JsObject CreateOctExport(
         Engine engine,
         ReadOnlySpan<byte> keyMaterial,
         string alg,
@@ -274,7 +395,7 @@ internal sealed class JsonWebKeyData
     {
         return JsObject.Create(
             engine,
-            _exportLayout,
+            _octExportLayout,
             [
                 JsString.Create(alg),
                 extractable ? JsBoolean.True : JsBoolean.False,
@@ -283,6 +404,66 @@ internal sealed class JsonWebKeyData
                 JsString.Create("oct"),
             ]);
     }
+
+    /// <summary>
+    /// The object <c>exportKey("jwk")</c> resolves with for an RSA public key: <c>n</c> and <c>e</c> "set
+    /// according to the corresponding definitions in JSON Web Algorithms, Section 6.3.1", plus the four
+    /// fields every export carries.
+    /// </summary>
+    internal static JsObject CreateRsaPublicExport(
+        Engine engine,
+        string alg,
+        ReadOnlySpan<byte> modulus,
+        ReadOnlySpan<byte> exponent,
+        KeyUsage usages,
+        bool extractable)
+    {
+        return JsObject.Create(
+            engine,
+            _rsaPublicExportLayout,
+            [
+                JsString.Create(alg),
+                Encode(exponent),
+                extractable ? JsBoolean.True : JsBoolean.False,
+                KeyUsages.ToArray(engine, usages),
+                JsString.Create("RSA"),
+                Encode(modulus),
+            ]);
+    }
+
+    /// <summary>
+    /// The object <c>exportKey("jwk")</c> resolves with for an RSA private key: the public members plus
+    /// <c>d</c>, <c>p</c>, <c>q</c>, <c>dp</c>, <c>dq</c> and <c>qi</c> "according to the corresponding
+    /// definitions in JSON Web Algorithms, Section 6.3.2".
+    /// </summary>
+    internal static JsObject CreateRsaPrivateExport(
+        Engine engine,
+        string alg,
+        in RsaJwkPrivateFields fields,
+        KeyUsage usages,
+        bool extractable)
+    {
+        return JsObject.Create(
+            engine,
+            _rsaPrivateExportLayout,
+            [
+                JsString.Create(alg),
+                Encode(fields.D),
+                Encode(fields.Dp),
+                Encode(fields.Dq),
+                Encode(fields.E),
+                extractable ? JsBoolean.True : JsBoolean.False,
+                KeyUsages.ToArray(engine, usages),
+                JsString.Create("RSA"),
+                Encode(fields.N),
+                Encode(fields.P),
+                Encode(fields.Q),
+                Encode(fields.Qi),
+            ]);
+    }
+
+    private static JsString Encode(ReadOnlySpan<byte> value)
+        => JsString.Create(WebEncoders.Base64UrlEncode(value, omitPadding: true));
 
     private static string Describe(string? value) => value is null ? "absent" : "'" + value + "'";
 }

--- a/Jint/WebApi/Crypto/RsaAlgorithm.cs
+++ b/Jint/WebApi/Crypto/RsaAlgorithm.cs
@@ -1,0 +1,1060 @@
+#if NET8_0_OR_GREATER
+using System.Numerics;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Crypto;
+
+/// <summary>
+/// The two halves of a generated RSA key pair, with the usages each of them ends up carrying.
+/// </summary>
+/// <remarks>
+/// One <see cref="CryptoKeyAlgorithm"/> for both, because the specification builds exactly one
+/// <c>RsaHashedKeyAlgorithm</c> and sets the <c>[[algorithm]]</c> slot of both keys to it.
+/// </remarks>
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct RsaKeyPairMaterial(
+    byte[] PublicHandle,
+    KeyUsage PublicUsages,
+    byte[] PrivateHandle,
+    KeyUsage PrivateUsages,
+    CryptoKeyAlgorithm Algorithm);
+
+/// <summary>
+/// The three RSA algorithms — RSASSA-PKCS1-v1_5 (https://w3c.github.io/webcrypto/#rsassa-pkcs1), RSA-PSS
+/// (https://w3c.github.io/webcrypto/#rsa-pss) and RSA-OAEP (https://w3c.github.io/webcrypto/#rsa-oaep) —
+/// which share every operation but <c>sign</c>/<c>verify</c> against <c>encrypt</c>/<c>decrypt</c>, and share
+/// all of <c>generateKey</c>, <c>importKey</c> and <c>exportKey</c> down to the usage sets and the JWK
+/// <c>alg</c> table.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The key's <c>[[handle]]</c> is DER, never a live <see cref="RSA"/>.</b> A public key holds the bytes of
+/// a <c>SubjectPublicKeyInfo</c> and a private key those of a <c>PrivateKeyInfo</c>, and each operation
+/// rehydrates an <see cref="RSA"/> inside one <c>using</c>. That is what keeps <see cref="JsCryptoKey"/> free
+/// of <see cref="IDisposable"/>: a script-reachable object holding a native key handle would tie an operating
+/// system resource to a garbage-collection schedule, and <c>CryptoKey</c> has no <c>close</c> for a script to
+/// call. The cost is one key import per operation, which is small beside the modular exponentiation that
+/// follows it, and the DER is the canonical re-encoding the platform itself produced, so it is also exactly
+/// what <c>exportKey</c> hands back.
+/// </para>
+/// <para>
+/// <b>Three limits of the platform are visible</b>, each reported as an <c>OperationError</c> naming the
+/// restriction rather than pretended away:
+/// </para>
+/// <list type="bullet">
+/// <item>
+/// <b>RSA-PSS salt length.</b> <see cref="RSASignaturePadding.Pss"/> takes no salt-length parameter and .NET
+/// fixes the salt at the hash's own output length, where <c>RsaPssParams.saltLength</c> is a caller-supplied
+/// value. The member is read and honoured for the one length the platform can produce, and any other length
+/// is refused — rather than silently signing with a salt the caller did not ask for, which would produce a
+/// signature that verifies nowhere the caller expects.
+/// </item>
+/// <item>
+/// <b>RSA-OAEP label.</b> <see cref="RSAEncryptionPadding"/> carries a hash and no label, so the only label
+/// this engine can honour is the empty one. An absent or empty <c>label</c> works; a non-empty one is
+/// refused, because encrypting with the empty label instead would produce a ciphertext the intended
+/// recipient cannot decrypt.
+/// </item>
+/// <item>
+/// <b>generateKey public exponent.</b> <see cref="RSA.Create(int)"/> takes a key size and nothing else; .NET
+/// exposes no way to choose <c>e</c>, and every implementation it can reach uses 65537. Any other exponent is
+/// refused.
+/// </item>
+/// </list>
+/// <para>
+/// A fourth restriction belongs to key <i>import</i> rather than to an operation: .NET's
+/// <see cref="RSAParameters"/> describes a private key by its CRT form, so a JWK carrying <c>d</c> without
+/// <c>p</c>, <c>q</c>, <c>dp</c>, <c>dq</c> and <c>qi</c> — which Section 6.3.2 of JSON Web Algorithms
+/// permits — cannot be imported and is a <c>DataError</c>. Recovering the primes from <c>(n, e, d)</c> is
+/// possible but is a probabilistic factoring routine, and writing one here would be this engine inventing
+/// cryptography rather than calling it.
+/// </para>
+/// </remarks>
+internal static class RsaAlgorithm
+{
+    /// <summary>The usages a signature key pair may be asked for — RSASSA-PKCS1-v1_5 and RSA-PSS.</summary>
+    private const KeyUsage SignatureUsages = KeyUsage.Sign | KeyUsage.Verify;
+
+    /// <summary>The usages an RSA-OAEP key pair may be asked for.</summary>
+    private const KeyUsage CipherUsages = KeyUsage.Encrypt | KeyUsage.Decrypt | KeyUsage.WrapKey | KeyUsage.UnwrapKey;
+
+    /// <summary>"The usage intersection of usages and [ 'verify' ]".</summary>
+    private const KeyUsage PublicSignatureUsages = KeyUsage.Verify;
+
+    /// <summary>"The usage intersection of usages and [ 'sign' ]".</summary>
+    private const KeyUsage PrivateSignatureUsages = KeyUsage.Sign;
+
+    /// <summary>"The usage intersection of usages and [ 'encrypt', 'wrapKey' ]".</summary>
+    private const KeyUsage PublicCipherUsages = KeyUsage.Encrypt | KeyUsage.WrapKey;
+
+    /// <summary>"The usage intersection of usages and [ 'decrypt', 'unwrapKey' ]".</summary>
+    private const KeyUsage PrivateCipherUsages = KeyUsage.Decrypt | KeyUsage.UnwrapKey;
+
+    /// <summary>
+    /// The largest modulus this engine will <i>generate</i>, in bits. The algorithm has no ceiling of its
+    /// own and the platform's goes to 16384, but RSA key generation is a prime search whose cost grows far
+    /// faster than the modulus does — a 16384-bit key is minutes of CPU inside one synchronous operation,
+    /// which no execution constraint can interrupt because it is a single BCL call. 8192 is comfortably
+    /// above every key size in use and bounds that to seconds. It bounds nothing about <i>importing</i> a
+    /// key, where the work is a parse.
+    /// </summary>
+    private const uint MaxGeneratedModulusLength = 8192;
+
+    /// <summary>The four registered hashes, in the order a JWK <c>alg</c> table lists them.</summary>
+    private static readonly string[] _hashes =
+    [
+        AlgorithmNormalization.Sha1,
+        AlgorithmNormalization.Sha256,
+        AlgorithmNormalization.Sha384,
+        AlgorithmNormalization.Sha512,
+    ];
+
+    // -------------------------------------------------------------------------------------------------
+    // generateKey
+    // -------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#rsassa-pkcs1-operations-generate-key,
+    /// https://w3c.github.io/webcrypto/#rsa-pss-operations-generate-key and
+    /// https://w3c.github.io/webcrypto/#rsa-oaep-operations-generate-key, which differ only in step 1's
+    /// usage set and in the name the resulting dictionary carries.
+    /// </summary>
+    internal static RsaKeyPairMaterial GenerateKey(
+        CryptoContext context,
+        NormalizedAlgorithm normalized,
+        KeyUsage usages,
+        string what)
+    {
+        var isCipher = string.Equals(normalized.Name, AlgorithmNormalization.RsaOaep, StringComparison.Ordinal);
+
+        // Step 1: "If usages contains an entry which is not …, then throw a SyntaxError."
+        RequireUsagesWithin(context, usages, isCipher ? CipherUsages : SignatureUsages, normalized.Name, what);
+
+        var modulusLength = normalized.ModulusLength!.Value;
+        var publicExponent = normalized.PublicExponent!;
+
+        // This engine's own ceiling comes first, ahead of step 2, so that the arithmetic step 2 performs on
+        // 2^modulusLength is bounded by something before it is performed. Both failures are the same
+        // OperationError, so nothing but the message can tell the order.
+        if (modulusLength > MaxGeneratedModulusLength)
+        {
+            context.ThrowOperationError(
+                what + ": a modulus length of " + modulusLength + " bits exceeds the " + MaxGeneratedModulusLength
+                + " bits this engine will generate.");
+        }
+
+        // Step 2: "Perform the validate RSA key generation parameters algorithm with normalizedAlgorithm."
+        ValidateKeyGenerationParameters(context, modulusLength, publicExponent, what);
+
+        RequireSupportedPublicExponent(context, publicExponent, what);
+        RequireGeneratableModulusLength(context, modulusLength, what);
+
+        byte[] publicHandle;
+        byte[] privateHandle;
+
+        // Steps 3 and 4: generate the pair, and report a generation that fails as an OperationError. Every
+        // way RSA.Create can refuse a size arrives as a CryptographicException, which must not escape a
+        // promise-returning operation as a CLR exception.
+        try
+        {
+            using var rsa = RSA.Create((int) modulusLength);
+            publicHandle = rsa.ExportSubjectPublicKeyInfo();
+            privateHandle = rsa.ExportPkcs8PrivateKey();
+        }
+        catch (CryptographicException)
+        {
+            context.ThrowOperationError(what + ": the RSA key pair could not be generated.");
+            return default;
+        }
+
+        // Steps 5 to 9: one RsaHashedKeyAlgorithm, shared by both halves. The exponent is stored in the
+        // minimal form the BigInteger definition asks values read from the API to have, rather than with
+        // whatever leading zeros the caller's array carried.
+        var algorithm = new CryptoKeyAlgorithm(
+            normalized.Name,
+            Length: 0,
+            normalized.HashName,
+            modulusLength,
+            Minimal(publicExponent));
+
+        return new RsaKeyPairMaterial(
+            publicHandle,
+            usages & (isCipher ? PublicCipherUsages : PublicSignatureUsages),
+            privateHandle,
+            usages & (isCipher ? PrivateCipherUsages : PrivateSignatureUsages),
+            algorithm);
+    }
+
+    /// <summary>
+    /// "Validate RSA key generation parameters" —
+    /// https://w3c.github.io/webcrypto/#rsa-key-generation-parameter-validation: "If modulusLength is less
+    /// than 4, or if publicExponent is less than 3, is even, or is greater than or equal to
+    /// 2^modulusLength - 1, then throw an OperationError."
+    /// </summary>
+    private static void ValidateKeyGenerationParameters(
+        CryptoContext context,
+        uint modulusLength,
+        byte[] publicExponent,
+        string what)
+    {
+        // "Let publicExponent be the result of converting the publicExponent member to a non-negative
+        // integer" — the array is the big-endian magnitude, and an empty one is zero.
+        var exponent = new BigInteger(publicExponent, isUnsigned: true, isBigEndian: true);
+
+        if (modulusLength < 4)
+        {
+            context.ThrowOperationError(what + ": a modulus length of " + modulusLength + " bits is less than the 4 bits an RSA modulus must have.");
+        }
+
+        if (exponent < 3 || exponent.IsEven || IsAtLeastAllOnes(exponent, modulusLength))
+        {
+            context.ThrowOperationError(
+                what + ": " + exponent + " is not a valid RSA public exponent — it must be an odd integer at least 3 and less than 2^"
+                + modulusLength + " - 1.");
+        }
+    }
+
+    /// <summary>
+    /// Whether <paramref name="value"/> is at least <c>2^modulusLength - 1</c>, without materializing that
+    /// number unless the bit lengths make it necessary. A value with more bits than the modulus is above it
+    /// outright; one with fewer is below it; and one with exactly as many is at least <c>2^m - 1</c> only if
+    /// every one of those bits is set, which is the one case worth building the comparand for.
+    /// </summary>
+    private static bool IsAtLeastAllOnes(BigInteger value, uint modulusLength)
+    {
+        var bits = value.GetBitLength();
+
+        if (bits != modulusLength)
+        {
+            return bits > modulusLength;
+        }
+
+        return value >= (BigInteger.One << (int) modulusLength) - BigInteger.One;
+    }
+
+    /// <summary>
+    /// The public exponent restriction. See the remarks on this class: .NET's RSA key generation takes a key
+    /// size and nothing else.
+    /// </summary>
+    private static void RequireSupportedPublicExponent(CryptoContext context, byte[] publicExponent, string what)
+    {
+        var minimal = Minimal(publicExponent);
+
+        // 65537 = 0x01 0x00 0x01, the F4 exponent every implementation .NET can reach generates with.
+        if (minimal is not [0x01, 0x00, 0x01])
+        {
+            context.ThrowOperationError(
+                what + ": this engine generates RSA keys with the public exponent 65537 only, and .NET's RSA key generation offers no way to choose another.");
+        }
+    }
+
+    /// <summary>
+    /// What the platform's own RSA implementation will generate, which is narrower than the algorithm's
+    /// "any modulus length" and differs per operating system — CNG takes 512 to 16384 bits in steps of 64,
+    /// OpenSSL 512 to 16384 in steps of 8. Asking rather than assuming is what keeps this an
+    /// <c>OperationError</c> naming the restriction instead of a <see cref="CryptographicException"/>
+    /// erupting out of a promise-returning operation.
+    /// </summary>
+    private static void RequireGeneratableModulusLength(CryptoContext context, uint modulusLength, string what)
+    {
+        using var probe = RSA.Create();
+        var legal = probe.LegalKeySizes;
+
+        foreach (var sizes in legal)
+        {
+            if (modulusLength < (uint) sizes.MinSize || modulusLength > (uint) sizes.MaxSize)
+            {
+                continue;
+            }
+
+            if (sizes.SkipSize == 0 ? modulusLength == (uint) sizes.MinSize : (modulusLength - sizes.MinSize) % sizes.SkipSize == 0)
+            {
+                return;
+            }
+        }
+
+        context.ThrowOperationError(
+            what + ": a modulus length of " + modulusLength + " bits is not one this platform's RSA implementation will generate ("
+            + DescribeKeySizes(legal) + ").");
+    }
+
+    private static string DescribeKeySizes(KeySizes[] legal)
+    {
+        var parts = new List<string>(legal.Length);
+        foreach (var sizes in legal)
+        {
+            parts.Add(sizes.SkipSize == 0
+                ? sizes.MinSize + " bits"
+                : sizes.MinSize + " to " + sizes.MaxSize + " bits in steps of " + sizes.SkipSize);
+        }
+
+        return string.Join(", ", parts);
+    }
+
+    // -------------------------------------------------------------------------------------------------
+    // importKey
+    // -------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#rsassa-pkcs1-operations-import-key and its two siblings, which
+    /// differ only in the usage set each format's first step checks, in the JWK <c>use</c> value and in the
+    /// JWK <c>alg</c> table.
+    /// </summary>
+    /// <remarks>
+    /// The usage check is the <i>first</i> step of each format's branch, before a single byte is parsed —
+    /// so <c>importKey('spki', garbage, …, ['sign'])</c> is the <c>SyntaxError</c> the usages earn rather
+    /// than the <c>DataError</c> the bytes would.
+    /// </remarks>
+    internal static (byte[] Handle, string KeyType, CryptoKeyAlgorithm Algorithm) ImportKey(
+        CryptoContext context,
+        KeyFormat format,
+        byte[]? rawData,
+        JsonWebKeyData? jwk,
+        NormalizedAlgorithm normalized,
+        bool extractable,
+        KeyUsage usages,
+        string what)
+    {
+        var isCipher = string.Equals(normalized.Name, AlgorithmNormalization.RsaOaep, StringComparison.Ordinal);
+
+        switch (format)
+        {
+            case KeyFormat.Spki:
+                RequireUsagesWithin(context, usages, isCipher ? PublicCipherUsages : PublicSignatureUsages, normalized.Name, what);
+                return ImportSpki(context, rawData!, normalized, what);
+
+            case KeyFormat.Pkcs8:
+                RequireUsagesWithin(context, usages, isCipher ? PrivateCipherUsages : PrivateSignatureUsages, normalized.Name, what);
+                return ImportPkcs8(context, rawData!, normalized, what);
+
+            case KeyFormat.Jwk:
+                return ImportJwk(context, jwk!, normalized, isCipher, extractable, usages, what);
+
+            default:
+                // "Otherwise: throw a NotSupportedError" — raw describes a symmetric key.
+                context.ThrowNotSupportedError(
+                    what + ": an " + normalized.Name + " key cannot be imported from the '" + KeyFormats.NameOf(format) + "' format.");
+                return default;
+        }
+    }
+
+    /// <summary>
+    /// The <c>spki</c> branch: parse a <c>SubjectPublicKeyInfo</c>, refuse anything that is not one, and keep
+    /// the platform's own canonical re-encoding as the handle.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="RSA.ImportSubjectPublicKeyInfo"/> is the whole of "parse a subjectPublicKeyInfo", the
+    /// <c>rsaEncryption</c> object identifier check and "parse an ASN.1 structure … as the RSAPublicKey
+    /// structure": it refuses a structure that is not one, and it refuses one whose algorithm identifier
+    /// names anything but RSA. <c>exactData set to true</c> is the <c>bytesRead</c> comparison — trailing
+    /// bytes after a well-formed structure are a <c>DataError</c> rather than something to ignore.
+    /// </remarks>
+    private static (byte[] Handle, string KeyType, CryptoKeyAlgorithm Algorithm) ImportSpki(
+        CryptoContext context,
+        byte[] data,
+        NormalizedAlgorithm normalized,
+        string what)
+    {
+        using var rsa = RSA.Create();
+
+        try
+        {
+            rsa.ImportSubjectPublicKeyInfo(data, out var read);
+            if (read != data.Length)
+            {
+                context.ThrowDataError(
+                    what + ": the SubjectPublicKeyInfo is followed by " + (data.Length - read) + " trailing byte(s).");
+            }
+        }
+        catch (CryptographicException)
+        {
+            context.ThrowDataError(what + ": the data is not a valid RSA SubjectPublicKeyInfo structure.");
+        }
+
+        return (Export(context, rsa, CryptoKeyTypes.Public, what), CryptoKeyTypes.Public, DescribeKey(context, rsa, normalized, what));
+    }
+
+    /// <summary>
+    /// The <c>pkcs8</c> branch, whose shape is the <c>spki</c> one with <c>PrivateKeyInfo</c> in place of
+    /// <c>SubjectPublicKeyInfo</c>.
+    /// </summary>
+    private static (byte[] Handle, string KeyType, CryptoKeyAlgorithm Algorithm) ImportPkcs8(
+        CryptoContext context,
+        byte[] data,
+        NormalizedAlgorithm normalized,
+        string what)
+    {
+        using var rsa = RSA.Create();
+
+        try
+        {
+            rsa.ImportPkcs8PrivateKey(data, out var read);
+            if (read != data.Length)
+            {
+                context.ThrowDataError(
+                    what + ": the PrivateKeyInfo is followed by " + (data.Length - read) + " trailing byte(s).");
+            }
+        }
+        catch (CryptographicException)
+        {
+            context.ThrowDataError(what + ": the data is not a valid RSA PrivateKeyInfo structure.");
+        }
+
+        return (Export(context, rsa, CryptoKeyTypes.Private, what), CryptoKeyTypes.Private, DescribeKey(context, rsa, normalized, what));
+    }
+
+    /// <summary>
+    /// The <c>jwk</c> branch, whose steps run in the specification's own order: the usage check that depends
+    /// on whether <c>d</c> is present, then <c>kty</c>, then <c>use</c>, <c>key_ops</c> and <c>ext</c>, then
+    /// the <c>alg</c> to hash mapping and its agreement with the requested hash, and only then the key
+    /// itself.
+    /// </summary>
+    private static (byte[] Handle, string KeyType, CryptoKeyAlgorithm Algorithm) ImportJwk(
+        CryptoContext context,
+        JsonWebKeyData jwk,
+        NormalizedAlgorithm normalized,
+        bool isCipher,
+        bool extractable,
+        KeyUsage usages,
+        string what)
+    {
+        var isPrivate = jwk.D is not null;
+
+        var allowed = (isPrivate, isCipher) switch
+        {
+            (true, true) => PrivateCipherUsages,
+            (true, false) => PrivateSignatureUsages,
+            (false, true) => PublicCipherUsages,
+            (false, false) => PublicSignatureUsages,
+        };
+
+        RequireUsagesWithin(context, usages, allowed, normalized.Name, what);
+
+        jwk.RequireKeyType(context, "RSA", what);
+        jwk.ValidateUseKeyOpsAndExt(context, usages, extractable, isCipher ? "enc" : "sig", what);
+
+        // "Let hash be a string whose initial value is undefined" and the alg table that follows it: an
+        // absent alg leaves the hash undefined and asserts nothing, a recognized one must agree with the
+        // hash the import asked for, and an unrecognized one is a DataError.
+        if (jwk.Alg is { } alg)
+        {
+            if (!TryHashFromJwkAlgorithm(normalized.Name, alg, out var hashName))
+            {
+                context.ThrowDataError(
+                    what + ": the alg field of the JSON Web Key is '" + alg + "', which names no hash this engine registers for " + normalized.Name + ".");
+            }
+
+            if (!string.Equals(hashName, normalized.HashName, StringComparison.Ordinal))
+            {
+                context.ThrowDataError(
+                    what + ": the alg field of the JSON Web Key names " + hashName + " where the import asks for " + normalized.HashName + ".");
+            }
+        }
+
+        var parameters = ReadJwkParameters(context, jwk, isPrivate, what);
+
+        using var rsa = RSA.Create();
+
+        try
+        {
+            rsa.ImportParameters(parameters);
+        }
+        catch (CryptographicException)
+        {
+            context.ThrowDataError(
+                what + ": the JSON Web Key does not describe a valid RSA " + (isPrivate ? "private" : "public") + " key.");
+        }
+
+        var keyType = isPrivate ? CryptoKeyTypes.Private : CryptoKeyTypes.Public;
+        return (Export(context, rsa, keyType, what), keyType, DescribeKey(context, rsa, normalized, what));
+    }
+
+    /// <summary>
+    /// "Let privateKey represent the RSA private key identified by interpreting jwk according to Section
+    /// 6.3.2 of JSON Web Algorithms", or the public key of Section 6.3.1 when <c>d</c> is absent.
+    /// </summary>
+    /// <remarks>
+    /// The lengths are what makes this more than a base64url decode. JSON Web Algorithms encodes each value
+    /// with "the minimum number of octets needed to represent" it, so <c>dp</c>, <c>dq</c> and <c>qi</c>
+    /// legitimately arrive shorter than <c>p</c> and <c>q</c>, while <see cref="RSAParameters"/> wants
+    /// <c>D</c> at the modulus' length and the five CRT values at exactly half of it. Left-padding with
+    /// zeros is the conversion between the two, and it is value-preserving because both are big-endian
+    /// magnitudes.
+    /// </remarks>
+    private static RSAParameters ReadJwkParameters(CryptoContext context, JsonWebKeyData jwk, bool isPrivate, string what)
+    {
+        var modulus = Minimal(JsonWebKeyData.RequireBase64UrlField(context, jwk.N, "n", what));
+        var exponent = Minimal(JsonWebKeyData.RequireBase64UrlField(context, jwk.E, "e", what));
+
+        if (modulus.Length == 0 || exponent.Length == 0)
+        {
+            context.ThrowDataError(what + ": the n and e fields of the JSON Web Key must describe non-zero values.");
+        }
+
+        if (!isPrivate)
+        {
+            return new RSAParameters { Modulus = modulus, Exponent = exponent };
+        }
+
+        // Section 6.3.2 permits a private key described by d alone, without the CRT parameters. See the
+        // remarks on this class for why this engine cannot import one.
+        if (jwk.P is null && jwk.Q is null && jwk.Dp is null && jwk.Dq is null && jwk.Qi is null)
+        {
+            context.ThrowDataError(
+                what + ": the JSON Web Key describes a private key by d alone, and this engine can only import one that also carries the CRT parameters p, q, dp, dq and qi.");
+        }
+
+        var half = (modulus.Length + 1) / 2;
+
+        return new RSAParameters
+        {
+            Modulus = modulus,
+            Exponent = exponent,
+            D = AlignTo(context, JsonWebKeyData.RequireBase64UrlField(context, jwk.D, "d", what), modulus.Length, "d", what),
+            P = AlignTo(context, JsonWebKeyData.RequireBase64UrlField(context, jwk.P, "p", what), half, "p", what),
+            Q = AlignTo(context, JsonWebKeyData.RequireBase64UrlField(context, jwk.Q, "q", what), half, "q", what),
+            DP = AlignTo(context, JsonWebKeyData.RequireBase64UrlField(context, jwk.Dp, "dp", what), half, "dp", what),
+            DQ = AlignTo(context, JsonWebKeyData.RequireBase64UrlField(context, jwk.Dq, "dq", what), half, "dq", what),
+            InverseQ = AlignTo(context, JsonWebKeyData.RequireBase64UrlField(context, jwk.Qi, "qi", what), half, "qi", what),
+        };
+    }
+
+    /// <summary>
+    /// The big-endian magnitude <paramref name="value"/> as exactly <paramref name="length"/> bytes, which
+    /// is the fixed-width form <see cref="RSAParameters"/> is described in. A value that does not fit even
+    /// after its leading zeros are dropped is not a parameter of a key of this size.
+    /// </summary>
+    private static byte[] AlignTo(CryptoContext context, byte[] value, int length, string field, string what)
+    {
+        var minimal = Minimal(value);
+
+        if (minimal.Length > length)
+        {
+            context.ThrowDataError(
+                what + ": the " + field + " field of the JSON Web Key is " + (minimal.Length * 8)
+                + " bits long, which is too long for a key with this modulus.");
+        }
+
+        if (minimal.Length == length)
+        {
+            return minimal;
+        }
+
+        var padded = new byte[length];
+        minimal.CopyTo(padded.AsSpan(length - minimal.Length));
+        return padded;
+    }
+
+    // -------------------------------------------------------------------------------------------------
+    // exportKey
+    // -------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#rsassa-pkcs1-operations-export-key and its two siblings.
+    /// </summary>
+    internal static JsValue ExportKey(CryptoContext context, JsCryptoKey key, KeyFormat format, string what)
+    {
+        switch (format)
+        {
+            case KeyFormat.Spki:
+                RequireKeyType(context, key, CryptoKeyTypes.Public, what);
+
+                // The handle already is the DER encoding the steps describe — the platform's own, produced
+                // when the key was made. It is copied on the way out: what a script is handed is mutable.
+                return context.CreateArrayBuffer(key.Handle.ToArray());
+
+            case KeyFormat.Pkcs8:
+                RequireKeyType(context, key, CryptoKeyTypes.Private, what);
+                return context.CreateArrayBuffer(key.Handle.ToArray());
+
+            case KeyFormat.Jwk:
+                return ExportJwk(context, key, what);
+
+            default:
+                context.ThrowNotSupportedError(
+                    what + ": an " + key.Algorithm.Name + " key cannot be exported to the '" + KeyFormats.NameOf(format) + "' format.");
+                return JsValue.Undefined;
+        }
+    }
+
+    private static JsValue ExportJwk(CryptoContext context, JsCryptoKey key, string what)
+    {
+        var isPrivate = string.Equals(key.KeyType, CryptoKeyTypes.Private, StringComparison.Ordinal);
+        var alg = JwkAlgorithm(key.Algorithm.Name, key.Algorithm.HashName!);
+
+        using var rsa = CreateRsa(context, key, what);
+
+        RSAParameters parameters;
+        try
+        {
+            parameters = rsa.ExportParameters(includePrivateParameters: isPrivate);
+        }
+        catch (CryptographicException)
+        {
+            context.ThrowOperationError(what + ": the key material could not be accessed.");
+            return JsValue.Undefined;
+        }
+
+        if (!isPrivate)
+        {
+            return JsonWebKeyData.CreateRsaPublicExport(
+                context.Engine,
+                alg,
+                Minimal(parameters.Modulus),
+                Minimal(parameters.Exponent),
+                key.Usages,
+                key.Extractable);
+        }
+
+        var fields = new RsaJwkPrivateFields(
+            Minimal(parameters.Modulus),
+            Minimal(parameters.Exponent),
+            Minimal(parameters.D),
+            Minimal(parameters.P),
+            Minimal(parameters.Q),
+            Minimal(parameters.DP),
+            Minimal(parameters.DQ),
+            Minimal(parameters.InverseQ));
+
+        return JsonWebKeyData.CreateRsaPrivateExport(context.Engine, alg, in fields, key.Usages, key.Extractable);
+    }
+
+    // -------------------------------------------------------------------------------------------------
+    // sign, verify, encrypt and decrypt
+    // -------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#rsassa-pkcs1-operations-sign — "the signature generation operation
+    /// defined in Section 8.2 of [RFC3447]" — and
+    /// https://w3c.github.io/webcrypto/#rsa-pss-operations-sign, which is Section 8.1 with MGF1 and the
+    /// caller's salt length.
+    /// </summary>
+    internal static byte[] Sign(
+        CryptoContext context,
+        NormalizedAlgorithm normalized,
+        JsCryptoKey key,
+        ReadOnlySpan<byte> message,
+        string what)
+    {
+        // Step 1: "If the [[type]] internal slot of key is not 'private', then throw an InvalidAccessError."
+        RequireKeyType(context, key, CryptoKeyTypes.Private, what);
+
+        var padding = SignaturePadding(context, normalized, key, what);
+
+        using var rsa = CreateRsa(context, key, what);
+
+        try
+        {
+            return rsa.SignData(message.ToArray(), HashName(key.Algorithm.HashName!), padding);
+        }
+        catch (CryptographicException)
+        {
+            // Step 3: "If performing the operation results in an error, then throw an OperationError." A
+            // modulus too short to carry the encoded hash is the way this is actually reached.
+            context.ThrowOperationError(what + ": the signature could not be produced.");
+            return null!;
+        }
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#rsassa-pkcs1-operations-verify and
+    /// https://w3c.github.io/webcrypto/#rsa-pss-operations-verify: "Let result be a boolean with value true
+    /// if the result of the operation was 'valid signature' and the value false otherwise."
+    /// </summary>
+    /// <remarks>
+    /// There is no error step here, which is why the platform's refusal to look at a malformed signature —
+    /// one of the wrong length, say — is <see langword="false"/> rather than an <c>OperationError</c>:
+    /// "otherwise" covers every way a signature can fail to be the valid one.
+    /// </remarks>
+    internal static bool Verify(
+        CryptoContext context,
+        NormalizedAlgorithm normalized,
+        JsCryptoKey key,
+        ReadOnlySpan<byte> signature,
+        ReadOnlySpan<byte> message,
+        string what)
+    {
+        // Step 1: "If the [[type]] internal slot of key is not 'public', then throw an InvalidAccessError."
+        RequireKeyType(context, key, CryptoKeyTypes.Public, what);
+
+        var padding = SignaturePadding(context, normalized, key, what);
+
+        using var rsa = CreateRsa(context, key, what);
+
+        try
+        {
+            return rsa.VerifyData(message, signature, HashName(key.Algorithm.HashName!), padding);
+        }
+        catch (CryptographicException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#rsa-oaep-operations-encrypt — "the encryption operation defined in
+    /// Section 7.1 of [RFC3447]" with MGF1 and the key's own hash.
+    /// </summary>
+    internal static byte[] Encrypt(
+        CryptoContext context,
+        NormalizedAlgorithm normalized,
+        JsCryptoKey key,
+        ReadOnlySpan<byte> plaintext,
+        string what)
+    {
+        // Step 1: "If the [[type]] internal slot of key is not 'public', then throw an InvalidAccessError."
+        RequireKeyType(context, key, CryptoKeyTypes.Public, what);
+
+        // Step 2: "Let label be the label member … or the empty byte sequence if … not present."
+        RequireEmptyLabel(context, normalized, what);
+
+        using var rsa = CreateRsa(context, key, what);
+
+        try
+        {
+            return rsa.Encrypt(plaintext.ToArray(), EncryptionPadding(key.Algorithm.HashName!));
+        }
+        catch (CryptographicException)
+        {
+            // Step 4: "If performing the operation results in an error, then throw an OperationError." A
+            // message longer than the modulus can carry with OAEP padding is how this is reached.
+            context.ThrowOperationError(what + ": the data could not be encrypted.");
+            return null!;
+        }
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#rsa-oaep-operations-decrypt.
+    /// </summary>
+    internal static byte[] Decrypt(
+        CryptoContext context,
+        NormalizedAlgorithm normalized,
+        JsCryptoKey key,
+        ReadOnlySpan<byte> ciphertext,
+        string what)
+    {
+        // Step 1: "If the [[type]] internal slot of key is not 'private', then throw an InvalidAccessError."
+        RequireKeyType(context, key, CryptoKeyTypes.Private, what);
+
+        RequireEmptyLabel(context, normalized, what);
+
+        using var rsa = CreateRsa(context, key, what);
+
+        try
+        {
+            return rsa.Decrypt(ciphertext.ToArray(), EncryptionPadding(key.Algorithm.HashName!));
+        }
+        catch (CryptographicException)
+        {
+            // Step 4 again. One message for every way the decryption can fail, carrying nothing about which
+            // part of the input was wrong: OAEP's padding check is what a chosen-ciphertext attack probes,
+            // and a distinguishable failure is the whole of that attack.
+            context.ThrowOperationError(what + ": the data could not be decrypted.");
+            return null!;
+        }
+    }
+
+    // -------------------------------------------------------------------------------------------------
+    // Shared helpers
+    // -------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Rehydrates the <see cref="RSA"/> a key's <c>[[handle]]</c> describes. See the remarks on this class
+    /// for why the handle is DER and this happens per operation.
+    /// </summary>
+    private static RSA CreateRsa(CryptoContext context, JsCryptoKey key, string what)
+    {
+        var rsa = RSA.Create();
+
+        try
+        {
+            if (string.Equals(key.KeyType, CryptoKeyTypes.Private, StringComparison.Ordinal))
+            {
+                rsa.ImportPkcs8PrivateKey(key.Handle, out _);
+            }
+            else
+            {
+                rsa.ImportSubjectPublicKeyInfo(key.Handle, out _);
+            }
+        }
+        catch (CryptographicException)
+        {
+            rsa.Dispose();
+
+            // "If the underlying cryptographic key material represented by the [[handle]] internal slot of
+            // key cannot be accessed, then throw an OperationError." Unreachable in practice — the bytes are
+            // the platform's own canonical encoding of a key it built — but a CryptographicException that
+            // escaped here would erupt as a CLR exception out of a promise-returning operation.
+            context.ThrowOperationError(what + ": the key material could not be accessed.");
+        }
+
+        return rsa;
+    }
+
+    /// <summary>
+    /// The canonical DER a key's <c>[[handle]]</c> holds, taken from a freshly imported
+    /// <see cref="RSA"/> — which is also exactly what <c>exportKey</c>'s <c>spki</c> and <c>pkcs8</c>
+    /// branches describe, so the two can never disagree.
+    /// </summary>
+    private static byte[] Export(CryptoContext context, RSA rsa, string keyType, string what)
+    {
+        try
+        {
+            return string.Equals(keyType, CryptoKeyTypes.Private, StringComparison.Ordinal)
+                ? rsa.ExportPkcs8PrivateKey()
+                : rsa.ExportSubjectPublicKeyInfo();
+        }
+        catch (CryptographicException)
+        {
+            context.ThrowDataError(what + ": the key could not be read back after being imported.");
+            return null!;
+        }
+    }
+
+    /// <summary>
+    /// The <c>RsaHashedKeyAlgorithm</c> an import ends in: the name and hash the caller asked for, and the
+    /// modulus length and public exponent read off the key that arrived.
+    /// </summary>
+    private static CryptoKeyAlgorithm DescribeKey(CryptoContext context, RSA rsa, NormalizedAlgorithm normalized, string what)
+    {
+        RSAParameters parameters;
+        try
+        {
+            parameters = rsa.ExportParameters(includePrivateParameters: false);
+        }
+        catch (CryptographicException)
+        {
+            context.ThrowDataError(what + ": the modulus and public exponent could not be read from the key.");
+            return default;
+        }
+
+        return new CryptoKeyAlgorithm(
+            normalized.Name,
+            Length: 0,
+            normalized.HashName,
+            (uint) rsa.KeySize,
+            Minimal(parameters.Exponent));
+    }
+
+    /// <summary>
+    /// The padding a signature operation uses, and the point at which RSA-PSS's salt length is checked
+    /// against what the platform can produce. See the remarks on this class.
+    /// </summary>
+    private static RSASignaturePadding SignaturePadding(
+        CryptoContext context,
+        NormalizedAlgorithm normalized,
+        JsCryptoKey key,
+        string what)
+    {
+        if (!string.Equals(normalized.Name, AlgorithmNormalization.RsaPss, StringComparison.Ordinal))
+        {
+            return RSASignaturePadding.Pkcs1;
+        }
+
+        var requested = normalized.SaltLength!.Value;
+        var supported = HashLengthInBytes(key.Algorithm.HashName!);
+
+        if (requested != supported)
+        {
+            context.ThrowOperationError(
+                what + ": a salt length of " + requested + " bytes was requested, and .NET's RSA-PSS implementation always uses the hash's own length, which for "
+                + key.Algorithm.HashName + " is " + supported + " bytes.");
+        }
+
+        return RSASignaturePadding.Pss;
+    }
+
+    /// <summary>
+    /// Step 2 of RSA-OAEP's encrypt and decrypt, as far as this engine can honour it. See the remarks on
+    /// this class.
+    /// </summary>
+    private static void RequireEmptyLabel(CryptoContext context, NormalizedAlgorithm normalized, string what)
+    {
+        if (normalized.Label is { Length: > 0 } label)
+        {
+            context.ThrowOperationError(
+                what + ": a label of " + label.Length + " byte(s) was given, and .NET's RSA-OAEP implementation accepts only the empty label.");
+        }
+    }
+
+    /// <summary>
+    /// "If usages contains an entry which is not …, then throw a SyntaxError" — the first step of every
+    /// generate and import branch, differing only in the set it names.
+    /// </summary>
+    private static void RequireUsagesWithin(CryptoContext context, KeyUsage usages, KeyUsage allowed, string algorithmName, string what)
+    {
+        if ((usages & ~allowed) != KeyUsage.None)
+        {
+            context.ThrowSyntaxError(
+                what + ": this " + algorithmName + " key supports the usages " + KeyUsages.Describe(allowed)
+                + ", not " + KeyUsages.Describe(usages & ~allowed) + ".");
+        }
+    }
+
+    /// <summary>
+    /// "If the [[type]] internal slot of key is not <c>expected</c>, then throw an InvalidAccessError" — the
+    /// first step of every RSA operation, and the one that makes a public key refuse to sign.
+    /// </summary>
+    private static void RequireKeyType(CryptoContext context, JsCryptoKey key, string expected, string what)
+    {
+        if (!string.Equals(key.KeyType, expected, StringComparison.Ordinal))
+        {
+            context.ThrowInvalidAccessError(
+                what + ": this operation needs a " + expected + " key, and the key given is a " + key.KeyType + " key.");
+        }
+    }
+
+    /// <summary>
+    /// The JWK <c>alg</c> field naming an RSA key with a given inner hash — the tables of
+    /// https://www.rfc-editor.org/rfc/rfc7518#section-3.1 (RS*, PS*) and
+    /// https://www.rfc-editor.org/rfc/rfc7518#section-4.3 (RSA-OAEP*), plus <c>RS1</c> and <c>PS1</c>, which
+    /// the Web Cryptography API names for SHA-1.
+    /// </summary>
+    internal static string JwkAlgorithm(string algorithmName, string hashName)
+    {
+        switch (algorithmName)
+        {
+            case AlgorithmNormalization.RsassaPkcs1V15:
+                return "RS" + JwkHashSuffix(hashName);
+            case AlgorithmNormalization.RsaPss:
+                return "PS" + JwkHashSuffix(hashName);
+            case AlgorithmNormalization.RsaOaep:
+                return string.Equals(hashName, AlgorithmNormalization.Sha1, StringComparison.Ordinal)
+                    ? "RSA-OAEP"
+                    : "RSA-OAEP-" + JwkHashSuffix(hashName);
+            default:
+                // Unreachable: the name came from the registry, and only the three RSA algorithms reach here.
+                Throw.InvalidOperationException("Unhandled RSA algorithm '" + algorithmName + "'.");
+                return null!;
+        }
+    }
+
+    /// <summary>
+    /// The number a JWK <c>alg</c> ends in, which is the hash's output length in bits for every hash but
+    /// SHA-1 — spelled <c>1</c> rather than <c>160</c>.
+    /// </summary>
+    private static string JwkHashSuffix(string hashName)
+    {
+        switch (hashName)
+        {
+            case AlgorithmNormalization.Sha1:
+                return "1";
+            case AlgorithmNormalization.Sha256:
+                return "256";
+            case AlgorithmNormalization.Sha384:
+                return "384";
+            case AlgorithmNormalization.Sha512:
+                return "512";
+            default:
+                // Unreachable: the hash was matched against the digest registry when the key was made. It is
+                // spelled out rather than folded into a last case so that a hash registered later cannot
+                // silently be labelled with another one's name.
+                Throw.InvalidOperationException("Unhandled RSA hash algorithm '" + hashName + "'.");
+                return null!;
+        }
+    }
+
+    /// <summary>
+    /// The inverse of <see cref="JwkAlgorithm"/>: the hash a JWK's <c>alg</c> names, or
+    /// <see langword="false"/> for an <c>alg</c> that names none of this engine's — which the caller reports
+    /// as the <c>DataError</c> the specification's "Otherwise: … throw a DataError" arm gives it.
+    /// </summary>
+    private static bool TryHashFromJwkAlgorithm(string algorithmName, string alg, out string hashName)
+    {
+        foreach (var candidate in _hashes)
+        {
+            if (string.Equals(alg, JwkAlgorithm(algorithmName, candidate), StringComparison.Ordinal))
+            {
+                hashName = candidate;
+                return true;
+            }
+        }
+
+        hashName = null!;
+        return false;
+    }
+
+    private static HashAlgorithmName HashName(string hashName)
+    {
+        switch (hashName)
+        {
+            case AlgorithmNormalization.Sha1:
+                // SHA-1 is one of the four hashes the specification registers for these algorithms, every
+                // browser offers them over it, and a script asking for it has already chosen; nothing in the
+                // engine picks it for anybody.
+                return HashAlgorithmName.SHA1;
+            case AlgorithmNormalization.Sha256:
+                return HashAlgorithmName.SHA256;
+            case AlgorithmNormalization.Sha384:
+                return HashAlgorithmName.SHA384;
+            case AlgorithmNormalization.Sha512:
+                return HashAlgorithmName.SHA512;
+            default:
+                Throw.InvalidOperationException("Unhandled RSA hash algorithm '" + hashName + "'.");
+                return default;
+        }
+    }
+
+    private static RSAEncryptionPadding EncryptionPadding(string hashName)
+    {
+        switch (hashName)
+        {
+            case AlgorithmNormalization.Sha1:
+                return RSAEncryptionPadding.OaepSHA1;
+            case AlgorithmNormalization.Sha256:
+                return RSAEncryptionPadding.OaepSHA256;
+            case AlgorithmNormalization.Sha384:
+                return RSAEncryptionPadding.OaepSHA384;
+            case AlgorithmNormalization.Sha512:
+                return RSAEncryptionPadding.OaepSHA512;
+            default:
+                Throw.InvalidOperationException("Unhandled RSA hash algorithm '" + hashName + "'.");
+                return null!;
+        }
+    }
+
+    /// <summary>The output length of each hash function, in bytes — [FIPS-180-4].</summary>
+    private static uint HashLengthInBytes(string hashName)
+    {
+        switch (hashName)
+        {
+            case AlgorithmNormalization.Sha1:
+                return 20;
+            case AlgorithmNormalization.Sha256:
+                return 32;
+            case AlgorithmNormalization.Sha384:
+                return 48;
+            case AlgorithmNormalization.Sha512:
+                return 64;
+            default:
+                Throw.InvalidOperationException("Unhandled RSA hash algorithm '" + hashName + "'.");
+                return 0;
+        }
+    }
+
+    /// <summary>
+    /// A big-endian magnitude with its leading zero bytes dropped — "minimal typed array length … except the
+    /// value 0 which shall have length 8 bits", https://w3c.github.io/webcrypto/#big-integer. It is also
+    /// what JSON Web Algorithms asks of every value it encodes: "the minimum number of octets needed to
+    /// represent the value".
+    /// </summary>
+    private static byte[] Minimal(byte[]? value)
+    {
+        if (value is null || value.Length == 0)
+        {
+            return [];
+        }
+
+        var start = 0;
+        while (start < value.Length - 1 && value[start] == 0)
+        {
+            start++;
+        }
+
+        return start == 0 ? value : value[start..];
+    }
+}
+#endif

--- a/Jint/WebApi/Crypto/SubtleCryptoInstance.cs
+++ b/Jint/WebApi/Crypto/SubtleCryptoInstance.cs
@@ -19,12 +19,14 @@ namespace Jint.WebApi.Crypto;
 /// <para>
 /// <b>Eight of the twelve operations exist</b>: <c>digest</c>, <c>sign</c>, <c>verify</c>, <c>encrypt</c>,
 /// <c>decrypt</c>, <c>generateKey</c>, <c>importKey</c> and <c>exportKey</c>, over the algorithms
-/// <c>HMAC</c> (SHA-1, SHA-256, SHA-384, SHA-512) and <c>AES-GCM</c> (128, 192 and 256 bits), plus the four
-/// SHA hashes for <c>digest</c>. <c>deriveKey</c>, <c>deriveBits</c>, <c>wrapKey</c> and <c>unwrapKey</c> are
-/// <b>absent</b> rather than present-and-throwing, and so is every asymmetric algorithm, so a library that
-/// checks <c>typeof crypto.subtle.deriveBits === 'function'</c> before reaching for it gets the truthful
-/// answer and takes its fallback path — the same promise <c>crypto.subtle</c> itself makes to an engine
-/// without the crypto feature. An algorithm that is absent for a <i>particular</i> operation is a
+/// <c>HMAC</c>, <c>AES-GCM</c> (128, 192 and 256 bits), <c>RSASSA-PKCS1-v1_5</c>, <c>RSA-PSS</c> and
+/// <c>RSA-OAEP</c> — each of the hashed ones over SHA-1, SHA-256, SHA-384 and SHA-512 — plus those four SHA
+/// hashes for <c>digest</c>, and the key formats <c>raw</c>, <c>spki</c>, <c>pkcs8</c> and <c>jwk</c>.
+/// <c>deriveKey</c>, <c>deriveBits</c>, <c>wrapKey</c> and <c>unwrapKey</c> are <b>absent</b> rather than
+/// present-and-throwing, so a library that checks
+/// <c>typeof crypto.subtle.deriveBits === 'function'</c> before reaching for it gets the truthful answer and
+/// takes its fallback path — the same promise <c>crypto.subtle</c> itself makes to an engine without the
+/// crypto feature. An algorithm that is absent for a <i>particular</i> operation is a
 /// <c>NotSupportedError</c>, which is what the specification says a name that is not registered for an
 /// operation is: <c>sign</c> with <c>AES-GCM</c> fails that way, and so does <c>encrypt</c> with
 /// <c>HMAC</c>.
@@ -65,6 +67,19 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
 {
     [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
     private static readonly JsString SubtleCryptoToStringTag = new("SubtleCrypto");
+
+    /// <summary>
+    /// <c>CryptoKeyPair</c> — https://w3c.github.io/webcrypto/#keypair. It is a <i>dictionary</i>, not an
+    /// interface, so what <c>generateKey</c> resolves with for an asymmetric algorithm is an ordinary object
+    /// with two own data properties and <c>Object.prototype</c> behind it: there is no <c>CryptoKeyPair</c>
+    /// interface object to be found on the global, in a browser as much as here. The member order is
+    /// WebIDL's own for converting a dictionary to an object,
+    /// https://webidl.spec.whatwg.org/#es-dictionary — lexicographic, so <c>privateKey</c> comes first.
+    /// </summary>
+    private static readonly JsObjectLayout _cryptoKeyPairLayout = JsObjectLayout.CreateBuilder()
+        .Add("privateKey")
+        .Add("publicKey")
+        .Build();
 
     private readonly Realm _realm;
 
@@ -124,9 +139,18 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
 
             RequireKeyFor(normalized, cryptoKey, KeyUsage.Sign, "sign", what);
 
-            // HMAC is the only algorithm registered for this operation, and the check above has just proved
-            // the key was made for the algorithm that normalization returned — so the dispatch is decided.
-            return Context.CreateArrayBuffer(HmacAlgorithm.Sign(cryptoKey, message));
+            // The check above has just proved the key was made for the algorithm normalization returned, so
+            // the key's own name and this one are the same string and either could decide the dispatch.
+            switch (normalized.Name)
+            {
+                case AlgorithmNormalization.Hmac:
+                    return Context.CreateArrayBuffer(HmacAlgorithm.Sign(cryptoKey, message));
+                case AlgorithmNormalization.RsassaPkcs1V15:
+                case AlgorithmNormalization.RsaPss:
+                    return Context.CreateArrayBuffer(RsaAlgorithm.Sign(Context, normalized, cryptoKey, message, what));
+                default:
+                    return UnhandledAlgorithm(normalized.Name, CryptoOperation.Sign);
+            }
         });
     }
 
@@ -149,7 +173,18 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
 
             RequireKeyFor(normalized, cryptoKey, KeyUsage.Verify, "verify", what);
 
-            return HmacAlgorithm.Verify(cryptoKey, signatureBytes, message) ? JsBoolean.True : JsBoolean.False;
+            switch (normalized.Name)
+            {
+                case AlgorithmNormalization.Hmac:
+                    return HmacAlgorithm.Verify(cryptoKey, signatureBytes, message) ? JsBoolean.True : JsBoolean.False;
+                case AlgorithmNormalization.RsassaPkcs1V15:
+                case AlgorithmNormalization.RsaPss:
+                    return RsaAlgorithm.Verify(Context, normalized, cryptoKey, signatureBytes, message, what)
+                        ? JsBoolean.True
+                        : JsBoolean.False;
+                default:
+                    return UnhandledAlgorithm(normalized.Name, CryptoOperation.Verify);
+            }
         });
     }
 
@@ -170,9 +205,15 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
 
             RequireKeyFor(normalized, cryptoKey, KeyUsage.Encrypt, "encrypt", what);
 
-            // AES-GCM is the only algorithm registered for this operation, so — as in sign above — the check
-            // that the key was made for the normalized algorithm is what decides the dispatch.
-            return Context.CreateArrayBuffer(AesGcmAlgorithm.Encrypt(Context, normalized, cryptoKey, plaintext, what));
+            switch (normalized.Name)
+            {
+                case AlgorithmNormalization.AesGcm:
+                    return Context.CreateArrayBuffer(AesGcmAlgorithm.Encrypt(Context, normalized, cryptoKey, plaintext, what));
+                case AlgorithmNormalization.RsaOaep:
+                    return Context.CreateArrayBuffer(RsaAlgorithm.Encrypt(Context, normalized, cryptoKey, plaintext, what));
+                default:
+                    return UnhandledAlgorithm(normalized.Name, CryptoOperation.Encrypt);
+            }
         });
     }
 
@@ -193,7 +234,15 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
 
             RequireKeyFor(normalized, cryptoKey, KeyUsage.Decrypt, "decrypt", what);
 
-            return Context.CreateArrayBuffer(AesGcmAlgorithm.Decrypt(Context, normalized, cryptoKey, ciphertext, what));
+            switch (normalized.Name)
+            {
+                case AlgorithmNormalization.AesGcm:
+                    return Context.CreateArrayBuffer(AesGcmAlgorithm.Decrypt(Context, normalized, cryptoKey, ciphertext, what));
+                case AlgorithmNormalization.RsaOaep:
+                    return Context.CreateArrayBuffer(RsaAlgorithm.Decrypt(Context, normalized, cryptoKey, ciphertext, what));
+                default:
+                    return UnhandledAlgorithm(normalized.Name, CryptoOperation.Decrypt);
+            }
         });
     }
 
@@ -203,8 +252,11 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
     /// boolean extractable, sequence&lt;KeyUsage&gt; keyUsages)</c>.
     /// </summary>
     /// <remarks>
-    /// Both algorithms here produce a single secret key, never a pair, so the union's second arm — and with
-    /// it <c>CryptoKeyPair</c>, which has no interface object in this engine — is unreachable.
+    /// Which arm of the union is returned is the algorithm's business: the symmetric algorithms produce a
+    /// single secret <c>CryptoKey</c>, and the three RSA algorithms produce a <c>CryptoKeyPair</c>. The
+    /// public half is always extractable, whatever <c>extractable</c> asked for — a public key is public —
+    /// and the two halves split the requested usages between them by the usage intersection each algorithm's
+    /// steps name.
     /// </remarks>
     [JsFunction(Name = "generateKey", Length = 3)]
     private JsValue GenerateKey(JsValue thisObject, JsValue algorithm, JsValue extractable, JsValue keyUsages)
@@ -217,18 +269,77 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
 
             var normalized = AlgorithmNormalization.Normalize(Context, identifier, CryptoOperation.GenerateKey, what);
 
-            var material = string.Equals(normalized.Name, AlgorithmNormalization.Hmac, StringComparison.Ordinal)
-                ? HmacAlgorithm.GenerateKey(Context, normalized, usages, what)
-                : AesGcmAlgorithm.GenerateKey(Context, normalized, usages, what);
+            switch (normalized.Name)
+            {
+                case AlgorithmNormalization.Hmac:
+                    return CreateSecretKey(HmacAlgorithm.GenerateKey(Context, normalized, usages, what), isExtractable, usages, what);
 
-            // "If result is a CryptoKey object: If the [[type]] internal slot of result is 'secret' or
-            // 'private' and usages is empty, then throw a SyntaxError." A secret key nobody may use is a
-            // mistake, not a key, and it is caught here rather than inside the algorithm because it is the
-            // same mistake whichever algorithm made the key.
-            RequireNonEmptyUsages(usages, what);
+                case AlgorithmNormalization.AesGcm:
+                    return CreateSecretKey(AesGcmAlgorithm.GenerateKey(Context, normalized, usages, what), isExtractable, usages, what);
 
-            return _realm.Intrinsics.CryptoKey.CreateKey(material.Handle, material.Algorithm, isExtractable, usages);
+                case AlgorithmNormalization.RsassaPkcs1V15:
+                case AlgorithmNormalization.RsaPss:
+                case AlgorithmNormalization.RsaOaep:
+                    return CreateKeyPair(RsaAlgorithm.GenerateKey(Context, normalized, usages, what), isExtractable, what);
+
+                default:
+                    return UnhandledAlgorithm(normalized.Name, CryptoOperation.GenerateKey);
+            }
         });
+    }
+
+    /// <summary>
+    /// The tail of <c>generateKey</c> for an algorithm that produced one secret key: "If result is a
+    /// CryptoKey object: If the [[type]] internal slot of result is 'secret' or 'private' and usages is
+    /// empty, then throw a SyntaxError." A secret key nobody may use is a mistake, not a key, and it is
+    /// caught here rather than inside the algorithm because it is the same mistake whichever algorithm made
+    /// the key.
+    /// </summary>
+    private JsCryptoKey CreateSecretKey(
+        (byte[] Handle, CryptoKeyAlgorithm Algorithm) material,
+        bool extractable,
+        KeyUsage usages,
+        string what)
+    {
+        RequireUsableKey(CryptoKeyTypes.Secret, usages, what);
+        return _realm.Intrinsics.CryptoKey.CreateKey(material.Handle, CryptoKeyTypes.Secret, material.Algorithm, extractable, usages);
+    }
+
+    /// <summary>
+    /// The same tail for a key an asymmetric algorithm's <c>importKey</c> produced, where the type is the
+    /// algorithm's answer rather than a foregone <c>"secret"</c> — which is exactly what decides whether the
+    /// empty usages list is a mistake.
+    /// </summary>
+    private JsCryptoKey CreateImportedKey(
+        (byte[] Handle, string KeyType, CryptoKeyAlgorithm Algorithm) imported,
+        bool extractable,
+        KeyUsage usages,
+        string what)
+    {
+        RequireUsableKey(imported.KeyType, usages, what);
+        return _realm.Intrinsics.CryptoKey.CreateKey(imported.Handle, imported.KeyType, imported.Algorithm, extractable, usages);
+    }
+
+    /// <summary>
+    /// The tail of <c>generateKey</c> for an algorithm that produced a pair: "If result is a CryptoKeyPair
+    /// object: If the [[usages]] internal slot of the privateKey attribute of result is the empty sequence,
+    /// then throw a SyntaxError." It is the private half alone that has to be usable — a pair generated with
+    /// <c>['verify']</c> is a pair nobody can sign with, which is the very mistake this catches, while a pair
+    /// generated with <c>['sign']</c> has a public half carrying no usages and is perfectly ordinary.
+    /// </summary>
+    private JsObject CreateKeyPair(in RsaKeyPairMaterial material, bool extractable, string what)
+    {
+        RequireUsableKey(CryptoKeyTypes.Private, material.PrivateUsages, what);
+
+        // "Set the [[extractable]] internal slot of publicKey to true" — the public half of a pair is always
+        // extractable, because there is nothing about it to protect.
+        var publicKey = _realm.Intrinsics.CryptoKey.CreateKey(
+            material.PublicHandle, CryptoKeyTypes.Public, material.Algorithm, extractable: true, material.PublicUsages);
+
+        var privateKey = _realm.Intrinsics.CryptoKey.CreateKey(
+            material.PrivateHandle, CryptoKeyTypes.Private, material.Algorithm, extractable, material.PrivateUsages);
+
+        return JsObject.Create(_engine, _cryptoKeyPairLayout, [privateKey, publicKey]);
     }
 
     /// <summary>
@@ -268,13 +379,34 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
                 Context.ThrowTypeError(what + ": the '" + KeyFormats.NameOf(keyFormat) + "' format needs a buffer source, not a JsonWebKey object.");
             }
 
-            var material = string.Equals(normalized.Name, AlgorithmNormalization.Hmac, StringComparison.Ordinal)
-                ? HmacAlgorithm.ImportKey(Context, keyFormat, rawData, jwk, normalized, isExtractable, usages, what)
-                : AesGcmAlgorithm.ImportKey(Context, keyFormat, rawData, jwk, isExtractable, usages, what);
+            switch (normalized.Name)
+            {
+                case AlgorithmNormalization.Hmac:
+                    return CreateSecretKey(
+                        HmacAlgorithm.ImportKey(Context, keyFormat, rawData, jwk, normalized, isExtractable, usages, what),
+                        isExtractable,
+                        usages,
+                        what);
 
-            RequireNonEmptyUsages(usages, what);
+                case AlgorithmNormalization.AesGcm:
+                    return CreateSecretKey(
+                        AesGcmAlgorithm.ImportKey(Context, keyFormat, rawData, jwk, isExtractable, usages, what),
+                        isExtractable,
+                        usages,
+                        what);
 
-            return _realm.Intrinsics.CryptoKey.CreateKey(material.Handle, material.Algorithm, isExtractable, usages);
+                case AlgorithmNormalization.RsassaPkcs1V15:
+                case AlgorithmNormalization.RsaPss:
+                case AlgorithmNormalization.RsaOaep:
+                    return CreateImportedKey(
+                        RsaAlgorithm.ImportKey(Context, keyFormat, rawData, jwk, normalized, isExtractable, usages, what),
+                        isExtractable,
+                        usages,
+                        what);
+
+                default:
+                    return UnhandledAlgorithm(normalized.Name, CryptoOperation.ImportKey);
+            }
         });
     }
 
@@ -310,9 +442,19 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
                 Context.ThrowInvalidAccessError(what + ": the key is not extractable.");
             }
 
-            return string.Equals(cryptoKey.Algorithm.Name, AlgorithmNormalization.Hmac, StringComparison.Ordinal)
-                ? HmacAlgorithm.ExportKey(Context, cryptoKey, keyFormat, what)
-                : AesGcmAlgorithm.ExportKey(Context, cryptoKey, keyFormat, what);
+            switch (cryptoKey.Algorithm.Name)
+            {
+                case AlgorithmNormalization.Hmac:
+                    return HmacAlgorithm.ExportKey(Context, cryptoKey, keyFormat, what);
+                case AlgorithmNormalization.AesGcm:
+                    return AesGcmAlgorithm.ExportKey(Context, cryptoKey, keyFormat, what);
+                case AlgorithmNormalization.RsassaPkcs1V15:
+                case AlgorithmNormalization.RsaPss:
+                case AlgorithmNormalization.RsaOaep:
+                    return RsaAlgorithm.ExportKey(Context, cryptoKey, keyFormat, what);
+                default:
+                    return UnhandledAlgorithm(cryptoKey.Algorithm.Name, CryptoOperation.ExportKey);
+            }
         });
     }
 
@@ -383,15 +525,37 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
 
     /// <summary>
     /// "If the [[type]] internal slot of result is 'secret' or 'private' and usages is empty, then throw a
-    /// SyntaxError" — the step <c>generateKey</c> and <c>importKey</c> both end in. Every key this engine
-    /// makes is a secret one.
+    /// SyntaxError" — the step <c>generateKey</c> and <c>importKey</c> both end in.
     /// </summary>
-    private void RequireNonEmptyUsages(KeyUsage usages, string what)
+    /// <remarks>
+    /// The two types the step names are exactly the two that carry material nobody else has: a key nobody may
+    /// use is then a mistake rather than a key, because it can never be anything else. A <b>public</b> key is
+    /// deliberately outside the check and may carry no usages at all —
+    /// <c>importKey('spki', …, false, [])</c> succeeds, which is how a script imports a certificate's key to
+    /// read its <c>algorithm</c> without granting it a use, and it is also what makes the public half of a
+    /// pair generated with <c>['sign']</c> alone a perfectly ordinary key.
+    /// </remarks>
+    private void RequireUsableKey(string keyType, KeyUsage usages, string what)
     {
-        if (usages == KeyUsage.None)
+        if (usages != KeyUsage.None || string.Equals(keyType, CryptoKeyTypes.Public, StringComparison.Ordinal))
         {
-            Context.ThrowSyntaxError(what + ": a secret key must be created with at least one usage.");
+            return;
         }
+
+        Context.ThrowSyntaxError(what + ": a " + keyType + " key must be created with at least one usage.");
+    }
+
+    /// <summary>
+    /// The arm of every dispatch below that cannot be reached: normalization matched the name against the
+    /// very registry that decides which algorithms an operation has, one call earlier. It throws rather than
+    /// falling through to a neighbouring algorithm, so that registering a name without implementing it fails
+    /// loudly instead of quietly running the wrong cipher.
+    /// </summary>
+    private static JsValue UnhandledAlgorithm(string name, CryptoOperation operation)
+    {
+        Throw.InvalidOperationException(
+            "Unhandled algorithm '" + name + "' for the " + AlgorithmNormalization.NameOf(operation) + " operation.");
+        return null!;
     }
 
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -246,26 +246,43 @@ other, for the neighbouring one — a cache outlives the evaluation that filled 
 and what bounds it, is a decision you make rather than inherit.
 
 `crypto.subtle` carries **`digest`, `sign`, `verify`, `encrypt`, `decrypt`, `generateKey`, `importKey` and
-`exportKey`**, over SHA-1/256/384/512 (for `digest` and as HMAC's inner hash), **HMAC**, and **AES-GCM** at
-128, 192 and 256 bits. Keys are real `CryptoKey` objects with `type`, `extractable`, `algorithm` and
-`usages`; the key material is never reachable from script except through `exportKey` on an extractable key,
-as `raw` bytes or as a JSON Web Key (`kty: "oct"`). `deriveKey`, `deriveBits`, `wrapKey`, `unwrapKey` and
-every asymmetric algorithm are *absent* rather than present-and-throwing, so
-`typeof crypto.subtle.deriveBits` tells a library the truth and it takes its fallback path.
+`exportKey`**, over SHA-1/256/384/512 (for `digest` and as every keyed algorithm's inner hash), **HMAC**,
+**AES-GCM** at 128, 192 and 256 bits, and the RSA family — **RSASSA-PKCS1-v1_5** and **RSA-PSS** for
+signatures, **RSA-OAEP** for encryption. Keys are real `CryptoKey` objects with `type`, `extractable`,
+`algorithm` and `usages`, and `generateKey` for an RSA algorithm hands back a `CryptoKeyPair`, which is the
+plain `{ privateKey, publicKey }` dictionary the specification defines rather than an interface. The key
+material is never reachable from script except through `exportKey` on an extractable key: `raw` bytes or a
+`kty: "oct"` JSON Web Key for a symmetric key, and `spki`, `pkcs8` or a `kty: "RSA"` JSON Web Key for an RSA
+one. `deriveKey`, `deriveBits`, `wrapKey` and `unwrapKey` are *absent* rather than present-and-throwing, so
+`typeof crypto.subtle.deriveBits` tells a library the truth and it takes its fallback path; so is every
+elliptic-curve algorithm.
 
 Nothing here ever throws: a promise-returning WebIDL operation converts every failure into a rejection. An
 algorithm that is not registered for the operation is a `NotSupportedError` `DOMException`, a key used
-against its own `usages` or against another algorithm is an `InvalidAccessError`, a malformed JWK is a
-`DataError`, a usage list an algorithm does not support is a `SyntaxError`, and anything an argument
-conversion refuses is a `TypeError`. An AES-GCM decryption that does not authenticate is one
+against its own `usages`, against another algorithm, or against the wrong half of its pair (signing with a
+public key) is an `InvalidAccessError`, a malformed JWK or a DER structure that is not what its format names
+is a `DataError`, a usage list an algorithm does not support is a `SyntaxError`, and anything an argument
+conversion refuses is a `TypeError`. An AES-GCM or RSA-OAEP decryption that does not authenticate is one
 `OperationError` carrying nothing about which part of the input was wrong. The work is synchronous, so the
 promise is already settled when you get it.
 
-Two limits of .NET's AES-GCM are visible, and both are reported as the `OperationError` the algorithm's own
-steps end in: the `iv` must be the 96 bits NIST SP 800-38D recommends, and `tagLength` must be 96, 104, 112,
-120 or 128 — the specification also lists 32 and 64, which `System.Security.Cryptography.AesGcm` will not
-produce. The ciphertext is `ciphertext || tag`, exactly as the specification defines it, so a host reading a
-script's output with `AesGcm` splits the last `tagLength / 8` bytes off itself.
+Where .NET's own cryptography is narrower than the specification the difference is visible, always as the
+`OperationError` the algorithm's own steps end in and always with a message naming the restriction:
+
+- **AES-GCM**: the `iv` must be the 96 bits NIST SP 800-38D recommends, and `tagLength` must be 96, 104,
+  112, 120 or 128 — the specification also lists 32 and 64, which `System.Security.Cryptography.AesGcm` will
+  not produce. The ciphertext is `ciphertext || tag`, exactly as the specification defines it, so a host
+  reading a script's output with `AesGcm` splits the last `tagLength / 8` bytes off itself.
+- **RSA-PSS**: `RSASignaturePadding.Pss` takes no salt-length parameter and always uses the hash's own
+  output length, so `saltLength` is accepted at that one value (20, 32, 48 or 64 for SHA-1/256/384/512) and
+  refused at any other rather than signing with a salt nobody asked for.
+- **RSA-OAEP**: `RSAEncryptionPadding` carries a hash and no label, so `label` must be absent or empty.
+- **RSA `generateKey`**: `publicExponent` must be 65537, which is the only exponent `RSA.Create` can be
+  asked for, and `modulusLength` must be one the platform will generate (512 to 16384 in steps of 64 on
+  Windows, of 8 elsewhere) and at most 8192, which is this engine's own ceiling on a prime search that no
+  execution constraint can interrupt.
+- **RSA `importKey`** from a JSON Web Key needs the CRT parameters `p`, `q`, `dp`, `dq` and `qi`, which
+  `RSAParameters` describes a private key by; a JWK carrying `d` alone is a `DataError`.
 
 `TextDecoder` understands every encoding the [Encoding Standard](https://encoding.spec.whatwg.org/#names-and-labels)
 names, with all of their labels, except the seven legacy multi-byte ones (`Big5`, `EUC-JP`, `EUC-KR`, `GBK`,


### PR DESCRIPTION
Adds the complete RSA family to `crypto.subtle` — RSASSA-PKCS1-v1_5 and RSA-PSS (sign/verify), RSA-OAEP (encrypt/decrypt), each over SHA-1/256/384/512 — together with the asymmetric foundation everything after it builds on: `CryptoKey.type` becomes real (`secret`/`public`/`private`), `CryptoKeyPair` (a dictionary per spec §17, so a plain two-property object and deliberately no interface object on the global), `RsaHashedKeyAlgorithm` with `modulusLength` and a `Uint8Array` `publicExponent`, and the `spki`/`pkcs8` formats plus asymmetric JWK (`n e d p q dp dq qi`).

First slice of #3162 (references, does not close). Still 8 of 12 operations: `deriveBits`/`deriveKey`/`wrapKey`/`unwrapKey` stay absent-as-properties and the four tests pinning that are untouched — a later slice adds them.

Design points worth knowing:

- **The key handle stays DER, and `CryptoKey` stays free of `IDisposable`**: a public key holds a `SubjectPublicKeyInfo`, a private one a `PrivateKeyInfo` — the platform's own canonical re-encoding — and each operation rehydrates an `RSA` inside one `using`. The bonus: `exportKey('spki'|'pkcs8')` is a copy of the handle, so import and export can never disagree (pinned byte-for-byte against externally produced DER).
- **No hand-written ASN.1**: `ImportSubjectPublicKeyInfo`/`ImportPkcs8PrivateKey` are the parsers, with the spec's `exactData` realized as the `bytesRead` comparison (trailing bytes are a `DataError`).
- **Platform restrictions are refused loudly, never silently substituted** (each an `OperationError`/`DataError` naming the restriction, each documented in code and README): RSA-PSS salt length other than the hash's own (the BCL takes no salt parameter — signing with a different salt than asked would verify nowhere the caller expects); a non-empty RSA-OAEP label; `generateKey` with a public exponent other than 65537; and a private JWK described by `d` without the CRT parameters (`RSAParameters` has no such form, and recovering the primes is a factoring routine that does not belong in a JS engine — Chrome and Node refuse the same way).
- **`generateKey` bounds the modulus at 8192 bits** before the spec's own parameter validation: key generation is a prime search inside a single uninterruptible BCL call, so 16384 bits is minutes of CPU no execution constraint can stop; the ceiling also bounds the `2^modulusLength − 1` arithmetic the spec's validation performs on an attacker-chosen length. Below the ceiling, `RSA.LegalKeySizes` is consulted rather than assumed (the `AesGcm.TagByteSizes` precedent). Import is unaffected.
- **Every `CryptographicException` is wrapped per-site** into the spec's error for that step — `Perform` deliberately doesn't catch it, so an unwrapped one would erupt CLR-side out of a promise-returning API; the full call-site inventory is in the code. `verify` maps it to `false` (the verify steps have no error arm; a malformed signature is "otherwise", as browsers answer).
- The five dispatch sites that were hardcoded to the single registered algorithm are real switches now, and every silent catch-all in the crypto area (`NameOf`, `RegisteredFor`, the JWK `alg` tables, hash tables) is explicit-cases-plus-throwing-default, so a name registered without being implemented fails loudly instead of running the wrong branch.
- OAEP decrypt failures produce one indistinguishable message — the padding check is what a chosen-ciphertext attack probes.

38 new test methods / 109 cases, all vectors cross-implementation rather than self-referential: RFC 7515's RSASSA signature byte-for-byte, RFC 7520's PSS and OAEP examples in the verify/decrypt directions (the randomized paddings additionally asserted non-deterministic in the forward direction), and `pkcs8`/`spki` DER encoded by hand outside the engine so the parser is checked against bytes it did not produce. Import-validation order (usages before parsing, JWK steps in spec order) is pinned, and 8 load-bearing invariants are mutation-verified — including the `CryptoKeyPair` member order, whose mutation silently swaps the two keys.

Full matrix green: solution build all TFMs, both test projects on net10.0 + net472, host-contract-verification leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014n5uCpi2vvHWBSiewUwBiY
