### PR TITLE
Web messaging: a MessagePort is transferable - the queue is the thing that travels

### DIFF
--- a/Jint.Tests.PublicInterface/WebApiMessagingTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiMessagingTests.cs
@@ -323,7 +323,201 @@ public class WebApiMessagingTests
         worker.Evaluate("received[0]").AsString().Should().Be("sent then restored");
     }
 
+    // ---------------------------------------------------------------- transferring a port between engines
+
+    [Fact]
+    public void APortTransferredToAnotherEngineIsEntangledWithTheOriginalPeer()
+    {
+        var (host, worker) = ConnectedPair();
+
+        worker.Execute("var moved = null; port.onmessage = function (e) { moved = e.ports[0]; };");
+
+        // The host makes a private channel and hands one end to the worker over the channel it already has.
+        host.Execute("""
+            var side = new MessageChannel();
+            side.port1.onmessage = function (e) { received.push('side:' + e.data); };
+            port.postMessage('here is a port', [side.port2]);
+            """);
+
+        worker.Advanced.ProcessTasks();
+
+        // The worker's engine built a MessagePort of its OWN realm — no JsValue crossed — and the event
+        // carries it in a frozen ports array.
+        worker.Evaluate("moved instanceof MessagePort").AsBoolean().Should().BeTrue();
+        worker.Evaluate("Object.getPrototypeOf(moved) === MessagePort.prototype").AsBoolean().Should().BeTrue();
+        // ... and it is entangled with the host's side.port1, which never learned that anything moved.
+        worker.Execute("moved.postMessage('hello from the worker');");
+        host.Advanced.ProcessTasks();
+        host.Evaluate("received.join(',')").AsString().Should().Be("side:hello from the worker");
+    }
+
+    [Fact]
+    public void ATransferredPortIsInertOnTheSendingEngine()
+    {
+        var (host, worker) = ConnectedPair();
+
+        host.Execute("""
+            var side = new MessageChannel();
+            side.port1.onmessage = function (e) { received.push('side:' + e.data); };
+            port.postMessage('handover', [side.port2]);
+
+            // Detached: postMessage is a silent no-op rather than a throw.
+            side.port2.postMessage('from the detached port');
+            """);
+
+        worker.Execute("port.onmessage = function (e) { e.ports[0].onmessage = function (ev) { received.push(ev.data); }; };");
+        worker.Advanced.ProcessTasks();
+        host.Advanced.ProcessTasks();
+
+        // Nothing came back through the detached object, and the worker got the one message the channel
+        // really carried.
+        host.Evaluate("received.length").AsNumber().Should().Be(0);
+        worker.Evaluate("received.length").AsNumber().Should().Be(0);
+
+        host.Execute("side.port1.postMessage('through the moved port');");
+        worker.Advanced.ProcessTasks();
+        worker.Evaluate("received.join(',')").AsString().Should().Be("through the moved port");
+    }
+
+    [Fact]
+    public void ATransferCarriesTheQueuedMessagesAndKeepsThemAhead()
+    {
+        var (host, worker) = ConnectedPair();
+
+        // Two messages queued on a port that was never started, the transfer, then one more posted while the
+        // port belongs to no engine at all — the window between the two engines' turns.
+        host.Execute("""
+            var side = new MessageChannel();
+            side.port1.postMessage('queued-1');
+            side.port1.postMessage('queued-2');
+            port.postMessage('handover', [side.port2]);
+            side.port1.postMessage('in-transit');
+            """);
+
+        worker.Execute("port.onmessage = function (e) { e.ports[0].onmessage = function (ev) { received.push(ev.data); }; };");
+        worker.Advanced.ProcessTasks();
+
+        worker.Evaluate("received.join(',')").AsString().Should().Be("queued-1,queued-2,in-transit");
+
+        host.Execute("side.port1.postMessage('after');");
+        worker.Advanced.ProcessTasks();
+        worker.Evaluate("received.join(',')").AsString().Should().Be("queued-1,queued-2,in-transit,after");
+    }
+
+    /// <summary>
+    /// The shape the whole design is for: the peer of a transferred port lives on an engine that is neither
+    /// the sender nor the receiver, and never hears about the move.
+    /// </summary>
+    [Fact]
+    public void APortRelayedThroughAThirdEngineStillTalksToTheFirst()
+    {
+        var a = MessagingEngine();
+        var b = MessagingEngine();
+        var c = MessagingEngine();
+
+        Wire(a, b, "ab");
+        Wire(b, c, "bc");
+
+        // A keeps one end of a private channel and sends the other to B ...
+        a.Execute("""
+            var received = [];
+            var side = new MessageChannel();
+            side.port1.onmessage = function (e) { received.push(e.data); };
+            side.port1.postMessage('queued before anything moved');
+            ab.postMessage('for you', [side.port2]);
+            """);
+
+        // ... B does not even look at it, it just forwards it on to C ...
+        b.Execute("ab.onmessage = function (e) { bc.postMessage('passing it on', [e.ports[0]]); };");
+        b.Advanced.ProcessTasks();
+
+        // ... and C ends up talking straight to A.
+        c.Execute("var received = []; bc.onmessage = function (e) { var p = e.ports[0]; p.onmessage = function (ev) { received.push(ev.data); }; p.postMessage('hello from C'); };");
+        c.Advanced.ProcessTasks();
+
+        a.Advanced.ProcessTasks();
+        a.Evaluate("received.join(',')").AsString().Should().Be("hello from C");
+
+        // The message A queued before the first hop survived both of them, and arrives at C in order ahead of
+        // anything posted afterwards.
+        a.Execute("side.port1.postMessage('after two hops');");
+        c.Advanced.ProcessTasks();
+        c.Evaluate("received.join(',')").AsString().Should().Be("queued before anything moved,after two hops");
+
+        // B was only ever a courier: it never bound the side, and its own port is untouched.
+        b.Evaluate("typeof ab").AsString().Should().Be("object");
+    }
+
+    [Fact]
+    public void ATransferredPortIsEndedWhenTheReceivingEngineRestores()
+    {
+        var (host, worker) = ConnectedPair();
+        var snapshot = worker.Advanced.CaptureGlobalSnapshot();
+
+        host.Execute("""
+            var side = new MessageChannel();
+            side.port1.onmessage = function (e) { received.push(e.data); };
+            port.postMessage('handover', [side.port2]);
+            """);
+
+        // The worker ends the cycle before it ever runs the delivery job, so the side that was in flight can
+        // never be bound to anything. It has to be ENDED rather than left waiting: the host's own port would
+        // otherwise go on serializing into a queue nobody can ever drain.
+        worker.Advanced.RestoreGlobalSnapshot(snapshot);
+        worker.Advanced.ProcessTasks();
+
+        host.Execute("side.port1.postMessage('into the void');");
+        host.Advanced.ProcessTasks();
+        host.Evaluate("received.length").AsNumber().Should().Be(0);
+
+        // The port that was in flight was detached by the transfer, so it cannot be handed over again
+        // either — the sender's half of the same fact.
+        Refusal(host, "port.postMessage('again', [side.port2])").Should().Be("DataCloneError");
+    }
+
+    [Fact]
+    public void ADoubleTransferOfTheSamePortIsRefused()
+    {
+        var (host, worker) = ConnectedPair();
+
+        host.Execute("var side = new MessageChannel(); port.postMessage('first', [side.port2]);");
+
+        Refusal(host, "port.postMessage('second', [side.port2])").Should().Be("DataCloneError");
+
+        // The first transfer is unaffected: the worker still gets exactly one port.
+        worker.Execute("var ports = 0; port.onmessage = function (e) { ports += e.ports.length; };");
+        worker.Advanced.ProcessTasks();
+        worker.Evaluate("ports").AsNumber().Should().Be(1);
+    }
+
+    [Fact]
+    public void APortCannotBeSentThroughItself()
+    {
+        var (host, _) = ConnectedPair();
+
+        Refusal(host, "port.postMessage('nope', [port])").Should().Be("DataCloneError");
+
+        // Nothing was detached, so the channel is untouched.
+        host.Execute("port.postMessage('still fine');");
+    }
+
     // ---------------------------------------------------------------- helpers
+
+    /// <summary>
+    /// The <c>DOMException</c> name <paramref name="body"/> is refused with, or <c>"no error"</c>.
+    /// </summary>
+    private static string Refusal(Engine engine, string body) => engine.Evaluate(
+        "(function () { try { " + body + "; return 'no error'; } catch (e) { return e.name; } })()").AsString();
+
+    /// <summary>
+    /// Gives two engines a port each under <paramref name="name"/>, so a chain of engines can be wired up.
+    /// </summary>
+    private static void Wire(Engine first, Engine second, string name)
+    {
+        var pair = first.Advanced.CreateMessagePortPair(second);
+        first.SetValue(name, pair.Local);
+        second.SetValue(name, pair.Remote);
+    }
 
     /// <summary>
     /// How many messages an engine has taken delivery of, read <b>without</b> pumping it — which

--- a/Jint.Tests/Runtime/WebApi/MessagingTests.cs
+++ b/Jint.Tests/Runtime/WebApi/MessagingTests.cs
@@ -3,6 +3,7 @@
 
 using Jint.Native;
 using Jint.Runtime.Descriptors;
+using Jint.WebApi.Messaging;
 
 namespace Jint.Tests.Runtime.WebApi;
 
@@ -562,20 +563,6 @@ public class MessagingTests
     }
 
     [Fact]
