### PR TITLE
Web Crypto: copy the caller's bytes at the step that copies them

### DIFF
--- a/Jint.Tests/Runtime/WebApi/SubtleCryptoKeyTests.cs
+++ b/Jint.Tests/Runtime/WebApi/SubtleCryptoKeyTests.cs
@@ -1200,17 +1200,170 @@ public class SubtleCryptoKeyTests
     }
 
     [Fact]
-    public void TheDataArgumentIsCopiedBeforeAnyGetterCanRun()
+    public void TheDataArgumentIsCopiedAfterTheAlgorithmIsNormalized()
     {
-        // The argument conversions run before the method body, and the body's first step normalizes an
-        // algorithm — which reads `name` and may run a script's getter, with the caller's buffer in scope. A
-        // window onto the engine's own array would hash what the getter left behind.
+        // Argument conversion and the method steps are two different times. Converting `data` to a
+        // BufferSource runs before the body, but *taking its bytes* does not: normalization is step 2 and
+        // "Let data be the result of getting a copy of the bytes held by the data parameter" is step 4 —
+        // https://w3c.github.io/webcrypto/#SubtleCrypto-method-digest. Normalizing reads `name`, so the
+        // getter below runs with the caller's buffer in scope and before the copy, and what it leaves behind
+        // is what gets hashed: this is the digest of '!!!', not of 'abc'.
         Run("""
             const data = ascii('abc');
             const digest = await crypto.subtle.digest({ get name() { data.fill(0x21); return 'SHA-256'; } }, data);
             return hex(digest) + '|' + hex(data);
             """).AsString().Should().Be(
+                "e84c538e7fe250730ef62de220c40dfa808d3008c0cdb437181564b88b8714b8|212121");
+    }
+
+    [Fact]
+    public void ADataArgumentTransferredDuringNormalizationIsDigestedAsEmpty()
+    {
+        // The same step 4, with the getter detaching the buffer rather than rewriting it. "Get a copy of the
+        // bytes held by" a detached buffer is the empty byte sequence —
+        // https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy step 7 — so what is hashed is nothing at
+        // all, and the answer is SHA-256 of the empty message.
+        Run("""
+            const data = ascii('abc');
+            const digest = await crypto.subtle.digest({ get name() { data.buffer.transfer(); return 'SHA-256'; } }, data);
+            return hex(digest);
+            """).AsString().Should().Be("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    }
+
+    [Fact]
+    public void TheDataArgumentIsNotReReadOnceTheCopyStepHasRun()
+    {
+        // The other half of the same step, and the one that was never in question: once step 4 has taken the
+        // bytes they are the operation's own, so a mutation the script makes after the call cannot reach
+        // them. Every operation here is synchronous CPU work, so this mutation lands between the call and the
+        // promise settling — the narrowest window there is.
+        Run("""
+            const data = ascii('abc');
+            const promise = crypto.subtle.digest('SHA-256', data);
+            data.fill(0x21);
+            return hex(await promise) + '|' + hex(data);
+            """).AsString().Should().Be(
                 "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad|212121");
+    }
+
+    [Fact]
+    public void VerifyCopiesBothOfItsBuffersAfterTheAlgorithmIsNormalized()
+    {
+        // verify is the only method with two BufferSource parameters, and the specification gives each its
+        // own step after normalization: signature at step 4 and data at step 5 —
+        // https://w3c.github.io/webcrypto/#SubtleCrypto-method-verify. A getter on `name` that repairs both
+        // is therefore in time for both, and a signature that was zeroed before the call verifies.
+        Run("""
+            const key = await crypto.subtle.generateKey({ name: 'HMAC', hash: 'SHA-256' }, false, ['sign', 'verify']);
+            const message = ascii('the message');
+            const mac = new Uint8Array(await crypto.subtle.sign('HMAC', key, message));
+
+            const signature = mac.slice();
+            const data = message.slice();
+            signature.fill(0);
+            data.fill(0);
+
+            const repaired = { get name() { signature.set(mac); data.set(message); return 'HMAC'; } };
+            return await crypto.subtle.verify(repaired, key, signature, data);
+            """).AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void VerifyOverBuffersTransferredDuringNormalizationDoesNotVerify()
+    {
+        // The same two steps with the getter detaching each buffer instead: both copies are empty, and an
+        // empty signature is not the MAC of an empty message. The corpus asserts exactly this shape.
+        Run("""
+            const key = await crypto.subtle.generateKey({ name: 'HMAC', hash: 'SHA-256' }, false, ['sign', 'verify']);
+            const message = ascii('the message');
+            const signature = new Uint8Array(await crypto.subtle.sign('HMAC', key, message));
+
+            const dropped = { get name() { signature.buffer.transfer(); message.buffer.transfer(); return 'HMAC'; } };
+            return await crypto.subtle.verify(dropped, key, signature, message);
+            """).AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void EncryptCopiesItsDataAfterTheAlgorithmIsNormalized()
+    {
+        // encrypt's step 4, made visible the same way: the plaintext is zeroed before the call and repaired
+        // by the `name` getter, so the ciphertext is the one the repaired bytes produce. The literal is the
+        // AES-CBC encryption of 'the message' under that key and iv, so a ciphertext of the zeroed bytes —
+        // or of nothing — cannot pass by agreeing with itself.
+        Run("""
+            const key = await crypto.subtle.importKey('raw', bytes('000102030405060708090a0b0c0d0e0f'), 'AES-CBC', false, ['encrypt']);
+            const iv = bytes('0f0e0d0c0b0a09080706050403020100');
+            const message = ascii('the message');
+
+            const plaintext = message.slice();
+            plaintext.fill(0);
+
+            const ciphertext = await crypto.subtle.encrypt(
+                { iv, get name() { plaintext.set(message); return 'AES-CBC'; } }, key, plaintext);
+
+            return hex(ciphertext);
+            """).AsString().Should().Be("6a3f7ea3473ed63281298b3e7c216409");
+    }
+
+    [Fact]
+    public void DecryptOverACiphertextTransferredDuringNormalizationFails()
+    {
+        // decrypt's step 4, with the getter detaching: the copy is the empty byte sequence, and AES-CBC's own
+        // step 2 refuses an empty ciphertext with an OperationError. Before the copy moved to its numbered
+        // place the detach came too late and the message decrypted perfectly well.
+        Settle(WebEngine(), Prelude + """
+
+            (async () => {
+                const key = await crypto.subtle.importKey('raw', bytes('000102030405060708090a0b0c0d0e0f'), 'AES-CBC', false, ['encrypt', 'decrypt']);
+                const iv = bytes('0f0e0d0c0b0a09080706050403020100');
+                const ciphertext = new Uint8Array(bytes('6a3f7ea3473ed63281298b3e7c216409'));
+
+                const dropped = { iv, get name() { ciphertext.buffer.transfer(); return 'AES-CBC'; } };
+                return await crypto.subtle.decrypt(dropped, key, ciphertext).then(() => 'decrypted', e => e.name);
+            })()
+            """).AsString().Should().Be("OperationError");
+    }
+
+    [Fact]
+    public void TheKeyDataIsCopiedAfterTheAlgorithmIsNormalized()
+    {
+        // importKey's step 4 carries both the format check and, for the BufferSource arm alone, "Let keyData
+        // be the result of getting a copy of the bytes held by the keyData parameter" —
+        // https://w3c.github.io/webcrypto/#SubtleCrypto-method-importKey. Step 2 normalized first, so a
+        // getter on `name` that rewrites the key material decides which key is imported; exporting it back is
+        // what makes the answer readable.
+        Run("""
+            const material = bytes('000102030405060708090a0b0c0d0e0f');
+            const keyData = material.slice();
+            keyData.fill(0xff);
+
+            const algorithm = { get name() { keyData.set(material); return 'AES-CBC'; } };
+            const key = await crypto.subtle.importKey('raw', keyData, algorithm, true, ['encrypt']);
+            return hex(await crypto.subtle.exportKey('raw', key));
+            """).AsString().Should().Be("000102030405060708090a0b0c0d0e0f");
+    }
+
+    [Fact]
+    public void TheWrappedKeyIsCopiedAfterBothOfUnwrapKeysAlgorithmsAreNormalized()
+    {
+        // unwrapKey normalizes twice — the unwrap algorithm at step 2 and the unwrapped key's own at step 4 —
+        // and only then reaches step 6, "Let wrappedKey be the result of getting a copy of the bytes held by
+        // the wrappedKey parameter": https://w3c.github.io/webcrypto/#SubtleCrypto-method-unwrapKey. It is
+        // the last of the three, so a getter on either `name` is still in time, and the key that comes out is
+        // the one the repaired bytes wrap.
+        Run("""
+            const wrappingKey = await crypto.subtle.importKey('raw', bytes('000102030405060708090a0b0c0d0e0f'), 'AES-KW', false, ['wrapKey', 'unwrapKey']);
+            const target = await crypto.subtle.importKey('raw', bytes('101112131415161718191a1b1c1d1e1f'), 'AES-CBC', true, ['encrypt']);
+            const wrapped = new Uint8Array(await crypto.subtle.wrapKey('raw', target, wrappingKey, 'AES-KW'));
+
+            const corrupted = wrapped.slice();
+            corrupted.fill(0);
+
+            const repaired = { get name() { corrupted.set(wrapped); return 'AES-KW'; } };
+            const unwrapped = await crypto.subtle.unwrapKey('raw', corrupted, wrappingKey, repaired, 'AES-CBC', true, ['encrypt']);
+
+            return hex(await crypto.subtle.exportKey('raw', unwrapped));
+            """).AsString().Should().Be("101112131415161718191a1b1c1d1e1f");
     }
 
     [Fact]

--- a/Jint.Tests/Wpt/Vendor/README.md
+++ b/Jint.Tests/Wpt/Vendor/README.md
@@ -67,7 +67,7 @@ settled; it is a change to `UrlCorpusTests` as well as to this directory, and it
 
 ## What the WebCryptoAPI corpus says about this engine
 
-2,839 of its ~24,000 assertions do not pass, and every one is named in the driver's table under one of six
+2,459 of its 24,136 assertions do not pass, and every one is named in the driver's table under one of seven
 categories, whose own documentation in `WptExclusions.cs` carries the citation. Three are the platform:
 `NeedsPlatformCryptoParameters` (AES-GCM's 96-bit-only iv and 96-to-128-bit tag, RSA-OAEP's empty-only label,
 RSA-PSS's hash-length-only salt — all four are limits of the BCL primitives, documented on the classes that
@@ -76,10 +76,15 @@ specification: `NeedsKeyEncapsulation` (ML-KEM's `encapsulateKey`/`decapsulateKe
 the current `KeyUsage` enumeration does not declare) and `NeedsQuotaExceededErrorInterface`. One is the
 corpus meeting an environment it was not written for: `NeedsSecureContextModel`.
 
-The sixth is `NeedsTriage`, and it is **debt**: two genuine defects the corpus found, recorded rather than
-fixed so that the change which first ran these suites was not also the change that moved the engine.
-`SubtleCrypto` copies its caller's bytes before normalizing the algorithm where the specification copies them
-after, which is every "… during call" row; and ECDH's mismatched-curve rows get the `OperationError` of the
+That figure is Windows and Linux, whose AES-GCM takes a 96- to 128-bit tag. **macOS has 216 more**, all in
+`aes_gcm.https.any.js`: Apple's implementation takes a 128-bit tag and nothing else, so the four tag lengths
+between 96 and 120 bits are refused there and their rows are scoped to that platform in the table.
+
+The seventh is `NeedsTriage`, and it is **debt**. It held two genuine defects the corpus found, recorded
+rather than fixed so that the change which first ran these suites was not also the change that moved the
+engine. One is fixed: `SubtleCrypto` copied its caller's bytes before normalizing the algorithm where the
+specification copies them after, which was every "… during call" row, and issue #3179 moved each copy to its
+numbered step. The one still open is ECDH's mismatched-curve rows, which get the `OperationError` of the
 prose where a browser answers `InvalidAccessError`.
 
 ## Updating the pin

--- a/Jint.Tests/Wpt/WptExclusions.cs
+++ b/Jint.Tests/Wpt/WptExclusions.cs
@@ -135,25 +135,20 @@ internal enum WptDivergence
     /// say, and mixing engine fixes into the change that first ran them would have hidden which of the two
     /// moved. The four the first phase recorded — WebIDL constant order, <c>TextDecoder.decode()</c> reading
     /// its input before the options dictionary was converted, and the shared UTF-16 decoder's end-of-queue
-    /// step for both endiannesses — were fixed by https://github.com/sebastienros/jint/issues/3121, and
-    /// ECDH's two mismatched-curve rows by https://github.com/sebastienros/jint/issues/3180: the corpus was
-    /// asserting the browsers' order rather than the prose's, so <c>EcAlgorithm.DeriveBits</c> now runs the
-    /// key-agreement checks before the <i>maximumLength</i> ceiling and documents the divergence on itself.
-    /// <para>
-    /// What the WebCryptoAPI corpus filed and nobody has answered yet is one disagreement:
-    /// </para>
-    /// <list type="bullet">
-    /// <item><description>
-    /// <b>Every "… during call" row.</b> <c>SubtleCrypto</c> copies the caller's <c>data</c>/<c>keyData</c>
-    /// <i>before</i> normalizing the algorithm; the specification copies it after — for <c>encrypt</c>,
-    /// normalization is step 2 and "let data be the result of getting a copy of the bytes held by the data
-    /// parameter" is step 4 (https://w3c.github.io/webcrypto/#SubtleCrypto-method-encrypt, and the same shape
-    /// in <c>decrypt</c>, <c>sign</c>, <c>verify</c>, <c>digest</c> and <c>importKey</c>). The corpus makes
-    /// the order observable by putting a getter on the algorithm's <c>name</c> that rewrites or transfers the
-    /// buffer. Note <c>SubtleCryptoKeyTests.TheDataArgumentIsCopiedBeforeAnyGetterCanRun</c> pins the order
-    /// Jint has today, so fixing this moves that test too.
-    /// </description></item>
-    /// </list>
+    /// step for both endiannesses — were fixed by https://github.com/sebastienros/jint/issues/3121. The
+    /// WebCryptoAPI corpus filed two more, and both are fixed as well. <b>Every "… during call" row</b>
+    /// failed because <c>SubtleCrypto</c> copied the caller's <c>data</c>/<c>keyData</c> <i>before</i>
+    /// normalizing the algorithm where the specification copies it after — normalization is step 2 and
+    /// "let data be the result of getting a copy of the bytes held by the data parameter" is step 4
+    /// (https://w3c.github.io/webcrypto/#SubtleCrypto-method-encrypt, and the same shape in <c>decrypt</c>,
+    /// <c>sign</c>, <c>digest</c> and <c>importKey</c>, steps 4 and 5 for <c>verify</c>'s two buffers, and
+    /// step 6 for <c>unwrapKey</c>); https://github.com/sebastienros/jint/issues/3179 moved each copy to its
+    /// numbered step, and the <c>SubtleCryptoKeyTests</c> pin that used to assert the old order now asserts
+    /// the new one. And <b>ECDH's two mismatched-curve rows</b> were the corpus asserting the browsers' order
+    /// rather than the prose's, so https://github.com/sebastienros/jint/issues/3180 made
+    /// <c>EcAlgorithm.DeriveBits</c> run the key-agreement checks before the <i>maximumLength</i> ceiling,
+    /// documenting the divergence on itself and raising it upstream as
+    /// https://github.com/w3c/webcrypto/issues/560. The category is empty today, which is what it wants to be.
     /// </summary>
     NeedsTriage,
 }
@@ -181,10 +176,15 @@ internal enum WptDivergence
 /// </param>
 /// <param name="ExceptPlatform">
 /// The one operating system this entry does <b>not</b> apply on, or <see langword="null"/>. The mirror image
-/// of <paramref name="Platform"/>, and its worked example is the same file's copy-order rows: a
-/// <c>decryption … during call</c> test that fails everywhere else <i>passes</i> on macOS, because the
-/// platform's tag refusal produces the very <c>OperationError</c> the test asserts — for the wrong reason,
-/// which the assertion cannot see. The entry would be stale there, so it excuses itself from that leg.
+/// of <paramref name="Platform"/>, for a divergence that is everywhere <i>but</i> one platform.
+/// <para>
+/// <b>No entry uses it today</b>, and the one that did is worth recording because it is the shape that will
+/// want it again. Before https://github.com/sebastienros/jint/issues/3179, AES-GCM's
+/// <c>decryption … during call</c> rows failed on Windows and Linux for the copy order and <i>passed</i> on
+/// macOS, where the platform's tag refusal produced the very <c>OperationError</c> the test asserts — for the
+/// wrong reason, which the assertion cannot see. A platform-neutral entry would have been stale on that one
+/// leg, so it excused itself from it. The fix removed the divergence rather than the mechanism.
+/// </para>
 /// </param>
 internal sealed record WptExclusion(
     string File,

--- a/Jint.Tests/Wpt/WptTestRunner.cs
+++ b/Jint.Tests/Wpt/WptTestRunner.cs
@@ -22,10 +22,10 @@ namespace Jint.Tests.Wpt;
 /// expected and found; the ones that are not a missing feature are parked under
 /// <see cref="WptDivergence.NeedsTriage"/> rather than fixed there, so that the change which first runs a
 /// suite is not also the change that moves the engine. The four the URL and Encoding suites found were fixed
-/// by https://github.com/sebastienros/jint/issues/3121; of the two the WebCryptoAPI corpus found, ECDH's
-/// mismatched-curve error was fixed by https://github.com/sebastienros/jint/issues/3180 and the point at
-/// which <c>SubtleCrypto</c> copies its caller's bytes is still open, with the category's own documentation
-/// saying what it is.
+/// by https://github.com/sebastienros/jint/issues/3121, and both the WebCryptoAPI corpus found are fixed too:
+/// the point at which <c>SubtleCrypto</c> copies its caller's bytes by
+/// https://github.com/sebastienros/jint/issues/3179, and ECDH's mismatched-curve error by
+/// https://github.com/sebastienros/jint/issues/3180. The category holds nothing today.
 /// </para>
 /// <para>
 /// <b>The WebCryptoAPI corpus is one suite per directory</b> rather than one for the lot, because
@@ -337,22 +337,13 @@ public class WptTestRunner
         // QuotaExceededError *interface*, and gets the name on a plain DOMException.
         new("WebCryptoAPI/getRandomValues.any.js", "Large length: *", WptDivergence.NeedsQuotaExceededErrorInterface),
 
-        // Every "… during call" family below is the same defect: the caller's bytes are copied before the
-        // algorithm is normalized rather than after, so a getter on the algorithm's `name` that rewrites or
-        // transfers the buffer is too late to be seen. The "… after call" siblings pass, which is what makes
-        // these globs safe: they name the half that the ordering decides. See WptDivergence.NeedsTriage.
-        new("WebCryptoAPI/digest/digest.https.any.js", "* and altered buffer during call", WptDivergence.NeedsTriage),
-        new("WebCryptoAPI/encrypt_decrypt/aes_cbc.https.any.js", "AES-CBC * with * during call", WptDivergence.NeedsTriage),
-        new("WebCryptoAPI/encrypt_decrypt/aes_cbc.https.any.js", "AES-CBC * decryption with * during call", WptDivergence.NeedsTriage),
-        new("WebCryptoAPI/encrypt_decrypt/aes_ctr.https.any.js", "AES-CTR * with * during call", WptDivergence.NeedsTriage),
-        new("WebCryptoAPI/encrypt_decrypt/aes_ctr.https.any.js", "AES-CTR * decryption with * during call", WptDivergence.NeedsTriage),
-        new("WebCryptoAPI/import_export/symmetric_importKey.https.any.js", "Key data altered during call: *", WptDivergence.NeedsTriage),
-        new("WebCryptoAPI/sign_verify/ecdsa.https.any.js", "ECDSA * with * during call", WptDivergence.NeedsTriage),
-        new("WebCryptoAPI/sign_verify/ecdsa.https.any.js", "ECDSA * verification with * during call", WptDivergence.NeedsTriage),
-        new("WebCryptoAPI/sign_verify/hmac.https.any.js", "HMAC * with * during call", WptDivergence.NeedsTriage),
-        new("WebCryptoAPI/sign_verify/hmac.https.any.js", "HMAC * verification with * during call", WptDivergence.NeedsTriage),
-        new("WebCryptoAPI/sign_verify/rsa_pkcs.https.any.js", "RSASSA-PKCS1-v1_5 * with * during call", WptDivergence.NeedsTriage),
-        new("WebCryptoAPI/sign_verify/rsa_pkcs.https.any.js", "RSASSA-PKCS1-v1_5 * verification with * during call", WptDivergence.NeedsTriage),
+        // Nothing here excludes a "… during call" row for the ordering any more. Those families — across
+        // digest, aes_cbc, aes_ctr, symmetric_importKey, ecdsa, hmac, rsa_pkcs, rsa_pss, rsa_oaep and
+        // aes_gcm — were one defect, the caller's bytes copied before the algorithm was normalized rather
+        // than after, and https://github.com/sebastienros/jint/issues/3179 moved each copy to the numbered
+        // step that performs it. The "… during call" globs that remain further down are all in the other
+        // category: the *platform* refuses the operation before the ordering could decide anything, so they
+        // would fail whatever order the bytes were taken in.
 
         // The X25519 rows of a file that is otherwise about the `length` parameter of deriveBits.
         new("WebCryptoAPI/derive_bits_keys/derived_bits_length.https.any.js", "X25519 derivation with *", WptDivergence.NeedsCurve25519),
@@ -382,49 +373,45 @@ public class WptTestRunner
         // AesGcm.TagByteSizes is 12 to 16 — and not on macOS, where Apple's implementation answers 16 to 16
         // and the engine's ask-the-platform gate refuses everything shorter. These rows therefore PASS on two
         // legs and FAIL on the third, which no platform-neutral entry can say; they are scoped to macOS, where
-        // the staleness rule still holds them to matching real failures. The "during call" variants are
-        // absent here deliberately: those rows fail on every OS for the copy-order reason and are the
-        // NeedsTriage entries below.
+        // the staleness rule still holds them to matching real failures.
+        //
+        // Each tag length gets the same six globs the 32- and 64-bit block above gets, and for the same
+        // reason: AesGcmAlgorithm resolves the tag length before it looks at anything else, so on macOS the
+        // refusal comes first and every row that wanted a result fails, whatever the rest of the request
+        // said. That includes the "… during call" rows, which is why they are *here* rather than under
+        // NeedsTriage — the copy order was never what decided them on this platform, and it decides nothing
+        // anywhere now that issue #3179 has moved the copy to its numbered step. One row of the family is
+        // deliberately in no entry, "decryption with transferred ciphertext during call": it asserts an
+        // OperationError and the tag refusal is one, so it passes here for a reason it cannot see, exactly as
+        // it does for the 32- and 64-bit tags.
         new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 96-bit tag, 96-bit iv", WptDivergence.NeedsPlatformCryptoParameters, MacOs),
         new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 96-bit tag, 96-bit iv decryption", WptDivergence.NeedsPlatformCryptoParameters, MacOs),
         new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 96-bit tag, 96-bit iv decryption with * after call", WptDivergence.NeedsPlatformCryptoParameters, MacOs),
+        new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 96-bit tag, 96-bit iv decryption with altered ciphertext during call", WptDivergence.NeedsPlatformCryptoParameters, MacOs),
         new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 96-bit tag, 96-bit iv with * after call", WptDivergence.NeedsPlatformCryptoParameters, MacOs),
+        new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 96-bit tag, 96-bit iv with * during call", WptDivergence.NeedsPlatformCryptoParameters, MacOs),
         new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 104-bit tag, 96-bit iv", WptDivergence.NeedsPlatformCryptoParameters, MacOs),
         new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 104-bit tag, 96-bit iv decryption", WptDivergence.NeedsPlatformCryptoParameters, MacOs),
         new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 104-bit tag, 96-bit iv decryption with * after call", WptDivergence.NeedsPlatformCryptoParameters, MacOs),
+        new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 104-bit tag, 96-bit iv decryption with altered ciphertext during call", WptDivergence.NeedsPlatformCryptoParameters, MacOs),
         new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 104-bit tag, 96-bit iv with * after call", WptDivergence.NeedsPlatformCryptoParameters, MacOs),
+        new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 104-bit tag, 96-bit iv with * during call", WptDivergence.NeedsPlatformCryptoParameters, MacOs),
         new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 112-bit tag, 96-bit iv", WptDivergence.NeedsPlatformCryptoParameters, MacOs),
         new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 112-bit tag, 96-bit iv decryption", WptDivergence.NeedsPlatformCryptoParameters, MacOs),
         new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 112-bit tag, 96-bit iv decryption with * after call", WptDivergence.NeedsPlatformCryptoParameters, MacOs),
+        new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 112-bit tag, 96-bit iv decryption with altered ciphertext during call", WptDivergence.NeedsPlatformCryptoParameters, MacOs),
         new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 112-bit tag, 96-bit iv with * after call", WptDivergence.NeedsPlatformCryptoParameters, MacOs),
+        new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 112-bit tag, 96-bit iv with * during call", WptDivergence.NeedsPlatformCryptoParameters, MacOs),
         new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 120-bit tag, 96-bit iv", WptDivergence.NeedsPlatformCryptoParameters, MacOs),
         new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 120-bit tag, 96-bit iv decryption", WptDivergence.NeedsPlatformCryptoParameters, MacOs),
         new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 120-bit tag, 96-bit iv decryption with * after call", WptDivergence.NeedsPlatformCryptoParameters, MacOs),
-        new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 120-bit tag, 96-bit iv with * after call", WptDivergence.NeedsPlatformCryptoParameters, MacOs),
-
-        // The altered-ciphertext decryption rows, which for the unsupported tag lengths mirror the 32- and
-        // 64-bit entries above exactly: the tag refusal fails them here where the copy-order defect fails
-        // them elsewhere. Their transferred-ciphertext siblings appear in no entry on this platform because
-        // the same refusal is the rejection they assert, so they pass — which is also why the copy-order
-        // globs below excuse themselves from macOS.
-        new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 96-bit tag, 96-bit iv decryption with altered ciphertext during call", WptDivergence.NeedsPlatformCryptoParameters, MacOs),
-        new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 104-bit tag, 96-bit iv decryption with altered ciphertext during call", WptDivergence.NeedsPlatformCryptoParameters, MacOs),
-        new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 112-bit tag, 96-bit iv decryption with altered ciphertext during call", WptDivergence.NeedsPlatformCryptoParameters, MacOs),
         new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 120-bit tag, 96-bit iv decryption with altered ciphertext during call", WptDivergence.NeedsPlatformCryptoParameters, MacOs),
+        new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 120-bit tag, 96-bit iv with * after call", WptDivergence.NeedsPlatformCryptoParameters, MacOs),
+        new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 120-bit tag, 96-bit iv with * during call", WptDivergence.NeedsPlatformCryptoParameters, MacOs),
 
-        // The same file's copy-order rows, for the five tag lengths that do work. Spelled per tag rather than
-        // as one "* during call" so that the tag-length rows above are not silently filed under the wrong
-        // cause: those two fail before the ordering could ever matter.
-        new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 96-bit tag, 96-bit iv with * during call", WptDivergence.NeedsTriage),
-        new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 96-bit tag, 96-bit iv decryption with * during call", WptDivergence.NeedsTriage, ExceptPlatform: MacOs),
-        new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 104-bit tag, 96-bit iv with * during call", WptDivergence.NeedsTriage),
-        new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 104-bit tag, 96-bit iv decryption with * during call", WptDivergence.NeedsTriage, ExceptPlatform: MacOs),
-        new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 112-bit tag, 96-bit iv with * during call", WptDivergence.NeedsTriage),
-        new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 112-bit tag, 96-bit iv decryption with * during call", WptDivergence.NeedsTriage, ExceptPlatform: MacOs),
-        new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 120-bit tag, 96-bit iv with * during call", WptDivergence.NeedsTriage),
-        new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 120-bit tag, 96-bit iv decryption with * during call", WptDivergence.NeedsTriage, ExceptPlatform: MacOs),
-        new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 128-bit tag, 96-bit iv with * during call", WptDivergence.NeedsTriage),
-        new("WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js", "AES-GCM *, 128-bit tag, 96-bit iv decryption with * during call", WptDivergence.NeedsTriage),
+        // The 128-bit tag has no entry of any kind: it is the one length every platform's AES-GCM takes, so
+        // its rows pass on all three legs — including the four "… during call" ones, which were the last
+        // NeedsTriage entries this file carried.
 
         // The whole of the 256-bit-iv file bar the rows that expect a throw for another reason — the
         // usage-matrix rows, the illegal-tag-length rows, and again "decryption with transferred ciphertext
@@ -436,24 +423,21 @@ public class WptTestRunner
         new("WebCryptoAPI/encrypt_decrypt/aes_gcm_256_iv.https.any.js", "AES-GCM *, 256-bit iv with * after call", WptDivergence.NeedsPlatformCryptoParameters),
         new("WebCryptoAPI/encrypt_decrypt/aes_gcm_256_iv.https.any.js", "AES-GCM *, 256-bit iv with * during call", WptDivergence.NeedsPlatformCryptoParameters),
 
-        // RSA-OAEP's label. The "a label" rows fail for the label, the "no label" and "empty label" rows only
-        // for the copy order — which is why the two causes are told apart by the label rather than lumped
-        // under one "* during call".
+        // RSA-OAEP's label, in the same six-glob shape as an unsupported AES-GCM tag length and for the same
+        // reason: RsaAlgorithm refuses a present and non-empty label outright, so every "a label" row that
+        // wanted a result fails whatever else the request said. The "no label" and "empty label" rows carry
+        // no entry at all — they used to, for the copy order alone, and issue #3179 fixed that.
         new("WebCryptoAPI/encrypt_decrypt/rsa_oaep.https.any.js", "RSA-OAEP with SHA-* and a label", WptDivergence.NeedsPlatformCryptoParameters),
         new("WebCryptoAPI/encrypt_decrypt/rsa_oaep.https.any.js", "RSA-OAEP with SHA-* and a label decryption", WptDivergence.NeedsPlatformCryptoParameters),
         new("WebCryptoAPI/encrypt_decrypt/rsa_oaep.https.any.js", "RSA-OAEP with SHA-* and a label decryption with * after call", WptDivergence.NeedsPlatformCryptoParameters),
         new("WebCryptoAPI/encrypt_decrypt/rsa_oaep.https.any.js", "RSA-OAEP with SHA-* and a label decryption with altered ciphertext during call", WptDivergence.NeedsPlatformCryptoParameters),
         new("WebCryptoAPI/encrypt_decrypt/rsa_oaep.https.any.js", "RSA-OAEP with SHA-* and a label with * after call", WptDivergence.NeedsPlatformCryptoParameters),
         new("WebCryptoAPI/encrypt_decrypt/rsa_oaep.https.any.js", "RSA-OAEP with SHA-* and a label with * during call", WptDivergence.NeedsPlatformCryptoParameters),
-        new("WebCryptoAPI/encrypt_decrypt/rsa_oaep.https.any.js", "RSA-OAEP with SHA-* and no label with * during call", WptDivergence.NeedsTriage),
-        new("WebCryptoAPI/encrypt_decrypt/rsa_oaep.https.any.js", "RSA-OAEP with SHA-* and no label decryption with * during call", WptDivergence.NeedsTriage),
-        new("WebCryptoAPI/encrypt_decrypt/rsa_oaep.https.any.js", "RSA-OAEP with SHA-* and empty label with * during call", WptDivergence.NeedsTriage),
-        new("WebCryptoAPI/encrypt_decrypt/rsa_oaep.https.any.js", "RSA-OAEP with SHA-* and empty label decryption with * during call", WptDivergence.NeedsTriage),
 
         // RSA-PSS's salt length. "no salt" is saltLength 0, which .NET cannot ask for, so every one of those
         // rows fails — except SHA-256's "wrong saltLength", whose wrong length happens to be SHA-256's own
-        // and is therefore the one .NET does accept. The ", salted" rows fail only where the *wrong* salt
-        // length is asked for, plus the copy-order family.
+        // and is therefore the one .NET does accept. The ", salted" rows now fail only where the *wrong* salt
+        // length is asked for: their copy-order family went with issue #3179.
         new("WebCryptoAPI/sign_verify/rsa_pss.https.any.js", "RSA-PSS with SHA-* and no salt round trip", WptDivergence.NeedsPlatformCryptoParameters),
         new("WebCryptoAPI/sign_verify/rsa_pss.https.any.js", "RSA-PSS with SHA-* and no salt verification", WptDivergence.NeedsPlatformCryptoParameters),
         new("WebCryptoAPI/sign_verify/rsa_pss.https.any.js", "RSA-PSS with SHA-* and no salt verification failure with altered *", WptDivergence.NeedsPlatformCryptoParameters),
@@ -463,8 +447,6 @@ public class WptTestRunner
         new("WebCryptoAPI/sign_verify/rsa_pss.https.any.js", "RSA-PSS with SHA-* and no salt verification with * call", WptDivergence.NeedsPlatformCryptoParameters),
         new("WebCryptoAPI/sign_verify/rsa_pss.https.any.js", "RSA-PSS with SHA-* and no salt with * call", WptDivergence.NeedsPlatformCryptoParameters),
         new("WebCryptoAPI/sign_verify/rsa_pss.https.any.js", "RSA-PSS with SHA-*, salted verification failure with wrong saltLength", WptDivergence.NeedsPlatformCryptoParameters),
-        new("WebCryptoAPI/sign_verify/rsa_pss.https.any.js", "RSA-PSS with SHA-*, salted verification with * during call", WptDivergence.NeedsTriage),
-        new("WebCryptoAPI/sign_verify/rsa_pss.https.any.js", "RSA-PSS with SHA-*, salted with * during call", WptDivergence.NeedsTriage),
 
         // wrapKey/unwrapKey, where the two platform limits above meet: the corpus wraps under AES-GCM with a
         // 128-bit iv and under RSA-OAEP with a label, so those two wrapping algorithms fail outright. The

--- a/Jint/WebApi/Crypto/SubtleCryptoInstance.cs
+++ b/Jint/WebApi/Crypto/SubtleCryptoInstance.cs
@@ -61,6 +61,22 @@ namespace Jint.WebApi.Crypto;
 /// constraint that became a rejection would no longer bound anything.
 /// </para>
 /// <para>
+/// <b>Argument conversion and the method steps are two different times, and every <c>BufferSource</c>
+/// parameter is split across both.</b> WebIDL converts the arguments first — that is where a <c>data</c>
+/// which is not a buffer source, or one backed by a <c>SharedArrayBuffer</c>, earns its <c>TypeError</c>,
+/// and it is why <c>digest('nonsense', 42)</c> rejects for the second argument rather than for the first.
+/// <i>Taking the bytes</i> is not part of that: "Let data be the result of getting a copy of the bytes held
+/// by the data parameter" is a numbered step of the method, and in every one of these methods it comes
+/// <b>after</b> the algorithm has been normalized — step 4 where normalization is step 2 for <c>encrypt</c>,
+/// <c>decrypt</c>, <c>sign</c>, <c>digest</c> and <c>importKey</c>, steps 4 and 5 for <c>verify</c>'s two
+/// buffers, and step 6 for <c>unwrapKey</c>, which normalizes twice first. Normalization reads the
+/// algorithm's <c>name</c>, so it can run a script's getter with the caller's buffer in scope; what that
+/// getter leaves behind — rewritten bytes, or a transferred and therefore detached buffer — is what the
+/// operation must run over. So <see cref="RequireBufferSource"/> is called with the other conversions and
+/// <see cref="CopyBufferSourceBytes"/> at the step that copies, and the two are never collapsed back
+/// together.
+/// </para>
+/// <para>
 /// The promise is already resolved when it is handed back: every operation here is synchronous CPU work over
 /// bytes that are already in memory, so there is nothing for an event-loop turn to wait for. "Return promise
 /// and perform the remaining steps in parallel" exists so that a browser's main thread is not blocked by a
@@ -123,7 +139,8 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
     /// of <c>algorithm</c> to <c>(object or DOMString)</c>, then the conversion of <c>data</c> to
     /// <c>BufferSource</c>, and only then step 2's normalization. So <c>digest('nonsense', 42)</c> rejects
     /// with the <c>TypeError</c> the second argument earns rather than the <c>NotSupportedError</c> the first
-    /// one would — argument conversion runs before a single step of the method body does.
+    /// one would — argument conversion runs before a single step of the method body does. The <i>bytes</i>
+    /// are a different matter and are step 4's, taken after normalization; see the remarks on this class.
     /// </remarks>
     [JsFunction(Name = "digest", Length = 2)]
     private JsValue Digest(JsValue thisObject, JsValue algorithm, JsValue data)
@@ -131,9 +148,14 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
         return Perform(thisObject, CryptoOperation.Digest, what =>
         {
             var identifier = AlgorithmNormalization.ConvertIdentifier(algorithm);
-            var message = GetBufferSourceBytes(data, what, "parameter 2");
+            RequireBufferSource(data, what, "parameter 2");
 
+            // Step 2.
             var normalized = AlgorithmNormalization.Normalize(Context, identifier, CryptoOperation.Digest, what);
+
+            // Step 4: "Let data be the result of getting a copy of the bytes held by the data parameter
+            // passed to the digest() method."
+            var message = CopyBufferSourceBytes(data);
 
             return Context.CreateArrayBuffer(ComputeDigest(normalized.Name, message));
         });
@@ -150,9 +172,14 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
         {
             var identifier = AlgorithmNormalization.ConvertIdentifier(algorithm);
             var cryptoKey = RequireCryptoKey(key, what, "parameter 2");
-            var message = GetBufferSourceBytes(data, what, "parameter 3");
+            RequireBufferSource(data, what, "parameter 3");
 
+            // Step 2.
             var normalized = AlgorithmNormalization.Normalize(Context, identifier, CryptoOperation.Sign, what);
+
+            // Step 4: "Let data be the result of getting a copy of the bytes held by the data parameter
+            // passed to the sign() method."
+            var message = CopyBufferSourceBytes(data);
 
             RequireKeyFor(normalized, cryptoKey, KeyUsage.Sign, "sign", what);
 
@@ -178,6 +205,15 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
     /// <c>Promise&lt;boolean&gt; verify(AlgorithmIdentifier algorithm, CryptoKey key, BufferSource signature,
     /// BufferSource data)</c>.
     /// </summary>
+    /// <remarks>
+    /// The only method with <b>two</b> buffer parameters, and the specification gives each its own step:
+    /// <c>signature</c> is copied at step 4 and <c>data</c> at step 5, both after normalization and in that
+    /// order. Both copies are therefore downstream of a getter on the algorithm's <c>name</c>, so one that
+    /// rewrites either buffer is honoured for that one and one that rewrites both is honoured for both. The
+    /// order between the two is not observable from script — the copies are consecutive and nothing runs in
+    /// between — but it is written the way the steps number it rather than the way the parameters happened to
+    /// be converted.
+    /// </remarks>
     [JsFunction(Name = "verify", Length = 4)]
     private JsValue Verify(JsValue thisObject, JsValue algorithm, JsValue key, JsValue signature, JsValue data)
     {
@@ -185,10 +221,16 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
         {
             var identifier = AlgorithmNormalization.ConvertIdentifier(algorithm);
             var cryptoKey = RequireCryptoKey(key, what, "parameter 2");
-            var signatureBytes = GetBufferSourceBytes(signature, what, "parameter 3");
-            var message = GetBufferSourceBytes(data, what, "parameter 4");
+            RequireBufferSource(signature, what, "parameter 3");
+            RequireBufferSource(data, what, "parameter 4");
 
+            // Step 2.
             var normalized = AlgorithmNormalization.Normalize(Context, identifier, CryptoOperation.Verify, what);
+
+            // Step 4: "Let signature be the result of getting a copy of the bytes held by the signature
+            // parameter passed to the verify() method." Then step 5, the same for data.
+            var signatureBytes = CopyBufferSourceBytes(signature);
+            var message = CopyBufferSourceBytes(data);
 
             RequireKeyFor(normalized, cryptoKey, KeyUsage.Verify, "verify", what);
 
@@ -222,9 +264,14 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
         {
             var identifier = AlgorithmNormalization.ConvertIdentifier(algorithm);
             var cryptoKey = RequireCryptoKey(key, what, "parameter 2");
-            var plaintext = GetBufferSourceBytes(data, what, "parameter 3");
+            RequireBufferSource(data, what, "parameter 3");
 
+            // Step 2.
             var normalized = AlgorithmNormalization.Normalize(Context, identifier, CryptoOperation.Encrypt, what);
+
+            // Step 4: "Let data be the result of getting a copy of the bytes held by the data parameter
+            // passed to the encrypt() method."
+            var plaintext = CopyBufferSourceBytes(data);
 
             RequireKeyFor(normalized, cryptoKey, KeyUsage.Encrypt, "encrypt", what);
 
@@ -266,9 +313,14 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
         {
             var identifier = AlgorithmNormalization.ConvertIdentifier(algorithm);
             var cryptoKey = RequireCryptoKey(key, what, "parameter 2");
-            var ciphertext = GetBufferSourceBytes(data, what, "parameter 3");
+            RequireBufferSource(data, what, "parameter 3");
 
+            // Step 2.
             var normalized = AlgorithmNormalization.Normalize(Context, identifier, CryptoOperation.Decrypt, what);
+
+            // Step 4: "Let data be the result of getting a copy of the bytes held by the data parameter
+            // passed to the decrypt() method."
+            var ciphertext = CopyBufferSourceBytes(data);
 
             RequireKeyFor(normalized, cryptoKey, KeyUsage.Decrypt, "decrypt", what);
 
@@ -415,8 +467,15 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
     /// a buffer source is one, and anything else that is an object (or <c>null</c>, or <c>undefined</c>)
     /// becomes a <c>JsonWebKey</c> dictionary, which is read <i>here</i>, with the other arguments, and not
     /// when the algorithm's steps get to it. So the getters on a JWK run before the algorithm is even
-    /// normalized. Step 4 then rejects the mismatches: a JWK with a format that is not <c>"jwk"</c>, and a
-    /// buffer source with the format that is.
+    /// normalized.
+    /// <para>
+    /// Step 4 is where the two arms are held to the format, and — for the buffer-source arm alone — where the
+    /// bytes are taken: "Otherwise: … Let keyData be the result of getting a copy of the bytes held by the
+    /// keyData parameter". That is <i>after</i> normalization, so a getter on the algorithm's <c>name</c> that
+    /// rewrites the key material is honoured and the key imported is the one those bytes describe. The JWK arm
+    /// has no such step, because the dictionary was materialized at conversion time and holds no live window
+    /// onto anything.
+    /// </para>
     /// </remarks>
     [JsFunction(Name = "importKey", Length = 5)]
     private JsValue ImportKey(JsValue thisObject, JsValue format, JsValue keyData, JsValue algorithm, JsValue extractable, JsValue keyUsages)
@@ -424,22 +483,32 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
         return Perform(thisObject, CryptoOperation.ImportKey, what =>
         {
             var keyFormat = ReadKeyFormat(format, what);
-            var (rawData, jwk) = ReadKeyData(keyData, what);
+            var jwk = ConvertKeyData(keyData, what);
             var identifier = AlgorithmNormalization.ConvertIdentifier(algorithm);
             var isExtractable = TypeConverter.ToBoolean(extractable);
             var usages = KeyUsages.ReadSequence(Context, keyUsages, what);
 
+            // Step 2.
             var normalized = AlgorithmNormalization.Normalize(Context, identifier, CryptoOperation.ImportKey, what);
 
-            // Step 4, after normalization as the numbering says.
-            if (keyFormat == KeyFormat.Jwk && jwk is null)
-            {
-                Context.ThrowTypeError(what + ": the 'jwk' format needs a JsonWebKey object, not a buffer source.");
-            }
+            // Step 4, after normalization as the numbering says, and both of its arms in full.
+            byte[]? rawData = null;
 
-            if (keyFormat != KeyFormat.Jwk && jwk is not null)
+            if (keyFormat == KeyFormat.Jwk)
             {
-                Context.ThrowTypeError(what + ": the '" + KeyFormats.NameOf(keyFormat) + "' format needs a buffer source, not a JsonWebKey object.");
+                if (jwk is null)
+                {
+                    Context.ThrowTypeError(what + ": the 'jwk' format needs a JsonWebKey object, not a buffer source.");
+                }
+            }
+            else
+            {
+                if (jwk is not null)
+                {
+                    Context.ThrowTypeError(what + ": the '" + KeyFormats.NameOf(keyFormat) + "' format needs a buffer source, not a JsonWebKey object.");
+                }
+
+                rawData = CopyBufferSourceBytes(keyData);
             }
 
             return PerformImportKey(normalized, keyFormat, rawData, jwk, isExtractable, usages, what);
@@ -823,16 +892,21 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
         return Perform(thisObject, CryptoOperation.UnwrapKey, what =>
         {
             var keyFormat = ReadKeyFormat(format, what);
-            var wrapped = GetBufferSourceBytes(wrappedKey, what, "parameter 2");
+            RequireBufferSource(wrappedKey, what, "parameter 2");
             var unwrapper = RequireCryptoKey(unwrappingKey, what, "parameter 3");
             var identifier = AlgorithmNormalization.ConvertIdentifier(unwrapAlgorithm);
             var keyIdentifier = AlgorithmNormalization.ConvertIdentifier(unwrappedKeyAlgorithm);
             var isExtractable = TypeConverter.ToBoolean(extractable);
             var usages = KeyUsages.ReadSequence(Context, keyUsages, what);
 
-            // Steps 2 to 4, in the specification's order and all before any step of any algorithm.
+            // Steps 2 to 5, in the specification's order and all before any step of any algorithm.
             var normalized = NormalizeForWrapping(identifier, CryptoOperation.UnwrapKey, CryptoOperation.Decrypt, what);
             var normalizedKey = AlgorithmNormalization.Normalize(Context, keyIdentifier, CryptoOperation.ImportKey, what);
+
+            // Step 6: "Let wrappedKey be the result of getting a copy of the bytes held by the wrappedKey
+            // parameter passed to the unwrapKey() method." It comes after both normalizations, so a getter on
+            // either algorithm's `name` — and this method reads two of them — is still in time to be seen.
+            var wrapped = CopyBufferSourceBytes(wrappedKey);
 
             // Steps 9 and 10.
             RequireKeyFor(normalized, unwrapper, KeyUsage.UnwrapKey, "unwrapKey", what);
@@ -1245,51 +1319,55 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
     }
 
     /// <summary>
-    /// The <c>(BufferSource or JsonWebKey)</c> union conversion. Exactly one of the two results is non-null.
+    /// The <c>(BufferSource or JsonWebKey)</c> union conversion, which is <c>importKey</c>'s alone.
+    /// <see langword="null"/> is the answer for the <c>BufferSource</c> arm.
     /// </summary>
     /// <remarks>
     /// <c>null</c> and <c>undefined</c> become a <c>JsonWebKey</c> with every member absent, which is what
     /// WebIDL does for a union containing a dictionary type; a number, a string or a boolean is a
     /// <c>TypeError</c>, because converting a non-object to a dictionary is one.
+    /// <para>
+    /// Only the <i>arm</i> is decided here. The bytes of the <c>BufferSource</c> arm are not taken, because
+    /// taking them is step 4 of <c>importKey</c> and runs after normalization — which is why this answers
+    /// with the dictionary or with nothing, rather than with one of two payloads.
+    /// </para>
     /// </remarks>
-    private (byte[]? Raw, JsonWebKeyData? Jwk) ReadKeyData(JsValue keyData, string what)
+    private JsonWebKeyData? ConvertKeyData(JsValue keyData, string what)
     {
-        if (BufferSource.TryGetBytes(keyData, out var bytes))
+        if (BufferSource.IsBufferSource(keyData))
         {
             if (AlgorithmNormalization.IsSharedBufferSource(keyData))
             {
                 Context.ThrowTypeError(what + ": parameter 2 is backed by a SharedArrayBuffer, which this operation does not accept.");
             }
 
-            return (bytes.ToArray(), null);
+            return null;
         }
 
         if (keyData.IsNull() || keyData.IsUndefined())
         {
-            return (null, new JsonWebKeyData());
+            return new JsonWebKeyData();
         }
 
         if (keyData is ObjectInstance source)
         {
-            return (null, JsonWebKeyData.Read(Context, source, what));
+            return JsonWebKeyData.Read(Context, source, what);
         }
 
         Context.ThrowTypeError(what + ": parameter 2 is neither a BufferSource nor a JsonWebKey object.");
-        return default;
+        return null;
     }
 
     /// <summary>
     /// WebIDL's conversion of a <c>BufferSource</c> argument, which is
-    /// <c>(ArrayBufferView or ArrayBuffer)</c> — https://webidl.spec.whatwg.org/#BufferSource — followed by
-    /// "getting a copy of the bytes" it holds.
+    /// <c>(ArrayBufferView or ArrayBuffer)</c> — https://webidl.spec.whatwg.org/#BufferSource. This is the
+    /// conversion and nothing else: it decides the type and refuses a shared buffer, and takes no bytes.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The copy is real, and it has to be: the argument conversions run before the method body, and the
-    /// first thing the body does is normalize an algorithm, which reads a <c>name</c> member and may
-    /// therefore run a script's getter — with the buffer this argument came from in scope. A window onto the
-    /// engine's own backing array would then be a window onto what that getter left behind, and the operation
-    /// would run over bytes the caller never passed.
+    /// It runs with the other argument conversions, before a single step of the method body, which is what
+    /// makes <c>digest('nonsense', 42)</c> a <c>TypeError</c> rather than a <c>NotSupportedError</c>. The
+    /// bytes are <see cref="CopyBufferSourceBytes"/>'s, at the numbered step that copies them.
     /// </para>
     /// <para>
     /// A view onto a <c>SharedArrayBuffer</c> is refused, and so is a <c>SharedArrayBuffer</c> itself: the
@@ -1304,13 +1382,13 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
     /// One deliberate divergence, in the permissive direction: a <b>resizable</b> <c>ArrayBuffer</c>, or a
     /// view onto one, is accepted. WebIDL's conversion refuses those too for a type without
     /// <c>[AllowResizable]</c>, which <c>BufferSource</c> does not carry — but the bytes taken are exactly
-    /// the ones the view spans at the moment of the call, so the answer is right rather than merely
+    /// the ones the view spans at the moment the copy step runs, so the answer is right rather than merely
     /// tolerated, and no engine an embedder is likely to be replacing refuses it.
     /// </para>
     /// </remarks>
-    private byte[] GetBufferSourceBytes(JsValue data, string what, string parameter)
+    private void RequireBufferSource(JsValue data, string what, string parameter)
     {
-        if (!BufferSource.TryGetBytes(data, out var bytes))
+        if (!BufferSource.IsBufferSource(data))
         {
             Context.ThrowTypeError(what + ": " + parameter + " is not of type 'BufferSource'.");
         }
@@ -1319,7 +1397,32 @@ internal sealed partial class SubtleCryptoInstance : BuiltinShapeObject
         {
             Context.ThrowTypeError(what + ": " + parameter + " is backed by a SharedArrayBuffer, which this operation does not accept.");
         }
+    }
 
+    /// <summary>
+    /// "Getting a copy of the bytes held by" a buffer source —
+    /// https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy — which every one of these methods performs
+    /// as a numbered step of its own, after the algorithm has been normalized.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The copy is real, and where it is taken from is the whole point: normalization reads the algorithm's
+    /// <c>name</c> and may run a script's getter with this very buffer in scope, so the bytes are read
+    /// <i>now</i> rather than carried over from the conversion. A getter that rewrites them is honoured, and
+    /// one that transfers the buffer leaves a detached view, whose copy is the empty byte sequence — which
+    /// is what https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy step 7 says it should be.
+    /// </para>
+    /// <para>
+    /// After the copy the array is the operation's own, so a mutation the script makes once the call has
+    /// returned changes nothing — that half was never in question and is what the corpus's "… after call"
+    /// rows assert.
+    /// </para>
+    /// </remarks>
+    private static byte[] CopyBufferSourceBytes(JsValue data)
+    {
+        // The conversion proved this is a buffer source, and nothing a getter can do takes that away: a
+        // detach or a resize changes the bytes on offer, never the type of the object holding them.
+        BufferSource.TryGetBytes(data, out var bytes);
         return bytes.ToArray();
     }
 

--- a/Jint/WebApi/Encoding/BufferSource.cs
+++ b/Jint/WebApi/Encoding/BufferSource.cs
@@ -13,8 +13,11 @@ namespace Jint.WebApi.Encoding;
 /// </summary>
 /// <remarks>
 /// The span returned is a window onto the engine's own backing array, not a copy: the specification's
-/// "get a copy of the buffer source" exists so that a later mutation cannot be observed, and every caller
-/// here consumes the bytes synchronously before returning to script, so the copy would be pure cost.
+/// "get a copy of the buffer source" exists so that a later mutation cannot be observed, and a caller that
+/// consumes the bytes synchronously before returning to script would pay for that copy and observe nothing.
+/// A caller whose bytes must survive something script can run — <c>crypto.subtle</c>'s operations, each of
+/// which normalizes an algorithm, and so may run a getter, before its copy step and again nowhere after it
+/// — asks for the span at the moment that step says to and takes its own <c>ToArray</c>.
 /// <para>
 /// A detached buffer yields the empty byte sequence rather than an error, which is what
 /// https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy step 7 says. A view left hanging outside
@@ -29,10 +32,12 @@ internal static class BufferSource
     /// <c>AllowSharedBufferSource</c> conversion decides, and it decides it before the operation runs.
     /// </summary>
     /// <remarks>
-    /// An operation whose <i>later</i> arguments can detach the buffer has to separate the two: the type
-    /// check belongs to the argument conversion, the bytes to the operation that follows it. Everything else
-    /// converts one buffer source and nothing that could run script, so it goes straight to
-    /// <see cref="TryGetBytes"/>.
+    /// An operation that can run script between converting its arguments and using the bytes has to separate
+    /// the two: the type check belongs to the argument conversion, the bytes to the numbered step that takes
+    /// them. That is <c>TextDecoder.decode</c>, whose <i>later</i> argument can detach the buffer, and every
+    /// byte-taking <c>crypto.subtle</c> method, whose algorithm normalization can run a getter with the
+    /// buffer in scope. A caller with no such gap converts one buffer source and nothing that could run
+    /// script, so it goes straight to <see cref="TryGetBytes"/>.
     /// </remarks>
     internal static bool IsBufferSource(JsValue value) => value is JsTypedArray or JsDataView or JsArrayBuffer;
 


### PR DESCRIPTION
Fixes the WebCryptoAPI corpus's largest finding: `crypto.subtle` copied the caller's bytes *before* normalizing the algorithm, where every method's numbered steps copy them *after* — so a getter on the algorithm's `name` that rewrote or transferred the buffer was too late to be seen.

Closes #3179.

The old `GetBufferSourceBytes` conflated two spec-different times, and the fix is the split: `RequireBufferSource` is WebIDL's *argument conversion* (type check, SharedArrayBuffer refusal — stays with the other conversions, which is why `digest('nonsense', 42)` still rejects for the second argument), and `CopyBufferSourceBytes` is the method's *copy step*, placed per method at its own number: step 4 for `digest`/`sign`/`encrypt`/`decrypt`, steps 4 and 5 for `verify`'s two buffers, step 4's `Otherwise` branch for `importKey` (whose union conversion now decides only the arm — the JWK dictionary still materializes at conversion time, having no live window to defer), and step 6 for `unwrapKey`, after both of its normalizations. A transfer during normalization now leaves a detached view whose copy is the empty byte sequence, exactly as WebIDL's *get a copy of the bytes* says.

**380 corpus assertions start passing** (2,839 → 2,459 not-passing), and `digest`, `aes_cbc`, `aes_ctr`, `symmetric_importKey`, `ecdsa`, `hmac` and `rsa_pkcs` are now fully green files. With #3183 alongside, **`NeedsTriage` is empty** — every genuine defect the corpus found is fixed, and its doc says so.

The exclusion-table rework is where the care went, per platform:

- The platform-neutral `during call` globs across ten files are deleted — the driver enforces it, they went stale the moment the copy moved.
- The aes_gcm **sub-128-bit-tag** `during call` rows are recategorized, not deleted: on macOS they keep failing because Apple's tag refusal fires before any byte is looked at, so they join the macOS-scoped `NeedsPlatformCryptoParameters` block, each tag now carrying the same six globs the 32/64-bit block always had. One row per family stays deliberately in no entry — `decryption with transferred ciphertext during call` *passes* there, the refusal being the very `OperationError` it asserts.
- This was **verified by simulation, not just reasoning**: the agent forced `IsSupportedTagSize` to Apple's 16-only shape and pointed the platform constant at Windows, ran the exact macOS-shaped table under the exact macOS limit, and got a fully green, zero-stale run. Both temporary edits are absent from the commit. The remaining risk is stated honestly in the review notes: Linux is derived from CNG≡OpenSSL on these families rather than run, and CI is the arbiter.
- `ExceptPlatform` loses its last user and is kept, its doc rewritten to record the case that needed it.

The old pin `TheDataArgumentIsCopiedBeforeAnyGetterCanRun` — which cited the spec while asserting the opposite of it — becomes `TheDataArgumentIsCopiedAfterTheAlgorithmIsNormalized`, joined by seven more pins covering altered and transferred buffers across `digest`/`verify`(both buffers)/`encrypt`(against a literal AES-CBC vector, so it cannot pass by agreeing with itself)/`decrypt`/`importKey`/`unwrapKey`, **all eight verified failing against the unfixed engine**, plus a control pinning that the copy is never re-read after its step.

Full matrix green on both TFMs including host-contract-verification legs; all WPT theory cases green; re-verified after rebasing over #3183 and #3035.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014n5uCpi2vvHWBSiewUwBiY
