### PR TITLE
Wpt: bring assert_throws_dom to upstream name-map fidelity

### DIFF
--- a/Jint.Tests/Wpt/Prelude/testharness-shim.js
+++ b/Jint.Tests/Wpt/Prelude/testharness-shim.js
@@ -266,17 +266,85 @@
         throw new AssertionError('did not throw' + describe(description));
     }
 
-    // https://webidl.spec.whatwg.org/#idl-DOMException-error-names — the legacy code each name carries, so a
-    // DOMException assertion checks the same two things a browser's testharness checks. A name absent here
-    // has no legacy code and `code` must read 0.
-    var domExceptionCodes = {
-        IndexSizeError: 1, HierarchyRequestError: 3, WrongDocumentError: 4, InvalidCharacterError: 5,
-        NoModificationAllowedError: 7, NotFoundError: 8, NotSupportedError: 9, InUseAttributeError: 10,
-        InvalidStateError: 11, SyntaxError: 12, InvalidModificationError: 13, NamespaceError: 14,
-        InvalidAccessError: 15, TypeMismatchError: 17, SecurityError: 18, NetworkError: 19,
-        AbortError: 20, URLMismatchError: 21, QuotaExceededError: 22, TimeoutError: 23,
-        InvalidNodeTypeError: 24, DataCloneError: 25
+    // https://webidl.spec.whatwg.org/#dfn-error-names-table — the two tables upstream's assert_throws_dom_impl
+    // carries, copied entry for entry. What they encode is not merely a lookup: `nameCodeMap` is a *closed
+    // set*, so a name it does not hold is a bug in the test rather than a name whose legacy code is 0, and
+    // saying so is what stops a typo'd expectation from being satisfied by a typo'd implementation. The
+    // entries mapped to 0 are the names added after the legacy code list closed, and they are listed rather
+    // than defaulted for exactly that reason.
+    //
+    // Two absences are deliberate and are upstream's, not shortcuts. `QuotaExceededError` is in neither table
+    // since it became an interface of its own (https://webidl.spec.whatwg.org/#quotaexceedederror), which is
+    // why the name and the legacy code 22 are refused below and sent to assert_throws_quotaexceedederror.
+    // `QUOTA_EXCEEDED_ERR` left `codenameNameMap` with it, so it is refused as an unrecognized name.
+    var codenameNameMap = {
+        INDEX_SIZE_ERR: 'IndexSizeError',
+        HIERARCHY_REQUEST_ERR: 'HierarchyRequestError',
+        WRONG_DOCUMENT_ERR: 'WrongDocumentError',
+        INVALID_CHARACTER_ERR: 'InvalidCharacterError',
+        NO_MODIFICATION_ALLOWED_ERR: 'NoModificationAllowedError',
+        NOT_FOUND_ERR: 'NotFoundError',
+        NOT_SUPPORTED_ERR: 'NotSupportedError',
+        INUSE_ATTRIBUTE_ERR: 'InUseAttributeError',
+        INVALID_STATE_ERR: 'InvalidStateError',
+        SYNTAX_ERR: 'SyntaxError',
+        INVALID_MODIFICATION_ERR: 'InvalidModificationError',
+        NAMESPACE_ERR: 'NamespaceError',
+        INVALID_ACCESS_ERR: 'InvalidAccessError',
+        TYPE_MISMATCH_ERR: 'TypeMismatchError',
+        SECURITY_ERR: 'SecurityError',
+        NETWORK_ERR: 'NetworkError',
+        ABORT_ERR: 'AbortError',
+        URL_MISMATCH_ERR: 'URLMismatchError',
+        TIMEOUT_ERR: 'TimeoutError',
+        INVALID_NODE_TYPE_ERR: 'InvalidNodeTypeError',
+        DATA_CLONE_ERR: 'DataCloneError'
     };
+
+    var nameCodeMap = {
+        IndexSizeError: 1,
+        HierarchyRequestError: 3,
+        WrongDocumentError: 4,
+        InvalidCharacterError: 5,
+        NoModificationAllowedError: 7,
+        NotFoundError: 8,
+        NotSupportedError: 9,
+        InUseAttributeError: 10,
+        InvalidStateError: 11,
+        SyntaxError: 12,
+        InvalidModificationError: 13,
+        NamespaceError: 14,
+        InvalidAccessError: 15,
+        TypeMismatchError: 17,
+        SecurityError: 18,
+        NetworkError: 19,
+        AbortError: 20,
+        URLMismatchError: 21,
+        TimeoutError: 23,
+        InvalidNodeTypeError: 24,
+        DataCloneError: 25,
+
+        EncodingError: 0,
+        NotReadableError: 0,
+        UnknownError: 0,
+        ConstraintError: 0,
+        DataError: 0,
+        TransactionInactiveError: 0,
+        ReadOnlyError: 0,
+        VersionError: 0,
+        OperationError: 0,
+        NotAllowedError: 0,
+        OptOutError: 0
+    };
+
+    // The inverse over the names that have a legacy code, so the numeric call form can say which name it
+    // means. Built once here rather than per call, which is upstream's only cost this shim declines to pay.
+    var codeNameMap = {};
+    for (var mappedName in nameCodeMap) {
+        if (nameCodeMap[mappedName] > 0) {
+            codeNameMap[nameCodeMap[mappedName]] = mappedName;
+        }
+    }
 
     // The synchronous form always means this global's DOMException. `promise_rejects_dom` may be told which
     // global the exception is expected to come from, so the matching half takes the constructor as an
@@ -294,19 +362,68 @@
             }
             assert(typeof e === 'object' && e !== null,
                 'threw ' + format_value(e) + ', not an object' + describe(description));