-    public void RefusesToTransferAPort()
-    {
-        var engine = MessagingEngine();
-        engine.Execute("var ch = new MessageChannel(); var other = new MessageChannel();");
-
-        // Transferring a port is out of scope for this version, so every port-in-transfer-list case the
-        // specification distinguishes — the port itself, its entangled peer, an unrelated port — is one
-        // DataCloneError.
-        Err(engine, "ch.port1.postMessage(0, [ch.port1])").Should().Be("DataCloneError");
-        Err(engine, "ch.port1.postMessage(0, [ch.port2])").Should().Be("DataCloneError");
-        Err(engine, "ch.port1.postMessage(0, [other.port1])").Should().Be("DataCloneError");
-    }
-
-    [Fact]
     public void RefusesAMalformedTransferOption()
     {
         var engine = MessagingEngine();
@@ -584,6 +571,423 @@ public class MessagingTests
         Err(engine, "ch.port1.postMessage(0, 5)").Should().Be("TypeError");
         Err(engine, "ch.port1.postMessage(0, [1])").Should().Be("TypeError");
         Err(engine, "ch.port1.postMessage(0, { transfer: 5 })").Should().Be("TypeError");
+    }
+
+    // ---------------------------------------------------------------- transferring a port
+
+    /// <summary>
+    /// A relay channel plus a channel to hand over: <c>relay</c> carries the transfer, <c>ch</c> is the
+    /// channel whose <c>port2</c> gets moved. The receiving side of the relay adopts whatever port arrives.
+    /// </summary>
+    private const string HandoverSetup = """
+        var relay = new MessageChannel();
+        var ch = new MessageChannel();
+        var moved = null;
+        relay.port2.onmessage = function (e) {
+            moved = e.ports[0];
+            moved.onmessage = function (ev) { log.push(ev.data); };
+        };
+        """;
+
+    [Fact]
+    public void TransfersAPortThroughTheChannel()
+    {
+        var engine = MessagingEngine();
+
+        engine.Execute(HandoverSetup + "relay.port1.postMessage('handover', [ch.port2]);");
+
+        // The receiver got a real MessagePort of its own realm, not a clone of the object.
+        engine.Evaluate("moved instanceof MessagePort").AsBoolean().Should().BeTrue();
+        engine.Evaluate("moved === ch.port2").AsBoolean().Should().BeFalse();
+
+        // ... and it is entangled with the peer the transferred port had, which never learned anything
+        // happened: a message posted on ch.port1 now arrives at the port the relay delivered.
+        engine.Execute("ch.port1.postMessage('through the moved port');");
+        Log(engine).Should().Be("through the moved port");
+
+        // The other direction works too.
+        engine.Execute("ch.port1.onmessage = function (e) { log.push('back:' + e.data); }; moved.postMessage('reply');");
+        Log(engine).Should().Be("through the moved port,back:reply");
+    }
+
+    [Fact]
+    public void LeavesTheTransferredPortInert()
+    {
+        var engine = MessagingEngine();
+
+        engine.Execute(HandoverSetup + """
+            ch.port2.onmessage = function (e) { log.push('old port saw ' + e.data); };
+            relay.port1.postMessage('handover', [ch.port2]);
+            """);
+
+        // [[Detached]]: postMessage is a silent no-op rather than a throw, and nothing will ever fire on the
+        // detached object again — not even the listener it still carries.
+        engine.Execute("ch.port2.postMessage('from the detached port'); ch.port1.postMessage('to the detached port');");
+        engine.Execute("ch.port2.start(); ch.port2.close();");
+
+        Log(engine).Should().Be("to the detached port");
+        engine.Evaluate("log.length").AsNumber().Should().Be(1);
+    }
+
+    /// <summary>
+    /// The port message queue travels with the port, and everything in flight keeps its place in it — which is
+    /// what HTML gets by passing the queue itself into the data holder rather than a copy of its contents.
+    /// </summary>
+    [Fact]
+    public void CarriesTheQueuedMessagesWithTheTransferredPortAndKeepsTheirOrder()
+    {
+        var engine = MessagingEngine();
+
+        // Two messages queued on a port that was never started, then the transfer, then one more posted while
+        // the port is in transit — no object owns that channel side at that instant. All three must arrive, in
+        // this order, on the port the transfer created.
+        engine.Execute(HandoverSetup + """
+            ch.port1.postMessage('queued-before-1');
+            ch.port1.postMessage('queued-before-2');
+            relay.port1.postMessage('handover', [ch.port2]);
+            ch.port1.postMessage('posted-in-transit');
+            """);
+
+        Log(engine).Should().Be("queued-before-1,queued-before-2,posted-in-transit");
+
+        // ... and the channel keeps working afterwards, so nothing about the handover left it half-drained.
+        engine.Execute("ch.port1.postMessage('after');");
+        Log(engine).Should().Be("queued-before-1,queued-before-2,posted-in-transit,after");
+    }
+
+    [Fact]
+    public void CarriesAStartedPortsUndeliveredBacklog()
+    {
+        var engine = MessagingEngine();
+
+        // The specification permits transferring a port whose queue is already enabled; the new port starts
+        // disabled again ("leaving value's port message queue in its initial disabled state"), so the backlog
+        // waits for the receiver's own start().
+        engine.Execute(HandoverSetup + """
+            relay.port2.onmessage = function (e) { moved = e.ports[0]; };
+            ch.port2.onmessage = function () { log.push('never'); };
+            ch.port1.postMessage('backlog');
+            relay.port1.postMessage('handover', [ch.port2]);
+            """);
+
+        // Nothing was delivered anywhere: the transfer happened synchronously inside postMessage, before the
+        // event-loop task that would have dispatched 'backlog' to the old port ever ran.
+        Log(engine).Should().Be("");
+
+        engine.Execute("moved.onmessage = function (e) { log.push(e.data); };");
+        Log(engine).Should().Be("backlog");
+    }
+
+    [Fact]
+    public void RefusesToTransferAPortThroughItself()
+    {
+        var engine = MessagingEngine();
+        engine.Execute("var ch = new MessageChannel();");
+
+        // Message port post message steps, step 2 — and it is decided before serialization, so nothing else
+        // in the list is transferred either.
+        engine.Execute("var buffer = new ArrayBuffer(4);");
+        Err(engine, "ch.port1.postMessage(0, [buffer, ch.port1])").Should().Be("DataCloneError");
+        engine.Evaluate("buffer.byteLength").AsNumber().Should().Be(4);
+        engine.Evaluate("ch.port1.postMessage('still works') === undefined").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void DoomsAMessageThatTransfersTheEntangledPeer()
+    {
+        var engine = MessagingEngine();
+
+        engine.Execute("""
+            var ch = new MessageChannel();
+            ch.port2.onmessage = function (e) { log.push(e.data); };
+            ch.port1.postMessage('doomed', [ch.port2]);
+            """);
+
+        // Step 4 dooms rather than refuses: no exception, and nothing is delivered.
+        Log(engine).Should().Be("");
+
+        // ... but step 5 still ran, so the peer really was transferred — and since the message carrying it can
+        // never be picked up, the channel is lost, exactly as the specification's own note says.
+        engine.Execute("ch.port1.postMessage('after the dooming');");
+        Log(engine).Should().Be("");
+
+        // Script cannot tell dooming from delivering-into-a-port-nobody-owns, because both are silent. The
+        // difference is on the side: doomed means the record was never queued at all and the transfer it
+        // carried was ended, rather than a record sitting in a queue that references the very side it is
+        // sitting in.
+        var sender = (JsMessagePort) engine.Evaluate("ch.port1");
+        sender.Endpoint!.Peer!.Closed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void EndsEveryTransferStrandedBehindAClosedPortHoweverDeeplyNested()
+    {
+        var engine = MessagingEngine();
+
+        // x2 is never started, so everything posted to it piles up on its side. The first message carries
+        // y2, and — because y2's side is then unbound — the second message piles up behind THAT, carrying z2.
+        engine.Execute("""
+            var x = new MessageChannel();
+            var y = new MessageChannel();
+            var z = new MessageChannel();
+            x.port1.postMessage('carrying y2', [y.port2]);
+            y.port1.postMessage('carrying z2', [z.port2]);
+            """);
+
+        var y1 = (JsMessagePort) engine.Evaluate("y.port1");
+        var z1 = (JsMessagePort) engine.Evaluate("z.port1");
+        y1.Endpoint!.Peer!.Closed.Should().BeFalse();
+        z1.Endpoint!.Peer!.Closed.Should().BeFalse();
+
+        // Closing the one port at the head of the chain has to end all of it: every side behind it is
+        // unreachable, and each would otherwise go on accepting messages from a peer that is still alive.
+        engine.Execute("x.port2.close();");
+
+        y1.Endpoint!.Peer!.Closed.Should().BeTrue();
+        z1.Endpoint!.Peer!.Closed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void RefusesAPortThatAppearsTwiceInOneTransferList()
+    {
+        var engine = MessagingEngine();
+        engine.Execute("var relay = new MessageChannel(); var ch = new MessageChannel();");
+
+        // StructuredSerializeWithTransfer step 2.3, which is checked before anything is detached.
+        Err(engine, "relay.port1.postMessage(0, [ch.port2, ch.port2])").Should().Be("DataCloneError");
+
+        // The port is untouched, so it can still be transferred properly.
+        engine.Execute("relay.port2.onmessage = function (e) { log.push(e.ports.length); }; relay.port1.postMessage(0, [ch.port2]);");
+        Log(engine).Should().Be("1");
+    }
+
+    [Fact]
+    public void RefusesToTransferAnAlreadyDetachedPort()
+    {
+        var engine = MessagingEngine();
+
+        engine.Execute(HandoverSetup + "relay.port1.postMessage('handover', [ch.port2]);");
+
+        // StructuredSerializeWithTransfer step 5.2, for a port a previous transfer detached ...
+        Err(engine, "relay.port1.postMessage(0, [ch.port2])").Should().Be("DataCloneError");
+
+        // ... and for one close() detached.
+        engine.Execute("var other = new MessageChannel(); other.port1.close();");
+        Err(engine, "relay.port1.postMessage(0, [other.port1])").Should().Be("DataCloneError");
+    }
+
+    [Fact]
+    public void RefusesAPortThatWasNotInTheTransferList()
+    {
+        var engine = MessagingEngine();
+        engine.Execute("var ch = new MessageChannel(); var other = new MessageChannel();");
+
+        // A MessagePort is transferable but not serializable, so putting one in the message without naming it
+        // in the transfer list is the plain "platform object that is not serializable" refusal.
+        Err(engine, "ch.port1.postMessage(other.port1)").Should().Be("DataCloneError");
+        Err(engine, "ch.port1.postMessage({ nested: other.port1 })").Should().Be("DataCloneError");
+
+        // ... and the untransferred port is unharmed.
+        engine.Execute("other.port2.onmessage = function (e) { log.push(e.data); }; other.port1.postMessage('fine');");
+        Log(engine).Should().Be("fine");
+    }
+
+    [Fact]
+    public void ResolvesAPortThatIsBothTransferredAndReferencedToOneObject()
+    {
+        var engine = MessagingEngine();
+
+        // StructuredDeserializeWithTransfer creates the transferred values BEFORE it walks the graph, so a
+        // reference to the port from inside the message resolves to the very object `ports` hands over.
+        engine.Execute("""
+            var relay = new MessageChannel();
+            var ch = new MessageChannel();
+            var event = null;
+            relay.port2.onmessage = function (e) { event = e; };
+            relay.port1.postMessage({ port: ch.port2, again: [ch.port2] }, [ch.port2]);
+            """);
+
+        engine.Evaluate("event.data.port === event.ports[0]").AsBoolean().Should().BeTrue();
+        engine.Evaluate("event.data.again[0] === event.ports[0]").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void GivesTheEventAFrozenPortsArrayInTransferListOrder()
+    {
+        var engine = MessagingEngine();
+
+        engine.Execute("""
+            var relay = new MessageChannel();
+            var first = new MessageChannel();
+            var second = new MessageChannel();
+            var event = null;
+            relay.port2.onmessage = function (e) { event = e; };
+            relay.port1.postMessage('two ports', [second.port2, first.port2]);
+            """);
+
+        engine.Evaluate("event.ports.length").AsNumber().Should().Be(2);
+        engine.Evaluate("Object.isFrozen(event.ports)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Array.isArray(event.ports)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("event.ports === event.ports").AsBoolean().Should().BeTrue();
+
+        // Transfer-list order, not creation order: ports[0] is second's half.
+        engine.Execute("""
+            event.ports[0].onmessage = function (e) { log.push('0:' + e.data); };
+            event.ports[1].onmessage = function (e) { log.push('1:' + e.data); };
+            second.port1.postMessage('from second');
+            first.port1.postMessage('from first');
+            """);
+
+        Log(engine).Should().Be("0:from second,1:from first");
+    }
+
+    [Fact]
+    public void TransfersBothEndsOfAChannelInOneMessage()
+    {
+        var engine = MessagingEngine();
+
+        engine.Execute("""
+            var relay = new MessageChannel();
+            var ch = new MessageChannel();
+            relay.port2.onmessage = function (e) {
+                e.ports[0].onmessage = function (ev) { log.push(ev.data); };
+                e.ports[1].postMessage('both ends moved');
+            };
+            relay.port1.postMessage('handover', [ch.port1, ch.port2]);
+            """);
+
+        // Each side was re-pointed independently, and they are still each other's peer.
+        Log(engine).Should().Be("both ends moved");
+    }
+
+    [Fact]
+    public void RelaysAPortThroughSeveralTransfers()
+    {
+        var engine = MessagingEngine();
+
+        engine.Execute("""
+            var first = new MessageChannel();
+            var second = new MessageChannel();
+            var ch = new MessageChannel();
+
+            // The port arriving on first.port2 is immediately forwarded through the second relay.
+            first.port2.onmessage = function (e) { second.port1.postMessage('forwarded', [e.ports[0]]); };
+            second.port2.onmessage = function (e) { e.ports[0].onmessage = function (ev) { log.push(ev.data); }; };
+
+            ch.port1.postMessage('queued at the very start');
+            first.port1.postMessage('handover', [ch.port2]);
+            """);
+
+        // The one message survived two hops, and the channel still works at the far end.
+        Log(engine).Should().Be("queued at the very start");
+
+        engine.Execute("ch.port1.postMessage('after two hops');");
+        Log(engine).Should().Be("queued at the very start,after two hops");
+    }
+
+    [Fact]
+    public void TransfersAPortThroughStructuredCloneIntoTheSameRealm()
+    {
+        var engine = MessagingEngine();
+
+        // A transfer needs a target realm, not a target agent, so structuredClone can do it — and does in
+        // every browser. The clone is entangled with the original's peer and the original is detached.
+        engine.Execute("""
+            var ch = new MessageChannel();
+            ch.port1.onmessage = function (e) { log.push(e.data); };
+            var clone = structuredClone(ch.port2, { transfer: [ch.port2] });
+            clone.onmessage = function (e) { log.push('clone got ' + e.data); };
+            clone.postMessage('from the clone');
+            ch.port1.postMessage('to the clone');
+            """);
+
+        engine.Evaluate("clone instanceof MessagePort").AsBoolean().Should().BeTrue();
+        engine.Evaluate("clone === ch.port2").AsBoolean().Should().BeFalse();
+        engine.Evaluate("ch.port2.postMessage('inert') === undefined").AsBoolean().Should().BeTrue();
+
+        Log(engine).Should().Be("from the clone,clone got to the clone");
+    }
+
+    [Fact]
+    public void StructuredCloneStillRefusesAPortThatIsNotTransferred()
+    {
+        var engine = MessagingEngine();
+        engine.Execute("var ch = new MessageChannel();");
+
+        Err(engine, "structuredClone(ch.port1)").Should().Be("DataCloneError");
+
+        // The refusal did not detach it.
+        engine.Execute("ch.port2.onmessage = function (e) { log.push(e.data); }; ch.port1.postMessage('unharmed');");
+        Log(engine).Should().Be("unharmed");
+    }
+
+    [Fact]
+    public void EndsAPortWhoseTransferCanNeverBePickedUp()
+    {
+        var engine = MessagingEngine();
+
+        // The relay's target is closed, so the message is serialized (the port really is detached) and then
+        // dropped. Nothing can ever bind that channel side, so it is closed rather than left waiting — which
+        // is what the peer observes.
+        engine.Execute("""
+            var relay = new MessageChannel();
+            var ch = new MessageChannel();
+            relay.port2.close();
+            relay.port1.postMessage('nowhere', [ch.port2]);
+            ch.port1.onmessage = function (e) { log.push(e.data); };
+            ch.port1.postMessage('into the void');
+            """);
+
+        engine.Evaluate("ch.port2.postMessage('inert') === undefined").AsBoolean().Should().BeTrue();
+        Log(engine).Should().Be("");
+
+        // Script cannot tell "closed" from "waiting for a receiver that will never come" — both make
+        // postMessage a no-op — so the assertion that matters is on the side itself. A side left merely
+        // unbound would go on accepting everything ch.port1 ever posts, into a queue nothing can drain.
+        var remaining = (JsMessagePort) engine.Evaluate("ch.port1");
+        remaining.Endpoint!.Peer!.Closed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void EndsAPortInFlightToAnEngineThatRestores()
+    {
+        var host = MessagingEngine();
+        var worker = MessagingEngine();
+
+        var pair = host.Advanced.CreateMessagePortPair(worker);
+        host.SetValue("port", pair.Local);
+        worker.SetValue("port", pair.Remote);
+
+        var snapshot = worker.Advanced.CaptureGlobalSnapshot();
+
+        host.Execute("var ch = new MessageChannel(); port.postMessage('handover', [ch.port2]);");
+
+        // The delivery job carries the worker's ended cycle, so it is discarded and the side that was in
+        // flight can never be bound. The restore is what has to end it: the fence stops delivery, it does not
+        // stop the host from serializing into a queue forever.
+        worker.Advanced.RestoreGlobalSnapshot(snapshot);
+        worker.Advanced.ProcessTasks();
+
+        var remaining = (JsMessagePort) host.Evaluate("ch.port1");
+        remaining.Endpoint!.Peer!.Closed.Should().BeTrue();
+
+        // The port the host kept is still perfectly usable as an object; it simply has nowhere to post.
+        host.Execute("ch.port1.postMessage('into the void');");
+    }
+
+    [Fact]
+    public void BroadcastChannelStillRefusesAPort()
+    {
+        var engine = MessagingEngine();
+        engine.Execute("var ch = new MessageChannel(); var bc = new BroadcastChannel('room');");
+
+        // BroadcastChannel's postMessage takes no transfer list at all — a message with several destinations
+        // has nowhere to move a transferable to — so a port in the message is simply uncloneable.
+        Err(engine, "bc.postMessage(ch.port1)").Should().Be("DataCloneError");
+        Err(engine, "bc.postMessage(ch.port1, [ch.port1])").Should().Be("DataCloneError");
+
+        engine.Execute("ch.port2.onmessage = function (e) { log.push(e.data); }; ch.port1.postMessage('unharmed');");
+        Log(engine).Should().Be("unharmed");
     }
 
     // ---------------------------------------------------------------- listeners

--- a/Jint.Tests/Runtime/WebApi/SerializationRecordTests.cs
+++ b/Jint.Tests/Runtime/WebApi/SerializationRecordTests.cs
@@ -14,11 +14,20 @@ namespace Jint.Tests.Runtime.WebApi;
 /// engine, so it can be built on one engine's thread and consumed on another's.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Two independent checks, because either one alone can be fooled. The declaration check reads the record
 /// types' own fields, which catches a new record type that stores a <c>JsValue</c> outright; it cannot see
 /// through <see cref="SerializedValue"/>'s <c>object</c> payload. The graph walk serializes a deliberately
 /// rich value and follows every reference the result actually holds, which does see through it but can only
 /// speak for the shapes the sample covers. Together they cover the rule.
+/// </para>
+/// <para>
+/// <b>A transferred <c>MessagePort</c> is the one sanctioned exception</b>, and it has a check of its own
+/// rather than a hole in these two: the walk stops at <c>MessagePortEndpoint</c>, which is the class whose
+/// whole job is to be touched from another engine's thread, and
+/// <see cref="CarriesExactlyOneChannelSideForATransferredPortAndNothingElseEngineAffine"/> pins that a record
+/// transferring a port reaches exactly one of them and nothing else the rule forbids.
+/// </para>
 /// </remarks>
 public class SerializationRecordTests
 {
@@ -128,6 +137,34 @@ public class SerializationRecordTests
         other.Evaluate("new Uint8Array(revived)[2]").AsNumber().Should().Be(9);
     }
 
+    [Fact]
+    public void CarriesExactlyOneChannelSideForATransferredPortAndNothingElseEngineAffine()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Messaging));
+
+        var channel = engine.Evaluate("new MessageChannel()");
+        var port = channel.Get("port2");
+
+        var record = new StructuredSerializer(engine, engine.Realm).Serialize(
+            engine.Evaluate("({ tag: 'with a port' })"),
+            [port]);
+
+        // The record does reach an Engine and a MessagePort — through the channel side, which is the one
+        // engine-crossing handle the design sanctions and whose members a foreign thread may touch. What must
+        // NOT be true is that anything else does, so the walk stops there and counts.
+        var sides = new List<object>();
+        var visited = new HashSet<object>(ReferenceEqualityComparer.Instance);
+        var reached = 0;
+        Walk(record, visited, ref reached, sides);
+
+        sides.Should().HaveCount(1);
+        reached.Should().BeGreaterThan(3);
+
+        // ... and it really is the side the transfer detached, not a copy: the port is now inert.
+        engine.SetValue("moved", port);
+        engine.Evaluate("moved.postMessage('inert') === undefined").AsBoolean().Should().BeTrue();
+    }
+
     // ---------------------------------------------------------------- helpers
 
     private static bool Forbidden(Type type) => Array.Exists(_forbidden, forbidden => forbidden.IsAssignableFrom(type));
@@ -158,13 +195,22 @@ public class SerializationRecordTests
     /// Follows every reference a live record graph holds.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// The traversal stops at any type declared outside Jint's own assembly other than an array or a
     /// collection — a <see cref="System.Text.RegularExpressions.Regex"/>, an Acornima parse result — because
     /// such a type cannot name a Jint type in its own declarations. That is the one thing this check takes on
     /// trust, and it is the same thing the record types' documentation claims when they carry a compiled
     /// matcher across.
+    /// </para>
+    /// <para>
+    /// It also stops at <c>MessagePortEndpoint</c>, which is the deliberate exception described in the class
+    /// remarks: a channel side is engine-affine by definition, because re-pointing a channel is what a port
+    /// transfer <i>is</i>. Passing <paramref name="channelSides"/> collects them so that a caller can assert
+    /// how many a record actually holds; passing <see langword="null"/> forbids them outright, which is what
+    /// every other record in the suite has to satisfy.
+    /// </para>
     /// </remarks>
-    private static void Walk(object? node, HashSet<object> visited, ref int reached)
+    private static void Walk(object? node, HashSet<object> visited, ref int reached, List<object>? channelSides = null)
     {
         if (node is null)
         {
@@ -172,6 +218,14 @@ public class SerializationRecordTests
         }
 
         var type = node.GetType();
+
+        if (type.FullName == "Jint.WebApi.Messaging.MessagePortEndpoint")
+        {
+            channelSides.Should().NotBeNull("only a record that transferred a port may reach a channel side");
+            channelSides!.Add(node);
+            return;
+        }
+
         Forbidden(type).Should().BeFalse($"a {type.Name} was reachable from a serialization record");
 
         if (type == typeof(string) || type.IsPrimitive)
@@ -191,7 +245,7 @@ public class SerializationRecordTests
         {
             foreach (var item in enumerable)
             {
-                Walk(item, visited, ref reached);
+                Walk(item, visited, ref reached, channelSides);
             }
 
             return;
@@ -209,7 +263,7 @@ public class SerializationRecordTests
                 continue;
             }
 
-            Walk(field.GetValue(node), visited, ref reached);
+            Walk(field.GetValue(node), visited, ref reached, channelSides);
         }
     }
 }

--- a/Jint/Engine.Advanced.WebApi.cs
+++ b/Jint/Engine.Advanced.WebApi.cs
@@ -212,7 +212,16 @@ public partial class Engine
         /// listeners are closures over the evaluation cycle it was created in, so delivering into it
         /// afterwards would run that dead cycle's code against the restored globals. Both ports record their
         /// engine's evaluation cycle when they are created, and every delivery job is dropped once that cycle
-        /// is over. A pooled engine wants a fresh pair per cycle.
+        /// is over; the restore additionally <i>closes</i> every port that engine still has, so the other end
+        /// stops queueing messages into a channel side nothing can ever drain. A pooled engine wants a fresh
+        /// pair per cycle.
+        /// </description></item>
+        /// <item><description>
+        /// <b>A port can be transferred over a port.</b> <c>postMessage(value, [somePort])</c> detaches
+        /// <c>somePort</c> and re-entangles its channel side with a fresh <c>MessagePort</c> in the receiving
+        /// engine's realm, which arrives as <c>event.ports[0]</c> — messages already queued on it included,
+        /// ahead of anything posted afterwards. The peer is untouched, so a port relayed through several
+        /// engines still talks to the one that created it.
         /// </description></item>
         /// </list>
         /// <para>

--- a/Jint/Engine.WebApi.cs
+++ b/Jint/Engine.WebApi.cs
@@ -196,6 +196,26 @@ internal sealed class WebApiEngineState
     /// </summary>
     private BroadcastChannelBroker? _broadcastChannelBroker;
 
+    /// <summary>
+    /// The <c>MessagePort</c> objects this engine has created, held <b>weakly</b>. Engine-thread-only, and
+    /// exists for one reason: a restore or a dispose has to be able to <i>close</i> this engine's ports, not
+    /// merely stop delivering into them — a port's side may be entangled with one belonging to an engine that
+    /// outlives this cycle, and it may be holding an undelivered message that itself carries a transferred
+    /// side nothing else can ever reach.
+    /// </summary>
+    /// <remarks>
+    /// Weak, because a strong list would turn <c>while (true) new MessageChannel();</c> into a leak that the
+    /// engine itself created — a channel whose two ports no script can name is garbage in a browser too, and a
+    /// port that has been collected cannot be holding anything that is not garbage with it. Pruned in
+    /// amortized constant time rather than on every registration: the threshold doubles, so a script creating
+    /// a great many channels does not turn each creation into a walk of everything before it.
+    /// </remarks>
+    private List<WeakReference<JsMessagePort>>? _messagePorts;
+
+    private int _messagePortPruneThreshold = MessagePortPruneFloor;
+
+    private const int MessagePortPruneFloor = 16;
+
     internal WebApiEngineState(Engine engine, TimeProvider timeProvider, TimerQueue? timers, Options.FetchOptions? fetchOptions, SchedulerQueue? scheduler, DiagnosticsSink? diagnostics, Options.StorageOptions? storage = null, CacheStorageProvider? cacheProvider = null, IdleCallbackQueue? idleCallbacks = null, Options.MessagingOptions? messaging = null)
     {
         _engine = engine;
@@ -408,6 +428,49 @@ internal sealed class WebApiEngineState
 
     /// <summary>Forgets one channel, which is what <c>close()</c> does to itself.</summary>
     internal void UnregisterBroadcastChannel(JsBroadcastChannel channel) => _broadcastChannels?.Remove(channel);
+
+    /// <summary>
+    /// Records a live <c>MessagePort</c>; see <see cref="_messagePorts"/>. There is deliberately no
+    /// unregister: a port that closes or is transferred away becomes inert, and the next prune drops it.
+    /// </summary>
+    internal void RegisterMessagePort(JsMessagePort port)
+    {
+        var ports = _messagePorts ??= new List<WeakReference<JsMessagePort>>();
+
+        if (ports.Count >= _messagePortPruneThreshold)
+        {
+            ports.RemoveAll(static entry => !entry.TryGetTarget(out var candidate) || candidate.IsInert);
+            _messagePortPruneThreshold = Math.Max(MessagePortPruneFloor, ports.Count * 2);
+        }
+
+        ports.Add(new WeakReference<JsMessagePort>(port));
+    }
+
+    /// <summary>
+    /// Closes every port this engine still has, which is what ends the channels the cycle being torn down
+    /// created. Closing rather than forgetting, for the reason <see cref="ResetTransientState"/> gives.
+    /// </summary>
+    private void CloseMessagePorts()
+    {
+        if (_messagePorts is not { Count: > 0 } ports)
+        {
+            return;
+        }
+
+        // Copied before the walk, exactly as the broadcast channels are: closing a port can close the sides
+        // stranded in its queue, and those can belong to ports of this engine too.
+        var live = ports.ToArray();
+        ports.Clear();
+        _messagePortPruneThreshold = MessagePortPruneFloor;
+
+        foreach (var entry in live)
+        {
+            if (entry.TryGetTarget(out var port))
+            {
+                port.Close();
+            }
+        }
+    }
 
     /// <summary>
     /// Gives a state that was built without one the timer queue a feature enabled later needs. Called only by
@@ -649,6 +712,14 @@ internal sealed class WebApiEngineState
     /// ending — with one addition: the broker it joined may be the host's and may outlive this engine, so
     /// leaving the subscription there would keep this engine reachable and go on costing every future sender a
     /// job the generation fence then throws away.
+    /// A <c>MessagePort</c> is closed for exactly those reasons and one more that is peculiar to it. The
+    /// generation fence already stops delivery — the port belongs to the cycle it was created in — but the
+    /// port message queue lives on the channel <i>side</i>, so a message posted before the restore is sitting
+    /// in it whether or not anything ever pumps again, and that message may be carrying a <b>transferred</b>
+    /// side, unbound and waiting for a deserialization that can now never happen while its own peer goes on
+    /// posting into it. Closing the port drains the queue and ends every side stranded in it, transitively.
+    /// The peer is deliberately <i>not</i> closed: disentangling is one-sided, and a peer on another engine is
+    /// in a cycle of its own that this restore has no business ending.
     /// </remarks>
     internal void ResetTransientState()
     {
@@ -659,6 +730,7 @@ internal sealed class WebApiEngineState
         AbandonEventSources();
         AbandonWebSockets();
         CloseBroadcastChannels();
+        CloseMessagePorts();
         IdleCallbacks?.Clear();
 
         // Dropped whole rather than emptied: the next cycle's first addEventListener builds a fresh target,
@@ -768,14 +840,17 @@ internal sealed class WebApiEngineState
 
     /// <summary>
     /// Called from <see cref="Engine.Dispose"/>: releases the state that reaches outside the engine, which is
-    /// the host token registrations and the subscriptions in a <see cref="BroadcastChannelBroker"/> the host
-    /// may share with engines that outlive this one. The queues need nothing — they hold no unmanaged resource
-    /// and no timer, and die with the engine.
+    /// the host token registrations, the subscriptions in a <see cref="BroadcastChannelBroker"/> the host may
+    /// share with engines that outlive this one, and the <c>MessagePort</c> sides entangled with ports of
+    /// another engine — each of which is a live reference to this disposed one, and each of which would go on
+    /// accepting messages into a queue nothing will ever drain. The queues need nothing — they hold no
+    /// unmanaged resource and no timer, and die with the engine.
     /// </summary>
     internal void Dispose()
     {
         ReleaseHostAbortBridges();
         CloseBroadcastChannels();
+        CloseMessagePorts();
     }
 }
 #endif

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -696,8 +696,9 @@ public enum WebApiFeatures
     /// <c>Engine.Advanced.CreateMessagePortPair</c>, which needs this flag on both of them; a
     /// <c>BroadcastChannel</c> spans as many engines as share a
     /// <see cref="Options.MessagingOptions.Broker"/>, and reaches every other channel of its name rather than
-    /// one peer. Transferring a port through a port is not supported, and a broadcast has no transfer list at
-    /// all.
+    /// one peer. A <c>MessagePort</c> is itself transferable, so a port can be handed over another port — or
+    /// relayed through an engine that never looks at it — and arrives as <c>event.ports</c>; a broadcast has
+    /// no transfer list at all.
     /// </summary>
     Messaging = 1 << 14,
 

--- a/Jint/WebApi/Messaging/JsMessageEvent.cs
+++ b/Jint/WebApi/Messaging/JsMessageEvent.cs
@@ -56,8 +56,10 @@ internal sealed class JsMessageEvent : JsEvent
 
     /// <summary>
     /// https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-ports — a frozen array, so the same
-    /// object is returned on every read. Always empty for an event a port fires, because transferring a port
-    /// is not supported; see <see cref="JsMessagePort"/>.
+    /// object is returned on every read. For an event a port fires it holds the ports the message
+    /// <i>transferred</i>, in transfer-list order, and is the shared empty array when it transferred none —
+    /// which is every event <c>EventSource</c>, <c>WebSocket</c> and <c>BroadcastChannel</c> ever fire, none
+    /// of which has a transfer list at all. See <see cref="JsMessagePort"/>.
     /// </summary>
     internal JsArray Ports { get; }
 }

--- a/Jint/WebApi/Messaging/JsMessagePort.cs
+++ b/Jint/WebApi/Messaging/JsMessagePort.cs
@@ -17,35 +17,42 @@ namespace Jint.WebApi.Messaging;
 /// <para>
 /// <b>Serialization happens on the sender, deserialization on the receiver.</b> That is what the specification
 /// says — <c>postMessage</c> runs StructuredSerializeWithTransfer synchronously and only then queues a task
-/// whose first act is StructuredDeserialize in the <i>target's</i> realm — and it is also what makes a port
-/// pair able to span two engines: the <see cref="SerializationRecord"/> in between belongs to neither.
-/// A message therefore reflects the state of the graph at the instant it was posted, and a
+/// whose first act is StructuredDeserializeWithTransfer in the <i>target's</i> realm — and it is also what
+/// makes a port pair able to span two engines: the <see cref="SerializationRecord"/> in between belongs to
+/// neither. A message therefore reflects the state of the graph at the instant it was posted, and a
 /// <c>DataCloneError</c> for an uncloneable value is raised at the <c>postMessage</c> call, synchronously, on
 /// the caller.
 /// </para>
 /// <para>
-/// <b>The port message queue is a real queue, and it starts disabled.</b> Nothing is dispatched until
-/// <c>start()</c> is called or <c>onmessage</c> is assigned; messages that arrive before then wait, in order,
-/// and are delivered when the queue is enabled. Two event-loop jobs are involved per message — one to put it
-/// on this port's queue on the receiving engine's thread, one to take the head off and dispatch it — which is
-/// what keeps the order right no matter when the queue is enabled relative to the messages in flight. It also
-/// means a message is delivered as a <i>task</i>: every promise reaction already queued runs first, exactly as
-/// in a browser.
+/// <b>The port message queue is a real queue, it starts disabled, and it belongs to the <i>side</i> rather
+/// than to this object.</b> Nothing is dispatched until <c>start()</c> is called or <c>onmessage</c> is
+/// assigned; messages that arrive before then wait, in order, and are delivered when the queue is enabled.
+/// Two event-loop jobs are involved per message — one to notice it on the receiving engine's thread, one to
+/// take the head off and dispatch it — which is what keeps the order right no matter when the queue is enabled
+/// relative to the messages in flight. It also means a message is delivered as a <i>task</i>: every promise
+/// reaction already queued runs first, exactly as in a browser. The queue living on
+/// <see cref="MessagePortEndpoint"/> is what lets it travel when the port is transferred, which is exactly how
+/// HTML writes it.
 /// </para>
 /// <para>
-/// <b>Transferring a port is not supported in this version.</b> An <c>ArrayBuffer</c> is the only transferable
-/// Jint has, so naming a port in a <c>transfer</c> list is a <c>DataCloneError</c>. That subsumes the
-/// specification's two port-specific transfer rules — a port may not be posted through itself, and posting a
-/// port through the port it is entangled with dooms the message — with a stricter answer: the browser dooms
-/// the second case silently, and Jint refuses it outright. A delivered <c>MessageEvent</c>'s <c>ports</c> is
-/// therefore always the empty frozen array.
+/// <b>A port is transferable.</b> Naming one in a <c>transfer</c> list detaches it: this object becomes
+/// permanently inert — <c>postMessage</c> is a silent no-op, no event will ever fire on it again — and its
+/// side, carrying whatever its queue still held, is re-entangled with a fresh <c>MessagePort</c> created in
+/// the receiving realm and handed to the listener as <c>event.ports</c>. The peer is untouched and never
+/// learns that the far end moved. The specification's two port-specific refusals are implemented as written:
+/// posting a port through <i>itself</i> is a <c>DataCloneError</c> (message port post message steps, step 2),
+/// and posting a port through the port it is entangled with dooms the message — the transfer still happens,
+/// nothing is delivered, and the channel is lost (steps 4 and 6). Naming one port twice in a single transfer
+/// list, or naming an already-detached one, is a <c>DataCloneError</c> from
+/// StructuredSerializeWithTransfer's own steps 2.3 and 5.2.
 /// </para>
 /// <para>
 /// <b><c>messageerror</c> is never fired.</b> The event and the <c>onmessageerror</c> attribute exist because
 /// the interface has them and a script may register for them, but the only thing that fires one is a
-/// deserialization that fails, and a record built by this engine's own serializer always deserializes. An
-/// execution-constraint failure during deserialization is not a candidate: a timeout or a cancellation must
-/// erupt from the pump, never be flattened into an event.
+/// deserialization that fails, and a record built by this engine's own serializer always deserializes into an
+/// engine that has the messaging feature — which a port's own existence proves it has. An execution-constraint
+/// failure during deserialization is not a candidate: a timeout or a cancellation must erupt from the pump,
+/// never be flattened into an event.
 /// </para>
 /// </remarks>
 internal sealed class JsMessagePort : JsEventTarget
@@ -59,10 +66,18 @@ internal sealed class JsMessagePort : JsEventTarget
     private static readonly JsString _messageEventName = new(MessageEventType);
 
     /// <summary>
-    /// https://html.spec.whatwg.org/multipage/web-messaging.html#port-message-queue. Only ever touched on this
-    /// port's own engine's thread — a message arriving from elsewhere joins it from inside an event-loop job.
+    /// The evaluation cycle this port belongs to — see <see cref="MessagePortEndpoint"/>'s remarks for why it
+    /// is captured once, here, rather than read when a message is posted.
     /// </summary>
-    private readonly Queue<SerializationRecord> _queue = new();
+    private readonly int _generation;
+
+    /// <summary>
+    /// The side of the channel this port speaks for, or <see langword="null"/> once it is detached — HTML's
+    /// <c>[[Detached]]</c>, expressed as "this object no longer owns a side". Both of the specification's two
+    /// ways of setting that slot land here: <c>close()</c>, which ends the side as it lets go of it, and a
+    /// transfer, which hands the side on intact.
+    /// </summary>
+    private MessagePortEndpoint? _endpoint;
 
     /// <summary>Whether the port message queue is enabled, i.e. whether <c>start()</c> has happened.</summary>
     private bool _enabled;
@@ -73,14 +88,65 @@ internal sealed class JsMessagePort : JsEventTarget
     /// </summary>
     private bool _drainScheduled;
 
-    internal JsMessagePort(Engine engine, Realm realm) : base(engine, realm)
+    /// <summary>
+    /// The two event-loop jobs this port ever queues, built once so that a sender posting in a loop allocates
+    /// one delegate for the port rather than one per message.
+    /// </summary>
+    /// <remarks>
+    /// Assigned in the constructor rather than lazily, because <see cref="RequestDelivery"/> runs on the
+    /// <i>sender's</i> thread: a <c>??=</c> there would be a cross-thread publication of a delegate this
+    /// engine's thread then invokes, which is a memory-model question not worth having for the price of two
+    /// allocations per port.
+    /// </remarks>
+    private readonly Action _arrivalJob;
+
+    private readonly Action _drainJob;
+
+    internal JsMessagePort(Engine engine, Realm realm) : this(engine, realm, endpoint: null)
     {
-        _prototype = realm.Intrinsics.MessagePort.PrototypeObject;
-        Endpoint = new MessagePortEndpoint(engine, this);
     }
 
-    /// <summary>The thread-crossing half of this port; see <see cref="MessagePortEndpoint"/>.</summary>
-    internal MessagePortEndpoint Endpoint { get; }
+    /// <param name="engine">The engine that owns this port.</param>
+    /// <param name="realm">The realm whose <c>MessagePort.prototype</c> the port gets.</param>
+    /// <param name="endpoint">
+    /// The side to bind to — a transferred one, from StructuredDeserializeWithTransfer — or
+    /// <see langword="null"/> to create a side of this port's own, which is what <c>new MessageChannel()</c>
+    /// and <c>Engine.Advanced.CreateMessagePortPair</c> do.
+    /// </param>
+    internal JsMessagePort(Engine engine, Realm realm, MessagePortEndpoint? endpoint) : base(engine, realm)
+    {
+        _prototype = realm.Intrinsics.MessagePort.PrototypeObject;
+        _generation = engine.EventLoopGeneration;
+        _arrivalJob = OnMessageArrived;
+        _drainJob = DrainOne;
+
+        _endpoint = endpoint ?? new MessagePortEndpoint();
+        _endpoint.Bind(this);
+
+        // So a restore or a dispose can end this port rather than leave its side reachable from an engine that
+        // has moved on. Nothing here wakes the queue: a freshly bound port is disabled, and start() is what
+        // drains whatever a transfer brought with it.
+        engine._webApi?.RegisterMessagePort(this);
+    }
+
+    /// <summary>
+    /// The channel side this port speaks for — the thread-crossing half — or <see langword="null"/> once it is
+    /// detached; see <see cref="MessagePortEndpoint"/>.
+    /// </summary>
+    internal MessagePortEndpoint? Endpoint => _endpoint;
+
+    /// <summary>
+    /// HTML's <c>[[Detached]]</c>: whether this port has let go of its side, by <c>close()</c> or by being
+    /// transferred. A detached port can never post, receive or fire anything again, and — StructuredSerialize
+    /// WithTransfer step 5.2 — can never be transferred either.
+    /// </summary>
+    internal bool Detached => _endpoint is null;
+
+    /// <summary>
+    /// Whether this port can no longer do anything — detached, or closed. What the engine's port registry
+    /// prunes on.
+    /// </summary>
+    internal bool IsInert => _endpoint is not { Closed: false };
 
     /// <summary>
     /// https://html.spec.whatwg.org/multipage/web-messaging.html#message-port-post-message-steps
@@ -89,32 +155,60 @@ internal sealed class JsMessagePort : JsEventTarget
     /// <param name="transferList">The already-converted <c>transfer</c> sequence, or <see langword="null"/>.</param>
     internal void PostMessage(JsValue message, List<JsValue>? transferList)
     {
+        var endpoint = _endpoint;
+        var target = endpoint?.Peer;
+
+        // Steps 2 and 4, both decided before anything is serialized. Step 2 is a refusal — a port cannot be
+        // sent through itself — and step 4 only dooms: the transfer still happens and the message is simply
+        // never delivered, which is the specification's own way of saying the channel is being thrown away.
+        var doomed = false;
+        if (transferList is not null)
+        {
+            foreach (var entry in transferList)
+            {
+                if (ReferenceEquals(entry, this))
+                {
+                    StructuredSerializer.ThrowDataCloneError(_realm, "A MessagePort cannot be transferred through itself");
+                }
+
+                // "transfer contains targetPort", asked of the SIDE rather than of the object, so it is a
+                // reference comparison that needs nothing from the other engine's thread.
+                if (target is not null && entry is JsMessagePort candidate && ReferenceEquals(candidate.Endpoint, target))
+                {
+                    doomed = true;
+                }
+            }
+        }
+
         // Step 5 comes before step 6, and the order is observable: the message is serialized — and any
         // transfer performed — even when there is nothing to deliver it to. So `port.close();
         // port.postMessage(function(){})` still throws a DataCloneError, and a buffer in the transfer list is
         // still detached, whether or not anybody was listening.
         var record = new StructuredSerializer(_engine, _realm).Serialize(message, transferList);
 
-        // Step 6: "If targetPort is null, or if doomed is true, then return." A closed port is disentangled,
-        // which is the same thing as having no target.
-        var endpoint = Endpoint;
-        if (endpoint.Closed || endpoint.Peer.Closed)
+        // Step 6: "If targetPort is null, or if doomed is true, then return." A closed or detached port is
+        // disentangled, which is the same thing as having no target.
+        if (doomed || endpoint is null || endpoint.Closed || target is null || target.Closed)
         {
+            // Whatever the message was carrying is now unreachable, so a side transferred into it would sit
+            // unbound forever while its own peer went on posting. Ending it here is what "causing the
+            // communication channel to be lost" means when nobody can ever pick the record up.
+            StructuredSerializer.StrandTransferredPorts(in record);
             return;
         }
 
         // Step 7: add a task to the target's port message queue. Cross-engine, this is where the record
         // leaves this thread; same-engine it is an ordinary generation-stamped event-loop job.
-        endpoint.Peer.Post(record);
+        target.Post(record);
     }
 
     /// <summary>
     /// https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messageport-start — "Enable this's port
-    /// message queue." Calling it again does nothing.
+    /// message queue." Calling it again does nothing, and a detached port has no queue to enable.
     /// </summary>
     internal void Start()
     {
-        if (_enabled)
+        if (_enabled || _endpoint is null)
         {
             return;
         }
@@ -130,33 +224,69 @@ internal sealed class JsMessagePort : JsEventTarget
     /// <remarks>
     /// The peer is <i>not</i> closed: it stays a perfectly usable object whose <c>postMessage</c> now goes
     /// nowhere, which is what disentangling means. Anything still waiting on this port's own queue is dropped,
-    /// because a detached port can never dispatch again.
+    /// because a detached port can never dispatch again. A port that has been <i>transferred</i> away owns no
+    /// side any more, so closing it is a no-op rather than a way to reach into somebody else's channel — and
+    /// closing twice is the same no-op, since the first call is what let go.
     /// </remarks>
     internal void Close()
     {
-        Endpoint.Close();
-        _queue.Clear();
+        var endpoint = _endpoint;
+        _endpoint = null;
+        _enabled = false;
+
+        endpoint?.Close();
     }
 
     /// <summary>
-    /// Step 7's task, first half: the message joins this port's queue. <b>Runs on this port's own engine's
-    /// thread</b>, inside a generation-fenced event-loop job, which is what makes touching the queue safe
-    /// however far away the sender was.
+    /// HTML's transfer steps for this object: the port is detached and its side handed to the caller, which
+    /// puts it in the serialization record. Runs on this port's own engine's thread, inside the
+    /// <c>postMessage</c> or <c>structuredClone</c> that is transferring it.
     /// </summary>
-    internal void Receive(SerializationRecord record)
+    internal MessagePortEndpoint DetachForTransfer()
     {
-        if (Endpoint.Closed)
+        var endpoint = _endpoint!;
+        _endpoint = null;
+
+        // Not strictly needed — every path consults _endpoint first — but it keeps a detached port from
+        // looking like a started one to anything that reads the flag later.
+        _enabled = false;
+
+        endpoint.Unbind();
+        return endpoint;
+    }
+
+    /// <summary>
+    /// The wake <see cref="MessagePortEndpoint.Post"/> asks for. <b>Runs on the sender's thread</b>, so it
+    /// does nothing but enqueue: everything that touches this port's own state happens in the job.
+    /// </summary>
+    internal void RequestDelivery()
+    {
+        // A cheap early-out for a channel whose receiver has since restored a global snapshot, so a sender
+        // that keeps posting into a dead port does not grow that engine's queue. It is not the fence: the
+        // authoritative check is the one every job gets at dequeue, on the engine's own thread, which is the
+        // only place the comparison is free of races.
+        var engine = _engine;
+        if (engine.EventLoopGeneration != _generation)
         {
             return;
         }
 
-        _queue.Enqueue(record);
-        ScheduleDrain();
+        engine.AddToEventLoop(_arrivalJob, _generation);
     }
 
     /// <summary>
-    /// Arms the job that takes one message off the queue, unless the queue is disabled, empty, or already has
-    /// a job armed.
+    /// Step 7's task, first half. <b>Runs on this port's own engine's thread</b>, inside a generation-fenced
+    /// event-loop job, which is what makes touching this port's state safe however far away the sender was.
+    /// </summary>
+    /// <remarks>
+    /// A job queued for a port whose side has since been transferred away simply finds nothing to do: the
+    /// message it was announcing is still on that side's queue, and travels with it.
+    /// </remarks>
+    private void OnMessageArrived() => ScheduleDrain();
+
+    /// <summary>
+    /// Arms the job that takes one message off the queue, unless the port is detached, the queue is disabled
+    /// or empty, or a job is already armed.
     /// </summary>
     /// <remarks>
     /// The job carries the port's own generation rather than the engine's current one, so a port left over
@@ -164,13 +294,13 @@ internal sealed class JsMessagePort : JsEventTarget
     /// </remarks>
     private void ScheduleDrain()
     {
-        if (_drainScheduled || !_enabled || _queue.Count == 0)
+        if (_drainScheduled || !_enabled || _endpoint is not { Closed: false } endpoint || !endpoint.HasQueuedMessages)
         {
             return;
         }
 
         _drainScheduled = true;
-        _engine.AddToEventLoop(DrainOne, Endpoint.Generation);
+        _engine.AddToEventLoop(_drainJob, _generation);
     }
 
     /// <summary>
@@ -180,14 +310,12 @@ internal sealed class JsMessagePort : JsEventTarget
     {
         _drainScheduled = false;
 
-        // Any of the three may have changed since the job was armed: close(), or a listener of the previous
-        // message emptying the queue.
-        if (Endpoint.Closed || !_enabled || _queue.Count == 0)
+        // Any of these may have changed since the job was armed: close(), a transfer, or a listener of the
+        // previous message emptying the queue.
+        if (!_enabled || _endpoint is not { } endpoint || !endpoint.TryDequeue(this, out var record))
         {
             return;
         }
-
-        var record = _queue.Dequeue();
 
         // The next message is armed BEFORE this one is dispatched, so a listener that throws — which erupts
         // from the pump, per JsEventTarget's contract — does not strand everything behind it.
@@ -197,12 +325,13 @@ internal sealed class JsMessagePort : JsEventTarget
     }
 
     /// <summary>
-    /// Steps 7.3 to 7.6: deserialize into this port's realm, then fire a trusted <c>message</c> event.
+    /// Steps 7.2 to 7.5: StructuredDeserializeWithTransfer into this port's realm, then a trusted
+    /// <c>message</c> event carrying the clone and the ports the transfer created.
     /// </summary>
     private void Dispatch(SerializationRecord record)
     {
-        var data = new StructuredDeserializer(_engine, _realm).Deserialize(in record);
-        var messageEvent = _realm.Intrinsics.MessageEvent.CreateTrustedMessageEvent(_messageEventName, data);
+        var message = new StructuredDeserializer(_engine, _realm).DeserializeWithTransfer(in record);
+        var messageEvent = _realm.Intrinsics.MessageEvent.CreateTrustedMessageEvent(_messageEventName, message.Value, message.Ports);
         DispatchEvent(messageEvent);
     }
 }

--- a/Jint/WebApi/Messaging/MessageEventConstructor.cs
+++ b/Jint/WebApi/Messaging/MessageEventConstructor.cs
@@ -87,6 +87,33 @@ internal sealed class MessageEventConstructor : Constructor
         => CreateTrustedMessageEvent(type, data, JsString.Empty, JsString.Empty);
 
     /// <summary>
+    /// <see cref="CreateTrustedMessageEvent(JsString, JsValue)"/> plus the one member the message port post
+    /// message steps do set beyond <c>data</c>: step 7.4's "new frozen array consisting of all
+    /// <c>MessagePort</c> objects in <c>deserializeRecord.[[TransferredValues]]</c>, maintaining their
+    /// relative order".
+    /// </summary>
+    /// <remarks>
+    /// A message that transferred no port keeps the shared frozen empty array, so the overwhelmingly common
+    /// delivery allocates nothing here — and the callers that can never transfer one (<c>EventSource</c>,
+    /// <c>WebSocket</c>, <c>BroadcastChannel</c>) go on using the overloads above, unchanged.
+    /// </remarks>
+    internal JsMessageEvent CreateTrustedMessageEvent(JsString type, JsValue data, List<JsMessagePort>? ports)
+    {
+        if (ports is not { Count: > 0 })
+        {
+            return CreateTrustedMessageEvent(type, data);
+        }
+
+        var values = new JsValue[ports.Count];
+        for (var i = 0; i < values.Length; i++)
+        {
+            values[i] = ports[i];
+        }
+
+        return CreateTrustedMessageEvent(type, data, JsString.Empty, JsString.Empty, FreezePorts(values));
+    }
+
+    /// <summary>
     /// <see cref="CreateTrustedMessageEvent(JsString, JsValue)"/> with the two members <c>EventSource</c>'s
     /// dispatch steps additionally set — the stream's origin and the last event ID,
     /// https://html.spec.whatwg.org/multipage/server-sent-events.html#dispatchMessage. <c>source</c> and
@@ -94,6 +121,9 @@ internal sealed class MessageEventConstructor : Constructor
     /// has none to hand over.
     /// </summary>
     internal JsMessageEvent CreateTrustedMessageEvent(JsString type, JsValue data, JsString origin, JsString lastEventId)
+        => CreateTrustedMessageEvent(type, data, origin, lastEventId, EmptyPorts);
+
+    private JsMessageEvent CreateTrustedMessageEvent(JsString type, JsValue data, JsString origin, JsString lastEventId, JsArray ports)
     {
         return new JsMessageEvent(
             _engine,
@@ -104,7 +134,7 @@ internal sealed class MessageEventConstructor : Constructor
             origin,
             lastEventId,
             Null,
-            EmptyPorts)
+            ports)
         {
             IsTrusted = true,
             _prototype = PrototypeObject,
@@ -156,9 +186,11 @@ internal sealed class MessageEventConstructor : Constructor
     }
 
     /// <summary>
-    /// The <c>sequence&lt;MessagePort&gt; ports = []</c> member. Nothing in this engine can transfer a port,
-    /// so this is the only way a <c>MessageEvent</c> ever carries one — and it carries whatever the script
-    /// put there, which is what a script constructing its own event for <c>dispatchEvent</c> expects.
+    /// The <c>sequence&lt;MessagePort&gt; ports = []</c> member: whatever the script put there, which is what
+    /// a script constructing its own event for <c>dispatchEvent</c> expects. Unrelated to the ports a
+    /// <i>transfer</i> produces — those reach a delivered event through
+    /// <see cref="CreateTrustedMessageEvent(JsString, JsValue, List{JsMessagePort})"/>, and a constructed
+    /// event has no transfer of its own.
     /// </summary>
     private JsArray ReadPorts(ObjectInstance dictionary)
     {

--- a/Jint/WebApi/Messaging/MessagePortBridge.cs
+++ b/Jint/WebApi/Messaging/MessagePortBridge.cs
@@ -1,4 +1,5 @@
 #if NET8_0_OR_GREATER
+using System.Threading;
 using Jint.Runtime;
 using Jint.WebApi.StructuredClone;
 
@@ -17,7 +18,8 @@ namespace Jint.WebApi.Messaging;
 /// tiny.</b> A message crosses as a <see cref="SerializationRecord"/>, which belongs to no engine at all: the
 /// sender serializes on its own thread, the receiver deserializes on its own, and neither ever touches a
 /// <c>JsValue</c> belonging to the other. Everything a sender reads from the far side is on
-/// <see cref="MessagePortEndpoint"/> and is either immutable or a single <see langword="volatile"/> flag.
+/// <see cref="MessagePortEndpoint"/> and is either immutable, a single <see langword="volatile"/> flag, or
+/// read under that endpoint's own lock.
 /// </para>
 /// <para>
 /// The delivery job is enqueued onto the receiving engine's event loop, which is a
@@ -48,61 +50,131 @@ internal static class MessagePortBridge
         var first = new JsMessagePort(firstEngine, firstRealm);
         var second = new JsMessagePort(secondEngine, secondRealm);
 
-        MessagePortEndpoint.Entangle(first.Endpoint, second.Endpoint);
+        MessagePortEndpoint.Entangle(first.Endpoint!, second.Endpoint!);
 
         return (first, second);
     }
 }
 
 /// <summary>
