### PR TITLE
Web API: script-facing fetch events - addEventListener('fetch', e => e.respondWith(...))

### DIFF
--- a/Jint.Tests.PublicInterface/WebApiFetchHandlerTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiFetchHandlerTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Jint;
 using Jint.Native;
 using Jint.Runtime;
+using Jint.WebApi;
 using Jint.WebApi.Fetch;
 
 namespace Jint.Tests.PublicInterface;
@@ -613,6 +614,266 @@ public class WebApiFetchHandlerTests
 
         // The handler itself is host state and survives, like Engine.Advanced.HostDefined.
         engine.Advanced.HasFetchHandler.Should().BeTrue();
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // The second registration form: WebApiFeatures.FetchEvents and addEventListener('fetch', …).
+    // ---------------------------------------------------------------------------------------------------
+
+    private sealed class RecordingSink : DiagnosticsSink
+    {
+        internal List<DiagnosticEvent> Reports { get; } = new();
+
+        public override void Report(DiagnosticEvent report) => Reports.Add(report);
+    }
+
+    /// <summary>
+    /// Builds an engine with the fetch-events feature and evaluates <paramref name="source"/>, which is
+    /// expected to register its own listener. Nothing is registered with <see cref="Engine.AdvancedOperations.SetFetchHandler"/>.
+    /// </summary>
+    private static Engine Listener(string source, Action<Options>? configure = null)
+    {
+        var engine = new Engine(options =>
+        {
+            options.UseWebApis(WebApiFeatures.FetchEvents);
+            configure?.Invoke(options);
+        });
+
+        engine.Execute(source);
+        return engine;
+    }
+
+    [Fact]
+    public void AScriptRegisteredListenerServesTheRequestThroughThePolledShape()
+    {
+        var engine = Listener("addEventListener('fetch', event => event.respondWith(new Response('from ' + event.request.url, { status: 201 })));");
+
+        // Nothing was registered with SetFetchHandler, and the host asks for the request exactly as before.
+        engine.Advanced.HasFetchHandler.Should().BeFalse();
+
+        using var response = Pump(engine, engine.Advanced.InvokeFetchHandler(Get("https://example.org/w")));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        Text(response).Should().Be("from https://example.org/w");
+    }
+
+    [Fact]
+    public async Task AScriptRegisteredListenerServesTheRequestThroughTheAwaitableShape()
+    {
+        var engine = Listener("""
+            addEventListener('fetch', event => {
+                event.respondWith(event.request.text().then(body => new Response('echo:' + body)));
+            });
+            """);
+
+        var message = new HttpRequestMessage(HttpMethod.Post, "https://example.org/")
+        {
+            Content = new StringContent("payload", Encoding.UTF8, "text/plain"),
+        };
+
+        using var response = await engine.Advanced.InvokeFetchHandlerAsync(message);
+        (await response.Content.ReadAsStringAsync()).Should().Be("echo:payload");
+    }
+
+    [Fact]
+    public void AnExplicitHandlerAlwaysWinsOverTheScriptsListeners()
+    {
+        var engine = Listener("""
+            globalThis.log = [];
+            addEventListener('fetch', event => { globalThis.log.push('listener'); event.respondWith(new Response('listener')); });
+            globalThis.handler = () => { globalThis.log.push('handler'); return new Response('handler'); };
+            """);
+
+        engine.Advanced.SetFetchHandler(engine.GetValue("handler"));
+
+        using (var response = engine.Advanced.InvokeFetchHandler(Get()).GetResult())
+        {
+            // A script that adds a listener must not be able to take the route away from the host.
+            Text(response).Should().Be("handler");
+        }
+
+        engine.Evaluate("globalThis.log.join(',')").AsString().Should().Be("handler");
+
+        // Clearing the handler is how a host hands the route over, deliberately.
+        engine.Advanced.SetFetchHandler(null);
+        using var second = Pump(engine, engine.Advanced.InvokeFetchHandler(Get()));
+        Text(second).Should().Be("listener");
+    }
+
+    [Fact]
+    public void WithoutTheFeatureFlagAListenerIsNotConsulted()
+    {
+        // Everything the listener form needs except the flag itself: the global addEventListener is there, so
+        // registering succeeds and simply routes nothing.
+        var engine = new Engine(options => options.UseWebApis(ModelFeatures | WebApiFeatures.GlobalEvents));
+        engine.Execute("addEventListener('fetch', event => event.respondWith(new Response('x')));");
+
+        engine.Evaluate("typeof FetchEvent").AsString().Should().Be("undefined");
+
+        var failure = Assert.Throws<InvalidOperationException>(() => engine.Advanced.InvokeFetchHandler(Get()));
+        failure.Message.Should().Contain("SetFetchHandler");
+        failure.Message.Should().Contain("WebApiFeatures.FetchEvents");
+    }
+
+    [Fact]
+    public void NoListenerRespondingFailsTheOperation()
+    {
+        var engine = Listener("addEventListener('fetch', () => { /* looks at the request and shrugs */ });");
+
+        var operation = engine.Advanced.InvokeFetchHandler(Get());
+
+        // There is no network for an unanswered request to fall through to, so this is a failure like any
+        // other — and it arrives through the operation rather than being thrown at the start call.
+        operation.IsCompleted.Should().BeTrue();
+        operation.IsFaulted.Should().BeTrue();
+        Assert.IsType<InvalidOperationException>(operation.Error).Message.Should().Contain("respondWith");
+    }
+
+    [Fact]
+    public async Task NoListenerRespondingThrowsFromTheAwaitableShape()
+    {
+        var engine = Listener("addEventListener('fetch', () => { });");
+
+        var failure = await Assert.ThrowsAsync<InvalidOperationException>(() => engine.Advanced.InvokeFetchHandlerAsync(Get()));
+        failure.Message.Should().Contain("respondWith");
+    }
+
+    [Fact]
+    public void AListenerThatThrowsFaultsTheOperationWhenNoSinkIsSet()
+    {
+        var engine = Listener("addEventListener('fetch', () => { throw new TypeError('listener boom'); });");
+
+        var operation = engine.Advanced.InvokeFetchHandler(Get());
+
+        // With no diagnostics sink an exception escaping a listener propagates — the EventTarget contract,
+        // unchanged — and the invoke turns it into the operation's failure, exactly as it does for a handler
+        // that threw.
+        operation.IsFaulted.Should().BeTrue();
+        var failure = Assert.IsType<JavaScriptException>(operation.Error);
+        failure.Error.Get("name").AsString().Should().Be("TypeError");
+        failure.Message.Should().Be("listener boom");
+    }
+
+    [Fact]
+    public void AListenerThatThrowsIsReportedAndALaterOneStillAnswers()
+    {
+        var sink = new RecordingSink();
+        var engine = Listener(
+            """
+            addEventListener('fetch', () => { throw new TypeError('first fails'); });
+            addEventListener('fetch', event => event.respondWith(new Response('second answers')));
+            """,
+            options => options.UseWebApis(webApi => webApi.Diagnostics.Sink = sink));
+
+        using var response = Pump(engine, engine.Advanced.InvokeFetchHandler(Get()));
+
+        // A sink is what turns "report the exception and carry on" from a lie into the specified behaviour, so
+        // the request is still served.
+        Text(response).Should().Be("second answers");
+        sink.Reports.Should().Contain(report => report.Kind == DiagnosticEventKind.UncaughtCallbackError);
+    }
+
+    [Fact]
+    public void AConstraintThatFiresDuringTheDispatchFaultsTheOperation()
+    {
+        var engine = Listener(
+            "addEventListener('fetch', event => { let n = 0; for (let i = 0; i < 10000; i++) { n += i; } event.respondWith(new Response(String(n))); });",
+            options => options.MaxStatements(50));
+
+        var operation = engine.Advanced.InvokeFetchHandler(Get());
+
+        // A constraint is a JintException that is not a JavaScriptException, so it erupts past a sink and past
+        // the dispatch — and the invoke turns it into the operation's failure rather than leaving the host
+        // polling a promise that can never settle.
+        operation.IsCompleted.Should().BeTrue();
+        operation.IsFaulted.Should().BeTrue();
+        Assert.IsType<StatementsCountOverflowException>(operation.Error);
+    }
+
+    [Fact]
+    public void AListenerThatAnswersAndThenThrowsServesItsResponseWhenASinkIsSet()
+    {
+        var sink = new RecordingSink();
+        var engine = Listener(
+            "addEventListener('fetch', event => { event.respondWith(new Response('answered')); throw new Error('after answering'); });",
+            options => options.UseWebApis(webApi => webApi.Diagnostics.Sink = sink));
+
+        using var response = Pump(engine, engine.Advanced.InvokeFetchHandler(Get()));
+
+        // respondWith() already committed the answer, and reporting the throw is what lets the dispatch finish
+        // — so the request is served and the failure is still visible. This is what a browser does.
+        Text(response).Should().Be("answered");
+        sink.Reports.Should().Contain(report => report.Kind == DiagnosticEventKind.UncaughtCallbackError);
+    }
+
+    [Fact]
+    public void AListenerThatAnswersAndThenThrowsFailsTheOperationWithNoSink()
+    {
+        var engine = Listener("addEventListener('fetch', event => { event.respondWith(new Response('answered')); throw new Error('after answering'); });");
+
+        var operation = engine.Advanced.InvokeFetchHandler(Get());
+
+        // The one case where the two configurations disagree about a request that was answered. With nowhere
+        // to report to, preferring the response would lose the exception entirely — so the exception wins and
+        // the host sees the failure, which is the same bargain every other engine-invoked callback makes.
+        operation.IsFaulted.Should().BeTrue();
+        Assert.IsType<JavaScriptException>(operation.Error).Message.Should().Be("after answering");
+    }
+
+    [Fact]
+    public void TheDispatchIsAHostEntryAndArmsTheConstraintsAfresh()
+    {
+        // The loop is there so the listener runs past the amortized check cadence: a wall-clock constraint is
+        // amortizable, so a three-statement listener would never reach a check at all and the test would pass
+        // whatever the dispatch did.
+        var engine = Listener(
+            "addEventListener('fetch', event => { let n = 0; for (let i = 0; i < 500; i++) { n += i; } event.respondWith(new Response('answered')); });",
+            options => options.TimeoutInterval(TimeSpan.FromMilliseconds(200)));
+
+        // Time the host spent between requests is the host's, not the script's. Entering the engine is what
+        // arms the wall-clock budget — a TimeConstraint otherwise measures from the moment the previous entry
+        // returned — so a request arriving long afterwards still gets its whole allowance. The dispatch is
+        // bracketed in exactly what Engine.Call brackets the registered-handler route in, which is what makes
+        // that true here as well.
+        Thread.Sleep(400);
+
+        using var response = Pump(engine, engine.Advanced.InvokeFetchHandler(Get()));
+        Text(response).Should().Be("answered");
+    }
+
+    [Fact]
+    public void AListenerInvocationTheEngineFencedOffCompletesAsFaulted()
+    {
+        var engine = Listener("addEventListener('fetch', event => event.respondWith(new Promise(() => { })));");
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+
+        var operation = engine.Advanced.InvokeFetchHandler(Get());
+        operation.IsCompleted.Should().BeFalse();
+
+        // The operation records the cycle it was started in before the dispatch runs, so a restore abandons it
+        // just as it abandons one started by a registered handler. A host polling IsCompleted must not poll
+        // forever.
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        operation.IsCompleted.Should().BeTrue();
+        operation.IsFaulted.Should().BeTrue();
+        Assert.IsType<InvalidOperationException>(operation.Error).Message.Should().Contain("abandoned");
+    }
+
+    [Fact]
+    public void TheFeatureInstallsTheObjectModelBeforeAnyScriptRuns()
+    {
+        // Unlike the SetFetchHandler door, whose install happens when the host registers, this one is part of
+        // building the engine — so a module may construct a Response at top level.
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.FetchEvents));
+        engine.Modules.Add("worker", "const canned = new Response('top level'); addEventListener('fetch', e => e.respondWith(canned.clone()));");
+        engine.Modules.Import("worker");
+
+        using var response = Pump(engine, engine.Advanced.InvokeFetchHandler(Get()));
+        Text(response).Should().Be("top level");
+
+        // And still no outbound network.
+        engine.Evaluate("typeof fetch").AsString().Should().Be("undefined");
     }
 }
 #endif

