### PR TITLE
Web Crypto: check the ECDH pair before the length ceiling, as every browser does

### DIFF
--- a/Jint.Tests/Runtime/WebApi/SubtleCryptoDeriveTests.cs
+++ b/Jint.Tests/Runtime/WebApi/SubtleCryptoDeriveTests.cs
@@ -459,7 +459,9 @@ public class SubtleCryptoDeriveTests
         // "Let maximumLength be the length in bits of the output of the field element to octet string
         // conversion … If length is not null and is greater than maximumLength, then throw an
         // OperationError." The conversion pads to whole octets, so P-521's maximum is 528 and not 521 — the
-        // one row of this table that cannot be read off the curve's name.
+        // one row of this table that cannot be read off the curve's name. Both keys are the same pair here,
+        // so the ceiling is the only thing that can refuse the request; where the two curves differ it is not
+        // reached at all, which is AMismatchedCurveIsAnInvalidAccessErrorWhateverTheLengthAsksFor's subject.
         Run($$"""
             const pair = await crypto.subtle.generateKey({ name: 'ECDH', namedCurve: '{{curve}}' }, false, ['deriveBits']);
             const params = { name: 'ECDH', public: pair.publicKey };
@@ -506,6 +508,49 @@ public class SubtleCryptoDeriveTests
                 await attempt({ name: 'ECDH', public: bobPub }, ecdsaPair.privateKey),
             ].join(',');
             """).AsString().Should().Be("InvalidAccessError,InvalidAccessError,InvalidAccessError,InvalidAccessError,InvalidAccessError");
+    }
+
+    [Fact]
+    public void AMismatchedCurveIsAnInvalidAccessErrorWhateverTheLengthAsksFor()
+    {
+        // The one place this engine deliberately departs from the ECDH derive-bits prose, and the reason is
+        // in EcAlgorithm.DeriveBits's remarks: steps 4 and 5 measure *maximumLength* off the **public** key's
+        // domain parameters and refuse an over-long `length` with an OperationError before steps 7 and 8 have
+        // established that the two keys are a pair at all. Read literally, a P-384 or P-521 base key handed a
+        // P-256 public key and asked for its own field width is therefore refused for its length. Chrome,
+        // Firefox, Safari and Node all answer the InvalidAccessError of the later step, and the corpus pins
+        // that in `WebCryptoAPI/derive_bits_keys/ecdh_bits.https.any.js`'s `P-384 mismatched curves` and
+        // `P-521 mismatched curves` rows — which ask for exactly 8 x the base key's field width. Jint follows
+        // the browsers, so the first two rows below are the ones that move: put steps 4 and 5 back above the
+        // key-agreement checks and they read OperationError again.
+        Run("""
+            const p256 = await crypto.subtle.generateKey({ name: 'ECDH', namedCurve: 'P-256' }, false, ['deriveBits']);
+            const p384 = await crypto.subtle.generateKey({ name: 'ECDH', namedCurve: 'P-384' }, false, ['deriveBits']);
+            const p521 = await crypto.subtle.generateKey({ name: 'ECDH', namedCurve: 'P-521' }, false, ['deriveBits']);
+
+            const attempt = async (pub, priv, length) => {
+                try { await crypto.subtle.deriveBits({ name: 'ECDH', public: pub }, priv, length); return 'derived'; }
+                catch (e) { return e.name; }
+            };
+
+            return [
+                // The corpus's own two rows: 8 x the *base* key's field width, against a narrower public key.
+                await attempt(p256.publicKey, p384.privateKey, 384),
+                await attempt(p256.publicKey, p521.privateKey, 528),
+                // The same two mismatches at a length no ceiling could object to, and at no length at all.
+                await attempt(p256.publicKey, p384.privateKey, 128),
+                await attempt(p256.publicKey, p521.privateKey, null),
+                // The corpus's P-256 row, which was green under either order because the curve it is
+                // mismatched against is the wider one — so on its own it proves nothing about the ordering.
+                await attempt(p384.publicKey, p256.privateKey, 256),
+                // Matched curves and an over-long length is still step 5's OperationError: the move reorders
+                // the ceiling, it does not remove it.
+                await attempt(p256.publicKey, p256.privateKey, 264),
+                await attempt(p521.publicKey, p521.privateKey, 536),
+            ].join(',');
+            """).AsString().Should().Be(
+                "InvalidAccessError,InvalidAccessError,InvalidAccessError,InvalidAccessError,InvalidAccessError"
+                + ",OperationError,OperationError");
     }
 
     [Fact]

--- a/Jint.Tests/Wpt/WptExclusions.cs
+++ b/Jint.Tests/Wpt/WptExclusions.cs
@@ -135,9 +135,12 @@ internal enum WptDivergence
     /// say, and mixing engine fixes into the change that first ran them would have hidden which of the two
     /// moved. The four the first phase recorded — WebIDL constant order, <c>TextDecoder.decode()</c> reading
     /// its input before the options dictionary was converted, and the shared UTF-16 decoder's end-of-queue