-/// One end of an entangled pair, as seen from the <i>other</i> end. Every member here may be read by the
-/// sending engine's thread, so every member here is immutable or volatile.
+/// One <i>side</i> of an entangled pair: the port message queue, whom that queue currently belongs to, and the
+/// side at the other end. Every member here may be read by the sending engine's thread, so every member here
+/// is immutable, <see langword="volatile"/>, or guarded by this object's own lock.
 /// </summary>
 /// <remarks>
-/// The endpoint carries the receiving engine's <see cref="Engine.EventLoopGeneration"/> as it was when the
-/// port was <b>created</b>, not as it is when a message is posted, and that is deliberate. A port's listeners
+/// <para>
+/// <b>A side outlives the <c>MessagePort</c> object bound to it, and that is what makes a port transferable.</b>
+/// HTML's transfer steps move a port's <i>port message queue</i> into the data holder and re-entangle the
+/// remote port with whatever object the transfer-receiving steps create; the queue is passed by reference, so a
+/// message posted while the port is in transit lands in the very queue that travels. This class is that queue
+/// plus its bookkeeping. A transfer <see cref="Unbind"/>s it from the port that is being detached, the
+/// serialization record carries <i>this object</i>, and the receiving engine <see cref="Bind"/>s it to a fresh
+/// <see cref="JsMessagePort"/> of its own realm. <see cref="Peer"/> never changes, so re-pointing one side is
+/// invisible to the other — which is what makes a three-engine relay work, and what makes both ends of one
+/// channel transferable at the same time.
+/// </para>
+/// <para>
+/// <b>The discipline that makes the swap race-free.</b> Everything mutable lives behind <c>_gate</c>, and there
+/// are exactly three operations:
+/// </para>
+/// <list type="bullet">
+/// <item><description>
+/// <b>Post</b> — any thread. Under the lock it appends to the queue <i>and</i> reads the current binding, so a
+/// message can never be enqueued against a binding that has already gone. Outside the lock it asks that binding
+/// (if any) to pump. That wake is a <i>hint</i>: a stale one is a no-op, because the job it queues is the
+/// port's own and a port whose side has been unbound refuses it.
+/// </description></item>
+/// <item><description>
+/// <b>Unbind</b> — only ever the bound engine's own thread, because a transfer happens inside that engine's
+/// <c>postMessage</c>. So no drain can be in progress when it runs, and no message can be lost: the queue is
+/// not touched at all.
+/// </description></item>
+/// <item><description>
+/// <b>Bind</b> — the receiving engine's thread, from the <see cref="JsMessagePort"/> constructor. It needs no
+/// wake of its own, and that is not an omission: a port's message queue starts <b>disabled</b>, so the new port
+/// cannot deliver anything until the script calls <c>start()</c> or assigns <c>onmessage</c> — and that call
+/// drains whatever the queue already holds. A message enqueued while the side was unbound is therefore
+/// delivered by the very act that makes delivery possible, and one enqueued afterwards sees the new binding and
+/// gets its own wake.
+/// </description></item>
+/// </list>
+/// <para>
+/// So a message in flight at the instant of a swap is neither lost nor delivered to the port that is going
+/// away: it is in the one queue, and the one queue travels.
+/// </para>
+/// <para>
+/// The binding carries the receiving engine's <see cref="Engine.EventLoopGeneration"/> as it was when the
+/// <b>port</b> was created, not as it is when a message is posted, and that is deliberate. A port's listeners
 /// are closures over the evaluation cycle the port was made in, so delivering into it after a
 /// <c>RestoreGlobalSnapshot</c> would run that dead cycle's code against the freshly restored globals — the
 /// exact cross-cycle channel the generation fence exists to forbid. Reading the receiver's <i>current</i>
 /// generation from the sender's thread would have permitted precisely that, as well as being a cross-thread
