### PR TITLE
Web API: deriveBits and deriveKey for crypto.subtle - HKDF, PBKDF2 and ECDH

### DIFF
--- a/Jint.Tests.PublicInterface/WebApiCryptoTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiCryptoTests.cs
@@ -109,11 +109,18 @@ public class WebApiCryptoTests
         engine.Evaluate("typeof crypto.subtle.importKey").AsString().Should().Be("function");
         engine.Evaluate("typeof CryptoKey").AsString().Should().Be("function");
 
-        // Key derivation and key wrapping are absent, not present-and-throwing, so a library that checks
-        // before reaching for one takes its fallback path.
+        // Key derivation is here, with the arities WebIDL gives it — deriveBits declares two required
+        // arguments because its `length` is optional and nullable.
         engine.Evaluate("""
-            ['deriveKey', 'deriveBits', 'wrapKey', 'unwrapKey'].map(name => typeof crypto.subtle[name]).join(',')
-            """).AsString().Should().Be("undefined,undefined,undefined,undefined");
+            ['deriveBits', 'deriveKey']
+                .map(name => typeof crypto.subtle[name] + ':' + crypto.subtle[name].length).join(',')
+            """).AsString().Should().Be("function:2,function:5");
+
+        // Key wrapping is absent, not present-and-throwing, so a library that checks before reaching for one
+        // takes its fallback path.
+        engine.Evaluate("""
+            ['wrapKey', 'unwrapKey'].map(name => typeof crypto.subtle[name]).join(',')
+            """).AsString().Should().Be("undefined,undefined");
     }
 
     [Fact]
@@ -216,6 +223,54 @@ public class WebApiCryptoTests
             """).UnwrapIfPromise();
 
         result.AsString().Should().Be("OperationError:true,OperationError:true,OperationError:true");
+    }
+
+    [Fact]
+    public void ReportsEveryDerivationRefusalAsACatchableDomException()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Crypto));
+
+        // Each of these is a shape the platform reports with a CLR exception of its own — an
+        // ArgumentOutOfRangeException for an HKDF output past 255 hash blocks and for a zero-length one, an
+        // ArgumentException for two ECDH keys of different sizes — and every one of them has to reach the
+        // script as a DOMException instead. A CLR exception erupting out of a promise-returning operation is
+        // the one thing this API must never do, and it is exactly what a host embedding the engine cannot
+        // catch.
+        var result = engine.Evaluate("""
+            (async () => {
+                const seen = [];
+                const attempt = async fn => {
+                    try { seen.push('ok:' + await fn()); }
+                    catch (e) { seen.push(e.name + ':' + (e instanceof DOMException)); }
+                };
+
+                const ikm = await crypto.subtle.importKey('raw', new Uint8Array(22), 'HKDF', false, ['deriveBits']);
+                const hkdf = { name: 'HKDF', hash: 'SHA-256', salt: new Uint8Array(0), info: new Uint8Array(0) };
+
+                // Past 255 * hashLength.
+                await attempt(() => crypto.subtle.deriveBits(hkdf, ikm, (255 * 32 + 1) * 8));
+                // Zero bits, which is the empty byte sequence and not a failure.
+                await attempt(async () => (await crypto.subtle.deriveBits(hkdf, ikm, 0)).byteLength);
+
+                const password = await crypto.subtle.importKey('raw', new Uint8Array(8), 'PBKDF2', false, ['deriveBits']);
+                // An iteration count no execution constraint could interrupt.
+                await attempt(() => crypto.subtle.deriveBits(
+                    { name: 'PBKDF2', salt: new Uint8Array(8), iterations: 2 ** 31, hash: 'SHA-256' }, password, 256));
+
+                const p256 = await crypto.subtle.generateKey({ name: 'ECDH', namedCurve: 'P-256' }, false, ['deriveBits']);
+                const p384 = await crypto.subtle.generateKey({ name: 'ECDH', namedCurve: 'P-384' }, false, ['deriveBits']);
+
+                // Two keys of different sizes, which the platform reports as an ArgumentException.
+                await attempt(() => crypto.subtle.deriveBits({ name: 'ECDH', public: p384.publicKey }, p256.privateKey, 256));
+                // More bits than the curve has.
+                await attempt(() => crypto.subtle.deriveBits({ name: 'ECDH', public: p256.publicKey }, p256.privateKey, 384));
+
+                return seen.join(',');
+            })()
+            """).UnwrapIfPromise();
+
+        result.AsString().Should().Be(
+            "OperationError:true,ok:0,OperationError:true,InvalidAccessError:true,OperationError:true");
     }
 
     [Fact]

--- a/Jint.Tests/Runtime/WebApi/CryptoTests.cs
+++ b/Jint.Tests/Runtime/WebApi/CryptoTests.cs
@@ -271,23 +271,23 @@ public class CryptoTests
     {
         var engine = WebEngine();
 
-        // `crypto.subtle` exists and answers a SubtleCrypto object. What it carries is the eight operations
-        // over SHA, HMAC and AES-GCM; key derivation and key wrapping are absent rather than
-        // present-and-throwing, because `if (crypto.subtle.deriveBits)` is how a library that does
-        // cryptography decides whether it can, and it has to get the truthful answer — see SubtleCryptoTests
-        // and SubtleCryptoKeyTests for the operations themselves.
+        // `crypto.subtle` exists and answers a SubtleCrypto object. What it carries is the ten operations
+        // over SHA, HMAC, AES-GCM, the RSA family, the elliptic curves, HKDF and PBKDF2; key wrapping is
+        // absent rather than present-and-throwing, because `if (crypto.subtle.wrapKey)` is how a library that
+        // does cryptography decides whether it can, and it has to get the truthful answer — see
+        // SubtleCryptoTests and SubtleCryptoKeyTests for the operations themselves.
         engine.Evaluate("typeof crypto.subtle").AsString().Should().Be("object");
         engine.Evaluate("'subtle' in crypto").AsBoolean().Should().BeTrue();
 
         engine.Evaluate("""
-            ['digest', 'encrypt', 'decrypt', 'sign', 'verify', 'generateKey', 'importKey', 'exportKey']
+            ['digest', 'encrypt', 'decrypt', 'sign', 'verify', 'generateKey', 'importKey', 'exportKey', 'deriveBits', 'deriveKey']
                 .map(name => typeof crypto.subtle[name]).join(',')
-            """).AsString().Should().Be("function,function,function,function,function,function,function,function");
+            """).AsString().Should().Be(
+                "function,function,function,function,function,function,function,function,function,function");
 
         engine.Evaluate("""
-            ['deriveKey', 'deriveBits', 'wrapKey', 'unwrapKey']
-                .map(name => typeof crypto.subtle[name]).join(',')
-            """).AsString().Should().Be("undefined,undefined,undefined,undefined");
+            ['wrapKey', 'unwrapKey'].map(name => typeof crypto.subtle[name]).join(',')
+            """).AsString().Should().Be("undefined,undefined");
     }
 
     [Fact]