-    /// step for both endiannesses — were fixed by https://github.com/sebastienros/jint/issues/3121.
+    /// step for both endiannesses — were fixed by https://github.com/sebastienros/jint/issues/3121, and
+    /// ECDH's two mismatched-curve rows by https://github.com/sebastienros/jint/issues/3180: the corpus was
+    /// asserting the browsers' order rather than the prose's, so <c>EcAlgorithm.DeriveBits</c> now runs the
+    /// key-agreement checks before the <i>maximumLength</i> ceiling and documents the divergence on itself.
     /// <para>
-    /// The WebCryptoAPI corpus filed two more, and both are one-line summaries of a real disagreement:
+    /// What the WebCryptoAPI corpus filed and nobody has answered yet is one disagreement:
     /// </para>
     /// <list type="bullet">
     /// <item><description>
@@ -149,14 +152,6 @@ internal enum WptDivergence
     /// the order observable by putting a getter on the algorithm's <c>name</c> that rewrites or transfers the
     /// buffer. Note <c>SubtleCryptoKeyTests.TheDataArgumentIsCopiedBeforeAnyGetterCanRun</c> pins the order
     /// Jint has today, so fixing this moves that test too.
-    /// </description></item>
-    /// <item><description>
-    /// <b>ECDH's two mismatched-curve rows.</b> <c>EcAlgorithm</c> follows the specification exactly —
-    /// <i>maximumLength</i> comes from the <b>public</b> key's domain parameters and its <c>OperationError</c>
-    /// is raised before the curves are compared, so a P-521 base key handed a P-256 public key is refused for
-    /// its length rather than for the mismatch. The corpus expects the <c>InvalidAccessError</c> of the later
-    /// step, which is what browsers answer. The P-256 row passes only because its other curve is wider.
-    /// Somebody has to decide whether Jint follows the prose or the browsers, and probably raise it upstream.
     /// </description></item>
     /// </list>
     /// </summary>

--- a/Jint.Tests/Wpt/WptTestRunner.cs
+++ b/Jint.Tests/Wpt/WptTestRunner.cs
@@ -22,9 +22,10 @@ namespace Jint.Tests.Wpt;
 /// expected and found; the ones that are not a missing feature are parked under
 /// <see cref="WptDivergence.NeedsTriage"/> rather than fixed there, so that the change which first runs a
 /// suite is not also the change that moves the engine. The four the URL and Encoding suites found were fixed
-/// by https://github.com/sebastienros/jint/issues/3121; the two the WebCryptoAPI corpus found — the point at
-/// which <c>SubtleCrypto</c> copies its caller's bytes, and ECDH's mismatched-curve error — are open, and the
-/// category's own documentation says what they are.
+/// by https://github.com/sebastienros/jint/issues/3121; of the two the WebCryptoAPI corpus found, ECDH's
+/// mismatched-curve error was fixed by https://github.com/sebastienros/jint/issues/3180 and the point at
+/// which <c>SubtleCrypto</c> copies its caller's bytes is still open, with the category's own documentation
+/// saying what it is.
 /// </para>
 /// <para>
 /// <b>The WebCryptoAPI corpus is one suite per directory</b> rather than one for the lot, because
@@ -352,12 +353,6 @@ public class WptTestRunner
         new("WebCryptoAPI/sign_verify/hmac.https.any.js", "HMAC * verification with * during call", WptDivergence.NeedsTriage),
         new("WebCryptoAPI/sign_verify/rsa_pkcs.https.any.js", "RSASSA-PKCS1-v1_5 * with * during call", WptDivergence.NeedsTriage),
         new("WebCryptoAPI/sign_verify/rsa_pkcs.https.any.js", "RSASSA-PKCS1-v1_5 * verification with * during call", WptDivergence.NeedsTriage),
-
-        // ECDH's step 4 takes maximumLength from the *public* key and raises its OperationError before step 8
-        // compares the curves, which is what the prose says and not what a browser answers. The P-256 row
-        // passes only because the curve it is mismatched against is the wider one.
-        new("WebCryptoAPI/derive_bits_keys/ecdh_bits.https.any.js", "P-384 mismatched curves", WptDivergence.NeedsTriage),
-        new("WebCryptoAPI/derive_bits_keys/ecdh_bits.https.any.js", "P-521 mismatched curves", WptDivergence.NeedsTriage),
 
         // The X25519 rows of a file that is otherwise about the `length` parameter of deriveBits.
         new("WebCryptoAPI/derive_bits_keys/derived_bits_length.https.any.js", "X25519 derivation with *", WptDivergence.NeedsCurve25519),