+            // Without this a type that is neither would fall past both branches below and leave nothing to
+            // check, so the assertion would pass on any exception at all.
+            assert(typeof type === 'number' || typeof type === 'string',
+                format_value(type) + ' is not a number or string' + describe(description));
+
+            // The refusals below are upstream's, message for message, and they are thrown rather than
+            // asserted because none of them is about the exception: the *test* named something the tables
+            // cannot, and reporting that as "it did not match" would let a typo read as a divergence. Note
+            // where they sit — inside the catch, as upstream — so a body that threw nothing is still
+            // reported as "did not throw" rather than as a test bug.
+            var required = {};
+            var name;
+            if (typeof type === 'number') {
+                if (type === 0) {
+                    throw new AssertionError('Test bug: ambiguous DOMException code 0 passed to assert_throws_dom()');
+                }
+                if (type === 22) {
+                    throw new AssertionError('Test bug: QuotaExceededError needs to be tested for using assert_throws_quotaexceedederror()');
+                }
+                if (!Object.prototype.hasOwnProperty.call(codeNameMap, type)) {
+                    throw new AssertionError('Test bug: unrecognized DOMException code "' + type + '" passed to assert_throws_dom()');
+                }
+                name = codeNameMap[type];
+                required.code = type;
+            } else {
+                // Upstream's own QuotaExceededError check sits here but reads `name`, which it does not
+                // assign until the line after, so the string form never reaches it and is refused one line
+                // later as an unrecognized name instead. The call is refused either way and no vendored test
+                // makes it; this shim tests `type` so that the refusal names the assertion to use, which is
+                // what upstream's message plainly intends to say. Mirroring the line as written would mean
+                // committing a branch that is dead by construction, which is why this is the one place the
+                // two differ — in the wording of a refusal, never in whether there is one.
+                if (type === 'QuotaExceededError') {
+                    throw new AssertionError('Test bug: QuotaExceededError needs to be tested for using assert_throws_quotaexceedederror()');
+                }
+                name = Object.prototype.hasOwnProperty.call(codenameNameMap, type) ? codenameNameMap[type] : type;
+                if (!Object.prototype.hasOwnProperty.call(nameCodeMap, name)) {
+                    throw new AssertionError('Test bug: unrecognized DOMException code name or name "' + type + '" passed to assert_throws_dom()');
+                }
+                required.code = nameCodeMap[name];
+            }
+
+            // Upstream's condition for checking the name as well as the code. A legacy exception object wore
+            // an all-caps name or called itself "DOMException", and comparing that against a modern name would
+            // say nothing; a name whose legacy code is 0 is checked either way, because there the code says
+            // nothing on its own.
+            if (required.code === 0 ||
+                ('name' in e && e.name !== e.name.toUpperCase() && e.name !== 'DOMException')) {
+                required.name = name;
+            }
+
+            for (var prop in required) {
+                // `==` rather than `===`, as upstream, and `prop in e` first so that a missing property is a
+                // failure rather than an undefined that compares loosely equal to nothing.
+                assert(prop in e && e[prop] == required[prop],
+                    'threw ' + format_value(e) + ', which is not a DOMException ' + type + ': property "' + prop +
+                    '" is ' + format_value(e[prop]) + ', expected ' + format_value(required[prop]) + describe(description));
+            }
+
+            // Last, so that a wrong shape is reported by the more informative checks above first.
             assert(e.constructor === constructor,
                 'expected a DOMException but got ' + format_value(e) + describe(description));