-/// read of a value the receiver is free to change underneath it. Capturing once, at creation, gives the
-/// stronger rule and needs no cross-thread read at all: <b>a port pair belongs to the evaluation cycle its
-/// engines were in when it was created, and a restore on either engine ends the channel permanently.</b>
+/// read of a value the receiver is free to change underneath it. Capturing once, per binding, gives the
+/// stronger rule and needs no cross-thread read at all: <b>a port belongs to the evaluation cycle its engine
+/// was in when it was created, and a restore on that engine closes it.</b> A transfer creates a new port, so
+/// the new binding belongs to the receiving engine's <i>current</i> cycle rather than to the sender's.
+/// </para>
 /// </remarks>
 internal sealed class MessagePortEndpoint
 {
+    /// <summary>
+    /// Guards <see cref="_queue"/>, <see cref="_boundPort"/> and the authoritative write of
+    /// <see cref="_closed"/>. Never held while script runs, and never held across a call into another
+    /// endpoint — <see cref="Close"/>'s cascade is deliberately driven from a work list outside the lock.
+    /// </summary>
+    private readonly Lock _gate = new();
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/web-messaging.html#port-message-queue. It belongs to the
+    /// <i>side</i> rather than to the port, which is what lets it travel through a transfer with a message
+    /// still in it.
+    /// </summary>
+    private readonly Queue<SerializationRecord> _queue = new();
+
+    /// <summary>
+    /// The <c>MessagePort</c> object this side currently delivers to, or <see langword="null"/> while it is in
+    /// transit — between the transfer that detached the old port and the deserialization that creates the new
+    /// one. Also <see langword="null"/> once closed.
+    /// </summary>
+    private JsMessagePort? _boundPort;
+
     private volatile bool _closed;
 
-    internal MessagePortEndpoint(Engine engine, JsMessagePort port)
-    {
-        Engine = engine;
-        Port = port;
-        Generation = engine.EventLoopGeneration;
-    }
-
-    /// <summary>The engine that owns <see cref="Port"/> and on whose pump a delivery job runs.</summary>
-    internal Engine Engine { get; }
-
-    /// <summary>The port itself. Only ever dereferenced on <see cref="Engine"/>'s own thread.</summary>
-    internal JsMessagePort Port { get; }
-
-    /// <summary>The evaluation cycle this port belongs to; see the class remarks.</summary>
-    internal int Generation { get; }
-
     /// <summary>
-    /// The endpoint this one is entangled with. Assigned once, by <see cref="Entangle"/>, before either port
-    /// can be reached by any script.
+    /// The side this one is entangled with, or <see langword="null"/> for a side that was never entangled.
+    /// Assigned once, by <see cref="Entangle"/>, before either port can be reached by any script, and
+    /// deliberately never reassigned: a transfer moves a <i>side</i>, so the other end goes on talking to the
+    /// same object it always did.
     /// </summary>
-    internal MessagePortEndpoint Peer { get; private set; } = null!;
+    /// <remarks>
+    /// The <see langword="null"/> case exists for one path that should be unreachable — a serialization record
+    /// carrying a transferred side being deserialized twice, which the "a record is consumed once" rule
+    /// forbids. Rather than hand two engines one side, the second deserialization gets a lone side, and a port
+    /// bound to one is inert.
+    /// </remarks>
+    internal MessagePortEndpoint? Peer { get; private set; }
 
     /// <summary>
-    /// Whether <c>close()</c> has been called on this port —
+    /// Whether <c>close()</c> has been called on the port bound to this side —
     /// https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messageport-close. Volatile because the
     /// peer's engine reads it from its own thread to decide whether it still has anywhere to post; that is a
     /// one-way flag, so a stale read can only cost one message that was in flight as the port closed, which is
-    /// exactly what closing a port means.
+    /// exactly what closing a port means. The authoritative test is the one <see cref="Post"/> makes under the
+    /// lock.
     /// </summary>
     internal bool Closed => _closed;
+
+    /// <summary>Whether anything is waiting to be taken off this side's queue. Bound engine's thread.</summary>
+    internal bool HasQueuedMessages
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _queue.Count > 0;
+            }
+        }
+    }
 
     internal static void Entangle(MessagePortEndpoint first, MessagePortEndpoint second)
     {
@@ -111,36 +183,155 @@ internal sealed class MessagePortEndpoint
     }
 
     /// <summary>