--- a/Jint/WebApi/Crypto/EcAlgorithm.cs
+++ b/Jint/WebApi/Crypto/EcAlgorithm.cs
@@ -627,11 +627,30 @@ internal static class EcAlgorithm
     /// arrived in .NET 8, which is this feature area's floor anyway.
     /// </para>
     /// <para>
-    /// <b>The nine steps run in the specification's order, and the order is observable.</b> A caller passing
-    /// a private key as <c>public</c>, an ECDSA key as <c>public</c>, a public key as <c>baseKey</c>, a
+    /// <b>Steps 4 and 5 deliberately do not run where the prose puts them.</b> The specification derives
+    /// <i>maximumLength</i> from the <b>public</b> key's domain parameters (step 4) and raises its
+    /// <c>OperationError</c> for an over-long <c>length</c> (step 5) <i>before</i> steps 7 and 8 have
+    /// established that the two keys are a pair at all — so read literally, a P-521 base key handed a P-256
+    /// public key and asked for 528 bits is refused for its length rather than for the mismatch. Chrome,
+    /// Firefox, Safari and Node all answer the <c>InvalidAccessError</c> of the later step instead, and the
+    /// web-platform-tests pin exactly that: the <c>P-384 mismatched curves</c> and <c>P-521 mismatched
+    /// curves</c> rows of <c>WebCryptoAPI/derive_bits_keys/ecdh_bits.https.any.js</c> ask for eight times the
+    /// <b>base</b> key's field width in bits — 384 and 528 against a P-256 public key — and assert
+    /// <c>InvalidAccessError</c>, which no implementation obeying step 5 where it is written can produce.
+    /// (Their <c>P-256</c> sibling passes either way only because the curve it is mismatched against is the
+    /// wider one.) Chrome, Firefox and Safari all report that file 40/40 on wpt.fyi, so the browser answer is
+    /// not one vendor's reading. This engine follows them: every key-agreement check runs first, and the
+    /// length ceiling is measured only once the pair is known to be one. The disagreement is
+    /// https://github.com/sebastienros/jint/issues/3180, to be raised with w3c/webcrypto; if the
+    /// specification reorders its steps, what goes is this comment and not the code.
+    /// </para>
+    /// <para>
+    /// <b>The order is observable, which is why the rest of it is spelled out below.</b> A caller passing a
+    /// private key as <c>public</c>, an ECDSA key as <c>public</c>, a public key as <c>baseKey</c>, a
     /// mismatched curve and an over-long <c>length</c> all earn different errors, and which one a request
-    /// carrying several of those mistakes gets is decided here: the checks on the <c>public</c> member come
-    /// first, then the length ceiling, then the checks on <c>baseKey</c>.
+    /// carrying several of those mistakes gets is decided here: the checks on the <c>public</c> member
+    /// (steps 2 and 3), then the checks on <c>baseKey</c> (steps 6, 7 and 8), then the length ceiling
+    /// (steps 4 and 5), then the agreement itself.
     /// </para>
     /// </remarks>
     internal static byte[] DeriveBits(
@@ -661,18 +680,6 @@ internal static class EcAlgorithm
                 what + ": the public member of the algorithm is an " + publicKey.Algorithm.Name + " key, not an " + normalized.Name + " one.");
         }
 
-        // Steps 4 and 5: "Let maximumLength be the length in bits of the output of the field element to octet
-        // string conversion … If length is not null and is greater than maximumLength, then throw an
-        // OperationError." The conversion pads to whole octets, so P-521's maximum is 528 rather than 521.
-        var maximumLength = 8 * FieldSizeInBytes(publicKey.Algorithm.NamedCurve!);
-
-        if (length is { } requested && requested > maximumLength)
-        {
-            context.ThrowOperationError(
-                what + ": a length of " + requested + " bits was asked for, and a shared secret on "
-                + publicKey.Algorithm.NamedCurve + " is " + maximumLength + " bits long.");
-        }
-
         // Step 6: "If the [[type]] internal slot of key is not 'private', then throw an InvalidAccessError."
         RequireKeyType(context, key, CryptoKeyTypes.Private, what);
 
@@ -696,6 +703,24 @@ internal static class EcAlgorithm
             context.ThrowInvalidAccessError(
                 what + ": the public key is on the curve " + publicKey.Algorithm.NamedCurve + " and the base key on "
                 + key.Algorithm.NamedCurve + "; an agreement needs one curve.");
