### PR TITLE
Web API: ECDSA and ECDH over P-256, P-384 and P-521 for crypto.subtle

### DIFF
--- a/Jint.Tests/Runtime/WebApi/SubtleCryptoEcTests.cs
+++ b/Jint.Tests/Runtime/WebApi/SubtleCryptoEcTests.cs
@@ -1,0 +1,1349 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Native;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// The elliptic-curve half of <c>crypto.subtle</c> — ECDSA (https://w3c.github.io/webcrypto/#ecdsa) and
+/// ECDH (https://w3c.github.io/webcrypto/#ecdh) over P-256, P-384 and P-521, together with the <c>raw</c>
+/// point format and the <c>kty: "EC"</c> JSON Web Key that arrived with them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The cryptography is checked against published vectors, which is the only way to check it. All three come
+/// from documents whose examples were produced by implementations that are not this one: RFC 7515 Appendix
+/// A.3 for ECDSA P-256 with SHA-256 (key, signing input and signature), RFC 7515 Appendix A.4 for P-521 with
+/// SHA-512, and RFC 6979 Appendix A.2.6 for P-384 with SHA-384 over the message "sample". ECDSA draws a
+/// fresh nonce for every signature, so only the <i>verify</i> direction can be a known answer; the signing
+/// direction is checked by round trip against the same key, together with an assertion that two signatures
+/// of one message differ, which is what makes the round trip evidence of anything.
+/// </para>
+/// <para>
+/// The <c>spki</c>, <c>pkcs8</c> and <c>raw</c> bytes were DER-encoded from each RFC's own coordinates, by
+/// hand, outside this engine — so a test that imports them and re-exports them byte for byte is checking
+/// this engine's parsing and re-encoding against an encoding it did not produce.
+/// </para>
+/// <para>
+/// ECDH appears throughout for its keys and nowhere for an operation, because it has none here yet:
+/// <c>deriveKey</c> and <c>deriveBits</c> are absent from <c>crypto.subtle</c>, which
+/// <see cref="SubtleCryptoTests"/> pins, so an ECDH key carrying those usages is a key nothing consumes.
+/// </para>
+/// </remarks>
+public class SubtleCryptoEcTests
+{
+    /// <summary>
+    /// The same helpers <see cref="SubtleCryptoRsaTests"/> uses, for the same reason: bytes are built from
+    /// hex or from character codes rather than through <c>TextEncoder</c> or <c>atob</c>, so that crypto is
+    /// the only feature the engine carries and nothing can be passing because of a neighbour.
+    /// </summary>
+    private const string Prelude = """
+        const hex = b => Array.from(new Uint8Array(b)).map(x => x.toString(16).padStart(2, '0')).join('');
+        const bytes = h => Uint8Array.from(h.match(/../g) || [], x => parseInt(x, 16));
+        const ascii = s => Uint8Array.from(s, c => c.charCodeAt(0));
+        """;
+
+    private static Engine WebEngine()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Crypto));
+        engine.Evaluate(Prelude);
+        return engine;
+    }
+
+    /// <summary>Runs an async body to completion and answers what it returned.</summary>
+    private static JsValue Run(string body, Engine? engine = null)
+    {
+        engine ??= WebEngine();
+        return engine.Evaluate("(async () => {\n" + body + "\n})()").UnwrapIfPromise();
+    }
+
+    /// <summary>Settles one expression's promise and answers whatever it resolved or rejected to.</summary>
+    private static JsValue Settle(Engine engine, string source) => engine.Evaluate(source).UnwrapIfPromise();
+
+    // ---------------------------------------------------------------------------------------------------
+    // The published vectors
+    // ---------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void VerifiesTheRfc7515Es256VectorFromEveryPublicFormat()
+    {
+        // https://www.rfc-editor.org/rfc/rfc7515#appendix-A.3 — the ECDSA P-256 SHA-256 signature over that
+        // appendix's JWS Signing Input. The same public key described three ways must reach the same answer,
+        // and a message one character different must not.
+        Run($$"""
+            const params = { name: 'ECDSA', namedCurve: 'P-256' };
+
+            const spki = await crypto.subtle.importKey('spki', bytes('{{Es256SpkiHex}}'), params, false, ['verify']);
+            const jwk = await crypto.subtle.importKey('jwk', { {{Es256PublicJwk}} }, params, false, ['verify']);
+            const raw = await crypto.subtle.importKey('raw', bytes('{{Es256RawHex}}'), params, false, ['verify']);
+
+            const signature = bytes('{{Es256SignatureHex}}');
+            const message = ascii('{{Es256SigningInput}}');
+            const verify = { name: 'ECDSA', hash: 'SHA-256' };
+
+            return [
+                await crypto.subtle.verify(verify, spki, signature, message),
+                await crypto.subtle.verify(verify, jwk, signature, message),
+                await crypto.subtle.verify(verify, raw, signature, message),
+                await crypto.subtle.verify(verify, spki, signature, ascii('{{Es256SigningInput}}x')),
+                // "If signature does not have a length of n * 2 bytes, then return false" — a step of its own.
+                await crypto.subtle.verify(verify, spki, new Uint8Array(64), message),
+                await crypto.subtle.verify(verify, spki, new Uint8Array(0), message),
+                await crypto.subtle.verify(verify, spki, new Uint8Array(63), message),
+            ].join(',');
+            """).AsString().Should().Be("true,true,true,false,false,false,false");
+    }
+
+    [Fact]
+    public void VerifiesTheRfc7515Es512VectorOnP521()
+    {
+        // https://www.rfc-editor.org/rfc/rfc7515#appendix-A.4 — ES512, which is ECDSA over **P-521** with
+        // SHA-512: the number in a JOSE alg is the hash's output length, not the curve's field size.
+        Run($$"""
+            const key = await crypto.subtle.importKey(
+                'jwk', { {{Es512PublicJwk}} }, { name: 'ECDSA', namedCurve: 'P-521' }, false, ['verify']);
+
+            const verify = { name: 'ECDSA', hash: 'SHA-512' };
+            const signature = bytes('{{Es512SignatureHex}}');
+
+            return [
+                signature.length,
+                await crypto.subtle.verify(verify, key, signature, ascii('{{Es512SigningInput}}')),
+                await crypto.subtle.verify(verify, key, signature, ascii('{{Es512SigningInput}}x')),
+                key.algorithm.namedCurve,
+            ].join('|');
+            """).AsString().Should().Be("132|true|false|P-521");
+    }
+
+    [Fact]
+    public void VerifiesTheRfc6979P384Vector()
+    {
+        // https://www.rfc-editor.org/rfc/rfc6979#appendix-A.2.6 — the (r, s) pair that document's own
+        // implementation produced for the message "sample" under P-384 with SHA-384. Deterministic ECDSA
+        // reaches a different signature from this engine's randomized one, but the *verification* of it is
+        // the same question either way.
+        Run($$"""
+            const key = await crypto.subtle.importKey(
+                'spki', bytes('{{P384SpkiHex}}'), { name: 'ECDSA', namedCurve: 'P-384' }, false, ['verify']);
+
+            const signature = bytes('{{P384SignatureHex}}');
+
+            return [
+                signature.length,
+                await crypto.subtle.verify({ name: 'ECDSA', hash: 'SHA-384' }, key, signature, ascii('sample')),
+                await crypto.subtle.verify({ name: 'ECDSA', hash: 'SHA-384' }, key, signature, ascii('samplf')),
+                // The vector is a SHA-384 one; the same bytes under another hash are simply not it.
+                await crypto.subtle.verify({ name: 'ECDSA', hash: 'SHA-256' }, key, signature, ascii('sample')),
+            ].join('|');
+            """).AsString().Should().Be("96|true|false|false");
+    }
+
+    [Theory]
+    [InlineData("P-256", 64)]
+    [InlineData("P-384", 96)]
+    [InlineData("P-521", 132)]
+    public void RoundTripsASignatureAtTheCurvesOwnFixedWidth(string namedCurve, int signatureLength)
+    {
+        // The signature is r || s at the field width — 32, 48 and 66 bytes per integer — which is
+        // IeeeP1363FixedFieldConcatenation and not the DER SEQUENCE .NET can also produce.
+        Run($$"""
+            const params = { name: 'ECDSA', namedCurve: '{{namedCurve}}' };
+            const priv = await crypto.subtle.importKey('pkcs8', bytes('{{Pkcs8For(namedCurve)}}'), params, false, ['sign']);
+            const pub = await crypto.subtle.importKey('spki', bytes('{{SpkiFor(namedCurve)}}'), params, false, ['verify']);
+
+            const sign = { name: 'ECDSA', hash: 'SHA-256' };
+            const message = ascii('the message');
+
+            const first = await crypto.subtle.sign(sign, priv, message);
+            const second = await crypto.subtle.sign(sign, priv, message);
+
+            return [
+                first.byteLength,
+                await crypto.subtle.verify(sign, pub, first, message),
+                await crypto.subtle.verify(sign, pub, second, message),
+                // ECDSA draws a fresh nonce each time, so two signatures over one message differ. Without
+                // this the round trip above would pass for an implementation that signed nothing at all.
+                hex(first) === hex(second),
+            ].join('|');
+            """).AsString().Should().Be(signatureLength + "|true|true|false");
+    }
+
+    [Theory]
+    [InlineData("P-256", "SHA-1", 64)]
+    [InlineData("P-256", "SHA-256", 64)]
+    [InlineData("P-256", "SHA-384", 64)]
+    [InlineData("P-256", "SHA-512", 64)]
+    [InlineData("P-521", "SHA-1", 132)]
+    [InlineData("P-521", "SHA-256", 132)]
+    public void EveryHashIsLegalOnEveryCurveAndTheKeyRemembersNeither(string namedCurve, string hash, int signatureLength)
+    {
+        // The hash belongs to the EcdsaParams of each call and the curve to the key, so P-256 with SHA-512
+        // is an ordinary thing to ask for and the signature's length is decided by the curve alone. The key's
+        // own algorithm dictionary is an EcKeyAlgorithm, which has no `hash` member at all.
+        Run($$"""
+            const params = { name: 'ECDSA', namedCurve: '{{namedCurve}}' };
+            const priv = await crypto.subtle.importKey('pkcs8', bytes('{{Pkcs8For(namedCurve)}}'), params, false, ['sign']);
+            const pub = await crypto.subtle.importKey('spki', bytes('{{SpkiFor(namedCurve)}}'), params, false, ['verify']);
+
+            const message = ascii('m');
+            const signature = await crypto.subtle.sign({ name: 'ECDSA', hash: '{{hash}}' }, priv, message);
+
+            return [
+                signature.byteLength,
+                await crypto.subtle.verify({ name: 'ECDSA', hash: '{{hash}}' }, pub, signature, message),
+                Object.keys(priv.algorithm).join(','),
+                priv.algorithm.hash === undefined,
+            ].join('|');
+            """).AsString().Should().Be(signatureLength + "|true|name,namedCurve|true");
+    }
+
+    [Fact]
+    public void ASignatureMadeUnderOneHashDoesNotVerifyUnderAnother()
+    {
+        // The corollary of the hash living on the call rather than on the key: the same key and the same
+        // message under a different hash is a different signing input, and verification says so.
+        Run($$"""
+            const params = { name: 'ECDSA', namedCurve: 'P-256' };
+            const priv = await crypto.subtle.importKey('pkcs8', bytes('{{Es256Pkcs8Hex}}'), params, false, ['sign']);
+            const pub = await crypto.subtle.importKey('spki', bytes('{{Es256SpkiHex}}'), params, false, ['verify']);
+
+            const message = ascii('m');
+            const signature = await crypto.subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, priv, message);
+
+            return [
+                await crypto.subtle.verify({ name: 'ECDSA', hash: 'SHA-256' }, pub, signature, message),
+                await crypto.subtle.verify({ name: 'ECDSA', hash: 'SHA-384' }, pub, signature, message),
+            ].join(',');
+            """).AsString().Should().Be("true,false");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // Key formats
+    // ---------------------------------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("ECDSA")]
+    [InlineData("ECDH")]
+    public void RoundTripsAnEcKeyThroughAllFourFormats(string algorithm)
+    {
+        // Both algorithms export to every format an EC key has — and the DER a key exports is the DER it was
+        // imported from, byte for byte, because the handle is the platform's canonical re-encoding of the
+        // structure that arrived. The two algorithms share one encoding, which is exactly why a
+        // SubjectPublicKeyInfo alone cannot say which of them a key is for.
+        var privateUsages = string.Equals(algorithm, "ECDH", StringComparison.Ordinal) ? "['deriveBits']" : "['sign']";
+        var publicUsages = string.Equals(algorithm, "ECDH", StringComparison.Ordinal) ? "[]" : "['verify']";
+
+        Run($$"""
+            const params = { name: '{{algorithm}}', namedCurve: 'P-256' };
+
+            const priv = await crypto.subtle.importKey('pkcs8', bytes('{{Es256Pkcs8Hex}}'), params, true, {{privateUsages}});
+            const pub = await crypto.subtle.importKey('spki', bytes('{{Es256SpkiHex}}'), params, true, {{publicUsages}});
+
+            const pkcs8 = await crypto.subtle.exportKey('pkcs8', priv);
+            const spki = await crypto.subtle.exportKey('spki', pub);
+            const raw = await crypto.subtle.exportKey('raw', pub);
+
+            const privJwk = await crypto.subtle.exportKey('jwk', priv);
+            const pubJwk = await crypto.subtle.exportKey('jwk', pub);
+
+            // ... and the private key's own spki, reached the long way round through jwk.
+            const fromJwk = await crypto.subtle.importKey('jwk', privJwk, params, true, {{privateUsages}});
+
+            return [
+                hex(pkcs8) === '{{Es256Pkcs8Hex}}',
+                hex(spki) === '{{Es256SpkiHex}}',
+                hex(raw) === '{{Es256RawHex}}',
+                hex(await crypto.subtle.exportKey('pkcs8', fromJwk)) === '{{Es256Pkcs8Hex}}',
+                privJwk.x === pubJwk.x && privJwk.y === pubJwk.y,
+                privJwk.crv + '/' + privJwk.kty + '/' + priv.algorithm.name,
+            ].join('|');
+            """).AsString().Should().Be("true|true|true|true|true|P-256/EC/" + algorithm);
+    }
+
+    [Fact]
+    public void ARawPointAndAJwkDescribingItReachTheSameKey()
+    {
+        // The uncompressed point 04||X||Y and a JSON Web Key carrying the same X and Y are two spellings of
+        // one public key, so they must export the same DER and verify the same signature.
+        Run($$"""
+            const params = { name: 'ECDSA', namedCurve: 'P-256' };
+
+            const fromRaw = await crypto.subtle.importKey('raw', bytes('{{Es256RawHex}}'), params, true, ['verify']);
+            const fromJwk = await crypto.subtle.importKey('jwk', { {{Es256PublicJwk}} }, params, true, ['verify']);
+
+            const signature = bytes('{{Es256SignatureHex}}');
+            const message = ascii('{{Es256SigningInput}}');
+
+            return [
+                hex(await crypto.subtle.exportKey('spki', fromRaw)) === hex(await crypto.subtle.exportKey('spki', fromJwk)),
+                hex(await crypto.subtle.exportKey('raw', fromRaw)) === hex(await crypto.subtle.exportKey('raw', fromJwk)),
+                JSON.stringify(await crypto.subtle.exportKey('jwk', fromRaw)) === JSON.stringify(await crypto.subtle.exportKey('jwk', fromJwk)),
+                await crypto.subtle.verify({ name: 'ECDSA', hash: 'SHA-256' }, fromRaw, signature, message),
+            ].join('|');
+            """).AsString().Should().Be("true|true|true|true");
+    }
+
+    [Fact]
+    public void EachFormatBelongsToOneKeyType()
+    {
+        // "If the [[type]] internal slot of key is not 'public', then throw an InvalidAccessError" — spki
+        // and raw describe a public key and pkcs8 a private one, and none can stand in for another.
+        Run($$"""
+            const params = { name: 'ECDSA', namedCurve: 'P-256' };
+            const priv = await crypto.subtle.importKey('pkcs8', bytes('{{Es256Pkcs8Hex}}'), params, true, ['sign']);
+            const pub = await crypto.subtle.importKey('spki', bytes('{{Es256SpkiHex}}'), params, true, ['verify']);
+
+            const outcomes = [];
+            for (const [key, format] of [[priv, 'spki'], [priv, 'raw'], [pub, 'pkcs8']]) {
+                try { await crypto.subtle.exportKey(format, key); outcomes.push('exported'); }
+                catch (e) { outcomes.push(e.name + '/' + (e instanceof DOMException)); }
+            }
+
+            return outcomes.join(',');
+            """).AsString().Should().Be("InvalidAccessError/true,InvalidAccessError/true,InvalidAccessError/true");
+    }
+
+    [Fact]
+    public void ANonExtractableEcKeyCannotBeExportedInAnyFormat()
+    {
+        Run($$"""
+            const key = await crypto.subtle.importKey(
+                'pkcs8', bytes('{{Es256Pkcs8Hex}}'), { name: 'ECDSA', namedCurve: 'P-256' }, false, ['sign']);
+
+            const outcomes = [];
+            for (const format of ['pkcs8', 'jwk']) {
+                try { await crypto.subtle.exportKey(format, key); outcomes.push('exported'); }
+                catch (e) { outcomes.push(e.name); }
+            }
+
+            // ... and it still signs: extractable is about the material, not about the key's use.
+            outcomes.push((await crypto.subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, key, ascii('x'))).byteLength);
+            return outcomes.join('|');
+            """).AsString().Should().Be("InvalidAccessError|InvalidAccessError|64");
+    }
+
+    [Theory]
+    // A compressed point, which this engine does not support and the step anticipates by name — at the
+    // length a compressed point actually has, and at the length an uncompressed one has.
+    [InlineData("'02' + '{{X}}'", "compressed")]
+    [InlineData("'03' + '{{X}}'", "compressed")]
+    [InlineData("'02' + '{{BODY}}'", "compressed")]
+    // The point at infinity, which is "an identity point".
+    [InlineData("'00'", "0x04")]
+    // A full-length point whose leading byte names no format at all: it is the marker rather than the
+    // length that refuses this one.
+    [InlineData("'05' + '{{BODY}}'", "0x04")]
+    [InlineData("'ff' + '{{BODY}}'", "0x04")]
+    // Wrong lengths.
+    [InlineData("'04' + '{{X}}'", "0x04")]
+    [InlineData("'{{RAW}}' + '00'", "0x04")]
+    [InlineData("''", "0x04")]
+    public void RefusesARawPointThatIsNotAnUncompressedOne(string expression, string expectedFragment)
+    {
+        var engine = WebEngine();
+
+        var source = expression
+            .Replace("{{BODY}}", Es256RawHex.Substring(2), StringComparison.Ordinal)
+            .Replace("{{X}}", Es256XHex, StringComparison.Ordinal)
+            .Replace("{{RAW}}", Es256RawHex, StringComparison.Ordinal);
+
+        Settle(engine, $$"""
+            crypto.subtle.importKey('raw', bytes({{source}}), { name: 'ECDSA', namedCurve: 'P-256' }, false, ['verify'])
+                .then(() => 'imported', e => e.name + '/' + (e instanceof DOMException) + '/' + (e.message.indexOf('{{expectedFragment}}') >= 0))
+            """).AsString().Should().Be("DataError/true/true");
+    }
+
+    [Fact]
+    public void RefusesDerThatIsNotTheStructureTheFormatNames()
+    {
+        var engine = WebEngine();
+
+        // "If an error occurred while parsing, then throw a DataError" — including an spki that is really a
+        // pkcs8 and the other way round, which parse cleanly as themselves and not at all as each other.
+        Settle(engine, $$"""
+            crypto.subtle.importKey('spki', bytes('{{Es256Pkcs8Hex}}'), { name: 'ECDSA', namedCurve: 'P-256' }, false, ['verify'])
+                .then(() => 'imported', e => e.name + '/' + (e instanceof DOMException))
+            """).AsString().Should().Be("DataError/true");
+
+        Settle(engine, $$"""
+            crypto.subtle.importKey('pkcs8', bytes('{{Es256SpkiHex}}'), { name: 'ECDSA', namedCurve: 'P-256' }, false, ['sign'])
+                .then(() => 'imported', e => e.name)
+            """).AsString().Should().Be("DataError");
+
+        foreach (var data in new[] { "new Uint8Array(0)", "new Uint8Array(16)", "new Uint8Array([0x30, 0x03, 0x02, 0x01, 0x00])" })
+        {
+            Settle(engine, $$"""
+                crypto.subtle.importKey('spki', {{data}}, { name: 'ECDSA', namedCurve: 'P-256' }, false, ['verify'])
+                    .then(() => 'imported', e => e.name)
+                """).AsString().Should().Be("DataError");
+        }
+
+        // An RSA SubjectPublicKeyInfo is a well-formed structure naming the wrong algorithm, so it reaches
+        // the id-ecPublicKey check rather than the parser.
+        Settle(engine, $$"""
+            crypto.subtle.importKey('spki', bytes('{{RsaSpkiHex}}'), { name: 'ECDSA', namedCurve: 'P-256' }, false, ['verify'])
+                .then(() => 'imported', e => e.name + '/' + (e.message.indexOf('id-ecPublicKey') >= 0))
+            """).AsString().Should().Be("DataError/true");
+    }
+
+    [Fact]
+    public void AcceptsAPkcs8ThatRepeatsItsCurveInsideAndReExportsTheCanonicalOne()
+    {
+        // RFC 5915's ECPrivateKey may carry the curve a second time, in its own optional parameters field,
+        // and .NET's own encoder omits it. So this is a valid structure another implementation produces that
+        // this engine does not — importing it and exporting a *different*, canonical encoding of the same key
+        // is what the handle being the platform's own re-encoding means.
+        Run($$"""
+            const key = await crypto.subtle.importKey(
+                'pkcs8', bytes('{{Es256Pkcs8WithInnerParametersHex}}'), { name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign']);
+
+            const exported = hex(await crypto.subtle.exportKey('pkcs8', key));
+
+            return [
+                exported === '{{Es256Pkcs8WithInnerParametersHex}}',
+                exported === '{{Es256Pkcs8Hex}}',
+                (await crypto.subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, key, ascii('m'))).byteLength,
+            ].join('|');
+            """).AsString().Should().Be("false|true|64");
+    }
+
+    [Fact]
+    public void RefusesAPkcs8WhoseInnerStructureContradictsItsOuterOne()
+    {
+        var engine = WebEngine();
+
+        // "If the parameters field of ecPrivateKey is present, and … does not contain the same object
+        // identifier as the parameters field of the privateKeyAlgorithm … then throw a DataError", and the
+        // publicKey field must be the one the private key value produces. Both are the platform's parser's
+        // to enforce, and both arrive here as the CryptographicException that becomes this DataError.
+        foreach (var data in new[] { Es256Pkcs8WithMismatchedInnerCurveHex, Es256Pkcs8WithMismatchedPublicKeyHex })
+        {
+            Settle(engine, $$"""
+                crypto.subtle.importKey('pkcs8', bytes('{{data}}'), { name: 'ECDSA', namedCurve: 'P-256' }, false, ['sign'])
+                    .then(() => 'imported', e => e.name + '/' + (e instanceof DOMException))
+                """).AsString().Should().Be("DataError/true");
+        }
+    }
+
+    [Fact]
+    public void RefusesTrailingBytesAfterAWellFormedStructure()
+    {
+        var engine = WebEngine();
+
+        // "parse an ASN.1 structure … with exactData set to true": a structure that is followed by anything
+        // is not the structure that was asked for, however well-formed its prefix is.
+        Settle(engine, $$"""
+            (() => {
+                const der = bytes('{{Es256SpkiHex}}');
+                const padded = new Uint8Array(der.length + 1);
+                padded.set(der);
+                return crypto.subtle.importKey('spki', padded, { name: 'ECDSA', namedCurve: 'P-256' }, false, ['verify'])
+                    .then(() => 'imported', e => e.name + '/' + (e.message.indexOf('trailing') >= 0));
+            })()
+            """).AsString().Should().Be("DataError/true");
+    }
+
+    [Theory]
+    [InlineData("spki", "P-384", "['verify']")]
+    [InlineData("spki", "P-521", "['verify']")]
+    [InlineData("pkcs8", "P-384", "['sign']")]
+    [InlineData("pkcs8", "P-521", "['sign']")]
+    public void RefusesADerStructureWhoseCurveIsNotTheOneRequested(string format, string namedCurve, string usages)
+    {
+        var engine = WebEngine();
+
+        // "If namedCurve is defined, and not equal to the namedCurve member of normalizedAlgorithm, throw a
+        // DataError." The platform's own importer accepts a key of any curve and reports the fact afterwards
+        // differently on each operating system, so the object identifier is read out of the DER itself —
+        // without which a P-256 import would quietly hand back a P-384 key.
+        var data = string.Equals(format, "spki", StringComparison.Ordinal) ? SpkiFor(namedCurve) : Pkcs8For(namedCurve);
+
+        Settle(engine, $$"""
+            crypto.subtle.importKey('{{format}}', bytes('{{data}}'), { name: 'ECDSA', namedCurve: 'P-256' }, false, {{usages}})
+                .then(key => 'imported as ' + key.algorithm.namedCurve, e => e.name + '/' + (e.message.indexOf('{{namedCurve}}') >= 0))
+            """).AsString().Should().Be("DataError/true");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // JSON Web Key
+    // ---------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void ExportsAnEcJwkWithTheFieldsAndTheOrderWebIdlGivesIt()
+    {
+        // A dictionary is converted to an object member by member in lexicographical order —
+        // https://webidl.spec.whatwg.org/#es-dictionary. An EC public key carries crv, x and y (Section
+        // 6.2.1 of JSON Web Algorithms) and a private key those plus d (6.2.2). There is deliberately **no**
+        // alg: the export steps set one for RSA and none here.
+        Run($$"""
+            const params = { name: 'ECDSA', namedCurve: 'P-256' };
+            const priv = await crypto.subtle.importKey('pkcs8', bytes('{{Es256Pkcs8Hex}}'), params, true, ['sign']);
+            const pub = await crypto.subtle.importKey('spki', bytes('{{Es256SpkiHex}}'), params, true, ['verify']);
+
+            const privJwk = await crypto.subtle.exportKey('jwk', priv);
+            const pubJwk = await crypto.subtle.exportKey('jwk', pub);
+
+            return [
+                Object.keys(privJwk).join(','),
+                Object.keys(pubJwk).join(','),
+                'alg' in privJwk,
+                privJwk.kty + '/' + privJwk.crv + '/' + privJwk.ext + '/' + privJwk.key_ops.join('+'),
+                privJwk.x === '{{Es256XB64}}' && privJwk.y === '{{Es256YB64}}' && privJwk.d === '{{Es256DB64}}',
+            ].join('|');
+            """).AsString().Should().Be(
+                "crv,d,ext,key_ops,kty,x,y|crv,ext,key_ops,kty,x,y|false|EC/P-256/true/sign|true");
+    }
+
+    [Fact]
+    public void AJwkCoordinateKeepsALeadingZeroByteOnBothDirections()
+    {
+        // Section 6.2.1.2 of JSON Web Algorithms: "The length of this octet string MUST be the full size of
+        // a coordinate for the curve" — the opposite of the minimal-length encoding every RSA field uses.
+        // The RFC 7515 A.4 key's y begins with a zero byte, so an implementation that trimmed it, or that
+        // left-padded on import rather than refusing a short value, would fail here and nowhere else.
+        Run($$"""
+            const params = { name: 'ECDSA', namedCurve: 'P-521' };
+            const key = await crypto.subtle.importKey('jwk', { {{Es512PrivateJwk}} }, params, true, ['sign']);
+            const jwk = await crypto.subtle.exportKey('jwk', key);
+
+            const decoded = new Uint8Array(await crypto.subtle.exportKey('raw',
+                await crypto.subtle.importKey('jwk', { {{Es512PublicJwk}} }, params, true, ['verify'])));
+
+            return [
+                jwk.y === '{{Es512YB64}}',
+                jwk.x === '{{Es512XB64}}',
+                jwk.d === '{{Es512DB64}}',
+                // 0x04 then two 66-byte coordinates, the second of which starts with the zero byte.
+                decoded.length + '/' + decoded[0] + '/' + decoded[67],
+            ].join('|');
+            """).AsString().Should().Be("true|true|true|133/4/0");
+    }
+
+    [Theory]
+    // A minimally encoded coordinate, which is exactly what an RSA field would be — the two encodings are
+    // deliberately not interchangeable, so this is a DataError rather than something to left-pad.
+    [InlineData("P-256", "x", Es256ShortX)]
+    [InlineData("P-256", "x", Es256LongX)]
+    [InlineData("P-521", "y", MinimalEs512Y)]
+    public void RefusesAJwkCoordinateThatIsNotTheCurvesFullWidth(string namedCurve, string field, string value)
+    {
+        var engine = WebEngine();
+
+        Settle(engine, $$"""
+            (() => {
+                const jwk = { {{PublicJwkFor(namedCurve)}} };
+                jwk.{{field}} = '{{value}}';
+                return crypto.subtle.importKey('jwk', jwk, { name: 'ECDSA', namedCurve: '{{namedCurve}}' }, false, ['verify'])
+                    .then(() => 'imported', e => e.name + '/' + (e.message.indexOf('full') >= 0));
+            })()
+            """).AsString().Should().Be("DataError/true");
+    }
+
+    [Theory]
+    // "If the kty field of jwk is not 'EC', then throw a DataError."
+    [InlineData("delete jwk.kty")]
+    [InlineData("jwk.kty = 'ec'")]
+    [InlineData("jwk.kty = 'RSA'")]
+    // "Let namedCurve be … the crv field of jwk. If namedCurve is not equal to the namedCurve member of
+    // normalizedAlgorithm, throw a DataError."
+    [InlineData("delete jwk.crv")]
+    [InlineData("jwk.crv = 'P-384'")]
+    [InlineData("jwk.crv = 'p-256'")]
+    // Section 6.2.1 of JSON Web Algorithms: x and y are what an EC public key is.
+    [InlineData("delete jwk.x")]
+    [InlineData("delete jwk.y")]
+    [InlineData("jwk.x = ''")]
+    [InlineData("jwk.y = 'not+base64url'")]
+    // The alg table, and an alg naming a curve the key does not carry.
+    [InlineData("jwk.alg = 'ES384'")]
+    [InlineData("jwk.alg = 'ES512'")]
+    [InlineData("jwk.alg = 'RS256'")]
+    [InlineData("jwk.alg = 'es256'")]
+    // The three fields every JWK import checks.
+    [InlineData("jwk.use = 'enc'")]
+    [InlineData("jwk.key_ops = ['sign']")]
+    [InlineData("jwk.key_ops = ['verify', 'verify']")]
+    [InlineData("jwk.ext = false")]
+    public void RefusesAMalformedEcdsaJwkWithADataError(string mutation)
+    {
+        var engine = WebEngine();
+
+        // Every row is imported as an extractable verifying P-256 key, so the `ext` and `key_ops` rows are
+        // about the JWK rather than about the request.
+        Settle(engine, $$"""
+            (() => {
+                const jwk = { {{Es256PublicJwk}} };
+                {{mutation}};
+                return crypto.subtle.importKey('jwk', jwk, { name: 'ECDSA', namedCurve: 'P-256' }, true, ['verify'])
+                    .then(() => 'imported', e => e.name + '/' + (e instanceof DOMException));
+            })()
+            """).AsString().Should().Be("DataError/true");
+    }
+
+    [Theory]
+    [InlineData("P-256", "ES256")]
+    [InlineData("P-384", "ES384")]
+    // The row that cannot be derived from the curve's name: ES512 is the SHA-512 pairing, and its curve is
+    // P-521 — https://www.rfc-editor.org/rfc/rfc7518#section-3.4.
+    [InlineData("P-521", "ES512")]
+    public void TheJwkAlgorithmNamesTheCurveByItsHashPairing(string namedCurve, string alg)
+    {
+        // The import table is honoured and the export deliberately writes no alg back, which is the one
+        // asymmetry an EC JWK has that an RSA one does not.
+        Run($$"""
+            const jwk = { {{PublicJwkFor(namedCurve)}} };
+            jwk.alg = '{{alg}}';
+
+            const key = await crypto.subtle.importKey('jwk', jwk, { name: 'ECDSA', namedCurve: '{{namedCurve}}' }, true, ['verify']);
+            const exported = await crypto.subtle.exportKey('jwk', key);
+
+            return [
+                key.algorithm.namedCurve,
+                'alg' in exported,
+                // ... and what comes back still imports, which is what makes the omission safe.
+                (await crypto.subtle.importKey('jwk', exported, { name: 'ECDSA', namedCurve: '{{namedCurve}}' }, true, ['verify'])).algorithm.namedCurve,
+            ].join('|');
+            """).AsString().Should().Be(namedCurve + "|false|" + namedCurve);
+    }
+
+    [Fact]
+    public void AnEcdhJwkNeitherRequiresNorChecksTheAlgField()
+    {
+        var engine = WebEngine();
+
+        // The ECDH import steps read no alg at all — there is no table for it in them — so a JWK carrying
+        // one that ECDSA would refuse imports here without complaint, and `use` is 'enc' rather than 'sig'.
+        Settle(engine, $$"""
+            (() => {
+                const jwk = { {{Es256PrivateJwk}} };
+                jwk.alg = 'ES512';
+                jwk.use = 'enc';
+                return crypto.subtle.importKey('jwk', jwk, { name: 'ECDH', namedCurve: 'P-256' }, true, ['deriveBits'])
+                    .then(key => key.algorithm.name + '/' + key.algorithm.namedCurve + '/' + key.usages.join('+'), e => e.name);
+            })()
+            """).AsString().Should().Be("ECDH/P-256/deriveBits");
+
+        // ... while ECDSA refuses both of those, which is what makes the difference a decision rather than
+        // an oversight.
+        Settle(engine, $$"""
+            (() => {
+                const jwk = { {{Es256PrivateJwk}} };
+                jwk.alg = 'ES512';
+                return crypto.subtle.importKey('jwk', jwk, { name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign'])
+                    .then(() => 'imported', e => e.name);
+            })()
+            """).AsString().Should().Be("DataError");
+
+        Settle(engine, $$"""
+            (() => {
+                const jwk = { {{Es256PrivateJwk}} };
+                jwk.use = 'enc';
+                return crypto.subtle.importKey('jwk', jwk, { name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign'])
+                    .then(() => 'imported', e => e.name);
+            })()
+            """).AsString().Should().Be("DataError");
+
+        // ... and ECDH refuses 'sig' for the same reason ECDSA refuses 'enc'.
+        Settle(engine, $$"""
+            (() => {
+                const jwk = { {{Es256PrivateJwk}} };
+                jwk.use = 'sig';
+                return crypto.subtle.importKey('jwk', jwk, { name: 'ECDH', namedCurve: 'P-256' }, true, ['deriveBits'])
+                    .then(() => 'imported', e => e.name);
+            })()
+            """).AsString().Should().Be("DataError");
+    }
+
+    [Fact]
+    public void ReadsEveryEcJwkFieldInWebIdlsOwnOrderAndOnlyOnce()
+    {
+        // A dictionary's members are converted in lexicographical order, each read exactly once — so crv
+        // comes straight after alg and x and y come last, after use. A second read would be a second chance
+        // for a getter to change the answer between the check and the import.
+        Run($$"""
+            const reads = [];
+            const source = { {{Es256PrivateJwk}} };
+            const jwk = {};
+            for (const name of ['y', 'x', 'kty', 'd', 'crv']) {
+                Object.defineProperty(jwk, name, { enumerable: true, get() { reads.push(name); return source[name]; } });
+            }
+            Object.defineProperty(jwk, 'alg', { enumerable: true, get() { reads.push('alg'); return 'ES256'; } });
+            Object.defineProperty(jwk, 'ext', { enumerable: true, get() { reads.push('ext'); return true; } });
+            Object.defineProperty(jwk, 'key_ops', { enumerable: true, get() { reads.push('key_ops'); return ['sign']; } });
+            Object.defineProperty(jwk, 'use', { enumerable: true, get() { reads.push('use'); return 'sig'; } });
+
+            await crypto.subtle.importKey('jwk', jwk, { name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign']);
+            return reads.join(',');
+            """).AsString().Should().Be("alg,crv,d,ext,key_ops,kty,use,x,y");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // Curves
+    // ---------------------------------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("ECDSA", "'P-192'")]
+    [InlineData("ECDSA", "'p-256'")]
+    [InlineData("ECDSA", "'secp256k1'")]
+    [InlineData("ECDSA", "'P-256 '")]
+    [InlineData("ECDSA", "'Ed25519'")]
+    [InlineData("ECDH", "'X25519'")]
+    [InlineData("ECDH", "'P-224'")]
+    [InlineData("ECDH", "42")]
+    [InlineData("ECDH", "null")]
+    public void RefusesACurveThisEngineDoesNotImplementWithANotSupportedError(string algorithm, string namedCurve)
+    {
+        var engine = WebEngine();
+
+        // NamedCurve is `typedef DOMString`, not a WebIDL enumeration, so nothing about the argument
+        // conversion refuses these — the operation's own first step does, and it matches case-sensitively
+        // where the algorithm *name* one member to its left matches case-insensitively.
+        Settle(engine, $$"""
+            crypto.subtle.generateKey({ name: '{{algorithm}}', namedCurve: {{namedCurve}} }, false, ['{{PrivateUsageOf(algorithm)}}'])
+                .then(() => 'generated', e => e.name + '/' + (e instanceof DOMException))
+            """).AsString().Should().Be("NotSupportedError/true");
+
+        Settle(engine, $$"""
+            crypto.subtle.importKey('raw', bytes('{{Es256RawHex}}'), { name: '{{algorithm}}', namedCurve: {{namedCurve}} }, false, [])
+                .then(() => 'imported', e => e.name)
+            """).AsString().Should().Be("NotSupportedError");
+    }
+
+    [Fact]
+    public void TheCurveIsCheckedBeforeAnythingElseAboutTheRequest()
+    {
+        var engine = WebEngine();
+
+        // Step 1 of importKey is the curve, before the format branch and therefore before that branch's own
+        // usage check — so a request that is wrong in both ways reports the curve.
+        Settle(engine, """
+            crypto.subtle.importKey('spki', new Uint8Array([1, 2, 3]), { name: 'ECDSA', namedCurve: 'P-192' }, false, ['sign'])
+                .then(() => 'imported', e => e.name)
+            """).AsString().Should().Be("NotSupportedError");
+
+        // With a curve that is recognized, the usages are next and the bytes are last.
+        Settle(engine, """
+            crypto.subtle.importKey('spki', new Uint8Array([1, 2, 3]), { name: 'ECDSA', namedCurve: 'P-256' }, false, ['sign'])
+                .then(() => 'imported', e => e.name)
+            """).AsString().Should().Be("SyntaxError");
+
+        Settle(engine, """
+            crypto.subtle.importKey('spki', new Uint8Array([1, 2, 3]), { name: 'ECDSA', namedCurve: 'P-256' }, false, ['verify'])
+                .then(() => 'imported', e => e.name)
+            """).AsString().Should().Be("DataError");
+    }
+
+    [Fact]
+    public void TheNamedCurveIsARequiredMemberOfBothEcDictionaries()
+    {
+        var engine = WebEngine();
+
+        // `required NamedCurve namedCurve` — an absent required member is the TypeError WebIDL raises,
+        // which is a different failure from a curve name the algorithm does not implement.
+        foreach (var algorithm in new[] { "'ECDSA'", "{ name: 'ECDSA' }", "{ name: 'ECDSA', namedCurve: undefined }" })
+        {
+            Settle(engine, $$"""
+                crypto.subtle.generateKey({{algorithm}}, false, ['sign', 'verify'])
+                    .then(() => 'generated', e => e.constructor.name)
+                """).AsString().Should().Be("TypeError");
+
+            Settle(engine, $$"""
+                crypto.subtle.importKey('raw', bytes('{{Es256RawHex}}'), {{algorithm}}, false, ['verify'])
+                    .then(() => 'imported', e => e.constructor.name)
+                """).AsString().Should().Be("TypeError");
+        }
+    }
+
+    [Fact]
+    public void TheHashIsARequiredMemberOfEcdsaParams()
+    {
+        var engine = WebEngine();
+
+        // `required HashAlgorithmIdentifier hash`, read per call — and a name that is not a registered
+        // digest is the NotSupportedError normalizing a hash gives it, not a TypeError.
+        foreach (var algorithm in new[] { "'ECDSA'", "{ name: 'ECDSA' }", "{ name: 'ECDSA', hash: undefined }" })
+        {
+            Settle(engine, $$"""
+                crypto.subtle.importKey('pkcs8', bytes('{{Es256Pkcs8Hex}}'), { name: 'ECDSA', namedCurve: 'P-256' }, false, ['sign'])
+                    .then(key => crypto.subtle.sign({{algorithm}}, key, new Uint8Array(4)))
+                    .then(() => 'signed', e => e.constructor.name)
+                """).AsString().Should().Be("TypeError");
+        }
+
+        Settle(engine, $$"""
+            crypto.subtle.importKey('pkcs8', bytes('{{Es256Pkcs8Hex}}'), { name: 'ECDSA', namedCurve: 'P-256' }, false, ['sign'])
+                .then(key => crypto.subtle.sign({ name: 'ECDSA', hash: 'MD5' }, key, new Uint8Array(4)))
+                .then(() => 'signed', e => e.name)
+            """).AsString().Should().Be("NotSupportedError");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // Points that are not on the curve
+    // ---------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void RefusesAPointThatIsNotOnTheCurveWithADataError()
+    {
+        var engine = WebEngine();
+
+        // The platform reports this differently per operating system — on Windows it is a
+        // PlatformNotSupportedException naming the curve, and elsewhere a CryptographicException — and
+        // neither may reach a script as anything but the DataError the step names.
+        Settle(engine, $$"""
+            (() => {
+                const jwk = { {{Es256PublicJwk}} };
+                jwk.y = '{{Es256FlippedY}}';
+                return crypto.subtle.importKey('jwk', jwk, { name: 'ECDSA', namedCurve: 'P-256' }, false, ['verify'])
+                    .then(() => 'imported', e => e.name + '/' + (e instanceof DOMException) + '/' + (e.message.indexOf('valid point') >= 0));
+            })()
+            """).AsString().Should().Be("DataError/true/true");
+
+        // The same point through raw, where the last byte of Y is the last byte of the whole encoding.
+        Settle(engine, $$"""
+            (() => {
+                const point = bytes('{{Es256RawHex}}');
+                point[point.length - 1] ^= 1;
+                return crypto.subtle.importKey('raw', point, { name: 'ECDSA', namedCurve: 'P-256' }, false, ['verify'])
+                    .then(() => 'imported', e => e.name + '/' + (e.message.indexOf('valid point') >= 0));
+            })()
+            """).AsString().Should().Be("DataError/true");
+
+        // ... and through spki, where the platform's own parser is what refuses it.
+        Settle(engine, $$"""
+            (() => {
+                const der = bytes('{{Es256SpkiHex}}');
+                der[der.length - 1] ^= 1;
+                return crypto.subtle.importKey('spki', der, { name: 'ECDH', namedCurve: 'P-256' }, false, [])
+                    .then(() => 'imported', e => e.name + '/' + (e instanceof DOMException));
+            })()
+            """).AsString().Should().Be("DataError/true");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // The key-type and usage matrices
+    // ---------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void AnOperationRefusesTheWrongHalfOfTheKeyPair()
+    {
+        // Step 1 of both ECDSA operations: sign needs a private key and verify a public one. It is an
+        // InvalidAccessError, and it comes from the algorithm rather than from the usages — which is why
+        // each key here carries the usage the operation asks for.
+        Run($$"""
+            const params = { name: 'ECDSA', namedCurve: 'P-256' };
+            const pub = await crypto.subtle.importKey('spki', bytes('{{Es256SpkiHex}}'), params, false, ['verify']);
+            const priv = await crypto.subtle.importKey('pkcs8', bytes('{{Es256Pkcs8Hex}}'), params, false, ['sign']);
+
+            const outcomes = [];
+            const attempt = async fn => { try { await fn(); outcomes.push('ok'); } catch (e) { outcomes.push(e.name); } };
+
+            await attempt(() => crypto.subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, pub, ascii('m')));
+            await attempt(() => crypto.subtle.verify({ name: 'ECDSA', hash: 'SHA-256' }, priv, new Uint8Array(64), ascii('m')));
+
+            return outcomes.join(',');
+            """).AsString().Should().Be("InvalidAccessError,InvalidAccessError");
+    }
+
+    [Fact]
+    public void AnEcdsaKeyTypeCarriesExactlyTheOneUsageItCanPerform()
+    {
+        var engine = WebEngine();
+
+        // A private ECDSA key may carry only 'sign' and a public one only 'verify', so a key carrying the
+        // wrong usage never exists — the mismatch is caught at import as the SyntaxError the format's first
+        // step raises, and the InvalidAccessError a usable key used wrongly would get is unreachable.
+        foreach (var (format, data, usages) in new[]
+        {
+            ("spki", Es256SpkiHex, "['sign']"),
+            ("spki", Es256SpkiHex, "['verify', 'sign']"),
+            ("spki", Es256SpkiHex, "['deriveBits']"),
+            ("raw", Es256RawHex, "['sign']"),
+            ("pkcs8", Es256Pkcs8Hex, "['verify']"),
+            ("pkcs8", Es256Pkcs8Hex, "['sign', 'deriveKey']"),
+        })
+        {
+            Settle(engine, $$"""
+                crypto.subtle.importKey('{{format}}', bytes('{{data}}'), { name: 'ECDSA', namedCurve: 'P-256' }, false, {{usages}})
+                    .then(() => 'imported', e => e.name + '/' + (e instanceof DOMException))
+                """).AsString().Should().Be("SyntaxError/true");
+        }
+    }
+
+    [Fact]
+    public void AnEcdhPublicKeyCarriesNoUsagesAtAll()
+    {
+        var engine = WebEngine();
+
+        // "If usages is not empty then throw a SyntaxError" — an ECDH public key's permitted usage set is
+        // empty rather than a list, which is a rule no other algorithm here has. A public key is one half of
+        // an agreement; the deriving is the private half's.
+        foreach (var (format, data) in new[] { ("spki", Es256SpkiHex), ("raw", Es256RawHex) })
+        {
+            foreach (var usages in new[] { "['deriveBits']", "['deriveKey']", "['verify']" })
+            {
+                Settle(engine, $$"""
+                    crypto.subtle.importKey('{{format}}', bytes('{{data}}'), { name: 'ECDH', namedCurve: 'P-256' }, false, {{usages}})
+                        .then(() => 'imported', e => e.name + '/' + (e.message.indexOf('no usages at all') >= 0))
+                    """).AsString().Should().Be("SyntaxError/true");
+            }
+
+            // With the empty list it is an ordinary key — which is how a script imports a peer's public key.
+            Settle(engine, $$"""
+                crypto.subtle.importKey('{{format}}', bytes('{{data}}'), { name: 'ECDH', namedCurve: 'P-256' }, false, [])
+                    .then(key => key.type + '/' + key.usages.length + '/' + key.algorithm.namedCurve, e => e.name)
+                """).AsString().Should().Be("public/0/P-256");
+        }
+
+        // A JWK without d is the same public key and gets the same rule.
+        Settle(engine, $$"""
+            crypto.subtle.importKey('jwk', { {{Es256PublicJwk}} }, { name: 'ECDH', namedCurve: 'P-256' }, false, ['deriveBits'])
+                .then(() => 'imported', e => e.name)
+            """).AsString().Should().Be("SyntaxError");
+    }
+
+    [Fact]
+    public void AnEcdhPrivateKeyMayCarryTheDerivationUsagesNothingConsumesYet()
+    {
+        var engine = WebEngine();
+
+        // deriveKey and deriveBits are absent from crypto.subtle, so these usages are real, checked, split
+        // and reported — and no operation reads them. That is the position AES-GCM's wrapKey and unwrapKey
+        // usages have always been in, and it is what makes the derive operations an addition rather than a
+        // change to the keys a script already makes.
+        Settle(engine, $$"""
+            crypto.subtle.importKey('pkcs8', bytes('{{Es256Pkcs8Hex}}'), { name: 'ECDH', namedCurve: 'P-256' }, false, ['deriveKey', 'deriveBits'])
+                .then(key => key.type + '/' + key.usages.join('+'), e => e.name)
+            """).AsString().Should().Be("private/deriveKey+deriveBits");
+
+        foreach (var usages in new[] { "['sign']", "['deriveBits', 'encrypt']", "['verify']" })
+        {
+            Settle(engine, $$"""
+                crypto.subtle.importKey('pkcs8', bytes('{{Es256Pkcs8Hex}}'), { name: 'ECDH', namedCurve: 'P-256' }, false, {{usages}})
+                    .then(() => 'imported', e => e.name)
+                """).AsString().Should().Be("SyntaxError");
+        }
+    }
+
+    [Fact]
+    public void APrivateKeyMustBeImportedWithAtLeastOneUsageAndAPublicKeyNeedNot()
+    {
+        var engine = WebEngine();
+
+        // "If the [[type]] internal slot of result is 'secret' or 'private' and usages is empty, then throw
+        // a SyntaxError" — a public key is deliberately outside that step, which is what makes the ECDH
+        // public key of the test above a key at all.
+        Settle(engine, $$"""
+            crypto.subtle.importKey('pkcs8', bytes('{{Es256Pkcs8Hex}}'), { name: 'ECDSA', namedCurve: 'P-256' }, false, [])
+                .then(() => 'imported', e => e.name + '/' + (e instanceof DOMException))
+            """).AsString().Should().Be("SyntaxError/true");
+
+        Settle(engine, $$"""
+            crypto.subtle.importKey('pkcs8', bytes('{{Es256Pkcs8Hex}}'), { name: 'ECDH', namedCurve: 'P-256' }, false, [])
+                .then(() => 'imported', e => e.name)
+            """).AsString().Should().Be("SyntaxError");
+
+        Settle(engine, $$"""
+            crypto.subtle.importKey('spki', bytes('{{Es256SpkiHex}}'), { name: 'ECDSA', namedCurve: 'P-256' }, false, [])
+                .then(key => key.type + '/' + key.usages.length, e => e.name)
+            """).AsString().Should().Be("public/0");
+    }
+
+    [Fact]
+    public void AKeyRemembersTheAlgorithmItWasMadeForAndRefusesAnother()
+    {
+        // The name check comes before everything the algorithm itself does, and it is an InvalidAccessError
+        // — the same key material described two ways is two keys. An algorithm that is not registered for
+        // the operation at all is a different failure, decided before any key is looked at.
+        Run($$"""
+            const ecdsa = await crypto.subtle.importKey(
+                'pkcs8', bytes('{{Es256Pkcs8Hex}}'), { name: 'ECDSA', namedCurve: 'P-256' }, false, ['sign']);
+            const ecdh = await crypto.subtle.importKey(
+                'pkcs8', bytes('{{Es256Pkcs8Hex}}'), { name: 'ECDH', namedCurve: 'P-256' }, false, ['deriveBits']);
+
+            const outcomes = [];
+            const attempt = async fn => { try { await fn(); outcomes.push('ok'); } catch (e) { outcomes.push(e.name); } };
+
+            await attempt(() => crypto.subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, ecdh, ascii('m')));
+            await attempt(() => crypto.subtle.sign({ name: 'ECDH', hash: 'SHA-256' }, ecdsa, ascii('m')));
+            await attempt(() => crypto.subtle.encrypt({ name: 'ECDSA' }, ecdsa, ascii('m')));
+            await attempt(() => crypto.subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, ecdsa, ascii('m')));
+
+            return outcomes.join(',');
+            """).AsString().Should().Be("InvalidAccessError,NotSupportedError,NotSupportedError,ok");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // generateKey and CryptoKeyPair
+    // ---------------------------------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("P-256", 64)]
+    [InlineData("P-384", 96)]
+    [InlineData("P-521", 132)]
+    public void GeneratesAnEcdsaPairWithTheShapeTheSpecificationDescribes(string namedCurve, int signatureLength)
+    {
+        Run($$"""
+            const pair = await crypto.subtle.generateKey(
+                { name: 'ECDSA', namedCurve: '{{namedCurve}}' }, false, ['sign', 'verify']);
+
+            const message = ascii('generated');
+            const signature = await crypto.subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, pair.privateKey, message);
+
+            return [
+                // CryptoKeyPair is a dictionary, not an interface: an ordinary object with two own data
+                // properties, no interface object on the global, and Object.prototype behind it.
+                Object.keys(pair).join(','),
+                Object.getPrototypeOf(pair) === Object.prototype,
+                typeof CryptoKeyPair,
+                pair.publicKey instanceof CryptoKey && pair.privateKey instanceof CryptoKey,
+
+                pair.privateKey.type + '/' + pair.publicKey.type,
+                // "Set the [[extractable]] internal slot of publicKey to true" — whatever was asked for.
+                pair.privateKey.extractable + '/' + pair.publicKey.extractable,
+                pair.privateKey.usages.join('+') + '/' + pair.publicKey.usages.join('+'),
+
+                // One EcKeyAlgorithm, shared by both halves, with no hash member.
+                Object.keys(pair.privateKey.algorithm).join(','),
+                pair.privateKey.algorithm.name + '/' + pair.privateKey.algorithm.namedCurve,
+
+                signature.byteLength,
+                await crypto.subtle.verify({ name: 'ECDSA', hash: 'SHA-256' }, pair.publicKey, signature, message),
+            ].join('|');
+            """).AsString().Should().Be(
+                "privateKey,publicKey|true|undefined|true|"
+                + "private/public|false/true|sign/verify|"
+                + "name,namedCurve|ECDSA/" + namedCurve + "|"
+                + signatureLength + "|true");
+    }
+
+    [Fact]
+    public void GeneratesAnEcdhPairWhosePublicHalfCarriesNoUsages()
+    {
+        // "Set the [[usages]] internal slot of publicKey to be the empty list" — flatly, not as an
+        // intersection, so a pair generated with both derivation usages still has an empty public half. The
+        // pair is exportable and round-trips, which is all a script can do with it today.
+        Run("""
+            const pair = await crypto.subtle.generateKey(
+                { name: 'ECDH', namedCurve: 'P-384' }, true, ['deriveKey', 'deriveBits']);
+
+            const spki = await crypto.subtle.exportKey('spki', pair.publicKey);
+            const raw = await crypto.subtle.exportKey('raw', pair.publicKey);
+            const reimported = await crypto.subtle.importKey('spki', spki, { name: 'ECDH', namedCurve: 'P-384' }, true, []);
+
+            return [
+                pair.privateKey.usages.join('+'),
+                pair.publicKey.usages.length,
+                pair.privateKey.algorithm.name + '/' + pair.privateKey.algorithm.namedCurve,
+                // 0x04 and two 48-byte coordinates.
+                raw.byteLength,
+                hex(await crypto.subtle.exportKey('raw', reimported)) === hex(raw),
+            ].join('|');
+            """).AsString().Should().Be("deriveKey+deriveBits|0|ECDH/P-384|97|true");
+    }
+
+    [Fact]
+    public void RefusesAPairWhosePrivateHalfWouldHaveNoUsages()
+    {
+        var engine = WebEngine();
+
+        // "If the [[usages]] internal slot of the privateKey attribute of result is the empty sequence, then
+        // throw a SyntaxError." For ECDH that is the whole of what generating with an empty list means; for
+        // ECDSA a pair generated with 'verify' alone is the same mistake.
+        Settle(engine, """
+            crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, false, ['verify'])
+                .then(() => 'generated', e => e.name + '/' + (e instanceof DOMException))
+            """).AsString().Should().Be("SyntaxError/true");
+
+        Settle(engine, """
+            crypto.subtle.generateKey({ name: 'ECDH', namedCurve: 'P-256' }, false, [])
+                .then(() => 'generated', e => e.name)
+            """).AsString().Should().Be("SyntaxError");
+
+        // A pair whose *public* half carries nothing is perfectly ordinary — for ECDH it is the only kind.
+        Settle(engine, """
+            crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, false, ['sign'])
+                .then(pair => pair.privateKey.usages.join('+') + '/' + pair.publicKey.usages.length, e => e.name)
+            """).AsString().Should().Be("sign/0");
+    }
+
+    [Theory]
+    [InlineData("ECDSA", "['encrypt']")]
+    [InlineData("ECDSA", "['sign', 'deriveKey']")]
+    [InlineData("ECDSA", "['sign', 'wrapKey']")]
+    [InlineData("ECDH", "['sign']")]
+    [InlineData("ECDH", "['deriveBits', 'verify']")]
+    [InlineData("ECDH", "['encrypt', 'decrypt']")]
+    public void RefusesAUsageAnEcAlgorithmDoesNotSupportWithASyntaxError(string algorithm, string usages)
+    {
+        var engine = WebEngine();
+
+        // Step 1 of generateKey, which runs before the curve is even looked at, so this generates nothing.
+        Settle(engine, $$"""
+            crypto.subtle.generateKey({ name: '{{algorithm}}', namedCurve: 'P-256' }, false, {{usages}})
+                .then(() => 'generated', e => e.name + '/' + (e instanceof DOMException))
+            """).AsString().Should().Be("SyntaxError/true");
+    }
+
+    [Fact]
+    public void TheUsageCheckPrecedesTheCurveCheckInGenerateKey()
+    {
+        var engine = WebEngine();
+
+        // The two operations order their first steps differently and both orders are pinned: generateKey
+        // checks the usages first (step 1) and the curve second, while importKey checks the curve first.
+        Settle(engine, """
+            crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-192' }, false, ['encrypt'])
+                .then(() => 'generated', e => e.name)
+            """).AsString().Should().Be("SyntaxError");
+
+        Settle(engine, """
+            crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-192' }, false, ['sign'])
+                .then(() => 'generated', e => e.name)
+            """).AsString().Should().Be("NotSupportedError");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // Normalization and the registry
+    // ---------------------------------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("ecdsa")]
+    [InlineData("EcDsA")]
+    [InlineData("ECDSA")]
+    public void MatchesTheRegisteredEcNameCaseInsensitivelyButNotTheCurve(string spelling)
+    {
+        // "Case-insensitive" is ASCII case-insensitive, and the key remembers the registered spelling rather
+        // than the caller's — which is what makes the name check on the next operation work at all. The
+        // curve, one member along, is matched case-sensitively, so the two rules sit side by side in the very
+        // same dictionary.
+        Run($$"""
+            const key = await crypto.subtle.importKey(
+                'spki', bytes('{{Es256SpkiHex}}'), { name: 'ecdsa', namedCurve: 'P-256' }, false, ['verify']);
+
+            return [
+                await crypto.subtle.verify(
+                    { name: '{{spelling}}', hash: 'sha-256' }, key, bytes('{{Es256SignatureHex}}'), ascii('{{Es256SigningInput}}')),
+                key.algorithm.name,
+                key.algorithm.namedCurve,
+            ].join('|');
+            """).AsString().Should().Be("true|ECDSA|P-256");
+
+        Settle(WebEngine(), $$"""
+            crypto.subtle.importKey('spki', bytes('{{Es256SpkiHex}}'), { name: '{{spelling}}', namedCurve: 'p-256' }, false, ['verify'])
+                .then(() => 'imported', e => e.name)
+            """).AsString().Should().Be("NotSupportedError");
+    }
+
+    [Fact]
+    public void TheEcAlgorithmsAreRegisteredForExactlyTheOperationsTheSpecificationGivesThem()
+    {
+        var engine = WebEngine();
+
+        // ECDSA registers sign, verify, generateKey, importKey and exportKey; ECDH registers generateKey,
+        // importKey, exportKey and — for a later slice — deriveBits. An algorithm that is not registered for
+        // an operation is a NotSupportedError, decided before any key is looked at.
+        Settle(engine, $$"""
+            (async () => {
+                const outcomes = [];
+                const attempt = async fn => { try { await fn(); outcomes.push('ok'); } catch (e) { outcomes.push(e.name); } };
+
+                const ecdh = await crypto.subtle.importKey(
+                    'spki', bytes('{{Es256SpkiHex}}'), { name: 'ECDH', namedCurve: 'P-256' }, true, []);
+                const ecdsa = await crypto.subtle.importKey(
+                    'raw', bytes('{{Es256RawHex}}'), { name: 'ECDSA', namedCurve: 'P-256' }, false, ['verify']);
+
+                await attempt(() => crypto.subtle.digest('ECDSA', new Uint8Array(0)));
+                await attempt(() => crypto.subtle.digest('ECDH', new Uint8Array(0)));
+                await attempt(() => crypto.subtle.encrypt({ name: 'ECDH' }, ecdh, new Uint8Array(0)));
+                await attempt(() => crypto.subtle.sign({ name: 'ECDH', hash: 'SHA-256' }, ecdh, new Uint8Array(0)));
+                await attempt(() => crypto.subtle.exportKey('raw', ecdh));
+                await attempt(() => crypto.subtle.verify(
+                    { name: 'ECDSA', hash: 'SHA-256' }, ecdsa, bytes('{{Es256SignatureHex}}'), ascii('{{Es256SigningInput}}')));
+
+                return outcomes.join(',');
+            })()
+            """).AsString().Should().Be(
+                "NotSupportedError,NotSupportedError,NotSupportedError,NotSupportedError,ok,ok");
+
+        // The derive operations are still absent rather than present-and-throwing, which is what a library
+        // that means to use them checks before it reaches for one.
+        engine.Evaluate("['deriveKey', 'deriveBits'].filter(name => name in crypto.subtle).join(',')")
+            .AsString().Should().Be("");
+    }
+
+    [Fact]
+    public void NoEcOperationEverThrowsSynchronouslyOrLeaksACryptographicException()
+    {
+        var engine = WebEngine();
+
+        // A promise-returning WebIDL operation reports every failure as a rejection, and the failures the
+        // platform's own cryptography raises are no exception. The third row is the one that matters most
+        // here: an off-curve point arrives on Windows as a PlatformNotSupportedException, which is not a
+        // CryptographicException and would escape a catch clause written for one alone.
+        engine.Evaluate($$"""
+            (() => {
+                const calls = [
+                    () => crypto.subtle.importKey('spki', new Uint8Array([9, 9, 9]), { name: 'ECDSA', namedCurve: 'P-256' }, false, ['verify']),
+                    () => crypto.subtle.importKey('pkcs8', new Uint8Array([9, 9, 9]), { name: 'ECDH', namedCurve: 'P-384' }, false, ['deriveBits']),
+                    () => crypto.subtle.importKey('raw', bytes('{{Es256RawHexWithFlippedY}}'), { name: 'ECDSA', namedCurve: 'P-256' }, false, ['verify']),
+                    () => crypto.subtle.importKey('jwk', { kty: 'EC', crv: 'P-256', x: 'AA', y: 'AA' }, { name: 'ECDSA', namedCurve: 'P-256' }, false, ['verify']),
+                    () => crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-192' }, false, ['sign']),
+                ];
+
+                return calls.map(call => {
+                    const promise = call();
+                    return (promise instanceof Promise) + ':' + typeof promise.then;
+                }).join(',');
+            })()
+            """).AsString().Should().Be("true:function,true:function,true:function,true:function,true:function");
+
+        // ... and each of them settles as a rejection carrying a DOMException.
+        Settle(engine, $$"""
+            Promise.all([
+                crypto.subtle.importKey('spki', new Uint8Array([9, 9, 9]), { name: 'ECDSA', namedCurve: 'P-256' }, false, ['verify']).catch(e => e.name),
+                crypto.subtle.importKey('pkcs8', new Uint8Array([9, 9, 9]), { name: 'ECDH', namedCurve: 'P-384' }, false, ['deriveBits']).catch(e => e.name),
+                crypto.subtle.importKey('raw', bytes('{{Es256RawHexWithFlippedY}}'), { name: 'ECDSA', namedCurve: 'P-256' }, false, ['verify']).catch(e => e.name),
+                crypto.subtle.importKey('jwk', { kty: 'EC', crv: 'P-256', x: 'AA', y: 'AA' }, { name: 'ECDSA', namedCurve: 'P-256' }, false, ['verify']).catch(e => e.name),
+                crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-192' }, false, ['sign']).catch(e => e.name),
+            ]).then(names => names.join(','))
+            """).AsString().Should().Be("DataError,DataError,DataError,DataError,NotSupportedError");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // Test vectors
+    //
+    // The coordinates and the expected outputs are transcribed from the RFCs named in this class's remarks.
+    // The spki, pkcs8 and raw bytes were encoded from those coordinates outside this engine.
+    // ---------------------------------------------------------------------------------------------------
+
+    private static string SpkiFor(string namedCurve) => namedCurve switch
+    {
+        "P-256" => Es256SpkiHex,
+        "P-384" => P384SpkiHex,
+        _ => Es512SpkiHex,
+    };
+
+    private static string Pkcs8For(string namedCurve) => namedCurve switch
+    {
+        "P-256" => Es256Pkcs8Hex,
+        "P-384" => P384Pkcs8Hex,
+        _ => Es512Pkcs8Hex,
+    };
+
+    private static string PublicJwkFor(string namedCurve) => namedCurve switch
+    {
+        "P-256" => Es256PublicJwk,
+        "P-384" => P384PublicJwk,
+        _ => Es512PublicJwk,
+    };
+
+    private static string PrivateUsageOf(string algorithm)
+        => string.Equals(algorithm, "ECDH", StringComparison.Ordinal) ? "deriveBits" : "sign";
+
+    // RFC 7515 Appendix A.3 — ECDSA P-256 SHA-256.
+    private const string Es256XB64 = "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU";
+    private const string Es256YB64 = "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0";
+    private const string Es256DB64 = "jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI";
+
+    private const string Es256PublicJwk = "kty: 'EC', crv: 'P-256', x: '" + Es256XB64 + "', y: '" + Es256YB64 + "'";
+
+    private const string Es256PrivateJwk =
+        "kty: 'EC', crv: 'P-256', x: '" + Es256XB64 + "', y: '" + Es256YB64 + "', d: '" + Es256DB64 + "'";
+
+    private const string Es256XHex = "7fcdce2770f6c45d4183cbee6fdb4b7b580733357be9ef13bacf6e3c7bd15445";
+
+    private const string Es256RawHex =
+        "047fcdce2770f6c45d4183cbee6fdb4b7b580733357be9ef13bacf6e3c7bd15445c7f144cd1bbd9b7e872cdfedb9eeb9f4b3695d6ea90b24ad8a4623288588e5ad";
+
+    /// <summary>The same point with the last byte of Y flipped, which is not on the curve.</summary>
+    private const string Es256RawHexWithFlippedY =
+        "047fcdce2770f6c45d4183cbee6fdb4b7b580733357be9ef13bacf6e3c7bd15445c7f144cd1bbd9b7e872cdfedb9eeb9f4b3695d6ea90b24ad8a4623288588e5ac";
+
+    private const string Es256FlippedY = "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5aw";
+
+    /// <summary>The x coordinate one byte short, which is what a minimal-length encoding of it would be.</summary>
+    private const string Es256ShortX = "zc4ncPbEXUGDy-5v20t7WAczNXvp7xO6z248e9FURQ";
+
+    /// <summary>The x coordinate with a leading zero byte added, which is one byte too long.</summary>
+    private const string Es256LongX = "AH_Nzidw9sRdQYPL7m_bS3tYBzM1e-nvE7rPbjx70VRF";
+
+    private const string Es256SpkiHex =
+        "3059301306072a8648ce3d020106082a8648ce3d030107034200047fcdce2770f6c45d4183cbee6fdb4b7b580733357be9ef13bacf6e3c7bd15445c7f144cd1bbd9b7e872cdfedb9eeb9f4b3695d6ea90b24ad8a4623288588e5ad";
+
+    private const string Es256Pkcs8Hex =
+        "308187020100301306072a8648ce3d020106082a8648ce3d030107046d306b02010104208e9b109e719098bf980487df1f5d77e9cb29606ebed2263b5f57c213df84f4b2a144034200047fcdce2770f6c45d4183cbee6fdb4b7b580733357be9ef13bacf6e3c7bd15445c7f144cd1bbd9b7e872cdfedb9eeb9f4b3695d6ea90b24ad8a4623288588e5ad";
+
+    /// <summary>
+    /// The same key with RFC 5915's optional <c>parameters</c> field present inside the <c>ECPrivateKey</c>,
+    /// which is a valid encoding .NET's own encoder does not produce.
+    /// </summary>
+    private const string Es256Pkcs8WithInnerParametersHex =
+        "308193020100301306072a8648ce3d020106082a8648ce3d0301070479307702010104208e9b109e719098bf980487df1f5d77e9cb29606ebed2263b5f57c213df84f4b2a00a06082a8648ce3d030107a144034200047fcdce2770f6c45d4183cbee6fdb4b7b580733357be9ef13bacf6e3c7bd15445c7f144cd1bbd9b7e872cdfedb9eeb9f4b3695d6ea90b24ad8a4623288588e5ad";
+
+    /// <summary>The same, with that inner field naming P-384 where the outer one names P-256.</summary>
+    private const string Es256Pkcs8WithMismatchedInnerCurveHex =
+        "308193020100301306072a8648ce3d020106082a8648ce3d0301070479307702010104208e9b109e719098bf980487df1f5d77e9cb29606ebed2263b5f57c213df84f4b2a00706052b81040022a144034200047fcdce2770f6c45d4183cbee6fdb4b7b580733357be9ef13bacf6e3c7bd15445c7f144cd1bbd9b7e872cdfedb9eeb9f4b3695d6ea90b24ad8a4623288588e5ad";
+
+    /// <summary>The canonical encoding with the last byte of its embedded public key flipped.</summary>
+    private const string Es256Pkcs8WithMismatchedPublicKeyHex =
+        "308187020100301306072a8648ce3d020106082a8648ce3d030107046d306b02010104208e9b109e719098bf980487df1f5d77e9cb29606ebed2263b5f57c213df84f4b2a144034200047fcdce2770f6c45d4183cbee6fdb4b7b580733357be9ef13bacf6e3c7bd15445c7f144cd1bbd9b7e872cdfedb9eeb9f4b3695d6ea90b24ad8a4623288588e5ac";
+
+    private const string Es256SigningInput =
+        "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ";
+
+    private const string Es256SignatureHex =
+        "0ed1215379636c483c2f7f155807d402a3b228033af97c7e17819ac3169ea665c50a07d38c3c70e5d8f12daf084a5480a66590c5f293509a8f3f7f8a83a354d5";
+
+    // RFC 7515 Appendix A.4 — ECDSA P-521 SHA-512. The y coordinate begins with a zero byte, which is the
+    // fixed-width rule's own test case.
+    private const string Es512XB64 =
+        "AekpBQ8ST8a8VcfVOTNl353vSrDCLLJXmPk06wTjxrrjcBpXp5EOnYG_NjFZ6OvLFV1jSfS9tsz4qUxcWceqwQGk";
+
+    private const string Es512YB64 =
+        "ADSmRA43Z1DSNx_RvcLI87cdL07l6jQyyBXMoxVg_l2Th-x3S1WDhjDly79ajL4Kkd0AZMaZmh9ubmf63e3kyMj2";
+
+    private const string Es512DB64 =
+        "AY5pb7A0UFiB3RELSD64fTLOSV_jazdF7fLYyuTw8lOfRhWg6Y6rUrPAxerEzgdRhajnu0ferB0d53vM9mE15j2C";
+
+    /// <summary>The same y with its leading zero byte dropped — 65 bytes where P-521 requires 66.</summary>
+    private const string MinimalEs512Y =
+        "NKZEDjdnUNI3H9G9wsjztx0vTuXqNDLIFcyjFWD-XZOH7HdLVYOGMOXLv1qMvgqR3QBkxpmaH25uZ_rd7eTIyPY";
+
+    private const string Es512PublicJwk = "kty: 'EC', crv: 'P-521', x: '" + Es512XB64 + "', y: '" + Es512YB64 + "'";
+
+    private const string Es512PrivateJwk =
+        "kty: 'EC', crv: 'P-521', x: '" + Es512XB64 + "', y: '" + Es512YB64 + "', d: '" + Es512DB64 + "'";
+
+    private const string Es512SpkiHex =
+        "30819b301006072a8648ce3d020106052b81040023038186000401e929050f124fc6bc55c7d5393365df9def4ab0c22cb25798f934eb04e3c6bae3701a57a7910e9d81bf363159e8ebcb155d6349f4bdb6ccf8a94c5c59c7aac101a40034a6440e376750d2371fd1bdc2c8f3b71d2f4ee5ea3432c815cca31560fe5d9387ec774b55838630e5cbbf5a8cbe0a91dd0064c6999a1f6e6e67faddede4c8c8f6";
+
+    private const string Es512Pkcs8Hex =
+        "3081ee020100301006072a8648ce3d020106052b810400230481d63081d30201010442018e696fb034505881dd110b483eb87d32ce495fe36b3745edf2d8cae4f0f2539f4615a0e98eab52b3c0c5eac4ce075185a8e7bb47deac1d1de77bccf66135e63d82a18189038186000401e929050f124fc6bc55c7d5393365df9def4ab0c22cb25798f934eb04e3c6bae3701a57a7910e9d81bf363159e8ebcb155d6349f4bdb6ccf8a94c5c59c7aac101a40034a6440e376750d2371fd1bdc2c8f3b71d2f4ee5ea3432c815cca31560fe5d9387ec774b55838630e5cbbf5a8cbe0a91dd0064c6999a1f6e6e67faddede4c8c8f6";
+
+    private const string Es512SigningInput = "eyJhbGciOiJFUzUxMiJ9.UGF5bG9hZA";
+
+    private const string Es512SignatureHex =
+        "01dc0c81e7abc2d1e887e975f7697ad21a7dc001d915525b2df0ff531322ef47309d93986912356ca3d644e73e99966ac2a4f6488f8a183281df85ced1ac3fed776d006f06692c0529d0803d98285c3d980496423c45f7c4aa51c1c74e3bc2a9107c098f2a8e8330ceee22af53cbdc9f036b9b161b496f444415ee90e5e894bcde3bf267";
+
+    // RFC 6979 Appendix A.2.6 — ECDSA P-384, the signature that document gives for SHA-384 over "sample".
+    private const string P384PublicJwk =
+        "kty: 'EC', crv: 'P-384', x: '7DpOQVtOGaRWhhgCn0J_pdqai8SukuAuBqrlKGswDGTe-PDqkFWGYGSiVFFUgLwT', y: 'gBXZty19VyROqO-awMYhiWcIpZNn-d-59UyoSz8cnbEoiyMcOuDU_nNE_SUzJkcg'";
+
+    private const string P384SpkiHex =
+        "3076301006072a8648ce3d020106052b8104002203620004ec3a4e415b4e19a4568618029f427fa5da9a8bc4ae92e02e06aae5286b300c64def8f0ea9055866064a254515480bc138015d9b72d7d57244ea8ef9ac0c621896708a59367f9dfb9f54ca84b3f1c9db1288b231c3ae0d4fe7344fd2533264720";
+
+    private const string P384Pkcs8Hex =
+        "3081b6020100301006072a8648ce3d020106052b8104002204819e30819b02010104306b9d3dad2e1b8c1c05b19875b6659f4de23c3b667bf297ba9aa47740787137d896d5724e4c70a825f872c9ea60d2edf5a16403620004ec3a4e415b4e19a4568618029f427fa5da9a8bc4ae92e02e06aae5286b300c64def8f0ea9055866064a254515480bc138015d9b72d7d57244ea8ef9ac0c621896708a59367f9dfb9f54ca84b3f1c9db1288b231c3ae0d4fe7344fd2533264720";
+
+    private const string P384SignatureHex =
+        "94edbb92a5ecb8aad4736e56c691916b3f88140666ce9fa73d64c4ea95ad133c81a648152e44acf96e36dd1e80fabe4699ef4aeb15f178cea1fe40db2603138f130e740a19624526203b6351d0a3a94fa329c145786e679e7b82c71a38628ac8";
+
+    /// <summary>
+    /// The RSA SubjectPublicKeyInfo of <see cref="SubtleCryptoRsaTests"/>, used here for one thing only: it
+    /// is a well-formed structure naming an algorithm that is not <c>id-ecPublicKey</c>.
+    /// </summary>
+    private const string RsaSpkiHex =
+        "30820122300d06092a864886f70d01010105000382010f003082010a0282010100a1f8160ae2e3c9b465ce8d2d656263362b927dbe29e1f02477fc1625cc90a136e38bd93497c5b6ea63dd7711e67c7429f956b0fb8a8f089adc4b69893cc1333f53edd019b87784252fec914fe4857769594bea4280d32c0f55bf62944f130396bc6e9bdf6ebdd2bda3678eeca0c668f701b38dbffb38c8342ce2fe6d27fade4a5a4874979dd4b9cf9adec4c75b05852c2c0f5ef8a5c1750392f944e8ed64c110c6b647609aa4783aeb9c6c9ad755313050638b83665c6f6f7a82a396702a1f641b82d3ebf2392219491fb686872c5716f50af8358d9a8b9d17c340728f7f87d89a18d8fcab67ad84590c2ecf759339363c07034d6f606f9e21e05456cae5e9a10203010001";
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/SubtleCryptoKeyTests.cs
+++ b/Jint.Tests/Runtime/WebApi/SubtleCryptoKeyTests.cs
@@ -862,16 +862,19 @@ public class SubtleCryptoKeyTests
     }
 
     [Theory]
-    [InlineData("sign", "'ECDSA'")]
+    [InlineData("sign", "'X25519'")]
     [InlineData("verify", "'Ed25519'")]
     [InlineData("encrypt", "'AES-CBC'")]
     [InlineData("decrypt", "{ name: 'AES-CTR' }")]
-    [InlineData("generateKey", "'ECDH'")]
+    [InlineData("generateKey", "'HKDF'")]
     [InlineData("importKey", "'PBKDF2'")]
-    // An algorithm that is registered, but not for this operation: RSA-OAEP encrypts and never signs, and
-    // RSASSA-PKCS1-v1_5 signs and never encrypts.
+    // An algorithm that is registered, but not for this operation: RSA-OAEP encrypts and never signs,
+    // RSASSA-PKCS1-v1_5 signs and never encrypts, and ECDH — which has keys here and no operation on them
+    // yet — neither signs nor encrypts.
     [InlineData("sign", "'RSA-OAEP'")]
     [InlineData("encrypt", "'RSASSA-PKCS1-v1_5'")]
+    [InlineData("sign", "'ECDH'")]
+    [InlineData("encrypt", "'ECDSA'")]
     public void RefusesAnUnregisteredAlgorithmWithANotSupportedError(string operation, string algorithm)
     {
         var engine = WebEngine();

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -589,10 +589,12 @@ public enum WebApiFeatures
     /// cryptographically secure generator, plus <c>crypto.subtle</c> and the <c>CryptoKey</c> interface
     /// object. <c>subtle</c> carries <c>digest</c> (SHA-1, SHA-256, SHA-384, SHA-512), <c>sign</c>,
     /// <c>verify</c>, <c>encrypt</c>, <c>decrypt</c>, <c>generateKey</c>, <c>importKey</c> and
-    /// <c>exportKey</c> over HMAC, AES-GCM, RSASSA-PKCS1-v1_5, RSA-PSS and RSA-OAEP, with the <c>raw</c>,
-    /// <c>spki</c>, <c>pkcs8</c> and <c>jwk</c> key formats. Key derivation and key wrapping are not
-    /// implemented and are absent rather than present-and-throwing, so feature detection sees the truth, and
-    /// neither is any elliptic-curve algorithm. Neither <c>subtle</c> nor <c>CryptoKey</c> has a flag of its
+    /// <c>exportKey</c> over HMAC, AES-GCM, RSASSA-PKCS1-v1_5, RSA-PSS, RSA-OAEP, ECDSA and ECDH — the last
+    /// two over the curves P-256, P-384 and P-521 — with the <c>raw</c>, <c>spki</c>, <c>pkcs8</c> and
+    /// <c>jwk</c> key formats. Key derivation and key wrapping are not implemented and are absent rather than
+    /// present-and-throwing, so feature detection sees the truth; ECDH is therefore present for its keys
+    /// alone, and a key it makes may carry <c>deriveKey</c> and <c>deriveBits</c> usages that no operation
+    /// consumes yet. Neither <c>subtle</c> nor <c>CryptoKey</c> has a flag of its
     /// own: <c>subtle</c> is a readonly attribute of the very same <c>Crypto</c> interface and
     /// <c>CryptoKey</c> is the type of what it hands out, so asking for one is asking for all three.
     /// </summary>

--- a/Jint/WebApi/Crypto/AlgorithmNormalization.cs
+++ b/Jint/WebApi/Crypto/AlgorithmNormalization.cs
@@ -138,6 +138,12 @@ internal sealed class NormalizedAlgorithm
     /// <see langword="null"/> when it is not present — which the operation reads as the empty byte sequence.
     /// </summary>
     internal byte[]? Label { get; set; }
+
+    /// <summary>
+    /// The <c>namedCurve</c> member of <c>EcKeyGenParams</c> or <c>EcKeyImportParams</c>, the caller's string
+    /// verbatim — the operation is what decides whether it names a curve at all.
+    /// </summary>
+    internal string? NamedCurve { get; set; }
 }
 
 /// <summary>
@@ -185,10 +191,32 @@ internal static class AlgorithmNormalization
     /// <summary>https://w3c.github.io/webcrypto/#rsa-oaep-registration</summary>
     internal const string RsaOaep = "RSA-OAEP";
 
+    /// <summary>https://w3c.github.io/webcrypto/#ecdsa-registration</summary>
+    internal const string Ecdsa = "ECDSA";
+
+    /// <summary>https://w3c.github.io/webcrypto/#ecdh-registration</summary>
+    internal const string Ecdh = "ECDH";
+
+    /// <summary>
+    /// The three values <c>NamedCurve</c> takes — https://w3c.github.io/webcrypto/#dfn-NamedCurve, "NIST
+    /// recommended curve P-256, also known as secp256r1" and its two siblings.
+    /// </summary>
+    /// <remarks>
+    /// <c>NamedCurve</c> is <c>typedef DOMString</c> rather than a WebIDL enumeration, so nothing about the
+    /// argument conversion restricts it and an unrecognized value reaches the operation intact. Each
+    /// operation then matches it <i>case-sensitively</i> — "If the namedCurve member of normalizedAlgorithm
+    /// is not one of 'P-256', 'P-384' or 'P-521' … throw a NotSupportedError" — which is why <c>'p-256'</c>
+    /// is a <c>NotSupportedError</c> where the algorithm <i>name</i> one word to its left would have matched
+    /// case-insensitively.
+    /// </remarks>
+    internal const string P256 = "P-256";
+    internal const string P384 = "P-384";
+    internal const string P521 = "P-521";
+
     private static readonly string[] _digestAlgorithms = [Sha1, Sha256, Sha384, Sha512];
-    private static readonly string[] _signatureAlgorithms = [Hmac, RsassaPkcs1V15, RsaPss];
+    private static readonly string[] _signatureAlgorithms = [Hmac, RsassaPkcs1V15, RsaPss, Ecdsa];
     private static readonly string[] _cipherAlgorithms = [AesGcm, RsaOaep];
-    private static readonly string[] _keyAlgorithms = [Hmac, AesGcm, RsassaPkcs1V15, RsaPss, RsaOaep];
+    private static readonly string[] _keyAlgorithms = [Hmac, AesGcm, RsassaPkcs1V15, RsaPss, RsaOaep, Ecdsa, Ecdh];
 
     private static readonly JsString _nameKey = new("name");
     private static readonly JsString _hashKey = new("hash");
@@ -200,6 +228,7 @@ internal static class AlgorithmNormalization
     private static readonly JsString _publicExponentKey = new("publicExponent");
     private static readonly JsString _saltLengthKey = new("saltLength");
     private static readonly JsString _labelKey = new("label");
+    private static readonly JsString _namedCurveKey = new("namedCurve");
 
     /// <summary>
     /// The associative container "stored at the <c>op</c> key of <c>supportedAlgorithms</c>".
@@ -423,6 +452,23 @@ internal static class AlgorithmNormalization
                 normalized.Label = ReadOptionalBufferSource(context, algorithm, _labelKey, what);
                 break;
 
+            // EcKeyGenParams and EcKeyImportParams are the same one-member dictionary, declared twice, and
+            // ECDSA and ECDH register both of them for the same two operations.
+            case (Ecdsa, CryptoOperation.GenerateKey):
+            case (Ecdh, CryptoOperation.GenerateKey):
+            case (Ecdsa, CryptoOperation.ImportKey):
+            case (Ecdh, CryptoOperation.ImportKey):
+                normalized.NamedCurve = ReadRequiredDomString(context, algorithm, _namedCurveKey, what);
+                break;
+
+            // EcdsaParams, whose one member is the hash — read per sign and per verify call, because for
+            // ECDSA the hash belongs to the operation and not to the key. The key carries only its curve, so
+            // one P-256 key signs under all four of them.
+            case (Ecdsa, CryptoOperation.Sign):
+            case (Ecdsa, CryptoOperation.Verify):
+                normalized.HashName = ReadRequiredHash(context, algorithm, what);
+                break;
+
             // Every remaining pair registers `None` as its parameters, so the Algorithm dictionary — the one
             // member of which has already been read — is the whole of it. RSASSA-PKCS1-v1_5's sign and
             // verify are in that set, as is every algorithm's exportKey.
@@ -445,6 +491,27 @@ internal static class AlgorithmNormalization
         }
 
         return Normalize(context, hash, CryptoOperation.Digest, what).Name;
+    }
+
+    /// <summary>
+    /// A <c>required DOMString</c> member, which is <c>ToString</c> and nothing else — the conversion
+    /// <c>NamedCurve</c> gets, being <c>typedef DOMString</c> rather than a WebIDL enumeration.
+    /// </summary>
+    /// <remarks>
+    /// Nothing here restricts the value, so a curve name this engine does not implement arrives at the
+    /// operation intact and earns the <c>NotSupportedError</c> the operation's own first step gives it. A
+    /// WebIDL enumeration would instead have been a <c>TypeError</c> raised before the method body ran, which
+    /// is what <c>KeyFormat</c> is and what this deliberately is not.
+    /// </remarks>
+    private static string ReadRequiredDomString(CryptoContext context, ObjectInstance? algorithm, JsString key, string what)
+    {
+        var value = algorithm?.Get(key) ?? JsValue.Undefined;
+        if (value.IsUndefined())
+        {
+            context.ThrowTypeError(what + ": required member " + key + " is undefined.");
+        }
+
+        return TypeConverter.ToString(value);
     }
 
     private static byte[] ReadRequiredBufferSource(CryptoContext context, ObjectInstance? algorithm, JsString key, string what)

--- a/Jint/WebApi/Crypto/EcAlgorithm.cs
+++ b/Jint/WebApi/Crypto/EcAlgorithm.cs
@@ -1,0 +1,1047 @@
+#if NET8_0_OR_GREATER
+using System.Formats.Asn1;
+using System.Security.Cryptography;
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Crypto;
+
+/// <summary>
+/// The two elliptic-curve algorithms — ECDSA (https://w3c.github.io/webcrypto/#ecdsa) and ECDH
+/// (https://w3c.github.io/webcrypto/#ecdh) — over the three curves this specification names, <c>P-256</c>,
+/// <c>P-384</c> and <c>P-521</c>. They share every key operation and differ only in the usage sets, in the
+/// JSON Web Key <c>use</c> value and <c>alg</c> table, and in what they can then be asked to <i>do</i>:
+/// ECDSA signs and verifies, and ECDH derives.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The key's <c>[[handle]]</c> is DER, never a live key object</b>, exactly as it is for the RSA family
+/// and for the reason given there: a public key holds the bytes of a <c>SubjectPublicKeyInfo</c> and a
+/// private key those of a <c>PrivateKeyInfo</c>, and each operation rehydrates a key inside one <c>using</c>
+/// so that a script-reachable <c>CryptoKey</c> never owns a native key handle. Which class is rehydrated
+/// follows the algorithm the key was made for — <see cref="ECDsa"/> for an ECDSA key and
+/// <see cref="ECDiffieHellman"/> for an ECDH one. The DER is identical either way (both are
+/// <c>id-ecPublicKey</c> with a named curve, and this was verified against the platform), so the split buys
+/// nothing today; it is what makes the derive operations, which need a real
+/// <see cref="ECDiffieHellman"/>, an addition rather than a rewrite.
+/// </para>
+/// <para>
+/// <b>A signature is <c>r || s</c> at fixed field width.</b> "Convert r to a byte sequence of length n and
+/// append it to result. Convert s to a byte sequence of length n and append it to result", where <c>n</c> is
+/// the field size in octets — 32, 48 and 66 for the three curves, so a signature is 64, 96 or 132 bytes.
+/// That is <see cref="DSASignatureFormat.IeeeP1363FixedFieldConcatenation"/>, which is also what
+/// <see cref="ECDsa.SignData(byte[], HashAlgorithmName)"/> produces by default; the overload naming the
+/// format is used anyway, so the one thing that would silently make every signature unreadable by every
+/// other implementation cannot be changed by a default moving underneath this code.
+/// </para>
+/// <para>
+/// <b>The curve a DER structure names is read out of the DER, not off the imported key.</b> The platform
+/// will happily import a P-384 <c>SubjectPublicKeyInfo</c> into a key an import asked for P-256, and what it
+/// reports afterwards through <c>ECParameters.Curve.Oid</c> differs between operating systems — Windows
+/// fills in the friendly name, other platforms the dotted value. So the algorithm identifier is parsed with
+/// <see cref="AsnReader"/>, which is what the specification's own steps describe ("If params is equivalent
+/// to the secp256r1 object identifier … set namedCurve 'P-256'"), gives the same answer everywhere, and
+/// makes the trailing-bytes check the same <c>exactData</c> the RSA formats get.
+/// </para>
+/// <para>
+/// <b>A bad point does not arrive as a <see cref="CryptographicException"/> on Windows.</b> Importing
+/// parameters whose <c>Q</c> is not on the named curve raises <see cref="PlatformNotSupportedException"/>
+/// there ("The specified curve 'nistP256' or its parameters are not valid for this platform"), where the
+/// same input on a platform backed by OpenSSL raises <see cref="CryptographicException"/>. Both are caught,
+/// at every site, by <see cref="IsCryptographicFailure"/>: one escaping would be a CLR exception erupting
+/// out of a promise-returning operation, which is the one thing this API must never do. The message is
+/// misleading rather than informative — every one of the three curves is supported on every platform Jint
+/// ships a net8 target for — so it is not repeated to script; the <c>DataError</c> says what was actually
+/// wrong.
+/// </para>
+/// <para>
+/// <b>Elliptic-curve JSON Web Key fields are fixed-width</b>, unlike every RSA one. Section 6.2.1.2 of JSON
+/// Web Algorithms says of <c>x</c> that "The length of this octet string MUST be the full size of a
+/// coordinate for the curve specified in the 'crv' parameter", and 6.2.2.1 says the same of <c>d</c>. So a
+/// value with a leading zero byte keeps it, on the way in and on the way out, and a value of the wrong
+/// length is a <c>DataError</c> rather than something to left-pad — which is exactly what the RSA branch
+/// does with its minimal-length integers, and the difference is deliberate on both sides.
+/// </para>
+/// <para>
+/// <b>ECDH's <c>deriveKey</c> and <c>deriveBits</c> usages exist and nothing consumes them yet.</b> An ECDH
+/// key generated or imported with them is a perfectly ordinary key that no operation on this
+/// <c>SubtleCrypto</c> accepts, because <c>deriveKey</c> and <c>deriveBits</c> are absent from it — the
+/// situation AES-GCM's <c>wrapKey</c> and <c>unwrapKey</c> usages have been in since AES-GCM landed. The
+/// usage bits are still checked, split and reported exactly as the specification says, so the keys a script
+/// makes today are the keys the derive operations will find when they arrive.
+/// </para>
+/// </remarks>
+internal static class EcAlgorithm
+{
+    /// <summary>The usages an ECDSA key pair may be asked for.</summary>
+    private const KeyUsage SignatureUsages = KeyUsage.Sign | KeyUsage.Verify;
+
+    /// <summary>The usages an ECDH key pair may be asked for.</summary>
+    private const KeyUsage DerivationUsages = KeyUsage.DeriveKey | KeyUsage.DeriveBits;
+
+    /// <summary>"The usage intersection of usages and [ 'verify' ]".</summary>
+    private const KeyUsage PublicSignatureUsages = KeyUsage.Verify;
+
+    /// <summary>"The usage intersection of usages and [ 'sign' ]".</summary>
+    private const KeyUsage PrivateSignatureUsages = KeyUsage.Sign;
+
+    /// <summary>
+    /// "Set the [[usages]] internal slot of publicKey to be the empty list" — an ECDH public key carries no
+    /// usages at all, which is not an intersection but a flat rule, and is why importing one with any usage
+    /// is a <c>SyntaxError</c>. A public key is one half of an agreement; the deriving is the private half's.
+    /// </summary>
+    private const KeyUsage PublicDerivationUsages = KeyUsage.None;
+
+    /// <summary>"The usage intersection of usages and [ 'deriveKey', 'deriveBits' ]".</summary>
+    private const KeyUsage PrivateDerivationUsages = KeyUsage.DeriveKey | KeyUsage.DeriveBits;
+
+    /// <summary>
+    /// <c>id-ecPublicKey</c>, https://www.rfc-editor.org/rfc/rfc5480#section-2.1.1 — the one algorithm
+    /// identifier both DER formats may carry here. It names an elliptic-curve key and not what the key is
+    /// for, which is why one <c>SubjectPublicKeyInfo</c> can be imported as ECDSA or as ECDH.
+    /// </summary>
+    private const string IdEcPublicKey = "1.2.840.10045.2.1";
+
+    /// <summary>The curve object identifiers of https://www.rfc-editor.org/rfc/rfc5480#section-2.1.1.1.</summary>
+    private const string Secp256r1 = "1.2.840.10045.3.1.7";
+    private const string Secp384r1 = "1.3.132.0.34";
+    private const string Secp521r1 = "1.3.132.0.35";
+
+    /// <summary>The uncompressed point format's leading byte, [SEC1] 2.3.3.</summary>
+    private const byte UncompressedPointMarker = 0x04;
+
+    // -------------------------------------------------------------------------------------------------
+    // generateKey
+    // -------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#ecdsa-operations-generate-key and
+    /// https://w3c.github.io/webcrypto/#ecdh-operations-generate-key, which differ only in step 1's usage
+    /// set, in the name the resulting dictionary carries, and in what the public half's usages are.
+    /// </summary>
+    internal static AsymmetricKeyPairMaterial GenerateKey(
+        CryptoContext context,
+        NormalizedAlgorithm normalized,
+        KeyUsage usages,
+        string what)
+    {
+        var isEcdh = IsEcdh(normalized.Name);
+
+        // Step 1: "If usages contains an entry which is not one of 'sign' or 'verify', then throw a
+        // SyntaxError" — and, for ECDH, "'deriveKey' or 'deriveBits'".
+        RequireUsagesWithin(context, usages, isEcdh ? DerivationUsages : SignatureUsages, normalized.Name, what);
+
+        // Step 2's "Otherwise: throw a NotSupportedError", which is the whole of what an unrecognized curve
+        // name earns — the argument conversion let it through because NamedCurve is a DOMString.
+        var namedCurve = RequireSupportedCurve(context, normalized.NamedCurve, normalized.Name, what);
+
+        byte[] publicHandle;
+        byte[] privateHandle;
+
+        // Steps 2 and 3: generate the pair, and report a generation that fails as an OperationError. The
+        // curve is one of three the platform has always had, so this is unreachable in practice; a failure
+        // escaping as a CLR exception out of a promise-returning operation would not be.
+        try
+        {
+            using var algorithm = CreateAlgorithm(normalized.Name, NamedCurveOf(namedCurve));
+            publicHandle = algorithm.ExportSubjectPublicKeyInfo();
+            privateHandle = algorithm.ExportPkcs8PrivateKey();
+        }
+        catch (Exception e) when (IsCryptographicFailure(e))
+        {
+            context.ThrowOperationError(
+                what + ": an " + normalized.Name + " key pair could not be generated on the curve " + namedCurve + ".");
+            return default;
+        }
+
+        // Steps 4 to 8: one EcKeyAlgorithm, shared by both halves.
+        var algorithmDictionary = new CryptoKeyAlgorithm(
+            normalized.Name,
+            Length: 0,
+            HashName: null,
+            NamedCurve: namedCurve);
+
+        return new AsymmetricKeyPairMaterial(
+            publicHandle,
+            usages & (isEcdh ? PublicDerivationUsages : PublicSignatureUsages),
+            privateHandle,
+            usages & (isEcdh ? PrivateDerivationUsages : PrivateSignatureUsages),
+            algorithmDictionary);
+    }
+
+    // -------------------------------------------------------------------------------------------------
+    // importKey
+    // -------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#ecdsa-operations-import-key and
+    /// https://w3c.github.io/webcrypto/#ecdh-operations-import-key, whose four format branches this follows
+    /// step for step.
+    /// </summary>
+    /// <remarks>
+    /// The curve check is step 1 of both, <i>before</i> the format is even looked at, so an unrecognized
+    /// curve is a <c>NotSupportedError</c> whatever else is wrong with the request. Each format branch then
+    /// opens with its own usage check, before a single byte is parsed, so
+    /// <c>importKey('spki', garbage, …, ['sign'])</c> is the <c>SyntaxError</c> the usages earn rather than
+    /// the <c>DataError</c> the bytes would.
+    /// </remarks>
+    internal static (byte[] Handle, string KeyType, CryptoKeyAlgorithm Algorithm) ImportKey(
+        CryptoContext context,
+        KeyFormat format,
+        byte[]? rawData,
+        JsonWebKeyData? jwk,
+        NormalizedAlgorithm normalized,
+        bool extractable,
+        KeyUsage usages,
+        string what)
+    {
+        var isEcdh = IsEcdh(normalized.Name);
+
+        // Step 1: "If the namedCurve member of normalizedAlgorithm is not one of 'P-256', 'P-384' or
+        // 'P-521' … then throw a NotSupportedError."
+        var namedCurve = RequireSupportedCurve(context, normalized.NamedCurve, normalized.Name, what);
+
+        switch (format)
+        {
+            case KeyFormat.Spki:
+                // "If usages contains an entry which is not 'verify' then throw a SyntaxError" for ECDSA;
+                // "If usages is not empty then throw a SyntaxError" for ECDH, which is the same statement
+                // written against an empty permitted set.
+                RequireUsagesWithin(context, usages, isEcdh ? PublicDerivationUsages : PublicSignatureUsages, normalized.Name, what);
+                return ImportDer(context, rawData!, normalized.Name, namedCurve, CryptoKeyTypes.Public, what);
+
+            case KeyFormat.Pkcs8:
+                RequireUsagesWithin(context, usages, isEcdh ? PrivateDerivationUsages : PrivateSignatureUsages, normalized.Name, what);
+                return ImportDer(context, rawData!, normalized.Name, namedCurve, CryptoKeyTypes.Private, what);
+
+            case KeyFormat.Raw:
+                // The raw branch's own first step — "If the namedCurve member of normalizedAlgorithm is not
+                // a named curve, then throw a DataError" — is unreachable, because step 1 above already
+                // refused every name that is not one, and with the NotSupportedError the steps there give it.
+                RequireUsagesWithin(context, usages, isEcdh ? PublicDerivationUsages : PublicSignatureUsages, normalized.Name, what);
+                return ImportRaw(context, rawData!, normalized.Name, namedCurve, what);
+
+            case KeyFormat.Jwk:
+                return ImportJwk(context, jwk!, normalized.Name, namedCurve, isEcdh, extractable, usages, what);
+
+            default:
+                // "Otherwise: throw a NotSupportedError" — unreachable, every KeyFormat is above.
+                context.ThrowNotSupportedError(
+                    what + ": an " + normalized.Name + " key cannot be imported from the '" + KeyFormats.NameOf(format) + "' format.");
+                return default;
+        }
+    }
+
+    /// <summary>
+    /// The <c>spki</c> and <c>pkcs8</c> branches, which are the same steps over two structures: read the
+    /// curve the DER names, check it against the one the import asked for, and let the platform parse the
+    /// rest. What is kept as the handle is the platform's own canonical re-encoding, which is also exactly
+    /// what <c>exportKey</c> hands back.
+    /// </summary>
+    /// <remarks>
+    /// "The rest" includes two checks the <c>pkcs8</c> steps spell out and this code does not repeat: that
+    /// the optional <c>parameters</c> field <i>inside</i> the <c>ECPrivateKey</c> names the same curve as the
+    /// outer algorithm identifier, and that its <c>publicKey</c> field is the point the private key value
+    /// produces. Both were measured, and both are refused by the platform's parser — as a
+    /// <see cref="CryptographicException"/>, so both become the <c>DataError</c> below. The re-encoding is
+    /// where that field goes: .NET's own encoder omits it, so a structure that carries it comes back out
+    /// without it, which is a different encoding of the same key rather than a lossy one.
+    /// </remarks>
+    private static (byte[] Handle, string KeyType, CryptoKeyAlgorithm Algorithm) ImportDer(
+        CryptoContext context,
+        byte[] data,
+        string algorithmName,
+        string namedCurve,
+        string keyType,
+        string what)
+    {
+        var isPrivate = string.Equals(keyType, CryptoKeyTypes.Private, StringComparison.Ordinal);
+        var structure = isPrivate ? "PrivateKeyInfo" : "SubjectPublicKeyInfo";
+
+        var derCurve = ReadNamedCurveFromDer(context, data, isPrivate, structure, what);
+
+        // "If namedCurve is defined, and not equal to the namedCurve member of normalizedAlgorithm, throw a
+        // DataError." The platform would import the key regardless, so this is the only thing standing
+        // between a script and a P-384 key that calls itself a P-256 one.
+        if (!string.Equals(derCurve, namedCurve, StringComparison.Ordinal))
+        {
+            context.ThrowDataError(
+                what + ": the " + structure + " names the curve " + derCurve + " where the import asks for " + namedCurve + ".");
+        }
+
+        using var algorithm = CreateAlgorithm(algorithmName);
+
+        try
+        {
+            if (isPrivate)
+            {
+                algorithm.ImportPkcs8PrivateKey(data, out _);
+            }
+            else
+            {
+                algorithm.ImportSubjectPublicKeyInfo(data, out _);
+            }
+
+            return (
+                isPrivate ? algorithm.ExportPkcs8PrivateKey() : algorithm.ExportSubjectPublicKeyInfo(),
+                keyType,
+                Describe(algorithmName, namedCurve));
+        }
+        catch (Exception e) when (IsCryptographicFailure(e))
+        {
+            // "If a decode error occurs or an identity point is found, throw a DataError", and "If the
+            // public key value is not a valid point on the Elliptic Curve … throw a DataError".
+            context.ThrowDataError(
+                what + ": the " + structure + " does not describe a valid " + namedCurve + " key.");
+            return default;
+        }
+    }
+
+    /// <summary>
+    /// The <c>raw</c> branch: "Let Q be the elliptic curve point … identified by performing the conversion
+    /// steps defined in Section 2.3.4 of [SEC1] on keyData", which for the uncompressed format is the single
+    /// byte <c>0x04</c> followed by the two coordinates at the curve's field width.
+    /// </summary>
+    /// <remarks>
+    /// "The uncompressed point format MUST be supported. If the implementation does not support the
+    /// compressed point format and a compressed point is provided, throw a DataError" — this engine does not,
+    /// so a <c>0x02</c> or <c>0x03</c> point is refused by the very step that anticipates it, and the message
+    /// says which format was given rather than calling the bytes malformed. The point at infinity, whose
+    /// encoding is the single byte <c>0x00</c>, is "an identity point" and is refused with it.
+    /// </remarks>
+    private static (byte[] Handle, string KeyType, CryptoKeyAlgorithm Algorithm) ImportRaw(
+        CryptoContext context,
+        byte[] data,
+        string algorithmName,
+        string namedCurve,
+        string what)
+    {
+        var fieldSize = FieldSizeInBytes(namedCurve);
+        var expected = 1 + (2 * fieldSize);
+
+        if (data.Length > 0 && (data[0] == 0x02 || data[0] == 0x03))
+        {
+            context.ThrowDataError(
+                what + ": the key data is a compressed elliptic-curve point, which this engine does not support — only the uncompressed format, which begins with 0x04.");
+        }
+
+        if (data.Length != expected || data[0] != UncompressedPointMarker)
+        {
+            context.ThrowDataError(
+                what + ": an uncompressed " + namedCurve + " point is 0x04 followed by " + (2 * fieldSize)
+                + " bytes, and the key data is " + data.Length + " byte(s) long.");
+        }
+
+        var parameters = new ECParameters
+        {
+            Curve = NamedCurveOf(namedCurve),
+            Q = new ECPoint
+            {
+                X = data[1..(1 + fieldSize)],
+                Y = data[(1 + fieldSize)..],
+            },
+        };
+
+        return (
+            ImportParameters(context, parameters, algorithmName, isPrivate: false, namedCurve, what),
+            CryptoKeyTypes.Public,
+            Describe(algorithmName, namedCurve));
+    }
+
+    /// <summary>
+    /// The <c>jwk</c> branch, whose steps run in the specification's own order: the usage check that depends
+    /// on whether <c>d</c> is present, then <c>kty</c>, then <c>use</c>, <c>key_ops</c> and <c>ext</c>, then
+    /// <c>crv</c> and — for ECDSA alone — the <c>alg</c> table, and only then the key itself.
+    /// </summary>
+    private static (byte[] Handle, string KeyType, CryptoKeyAlgorithm Algorithm) ImportJwk(
+        CryptoContext context,
+        JsonWebKeyData jwk,
+        string algorithmName,
+        string namedCurve,
+        bool isEcdh,
+        bool extractable,
+        KeyUsage usages,
+        string what)
+    {
+        var isPrivate = jwk.D is not null;
+
+        var allowed = (isPrivate, isEcdh) switch
+        {
+            (true, true) => PrivateDerivationUsages,
+            (true, false) => PrivateSignatureUsages,
+            (false, true) => PublicDerivationUsages,
+            (false, false) => PublicSignatureUsages,
+        };
+
+        RequireUsagesWithin(context, usages, allowed, algorithmName, what);
+
+        jwk.RequireKeyType(context, "EC", what);
+
+        // ECDSA is a signing key and ECDH an encryption one, which is the only difference these three steps
+        // have between the two algorithms.
+        jwk.ValidateUseKeyOpsAndExt(context, usages, extractable, isEcdh ? "enc" : "sig", what);
+
+        // "Let namedCurve be a string whose value is equal to the crv field of jwk. If namedCurve is not
+        // equal to the namedCurve member of normalizedAlgorithm, throw a DataError." An absent crv is not
+        // equal to anything, so it lands here rather than in a missing-field message of its own.
+        if (!string.Equals(jwk.Crv, namedCurve, StringComparison.Ordinal))
+        {
+            context.ThrowDataError(
+                what + ": the crv field of the JSON Web Key is " + Describe(jwk.Crv) + " rather than '" + namedCurve + "'.");
+        }
+
+        // The alg table, which ECDSA has and ECDH does not: the ECDH import steps read no alg at all, so a
+        // JWK carrying one is imported with it ignored rather than checked.
+        if (!isEcdh && jwk.Alg is { } alg)
+        {
+            if (!TryCurveFromJwkAlgorithm(alg, out var algNamedCurve))
+            {
+                context.ThrowDataError(
+                    what + ": the alg field of the JSON Web Key is '" + alg + "', which names no curve this engine registers for ECDSA (ES256, ES384, ES512).");
+            }
+
+            if (!string.Equals(algNamedCurve, namedCurve, StringComparison.Ordinal))
+            {
+                context.ThrowDataError(
+                    what + ": the alg field of the JSON Web Key is '" + alg + "', which names the curve " + algNamedCurve
+                    + " where the key says " + namedCurve + ".");
+            }
+        }
+
+        // "If jwk does not meet the requirements of Section 6.2.1 [or 6.2.2] of JSON Web Algorithms, then
+        // throw a DataError" — which for an EC key is x, y and, for a private key, d, each present and each
+        // at the curve's own field width.
+        var fieldSize = FieldSizeInBytes(namedCurve);
+
+        var parameters = new ECParameters
+        {
+            Curve = NamedCurveOf(namedCurve),
+            Q = new ECPoint
+            {
+                X = ReadFixedWidthField(context, jwk.X, "x", fieldSize, namedCurve, what),
+                Y = ReadFixedWidthField(context, jwk.Y, "y", fieldSize, namedCurve, what),
+            },
+            D = isPrivate ? ReadFixedWidthField(context, jwk.D, "d", fieldSize, namedCurve, what) : null,
+        };
+
+        var keyType = isPrivate ? CryptoKeyTypes.Private : CryptoKeyTypes.Public;
+
+        return (
+            ImportParameters(context, parameters, algorithmName, isPrivate, namedCurve, what),
+            keyType,
+            Describe(algorithmName, namedCurve));
+    }
+
+    /// <summary>
+    /// A JSON Web Key field that must be present, must decode as base64url, and must be exactly the curve's
+    /// field size in octets — see the remarks on this class for why the width is checked rather than padded.
+    /// </summary>
+    private static byte[] ReadFixedWidthField(
+        CryptoContext context,
+        string? value,
+        string field,
+        int fieldSize,
+        string namedCurve,
+        string what)
+    {
+        var bytes = JsonWebKeyData.RequireBase64UrlField(context, value, field, what);
+
+        if (bytes.Length != fieldSize)
+        {
+            context.ThrowDataError(
+                what + ": the " + field + " field of the JSON Web Key is " + bytes.Length + " byte(s) long, and JSON Web Algorithms requires the full "
+                + fieldSize + " bytes a " + namedCurve + " value has.");
+        }
+
+        return bytes;
+    }
+
+    // -------------------------------------------------------------------------------------------------
+    // exportKey
+    // -------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#ecdsa-operations-export-key and
+    /// https://w3c.github.io/webcrypto/#ecdh-operations-export-key, which are the same steps — an EC key
+    /// exports to all four formats, where an RSA one has no <c>raw</c> and a symmetric one no <c>spki</c> or
+    /// <c>pkcs8</c>.
+    /// </summary>
+    internal static JsValue ExportKey(CryptoContext context, JsCryptoKey key, KeyFormat format, string what)
+    {
+        var namedCurve = key.Algorithm.NamedCurve!;
+
+        switch (format)
+        {
+            case KeyFormat.Spki:
+                RequireKeyType(context, key, CryptoKeyTypes.Public, what);
+
+                // The handle already is the DER encoding the steps describe — the platform's own, produced
+                // when the key was made. It is copied on the way out: what a script is handed is mutable.
+                return context.CreateArrayBuffer(key.Handle.ToArray());
+
+            case KeyFormat.Pkcs8:
+                RequireKeyType(context, key, CryptoKeyTypes.Private, what);
+                return context.CreateArrayBuffer(key.Handle.ToArray());
+
+            case KeyFormat.Raw:
+                // "Let data be a byte sequence representing the Elliptic Curve point Q … according to [SEC1]
+                // 2.3.3 using the uncompressed format."
+                RequireKeyType(context, key, CryptoKeyTypes.Public, what);
+                return context.CreateArrayBuffer(UncompressedPoint(ReadKeyParameters(context, key, includePrivateParameters: false, what), namedCurve));
+
+            case KeyFormat.Jwk:
+                return ExportJwk(context, key, namedCurve, what);
+
+            default:
+                // "Otherwise: throw a NotSupportedError" — unreachable, every KeyFormat is above.
+                context.ThrowNotSupportedError(
+                    what + ": an " + key.Algorithm.Name + " key cannot be exported to the '" + KeyFormats.NameOf(format) + "' format.");
+                return JsValue.Undefined;
+        }
+    }
+
+    private static JsObject ExportJwk(CryptoContext context, JsCryptoKey key, string namedCurve, string what)
+    {
+        var isPrivate = string.Equals(key.KeyType, CryptoKeyTypes.Private, StringComparison.Ordinal);
+        var parameters = ReadKeyParameters(context, key, isPrivate, what);
+        var fieldSize = FieldSizeInBytes(namedCurve);
+
+        // The platform hands back coordinates already at the field width, which is the width JSON Web
+        // Algorithms asks for; the alignment is what makes that a promise rather than an observation.
+        var x = AtFieldWidth(parameters.Q.X, fieldSize);
+        var y = AtFieldWidth(parameters.Q.Y, fieldSize);
+
+        if (!isPrivate)
+        {
+            return JsonWebKeyData.CreateEcPublicExport(context.Engine, namedCurve, x, y, key.Usages, key.Extractable);
+        }
+
+        return JsonWebKeyData.CreateEcPrivateExport(
+            context.Engine, namedCurve, x, y, AtFieldWidth(parameters.D, fieldSize), key.Usages, key.Extractable);
+    }
+
+    // -------------------------------------------------------------------------------------------------
+    // sign and verify
+    // -------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#ecdsa-operations-sign — "Perform the ECDSA signing process, as
+    /// specified in [RFC6090], Section 5.4.2", with the hash taken from <c>EcdsaParams</c> rather than from
+    /// the key.
+    /// </summary>
+    internal static byte[] Sign(
+        CryptoContext context,
+        NormalizedAlgorithm normalized,
+        JsCryptoKey key,
+        ReadOnlySpan<byte> message,
+        string what)
+    {
+        // Step 1: "If the [[type]] internal slot of key is not 'private', then throw an InvalidAccessError."
+        RequireKeyType(context, key, CryptoKeyTypes.Private, what);
+
+        using var algorithm = CreateFromHandle(context, key, what);
+
+        // The dispatch proved the key was made for ECDSA before this was called, and an ECDSA key is
+        // rehydrated as an ECDsa — see the remarks on this class.
+        var ecdsa = (ECDsa) algorithm;
+
+        try
+        {
+            return ecdsa.SignData(
+                message.ToArray(),
+                HashName(normalized.HashName!),
+                DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
+        }
+        catch (Exception e) when (IsCryptographicFailure(e))
+        {
+            // The signing steps name no error of their own, unlike RSA's — but a promise-returning operation
+            // reports every failure as a rejection, and OperationError, "the operation failed for an
+            // operation-specific reason", is what its siblings use for exactly this.
+            context.ThrowOperationError(what + ": the signature could not be produced.");
+            return null!;
+        }
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#ecdsa-operations-verify: "Let result be a boolean with the value
+    /// true if the signature is valid and the value false otherwise."
+    /// </summary>
+    internal static bool Verify(
+        CryptoContext context,
+        NormalizedAlgorithm normalized,
+        JsCryptoKey key,
+        ReadOnlySpan<byte> signature,
+        ReadOnlySpan<byte> message,
+        string what)
+    {
+        // Step 1: "If the [[type]] internal slot of key is not 'public', then throw an InvalidAccessError."
+        RequireKeyType(context, key, CryptoKeyTypes.Public, what);
+
+        // "If signature does not have a length of n * 2 bytes, then return false" — a step of its own, and
+        // one of the two places this algorithm answers false rather than failing.
+        //
+        // Nothing observable depends on it: the platform's own verification answers false for a signature of
+        // the wrong length too, which was measured rather than assumed. It is kept because it is the
+        // specification's step and because it runs *before* the key is rehydrated, so a signature that
+        // cannot be the right one costs no key import — and because "it happens to agree today" is a thin
+        // reason to leave a normative step to somebody else's implementation.
+        if (signature.Length != 2 * FieldSizeInBytes(key.Algorithm.NamedCurve!))
+        {
+            return false;
+        }
+
+        using var algorithm = CreateFromHandle(context, key, what);
+        var ecdsa = (ECDsa) algorithm;
+
+        try
+        {
+            return ecdsa.VerifyData(
+                message,
+                signature,
+                HashName(normalized.HashName!),
+                DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
+        }
+        catch (Exception e) when (IsCryptographicFailure(e))
+        {
+            // There is no error step here either, so the platform's refusal to look at a signature is
+            // "otherwise", which covers every way a signature can fail to be the valid one.
+            return false;
+        }
+    }
+
+    // -------------------------------------------------------------------------------------------------
+    // Curves
+    // -------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Step 1 of both import operations and the "Otherwise" arm of both generate operations: the only names
+    /// this engine implements are the three the specification defines, matched case-sensitively.
+    /// </summary>
+    /// <remarks>
+    /// The curves an "applicable specification" may add — secp256k1, and the Edwards and Montgomery curves
+    /// of the Secure Curves draft — are deliberately not among them: each has its own registration with its
+    /// own algorithm names, and reaching one of them through this member would be Jint inventing a curve
+    /// registry of its own.
+    /// </remarks>
+    private static string RequireSupportedCurve(CryptoContext context, string? namedCurve, string algorithmName, string what)
+    {
+        switch (namedCurve)
+        {
+            case AlgorithmNormalization.P256:
+            case AlgorithmNormalization.P384:
+            case AlgorithmNormalization.P521:
+                return namedCurve;
+            default:
+                context.ThrowNotSupportedError(
+                    what + ": " + Describe(namedCurve) + " is not a curve this engine registers for " + algorithmName
+                    + " (" + AlgorithmNormalization.P256 + ", " + AlgorithmNormalization.P384 + ", " + AlgorithmNormalization.P521 + ").");
+                return null!;
+        }
+    }
+
+    /// <summary>
+    /// The algorithm identifier of a <c>SubjectPublicKeyInfo</c> or a <c>PrivateKeyInfo</c>, read as the
+    /// specification's own steps enumerate it. See the remarks on this class for why the DER is parsed here
+    /// rather than the imported key questioned afterwards.
+    /// </summary>
+    private static string ReadNamedCurveFromDer(
+        CryptoContext context,
+        byte[] data,
+        bool isPrivate,
+        string structure,
+        string what)
+    {
+        string curveOid;
+
+        try
+        {
+            var reader = new AsnReader(data, AsnEncodingRules.DER);
+            var contents = reader.ReadSequence();
+
+            // "parse an ASN.1 structure … with exactData set to true": a structure that is followed by
+            // anything is not the structure that was asked for, however well-formed its prefix is.
+            if (reader.HasData)
+            {
+                context.ThrowDataError(what + ": the " + structure + " is followed by trailing byte(s).");
+            }
+
+            if (isPrivate)
+            {
+                // PrivateKeyInfo's own version field, which precedes the algorithm identifier.
+                contents.ReadInteger();
+            }
+
+            var algorithmIdentifier = contents.ReadSequence();
+
+            // "If the algorithm object identifier field … is not equal to the id-ecPublicKey object
+            // identifier defined in [RFC5480], then throw a DataError."
+            var algorithmOid = algorithmIdentifier.ReadObjectIdentifier();
+            if (!string.Equals(algorithmOid, IdEcPublicKey, StringComparison.Ordinal))
+            {
+                context.ThrowDataError(
+                    what + ": the " + structure + " names the algorithm " + algorithmOid + " rather than id-ecPublicKey (" + IdEcPublicKey + ").");
+            }
+
+            // "If the parameters field … is absent, then throw a DataError", and then "If params is not an
+            // instance of the ECParameters ASN.1 type … that specifies a namedCurve, then throw a
+            // DataError" — which is what reading an object identifier here says.
+            if (!algorithmIdentifier.HasData)
+            {
+                context.ThrowDataError(what + ": the " + structure + " carries no curve parameters.");
+            }
+
+            curveOid = algorithmIdentifier.ReadObjectIdentifier();
+        }
+        catch (AsnContentException)
+        {
+            // "If an error occurred while parsing, then throw a DataError."
+            context.ThrowDataError(what + ": the data is not a valid " + structure + " structure.");
+            return null!;
+        }
+
+        switch (curveOid)
+        {
+            case Secp256r1:
+                return AlgorithmNormalization.P256;
+            case Secp384r1:
+                return AlgorithmNormalization.P384;
+            case Secp521r1:
+                return AlgorithmNormalization.P521;
+            default:
+                // The "Otherwise" arm, whose end is "If an error occurred or there are no applicable
+                // specifications, throw a DataError" — there are none here.
+                context.ThrowDataError(
+                    what + ": the " + structure + " names the curve " + curveOid + ", which is not one this engine implements.");
+                return null!;
+        }
+    }
+
+    /// <summary>The <see cref="ECCurve"/> a recognized curve name denotes.</summary>
+    /// <remarks>
+    /// Every name is spelled out and the default throws rather than one of them standing in as a fallback: a
+    /// curve added to the registry without a case here would silently be built on another curve's domain
+    /// parameters, which is the one mistake in this file that would produce keys instead of errors.
+    /// </remarks>
+    private static ECCurve NamedCurveOf(string namedCurve)
+    {
+        switch (namedCurve)
+        {
+            case AlgorithmNormalization.P256:
+                return ECCurve.NamedCurves.nistP256;
+            case AlgorithmNormalization.P384:
+                return ECCurve.NamedCurves.nistP384;
+            case AlgorithmNormalization.P521:
+                return ECCurve.NamedCurves.nistP521;
+            default:
+                Throw.InvalidOperationException("Unhandled named curve '" + namedCurve + "'.");
+                return default;
+        }
+    }
+
+    /// <summary>
+    /// The length of one coordinate, and of the private key value, in octets — "the full size of a
+    /// coordinate for the curve", https://www.rfc-editor.org/rfc/rfc7518#section-6.2.1.2.
+    /// </summary>
+    /// <remarks>
+    /// It is the field size rounded <i>up</i> to whole octets, which for P-521 is 66 rather than 65: 521
+    /// bits is 65.125 bytes, and the RFC spells that case out — "if the value of 'crv' is 'P-521', the octet
+    /// string must be 66 octets long". It is also the <c>n</c> of the signature steps, "the smallest integer
+    /// such that n * 8 is greater than the logarithm to base 2 of the order of the base point", so the same
+    /// number decides a JSON Web Key field's width and a signature's length.
+    /// </remarks>
+    private static int FieldSizeInBytes(string namedCurve)
+    {
+        switch (namedCurve)
+        {
+            case AlgorithmNormalization.P256:
+                return 32;
+            case AlgorithmNormalization.P384:
+                return 48;
+            case AlgorithmNormalization.P521:
+                return 66;
+            default:
+                Throw.InvalidOperationException("Unhandled named curve '" + namedCurve + "'.");
+                return 0;
+        }
+    }
+
+    /// <summary>
+    /// The <c>alg</c> table of the ECDSA import steps: "If the alg field is equal to the string 'ES256':
+    /// let algNamedCurve be the string 'P-256'", and so on.
+    /// </summary>
+    /// <remarks>
+    /// <c>ES512</c> names <b>P-521</b>, not a curve of 512 bits — the number in a JOSE <c>alg</c> is the
+    /// hash's output length, and ECDSA over P-521 is paired with SHA-512 by
+    /// https://www.rfc-editor.org/rfc/rfc7518#section-3.4. It is the one row of this table that cannot be
+    /// derived from the curve's own name, which is why the table is written out.
+    /// </remarks>
+    private static bool TryCurveFromJwkAlgorithm(string alg, out string namedCurve)
+    {
+        switch (alg)
+        {
+            case "ES256":
+                namedCurve = AlgorithmNormalization.P256;
+                return true;
+            case "ES384":
+                namedCurve = AlgorithmNormalization.P384;
+                return true;
+            case "ES512":
+                namedCurve = AlgorithmNormalization.P521;
+                return true;
+            default:
+                namedCurve = null!;
+                return false;
+        }
+    }
+
+    // -------------------------------------------------------------------------------------------------
+    // Shared helpers
+    // -------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// The two exception types the platform reports a key it will not accept by. See the remarks on this
+    /// class: on Windows a point that is not on its curve arrives as a
+    /// <see cref="PlatformNotSupportedException"/>, which is not a <see cref="CryptographicException"/> and
+    /// would otherwise escape as a CLR exception out of a promise-returning operation.
+    /// </summary>
+    private static bool IsCryptographicFailure(Exception exception)
+        => exception is CryptographicException or PlatformNotSupportedException;
+
+    private static bool IsEcdh(string algorithmName)
+        => string.Equals(algorithmName, AlgorithmNormalization.Ecdh, StringComparison.Ordinal);
+
+    /// <summary>
+    /// An empty key object of the class the algorithm names — see the remarks on this class for why ECDSA
+    /// and ECDH are kept apart even though their DER is the same.
+    /// </summary>
+    private static AsymmetricAlgorithm CreateAlgorithm(string algorithmName)
+        => IsEcdh(algorithmName) ? ECDiffieHellman.Create() : (AsymmetricAlgorithm) ECDsa.Create();
+
+    /// <summary>A freshly generated key on <paramref name="curve"/>, of the class the algorithm names.</summary>
+    private static AsymmetricAlgorithm CreateAlgorithm(string algorithmName, ECCurve curve)
+        => IsEcdh(algorithmName) ? ECDiffieHellman.Create(curve) : (AsymmetricAlgorithm) ECDsa.Create(curve);
+
+    /// <summary>
+    /// Rehydrates the key a <c>[[handle]]</c> describes. See the remarks on this class for why the handle is
+    /// DER and this happens per operation.
+    /// </summary>
+    private static AsymmetricAlgorithm CreateFromHandle(CryptoContext context, JsCryptoKey key, string what)
+    {
+        var algorithm = CreateAlgorithm(key.Algorithm.Name);
+
+        try
+        {
+            if (string.Equals(key.KeyType, CryptoKeyTypes.Private, StringComparison.Ordinal))
+            {
+                algorithm.ImportPkcs8PrivateKey(key.Handle, out _);
+            }
+            else
+            {
+                algorithm.ImportSubjectPublicKeyInfo(key.Handle, out _);
+            }
+
+            return algorithm;
+        }
+        catch (Exception e) when (IsCryptographicFailure(e))
+        {
+            algorithm.Dispose();
+
+            // "If the underlying cryptographic key material represented by the [[handle]] internal slot of
+            // key cannot be accessed, then throw an OperationError." Unreachable in practice — the bytes are
+            // the platform's own canonical encoding of a key it built.
+            context.ThrowOperationError(what + ": the key material could not be accessed.");
+            return null!;
+        }
+    }
+
+    /// <summary>
+    /// Builds a key from parameters a <c>jwk</c> or a <c>raw</c> import produced and keeps the platform's own
+    /// canonical DER as the handle — which is exactly what <c>exportKey</c>'s <c>spki</c> and <c>pkcs8</c>
+    /// branches describe, so the two can never disagree.
+    /// </summary>
+    private static byte[] ImportParameters(
+        CryptoContext context,
+        ECParameters parameters,
+        string algorithmName,
+        bool isPrivate,
+        string namedCurve,
+        string what)
+    {
+        using var algorithm = CreateAlgorithm(algorithmName);
+
+        try
+        {
+            switch (algorithm)
+            {
+                case ECDiffieHellman ecdh:
+                    ecdh.ImportParameters(parameters);
+                    break;
+                case ECDsa ecdsa:
+                    ecdsa.ImportParameters(parameters);
+                    break;
+                default:
+                    // Unreachable: CreateAlgorithm produces one of exactly those two.
+                    Throw.InvalidOperationException("Unhandled elliptic-curve algorithm '" + algorithmName + "'.");
+                    break;
+            }
+
+            return isPrivate ? algorithm.ExportPkcs8PrivateKey() : algorithm.ExportSubjectPublicKeyInfo();
+        }
+        catch (Exception e) when (IsCryptographicFailure(e))
+        {
+            // "If the key value is not a valid point on the Elliptic Curve identified by the namedCurve
+            // member of normalizedAlgorithm throw a DataError."
+            context.ThrowDataError(
+                what + ": the key value is not a valid point on the curve " + namedCurve + ".");
+            return null!;
+        }
+    }
+
+    /// <summary>
+    /// The <see cref="ECParameters"/> of the key a <c>[[handle]]</c> describes — what the <c>jwk</c> and
+    /// <c>raw</c> export branches are written in terms of.
+    /// </summary>
+    private static ECParameters ReadKeyParameters(
+        CryptoContext context,
+        JsCryptoKey key,
+        bool includePrivateParameters,
+        string what)
+    {
+        using var algorithm = CreateFromHandle(context, key, what);
+
+        try
+        {
+            switch (algorithm)
+            {
+                case ECDiffieHellman ecdh:
+                    return ecdh.ExportParameters(includePrivateParameters);
+                case ECDsa ecdsa:
+                    return ecdsa.ExportParameters(includePrivateParameters);
+                default:
+                    // Unreachable: CreateFromHandle produces one of exactly those two.
+                    Throw.InvalidOperationException("Unhandled elliptic-curve algorithm '" + key.Algorithm.Name + "'.");
+                    return default;
+            }
+        }
+        catch (Exception e) when (IsCryptographicFailure(e))
+        {
+            context.ThrowOperationError(what + ": the key material could not be accessed.");
+            return default;
+        }
+    }
+
+    /// <summary>
+    /// The uncompressed encoding of a public point, [SEC1] 2.3.3: <c>0x04</c> followed by the two
+    /// coordinates, each at the curve's field width.
+    /// </summary>
+    private static byte[] UncompressedPoint(ECParameters parameters, string namedCurve)
+    {
+        var fieldSize = FieldSizeInBytes(namedCurve);
+        var point = new byte[1 + (2 * fieldSize)];
+
+        point[0] = UncompressedPointMarker;
+        AtFieldWidth(parameters.Q.X, fieldSize).CopyTo(point.AsSpan(1));
+        AtFieldWidth(parameters.Q.Y, fieldSize).CopyTo(point.AsSpan(1 + fieldSize));
+
+        return point;
+    }
+
+    /// <summary>
+    /// A big-endian value at exactly <paramref name="fieldSize"/> bytes, left-padded with zeros if the
+    /// platform handed back fewer. It never does for the three named curves — <see cref="ECParameters"/>
+    /// describes a named curve's values at the field width, and that was verified — so this is the promise
+    /// rather than a conversion, and it is what keeps a coordinate whose leading byte is zero from being
+    /// exported one byte short of what JSON Web Algorithms requires.
+    /// </summary>
+    private static byte[] AtFieldWidth(byte[]? value, int fieldSize)
+    {
+        if (value is null)
+        {
+            return new byte[fieldSize];
+        }
+
+        if (value.Length == fieldSize)
+        {
+            return value;
+        }
+
+        var padded = new byte[fieldSize];
+        var offset = fieldSize - value.Length;
+
+        // A value longer than the field cannot describe a point on it, and the platform cannot produce one;
+        // the trailing bytes are the ones kept so that the result is still the value's low-order end.
+        if (offset < 0)
+        {
+            value.AsSpan(-offset).CopyTo(padded);
+            return padded;
+        }
+
+        value.CopyTo(padded.AsSpan(offset));
+        return padded;
+    }
+
+    /// <summary>The <c>EcKeyAlgorithm</c> a generate or an import ends in.</summary>
+    private static CryptoKeyAlgorithm Describe(string algorithmName, string namedCurve)
+        => new(algorithmName, Length: 0, HashName: null, NamedCurve: namedCurve);
+
+    /// <summary>
+    /// "If usages contains an entry which is not …, then throw a SyntaxError" — the first step of every
+    /// generate and import branch, differing only in the set it names.
+    /// </summary>
+    private static void RequireUsagesWithin(CryptoContext context, KeyUsage usages, KeyUsage allowed, string algorithmName, string what)
+    {
+        if ((usages & ~allowed) == KeyUsage.None)
+        {
+            return;
+        }
+
+        if (allowed == KeyUsage.None)
+        {
+            // ECDH's public key, whose steps say "If usages is not empty" rather than naming a set — so the
+            // message says that too, rather than offering an empty list of permitted usages.
+            context.ThrowSyntaxError(
+                what + ": an " + algorithmName + " public key carries no usages at all, and " + KeyUsages.Describe(usages) + " was asked for.");
+        }
+
+        context.ThrowSyntaxError(
+            what + ": this " + algorithmName + " key supports the usages " + KeyUsages.Describe(allowed)
+            + ", not " + KeyUsages.Describe(usages & ~allowed) + ".");
+    }
+
+    /// <summary>
+    /// "If the [[type]] internal slot of key is not <c>expected</c>, then throw an InvalidAccessError" — the
+    /// first step of both operations, and the one that makes a public key refuse to sign.
+    /// </summary>
+    private static void RequireKeyType(CryptoContext context, JsCryptoKey key, string expected, string what)
+    {
+        if (!string.Equals(key.KeyType, expected, StringComparison.Ordinal))
+        {
+            context.ThrowInvalidAccessError(
+                what + ": this operation needs a " + expected + " key, and the key given is a " + key.KeyType + " key.");
+        }
+    }
+
+    private static HashAlgorithmName HashName(string hashName)
+    {
+        switch (hashName)
+        {
+            case AlgorithmNormalization.Sha1:
+                // SHA-1 is one of the four hashes the digest registry carries, so an EcdsaParams may name it
+                // and a script asking for it has already chosen; nothing in the engine picks it for anybody.
+                return HashAlgorithmName.SHA1;
+            case AlgorithmNormalization.Sha256:
+                return HashAlgorithmName.SHA256;
+            case AlgorithmNormalization.Sha384:
+                return HashAlgorithmName.SHA384;
+            case AlgorithmNormalization.Sha512:
+                return HashAlgorithmName.SHA512;
+            default:
+                // Unreachable: the hash was matched against the digest registry during normalization.
+                Throw.InvalidOperationException("Unhandled ECDSA hash algorithm '" + hashName + "'.");
+                return default;
+        }
+    }
+
+    private static string Describe(string? value) => value is null ? "an absent curve name" : "'" + value + "'";
+}
+#endif

--- a/Jint/WebApi/Crypto/JsCryptoKey.cs
+++ b/Jint/WebApi/Crypto/JsCryptoKey.cs
@@ -27,15 +27,36 @@ internal static class CryptoKeyTypes
 /// </para>
 /// </summary>
 /// <remarks>
+/// <para>
 /// One struct rather than a type per dictionary, for the reason <see cref="NormalizedAlgorithm"/> is one
-/// class: the union of the members across the dictionaries this engine produces is five fields, and which
-/// dictionary a value describes is decided by which of them are filled in. <see cref="PublicExponent"/> is
-/// the discriminator — an <c>RsaHashedKeyAlgorithm</c> is the only one that has one, so a non-null value
-/// there means <see cref="Length"/> is meaningless and <see cref="ModulusLength"/> is what describes the key.
+/// class: the union of the members across the dictionaries this engine produces is six fields, and which
+/// dictionary a value describes is decided by which of them are filled in.
+/// </para>
+/// <para>
+/// <b>Two of the six are discriminators</b>, and they are tested in this order, because the dictionaries
+/// they name carry none of the other members at all:
+/// </para>
+/// <list type="number">
+/// <item>
+/// <see cref="NamedCurve"/> non-null means an <c>EcKeyAlgorithm</c>: <see cref="Length"/>,
+/// <see cref="HashName"/>, <see cref="ModulusLength"/> and <see cref="PublicExponent"/> are all unused, an
+/// EC key being described by its curve and nothing else. It is tested first precisely because it is the one
+/// dictionary that fills in <i>only</i> its own member — an <c>AesKeyAlgorithm</c> is what a null
+/// <see cref="HashName"/> would otherwise be read as.
+/// </item>
+/// <item>
+/// <see cref="PublicExponent"/> non-null means an <c>RsaHashedKeyAlgorithm</c>: <see cref="Length"/> is
+/// meaningless and <see cref="ModulusLength"/> is what describes the key.
+/// </item>
+/// </list>
+/// <para>
+/// With neither set the key is symmetric, and a null <see cref="HashName"/> then separates an
+/// <c>AesKeyAlgorithm</c> from an <c>HmacKeyAlgorithm</c>.
+/// </para>
 /// </remarks>
 /// <param name="Name">
-/// The recognized algorithm name — <c>HMAC</c>, <c>AES-GCM</c>, <c>RSASSA-PKCS1-v1_5</c>, <c>RSA-PSS</c> or
-/// <c>RSA-OAEP</c>.
+/// The recognized algorithm name — <c>HMAC</c>, <c>AES-GCM</c>, <c>RSASSA-PKCS1-v1_5</c>, <c>RSA-PSS</c>,
+/// <c>RSA-OAEP</c>, <c>ECDSA</c> or <c>ECDH</c>.
 /// </param>
 /// <param name="Length">
 /// The length of a symmetric key in bits, which <c>HmacKeyAlgorithm</c> and <c>AesKeyAlgorithm</c> both
@@ -53,13 +74,34 @@ internal static class CryptoKeyTypes
 /// <c>BigInteger</c> is (https://w3c.github.io/webcrypto/#big-integer) and surfaced to script as a
 /// <c>Uint8Array</c>. <see langword="null"/> for every symmetric algorithm.
 /// </param>
+/// <param name="NamedCurve">
+/// The <c>namedCurve</c> member of an <c>EcKeyAlgorithm</c> — <c>P-256</c>, <c>P-384</c> or <c>P-521</c>, in
+/// the registered spelling. <see langword="null"/> for every algorithm that is not an elliptic-curve one.
+/// </param>
 [StructLayout(LayoutKind.Auto)]
 internal readonly record struct CryptoKeyAlgorithm(
     string Name,
     uint Length,
     string? HashName,
     uint ModulusLength = 0,
-    byte[]? PublicExponent = null);
+    byte[]? PublicExponent = null,
+    string? NamedCurve = null);
+
+/// <summary>
+/// The two halves of a generated asymmetric key pair, with the usages each of them ends up carrying.
+/// </summary>
+/// <remarks>
+/// One <see cref="CryptoKeyAlgorithm"/> for both halves, because every generate operation that produces a
+/// pair builds exactly one key algorithm dictionary and sets the <c>[[algorithm]]</c> slot of both keys to
+/// it — one <c>RsaHashedKeyAlgorithm</c> for the RSA family, one <c>EcKeyAlgorithm</c> for ECDSA and ECDH.
+/// </remarks>
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct AsymmetricKeyPairMaterial(
+    byte[] PublicHandle,
+    KeyUsage PublicUsages,
+    byte[] PrivateHandle,
+    KeyUsage PrivateUsages,
+    CryptoKeyAlgorithm Algorithm);
 
 /// <summary>
 /// A <c>CryptoKey</c> — "an opaque reference to keying material".
@@ -131,6 +173,16 @@ internal sealed class JsCryptoKey : ObjectInstance
         .Add("hash")
         .Build();
 
+    /// <summary>
+    /// <c>EcKeyAlgorithm</c>, https://w3c.github.io/webcrypto/#EcKeyAlgorithm-dictionary, whose one own
+    /// member is <c>namedCurve</c> — so <c>name</c> comes first, from <c>KeyAlgorithm</c>. There is no
+    /// <c>hash</c>: an ECDSA key's hash belongs to each sign and verify call, not to the key.
+    /// </summary>
+    private static readonly JsObjectLayout _ecKeyAlgorithmLayout = JsObjectLayout.CreateBuilder()
+        .Add("name")
+        .Add("namedCurve")
+        .Build();
+
     private readonly byte[] _handle;
 
     private ObjectInstance? _algorithmCached;
@@ -158,9 +210,9 @@ internal sealed class JsCryptoKey : ObjectInstance
     /// </summary>
     /// <remarks>
     /// What the bytes <i>are</i> is the algorithm's business: for a symmetric key they are the key material
-    /// itself, and for an RSA key they are the DER encoding of a <c>SubjectPublicKeyInfo</c> or of a
-    /// <c>PrivateKeyInfo</c>. Holding a serialized form rather than a live
-    /// <see cref="System.Security.Cryptography.RSA"/> is deliberate: an <c>RSA</c> is
+    /// itself, and for every asymmetric key — RSA, ECDSA and ECDH alike — they are the DER encoding of a
+    /// <c>SubjectPublicKeyInfo</c> or of a <c>PrivateKeyInfo</c>. Holding a serialized form rather than a
+    /// live <see cref="System.Security.Cryptography.AsymmetricAlgorithm"/> is deliberate: one is
     /// <see cref="IDisposable"/> and would give a script-reachable object a native lifetime the garbage
     /// collector decides, where a byte array has none. Each operation rehydrates one, uses it and disposes it
     /// inside a single <c>using</c>, which costs a key import per call and buys a <c>CryptoKey</c> that is
@@ -200,7 +252,12 @@ internal sealed class JsCryptoKey : ObjectInstance
 
         var name = JsString.Create(Algorithm.Name);
 
-        if (Algorithm.PublicExponent is { } publicExponent)
+        // The discriminators, in the order the remarks on CryptoKeyAlgorithm give them.
+        if (Algorithm.NamedCurve is { } namedCurve)
+        {
+            _algorithmCached = JsObject.Create(_engine, _ecKeyAlgorithmLayout, [name, JsString.Create(namedCurve)]);
+        }
+        else if (Algorithm.PublicExponent is { } publicExponent)
         {
             var rsaHash = JsObject.Create(_engine, _keyAlgorithmLayout, [JsString.Create(Algorithm.HashName!)]);
             _algorithmCached = JsObject.Create(

--- a/Jint/WebApi/Crypto/JsonWebKeyData.cs
+++ b/Jint/WebApi/Crypto/JsonWebKeyData.cs
@@ -30,30 +30,30 @@ internal readonly record struct RsaJwkPrivateFields(
 /// </summary>
 /// <remarks>
 /// <para>
-/// A documented simplification: the dictionary declares eighteen members and this reads the fourteen an
-/// <c>oct</c> key or an <c>RSA</c> key can be described by — <c>alg</c>, <c>d</c>, <c>dp</c>, <c>dq</c>,
-/// <c>e</c>, <c>ext</c>, <c>k</c>, <c>key_ops</c>, <c>kty</c>, <c>n</c>, <c>p</c>, <c>q</c>, <c>qi</c> and
-/// <c>use</c>. A getter on one of the four elliptic-curve or multi-prime members — <c>crv</c>, <c>x</c>,
-/// <c>y</c> and <c>oth</c> — is therefore not invoked, where a browser's WebIDL conversion would invoke it
-/// and could raise a <c>TypeError</c> from converting its value. The specification's own note covers the
-/// difference: "fields that are not explicitly referred to in the key import procedures for an algorithm are
-/// ignored".
+/// A documented simplification: the dictionary declares eighteen members and this reads the seventeen an
+/// <c>oct</c>, an <c>RSA</c> or an <c>EC</c> key can be described by — <c>alg</c>, <c>crv</c>, <c>d</c>,
+/// <c>dp</c>, <c>dq</c>, <c>e</c>, <c>ext</c>, <c>k</c>, <c>key_ops</c>, <c>kty</c>, <c>n</c>, <c>p</c>,
+/// <c>q</c>, <c>qi</c>, <c>use</c>, <c>x</c> and <c>y</c>. The one left is <c>oth</c>, so a getter on it is
+/// not invoked where a browser's WebIDL conversion would invoke it and could raise a <c>TypeError</c> from
+/// converting its value. The specification's own note covers the difference: "fields that are not explicitly
+/// referred to in the key import procedures for an algorithm are ignored".
 /// </para>
 /// <para>
-/// <c>oth</c> is the one whose absence is worth naming, because a JWK carrying it describes a key with more
-/// than two prime factors and the five CRT fields read here then describe only the first two. Nothing
-/// silently succeeds: the parameters are handed to the platform's own RSA importer, which validates them
-/// against <c>n</c> and refuses the mismatch, so such a key is a <c>DataError</c> rather than a key that is
-/// quietly wrong.
+/// <c>oth</c>'s absence is worth naming, because a JWK carrying it describes an RSA key with more than two
+/// prime factors and the five CRT fields read here then describe only the first two. Nothing silently
+/// succeeds: the parameters are handed to the platform's own RSA importer, which validates them against
+/// <c>n</c> and refuses the mismatch, so such a key is a <c>DataError</c> rather than a key that is quietly
+/// wrong.
 /// </para>
 /// <para>
-/// The fourteen that <i>are</i> read are read in lexicographical order, which is the order WebIDL converts a
+/// The seventeen that <i>are</i> read are read in lexicographical order, which is the order WebIDL converts a
 /// dictionary's members in, so a JWK built out of getters sees them run in the order a browser runs them.
 /// </para>
 /// </remarks>
 internal sealed class JsonWebKeyData
 {
     private static readonly JsString _algKey = new("alg");
+    private static readonly JsString _crvKey = new("crv");
     private static readonly JsString _dKey = new("d");
     private static readonly JsString _dpKey = new("dp");
     private static readonly JsString _dqKey = new("dq");
@@ -67,6 +67,8 @@ internal sealed class JsonWebKeyData
     private static readonly JsString _qKey = new("q");
     private static readonly JsString _qiKey = new("qi");
     private static readonly JsString _useKey = new("use");
+    private static readonly JsString _xKey = new("x");
+    private static readonly JsString _yKey = new("y");
 
     /// <summary>
     /// The shape <c>exportKey("jwk")</c> answers with for a symmetric key. Both algorithms set every one of
@@ -114,8 +116,46 @@ internal sealed class JsonWebKeyData
         .Add("qi")
         .Build();
 
+    /// <summary>
+    /// The shape <c>exportKey("jwk")</c> answers with for an elliptic-curve <i>public</i> key: the three
+    /// members Section 6.2.1 of JSON Web Algorithms defines, plus the three every export carries — again in
+    /// lexicographical order.
+    /// </summary>
+    /// <remarks>
+    /// <b>There is no <c>alg</c>.</b> The RSA export steps set one and the ECDSA and ECDH export steps
+    /// deliberately do not: an EC key's curve is in <c>crv</c>, and for ECDSA the hash is not a property of
+    /// the key at all, so there is nothing an <c>alg</c> could truthfully name. Import still reads the field
+    /// when it is present — a JOSE document carries <c>ES256</c> — which is why the two directions are not
+    /// symmetric here and are symmetric for RSA. It is what a browser exports too.
+    /// </remarks>
+    private static readonly JsObjectLayout _ecPublicExportLayout = JsObjectLayout.CreateBuilder()
+        .Add("crv")
+        .Add("ext")
+        .Add("key_ops")
+        .Add("kty")
+        .Add("x")
+        .Add("y")
+        .Build();
+
+    /// <summary>
+    /// The shape <c>exportKey("jwk")</c> answers with for an elliptic-curve <i>private</i> key: the public
+    /// members plus <c>d</c> of Section 6.2.2.1, in lexicographical order.
+    /// </summary>
+    private static readonly JsObjectLayout _ecPrivateExportLayout = JsObjectLayout.CreateBuilder()
+        .Add("crv")
+        .Add("d")
+        .Add("ext")
+        .Add("key_ops")
+        .Add("kty")
+        .Add("x")
+        .Add("y")
+        .Build();
+
     /// <summary>The <c>alg</c> field, or <see langword="null"/> when it is not present.</summary>
     internal string? Alg { get; private set; }
+
+    /// <summary>The <c>crv</c> field, or <see langword="null"/> when it is not present.</summary>
+    internal string? Crv { get; private set; }
 
     /// <summary>The <c>d</c> field, or <see langword="null"/> when it is not present.</summary>
     internal string? D { get; private set; }
@@ -156,6 +196,12 @@ internal sealed class JsonWebKeyData
     /// <summary>The <c>use</c> field, or <see langword="null"/> when it is not present.</summary>
     internal string? Use { get; private set; }
 
+    /// <summary>The <c>x</c> field, or <see langword="null"/> when it is not present.</summary>
+    internal string? X { get; private set; }
+
+    /// <summary>The <c>y</c> field, or <see langword="null"/> when it is not present.</summary>
+    internal string? Y { get; private set; }
+
     /// <summary>
     /// Converts the ECMAScript object a script passed as <c>keyData</c> to the dictionary.
     /// </summary>
@@ -164,6 +210,7 @@ internal sealed class JsonWebKeyData
         var jwk = new JsonWebKeyData
         {
             Alg = ReadString(source, _algKey),
+            Crv = ReadString(source, _crvKey),
             D = ReadString(source, _dKey),
             Dp = ReadString(source, _dpKey),
             Dq = ReadString(source, _dqKey),
@@ -177,6 +224,8 @@ internal sealed class JsonWebKeyData
             Q = ReadString(source, _qKey),
             Qi = ReadString(source, _qiKey),
             Use = ReadString(source, _useKey),
+            X = ReadString(source, _xKey),
+            Y = ReadString(source, _yKey),
         };
 
         return jwk;
@@ -459,6 +508,67 @@ internal sealed class JsonWebKeyData
                 Encode(fields.P),
                 Encode(fields.Q),
                 Encode(fields.Qi),
+            ]);
+    }
+
+    /// <summary>
+    /// The object <c>exportKey("jwk")</c> resolves with for an elliptic-curve public key: <c>crv</c>, and
+    /// <c>x</c> and <c>y</c> "according to the definition in Section 6.2.1.2 [and 6.2.1.3] of JSON Web
+    /// Algorithms", plus the three fields every export carries. See <see cref="_ecPublicExportLayout"/> for
+    /// why there is no <c>alg</c>.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="x"/> and <paramref name="y"/> arrive at the curve's own field width and are encoded as
+    /// they are — Section 6.2.1.2 says "The length of this octet string MUST be the full size of a coordinate
+    /// for the curve", which is the opposite of the minimal-length encoding every RSA field uses, and it is
+    /// what makes a coordinate whose leading byte is zero keep its width instead of losing it.
+    /// </remarks>
+    internal static JsObject CreateEcPublicExport(
+        Engine engine,
+        string namedCurve,
+        ReadOnlySpan<byte> x,
+        ReadOnlySpan<byte> y,
+        KeyUsage usages,
+        bool extractable)
+    {
+        return JsObject.Create(
+            engine,
+            _ecPublicExportLayout,
+            [
+                JsString.Create(namedCurve),
+                extractable ? JsBoolean.True : JsBoolean.False,
+                KeyUsages.ToArray(engine, usages),
+                JsString.Create("EC"),
+                Encode(x),
+                Encode(y),
+            ]);
+    }
+
+    /// <summary>
+    /// The object <c>exportKey("jwk")</c> resolves with for an elliptic-curve private key: the public
+    /// members plus <c>d</c> "according to the definition in Section 6.2.2.1 of JSON Web Algorithms", which
+    /// is fixed-width for the same reason the coordinates are.
+    /// </summary>
+    internal static JsObject CreateEcPrivateExport(
+        Engine engine,
+        string namedCurve,
+        ReadOnlySpan<byte> x,
+        ReadOnlySpan<byte> y,
+        ReadOnlySpan<byte> d,
+        KeyUsage usages,
+        bool extractable)
+    {
+        return JsObject.Create(
+            engine,
+            _ecPrivateExportLayout,
+            [
+                JsString.Create(namedCurve),
+                Encode(d),
+                extractable ? JsBoolean.True : JsBoolean.False,
+                KeyUsages.ToArray(engine, usages),
+                JsString.Create("EC"),
+                Encode(x),
+                Encode(y),
             ]);
     }
 

--- a/Jint/WebApi/Crypto/RsaAlgorithm.cs
+++ b/Jint/WebApi/Crypto/RsaAlgorithm.cs
@@ -1,26 +1,10 @@
 #if NET8_0_OR_GREATER
 using System.Numerics;
-using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using Jint.Native;
 using Jint.Runtime;
 
 namespace Jint.WebApi.Crypto;
-
-/// <summary>
-/// The two halves of a generated RSA key pair, with the usages each of them ends up carrying.
-/// </summary>
-/// <remarks>
-/// One <see cref="CryptoKeyAlgorithm"/> for both, because the specification builds exactly one
-/// <c>RsaHashedKeyAlgorithm</c> and sets the <c>[[algorithm]]</c> slot of both keys to it.
-/// </remarks>
-[StructLayout(LayoutKind.Auto)]
-internal readonly record struct RsaKeyPairMaterial(
-    byte[] PublicHandle,
-    KeyUsage PublicUsages,
-    byte[] PrivateHandle,
-    KeyUsage PrivateUsages,
-    CryptoKeyAlgorithm Algorithm);
 
 /// <summary>
 /// The three RSA algorithms — RSASSA-PKCS1-v1_5 (https://w3c.github.io/webcrypto/#rsassa-pkcs1), RSA-PSS
@@ -122,7 +106,7 @@ internal static class RsaAlgorithm
     /// https://w3c.github.io/webcrypto/#rsa-oaep-operations-generate-key, which differ only in step 1's
     /// usage set and in the name the resulting dictionary carries.
     /// </summary>
-    internal static RsaKeyPairMaterial GenerateKey(
+    internal static AsymmetricKeyPairMaterial GenerateKey(
         CryptoContext context,
         NormalizedAlgorithm normalized,
         KeyUsage usages,
@@ -180,7 +164,7 @@ internal static class RsaAlgorithm
             modulusLength,
             Minimal(publicExponent));
 
-        return new RsaKeyPairMaterial(
+        return new AsymmetricKeyPairMaterial(
             publicHandle,
             usages & (isCipher ? PublicCipherUsages : PublicSignatureUsages),
             privateHandle,

--- a/Jint/WebApi/Crypto/SubtleCryptoInstance.cs
+++ b/Jint/WebApi/Crypto/SubtleCryptoInstance.cs
@@ -19,9 +19,10 @@ namespace Jint.WebApi.Crypto;
 /// <para>
 /// <b>Eight of the twelve operations exist</b>: <c>digest</c>, <c>sign</c>, <c>verify</c>, <c>encrypt</c>,
 /// <c>decrypt</c>, <c>generateKey</c>, <c>importKey</c> and <c>exportKey</c>, over the algorithms
-/// <c>HMAC</c>, <c>AES-GCM</c> (128, 192 and 256 bits), <c>RSASSA-PKCS1-v1_5</c>, <c>RSA-PSS</c> and
-/// <c>RSA-OAEP</c> — each of the hashed ones over SHA-1, SHA-256, SHA-384 and SHA-512 — plus those four SHA
-/// hashes for <c>digest</c>, and the key formats <c>raw</c>, <c>spki</c>, <c>pkcs8</c> and <c>jwk</c>.
+/// <c>HMAC</c>, <c>AES-GCM</c> (128, 192 and 256 bits), <c>RSASSA-PKCS1-v1_5</c>, <c>RSA-PSS</c>,
+/// <c>RSA-OAEP</c>, <c>ECDSA</c> and <c>ECDH</c> — each of the hashed ones over SHA-1, SHA-256, SHA-384 and
+/// SHA-512, and each of the elliptic-curve ones over P-256, P-384 and P-521 — plus those four SHA hashes for
+/// <c>digest</c>, and the key formats <c>raw</c>, <c>spki</c>, <c>pkcs8</c> and <c>jwk</c>.
 /// <c>deriveKey</c>, <c>deriveBits</c>, <c>wrapKey</c> and <c>unwrapKey</c> are <b>absent</b> rather than
 /// present-and-throwing, so a library that checks
 /// <c>typeof crypto.subtle.deriveBits === 'function'</c> before reaching for it gets the truthful answer and
@@ -30,6 +31,13 @@ namespace Jint.WebApi.Crypto;
 /// <c>NotSupportedError</c>, which is what the specification says a name that is not registered for an
 /// operation is: <c>sign</c> with <c>AES-GCM</c> fails that way, and so does <c>encrypt</c> with
 /// <c>HMAC</c>.
+/// </para>
+/// <para>
+/// So <c>ECDH</c> is here for its <i>keys</i> alone — <c>generateKey</c>, <c>importKey</c> and
+/// <c>exportKey</c> — and a key it makes may carry the <c>deriveKey</c> and <c>deriveBits</c> usages that no
+/// operation on this object consumes. That is not a half-implemented algorithm but the same shape AES-GCM's
+/// <c>wrapKey</c> and <c>unwrapKey</c> usages have always had: the usage bits are checked and split exactly
+/// as the specification says, and the operations that read them are the absent ones above.
 /// </para>
 /// <para>
 /// <b>Nothing here ever throws to its caller.</b> WebIDL turns an exception out of a promise-returning
@@ -148,6 +156,8 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
                 case AlgorithmNormalization.RsassaPkcs1V15:
                 case AlgorithmNormalization.RsaPss:
                     return Context.CreateArrayBuffer(RsaAlgorithm.Sign(Context, normalized, cryptoKey, message, what));
+                case AlgorithmNormalization.Ecdsa:
+                    return Context.CreateArrayBuffer(EcAlgorithm.Sign(Context, normalized, cryptoKey, message, what));
                 default:
                     return UnhandledAlgorithm(normalized.Name, CryptoOperation.Sign);
             }
@@ -180,6 +190,10 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
                 case AlgorithmNormalization.RsassaPkcs1V15:
                 case AlgorithmNormalization.RsaPss:
                     return RsaAlgorithm.Verify(Context, normalized, cryptoKey, signatureBytes, message, what)
+                        ? JsBoolean.True
+                        : JsBoolean.False;
+                case AlgorithmNormalization.Ecdsa:
+                    return EcAlgorithm.Verify(Context, normalized, cryptoKey, signatureBytes, message, what)
                         ? JsBoolean.True
                         : JsBoolean.False;
                 default:
@@ -253,10 +267,10 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
     /// </summary>
     /// <remarks>
     /// Which arm of the union is returned is the algorithm's business: the symmetric algorithms produce a
-    /// single secret <c>CryptoKey</c>, and the three RSA algorithms produce a <c>CryptoKeyPair</c>. The
-    /// public half is always extractable, whatever <c>extractable</c> asked for — a public key is public —
-    /// and the two halves split the requested usages between them by the usage intersection each algorithm's
-    /// steps name.
+    /// single secret <c>CryptoKey</c>, and the three RSA algorithms and the two elliptic-curve ones produce a
+    /// <c>CryptoKeyPair</c>. The public half is always extractable, whatever <c>extractable</c> asked for — a
+    /// public key is public — and the two halves split the requested usages between them by the usage
+    /// intersection each algorithm's steps name, which for an ECDH public key is the empty list.
     /// </remarks>
     [JsFunction(Name = "generateKey", Length = 3)]
     private JsValue GenerateKey(JsValue thisObject, JsValue algorithm, JsValue extractable, JsValue keyUsages)
@@ -281,6 +295,10 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
                 case AlgorithmNormalization.RsaPss:
                 case AlgorithmNormalization.RsaOaep:
                     return CreateKeyPair(RsaAlgorithm.GenerateKey(Context, normalized, usages, what), isExtractable, what);
+
+                case AlgorithmNormalization.Ecdsa:
+                case AlgorithmNormalization.Ecdh:
+                    return CreateKeyPair(EcAlgorithm.GenerateKey(Context, normalized, usages, what), isExtractable, what);
 
                 default:
                     return UnhandledAlgorithm(normalized.Name, CryptoOperation.GenerateKey);
@@ -327,7 +345,7 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
     /// <c>['verify']</c> is a pair nobody can sign with, which is the very mistake this catches, while a pair
     /// generated with <c>['sign']</c> has a public half carrying no usages and is perfectly ordinary.
     /// </summary>
-    private JsObject CreateKeyPair(in RsaKeyPairMaterial material, bool extractable, string what)
+    private JsObject CreateKeyPair(in AsymmetricKeyPairMaterial material, bool extractable, string what)
     {
         RequireUsableKey(CryptoKeyTypes.Private, material.PrivateUsages, what);
 
@@ -404,6 +422,14 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
                         usages,
                         what);
 
+                case AlgorithmNormalization.Ecdsa:
+                case AlgorithmNormalization.Ecdh:
+                    return CreateImportedKey(
+                        EcAlgorithm.ImportKey(Context, keyFormat, rawData, jwk, normalized, isExtractable, usages, what),
+                        isExtractable,
+                        usages,
+                        what);
+
                 default:
                     return UnhandledAlgorithm(normalized.Name, CryptoOperation.ImportKey);
             }
@@ -452,6 +478,9 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
                 case AlgorithmNormalization.RsaPss:
                 case AlgorithmNormalization.RsaOaep:
                     return RsaAlgorithm.ExportKey(Context, cryptoKey, keyFormat, what);
+                case AlgorithmNormalization.Ecdsa:
+                case AlgorithmNormalization.Ecdh:
+                    return EcAlgorithm.ExportKey(Context, cryptoKey, keyFormat, what);
                 default:
                     return UnhandledAlgorithm(cryptoKey.Algorithm.Name, CryptoOperation.ExportKey);
             }

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ its own `console` (or any other name in the table below), enabling the feature l
 | `TextEncoder` (UTF-8) / `TextDecoder` (UTF-8, UTF-16LE/BE, every legacy single-byte encoding, `x-user-defined`; `fatal`, `ignoreBOM`, streaming) | `Encoding` | ✔ shipped |
 | `atob` / `btoa` | `Base64` | ✔ shipped |
 | `structuredClone` (incl. `{ transfer }` of `ArrayBuffer`s) | `StructuredClone` | ✔ shipped |
-| `crypto.getRandomValues` / `crypto.randomUUID` / `crypto.subtle` (SHA digests, HMAC, AES-GCM, `CryptoKey`) | `WebApiFeatures.Crypto` | ✔ shipped |
+| `crypto.getRandomValues` / `crypto.randomUUID` / `crypto.subtle` (SHA digests, HMAC, AES-GCM, RSA, ECDSA/ECDH, `CryptoKey`) | `WebApiFeatures.Crypto` | ✔ shipped |
 | `performance.now` / `timeOrigin` / `mark` / `measure` / `getEntries*` / `clearMarks` / `clearMeasures` | `WebApiFeatures.Performance` | ✔ shipped |
 | `Event` / `EventTarget` / `CustomEvent` / `AbortController` / `AbortSignal` | `Events` | ✔ shipped |
 | `URL` / `URLSearchParams` / `URLPattern` | `Url` | ✔ shipped |
@@ -250,15 +250,29 @@ a `fetch` listener can take over every request you route into the engine.
 
 `crypto.subtle` carries **`digest`, `sign`, `verify`, `encrypt`, `decrypt`, `generateKey`, `importKey` and
 `exportKey`**, over SHA-1/256/384/512 (for `digest` and as every keyed algorithm's inner hash), **HMAC**,
-**AES-GCM** at 128, 192 and 256 bits, and the RSA family — **RSASSA-PKCS1-v1_5** and **RSA-PSS** for
-signatures, **RSA-OAEP** for encryption. Keys are real `CryptoKey` objects with `type`, `extractable`,
-`algorithm` and `usages`, and `generateKey` for an RSA algorithm hands back a `CryptoKeyPair`, which is the
-plain `{ privateKey, publicKey }` dictionary the specification defines rather than an interface. The key
-material is never reachable from script except through `exportKey` on an extractable key: `raw` bytes or a
-`kty: "oct"` JSON Web Key for a symmetric key, and `spki`, `pkcs8` or a `kty: "RSA"` JSON Web Key for an RSA
-one. `deriveKey`, `deriveBits`, `wrapKey` and `unwrapKey` are *absent* rather than present-and-throwing, so
-`typeof crypto.subtle.deriveBits` tells a library the truth and it takes its fallback path; so is every
-elliptic-curve algorithm.
+**AES-GCM** at 128, 192 and 256 bits, the RSA family — **RSASSA-PKCS1-v1_5** and **RSA-PSS** for signatures,
+**RSA-OAEP** for encryption — and the elliptic curves **P-256**, **P-384** and **P-521** under **ECDSA** and
+**ECDH**. Keys are real `CryptoKey` objects with `type`, `extractable`, `algorithm` and `usages`, and
+`generateKey` for an asymmetric algorithm hands back a `CryptoKeyPair`, which is the plain
+`{ privateKey, publicKey }` dictionary the specification defines rather than an interface. The key material
+is never reachable from script except through `exportKey` on an extractable key: `raw` bytes or a
+`kty: "oct"` JSON Web Key for a symmetric key, `spki`, `pkcs8` or a `kty: "RSA"` JSON Web Key for an RSA one,
+and all four of those — `raw` being the uncompressed point `04||X||Y` — for an elliptic-curve one.
+`deriveKey`, `deriveBits`, `wrapKey` and `unwrapKey` are *absent* rather than present-and-throwing, so
+`typeof crypto.subtle.deriveBits` tells a library the truth and it takes its fallback path.
+
+ECDH is therefore here **for its keys alone**: you can generate, import and export an ECDH key pair, and the
+private half may carry the `deriveKey` and `deriveBits` usages, but nothing on `crypto.subtle` consumes them
+yet — the same position AES-GCM's `wrapKey` and `unwrapKey` usages have always been in. An ECDSA key carries
+only its curve: the hash lives in the `EcdsaParams` of each `sign` and `verify` call, so one P-256 key signs
+under SHA-256 and SHA-512 alike. Signatures are the raw `r || s` concatenation at the curve's field width
+(64, 96 and 132 bytes) that the Web Cryptography API defines — not the DER `SEQUENCE` that .NET's
+`ECDsa.SignData` produces when asked for `DSASignatureFormat.Rfc3279DerSequence`, so a host verifying a
+script's signature with `ECDsa` must pass `IeeeP1363FixedFieldConcatenation`. An elliptic-curve JSON Web
+Key's `x`, `y` and `d` are fixed-width, as RFC 7518 §6.2 requires and unlike RSA's minimal-length integers,
+so a coordinate whose leading byte is zero keeps it; and an exported EC JWK carries no `alg`, exactly as the
+export steps say, though `ES256`/`ES384`/`ES512` are honoured on the way in (`ES512` names **P-521** — the
+number is the hash's).
 
 Nothing here ever throws: a promise-returning WebIDL operation converts every failure into a rejection. An
 algorithm that is not registered for the operation is a `NotSupportedError` `DOMException`, a key used


### PR DESCRIPTION
Adds ECDSA and ECDH over P-256, P-384 and P-521 to `crypto.subtle` — the second slice of #3162 (references, does not close). ECDSA slots into sign/verify and the key operations; ECDH into the key operations alone, so **still 8 of 12 operations**: `deriveBits`/`deriveKey` arrive in the next slice, and an ECDH key generated today with those usages is a perfectly ordinary key nothing consumes yet — the exact situation AES-GCM's `wrapKey`/`unwrapKey` usages have been in since AES-GCM landed, documented as such. The four feature-detection pins are untouched.

The ES256/ES384 half of the JWT story this enables byte-verifies RFC 7515's own example signatures.

What a reviewer should know, each measured rather than assumed and pinned:

- **An off-curve point raises `PlatformNotSupportedException` on Windows, not `CryptographicException`** — and it is not a subclass, so a catch written to the RSA precedent alone would let a CLR exception erupt out of a promise-returning API. Every catch site takes both (`IsCryptographicFailure`); the mutation dropping the second type kills two tests, including the off-curve probe.
- **The curve a DER structure names is read out of the DER with `AsnReader`** (shared framework since .NET 5 — no package reference, and the net462/netstandard legs confirm the `#if` gating holds). The platform happily imports a P-384 SPKI into an import that asked for P-256, and what it reports afterwards through `ECParameters.Curve.Oid` differs per OS — so the spec's own algorithm-identifier steps are implemented directly, which is also what makes the trailing-bytes `exactData` check uniform with the RSA formats. This is the only thing standing between a script and a P-384 key that calls itself P-256.
- **Signatures are IEEE P1363 `r‖s` at fixed field width** (64/96/132 bytes) — WebCrypto's own format and the BCL's default, but the explicit `DSASignatureFormat` overload is used so a default moving underneath cannot silently make every signature unreadable elsewhere.
- **EC JWK fields are fixed-width, unlike RSA's minimal integers** — RFC 7518 requires the full coordinate size (66 bytes for P-521: 521 bits rounds up), so a leading zero byte is kept in both directions and a wrong-length field is a `DataError` rather than something to pad. Pinned with RFC 7515 A.4's own key, whose `y` begins `0x00`.
- **`ES512` names P-521** — the one row of the JOSE alg table that cannot be derived from the curve name, written out and mutation-pinned.
- **ECDH public keys carry the empty usage list flatly** (not an intersection): importing one with any usage is a `SyntaxError`, and ECDH's JWK steps read no `alg` and want `use: "enc"` — both read verbatim from the operation steps and pinned.
- `raw` import/export is the SEC1 uncompressed point for public keys of both algorithms; a compressed point is refused by the step that anticipates it, with a message naming the format rather than calling the bytes malformed (the mutation that ignored the `0x04` marker survived the first test rows and got three dedicated ones).
- One deliberate surviving mutant, documented in code: the spec's explicit wrong-length-verify step is redundant with the platform's own answer (measured) but kept — it is normative, and it runs before the key import so an impossible signature costs nothing.

Vectors are cross-implementation for all three curves (RFC 7515 A.3/A.4, RFC 7520, plus externally-encoded DER the engine did not produce), with non-determinism asserted in the signing direction. 189 new cases; 19 mutants, 18 killed. Foundation reuse: `RsaKeyPairMaterial` generalized to `AsymmetricKeyPairMaterial` (rename + move, no behavior change).

Full matrix green on net10.0 + net472 including the host-contract-verification legs, re-verified after rebasing onto current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014n5uCpi2vvHWBSiewUwBiY