--- a/Jint.Tests/Runtime/WebApi/SubtleCryptoDeriveTests.cs
+++ b/Jint.Tests/Runtime/WebApi/SubtleCryptoDeriveTests.cs
@@ -1,0 +1,979 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Native;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// The key-derivation half of <c>crypto.subtle</c> — <c>deriveBits</c> and <c>deriveKey</c>
+/// (https://w3c.github.io/webcrypto/#SubtleCrypto-method-deriveBits and
+/// https://w3c.github.io/webcrypto/#SubtleCrypto-method-deriveKey) over the three algorithms registered for
+/// them: HKDF (https://w3c.github.io/webcrypto/#hkdf), PBKDF2 (https://w3c.github.io/webcrypto/#pbkdf2) and
+/// ECDH (https://w3c.github.io/webcrypto/#ecdh-operations-derive-bits).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every derivation is checked against a vector published by somebody else, which is the only way to check
+/// cryptography: RFC 6070 for PBKDF2-HMAC-SHA-1, RFC 7914 §11 for PBKDF2-HMAC-SHA-256, RFC 5869 Appendix A
+/// for HKDF over both SHA-256 and SHA-1, and RFC 5903 §8.1 for an ECDH agreement on P-256 — that last one
+/// supplying both private keys, both public points <i>and</i> the shared secret, so both directions of the
+/// agreement have a known answer rather than merely agreeing with each other.
+/// </para>
+/// <para>
+/// The derived-key round trips (PBKDF2 to AES-GCM, ECDH to HMAC) go one step further and pin the exact key
+/// bytes, computed outside this engine from the BCL's own one-shot primitives. A round trip on its own would
+/// pass just as well against a derivation that is internally consistent and wrong.
+/// </para>
+/// <para>
+/// The <c>length</c> argument's whole matrix — null, omitted, zero, not a multiple of eight, past the
+/// maximum, and the <c>[EnforceRange]</c> refusals — is pinned per algorithm, because the three answer it
+/// differently and the differences are normative rather than incidental.
+/// </para>
+/// </remarks>
+public class SubtleCryptoDeriveTests
+{
+    /// <summary>
+    /// The same helpers <see cref="SubtleCryptoEcTests"/> uses, plus <c>seq</c> for RFC 5869's long
+    /// vectors, whose inputs the RFC itself describes as runs of consecutive byte values.
+    /// </summary>
+    private const string Prelude = """
+        const hex = b => Array.from(new Uint8Array(b)).map(x => x.toString(16).padStart(2, '0')).join('');
+        const bytes = h => Uint8Array.from(h.match(/../g) || [], x => parseInt(x, 16));
+        const ascii = s => Uint8Array.from(s, c => c.charCodeAt(0));
+        const seq = (start, count) => Uint8Array.from({ length: count }, (_, i) => start + i);
+        const empty = new Uint8Array(0);
+        """;
+
+    private static Engine WebEngine()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Crypto));
+        engine.Evaluate(Prelude);
+        return engine;
+    }
+
+    /// <summary>Runs an async body to completion and answers what it returned.</summary>
+    private static JsValue Run(string body, Engine? engine = null)
+    {
+        engine ??= WebEngine();
+        return engine.Evaluate("(async () => {\n" + body + "\n})()").UnwrapIfPromise();
+    }
+
+    /// <summary>Settles one expression's promise and answers whatever it resolved or rejected to.</summary>
+    private static JsValue Settle(Engine engine, string source) => engine.Evaluate(source).UnwrapIfPromise();
+
+    // ---------------------------------------------------------------------------------------------------
+    // The RFC 5903 §8.1 ECDH vector, which every ECDH test below is built from
+    // ---------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// "i" — the initiator's private key, base64url-encoded as JSON Web Algorithms §6.2.2.1 requires.
+    /// </summary>
+    private const string AlicePrivateJwk = """
+        kty: 'EC', crv: 'P-256',
+        d: 'yI8B9RDZrD9wopLaojFt5UTpqriv6EBJxiqcV4YtFDM',
+        x: '2tC2U5QiHPmwUeH-yleH0Jjf5jf8kLnvlF0MN3JYEYA',
+        y: 'UnGgRhzbglLWHxxFb6PlmrH0WzOsz19YOJ4Fd7iZC7M'
+        """;
+
+    /// <summary>"r" — the responder's private key.</summary>
+    private const string BobPrivateJwk = """
+        kty: 'EC', crv: 'P-256',
+        d: 'xu-cXXiuASoBEWSss5fOIIhoXY8Gv5vgsoOrRkdr7lM',
+        x: '0S37UonI1PgSCLcCcDmMNCKWlwoLzLdMc2_HVUSUv2M',
+        y: 'VvvzyjZswj6BV4VME8WNaqwj8Eatow-DU-dPMwOYcqs'
+        """;
+
+    /// <summary>"gi" — the initiator's public point, as the uncompressed <c>04 || X || Y</c> of [SEC1] 2.3.3.</summary>
+    private const string AlicePublicRawHex =
+        "04dad0b65394221cf9b051e1feca5787d098dfe637fc90b9ef945d0c3772581180"
+        + "5271a0461cdb8252d61f1c456fa3e59ab1f45b33accf5f58389e0577b8990bb3";
+
+    /// <summary>"gr" — the responder's public point.</summary>
+    private const string BobPublicRawHex =
+        "04d12dfb5289c8d4f81208b70270398c342296970a0bccb74c736fc7554494bf63"
+        + "56fbf3ca366cc23e8157854c13c58d6aac23f046ada30f8353e74f33039872ab";
+
+    /// <summary>"girx" — the x-coordinate of the shared point, which is the whole of the secret.</summary>
+    private const string SharedSecretHex = "d6840f6b42f6edafd13116e0e12565202fef8e9ece7dce03812464d04b9442de";
+
+    /// <summary>
+    /// The four keys of the RFC 5903 vector, as a prelude every ECDH test starts from. The public halves are
+    /// imported from <c>raw</c> points and the private halves from JSON Web Keys, so the vector's own hex
+    /// reaches the engine by two different doors.
+    /// </summary>
+    private const string EcdhKeys = $$"""
+        const P256 = { name: 'ECDH', namedCurve: 'P-256' };
+        const alicePriv = await crypto.subtle.importKey('jwk', { {{AlicePrivateJwk}} }, P256, false, ['deriveBits', 'deriveKey']);
+        const bobPriv = await crypto.subtle.importKey('jwk', { {{BobPrivateJwk}} }, P256, false, ['deriveBits', 'deriveKey']);
+        const alicePub = await crypto.subtle.importKey('raw', bytes('{{AlicePublicRawHex}}'), P256, false, []);
+        const bobPub = await crypto.subtle.importKey('raw', bytes('{{BobPublicRawHex}}'), P256, false, []);
+        """;
+
+    // ---------------------------------------------------------------------------------------------------
+    // PBKDF2 — RFC 6070 and RFC 7914 §11
+    // ---------------------------------------------------------------------------------------------------
+
+    [Theory]
+    // https://www.rfc-editor.org/rfc/rfc6070#section-2, the PBKDF2-HMAC-SHA-1 test vectors.
+    [InlineData("password", "salt", 1, 160, "SHA-1", "0c60c80f961f0e71f3a9b524af6012062fe037a6")]
+    [InlineData("password", "salt", 2, 160, "SHA-1", "ea6c014dc72d6f8ccd1ed92ace1d41f0d8de8957")]
+    [InlineData("password", "salt", 4096, 160, "SHA-1", "4b007901b765489abead49d926f721d065a429c1")]
+    [InlineData(
+        "passwordPASSWORDpassword", "saltSALTsaltSALTsaltSALTsaltSALTsalt", 4096, 200, "SHA-1",
+        "3d2eec4fe41c849b80c8d83662c0e44a8b291a964cf2f07038")]
+    // https://www.rfc-editor.org/rfc/rfc7914#section-11, whose first two vectors are PBKDF2-HMAC-SHA-256.
+    [InlineData("passwd", "salt", 1, 512, "SHA-256",
+        "55ac046e56e3089fec1691c22544b605f94185216dde0465e68b9d57c20dacbc"
+        + "49ca9cccf179b645991664b39d77ef317c71b845b1e30bd509112041d3a19783")]
+    [InlineData("Password", "NaCl", 80000, 512, "SHA-256",
+        "4ddcd8f60b98be21830cee5ef22701f9641a4418d04c0414aeff08876b34ab56"
+        + "a1d425a1225833549adb841b51c9b3176a272bdebba1d078478f62b397f33c8d")]
+    public void DerivesThePublishedPbkdf2Vectors(
+        string password,
+        string salt,
+        int iterations,
+        int length,
+        string hash,
+        string expected)
+    {
+        Run($$"""
+            const key = await crypto.subtle.importKey('raw', ascii('{{password}}'), 'PBKDF2', false, ['deriveBits']);
+            const params = { name: 'PBKDF2', salt: ascii('{{salt}}'), iterations: {{iterations}}, hash: '{{hash}}' };
+            return hex(await crypto.subtle.deriveBits(params, key, {{length}}));
+            """).AsString().Should().Be(expected);
+    }
+
+    [Fact]
+    public void DerivesTheRfc6070VectorWhoseInputsContainANullByte()
+    {
+        // The sixth vector of https://www.rfc-editor.org/rfc/rfc6070#section-2 is P = "pass\0word" and
+        // S = "sa\0lt". It is here because a NUL inside the password is exactly what a length-prefixed byte
+        // sequence handles and a C string does not, and the key material reaches PBKDF2 as the former.
+        Run("""
+            const key = await crypto.subtle.importKey('raw', bytes('7061737300776f7264'), 'PBKDF2', false, ['deriveBits']);
+            const params = { name: 'PBKDF2', salt: bytes('7361006c74'), iterations: 4096, hash: 'SHA-1' };
+            return hex(await crypto.subtle.deriveBits(params, key, 128));
+            """).AsString().Should().Be("56fa6aa75548099dcc37d7f03425e0c3");
+    }
+
+    [Fact]
+    public void RefusesAnIterationCountOfZeroWithAnOperationError()
+    {
+        // "If the iterations member of normalizedAlgorithm is zero, then throw an OperationError" — step 2.
+        //
+        // The second row is what makes this a pin on the *step* rather than on the platform: step 2 runs
+        // before step 3's "if length is zero, return an empty byte sequence", so a zero-length request with
+        // a zero iteration count is still the error. Without the check that request short-circuits to the
+        // empty array and never reaches the platform, whose own refusal — an ArgumentOutOfRangeException
+        // this code turns into an OperationError — would otherwise cover for the missing step on the first
+        // row alone.
+        Run("""
+            const key = await crypto.subtle.importKey('raw', ascii('password'), 'PBKDF2', false, ['deriveBits']);
+
+            const attempt = async length => {
+                try {
+                    const bits = await crypto.subtle.deriveBits(
+                        { name: 'PBKDF2', salt: ascii('salt'), iterations: 0, hash: 'SHA-1' }, key, length);
+                    return 'derived:' + bits.byteLength;
+                } catch (e) {
+                    return e.name + '/' + (e instanceof DOMException);
+                }
+            };
+
+            return (await attempt(160)) + ',' + (await attempt(0));
+            """).AsString().Should().Be("OperationError/true,OperationError/true");
+    }
+
+    [Fact]
+    public void RefusesAnIterationCountAboveThisEnginesCeiling()
+    {
+        // PBKDF2 is a deliberately slow loop whose trip count comes from script and which happens inside one
+        // BCL call, so no execution constraint can interrupt it. The ceiling is this engine's, the algorithm
+        // has none, and the message names the restriction rather than pretending the request was malformed.
+        var message = Run("""
+            const key = await crypto.subtle.importKey('raw', ascii('password'), 'PBKDF2', false, ['deriveBits']);
+            try {
+                await crypto.subtle.deriveBits({ name: 'PBKDF2', salt: ascii('salt'), iterations: 4194305, hash: 'SHA-1' }, key, 160);
+                return 'derived';
+            } catch (e) {
+                return e.name + ': ' + e.message;
+            }
+            """).AsString();
+
+        message.Should().StartWith("OperationError: ");
+        message.Should().Contain("4194305");
+        message.Should().Contain("4194304");
+
+        // One below the ceiling still runs, so the bound is the number it says and not a smaller one it
+        // happens to enforce.
+        Run("""
+            const key = await crypto.subtle.importKey('raw', ascii('password'), 'PBKDF2', false, ['deriveBits']);
+            const out = await crypto.subtle.deriveBits({ name: 'PBKDF2', salt: ascii('salt'), iterations: 4194304, hash: 'SHA-256' }, key, 8);
+            return out.byteLength;
+            """).AsNumber().Should().Be(1);
+    }
+
+    [Fact]
+    public void APbkdf2KeyIsImportOnlyAndNeverExtractable()
+    {
+        var engine = WebEngine();
+
+        // "If extractable is not false, then throw a SyntaxError." The [[handle]] of a PBKDF2 key is the
+        // password itself, so an extractable one would be a way to read a password back out of a key.
+        Settle(engine, """
+            crypto.subtle.importKey('raw', new Uint8Array(8), 'PBKDF2', true, ['deriveBits'])
+                .then(() => 'imported', e => e.name)
+            """).AsString().Should().Be("SyntaxError");
+
+        // "If format is not 'raw', throw a NotSupportedError" — all three of the others.
+        Settle(engine, """
+            Promise.all(['jwk', 'spki', 'pkcs8'].map(format =>
+                crypto.subtle.importKey(format, format === 'jwk' ? { kty: 'oct', k: 'AAAA' } : new Uint8Array(8), 'PBKDF2', false, ['deriveBits'])
+                    .then(() => 'imported', e => e.name))).then(names => names.join(','))
+            """).AsString().Should().Be("NotSupportedError,NotSupportedError,NotSupportedError");
+
+        // Neither generateKey nor exportKey is registered for PBKDF2 at all, which is the registry's answer
+        // and not the algorithm's — so both are a NotSupportedError before any step runs.
+        Settle(engine, """
+            crypto.subtle.generateKey({ name: 'PBKDF2' }, false, ['deriveBits']).then(() => 'generated', e => e.name)
+            """).AsString().Should().Be("NotSupportedError");
+
+        Settle(engine, """
+            crypto.subtle.importKey('raw', new Uint8Array(8), 'PBKDF2', false, ['deriveBits'])
+                .then(key => crypto.subtle.exportKey('raw', key))
+                .then(() => 'exported', e => e.name)
+            """).AsString().Should().Be("NotSupportedError");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // HKDF — RFC 5869 Appendix A
+    // ---------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void DerivesTheRfc5869Sha256Vectors()
+    {
+        // https://www.rfc-editor.org/rfc/rfc5869#appendix-A — A.1 (basic), A.2 (long inputs and a
+        // multi-block expansion, which is the one that exercises the T(1)..T(N) counter) and A.3 (zero-length
+        // salt and info, which the RFC writes as "not provided" and which this API can only spell as the
+        // empty byte sequence, `salt` and `info` being required members).
+        Run("""
+            const derive = async (ikm, salt, info, bits) => {
+                const key = await crypto.subtle.importKey('raw', ikm, 'HKDF', false, ['deriveBits']);
+                return hex(await crypto.subtle.deriveBits({ name: 'HKDF', hash: 'SHA-256', salt, info }, key, bits));
+            };
+
+            return [
+                await derive(bytes('0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b'), bytes('000102030405060708090a0b0c'), bytes('f0f1f2f3f4f5f6f7f8f9'), 42 * 8),
+                await derive(seq(0x00, 80), seq(0x60, 80), seq(0xb0, 80), 82 * 8),
+                await derive(bytes('0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b'), empty, empty, 42 * 8),
+            ].join('|');
+            """).AsString().Should().Be(
+                "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865"
+                + "|b11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71cc30c58179ec3e87c14c01d5c1f3434f1d87"
+                + "|8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d9d201395faa4b61a96c8");
+    }
+
+    [Fact]
+    public void DerivesTheRfc5869Sha1Vectors()
+    {
+        // A.4 and A.6 of the same appendix, which are the SHA-1 half — HKDF's security rests on HMAC, so
+        // SHA-1 stays a registered hash here as it does in every browser.
+        Run("""
+            const derive = async (ikm, salt, info, bits) => {
+                const key = await crypto.subtle.importKey('raw', ikm, 'HKDF', false, ['deriveBits']);
+                return hex(await crypto.subtle.deriveBits({ name: 'HKDF', hash: 'SHA-1', salt, info }, key, bits));
+            };
+
+            return [
+                await derive(bytes('0b0b0b0b0b0b0b0b0b0b0b'), bytes('000102030405060708090a0b0c'), bytes('f0f1f2f3f4f5f6f7f8f9'), 42 * 8),
+                await derive(bytes('0b0b0b0b0b0b0b0b0b0b0b'), empty, empty, 42 * 8),
+            ].join('|');
+            """).AsString().Should().Be(
+                "085a01ea1b10f36933068b56efa5ad81a4f14b822f5b091568a9cdd4f155fda2c22e422478d305f3f896"
+                + "|14101530f62ccf2b30cc6d220554d8d96802825489c52c84c99342b96e018c221c71a88a4a258f71ffea");
+    }
+
+    [Theory]
+    [InlineData("SHA-1", 160)]
+    [InlineData("SHA-256", 256)]
+    [InlineData("SHA-384", 384)]
+    [InlineData("SHA-512", 512)]
+    public void RefusesAnHkdfLengthPastTheExpansionCeiling(string hash, int hashLength)
+    {
+        // "If length is greater than 255 * hashLength, then throw an OperationError" — RFC 5869's own bound,
+        // the expansion counter T(1)..T(N) being a single octet. The check is this engine's rather than the
+        // platform's, because .NET reports an over-long request as an ArgumentOutOfRangeException, which is
+        // a CLR exception and must never escape a promise-returning operation.
+        var maximum = 255 * hashLength;
+
+        var result = Run($$"""
+            const key = await crypto.subtle.importKey('raw', new Uint8Array(22), 'HKDF', false, ['deriveBits']);
+            const params = { name: 'HKDF', hash: '{{hash}}', salt: empty, info: empty };
+
+            const atCeiling = (await crypto.subtle.deriveBits(params, key, {{maximum}})).byteLength;
+
+            try {
+                await crypto.subtle.deriveBits(params, key, {{maximum}} + 8);
+                return atCeiling + '|derived';
+            } catch (e) {
+                return atCeiling + '|' + e.name + '/' + (e instanceof DOMException) + '/' + e.message;
+            }
+            """).AsString();
+
+        // The message is part of the pin, not decoration: the platform refuses an over-long output too, with
+        // an ArgumentOutOfRangeException that this code turns into an OperationError of its own — so a test
+        // asserting only the error's *name* cannot tell the specification's step 3 from the platform's
+        // accident, and would go green if the step were deleted. Naming the ceiling is what distinguishes
+        // them, and the ceiling is what the step is.
+        result.Should().StartWith((maximum / 8) + "|OperationError/true/");
+        result.Should().Contain($"a length of {maximum + 8} bits exceeds the {maximum} bits HKDF can expand to with {hash} (255 * {hashLength})");
+    }
+
+    [Fact]
+    public void AnHkdfKeyIsImportOnlyAndNeverExtractable()
+    {
+        var engine = WebEngine();
+
+        Settle(engine, """
+            crypto.subtle.importKey('raw', new Uint8Array(8), 'HKDF', true, ['deriveBits'])
+                .then(() => 'imported', e => e.name)
+            """).AsString().Should().Be("SyntaxError");
+
+        Settle(engine, """
+            Promise.all(['jwk', 'spki', 'pkcs8'].map(format =>
+                crypto.subtle.importKey(format, format === 'jwk' ? { kty: 'oct', k: 'AAAA' } : new Uint8Array(8), 'HKDF', false, ['deriveBits'])
+                    .then(() => 'imported', e => e.name))).then(names => names.join(','))
+            """).AsString().Should().Be("NotSupportedError,NotSupportedError,NotSupportedError");
+
+        Settle(engine, """
+            crypto.subtle.generateKey({ name: 'HKDF' }, false, ['deriveBits']).then(() => 'generated', e => e.name)
+            """).AsString().Should().Be("NotSupportedError");
+
+        Settle(engine, """
+            crypto.subtle.importKey('raw', new Uint8Array(8), 'HKDF', false, ['deriveBits'])
+                .then(key => crypto.subtle.exportKey('raw', key))
+                .then(() => 'exported', e => e.name)
+            """).AsString().Should().Be("NotSupportedError");
+    }
+
+    [Theory]
+    [InlineData("HKDF")]
+    [InlineData("PBKDF2")]
+    public void ADerivationKeyCarriesTheBareKeyAlgorithmAndOnlyTheDerivationUsages(string algorithm)
+    {
+        // "Let algorithm be a new KeyAlgorithm object. Set the name attribute of algorithm to 'HKDF'" — and
+        // nothing else. There is no hash and no length on the key, because for both of these the hash, the
+        // salt and the iteration count all belong to each derivation instead.
+        Run($$"""
+            const key = await crypto.subtle.importKey('raw', new Uint8Array(8), '{{algorithm}}', false, ['deriveKey', 'deriveBits']);
+            return JSON.stringify(key.algorithm) + '|' + key.type + '|' + key.extractable + '|' + JSON.stringify(key.usages);
+            """).AsString().Should().Be($$"""{"name":"{{algorithm}}"}|secret|false|["deriveKey","deriveBits"]""");
+
+        var engine = WebEngine();
+
+        // "If usages contains a value that is not 'deriveKey' or 'deriveBits', then throw a SyntaxError."
+        Settle(engine, $$"""
+            crypto.subtle.importKey('raw', new Uint8Array(8), '{{algorithm}}', false, ['sign'])
+                .then(() => 'imported', e => e.name)
+            """).AsString().Should().Be("SyntaxError");
+
+        // The empty list is within the permitted set, so it survives the algorithm's own step — and is then
+        // refused by importKey's shared tail, "if the [[type]] internal slot of result is 'secret' … and
+        // usages is empty, then throw a SyntaxError". A key of these two algorithms is always secret, so
+        // there is no usable key with no usages.
+        Settle(engine, $$"""
+            crypto.subtle.importKey('raw', new Uint8Array(8), '{{algorithm}}', false, [])
+                .then(() => 'imported', e => e.name)
+            """).AsString().Should().Be("SyntaxError");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // ECDH
+    // ---------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void DerivesTheRfc5903P256SharedSecretInBothDirections()
+    {
+        // https://www.rfc-editor.org/rfc/rfc5903#section-8.1 supplies both private keys, both public points
+        // and the x-coordinate of the shared point, so this is a known answer and not merely a pair of
+        // results that agree.
+        Run($$"""
+            {{EcdhKeys}}
+
+            return [
+                hex(await crypto.subtle.deriveBits({ name: 'ECDH', public: bobPub }, alicePriv, null)),
+                hex(await crypto.subtle.deriveBits({ name: 'ECDH', public: alicePub }, bobPriv, null)),
+            ].join('|');
+            """).AsString().Should().Be(SharedSecretHex + "|" + SharedSecretHex);
+    }
+
+    [Fact]
+    public void ANullLengthIsTheWholeSharedSecretAndAnOmittedArgumentMeansNull()
+    {
+        // "If length is null: return secret." The argument is `optional … unsigned long? length = null`, so
+        // omitting it, passing undefined and passing null are three spellings of the same request — which is
+        // what makes deriveBits usable for ECDH without knowing a curve's field width.
+        Run($$"""
+            {{EcdhKeys}}
+            const params = { name: 'ECDH', public: bobPub };
+
+            return [
+                hex(await crypto.subtle.deriveBits(params, alicePriv)),
+                hex(await crypto.subtle.deriveBits(params, alicePriv, undefined)),
+                hex(await crypto.subtle.deriveBits(params, alicePriv, null)),
+            ].join('|');
+            """).AsString().Should().Be(string.Join("|", SharedSecretHex, SharedSecretHex, SharedSecretHex));
+    }
+
+    [Fact]
+    public void TruncatesToTheFirstLengthBitsIncludingAPartialByte()
+    {
+        // "Return a byte sequence containing the first length bits of secret" — a bit count, not a byte
+        // count, and ECDH's steps impose none of the multiple-of-eight restriction HKDF's and PBKDF2's do.
+        // 230 bits is 28 whole bytes plus 6 bits, so the answer is 29 bytes whose last one keeps its top six
+        // bits and has the other two cleared: 0x4b becomes 0x48.
+        Run($$"""
+            {{EcdhKeys}}
+            const params = { name: 'ECDH', public: bobPub };
+
+            return [
+                hex(await crypto.subtle.deriveBits(params, alicePriv, 128)),
+                hex(await crypto.subtle.deriveBits(params, alicePriv, 230)),
+                (await crypto.subtle.deriveBits(params, alicePriv, 0)).byteLength,
+                hex(await crypto.subtle.deriveBits(params, alicePriv, 256)),
+            ].join('|');
+            """).AsString().Should().Be(
+                SharedSecretHex.Substring(0, 32)
+                + "|" + SharedSecretHex.Substring(0, 56) + "48"
+                + "|0"
+                + "|" + SharedSecretHex);
+    }
+
+    [Theory]
+    [InlineData("P-256", 256)]
+    [InlineData("P-384", 384)]
+    [InlineData("P-521", 528)]
+    public void TheMaximumLengthIsTheCurvesFieldWidthRoundedUpToWholeOctets(string curve, int maximum)
+    {
+        // "Let maximumLength be the length in bits of the output of the field element to octet string
+        // conversion … If length is not null and is greater than maximumLength, then throw an
+        // OperationError." The conversion pads to whole octets, so P-521's maximum is 528 and not 521 — the
+        // one row of this table that cannot be read off the curve's name.
+        Run($$"""
+            const pair = await crypto.subtle.generateKey({ name: 'ECDH', namedCurve: '{{curve}}' }, false, ['deriveBits']);
+            const params = { name: 'ECDH', public: pair.publicKey };
+
+            const atMaximum = (await crypto.subtle.deriveBits(params, pair.privateKey, {{maximum}})).byteLength;
+            const withoutLength = (await crypto.subtle.deriveBits(params, pair.privateKey)).byteLength;
+
+            try {
+                await crypto.subtle.deriveBits(params, pair.privateKey, {{maximum}} + 8);
+                return atMaximum + '|' + withoutLength + '|derived';
+            } catch (e) {
+                return atMaximum + '|' + withoutLength + '|' + e.name;
+            }
+            """).AsString().Should().Be($"{maximum / 8}|{maximum / 8}|OperationError");
+    }
+
+    [Fact]
+    public void RefusesEveryWrongKeyRoleWithAnInvalidAccessError()
+    {
+        // The five checks the ECDH derive-bits steps make, in the order they make them: the `public` member
+        // must be a public key (step 2) of an ECDH key (step 3), the base key must be a private one
+        // (step 6), and the two must share a curve (step 8).
+        Run($$"""
+            {{EcdhKeys}}
+            const ecdsaPair = await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, false, ['sign', 'verify']);
+            const p384 = await crypto.subtle.generateKey({ name: 'ECDH', namedCurve: 'P-384' }, false, ['deriveBits']);
+
+            const attempt = async (params, key) => {
+                try { await crypto.subtle.deriveBits(params, key, 128); return 'derived'; }
+                catch (e) { return e.name; }
+            };
+
+            return [
+                // The public member is a private key.
+                await attempt({ name: 'ECDH', public: bobPriv }, alicePriv),
+                // ... is an ECDSA key, over the very same curve.
+                await attempt({ name: 'ECDH', public: ecdsaPair.publicKey }, alicePriv),
+                // The base key is a public key.
+                await attempt({ name: 'ECDH', public: bobPub }, bobPub),
+                // The two keys are on different curves.
+                await attempt({ name: 'ECDH', public: p384.publicKey }, alicePriv),
+                // The base key is not an ECDH key at all, which deriveBits itself catches before the
+                // algorithm's steps run.
+                await attempt({ name: 'ECDH', public: bobPub }, ecdsaPair.privateKey),
+            ].join(',');
+            """).AsString().Should().Be("InvalidAccessError,InvalidAccessError,InvalidAccessError,InvalidAccessError,InvalidAccessError");
+    }
+
+    [Fact]
+    public void ThePublicMemberIsACryptoKeyInterfaceAndCoercesNothing()
+    {
+        // `required CryptoKey public` is an interface type, so WebIDL accepts a platform object of that
+        // interface and raises a TypeError for everything else — including an object shaped like a key, and
+        // including a real key's own `algorithm` dictionary, which is the mistake this is most likely to
+        // catch.
+        Run($$"""
+            {{EcdhKeys}}
+
+            const attempt = async member => {
+                try { await crypto.subtle.deriveBits({ name: 'ECDH', public: member }, alicePriv, 128); return 'derived'; }
+                catch (e) { return e.constructor.name; }
+            };
+
+            return [
+                await attempt(undefined),
+                await attempt(null),
+                await attempt({ type: 'public', algorithm: { name: 'ECDH', namedCurve: 'P-256' } }),
+                await attempt(bobPub.algorithm),
+            ].join(',');
+            """).AsString().Should().Be("TypeError,TypeError,TypeError,TypeError");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // The length argument, across all three algorithms
+    // ---------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void HkdfAndPbkdf2RefuseANullLengthAndANonMultipleOfEight()
+    {
+        // "If length is null or is not a multiple of 8, then throw an OperationError" — the first step of
+        // both, and the whole of the difference from ECDH, which has a natural output size to fall back on
+        // and truncates to a bit.
+        Run("""
+            const hkdf = await crypto.subtle.importKey('raw', new Uint8Array(22), 'HKDF', false, ['deriveBits']);
+            const pbkdf2 = await crypto.subtle.importKey('raw', ascii('password'), 'PBKDF2', false, ['deriveBits']);
+            const hkdfParams = { name: 'HKDF', hash: 'SHA-256', salt: empty, info: empty };
+            const pbkdf2Params = { name: 'PBKDF2', salt: ascii('salt'), iterations: 1, hash: 'SHA-256' };
+
+            const attempt = async (params, key, ...length) => {
+                try { await crypto.subtle.deriveBits(params, key, ...length); return 'derived'; }
+                catch (e) { return e.name; }
+            };
+
+            return [
+                await attempt(hkdfParams, hkdf),
+                await attempt(hkdfParams, hkdf, undefined),
+                await attempt(hkdfParams, hkdf, null),
+                await attempt(hkdfParams, hkdf, 230),
+                await attempt(pbkdf2Params, pbkdf2),
+                await attempt(pbkdf2Params, pbkdf2, null),
+                await attempt(pbkdf2Params, pbkdf2, 230),
+            ].join(',');
+            """).AsString().Should().Be(
+                "OperationError,OperationError,OperationError,OperationError,OperationError,OperationError,OperationError");
+    }
+
+    [Fact]
+    public void AZeroLengthIsTheEmptyByteSequenceForAllThree()
+    {
+        // PBKDF2's steps say so outright ("If length is zero, return an empty byte sequence"); HKDF's do not
+        // mention it, but HKDF-Expand with L = 0 runs no iterations and yields the empty string, so it is
+        // the same answer — and it has to be produced without asking the platform, which refuses an output
+        // length of zero with an ArgumentOutOfRangeException.
+        Run($$"""
+            {{EcdhKeys}}
+            const hkdf = await crypto.subtle.importKey('raw', new Uint8Array(22), 'HKDF', false, ['deriveBits']);
+            const pbkdf2 = await crypto.subtle.importKey('raw', ascii('password'), 'PBKDF2', false, ['deriveBits']);
+
+            return [
+                (await crypto.subtle.deriveBits({ name: 'HKDF', hash: 'SHA-256', salt: empty, info: empty }, hkdf, 0)).byteLength,
+                (await crypto.subtle.deriveBits({ name: 'PBKDF2', salt: ascii('salt'), iterations: 1, hash: 'SHA-256' }, pbkdf2, 0)).byteLength,
+                (await crypto.subtle.deriveBits({ name: 'ECDH', public: bobPub }, alicePriv, 0)).byteLength,
+            ].join(',');
+            """).AsString().Should().Be("0,0,0");
+    }
+
+    [Fact]
+    public void TheLengthArgumentIsEnforceRange()
+    {
+        // `[EnforceRange] unsigned long?`, so a value that is not a finite number or whose truncated value
+        // falls outside [0, 2^32 - 1] is a TypeError raised by the argument conversion — before a single
+        // step of the method body, and therefore before the algorithm is even normalized.
+        Run($$"""
+            {{EcdhKeys}}
+            const params = { name: 'ECDH', public: bobPub };
+
+            const attempt = async length => {
+                try { await crypto.subtle.deriveBits(params, alicePriv, length); return 'derived'; }
+                catch (e) { return e.constructor.name; }
+            };
+
+            return [
+                await attempt(NaN),
+                await attempt(Infinity),
+                await attempt(-8),
+                await attempt(2 ** 32 + 8),
+                // A fractional value truncates rather than failing, which is what ConvertToInt does before
+                // it checks the range.
+                hex(await crypto.subtle.deriveBits(params, alicePriv, 128.9)),
+            ].join(',');
+            """).AsString().Should().Be(
+                "TypeError,TypeError,TypeError,TypeError," + SharedSecretHex.Substring(0, 32));
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // deriveKey
+    // ---------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void DerivesAnAesGcmKeyFromAPassword()
+    {
+        // The shape an embedder actually reaches for. The expected key is PBKDF2-HMAC-SHA-256 over
+        // ("password", "salt", 1000) truncated to 32 bytes, computed outside this engine — so the round trip
+        // below is evidence rather than a tautology.
+        Run("""
+            const password = await crypto.subtle.importKey('raw', ascii('password'), 'PBKDF2', false, ['deriveKey']);
+
+            const key = await crypto.subtle.deriveKey(
+                { name: 'PBKDF2', salt: ascii('salt'), iterations: 1000, hash: 'SHA-256' },
+                password,
+                { name: 'AES-GCM', length: 256 },
+                true,
+                ['encrypt', 'decrypt']);
+
+            const iv = new Uint8Array(12);
+            const sealed = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, ascii('attack at dawn'));
+            const opened = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, sealed);
+
+            return [
+                key.type,
+                JSON.stringify(key.algorithm),
+                key.extractable,
+                JSON.stringify(key.usages),
+                hex(await crypto.subtle.exportKey('raw', key)),
+                String.fromCharCode(...new Uint8Array(opened)),
+            ].join('|');
+            """).AsString().Should().Be(
+                "secret"
+                + """|{"name":"AES-GCM","length":256}"""
+                + "|true"
+                + """|["encrypt","decrypt"]"""
+                + "|632c2812e46d4604102ba7618e9d6d7d2f8128f6266b4a03264d2a0460b7dcb3"
+                + "|attack at dawn");
+    }
+
+    [Fact]
+    public void DerivesAnHmacKeyFromAnEcdhAgreement()
+    {
+        // The derived key is the first 256 bits of the RFC 5903 shared secret, and the MAC is
+        // HMAC-SHA-256 over "x" under exactly those bytes — both computed outside this engine.
+        Run($$"""
+            {{EcdhKeys}}
+
+            const mac = await crypto.subtle.deriveKey(
+                { name: 'ECDH', public: bobPub },
+                alicePriv,
+                { name: 'HMAC', hash: 'SHA-256', length: 256 },
+                false,
+                ['sign', 'verify']);
+
+            const signature = await crypto.subtle.sign('HMAC', mac, ascii('x'));
+
+            return [
+                mac.type,
+                JSON.stringify(mac.algorithm),
+                mac.extractable,
+                hex(signature),
+                await crypto.subtle.verify('HMAC', mac, signature, ascii('x')),
+            ].join('|');
+            """).AsString().Should().Be(
+                "secret"
+                + """|{"name":"HMAC","hash":{"name":"SHA-256"},"length":256}"""
+                + "|false"
+                + "|fb4edf4b94a401d3004cebbdd5e4882f4520efbcee04468c178c5f7fd9e44dad"
+                + "|true");
+    }
+
+    [Fact]
+    public void DerivesAnHkdfKeyFromAnEcdhAgreementAndThenBitsFromIt()
+    {
+        // The specification's own worked example (§35.1, written there over X25519): agree, derive the whole
+        // shared secret into an HKDF key — which works precisely because HKDF's `get key length` answers
+        // null and ECDH's derive-bits reads a null length as "all of it" — and expand that.
+        Run($$"""
+            {{EcdhKeys}}
+
+            const shared = await crypto.subtle.deriveKey({ name: 'ECDH', public: bobPub }, alicePriv, 'HKDF', false, ['deriveBits']);
+            const bits = await crypto.subtle.deriveBits({ name: 'HKDF', hash: 'SHA-256', salt: empty, info: empty }, shared, 128);
+
+            return JSON.stringify(shared.algorithm) + '|' + shared.type + '|' + shared.extractable + '|' + hex(bits);
+            """).AsString().Should().Be("""{"name":"HKDF"}|secret|false|3bf511eebadf44c1f7b0282a1262fe4d""");
+    }
+
+    [Fact]
+    public void ThePbkdf2ToHkdfCompositionFailsBecauseNeitherSideSuppliesALength()
+    {
+        // The mirror image of the test above, and the reason the null is not merely bookkeeping: HKDF's
+        // `get key length` answers null, and PBKDF2's derive-bits refuses a null length with an
+        // OperationError, so the composition has nowhere to get a number from.
+        Run("""
+            const password = await crypto.subtle.importKey('raw', ascii('password'), 'PBKDF2', false, ['deriveKey']);
+            try {
+                await crypto.subtle.deriveKey(
+                    { name: 'PBKDF2', salt: ascii('salt'), iterations: 1, hash: 'SHA-256' }, password, 'HKDF', false, ['deriveBits']);
+                return 'derived';
+            } catch (e) {
+                return e.name;
+            }
+            """).AsString().Should().Be("OperationError");
+    }
+
+    [Fact]
+    public void TheGetKeyLengthOperationDecidesHowManyBitsAreDerived()
+    {
+        // HMAC's `get key length` reads HmacImportParams: an absent length is the hash's block size, a
+        // present non-zero one is itself, and a present zero is a *TypeError* — the specification's own
+        // choice, and the only place in this API where a wrong value is one. AES-GCM's reads
+        // AesDerivedKeyParams and refuses anything that is not 128, 192 or 256 with an OperationError.
+        Run("""
+            const password = await crypto.subtle.importKey('raw', ascii('password'), 'PBKDF2', false, ['deriveKey']);
+            const params = { name: 'PBKDF2', salt: ascii('salt'), iterations: 1, hash: 'SHA-256' };
+
+            const derive = async derivedKeyType => {
+                try {
+                    const key = await crypto.subtle.deriveKey(params, password, derivedKeyType, false, ['sign']);
+                    return key.algorithm.length;
+                } catch (e) {
+                    return e.constructor === DOMException ? e.name : e.constructor.name;
+                }
+            };
+
+            return [
+                // An absent length is the block size: 512 bits for SHA-256, 1024 for SHA-512.
+                await derive({ name: 'HMAC', hash: 'SHA-256' }),
+                await derive({ name: 'HMAC', hash: 'SHA-512' }),
+                await derive({ name: 'HMAC', hash: 'SHA-256', length: 128 }),
+                await derive({ name: 'HMAC', hash: 'SHA-256', length: 0 }),
+            ].join(',');
+            """).AsString().Should().Be("512,1024,128,TypeError");
+
+        Run("""
+            const password = await crypto.subtle.importKey('raw', ascii('password'), 'PBKDF2', false, ['deriveKey']);
+            const params = { name: 'PBKDF2', salt: ascii('salt'), iterations: 1, hash: 'SHA-256' };
+
+            const derive = async length => {
+                try {
+                    const key = await crypto.subtle.deriveKey(params, password, { name: 'AES-GCM', length }, false, ['encrypt']);
+                    return key.algorithm.length;
+                } catch (e) {
+                    return e.name;
+                }
+            };
+
+            return [await derive(128), await derive(192), await derive(256), await derive(100), await derive(512)].join(',');
+            """).AsString().Should().Be("128,192,256,OperationError,OperationError");
+    }
+
+    [Fact]
+    public void NormalizesTheDerivedKeyTypeTwiceInTheSpecifiedOrder()
+    {
+        // Steps 2 to 7: the algorithm is normalized for deriveBits, and the derivedKeyType is normalized
+        // twice — once for importKey and once for `get key length` — with all three happening before a
+        // single algorithm step runs. The second reading is observable, and pinning it is what keeps a
+        // future "optimisation" that normalizes the derivedKeyType once from silently changing what a
+        // script's getters see.
+        Run("""
+            const password = await crypto.subtle.importKey('raw', ascii('password'), 'PBKDF2', false, ['deriveKey']);
+            const reads = [];
+
+            // HMAC is the derivedKeyType that makes the double reading visible: HmacImportParams is what it
+            // registers for *both* importKey and get key length, so all three members are read twice.
+            const derivedKeyType = {
+                get name() { reads.push('name'); return 'HMAC'; },
+                get hash() { reads.push('hash'); return 'SHA-256'; },
+                get length() { reads.push('length'); return 256; },
+            };
+
+            const params = {
+                get name() { reads.push('algorithm.name'); return 'PBKDF2'; },
+                get hash() { reads.push('algorithm.hash'); return 'SHA-256'; },
+                get iterations() { reads.push('algorithm.iterations'); return 1; },
+                get salt() { reads.push('algorithm.salt'); return ascii('salt'); },
+            };
+
+            const key = await crypto.subtle.deriveKey(params, password, derivedKeyType, false, ['sign']);
+            return reads.join(',') + '|' + key.algorithm.length;
+            """).AsString().Should().Be(
+                // The algorithm's own members, in WebIDL's lexicographical order after `name`.
+                "algorithm.name,algorithm.hash,algorithm.iterations,algorithm.salt,"
+                // Then the derivedKeyType, twice: once as HmacImportParams for importKey, once as
+                // HmacImportParams for get key length.
+                + "name,hash,length,name,hash,length"
+                + "|256");
+    }
+
+    [Fact]
+    public void TheBaseKeyNeedsDeriveKeyForDeriveKeyAndDeriveBitsForDeriveBits()
+    {
+        // The two methods check *different* usages — deriveKey wants 'deriveKey' even though bits are what
+        // the derivation produces — and neither consults the base key's own extractability, which is what
+        // lets a non-extractable password produce an extractable key.
+        Run("""
+            const forBits = await crypto.subtle.importKey('raw', ascii('password'), 'PBKDF2', false, ['deriveBits']);
+            const forKey = await crypto.subtle.importKey('raw', ascii('password'), 'PBKDF2', false, ['deriveKey']);
+            const params = { name: 'PBKDF2', salt: ascii('salt'), iterations: 1, hash: 'SHA-256' };
+
+            const attempt = async fn => {
+                try { await fn(); return 'ok'; } catch (e) { return e.name; }
+            };
+
+            return [
+                await attempt(() => crypto.subtle.deriveBits(params, forBits, 128)),
+                await attempt(() => crypto.subtle.deriveBits(params, forKey, 128)),
+                await attempt(() => crypto.subtle.deriveKey(params, forKey, { name: 'AES-GCM', length: 128 }, false, ['encrypt'])),
+                await attempt(() => crypto.subtle.deriveKey(params, forBits, { name: 'AES-GCM', length: 128 }, false, ['encrypt'])),
+            ].join(',');
+            """).AsString().Should().Be("ok,InvalidAccessError,ok,InvalidAccessError");
+    }
+
+    [Fact]
+    public void TheDerivedKeyIsBuiltByTheImportPathAndInheritsItsRefusals()
+    {
+        // deriveKey is a composition: the bits are imported through exactly the `raw` branch importKey would
+        // have taken, so a derived secret key with no usages is the SyntaxError importKey's shared tail
+        // gives. What it will *not* accept at all is an asymmetric derivedKeyType — the registry decides
+        // that, not any step: RSA and the elliptic curves register importKey but not `get key length`, so
+        // step 6's normalization refuses them before a single bit is derived.
+        Run("""
+            const password = await crypto.subtle.importKey('raw', ascii('password'), 'PBKDF2', false, ['deriveKey']);
+            const params = { name: 'PBKDF2', salt: ascii('salt'), iterations: 1, hash: 'SHA-256' };
+
+            const attempt = async (derivedKeyType, usages) => {
+                try { await crypto.subtle.deriveKey(params, password, derivedKeyType, false, usages); return 'derived'; }
+                catch (e) { return e.name; }
+            };
+
+            return [
+                // Asymmetric derivedKeyTypes: registered for importKey, not for get key length.
+                await attempt({ name: 'RSA-OAEP', hash: 'SHA-256' }, ['encrypt']),
+                await attempt({ name: 'ECDSA', namedCurve: 'P-256' }, ['sign']),
+                // A secret key nobody may use is a mistake, not a key.
+                await attempt({ name: 'AES-GCM', length: 128 }, []),
+                // A usage the derived algorithm does not support.
+                await attempt({ name: 'AES-GCM', length: 128 }, ['sign']),
+            ].join(',');
+            """).AsString().Should().Be("NotSupportedError,NotSupportedError,SyntaxError,SyntaxError");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // The registries
+    // ---------------------------------------------------------------------------------------------------
+
+    [Theory]
+    // ECDH derives and never signs or encrypts; ECDSA is the reverse.
+    [InlineData("deriveBits", "{ name: 'ECDSA', namedCurve: 'P-256' }")]
+    [InlineData("deriveBits", "'HMAC'")]
+    [InlineData("deriveBits", "'AES-GCM'")]
+    [InlineData("deriveBits", "'RSA-OAEP'")]
+    // HKDF and PBKDF2 derive and nothing else, so every other operation is a NotSupportedError.
+    [InlineData("sign", "'HKDF'")]
+    [InlineData("encrypt", "'PBKDF2'")]
+    [InlineData("generateKey", "'HKDF'")]
+    [InlineData("generateKey", "'PBKDF2'")]
+    public void RefusesAnAlgorithmThatIsNotRegisteredForTheOperation(string operation, string algorithm)
+    {
+        var engine = WebEngine();
+
+        var call = operation switch
+        {
+            "deriveBits" => $"crypto.subtle.deriveBits({algorithm}, key, 128)",
+            "sign" => $"crypto.subtle.sign({algorithm}, key, new Uint8Array(0))",
+            "encrypt" => $"crypto.subtle.encrypt({algorithm}, key, new Uint8Array(0))",
+            _ => $"crypto.subtle.generateKey({algorithm}, false, ['deriveBits'])",
+        };
+
+        Settle(engine, $$"""
+            crypto.subtle.importKey('raw', new Uint8Array(16), 'PBKDF2', false, ['deriveBits'])
+                .then(key => {{call}})
+                .then(() => 'succeeded', e => e.name + '/' + e.code)
+            """).AsString().Should().Be("NotSupportedError/9");
+    }
+
+    [Fact]
+    public void ADerivationAgainstTheWrongAlgorithmIsAnInvalidAccessError()
+    {
+        // "If the name member of normalizedAlgorithm is not equal to the name attribute of the [[algorithm]]
+        // internal slot of baseKey then throw an InvalidAccessError" — the check both methods make before
+        // anything else. The two derivation algorithms are registered for the same operation, so this is the
+        // only thing keeping an HKDF key out of a PBKDF2 derivation.
+        Run("""
+            const hkdf = await crypto.subtle.importKey('raw', new Uint8Array(22), 'HKDF', false, ['deriveBits']);
+
+            try {
+                await crypto.subtle.deriveBits({ name: 'PBKDF2', salt: ascii('salt'), iterations: 1, hash: 'SHA-256' }, hkdf, 128);
+                return 'derived';
+            } catch (e) {
+                return e.name;
+            }
+            """).AsString().Should().Be("InvalidAccessError");
+    }
+
+    [Fact]
+    public void TheHkdfAndPbkdf2ParameterMembersAreAllRequired()
+    {
+        // HkdfParams declares `required hash`, `required salt` and `required info`, and Pbkdf2Params
+        // `required salt`, `required iterations` and `required hash` — so "no salt" is the empty byte
+        // sequence and never an omission, and a missing member is the TypeError WebIDL raises for a required
+        // one rather than a defaulted derivation.
+        Run("""
+            const hkdf = await crypto.subtle.importKey('raw', new Uint8Array(22), 'HKDF', false, ['deriveBits']);
+            const pbkdf2 = await crypto.subtle.importKey('raw', ascii('password'), 'PBKDF2', false, ['deriveBits']);
+
+            const attempt = async (params, key) => {
+                try { await crypto.subtle.deriveBits(params, key, 128); return 'derived'; }
+                catch (e) { return e.constructor.name; }
+            };
+
+            return [
+                await attempt({ name: 'HKDF', salt: empty, info: empty }, hkdf),
+                await attempt({ name: 'HKDF', hash: 'SHA-256', info: empty }, hkdf),
+                await attempt({ name: 'HKDF', hash: 'SHA-256', salt: empty }, hkdf),
+                await attempt({ name: 'PBKDF2', iterations: 1, hash: 'SHA-256' }, pbkdf2),
+                await attempt({ name: 'PBKDF2', salt: empty, hash: 'SHA-256' }, pbkdf2),
+                await attempt({ name: 'PBKDF2', salt: empty, iterations: 1 }, pbkdf2),
+                // A salt that is not a buffer source is the same failure, and a SharedArrayBuffer view is
+                // refused because the IDL says BufferSource and not AllowSharedBufferSource.
+                await attempt({ name: 'HKDF', hash: 'SHA-256', salt: 'salt', info: empty }, hkdf),
+            ].join(',');
+            """).AsString().Should().Be("TypeError,TypeError,TypeError,TypeError,TypeError,TypeError,TypeError");
+    }
+
+    [Fact]
+    public void BufferSourceMembersAreCopiedAtNormalizationTime()
+    {
+        // "Set the dictionary member to the result of getting a copy of the bytes held by idlValue." The copy
+        // is real and it has to be: normalization goes on to read further members, which may run a script's
+        // getter with an already-read array still in scope, so a window onto the engine's backing store would
+        // be a window onto whatever that getter left behind.
+        //
+        // `info` is read before `salt` — WebIDL walks a dictionary's own members in lexicographical order —
+        // so the mutation goes the other way round: a `salt` getter that rewrites the *info* array must not
+        // change the derivation, because those bytes were copied one member earlier.
+        Run("""
+            const key = await crypto.subtle.importKey('raw', new Uint8Array(22), 'HKDF', false, ['deriveBits']);
+            const info = new Uint8Array([1, 2, 3, 4]);
+
+            const params = {
+                name: 'HKDF',
+                hash: 'SHA-256',
+                info,
+                get salt() { info.fill(0xff); return empty; },
+            };
+
+            const derived = hex(await crypto.subtle.deriveBits(params, key, 128));
+
+            // The control derives with the bytes the caller actually passed, from an object no getter can
+            // reach, and the mutated array is the third answer this must not equal.
+            const control = hex(await crypto.subtle.deriveBits(
+                { name: 'HKDF', hash: 'SHA-256', salt: empty, info: new Uint8Array([1, 2, 3, 4]) }, key, 128));
+            const mutated = hex(await crypto.subtle.deriveBits(
+                { name: 'HKDF', hash: 'SHA-256', salt: empty, info: new Uint8Array([0xff, 0xff, 0xff, 0xff]) }, key, 128));
+
+            return (derived === control) + '|' + (derived === mutated) + '|' + hex(info);
+            """).AsString().Should().Be("true|false|ffffffff");
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/SubtleCryptoEcTests.cs
+++ b/Jint.Tests/Runtime/WebApi/SubtleCryptoEcTests.cs
@@ -26,9 +26,10 @@ namespace Jint.Tests.Runtime.WebApi;
 /// this engine's parsing and re-encoding against an encoding it did not produce.
 /// </para>
 /// <para>
-/// ECDH appears throughout for its keys and nowhere for an operation, because it has none here yet:
-/// <c>deriveKey</c> and <c>deriveBits</c> are absent from <c>crypto.subtle</c>, which
-/// <see cref="SubtleCryptoTests"/> pins, so an ECDH key carrying those usages is a key nothing consumes.
+/// ECDH appears throughout for its <i>keys</i>: what it does with them — <c>deriveBits</c>, and the
+/// <c>deriveKey</c> composition over it — lives in <see cref="SubtleCryptoDeriveTests"/>, together with the
+/// RFC 5903 agreement vector. What is pinned here is the split that keeps the two elliptic-curve algorithms
+/// apart: an ECDH key carries only the derivation usages and an ECDSA key only the signature ones.
 /// </para>
 /// </remarks>
 public class SubtleCryptoEcTests
@@ -903,14 +904,15 @@ public class SubtleCryptoEcTests
     }
 
     [Fact]
-    public void AnEcdhPrivateKeyMayCarryTheDerivationUsagesNothingConsumesYet()
+    public void AnEcdhPrivateKeyCarriesTheDerivationUsagesAndNoOthers()
     {
         var engine = WebEngine();
 
-        // deriveKey and deriveBits are absent from crypto.subtle, so these usages are real, checked, split
-        // and reported — and no operation reads them. That is the position AES-GCM's wrapKey and unwrapKey
-        // usages have always been in, and it is what makes the derive operations an addition rather than a
-        // change to the keys a script already makes.
+        // The usage set an ECDH key may be imported with is exactly ['deriveKey', 'deriveBits'], and it is
+        // checked before a byte of the key data is parsed — so a request naming a signature usage is the
+        // SyntaxError the usages earn rather than anything the DER might have said. It is the mirror of the
+        // ECDSA key one test above, and between them they are what keeps `sign` and `deriveBits` from ever
+        // meeting the same key.
         Settle(engine, $$"""
             crypto.subtle.importKey('pkcs8', bytes('{{Es256Pkcs8Hex}}'), { name: 'ECDH', namedCurve: 'P-256' }, false, ['deriveKey', 'deriveBits'])
                 .then(key => key.type + '/' + key.usages.join('+'), e => e.name)
@@ -1141,8 +1143,8 @@ public class SubtleCryptoEcTests
         var engine = WebEngine();
 
         // ECDSA registers sign, verify, generateKey, importKey and exportKey; ECDH registers generateKey,
-        // importKey, exportKey and — for a later slice — deriveBits. An algorithm that is not registered for
-        // an operation is a NotSupportedError, decided before any key is looked at.
+        // importKey, exportKey and deriveBits. An algorithm that is not registered for an operation is a
+        // NotSupportedError, decided before any key is looked at.
         Settle(engine, $$"""
             (async () => {
                 const outcomes = [];
@@ -1166,10 +1168,20 @@ public class SubtleCryptoEcTests
             """).AsString().Should().Be(
                 "NotSupportedError,NotSupportedError,NotSupportedError,NotSupportedError,ok,ok");
 
-        // The derive operations are still absent rather than present-and-throwing, which is what a library
-        // that means to use them checks before it reaches for one.
-        engine.Evaluate("['deriveKey', 'deriveBits'].filter(name => name in crypto.subtle).join(',')")
-            .AsString().Should().Be("");
+        // ECDSA is not registered for deriveBits and ECDH is, which is the one asymmetry between the two
+        // that is not about usages. SubtleCryptoDeriveTests carries the derivations themselves.
+        Settle(engine, $$"""
+            (async () => {
+                const pair = await crypto.subtle.generateKey({ name: 'ECDH', namedCurve: 'P-256' }, false, ['deriveBits']);
+                const outcomes = [];
+                const attempt = async fn => { try { await fn(); outcomes.push('ok'); } catch (e) { outcomes.push(e.name); } };
+
+                await attempt(() => crypto.subtle.deriveBits({ name: 'ECDSA', public: pair.publicKey }, pair.privateKey, 128));
+                await attempt(() => crypto.subtle.deriveBits({ name: 'ECDH', public: pair.publicKey }, pair.privateKey, 128));
+
+                return outcomes.join(',');
+            })()
+            """).AsString().Should().Be("NotSupportedError,ok");
     }
 
     [Fact]

--- a/Jint.Tests/Runtime/WebApi/SubtleCryptoKeyTests.cs
+++ b/Jint.Tests/Runtime/WebApi/SubtleCryptoKeyTests.cs
@@ -867,14 +867,15 @@ public class SubtleCryptoKeyTests
     [InlineData("encrypt", "'AES-CBC'")]
     [InlineData("decrypt", "{ name: 'AES-CTR' }")]
     [InlineData("generateKey", "'HKDF'")]
-    [InlineData("importKey", "'PBKDF2'")]
+    [InlineData("importKey", "'X25519'")]
     // An algorithm that is registered, but not for this operation: RSA-OAEP encrypts and never signs,
-    // RSASSA-PKCS1-v1_5 signs and never encrypts, and ECDH — which has keys here and no operation on them
-    // yet — neither signs nor encrypts.
+    // RSASSA-PKCS1-v1_5 signs and never encrypts, ECDH derives and never signs, and PBKDF2 — whose keys
+    // this engine imports — does nothing but derive.
     [InlineData("sign", "'RSA-OAEP'")]
     [InlineData("encrypt", "'RSASSA-PKCS1-v1_5'")]
     [InlineData("sign", "'ECDH'")]
     [InlineData("encrypt", "'ECDSA'")]
+    [InlineData("sign", "'PBKDF2'")]
     public void RefusesAnUnregisteredAlgorithmWithANotSupportedError(string operation, string algorithm)
     {
         var engine = WebEngine();
@@ -902,14 +903,15 @@ public class SubtleCryptoKeyTests
         var engine = WebEngine();
 
         engine.Evaluate("""
-            ['digest', 'sign', 'verify', 'encrypt', 'decrypt', 'generateKey', 'importKey', 'exportKey']
+            ['digest', 'sign', 'verify', 'encrypt', 'decrypt', 'generateKey', 'importKey', 'exportKey', 'deriveBits', 'deriveKey']
                 .map(name => typeof crypto.subtle[name]).join(',')
-            """).AsString().Should().Be("function,function,function,function,function,function,function,function");
+            """).AsString().Should().Be(
+                "function,function,function,function,function,function,function,function,function,function");
 
-        // Absent rather than present-and-throwing: `typeof crypto.subtle.deriveBits` is how a library that
-        // does cryptography decides whether it can, and it has to get the truthful answer.
+        // Absent rather than present-and-throwing: `typeof crypto.subtle.wrapKey` is how a library that does
+        // cryptography decides whether it can, and it has to get the truthful answer.
         engine.Evaluate("""
-            ['deriveKey', 'deriveBits', 'wrapKey', 'unwrapKey'].filter(name => name in crypto.subtle).join(',')
+            ['wrapKey', 'unwrapKey'].filter(name => name in crypto.subtle).join(',')
             """).AsString().Should().Be("");
     }
 
@@ -918,13 +920,16 @@ public class SubtleCryptoKeyTests
     {
         var engine = WebEngine();
 
-        // WebIDL's length counts the required arguments only.
+        // WebIDL's length counts the required arguments only — which is why deriveBits is 2 and not 3: its
+        // `length` argument is `optional [EnforceRange] unsigned long? length = null`, so it does not count.
+        // A browser predating that change to the IDL answers 3; Node, which has taken it, answers 2.
         engine.Evaluate("""
-            ['digest', 'sign', 'verify', 'encrypt', 'decrypt', 'generateKey', 'importKey', 'exportKey']
+            ['digest', 'sign', 'verify', 'encrypt', 'decrypt', 'generateKey', 'importKey', 'exportKey', 'deriveBits', 'deriveKey']
                 .map(name => name + ':' + crypto.subtle[name].length + ':' + crypto.subtle[name].name).join(',')
             """).AsString().Should().Be(
                 "digest:2:digest,sign:3:sign,verify:4:verify,encrypt:3:encrypt,decrypt:3:decrypt,"
-                + "generateKey:3:generateKey,importKey:5:importKey,exportKey:2:exportKey");
+                + "generateKey:3:generateKey,importKey:5:importKey,exportKey:2:exportKey,"
+                + "deriveBits:2:deriveBits,deriveKey:5:deriveKey");
 
         engine.Evaluate("JSON.stringify(Object.keys(crypto.subtle))").AsString().Should().Be("[]");
     }

--- a/Jint.Tests/Runtime/WebApi/SubtleCryptoTests.cs
+++ b/Jint.Tests/Runtime/WebApi/SubtleCryptoTests.cs
@@ -487,17 +487,21 @@ public class SubtleCryptoTests
     }
 
     [Fact]
-    public void ExposesDigestAndTheKeyedOperationsButNotKeyDerivation()
+    public void ExposesDigestAndTheKeyedOperationsAndKeyDerivationButNotKeyWrapping()
     {
         var engine = WebEngine();
 
-        // Absent rather than present-and-throwing: a library checking `typeof crypto.subtle.deriveBits`
-        // before reaching for it has to get the truthful answer, which is the same reason `crypto.subtle`
-        // itself is absent from an engine without the crypto feature.
+        // Absent rather than present-and-throwing: a library checking `typeof crypto.subtle.wrapKey` before
+        // reaching for it has to get the truthful answer, which is the same reason `crypto.subtle` itself is
+        // absent from an engine without the crypto feature.
         engine.Evaluate("typeof crypto.subtle.digest").AsString().Should().Be("function");
 
         engine.Evaluate("""
-            ['deriveKey', 'deriveBits', 'wrapKey', 'unwrapKey'].filter(name => name in crypto.subtle).join(',')
+            ['deriveKey', 'deriveBits'].filter(name => name in crypto.subtle).join(',')
+            """).AsString().Should().Be("deriveKey,deriveBits");
+
+        engine.Evaluate("""
+            ['wrapKey', 'unwrapKey'].filter(name => name in crypto.subtle).join(',')
             """).AsString().Should().Be("");
 
         // As with crypto itself, the operation is an own property with a built-in method's attributes, so

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -588,15 +588,17 @@ public enum WebApiFeatures
     /// The <c>crypto</c> object: <c>getRandomValues</c> and <c>randomUUID</c>, both backed by the BCL's
     /// cryptographically secure generator, plus <c>crypto.subtle</c> and the <c>CryptoKey</c> interface
     /// object. <c>subtle</c> carries <c>digest</c> (SHA-1, SHA-256, SHA-384, SHA-512), <c>sign</c>,
-    /// <c>verify</c>, <c>encrypt</c>, <c>decrypt</c>, <c>generateKey</c>, <c>importKey</c> and
-    /// <c>exportKey</c> over HMAC, AES-GCM, RSASSA-PKCS1-v1_5, RSA-PSS, RSA-OAEP, ECDSA and ECDH — the last
-    /// two over the curves P-256, P-384 and P-521 — with the <c>raw</c>, <c>spki</c>, <c>pkcs8</c> and
-    /// <c>jwk</c> key formats. Key derivation and key wrapping are not implemented and are absent rather than
-    /// present-and-throwing, so feature detection sees the truth; ECDH is therefore present for its keys
-    /// alone, and a key it makes may carry <c>deriveKey</c> and <c>deriveBits</c> usages that no operation
-    /// consumes yet. Neither <c>subtle</c> nor <c>CryptoKey</c> has a flag of its
-    /// own: <c>subtle</c> is a readonly attribute of the very same <c>Crypto</c> interface and
-    /// <c>CryptoKey</c> is the type of what it hands out, so asking for one is asking for all three.
+    /// <c>verify</c>, <c>encrypt</c>, <c>decrypt</c>, <c>generateKey</c>, <c>importKey</c>,
+    /// <c>exportKey</c>, <c>deriveBits</c> and <c>deriveKey</c> over HMAC, AES-GCM, RSASSA-PKCS1-v1_5,
+    /// RSA-PSS, RSA-OAEP, ECDSA, ECDH, HKDF and PBKDF2 — the elliptic-curve pair over P-256, P-384 and
+    /// P-521 — with the <c>raw</c>, <c>spki</c>, <c>pkcs8</c> and <c>jwk</c> key formats. Key <i>wrapping</i>
+    /// is not implemented and <c>wrapKey</c>/<c>unwrapKey</c> are absent rather than present-and-throwing, so
+    /// feature detection sees the truth. HKDF and PBKDF2 keys are <c>importKey</c>-only and never
+    /// extractable, which is what their own registrations say; and PBKDF2's iteration count is capped at
+    /// 2^22 by this engine, because the loop is one uninterruptible call that no execution constraint can
+    /// bound. Neither <c>subtle</c> nor <c>CryptoKey</c> has a flag of its own: <c>subtle</c> is a readonly
+    /// attribute of the very same <c>Crypto</c> interface and <c>CryptoKey</c> is the type of what it hands
+    /// out, so asking for one is asking for all three.
     /// </summary>
     Crypto = 1 << 5,
 

--- a/Jint/WebApi/Crypto/AesGcmAlgorithm.cs
+++ b/Jint/WebApi/Crypto/AesGcmAlgorithm.cs
@@ -143,6 +143,29 @@ internal static class AesGcmAlgorithm
     }
 
     /// <summary>
+    /// https://w3c.github.io/webcrypto/#aes-gcm-operations-get-key-length — "If the length member of
+    /// normalizedDerivedKeyAlgorithm is not 128, 192 or 256, then throw an OperationError. Return the length
+    /// member of normalizedDerivedKeyAlgorithm."
+    /// </summary>
+    /// <remarks>
+    /// The registered parameters are <c>AesDerivedKeyParams</c>, which is <c>AesKeyGenParams</c> declared a
+    /// second time under another name — one <c>required [EnforceRange] unsigned short length</c> — so the
+    /// member is already read and range-checked by the time this is called, and the three lengths AES has are
+    /// the whole of what is left to say.
+    /// </remarks>
+    internal static uint GetKeyLength(CryptoContext context, NormalizedAlgorithm normalized, string what)
+    {
+        var length = normalized.Length!.Value;
+
+        if (!IsValidKeyLength(length))
+        {
+            context.ThrowOperationError(what + ": " + length + " is not a valid AES key length (128, 192 or 256 bits).");
+        }
+
+        return length;
+    }
+
+    /// <summary>
     /// https://w3c.github.io/webcrypto/#aes-gcm-operations-export-key
     /// </summary>
     internal static JsValue ExportKey(CryptoContext context, JsCryptoKey key, KeyFormat format, string what)

--- a/Jint/WebApi/Crypto/AlgorithmNormalization.cs
+++ b/Jint/WebApi/Crypto/AlgorithmNormalization.cs
@@ -12,9 +12,16 @@ namespace Jint.WebApi.Crypto;
 /// <summary>
 /// The operations <c>supportedAlgorithms</c> is keyed by —
 /// https://w3c.github.io/webcrypto/#algorithm-normalization-internal — restricted to the ones this engine
-/// implements. <c>deriveBits</c>, <c>wrapKey</c>, <c>unwrapKey</c> and <c>get key length</c> are absent
-/// because no method that would reach them exists.
+/// implements. <c>wrapKey</c> and <c>unwrapKey</c> are absent because no method that would reach them exists.
 /// </summary>
+/// <remarks>
+/// <see cref="DeriveKey"/> is the one member that is <b>not</b> a key of that container. There is no
+/// "deriveKey" registry: the <c>deriveKey</c> method normalizes its <c>algorithm</c> for <c>deriveBits</c>
+/// and its <c>derivedKeyType</c> for both <c>importKey</c> and <c>get key length</c>, so the only thing the
+/// member names is the method — which is what <see cref="AlgorithmNormalization.NameOf"/> reports in an error
+/// message and what <c>SubtleCrypto</c> dispatches on.
+/// <see cref="AlgorithmNormalization.RegisteredFor"/> therefore refuses it rather than answering with a list.
+/// </remarks>
 internal enum CryptoOperation
 {
     Digest,
@@ -25,6 +32,9 @@ internal enum CryptoOperation
     GenerateKey,
     ImportKey,
     ExportKey,
+    DeriveBits,
+    DeriveKey,
+    GetKeyLength,
 }
 
 /// <summary>
@@ -144,6 +154,28 @@ internal sealed class NormalizedAlgorithm
     /// verbatim — the operation is what decides whether it names a curve at all.
     /// </summary>
     internal string? NamedCurve { get; set; }
+
+    /// <summary>
+    /// The <c>salt</c> member of <c>HkdfParams</c> or <c>Pbkdf2Params</c>, copied at normalization time. It
+    /// is a required member of both, so an empty salt — which RFC 5869 §2.2 explicitly permits and treats as
+    /// <c>HashLen</c> zero bytes — is spelled as a zero-length <c>Uint8Array</c> and never as an absent one.
+    /// </summary>
+    internal byte[]? Salt { get; set; }
+
+    /// <summary>
+    /// The <c>info</c> member of <c>HkdfParams</c>, copied at normalization time. Required, like
+    /// <see cref="Salt"/>, so "no context information" is the empty byte sequence rather than an omission.
+    /// </summary>
+    internal byte[]? Info { get; set; }
+
+    /// <summary>The <c>iterations</c> member of <c>Pbkdf2Params</c>.</summary>
+    internal uint? Iterations { get; set; }
+
+    /// <summary>
+    /// The <c>public</c> member of <c>EcdhKeyDeriveParams</c> — "the peer's EC public key". Its IDL type is
+    /// the <c>CryptoKey</c> <i>interface</i>, so nothing is coerced into one.
+    /// </summary>
+    internal JsCryptoKey? PublicKey { get; set; }
 }
 
 /// <summary>
@@ -197,6 +229,12 @@ internal static class AlgorithmNormalization
     /// <summary>https://w3c.github.io/webcrypto/#ecdh-registration</summary>
     internal const string Ecdh = "ECDH";
 
+    /// <summary>https://w3c.github.io/webcrypto/#hkdf-registration</summary>
+    internal const string Hkdf = "HKDF";
+
+    /// <summary>https://w3c.github.io/webcrypto/#pbkdf2-registration</summary>
+    internal const string Pbkdf2 = "PBKDF2";
+
     /// <summary>
     /// The three values <c>NamedCurve</c> takes — https://w3c.github.io/webcrypto/#dfn-NamedCurve, "NIST
     /// recommended curve P-256, also known as secp256r1" and its two siblings.
@@ -216,7 +254,28 @@ internal static class AlgorithmNormalization
     private static readonly string[] _digestAlgorithms = [Sha1, Sha256, Sha384, Sha512];
     private static readonly string[] _signatureAlgorithms = [Hmac, RsassaPkcs1V15, RsaPss, Ecdsa];
     private static readonly string[] _cipherAlgorithms = [AesGcm, RsaOaep];
-    private static readonly string[] _keyAlgorithms = [Hmac, AesGcm, RsassaPkcs1V15, RsaPss, RsaOaep, Ecdsa, Ecdh];
+
+    /// <summary>
+    /// The three key registries are separate lists because the registrations are: HKDF and PBKDF2 register
+    /// <c>importKey</c> and nothing else, so a script may build one of their keys and can neither generate one
+    /// (there is nothing to generate — the "key" is a password or an input keying material the caller already
+    /// has) nor export one (their keys are non-extractable by construction).
+    /// </summary>
+    private static readonly string[] _generateKeyAlgorithms = [Hmac, AesGcm, RsassaPkcs1V15, RsaPss, RsaOaep, Ecdsa, Ecdh];
+    private static readonly string[] _importKeyAlgorithms = [Hmac, AesGcm, RsassaPkcs1V15, RsaPss, RsaOaep, Ecdsa, Ecdh, Hkdf, Pbkdf2];
+    private static readonly string[] _exportKeyAlgorithms = [Hmac, AesGcm, RsassaPkcs1V15, RsaPss, RsaOaep, Ecdsa, Ecdh];
+
+    /// <summary>The three algorithms registered for <c>deriveBits</c>.</summary>
+    private static readonly string[] _deriveAlgorithms = [Ecdh, Hkdf, Pbkdf2];
+
+    /// <summary>
+    /// The algorithms registered for <c>get key length</c>, which is the internal operation <c>deriveKey</c>
+    /// runs over its <c>derivedKeyType</c> to decide how many bits to derive. HKDF and PBKDF2 are in the list
+    /// and answer <see langword="null"/>: a key of theirs has no length of its own, which is exactly what
+    /// makes <c>deriveKey(ecdhParams, priv, 'HKDF', …)</c> — deriving the whole shared secret into an HKDF
+    /// key — the shape the specification's own worked example uses.
+    /// </summary>
+    private static readonly string[] _keyLengthAlgorithms = [Hmac, AesGcm, Hkdf, Pbkdf2];
 
     private static readonly JsString _nameKey = new("name");
     private static readonly JsString _hashKey = new("hash");
@@ -229,6 +288,10 @@ internal static class AlgorithmNormalization
     private static readonly JsString _saltLengthKey = new("saltLength");
     private static readonly JsString _labelKey = new("label");
     private static readonly JsString _namedCurveKey = new("namedCurve");
+    private static readonly JsString _saltKey = new("salt");
+    private static readonly JsString _infoKey = new("info");
+    private static readonly JsString _iterationsKey = new("iterations");
+    private static readonly JsString _publicMemberKey = new("public");
 
     /// <summary>
     /// The associative container "stored at the <c>op</c> key of <c>supportedAlgorithms</c>".
@@ -252,9 +315,21 @@ internal static class AlgorithmNormalization
             case CryptoOperation.Verify:
                 return _signatureAlgorithms;
             case CryptoOperation.GenerateKey:
+                return _generateKeyAlgorithms;
             case CryptoOperation.ImportKey:
+                return _importKeyAlgorithms;
             case CryptoOperation.ExportKey:
-                return _keyAlgorithms;
+                return _exportKeyAlgorithms;
+            case CryptoOperation.DeriveBits:
+                return _deriveAlgorithms;
+            case CryptoOperation.GetKeyLength:
+                return _keyLengthAlgorithms;
+            case CryptoOperation.DeriveKey:
+                // Not a key of supportedAlgorithms at all — see the remarks on CryptoOperation. Answering
+                // with any list would make `normalizing an algorithm` for it look meaningful.
+                Throw.InvalidOperationException(
+                    "The deriveKey method normalizes for deriveBits, importKey and get key length; there is no deriveKey registry.");
+                return null!;
             default:
                 Throw.InvalidOperationException("Unhandled crypto operation '" + operation + "'.");
                 return null!;
@@ -287,6 +362,14 @@ internal static class AlgorithmNormalization
                 return "importKey";
             case CryptoOperation.ExportKey:
                 return "exportKey";
+            case CryptoOperation.DeriveBits:
+                return "deriveBits";
+            case CryptoOperation.DeriveKey:
+                return "deriveKey";
+            case CryptoOperation.GetKeyLength:
+                // The specification's own name for it. It is not a method, so this reaches a script only
+                // inside the NotSupportedError a derivedKeyType that no algorithm registers earns.
+                return "get key length";
             default:
                 Throw.InvalidOperationException("Unhandled crypto operation '" + operation + "'.");
                 return null!;
@@ -402,15 +485,20 @@ internal static class AlgorithmNormalization
         switch (normalized.Name, operation)
         {
             // HmacKeyGenParams and HmacImportParams declare the same two members, and the difference between
-            // them is entirely in what the two operations do with `length`.
+            // them is entirely in what the three operations do with `length`. HMAC registers HmacImportParams
+            // for `get key length` too, which is the third reading of it.
             case (Hmac, CryptoOperation.GenerateKey):
             case (Hmac, CryptoOperation.ImportKey):
+            case (Hmac, CryptoOperation.GetKeyLength):
                 normalized.HashName = ReadRequiredHash(context, algorithm, what);
                 normalized.Length = ReadOptionalUnsignedLong(context, algorithm, _lengthKey, what);
                 break;
 
-            // AesKeyGenParams: `required [EnforceRange] unsigned short length`.
+            // AesKeyGenParams: `required [EnforceRange] unsigned short length`. AesDerivedKeyParams, which
+            // AES-GCM registers for `get key length`, is that dictionary declared a second time under another
+            // name — same one member, same type.
             case (AesGcm, CryptoOperation.GenerateKey):
+            case (AesGcm, CryptoOperation.GetKeyLength):
                 normalized.Length = ReadRequiredUnsignedShort(context, algorithm, _lengthKey, what);
                 break;
 
@@ -469,9 +557,32 @@ internal static class AlgorithmNormalization
                 normalized.HashName = ReadRequiredHash(context, algorithm, what);
                 break;
 
+            // HkdfParams. WebIDL converts a dictionary by walking the inherited dictionaries from least to
+            // most derived and each dictionary's own members in *lexicographical* order —
+            // https://webidl.spec.whatwg.org/#es-dictionary — so after Algorithm's `name` the getters run in
+            // the order hash, info, salt, and not the order the IDL block writes them in.
+            case (Hkdf, CryptoOperation.DeriveBits):
+                normalized.HashName = ReadRequiredHash(context, algorithm, what);
+                normalized.Info = ReadRequiredBufferSource(context, algorithm, _infoKey, what);
+                normalized.Salt = ReadRequiredBufferSource(context, algorithm, _saltKey, what);
+                break;
+
+            // Pbkdf2Params, in the same lexicographical order: hash, iterations, salt.
+            case (Pbkdf2, CryptoOperation.DeriveBits):
+                normalized.HashName = ReadRequiredHash(context, algorithm, what);
+                normalized.Iterations = ReadRequiredUnsignedLong(context, algorithm, _iterationsKey, what);
+                normalized.Salt = ReadRequiredBufferSource(context, algorithm, _saltKey, what);
+                break;
+
+            // EcdhKeyDeriveParams, whose one member is `required CryptoKey public`.
+            case (Ecdh, CryptoOperation.DeriveBits):
+                normalized.PublicKey = ReadRequiredCryptoKey(context, algorithm, _publicMemberKey, what);
+                break;
+
             // Every remaining pair registers `None` as its parameters, so the Algorithm dictionary — the one
             // member of which has already been read — is the whole of it. RSASSA-PKCS1-v1_5's sign and
-            // verify are in that set, as is every algorithm's exportKey.
+            // verify are in that set, as is every algorithm's exportKey, HKDF's and PBKDF2's importKey, and
+            // HKDF's and PBKDF2's `get key length`.
             default:
                 break;
         }
@@ -512,6 +623,33 @@ internal static class AlgorithmNormalization
         }
 
         return TypeConverter.ToString(value);
+    }
+
+    /// <summary>
+    /// A <c>required CryptoKey</c> member — the one member of <c>EcdhKeyDeriveParams</c>.
+    /// </summary>
+    /// <remarks>
+    /// An interface type converts nothing: WebIDL accepts a platform object implementing that interface and
+    /// raises a <c>TypeError</c> for everything else, https://webidl.spec.whatwg.org/#es-interface. So an
+    /// ordinary object shaped like a key — or a real key's own <c>algorithm</c> dictionary, which is the
+    /// mistake this is most likely to catch — is a <c>TypeError</c> here rather than a failure deep inside
+    /// the derivation.
+    /// </remarks>
+    private static JsCryptoKey ReadRequiredCryptoKey(CryptoContext context, ObjectInstance? algorithm, JsString key, string what)
+    {
+        var value = algorithm?.Get(key) ?? JsValue.Undefined;
+        if (value.IsUndefined())
+        {
+            context.ThrowTypeError(what + ": required member " + key + " is undefined.");
+        }
+
+        if (value is JsCryptoKey cryptoKey)
+        {
+            return cryptoKey;
+        }
+
+        context.ThrowTypeError(what + ": member " + key + " is not of type 'CryptoKey'.");
+        return null!;
     }
 
     private static byte[] ReadRequiredBufferSource(CryptoContext context, ObjectInstance? algorithm, JsString key, string what)
@@ -585,7 +723,7 @@ internal static class AlgorithmNormalization
             return null;
         }
 
-        return (uint) EnforceRange(context, value, key, what, uint.MaxValue);
+        return (uint) EnforceRange(context, value, "member " + key, what, uint.MaxValue);
     }
 
     private static uint ReadRequiredUnsignedLong(CryptoContext context, ObjectInstance? algorithm, JsString key, string what)