--- a/Jint.Tests/Runtime/WebApi/FetchEventTests.cs
+++ b/Jint.Tests/Runtime/WebApi/FetchEventTests.cs
@@ -1,0 +1,540 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.Net.Http;
+using System.Text;
+using Jint.Runtime;
+using Jint.WebApi;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// The script's half of <c>WebApiFeatures.FetchEvents</c>: the <c>FetchEvent</c> interface, and what
+/// <c>respondWith()</c> and <c>waitUntil()</c> do inside a listener.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The specification is Service Workers,
+/// <see href="https://w3c.github.io/ServiceWorker/#fetchevent-interface">§4.6 FetchEvent</see> over
+/// <see href="https://w3c.github.io/ServiceWorker/#extendableevent-interface">§4.4 ExtendableEvent</see>. Two
+/// reductions are deliberate and asserted here rather than merely written down: there is <b>no
+/// <c>ExtendableEvent</c> interface object</b> — <c>waitUntil</c> is a member of <c>FetchEvent.prototype</c>,
+/// the flat shape Cloudflare Workers exposes — and there is <b>no timed out flag</b>, so an event stays
+/// extendable exactly as long as its own lifetime promises are pending.
+/// </para>
+/// <para>
+/// The host-facing contract — which route an invocation takes, and how a failure reaches the host — is pinned
+/// from outside the assembly in <c>Jint.Tests.PublicInterface.WebApiFetchHandlerTests</c>.
+/// </para>
+/// </remarks>
+public class FetchEventTests
+{
+    private sealed class RecordingSink : DiagnosticsSink
+    {
+        internal List<DiagnosticEvent> Reports { get; } = new();
+
+        public override void Report(DiagnosticEvent report) => Reports.Add(report);
+    }
+
+    private static Engine Worker(string source, DiagnosticsSink? sink = null)
+    {
+        var engine = new Engine(options => options.UseWebApis(webApi =>
+        {
+            webApi.Features = WebApiFeatures.FetchEvents;
+            webApi.Diagnostics.Sink = sink;
+        }));
+
+        engine.Execute(source);
+        return engine;
+    }
+
+    private static HttpRequestMessage Get(string url = "https://example.org/hello") => new(HttpMethod.Get, url);
+
+    /// <summary>
+    /// Runs one request through whatever the engine has registered, pumping until it is done, and answers with
+    /// the response body as text.
+    /// </summary>
+    private static string Answer(Engine engine, HttpRequestMessage? request = null)
+    {
+        var operation = engine.Advanced.InvokeFetchHandler(request ?? Get());
+        for (var i = 0; i < 100 && !operation.IsCompleted; i++)
+        {
+            engine.Advanced.ProcessTasks();
+        }
+
+        using var response = operation.GetResult();
+        using var stream = response.Content.ReadAsStream();
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        return reader.ReadToEnd();
+    }
+
+    // The surface
+
+    [Fact]
+    public void TheFeatureInstallsTheEventAndTheObjectModelButNeverFetch()
+    {
+        var engine = Worker("");
+
+        engine.Evaluate("typeof FetchEvent").AsString().Should().Be("function");
+        engine.Evaluate("typeof Response").AsString().Should().Be("function");
+        engine.Evaluate("typeof Request").AsString().Should().Be("function");
+        engine.Evaluate("typeof Headers").AsString().Should().Be("function");
+
+        // The closure: addEventListener comes from GlobalEvents, URL from Url, Blob from Files.
+        engine.Evaluate("typeof addEventListener").AsString().Should().Be("function");
+        engine.Evaluate("typeof URL").AsString().Should().Be("function");
+        engine.Evaluate("typeof Blob").AsString().Should().Be("function");
+
+        // The whole point of the separate flag: routing requests IN is not a grant to reach OUT.
+        engine.Evaluate("typeof fetch").AsString().Should().Be("undefined");
+        engine.Advanced.WebApiFeatures.Should().NotHaveFlag(WebApiFeatures.Fetch);
+    }
+
+    [Fact]
+    public void TheFeatureIsNotInDefaultAndFetchDoesNotBringIt()
+    {
+        WebApiFeatures.Default.Should().NotHaveFlag(WebApiFeatures.FetchEvents);
+
+        var standard = new Engine(options => options.UseWebApis());
+        standard.Evaluate("typeof FetchEvent").AsString().Should().Be("undefined");
+
+        // Deliberately not implied in either direction — outbound network and inbound routing are two grants.
+        var fetching = new Engine(options => options.UseFetch());
+        fetching.Advanced.WebApiFeatures.Should().NotHaveFlag(WebApiFeatures.FetchEvents);
+        fetching.Evaluate("typeof FetchEvent").AsString().Should().Be("undefined");
+    }
+
+    [Fact]
+    public void TheInterfaceObjectHasTheWebIdlShape()
+    {
+        var engine = Worker("");
+
+        engine.Evaluate("FetchEvent.name").AsString().Should().Be("FetchEvent");
+
+        // 2, not 1: FetchEventInit is declared without `optional` because it has a required member.
+        engine.Evaluate("FetchEvent.length").AsNumber().Should().Be(2);
+
+        // https://webidl.spec.whatwg.org/#es-interfaces — writable and configurable, not enumerable.
+        var descriptor = engine.Evaluate("Object.getOwnPropertyDescriptor(globalThis, 'FetchEvent')").AsObject();
+        descriptor.Get("writable").AsBoolean().Should().BeTrue();
+        descriptor.Get("enumerable").AsBoolean().Should().BeFalse();
+        descriptor.Get("configurable").AsBoolean().Should().BeTrue();
+
+        // The flat shape: the IDL puts ExtendableEvent between these two, and Jint does not materialize it.
+        engine.Evaluate("Object.getPrototypeOf(FetchEvent) === Event").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.getPrototypeOf(FetchEvent.prototype) === Event.prototype").AsBoolean().Should().BeTrue();
+        engine.Evaluate("typeof ExtendableEvent").AsString().Should().Be("undefined");
+
+        // waitUntil therefore lives here rather than one level up.
+        engine.Evaluate("Object.prototype.hasOwnProperty.call(FetchEvent.prototype, 'waitUntil')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("FetchEvent.prototype.respondWith.length").AsNumber().Should().Be(1);
+        engine.Evaluate("FetchEvent.prototype.waitUntil.length").AsNumber().Should().Be(1);
+        engine.Evaluate("FetchEvent.prototype[Symbol.toStringTag]").AsString().Should().Be("FetchEvent");
+    }
+
+    [Fact]
+    public void TheMembersBrandCheckTheirReceiver()
+    {
+        var engine = Worker("");
+
+        foreach (var member in new[] { "FetchEvent.prototype.respondWith.call({})", "FetchEvent.prototype.waitUntil.call({})", "Object.getOwnPropertyDescriptor(FetchEvent.prototype, 'request').get.call({})" })
+        {
+            var failure = Assert.Throws<JavaScriptException>(() => engine.Evaluate(member));
+            failure.Error.Get("name").AsString().Should().Be("TypeError");
+            failure.Message.Should().Contain("not a FetchEvent");
+        }
+    }
+
+    // The constructor
+
+    [Fact]
+    public void TheConstructorRequiresATypeAndARequestOfTheRightType()
+    {
+        var engine = Worker("var request = new Request('https://example.org/');");
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new FetchEvent()"))
+            .Message.Should().Contain("1 argument required");
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new FetchEvent('fetch')"))
+            .Message.Should().Contain("2 arguments required");
+
+        // undefined and null both convert to a dictionary with no members, which is missing a required one.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new FetchEvent('fetch', undefined)"))
+            .Message.Should().Contain("required member request is undefined");
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new FetchEvent('fetch', {})"))
+            .Message.Should().Contain("required member request is undefined");
+
+        // An interface type coerces nothing: https://webidl.spec.whatwg.org/#es-interface.
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new FetchEvent('fetch', { request: 'https://example.org/' })"))
+            .Message.Should().Contain("not of type 'Request'");
+
+        engine.Evaluate("new FetchEvent('fetch', { request }).request === request").AsBoolean().Should().BeTrue();
+        engine.Evaluate("new FetchEvent('fetch', { request }) instanceof Event").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void TheInheritedEventInitMembersAreConvertedBeforeTheDictionarysOwn()
+    {
+        var engine = Worker("""
+            var seen = [];
+            var request = new Request('https://example.org/');
+            var init = {
+                get bubbles() { seen.push('bubbles'); return true; },
+                get cancelable() { seen.push('cancelable'); return true; },
+                get composed() { seen.push('composed'); return false; },
+                get request() { seen.push('request'); return request; },
+            };
+            var event = new FetchEvent('fetch', init);
+            """);
+
+        // https://webidl.spec.whatwg.org/#es-dictionary — inherited members first, and the order is observable.
+        engine.Evaluate("seen.join(',')").AsString().Should().Be("bubbles,cancelable,composed,request");
+        engine.Evaluate("event.bubbles && event.cancelable").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void AScriptConstructedEventIsUntrustedAndCanNeitherRespondNorBeExtended()
+    {
+        var engine = Worker("""
+            var log = [];
+            addEventListener('fetch', event => {
+                try { event.respondWith(new Response('nope')); } catch (e) { log.push('respondWith:' + e.name); }
+                try { event.waitUntil(Promise.resolve()); } catch (e) { log.push('waitUntil:' + e.name); }
+            });
+
+            var request = new Request('https://example.org/');
+            var returned = dispatchEvent(new FetchEvent('fetch', { request }));
+            """);
+
+        // Step 1 of "add lifetime promise": an untrusted event cannot be extended, so neither operation works
+        // — only the event the engine created for an inbound request can be answered.
+        engine.Evaluate("log.join(',')").AsString().Should().Be("respondWith:InvalidStateError,waitUntil:InvalidStateError");
+
+        // ... and the dispatch itself behaved like any other: nothing cancelled it.
+        engine.Evaluate("returned").AsBoolean().Should().BeTrue();
+    }
+
+    // The trusted event, through the hosting path
+
+    [Fact]
+    public void TheDispatchedEventIsATrustedCancelableFetchEventCarryingTheRequest()
+    {
+        var engine = Worker("""
+            addEventListener('fetch', event => {
+                event.respondWith(new Response(JSON.stringify({
+                    type: event.type,
+                    isTrusted: event.isTrusted,
+                    cancelable: event.cancelable,
+                    bubbles: event.bubbles,
+                    isFetchEvent: event instanceof FetchEvent,
+                    isEvent: event instanceof Event,
+                    target: event.target === globalThis,
+                    thisIsGlobal: this === globalThis,
+                    url: event.request.url,
+                    method: event.request.method,
+                    sameObject: event.request === event.request,
+                })));
+            });
+            """);
+
+        var json = Answer(engine, new HttpRequestMessage(HttpMethod.Post, "https://example.org/a?b=1"));
+
+        json.Should().Contain("\"type\":\"fetch\"");
+        json.Should().Contain("\"isTrusted\":true");
+
+        // "Initialize e's cancelable attribute to true" — the on-fetch-request algorithm.
+        json.Should().Contain("\"cancelable\":true");
+        json.Should().Contain("\"bubbles\":false");
+        json.Should().Contain("\"isFetchEvent\":true");
+        json.Should().Contain("\"isEvent\":true");
+        json.Should().Contain("\"target\":true");
+        json.Should().Contain("\"thisIsGlobal\":true");
+        json.Should().Contain("\"url\":\"https://example.org/a?b=1\"");
+        json.Should().Contain("\"method\":\"POST\"");
+        json.Should().Contain("\"sameObject\":true");
+    }
+
+    [Fact]
+    public void TheListenerSeesARealRequestWithTheWholeBodyMixin()
+    {
+        var engine = Worker("""
+            addEventListener('fetch', event => {
+                event.respondWith(event.request.json().then(body => new Response('n=' + body.n)));
+            });
+            """);
+
+        var message = new HttpRequestMessage(HttpMethod.Post, "https://example.org/")
+        {
+            Content = new StringContent("{\"n\":7}", Encoding.UTF8, "application/json"),
+        };
+
+        Answer(engine, message).Should().Be("n=7");
+    }
+
+    [Fact]
+    public void RespondWithAcceptsAPlainResponseThroughThePromiseConversion()
+    {
+        // `Promise<Response> r` converts anything, so a Response goes in directly — which is what every
+        // Workers script writes.
+        var engine = Worker("addEventListener('fetch', e => e.respondWith(new Response('plain')));");
+        Answer(engine).Should().Be("plain");
+    }
+
+    [Fact]
+    public void RespondWithWithNoArgumentIsTheWebIdlArityError()
+    {
+        var engine = Worker("""
+            var log = [];
+            addEventListener('fetch', event => {
+                try { event.respondWith(); } catch (e) { log.push(e.name + ':' + (e instanceof TypeError)); }
+                event.respondWith(new Response('after'));
+            });
+            """);
+
+        // Without the arity check the Promise<T> conversion would happily resolve with undefined and the
+        // request would fail a turn later complaining about the answer not being a Response.
+        Answer(engine).Should().Be("after");
+        engine.Evaluate("log.join(',')").AsString().Should().Be("TypeError:true");
+    }
+
+    // respondWith's state machine
+
+    [Fact]
+    public void ASecondRespondWithIsAnInvalidStateError()
+    {
+        var engine = Worker("""
+            var log = [];
+            addEventListener('fetch', event => {
+                event.respondWith(new Response('first'));
+                try { event.respondWith(new Response('second')); } catch (e) { log.push(e.name); }
+            });
+            """);
+
+        Answer(engine).Should().Be("first");
+        engine.Evaluate("log.join(',')").AsString().Should().Be("InvalidStateError");
+    }
+
+    [Fact]
+    public void RespondWithAfterTheDispatchIsAnInvalidStateError()
+    {
+        var engine = Worker("""
+            var captured = null;
+            addEventListener('fetch', event => {
+                captured = event;
+                event.respondWith(new Response('answered'));
+            });
+            """);
+
+        Answer(engine).Should().Be("answered");
+
+        // The dispatch flag is unset, so step 2 refuses — before the entered flag is even looked at.
+        var failure = Assert.Throws<JavaScriptException>(() => engine.Evaluate("captured.respondWith(new Response('late'))"));
+        failure.Error.Get("name").AsString().Should().Be("InvalidStateError");
+        failure.Message.Should().Contain("not being dispatched");
+    }
+
+    [Fact]
+    public void RespondWithEndsTheDispatchForEveryLaterListener()
+    {
+        var engine = Worker("""
+            var log = [];
+            addEventListener('fetch', event => { log.push('first'); event.respondWith(new Response('from first')); });
+            addEventListener('fetch', () => { log.push('second'); });
+            addEventListener('fetch', () => { log.push('capturing'); }, true);
+            """);
+
+        // Step 5 sets both the stop propagation and the stop immediate propagation flags, so the first
+        // responder wins the dispatch outright. The capturing listener still ran: a capturing listener runs in
+        // the first pass, before any non-capturing one.
+        Answer(engine).Should().Be("from first");
+        engine.Evaluate("log.join(',')").AsString().Should().Be("capturing,first");
+    }
+
+    [Fact]
+    public void RespondWithDoesNotCancelTheEvent()
+    {
+        var engine = Worker("""
+            var prevented = null;
+            addEventListener('fetch', event => {
+                event.respondWith(new Response('x'));
+                prevented = event.defaultPrevented;
+            });
+            """);
+
+        Answer(engine).Should().Be("x");
+
+        // The current respondWith(r) steps set the two propagation flags and nothing else — an older edition
+        // of the specification, and MDN's prose, describe an implicit preventDefault() that the algorithm no
+        // longer performs. Setting the canceled flag here would be observable and wrong.
+        engine.Evaluate("prevented").AsBoolean().Should().BeFalse();
+    }
+
+    // waitUntil and the lifetime
+
+    [Fact]
+    public void WaitUntilIsAllowedWhileTheEventIsStillActiveAndRefusedAfterwards()
+    {
+        var engine = Worker("""
+            var log = [];
+            var captured = null;
+            var release = null;
+            addEventListener('fetch', event => {
+                captured = event;
+                event.respondWith(new Promise(resolve => { release = resolve; }));
+            });
+            """);
+
+        var operation = engine.Advanced.InvokeFetchHandler(Get());
+        operation.IsCompleted.Should().BeFalse();
+
+        // The response promise is a lifetime promise too, so the event is still active with the dispatch over.
+        engine.Execute("captured.waitUntil(Promise.resolve('background'));");
+
+        engine.Execute("release(new Response('done'));");
+        for (var i = 0; i < 100 && !operation.IsCompleted; i++)
+        {
+            engine.Advanced.ProcessTasks();
+        }
+
+        using (var response = operation.GetResult())
+        {
+            using var reader = new StreamReader(response.Content.ReadAsStream(), Encoding.UTF8);
+            reader.ReadToEnd().Should().Be("done");
+        }
+
+        // Both lifetime promises have settled and the dispatch is long over, so the event is no longer active
+        // — which is the specification's own note about calling waitUntil() from a later task.
+        var failure = Assert.Throws<JavaScriptException>(() => engine.Evaluate("captured.waitUntil(Promise.resolve())"));
+        failure.Error.Get("name").AsString().Should().Be("InvalidStateError");
+        failure.Message.Should().Contain("no longer active");
+    }
+
+    [Fact]
+    public void WaitUntilWorkIsJustJobsTheHostPumps()
+    {
+        var engine = Worker("""
+            var log = [];
+            addEventListener('fetch', event => {
+                event.waitUntil(Promise.resolve().then(() => { log.push('background'); }));
+                event.respondWith(new Response('immediate'));
+            });
+            """);
+
+        Answer(engine).Should().Be("immediate");
+
+        // Nothing waited for it and nothing had to: it is a job like any other, and the pump the response
+        // needed ran it.
+        engine.Evaluate("log.join(',')").AsString().Should().Be("background");
+    }
+
+    [Fact]
+    public void ARejectedWaitUntilPromiseIsReportedOnceRatherThanLost()
+    {
+        var sink = new RecordingSink();
+        var engine = Worker("""
+            var log = [];
+            addEventListener('unhandledrejection', e => { log.push('event:' + e.reason.message); });
+            addEventListener('fetch', event => {
+                event.waitUntil(Promise.resolve().then(() => { throw new Error('background failed'); }));
+                event.respondWith(new Response('ok'));
+            });
+            """, sink);
+
+        Answer(engine).Should().Be("ok");
+
+        // The promise was pending and unhandled when waitUntil() took it, so the reaction the event installs
+        // is what marks it handled — and without this report the failure would vanish entirely, because the
+        // rejection tracker would never have seen an unhandled promise.
+        engine.Evaluate("log.join(',')").AsString().Should().Be("event:background failed");
+
+        var reports = sink.Reports.Where(report => report.Kind == DiagnosticEventKind.UnhandledPromiseRejection).ToArray();
+        reports.Should().HaveCount(1, "the rejection is announced once, at the settle");
+        reports[0].RejectionHandled.Should().BeFalse();
+        reports[0].Value.AsObject().Get("message").AsString().Should().Be("background failed");
+    }
+
+    [Fact]
+    public void AnAlreadyRejectedWaitUntilPromiseIsNotAnnouncedASecondTime()
+    {
+        var sink = new RecordingSink();
+        var engine = Worker("""
+            var log = [];
+            addEventListener('unhandledrejection', e => { log.push('unhandled:' + e.reason.message); });
+            addEventListener('rejectionhandled', () => { log.push('handled'); });
+            addEventListener('fetch', event => {
+                event.waitUntil(Promise.reject(new Error('already')));
+                event.respondWith(new Response('ok'));
+            });
+            """, sink);
+
+        Answer(engine).Should().Be("ok");
+
+        // Promise.reject() went through the rejection tracker as that very expression was evaluated, before
+        // waitUntil() could attach anything — so this is the engine's ordinary announce-then-handle pair and
+        // not a third report of the same failure.
+        engine.Evaluate("log.join(',')").AsString().Should().Be("unhandled:already,handled");
+        sink.Reports.Count(report => report.Kind == DiagnosticEventKind.UnhandledPromiseRejection && !report.RejectionHandled)
+            .Should().Be(1);
+    }
+
+    [Fact]
+    public void ARejectedResponsePromiseIsNotAlsoReportedAsAnUnhandledRejection()
+    {
+        var sink = new RecordingSink();
+        var engine = Worker("""
+            var log = [];
+            addEventListener('unhandledrejection', e => { log.push('event'); });
+            addEventListener('fetch', event => {
+                event.respondWith(Promise.resolve().then(() => { throw new Error('handler failed'); }));
+            });
+            """, sink);
+
+        var operation = engine.Advanced.InvokeFetchHandler(Get());
+        for (var i = 0; i < 100 && !operation.IsCompleted; i++)
+        {
+            engine.Advanced.ProcessTasks();
+        }
+
+        // The host already learns about it, as the operation's failure — reporting it a second time as a lost
+        // background rejection would be noise about something nobody lost.
+        operation.IsFaulted.Should().BeTrue();
+        Assert.IsType<PromiseRejectedException>(operation.Error)
+            .RejectedValue.AsObject().Get("message").AsString().Should().Be("handler failed");
+
+        engine.Evaluate("log.join(',')").AsString().Should().BeEmpty();
+        sink.Reports.Should().NotContain(report => report.Kind == DiagnosticEventKind.UnhandledPromiseRejection);
+    }
+
+    [Fact]
+    public void TheListenerFormAlwaysNeedsAtLeastOneTurn()
+    {
+        var engine = Worker("addEventListener('fetch', e => e.respondWith(new Response('sync')));");
+
+        var operation = engine.Advanced.InvokeFetchHandler(Get());
+
+        // Unlike a SetFetchHandler handler that returns a Response, respondWith() puts its argument through
+        // PromiseResolve, and a promise reaction is a job — so even the most synchronous listener needs a pump.
+        operation.IsCompleted.Should().BeFalse();
+
+        engine.Advanced.ProcessTasks();
+        operation.IsCompleted.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ARestoreDropsTheListenersWithTheRestOfTheCycle()
+    {
+        var engine = Worker("addEventListener('fetch', e => e.respondWith(new Response('before')));");
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+
+        Answer(engine).Should().Be("before");
+
+        // The listener list is a closure over the ended cycle, so the restore takes it away with everything
+        // else — and the invocation is then refused, which is the same answer an engine that never had one
+        // gives.
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        Assert.Throws<InvalidOperationException>(() => engine.Advanced.InvokeFetchHandler(Get()))
+            .Message.Should().Contain("addEventListener('fetch'");
+    }
+}
+#endif

--- a/Jint/Engine.Advanced.WebApi.cs
+++ b/Jint/Engine.Advanced.WebApi.cs
@@ -1,12 +1,16 @@
 #if NET8_0_OR_GREATER
 using Jint.Native;
+using Jint.Native.Promise;
 using Jint.Runtime;
 using Jint.WebApi.Abort;
 using Jint.WebApi.Fetch;
+using Jint.WebApi.FetchEvents;
+using Jint.WebApi.GlobalEvents;
 using Jint.WebApi.Messaging;
 using Jint.WebApi.Streams;
 using Jint.WebApi;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using System.Threading;
 
@@ -255,8 +259,18 @@ public partial class Engine
         private const WebApiFeatures FetchModelFeatures = WebApiFeatures.Events | WebApiFeatures.Url | WebApiFeatures.Files;
 
         /// <summary>
-        /// Whether a fetch handler is registered on this engine. Requires .NET 8 or higher.
+        /// Whether a fetch handler is registered on this engine <b>through <see cref="SetFetchHandler"/></b>.
+        /// Requires .NET 8 or higher.
         /// </summary>
+        /// <remarks>
+        /// It is deliberately about that registration alone, and answers <see langword="false"/> for an engine
+        /// whose script registered a <c>fetch</c> listener instead (<see cref="WebApiFeatures.FetchEvents"/>) —
+        /// it is the host's own record of what the host did, and a script must not be able to change the
+        /// answer. It is therefore <b>not</b> the way to ask "can this engine serve a request": listeners come
+        /// and go with the evaluation cycle, a script may add one after this was read, and one that exists may
+        /// still decline to respond. Call <see cref="InvokeFetchHandler"/> and let it fail — every other
+        /// failure of an invocation arrives that way too.
+        /// </remarks>
         public bool HasFetchHandler => _engine._webApi?.FetchHandler is not null;
 
         /// <summary>
@@ -308,6 +322,13 @@ public partial class Engine
         /// <see cref="FetchHandlerOperation.IsCompleted"/>. Registering again replaces the previous handler;
         /// passing <see langword="null"/>, <c>undefined</c> or <c>null</c> clears it.
         /// </para>
+        /// <para>
+        /// <b>It outranks the script's own <c>fetch</c> listeners.</b> On an engine with
+        /// <see cref="WebApiFeatures.FetchEvents"/> a script may register a handler itself with
+        /// <c>addEventListener('fetch', …)</c>, and <see cref="InvokeFetchHandler"/> dispatches to those
+        /// listeners <em>only</em> when nothing was registered here. A handler the host named is never taken
+        /// away from it by script — clear it with <see langword="null"/> to hand the route over deliberately.
+        /// </para>
         /// </remarks>
         /// <param name="handler">The handler, or <see langword="null"/> to clear it.</param>
         /// <exception cref="ArgumentException"><paramref name="handler"/> matches none of the three shapes.</exception>
@@ -332,10 +353,22 @@ public partial class Engine
         }
 
         /// <summary>
-        /// Routes an inbound request to the registered fetch handler and hands back an operation the host
-        /// drives with its own pump. Requires .NET 8 or higher.
+        /// Routes an inbound request to the registered fetch handler — or, failing that, to the script's own
+        /// <c>fetch</c> listeners — and hands back an operation the host drives with its own pump. Requires
+        /// .NET 8 or higher.
         /// </summary>
         /// <remarks>
+        /// <para>
+        /// <b>Two ways to be routed, in this order.</b> A handler registered with
+        /// <see cref="SetFetchHandler"/> is called with the <c>Request</c>. With no such handler, and only on
+        /// an engine carrying <see cref="WebApiFeatures.FetchEvents"/>, a trusted <c>FetchEvent</c> is
+        /// dispatched at the global scope and the operation settles from whatever a listener passed to
+        /// <c>event.respondWith()</c> — the shape a Cloudflare Workers or service-worker script is written in.
+        /// The order is fixed and not a fallback chain a script can climb: what the host registered wins, and
+        /// listeners are consulted only where there was nothing to win against. A dispatch that reaches no
+        /// <c>respondWith()</c> — because no listener called it, or because the ones that ran threw — fails the
+        /// operation, since an embedded engine has no network for a request to fall through to.
+        /// </para>
         /// <para>
         /// <b>Nothing is pumped here.</b> A handler that answers a <c>Response</c> synchronously produces an
         /// operation that is already complete; one that answers a promise — every <c>async</c> handler, and
@@ -377,7 +410,9 @@ public partial class Engine
         /// </param>
         /// <returns>The invocation in progress; see <see cref="FetchHandlerOperation"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="request"/> is <see langword="null"/>.</exception>
-        /// <exception cref="InvalidOperationException">No fetch handler is registered on this engine.</exception>
+        /// <exception cref="InvalidOperationException">
+        /// Neither a fetch handler nor a <c>fetch</c> listener is registered on this engine.
+        /// </exception>
         public FetchHandlerOperation InvokeFetchHandler(HttpRequestMessage request)
         {
             if (request is null)
@@ -385,13 +420,17 @@ public partial class Engine
                 Throw.ArgumentNullException(nameof(request));
             }
 
-            var handler = RequireFetchHandler();
+            var route = RequireFetchRoute();
+
+            // Before the invocation, so that the evaluation cycle the operation is fenced against is the one
+            // the script actually ran in — a RestoreGlobalSnapshot from inside a listener must abandon this
+            // operation rather than be invisible to it.
             var operation = new FetchHandlerOperation(_engine);
 
             JsValue result;
             try
             {
-                result = CallHandler(handler, request, ReadBody(request));
+                result = InvokeRoute(in route, request, ReadBody(request));
             }
             catch (Exception ex) when (ex is not OutOfMemoryException)
             {
@@ -439,8 +478,9 @@ public partial class Engine
         /// <returns>The response the handler produced. The caller owns it and disposes it.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="request"/> is <see langword="null"/>.</exception>
         /// <exception cref="InvalidOperationException">
-        /// No fetch handler is registered, the request cannot be expressed as a <c>Request</c>, or the handler
-        /// answered with something that is not a <c>Response</c>.
+        /// Neither a fetch handler nor a <c>fetch</c> listener is registered, no listener answered the
+        /// dispatched event with <c>respondWith()</c>, the request cannot be expressed as a <c>Request</c>, or
+        /// the handler answered with something that is not a <c>Response</c>.
         /// </exception>
         /// <exception cref="JavaScriptException">The handler threw.</exception>
         /// <exception cref="PromiseRejectedException">The handler's promise rejected.</exception>
@@ -451,16 +491,27 @@ public partial class Engine
                 Throw.ArgumentNullException(nameof(request));
             }
 
-            var handler = RequireFetchHandler();
+            var route = RequireFetchRoute();
 
             var content = request.Content;
             var body = content is null
                 ? null
                 : await content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
 
-            var result = CallHandler(handler, request, body);
+            var result = InvokeRoute(in route, request, body);
             var settled = await _engine.UnwrapResultAsync(result, cancellationToken).ConfigureAwait(false);
             return FetchHandlerHosting.CreateResponse(settled);
+        }
+
+        /// <summary>
+        /// Runs whichever of the two routes <see cref="RequireFetchRoute"/> chose, and answers with the value
+        /// the operation settles from.
+        /// </summary>
+        private JsValue InvokeRoute(in FetchRoute route, HttpRequestMessage request, byte[]? body)
+        {
+            return route.Handler is { } handler
+                ? CallHandler(handler, request, body)
+                : DispatchFetchEvent(route.Listeners!, request, body);
         }
 
         /// <summary>
@@ -478,6 +529,58 @@ public partial class Engine
         {
             var jsRequest = FetchHandlerHosting.CreateRequest(_engine, _engine._mainRealm, request, body);
             return _engine.Call(handler.Callable, handler.ThisObject, [jsRequest]);
+        }
+
+        /// <summary>
+        /// The script-facing route: build the same <c>Request</c> the handler route builds, fire a trusted
+        /// <c>fetch</c> event at the global scope, and answer with the promise a listener responded with.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The dispatch is bracketed in <see cref="Engine.ExecuteWithConstraints{T}"/> — which is literally
+        /// what <see cref="Engine.Call(JsValue, JsValue, JsValue[])"/> does for the handler route — so the
+        /// whole dispatch is <b>one</b> entry into the engine and therefore one constraint budget, however many
+        /// listeners run. Bracketing each listener instead would hand every one of them a fresh
+        /// <c>MaxStatements</c> allowance and a freshly armed timeout, which is the trap the constraints
+        /// section of the README warns hosts about.
+        /// </para>
+        /// <para>
+        /// What a throwing listener does is the <c>EventTarget</c> contract unchanged: with a
+        /// <see cref="DiagnosticsSink"/> it is reported and the dispatch carries on to the next listener, so a
+        /// later one may still answer; with no sink the <c>JavaScriptException</c> propagates out of here and
+        /// the caller turns it into the operation's failure. A constraint is neither — it is a
+        /// <c>JintException</c> that is not a <c>JavaScriptException</c>, so it erupts past the sink either
+        /// way and, again, becomes the operation's failure rather than a promise that never settles.
+        /// </para>
+        /// <para>
+        /// One consequence is worth stating on its own, because it is the one place the two configurations
+        /// disagree about a request that <i>was</i> answered: a listener that calls <c>respondWith()</c> and
+        /// <b>then</b> throws serves its response on an engine with a sink — the throw is reported and the
+        /// dispatch finishes normally, which is what a browser does — and fails the operation on an engine
+        /// without one, where the exception is the only thing that can carry the failure anywhere at all. That
+        /// follows from the sink contract rather than from anything decided here: with nowhere to report to,
+        /// preferring the response would lose the exception entirely.
+        /// </para>
+        /// </remarks>
+        private JsPromise DispatchFetchEvent(GlobalEventTarget listeners, HttpRequestMessage request, byte[]? body)
+        {
+            var realm = _engine._mainRealm;
+            var jsRequest = FetchHandlerHosting.CreateRequest(_engine, realm, request, body);
+            var fetchEvent = realm.Intrinsics.FetchEvent.CreateTrustedFetchEvent(jsRequest);
+
+            _engine.ExecuteWithConstraints(_engine.Options.Strict, () =>
+            {
+                listeners.DispatchEvent(fetchEvent);
+                return JsValue.Undefined;
+            });
+
+            if (fetchEvent.ResponsePromise is not { } response)
+            {
+                Throw.InvalidOperationException("The 'fetch' event was dispatched, but no listener called event.respondWith(...), so there is nothing to answer the request with. Call event.respondWith(new Response(...)) synchronously from the listener — an embedded engine has no network for an unanswered request to fall through to.");
+                return null!;
+            }
+
+            return response;
         }
 
         /// <summary>
@@ -499,15 +602,54 @@ public partial class Engine
             return buffer.ToArray();
         }
 
-        private FetchHandler RequireFetchHandler()
+        /// <summary>
+        /// Which of the two registration forms this invocation goes to. Exactly one of the two is set.
+        /// </summary>
+        /// <param name="Handler">The handler <see cref="SetFetchHandler"/> registered, if there is one.</param>
+        /// <param name="Listeners">
+        /// The synthetic global event target to dispatch a <c>FetchEvent</c> at, when there is no handler and
+        /// the script registered a <c>fetch</c> listener instead.
+        /// </param>
+        [StructLayout(LayoutKind.Auto)]
+        private readonly record struct FetchRoute(FetchHandler? Handler, GlobalEventTarget? Listeners);
+
+        /// <summary>
+        /// Decides where an inbound request goes, and refuses the invocation when nothing can take it.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>The registered handler is looked at first and wins outright.</b> A script that also registered a
+        /// <c>fetch</c> listener does not get to intercept requests the host had already routed somewhere:
+        /// that would let evaluated script take over the engine's request handling by adding one line, which is
+        /// not a decision a script may make for its host.
+        /// </para>
+        /// <para>
+        /// <b>An engine with neither pays two reads.</b> The feature flag is tested before the listener list is
+        /// even asked for, and the list is read through
+        /// <c>WebApiEngineState.GlobalEventTargetIfCreated</c> — a plain field — so an engine that never
+        /// enabled the feature, and one whose script never called <c>addEventListener</c>, both answer without
+        /// allocating anything. There is nothing to race here: listeners are registered by script, and script
+        /// runs on the engine's thread, which is the thread this is being called on.
+        /// </para>
+        /// </remarks>
+        private FetchRoute RequireFetchRoute()
         {
-            var handler = RequireFetchModel().FetchHandler;
-            if (handler is null)
+            var state = RequireFetchModel();
+
+            if (state.FetchHandler is { } handler)
             {
-                Throw.InvalidOperationException("No fetch handler is registered on this engine. Register one with engine.Advanced.SetFetchHandler — a function, an object with a callable 'fetch' property, or the namespace of a module whose default export is one of those.");
+                return new FetchRoute(handler, null);
             }
 
-            return handler;
+            if ((_engine._webApiFeatures & WebApiFeatures.FetchEvents) != WebApiFeatures.None
+                && state.GlobalEventTargetIfCreated is { } listeners
+                && listeners.HasListenerOfType(FetchEventNames.FetchName))
+            {
+                return new FetchRoute(null, listeners);
+            }
+
+            Throw.InvalidOperationException("No fetch handler is registered on this engine, and no script listener is registered for the 'fetch' event. Register a handler with engine.Advanced.SetFetchHandler — a function, an object with a callable 'fetch' property, or the namespace of a module whose default export is one of those — or build the engine with WebApiFeatures.FetchEvents and let the script register one with addEventListener('fetch', event => event.respondWith(...)).");
+            return default;
         }
 
         private WebApiEngineState RequireFetchModel()

--- a/Jint/Engine.WebApi.cs
+++ b/Jint/Engine.WebApi.cs
@@ -549,6 +549,14 @@ internal sealed class WebApiEngineState
         _globalEventTarget ??= new GlobalEventTarget(_engine, _engine._mainRealm);
 
     /// <summary>
+    /// The same target, or <see langword="null"/> when nothing has built one yet. What
+    /// <c>Engine.Advanced.InvokeFetchHandler</c> asks, because a host invoking a handler must not be the thing
+    /// that creates a listener list: an engine whose script never called <c>addEventListener</c> answers the
+    /// question with one field read and allocates nothing.
+    /// </summary>
+    internal GlobalEventTarget? GlobalEventTargetIfCreated => _globalEventTarget;
+
+    /// <summary>
     /// <c>reportError(e)</c>: HTML's <i>report an exception</i> —
     /// https://html.spec.whatwg.org/multipage/webappapis.html#report-an-exception. See
     /// <c>ReportErrorFunction</c>.

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -853,6 +853,41 @@ public enum WebApiFeatures
     GlobalEvents = 1 << 22,
 
     /// <summary>
+    /// The <c>FetchEvent</c> interface and the script-facing registration form the service-worker and
+    /// edge-worker world writes — <c>addEventListener('fetch', event =&gt; event.respondWith(…))</c> —
+    /// https://w3c.github.io/ServiceWorker/#fetchevent-interface. With it enabled,
+    /// <c>Engine.Advanced.InvokeFetchHandler</c> dispatches the inbound request at the global scope as a
+    /// trusted <c>fetch</c> event whenever the host registered no handler of its own, so an unmodified
+    /// Workers-shaped script runs without the host adapting it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Never part of <see cref="Default"/>, and deliberately unrelated to <see cref="Fetch"/> in both
+    /// directions:</b> naming this does not enable fetch and naming fetch does not enable this. The two are
+    /// separate grants — <see cref="Fetch"/> lets the script reach <i>out</i> to the network, while this one
+    /// routes requests the host already has <i>in</i> to the script — and coupling them would contradict the
+    /// refusal <c>Engine.Advanced.SetFetchHandler</c> already makes, which installs the object model and
+    /// pointedly not <c>fetch</c>. It is nevertheless a capability worth naming on its own: a script that can
+    /// register a <c>fetch</c> listener can take over every request the host routes into the engine, including
+    /// ones a host handler would otherwise have answered.
+    /// </para>
+    /// <para>
+    /// Implies <see cref="GlobalEvents"/> — which is where <c>addEventListener</c> and the listener list it
+    /// registers on come from, and which brings <see cref="Events"/> with it — plus <see cref="Url"/> and
+    /// <see cref="Files"/>, so that the closure is exactly the set fetch-handler hosting already requires.
+    /// Enabling it also installs <c>Headers</c>, <c>Request</c> and <c>Response</c>, for the reason
+    /// <see cref="CacheApi"/> does: a listener that cannot build a <c>Response</c> has nothing to respond
+    /// with. Unlike the <c>SetFetchHandler</c> door, that install happens while the engine is being built, so
+    /// a module may construct a <c>Response</c> at top level.
+    /// </para>
+    /// <para>
+    /// <b>A handler registered with <c>SetFetchHandler</c> always wins.</b> The listeners are the fallback for
+    /// an engine that has none, never an override of one the host chose.
+    /// </para>
+    /// </remarks>
+    FetchEvents = 1 << 23,
+
+    /// <summary>
     /// The web APIs a host normally wants: everything except outbound network access and persistent state.
     /// Today that is
     /// <see cref="Console"/>, <see cref="Timers"/>, <see cref="Encoding"/>, <see cref="Base64"/>,
@@ -860,7 +895,7 @@ public enum WebApiFeatures
     /// <see cref="Url"/>, <see cref="Files"/>, <see cref="Navigator"/>, <see cref="Streams"/>,
     /// <see cref="Scheduler"/>, <see cref="Messaging"/>, <see cref="Reporting"/>, <see cref="Compression"/>,
     /// <see cref="IdleCallback"/> and <see cref="GlobalEvents"/>; it grows as further features land, and never
-    /// comes to include fetch or <see cref="Storage"/>.
+    /// comes to include fetch, <see cref="Storage"/> or <see cref="FetchEvents"/>.
     /// </summary>
     Default = Console | Timers | Encoding | Base64 | StructuredClone | Crypto | Performance | Events | Url | Files | Navigator | Streams | Scheduler | Messaging | Reporting | Compression | IdleCallback | GlobalEvents,
 }