-    /// https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messageport-close: detach this port,
-    /// which is also what disentangles the pair — the peer's <c>postMessage</c> consults this flag and finds
-    /// it has no target any more.
+    /// Makes <paramref name="port"/> the object this side delivers to. Called from the port's own constructor,
+    /// on the engine that owns it: once at creation, and again for the port a transfer's receiving steps build.
     /// </summary>
-    internal void Close() => _closed = true;
+    internal void Bind(JsMessagePort port)
+    {
+        lock (_gate)
+        {
+            if (_closed)
+            {
+                return;
+            }
+
+            _boundPort = port;
+        }
+    }
 
     /// <summary>
-    /// Hands a serialized message to this endpoint's engine. <b>Runs on the sender's thread</b>, so it does
-    /// exactly two things: check the fences, and enqueue.
+    /// HTML's transfer steps, from this side's point of view: the port that was bound here is detached, and the
+    /// side — queue and all — is left waiting for the transfer-receiving steps to bind it somewhere else.
+    /// </summary>
+    /// <remarks>
+    /// Runs on the bound engine's own thread, inside the <c>postMessage</c> or <c>structuredClone</c> that is
+    /// transferring the port, which is why no drain can be in progress and the queue needs no protection beyond
+    /// the lock's fence.
+    /// </remarks>
+    internal void Unbind()
+    {
+        lock (_gate)
+        {
+            _boundPort = null;
+        }
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messageport-close: detach this port,
+    /// which is also what disentangles the pair — the peer's <c>postMessage</c> consults
+    /// <see cref="Closed"/> and finds it has no target any more.
+    /// </summary>
+    /// <remarks>
+    /// Anything still on the queue is dropped, because a detached port can never dispatch again — and a
+    /// dropped message may itself be carrying a transferred side, which would otherwise sit unbound forever
+    /// while its own peer went on posting into it. Those are closed too, transitively, from a work list rather
+    /// than by recursion: the chain is as deep as a script cares to nest undelivered transfers.
+    /// </remarks>
+    internal void Close()
+    {
+        // Allocated only if a discarded message actually carried a transfer, which is what makes closing an
+        // ordinary port — the case a restore runs for every port an engine has — allocation-free.
+        Stack<MessagePortEndpoint>? stranded = null;
+        var endpoint = this;
+
+        while (true)
+        {
+            List<SerializationRecord>? discarded = null;
+
+            lock (endpoint._gate)
+            {
+                if (!endpoint._closed)
+                {
+                    endpoint._closed = true;
+                    endpoint._boundPort = null;
+
+                    if (endpoint._queue.Count > 0)
+                    {
+                        discarded = new List<SerializationRecord>(endpoint._queue);
+                        endpoint._queue.Clear();
+                    }
+                }
+            }
+
+            if (discarded is not null)
+            {
+                foreach (var record in discarded)
+                {
+                    if (record.TransferredPorts is not { } holders)
+                    {
+                        continue;
+                    }
+
+                    foreach (var holder in holders)
+                    {
+                        if (holder.Endpoint is { } carried)
+                        {
+                            (stranded ??= new Stack<MessagePortEndpoint>()).Push(carried);
+                        }
+                    }
+                }
+            }
+
+            if (stranded is not { Count: > 0 })
+            {
+                return;
+            }
+
+            endpoint = stranded.Pop();
+        }
+    }
+
+    /// <summary>
+    /// Hands a serialized message to this side. <b>Runs on the sender's thread</b>, so it does exactly two
+    /// things: join the queue, and ask whatever engine currently owns the side to pump.
     /// </summary>
     internal void Post(SerializationRecord record)
     {
-        if (_closed)
+        JsMessagePort? port;
+
+        lock (_gate)
         {
-            return;
+            // The authoritative closed test. The volatile read callers make first is only an early-out.
+            if (_closed)
+            {
+                return;
+            }
+
+            _queue.Enqueue(record);
+            port = _boundPort;
         }
 
-        var engine = Engine;
+        // A hint, and deliberately outside the lock: if the side is rebound between here and there, the job
+        // this queues is refused by a port that no longer owns the side, and the message is delivered by the
+        // start() that the new port's script has to call anyway. See the class remarks.
+        port?.RequestDelivery();
+    }
 
-        // A cheap early-out for a channel whose receiver has since restored a global snapshot, so a sender
-        // that keeps posting into a dead port does not grow that engine's queue. It is not the fence: the
-        // authoritative check is the one every job gets at dequeue, on the engine's own thread, which is the
-        // only place the comparison is free of races.
-        if (engine.EventLoopGeneration != Generation)
+    /// <summary>
+    /// Takes the head of the queue, but only for the port the side is actually bound to. Bound engine's thread,
+    /// from <c>JsMessagePort.DrainOne</c>.
+    /// </summary>
+    /// <remarks>
+    /// The <paramref name="caller"/> test is an <b>invariant guard, not a behaviour</b>, and no test can make
+    /// it fire: a transfer detaches the old port before the new one binds, so a port that does not own the
+    /// side has already forgotten it and never gets this far. It is here because the invariant it asserts —
+    /// one queue, one draining port — is the whole reason a transfer cannot split or reorder a channel, and a
+    /// future rebind path that forgot to detach first would otherwise let two ports take alternate messages
+    /// off one queue in silence.
+    /// </remarks>
+    internal bool TryDequeue(JsMessagePort caller, out SerializationRecord record)
+    {
+        lock (_gate)
         {
-            return;
-        }
+            if (_closed || !ReferenceEquals(_boundPort, caller) || _queue.Count == 0)
+            {
+                record = default;
+                return false;
+            }
 
-        var port = Port;
-        engine.AddToEventLoop(() => port.Receive(record), Generation);
+            record = _queue.Dequeue();
+            return true;
+        }
     }
 }
 #endif