@@ -596,7 +734,7 @@ internal static class AlgorithmNormalization
             context.ThrowTypeError(what + ": required member " + key + " is undefined.");
         }
 
-        return (uint) EnforceRange(context, value, key, what, uint.MaxValue);
+        return (uint) EnforceRange(context, value, "member " + key, what, uint.MaxValue);
     }
 
     /// <summary>
@@ -643,7 +781,7 @@ internal static class AlgorithmNormalization
             context.ThrowTypeError(what + ": required member " + key + " is undefined.");
         }
 
-        return (uint) EnforceRange(context, value, key, what, ushort.MaxValue);
+        return (uint) EnforceRange(context, value, "member " + key, what, ushort.MaxValue);
     }
 
     private static int? ReadOptionalOctet(CryptoContext context, ObjectInstance? algorithm, JsString key, string what)
@@ -654,7 +792,31 @@ internal static class AlgorithmNormalization
             return null;
         }
 
-        return (int) EnforceRange(context, value, key, what, byte.MaxValue);
+        return (int) EnforceRange(context, value, "member " + key, what, byte.MaxValue);
+    }
+
+    /// <summary>
+    /// The <c>optional [EnforceRange] unsigned long? length = null</c> argument of <c>deriveBits</c>, which
+    /// is the only nullable integer in this API.
+    /// </summary>
+    /// <remarks>
+    /// Three spellings mean <see langword="null"/>, and each for its own reason: the argument is
+    /// <b>optional</b>, so omitting it takes the declared default; an omitted argument and an explicit
+    /// <c>undefined</c> are the same thing to WebIDL; and the type is <b>nullable</b>, so an explicit
+    /// <c>null</c> converts to null rather than to zero. Everything else is the ordinary
+    /// <c>[EnforceRange] unsigned long</c> conversion, so <c>NaN</c>, <c>Infinity</c>, <c>-8</c> and
+    /// <c>2 ** 32</c> are <c>TypeError</c>s and not a wrap or a clamp. What the algorithms then do with a
+    /// null differs: ECDH returns the whole shared secret, and HKDF and PBKDF2 have nothing to fall back on
+    /// and raise an <c>OperationError</c>.
+    /// </remarks>
+    internal static uint? ConvertOptionalLength(CryptoContext context, JsValue value, string what, string subject)
+    {
+        if (value.IsUndefined() || value.IsNull())
+        {
+            return null;
+        }
+
+        return (uint) EnforceRange(context, value, subject, what, uint.MaxValue);
     }
 
     /// <summary>