-            if (typeof type === 'number') {
-                assert(e.code === type,
-                    'expected DOMException code ' + type + ' but got ' + e.code + describe(description));
-            } else {
-                assert(e.name === type,
-                    'expected DOMException "' + type + '" but got "' + e.name + '"' + describe(description));
-                var expectedCode = Object.prototype.hasOwnProperty.call(domExceptionCodes, type) ? domExceptionCodes[type] : 0;
-                assert(e.code === expectedCode,
-                    'expected DOMException "' + type + '" to carry code ' + expectedCode +
-                    ' but it carried ' + e.code + describe(description));
-            }
             return;
         }
         throw new AssertionError('did not throw' + describe(description));

--- a/Jint.Tests/Wpt/WptHarnessTests.cs
+++ b/Jint.Tests/Wpt/WptHarnessTests.cs
@@ -29,6 +29,9 @@ public class WptHarnessTests
         return outcome.Results[0].Status;
     }
 
+    /// <summary>The message recorded for a test whose whole body is <paramref name="body"/>.</summary>
+    private static string? MessageOf(string body) => Run($"test(() => {body}, 'row');").Results[0].Message;
+
     [Theory]
     // Each row is one assertion, a body that must be recorded PASS and a body that must be recorded FAIL.
     [InlineData("assert_true(true)", "assert_true(1)")]
@@ -50,6 +53,18 @@ public class WptHarnessTests
     [InlineData(
         "assert_throws_dom('NotFoundError', () => { throw new DOMException('x', 'NotFoundError'); })",
         "assert_throws_dom('NotFoundError', () => { var e = new Error(); e.name = 'NotFoundError'; e.code = 8; throw e; })")]
+    // A legacy code *name* is accepted and mapped to the name it stands for, so it expects `NotFoundError`
+    // rather than an exception literally called NOT_FOUND_ERR — upstream's `codename_name_map`.
+    [InlineData(
+        "assert_throws_dom('NOT_FOUND_ERR', () => { throw new DOMException('x', 'NotFoundError'); })",
+        "assert_throws_dom('NOT_FOUND_ERR', () => { throw new DOMException('x', 'DataCloneError'); })")]
+    [InlineData(
+        "assert_throws_dom('DATA_CLONE_ERR', () => { throw new DOMException('x', 'DataCloneError'); })",
+        "assert_throws_dom('DATA_CLONE_ERR', () => { throw new DOMException('x', 'NotFoundError'); })")]
+    // The numeric form names a code, and the name that code stands for is checked with it.
+    [InlineData(
+        "assert_throws_dom(8, () => { throw new DOMException('x', 'NotFoundError'); })",
+        "assert_throws_dom(8, () => { throw new DOMException('x', 'DataCloneError'); })")]
     [InlineData("assert_throws_exactly(1, () => { throw 1; })", "assert_throws_exactly(1, () => { throw 2; })")]
     [InlineData("if (false) assert_unreached('x')", "assert_unreached('x')")]
     [InlineData("assert_in_array(2, [1, 2, 3])", "assert_in_array(4, [1, 2, 3])")]
@@ -113,6 +128,11 @@ public class WptHarnessTests
     [InlineData(
         "promise_rejects_dom(t, 'AbortError', Promise.reject(new DOMException('x', 'AbortError')))",
         "promise_rejects_dom(t, 'NotFoundError', Promise.reject(Object.assign(new Error(), { name: 'NotFoundError', code: 8 })))")]