--- a/Jint/WebApi/StructuredClone/SerializationRecord.cs
+++ b/Jint/WebApi/StructuredClone/SerializationRecord.cs
@@ -26,6 +26,17 @@ namespace Jint.WebApi.StructuredClone;
 /// declarations and from a walk of an actual graph.
 /// </para>
 /// <para>
+/// <b>A transferred <c>MessagePort</c> is the one deliberate exception, and it is an exception to the letter
+/// of that rule rather than to its point.</b> <see cref="TransferredPorts"/> carries
+/// <see cref="Messaging.MessagePortEndpoint"/>s, and a side does reach an <c>Engine</c> and the
+/// <c>MessagePort</c> object currently bound to it. But that class <i>is</i> the sanctioned engine-crossing
+/// handle — it is what a sender has always held for its peer, and every member of it a foreign thread may
+/// touch is immutable, <see langword="volatile"/> or behind its own lock. Nothing else changes: no
+/// <c>JsValue</c> is read or written across the boundary, and the receiving engine never dereferences the
+/// sending engine. Re-pointing a channel is exactly the operation a transfer <i>is</i>, so the handle that
+/// does it is what the record has to carry.
+/// </para>
+/// <para>
 /// <b>A record is consumed once, unless the reader is told otherwise.</b> Deserializing takes ownership of the
 /// byte arrays it finds — a transferred <c>ArrayBuffer</c>'s storage is moved rather than copied, which is the
 /// whole point of transferring — so deserializing one record twice would hand two engines one mutable buffer.
@@ -43,8 +54,20 @@ namespace Jint.WebApi.StructuredClone;
 /// </para>
 /// </remarks>
 /// <param name="Root">The serialized form of the value that was handed to StructuredSerialize.</param>
+/// <param name="TransferredPorts">
+/// StructuredSerializeWithTransfer's <c>[[TransferDataHolders]]</c>, narrowed to the ports — in transfer-list
+/// order, which is the order <c>MessageEvent.ports</c> has to preserve. <see langword="null"/> when no port
+/// was transferred, which is every message <c>BroadcastChannel</c> ever produces and almost every other one.
+/// <para>
+/// A transferred <c>ArrayBuffer</c> is deliberately <i>not</i> listed here even though the specification puts
+/// it in the same list: nothing consumes the transferred values of a buffer, and the walk already resolves one
+/// through the serializer's memory map. Ports need the list because they are created <b>before</b> the graph
+/// is walked — a port referenced from the message must be the very object <c>ports</c> hands over — and
+/// because the event exposes them in order.
+/// </para>
+/// </param>
 [StructLayout(LayoutKind.Auto)]