@@ -662,18 +824,18 @@ internal static class AlgorithmNormalization
     /// a value that is not a finite number, or whose truncated value falls outside the type, is a
     /// <c>TypeError</c> rather than a wrap or a clamp.
     /// </summary>
-    private static double EnforceRange(CryptoContext context, JsValue value, JsString key, string what, double max)
+    private static double EnforceRange(CryptoContext context, JsValue value, string subject, string what, double max)
     {
         var number = TypeConverter.ToNumber(value);
         if (!double.IsFinite(number))
         {
-            context.ThrowTypeError(what + ": member " + key + " is not a finite number.");
+            context.ThrowTypeError(what + ": " + subject + " is not a finite number.");
         }
 
         var integer = double.Truncate(number);
         if (integer < 0 || integer > max)
         {
-            context.ThrowTypeError(what + ": member " + key + " is outside the range [0, " + max + "].");
+            context.ThrowTypeError(what + ": " + subject + " is outside the range [0, " + max + "].");
         }
 
         return integer;

--- a/Jint/WebApi/Crypto/CryptoInstance.cs
+++ b/Jint/WebApi/Crypto/CryptoInstance.cs
@@ -26,9 +26,9 @@ namespace Jint.WebApi.Crypto;
 /// nowhere near this file.
 /// </para>
 /// <para>
-/// <c>crypto.subtle</c> exists and carries <b>eight of the twelve operations</b>: <c>digest</c>,
-/// <c>sign</c>, <c>verify</c>, <c>encrypt</c>, <c>decrypt</c>, <c>generateKey</c>, <c>importKey</c> and
-/// <c>exportKey</c>. <c>deriveKey</c>, <c>deriveBits</c>, <c>wrapKey</c> and <c>unwrapKey</c> are absent
+/// <c>crypto.subtle</c> exists and carries <b>ten of the twelve operations</b>: <c>digest</c>,
+/// <c>sign</c>, <c>verify</c>, <c>encrypt</c>, <c>decrypt</c>, <c>generateKey</c>, <c>importKey</c>,
+/// <c>exportKey</c>, <c>deriveBits</c> and <c>deriveKey</c>. <c>wrapKey</c> and <c>unwrapKey</c> are absent
 /// rather than present-and-throwing, so the feature detection a library performing cryptography starts with
 /// gets the truthful answer about each operation it means to use. See <see cref="SubtleCryptoInstance"/>.
 /// </para>

--- a/Jint/WebApi/Crypto/EcAlgorithm.cs
+++ b/Jint/WebApi/Crypto/EcAlgorithm.cs
@@ -21,9 +21,9 @@ namespace Jint.WebApi.Crypto;
 /// so that a script-reachable <c>CryptoKey</c> never owns a native key handle. Which class is rehydrated
 /// follows the algorithm the key was made for — <see cref="ECDsa"/> for an ECDSA key and
 /// <see cref="ECDiffieHellman"/> for an ECDH one. The DER is identical either way (both are
-/// <c>id-ecPublicKey</c> with a named curve, and this was verified against the platform), so the split buys
-/// nothing today; it is what makes the derive operations, which need a real
-/// <see cref="ECDiffieHellman"/>, an addition rather than a rewrite.
+/// <c>id-ecPublicKey</c> with a named curve, and this was verified against the platform), and the split is
+/// what lets <c>deriveBits</c> below cast straight to the <see cref="ECDiffieHellman"/> the ECDH primitive
+/// needs.
 /// </para>
 /// <para>
 /// <b>A signature is <c>r || s</c> at fixed field width.</b> "Convert r to a byte sequence of length n and
@@ -63,12 +63,11 @@ namespace Jint.WebApi.Crypto;
 /// does with its minimal-length integers, and the difference is deliberate on both sides.
 /// </para>
 /// <para>
-/// <b>ECDH's <c>deriveKey</c> and <c>deriveBits</c> usages exist and nothing consumes them yet.</b> An ECDH
-/// key generated or imported with them is a perfectly ordinary key that no operation on this
-/// <c>SubtleCrypto</c> accepts, because <c>deriveKey</c> and <c>deriveBits</c> are absent from it — the
-/// situation AES-GCM's <c>wrapKey</c> and <c>unwrapKey</c> usages have been in since AES-GCM landed. The
-/// usage bits are still checked, split and reported exactly as the specification says, so the keys a script
-/// makes today are the keys the derive operations will find when they arrive.
+/// <b>ECDH is the only one of the two that derives.</b> Its <c>deriveBits</c> operation is below; ECDSA has
+/// none, which is why <c>deriveBits({ name: 'ECDSA', … }, …)</c> is a <c>NotSupportedError</c> from the
+/// registry rather than anything this class decides. An ECDH key still carries no <c>sign</c> or
+/// <c>verify</c> usage and an ECDSA key no <c>deriveKey</c> or <c>deriveBits</c> one, so the split the
+/// generate and import steps make is what keeps the two apart from the first line of script.
 /// </para>
 /// </remarks>
 internal static class EcAlgorithm
@@ -610,6 +609,165 @@ internal static class EcAlgorithm
     }
 
     // -------------------------------------------------------------------------------------------------
