### PR TITLE
Web API: AES-CBC, AES-CTR, AES-KW and wrapKey/unwrapKey - crypto.subtle completes at 12 of 12 operations

### DIFF
--- a/Jint.Tests.PublicInterface/WebApiCryptoTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiCryptoTests.cs
@@ -116,11 +116,12 @@ public class WebApiCryptoTests
                 .map(name => typeof crypto.subtle[name] + ':' + crypto.subtle[name].length).join(',')
             """).AsString().Should().Be("function:2,function:5");
 
-        // Key wrapping is absent, not present-and-throwing, so a library that checks before reaching for one
-        // takes its fallback path.
+        // Key wrapping is here too, with WebIDL's own arities — the whole SubtleCrypto interface, so a
+        // library that feature-detects before reaching for one finds it.
         engine.Evaluate("""
-            ['wrapKey', 'unwrapKey'].map(name => typeof crypto.subtle[name]).join(',')
-            """).AsString().Should().Be("undefined,undefined");
+            ['wrapKey', 'unwrapKey']
+                .map(name => typeof crypto.subtle[name] + ':' + crypto.subtle[name].length).join(',')
+            """).AsString().Should().Be("function:4,function:7");
     }
 
     [Fact]

--- a/Jint.Tests/Runtime/WebApi/CryptoTests.cs
+++ b/Jint.Tests/Runtime/WebApi/CryptoTests.cs
@@ -271,11 +271,9 @@ public class CryptoTests
     {
         var engine = WebEngine();
 
-        // `crypto.subtle` exists and answers a SubtleCrypto object. What it carries is the ten operations
-        // over SHA, HMAC, AES-GCM, the RSA family, the elliptic curves, HKDF and PBKDF2; key wrapping is
-        // absent rather than present-and-throwing, because `if (crypto.subtle.wrapKey)` is how a library that
-        // does cryptography decides whether it can, and it has to get the truthful answer — see
-        // SubtleCryptoTests and SubtleCryptoKeyTests for the operations themselves.
+        // `crypto.subtle` exists and answers a SubtleCrypto object. What it carries is all twelve operations
+        // over SHA, HMAC, the four AES modes, the RSA family, the elliptic curves, HKDF and PBKDF2 — see
+        // SubtleCryptoTests, SubtleCryptoKeyTests and SubtleCryptoAesWrapTests for the operations themselves.
         engine.Evaluate("typeof crypto.subtle").AsString().Should().Be("object");
         engine.Evaluate("'subtle' in crypto").AsBoolean().Should().BeTrue();
 
@@ -287,7 +285,7 @@ public class CryptoTests
 
         engine.Evaluate("""
             ['wrapKey', 'unwrapKey'].map(name => typeof crypto.subtle[name]).join(',')
-            """).AsString().Should().Be("undefined,undefined");
+            """).AsString().Should().Be("function,function");
     }
 
     [Fact]

--- a/Jint.Tests/Runtime/WebApi/SubtleCryptoAesWrapTests.cs
+++ b/Jint.Tests/Runtime/WebApi/SubtleCryptoAesWrapTests.cs
@@ -1,0 +1,1100 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Native;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// The three AES modes this engine added last — AES-CBC (https://w3c.github.io/webcrypto/#aes-cbc), AES-CTR
+/// (https://w3c.github.io/webcrypto/#aes-ctr) and AES-KW (https://w3c.github.io/webcrypto/#aes-kw) — and the
+/// two operations that complete <c>crypto.subtle</c>, <c>wrapKey</c>
+/// (https://w3c.github.io/webcrypto/#SubtleCrypto-method-wrapKey) and <c>unwrapKey</c>
+/// (https://w3c.github.io/webcrypto/#SubtleCrypto-method-unwrapKey).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every cipher is checked against a vector somebody else published, which is the only way to check
+/// cryptography: Appendix F.2 and F.5 of [NIST-SP800-38A] for CBC and CTR at all three key sizes, and Section
+/// 4 of [RFC3394] for all six AES-KW combinations of key-encryption-key and payload size. A round trip proves
+/// only that the engine agrees with itself.
+/// </para>
+/// <para>
+/// Three expectations here are <b>not</b> published and were computed outside this engine, with a from-scratch
+/// AES written for the purpose and validated against the NIST single-block ECB vectors of Appendix F.1: the
+/// fifth block of each CBC ciphertext, which is the PKCS#7 padding block the Web Cryptography API adds and
+/// NIST's unpadded example does not have; and the two CTR counter-wrap cases, where the counter field runs
+/// past its maximum and has to continue at zero with the nonce to its left untouched. Those are the cases an
+/// implementation gets wrong by treating the whole 128-bit block as one integer, and they are exactly where a
+/// self-consistent round trip would notice nothing.
+/// </para>
+/// </remarks>
+public class SubtleCryptoAesWrapTests
+{
+    /// <summary>The helpers the other <c>crypto.subtle</c> suites use, so a script here reads like theirs.</summary>
+    private const string Prelude = """
+        const hex = b => Array.from(new Uint8Array(b)).map(x => x.toString(16).padStart(2, '0')).join('');
+        const bytes = h => Uint8Array.from(h.match(/../g) || [], x => parseInt(x, 16));
+        const ascii = s => Uint8Array.from(s, c => c.charCodeAt(0));
+        const repeat = (byte, count) => new Uint8Array(count).fill(byte);
+        """;
+
+    // ---------------------------------------------------------------------------------------------------
+    // The NIST SP 800-38A Appendix F inputs, shared by the CBC and CTR vectors
+    // ---------------------------------------------------------------------------------------------------
+
+    /// <summary>The three example keys of Appendix F, at 128, 192 and 256 bits.</summary>
+    private const string Key128 = "2b7e151628aed2a6abf7158809cf4f3c";
+    private const string Key192 = "8e73b0f7da0e6452c810f32b809079e562f8ead2522c6b7b";
+    private const string Key256 = "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4";
+
+    /// <summary>The four example plaintext blocks every one of those vectors is built from.</summary>
+    private const string PlaintextBlocks =
+        "6bc1bee22e409f96e93d7e117393172a"
+        + "ae2d8a571e03ac9c9eb76fac45af8e51"
+        + "30c81c46a35ce411e5fbc1191a0a52ef"
+        + "f69f2445df4f9b17ad2b417be66c3710";
+
+    /// <summary>The IV of the CBC examples and the initial counter block of the CTR ones.</summary>
+    private const string CbcIv = "000102030405060708090a0b0c0d0e0f";
+    private const string CtrCounter = "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff";
+
+    private static Engine WebEngine() => new(options => options.UseWebApis(WebApiFeatures.Crypto));
+
+    /// <summary>Runs an async body to completion and answers what it returned.</summary>
+    private static JsValue Run(string body, Engine? engine = null)
+    {
+        engine ??= WebEngine();
+        return engine.Evaluate(Prelude + "\n(async () => {\n" + body + "\n})()").UnwrapIfPromise();
+    }
+
+    /// <summary>Settles one expression's promise and answers whatever it resolved or rejected to.</summary>
+    private static JsValue Settle(Engine engine, string source) => engine.Evaluate(source).UnwrapIfPromise();
+
+    // ---------------------------------------------------------------------------------------------------
+    // AES-CBC — NIST SP 800-38A Appendix F.2
+    // ---------------------------------------------------------------------------------------------------
+
+    [Theory]
+    // The ciphertext is the four blocks of F.2.1 / F.2.3 / F.2.5 followed by one more: the Web Cryptography
+    // API always adds PKCS#7 padding, and a plaintext that is already a whole number of blocks gains a whole
+    // block of 0x10 octets. That fifth block is the one figure here NIST does not publish — see the remarks
+    // on this class for how it was computed.
+    [InlineData(
+        Key128,
+        "7649abac8119b246cee98e9b12e9197d5086cb9b507219ee95db113a917678b2"
+        + "73bed6b8e3c1743b7116e69e222295163ff1caa1681fac09120eca307586e1a7"
+        + "8cb82807230e1321d3fae00d18cc2012")]
+    [InlineData(
+        Key192,
+        "4f021db243bc633d7178183a9fa071e8b4d9ada9ad7dedf4e5e738763f69145a"
+        + "571b242012fb7ae07fa9baac3df102e008b0e27988598881d920a9e64f5615cd"
+        + "612ccd79224b350935d45dd6a98f8176")]
+    [InlineData(
+        Key256,
+        "f58c4c04d6e5f1ba779eabfb5f7bfbd69cfc4e967edb808d679f777bc6702c7d"
+        + "39f23369a9d9bacfa530e26304231461b2eb05e2c39be9fcda6c19078c6a9d1b"
+        + "3f461796d6b0d6b2e0c2a72b4d80e644")]
+    public void EncryptsThePublishedAesCbcVectors(string keyHex, string expected)
+    {
+        Run($$"""
+            const key = await crypto.subtle.importKey('raw', bytes('{{keyHex}}'), 'AES-CBC', false, ['encrypt', 'decrypt']);
+            const params = { name: 'AES-CBC', iv: bytes('{{CbcIv}}') };
+
+            const ciphertext = await crypto.subtle.encrypt(params, key, bytes('{{PlaintextBlocks}}'));
+            const plaintext = await crypto.subtle.decrypt(params, key, ciphertext);
+
+            // The first four blocks are NIST's own ciphertext, and decrypting the whole thing gives the
+            // plaintext back — so both directions are pinned against the published bytes.
+            return hex(ciphertext) + '|' + (hex(ciphertext).startsWith('{{expected}}'.slice(0, 128)))
+                + '|' + hex(plaintext);
+            """).AsString().Should().Be(expected + "|true|" + PlaintextBlocks);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(15)]
+    [InlineData(16)]
+    [InlineData(17)]
+    [InlineData(31)]
+    [InlineData(32)]
+    public void PadsEveryPlaintextLengthToTheNextWholeBlockAndRecoversIt(int length)
+    {
+        // "Let paddedPlaintext be the result of adding padding octets to plaintext according to the procedure
+        // defined in Section 10.3 of [RFC2315], step 2, with a value of k of 16" — which always adds between
+        // one and sixteen octets, so the ciphertext is strictly longer than the plaintext and a plaintext on
+        // a block boundary costs a whole extra block.
+        var expectedLength = length + 16 - (length % 16);
+
+        Run($$"""
+            const key = await crypto.subtle.generateKey({ name: 'AES-CBC', length: 256 }, false, ['encrypt', 'decrypt']);
+            const params = { name: 'AES-CBC', iv: repeat(7, 16) };
+            const message = Uint8Array.from({ length: {{length}} }, (_, i) => i & 0xff);
+
+            const ciphertext = await crypto.subtle.encrypt(params, key, message);
+            const plaintext = await crypto.subtle.decrypt(params, key, ciphertext);
+
+            return ciphertext.byteLength + '|' + hex(plaintext) + '|' + hex(message);
+            """).AsString().Should().Match($"{expectedLength}|*");
+
+        Run($$"""
+            const key = await crypto.subtle.generateKey({ name: 'AES-CBC', length: 256 }, false, ['encrypt', 'decrypt']);
+            const params = { name: 'AES-CBC', iv: repeat(7, 16) };
+            const message = Uint8Array.from({ length: {{length}} }, (_, i) => i & 0xff);
+
+            const ciphertext = await crypto.subtle.encrypt(params, key, message);
+            const plaintext = await crypto.subtle.decrypt(params, key, ciphertext);
+
+            return hex(plaintext) === hex(message);
+            """).AsBoolean().Should().BeTrue();
+    }
+
+    [Theory]
+    // Steps 4 and 5: "Let p be the value of the last octet of paddedPlaintext. If p is zero or greater than
+    // 16, or if any of the last p octets of paddedPlaintext have a value which is not p, then throw an
+    // OperationError." Each of the three ways that can fail is constructed rather than stumbled on, which is
+    // what makes this deterministic and what makes each clause of the check load-bearing.
+    //
+    // The plaintext of block N is D(C[N]) xor C[N-1], so a byte of the *first* ciphertext block chooses a
+    // byte of the padding block exactly. The three corruptions below are the whole of the check:
+    //
+    //   index 0, xor 0x01  — the padding's first octet becomes 0x11 while the last stays 0x10, so p is a
+    //                        perfectly good 16 and one of the octets it claims is not 16. Only a check that
+    //                        reads all p octets catches this one.
+    [InlineData(0, "0x01")]
+    //   index 15, xor 0x10 — the last octet becomes 0x00, which is "p is zero".
+    [InlineData(15, "0x10")]
+    //   index 15, xor 0x80 — the last octet becomes 0x90, which is "p is greater than 16".
+    [InlineData(15, "0x80")]
+    //   ... and a byte of the padding block itself, which randomizes the whole block and its padding with it.
+    [InlineData(16, "0x01")]
+    [InlineData(31, "0x01")]
+    public void RefusesACiphertextWhosePaddingIsWrong(int index, string mask)
+    {
+        // The failure is the one message every other CBC failure gives: a decrypt that can tell "the padding
+        // was malformed" from "the padding was fine" is a padding oracle, and CBC without an authentication
+        // tag is the shape that attack was invented for.
+        Run($$"""
+            const key = await crypto.subtle.importKey('raw', bytes('{{Key128}}'), 'AES-CBC', false, ['encrypt', 'decrypt']);
+            const params = { name: 'AES-CBC', iv: bytes('{{CbcIv}}') };
+
+            const ciphertext = new Uint8Array(
+                await crypto.subtle.encrypt(params, key, bytes('00112233445566778899aabbccddeeff')));
+
+            // One 16-byte message becomes two blocks: the message and a whole block of 0x10 padding.
+            const corrupted = ciphertext.slice();
+            corrupted[{{index}}] ^= {{mask}};
+
+            try {
+                await crypto.subtle.decrypt(params, key, corrupted);
+                return 'decrypted';
+            } catch (e) {
+                return ciphertext.byteLength + '|' + e.name + ':' + e.message.slice(e.message.indexOf(': ') + 2);
+            }
+            """).AsString().Should().Be("32|OperationError:the data could not be decrypted.");
+    }
+
+    [Theory]
+    [InlineData("repeat(0, 15)")]
+    [InlineData("repeat(0, 17)")]
+    [InlineData("new Uint8Array(0)")]
+    public void RefusesAnAesCbcIvThatIsNotOneBlock(string iv)
+    {
+        var engine = WebEngine();
+
+        // "If the iv member of normalizedAlgorithm does not have a length of 16 bytes, then throw an
+        // OperationError" — the algorithm's own restriction, not the platform's, unlike AES-GCM's nonce.
+        Settle(engine, $$"""
+            (async () => {
+                const key = await crypto.subtle.generateKey({ name: 'AES-CBC', length: 128 }, false, ['encrypt', 'decrypt']);
+                const repeat = (byte, count) => new Uint8Array(count).fill(byte);
+                return crypto.subtle.encrypt({ name: 'AES-CBC', iv: {{iv}} }, key, new Uint8Array(0))
+                    .then(() => 'encrypted', e => e.name);
+            })()
+            """).AsString().Should().Be("OperationError");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(15)]
+    [InlineData(17)]
+    public void RefusesAnAesCbcCiphertextThatIsNotAWholeNumberOfBlocks(int length)
+    {
+        // "If the length of ciphertext is zero or is not a multiple of 16 bytes, then throw an
+        // OperationError." The zero case is separate from the multiple: an AES-CBC ciphertext is never empty,
+        // because the padding alone is a block.
+        Run($$"""
+            const key = await crypto.subtle.generateKey({ name: 'AES-CBC', length: 128 }, false, ['encrypt', 'decrypt']);
+            try {
+                await crypto.subtle.decrypt({ name: 'AES-CBC', iv: repeat(0, 16) }, key, new Uint8Array({{length}}));
+                return 'decrypted';
+            } catch (e) {
+                return e.name;
+            }
+            """).AsString().Should().Be("OperationError");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // AES-CTR — NIST SP 800-38A Appendix F.5
+    // ---------------------------------------------------------------------------------------------------
+
+    [Theory]
+    // F.5.1, F.5.3 and F.5.5, whose counter is the whole 128-bit block (m = 128) and whose plaintext is the
+    // same four blocks. There is no padding: CTR is a stream cipher, so the ciphertext is the length of the
+    // plaintext exactly.
+    [InlineData(
+        Key128,
+        "874d6191b620e3261bef6864990db6ce9806f66b7970fdff8617187bb9fffdff"
+        + "5ae4df3edbd5d35e5b4f09020db03eab1e031dda2fbe03d1792170a0f3009cee")]
+    [InlineData(
+        Key192,
+        "1abc932417521ca24f2b0459fe7e6e0b090339ec0aa6faefd5ccc2c6f4ce8e94"
+        + "1e36b26bd1ebc670d1bd1d665620abf74f78a7f6d29809585a97daec58c6b050")]
+    [InlineData(
+        Key256,
+        "601ec313775789a5b7a7f504bbf3d228f443e3ca4d62b59aca84e990cacaf5c5"
+        + "2b0930daa23de94ce87017ba2d84988ddfc9c58db67aada613c2dd08457941a6")]
+    public void EncryptsThePublishedAesCtrVectors(string keyHex, string expected)
+    {
+        Run($$"""
+            const key = await crypto.subtle.importKey('raw', bytes('{{keyHex}}'), 'AES-CTR', false, ['encrypt', 'decrypt']);
+            const params = { name: 'AES-CTR', counter: bytes('{{CtrCounter}}'), length: 128 };
+
+            const ciphertext = await crypto.subtle.encrypt(params, key, bytes('{{PlaintextBlocks}}'));
+
+            // Encryption and decryption are one operation, so decrypting the published ciphertext must give
+            // the published plaintext with the same call.
+            const plaintext = await crypto.subtle.decrypt(params, key, bytes('{{expected}}'));
+
+            return hex(ciphertext) + '|' + hex(plaintext);
+            """).AsString().Should().Be(expected + "|" + PlaintextBlocks);
+    }
+
+    [Fact]
+    public void IncrementsOnlyTheRightmostLengthBitsAndWrapsThemModuloTwoToTheLength()
+    {
+        // The case the specification points at Appendix B.1 of [NIST-SP800-38A] for: with length 32 the
+        // counter is the last four bytes, and 0xffffffff is followed by 0x00000000 — not by a carry into the
+        // twelve bytes of nonce to its left. An implementation that treated the block as one 128-bit integer
+        // would produce a third keystream block from …0c00000000 and a different ciphertext from block two on.
+        //
+        // The expectation was computed outside this engine — see the remarks on this class.
+        Run($$"""
+            const key = await crypto.subtle.importKey('raw', bytes('{{Key128}}'), 'AES-CTR', false, ['encrypt']);
+            const ciphertext = await crypto.subtle.encrypt(
+                { name: 'AES-CTR', counter: bytes('000102030405060708090a0bffffffff'), length: 32 },
+                key,
+                new Uint8Array(48));
+            return hex(ciphertext);
+            """).AsString().Should().Be(
+                "bdb7c0ef49717942fc68eeb17692fcf4"
+                + "94193f8116eb745cfe7465d70c756236"
+                + "a715b99567eaea4806b3a91c785f11cc");
+    }
+
+    [Theory]
+    // length 4 puts the whole counter in the low nibble of the last byte: 0x1f becomes 0x10 and then 0x11, so
+    // the nibble wraps and the *nonce* nibble above it keeps its value. The deliberate choice here is a nonce
+    // nibble that is not 0xf — with 0xff a carry out of the nibble happens to land on bits that were already
+    // set, and an implementation that forgot to mask the increment would give the same answer by luck.
+    [InlineData("000102030405060708090a0b0c0d0e1f", 4,
+        "d382e6e0f67d3973b51ef9c0321691e3af218e4e87e393aada314be47bf7a35f96ea8f8905839042b9ce80980c8d2630")]
+    // length 12 straddles a byte boundary: the counter is all of the last byte and the low nibble of the one
+    // before it, so 0x1fff becomes 0x1000 — a carry out of a whole byte into a partial one, with four bits of
+    // nonce immediately above the carry.
+    [InlineData("000102030405060708090a0b0c0d1fff", 12,
+        "8250c610f6a654214a55c545382342f66cd367d6b58575858b44a7cbac0431fa51367ca1f0054dc9088d431c6c41ee1f")]
+    public void WrapsACounterFieldThatDoesNotEndOnAByteBoundary(string counter, int length, string expected)
+    {
+        // Computed outside this engine, like the case above.
+        Run($$"""
+            const key = await crypto.subtle.importKey('raw', bytes('{{Key128}}'), 'AES-CTR', false, ['encrypt']);
+            const ciphertext = await crypto.subtle.encrypt(
+                { name: 'AES-CTR', counter: bytes('{{counter}}'), length: {{length}} },
+                key,
+                new Uint8Array(48));
+            return hex(ciphertext);
+            """).AsString().Should().Be(expected);
+    }
+
+    [Fact]
+    public void WrapsTheWholeBlockWhenTheCounterFieldIsAllOfIt()
+    {
+        // length 128 and a counter block of all ones: the whole block wraps to zero, and the carry out of the
+        // most significant bit is dropped rather than being anything at all.
+        Run($$"""
+            const key = await crypto.subtle.importKey('raw', bytes('{{Key128}}'), 'AES-CTR', false, ['encrypt']);
+            const ciphertext = await crypto.subtle.encrypt(
+                { name: 'AES-CTR', counter: bytes('ffffffffffffffffffffffffffffffff'), length: 128 },
+                key,
+                new Uint8Array(32));
+            return hex(ciphertext);
+            """).AsString().Should().Be("8af2860142f786f409307c1a3f7eaaac7df76b0c1ab899b33e42f047b91b546f");
+    }
+
+    [Theory]
+    [InlineData("repeat(0, 15)", "128", "OperationError")]
+    [InlineData("repeat(0, 17)", "128", "OperationError")]
+    [InlineData("repeat(0, 16)", "0", "OperationError")]
+    [InlineData("repeat(0, 16)", "129", "OperationError")]
+    [InlineData("repeat(0, 16)", "255", "OperationError")]
+    // The member's IDL type is `octet`, so a value outside 0..255 fails the [EnforceRange] conversion during
+    // normalization, before a single step of the operation runs — a TypeError, not an OperationError.
+    [InlineData("repeat(0, 16)", "256", "TypeError")]
+    [InlineData("repeat(0, 16)", "-1", "TypeError")]
+    [InlineData("repeat(0, 16)", "1", "ok")]
+    [InlineData("repeat(0, 16)", "128", "ok")]
+    public void EnforcesTheAesCtrCounterAndLengthMatrix(string counter, string length, string expected)
+    {
+        Run($$"""
+            const key = await crypto.subtle.generateKey({ name: 'AES-CTR', length: 128 }, false, ['encrypt']);
+            try {
+                await crypto.subtle.encrypt({ name: 'AES-CTR', counter: {{counter}}, length: {{length}} }, key, ascii('m'));
+                return 'ok';
+            } catch (e) {
+                return e.name === undefined ? e.constructor.name : e.name;
+            }
+            """).AsString().Should().Be(expected);
+    }
+
+    [Fact]
+    public void EncryptsTheEmptyMessageToTheEmptyCiphertext()
+    {
+        // CTR needs no keystream at all for a zero-length message, and a stream cipher's ciphertext is the
+        // length of its plaintext — unlike CBC, whose padding makes even the empty message a whole block.
+        Run($$"""
+            const ctr = await crypto.subtle.generateKey({ name: 'AES-CTR', length: 128 }, false, ['encrypt']);
+            const cbc = await crypto.subtle.generateKey({ name: 'AES-CBC', length: 128 }, false, ['encrypt']);
+
+            const a = await crypto.subtle.encrypt({ name: 'AES-CTR', counter: repeat(0, 16), length: 64 }, ctr, new Uint8Array(0));
+            const b = await crypto.subtle.encrypt({ name: 'AES-CBC', iv: repeat(0, 16) }, cbc, new Uint8Array(0));
+
+            return a.byteLength + ',' + b.byteLength;
+            """).AsString().Should().Be("0,16");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // AES-KW — RFC 3394 section 4
+    // ---------------------------------------------------------------------------------------------------
+
+    [Theory]
+    // https://www.rfc-editor.org/rfc/rfc3394#section-4, all six combinations. The key data of each vector is
+    // itself a valid AES key length, so it is imported as an AES-CBC key and wrapped in the `raw` format —
+    // which makes the bytes handed to the wrap operation exactly the vector's "Key Data".
+    [InlineData("000102030405060708090A0B0C0D0E0F", "00112233445566778899AABBCCDDEEFF",
+        "1fa68b0a8112b447aef34bd8fb5a7b829d3e862371d2cfe5")]
+    [InlineData("000102030405060708090A0B0C0D0E0F1011121314151617", "00112233445566778899AABBCCDDEEFF",
+        "96778b25ae6ca435f92b5b97c050aed2468ab8a17ad84e5d")]
+    [InlineData("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F", "00112233445566778899AABBCCDDEEFF",
+        "64e8c3f9ce0f5ba263e9777905818a2a93c8191e7d6e8ae7")]
+    [InlineData("000102030405060708090A0B0C0D0E0F1011121314151617", "00112233445566778899AABBCCDDEEFF0001020304050607",
+        "031d33264e15d33268f24ec260743edce1c6c7ddee725a936ba814915c6762d2")]
+    [InlineData("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F", "00112233445566778899AABBCCDDEEFF0001020304050607",
+        "a8f9bc1612c68b3ff6e6f4fbe30e71e4769c8b80a32cb8958cd5d17d6b254da1")]
+    [InlineData("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F", "00112233445566778899AABBCCDDEEFF000102030405060708090A0B0C0D0E0F",
+        "28c9f404c4b810f4cbccb35cfb87f8263f5786e2d80ed326cbc7f0e71a99f43bfb988b9b7a02dd21")]
+    public void WrapsAndUnwrapsThePublishedRfc3394Vectors(string kekHex, string keyDataHex, string expected)
+    {
+        Run($$"""
+            const kek = await crypto.subtle.importKey('raw', bytes('{{kekHex}}'), 'AES-KW', false, ['wrapKey', 'unwrapKey']);
+            const keyData = await crypto.subtle.importKey('raw', bytes('{{keyDataHex}}'), 'AES-CBC', true, ['encrypt']);
+
+            const wrapped = await crypto.subtle.wrapKey('raw', keyData, kek, 'AES-KW');
+
+            const unwrapped = await crypto.subtle.unwrapKey(
+                'raw', bytes('{{expected}}'), kek, 'AES-KW', { name: 'AES-CBC', length: {{keyDataHex.Length * 4}} }, true, ['encrypt']);
+
+            // Both directions against the published bytes: the wrap produces the vector's ciphertext, and
+            // the vector's ciphertext unwraps to the vector's key data.
+            return hex(wrapped) + '|' + hex(await crypto.subtle.exportKey('raw', unwrapped));
+            """).AsString().Should().Be(expected + "|" + keyDataHex.ToLowerInvariant());
+    }
+
+    [Fact]
+    public void RefusesAWrappedPayloadThatIsNotAWholeNumberOfBlocks()
+    {
+        // "If plaintext is not a multiple of 64 bits in length, then throw an OperationError." An HMAC key of
+        // 100 bits exports as a 13-byte raw key, which is exactly such a payload — and the 8-byte one below
+        // is a whole number of blocks but only one of them, which the wrap algorithm has no reading of.
+        Run("""
+            const kek = await crypto.subtle.generateKey({ name: 'AES-KW', length: 256 }, false, ['wrapKey', 'unwrapKey']);
+
+            const outcomes = [];
+            for (const bits of [104, 64]) {
+                const key = await crypto.subtle.importKey(
+                    'raw', new Uint8Array(bits / 8), { name: 'HMAC', hash: 'SHA-256' }, true, ['sign']);
+                try {
+                    await crypto.subtle.wrapKey('raw', key, kek, 'AES-KW');
+                    outcomes.push('wrapped');
+                } catch (e) {
+                    outcomes.push(e.name);
+                }
+            }
+
+            return outcomes.join(',');
+            """).AsString().Should().Be("OperationError,OperationError");
+    }
+
+    [Fact]
+    public void RefusesAWrappedKeyWhoseIntegrityCheckFailsWithAnIndistinguishableMessage()
+    {
+        // "If the Key Unwrap operation returns an error, then throw an OperationError." Every way the unwrap
+        // can fail — a flipped bit anywhere in the ciphertext, the wrong key-encryption key, a ciphertext of
+        // the wrong shape — gives the one message, which is the same CCA discipline RSA-OAEP's decrypt keeps.
+        Run("""
+            const kek = await crypto.subtle.generateKey({ name: 'AES-KW', length: 128 }, true, ['wrapKey', 'unwrapKey']);
+            const other = await crypto.subtle.generateKey({ name: 'AES-KW', length: 128 }, false, ['wrapKey', 'unwrapKey']);
+            const key = await crypto.subtle.generateKey({ name: 'AES-CBC', length: 128 }, true, ['encrypt']);
+            const wrapped = new Uint8Array(await crypto.subtle.wrapKey('raw', key, kek, 'AES-KW'));
+
+            const unwrap = (data, using_) => crypto.subtle.unwrapKey(
+                'raw', data, using_, 'AES-KW', { name: 'AES-CBC', length: 128 }, true, ['encrypt']);
+
+            const outcomes = [];
+            for (const index of [0, 7, 8, wrapped.length - 1]) {
+                const corrupted = wrapped.slice();
+                corrupted[index] ^= 0x80;
+                try { await unwrap(corrupted, kek); outcomes.push('unwrapped'); }
+                catch (e) { outcomes.push(e.name + ':' + e.message.slice(e.message.indexOf(': ') + 2)); }
+            }
+
+            try { await unwrap(wrapped, other); outcomes.push('unwrapped'); }
+            catch (e) { outcomes.push(e.name + ':' + e.message.slice(e.message.indexOf(': ') + 2)); }
+
+            // Every entry the same string, and the wrapped key still unwraps under the key that made it.
+            const distinct = [...new Set(outcomes)];
+            const roundTrip = hex(await crypto.subtle.exportKey('raw', await unwrap(wrapped, kek)))
+                === hex(await crypto.subtle.exportKey('raw', key));
+
+            return distinct.length + '|' + distinct[0] + '|' + roundTrip;
+            """).AsString().Should().Be("1|OperationError:the key could not be unwrapped.|true");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(8)]
+    [InlineData(16)]
+    [InlineData(20)]
+    [InlineData(25)]
+    public void RefusesAnAesKwCiphertextOfTheWrongShape(int length)
+    {
+        // A wrapped payload is (n + 1) blocks for n of at least two, so anything under three blocks — or not
+        // a whole number of them — is an input the unwrap algorithm has no reading of. It is the same
+        // OperationError an integrity failure earns.
+        Run($$"""
+            const kek = await crypto.subtle.generateKey({ name: 'AES-KW', length: 128 }, false, ['wrapKey', 'unwrapKey']);
+            try {
+                await crypto.subtle.unwrapKey(
+                    'raw', new Uint8Array({{length}}), kek, 'AES-KW', { name: 'AES-CBC', length: 128 }, true, ['encrypt']);
+                return 'unwrapped';
+            } catch (e) {
+                return e.name;
+            }
+            """).AsString().Should().Be("OperationError");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // The shared AES key management, at the three names that are new
+    // ---------------------------------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("AES-CTR", 128, "A128CTR")]
+    [InlineData("AES-CTR", 192, "A192CTR")]
+    [InlineData("AES-CTR", 256, "A256CTR")]
+    [InlineData("AES-CBC", 128, "A128CBC")]
+    [InlineData("AES-CBC", 192, "A192CBC")]
+    [InlineData("AES-CBC", 256, "A256CBC")]
+    [InlineData("AES-GCM", 128, "A128GCM")]
+    [InlineData("AES-GCM", 256, "A256GCM")]
+    [InlineData("AES-KW", 128, "A128KW")]
+    [InlineData("AES-KW", 192, "A192KW")]
+    [InlineData("AES-KW", 256, "A256KW")]
+    public void ExportsAndReimportsAJsonWebKeyWithTheAlgorithmsOwnAlgField(string name, int length, string alg)
+    {
+        // https://www.rfc-editor.org/rfc/rfc7518#section-4.7 for the ciphers and #section-4.4 for AES-KW —
+        // the twelve names A128CBC … A256KW. The four algorithms' import and export steps are the same to the
+        // letter apart from this string and the algorithm's own name, which is why they share an
+        // implementation, and this is what proves the two strings are still the algorithm's own.
+        var usages = string.Equals(name, "AES-KW", StringComparison.Ordinal) ? "['wrapKey']" : "['encrypt']";
+
+        Run($$"""
+            const key = await crypto.subtle.generateKey({ name: '{{name}}', length: {{length}} }, true, {{usages}});
+            const jwk = await crypto.subtle.exportKey('jwk', key);
+
+            const reimported = await crypto.subtle.importKey('jwk', jwk, '{{name}}', true, {{usages}});
+            const raw = hex(await crypto.subtle.exportKey('raw', key));
+
+            return jwk.alg + '|' + jwk.kty + '|' + jwk.ext + '|' + jwk.key_ops.join(',')
+                + '|' + key.algorithm.name + '|' + key.algorithm.length
+                + '|' + (hex(await crypto.subtle.exportKey('raw', reimported)) === raw);
+            """).AsString().Should().Be(
+                alg + "|oct|true|" + usages.Trim('[', ']').Replace("'", "") + "|" + name + "|" + length + "|true");
+    }
+
+    [Fact]
+    public void RefusesAJsonWebKeyWhoseAlgNamesAnotherAesMode()
+    {
+        var engine = WebEngine();
+
+        // "If the length in bits of data is 128: If the alg field of jwk is present, and is not 'A128CBC',
+        // then throw a DataError." A128GCM is a perfectly good alg for a 128-bit AES key and is the wrong one
+        // for AES-CBC, which is exactly the mistake this catches — the two modes are not interchangeable.
+        Settle(engine, """
+            crypto.subtle.importKey(
+                'jwk',
+                { kty: 'oct', alg: 'A128GCM', k: 'AAAAAAAAAAAAAAAAAAAAAA' },
+                'AES-CBC',
+                false,
+                ['encrypt'])
+                .then(() => 'imported', e => e.name + '/' + (e.message.indexOf('A128CBC') >= 0))
+            """).AsString().Should().Be("DataError/true");
+    }
+
+    [Theory]
+    // The three ciphers take all four usages; AES-KW's registration names only the two wrapping ones, so
+    // encrypt and decrypt are the SyntaxError step 1 raises.
+    [InlineData("AES-CTR", "['encrypt', 'decrypt', 'wrapKey', 'unwrapKey']", "ok")]
+    [InlineData("AES-CBC", "['encrypt', 'decrypt', 'wrapKey', 'unwrapKey']", "ok")]
+    [InlineData("AES-GCM", "['encrypt', 'decrypt', 'wrapKey', 'unwrapKey']", "ok")]
+    [InlineData("AES-KW", "['wrapKey', 'unwrapKey']", "ok")]
+    [InlineData("AES-KW", "['encrypt']", "SyntaxError")]
+    [InlineData("AES-KW", "['wrapKey', 'decrypt']", "SyntaxError")]
+    [InlineData("AES-CBC", "['sign']", "SyntaxError")]
+    [InlineData("AES-CTR", "['deriveBits']", "SyntaxError")]
+    public void EnforcesEachAesAlgorithmsOwnUsageSet(string name, string usages, string expected)
+    {
+        var engine = WebEngine();
+
+        Settle(engine, $$"""
+            crypto.subtle.generateKey({ name: '{{name}}', length: 128 }, false, {{usages}})
+                .then(() => 'ok', e => e.name)
+            """).AsString().Should().Be(expected);
+
+        Settle(engine, $$"""
+            crypto.subtle.importKey('raw', new Uint8Array(16), '{{name}}', false, {{usages}})
+                .then(() => 'ok', e => e.name)
+            """).AsString().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("AES-CTR")]
+    [InlineData("AES-CBC")]
+    [InlineData("AES-KW")]
+    public void DerivesEachAesModeThroughDeriveKey(string name)
+    {
+        // All four AES algorithms register `get key length`, so any of them may be a deriveKey
+        // derivedKeyType — and the key that comes out is exactly the key importKey('raw', …) would have made
+        // from the derived bytes, which is what the second half of this asserts.
+        var usages = string.Equals(name, "AES-KW", StringComparison.Ordinal) ? "['wrapKey']" : "['encrypt']";
+
+        Run($$"""
+            const password = await crypto.subtle.importKey('raw', ascii('password'), 'PBKDF2', false, ['deriveKey', 'deriveBits']);
+            const params = { name: 'PBKDF2', salt: ascii('salt'), iterations: 1000, hash: 'SHA-256' };
+
+            const derived = await crypto.subtle.deriveKey(params, password, { name: '{{name}}', length: 192 }, true, {{usages}});
+            const bits = await crypto.subtle.deriveBits(params, password, 192);
+            const imported = await crypto.subtle.importKey('raw', bits, '{{name}}', true, {{usages}});
+
+            return derived.algorithm.name + '|' + derived.algorithm.length
+                + '|' + (hex(await crypto.subtle.exportKey('raw', derived)) === hex(await crypto.subtle.exportKey('raw', imported)));
+            """).AsString().Should().Be(name + "|192|true");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // wrapKey and unwrapKey
+    // ---------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void WrapsARawAesKeyUnderAesKwAndUnwrapsItIntact()
+    {
+        // The shape AES-KW exists for, end to end: a content key wrapped for transport under a
+        // key-encryption key, and recovered by the other side with the usages and extractability that side
+        // chose. 16 bytes of key data wrap to 24, the extra block being RFC 3394's integrity check.
+        Run("""
+            const kek = await crypto.subtle.generateKey({ name: 'AES-KW', length: 256 }, false, ['wrapKey', 'unwrapKey']);
+            const content = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 128 }, true, ['encrypt', 'decrypt']);
+
+            const wrapped = await crypto.subtle.wrapKey('raw', content, kek, 'AES-KW');
+            const recovered = await crypto.subtle.unwrapKey(
+                'raw', wrapped, kek, 'AES-KW', { name: 'AES-GCM', length: 128 }, false, ['decrypt']);
+
+            const iv = repeat(9, 12);
+            const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, content, ascii('the message'));
+            const plaintext = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, recovered, ciphertext);
+
+            // The recovered key is the same key — it decrypts what the original encrypted — and carries the
+            // usages and extractability unwrapKey was told, not the ones the original had.
+            return wrapped.byteLength + '|' + String.fromCharCode(...new Uint8Array(plaintext))
+                + '|' + recovered.extractable + '|' + recovered.usages.join(',');
+            """).AsString().Should().Be("24|the message|false|decrypt");
+    }
+
+    [Fact]
+    public void WrapsAJsonWebKeyUnderAesGcmThroughTheEncryptFallback()
+    {
+        // AES-GCM registers `encrypt` and never `wrapKey`, so this is the second normalization of step 2
+        // doing its work — and the bytes that get encrypted are the UTF-8 of JSON.stringify of exactly the
+        // object exportKey('jwk', …) hands a script.
+        Run("""
+            // The wrapping key carries `encrypt` as well, only so that the last assertion below can compute
+            // the same bytes the wrap produced through the encrypt operation the fallback routes to.
+            const kek = await crypto.subtle.generateKey(
+                { name: 'AES-GCM', length: 256 }, false, ['wrapKey', 'unwrapKey', 'encrypt']);
+            const key = await crypto.subtle.generateKey({ name: 'HMAC', hash: 'SHA-256' }, true, ['sign', 'verify']);
+            const params = { name: 'AES-GCM', iv: repeat(3, 12) };
+
+            const wrapped = await crypto.subtle.wrapKey('jwk', key, kek, params);
+            const recovered = await crypto.subtle.unwrapKey(
+                'jwk', wrapped, kek, params, { name: 'HMAC', hash: 'SHA-256' }, false, ['verify']);
+
+            const signature = await crypto.subtle.sign('HMAC', key, ascii('m'));
+            const verified = await crypto.subtle.verify('HMAC', recovered, signature, ascii('m'));
+
+            const jwk = await crypto.subtle.exportKey('jwk', key);
+            const asEncrypted = await crypto.subtle.encrypt(
+                params, kek, Uint8Array.from(JSON.stringify(jwk), c => c.charCodeAt(0)));
+
+            return verified + '|' + recovered.usages.join(',') + '|' + recovered.extractable
+                + '|' + (hex(wrapped) === hex(asEncrypted));
+            """).AsString().Should().Be("true|verify|false|true");
+    }
+
+    [Fact]
+    public void PadsAJsonWebKeyToAWholeNumberOfBlocksWhenTheWrappingAlgorithmIsAesKw()
+    {
+        // The convention the web-platform tests compute their expectation with, in
+        // WebCryptoAPI/wrapKey_unwrapKey/wrapKey_unwrapKey.https.any.js:
+        //     jwk.slice(0, -1) + " ".repeat(jwk.length % 8 ? 8 - jwk.length % 8 : 0) + "}"
+        // The spaces go immediately before the closing brace, where JSON's grammar allows insignificant
+        // whitespace, so the padded document parses back to the very same object. The specification's own
+        // note is what permits it: "implementations may choose to adapt the serialization to the constraints
+        // of the wrapping algorithm".
+        Run("""
+            const kek = await crypto.subtle.generateKey({ name: 'AES-KW', length: 256 }, false, ['wrapKey', 'unwrapKey']);
+            const key = await crypto.subtle.generateKey({ name: 'AES-CBC', length: 128 }, true, ['encrypt']);
+
+            const wrapped = await crypto.subtle.wrapKey('jwk', key, kek, 'AES-KW');
+
+            // What the padded document is, computed here the way the web-platform tests compute it.
+            const jwk = JSON.stringify(await crypto.subtle.exportKey('jwk', key));
+            const padded = jwk.slice(0, -1) + ' '.repeat(jwk.length % 8 ? 8 - jwk.length % 8 : 0) + '}';
+
+            // The exact bytes that were wrapped, recovered by unwrapping them as a `raw` HMAC key — which
+            // imports any length of key material verbatim — rather than as the JWK they are. That is what
+            // pins where the spaces went: appending them after the closing brace would produce a document
+            // JSON.parse still accepts, so a round trip alone would notice nothing.
+            const asRaw = await crypto.subtle.unwrapKey(
+                'raw', wrapped, kek, 'AES-KW', { name: 'HMAC', hash: 'SHA-256' }, true, ['sign']);
+            const wrappedText = String.fromCharCode(...new Uint8Array(await crypto.subtle.exportKey('raw', asRaw)));
+
+            // Unwrapping as the JWK it is reads the padding as the whitespace it is and gives the same key.
+            const recovered = await crypto.subtle.unwrapKey(
+                'jwk', wrapped, kek, 'AES-KW', { name: 'AES-CBC', length: 128 }, true, ['encrypt']);
+
+            return (jwk.length % 8 !== 0) + '|' + (padded.length % 8) + '|' + (wrapped.byteLength === padded.length + 8)
+                + '|' + (wrappedText === padded)
+                + '|' + (hex(await crypto.subtle.exportKey('raw', recovered)) === hex(await crypto.subtle.exportKey('raw', key)))
+                + '|' + (JSON.stringify(JSON.parse(padded)) === JSON.stringify(JSON.parse(jwk)));
+            """).AsString().Should().Be("true|0|true|true|true|true");
+    }
+
+    [Fact]
+    public void SerializesAJsonWebKeyInTheExportLayoutsOwnOrder()
+    {
+        // The member order is the export layout's, which is what makes the wrapped bytes deterministic for
+        // this engine: JsonWebKeyData builds every JWK from a fixed JsObjectLayout, and a layout's order is
+        // its enumeration order. So JSON.stringify of an exported JWK is stable and a wrap of one key under
+        // one wrapping key is the same bytes every time.
+        Run("""
+            const key = await crypto.subtle.generateKey({ name: 'AES-KW', length: 128 }, true, ['wrapKey', 'unwrapKey']);
+            const jwk = await crypto.subtle.exportKey('jwk', key);
+
+            const kek = await crypto.subtle.generateKey({ name: 'AES-KW', length: 256 }, false, ['wrapKey']);
+            const first = hex(await crypto.subtle.wrapKey('jwk', key, kek, 'AES-KW'));
+            const second = hex(await crypto.subtle.wrapKey('jwk', key, kek, 'AES-KW'));
+
+            return Object.keys(jwk).join(',') + '|' + (first === second);
+            """).AsString().Should().Be("alg,ext,k,key_ops,kty|true");
+    }
+
+    [Fact]
+    public void WrapsAnAesKeyUnderRsaOaepThroughTheEncryptFallback()
+    {
+        // The other half of the fallback: an asymmetric wrapping key, so the wrap and the unwrap are done
+        // with different keys. RSA-OAEP registers `encrypt` and `decrypt` and never wrapKey or unwrapKey, and
+        // the public half carries wrapKey where the private half carries unwrapKey — "the usage intersection
+        // of usages and [ 'encrypt', 'wrapKey' ]" against "[ 'decrypt', 'unwrapKey' ]".
+        Run("""
+            const pair = await crypto.subtle.generateKey(
+                { name: 'RSA-OAEP', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' },
+                false,
+                ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey']);
+
+            const content = await crypto.subtle.generateKey({ name: 'AES-CTR', length: 256 }, true, ['encrypt', 'decrypt']);
+
+            const wrapped = await crypto.subtle.wrapKey('raw', content, pair.publicKey, { name: 'RSA-OAEP' });
+            const recovered = await crypto.subtle.unwrapKey(
+                'raw', wrapped, pair.privateKey, { name: 'RSA-OAEP' }, { name: 'AES-CTR', length: 256 }, true, ['encrypt']);
+
+            return pair.publicKey.usages.join('+') + '|' + pair.privateKey.usages.join('+')
+                + '|' + wrapped.byteLength
+                + '|' + (hex(await crypto.subtle.exportKey('raw', recovered)) === hex(await crypto.subtle.exportKey('raw', content)));
+            """).AsString().Should().Be("encrypt+wrapKey|decrypt+unwrapKey|256|true");
+    }
+
+    [Fact]
+    public void RefusesToWrapAKeyThatIsNotExtractable()
+    {
+        // "Because the wrapKey method effectively exports the key, only keys marked as extractable may be
+        // wrapped" — step 10, and it is the same InvalidAccessError exportKey gives, made before any
+        // wrapping happens.
+        Run("""
+            const kek = await crypto.subtle.generateKey({ name: 'AES-KW', length: 128 }, false, ['wrapKey', 'unwrapKey']);
+            const sealed_ = await crypto.subtle.generateKey({ name: 'AES-CBC', length: 128 }, false, ['encrypt']);
+
+            try {
+                await crypto.subtle.wrapKey('raw', sealed_, kek, 'AES-KW');
+                return 'wrapped';
+            } catch (e) {
+                return e.name + '/' + (e.message.indexOf('not extractable') >= 0);
+            }
+            """).AsString().Should().Be("InvalidAccessError/true");
+    }
+
+    [Fact]
+    public void RefusesAWrappingKeyWithoutTheWrapKeyUsage()
+    {
+        // Steps 7 and 8, and their mirrors in unwrapKey: the wrapping key was made for this algorithm, and it
+        // permits this use. Both are InvalidAccessError, and the algorithm check comes first.
+        Run("""
+            const wrapOnly = await crypto.subtle.generateKey({ name: 'AES-KW', length: 128 }, false, ['wrapKey']);
+            const unwrapOnly = await crypto.subtle.generateKey({ name: 'AES-KW', length: 128 }, false, ['unwrapKey']);
+            const cbc = await crypto.subtle.generateKey({ name: 'AES-CBC', length: 128 }, false, ['encrypt', 'decrypt']);
+            const key = await crypto.subtle.generateKey({ name: 'AES-CBC', length: 128 }, true, ['encrypt']);
+
+            const outcomes = [];
+            const attempt = async fn => {
+                try { await fn(); outcomes.push('ok'); } catch (e) { outcomes.push(e.name); }
+            };
+
+            // A key that may unwrap but not wrap, and the reverse.
+            await attempt(() => crypto.subtle.wrapKey('raw', key, unwrapOnly, 'AES-KW'));
+            const wrapped = await crypto.subtle.wrapKey('raw', key, wrapOnly, 'AES-KW');
+            await attempt(() => crypto.subtle.unwrapKey(
+                'raw', wrapped, wrapOnly, 'AES-KW', { name: 'AES-CBC', length: 128 }, true, ['encrypt']));
+
+            // And a wrapping key made for another algorithm entirely.
+            await attempt(() => crypto.subtle.wrapKey('raw', key, cbc, 'AES-KW'));
+
+            return outcomes.join(',');
+            """).AsString().Should().Be("InvalidAccessError,InvalidAccessError,InvalidAccessError");
+    }
+
+    [Fact]
+    public void ReportsAnUnwrappedJwkThatIsNotOneThroughTheImportTaxonomy()
+    {
+        // Everything after the unwrapping is an import failure in the taxonomy that already exists — except
+        // the one failure "parse a JWK" owns, which is bytes that are not a JSON document at all. That is the
+        // shape a wrong unwrapping key produces under a cipher with no integrity check, so it is a real path
+        // and not a curiosity.
+        Run("""
+            const kek = await crypto.subtle.generateKey({ name: 'AES-KW', length: 256 }, false, ['wrapKey', 'unwrapKey']);
+            const raw = await crypto.subtle.importKey('raw', repeat(0, 16), 'AES-CBC', true, ['encrypt']);
+            const hmac = await crypto.subtle.generateKey({ name: 'HMAC', hash: 'SHA-256' }, true, ['sign']);
+
+            const outcomes = [];
+            const attempt = async fn => {
+                try { await fn(); outcomes.push('unwrapped'); } catch (e) { outcomes.push(e.name); }
+            };
+
+            // Sixteen zero bytes are a wrappable payload and are not JSON: a DataError from "parse a JWK".
+            const notJson = await crypto.subtle.wrapKey('raw', raw, kek, 'AES-KW');
+            await attempt(() => crypto.subtle.unwrapKey(
+                'jwk', notJson, kek, 'AES-KW', { name: 'AES-CBC', length: 128 }, true, ['encrypt']));
+
+            // A real JWK, but of the wrong key type for the algorithm being asked for: the DataError the
+            // import steps raise for a kty that is not what they name.
+            const octJwk = await crypto.subtle.wrapKey('jwk', hmac, kek, 'AES-KW');
+            await attempt(() => crypto.subtle.unwrapKey(
+                'jwk', octJwk, kek, 'AES-KW', { name: 'ECDSA', namedCurve: 'P-256' }, true, ['verify']));
+
+            // A usage the imported algorithm does not support is the SyntaxError its own first step raises,
+            // and an empty usages list for a secret key is the SyntaxError step 14 names.
+            await attempt(() => crypto.subtle.unwrapKey(
+                'jwk', octJwk, kek, 'AES-KW', { name: 'HMAC', hash: 'SHA-256' }, true, ['encrypt']));
+            await attempt(() => crypto.subtle.unwrapKey(
+                'jwk', octJwk, kek, 'AES-KW', { name: 'HMAC', hash: 'SHA-256' }, true, []));
+
+            // ... and the same bytes with the algorithm they actually describe.
+            await attempt(() => crypto.subtle.unwrapKey(
+                'jwk', octJwk, kek, 'AES-KW', { name: 'HMAC', hash: 'SHA-256' }, true, ['sign']));
+
+            return outcomes.join(',');
+            """).AsString().Should().Be("DataError,DataError,SyntaxError,SyntaxError,unwrapped");
+    }
+
+    [Fact]
+    public void ParsesTheJwkBeforeItRunsTheImportStepsAtAll()
+    {
+        // "Parse a JWK" is step 12 and the import operation is step 13, and the last thing the parse does is
+        // "If the kty field of key is not defined, then throw a DataError". That ordering is observable: HKDF
+        // registers importKey but refuses the jwk format with a NotSupportedError, so if the import ran first
+        // that is what a kty-less document would earn. It is a DataError instead, because the document never
+        // reached the import steps.
+        Run("""
+            const kek = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, false, ['unwrapKey', 'encrypt']);
+            const params = { name: 'AES-GCM', iv: repeat(2, 12) };
+            const wrapped = await crypto.subtle.encrypt(params, kek, ascii('{"foo":1}'));
+
+            const outcomes = [];
+            const attempt = async fn => {
+                try { await fn(); outcomes.push('unwrapped'); }
+                catch (e) { outcomes.push(e.name + ':' + (e.message.indexOf('no kty field') >= 0)); }
+            };
+
+            await attempt(() => crypto.subtle.unwrapKey(
+                'jwk', wrapped, kek, params, 'HKDF', false, ['deriveBits']));
+
+            // ... and the same document against an algorithm that does handle jwk, which reaches the very
+            // same failure at the very same step rather than the one its own kty check would have given.
+            await attempt(() => crypto.subtle.unwrapKey(
+                'jwk', wrapped, kek, params, { name: 'AES-CBC', length: 128 }, true, ['encrypt']));
+
+            return outcomes.join(',');
+            """).AsString().Should().Be("DataError:true,DataError:true");
+    }
+
+    [Fact]
+    public void HonoursAnExtFalseJsonWebKeyOnTheWayBackIn()
+    {
+        // The asymmetry the specification's own note describes: wrapKey cannot produce a JWK marked
+        // non-extractable, because it can only wrap an extractable key — but unwrapKey reads the member, "so
+        // that wrapped non-extractable keys created elsewhere, for example by a server, can be unwrapped
+        // using this API".
+        Run("""
+            // `encrypt` is here only so the test can play the part of the server that produced the bytes.
+            const kek = await crypto.subtle.generateKey(
+                { name: 'AES-GCM', length: 256 }, false, ['unwrapKey', 'encrypt']);
+            const params = { name: 'AES-GCM', iv: repeat(1, 12) };
+
+            // A JWK a server might have produced, with ext: false, encrypted with the wrapping key.
+            const jwk = JSON.stringify({ kty: 'oct', alg: 'A128CBC', k: 'AAAAAAAAAAAAAAAAAAAAAA', ext: false });
+            const wrapped = await crypto.subtle.encrypt(params, kek, Uint8Array.from(jwk, c => c.charCodeAt(0)));
+
+            const outcomes = [];
+            try {
+                const key = await crypto.subtle.unwrapKey(
+                    'jwk', wrapped, kek, params, { name: 'AES-CBC', length: 128 }, false, ['encrypt']);
+                outcomes.push('extractable=' + key.extractable);
+            } catch (e) { outcomes.push(e.name); }
+
+            // Asking for it as an extractable key is the DataError the import steps raise.
+            try {
+                await crypto.subtle.unwrapKey(
+                    'jwk', wrapped, kek, params, { name: 'AES-CBC', length: 128 }, true, ['encrypt']);
+                outcomes.push('unwrapped');
+            } catch (e) { outcomes.push(e.name); }
+
+            return outcomes.join(',');
+            """).AsString().Should().Be("extractable=false,DataError");
+    }
+
+    [Fact]
+    public void NormalizesForWrapKeyFirstAndForTheCipherOperationSecond()
+    {
+        // Step 2 of both methods: normalize for wrapKey and, "if an error occurred", for encrypt instead. The
+        // two registries are disjoint, so which route a name takes is decided entirely by its own
+        // registration — and a name in neither is reported against the *encrypt* registry, because that is
+        // the normalization that ran last.
+        Run("""
+            const kw = await crypto.subtle.generateKey({ name: 'AES-KW', length: 128 }, false, ['wrapKey', 'unwrapKey']);
+            const gcm = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 128 }, false, ['wrapKey', 'unwrapKey']);
+            const key = await crypto.subtle.generateKey({ name: 'AES-CBC', length: 128 }, true, ['encrypt']);
+
+            const outcomes = [];
+            const attempt = async fn => {
+                try { await fn(); outcomes.push('ok'); }
+                catch (e) { outcomes.push(e.name + (e.message.indexOf('encrypt operation') >= 0 ? '/encrypt' : '')); }
+            };
+
+            // AES-KW takes the wrap route; AES-GCM the encrypt route, which needs its own parameters.
+            await attempt(() => crypto.subtle.wrapKey('raw', key, kw, 'AES-KW'));
+            await attempt(() => crypto.subtle.wrapKey('raw', key, gcm, { name: 'AES-GCM', iv: repeat(0, 12) }));
+
+            // An unregistered name fails against the encrypt registry, which is the second normalization.
+            await attempt(() => crypto.subtle.wrapKey('raw', key, kw, 'AES-XTS'));
+
+            // And AES-KW itself is not in the encrypt registry at all, which is what makes the two routes
+            // disjoint rather than merely ordered. That one names the encrypt registry for the ordinary
+            // reason — it *is* an encrypt call — where the row above it names it because of the fallback.
+            await attempt(() => crypto.subtle.encrypt({ name: 'AES-KW' }, kw, new Uint8Array(16)));
+
+            return outcomes.join(',');
+            """).AsString().Should().Be("ok,ok,NotSupportedError/encrypt,NotSupportedError/encrypt");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // Feature detection: twelve of twelve
+    // ---------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void ExposesAllTwelveOperationsWithTheirIdlNameAndArity()
+    {
+        var engine = WebEngine();
+
+        // WebIDL's length counts the required arguments only: wrapKey declares four and unwrapKey seven,
+        // which are all of theirs. deriveBits stays 2 because its `length` is optional and nullable.
+        engine.Evaluate("""
+            ['digest', 'sign', 'verify', 'encrypt', 'decrypt', 'generateKey', 'importKey', 'exportKey',
+             'deriveBits', 'deriveKey', 'wrapKey', 'unwrapKey']
+                .map(name => name + ':' + typeof crypto.subtle[name] + ':' + crypto.subtle[name].length
+                    + ':' + crypto.subtle[name].name).join(',')
+            """).AsString().Should().Be(
+                "digest:function:2:digest,sign:function:3:sign,verify:function:4:verify,"
+                + "encrypt:function:3:encrypt,decrypt:function:3:decrypt,generateKey:function:3:generateKey,"
+                + "importKey:function:5:importKey,exportKey:function:2:exportKey,"
+                + "deriveBits:function:2:deriveBits,deriveKey:function:5:deriveKey,"
+                + "wrapKey:function:4:wrapKey,unwrapKey:function:7:unwrapKey");
+
+        // Own properties with an ECMAScript built-in method's attributes, as every other operation is.
+        engine.Evaluate("JSON.stringify(Object.keys(crypto.subtle))").AsString().Should().Be("[]");
+
+        var descriptor = engine.Evaluate("Object.getOwnPropertyDescriptor(crypto.subtle, 'wrapKey')").AsObject();
+        descriptor.Get("writable").AsBoolean().Should().BeTrue();
+        descriptor.Get("configurable").AsBoolean().Should().BeTrue();
+        descriptor.Get("enumerable").AsBoolean().Should().BeFalse();
+    }
+
+    [Theory]
+    // AES-KW registers wrapKey, unwrapKey, generateKey, importKey, exportKey and get key length — and nothing
+    // else, so every cipher and signature operation is a NotSupportedError.
+    [InlineData("sign", "'AES-KW'")]
+    [InlineData("verify", "'AES-KW'")]
+    [InlineData("encrypt", "'AES-KW'")]
+    [InlineData("decrypt", "'AES-KW'")]
+    [InlineData("deriveBits", "'AES-KW'")]
+    // ... and the three ciphers are the reverse: they encrypt and decrypt and never wrap.
+    [InlineData("sign", "'AES-CBC'")]
+    [InlineData("verify", "'AES-CTR'")]
+    [InlineData("deriveBits", "'AES-CBC'")]
+    public void RefusesAnOperationTheAesAlgorithmIsNotRegisteredFor(string operation, string algorithm)
+    {
+        var engine = WebEngine();
+
+        var call = operation switch
+        {
+            "sign" => $"crypto.subtle.sign({algorithm}, key, new Uint8Array(0))",
+            "verify" => $"crypto.subtle.verify({algorithm}, key, new Uint8Array(0), new Uint8Array(0))",
+            "encrypt" => $"crypto.subtle.encrypt({algorithm}, key, new Uint8Array(16))",
+            "decrypt" => $"crypto.subtle.decrypt({algorithm}, key, new Uint8Array(16))",
+            _ => $"crypto.subtle.deriveBits({algorithm}, key, 128)",
+        };
+
+        Settle(engine, $$"""
+            crypto.subtle.generateKey({ name: 'AES-KW', length: 128 }, false, ['wrapKey', 'unwrapKey'])
+                .then(key => {{call}})
+                .then(() => 'succeeded', e => e.name + '/' + e.code)
+            """).AsString().Should().Be("NotSupportedError/9");
+    }
+
+    [Theory]
+    // Only AES-KW is registered for wrapKey and unwrapKey, so a name in neither that registry nor the
+    // encrypt/decrypt one is a NotSupportedError — HMAC and the signature algorithms cannot wrap.
+    [InlineData("'HMAC'")]
+    [InlineData("'RSASSA-PKCS1-v1_5'")]
+    [InlineData("'ECDSA'")]
+    [InlineData("'PBKDF2'")]
+    [InlineData("'AES-XTS'")]
+    public void RefusesAWrappingAlgorithmThatIsInNeitherRegistry(string algorithm)
+    {
+        var engine = WebEngine();
+
+        Settle(engine, $$"""
+            (async () => {
+                const kek = await crypto.subtle.generateKey({ name: 'AES-KW', length: 128 }, false, ['wrapKey', 'unwrapKey']);
+                const key = await crypto.subtle.generateKey({ name: 'AES-CBC', length: 128 }, true, ['encrypt']);
+                return crypto.subtle.wrapKey('raw', key, kek, {{algorithm}}).then(() => 'wrapped', e => e.name);
+            })()
+            """).AsString().Should().Be("NotSupportedError");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // Nothing erupts
+    // ---------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void NoAesOperationEverThrowsSynchronouslyOrLeaksACryptographicException()
+    {
+        var engine = WebEngine();
+
+        // A promise-returning WebIDL operation reports every failure as a rejection, and the failures the
+        // platform's own cryptography raises are no exception: a CryptographicException reaching the host
+        // would be a CLR exception erupting out of a promise-returning API.
+        engine.Evaluate("""
+            (() => {
+                const calls = [
+                    () => crypto.subtle.importKey('raw', new Uint8Array(7), 'AES-CBC', false, ['encrypt']),
+                    () => crypto.subtle.importKey('jwk', { kty: 'oct', k: '' }, 'AES-KW', false, ['wrapKey']),
+                    () => crypto.subtle.generateKey({ name: 'AES-CTR', length: 64 }, false, ['encrypt']),
+                    () => crypto.subtle.wrapKey('raw', 42, 42, 'AES-KW'),
+                    () => crypto.subtle.unwrapKey('raw', new Uint8Array(24), 42, 'AES-KW', 'AES-CBC', true, ['encrypt']),
+                ];
+
+                return calls.map(call => {
+                    const promise = call();
+                    return (promise instanceof Promise) + ':' + typeof promise.then;
+                }).join(',');
+            })()
+            """).AsString().Should().Be(
+                "true:function,true:function,true:function,true:function,true:function");
+
+        // ... and each of them settles as a rejection of the kind the specification names, with nothing of
+        // the CLR in it. The last two are WebIDL conversion failures, which are TypeErrors and not
+        // DOMExceptions — the brand check of a CryptoKey argument runs before any step of the method.
+        Settle(engine, """
+            Promise.all([
+                crypto.subtle.importKey('raw', new Uint8Array(7), 'AES-CBC', false, ['encrypt']).catch(e => e.name),
+                crypto.subtle.importKey('jwk', { kty: 'oct', k: '' }, 'AES-KW', false, ['wrapKey']).catch(e => e.name),
+                crypto.subtle.generateKey({ name: 'AES-CTR', length: 64 }, false, ['encrypt']).catch(e => e.name),
+                crypto.subtle.wrapKey('raw', 42, 42, 'AES-KW').catch(e => e.constructor.name),
+                crypto.subtle.unwrapKey('raw', new Uint8Array(24), 42, 'AES-KW', 'AES-CBC', true, ['encrypt']).catch(e => e.constructor.name),
+            ]).then(names => names.join(','))
+            """).AsString().Should().Be("DataError,DataError,OperationError,TypeError,TypeError");
+    }
+
+    [Fact]
+    public void RunsEveryArgumentConversionBeforeAnyStepOfTheMethod()
+    {
+        var engine = WebEngine();
+
+        // WebIDL converts the arguments in order before the body runs, so the KeyFormat enumeration of
+        // parameter 1 outranks the CryptoKey brand check of parameter 2, which outranks the algorithm
+        // normalization of step 2 — the same order every other operation here has.
+        Settle(engine, """
+            (async () => {
+                const kek = await crypto.subtle.generateKey({ name: 'AES-KW', length: 128 }, false, ['wrapKey']);
+                const key = await crypto.subtle.generateKey({ name: 'AES-CBC', length: 128 }, true, ['encrypt']);
+
+                const outcomes = [];
+                const attempt = async fn => {
+                    try { await fn(); outcomes.push('ok'); }
+                    catch (e) { outcomes.push(e.name === undefined ? e.constructor.name : e.name); }
+                };
+
+                await attempt(() => crypto.subtle.wrapKey('pem', key, kek, 'nonsense'));
+                await attempt(() => crypto.subtle.wrapKey('raw', {}, kek, 'nonsense'));
+                await attempt(() => crypto.subtle.wrapKey('raw', key, kek, 'nonsense'));
+
+                await attempt(() => crypto.subtle.unwrapKey('pem', new Uint8Array(24), kek, 'AES-KW', 'AES-CBC', true, ['encrypt']));
+                await attempt(() => crypto.subtle.unwrapKey('raw', 'not a buffer', kek, 'AES-KW', 'AES-CBC', true, ['encrypt']));
+                await attempt(() => crypto.subtle.unwrapKey('raw', new Uint8Array(24), kek, 'AES-KW', 'nonsense', true, ['encrypt']));
+
+                return outcomes.join(',');
+            })()
+            """).AsString().Should().Be(
+                "TypeError,TypeError,NotSupportedError,TypeError,TypeError,NotSupportedError");
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/SubtleCryptoKeyTests.cs
+++ b/Jint.Tests/Runtime/WebApi/SubtleCryptoKeyTests.cs
@@ -864,8 +864,8 @@ public class SubtleCryptoKeyTests
     [Theory]
     [InlineData("sign", "'X25519'")]
     [InlineData("verify", "'Ed25519'")]
-    [InlineData("encrypt", "'AES-CBC'")]
-    [InlineData("decrypt", "{ name: 'AES-CTR' }")]
+    [InlineData("encrypt", "'AES-XTS'")]
+    [InlineData("decrypt", "{ name: 'ChaCha20-Poly1305' }")]
     [InlineData("generateKey", "'HKDF'")]
     [InlineData("importKey", "'X25519'")]
     // An algorithm that is registered, but not for this operation: RSA-OAEP encrypts and never signs,
@@ -908,11 +908,12 @@ public class SubtleCryptoKeyTests
             """).AsString().Should().Be(
                 "function,function,function,function,function,function,function,function,function,function");
 