--- a/Jint/Runtime/Intrinsics.WebApi.cs
+++ b/Jint/Runtime/Intrinsics.WebApi.cs
@@ -9,6 +9,7 @@ using Jint.WebApi.DomException;
 using Jint.WebApi.Encoding;
 using Jint.WebApi.Events;
 using Jint.WebApi.Fetch;
+using Jint.WebApi.FetchEvents;
 using Jint.WebApi.Files;
 using Jint.WebApi.GlobalEvents;
 using Jint.WebApi.Idle;
@@ -384,6 +385,15 @@ public sealed partial class Intrinsics
     /// </summary>
     internal GlobalEventFunctions GlobalEventFunctions =>
         _globalEventFunctions ??= Jint.WebApi.GlobalEvents.GlobalEventFunctions.Create(_engine, _realm);
+
+    private FetchEventConstructor? _fetchEvent;
+
+    /// <summary>
+    /// <c>FetchEvent</c> inherits from <c>ExtendableEvent</c> in the IDL and from <c>Event</c> here, which is
+    /// the whole of the flat-shape reduction — <c>Jint.WebApi.FetchEvents.JsFetchEvent</c> argues it.
+    /// </summary>
+    internal FetchEventConstructor FetchEvent =>
+        _fetchEvent ??= new FetchEventConstructor(_engine, _realm, Event);
 
     private StorageConstructor? _storage;
     private JsStorage? _localStorage;