+    // deriveBits
+    // -------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#ecdh-operations-derive-bits — "Perform the ECDH primitive specified
+    /// in [RFC6090] Section 4 … Let secret be a byte sequence containing the result of applying the field
+    /// element to octet string conversion defined in Section 6.2 of [RFC6090] to the output of the ECDH
+    /// primitive."
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The secret is the raw x-coordinate, not a hashed or KDF'd derivative</b>, which is what
+    /// <see cref="ECDiffieHellman.DeriveRawSecretAgreement"/> produces and what the every-other
+    /// <c>DeriveKeyFrom*</c> method on that class deliberately does not — those apply a KDF of their own,
+    /// which would be this engine inventing a derivation the specification does not describe. The raw method
+    /// arrived in .NET 8, which is this feature area's floor anyway.
+    /// </para>
+    /// <para>
+    /// <b>The nine steps run in the specification's order, and the order is observable.</b> A caller passing
+    /// a private key as <c>public</c>, an ECDSA key as <c>public</c>, a public key as <c>baseKey</c>, a
+    /// mismatched curve and an over-long <c>length</c> all earn different errors, and which one a request
+    /// carrying several of those mistakes gets is decided here: the checks on the <c>public</c> member come
+    /// first, then the length ceiling, then the checks on <c>baseKey</c>.
+    /// </para>
+    /// </remarks>
+    internal static byte[] DeriveBits(
+        CryptoContext context,
+        NormalizedAlgorithm normalized,
+        JsCryptoKey key,
+        uint? length,
+        string what)
+    {
+        // Step 1: "Let publicKey be the public member of normalizedAlgorithm."
+        var publicKey = normalized.PublicKey!;
+
+        // Step 2: "If the [[type]] internal slot of publicKey is not 'public', then throw an
+        // InvalidAccessError."
+        if (!string.Equals(publicKey.KeyType, CryptoKeyTypes.Public, StringComparison.Ordinal))
+        {
+            context.ThrowInvalidAccessError(
+                what + ": the public member of the algorithm is a " + publicKey.KeyType + " key, and this operation needs a public one.");
+        }
+
+        // Step 3: "If the name attribute of the [[algorithm]] internal slot of publicKey is not equal to the
+        // name member of normalizedAlgorithm, then throw an InvalidAccessError." An ECDSA key over the very
+        // same curve lands here — the two algorithms share a key encoding and not a purpose.
+        if (!string.Equals(publicKey.Algorithm.Name, normalized.Name, StringComparison.Ordinal))
+        {
+            context.ThrowInvalidAccessError(
+                what + ": the public member of the algorithm is an " + publicKey.Algorithm.Name + " key, not an " + normalized.Name + " one.");
+        }
+
+        // Steps 4 and 5: "Let maximumLength be the length in bits of the output of the field element to octet
+        // string conversion … If length is not null and is greater than maximumLength, then throw an
+        // OperationError." The conversion pads to whole octets, so P-521's maximum is 528 rather than 521.
+        var maximumLength = 8 * FieldSizeInBytes(publicKey.Algorithm.NamedCurve!);
+
+        if (length is { } requested && requested > maximumLength)
+        {
+            context.ThrowOperationError(
+                what + ": a length of " + requested + " bits was asked for, and a shared secret on "
+                + publicKey.Algorithm.NamedCurve + " is " + maximumLength + " bits long.");
+        }
+
+        // Step 6: "If the [[type]] internal slot of key is not 'private', then throw an InvalidAccessError."
+        RequireKeyType(context, key, CryptoKeyTypes.Private, what);
+
+        // Step 7 is already true: the deriveBits method proved the base key's algorithm name equals
+        // normalizedAlgorithm's, and step 3 proved the public key's does, so the two are the same string. It
+        // is written out anyway because the operation is defined to make it, and because that reasoning stops
+        // holding the moment anything reaches these steps by another route.
+        if (!string.Equals(publicKey.Algorithm.Name, key.Algorithm.Name, StringComparison.Ordinal))
+        {
+            context.ThrowInvalidAccessError(
+                what + ": the public member of the algorithm is an " + publicKey.Algorithm.Name + " key and the base key is an "
+                + key.Algorithm.Name + " one.");
+        }
+
+        // Step 8: "If the namedCurve attribute of the [[algorithm]] internal slot of publicKey is not equal
+        // to the namedCurve property of the [[algorithm]] internal slot of key, then throw an
+        // InvalidAccessError." This is the check that stands between a script and a platform
+        // ArgumentException — .NET reports two keys of different sizes that way, which was measured.
+        if (!string.Equals(publicKey.Algorithm.NamedCurve, key.Algorithm.NamedCurve, StringComparison.Ordinal))
+        {
+            context.ThrowInvalidAccessError(
+                what + ": the public key is on the curve " + publicKey.Algorithm.NamedCurve + " and the base key on "
+                + key.Algorithm.NamedCurve + "; an agreement needs one curve.");
+        }
+
+        byte[] secret;
+
+        // Steps 9 and 10: the ECDH primitive, and "If performing the operation results in an error, then
+        // throw an OperationError".
+        using (var privateAlgorithm = CreateFromHandle(context, key, what))
+        using (var publicAlgorithm = CreateFromHandle(context, publicKey, what))
+        {
+            // Both keys were made for ECDH — steps 3 and 7 — and an ECDH key is rehydrated as an
+            // ECDiffieHellman; see the remarks on this class.
+            var privateEcdh = (ECDiffieHellman) privateAlgorithm;
+
+            using var peer = ((ECDiffieHellman) publicAlgorithm).PublicKey;
+
+            try
+            {
+                secret = privateEcdh.DeriveRawSecretAgreement(peer);
+            }
+            catch (Exception e) when (IsDerivationFailure(e))
+            {
+                context.ThrowOperationError(what + ": the shared secret could not be derived.");
+                return null!;
+            }
+        }
+
+        // Step 11: "If length is null: return secret. Otherwise: if the length in bits of secret is less than
+        // length, throw an OperationError; otherwise return a byte sequence containing the first length bits
+        // of secret."
+        if (length is not { } bits)
+        {
+            return secret;
+        }
+
+        if (8L * secret.Length < bits)
+        {
+            // Unreachable: step 5 measured the same curve's field width, and step 8 proved the two keys share
+            // a curve. It is the specification's step and it costs nothing.
+            context.ThrowOperationError(
+                what + ": a length of " + bits + " bits was asked for, and the shared secret is " + (8 * secret.Length) + " bits long.");
+        }
+
+        return FirstBits(secret, bits);
+    }
+
+    /// <summary>
+    /// "A byte sequence containing the first <c>length</c> bits of secret" — <c>ceil(length / 8)</c> bytes,
+    /// with the bits past <c>length</c> in the last one cleared.
+    /// </summary>
+    /// <remarks>
+    /// A length that is not a whole number of bytes is deliberately not refused: the ECDH steps impose no
+    /// such restriction, where HKDF's and PBKDF2's step 1 both do, and truncating to a bit is what the step
+    /// says. Clearing the tail rather than leaving it is what makes the answer a function of
+    /// <c>length</c> alone — the same 230-bit prefix of one secret must be one byte sequence however it was
+    /// asked for.
+    /// </remarks>
+    private static byte[] FirstBits(byte[] secret, uint bits)
+    {
+        var wholeBytes = (int) (bits / 8);
+        var remainder = (int) (bits % 8);
+
+        if (remainder == 0)
+        {
+            return secret.AsSpan(0, wholeBytes).ToArray();
+        }
+
+        var truncated = secret.AsSpan(0, wholeBytes + 1).ToArray();
+        truncated[wholeBytes] &= (byte) (0xFF << (8 - remainder));
+        return truncated;
+    }
+
+    // -------------------------------------------------------------------------------------------------
     // Curves
     // -------------------------------------------------------------------------------------------------
 