+        }
+
+        // Steps 4 and 5, run here rather than where the prose writes them — see the remarks above: "Let
+        // maximumLength be the length in bits of the output of the field element to octet string conversion …
+        // for the EC domain parameters associated with publicKey … If length is not null and is greater than
+        // maximumLength, then throw an OperationError." Step 8 has
+        // just proved the two curves are one, so measuring the ceiling off the public key's domain parameters
+        // and off the base key's are now the same measurement, and the only request whose answer this move
+        // changes is one that was never going to derive anything: a mismatched pair, which browsers and the
+        // corpus's mismatched-curve rows say earns the InvalidAccessError above. The conversion pads to whole
+        // octets, so P-521's maximum is 528 rather than 521.
+        var maximumLength = 8 * FieldSizeInBytes(publicKey.Algorithm.NamedCurve!);
+
+        if (length is { } requested && requested > maximumLength)
+        {
+            context.ThrowOperationError(
+                what + ": a length of " + requested + " bits was asked for, and a shared secret on "
+                + publicKey.Algorithm.NamedCurve + " is " + maximumLength + " bits long.");
         }
 
         byte[] secret;
@@ -732,8 +757,8 @@ internal static class EcAlgorithm
 
         if (8L * secret.Length < bits)
         {
-            // Unreachable: step 5 measured the same curve's field width, and step 8 proved the two keys share
-            // a curve. It is the specification's step and it costs nothing.
+            // Unreachable: step 8 proved the two keys share a curve, and step 5 then measured that very
+            // curve's field width. It is the specification's step and it costs nothing.
             context.ThrowOperationError(
                 what + ": a length of " + bits + " bits was asked for, and the shared secret is " + (8 * secret.Length) + " bits long.");
         }

--- a/Jint/WebApi/Crypto/EcAlgorithm.cs
+++ b/Jint/WebApi/Crypto/EcAlgorithm.cs
@@ -641,8 +641,9 @@ internal static class EcAlgorithm
     /// wider one.) Chrome, Firefox and Safari all report that file 40/40 on wpt.fyi, so the browser answer is
     /// not one vendor's reading. This engine follows them: every key-agreement check runs first, and the
     /// length ceiling is measured only once the pair is known to be one. The disagreement is
-    /// https://github.com/sebastienros/jint/issues/3180, to be raised with w3c/webcrypto; if the
-    /// specification reorders its steps, what goes is this comment and not the code.
+    /// filed as https://github.com/w3c/webcrypto/issues/560 (from
+    /// https://github.com/sebastienros/jint/issues/3180); if the specification reorders its steps, what goes
+    /// is this comment and not the code.
     /// </para>
     /// <para>
     /// <b>The order is observable, which is why the rest of it is spelled out below.</b> A caller passing a


### PR DESCRIPTION
Resolves the ECDH `deriveBits` prose-vs-browsers disagreement by matching the browsers: the key-agreement checks (base key is private, algorithm names match, named curves match — steps 6/7/8) now run **before** the `maximumLength`/`length` ceiling (steps 4/5), so a mismatched pair earns `InvalidAccessError` whatever the length asked for. Every check body is byte-for-byte unchanged; only the ceiling moved, and once step 8 has proved the curves are one, measuring it off the public key's parameters is the same measurement the prose describes.

Closes #3180.

The evidence, verified rather than recalled: the two WPT rows ask for eight times the *base* key's field width against a P-256 public key (384 and 528 bits), which no implementation obeying step 5 where it is written can satisfy — and `ecdh_bits.https.any.html` is 40/40 in Chrome 152, Firefox 154 and Safari 26.6 on wpt.fyi, with Chromium/Gecko/WebKit/Node sources all validating the pair before any length reasoning. Nothing in w3c/webcrypto's issues covers this (searched); a ready-to-file upstream issue draft — including the analysis of why the P-256 row passes either way and why reordering beats re-deriving the ceiling from the base key — is attached below in a comment for the maintainer to file. If the spec reorders its steps, what goes is Jint's divergence comment, not the code.

One deliberate widening over the issue's ask, argued in the code: step 6 (base-key-is-private) hoists too, keeping 6/7/8 in their prose order among themselves — lifting only 7/8 would have left a public base key on a matched curve with an over-long length answering `OperationError` where Chromium answers `InvalidAccessError`, a *new* divergence no WPT row covers.

The two `NeedsTriage` exclusion rows are deleted (the driver enforces it — they would have gone stale the moment the code moved); `ecdh_keys` was audited and needed no change (its rows never reached the ceiling). The reordering is entirely Jint-level ordinal string comparisons decided before any BCL primitive is touched, so for once no platform can pick a different step — no `Platform:` scoping needed.

New pin `AMismatchedCurveIsAnInvalidAccessErrorWhateverTheLengthAsksFor` covers the two discriminating shapes plus a matched-curve over-long-length row that must stay `OperationError`; mutation-verified by reinstating the prose order (exactly that one test fails, on exactly the two discriminating rows). Full matrix green on both TFMs including host-contract-verification legs; all WPT suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014n5uCpi2vvHWBSiewUwBiY