--- a/Jint/WebApi/FetchEvents/FetchEventConstructor.cs
+++ b/Jint/WebApi/FetchEvents/FetchEventConstructor.cs
@@ -1,0 +1,132 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.Events;
+using Jint.WebApi.Fetch;
+
+namespace Jint.WebApi.FetchEvents;
+
+/// <summary>
+/// The <c>FetchEvent</c> interface object.
+/// <para>
+/// https://w3c.github.io/ServiceWorker/#fetchevent-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// Its <c>[[Prototype]]</c> is the <c>Event</c> interface object —
+/// https://webidl.spec.whatwg.org/#interface-object — where the IDL says <c>ExtendableEvent</c>. That
+/// interface is deliberately not materialized; <see cref="JsFetchEvent"/> says why.
+/// </para>
+/// <para>
+/// <c>length</c> is 2, not 1: <c>constructor(DOMString type, FetchEventInit eventInitDict)</c> declares the
+/// dictionary <b>without</b> <c>optional</c>, because it has a <c>required</c> member. That is the same shape
+/// <c>PromiseRejectionEvent</c> has, and for the same reason.
+/// </para>
+/// </remarks>
+internal sealed class FetchEventConstructor : Constructor
+{
+    private static readonly JsString _functionName = new("FetchEvent");
+    private static readonly JsString _request = new("request");
+
+    internal FetchEventConstructor(Engine engine, Realm realm, EventConstructor eventConstructor)
+        : base(engine, realm, _functionName)
+    {
+        _prototype = eventConstructor;
+        PrototypeObject = new FetchEventPrototype(engine, realm, this, eventConstructor.PrototypeObject);
+        _length = new PropertyDescriptor(JsNumber.Create(2), PropertyFlag.Configurable);
+        _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+    }
+
+    internal FetchEventPrototype PrototypeObject { get; }
+
+    /// <summary>
+    /// The ordinary event constructor over <c>FetchEventInit</c>,
+    /// https://w3c.github.io/ServiceWorker/#dictdef-fetcheventinit.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The inherited <c>EventInit</c> members (through the empty <c>ExtendableEventInit</c>) are converted
+    /// first and this dictionary's own after them, per https://webidl.spec.whatwg.org/#es-dictionary — an
+    /// order that is observable through getters on the dictionary. Only <c>request</c> is read: the other five
+    /// members describe navigation preload and service worker clients, neither of which exists here, and a
+    /// member that is read and then ignored is worse than one that is not read at all.
+    /// </para>
+    /// <para>
+    /// <c>required Request request</c>, so an absent member — and an explicit <c>undefined</c>, which WebIDL
+    /// treats as absent — is a <c>TypeError</c>, and so is anything present that is not a <c>Request</c>: an
+    /// interface type performs no coercion (https://webidl.spec.whatwg.org/#es-interface).
+    /// </para>
+    /// <para>
+    /// A <c>FetchEvent</c> a script constructs is <b>not</b> trusted, and an untrusted one refuses both
+    /// <c>respondWith()</c> and <c>waitUntil()</c> — see <see cref="JsFetchEvent"/>. It is still worth being
+    /// constructible: it is what the interface's own IDL says, it is what makes the interface object more than
+    /// a brand, and a script can dispatch one at an <c>EventTarget</c> of its own to exercise a listener.
+    /// </para>
+    /// </remarks>
+    public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
+    {
+        var type = EventConstructor.RequireType(_realm, arguments, "FetchEvent");
+
+        if (arguments.Length < 2)
+        {
+            Throw.TypeError(_realm, "Failed to construct 'FetchEvent': 2 arguments required, but only 1 present.");
+        }
+
+        var initArgument = arguments[1];
+
+        // The inherited members first, which is also what refuses anything that is neither an object nor
+        // undefined nor null.
+        var init = EventConstructor.ReadEventInit(_realm, initArgument, "FetchEvent");
+
+        // So what is left here is undefined or null, both of which convert to a dictionary with no members at
+        // all — and a dictionary with no members is missing a required one.
+        if (initArgument is not ObjectInstance dictionary)
+        {
+            Throw.TypeError(_realm, "Failed to construct 'FetchEvent': required member request is undefined.");
+            return null!;
+        }
+
+        var requestValue = dictionary.Get(_request);
+        if (requestValue.IsUndefined())
+        {
+            Throw.TypeError(_realm, "Failed to construct 'FetchEvent': required member request is undefined.");
+        }
+
+        if (requestValue is not JsRequest request)
+        {
+            Throw.TypeError(_realm, "Failed to construct 'FetchEvent': member request is not of type 'Request'.");
+            return null!;
+        }
+
+        return OrdinaryCreateFromConstructor(
+            newTarget,
+            static intrinsics => intrinsics.FetchEvent.PrototypeObject,
+            static (Engine engine, Realm realm, (JsString Type, EventInit Init, double TimeStamp, JsRequest Request) state)
+                => new JsFetchEvent(engine, realm, state.Type, state.Init, state.TimeStamp, state.Request),
+            (Type: type, Init: init, TimeStamp: EventConstructor.TimeStampNow(_engine), Request: request));
+    }
+
+    /// <summary>
+    /// The trusted <c>fetch</c> event the engine dispatches for an inbound request, which is
+    /// https://w3c.github.io/ServiceWorker/#on-fetch-request-algorithm reduced to the three initializations
+    /// that mean anything here: the type, <c>cancelable</c> — "Initialize e's cancelable attribute to true" —
+    /// and the request.
+    /// </summary>
+    /// <remarks>
+    /// It is created by the engine rather than by a script, so <c>isTrusted</c> is true, and that is precisely
+    /// what lets <c>respondWith()</c> and <c>waitUntil()</c> work on it at all.
+    /// </remarks>
+    internal JsFetchEvent CreateTrustedFetchEvent(JsRequest request)
+    {
+        var init = new EventInit(Bubbles: false, Cancelable: true, Composed: false);
+        return new JsFetchEvent(_engine, _realm, FetchEventNames.Fetch, init, EventConstructor.TimeStampNow(_engine), request)
+        {
+            IsTrusted = true,
+            _prototype = PrototypeObject,
+        };
+    }
+}
+#endif