-internal readonly record struct SerializationRecord(SerializedValue Root);
+internal readonly record struct SerializationRecord(SerializedValue Root, List<SerializedMessagePort>? TransferredPorts = null);
 
 /// <summary>
 /// Which of the seven shapes a <see cref="SerializedValue"/> holds.
@@ -228,6 +251,27 @@ internal sealed class SerializedArrayBufferView : SerializedObject
     /// <see langword="null"/> for a length-tracking view over a resizable buffer.
     /// </summary>
     internal uint? Length { get; init; }
+}
+
+/// <summary>
+/// A transferred <c>MessagePort</c>: the specification's data holder, whose
+/// <c>[[PortMessageQueue]]</c> and <c>[[RemotePort]]</c> are both reached through the one
+/// <see cref="Messaging.MessagePortEndpoint"/> the transfer detached from the source port.
+/// <para>
+/// https://html.spec.whatwg.org/multipage/web-messaging.html#messageport — "their transfer steps".
+/// </para>
+/// </summary>
+/// <remarks>
+/// <see cref="Endpoint"/> is settable for the same reason <see cref="SerializedArrayBuffer.Bytes"/> is: a
+/// transferable is given its (still empty) record before the walk so that a reference to it inside the message
+/// resolves here, and the source is only detached at the very end of StructuredSerializeWithTransfer. It is
+/// also <i>taken</i> — set back to <see langword="null"/> — by the deserialization that binds it, so a record
+/// read a second time cannot hand two engines one side of a channel; see <see cref="SerializationRecord"/> on
+/// a record being consumed once.
+/// </remarks>
+internal sealed class SerializedMessagePort : SerializedObject
+{
+    internal Messaging.MessagePortEndpoint? Endpoint { get; set; }
 }
 
 /// <summary>

--- a/Jint/WebApi/StructuredClone/StructuredCloner.cs
+++ b/Jint/WebApi/StructuredClone/StructuredCloner.cs
@@ -28,6 +28,13 @@ namespace Jint.WebApi.StructuredClone;
 /// transfer steps still run after the whole walk, which is what lets a getter reached during the walk resize
 /// or write into a buffer the caller is transferring and have the clone see the result.
 /// </para>
+/// <para>
+/// <b>A <c>MessagePort</c> in the transfer list works here too, and falls straight out of the composition.</b>
+/// <c>structuredClone(port, { transfer: [port] })</c> detaches the argument and re-entangles its side with a
+/// fresh port of this same realm, which is exactly what a browser does — a transfer needs a target realm, not
+/// a target agent, and here the two realms happen to be one. The peer is untouched and goes on posting to the
+/// side it always talked to, which is now reached through the clone.
+/// </para>
 /// </remarks>
 internal static class StructuredCloner
 {
@@ -43,7 +50,7 @@ internal static class StructuredCloner
     internal static JsValue Clone(Engine engine, Realm realm, JsValue value, List<JsValue>? transferList)
     {
         var record = new StructuredSerializer(engine, realm).Serialize(value, transferList);
-        return new StructuredDeserializer(engine, realm).Deserialize(in record);
+        return new StructuredDeserializer(engine, realm).DeserializeWithTransfer(in record).Value;
     }
 }
 #endif

--- a/Jint/WebApi/StructuredClone/StructuredDeserializer.cs
+++ b/Jint/WebApi/StructuredClone/StructuredDeserializer.cs
@@ -1,4 +1,5 @@
 #if NET8_0_OR_GREATER
+using System.Runtime.InteropServices;
 using Jint.Native;
 using Jint.Native.Error;
 using Jint.Native.Object;
@@ -6,8 +7,22 @@ using Jint.Native.TypedArray;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 using Jint.WebApi.DomException;
+using Jint.WebApi.Messaging;
 
 namespace Jint.WebApi.StructuredClone;
+
+/// <summary>
+/// StructuredDeserializeWithTransfer's result: <c>[[Deserialized]]</c>, and <c>[[TransferredValues]]</c>
+/// narrowed to the ports — which is all any caller needs, because a transferred <c>ArrayBuffer</c> is
+/// reachable only from the message itself.
+/// </summary>
+/// <param name="Value">The clone of the message, in the deserializer's own realm.</param>
+/// <param name="Ports">
+/// The ports the transfer created, in transfer-list order, or <see langword="null"/> when none were
+/// transferred — which is the overwhelmingly common case and the reason this is not an empty list.
+/// </param>
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct DeserializedMessage(JsValue Value, List<JsMessagePort>? Ports);
 
 /// <summary>
 /// StructuredDeserialize: turns an engine-neutral <see cref="SerializationRecord"/> back into objects, all of
@@ -75,13 +90,67 @@ internal sealed class StructuredDeserializer
     }
 
     /// <summary>
+    /// StructuredDeserialize for a record that transferred nothing but buffers, which is every message
+    /// <c>BroadcastChannel</c> produces. Equivalent to <see cref="DeserializeWithTransfer"/> and its
+    /// <c>Value</c>; a caller that has to expose <c>ports</c> wants the other one.
+    /// </summary>
+    internal JsValue Deserialize(in SerializationRecord record) => DeserializeWithTransfer(in record).Value;
+
+    /// <summary>
     /// https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserializewithtransfer
     /// </summary>
-    internal JsValue Deserialize(in SerializationRecord record)
+    /// <remarks>
+    /// Step 3 runs <b>before</b> step 4, and the order is load-bearing rather than incidental: every
+    /// transferred port exists, in this realm, before a single node of the message graph is looked at, so a
+    /// reference to one from inside the message resolves — through the same memory map that carries sharing
+    /// and cycles — to the very object <c>event.ports</c> hands over.
+    /// </remarks>
+    internal DeserializedMessage DeserializeWithTransfer(in SerializationRecord record)
     {
+        // Step 3.
+        var ports = DeserializeTransferredPorts(record.TransferredPorts);
+
+        // Step 4.
         var result = DeserializeValue(record.Root);
         Drain();
-        return result;
+
+        return new DeserializedMessage(result, ports);
+    }
+
+    /// <summary>
+    /// Step 3, for the transfer data holders that are ports: one <c>MessagePort</c> per holder, created in
+    /// this realm and bound to the side the sender detached, in transfer-list order.
+    /// </summary>
+    /// <remarks>
+    /// The side is <i>taken</i> from the holder, so a record deserialized twice — which
+    /// <see cref="SerializationRecord"/> forbids and only <c>BroadcastChannel</c> comes near, and it has no
+    /// transfer list at all — cannot bind one channel side to two engines. The second read builds a port with
+    /// a side of its own that is entangled with nothing, which is inert.
+    /// <para>
+    /// Step 3.3.2's "if the interface is not exposed in targetRealm, throw a DataCloneError" cannot fire here:
+    /// the only way to hold a port is to have the messaging feature, and the only way a record reaches this
+    /// engine is through a port of its own.
+    /// </para>
+    /// </remarks>
+    private List<JsMessagePort>? DeserializeTransferredPorts(List<SerializedMessagePort>? holders)
+    {
+        if (holders is not { Count: > 0 })
+        {
+            return null;
+        }
+
+        var ports = new List<JsMessagePort>(holders.Count);
+        foreach (var holder in holders)
+        {
+            var endpoint = holder.Endpoint;
+            holder.Endpoint = null;
+
+            var port = new JsMessagePort(_engine, _realm, endpoint);
+            _memory[holder] = port;
+            ports.Add(port);
+        }
+
+        return ports;
     }
 
     private void Drain()

--- a/Jint/WebApi/StructuredClone/StructuredSerializer.cs
+++ b/Jint/WebApi/StructuredClone/StructuredSerializer.cs
@@ -8,6 +8,7 @@ using Jint.Native.Object;
 using Jint.Native.TypedArray;
 using Jint.Runtime;
 using Jint.WebApi.DomException;
+using Jint.WebApi.Messaging;
 
 namespace Jint.WebApi.StructuredClone;
 
@@ -48,6 +49,12 @@ internal sealed class StructuredSerializer
 
     private readonly Stack<SerializeFrame> _pending = new();
 
+    /// <summary>
+    /// The port half of <c>[[TransferDataHolders]]</c>, in transfer-list order; see
+    /// <see cref="SerializationRecord.TransferredPorts"/>. Null until a port is actually named.
+    /// </summary>
+    private List<SerializedMessagePort>? _transferredPorts;
+
     private int _visited;
 
     internal StructuredSerializer(Engine engine, Realm realm)