-        // Absent rather than present-and-throwing: `typeof crypto.subtle.wrapKey` is how a library that does
-        // cryptography decides whether it can, and it has to get the truthful answer.
+        // Key wrapping completes the interface — `typeof crypto.subtle.wrapKey` is how a library that does
+        // cryptography decides whether it can, and it has to get the truthful answer. See
+        // SubtleCryptoAesWrapTests for the operations themselves.
         engine.Evaluate("""
             ['wrapKey', 'unwrapKey'].filter(name => name in crypto.subtle).join(',')
-            """).AsString().Should().Be("");
+            """).AsString().Should().Be("wrapKey,unwrapKey");
     }
 
     [Fact]
@@ -924,12 +925,13 @@ public class SubtleCryptoKeyTests
         // `length` argument is `optional [EnforceRange] unsigned long? length = null`, so it does not count.
         // A browser predating that change to the IDL answers 3; Node, which has taken it, answers 2.
         engine.Evaluate("""
-            ['digest', 'sign', 'verify', 'encrypt', 'decrypt', 'generateKey', 'importKey', 'exportKey', 'deriveBits', 'deriveKey']
+            ['digest', 'sign', 'verify', 'encrypt', 'decrypt', 'generateKey', 'importKey', 'exportKey',
+             'deriveBits', 'deriveKey', 'wrapKey', 'unwrapKey']
                 .map(name => name + ':' + crypto.subtle[name].length + ':' + crypto.subtle[name].name).join(',')
             """).AsString().Should().Be(
                 "digest:2:digest,sign:3:sign,verify:4:verify,encrypt:3:encrypt,decrypt:3:decrypt,"
                 + "generateKey:3:generateKey,importKey:5:importKey,exportKey:2:exportKey,"
-                + "deriveBits:2:deriveBits,deriveKey:5:deriveKey");
+                + "deriveBits:2:deriveBits,deriveKey:5:deriveKey,wrapKey:4:wrapKey,unwrapKey:7:unwrapKey");
 
         engine.Evaluate("JSON.stringify(Object.keys(crypto.subtle))").AsString().Should().Be("[]");
     }

--- a/Jint.Tests/Runtime/WebApi/SubtleCryptoTests.cs
+++ b/Jint.Tests/Runtime/WebApi/SubtleCryptoTests.cs
@@ -487,13 +487,13 @@ public class SubtleCryptoTests
     }
 
     [Fact]
-    public void ExposesDigestAndTheKeyedOperationsAndKeyDerivationButNotKeyWrapping()
+    public void ExposesAllTwelveOperations()
     {
         var engine = WebEngine();
 
-        // Absent rather than present-and-throwing: a library checking `typeof crypto.subtle.wrapKey` before
-        // reaching for it has to get the truthful answer, which is the same reason `crypto.subtle` itself is
-        // absent from an engine without the crypto feature.
+        // The whole SubtleCrypto surface is here, which is what a library checking `typeof
+        // crypto.subtle.wrapKey` before reaching for it now finds. `crypto.subtle` itself remains absent from
+        // an engine without the crypto feature, which is the same promise one level up.
         engine.Evaluate("typeof crypto.subtle.digest").AsString().Should().Be("function");
 
         engine.Evaluate("""