+    // The rejection form shares one implementation with the synchronous one, so the legacy code names it
+    // accepts and the names it refuses are the same set — this row is what would catch the two drifting.
+    [InlineData(
+        "promise_rejects_dom(t, 'ABORT_ERR', Promise.reject(new DOMException('x', 'AbortError')))",
+        "promise_rejects_dom(t, 'ABORT_ERR', Promise.reject(new DOMException('x', 'NotFoundError')))")]
     // The four-argument form names the global the exception must come from: this one satisfies it, and a
     // DOMException constructor that is not this global's does not, however right the name and code are.
     [InlineData(
@@ -196,8 +216,6 @@ public class WptHarnessTests
     {
         // Messages are what an exclusion is triaged from, and every one of these is a name the corresponding
         // upstream assertion produces once its ${p}/${actual} substitutions have gone through format_value.
-        static string? MessageOf(string body) => Run($"test(() => {body}, 'row');").Results[0].Message;
-
         MessageOf("assert_object_equals({ a: 1 }, { a: 2 }, 'why')").Should().Be("property \"a\" expected 2 got 1 (why)");
         MessageOf("assert_object_equals({ a: 1, b: 2 }, { a: 1 })").Should().Be("unexpected property \"b\"");
         MessageOf("assert_object_equals({ a: 1 }, { a: 1, b: 2 })").Should().Be("expected property \"b\" missing");
@@ -308,6 +326,79 @@ public class WptHarnessTests
             .Should().Be("PASS");
         StatusOf("test(() => assert_throws_dom('EncodingError', () => { throw new DOMException('x', 'EncodingError'); }), 'row');")
             .Should().Be("PASS");
+    }
+
+    [Fact]
+    public void ADomExceptionAssertionRefusesANameItsTableCannotHold()
+    {
+        // https://webidl.spec.whatwg.org/#dfn-error-names-table — upstream's `name_code_map` is a closed set,
+        // and a name it does not hold is a bug in the test rather than a name whose legacy code happens to be
+        // 0. Accepting one is the quiet wrong green this exists to stop: `assert_throws_dom('NotFundError',
+        // …)` would be satisfied by an implementation that threw exactly that typo, and both sides would
+        // agree while both were wrong. The refusal is upstream's message verbatim.
+        MessageOf("assert_throws_dom('NotFundError', () => { throw new DOMException('x', 'NotFundError'); })")
+            .Should().Be("Test bug: unrecognized DOMException code name or name \"NotFundError\" passed to assert_throws_dom()");
+        StatusOf("test(() => assert_throws_dom('NotFundError', () => { throw new DOMException('x', 'NotFundError'); }), 'row');")
+            .Should().Be("FAIL");
+
+        // `QUOTA_EXCEEDED_ERR` left `codename_name_map` when the interface moved out, so the legacy code name
+        // is refused as a name like any other rather than pointed anywhere.
+        MessageOf("assert_throws_dom('QUOTA_EXCEEDED_ERR', () => { throw new DOMException('x', 'QuotaExceededError'); })")
+            .Should().Be("Test bug: unrecognized DOMException code name or name \"QUOTA_EXCEEDED_ERR\" passed to assert_throws_dom()");
+
+        // The numeric form has two refusals of its own: 0 names no single error, and a code outside the table
+        // names none at all.
+        MessageOf("assert_throws_dom(0, () => { throw new DOMException('x', 'EncodingError'); })")
+            .Should().Be("Test bug: ambiguous DOMException code 0 passed to assert_throws_dom()");
+        MessageOf("assert_throws_dom(2, () => { throw new DOMException('x', 'NotFoundError'); })")
+            .Should().Be("Test bug: unrecognized DOMException code \"2\" passed to assert_throws_dom()");
+
+        // And an expectation that is neither has to be caught before the two branches, or it would reach
+        // neither of them and leave nothing at all to compare the exception against.
+        MessageOf("assert_throws_dom(undefined, () => { throw new DOMException('x', 'NotFoundError'); })")
+            .Should().Be("undefined is not a number or string");
+    }
+
+    [Fact]
+    public void QuotaExceededErrorIsSentToItsOwnAssertionRatherThanMatchedAsADomExceptionName()
+    {
+        // https://webidl.spec.whatwg.org/#quotaexceedederror — since it became an interface of its own it is
+        // in neither of upstream's tables, so the name and the legacy code 22 are both refused and named at
+        // assert_throws_quotaexceedederror. The exception the body throws is precisely the shape that would
+        // have satisfied the old table — a DOMException called QuotaExceededError, which is what Jint's
+        // getRandomValues throws today — so this pins the refusal and not merely a mismatch.
+        const string sendItThere = "Test bug: QuotaExceededError needs to be tested for using assert_throws_quotaexceedederror()";
+
+        MessageOf("assert_throws_dom('QuotaExceededError', () => { throw new DOMException('x', 'QuotaExceededError'); })")
+            .Should().Be(sendItThere);
+        MessageOf("assert_throws_dom(22, () => { throw new DOMException('x', 'QuotaExceededError'); })")
+            .Should().Be(sendItThere);
+        StatusOf("test(() => assert_throws_dom('QuotaExceededError', () => { throw new DOMException('x', 'QuotaExceededError'); }), 'row');")
+            .Should().Be("FAIL");
+    }
+
+    [Fact]
+    public void TheRejectionFormRefusesWhatTheSynchronousFormRefuses()
+    {
+        // Both forms share `assert_throws_dom_impl`, which is what keeps the accepted set and the refused set
+        // from drifting apart — and why upstream's message names `assert_throws_dom()` from either entrance.
+        var outcome = Run(
+            "promise_test(t => promise_rejects_dom(t, 'NotFundError', Promise.reject(new DOMException('x', 'NotFundError'))), 'row');");
+
+        outcome.HarnessError.Should().BeNull();
+        outcome.Results[0].Status.Should().Be("FAIL");
+        outcome.Results[0].Message
+            .Should().Be("Test bug: unrecognized DOMException code name or name \"NotFundError\" passed to assert_throws_dom()");
+    }
+
+    [Fact]
+    public void ABodyThatThrewNothingIsReportedAsSuchEvenWhenTheNameWouldHaveBeenRefused()
+    {
+        // The refusals sit inside the catch, where upstream's are, so "it did not throw" outranks "the name
+        // is not one I hold". Hoisting them above the try would silently reclassify every did-not-throw
+        // failure in a suite that named something the table does not carry.
+        MessageOf("assert_throws_dom('NotFundError', () => {})").Should().Be("did not throw");
+        MessageOf("assert_throws_dom(22, () => {}, 'why')").Should().Be("did not throw (why)");
     }
 
     [Fact]


### PR DESCRIPTION
Brings the WPT shim's `assert_throws_dom` / `promise_rejects_dom` to upstream name-map fidelity, closing the two gaps #3169 recorded before a future corpus bump could turn either into a wrong green.

Closes #3169.

The shim now carries upstream's two tables entry for entry — `codename_name_map` (legacy code names like `NOT_FOUND_ERR` accepted and mapped) and `name_code_map` as a **closed set**, so an unrecognized name is upstream's "Test bug" refusal rather than a name whose code happens to be 0, and a typo'd expectation can no longer be satisfied by a typo'd implementation. `QuotaExceededError` (by name, and legacy code 22, and the ambiguous code 0) are refused with the redirect to `assert_throws_quotaexceedederror`, which this shim already ships. The refusals sit inside the catch, as upstream's do, so "did not throw" still outranks "that name is not one I hold"; the numeric call form checks both properties via the derived inverse; the constructor check moves last so the informative mismatch reports first.

Two findings worth the read:

- **Upstream's own `QuotaExceededError`-by-name check is dead code**: it reads `name` one line before `name` is assigned, so the string form falls through to the unrecognized-name refusal with the *wrong message*. This shim is deliberately one wording different — it tests `type` and gives the quota-redirect message the dead branch plainly intended — refusal identical either way, and the divergence is argued in a comment at the exact line. Probably worth filing against web-platform-tests.
- Every vendored call site was enumerated rather than sampled: exactly three distinct expectations across the whole tree (`TypeMismatchError`, `NotSupportedError`, `DataCloneError`), all held by the table, so the stricter shim refuses nothing the corpus calls and no exclusion entry moved.

8 mutations, all killed — including the two defects the issue recorded (each now has a row that fails without the fix) and the restructure's own new hazard (a non-string non-number `type` falling past both branches). 4 new both-sides theory rows + 4 facts. Test-only change; full matrix green on both TFMs, all 10 vendored WPT suites green including under host-contract verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014n5uCpi2vvHWBSiewUwBiY