--- a/Jint/WebApi/FetchEvents/FetchEventPrototype.cs
+++ b/Jint/WebApi/FetchEvents/FetchEventPrototype.cs
@@ -1,0 +1,116 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.WebApi.Fetch;
+
+namespace Jint.WebApi.FetchEvents;
+
+/// <summary>
+/// <c>FetchEvent.prototype</c> — the interface prototype object.
+/// <para>
+/// https://w3c.github.io/ServiceWorker/#fetchevent-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// Its <c>[[Prototype]]</c> is <c>Event.prototype</c>, so a <c>fetch</c> event has every <c>Event</c> member
+/// and <c>event instanceof Event</c> holds inside the listener. The IDL puts <c>ExtendableEvent.prototype</c>
+/// between the two and <c>waitUntil()</c> on it; that interface is not materialized here, so
+/// <c>waitUntil</c> is a member of this object instead — see <see cref="JsFetchEvent"/>.
+/// </para>
+/// <para>
+/// The two operations are non-enumerable, where a WebIDL interface prototype object's operations are
+/// enumerable — the same documented simplification <c>Event.prototype</c> and <c>EventTarget.prototype</c>
+/// carry.
+/// </para>
+/// </remarks>
+[JsObject(UseShape = true)]
+internal sealed partial class FetchEventPrototype : Prototype
+{
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
+    private readonly FetchEventConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString FetchEventToStringTag = new("FetchEvent");
+
+    internal FetchEventPrototype(
+        Engine engine,
+        Realm realm,
+        FetchEventConstructor constructor,
+        ObjectInstance eventPrototype) : base(engine, realm)
+    {
+        _prototype = eventPrototype;
+        _constructor = constructor;
+    }
+
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/ServiceWorker/#dom-fetchevent-request
+    /// </summary>
+    [JsAccessor("request", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
+    private JsRequest RequestGet(JsValue thisObject) => Brand(thisObject).Request;
+
+    /// <summary>
+    /// https://w3c.github.io/ServiceWorker/#fetch-event-respondwith
+    /// </summary>
+    [JsFunction(Name = "respondWith", Length = 1)]
+    private JsValue RespondWith(JsValue thisObject, JsCallArguments arguments)
+    {
+        var ev = Brand(thisObject);
+        RequireArguments(arguments, 1, "respondWith");
+        ev.RespondWith(arguments.At(0));
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/ServiceWorker/#dom-extendableevent-waituntil
+    /// </summary>
+    [JsFunction(Name = "waitUntil", Length = 1)]
+    private JsValue WaitUntil(JsValue thisObject, JsCallArguments arguments)
+    {
+        var ev = Brand(thisObject);
+        RequireArguments(arguments, 1, "waitUntil");
+        ev.WaitUntil(arguments.At(0));
+        return Undefined;
+    }
+
+    /// <summary>
+    /// The WebIDL brand check every member performs: a receiver that is not a platform object implementing the
+    /// interface raises a <c>TypeError</c> — <c>FetchEvent.prototype</c> itself included, which is not one.
+    /// </summary>
+    private JsFetchEvent Brand(JsValue thisObject)
+    {
+        if (thisObject is JsFetchEvent ev)
+        {
+            return ev;
+        }
+
+        Throw.TypeError(_realm, "Illegal invocation: receiver is not a FetchEvent");
+        return null!;
+    }
+
+    /// <summary>
+    /// WebIDL's arity check, https://webidl.spec.whatwg.org/#dfn-create-operation-function: an operation whose
+    /// required arguments were not all supplied raises a <c>TypeError</c> before its arguments are converted.
+    /// It matters here rather than being pedantry — <c>Promise&lt;T&gt;</c> converts <i>anything</i>, so a bare
+    /// <c>respondWith()</c> would otherwise resolve with <c>undefined</c> and fail the request one turn later
+    /// with a message about the answer not being a <c>Response</c>.
+    /// </summary>
+    private void RequireArguments(JsCallArguments arguments, int required, string operationName)
+    {
+        if (arguments.Length < required)
+        {
+            Throw.TypeError(
+                _realm,
+                $"Failed to execute '{operationName}' on 'FetchEvent': {required} argument required, but only {arguments.Length} present.");
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/FetchEvents/JsFetchEvent.cs
+++ b/Jint/WebApi/FetchEvents/JsFetchEvent.cs
@@ -1,0 +1,251 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Promise;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Interop;
+using Jint.WebApi.DomException;
+using Jint.WebApi.Events;
+using Jint.WebApi.Fetch;
+
+namespace Jint.WebApi.FetchEvents;
+
+/// <summary>
+/// A <c>FetchEvent</c> instance: the inbound request as script sees it, plus the two operations that answer
+/// it and that keep it alive.
+/// <para>
+/// https://w3c.github.io/ServiceWorker/#fetchevent-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>It extends <c>Event</c> directly.</b> The Service Workers Standard interposes <c>ExtendableEvent</c>
+/// (https://w3c.github.io/ServiceWorker/#extendableevent-interface), whose sole member is
+/// <c>waitUntil()</c>, and puts the lifetime machinery there so that <c>install</c> and <c>activate</c> can
+/// share it. Jint has neither of those events and no service worker lifecycle for them to extend, so an
+/// interface object whose only instances would be <c>FetchEvent</c>s would be a name with nothing behind it:
+/// <c>waitUntil</c> lives on <c>FetchEvent.prototype</c> instead and there is no <c>ExtendableEvent</c>
+/// global. This is the flat shape Cloudflare Workers exposes, and the one consequence a script can observe is
+/// that <c>event instanceof ExtendableEvent</c> cannot be written — <c>instanceof FetchEvent</c> and
+/// <c>instanceof Event</c> both hold.
+/// </para>
+/// <para>
+/// <b>Five attributes are absent rather than faked</b>: <c>preloadResponse</c> (navigation preload is a
+/// registration feature), <c>clientId</c>, <c>resultingClientId</c> and <c>replacesClientId</c> (there are no
+/// service worker clients here, and answering <c>""</c> would let a script believe it had asked), and
+/// <c>handled</c> (a promise about a fetch this engine does not perform). The <b>timed out flag</b> is absent
+/// too: it is set "after an optional user agent imposed delay", and the delay exists to stop a service worker
+/// being kept alive forever — here the host owns the engine's lifetime and pumps it, so there is nothing for
+/// the engine to impose a deadline on. <see cref="IsActive"/> is therefore the specification's definition with
+/// that flag read as permanently unset.
+/// </para>
+/// </remarks>
+internal sealed class JsFetchEvent : JsEvent
+{
+    private readonly Realm _realm;
+
+    /// <summary>
+    /// https://w3c.github.io/ServiceWorker/#extendableevent-pending-promises-count — "the number of pending
+    /// promises in the extend lifetime promises". The promises themselves are not kept: nothing here ever
+    /// enumerates them, so counting them is the whole of what the list is for.
+    /// </summary>
+    private int _pendingPromises;
+
+    internal JsFetchEvent(Engine engine, Realm realm, JsString type, EventInit init, double timeStamp, JsRequest request)
+        : base(engine, type, init, timeStamp)
+    {
+        _realm = realm;
+        Request = request;
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/ServiceWorker/#dom-fetchevent-request. <c>[SameObject]</c> in the IDL, which is
+    /// what holding it in a field rather than rebuilding it per read gives for free.
+    /// </summary>
+    internal JsRequest Request { get; }
+
+    /// <summary>
+    /// https://w3c.github.io/ServiceWorker/#fetch-event-respond-with-entered-flag — set by the first
+    /// <c>respondWith()</c>, which is what makes a second one an <c>InvalidStateError</c>, and what the host
+    /// reads to tell "a listener answered" from "nobody did".
+    /// </summary>
+    internal bool RespondWithEntered { get; private set; }
+
+    /// <summary>
+    /// What <c>respondWith()</c> was given, after the <c>Promise&lt;Response&gt;</c> conversion. This is Jint's
+    /// stand-in for the specification's <i>wait to respond flag</i> plus the reaction it installs on <c>r</c>:
+    /// there the flag gates the Handle Fetch algorithm, here the host's
+    /// <c>FetchHandlerOperation</c> is what settles from this promise, and both amount to "the response is
+    /// whatever this settles to".
+    /// </summary>
+    internal JsPromise? ResponsePromise { get; private set; }
+
+    /// <summary>
+    /// https://w3c.github.io/ServiceWorker/#extendableevent-active: "active when its timed out flag is unset
+    /// and either its pending promises count is greater than zero or its dispatch flag is set". The timed out
+    /// flag does not exist here (see the class remarks), so this is the other two terms.
+    /// </summary>
+    internal bool IsActive => _pendingPromises > 0 || DispatchFlag;
+
+    /// <summary>
+    /// https://w3c.github.io/ServiceWorker/#fetch-event-respondwith — <c>respondWith(r)</c>, whose steps are
+    /// followed here in the order they are written, because the order is observable: a second call on an event
+    /// that is no longer being dispatched reports the dispatch flag rather than the entered flag.
+    /// </summary>
+    internal void RespondWith(JsValue r)
+    {
+        // Step 2.
+        if (!DispatchFlag)
+        {
+            ThrowInvalidState("respondWith", "the event is not being dispatched. respondWith() must be called synchronously from a 'fetch' listener.");
+        }
+
+        // Step 3.
+        if (RespondWithEntered)
+        {
+            ThrowInvalidState("respondWith", "respondWith() has already been called on this event.");
+        }
+
+        // Step 4: "Add lifetime promise r to event." The note says it plainly — respondWith() extends the
+        // lifetime of the event by default as if waitUntil(r) had been called — so the response promise is a
+        // lifetime promise like any other, which is what keeps the event active while it is outstanding and
+        // therefore what lets a listener call waitUntil() from inside its own .then().
+        //
+        // Its rejection is deliberately not reported: it is the one lifetime promise whose failure the host
+        // already learns about, as the operation's PromiseRejectedException.
+        var promise = AddLifetimePromise(r, reportRejection: false, "respondWith");
+
+        // Step 5. This is why a second listener does not run after the first has answered, and why the
+        // bubbling pass is skipped: the first responder wins, and the rest of the dispatch is pointless.
+        StopPropagationFlag = true;
+        StopImmediatePropagationFlag = true;
+
+        // Steps 6 and 7.
+        RespondWithEntered = true;
+        ResponsePromise = promise;
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/ServiceWorker/#dom-extendableevent-waituntil — "the waitUntil(f) method steps are
+    /// to add lifetime promise f to this", and nothing else.
+    /// </summary>
+    internal void WaitUntil(JsValue f) => AddLifetimePromise(f, reportRejection: true, "waitUntil");
+
+    /// <summary>
+    /// https://w3c.github.io/ServiceWorker/#extendableevent-add-lifetime-promise.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Step 1 — <b>an untrusted event cannot be extended</b> — is implemented rather than dropped, and it is
+    /// what a script constructing its own <c>FetchEvent</c> and dispatching it runs into: only the event the
+    /// engine created for an inbound request can be responded to. That is the same conclusion a browser
+    /// reaches, and here it is also the property that keeps the host's operation honest, since the operation
+    /// settles from an event nothing else could have produced.
+    /// </para>
+    /// <para>
+    /// Step 5's decrement runs in "a microtask queued by the reaction to the promise", which is exactly what a
+    /// promise reaction job is. What Jint does <b>not</b> inherit is what the specification does when the count
+    /// reaches zero: that ends a service worker's extended lifetime, and here there is no worker to end — the
+    /// host owns the engine and stops pumping it when it likes.
+    /// </para>
+    /// </remarks>
+    /// <param name="value">The value to extend the lifetime with, before the <c>Promise</c> conversion.</param>
+    /// <param name="reportRejection">
+    /// Whether a rejection of this promise may be reported. True for <c>waitUntil()</c>, whose work nobody is
+    /// awaiting: the reaction installed here <i>handles</i> the rejection, so without this the failure would
+    /// vanish instead of reaching <c>unhandledrejection</c> and the host's <see cref="DiagnosticsSink"/> — the
+    /// promise would simply never have looked unhandled to the rejection tracker. False for
+    /// <c>respondWith()</c>, whose rejection is the operation's to report and would be noise a second time.
+    /// <para>
+    /// Even when true it is reported only for a promise this reaction is the <b>first</b> handler of and which
+    /// is still <b>pending</b>, because those are exactly the promises the tracker will now never see: one that
+    /// has already rejected has been through the tracker as this very statement ran
+    /// (<c>waitUntil(Promise.reject(e))</c>), and one that already has a handler belongs to whoever attached
+    /// it. Announcing either again would double-report a failure rather than rescue a lost one.
+    /// </para>
+    /// </param>
+    /// <param name="operationName">
+    /// Which member is asking, so that the two <c>InvalidStateError</c>s name the call the script actually
+    /// made rather than the internal algorithm both of them run.
+    /// </param>
+    private JsPromise AddLifetimePromise(JsValue value, bool reportRejection, string operationName)
+    {
+        // Step 1.
+        if (!IsTrusted)
+        {
+            ThrowInvalidState(operationName, "the event was not created by the engine. Only the 'fetch' event dispatched for an inbound request can be responded to or extended.");
+        }
+
+        // Step 2. The note is the behaviour worth knowing: once nothing is outstanding and the dispatch is
+        // over, a later call throws rather than silently extending an event nobody is waiting for.
+        if (!IsActive)
+        {
+            ThrowInvalidState(operationName, "the event is no longer active: its dispatch is over and none of its lifetime promises is still pending.");
+        }
+
+        // The `Promise<T>` conversion, https://webidl.spec.whatwg.org/#es-promise: any value becomes a
+        // promise, so a listener may hand over a Response directly. PromiseResolve answers with the argument
+        // itself only when it is already a promise whose constructor is %Promise%, and otherwise with a fresh
+        // one — either way a JsPromise, which is what the reaction below needs.
+        var promise = (JsPromise) _realm.Intrinsics.Promise.PromiseResolve(value);
+
+        // Decided before PerformPromiseThen, which is what changes both of these facts. See the parameter's
+        // own documentation for why each term is there.
+        var announce = reportRejection && !promise.PromiseIsHandled && promise.State == PromiseState.Pending;
+
+        // Step 4, before the reaction is installed: "The pending promises count is incremented even if the
+        // given promise has already been settled."
+        _pendingPromises++;
+
+        var onFulfilled = new ClrFunction(_engine, "", (_, _) =>
+        {
+            _pendingPromises--;
+            return Undefined;
+        }, 1, PropertyFlag.Configurable);
+
+        var onRejected = new ClrFunction(_engine, "", (_, _) =>
+        {
+            _pendingPromises--;
+
+            if (announce)
+            {
+                _engine._webApi?.ReportPromiseRejection(promise, PromiseRejectionOperation.Reject);
+            }
+
+            return Undefined;
+        }, 1, PropertyFlag.Configurable);
+
+        // Step 5. Reactions rather than polling, for the reason FetchHandlerOperation gives: attaching them is
+        // also what marks the promise handled, so a lifetime promise cannot be counted twice — once by the
+        // rejection tracker and once here.
+        PromiseOperations.PerformPromiseThen(_engine, promise, onFulfilled, onRejected, resultCapability: null);
+
+        return promise;
+    }
+
+    /// <summary>
+    /// The <c>InvalidStateError</c> both operations raise, as a JavaScript exception the listener can catch —
+    /// the same shape <c>AbortSignal</c> and <c>dispatchEvent</c> raise theirs in.
+    /// </summary>
+    private void ThrowInvalidState(string operationName, string detail)
+    {
+        var exception = _realm.Intrinsics.DomException.CreateException(
+            DomExceptionNames.InvalidState,
+            $"Failed to execute '{operationName}' on 'FetchEvent': {detail}");
+
+        var location = _engine._lastSyntaxElement?.Location ?? default;
+        Throw.JavaScriptException(_engine, exception, in location);
+    }
+}
+
+/// <summary>
+/// The one event type this feature fires, interned once — the sibling of
+/// <c>Jint.WebApi.GlobalEvents.GlobalEventNames</c>.
+/// </summary>
+internal static class FetchEventNames
+{
+    internal const string FetchName = "fetch";
+
+    internal static readonly JsString Fetch = new(FetchName);
+}
+#endif

--- a/Jint/WebApi/WebApiRegistration.cs
+++ b/Jint/WebApi/WebApiRegistration.cs
@@ -215,6 +215,17 @@ internal static class WebApiRegistration
             Install(global, engine, "PromiseRejectionEvent", static e => e.Realm.Intrinsics.PromiseRejectionEvent, PropertyFlag.NonEnumerable);
         }
 
+        if ((features & WebApiFeatures.FetchEvents) != WebApiFeatures.None)
+        {
+            // A listener that cannot build a Response has nothing to respond with, so this feature installs
+            // the object model exactly as SetFetchHandler does — and, like it, pointedly not `fetch`. Unlike
+            // it, the install happens while the engine is being built, so a module that constructs a Response
+            // at top level works without the host having had to register anything first.
+            InstallFetchModel(engine);
+
+            Install(global, engine, "FetchEvent", static e => e.Realm.Intrinsics.FetchEvent, PropertyFlag.NonEnumerable);
+        }
+
         if ((features & WebApiFeatures.Crypto) != WebApiFeatures.None)
         {
             // WebIDL exposes crypto through a [Replaceable] accessor pair; an ordinary enumerable data
@@ -430,6 +441,18 @@ internal static class WebApiRegistration
             features |= WebApiFeatures.Events | WebApiFeatures.Url | WebApiFeatures.Files | WebApiFeatures.Streams;
         }
 
+        // Deliberately BEFORE the GlobalEvents rule below, which is what turns the flag added here into
+        // WebApiFeatures.Events as well. What a fetch listener is registered with is the global
+        // addEventListener, and what it answers with is a Response — so the closure is exactly the set
+        // fetch-handler hosting already demands (Events | Url | Files), reached through the feature that owns
+        // the listener list. Pointedly not WebApiFeatures.Fetch: dispatching an inbound request into script is
+        // a different grant from letting the script reach out to the network, the same split
+        // Engine.Advanced.SetFetchHandler makes when it installs the object model and not `fetch`.
+        if ((features & WebApiFeatures.FetchEvents) != WebApiFeatures.None)
+        {
+            features |= WebApiFeatures.GlobalEvents | WebApiFeatures.Url | WebApiFeatures.Files;
+        }
+
         // The three global operations register listeners on an EventTarget and dispatch an Event, and the two
         // interface objects the feature adds are Event subclasses — so without the events feature it would
         // install operations with nothing to use them on.
@@ -470,10 +493,13 @@ internal static class WebApiRegistration
     /// keeps its providers here, which is why each of them wants the state even without the timers flag.
     /// The global events keep their synthetic listener target here. That flag is named explicitly rather than
     /// left to the closure that already brings <see cref="WebApiFeatures.Events"/> with it, because the reason
-    /// it needs the state is its own — a target to fire at, not the time origin the events feature wants.
+    /// it needs the state is its own — a target to fire at, not the time origin the events feature wants. The
+    /// fetch events are named for the same reason once more removed: what
+    /// <c>Engine.Advanced.InvokeFetchHandler</c> reads is that very target plus the registered handler slot,
+    /// both of which live here, and a closure is not a reason to depend on one.
     /// </summary>
     private const WebApiFeatures NeedsEngineState =
-        WebApiFeatures.Timers | WebApiFeatures.Events | WebApiFeatures.Performance | WebApiFeatures.Fetch | WebApiFeatures.Scheduler | WebApiFeatures.Messaging | WebApiFeatures.Storage | WebApiFeatures.WebSocket | WebApiFeatures.CacheApi | WebApiFeatures.IdleCallback | WebApiFeatures.GlobalEvents;
+        WebApiFeatures.Timers | WebApiFeatures.Events | WebApiFeatures.Performance | WebApiFeatures.Fetch | WebApiFeatures.Scheduler | WebApiFeatures.Messaging | WebApiFeatures.Storage | WebApiFeatures.WebSocket | WebApiFeatures.CacheApi | WebApiFeatures.IdleCallback | WebApiFeatures.GlobalEvents | WebApiFeatures.FetchEvents;
 
     /// <summary>
     /// The queue exists for the timer globals, for AbortSignal.timeout() and for a delayed

--- a/README.md
+++ b/README.md
@@ -239,12 +239,14 @@ its own `console` (or any other name in the table below), enabling the feature l
 | `EventSource` / `MessageEvent` (server-sent events) | `EventSource` — **opt-in on its own, see below** | ✔ shipped |
 | `WebSocket` / `CloseEvent` (and the `MessageEvent` its messages arrive as) | `WebSocket` — **opt-in on its own, see below** | ✔ shipped |
 | `caches` / `Cache` / `CacheStorage` | `CacheApi` — **opt-in on its own, see below** | ✔ shipped |
+| `FetchEvent` and `addEventListener('fetch', e => e.respondWith(…))` — script-facing request handling | `FetchEvents` — **opt-in on its own, see below** | ✔ shipped |
 
 `WebApiFeatures.Default` — what `UseWebApis()` enables — is every non-network feature that has landed. It
 grows as the table fills in, and it will never include `fetch`: network egress is always an explicit choice.
-`Storage` is one standing exception, for the reason in its own section below, and `CacheApi` is the
-other, for the neighbouring one — a cache outlives the evaluation that filled it, so where its data goes,
-and what bounds it, is a decision you make rather than inherit.
+`Storage` is one standing exception, for the reason in its own section below; `CacheApi` is another, for the
+neighbouring one — a cache outlives the evaluation that filled it, so where its data goes, and what bounds it,
+is a decision you make rather than inherit; and `FetchEvents` is the third, because a script that can register
+a `fetch` listener can take over every request you route into the engine.
 
 `crypto.subtle` carries **`digest`, `sign`, `verify`, `encrypt`, `decrypt`, `generateKey`, `importKey` and
 `exportKey`**, over SHA-1/256/384/512 (for `digest` and as every keyed algorithm's inner hash), **HMAC**,
@@ -1002,8 +1004,9 @@ engine.Execute("function handle(request) { return new Response('hi'); }");
 engine.Advanced.SetFetchHandler(engine.GetValue("handle"));
 ```
 
-**There is no feature flag for this, and registering a handler never grants network access.** What the object
-model needs is the three features its own interfaces are built out of — a `Request` has an `AbortSignal`, its
+**There is no feature flag for registering a handler this way, and doing so never grants network access.**
+(The script-facing form below does have one, because letting a script claim the route is a different
+decision.) What the object model needs is the three features its own interfaces are built out of — a `Request` has an `AbortSignal`, its
 URL is a WHATWG URL, `response.blob()` answers with a `Blob` — so an engine built without `Events | Url |
 Files` refuses the registration with a message naming them. Registering the handler is itself what installs
 the `Headers`, `Request` and `Response` globals, lazily and without replacing anything already under those
@@ -1016,6 +1019,70 @@ response when it runs, does not care.
 Only the request is passed. A Workers handler takes `(request, env, ctx)`; per-request host state reaches this
 one the way it always has, through `engine.Advanced.AddLazyGlobal(...)` or a host function reading
 `engine.Advanced.HostDefined`.
+
+#### The script-facing form: `addEventListener('fetch', …)`
+
+Enable `WebApiFeatures.FetchEvents` and the script registers the handler itself, with no host call at all —
+which is what a service worker and a Cloudflare Workers script written in the older, non-module style look
+like. The host keeps calling exactly the same `InvokeFetchHandler` / `InvokeFetchHandlerAsync` it already
+does:
+
+```js
+// worker.js
+addEventListener('fetch', event => {
+    event.respondWith(handle(event.request));
+
+    // Fire-and-forget work: it keeps the event alive, and it is just jobs you pump.
+    event.waitUntil(recordHit(event.request.url));
+});
+
+async function handle(request) {
+    const body = await request.json();
+    return Response.json({ echoed: body, path: new URL(request.url).pathname });
+}
+```
+
+```csharp
+var engine = new Engine(options => options.UseWebApis(WebApiFeatures.FetchEvents));
+engine.Execute(File.ReadAllText("worker.js"));
+
+using var response = await engine.Advanced.InvokeFetchHandlerAsync(request);
+```
+
+**The flag is its own grant, and is not `Fetch`.** Naming it does not enable `fetch` and enabling `fetch` does
+not name it: one lets the script reach *out* to the network, the other routes requests you already have *in*
+to the script, and coupling them would contradict the refusal `SetFetchHandler` already makes. What it does
+imply is `GlobalEvents` (where `addEventListener` comes from, which brings `Events`), `Url` and `Files` — the
+same closure the object model needs — and it installs `Headers`, `Request` and `Response` while the engine is
+being built, so unlike the `SetFetchHandler` door a module may construct a `Response` at top level.
+
+**A handler registered with `SetFetchHandler` always wins.** The listeners are the fallback for an engine that
+has none, never an override of the one you chose; clearing the handler with `null` is how you hand the route
+over deliberately. `HasFetchHandler` stays strictly about `SetFetchHandler` for the same reason — it is your
+record of what *you* did, and a script must not be able to change the answer. To ask whether a request can be
+served, invoke and let it fail.
+
+**Not responding is a failure, like every other.** A dispatch that reaches no `event.respondWith(...)` — no
+listener called it, or the ones that ran threw — fails the operation with an `InvalidOperationException`,
+because an embedded engine has no network for an unanswered request to fall through to. A listener that throws
+behaves as it does anywhere else on an `EventTarget`: with a `DiagnosticsSink` it is reported and the dispatch
+carries on, so a later listener may still answer; with no sink it propagates, and the invoke turns it into the
+operation's failure. (A listener that answers and *then* throws therefore serves its response on an engine
+with a sink and fails on one without — with nowhere to report to, preferring the response would lose the
+exception entirely.) A constraint firing is neither, and erupts past both.
+
+`FetchEvent` carries `request`, `respondWith(r)` and `waitUntil(f)`, and two reductions from the Service
+Workers Standard are deliberate. There is **no `ExtendableEvent` interface object** — `waitUntil` is a member
+of `FetchEvent.prototype`, the flat shape Workers exposes — and there is **no timed-out flag**, so the event
+stays extendable exactly as long as its own promises are pending and no longer; `respondWith` after the
+dispatch, or `waitUntil` once nothing is outstanding, is an `InvalidStateError`. `respondWith` may be called
+once, stops the dispatch for every later listener, and takes a `Response` or a promise of one. A `waitUntil`
+promise that rejects is reported once, through `unhandledrejection` and the sink, rather than vanishing —
+attaching the lifetime reaction is what would otherwise have made it look handled. `preloadResponse`,
+`clientId`, `resultingClientId`, `replacesClientId` and `handled` are absent rather than faked, since every one
+of them describes a service worker registration that does not exist here. One timing difference from the
+handler form: `respondWith` puts its argument through `PromiseResolve`, so even the most synchronous listener
+needs one turn of the pump.
 
 **Two invoke shapes**, and the difference is who owns the thread. `InvokeFetchHandlerAsync` is the one an
 ASP.NET Core host wants — `await` it and the continuations run wherever the await resumes.


### PR DESCRIPTION
Adds `WebApiFeatures.FetchEvents` (`1 << 23`, not in `Default`): the script-facing registration form for fetch-handler hosting, so an unmodified Workers-shaped script runs on Jint —

```js
addEventListener('fetch', event => {
  event.respondWith(new Response('hello'));
});
```

— while the host keeps calling the same `Engine.Advanced.InvokeFetchHandler` / `InvokeFetchHandlerAsync` it already does.

Closes #3164.

**The flag is its own grant in both directions.** It neither implies nor is implied by `Fetch`: outbound network and routing inbound requests into script are different capabilities, the same split `SetFetchHandler` makes when it installs the object model and pointedly not `fetch`. Its closure is `GlobalEvents | Url | Files` — exactly the set fetch-handler hosting already demands — and it installs `Headers`/`Request`/`Response` at construction, so a module can build a `Response` at top level without the host registering anything first.

**A handler the host registered always wins.** `InvokeFetchHandler` consults listeners only when `SetFetchHandler` registered nothing — a script must not be able to take over request handling by adding one line; the host hands the route over deliberately by clearing the handler. A dispatch that reaches no `respondWith()` fails the operation: an embedded engine has no network for an unanswered request to fall through to. `HasFetchHandler` stays strictly the host's record of what the host did, documented accordingly.

**`FetchEvent` extends `Event` directly** — no `ExtendableEvent` interface object (Jint has no `install`/`activate` and no service-worker lifecycle; the flat Cloudflare Workers shape, documented). `request`, `respondWith(r)` and `waitUntil(f)` follow the Service Workers Standard's current algorithms read verbatim, which produced one correction to the plan: **`respondWith` does not call `preventDefault()`** — the current spec sets the stop-propagation and stop-immediate-propagation flags and never the canceled flag, so `defaultPrevented` stays `false` (pinned) while the first responder still ends the dispatch for every later listener (pinned separately). Five attributes are absent rather than faked (`clientId` and friends, `preloadResponse`, `handled`), and the *timed out* flag doesn't exist because the host owns the engine's lifetime.

Semantics worth knowing, each pinned:

- The whole dispatch is **one entry into the engine** (`ExecuteWithConstraints`), so one constraint budget however many listeners run — per-listener bracketing would hand each a fresh timeout, the exact trap the README's constraints section warns about. The mutation pin for this needed real care: two plausible tests survived the mutation before one was found that kills it.
- An untrusted (script-constructed) `FetchEvent` refuses both `respondWith` and `waitUntil`, which also keeps the host's operation structurally honest — it settles only from an event the engine created.
- The event stays *active* while lifetime promises are pending, so `waitUntil` from inside a `.then()` works and a call after everything settled is `InvalidStateError`.
- A rejected `waitUntil` promise is announced exactly once through `unhandledrejection` + the `DiagnosticsSink` — but only when the lifetime reaction was its first handler and it was still pending, because attaching the reaction is what would otherwise hide the failure from the rejection tracker entirely; an already-rejected or already-handled promise is somebody else's report. `respondWith`'s promise is exempt: its rejection reaches the host as the operation's failure. Three tests pin the three directions.
- A listener that throws follows the sink contract unchanged; the one case the two configurations answer differently (responded, *then* threw: serve the response with a sink, fail the operation without one) is documented and pinned from both sides.
- Constraint failures still erupt as the operation's failure — never a promise that never settles — and a `RestoreGlobalSnapshot` mid-flight abandons the operation through its existing generation fence.

41 new tests (22 script-facing, 19 host-facing in `Jint.Tests.PublicInterface`), 13 mutation-verified pins. Full matrix green: solution build all TFMs, both test projects on net10.0 + net472, host-contract-verification legs; re-verified after rebasing onto current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014n5uCpi2vvHWBSiewUwBiY