@@ -806,6 +964,17 @@ internal static class EcAlgorithm
     /// </summary>
     private static bool IsCryptographicFailure(Exception exception)
         => exception is CryptographicException or PlatformNotSupportedException;
+
+    /// <summary>
+    /// The same two, plus <see cref="ArgumentException"/>, which is how .NET reports two keys of different
+    /// sizes to <see cref="ECDiffieHellman.DeriveRawSecretAgreement"/> ("The keys from both parties must be
+    /// the same size to generate a secret agreement", measured on Windows). The specification's step 8 makes
+    /// that unreachable from <c>deriveBits</c> — but the lesson this file already records for
+    /// <see cref="PlatformNotSupportedException"/> is that guessing which exception type a platform picks is
+    /// how a CLR exception ends up erupting out of a promise-returning operation, and the catch costs nothing.
+    /// </summary>
+    private static bool IsDerivationFailure(Exception exception)
+        => IsCryptographicFailure(exception) || exception is ArgumentException;
 
     private static bool IsEcdh(string algorithmName)
         => string.Equals(algorithmName, AlgorithmNormalization.Ecdh, StringComparison.Ordinal);

--- a/Jint/WebApi/Crypto/HkdfAlgorithm.cs
+++ b/Jint/WebApi/Crypto/HkdfAlgorithm.cs
@@ -1,0 +1,210 @@
+#if NET8_0_OR_GREATER
+using System.Security.Cryptography;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Crypto;
+
+/// <summary>
+/// The HKDF operations — https://w3c.github.io/webcrypto/#hkdf, "key derivation using the
+/// extraction-then-expansion approach described in [RFC5869] and using the SHA hash functions defined in this
+/// specification".
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>An HKDF key is a key only in the sense that <c>importKey</c> makes one.</b> The registration lists
+/// <c>deriveBits</c>, <c>importKey</c> and <c>get key length</c> and nothing else — there is no
+/// <c>generateKey</c> (the input keying material is something the caller already has) and no
+/// <c>exportKey</c>, which the import steps make unreachable anyway by refusing any <c>extractable</c> that
+/// is not <see langword="false"/>. The <c>[[handle]]</c> is the input keying material verbatim, and the
+/// <c>[[algorithm]]</c> is the bare <c>KeyAlgorithm</c> — a <c>name</c> and nothing else, no <c>hash</c> and
+/// no <c>length</c>, because for HKDF both belong to the derivation rather than to the key.
+/// </para>
+/// <para>
+/// <b>The 255 &#215; <i>HashLen</i> ceiling is RFC 5869's own</b>, from the definition of HKDF-Expand: the
+/// expansion counter <c>T(1) … T(N)</c> is a single octet, so <c>N &#8804; 255</c> and the output cannot
+/// exceed 255 hash blocks. The specification's step 3 says exactly that ("If length is greater than
+/// 255 * hashLength, then throw an OperationError"), and the check is made <i>here</i> rather than left to
+/// the platform: <see cref="HKDF.DeriveKey(HashAlgorithmName, byte[], int, byte[], byte[])"/> reports an
+/// over-long request as an <see cref="ArgumentOutOfRangeException"/>, which is a CLR exception erupting out
+/// of a promise-returning operation — the one thing this API must never do. The <c>catch</c> below is the
+/// backstop for the same reason, not the mechanism.
+/// </para>
+/// <para>
+/// <b>A zero length is the empty byte sequence, and the platform will not produce it.</b> HKDF-Expand with
+/// <c>L = 0</c> runs zero iterations and yields the empty string, so a zero-bit derivation is well defined
+/// even though this algorithm's steps — unlike PBKDF2's, which spells the case out — never mention it. The
+/// BCL refuses <c>outputLength</c> of zero with an <see cref="ArgumentOutOfRangeException"/> (measured), so
+/// the case is answered before the call rather than through it.
+/// </para>
+/// </remarks>
+internal static class HkdfAlgorithm
+{
+    /// <summary>
+    /// The usages an HKDF key may carry — "If usages contains a value that is not 'deriveKey' or
+    /// 'deriveBits', then throw a SyntaxError".
+    /// </summary>
+    private const KeyUsage AllowedUsages = KeyUsage.DeriveKey | KeyUsage.DeriveBits;
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#hkdf-operations — "Derive Bits".
+    /// </summary>
+    internal static byte[] DeriveBits(
+        CryptoContext context,
+        NormalizedAlgorithm normalized,
+        JsCryptoKey key,
+        uint? length,
+        string what)
+    {
+        // Step 1: "If length is null or is not a multiple of 8, then throw an OperationError." An absent
+        // length argument defaults to null, so `deriveBits(hkdfParams, key)` lands here — HKDF has no
+        // natural output size to fall back on, unlike ECDH.
+        if (length is not { } bits)
+        {
+            context.ThrowOperationError(
+                what + ": HKDF has no output length of its own, so deriveBits needs one — a length of null, which is what an omitted argument means, cannot be derived.");
+            return null!;
+        }
+
+        if (bits % 8 != 0)
+        {
+            context.ThrowOperationError(
+                what + ": a length of " + bits + " bits is not a whole number of bytes, which this operation requires.");
+        }
+
+        // Steps 2 and 3: the ceiling of the expansion step. See the remarks on this class.
+        var hashLength = OutputLengthInBits(normalized.HashName!);
+        var maximumLength = 255 * hashLength;
+
+        if (bits > maximumLength)
+        {
+            context.ThrowOperationError(
+                what + ": a length of " + bits + " bits exceeds the " + maximumLength + " bits HKDF can expand to with "
+                + normalized.HashName + " (255 * " + hashLength + ").");
+        }
+
+        // HKDF-Expand with L = 0 is the empty byte sequence; the BCL declines to say so. See the remarks.
+        if (bits == 0)
+        {
+            return [];
+        }
+
+        // Steps 4 and 5: extract, then expand, with the key's own bytes as the input keying material. The
+        // span overload is the one that takes the key's [[handle]] without copying it out first.
+        var result = new byte[bits / 8];
+
+        try
+        {
+            HKDF.DeriveKey(HashName(normalized.HashName!), key.Handle, result, normalized.Salt!, normalized.Info!);
+            return result;
+        }
+        catch (Exception e) when (e is CryptographicException or ArgumentException)
+        {
+            // Step 6: "If the key derivation operation fails, then throw an OperationError." The catch is
+            // deliberately wider than CryptographicException — the platform reports a length it will not
+            // produce as an ArgumentOutOfRangeException, which is an ArgumentException and is not a
+            // CryptographicException, and a CLR exception must never escape a promise-returning operation.
+            context.ThrowOperationError(what + ": the key derivation failed.");
+            return null!;
+        }
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#hkdf-operations — "Import key", whose whole content is that the key
+    /// may only come from <c>raw</c> bytes and may never be extractable.
+    /// </summary>
+    /// <remarks>
+    /// The <c>extractable</c> check is a real restriction rather than a formality: the <c>[[handle]]</c> of
+    /// an HKDF key is the input keying material verbatim — very often a shared secret or a password — so a
+    /// key that could be exported would be a way to read back what was imported. That is also why HKDF has no
+    /// <c>exportKey</c> registration at all; the two together mean the bytes have no door out.
+    /// </remarks>
+    internal static (byte[] Handle, string KeyType, CryptoKeyAlgorithm Algorithm) ImportKey(
+        CryptoContext context,
+        KeyFormat format,
+        byte[]? rawData,
+        bool extractable,
+        KeyUsage usages,
+        string what)
+    {
+        // "If format is 'raw': … Otherwise: throw a NotSupportedError." The format is step 1 for HKDF, where
+        // PBKDF2 writes the same refusal as its own first step — the two orders agree.
+        if (format != KeyFormat.Raw)
+        {
+            context.ThrowNotSupportedError(
+                what + ": an HKDF key can only be imported from the 'raw' format, not from '" + KeyFormats.NameOf(format) + "'.");
+        }
+
+        // "If usages contains a value that is not 'deriveKey' or 'deriveBits', then throw a SyntaxError."
+        if ((usages & ~AllowedUsages) != KeyUsage.None)
+        {
+            context.ThrowSyntaxError(
+                what + ": an HKDF key supports the usages deriveKey and deriveBits, not "
+                + KeyUsages.Describe(usages & ~AllowedUsages) + ".");
+        }
+
+        // "If extractable is not false, then throw a SyntaxError." See the remarks on this method.
+        if (extractable)
+        {
+            context.ThrowSyntaxError(what + ": an HKDF key must be imported with extractable false.");
+        }
+
+        return (rawData!, CryptoKeyTypes.Secret, new CryptoKeyAlgorithm(AlgorithmNormalization.Hkdf, Length: 0, HashName: null));
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#hkdf-operations — "Get key length": "Return null." An HKDF key has
+    /// no length of its own, so <c>deriveKey(…, 'HKDF', …)</c> derives the whole of whatever the base
+    /// algorithm produces.
+    /// </summary>
+    internal static uint? GetKeyLength() => null;
+
+    /// <summary>
+    /// "The length in bits of the output of the hash function identified by the hash member" — [FIPS-180-4]:
+    /// 160 for SHA-1, and the number in the name for the SHA-2 family.
+    /// </summary>
+    /// <remarks>
+    /// Every registered hash is spelled out and the default throws rather than one of them standing in as the
+    /// fallback, which is the convention every table in this folder follows: a hash registered later would
+    /// otherwise silently inherit SHA-512's ceiling.
+    /// </remarks>
+    private static int OutputLengthInBits(string hashName)
+    {
+        switch (hashName)
+        {
+            case AlgorithmNormalization.Sha1:
+                return 160;
+            case AlgorithmNormalization.Sha256:
+                return 256;
+            case AlgorithmNormalization.Sha384:
+                return 384;
+            case AlgorithmNormalization.Sha512:
+                return 512;
+            default:
+                // Unreachable: the hash was matched against the digest registry during normalization.
+                Throw.InvalidOperationException("Unhandled HKDF hash algorithm '" + hashName + "'.");
+                return 0;
+        }
+    }
+
+    private static HashAlgorithmName HashName(string hashName)
+    {
+        switch (hashName)
+        {
+            case AlgorithmNormalization.Sha1:
+                // SHA-1 is one of the four hashes the digest registry carries, so an HkdfParams may name it.
+                // HKDF's security rests on HMAC, which the collision attacks that retired plain SHA-1 do not
+                // break, and a script asking for it has already chosen; nothing here picks it for anybody.
+                return HashAlgorithmName.SHA1;
+            case AlgorithmNormalization.Sha256:
+                return HashAlgorithmName.SHA256;
+            case AlgorithmNormalization.Sha384:
+                return HashAlgorithmName.SHA384;
+            case AlgorithmNormalization.Sha512:
+                return HashAlgorithmName.SHA512;
+            default:
+                Throw.InvalidOperationException("Unhandled HKDF hash algorithm '" + hashName + "'.");
+                return default;
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/Crypto/HmacAlgorithm.cs
+++ b/Jint/WebApi/Crypto/HmacAlgorithm.cs
@@ -231,6 +231,34 @@ internal static class HmacAlgorithm
     }
 
     /// <summary>
+    /// https://w3c.github.io/webcrypto/#hmac-operations-get-key-length — the internal operation
+    /// <c>deriveKey</c> runs over its <c>derivedKeyType</c> to decide how many bits to derive.
+    /// </summary>
+    /// <remarks>
+    /// The registered parameters are <c>HmacImportParams</c>, the same dictionary <c>importKey</c> takes, and
+    /// the three cases are its <c>length</c> member: absent means the hash's block size, non-zero means
+    /// itself, and a present zero is a <b><c>TypeError</c></b>. That last one is the specification's own
+    /// choice and is worth not tidying — every other "this value is wrong" in this folder is a
+    /// <c>DataError</c>, an <c>OperationError</c> or a <c>SyntaxError</c>, and HMAC's own <c>generateKey</c>
+    /// answers the very same zero with an <c>OperationError</c> and its <c>importKey</c> with a
+    /// <c>DataError</c>.
+    /// </remarks>
+    internal static uint GetKeyLength(CryptoContext context, NormalizedAlgorithm normalized, string what)
+    {
+        if (normalized.Length is not { } length)
+        {
+            return BlockSizeInBits(normalized.HashName!);
+        }
+
+        if (length == 0)
+        {
+            context.ThrowTypeError(what + ": a derived HMAC key of zero bits was asked for.");
+        }
+
+        return length;
+    }
+
+    /// <summary>
     /// https://w3c.github.io/webcrypto/#hmac-operations-export-key
     /// </summary>
     internal static JsValue ExportKey(CryptoContext context, JsCryptoKey key, KeyFormat format, string what)

--- a/Jint/WebApi/Crypto/JsCryptoKey.cs
+++ b/Jint/WebApi/Crypto/JsCryptoKey.cs
@@ -33,16 +33,20 @@ internal static class CryptoKeyTypes
 /// dictionary a value describes is decided by which of them are filled in.
 /// </para>
 /// <para>
-/// <b>Two of the six are discriminators</b>, and they are tested in this order, because the dictionaries
+/// <b>Three of the six are discriminators</b>, and they are tested in this order, because the dictionaries
 /// they name carry none of the other members at all:
 /// </para>
 /// <list type="number">
 /// <item>
+/// A <see cref="Name"/> of <c>HKDF</c> or <c>PBKDF2</c> means the bare <c>KeyAlgorithm</c> — a <c>name</c>
+/// and nothing else. It is the one case the other members cannot decide, because every one of them is unset:
+/// for those two algorithms the hash, the salt and the iteration count all belong to each <i>derivation</i>
+/// rather than to the key, so there is nothing left to describe. It is tested first for that reason.
+/// </item>
+/// <item>
 /// <see cref="NamedCurve"/> non-null means an <c>EcKeyAlgorithm</c>: <see cref="Length"/>,
 /// <see cref="HashName"/>, <see cref="ModulusLength"/> and <see cref="PublicExponent"/> are all unused, an
-/// EC key being described by its curve and nothing else. It is tested first precisely because it is the one
-/// dictionary that fills in <i>only</i> its own member — an <c>AesKeyAlgorithm</c> is what a null
-/// <see cref="HashName"/> would otherwise be read as.
+/// EC key being described by its curve and nothing else.
 /// </item>
 /// <item>
 /// <see cref="PublicExponent"/> non-null means an <c>RsaHashedKeyAlgorithm</c>: <see cref="Length"/> is
@@ -50,7 +54,7 @@ internal static class CryptoKeyTypes
 /// </item>
 /// </list>
 /// <para>
-/// With neither set the key is symmetric, and a null <see cref="HashName"/> then separates an
+/// With none of them set the key is symmetric, and a null <see cref="HashName"/> then separates an
 /// <c>AesKeyAlgorithm</c> from an <c>HmacKeyAlgorithm</c>.
 /// </para>
 /// </remarks>
@@ -253,7 +257,11 @@ internal sealed class JsCryptoKey : ObjectInstance
         var name = JsString.Create(Algorithm.Name);
 
         // The discriminators, in the order the remarks on CryptoKeyAlgorithm give them.
-        if (Algorithm.NamedCurve is { } namedCurve)
+        if (IsBareKeyAlgorithm(Algorithm.Name))
+        {
+            _algorithmCached = JsObject.Create(_engine, _keyAlgorithmLayout, [name]);
+        }
+        else if (Algorithm.NamedCurve is { } namedCurve)
         {
             _algorithmCached = JsObject.Create(_engine, _ecKeyAlgorithmLayout, [name, JsString.Create(namedCurve)]);
         }
@@ -277,6 +285,16 @@ internal sealed class JsCryptoKey : ObjectInstance
 
         return _algorithmCached;
     }
+
+    /// <summary>
+    /// The two algorithms whose <c>[[algorithm]]</c> is the bare <c>KeyAlgorithm</c> — see the first
+    /// discriminator in the remarks on <see cref="CryptoKeyAlgorithm"/>. Their import steps say "Let
+    /// algorithm be a new KeyAlgorithm object. Set the name attribute of algorithm to 'HKDF' [or 'PBKDF2']"
+    /// and stop there.
+    /// </summary>
+    private static bool IsBareKeyAlgorithm(string name)
+        => string.Equals(name, AlgorithmNormalization.Hkdf, StringComparison.Ordinal)
+        || string.Equals(name, AlgorithmNormalization.Pbkdf2, StringComparison.Ordinal);
 
     /// <summary>
     /// A <c>BigInteger</c> — https://w3c.github.io/webcrypto/#big-integer, which is

--- a/Jint/WebApi/Crypto/Pbkdf2Algorithm.cs
+++ b/Jint/WebApi/Crypto/Pbkdf2Algorithm.cs
@@ -1,0 +1,183 @@
+#if NET8_0_OR_GREATER
+using System.Security.Cryptography;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Crypto;
+
+/// <summary>
+/// The PBKDF2 operations — https://w3c.github.io/webcrypto/#pbkdf2, "key derivation using the PKCS#5
+/// password-based key derivation function version 2, as defined in [RFC8018] using HMAC as the pseudo-random
+/// function, using the SHA hash functions defined in this specification".
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>A PBKDF2 key is <c>importKey</c>-only</b>, exactly as an HKDF key is and for the same reasons — the
+/// registration lists <c>deriveBits</c>, <c>importKey</c> and <c>get key length</c>, the import steps refuse
+/// any <c>extractable</c> that is not <see langword="false"/>, and the <c>[[handle]]</c> is the password
+/// verbatim, so there is deliberately no way to read it back. The <c>[[algorithm]]</c> is the bare
+/// <c>KeyAlgorithm</c>: the hash, the salt and the iteration count all belong to each derivation, so one
+/// imported password derives under SHA-256 and SHA-512 alike.
+/// </para>
+/// <para>
+/// <b>The iteration count is bounded by this engine, and the bound is a real one.</b> PBKDF2 is a loop whose
+/// only purpose is to be slow, its trip count comes straight from script, and the whole of it happens inside
+/// one BCL call — so no execution constraint can interrupt it, not a timeout, not a statement budget, not a
+/// cancellation token. <c>iterations: 2 ** 40</c> is one line of script that takes days. The ceiling is
+/// <see cref="MaxIterations"/> = 2^22 = 4,194,304, which is above every OWASP 2023 recommendation for this
+/// function (1,300,000 for SHA-1, 600,000 for SHA-256, 210,000 for SHA-512) and bounds one call to roughly
+/// 1.7 seconds at the ceiling itself — measured 0.35 s for SHA-256, 1.5 s for SHA-1 and 1.7 s for SHA-512 —
+/// and the refusal names the restriction. It is the same reasoning as the 8192-bit ceiling on RSA key
+/// generation, one file over.
+/// </para>
+/// </remarks>
+internal static class Pbkdf2Algorithm
+{
+    /// <summary>
+    /// The usages a PBKDF2 key may carry — "If usages contains a value that is not 'deriveKey' or
+    /// 'deriveBits', then throw a SyntaxError".
+    /// </summary>
+    private const KeyUsage AllowedUsages = KeyUsage.DeriveKey | KeyUsage.DeriveBits;
+
+    /// <summary>
+    /// The largest iteration count this engine will run. See the remarks on this class for why the algorithm
+    /// having no ceiling of its own is not a reason for this engine to have none either.
+    /// </summary>
+    private const uint MaxIterations = 4_194_304;
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#pbkdf2-operations — "Derive Bits".
+    /// </summary>
+    internal static byte[] DeriveBits(
+        CryptoContext context,
+        NormalizedAlgorithm normalized,
+        JsCryptoKey key,
+        uint? length,
+        string what)
+    {
+        // Step 1: "If length is null or is not a multiple of 8, then throw an OperationError."
+        if (length is not { } bits)
+        {
+            context.ThrowOperationError(
+                what + ": PBKDF2 has no output length of its own, so deriveBits needs one — a length of null, which is what an omitted argument means, cannot be derived.");
+            return null!;
+        }
+
+        if (bits % 8 != 0)
+        {
+            context.ThrowOperationError(
+                what + ": a length of " + bits + " bits is not a whole number of bytes, which this operation requires.");
+        }
+
+        // Step 2: "If the iterations member of normalizedAlgorithm is zero, then throw an OperationError."
+        var iterations = normalized.Iterations!.Value;
+        if (iterations == 0)
+        {
+            context.ThrowOperationError(what + ": an iteration count of zero was requested.");
+        }
+
+        // This engine's own ceiling, after the algorithm's own two checks so that they still outrank it.
+        if (iterations > MaxIterations)
+        {
+            context.ThrowOperationError(
+                what + ": an iteration count of " + iterations + " exceeds the " + MaxIterations
+                + " this engine will run, because the loop is a single uninterruptible call that no execution constraint can bound.");
+        }
+
+        // Step 3: "If length is zero, return an empty byte sequence." Spelled out by this algorithm where
+        // HKDF's steps leave it implied.
+        if (bits == 0)
+        {
+            return [];
+        }
+
+        // Steps 4 and 5: PBKDF2 with HMAC as the pseudo-random function, the key's own bytes as the password,
+        // and length divided by 8 as dkLen.
+        try
+        {
+            return Rfc2898DeriveBytes.Pbkdf2(
+                key.Handle,
+                normalized.Salt!,
+                (int) iterations,
+                HashName(normalized.HashName!),
+                (int) (bits / 8));
+        }
+        catch (Exception e) when (e is CryptographicException or ArgumentException)
+        {
+            // Step 6: "If the key derivation operation fails, then throw an OperationError." The catch is
+            // wider than CryptographicException for the reason HKDF's is: an argument the platform will not
+            // accept arrives as an ArgumentException, and a CLR exception must never escape a
+            // promise-returning operation.
+            context.ThrowOperationError(what + ": the key derivation failed.");
+            return null!;
+        }
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#pbkdf2-operations — "Import key".
+    /// </summary>
+    /// <remarks>
+    /// The <c>[[handle]]</c> of a PBKDF2 key <i>is</i> the password, so an extractable one would be a way to
+    /// read a password back out of a key; the import steps refuse it, and the algorithm has no
+    /// <c>exportKey</c> registration either, so the two together leave the bytes no door out.
+    /// </remarks>
+    internal static (byte[] Handle, string KeyType, CryptoKeyAlgorithm Algorithm) ImportKey(
+        CryptoContext context,
+        KeyFormat format,
+        byte[]? rawData,
+        bool extractable,
+        KeyUsage usages,
+        string what)
+    {
+        // Step 1: "If format is not 'raw', throw a NotSupportedError."
+        if (format != KeyFormat.Raw)
+        {
+            context.ThrowNotSupportedError(
+                what + ": a PBKDF2 key can only be imported from the 'raw' format, not from '" + KeyFormats.NameOf(format) + "'.");
+        }
+
+        // Step 2.
+        if ((usages & ~AllowedUsages) != KeyUsage.None)
+        {
+            context.ThrowSyntaxError(
+                what + ": a PBKDF2 key supports the usages deriveKey and deriveBits, not "
+                + KeyUsages.Describe(usages & ~AllowedUsages) + ".");
+        }
+
+        // Step 3.
+        if (extractable)
+        {
+            context.ThrowSyntaxError(what + ": a PBKDF2 key must be imported with extractable false.");
+        }
+
+        return (rawData!, CryptoKeyTypes.Secret, new CryptoKeyAlgorithm(AlgorithmNormalization.Pbkdf2, Length: 0, HashName: null));
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#pbkdf2-operations — "Get key length": "Return null." A PBKDF2 key is
+    /// a password and has no length of its own.
+    /// </summary>
+    internal static uint? GetKeyLength() => null;
+
+    private static HashAlgorithmName HashName(string hashName)
+    {
+        switch (hashName)
+        {
+            case AlgorithmNormalization.Sha1:
+                // PBKDF2-HMAC-SHA-1 is what a great deal of existing data was derived with, and reading that
+                // data back is the case this exists for. A script asking for it has already chosen; nothing
+                // here picks it for anybody.
+                return HashAlgorithmName.SHA1;
+            case AlgorithmNormalization.Sha256:
+                return HashAlgorithmName.SHA256;
+            case AlgorithmNormalization.Sha384:
+                return HashAlgorithmName.SHA384;
+            case AlgorithmNormalization.Sha512:
+                return HashAlgorithmName.SHA512;
+            default:
+                // Unreachable: the hash was matched against the digest registry during normalization.
+                Throw.InvalidOperationException("Unhandled PBKDF2 hash algorithm '" + hashName + "'.");
+                return default;
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/Crypto/SubtleCryptoInstance.cs
+++ b/Jint/WebApi/Crypto/SubtleCryptoInstance.cs
@@ -17,27 +17,33 @@ namespace Jint.WebApi.Crypto;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b>Eight of the twelve operations exist</b>: <c>digest</c>, <c>sign</c>, <c>verify</c>, <c>encrypt</c>,
-/// <c>decrypt</c>, <c>generateKey</c>, <c>importKey</c> and <c>exportKey</c>, over the algorithms
-/// <c>HMAC</c>, <c>AES-GCM</c> (128, 192 and 256 bits), <c>RSASSA-PKCS1-v1_5</c>, <c>RSA-PSS</c>,
-/// <c>RSA-OAEP</c>, <c>ECDSA</c> and <c>ECDH</c> — each of the hashed ones over SHA-1, SHA-256, SHA-384 and
-/// SHA-512, and each of the elliptic-curve ones over P-256, P-384 and P-521 — plus those four SHA hashes for
-/// <c>digest</c>, and the key formats <c>raw</c>, <c>spki</c>, <c>pkcs8</c> and <c>jwk</c>.
-/// <c>deriveKey</c>, <c>deriveBits</c>, <c>wrapKey</c> and <c>unwrapKey</c> are <b>absent</b> rather than
-/// present-and-throwing, so a library that checks
-/// <c>typeof crypto.subtle.deriveBits === 'function'</c> before reaching for it gets the truthful answer and
-/// takes its fallback path — the same promise <c>crypto.subtle</c> itself makes to an engine without the
+/// <b>Ten of the twelve operations exist</b>: <c>digest</c>, <c>sign</c>, <c>verify</c>, <c>encrypt</c>,
+/// <c>decrypt</c>, <c>generateKey</c>, <c>importKey</c>, <c>exportKey</c>, <c>deriveBits</c> and
+/// <c>deriveKey</c>, over the algorithms <c>HMAC</c>, <c>AES-GCM</c> (128, 192 and 256 bits),
+/// <c>RSASSA-PKCS1-v1_5</c>, <c>RSA-PSS</c>, <c>RSA-OAEP</c>, <c>ECDSA</c>, <c>ECDH</c>, <c>HKDF</c> and
+/// <c>PBKDF2</c> — each of the hashed ones over SHA-1, SHA-256, SHA-384 and SHA-512, and each of the
+/// elliptic-curve ones over P-256, P-384 and P-521 — plus those four SHA hashes for <c>digest</c>, and the
+/// key formats <c>raw</c>, <c>spki</c>, <c>pkcs8</c> and <c>jwk</c>.
+/// <c>wrapKey</c> and <c>unwrapKey</c> are <b>absent</b> rather than present-and-throwing, so a library that
+/// checks <c>typeof crypto.subtle.wrapKey === 'function'</c> before reaching for it gets the truthful answer
+/// and takes its fallback path — the same promise <c>crypto.subtle</c> itself makes to an engine without the
 /// crypto feature. An algorithm that is absent for a <i>particular</i> operation is a
 /// <c>NotSupportedError</c>, which is what the specification says a name that is not registered for an
 /// operation is: <c>sign</c> with <c>AES-GCM</c> fails that way, and so does <c>encrypt</c> with
-/// <c>HMAC</c>.
+/// <c>HMAC</c> and <c>generateKey</c> with <c>PBKDF2</c>.
 /// </para>
 /// <para>
-/// So <c>ECDH</c> is here for its <i>keys</i> alone — <c>generateKey</c>, <c>importKey</c> and
-/// <c>exportKey</c> — and a key it makes may carry the <c>deriveKey</c> and <c>deriveBits</c> usages that no
-/// operation on this object consumes. That is not a half-implemented algorithm but the same shape AES-GCM's
-/// <c>wrapKey</c> and <c>unwrapKey</c> usages have always had: the usage bits are checked and split exactly
-/// as the specification says, and the operations that read them are the absent ones above.
+/// The registries are per operation and are not symmetric. <c>HKDF</c> and <c>PBKDF2</c> register
+/// <c>importKey</c>, <c>deriveBits</c> and the internal <c>get key length</c> and nothing else — there is
+/// nothing to <c>generateKey</c> and, their keys being non-extractable by construction, nothing to
+/// <c>exportKey</c>. <c>ECDH</c> registers <c>deriveBits</c> and never <c>sign</c>; <c>ECDSA</c> the reverse.
+/// An AES-GCM key may still carry the <c>wrapKey</c> and <c>unwrapKey</c> usages that no operation here
+/// consumes, which is the one remaining case of a usage bit without an operation behind it.
+/// </para>
+/// <para>
+/// <c>deriveKey</c> is a composition rather than an algorithm: it derives bits with one algorithm and imports
+/// them with another, so the key it hands back is exactly the key <c>importKey</c> would have made from the
+/// same bytes in the <c>raw</c> format.
 /// </para>
 /// <para>
 /// <b>Nothing here ever throws to its caller.</b> WebIDL turns an exception out of a promise-returning
@@ -430,6 +436,20 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
                         usages,
                         what);
 
+                case AlgorithmNormalization.Hkdf:
+                    return CreateImportedKey(
+                        HkdfAlgorithm.ImportKey(Context, keyFormat, rawData, isExtractable, usages, what),
+                        isExtractable,
+                        usages,
+                        what);
+
+                case AlgorithmNormalization.Pbkdf2:
+                    return CreateImportedKey(
+                        Pbkdf2Algorithm.ImportKey(Context, keyFormat, rawData, isExtractable, usages, what),
+                        isExtractable,
+                        usages,
+                        what);
+
                 default:
                     return UnhandledAlgorithm(normalized.Name, CryptoOperation.ImportKey);
             }
@@ -485,6 +505,201 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
                     return UnhandledAlgorithm(cryptoKey.Algorithm.Name, CryptoOperation.ExportKey);
             }
         });
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#SubtleCrypto-method-deriveBits, whose IDL is
+    /// <c>Promise&lt;ArrayBuffer&gt; deriveBits(AlgorithmIdentifier algorithm, CryptoKey baseKey,
+    /// optional [EnforceRange] unsigned long? length = null)</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The declared length is 2, not 3</b>, because WebIDL's <c>length</c> counts the <i>required</i>
+    /// arguments and <c>length</c> has been optional-and-nullable since the specification stopped requiring
+    /// a bit count that ECDH does not need. A browser predating that change answers 3; Node's WebCrypto,
+    /// which has taken the change, answers 2, and so does this.
+    /// </para>
+    /// <para>
+    /// What a null <c>length</c> means is the algorithm's business and the three differ: ECDH returns the
+    /// whole shared secret, and HKDF and PBKDF2 have no natural output size, so their first step is to refuse
+    /// it with an <c>OperationError</c>. A length that is not a multiple of 8 is likewise an
+    /// <c>OperationError</c> for those two and a <i>bit</i>-exact truncation for ECDH, whose steps impose no
+    /// such restriction.
+    /// </para>
+    /// </remarks>
+    [JsFunction(Name = "deriveBits", Length = 2)]
+    private JsValue DeriveBits(JsValue thisObject, JsValue algorithm, JsValue baseKey, JsValue length)
+    {
+        return Perform(thisObject, CryptoOperation.DeriveBits, what =>
+        {
+            var identifier = AlgorithmNormalization.ConvertIdentifier(algorithm);
+            var cryptoKey = RequireCryptoKey(baseKey, what, "parameter 2");
+            var bits = AlgorithmNormalization.ConvertOptionalLength(Context, length, what, "parameter 3");
+
+            var normalized = AlgorithmNormalization.Normalize(Context, identifier, CryptoOperation.DeriveBits, what);
+
+            RequireKeyFor(normalized, cryptoKey, KeyUsage.DeriveBits, "deriveBits", what);
+
+            return Context.CreateArrayBuffer(Derive(normalized, cryptoKey, bits, what));
+        });
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#SubtleCrypto-method-deriveKey, whose IDL is
+    /// <c>Promise&lt;CryptoKey&gt; deriveKey(AlgorithmIdentifier algorithm, CryptoKey baseKey,
+    /// AlgorithmIdentifier derivedKeyType, boolean extractable, sequence&lt;KeyUsage&gt; keyUsages)</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// It is a composition and not an operation of its own: <b>three</b> normalizations, then a derivation,
+    /// then an import. The <c>algorithm</c> is normalized for <c>deriveBits</c> — there is no "deriveKey"
+    /// registry — and the <c>derivedKeyType</c> is normalized <i>twice</i>, once for <c>importKey</c> and
+    /// once for the internal <c>get key length</c> operation. That second reading is observable: a
+    /// <c>derivedKeyType</c> whose members are getters has each of them called twice, in that order, before
+    /// anything else happens, which is what the specification's steps 4 and 6 say and is the same reason
+    /// every conversion in this file runs before a single algorithm step does.
+    /// </para>
+    /// <para>
+    /// <c>extractable</c> and <c>keyUsages</c> belong to the <b>derived</b> key alone. The base key is
+    /// checked for the <c>deriveKey</c> usage — not <c>deriveBits</c>, even though the bits are what the
+    /// derivation produces — and its own extractability is never consulted, which is what lets a
+    /// non-extractable PBKDF2 password produce an extractable AES-GCM key.
+    /// </para>
+    /// </remarks>
+    [JsFunction(Name = "deriveKey", Length = 5)]
+    private JsValue DeriveKey(
+        JsValue thisObject,
+        JsValue algorithm,
+        JsValue baseKey,
+        JsValue derivedKeyType,
+        JsValue extractable,
+        JsValue keyUsages)
+    {
+        return Perform(thisObject, CryptoOperation.DeriveKey, what =>
+        {
+            var identifier = AlgorithmNormalization.ConvertIdentifier(algorithm);
+            var cryptoKey = RequireCryptoKey(baseKey, what, "parameter 2");
+            var derivedIdentifier = AlgorithmNormalization.ConvertIdentifier(derivedKeyType);
+            var isExtractable = TypeConverter.ToBoolean(extractable);
+            var usages = KeyUsages.ReadSequence(Context, keyUsages, what);
+
+            // Steps 2 to 7, in the specification's order and all three before any step of any algorithm.
+            var normalized = AlgorithmNormalization.Normalize(Context, identifier, CryptoOperation.DeriveBits, what);
+            var normalizedImport = AlgorithmNormalization.Normalize(Context, derivedIdentifier, CryptoOperation.ImportKey, what);
+            var normalizedLength = AlgorithmNormalization.Normalize(Context, derivedIdentifier, CryptoOperation.GetKeyLength, what);
+
+            // Steps 12 and 13: the base key was made for this algorithm, and it permits deriveKey.
+            RequireKeyFor(normalized, cryptoKey, KeyUsage.DeriveKey, "deriveKey", what);
+
+            // Step 14, then step 15.
+            var bits = GetKeyLength(normalizedLength, what);
+            var secret = Derive(normalized, cryptoKey, bits, what);
+
+            // Steps 16 to 19: the derived bytes are imported as though a script had handed them to importKey
+            // in the 'raw' format, so a derived key is exactly as ordinary as an imported one.
+            return ImportDerivedKey(normalizedImport, secret, isExtractable, usages, what);
+        });
+    }
+
+    /// <summary>
+    /// "The derive bits operation specified by normalizedAlgorithm using baseKey, algorithm and length" —
+    /// the one step <c>deriveBits</c> and <c>deriveKey</c> share.
+    /// </summary>
+    private byte[] Derive(NormalizedAlgorithm normalized, JsCryptoKey key, uint? length, string what)
+    {
+        switch (normalized.Name)
+        {
+            case AlgorithmNormalization.Ecdh:
+                return EcAlgorithm.DeriveBits(Context, normalized, key, length, what);
+            case AlgorithmNormalization.Hkdf:
+                return HkdfAlgorithm.DeriveBits(Context, normalized, key, length, what);
+            case AlgorithmNormalization.Pbkdf2:
+                return Pbkdf2Algorithm.DeriveBits(Context, normalized, key, length, what);
+            default:
+                UnhandledAlgorithm(normalized.Name, CryptoOperation.DeriveBits);
+                return null!;
+        }
+    }
+
+    /// <summary>
+    /// "The get key length algorithm specified by normalizedDerivedKeyAlgorithmLength using derivedKeyType" —
+    /// the internal operation https://w3c.github.io/webcrypto/#algorithm-normalization-internal registers
+    /// alongside the script-visible ones.
+    /// </summary>
+    /// <remarks>
+    /// <see langword="null"/> is a real answer and not a failure: it is what HKDF and PBKDF2 return, and it
+    /// is then handed to the derive operation as the <c>length</c> argument — so
+    /// <c>deriveKey(ecdhParams, priv, 'HKDF', false, ['deriveBits'])</c> derives the whole shared secret into
+    /// an HKDF key, which is the specification's own worked example, while the same request against a PBKDF2
+    /// base key is the <c>OperationError</c> PBKDF2's first derive step gives a null length.
+    /// </remarks>
+    private uint? GetKeyLength(NormalizedAlgorithm normalized, string what)
+    {
+        switch (normalized.Name)
+        {
+            case AlgorithmNormalization.Hmac:
+                return HmacAlgorithm.GetKeyLength(Context, normalized, what);
+            case AlgorithmNormalization.AesGcm:
+                return AesGcmAlgorithm.GetKeyLength(Context, normalized, what);
+            case AlgorithmNormalization.Hkdf:
+                return HkdfAlgorithm.GetKeyLength();
+            case AlgorithmNormalization.Pbkdf2:
+                return Pbkdf2Algorithm.GetKeyLength();
+            default:
+                UnhandledAlgorithm(normalized.Name, CryptoOperation.GetKeyLength);
+                return null;
+        }
+    }
+
+    /// <summary>
+    /// "The import key operation specified by normalizedDerivedKeyAlgorithmImport using 'raw' as format,
+    /// secret as keyData …" — the tail of <c>deriveKey</c>, which is the body of <c>importKey</c> with the
+    /// format fixed and the key data supplied by the derivation rather than by the caller.
+    /// </summary>
+    /// <remarks>
+    /// Only the four algorithms that also register <c>get key length</c> can arrive here, and not the seven
+    /// that register <c>importKey</c>: step 6 normalizes the same <c>derivedKeyType</c> for that operation
+    /// first, so <c>deriveKey(…, { name: 'RSA-OAEP', hash: 'SHA-256' }, …)</c> is already a
+    /// <c>NotSupportedError</c> by the time anything is derived. An asymmetric key cannot be derived at all,
+    /// which is the registry saying so rather than any step refusing it. Nothing is special-cased for the
+    /// derived case otherwise, so a derived key is the same object an imported one is.
+    /// </remarks>
+    private JsCryptoKey ImportDerivedKey(NormalizedAlgorithm normalized, byte[] secret, bool extractable, KeyUsage usages, string what)
+    {
+        switch (normalized.Name)
+        {
+            case AlgorithmNormalization.Hmac:
+                return CreateSecretKey(
+                    HmacAlgorithm.ImportKey(Context, KeyFormat.Raw, secret, jwk: null, normalized, extractable, usages, what),
+                    extractable,
+                    usages,
+                    what);
+
+            case AlgorithmNormalization.AesGcm:
+                return CreateSecretKey(
+                    AesGcmAlgorithm.ImportKey(Context, KeyFormat.Raw, secret, jwk: null, extractable, usages, what),
+                    extractable,
+                    usages,
+                    what);
+
+            case AlgorithmNormalization.Hkdf:
+                return CreateImportedKey(
+                    HkdfAlgorithm.ImportKey(Context, KeyFormat.Raw, secret, extractable, usages, what),
+                    extractable,
+                    usages,
+                    what);
+
+            case AlgorithmNormalization.Pbkdf2:
+                return CreateImportedKey(
+                    Pbkdf2Algorithm.ImportKey(Context, KeyFormat.Raw, secret, extractable, usages, what),
+                    extractable,
+                    usages,
+                    what);
+
+            default:
+                UnhandledAlgorithm(normalized.Name, CryptoOperation.ImportKey);
+                return null!;
+        }
     }
 
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ its own `console` (or any other name in the table below), enabling the feature l
 | `TextEncoder` (UTF-8) / `TextDecoder` (UTF-8, UTF-16LE/BE, every legacy single-byte encoding, `x-user-defined`; `fatal`, `ignoreBOM`, streaming) | `Encoding` | ✔ shipped |
 | `atob` / `btoa` | `Base64` | ✔ shipped |
 | `structuredClone` (incl. `{ transfer }` of `ArrayBuffer`s) | `StructuredClone` | ✔ shipped |
-| `crypto.getRandomValues` / `crypto.randomUUID` / `crypto.subtle` (SHA digests, HMAC, AES-GCM, RSA, ECDSA/ECDH, `CryptoKey`) | `WebApiFeatures.Crypto` | ✔ shipped |
+| `crypto.getRandomValues` / `crypto.randomUUID` / `crypto.subtle` (SHA digests, HMAC, AES-GCM, RSA, ECDSA/ECDH, HKDF, PBKDF2, `CryptoKey`) | `WebApiFeatures.Crypto` | ✔ shipped |
 | `performance.now` / `timeOrigin` / `mark` / `measure` / `getEntries*` / `clearMarks` / `clearMeasures` | `WebApiFeatures.Performance` | ✔ shipped |
 | `Event` / `EventTarget` / `CustomEvent` / `AbortController` / `AbortSignal` | `Events` | ✔ shipped |
 | `URL` / `URLSearchParams` / `URLPattern` | `Url` | ✔ shipped |
@@ -248,22 +248,48 @@ neighbouring one — a cache outlives the evaluation that filled it, so where it
 is a decision you make rather than inherit; and `FetchEvents` is the third, because a script that can register
 a `fetch` listener can take over every request you route into the engine.
 
-`crypto.subtle` carries **`digest`, `sign`, `verify`, `encrypt`, `decrypt`, `generateKey`, `importKey` and
-`exportKey`**, over SHA-1/256/384/512 (for `digest` and as every keyed algorithm's inner hash), **HMAC**,
-**AES-GCM** at 128, 192 and 256 bits, the RSA family — **RSASSA-PKCS1-v1_5** and **RSA-PSS** for signatures,
-**RSA-OAEP** for encryption — and the elliptic curves **P-256**, **P-384** and **P-521** under **ECDSA** and
-**ECDH**. Keys are real `CryptoKey` objects with `type`, `extractable`, `algorithm` and `usages`, and
+`crypto.subtle` carries **`digest`, `sign`, `verify`, `encrypt`, `decrypt`, `generateKey`, `importKey`,
+`exportKey`, `deriveBits` and `deriveKey`**, over SHA-1/256/384/512 (for `digest` and as every keyed
+algorithm's inner hash), **HMAC**, **AES-GCM** at 128, 192 and 256 bits, the RSA family —
+**RSASSA-PKCS1-v1_5** and **RSA-PSS** for signatures, **RSA-OAEP** for encryption — the elliptic curves
+**P-256**, **P-384** and **P-521** under **ECDSA** and **ECDH**, and **HKDF** and **PBKDF2** for derivation.
+Keys are real `CryptoKey` objects with `type`, `extractable`, `algorithm` and `usages`, and
 `generateKey` for an asymmetric algorithm hands back a `CryptoKeyPair`, which is the plain
 `{ privateKey, publicKey }` dictionary the specification defines rather than an interface. The key material
 is never reachable from script except through `exportKey` on an extractable key: `raw` bytes or a
 `kty: "oct"` JSON Web Key for a symmetric key, `spki`, `pkcs8` or a `kty: "RSA"` JSON Web Key for an RSA one,
 and all four of those — `raw` being the uncompressed point `04||X||Y` — for an elliptic-curve one.
-`deriveKey`, `deriveBits`, `wrapKey` and `unwrapKey` are *absent* rather than present-and-throwing, so
-`typeof crypto.subtle.deriveBits` tells a library the truth and it takes its fallback path.
+`wrapKey` and `unwrapKey` are *absent* rather than present-and-throwing, so `typeof crypto.subtle.wrapKey`
+tells a library the truth and it takes its fallback path.
 
-ECDH is therefore here **for its keys alone**: you can generate, import and export an ECDH key pair, and the
-private half may carry the `deriveKey` and `deriveBits` usages, but nothing on `crypto.subtle` consumes them
-yet — the same position AES-GCM's `wrapKey` and `unwrapKey` usages have always been in. An ECDSA key carries
+**The registries are per operation, and they are not symmetric.** HKDF and PBKDF2 register `importKey`,
+`deriveBits` and the internal *get key length* and nothing else: there is nothing to `generateKey` (the key
+*is* the password, or the input keying material you already have) and nothing to `exportKey`, their import
+steps refusing any `extractable` that is not `false`. So a PBKDF2 key is a one-way door — the bytes go in and
+only derived material comes out. ECDH registers `deriveBits` and never `sign`; ECDSA the reverse. An
+AES-GCM key may still carry the `wrapKey` and `unwrapKey` usages that nothing here consumes.
+
+`deriveKey` is a composition rather than an algorithm of its own: it derives bits with one algorithm and
+imports them with another, so `deriveKey(pbkdf2Params, password, { name: 'AES-GCM', length: 256 }, …)` hands
+back exactly the key `importKey('raw', …)` would have made from the same bytes. What it will not do is derive
+an *asymmetric* key: RSA and the elliptic curves register `importKey` but not *get key length*, so a
+`derivedKeyType` naming one is a `NotSupportedError` before anything is derived — which is what a browser
+answers too. The `length` argument of `deriveBits` is optional and nullable, and the three algorithms read a
+null differently: ECDH returns the whole shared secret (and truncates to a *bit*, not a byte, when you do
+give a length), while HKDF and PBKDF2 have no natural output size and refuse it with an `OperationError`.
+A length that is not a multiple of eight is likewise an `OperationError` for those two and a bit-exact
+truncation for ECDH, and a length of zero is the empty `ArrayBuffer` for all three.
+
+The two shapes an embedder actually reaches for are both one call each. A password becomes a content key —
+`deriveKey({ name: 'PBKDF2', salt, iterations, hash: 'SHA-256' }, password, { name: 'AES-GCM', length: 256 },
+false, ['encrypt', 'decrypt'])` — and two parties agree one, `deriveKey({ name: 'ECDH', public: theirPublicKey },
+myPrivateKey, 'HKDF', false, ['deriveBits'])` followed by an HKDF expansion, which is the worked example the
+specification itself gives. Together with the signature side that was already here, a script can now do the
+whole of a JOSE flow in-engine: `HS*` under HMAC, `RS*` under RSASSA-PKCS1-v1_5, `PS*` under RSA-PSS and
+`ES*` under ECDSA for signing and verification, and PBKDF2 or ECDH-plus-HKDF for the key that protects the
+payload.
+
+An ECDSA key carries
 only its curve: the hash lives in the `EcdsaParams` of each `sign` and `verify` call, so one P-256 key signs
 under SHA-256 and SHA-512 alike. Signatures are the raw `r || s` concatenation at the curve's field width
 (64, 96 and 132 bytes) that the Web Cryptography API defines — not the DER `SEQUENCE` that .NET's
@@ -300,6 +326,13 @@ Where .NET's own cryptography is narrower than the specification the difference 
   execution constraint can interrupt.
 - **RSA `importKey`** from a JSON Web Key needs the CRT parameters `p`, `q`, `dp`, `dq` and `qi`, which
   `RSAParameters` describes a private key by; a JWK carrying `d` alone is a `DataError`.
+- **PBKDF2 `deriveBits`**: `iterations` must be at most **4,194,304** (2^22). The algorithm has no ceiling
+  of its own, but PBKDF2 is a loop whose only purpose is to be slow, whose trip count comes straight from
+  script, and which happens inside one BCL call — so `iterations: 2 ** 40` is one line of script that no
+  timeout, statement budget or cancellation token can interrupt. The cap is above every OWASP 2023
+  recommendation for the function (1,300,000 for SHA-1, 600,000 for SHA-256, 210,000 for SHA-512) and bounds
+  a single call to roughly 1.7 seconds at the ceiling itself. It is the same reasoning as the 8192-bit
+  ceiling on RSA key generation above.
 
 `TextDecoder` understands every encoding the [Encoding Standard](https://encoding.spec.whatwg.org/#names-and-labels)
 names, with all of their labels, except the seven legacy multi-byte ones (`Big5`, `EUC-JP`, `EUC-KR`, `GBK`,


### PR DESCRIPTION
Adds `deriveBits` and `deriveKey` to `crypto.subtle`, with HKDF, PBKDF2 and ECDH registered for them — the third slice of #3162 (references, does not close). **Ten of the twelve operations now exist**; this is the first PR to add one since the feature landed, so the feature-detection pins move for the first time: `deriveBits`/`deriveKey` pinned present with their WebIDL name and length, `wrapKey`/`unwrapKey` still pinned absent (six pins updated — two more than expected asserted the same fact).

- **HKDF and PBKDF2 keys are `importKey`-only, raw-only, and never extractable** — their `[[handle]]` is the input keying material or password verbatim, and the spec's non-extractable rule plus the missing `exportKey` registration together leave the bytes no door out. Their `[[algorithm]]` is the bare `KeyAlgorithm`: hash, salt, info and iterations all belong to each derivation, so one imported password derives under any hash.
- **PBKDF2's iteration count gets an engine ceiling (2^22)**, the sibling of RSA's 8192-bit generation ceiling: the loop's only purpose is to be slow, its trip count comes straight from script, and the whole of it is one uninterruptible BCL call no execution constraint can bound. The ceiling is above every OWASP 2023 recommendation and bounds one call to ~1.7 s worst-case (measured per hash); the refusal names the restriction.
- **ECDH derives the raw shared secret** (`DeriveRawSecretAgreement` — the one method on that class that does *not* apply a KDF of its own), with the nine spec steps in their observable order and `length: null` returning the whole secret. Truncation is bit-exact with the tail bits cleared, because ECDH's steps impose no multiple-of-8 rule where HKDF's and PBKDF2's do.
- **`deriveKey` is the spec's composition, not an operation of its own**: three normalizations up front (the derivation for `deriveBits`, the `derivedKeyType` twice — `importKey` and the internal *get key length*), then derive, then the ordinary raw-import path — so a derived key is exactly the key `importKey` would have made from the same bytes, and a non-extractable PBKDF2 password can produce an extractable AES-GCM key because `extractable`/`keyUsages` belong to the derived key alone. Only algorithms registering *get key length* (HMAC, AES-GCM, HKDF, PBKDF2) can be derived into; an asymmetric derived key is refused by the registry itself.
- **One WebIDL deviation from older browsers, deliberately**: `deriveBits.length` is **2** — the current spec declares `length` as `optional [EnforceRange] unsigned long? = null` and WebIDL counts required arguments only; Node's WebCrypto answers 2 as well (measured). Documented at the method and the pin.

Platform behavior measured rather than assumed, continuing the chain's discipline: `HKDF.DeriveKey` reports an over-cap or zero output as `ArgumentOutOfRangeException` (not `CryptographicException`) — both answered before the call, zero being the RFC's own empty sequence; `DeriveRawSecretAgreement` reports mismatched key sizes as `ArgumentException` — unreachable behind the spec's same-curve step, caught anyway per the file's recorded lesson.

Two mutations survived the first pass and exposed real test gaps, both fixed rather than papered over: deleting the HKDF 255-block ceiling and PBKDF2's zero-iterations check each still produced `OperationError` because the *platform's* refusal covered for the missing spec step — the pins now assert the ceiling's message, and a `length: 0` row proves the zero-iterations check is the only thing that can fail that request. 16 mutations total, all caught.

Vectors all external: RFC 6070 and RFC 7914 §11 (PBKDF2), RFC 5869 A.1–A.4/A.6 (HKDF, both hash families), RFC 5903 §8.1 (ECDH P-256, both directions against the published secret), and derived-key round trips pin exact key bytes computed outside the engine. 26 new tests / 40 cases.

Full matrix green on net10.0 + net472 including host-contract-verification legs, re-verified after rebasing onto current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014n5uCpi2vvHWBSiewUwBiY