@@ -68,16 +75,50 @@ internal sealed class StructuredSerializer
     internal SerializationRecord Serialize(JsValue value, List<JsValue>? transferList)
     {
         // Steps 2-4: every transferable is validated and given its (still empty) record BEFORE the walk, so a
-        // transferred buffer reached from `value` resolves to that same record.
+        // transferred buffer or port reached from `value` resolves to that same record.
         var transfers = PrepareTransfers(transferList);
 
-        var root = SerializeValue(value);
-        Drain();
+        try
+        {
+            var root = SerializeValue(value);
+            Drain();
 
-        // Step 5: only now is anything detached.
-        CompleteTransfers(transfers);
+            // Step 5: only now is anything detached.
+            CompleteTransfers(transfers);
 
-        return new SerializationRecord(root);
+            return new SerializationRecord(root, _transferredPorts);
+        }
+        catch
+        {
+            // A throw anywhere from the walk onwards discards the half-built record, and step 5 detaches in
+            // list order, so a port earlier in the list may already have handed its side over with nothing
+            // left that can ever bind it. Ending those is the same answer step 6's doomed case gets, for the
+            // same reason: a side nobody can pick up must not leave its peer posting into a queue forever.
+            StrandTransferredPorts(_transferredPorts);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Ends every channel side a record carries but nobody will ever bind — which is what a message that is
+    /// serialized and then not delivered leaves behind. See <c>JsMessagePort.PostMessage</c>'s step 6.
+    /// </summary>
+    internal static void StrandTransferredPorts(in SerializationRecord record) => StrandTransferredPorts(record.TransferredPorts);
+
+    private static void StrandTransferredPorts(List<SerializedMessagePort>? holders)
+    {
+        if (holders is null)
+        {
+            return;
+        }
+
+        foreach (var holder in holders)
+        {
+            // Null for a holder whose source was never detached, because the throw came before step 5 reached
+            // it — there is nothing to end there.
+            holder.Endpoint?.Close();
+            holder.Endpoint = null;
+        }
     }
 
     /// <summary>
@@ -456,12 +497,34 @@ internal sealed class StructuredSerializer
         var records = new List<TransferRecord>(transferList.Count);
         foreach (var entry in transferList)
         {
-            // Step 2.1 / 2.2: an ArrayBuffer is the only transferable Jint has. A SharedArrayBuffer is
-            // explicitly not one, and neither is a MessagePort — transferring a port is out of scope for this
-            // version, so one named here is refused rather than silently copied.
+            // Step 2.3, hoisted so it is asked once for both kinds: a duplicate is a DataCloneError, not a
+            // silent second transfer. The entry is always an object — WebIDL's sequence<object> conversion
+            // has already refused anything else — and nothing but this loop has put anything in the memory
+            // map yet, so hoisting it above the type test cannot change which refusal a list earns.
+            if (entry is ObjectInstance transferable && _memory.ContainsKey(transferable))
+            {
+                ThrowDataCloneError(entry is JsMessagePort
+                    ? "A MessagePort appears more than once in the transfer list"
+                    : "An ArrayBuffer appears more than once in the transfer list");
+            }
+
+            // Step 2.4 for a MessagePort: an empty data holder, which the walk resolves a reference to the
+            // port itself to. It stays empty until CompleteTransfers takes the port's side, exactly as a
+            // buffer's bytes do — the specification's uninitialized placeholder.
+            if (entry is JsMessagePort port)
+            {
+                var holder = new SerializedMessagePort();
+                _memory[port] = holder;
+                (_transferredPorts ??= new List<SerializedMessagePort>()).Add(holder);
+                records.Add(new TransferRecord(port, holder));
+                continue;
+            }
+
+            // Step 2.1 / 2.2: an ArrayBuffer and a MessagePort are the transferables Jint has. A
+            // SharedArrayBuffer is explicitly not one.
             if (entry is not JsArrayBuffer buffer || buffer.IsSharedArrayBuffer)
             {
-                ThrowDataCloneError("Only ArrayBuffer objects can be transferred");
+                ThrowDataCloneError("Only ArrayBuffer and MessagePort objects can be transferred");
                 return null;
             }
 
@@ -470,12 +533,6 @@ internal sealed class StructuredSerializer
             if (buffer.IsImmutableBuffer)
             {
                 ThrowDataCloneError("An immutable ArrayBuffer cannot be transferred");
-            }
-
-            // Step 2.3: a duplicate is a DataCloneError, not a silent second transfer.
-            if (_memory.ContainsKey(buffer))
-            {
-                ThrowDataCloneError("An ArrayBuffer appears more than once in the transfer list");
             }
 
             // Step 2.4: the record the walk resolves the source buffer to. Its bytes stay empty until
@@ -511,16 +568,34 @@ internal sealed class StructuredSerializer
 
         foreach (var record in transfers)
         {
+            if (record.Source is JsMessagePort port)
+            {
+                // Step 5.2: a port already detached — by close(), or by an earlier transfer — has no side
+                // left to hand over. Asked here rather than in PrepareTransfers because the specification
+                // asks it here, and the order is observable: an uncloneable message throws before this does.
+                if (port.Detached)
+                {
+                    ThrowDataCloneError("A detached MessagePort cannot be transferred");
+                }
+
+                // Steps 5.5.4 and 5.5.5, which for a MessagePort are one act: the side — queue, peer and all
+                // — leaves this port, and the port is detached.
+                ((SerializedMessagePort) record.Target).Endpoint = port.DetachForTransfer();
+                continue;
+            }
+
+            var buffer = (JsArrayBuffer) record.Source;
+
             // Step 5.1: a buffer detached during the walk cannot be transferred any more.
-            if (record.Source.IsDetachedBuffer)
+            if (buffer.IsDetachedBuffer)
             {
                 ThrowDataCloneError("An ArrayBuffer in the transfer list was detached while it was being cloned");
             }
 
             // Read now rather than in PrepareTransfers: a getter reached during the walk may have resized the
             // buffer, which replaces its data block outright.
-            record.Target.Bytes = record.Source.ArrayBufferData ?? [];
-            record.Source.DetachArrayBuffer();
+            ((SerializedArrayBuffer) record.Target).Bytes = buffer.ArrayBufferData ?? [];
+            buffer.DetachArrayBuffer();
         }
     }
 
@@ -545,6 +620,11 @@ internal sealed class StructuredSerializer
         {
             JsProxy => "A Proxy",
             JsPromise => "A Promise",
+
+            // A MessagePort is transferable but not serializable, so reaching one during the walk means it
+            // was in the message and not in the transfer list — which the specification refuses at its
+            // "platform object that is not serializable" arm rather than at the transfer steps.
+            JsMessagePort => "A MessagePort that was not in the transfer list",
             _ => "An object",
         };
 
@@ -552,12 +632,25 @@ internal sealed class StructuredSerializer
     }
 
     [DoesNotReturn]
-    private void ThrowDataCloneError(string message)
+    private void ThrowDataCloneError(string message) => ThrowDataCloneError(_realm, message);
+
+    /// <summary>
+    /// The one place a <c>DataCloneError</c> is raised, shared with the refusals
+    /// <c>JsMessagePort.PostMessage</c> makes before it ever reaches serialization.
+    /// </summary>
+    [DoesNotReturn]
+    internal static void ThrowDataCloneError(Realm realm, string message)
     {
-        throw new JavaScriptException(_realm.Intrinsics.DomException.CreateException(DomExceptionNames.DataClone, message));
+        throw new JavaScriptException(realm.Intrinsics.DomException.CreateException(DomExceptionNames.DataClone, message));
     }
 
-    private readonly record struct TransferRecord(JsArrayBuffer Source, SerializedArrayBuffer Target);
+    /// <summary>
+    /// One entry of <c>[[TransferDataHolders]]</c> before step 5 has filled it in: the source object and the
+    /// record the walk resolves it to. Both are typed loosely because the list is in transfer-list order and
+    /// mixes the two kinds — which is the order step 5 detaches in, and therefore the order a refusal
+    /// part-way through leaves half the list transferred in.
+    /// </summary>
+    private readonly record struct TransferRecord(ObjectInstance Source, SerializedObject Target);
 
     /// <summary>
     /// One container whose contents are still to be serialized. The specification recurses here; this is the

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ its own `console` (or any other name in the table below), enabling the feature l
 | `setTimeout` / `setInterval` / `clearTimeout` / `clearInterval` / `queueMicrotask` | `WebApiFeatures.Timers` | ✔ shipped |
 | `TextEncoder` (UTF-8) / `TextDecoder` (UTF-8, UTF-16LE/BE, every legacy single-byte encoding, `x-user-defined`; `fatal`, `ignoreBOM`, streaming) | `Encoding` | ✔ shipped |
 | `atob` / `btoa` | `Base64` | ✔ shipped |
-| `structuredClone` (incl. `{ transfer }` of `ArrayBuffer`s) | `StructuredClone` | ✔ shipped |
+| `structuredClone` (incl. `{ transfer }` of `ArrayBuffer`s and `MessagePort`s) | `StructuredClone` | ✔ shipped |
 | `crypto.getRandomValues` / `crypto.randomUUID` / `crypto.subtle` (SHA digests, HMAC, AES-GCM, RSA, ECDSA/ECDH, HKDF, PBKDF2, `CryptoKey`) | `WebApiFeatures.Crypto` | ✔ shipped |
 | `performance.now` / `timeOrigin` / `mark` / `measure` / `getEntries*` / `clearMarks` / `clearMeasures` | `WebApiFeatures.Performance` | ✔ shipped |
 | `Event` / `EventTarget` / `CustomEvent` / `AbortController` / `AbortSignal` | `Events` | ✔ shipped |
@@ -231,7 +231,7 @@ its own `console` (or any other name in the table below), enabling the feature l
 | `CompressionStream` / `DecompressionStream` (`gzip`, `deflate`, `deflate-raw`) | `Compression` **and** `Streams` | ✔ shipped |
 | `scheduler.postTask` / `scheduler.yield` / `TaskController` / `TaskSignal` | `Scheduler` | ✔ shipped |
 | `requestIdleCallback` / `cancelIdleCallback` / `IdleDeadline` | `IdleCallback` | ✔ shipped |
-| `MessageChannel` / `MessagePort` / `MessageEvent` (incl. cross-engine ports) / `BroadcastChannel` | `Messaging` | ✔ shipped |
+| `MessageChannel` / `MessagePort` / `MessageEvent` (incl. cross-engine ports and port transfer) / `BroadcastChannel` | `Messaging` | ✔ shipped |
 | `reportError` (and the `DiagnosticsSink` behind it) | `Reporting` | ✔ shipped |
 | `addEventListener` / `removeEventListener` / `dispatchEvent` / `self` on the global scope, with `ErrorEvent` / `PromiseRejectionEvent` and the `error` / `unhandledrejection` / `rejectionhandled` events | `GlobalEvents` | ✔ shipped |
 | `localStorage` / `sessionStorage` / `Storage` | `Storage` *(not in `Default` — see below)* | ✔ shipped |
@@ -540,8 +540,31 @@ message is structured-cloned *when it is posted* — so a `DataCloneError` is th
 event-loop task, so every already-queued promise reaction runs first. A port's message queue starts
 **disabled**: nothing arrives until `start()` is called or `onmessage` is assigned, and
 `addEventListener('message', …)` on its own does not start it. `{ transfer: [buffer] }` moves an
-`ArrayBuffer` instead of copying it, exactly as `structuredClone` does; transferring a *port* is not
-supported and is refused with a `DataCloneError`.
+`ArrayBuffer` instead of copying it, exactly as `structuredClone` does.
+
+**A `MessagePort` can be transferred too**, which is how a script hands one channel's end over another
+channel:
+
+```js
+var side = new MessageChannel();
+side.port1.onmessage = e => log('reply: ' + e.data);
+side.port1.postMessage('queued before the handover');   // waits; nobody owns the far end yet
+
+port.postMessage('here is a private channel', [side.port2]);
+```
+
+The named port is **detached**: `postMessage` on it becomes a silent no-op and no event will ever fire on it
+again. Its *side* of the channel — including every message still queued on it, and every message the peer
+posts while it is in transit — travels in the message and is re-entangled with a fresh `MessagePort` created
+in the receiving realm, which arrives as `event.ports[0]`. The peer is untouched and never learns that the
+far end moved, so a port can be relayed through as many engines as you like and still talk to the one that
+created it. `structuredClone(port, { transfer: [port] })` does the same thing into the current realm.
+
+The specification's refusals are implemented as written: transferring a port through *itself* is a
+`DataCloneError`, naming one twice in a single transfer list or naming an already-closed or already-transferred
+one is a `DataCloneError`, transferring the port you are posting *to* dooms the message (the transfer happens,
+nothing is delivered, the channel is lost), and a port that is in the message but not in the transfer list is
+a `DataCloneError` — a port is transferable, not serializable.
 
 The same pair can also connect **two engines**, which is what makes a worker-style split possible without a
 second process:
@@ -569,6 +592,13 @@ and the listeners all run on whichever thread pumps that engine, so nothing on t
 its own pump. The receiver must actually be pumped, exactly as for timers: an engine nobody pumps never
 delivers a message. And a `RestoreGlobalSnapshot` on either engine ends that channel permanently — a port's
 listeners are closures over the cycle it was created in — so a pooled engine wants a fresh pair per cycle.
+
+Transferring a port works between engines too, and a transferred port is not tied to the two engines that
+happened to move it: engine A can create a pair, send one end to B, have B forward that same end to C without
+ever looking at it, and end up with A and C talking directly. The one thing that does cross in that case is
+the channel *side* — a small object holding the message queue, a lock and the peer — which is the same handle
+a sender has always held for its peer. A restore on the engine a transfer was in flight to **ends** that side
+rather than leaving it waiting, so the other end stops queueing into something that can never be drained.
 
 `BroadcastChannel` rides the same `Messaging` flag and is the same machinery addressed by *name* instead of by
 peer. `new BroadcastChannel('room')` joins a name; `postMessage(value)` reaches every **other** channel of that

--- a/docs/design/web-workers.md
+++ b/docs/design/web-workers.md
@@ -593,11 +593,17 @@ proposed.
   cannot synchronize them. **Two Jint engines are always two agent clusters**, whatever threads they run on.
   This is a deliberate non-goal, not an oversight: a cross-engine `SharedArrayBuffer` would need a cross-engine
   waiter list and would make `Atomics.wait` on the parent's thread block a thread the host owns.
-- **Transferring a `MessagePort` is refused** (`StructuredSerializer.cs:460`), so `new MessageChannel()` cannot
-  be handed to a worker and `worker.postMessage(msg, [port])` is a `DataCloneError`. **This is the largest
-  observable gap against the web platform in the whole proposal** and should be named as such. It is also the
-  natural follow-up: the endpoint machinery already spans engines, so what is missing is a serialized form for
-  "an endpoint to re-entangle on the far side", not a new transport.
+- **Transferring a `MessagePort` works**, so `new MessageChannel()` *can* be handed to a worker and
+  `worker.postMessage(msg, [port])` is the way to give it a private channel. This was the largest observable
+  gap in the proposal as first written, and it was closed exactly as predicted here — the endpoint machinery
+  already spanned engines, so what was missing was a serialized form for "a channel side to re-entangle on the
+  far side" rather than a new transport. Two consequences for the worker design: the port message queue now
+  lives on `MessagePortEndpoint` rather than on `JsMessagePort` (which is what makes it travel, and is what
+  HTML's transfer steps describe), and `WebApiEngineState.ResetTransientState` **closes** this engine's ports
+  rather than relying on the generation fence alone — a transfer in flight to an engine that restores would
+  otherwise leave its peer posting into a queue nothing can ever drain. §8's "close both ports rather than
+  merely forgetting the local one" is therefore already the shipped rule for ports, not only the proposed one
+  for workers.
 - `Error` objects clone as data (name flattened to the seven standard names, plus message and stack); functions
   and symbols do not.
 


### PR DESCRIPTION
Makes `MessagePort` transferable through `postMessage` (and `structuredClone`), closing the largest observable web-platform gap left in the messaging story - the one that blocks Comlink-shaped code and that the Workers design named as its own prerequisite follow-up.

Closes #3186.

**The design is one sentence: the queue is the thing that travels.** `MessagePortEndpoint` becomes one *side* of a channel - the port message queue, its lock, whom the queue is currently bound to, and the peer - and a transfer moves that object, exactly as HTML's transfer steps pass `[[PortMessageQueue]]` by reference. `Peer` is assigned once at entanglement and never reassigned, so the far end of a transferred port - which in a three-engine relay lives on neither the sender nor the receiver - is never touched, never told, and never synchronizes with anything.

**The race is walked, not waved at**: `Post` appends and reads the binding in one atomic step; `Unbind` only ever runs on the bound engine's own thread (a transfer happens inside its `postMessage`); the wake is a hint a stale receiver refuses; and `Bind` needs no wake because a bound port's queue starts disabled and the `start()` a script must call is what drains everything the transfer brought. A message in flight at the instant of a swap is neither lost nor delivered to the dying port - one queue, and it travels. The spec's full refusal/dooming matrix is implemented as written (self-transfer `DataCloneError`, entangled-peer transfer dooms silently, duplicates and detached ports refused at SSWT's own steps, ports created before the graph walk so references resolve), and `MessageEvent.ports` is a real frozen array in transfer-list order - with `EventSource`/`WebSocket`/`BroadcastChannel` untouched on the shared empty one.

Three decisions the review weighed and kept, each argued in code:

- **A `SerializationRecord` now reaches an `Engine` through the transferred side** - the "nothing engine-affine" rule relaxed in letter but not in hazard: it is the same handle a sender always held for its peer, nothing a foreign thread touches is unguarded, and no `JsValue`/`Realm`/`Intrinsics` is reachable. The record-walk test now pins exactly that boundary.
- **A restore and `Engine.Dispose` close the engine's ports** (new weak-reference registry, amortized pruning): the generation fence stops delivery, but a record stranded in an undrainable queue can itself carry an unbound side whose peer keeps posting - so undeliverable transfers are ended transitively, from a work list, wherever they are orphaned (dooming, closed targets, a throw mid-serialization).
- **One honest surviving mutant**: the one-queue-one-drainer guard in `TryDequeue` is unreachable today (detach always precedes bind) and is kept as a commented invariant guard rather than a `Debug.Assert`, because losing it in Release would silently split a queue rather than stall it.

11 of 12 mutations killed - two first-pass survivors drove two extra pins before dying. Tests cover same-engine, cross-engine, and the three-engine relay; queued-messages-travel ordering; inertness at the sender; the full refusal matrix; restore/dispose; and the BroadcastChannel non-change. Full matrix green on both TFMs including host-contract-verification legs, re-verified after rebasing onto current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014n5uCpi2vvHWBSiewUwBiY