@@ -502,7 +502,7 @@ public class SubtleCryptoTests
 
         engine.Evaluate("""
             ['wrapKey', 'unwrapKey'].filter(name => name in crypto.subtle).join(',')
-            """).AsString().Should().Be("");
+            """).AsString().Should().Be("wrapKey,unwrapKey");
 
         // As with crypto itself, the operation is an own property with a built-in method's attributes, so
         // enumeration sees nothing.

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -587,13 +587,15 @@ public enum WebApiFeatures
     /// <summary>
     /// The <c>crypto</c> object: <c>getRandomValues</c> and <c>randomUUID</c>, both backed by the BCL's
     /// cryptographically secure generator, plus <c>crypto.subtle</c> and the <c>CryptoKey</c> interface
-    /// object. <c>subtle</c> carries <c>digest</c> (SHA-1, SHA-256, SHA-384, SHA-512), <c>sign</c>,
-    /// <c>verify</c>, <c>encrypt</c>, <c>decrypt</c>, <c>generateKey</c>, <c>importKey</c>,
-    /// <c>exportKey</c>, <c>deriveBits</c> and <c>deriveKey</c> over HMAC, AES-GCM, RSASSA-PKCS1-v1_5,
-    /// RSA-PSS, RSA-OAEP, ECDSA, ECDH, HKDF and PBKDF2 — the elliptic-curve pair over P-256, P-384 and
-    /// P-521 — with the <c>raw</c>, <c>spki</c>, <c>pkcs8</c> and <c>jwk</c> key formats. Key <i>wrapping</i>
-    /// is not implemented and <c>wrapKey</c>/<c>unwrapKey</c> are absent rather than present-and-throwing, so
-    /// feature detection sees the truth. HKDF and PBKDF2 keys are <c>importKey</c>-only and never
+    /// object. <c>subtle</c> carries all twelve operations — <c>digest</c> (SHA-1, SHA-256, SHA-384,
+    /// SHA-512), <c>sign</c>, <c>verify</c>, <c>encrypt</c>, <c>decrypt</c>, <c>generateKey</c>,
+    /// <c>importKey</c>, <c>exportKey</c>, <c>deriveBits</c>, <c>deriveKey</c>, <c>wrapKey</c> and
+    /// <c>unwrapKey</c> — over HMAC, AES-CTR, AES-CBC, AES-GCM, AES-KW, RSASSA-PKCS1-v1_5, RSA-PSS,
+    /// RSA-OAEP, ECDSA, ECDH, HKDF and PBKDF2 — the AES family at 128, 192 and 256 bits and the
+    /// elliptic-curve pair over P-256, P-384 and P-521 — with the <c>raw</c>, <c>spki</c>, <c>pkcs8</c> and
+    /// <c>jwk</c> key formats. The registries are per operation and asymmetric: AES-KW wraps and unwraps and
+    /// never encrypts, where AES-CTR, AES-CBC, AES-GCM and RSA-OAEP encrypt and are reached for wrapping
+    /// through the specification's own fallback. HKDF and PBKDF2 keys are <c>importKey</c>-only and never
     /// extractable, which is what their own registrations say; and PBKDF2's iteration count is capped at
     /// 2^22 by this engine, because the loop is one uninterruptible call that no execution constraint can
     /// bound. Neither <c>subtle</c> nor <c>CryptoKey</c> has a flag of its own: <c>subtle</c> is a readonly

--- a/Jint/WebApi/Crypto/AesCbcAlgorithm.cs
+++ b/Jint/WebApi/Crypto/AesCbcAlgorithm.cs
@@ -1,0 +1,155 @@
+#if NET8_0_OR_GREATER
+using System.Security.Cryptography;
+
+namespace Jint.WebApi.Crypto;
+
+/// <summary>
+/// The AES-CBC <c>encrypt</c> and <c>decrypt</c> operations — https://w3c.github.io/webcrypto/#aes-cbc,
+/// "encryption and decryption using AES in Cipher Block Chaining mode, as described in [NIST-SP800-38A]".
+/// Its key management is <see cref="AesKeyManagement"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The padding is always there and is always PKCS#7.</b> "In the Web Crypto API, the only padding mode
+/// that is supported is that of PKCS#7", and the encrypt steps add it unconditionally — so a plaintext that
+/// is already a whole number of blocks gains a <i>whole extra block</i> of <c>0x10</c> bytes, and the
+/// ciphertext of the four NIST SP 800-38A example blocks is five blocks long here. There is no way to ask for
+/// an unpadded CBC through this API, which is what makes <c>decrypt</c> able to recover the exact length.
+/// </para>
+/// <para>
+/// <b>The padding check is written out rather than left to the platform.</b>
+/// <see cref="SymmetricAlgorithm.DecryptCbc(ReadOnlySpan{byte}, ReadOnlySpan{byte}, PaddingMode)"/> with
+/// <see cref="PaddingMode.PKCS7"/> would strip the padding itself, but what it does with padding that is
+/// <i>wrong</i> is the platform's business — .NET raises a <see cref="CryptographicException"/> whose message
+/// differs per implementation, and which of the two failures a given build reports first is not something to
+/// pin. So the decryption is asked for with <see cref="PaddingMode.None"/> and steps 4 to 6 are performed
+/// here, exactly as the specification numbers them: read the last octet, check every one of the last <c>p</c>
+/// octets against it, and remove them. That also makes the failure the specification's own
+/// <c>OperationError</c> rather than a CLR exception erupting out of a promise-returning operation.
+/// </para>
+/// <para>
+/// <b>A padding failure says nothing about which block was wrong.</b> One message covers every way the
+/// unpadding can fail, for the reason AES-GCM's decrypt gives: an attacker who can tell "the padding was
+/// malformed" from "the padding was fine" has a padding oracle, and CBC without an authentication tag is
+/// exactly the shape that attack was invented for. This engine cannot make CBC authenticated — the
+/// specification's algorithm is unauthenticated by construction — but it can decline to be the oracle's
+/// distinguisher, and the check runs over the whole padding rather than stopping at the first bad octet.
+/// </para>
+/// </remarks>
+internal static class AesCbcAlgorithm
+{
+    /// <summary>The AES block size in bytes, which is the <c>iv</c> length and the padding modulus <c>k</c>.</summary>
+    private const int BlockSize = AesCiphers.BlockSize;
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#aes-cbc-operations-encrypt
+    /// </summary>
+    internal static byte[] Encrypt(
+        CryptoContext context,
+        NormalizedAlgorithm normalized,
+        JsCryptoKey key,
+        ReadOnlySpan<byte> plaintext,
+        string what)
+    {
+        var iv = RequireIv(context, normalized, what);
+
+        using var aes = AesCiphers.Create(key);
+
+        try
+        {
+            // Steps 2 and 3 in one call: the BCL's own PKCS#7 padding is "the procedure defined in Section
+            // 10.3 of [RFC2315], step 2, with a value of k of 16" — k octets each holding k, and a whole
+            // block of them when the plaintext already ends on a boundary.
+            return aes.EncryptCbc(plaintext, iv, PaddingMode.PKCS7);
+        }
+        catch (Exception e) when (AesCiphers.IsCipherFailure(e))
+        {
+            context.ThrowOperationError(what + ": the data could not be encrypted.");
+            return null!;
+        }
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#aes-cbc-operations-decrypt
+    /// </summary>
+    internal static byte[] Decrypt(
+        CryptoContext context,
+        NormalizedAlgorithm normalized,
+        JsCryptoKey key,
+        ReadOnlySpan<byte> ciphertext,
+        string what)
+    {
+        var iv = RequireIv(context, normalized, what);
+
+        // Step 2: "If the length of ciphertext is zero or is not a multiple of 16 bytes, then throw an
+        // OperationError." The empty ciphertext is refused rather than answered with the empty plaintext,
+        // because an AES-CBC encryption of anything is at least one padding block long.
+        if (ciphertext.Length == 0 || ciphertext.Length % BlockSize != 0)
+        {
+            context.ThrowOperationError(
+                what + ": the ciphertext is " + ciphertext.Length
+                + " bytes long, and an AES-CBC ciphertext is a non-zero whole number of 16-byte blocks.");
+        }
+
+        using var aes = AesCiphers.Create(key);
+
+        byte[] paddedPlaintext;
+
+        try
+        {
+            // Step 3, with the unpadding left to steps 4 to 6 below — see the remarks on this class.
+            paddedPlaintext = aes.DecryptCbc(ciphertext, iv, PaddingMode.None);
+        }
+        catch (Exception e) when (AesCiphers.IsCipherFailure(e))
+        {
+            // The same message the padding check below gives, so that a platform which refuses something
+            // here and a padding that is merely wrong are one answer rather than two.
+            context.ThrowOperationError(what + ": the data could not be decrypted.");
+            return null!;
+        }
+
+        // Steps 4 and 5: "Let p be the value of the last octet of paddedPlaintext. If p is zero or greater
+        // than 16, or if any of the last p octets of paddedPlaintext have a value which is not p, then throw
+        // an OperationError."
+        var p = paddedPlaintext[paddedPlaintext.Length - 1];
+        var valid = p is > 0 and <= BlockSize;
+
+        // Every octet of the claimed padding is examined even once one has already failed, so that the time
+        // taken does not report how much of the padding was right.
+        for (var i = 1; i <= BlockSize; i++)
+        {
+            var inPadding = i <= p;
+            var octet = paddedPlaintext[paddedPlaintext.Length - i];
+            valid &= !inPadding || octet == p;
+        }
+
+        if (!valid)
+        {
+            CryptographicOperations.ZeroMemory(paddedPlaintext);
+            context.ThrowOperationError(what + ": the data could not be decrypted.");
+        }
+
+        // Step 6: "Let plaintext be the result of removing p octets from the end of paddedPlaintext."
+        var plaintext = paddedPlaintext.AsSpan(0, paddedPlaintext.Length - p).ToArray();
+        CryptographicOperations.ZeroMemory(paddedPlaintext);
+        return plaintext;
+    }
+
+    /// <summary>
+    /// Step 1 of both operations: "If the iv member of normalizedAlgorithm does not have a length of 16
+    /// bytes, then throw an OperationError." Unlike AES-GCM's, this restriction is the algorithm's own and
+    /// not the platform's — CBC's IV is one block by definition.
+    /// </summary>
+    private static byte[] RequireIv(CryptoContext context, NormalizedAlgorithm normalized, string what)
+    {
+        var iv = normalized.Iv!;
+        if (iv.Length != BlockSize)
+        {
+            context.ThrowOperationError(
+                what + ": the iv is " + iv.Length + " bytes long, and an AES-CBC iv is exactly 16 bytes — one AES block.");
+        }
+
+        return iv;
+    }
+}
+#endif

--- a/Jint/WebApi/Crypto/AesCiphers.cs
+++ b/Jint/WebApi/Crypto/AesCiphers.cs
@@ -1,0 +1,51 @@
+#if NET8_0_OR_GREATER
+using System.Security.Cryptography;
+
+namespace Jint.WebApi.Crypto;
+
+/// <summary>
+/// The two things AES-CBC, AES-CTR and AES-KW each need from the block cipher itself: an <see cref="Aes"/>
+/// carrying a key's material, and one predicate deciding which exceptions the platform's cipher may raise.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The exception predicate is deliberately wider than <see cref="CryptographicException"/>.</b> This
+/// folder has already learned twice that guessing which exception type a platform picks — and which step it
+/// picks it at — is how a CLR exception ends up erupting out of a promise-returning operation:
+/// <see cref="EcAlgorithm"/> records <see cref="PlatformNotSupportedException"/> for a point that is not on
+/// its curve and <see cref="ArgumentException"/> for a key-size mismatch, neither of which is a
+/// <see cref="CryptographicException"/>. The one-shot <see cref="SymmetricAlgorithm"/> methods used here
+/// report a length they will not accept as an <see cref="ArgumentException"/> and a key they will not accept
+/// as a <see cref="CryptographicException"/>, and every such condition is checked before the call — so this
+/// catches nothing on any measured path and exists as the backstop rather than the mechanism.
+/// </para>
+/// <para>
+/// What it must <b>not</b> catch is everything else a <see cref="Exception"/> can be: an execution
+/// constraint, a cancellation or a stack-depth overflow is not a failure of the cipher and turning one into
+/// an <c>OperationError</c> would mean a constraint that no longer bounds anything. Naming the three types
+/// rather than catching broadly is what keeps that true.
+/// </para>
+/// </remarks>
+internal static class AesCiphers
+{
+    /// <summary>The AES block size in bytes — the one constant all three modes are written against.</summary>
+    internal const int BlockSize = 16;
+
+    /// <summary>
+    /// An <see cref="Aes"/> holding the key's material. The bytes are copied because
+    /// <see cref="SymmetricAlgorithm.Key"/> is a <c>byte[]</c> property that keeps what it is given, and the
+    /// <c>[[handle]]</c> of a <see cref="JsCryptoKey"/> is not something to hand to anything that outlives
+    /// the call — the object is disposed inside the operation that created it.
+    /// </summary>
+    internal static Aes Create(JsCryptoKey key)
+    {
+        var aes = Aes.Create();
+        aes.Key = key.Handle.ToArray();
+        return aes;
+    }
+
+    /// <summary>See the remarks on this class: the backstop, not the mechanism.</summary>
+    internal static bool IsCipherFailure(Exception exception)
+        => exception is CryptographicException or ArgumentException or PlatformNotSupportedException;
+}
+#endif

--- a/Jint/WebApi/Crypto/AesCtrAlgorithm.cs
+++ b/Jint/WebApi/Crypto/AesCtrAlgorithm.cs
@@ -1,0 +1,189 @@
+#if NET8_0_OR_GREATER
+using System.Security.Cryptography;
+
+namespace Jint.WebApi.Crypto;
+
+/// <summary>
+/// The AES-CTR <c>encrypt</c> and <c>decrypt</c> operations — https://w3c.github.io/webcrypto/#aes-ctr,
+/// "encryption and decryption using AES in Counter mode, as described in [NIST-SP800-38A]". Its key
+/// management is <see cref="AesKeyManagement"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Encryption and decryption are one operation.</b> CTR turns the block cipher into a keystream generator
+/// and the data is exclusive-ored with it, so the two directions differ in nothing at all — the specification
+/// writes them out twice with the words "plaintext" and "ciphertext" exchanged, and
+/// <see cref="Transform"/> is both.
+/// </para>
+/// <para>
+/// <b>The counter is hand-rolled because the BCL has no CTR mode</b>, and it has to be: the increment is over
+/// <i>the rightmost <c>length</c> bits</i> of the block, "the rest of the counter block is for the nonce" and
+/// stays fixed, and the counter field wraps modulo 2^length rather than carrying into the nonce. .NET's
+/// <see cref="Aes"/> offers ECB, CBC and CFB; the keystream is therefore built by encrypting successive
+/// counter blocks with <see cref="PaddingMode.None"/> ECB, which is exactly the "forward cipher function"
+/// Section 6.5 of [NIST-SP800-38A] applies. Nothing here is ECB <i>encryption</i> of the caller's data — the
+/// data never enters the cipher.
+/// </para>
+/// <para>
+/// <b>The wrap is required, not merely tolerated.</b> A <c>length</c> of 32 with a counter field at
+/// <c>0xFFFFFFFF</c> continues at zero, leaving the leftmost 96 bits untouched, and the specification says so
+/// by pointing at Appendix B.1 of [NIST-SP800-38A] — the standard incrementing function is defined modulo
+/// 2^m. The web-platform tests pin exactly that case, so an implementation that carried into the nonce, or
+/// that treated the whole block as one integer, would produce a keystream nobody else produces.
+/// </para>
+/// <para>
+/// <b>Nothing stops a caller from reusing a counter block</b>, and nothing can: CTR's security rests entirely
+/// on never encrypting two messages under one (key, counter) pair, and the counter is a caller-supplied
+/// parameter. Neither this engine nor a browser tracks it. The same is true of a message long enough to
+/// exhaust a short counter field and wrap back onto its own keystream, which is a real hazard of a small
+/// <c>length</c> and is the caller's to avoid.
+/// </para>
+/// </remarks>
+internal static class AesCtrAlgorithm
+{
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#aes-ctr-operations-encrypt
+    /// </summary>
+    internal static byte[] Encrypt(
+        CryptoContext context,
+        NormalizedAlgorithm normalized,
+        JsCryptoKey key,
+        ReadOnlySpan<byte> plaintext,
+        string what)
+        => Transform(context, normalized, key, plaintext, what);
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#aes-ctr-operations-decrypt, whose steps are the encrypt steps with
+    /// the two words exchanged — see the remarks on this class.
+    /// </summary>
+    internal static byte[] Decrypt(
+        CryptoContext context,
+        NormalizedAlgorithm normalized,
+        JsCryptoKey key,
+        ReadOnlySpan<byte> ciphertext,
+        string what)
+        => Transform(context, normalized, key, ciphertext, what);
+
+    /// <summary>
+    /// "The CTR Encryption operation described in Section 6.5 of [NIST-SP800-38A] using AES as the block
+    /// cipher, the counter member of normalizedAlgorithm as the initial value of the counter block, the
+    /// length member of normalizedAlgorithm as the input parameter m to the standard counter block
+    /// incrementing function defined in Appendix B.1".
+    /// </summary>
+    private static byte[] Transform(
+        CryptoContext context,
+        NormalizedAlgorithm normalized,
+        JsCryptoKey key,
+        ReadOnlySpan<byte> data,
+        string what)
+    {
+        // Step 1: "If the counter member of normalizedAlgorithm does not have a length of 16 bytes, then
+        // throw an OperationError."
+        var counter = normalized.Counter!;
+        if (counter.Length != AesCiphers.BlockSize)
+        {
+            context.ThrowOperationError(
+                what + ": the counter is " + counter.Length
+                + " bytes long, and an AES-CTR counter block is exactly 16 bytes — one AES block.");
+        }
+
+        // Step 2: "If the length member of normalizedAlgorithm is zero or is greater than 128, then throw an
+        // OperationError." The member's IDL type is `octet`, so 256 was already a TypeError during
+        // normalization; 0 and 129 are inside an octet and are refused here.
+        var counterLength = normalized.CounterLength!.Value;
+        if (counterLength is 0 or > 128)
+        {
+            context.ThrowOperationError(
+                what + ": " + counterLength
+                + " is not a valid AES-CTR counter length; the counter field is between 1 and 128 bits of the counter block.");
+        }
+
+        var result = new byte[data.Length];
+        if (data.Length == 0)
+        {
+            // A zero-length message needs no keystream at all, and asking for one would encrypt a counter
+            // block whose only use would be to be discarded.
+            return result;
+        }
+
+        using var aes = AesCiphers.Create(key);
+
+        Span<byte> block = stackalloc byte[AesCiphers.BlockSize];
+        Span<byte> keystream = stackalloc byte[AesCiphers.BlockSize];
+        counter.CopyTo(block);
+
+        try
+        {
+            for (var offset = 0; offset < data.Length; offset += AesCiphers.BlockSize)
+            {
+                // The forward cipher function applied to the counter block. PaddingMode.None is what makes
+                // this one block in and one block out rather than a padded two.
+                aes.EncryptEcb(block, keystream, PaddingMode.None);
+
+                var count = Math.Min(AesCiphers.BlockSize, data.Length - offset);
+                for (var i = 0; i < count; i++)
+                {
+                    result[offset + i] = (byte) (data[offset + i] ^ keystream[i]);
+                }
+
+                Increment(block, counterLength);
+            }
+        }
+        catch (Exception e) when (AesCiphers.IsCipherFailure(e))
+        {
+            CryptographicOperations.ZeroMemory(result);
+            context.ThrowOperationError(what + ": the data could not be transformed.");
+            return null!;
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(keystream);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// The standard incrementing function of Appendix B.1 of [NIST-SP800-38A], applied to the rightmost
+    /// <paramref name="counterLength"/> bits of <paramref name="block"/>: "the counter bits are interpreted
+    /// as a big-endian integer and incremented by one", modulo 2^m, with everything to their left left alone.
+    /// </summary>
+    /// <remarks>
+    /// The window rarely lands on a byte boundary, so the last byte it reaches is only partly its own: with
+    /// <c>length</c> 12 the counter is the low four bits of byte 14 and all of byte 15, and the high four
+    /// bits of byte 14 are nonce. The loop therefore carries through the whole bytes first and finishes with
+    /// a masked add on the partial one — the carry out of the counter field is dropped rather than propagated
+    /// into the nonce, which is what makes the field wrap modulo 2^m.
+    /// </remarks>
+    private static void Increment(Span<byte> block, int counterLength)
+    {
+        var wholeBytes = counterLength / 8;
+        var partialBits = counterLength % 8;
+
+        // The whole bytes at the right-hand end, least significant first.
+        for (var i = 0; i < wholeBytes; i++)
+        {
+            var index = block.Length - 1 - i;
+            block[index]++;
+            if (block[index] != 0)
+            {
+                // No carry out of this byte, so nothing above it changes.
+                return;
+            }
+        }
+
+        if (partialBits == 0)
+        {
+            // The field is a whole number of bytes and every one of them wrapped: the counter is back at
+            // zero, and the carry stops here rather than reaching the nonce.
+            return;
+        }
+
+        // The partial byte: increment only the low `partialBits` of it, and put the untouched high bits back.
+        var partialIndex = block.Length - 1 - wholeBytes;
+        var mask = (byte) ((1 << partialBits) - 1);
+        var incremented = (byte) ((block[partialIndex] + 1) & mask);
+        block[partialIndex] = (byte) ((block[partialIndex] & ~mask) | incremented);
+    }
+}
+#endif

--- a/Jint/WebApi/Crypto/AesGcmAlgorithm.cs
+++ b/Jint/WebApi/Crypto/AesGcmAlgorithm.cs
@@ -1,13 +1,13 @@
 #if NET8_0_OR_GREATER
 using System.Security.Cryptography;
-using Jint.Native;
-using Jint.Runtime;
 
 namespace Jint.WebApi.Crypto;
 
 /// <summary>
-/// The AES-GCM operations — https://w3c.github.io/webcrypto/#aes-gcm, "authenticated encryption and
-/// decryption using AES in Galois/Counter Mode mode, as described in [NIST-SP800-38D]".
+/// The AES-GCM <c>encrypt</c> and <c>decrypt</c> operations — https://w3c.github.io/webcrypto/#aes-gcm,
+/// "authenticated encryption and decryption using AES in Galois/Counter Mode mode, as described in
+/// [NIST-SP800-38D]". Its key management is <see cref="AesKeyManagement"/>, shared with the three other AES
+/// algorithms whose steps are the same four to the letter.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -39,156 +39,11 @@ namespace Jint.WebApi.Crypto;
 /// </remarks>
 internal static class AesGcmAlgorithm
 {
-    /// <summary>The usages an AES-GCM key may carry.</summary>
-    private const KeyUsage AllowedUsages = KeyUsage.Encrypt | KeyUsage.Decrypt | KeyUsage.WrapKey | KeyUsage.UnwrapKey;
-
     /// <summary>The only nonce length <see cref="AesGcm"/> accepts, in bytes.</summary>
     private const int SupportedIvLength = 12;
 
     /// <summary>The default tag length in bits, "If the tagLength member of normalizedAlgorithm is not present".</summary>
     private const int DefaultTagLength = 128;
-
-    /// <summary>
-    /// https://w3c.github.io/webcrypto/#aes-gcm-operations-generate-key
-    /// </summary>
-    internal static (byte[] Handle, CryptoKeyAlgorithm Algorithm) GenerateKey(
-        CryptoContext context,
-        NormalizedAlgorithm normalized,
-        KeyUsage usages,
-        string what)
-    {
-        // Step 1.
-        if ((usages & ~AllowedUsages) != KeyUsage.None)
-        {
-            context.ThrowSyntaxError(
-                what + ": an AES-GCM key supports the usages encrypt, decrypt, wrapKey and unwrapKey, not " + KeyUsages.Describe(usages & ~AllowedUsages) + ".");
-        }
-
-        // Step 2: "If the length member of normalizedAlgorithm is not equal to one of 128, 192 or 256, then
-        // throw an OperationError."
-        var length = normalized.Length!.Value;
-        if (!IsValidKeyLength(length))
-        {
-            context.ThrowOperationError(what + ": " + length + " is not a valid AES key length (128, 192 or 256 bits).");
-        }
-
-        var handle = new byte[length / 8];
-        RandomNumberGenerator.Fill(handle);
-
-        return (handle, new CryptoKeyAlgorithm(AlgorithmNormalization.AesGcm, length, HashName: null));
-    }
-
-    /// <summary>
-    /// https://w3c.github.io/webcrypto/#aes-gcm-operations-import-key
-    /// </summary>
-    internal static (byte[] Handle, CryptoKeyAlgorithm Algorithm) ImportKey(
-        CryptoContext context,
-        KeyFormat format,
-        byte[]? rawData,
-        JsonWebKeyData? jwk,
-        bool extractable,
-        KeyUsage usages,
-        string what)
-    {
-        // Step 1.
-        if ((usages & ~AllowedUsages) != KeyUsage.None)
-        {
-            context.ThrowSyntaxError(
-                what + ": an AES-GCM key supports the usages encrypt, decrypt, wrapKey and unwrapKey, not " + KeyUsages.Describe(usages & ~AllowedUsages) + ".");
-        }
-
-        byte[] data;
-
-        switch (format)
-        {
-            case KeyFormat.Raw:
-                data = rawData!;
-                if (!IsValidKeyLength((uint) data.Length * 8))
-                {
-                    context.ThrowDataError(
-                        what + ": " + ((uint) data.Length * 8) + " is not a valid AES key length (128, 192 or 256 bits).");
-                }
-
-                break;
-
-            case KeyFormat.Jwk:
-                data = jwk!.RequireOctAndDecodeKey(context, what);
-
-                // "If the length in bits of data is 128 / 192 / 256: if the alg field of jwk is present and
-                // is not A128GCM / A192GCM / A256GCM, then throw a DataError. Otherwise: throw a DataError."
-                // The final "otherwise" is what catches a key of any other length, so the length check and
-                // the alg check are one step here rather than two.
-                if (!IsValidKeyLength((uint) data.Length * 8))
-                {
-                    context.ThrowDataError(
-                        what + ": " + ((uint) data.Length * 8) + " is not a valid AES key length (128, 192 or 256 bits).");
-                }
-
-                var expectedAlg = JwkAlgorithm((uint) data.Length * 8);
-                if (jwk.Alg is not null && !string.Equals(jwk.Alg, expectedAlg, StringComparison.Ordinal))
-                {
-                    context.ThrowDataError(
-                        what + ": the alg field of the JSON Web Key is '" + jwk.Alg + "' rather than '" + expectedAlg + "', which is what a " + (data.Length * 8) + "-bit AES-GCM key requires.");
-                }
-
-                jwk.ValidateUseKeyOpsAndExt(context, usages, extractable, "enc", what);
-                break;
-
-            default:
-                context.ThrowNotSupportedError(what + ": an AES-GCM key cannot be imported from the '" + KeyFormats.NameOf(format) + "' format.");
-                return default;
-        }
-
-        return (data, new CryptoKeyAlgorithm(AlgorithmNormalization.AesGcm, (uint) data.Length * 8, HashName: null));
-    }
-
-    /// <summary>
-    /// https://w3c.github.io/webcrypto/#aes-gcm-operations-get-key-length — "If the length member of
-    /// normalizedDerivedKeyAlgorithm is not 128, 192 or 256, then throw an OperationError. Return the length
-    /// member of normalizedDerivedKeyAlgorithm."
-    /// </summary>
-    /// <remarks>
-    /// The registered parameters are <c>AesDerivedKeyParams</c>, which is <c>AesKeyGenParams</c> declared a
-    /// second time under another name — one <c>required [EnforceRange] unsigned short length</c> — so the
-    /// member is already read and range-checked by the time this is called, and the three lengths AES has are
-    /// the whole of what is left to say.
-    /// </remarks>
-    internal static uint GetKeyLength(CryptoContext context, NormalizedAlgorithm normalized, string what)
-    {
-        var length = normalized.Length!.Value;
-
-        if (!IsValidKeyLength(length))
-        {
-            context.ThrowOperationError(what + ": " + length + " is not a valid AES key length (128, 192 or 256 bits).");
-        }
-
-        return length;
-    }
-
-    /// <summary>
-    /// https://w3c.github.io/webcrypto/#aes-gcm-operations-export-key
-    /// </summary>
-    internal static JsValue ExportKey(CryptoContext context, JsCryptoKey key, KeyFormat format, string what)
-    {
-        switch (format)
-        {
-            case KeyFormat.Raw:
-                // Copied on the way out: what a script is handed is mutable, and the key is not.
-                return context.CreateArrayBuffer(key.Handle.ToArray());
-
-            case KeyFormat.Jwk:
-                return JsonWebKeyData.CreateOctExport(
-                    context.Engine,
-                    key.Handle,
-                    JwkAlgorithm(key.Algorithm.Length),
-                    key.Usages,
-                    key.Extractable);
-
-            default:
-                context.ThrowNotSupportedError(what + ": an AES-GCM key cannot be exported to the '" + KeyFormats.NameOf(format) + "' format.");
-                return JsValue.Undefined;
-        }
-    }
 
     /// <summary>
     /// https://w3c.github.io/webcrypto/#aes-gcm-operations-encrypt
@@ -332,34 +187,6 @@ internal static class AesGcmAlgorithm
         }
 
         return new AesGcm(key.Handle, tagBytes);
-    }
-
-    /// <summary>The three key lengths AES has, in bits.</summary>
-    private static bool IsValidKeyLength(uint bits) => bits is 128 or 192 or 256;
-
-    /// <summary>
-    /// The JWK <c>alg</c> field naming an AES-GCM key of a given length —
-    /// https://www.rfc-editor.org/rfc/rfc7518#section-4.7.
-    /// </summary>
-    /// <remarks>
-    /// The three lengths AES has are spelled out and the default throws rather than one of them standing in
-    /// as the fallback: a key of another length labelled <c>A256GCM</c> would be a JWK naming an algorithm
-    /// it is not. The lengths have all been checked before a key exists, so the arm is unreachable.
-    /// </remarks>
-    private static string JwkAlgorithm(uint bits)
-    {
-        switch (bits)
-        {
-            case 128:
-                return "A128GCM";
-            case 192:
-                return "A192GCM";
-            case 256:
-                return "A256GCM";
-            default:
-                Throw.InvalidOperationException("Unhandled AES key length of " + bits + " bits.");
-                return null!;
-        }
     }
 }
 #endif

--- a/Jint/WebApi/Crypto/AesKeyManagement.cs
+++ b/Jint/WebApi/Crypto/AesKeyManagement.cs
@@ -1,0 +1,284 @@
+#if NET8_0_OR_GREATER
+using System.Security.Cryptography;
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.WebApi.Crypto;
+
+/// <summary>
+/// The <c>generateKey</c>, <c>importKey</c>, <c>exportKey</c> and <c>get key length</c> operations of the four
+/// AES algorithms — AES-CTR (https://w3c.github.io/webcrypto/#aes-ctr), AES-CBC
+/// (https://w3c.github.io/webcrypto/#aes-cbc), AES-GCM (https://w3c.github.io/webcrypto/#aes-gcm) and AES-KW
+/// (https://w3c.github.io/webcrypto/#aes-kw).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>All four write the same four operations out four times.</b> Read
+/// https://w3c.github.io/webcrypto/#aes-ctr-operations-import-key beside
+/// https://w3c.github.io/webcrypto/#aes-cbc-operations-import-key and the difference is two strings: the
+/// name the resulting <c>AesKeyAlgorithm</c> carries, and the JWK <c>alg</c> suffix the key material's length
+/// is spelled with (<c>A128CTR</c> against <c>A128CBC</c>). So the steps live here once, parameterized by the
+/// algorithm name, and each algorithm's own file holds only what is actually different about it — its
+/// cipher. The one place a third value is needed is step 1's usage set, which AES-KW alone narrows.
+/// </para>
+/// <para>
+/// <b>AES-KW's usage set is the reason step 1 is not shared as a constant.</b> Its registration lists
+/// <c>wrapKey</c> and <c>unwrapKey</c> and nothing else, where the three ciphers list all four — so
+/// <c>generateKey({ name: 'AES-KW', length: 128 }, false, ['encrypt'])</c> is a <c>SyntaxError</c> and the
+/// same request against AES-CBC is an ordinary key. That asymmetry is normative and is what
+/// <see cref="AllowedUsages"/> spells out.
+/// </para>
+/// <para>
+/// The key material is the raw bytes and nothing else: unlike every asymmetric algorithm here, an AES key has
+/// no DER form to hold, so the <c>[[handle]]</c> is what <c>importKey('raw', …)</c> was given and what
+/// <c>exportKey('raw', …)</c> hands back — a fresh copy, because script may write into what it is given.
+/// </para>
+/// </remarks>
+internal static class AesKeyManagement
+{
+    /// <summary>The usages an AES cipher key may carry — the set AES-CTR, AES-CBC and AES-GCM all name.</summary>
+    private const KeyUsage CipherUsages = KeyUsage.Encrypt | KeyUsage.Decrypt | KeyUsage.WrapKey | KeyUsage.UnwrapKey;
+
+    /// <summary>
+    /// The usages an AES-KW key may carry — "If usages contains an entry which is not one of 'wrapKey' or
+    /// 'unwrapKey', then throw a SyntaxError."
+    /// </summary>
+    private const KeyUsage KeyWrapUsages = KeyUsage.WrapKey | KeyUsage.UnwrapKey;
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#aes-ctr-operations-generate-key and its three siblings, which differ
+    /// only in step 1's usage set and in the name the <c>AesKeyAlgorithm</c> carries.
+    /// </summary>
+    internal static (byte[] Handle, CryptoKeyAlgorithm Algorithm) GenerateKey(
+        CryptoContext context,
+        string name,
+        NormalizedAlgorithm normalized,
+        KeyUsage usages,
+        string what)
+    {
+        // Step 1.
+        RequireUsagesWithin(context, usages, name, what);
+
+        // Step 2: "If the length member of normalizedAlgorithm is not equal to one of 128, 192 or 256, then
+        // throw an OperationError."
+        var length = normalized.Length!.Value;
+        if (!IsValidKeyLength(length))
+        {
+            context.ThrowOperationError(what + ": " + length + " is not a valid AES key length (128, 192 or 256 bits).");
+        }
+
+        var handle = new byte[length / 8];
+        RandomNumberGenerator.Fill(handle);
+
+        return (handle, new CryptoKeyAlgorithm(name, length, HashName: null));
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#aes-ctr-operations-import-key and its three siblings.
+    /// </summary>
+    internal static (byte[] Handle, CryptoKeyAlgorithm Algorithm) ImportKey(
+        CryptoContext context,
+        string name,
+        KeyFormat format,
+        byte[]? rawData,
+        JsonWebKeyData? jwk,
+        bool extractable,
+        KeyUsage usages,
+        string what)
+    {
+        // Step 1.
+        RequireUsagesWithin(context, usages, name, what);
+
+        byte[] data;
+
+        switch (format)
+        {
+            case KeyFormat.Raw:
+                data = rawData!;
+                if (!IsValidKeyLength((uint) data.Length * 8))
+                {
+                    context.ThrowDataError(
+                        what + ": " + ((uint) data.Length * 8) + " is not a valid AES key length (128, 192 or 256 bits).");
+                }
+
+                break;
+
+            case KeyFormat.Jwk:
+                data = jwk!.RequireOctAndDecodeKey(context, what);
+
+                // "If the length in bits of data is 128 / 192 / 256: if the alg field of jwk is present and
+                // is not A128CTR / A192CTR / A256CTR, then throw a DataError. Otherwise: throw a DataError."
+                // The final "otherwise" is what catches a key of any other length, so the length check and
+                // the alg check are one step here rather than two.
+                if (!IsValidKeyLength((uint) data.Length * 8))
+                {
+                    context.ThrowDataError(
+                        what + ": " + ((uint) data.Length * 8) + " is not a valid AES key length (128, 192 or 256 bits).");
+                }
+
+                var expectedAlg = JwkAlgorithm(name, (uint) data.Length * 8);
+                if (jwk.Alg is not null && !string.Equals(jwk.Alg, expectedAlg, StringComparison.Ordinal))
+                {
+                    context.ThrowDataError(
+                        what + ": the alg field of the JSON Web Key is '" + jwk.Alg + "' rather than '" + expectedAlg
+                        + "', which is what a " + (data.Length * 8) + "-bit " + name + " key requires.");
+                }
+
+                jwk.ValidateUseKeyOpsAndExt(context, usages, extractable, "enc", what);
+                break;
+
+            default:
+                context.ThrowNotSupportedError(
+                    what + ": an " + name + " key cannot be imported from the '" + KeyFormats.NameOf(format) + "' format.");
+                return default;
+        }
+
+        return (data, new CryptoKeyAlgorithm(name, (uint) data.Length * 8, HashName: null));
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#aes-ctr-operations-get-key-length and its three siblings — "If the
+    /// length member of normalizedDerivedKeyAlgorithm is not 128, 192 or 256, then throw an OperationError.
+    /// Return the length member of normalizedDerivedKeyAlgorithm."
+    /// </summary>
+    /// <remarks>
+    /// The registered parameters are <c>AesDerivedKeyParams</c>, which is <c>AesKeyGenParams</c> declared a
+    /// second time under another name — one <c>required [EnforceRange] unsigned short length</c> — so the
+    /// member is already read and range-checked by the time this is called, and the three lengths AES has are
+    /// the whole of what is left to say. Nothing about it depends on which of the four algorithms asked, which
+    /// is why this one takes no name.
+    /// </remarks>
+    internal static uint GetKeyLength(CryptoContext context, NormalizedAlgorithm normalized, string what)
+    {
+        var length = normalized.Length!.Value;
+
+        if (!IsValidKeyLength(length))
+        {
+            context.ThrowOperationError(what + ": " + length + " is not a valid AES key length (128, 192 or 256 bits).");
+        }
+
+        return length;
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#aes-ctr-operations-export-key and its three siblings.
+    /// </summary>
+    internal static JsValue ExportKey(CryptoContext context, JsCryptoKey key, KeyFormat format, string what)
+    {
+        var name = key.Algorithm.Name;
+
+        switch (format)
+        {
+            case KeyFormat.Raw:
+                // Copied on the way out: what a script is handed is mutable, and the key is not.
+                return context.CreateArrayBuffer(key.Handle.ToArray());
+
+            case KeyFormat.Jwk:
+                return JsonWebKeyData.CreateOctExport(
+                    context.Engine,
+                    key.Handle,
+                    JwkAlgorithm(name, key.Algorithm.Length),
+                    key.Usages,
+                    key.Extractable);
+
+            default:
+                context.ThrowNotSupportedError(
+                    what + ": an " + name + " key cannot be exported to the '" + KeyFormats.NameOf(format) + "' format.");
+                return JsValue.Undefined;
+        }
+    }
+
+    /// <summary>The three key lengths AES has, in bits.</summary>
+    internal static bool IsValidKeyLength(uint bits) => bits is 128 or 192 or 256;
+
+    /// <summary>
+    /// Step 1 of both <c>generateKey</c> and <c>importKey</c>: "If usages contains an entry which is not one
+    /// of … then throw a SyntaxError."
+    /// </summary>
+    private static void RequireUsagesWithin(CryptoContext context, KeyUsage usages, string name, string what)
+    {
+        var allowed = AllowedUsages(name);
+        var extra = usages & ~allowed;
+
+        if (extra != KeyUsage.None)
+        {
+            context.ThrowSyntaxError(
+                what + ": an " + name + " key supports the usages " + KeyUsages.Describe(allowed) + ", not "
+                + KeyUsages.Describe(extra) + ".");
+        }
+    }
+
+    /// <summary>
+    /// The usage set step 1 of each algorithm's <c>generateKey</c> and <c>importKey</c> names — see the
+    /// remarks on this class for why AES-KW's is the narrow one.
+    /// </summary>
+    /// <remarks>
+    /// Every registered AES name is spelled out and the default throws rather than one of them standing in as
+    /// the fallback, which is the convention every table in this folder follows: an algorithm added without a
+    /// case here would silently inherit whichever set was chosen as the default, and for a usage set that
+    /// means silently granting a use its registration does not.
+    /// </remarks>
+    private static KeyUsage AllowedUsages(string name)
+    {
+        switch (name)
+        {
+            case AlgorithmNormalization.AesCtr:
+            case AlgorithmNormalization.AesCbc:
+            case AlgorithmNormalization.AesGcm:
+                return CipherUsages;
+            case AlgorithmNormalization.AesKw:
+                return KeyWrapUsages;
+            default:
+                Throw.InvalidOperationException("Unhandled AES algorithm '" + name + "'.");
+                return default;
+        }
+    }
+
+    /// <summary>
+    /// The JWK <c>alg</c> field naming an AES key of a given algorithm and length —
+    /// https://www.rfc-editor.org/rfc/rfc7518#section-4.7 for the ciphers and #section-4.4 for AES-KW, which
+    /// is where the twelve names <c>A128CBC</c> … <c>A256KW</c> come from.
+    /// </summary>
+    /// <remarks>
+    /// Both halves are tables with a throwing default rather than a computation over the name: a key of a
+    /// length AES does not have, labelled <c>A256GCM</c>, would be a JWK naming an algorithm it is not, and an
+    /// algorithm whose suffix nobody chose would be labelled with whichever one happened to be last. Every
+    /// length has been checked before a key exists, so neither arm is reachable.
+    /// </remarks>
+    private static string JwkAlgorithm(string name, uint bits) => string.Concat("A", KeySizeName(bits), JwkSuffix(name));
+
+    private static string KeySizeName(uint bits)
+    {
+        switch (bits)
+        {
+            case 128:
+                return "128";
+            case 192:
+                return "192";
+            case 256:
+                return "256";
+            default:
+                Throw.InvalidOperationException("Unhandled AES key length of " + bits + " bits.");
+                return null!;
+        }
+    }
+
+    private static string JwkSuffix(string name)
+    {
+        switch (name)
+        {
+            case AlgorithmNormalization.AesCtr:
+                return "CTR";
+            case AlgorithmNormalization.AesCbc:
+                return "CBC";
+            case AlgorithmNormalization.AesGcm:
+                return "GCM";
+            case AlgorithmNormalization.AesKw:
+                return "KW";
+            default:
+                Throw.InvalidOperationException("Unhandled AES algorithm '" + name + "'.");
+                return null!;
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/Crypto/AesKwAlgorithm.cs
+++ b/Jint/WebApi/Crypto/AesKwAlgorithm.cs
@@ -1,0 +1,203 @@
+#if NET8_0_OR_GREATER
+using System.Security.Cryptography;
+
+namespace Jint.WebApi.Crypto;
+
+/// <summary>
+/// The AES-KW <c>wrap key</c> and <c>unwrap key</c> operations — https://w3c.github.io/webcrypto/#aes-kw,
+/// "key wrapping using AES, as described in [RFC3394]". Its key management is
+/// <see cref="AesKeyManagement"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>It is the only algorithm here registered for <c>wrapKey</c> and <c>unwrapKey</c>, and it is registered
+/// for nothing else.</b> There is no <c>encrypt</c> and no <c>decrypt</c>: RFC 3394 wrapping takes a whole
+/// number of 64-bit blocks, carries an integrity check of its own, and is not a general-purpose cipher — so
+/// <c>encrypt({ name: 'AES-KW' }, …)</c> is a <c>NotSupportedError</c>, in a browser too. Every other way to
+/// wrap a key in this engine — AES-GCM, AES-CBC, AES-CTR, RSA-OAEP — arrives through the <c>encrypt</c>
+/// registry instead, which is what the <c>wrapKey</c> method's second normalization is for.
+/// </para>
+/// <para>
+/// <b>The algorithm is hand-rolled because the BCL has no unpadded AES-KW.</b> .NET 8 has no key-wrap API at
+/// all, and .NET 10 added only the <i>padded</i> variant of RFC 5649 (<c>AesKwp</c>) — a different algorithm
+/// with a different initial value and a different ciphertext, which would silently interoperate with nobody.
+/// So Section 2.2.1 and 2.2.2 of [RFC3394] are written out here in their index-based form, over the ECB
+/// one-shots: 6n rounds, each one an AES block over <c>A | R[i]</c>, with the round counter <c>t</c>
+/// exclusive-ored into the 64-bit register <c>A</c>. The published test vectors of Section 4 are pinned
+/// byte-for-byte, which is the only way to check cryptography.
+/// </para>
+/// <para>
+/// <b>The wrapped payload has a floor of two blocks as well as a step of one.</b> The Web Cryptography API's
+/// own step is the multiple ("If plaintext is not a multiple of 64 bits in length, then throw an
+/// OperationError"), and the floor is the wrapping algorithm's: NIST SP 800-38F §6.1 defines KW over a
+/// plaintext of "2 ≤ n" semiblocks, and RFC 3394's 6n rounds degenerate for a single one. So the smallest
+/// wrappable payload is 16 bytes and the smallest unwrappable ciphertext is 24 — both reported as the
+/// <c>OperationError</c> the operation's own steps end in.
+/// </para>
+/// <para>
+/// <b>An unwrap that fails says only that it failed.</b> The integrity check is a comparison of the recovered
+/// <c>A</c> against the constant initial value, and it is made with
+/// <see cref="CryptographicOperations.FixedTimeEquals"/> against one message that carries nothing about how
+/// close the ciphertext came — the same discipline RSA-OAEP's decrypt keeps, and for the same reason: a
+/// distinguishable failure is an oracle. The recovered register file is zeroed before the throw, so nothing
+/// that failed its check survives the frame.
+/// </para>
+/// </remarks>
+internal static class AesKwAlgorithm
+{
+    /// <summary>The size of a 64-bit register — RFC 3394's <c>A</c> and each <c>R[i]</c> — in bytes.</summary>
+    private const int SemiBlockSize = 8;
+
+    /// <summary>
+    /// "The default initial value (IV) is defined to be the hexadecimal constant A6A6A6A6A6A6A6A6" —
+    /// https://www.rfc-editor.org/rfc/rfc3394#section-2.2.3.1, which is the value the Web Cryptography API's
+    /// steps name for both directions.
+    /// </summary>
+    private static ReadOnlySpan<byte> DefaultIv => [0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6];
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#aes-kw-operations-wrap-key — "the Key Wrap operation described in
+    /// Section 2.2.1 of [RFC3394] with plaintext as the plaintext to be wrapped and using the default Initial
+    /// Value defined in Section 2.2.3.1".
+    /// </summary>
+    internal static byte[] WrapKey(CryptoContext context, JsCryptoKey key, ReadOnlySpan<byte> plaintext, string what)
+    {
+        // Step 1, plus the floor the wrapping algorithm itself has — see the remarks on this class.
+        if (plaintext.Length % SemiBlockSize != 0 || plaintext.Length < 2 * SemiBlockSize)
+        {
+            context.ThrowOperationError(
+                what + ": the data to wrap is " + plaintext.Length
+                + " bytes long, and AES-KW wraps a whole number of 64-bit blocks, at least two of them.");
+        }
+
+        var n = plaintext.Length / SemiBlockSize;
+
+        // C[0] is A and C[1..n] are the registers, laid out in the buffer the operation returns so that the
+        // whole of step 2 runs in place — the index-based form of the algorithm, which RFC 3394 gives
+        // precisely so that no rotation is needed.
+        var buffer = new byte[plaintext.Length + SemiBlockSize];
+        DefaultIv.CopyTo(buffer);
+        plaintext.CopyTo(buffer.AsSpan(SemiBlockSize));
+
+        using var aes = AesCiphers.Create(key);
+
+        Span<byte> input = stackalloc byte[AesCiphers.BlockSize];
+        Span<byte> output = stackalloc byte[AesCiphers.BlockSize];
+
+        try
+        {
+            for (var j = 0; j < 6; j++)
+            {
+                for (var i = 1; i <= n; i++)
+                {
+                    // B = AES(K, A | R[i])
+                    buffer.AsSpan(0, SemiBlockSize).CopyTo(input);
+                    buffer.AsSpan(i * SemiBlockSize, SemiBlockSize).CopyTo(input.Slice(SemiBlockSize));
+                    aes.EncryptEcb(input, output, PaddingMode.None);
+
+                    // A = MSB(64, B) ^ t, where t = (n * j) + i.
+                    output.Slice(0, SemiBlockSize).CopyTo(buffer);
+                    XorCounter(buffer.AsSpan(0, SemiBlockSize), (long) n * j + i);
+
+                    // R[i] = LSB(64, B)
+                    output.Slice(SemiBlockSize).CopyTo(buffer.AsSpan(i * SemiBlockSize));
+                }
+            }
+        }
+        catch (Exception e) when (AesCiphers.IsCipherFailure(e))
+        {
+            CryptographicOperations.ZeroMemory(buffer);
+            context.ThrowOperationError(what + ": the key could not be wrapped.");
+            return null!;
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(input);
+            CryptographicOperations.ZeroMemory(output);
+        }
+
+        return buffer;
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#aes-kw-operations-unwrap-key — "the Key Unwrap operation described in
+    /// Section 2.2.2 of [RFC3394] … If the Key Unwrap operation returns an error, then throw an
+    /// OperationError."
+    /// </summary>
+    internal static byte[] UnwrapKey(CryptoContext context, JsCryptoKey key, ReadOnlySpan<byte> ciphertext, string what)
+    {
+        // A wrapped payload is (n + 1) blocks for n ≥ 2, so anything shorter than three blocks, or not a
+        // whole number of them, is an input the unwrap algorithm has no reading of at all. It is the same
+        // OperationError an integrity failure earns, because a ciphertext of the wrong shape and one of the
+        // right shape that does not verify are equally "this did not unwrap".
+        if (ciphertext.Length % SemiBlockSize != 0 || ciphertext.Length < 3 * SemiBlockSize)
+        {
+            context.ThrowOperationError(
+                what + ": the wrapped data is " + ciphertext.Length
+                + " bytes long, and an AES-KW ciphertext is a whole number of 64-bit blocks, at least three of them.");
+        }
+
+        var n = ciphertext.Length / SemiBlockSize - 1;
+
+        var buffer = ciphertext.ToArray();
+
+        using var aes = AesCiphers.Create(key);
+
+        Span<byte> input = stackalloc byte[AesCiphers.BlockSize];
+        Span<byte> output = stackalloc byte[AesCiphers.BlockSize];
+
+        try
+        {
+            for (var j = 5; j >= 0; j--)
+            {
+                for (var i = n; i >= 1; i--)
+                {
+                    // B = AES-1(K, (A ^ t) | R[i]), where t = (n * j) + i.
+                    buffer.AsSpan(0, SemiBlockSize).CopyTo(input);
+                    XorCounter(input.Slice(0, SemiBlockSize), (long) n * j + i);
+                    buffer.AsSpan(i * SemiBlockSize, SemiBlockSize).CopyTo(input.Slice(SemiBlockSize));
+                    aes.DecryptEcb(input, output, PaddingMode.None);
+
+                    // A = MSB(64, B); R[i] = LSB(64, B)
+                    output.Slice(0, SemiBlockSize).CopyTo(buffer);
+                    output.Slice(SemiBlockSize).CopyTo(buffer.AsSpan(i * SemiBlockSize));
+                }
+            }
+        }
+        catch (Exception e) when (AesCiphers.IsCipherFailure(e))
+        {
+            CryptographicOperations.ZeroMemory(buffer);
+            context.ThrowOperationError(what + ": the key could not be unwrapped.");
+            return null!;
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(input);
+            CryptographicOperations.ZeroMemory(output);
+        }
+
+        // Step 3: "If A is an appropriate initial value … Else Return an error." See the remarks on this
+        // class for why the comparison and the message are both indistinguishable.
+        if (!CryptographicOperations.FixedTimeEquals(buffer.AsSpan(0, SemiBlockSize), DefaultIv))
+        {
+            CryptographicOperations.ZeroMemory(buffer);
+            context.ThrowOperationError(what + ": the key could not be unwrapped.");
+        }
+
+        return buffer.AsSpan(SemiBlockSize).ToArray();
+    }
+
+    /// <summary>
+    /// <c>A ^ t</c>, where <c>t</c> is the round counter taken as a 64-bit big-endian integer — the one place
+    /// the algorithm's round number reaches the data, and what makes the 6n rounds distinguishable from one
+    /// another.
+    /// </summary>
+    private static void XorCounter(Span<byte> register, long t)
+    {
+        for (var k = 0; k < SemiBlockSize; k++)
+        {
+            register[SemiBlockSize - 1 - k] ^= (byte) (t >>> (8 * k));
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/Crypto/AlgorithmNormalization.cs
+++ b/Jint/WebApi/Crypto/AlgorithmNormalization.cs
@@ -12,15 +12,23 @@ namespace Jint.WebApi.Crypto;
 /// <summary>
 /// The operations <c>supportedAlgorithms</c> is keyed by —
 /// https://w3c.github.io/webcrypto/#algorithm-normalization-internal — restricted to the ones this engine
-/// implements. <c>wrapKey</c> and <c>unwrapKey</c> are absent because no method that would reach them exists.
+/// implements.
 /// </summary>
 /// <remarks>
+/// <para>
 /// <see cref="DeriveKey"/> is the one member that is <b>not</b> a key of that container. There is no
 /// "deriveKey" registry: the <c>deriveKey</c> method normalizes its <c>algorithm</c> for <c>deriveBits</c>
 /// and its <c>derivedKeyType</c> for both <c>importKey</c> and <c>get key length</c>, so the only thing the
 /// member names is the method — which is what <see cref="AlgorithmNormalization.NameOf"/> reports in an error
 /// message and what <c>SubtleCrypto</c> dispatches on.
 /// <see cref="AlgorithmNormalization.RegisteredFor"/> therefore refuses it rather than answering with a list.
+/// </para>
+/// <para>
+/// <see cref="WrapKey"/> and <see cref="UnwrapKey"/> <i>are</i> keys of it, and their registries hold exactly
+/// one algorithm — AES-KW, the only one whose registration names those operations. Every other way to wrap a
+/// key goes through the <c>encrypt</c>/<c>decrypt</c> registries instead, which is what the methods' own
+/// second normalization is for.
+/// </para>
 /// </remarks>
 internal enum CryptoOperation
 {
@@ -32,6 +40,8 @@ internal enum CryptoOperation
     GenerateKey,
     ImportKey,
     ExportKey,
+    WrapKey,
+    UnwrapKey,
     DeriveBits,
     DeriveKey,
     GetKeyLength,
@@ -122,8 +132,24 @@ internal sealed class NormalizedAlgorithm
     /// <summary>The <c>length</c> member of <c>HmacKeyGenParams</c>, <c>HmacImportParams</c> or <c>AesKeyGenParams</c>.</summary>
     internal uint? Length { get; set; }
 
-    /// <summary>The <c>iv</c> member of <c>AesGcmParams</c>, copied at normalization time as the specification says.</summary>
+    /// <summary>
+    /// The <c>iv</c> member of <c>AesGcmParams</c> or <c>AesCbcParams</c>, copied at normalization time as
+    /// the specification says.
+    /// </summary>
     internal byte[]? Iv { get; set; }
+
+    /// <summary>
+    /// The <c>counter</c> member of <c>AesCtrParams</c> — "the initial value of the counter block", copied at
+    /// normalization time.
+    /// </summary>
+    internal byte[]? Counter { get; set; }
+
+    /// <summary>
+    /// The <c>length</c> member of <c>AesCtrParams</c>: "the length, in bits, of the rightmost part of the
+    /// counter block that is incremented". It is a separate field from <see cref="Length"/> because it means
+    /// something else entirely — that one is a key size — and one algorithm object never carries both.
+    /// </summary>
+    internal int? CounterLength { get; set; }
 
     /// <summary>The <c>additionalData</c> member of <c>AesGcmParams</c>.</summary>
     internal byte[]? AdditionalData { get; set; }
@@ -211,8 +237,17 @@ internal static class AlgorithmNormalization
     /// <summary>https://w3c.github.io/webcrypto/#hmac-registration</summary>
     internal const string Hmac = "HMAC";
 
+    /// <summary>https://w3c.github.io/webcrypto/#aes-ctr-registration</summary>
+    internal const string AesCtr = "AES-CTR";
+
+    /// <summary>https://w3c.github.io/webcrypto/#aes-cbc-registration</summary>
+    internal const string AesCbc = "AES-CBC";
+
     /// <summary>https://w3c.github.io/webcrypto/#aes-gcm-registration</summary>
     internal const string AesGcm = "AES-GCM";
+
+    /// <summary>https://w3c.github.io/webcrypto/#aes-kw-registration</summary>
+    internal const string AesKw = "AES-KW";
 
     /// <summary>https://w3c.github.io/webcrypto/#rsassa-pkcs1-registration</summary>
     internal const string RsassaPkcs1V15 = "RSASSA-PKCS1-v1_5";
@@ -253,7 +288,21 @@ internal static class AlgorithmNormalization
 
     private static readonly string[] _digestAlgorithms = [Sha1, Sha256, Sha384, Sha512];
     private static readonly string[] _signatureAlgorithms = [Hmac, RsassaPkcs1V15, RsaPss, Ecdsa];
-    private static readonly string[] _cipherAlgorithms = [AesGcm, RsaOaep];
+    private static readonly string[] _cipherAlgorithms = [AesCtr, AesCbc, AesGcm, RsaOaep];
+
+    /// <summary>
+    /// The two operations AES-KW registers and no other algorithm here does —
+    /// https://w3c.github.io/webcrypto/#aes-kw-registration, whose table lists <c>wrapKey</c> and
+    /// <c>unwrapKey</c> where every other cipher's lists <c>encrypt</c> and <c>decrypt</c>.
+    /// </summary>
+    /// <remarks>
+    /// AES-KW is deliberately <b>not</b> in <see cref="_cipherAlgorithms"/>: RFC 3394 wrapping is not a
+    /// general-purpose cipher — it takes a whole number of 64-bit blocks and carries an integrity check of
+    /// its own — so <c>encrypt({ name: 'AES-KW' }, …)</c> is the <c>NotSupportedError</c> the registry gives
+    /// it, in a browser too. The reverse asymmetry is what makes the <c>wrapKey</c> method's second
+    /// normalization matter: AES-GCM, AES-CBC, AES-CTR and RSA-OAEP reach it through <c>encrypt</c>.
+    /// </remarks>
+    private static readonly string[] _wrapAlgorithms = [AesKw];
 
     /// <summary>
     /// The three key registries are separate lists because the registrations are: HKDF and PBKDF2 register
@@ -261,9 +310,14 @@ internal static class AlgorithmNormalization
     /// (there is nothing to generate — the "key" is a password or an input keying material the caller already
     /// has) nor export one (their keys are non-extractable by construction).
     /// </summary>
-    private static readonly string[] _generateKeyAlgorithms = [Hmac, AesGcm, RsassaPkcs1V15, RsaPss, RsaOaep, Ecdsa, Ecdh];
-    private static readonly string[] _importKeyAlgorithms = [Hmac, AesGcm, RsassaPkcs1V15, RsaPss, RsaOaep, Ecdsa, Ecdh, Hkdf, Pbkdf2];
-    private static readonly string[] _exportKeyAlgorithms = [Hmac, AesGcm, RsassaPkcs1V15, RsaPss, RsaOaep, Ecdsa, Ecdh];
+    private static readonly string[] _generateKeyAlgorithms =
+        [Hmac, AesCtr, AesCbc, AesGcm, AesKw, RsassaPkcs1V15, RsaPss, RsaOaep, Ecdsa, Ecdh];
+
+    private static readonly string[] _importKeyAlgorithms =
+        [Hmac, AesCtr, AesCbc, AesGcm, AesKw, RsassaPkcs1V15, RsaPss, RsaOaep, Ecdsa, Ecdh, Hkdf, Pbkdf2];
+
+    private static readonly string[] _exportKeyAlgorithms =
+        [Hmac, AesCtr, AesCbc, AesGcm, AesKw, RsassaPkcs1V15, RsaPss, RsaOaep, Ecdsa, Ecdh];
 
     /// <summary>The three algorithms registered for <c>deriveBits</c>.</summary>
     private static readonly string[] _deriveAlgorithms = [Ecdh, Hkdf, Pbkdf2];
@@ -275,7 +329,7 @@ internal static class AlgorithmNormalization
     /// makes <c>deriveKey(ecdhParams, priv, 'HKDF', …)</c> — deriving the whole shared secret into an HKDF
     /// key — the shape the specification's own worked example uses.
     /// </summary>
-    private static readonly string[] _keyLengthAlgorithms = [Hmac, AesGcm, Hkdf, Pbkdf2];
+    private static readonly string[] _keyLengthAlgorithms = [Hmac, AesCtr, AesCbc, AesGcm, AesKw, Hkdf, Pbkdf2];
 
     private static readonly JsString _nameKey = new("name");
     private static readonly JsString _hashKey = new("hash");
@@ -283,6 +337,7 @@ internal static class AlgorithmNormalization
     private static readonly JsString _ivKey = new("iv");
     private static readonly JsString _additionalDataKey = new("additionalData");
     private static readonly JsString _tagLengthKey = new("tagLength");
+    private static readonly JsString _counterKey = new("counter");
     private static readonly JsString _modulusLengthKey = new("modulusLength");
     private static readonly JsString _publicExponentKey = new("publicExponent");
     private static readonly JsString _saltLengthKey = new("saltLength");
@@ -320,6 +375,9 @@ internal static class AlgorithmNormalization
                 return _importKeyAlgorithms;
             case CryptoOperation.ExportKey:
                 return _exportKeyAlgorithms;
+            case CryptoOperation.WrapKey:
+            case CryptoOperation.UnwrapKey:
+                return _wrapAlgorithms;
             case CryptoOperation.DeriveBits:
                 return _deriveAlgorithms;
             case CryptoOperation.GetKeyLength:
@@ -362,6 +420,10 @@ internal static class AlgorithmNormalization
                 return "importKey";
             case CryptoOperation.ExportKey:
                 return "exportKey";
+            case CryptoOperation.WrapKey:
+                return "wrapKey";
+            case CryptoOperation.UnwrapKey:
+                return "unwrapKey";
             case CryptoOperation.DeriveBits:
                 return "deriveBits";
             case CryptoOperation.DeriveKey:
@@ -495,11 +557,32 @@ internal static class AlgorithmNormalization
                 break;
 
             // AesKeyGenParams: `required [EnforceRange] unsigned short length`. AesDerivedKeyParams, which
-            // AES-GCM registers for `get key length`, is that dictionary declared a second time under another
-            // name — same one member, same type.
+            // all four AES algorithms register for `get key length`, is that dictionary declared a second
+            // time under another name — same one member, same type.
+            case (AesCtr, CryptoOperation.GenerateKey):
+            case (AesCtr, CryptoOperation.GetKeyLength):
+            case (AesCbc, CryptoOperation.GenerateKey):
+            case (AesCbc, CryptoOperation.GetKeyLength):
             case (AesGcm, CryptoOperation.GenerateKey):
             case (AesGcm, CryptoOperation.GetKeyLength):
+            case (AesKw, CryptoOperation.GenerateKey):
+            case (AesKw, CryptoOperation.GetKeyLength):
                 normalized.Length = ReadRequiredUnsignedShort(context, algorithm, _lengthKey, what);
+                break;
+
+            // AesCtrParams, in WebIDL's lexicographical order: `required BufferSource counter` then
+            // `required [EnforceRange] octet length` — which is the width of the counter *field* in bits and
+            // has nothing to do with the AesKeyGenParams member of the same name.
+            case (AesCtr, CryptoOperation.Encrypt):
+            case (AesCtr, CryptoOperation.Decrypt):
+                normalized.Counter = ReadRequiredBufferSource(context, algorithm, _counterKey, what);
+                normalized.CounterLength = ReadRequiredOctet(context, algorithm, _lengthKey, what);
+                break;
+
+            // AesCbcParams, whose one member is `required BufferSource iv`.
+            case (AesCbc, CryptoOperation.Encrypt):
+            case (AesCbc, CryptoOperation.Decrypt):
+                normalized.Iv = ReadRequiredBufferSource(context, algorithm, _ivKey, what);
                 break;
 
             // AesGcmParams.
@@ -581,8 +664,8 @@ internal static class AlgorithmNormalization
 
             // Every remaining pair registers `None` as its parameters, so the Algorithm dictionary — the one
             // member of which has already been read — is the whole of it. RSASSA-PKCS1-v1_5's sign and
-            // verify are in that set, as is every algorithm's exportKey, HKDF's and PBKDF2's importKey, and
-            // HKDF's and PBKDF2's `get key length`.
+            // verify are in that set, as is every algorithm's exportKey and importKey, AES-KW's wrapKey and
+            // unwrapKey, and HKDF's and PBKDF2's `get key length`.
             default:
                 break;
         }
@@ -782,6 +865,23 @@ internal static class AlgorithmNormalization
         }
 
         return (uint) EnforceRange(context, value, "member " + key, what, ushort.MaxValue);
+    }
+
+    /// <summary>
+    /// A <c>required [EnforceRange] octet</c> member — the <c>length</c> of <c>AesCtrParams</c>. The range
+    /// check is the octet type's own, so <c>length: 256</c> is a <c>TypeError</c> raised during
+    /// normalization, where <c>length: 0</c> and <c>length: 129</c> are inside an octet and reach the
+    /// operation, which refuses them with the <c>OperationError</c> its own first steps name.
+    /// </summary>
+    private static int ReadRequiredOctet(CryptoContext context, ObjectInstance? algorithm, JsString key, string what)
+    {
+        var value = algorithm?.Get(key) ?? JsValue.Undefined;
+        if (value.IsUndefined())
+        {
+            context.ThrowTypeError(what + ": required member " + key + " is undefined.");
+        }
+
+        return (int) EnforceRange(context, value, "member " + key, what, byte.MaxValue);
     }
 
     private static int? ReadOptionalOctet(CryptoContext context, ObjectInstance? algorithm, JsString key, string what)

--- a/Jint/WebApi/Crypto/CryptoInstance.cs
+++ b/Jint/WebApi/Crypto/CryptoInstance.cs
@@ -26,11 +26,13 @@ namespace Jint.WebApi.Crypto;
 /// nowhere near this file.
 /// </para>
 /// <para>
-/// <c>crypto.subtle</c> exists and carries <b>ten of the twelve operations</b>: <c>digest</c>,
-/// <c>sign</c>, <c>verify</c>, <c>encrypt</c>, <c>decrypt</c>, <c>generateKey</c>, <c>importKey</c>,
-/// <c>exportKey</c>, <c>deriveBits</c> and <c>deriveKey</c>. <c>wrapKey</c> and <c>unwrapKey</c> are absent
-/// rather than present-and-throwing, so the feature detection a library performing cryptography starts with
-/// gets the truthful answer about each operation it means to use. See <see cref="SubtleCryptoInstance"/>.
+/// <c>crypto.subtle</c> exists and carries <b>all twelve operations</b>: <c>digest</c>, <c>sign</c>,
+/// <c>verify</c>, <c>encrypt</c>, <c>decrypt</c>, <c>generateKey</c>, <c>importKey</c>, <c>exportKey</c>,
+/// <c>deriveBits</c>, <c>deriveKey</c>, <c>wrapKey</c> and <c>unwrapKey</c>. What each of them will do is
+/// then a question of which algorithms are registered for it, and a name that is not registered for an
+/// operation is the <c>NotSupportedError</c> the specification says it is — so the feature detection a
+/// library performing cryptography starts with gets the truthful answer at both levels. See
+/// <see cref="SubtleCryptoInstance"/>.
 /// </para>
 /// <para>
 /// Three documented simplifications against WebIDL, the first pair of which <c>console</c> carries too. There

--- a/Jint/WebApi/Crypto/SubtleCryptoInstance.cs
+++ b/Jint/WebApi/Crypto/SubtleCryptoInstance.cs
@@ -1,6 +1,7 @@
 #if NET8_0_OR_GREATER
 using System.Security.Cryptography;
 using Jint.Native;
+using Jint.Native.Json;
 using Jint.Native.Object;
 using Jint.Native.Promise;
 using Jint.Runtime;
@@ -17,33 +18,35 @@ namespace Jint.WebApi.Crypto;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b>Ten of the twelve operations exist</b>: <c>digest</c>, <c>sign</c>, <c>verify</c>, <c>encrypt</c>,
-/// <c>decrypt</c>, <c>generateKey</c>, <c>importKey</c>, <c>exportKey</c>, <c>deriveBits</c> and
-/// <c>deriveKey</c>, over the algorithms <c>HMAC</c>, <c>AES-GCM</c> (128, 192 and 256 bits),
+/// <b>All twelve operations exist</b>: <c>digest</c>, <c>sign</c>, <c>verify</c>, <c>encrypt</c>,
+/// <c>decrypt</c>, <c>generateKey</c>, <c>importKey</c>, <c>exportKey</c>, <c>deriveBits</c>,
+/// <c>deriveKey</c>, <c>wrapKey</c> and <c>unwrapKey</c>, over the algorithms <c>HMAC</c>, <c>AES-CTR</c>,
+/// <c>AES-CBC</c>, <c>AES-GCM</c> and <c>AES-KW</c> (each at 128, 192 and 256 bits),
 /// <c>RSASSA-PKCS1-v1_5</c>, <c>RSA-PSS</c>, <c>RSA-OAEP</c>, <c>ECDSA</c>, <c>ECDH</c>, <c>HKDF</c> and
 /// <c>PBKDF2</c> — each of the hashed ones over SHA-1, SHA-256, SHA-384 and SHA-512, and each of the
 /// elliptic-curve ones over P-256, P-384 and P-521 — plus those four SHA hashes for <c>digest</c>, and the
-/// key formats <c>raw</c>, <c>spki</c>, <c>pkcs8</c> and <c>jwk</c>.
-/// <c>wrapKey</c> and <c>unwrapKey</c> are <b>absent</b> rather than present-and-throwing, so a library that
-/// checks <c>typeof crypto.subtle.wrapKey === 'function'</c> before reaching for it gets the truthful answer
-/// and takes its fallback path — the same promise <c>crypto.subtle</c> itself makes to an engine without the
-/// crypto feature. An algorithm that is absent for a <i>particular</i> operation is a
-/// <c>NotSupportedError</c>, which is what the specification says a name that is not registered for an
-/// operation is: <c>sign</c> with <c>AES-GCM</c> fails that way, and so does <c>encrypt</c> with
-/// <c>HMAC</c> and <c>generateKey</c> with <c>PBKDF2</c>.
+/// key formats <c>raw</c>, <c>spki</c>, <c>pkcs8</c> and <c>jwk</c>. An algorithm that is absent for a
+/// <i>particular</i> operation is a <c>NotSupportedError</c>, which is what the specification says a name
+/// that is not registered for an operation is: <c>sign</c> with <c>AES-GCM</c> fails that way, and so does
+/// <c>encrypt</c> with <c>HMAC</c>, <c>generateKey</c> with <c>PBKDF2</c> and <c>encrypt</c> with
+/// <c>AES-KW</c>.
 /// </para>
 /// <para>
 /// The registries are per operation and are not symmetric. <c>HKDF</c> and <c>PBKDF2</c> register
 /// <c>importKey</c>, <c>deriveBits</c> and the internal <c>get key length</c> and nothing else — there is
 /// nothing to <c>generateKey</c> and, their keys being non-extractable by construction, nothing to
 /// <c>exportKey</c>. <c>ECDH</c> registers <c>deriveBits</c> and never <c>sign</c>; <c>ECDSA</c> the reverse.
-/// An AES-GCM key may still carry the <c>wrapKey</c> and <c>unwrapKey</c> usages that no operation here
-/// consumes, which is the one remaining case of a usage bit without an operation behind it.
+/// <c>AES-KW</c> is the only algorithm registered for <c>wrapKey</c> and <c>unwrapKey</c>, and it registers
+/// neither <c>encrypt</c> nor <c>decrypt</c> — the exact reverse of every other cipher, and the reason those
+/// two methods normalize twice. Every usage bit now has an operation behind it.
 /// </para>
 /// <para>
-/// <c>deriveKey</c> is a composition rather than an algorithm: it derives bits with one algorithm and imports
-/// them with another, so the key it hands back is exactly the key <c>importKey</c> would have made from the
-/// same bytes in the <c>raw</c> format.
+/// <c>deriveKey</c>, <c>wrapKey</c> and <c>unwrapKey</c> are compositions rather than algorithms.
+/// <c>deriveKey</c> derives bits with one algorithm and imports them with another, so the key it hands back
+/// is exactly the key <c>importKey</c> would have made from the same bytes in the <c>raw</c> format;
+/// <c>wrapKey</c> is <c>exportKey</c> followed by a wrap or an encrypt, and <c>unwrapKey</c> is an unwrap or
+/// a decrypt followed by <c>importKey</c>. All three reach the very same import and export dispatches the
+/// script-visible methods do, so nothing about a key is special-cased for having arrived that way.
 /// </para>
 /// <para>
 /// <b>Nothing here ever throws to its caller.</b> WebIDL turns an exception out of a promise-returning
@@ -225,16 +228,31 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
 
             RequireKeyFor(normalized, cryptoKey, KeyUsage.Encrypt, "encrypt", what);
 
-            switch (normalized.Name)
-            {
-                case AlgorithmNormalization.AesGcm:
-                    return Context.CreateArrayBuffer(AesGcmAlgorithm.Encrypt(Context, normalized, cryptoKey, plaintext, what));
-                case AlgorithmNormalization.RsaOaep:
-                    return Context.CreateArrayBuffer(RsaAlgorithm.Encrypt(Context, normalized, cryptoKey, plaintext, what));
-                default:
-                    return UnhandledAlgorithm(normalized.Name, CryptoOperation.Encrypt);
-            }
+            return Context.CreateArrayBuffer(PerformEncrypt(normalized, cryptoKey, plaintext, what));
         });
+    }
+
+    /// <summary>
+    /// "The encrypt operation specified by normalizedAlgorithm using key and algorithm" — the step
+    /// <c>encrypt</c> shares with <c>wrapKey</c>, which reaches four of these five algorithms through its own
+    /// second normalization.
+    /// </summary>
+    private byte[] PerformEncrypt(NormalizedAlgorithm normalized, JsCryptoKey key, byte[] plaintext, string what)
+    {
+        switch (normalized.Name)
+        {
+            case AlgorithmNormalization.AesCtr:
+                return AesCtrAlgorithm.Encrypt(Context, normalized, key, plaintext, what);
+            case AlgorithmNormalization.AesCbc:
+                return AesCbcAlgorithm.Encrypt(Context, normalized, key, plaintext, what);
+            case AlgorithmNormalization.AesGcm:
+                return AesGcmAlgorithm.Encrypt(Context, normalized, key, plaintext, what);
+            case AlgorithmNormalization.RsaOaep:
+                return RsaAlgorithm.Encrypt(Context, normalized, key, plaintext, what);
+            default:
+                UnhandledAlgorithm(normalized.Name, CryptoOperation.Encrypt);
+                return null!;
+        }
     }
 
     /// <summary>
@@ -254,16 +272,30 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
 
             RequireKeyFor(normalized, cryptoKey, KeyUsage.Decrypt, "decrypt", what);
 
-            switch (normalized.Name)
-            {
-                case AlgorithmNormalization.AesGcm:
-                    return Context.CreateArrayBuffer(AesGcmAlgorithm.Decrypt(Context, normalized, cryptoKey, ciphertext, what));
-                case AlgorithmNormalization.RsaOaep:
-                    return Context.CreateArrayBuffer(RsaAlgorithm.Decrypt(Context, normalized, cryptoKey, ciphertext, what));
-                default:
-                    return UnhandledAlgorithm(normalized.Name, CryptoOperation.Decrypt);
-            }
+            return Context.CreateArrayBuffer(PerformDecrypt(normalized, cryptoKey, ciphertext, what));
         });
+    }
+
+    /// <summary>
+    /// "The decrypt operation specified by normalizedAlgorithm using key and algorithm" — the step
+    /// <c>decrypt</c> shares with <c>unwrapKey</c>.
+    /// </summary>
+    private byte[] PerformDecrypt(NormalizedAlgorithm normalized, JsCryptoKey key, byte[] ciphertext, string what)
+    {
+        switch (normalized.Name)
+        {
+            case AlgorithmNormalization.AesCtr:
+                return AesCtrAlgorithm.Decrypt(Context, normalized, key, ciphertext, what);
+            case AlgorithmNormalization.AesCbc:
+                return AesCbcAlgorithm.Decrypt(Context, normalized, key, ciphertext, what);
+            case AlgorithmNormalization.AesGcm:
+                return AesGcmAlgorithm.Decrypt(Context, normalized, key, ciphertext, what);
+            case AlgorithmNormalization.RsaOaep:
+                return RsaAlgorithm.Decrypt(Context, normalized, key, ciphertext, what);
+            default:
+                UnhandledAlgorithm(normalized.Name, CryptoOperation.Decrypt);
+                return null!;
+        }
     }
 
     /// <summary>
@@ -294,8 +326,15 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
                 case AlgorithmNormalization.Hmac:
                     return CreateSecretKey(HmacAlgorithm.GenerateKey(Context, normalized, usages, what), isExtractable, usages, what);
 
+                case AlgorithmNormalization.AesCtr:
+                case AlgorithmNormalization.AesCbc:
                 case AlgorithmNormalization.AesGcm:
-                    return CreateSecretKey(AesGcmAlgorithm.GenerateKey(Context, normalized, usages, what), isExtractable, usages, what);
+                case AlgorithmNormalization.AesKw:
+                    return CreateSecretKey(
+                        AesKeyManagement.GenerateKey(Context, normalized.Name, normalized, usages, what),
+                        isExtractable,
+                        usages,
+                        what);
 
                 case AlgorithmNormalization.RsassaPkcs1V15:
                 case AlgorithmNormalization.RsaPss:
@@ -403,57 +442,79 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
                 Context.ThrowTypeError(what + ": the '" + KeyFormats.NameOf(keyFormat) + "' format needs a buffer source, not a JsonWebKey object.");
             }
 
-            switch (normalized.Name)
-            {
-                case AlgorithmNormalization.Hmac:
-                    return CreateSecretKey(
-                        HmacAlgorithm.ImportKey(Context, keyFormat, rawData, jwk, normalized, isExtractable, usages, what),
-                        isExtractable,
-                        usages,
-                        what);
-
-                case AlgorithmNormalization.AesGcm:
-                    return CreateSecretKey(
-                        AesGcmAlgorithm.ImportKey(Context, keyFormat, rawData, jwk, isExtractable, usages, what),
-                        isExtractable,
-                        usages,
-                        what);
-
-                case AlgorithmNormalization.RsassaPkcs1V15:
-                case AlgorithmNormalization.RsaPss:
-                case AlgorithmNormalization.RsaOaep:
-                    return CreateImportedKey(
-                        RsaAlgorithm.ImportKey(Context, keyFormat, rawData, jwk, normalized, isExtractable, usages, what),
-                        isExtractable,
-                        usages,
-                        what);
-
-                case AlgorithmNormalization.Ecdsa:
-                case AlgorithmNormalization.Ecdh:
-                    return CreateImportedKey(
-                        EcAlgorithm.ImportKey(Context, keyFormat, rawData, jwk, normalized, isExtractable, usages, what),
-                        isExtractable,
-                        usages,
-                        what);
-
-                case AlgorithmNormalization.Hkdf:
-                    return CreateImportedKey(
-                        HkdfAlgorithm.ImportKey(Context, keyFormat, rawData, isExtractable, usages, what),
-                        isExtractable,
-                        usages,
-                        what);
-
-                case AlgorithmNormalization.Pbkdf2:
-                    return CreateImportedKey(
-                        Pbkdf2Algorithm.ImportKey(Context, keyFormat, rawData, isExtractable, usages, what),
-                        isExtractable,
-                        usages,
-                        what);
-
-                default:
-                    return UnhandledAlgorithm(normalized.Name, CryptoOperation.ImportKey);
-            }
+            return PerformImportKey(normalized, keyFormat, rawData, jwk, isExtractable, usages, what);
         });
+    }
+
+    /// <summary>
+    /// "The import key operation specified by normalizedAlgorithm using keyData, algorithm, format,
+    /// extractable and usages" — the step <c>importKey</c> shares with <c>deriveKey</c> (whose format is
+    /// fixed at <c>raw</c> and whose key data is the derivation's) and with <c>unwrapKey</c> (whose key data
+    /// is whatever the unwrapping produced).
+    /// </summary>
+    private JsCryptoKey PerformImportKey(
+        NormalizedAlgorithm normalized,
+        KeyFormat format,
+        byte[]? rawData,
+        JsonWebKeyData? jwk,
+        bool extractable,
+        KeyUsage usages,
+        string what)
+    {
+        switch (normalized.Name)
+        {
+            case AlgorithmNormalization.Hmac:
+                return CreateSecretKey(
+                    HmacAlgorithm.ImportKey(Context, format, rawData, jwk, normalized, extractable, usages, what),
+                    extractable,
+                    usages,
+                    what);
+
+            case AlgorithmNormalization.AesCtr:
+            case AlgorithmNormalization.AesCbc:
+            case AlgorithmNormalization.AesGcm:
+            case AlgorithmNormalization.AesKw:
+                return CreateSecretKey(
+                    AesKeyManagement.ImportKey(Context, normalized.Name, format, rawData, jwk, extractable, usages, what),
+                    extractable,
+                    usages,
+                    what);
+
+            case AlgorithmNormalization.RsassaPkcs1V15:
+            case AlgorithmNormalization.RsaPss:
+            case AlgorithmNormalization.RsaOaep:
+                return CreateImportedKey(
+                    RsaAlgorithm.ImportKey(Context, format, rawData, jwk, normalized, extractable, usages, what),
+                    extractable,
+                    usages,
+                    what);
+
+            case AlgorithmNormalization.Ecdsa:
+            case AlgorithmNormalization.Ecdh:
+                return CreateImportedKey(
+                    EcAlgorithm.ImportKey(Context, format, rawData, jwk, normalized, extractable, usages, what),
+                    extractable,
+                    usages,
+                    what);
+
+            case AlgorithmNormalization.Hkdf:
+                return CreateImportedKey(
+                    HkdfAlgorithm.ImportKey(Context, format, rawData, extractable, usages, what),
+                    extractable,
+                    usages,
+                    what);
+
+            case AlgorithmNormalization.Pbkdf2:
+                return CreateImportedKey(
+                    Pbkdf2Algorithm.ImportKey(Context, format, rawData, extractable, usages, what),
+                    extractable,
+                    usages,
+                    what);
+
+            default:
+                UnhandledAlgorithm(normalized.Name, CryptoOperation.ImportKey);
+                return null!;
+        }
     }
 
     /// <summary>
@@ -474,37 +535,58 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
             var keyFormat = ReadKeyFormat(format, what);
             var cryptoKey = RequireCryptoKey(key, what, "parameter 2");
 
-            // "If the name member of the [[algorithm]] internal slot of key does not identify a registered
-            // algorithm that supports the export key operation, then throw a NotSupportedError."
-            if (Array.IndexOf(AlgorithmNormalization.RegisteredFor(CryptoOperation.ExportKey), cryptoKey.Algorithm.Name) < 0)
-            {
-                Context.ThrowNotSupportedError(
-                    what + ": " + cryptoKey.Algorithm.Name + " is not registered for the exportKey operation.");
-            }
+            RequireExportableKey(cryptoKey, what);
 
-            // "If the [[extractable]] internal slot of key is false, then throw an InvalidAccessError."
-            if (!cryptoKey.Extractable)
-            {
-                Context.ThrowInvalidAccessError(what + ": the key is not extractable.");
-            }
-
-            switch (cryptoKey.Algorithm.Name)
-            {
-                case AlgorithmNormalization.Hmac:
-                    return HmacAlgorithm.ExportKey(Context, cryptoKey, keyFormat, what);
-                case AlgorithmNormalization.AesGcm:
-                    return AesGcmAlgorithm.ExportKey(Context, cryptoKey, keyFormat, what);
-                case AlgorithmNormalization.RsassaPkcs1V15:
-                case AlgorithmNormalization.RsaPss:
-                case AlgorithmNormalization.RsaOaep:
-                    return RsaAlgorithm.ExportKey(Context, cryptoKey, keyFormat, what);
-                case AlgorithmNormalization.Ecdsa:
-                case AlgorithmNormalization.Ecdh:
-                    return EcAlgorithm.ExportKey(Context, cryptoKey, keyFormat, what);
-                default:
-                    return UnhandledAlgorithm(cryptoKey.Algorithm.Name, CryptoOperation.ExportKey);
-            }
+            return PerformExportKey(cryptoKey, keyFormat, what);
         });
+    }
+
+    /// <summary>
+    /// The two checks <c>exportKey</c> makes before asking the algorithm for anything, which <c>wrapKey</c>
+    /// makes too (its steps 9 and 10) because wrapping "effectively exports the key".
+    /// </summary>
+    private void RequireExportableKey(JsCryptoKey key, string what)
+    {
+        // "If the name member of the [[algorithm]] internal slot of key does not identify a registered
+        // algorithm that supports the export key operation, then throw a NotSupportedError."
+        if (Array.IndexOf(AlgorithmNormalization.RegisteredFor(CryptoOperation.ExportKey), key.Algorithm.Name) < 0)
+        {
+            Context.ThrowNotSupportedError(
+                what + ": " + key.Algorithm.Name + " is not registered for the exportKey operation.");
+        }
+
+        // "If the [[extractable]] internal slot of key is false, then throw an InvalidAccessError."
+        if (!key.Extractable)
+        {
+            Context.ThrowInvalidAccessError(what + ": the key is not extractable.");
+        }
+    }
+
+    /// <summary>
+    /// "The export key operation specified by the [[algorithm]] internal slot of key using key and format" —
+    /// the step <c>exportKey</c> shares with <c>wrapKey</c>, which wraps whatever it produces.
+    /// </summary>
+    private JsValue PerformExportKey(JsCryptoKey key, KeyFormat format, string what)
+    {
+        switch (key.Algorithm.Name)
+        {
+            case AlgorithmNormalization.Hmac:
+                return HmacAlgorithm.ExportKey(Context, key, format, what);
+            case AlgorithmNormalization.AesCtr:
+            case AlgorithmNormalization.AesCbc:
+            case AlgorithmNormalization.AesGcm:
+            case AlgorithmNormalization.AesKw:
+                return AesKeyManagement.ExportKey(Context, key, format, what);
+            case AlgorithmNormalization.RsassaPkcs1V15:
+            case AlgorithmNormalization.RsaPss:
+            case AlgorithmNormalization.RsaOaep:
+                return RsaAlgorithm.ExportKey(Context, key, format, what);
+            case AlgorithmNormalization.Ecdsa:
+            case AlgorithmNormalization.Ecdh:
+                return EcAlgorithm.ExportKey(Context, key, format, what);
+            default:
+                return UnhandledAlgorithm(key.Algorithm.Name, CryptoOperation.ExportKey);
+        }
     }
 
     /// <summary>
@@ -602,6 +684,354 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
     }
 
     /// <summary>
+    /// https://w3c.github.io/webcrypto/#SubtleCrypto-method-wrapKey, whose IDL is
+    /// <c>Promise&lt;ArrayBuffer&gt; wrapKey(KeyFormat format, CryptoKey key, CryptoKey wrappingKey,
+    /// AlgorithmIdentifier wrapAlgorithm)</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Like <c>deriveKey</c> it is a composition, and its parts are already here: it is <c>exportKey</c>
+    /// followed by either a <b>wrap key</b> operation or an <b>encrypt</b> one. Which of the two is decided by
+    /// the <b>double normalization</b> of step 2 — the <c>wrapAlgorithm</c> is normalized for <c>wrapKey</c>
+    /// and, "if an error occurred", for <c>encrypt</c> instead. AES-KW takes the first route because that is
+    /// the only operation its registration names; AES-GCM, AES-CBC, AES-CTR and RSA-OAEP take the second,
+    /// because theirs name <c>encrypt</c> and never <c>wrapKey</c>. A name that is in neither registry is
+    /// therefore reported against the <i>encrypt</i> registry, which is the normalization that ran last, and
+    /// an algorithm object whose members are getters has them read twice for the same reason
+    /// <c>deriveKey</c>'s <c>derivedKeyType</c> is read twice.
+    /// </para>
+    /// <para>
+    /// <b>Wrapping is exporting</b>, so the two checks <c>exportKey</c> makes are made here too: the wrapped
+    /// key's algorithm has to be registered for <c>exportKey</c>, and the key has to be extractable. The
+    /// specification's own note is worth repeating — "this API cannot create a wrapped JWK key that is marked
+    /// as non-extractable using the ext JWK member. However, the unwrapKey method does support the ext JWK
+    /// member", which is what lets a server hand a script a wrapped key it can use and cannot export.
+    /// </para>
+    /// <para>
+    /// <b>The <c>jwk</c> format is serialized with this engine's own <c>JSON.stringify</c></b> — "the result
+    /// of representing exportedKey as a UTF-16 string conforming to the JSON grammar; for example, by
+    /// executing the JSON.stringify algorithm specified in [ECMA-262] in the context of a new global object",
+    /// then UTF-8 encoded. The member order is the export layout's own (<see cref="JsonWebKeyData"/> builds
+    /// every JWK from a fixed <see cref="JsObjectLayout"/>, and a layout's order is its enumeration order), so
+    /// the bytes a given key wraps to are deterministic and equal to
+    /// <c>new TextEncoder().encode(JSON.stringify(await crypto.subtle.exportKey('jwk', key)))</c>. The one
+    /// divergence from the quoted step is the phrase "a new global object": the serialization runs in this
+    /// realm, so a <c>toJSON</c> a script has installed on <c>Object.prototype</c> participates in it where a
+    /// browser's would not. What that can do is confined to the script's own keys — it changes bytes the same
+    /// script then fails to unwrap — and it is named here rather than papered over.
+    /// </para>
+    /// <para>
+    /// <b>A JWK wrapped under AES-KW is padded with spaces to a multiple of 8 bytes.</b> AES-KW wraps a whole
+    /// number of 64-bit blocks and a JSON document is whatever length it is, which is exactly the case the
+    /// specification's note anticipates: "implementations may choose to adapt the serialization to the
+    /// constraints of the wrapping algorithm. This is why JSON.stringify is not normatively required, as
+    /// otherwise it would prohibit implementations from introducing added padding." The convention every
+    /// implementation follows — and the one the web-platform tests compute their expectation with, in
+    /// <c>WebCryptoAPI/wrapKey_unwrapKey/wrapKey_unwrapKey.https.any.js</c> — is
+    /// <c>jwk.slice(0, -1) + ' '.repeat(pad) + '}'</c>: the spaces go immediately before the closing brace,
+    /// where JSON's grammar allows insignificant whitespace, so the padded document parses back to the very
+    /// same object and <c>unwrapKey</c> needs to know nothing about the padding at all. It is applied to the
+    /// UTF-8 bytes rather than to the UTF-16 string, which is the same thing for every JWK this engine
+    /// exports — all of them are ASCII — and is the count AES-KW actually constrains.
+    /// </para>
+    /// </remarks>
+    [JsFunction(Name = "wrapKey", Length = 4)]
+    private JsValue WrapKey(JsValue thisObject, JsValue format, JsValue key, JsValue wrappingKey, JsValue wrapAlgorithm)
+    {
+        return Perform(thisObject, CryptoOperation.WrapKey, what =>
+        {
+            var keyFormat = ReadKeyFormat(format, what);
+            var cryptoKey = RequireCryptoKey(key, what, "parameter 2");
+            var wrapper = RequireCryptoKey(wrappingKey, what, "parameter 3");
+            var identifier = AlgorithmNormalization.ConvertIdentifier(wrapAlgorithm);
+
+            // Steps 2 and 3.
+            var normalized = NormalizeForWrapping(identifier, CryptoOperation.WrapKey, CryptoOperation.Encrypt, what);
+
+            // Steps 7 and 8: the wrapping key was made for this algorithm, and it permits wrapKey.
+            RequireKeyFor(normalized, wrapper, KeyUsage.WrapKey, "wrapKey", what);
+
+            // Steps 9 and 10, which are exportKey's own two checks — see the remarks on this method.
+            RequireExportableKey(cryptoKey, what);
+
+            // Steps 11 and 12.
+            var exported = PerformExportKey(cryptoKey, keyFormat, what);
+            var bytes = keyFormat == KeyFormat.Jwk
+                ? SerializeJsonWebKey(exported, normalized.Name)
+                : CopyExportedBytes(exported);
+
+            // Step 13.
+            if (IsRegisteredFor(CryptoOperation.WrapKey, normalized.Name))
+            {
+                return Context.CreateArrayBuffer(PerformWrap(normalized, wrapper, bytes, what));
+            }
+
+            if (IsRegisteredFor(CryptoOperation.Encrypt, normalized.Name))
+            {
+                return Context.CreateArrayBuffer(PerformEncrypt(normalized, wrapper, bytes, what));
+            }
+
+            // "Otherwise: throw a NotSupportedError." Unreachable: the normalization above succeeded against
+            // one of these two registries, and it is written out because the step is.
+            Context.ThrowNotSupportedError(
+                what + ": " + normalized.Name + " supports neither the wrapKey operation nor the encrypt operation.");
+            return JsValue.Undefined;
+        });
+    }
+
+    /// <summary>
+    /// https://w3c.github.io/webcrypto/#SubtleCrypto-method-unwrapKey, whose IDL is
+    /// <c>Promise&lt;CryptoKey&gt; unwrapKey(KeyFormat format, BufferSource wrappedKey,
+    /// CryptoKey unwrappingKey, AlgorithmIdentifier unwrapAlgorithm,
+    /// AlgorithmIdentifier unwrappedKeyAlgorithm, boolean extractable, sequence&lt;KeyUsage&gt; keyUsages)</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The mirror of <c>wrapKey</c>, with <b>three</b> normalizations rather than two: the
+    /// <c>unwrapAlgorithm</c> for <c>unwrapKey</c> and then, on failure, for <c>decrypt</c>; and the
+    /// <c>unwrappedKeyAlgorithm</c> for <c>importKey</c>, which is the algorithm the <i>new</i> key will
+    /// belong to. The two are independent — an AES-KW key unwraps an RSA private key perfectly well — and it
+    /// is the second that decides everything about the key that comes out.
+    /// </para>
+    /// <para>
+    /// <c>extractable</c> and <c>keyUsages</c> belong to the <b>new</b> key alone, exactly as
+    /// <c>deriveKey</c>'s do, and the unwrapping key's own extractability is never consulted. A <c>jwk</c>
+    /// carrying <c>ext: false</c> is honoured against them, which is the asymmetry <c>wrapKey</c>'s note
+    /// describes: a key wrapped elsewhere may say it is not to be extractable, and this is where that is read.
+    /// </para>
+    /// <para>
+    /// <b>Everything that can go wrong after the unwrapping is an import failure, in the existing taxonomy.</b>
+    /// The unwrapped bytes are handed to the very same import steps <c>importKey</c> runs, so a JWK whose
+    /// <c>kty</c> is wrong for the requested algorithm is a <c>DataError</c>, a usage the algorithm does not
+    /// support is a <c>SyntaxError</c>, and a secret key with no usages at all is the <c>SyntaxError</c> step
+    /// 14 names. The one failure that is unwrapping's own is a <c>jwk</c> whose bytes are not a JSON document
+    /// at all — "parse a JWK" is where that becomes a <c>DataError</c>, and it is the shape a wrong
+    /// unwrapping key produces under a cipher with no integrity check of its own.
+    /// </para>
+    /// </remarks>
+    [JsFunction(Name = "unwrapKey", Length = 7)]
+    private JsValue UnwrapKey(
+        JsValue thisObject,
+        JsValue format,
+        JsValue wrappedKey,
+        JsValue unwrappingKey,
+        JsValue unwrapAlgorithm,
+        JsValue unwrappedKeyAlgorithm,
+        JsValue extractable,
+        JsValue keyUsages)
+    {
+        return Perform(thisObject, CryptoOperation.UnwrapKey, what =>
+        {
+            var keyFormat = ReadKeyFormat(format, what);
+            var wrapped = GetBufferSourceBytes(wrappedKey, what, "parameter 2");
+            var unwrapper = RequireCryptoKey(unwrappingKey, what, "parameter 3");
+            var identifier = AlgorithmNormalization.ConvertIdentifier(unwrapAlgorithm);
+            var keyIdentifier = AlgorithmNormalization.ConvertIdentifier(unwrappedKeyAlgorithm);
+            var isExtractable = TypeConverter.ToBoolean(extractable);
+            var usages = KeyUsages.ReadSequence(Context, keyUsages, what);
+
+            // Steps 2 to 4, in the specification's order and all before any step of any algorithm.
+            var normalized = NormalizeForWrapping(identifier, CryptoOperation.UnwrapKey, CryptoOperation.Decrypt, what);
+            var normalizedKey = AlgorithmNormalization.Normalize(Context, keyIdentifier, CryptoOperation.ImportKey, what);
+
+            // Steps 9 and 10.
+            RequireKeyFor(normalized, unwrapper, KeyUsage.UnwrapKey, "unwrapKey", what);
+
+            // Step 11.
+            byte[] bytes;
+            if (IsRegisteredFor(CryptoOperation.UnwrapKey, normalized.Name))
+            {
+                bytes = PerformUnwrap(normalized, unwrapper, wrapped, what);
+            }
+            else if (IsRegisteredFor(CryptoOperation.Decrypt, normalized.Name))
+            {
+                bytes = PerformDecrypt(normalized, unwrapper, wrapped, what);
+            }
+            else
+            {
+                // Unreachable, for the reason wrapKey's own third arm is.
+                Context.ThrowNotSupportedError(
+                    what + ": " + normalized.Name + " supports neither the unwrapKey operation nor the decrypt operation.");
+                return JsValue.Undefined;
+            }
+
+            // Step 12: "If format is equal to the string 'jwk': Let key be the result of executing the parse
+            // a JWK algorithm, with bytes as the data to be parsed. Otherwise: Let key be bytes."
+            var jwk = keyFormat == KeyFormat.Jwk ? ParseJsonWebKey(bytes, what) : null;
+            var rawData = keyFormat == KeyFormat.Jwk ? null : bytes;
+
+            // Steps 13 to 16. The empty-usages SyntaxError of step 14, and the setting of the two internal
+            // slots, are what the import dispatch already does for importKey and deriveKey.
+            return PerformImportKey(normalizedKey, keyFormat, rawData, jwk, isExtractable, usages, what);
+        });
+    }
+
+    /// <summary>
+    /// Step 2 of <c>wrapKey</c> and <c>unwrapKey</c>: normalize for the wrapping operation and, "if an error
+    /// occurred", for the cipher operation instead.
+    /// </summary>
+    /// <remarks>
+    /// The three exceptions caught are the ones <see cref="Perform"/> catches, for the same reason it catches
+    /// exactly those: they are the whole of what a script-visible failure here can arrive as, and everything
+    /// else a <c>JintException</c> covers is an execution constraint or a cancellation, which must not be
+    /// turned into a second attempt any more than into a rejection. Whatever the <i>second</i> normalization
+    /// raises is left to propagate, which is what makes it the failure the caller sees.
+    /// </remarks>
+    private NormalizedAlgorithm NormalizeForWrapping(
+        JsValue identifier,
+        CryptoOperation wrapping,
+        CryptoOperation cipher,
+        string what)
+    {
+        try
+        {
+            return AlgorithmNormalization.Normalize(Context, identifier, wrapping, what);
+        }
+        catch (Exception e) when (e is JavaScriptException or TypeErrorException or RangeErrorException)
+        {
+            return AlgorithmNormalization.Normalize(Context, identifier, cipher, what);
+        }
+    }
+
+    /// <summary>"If normalizedAlgorithm supports the wrap key operation" — a lookup in that operation's registry.</summary>
+    private static bool IsRegisteredFor(CryptoOperation operation, string name)
+        => Array.IndexOf(AlgorithmNormalization.RegisteredFor(operation), name) >= 0;
+
+    /// <summary>
+    /// "The wrap key operation specified by normalizedAlgorithm using wrappingKey as key and bytes as
+    /// plaintext" — which only AES-KW registers.
+    /// </summary>
+    private byte[] PerformWrap(NormalizedAlgorithm normalized, JsCryptoKey key, byte[] plaintext, string what)
+    {
+        switch (normalized.Name)
+        {
+            case AlgorithmNormalization.AesKw:
+                return AesKwAlgorithm.WrapKey(Context, key, plaintext, what);
+            default:
+                UnhandledAlgorithm(normalized.Name, CryptoOperation.WrapKey);
+                return null!;
+        }
+    }
+
+    /// <summary>
+    /// "The unwrap key operation specified by normalizedAlgorithm using unwrappingKey as key and wrappedKey
+    /// as ciphertext".
+    /// </summary>
+    private byte[] PerformUnwrap(NormalizedAlgorithm normalized, JsCryptoKey key, byte[] ciphertext, string what)
+    {
+        switch (normalized.Name)
+        {
+            case AlgorithmNormalization.AesKw:
+                return AesKwAlgorithm.UnwrapKey(Context, key, ciphertext, what);
+            default:
+                UnhandledAlgorithm(normalized.Name, CryptoOperation.UnwrapKey);
+                return null!;
+        }
+    }
+
+    /// <summary>
+    /// Step 12 of <c>wrapKey</c> for the <c>jwk</c> format — see the remarks on that method for both the
+    /// serializer this uses and the padding AES-KW gets.
+    /// </summary>
+    private byte[] SerializeJsonWebKey(JsValue exported, string wrapAlgorithmName)
+    {
+        if (new JsonSerializer(_engine).Serialize(exported) is not JsString json)
+        {
+            // Unreachable: the value is an object this engine built out of strings, booleans and an array of
+            // strings, none of which JSON.stringify answers `undefined` for.
+            Throw.InvalidOperationException("The exported JSON Web Key has no JSON representation.");
+            return null!;
+        }
+
+        var bytes = System.Text.Encoding.UTF8.GetBytes(json.ToString());
+
+        return string.Equals(wrapAlgorithmName, AlgorithmNormalization.AesKw, StringComparison.Ordinal)
+            ? PadToWrappableLength(bytes)
+            : bytes;
+    }
+
+    /// <summary>
+    /// The JSON document with enough <c>U+0020</c> characters inserted before its closing brace to make it a
+    /// whole number of 64-bit blocks — see the remarks on <see cref="WrapKey"/> for where the convention
+    /// comes from and why it round-trips.
+    /// </summary>
+    private static byte[] PadToWrappableLength(byte[] json)
+    {
+        var remainder = json.Length % 8;
+        if (remainder == 0)
+        {
+            return json;
+        }
+
+        var padded = new byte[json.Length + (8 - remainder)];
+
+        // Everything but the closing brace, then the spaces, then the brace back on the end.
+        json.AsSpan(0, json.Length - 1).CopyTo(padded);
+        padded.AsSpan(json.Length - 1, 8 - remainder).Fill((byte) ' ');
+        padded[padded.Length - 1] = json[json.Length - 1];
+
+        return padded;
+    }
+
+    /// <summary>
+    /// Step 12's "Otherwise: Let bytes be exportedKey" — the bytes of the <c>ArrayBuffer</c> the export
+    /// produced, which for every non-<c>jwk</c> format is what it returns.
+    /// </summary>
+    private static byte[] CopyExportedBytes(JsValue exported)
+    {
+        if (!BufferSource.TryGetBytes(exported, out var bytes))
+        {
+            // Unreachable: every format but jwk exports an ArrayBuffer, which is what the export dispatch
+            // above hands back.
+            Throw.InvalidOperationException("The exported key is not a buffer source.");
+        }
+
+        return bytes.ToArray();
+    }
+
+    /// <summary>
+    /// "Parse a JWK" — https://w3c.github.io/webcrypto/#dfn-parse-a-jwk: interpret the bytes as UTF-8, parse
+    /// the text as JSON, convert the result to a <c>JsonWebKey</c> dictionary, "If the kty field of key is
+    /// not defined, then throw a DataError".
+    /// </summary>
+    /// <remarks>
+    /// The parser is the engine's own <c>JSON.parse</c>, which reports a malformed document — and a byte
+    /// sequence that is not well-formed UTF-8 — as a <c>SyntaxError</c>. That is turned into the
+    /// <c>DataError</c> this algorithm names: a script asking to unwrap a key never asked to parse JSON, and
+    /// what it is being told is that the data does not meet the operation's requirements. Nothing else on
+    /// this path raises a <c>SyntaxError</c>, so the conversion cannot capture anything it did not mean to.
+    /// </remarks>
+    private JsonWebKeyData ParseJsonWebKey(byte[] bytes, string what)
+    {
+        JsValue parsed;
+
+        try
+        {
+            parsed = new JsonParser(_engine).Parse(bytes);
+        }
+        catch (JavaScriptException)
+        {
+            Context.ThrowDataError(what + ": the unwrapped data is not a JSON document.");
+            return null!;
+        }
+
+        if (parsed is not ObjectInstance source)
+        {
+            Context.ThrowDataError(what + ": the unwrapped data is a JSON document but not a JSON Web Key object.");
+            return null!;
+        }
+
+        var jwk = JsonWebKeyData.Read(Context, source, what);
+
+        if (jwk.Kty is null)
+        {
+            Context.ThrowDataError(what + ": the unwrapped JSON Web Key has no kty field.");
+        }
+
+        return jwk;
+    }
+
+    /// <summary>
     /// "The derive bits operation specified by normalizedAlgorithm using baseKey, algorithm and length" —
     /// the one step <c>deriveBits</c> and <c>deriveKey</c> share.
     /// </summary>
@@ -639,8 +1069,11 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
         {
             case AlgorithmNormalization.Hmac:
                 return HmacAlgorithm.GetKeyLength(Context, normalized, what);
+            case AlgorithmNormalization.AesCtr:
+            case AlgorithmNormalization.AesCbc:
             case AlgorithmNormalization.AesGcm:
-                return AesGcmAlgorithm.GetKeyLength(Context, normalized, what);
+            case AlgorithmNormalization.AesKw:
+                return AesKeyManagement.GetKeyLength(Context, normalized, what);
             case AlgorithmNormalization.Hkdf:
                 return HkdfAlgorithm.GetKeyLength();
             case AlgorithmNormalization.Pbkdf2:
@@ -657,50 +1090,17 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
     /// format fixed and the key data supplied by the derivation rather than by the caller.
     /// </summary>
     /// <remarks>
-    /// Only the four algorithms that also register <c>get key length</c> can arrive here, and not the seven
-    /// that register <c>importKey</c>: step 6 normalizes the same <c>derivedKeyType</c> for that operation
-    /// first, so <c>deriveKey(…, { name: 'RSA-OAEP', hash: 'SHA-256' }, …)</c> is already a
+    /// Only the algorithms that also register <c>get key length</c> can arrive here, and not the twelve that
+    /// register <c>importKey</c>: step 6 normalizes the same <c>derivedKeyType</c> for that operation first,
+    /// so <c>deriveKey(…, { name: 'RSA-OAEP', hash: 'SHA-256' }, …)</c> is already a
     /// <c>NotSupportedError</c> by the time anything is derived. An asymmetric key cannot be derived at all,
     /// which is the registry saying so rather than any step refusing it. Nothing is special-cased for the
-    /// derived case otherwise, so a derived key is the same object an imported one is.
+    /// derived case otherwise, so a derived key is the same object an imported one is — which is exactly why
+    /// this delegates to the very dispatch <c>importKey</c> uses rather than keeping a second, shorter list
+    /// that would have to be remembered whenever an algorithm is added.
     /// </remarks>
     private JsCryptoKey ImportDerivedKey(NormalizedAlgorithm normalized, byte[] secret, bool extractable, KeyUsage usages, string what)
-    {
-        switch (normalized.Name)
-        {
-            case AlgorithmNormalization.Hmac:
-                return CreateSecretKey(
-                    HmacAlgorithm.ImportKey(Context, KeyFormat.Raw, secret, jwk: null, normalized, extractable, usages, what),
-                    extractable,
-                    usages,
-                    what);
-
-            case AlgorithmNormalization.AesGcm:
-                return CreateSecretKey(
-                    AesGcmAlgorithm.ImportKey(Context, KeyFormat.Raw, secret, jwk: null, extractable, usages, what),
-                    extractable,
-                    usages,
-                    what);
-
-            case AlgorithmNormalization.Hkdf:
-                return CreateImportedKey(
-                    HkdfAlgorithm.ImportKey(Context, KeyFormat.Raw, secret, extractable, usages, what),
-                    extractable,
-                    usages,
-                    what);
-
-            case AlgorithmNormalization.Pbkdf2:
-                return CreateImportedKey(
-                    Pbkdf2Algorithm.ImportKey(Context, KeyFormat.Raw, secret, extractable, usages, what),
-                    extractable,
-                    usages,
-                    what);
-
-            default:
-                UnhandledAlgorithm(normalized.Name, CryptoOperation.ImportKey);
-                return null!;
-        }
-    }
+        => PerformImportKey(normalized, KeyFormat.Raw, secret, jwk: null, extractable, usages, what);
 
     /// <summary>
     /// Runs one operation's steps and settles a promise with whatever they produce — the whole of what

--- a/README.md
+++ b/README.md
@@ -248,9 +248,10 @@ neighbouring one — a cache outlives the evaluation that filled it, so where it
 is a decision you make rather than inherit; and `FetchEvents` is the third, because a script that can register
 a `fetch` listener can take over every request you route into the engine.
 
-`crypto.subtle` carries **`digest`, `sign`, `verify`, `encrypt`, `decrypt`, `generateKey`, `importKey`,
-`exportKey`, `deriveBits` and `deriveKey`**, over SHA-1/256/384/512 (for `digest` and as every keyed
-algorithm's inner hash), **HMAC**, **AES-GCM** at 128, 192 and 256 bits, the RSA family —
+`crypto.subtle` carries **all twelve operations** — `digest`, `sign`, `verify`, `encrypt`, `decrypt`,
+`generateKey`, `importKey`, `exportKey`, `deriveBits`, `deriveKey`, `wrapKey` and `unwrapKey` — over
+SHA-1/256/384/512 (for `digest` and as every keyed algorithm's inner hash), **HMAC**, the AES family
+(**AES-CTR**, **AES-CBC**, **AES-GCM** and **AES-KW**, each at 128, 192 and 256 bits), the RSA family —
 **RSASSA-PKCS1-v1_5** and **RSA-PSS** for signatures, **RSA-OAEP** for encryption — the elliptic curves
 **P-256**, **P-384** and **P-521** under **ECDSA** and **ECDH**, and **HKDF** and **PBKDF2** for derivation.
 Keys are real `CryptoKey` objects with `type`, `extractable`, `algorithm` and `usages`, and
@@ -259,15 +260,29 @@ Keys are real `CryptoKey` objects with `type`, `extractable`, `algorithm` and `u
 is never reachable from script except through `exportKey` on an extractable key: `raw` bytes or a
 `kty: "oct"` JSON Web Key for a symmetric key, `spki`, `pkcs8` or a `kty: "RSA"` JSON Web Key for an RSA one,
 and all four of those — `raw` being the uncompressed point `04||X||Y` — for an elliptic-curve one.
-`wrapKey` and `unwrapKey` are *absent* rather than present-and-throwing, so `typeof crypto.subtle.wrapKey`
-tells a library the truth and it takes its fallback path.
 
 **The registries are per operation, and they are not symmetric.** HKDF and PBKDF2 register `importKey`,
 `deriveBits` and the internal *get key length* and nothing else: there is nothing to `generateKey` (the key
 *is* the password, or the input keying material you already have) and nothing to `exportKey`, their import
 steps refusing any `extractable` that is not `false`. So a PBKDF2 key is a one-way door — the bytes go in and
-only derived material comes out. ECDH registers `deriveBits` and never `sign`; ECDSA the reverse. An
-AES-GCM key may still carry the `wrapKey` and `unwrapKey` usages that nothing here consumes.
+only derived material comes out. ECDH registers `deriveBits` and never `sign`; ECDSA the reverse. And
+**AES-KW registers `wrapKey` and `unwrapKey` and neither `encrypt` nor `decrypt`**, which is the exact
+reverse of every other cipher: RFC 3394 wrapping takes a whole number of 64-bit blocks and carries an
+integrity check of its own, so `encrypt({ name: 'AES-KW' }, …)` is a `NotSupportedError` here and in a
+browser. That asymmetry is what `wrapKey`'s **double normalization** is for — the algorithm is normalized
+for `wrapKey` and, if that fails, for `encrypt` — so `wrapKey(format, key, kek, 'AES-KW')` takes the first
+route and `wrapKey(format, key, kek, { name: 'AES-GCM', iv })` (or AES-CBC, AES-CTR, RSA-OAEP) the second,
+with one method call either way.
+
+Wrapping *is* exporting, so `wrapKey` refuses a key that is not `extractable` with an `InvalidAccessError`
+and needs the `wrapKey` usage on the wrapping key. `unwrapKey` is the mirror, and it is where `extractable`
+and `keyUsages` for the *new* key are decided — which is what lets a server hand a script a key it can use
+and cannot export, `ext: false` in the wrapped JWK being honoured on the way in. For the `jwk` format the
+bytes wrapped are the UTF-8 of `JSON.stringify` of exactly the object `exportKey('jwk', key)` hands a script,
+and under AES-KW they are padded with spaces before the closing brace to a multiple of 8 — the convention
+every implementation follows and the web-platform tests compute their expectation with, which the
+specification's own note permits ("implementations may choose to adapt the serialization to the constraints
+of the wrapping algorithm").
 
 `deriveKey` is a composition rather than an algorithm of its own: it derives bits with one algorithm and
 imports them with another, so `deriveKey(pbkdf2Params, password, { name: 'AES-GCM', length: 256 }, …)` hands
@@ -305,9 +320,11 @@ algorithm that is not registered for the operation is a `NotSupportedError` `DOM
 against its own `usages`, against another algorithm, or against the wrong half of its pair (signing with a
 public key) is an `InvalidAccessError`, a malformed JWK or a DER structure that is not what its format names
 is a `DataError`, a usage list an algorithm does not support is a `SyntaxError`, and anything an argument
-conversion refuses is a `TypeError`. An AES-GCM or RSA-OAEP decryption that does not authenticate is one
-`OperationError` carrying nothing about which part of the input was wrong. The work is synchronous, so the
-promise is already settled when you get it.
+conversion refuses is a `TypeError`. An AES-GCM, AES-CBC or RSA-OAEP decryption that does not come out
+right, and an AES-KW unwrap whose integrity check fails, are each one `OperationError` carrying nothing
+about which part of the input was wrong — a decrypt that could tell "the padding was malformed" from "the
+padding was fine" is a padding oracle. The work is synchronous, so the promise is already settled when you
+get it.
 
 Where .NET's own cryptography is narrower than the specification the difference is visible, always as the
 `OperationError` the algorithm's own steps end in and always with a message naming the restriction:
@@ -316,6 +333,15 @@ Where .NET's own cryptography is narrower than the specification the difference 
   112, 120 or 128 — the specification also lists 32 and 64, which `System.Security.Cryptography.AesGcm` will
   not produce. The ciphertext is `ciphertext || tag`, exactly as the specification defines it, so a host
   reading a script's output with `AesGcm` splits the last `tagLength / 8` bytes off itself.
+- **AES-KW**: the payload must be a whole number of 64-bit blocks — the specification's own step — and at
+  least two of them, which is the wrapping algorithm's (NIST SP 800-38F §6.1 defines KW over `2 ≤ n`
+  semiblocks). The BCL has no unpadded key wrap at all — .NET 10 added only the *padded* RFC 5649 variant,
+  which is a different algorithm producing different bytes — so RFC 3394 is implemented here over the AES
+  ECB one-shots and pinned against all six published test vectors of its Section 4.
+- **AES-CTR**: .NET has no counter mode either, so the keystream is built from ECB over successive counter
+  blocks. The `length` member is the width of the counter field in bits and the rest of the block is nonce,
+  so the field wraps modulo 2^`length` rather than carrying into the nonce — which the specification
+  requires and which is pinned against expectations computed outside the engine.
 - **RSA-PSS**: `RSASignaturePadding.Pss` takes no salt-length parameter and always uses the hash's own
   output length, so `saltLength` is accepted at that one value (20, 32, 48 or 64 for SHA-1/256/384/512) and
   refused at any other rather than signing with a salt nobody asked for.


### PR DESCRIPTION
Adds AES-CBC, AES-CTR and AES-KW, and the `wrapKey`/`unwrapKey` operations — **`crypto.subtle` reaches 12 of 12 operations**, completing the final implementation slice.

Closes #3162.

The four AES algorithms now share one key-management core (`AesKeyManagement`, parameterized by name with throwing-default tables for the JWK `alg` suffix and usage set); `AesGcmAlgorithm` shrank to its cipher with no GCM pin touched. The wrap/encrypt registries are deliberately disjoint — AES-KW registers `wrapKey`/`unwrapKey` and nothing else, so `encrypt({name:'AES-KW'},…)` is a `NotSupportedError` as in a browser, and the other ciphers plus RSA-OAEP wrap through the spec's literal encrypt-fallback double normalization.

The two hand-rolled pieces the BCL lacks, each validated byte-for-byte against the standards' own vectors:

- **AES-KW is RFC 3394 §2.2.1/§2.2.2 in index-based form over the ECB one-shots** — .NET 8 has no key-wrap API and .NET 10 added only the padded RFC 5649 variant (`AesKwp`), a different algorithm with a different initial value, refused by name in the class docs so nobody "simplifies" to it. All six §4 vectors pinned both directions; the payload floor of two semiblocks is NIST SP 800-38F's, cited; the unwrap integrity check is `FixedTimeEquals` against one indistinguishable message with the register file zeroed before the throw — the CCA discipline RSA-OAEP's decrypt established.
- **AES-CTR builds its keystream by ECB-encrypting counter blocks** (the caller's data never enters the cipher), with NIST SP 800-38A's Appendix B.1 increment over the rightmost `length` bits — the carry stops at the field boundary, so the counter wraps modulo 2^length without touching the nonce, which the spec requires and WPT pins. The wrap boundary and the partial-byte carry are tested against independently computed expectations.

AES-CBC uses the BCL one-shots for the cipher but **performs the spec's unpadding steps itself** over a `PaddingMode.None` decryption — what the platform reports for wrong padding, and which of two failures it reports first, is exactly the kind of thing this chain has twice learned not to pin. Every octet of the claimed padding window is examined even after one fails, and one message covers every failure: CBC without a tag is the shape the padding-oracle attack was invented for, and the engine declines to be the distinguisher.

`wrapKey` (length 4) and `unwrapKey` (length 7) are compositions like `deriveKey`: the export/import dispatches were extracted and shared, so a wrapped-then-unwrapped key is exactly the key `importKey` would have made — `extractable`/`keyUsages` belong to the new key, a `jwk` carrying `ext: false` is honoured against them, and the unwrap-then-import failure taxonomy (shape vs. integrity vs. JSON vs. JWK contents) follows each step's own error. JWK wrapping serializes with this realm's `JSON.stringify` and, under AES-KW, pads with spaces before the closing brace — WPT's own construction, byte-recovered in a test; the spec quotes its own non-normative note on exactly this freedom. One documented divergence: the serialization runs in this realm rather than the spec's pristine one, so a script's own `Object.prototype.toJSON` can perturb bytes only that same script then fails to unwrap — documented at the method rather than papered over.

Verification kept the chain's standard: NIST SP 800-38A F.2/F.5 and RFC 3394 §4 vectors extracted from the source documents; three unpublished expectations computed with a from-scratch Python AES oracle self-checked against Appendix F.1 and reproducing every published vector. 102 new tests; **26 mutants, all killed** — the first round surfaced two genuine survivors and three weak pins (a counter nibble that masked the unmasked-increment mutant by luck, space-padding invisible to `JSON.parse`, probabilistic CBC-padding rows), each turned into a stronger deterministic test rather than written off.

The feature-detection pins complete their arc: all twelve operations present with WebIDL name and length. Full matrix green on net10.0 + net472 including host-contract-verification legs, re-verified after rebasing onto current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014n5uCpi2vvHWBSiewUwBiY
