### PR TITLE
Polish: the REPL gains the shipped web-API surface, and the README a WinterTC member-by-member table

### DIFF
--- a/Jint.Repl/Program.cs
+++ b/Jint.Repl/Program.cs
@@ -16,6 +16,7 @@ using Jint.Runtime.Modules;
 string? inputFile = null;
 int? timeoutSeconds = null;
 bool runAsModule = false;
+bool enableFetch = false;
 
 for (int i = 0; i < args.Length; i++)
 {
@@ -50,6 +51,9 @@ for (int i = 0; i < args.Length; i++)
         case "-m" or "--module":
             runAsModule = true;
             break;
+        case "--fetch":
+            enableFetch = true;
+            break;
         case "-h" or "--help":
             PrintHelp();
             return 0;
@@ -72,12 +76,21 @@ var engine = new Engine(cfg =>
     cfg.AllowClr();
     cfg.UseConsole(Console.Out);
 
-    // Timers, so a script pasted from the web behaves. Note that the REPL pumps the event loop only as part
-    // of evaluating each input, so a timer fires on the evaluation it is already due for or on a later one —
-    // a `setTimeout(f, 1000)` typed at the prompt runs f on the next line you enter, and one scheduled by a
-    // `-f script.js` run that outlives the script never runs at all. That is the engine's contract, not a
-    // REPL limitation: nothing anywhere in Jint pumps an engine on its own.
-    cfg.UseWebApis(WebApiFeatures.Timers);
+    // The whole non-network web-API surface, so a script pasted from the web behaves. Note that the REPL
+    // pumps the event loop only as part of evaluating each input, so a timer fires on the evaluation it is
+    // already due for or on a later one — a `setTimeout(f, 1000)` typed at the prompt runs f on the next line
+    // you enter, and one scheduled by a `-f script.js` run that outlives the script never runs at all. That
+    // is the engine's contract, not a REPL limitation: nothing anywhere in Jint pumps an engine on its own.
+    cfg.UseWebApis(WebApiFeatures.Default);
+
+    // Outbound network access is a named grant even here. `WebApiFeatures.Default` never includes fetch, and
+    // a demo tool is no reason to hand a pasted script the host process's network position, so it takes
+    // `--fetch` on the command line and nothing less.
+    if (enableFetch)
+    {
+        cfg.UseFetch();
+    }
+
     if (timeoutSeconds.HasValue)
     {
         cfg.TimeoutInterval(TimeSpan.FromSeconds(timeoutSeconds.Value));
@@ -300,13 +313,24 @@ static void PrintHelp()
     Console.WriteLine("  -f, --file <path>     Execute JavaScript file");
     Console.WriteLine("  -m, --module          Run script as ES6 module");
     Console.WriteLine("  -t, --timeout <secs>  Set execution timeout in seconds");
+    Console.WriteLine("      --fetch           Allow the script to make network requests");
     Console.WriteLine("  -h, --help            Show this help message");
+    Console.WriteLine();
+    Console.WriteLine("Web APIs:");
+    Console.WriteLine("  console, timers, TextEncoder/TextDecoder, atob/btoa, structuredClone, crypto,");
+    Console.WriteLine("  performance, Event/AbortController, URL, Blob/File/FormData, navigator, streams,");
+    Console.WriteLine("  compression, scheduler, requestIdleCallback, messaging, reportError and the global");
+    Console.WriteLine("  error events are all on - WebApiFeatures.Default, the same set UseWebApis() gives.");
+    Console.WriteLine("  fetch is NOT: outbound network access stays a grant you name, even in a demo tool,");
+    Console.WriteLine("  because it hands a pasted script this process's network position. Pass --fetch to");
+    Console.WriteLine("  turn it on. localStorage and caches are off too - they outlive the evaluation.");
     Console.WriteLine();
     Console.WriteLine("Examples:");
     Console.WriteLine("  jint                          Start interactive REPL");
     Console.WriteLine("  jint script.js                Execute script.js");
     Console.WriteLine("  jint -m module.js             Execute module.js as ES6 module");
     Console.WriteLine("  jint -f script.js -t 10       Execute with 10 second timeout");
+    Console.WriteLine("  jint -f script.js --fetch     Execute with network access enabled");
     Console.WriteLine("  echo \"1+1\" | jint             Execute from stdin");
     Console.WriteLine("  echo \"1+1\" | jint -t 5        Execute from stdin with timeout");
 }

--- a/Jint.Tests/Runtime/WebApi/WinterTcMinimumCommonApiTests.cs
+++ b/Jint.Tests/Runtime/WebApi/WinterTcMinimumCommonApiTests.cs
@@ -1,0 +1,246 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// The member index of WinterTC's Minimum Common Web Platform API
+/// (https://min-common-api.proposal.wintertc.org/), §5.1 <i>Common interfaces</i> and §5.2 <i>Common methods
+/// and properties</i> of the 2025 snapshot, transcribed member for member and asserted against the engine.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the pin behind the conformance table in <c>README.md</c>. The table claims, row by row, which
+/// <see cref="WebApiFeatures"/> flag provides each member and which ones are absent; a change that installs a
+/// global WinterTC does not name, stops installing one it does, or quietly closes one of the documented gaps
+/// fails here, so the table cannot go stale without the build saying so.
+/// </para>
+/// <para>
+/// Membership is tested with <c>in</c> rather than <c>typeof</c>, so a property that exists and holds
+/// <see langword="undefined"/> counts as present — which is exactly the distinction the three
+/// <c>on*</c> handlers turn on, since a browser's are <see langword="null"/>.
+/// </para>
+/// </remarks>
+public class WinterTcMinimumCommonApiTests
+{
+    /// <summary>§5.1 Common interfaces, in the standard's own order.</summary>
+    private static readonly string[] CommonInterfaces =
+    [
+        // [DOM]
+        "AbortController", "AbortSignal", "Event", "EventTarget",
+        // [HTML] (CustomEvent is the DOM Standard's; §5.1 groups it here)
+        "CustomEvent", "ErrorEvent", "MessageChannel", "MessageEvent", "MessagePort", "PromiseRejectionEvent",
+        // [WEBIDL]
+        "DOMException",
+        // [FETCH]
+        "Headers", "Request", "Response",
+        // [XHR]
+        "FormData",
+        // [FILEAPI]
+        "Blob", "File",
+        // [COMPRESSION]
+        "CompressionStream", "DecompressionStream",
+        // [STREAMS]
+        "ByteLengthQueuingStrategy", "CountQueuingStrategy", "ReadableByteStreamController", "ReadableStream",
+        "ReadableStreamBYOBReader", "ReadableStreamBYOBRequest", "ReadableStreamDefaultController",
+        "ReadableStreamDefaultReader", "TransformStream", "TransformStreamDefaultController", "WritableStream",
+        "WritableStreamDefaultController", "WritableStreamDefaultWriter",
+        // [ENCODING]
+        "TextDecoder", "TextDecoderStream", "TextEncoder", "TextEncoderStream",
+        // [URL]
+        "URL", "URLSearchParams",
+        // [URLPATTERN]
+        "URLPattern",
+        // [WEBCRYPTO]
+        "Crypto", "CryptoKey", "SubtleCrypto",
+        // [HR-TIME]
+        "Performance",
+        // [WASM-JS-API-2]
+        "WebAssembly.Global", "WebAssembly.Instance", "WebAssembly.Memory", "WebAssembly.Module",
+        "WebAssembly.Table", "WebAssembly.Tag", "WebAssembly.Exception", "WebAssembly.CompileError",
+        "WebAssembly.LinkError", "WebAssembly.RuntimeError",
+    ];
+
+    /// <summary>§5.2 Common methods and properties, in the standard's own order.</summary>
+    private static readonly string[] CommonMethodsAndProperties =
+    [
+        // [ECMASCRIPT]
+        "globalThis",
+        // [HTML]
+        "atob", "btoa", "clearTimeout", "clearInterval", "navigator.userAgent", "onerror",
+        "onunhandledrejection", "onrejectionhandled", "queueMicrotask", "reportError", "self", "setTimeout",
+        "setInterval", "structuredClone",
+        // [FETCH]
+        "fetch",
+        // [CONSOLE]
+        "console",
+        // [WEBCRYPTO]
+        "crypto",
+        // [HR-TIME]
+        "performance",
+        // [WASM-JS-API-2] and [WASM-WEB-API-2]
+        "WebAssembly.compile", "WebAssembly.compileStreaming", "WebAssembly.instantiate",
+        "WebAssembly.instantiateStreaming", "WebAssembly.JSTag", "WebAssembly.validate",
+    ];
+
+    /// <summary>
+    /// Everything the README's table records as absent from a <see cref="WebApiFeatures.Default"/> engine,
+    /// with the reason each one is on this list.
+    /// </summary>
+    private static readonly string[] AbsentFromDefault =
+    [
+        // Outbound network access is a grant a host names, so these four sit behind WebApiFeatures.Fetch
+        // (the three interfaces also arrive with CacheApi and FetchEvents).
+        "Headers", "Request", "Response", "fetch",
+
+        // Implemented, and their interface objects are real; only the five interfaces a script constructs by
+        // name are installed on the global object.
+        "ReadableByteStreamController", "ReadableStreamBYOBReader", "ReadableStreamBYOBRequest",
+        "ReadableStreamDefaultController", "ReadableStreamDefaultReader", "TransformStreamDefaultController",
+        "WritableStreamDefaultController", "WritableStreamDefaultWriter",
+
+        // The instances exist and carry every member; the interface objects do not exist at all.
+        "Crypto", "SubtleCrypto", "Performance",
+
+        // §6 The global scope: a runtime whose global is not an EventTarget "shall not support" these three.
+        "onerror", "onunhandledrejection", "onrejectionhandled",
+
+        // Declined: a second virtual machine, sharing nothing with a tree-walking AST interpreter.
+        "WebAssembly.Global", "WebAssembly.Instance", "WebAssembly.Memory", "WebAssembly.Module",
+        "WebAssembly.Table", "WebAssembly.Tag", "WebAssembly.Exception", "WebAssembly.CompileError",
+        "WebAssembly.LinkError", "WebAssembly.RuntimeError",
+        "WebAssembly.compile", "WebAssembly.compileStreaming", "WebAssembly.instantiate",
+        "WebAssembly.instantiateStreaming", "WebAssembly.JSTag", "WebAssembly.validate",
+    ];
+
+    private static string[] AllMembers => [.. CommonInterfaces, .. CommonMethodsAndProperties];
+
+    [Fact]
+    public void ADefaultEngineIsMissingExactlyTheMembersTheReadmeRecordsAsAbsent()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        MissingFrom(engine, AllMembers).Should().BeEquivalentTo(AbsentFromDefault);
+    }
+
+    [Fact]
+    public void TheFetchGrantAddsTheFourNetworkMembersAndNothingElse()
+    {
+        var engine = new Engine(options => options.UseWebApis().UseFetch());
+
+        string[] stillAbsent = [.. AbsentFromDefault.Where(static m => m is not ("Headers" or "Request" or "Response" or "fetch"))];
+
+        MissingFrom(engine, AllMembers).Should().BeEquivalentTo(stillAbsent);
+    }
+
+    [Fact]
+    public void AnEngineThatAskedForNoFeatureCarriesNoneOfThem()
+    {
+        var engine = new Engine();
+
+        // Everything but `globalThis`, which is the language's and was never ours to install.
+        string[] everythingElse = [.. AllMembers.Where(static m => m is not "globalThis")];
+
+        MissingFrom(engine, AllMembers).Should().BeEquivalentTo(everythingElse);
+    }
+
+    [Theory]
+    [InlineData("ReadableStreamDefaultReader", "new ReadableStream().getReader()")]
+    [InlineData("ReadableStreamBYOBReader", "new ReadableStream({ type: 'bytes' }).getReader({ mode: 'byob' })")]
+    [InlineData("WritableStreamDefaultWriter", "new WritableStream().getWriter()")]
+    [InlineData("ReadableStreamDefaultController", "captured(c => new ReadableStream({ start: c }))")]
+    [InlineData("ReadableByteStreamController", "captured(c => new ReadableStream({ type: 'bytes', start: c }))")]
+    [InlineData("WritableStreamDefaultController", "captured(c => new WritableStream({ start: c }))")]
+    [InlineData("TransformStreamDefaultController", "captured(c => new TransformStream({ start: c }))")]
+    public void AStreamInterfaceObjectWithoutAGlobalIsStillTheRealThing(string name, string instance)
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        // The point of the reduction: not a global, but reachable and genuine through its instances.
+        engine.Evaluate($"'{name}' in globalThis").AsBoolean().Should().BeFalse();
+
+        engine.Execute("function captured(build) { var seen; build(c => { seen = c; }); return seen; }");
+        engine.Evaluate($"Object.getPrototypeOf({instance}).constructor.name").AsString().Should().Be(name);
+    }
+
+    [Fact]
+    public void TheByobRequestInterfaceObjectIsTheRealThingToo()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        engine.Evaluate("'ReadableStreamBYOBRequest' in globalThis").AsBoolean().Should().BeFalse();
+
+        engine.Execute("""
+            var seen = '';
+            var stream = new ReadableStream({
+                type: 'bytes',
+                autoAllocateChunkSize: 16,
+                pull(controller) {
+                    var request = controller.byobRequest;
+                    if (request) {
+                        seen = Object.getPrototypeOf(request).constructor.name;
+                        request.view[0] = 1;
+                        request.respond(1);
+                    }
+                }
+            });
+            stream.getReader().read();
+            """);
+
+        engine.Evaluate("seen").AsString().Should().Be("ReadableStreamBYOBRequest");
+    }
+
+    [Fact]
+    public void CryptoSubtleCryptoAndPerformanceHaveNoInterfaceObjectAtAll()
+    {
+        var engine = new Engine(options => options.UseWebApis());
+
+        // Not merely unnameable: there is no interface prototype either, so the members are own properties
+        // and the object inherits straight from Object.prototype.
+        foreach (var instance in new[] { "crypto", "crypto.subtle", "performance" })
+        {
+            engine.Evaluate($"Object.getPrototypeOf({instance}) === Object.prototype")
+                .AsBoolean().Should().BeTrue(instance);
+        }
+
+        // What a script can observe of that is still what a browser shows, because there the members live one
+        // level up on the prototype.
+        engine.Evaluate("Object.keys(crypto).length + Object.keys(performance).length").AsNumber().Should().Be(0);
+
+        // And the members themselves are all there.
+        engine.Evaluate("typeof crypto.randomUUID").AsString().Should().Be("function");
+        engine.Evaluate("typeof crypto.subtle.digest").AsString().Should().Be("function");
+        engine.Evaluate("typeof performance.now").AsString().Should().Be("function");
+    }
+
+    /// <summary>
+    /// Which of <paramref name="members"/> the engine does not have, resolved as dotted paths so that
+    /// <c>navigator.userAgent</c> and <c>WebAssembly.Module</c> are asked the way WinterTC writes them.
+    /// </summary>
+    private static string[] MissingFrom(Engine engine, string[] members)
+    {
+        var script = $$"""
+            (function (names) {
+                var missing = [];
+                for (var i = 0; i < names.length; i++) {
+                    var parts = names[i].split('.');
+                    var current = globalThis;
+                    var found = true;
+                    for (var j = 0; j < parts.length; j++) {
+                        if (current === null || current === undefined || !(parts[j] in Object(current))) {
+                            found = false;
+                            break;
+                        }
+                        current = current[parts[j]];
+                    }
+                    if (!found) { missing.push(names[i]); }
+                }
+                return missing.join(' ');
+            })(['{{string.Join("','", members)}}'])
+            """;
+
+        var joined = engine.Evaluate(script).AsString();
+        return joined.Length == 0 ? [] : joined.Split(' ');
+    }
+}
+#endif

--- a/README.md
+++ b/README.md
@@ -367,6 +367,140 @@ encoding, never decoded as something else. The label table and the single-byte i
 from the standard's own data files; `TextEncoder` is UTF-8 only, as the standard requires.
 
 
+### WinterTC's Minimum Common API, member by member
+
+The surface above is guided by [WinterTC's Minimum Common Web Platform API](https://min-common-api.proposal.wintertc.org/),
+the Ecma TC55 standard that names the slice of the web platform a non-browser runtime should carry. The two
+tables below are that standard's own index — §5.1 *Common interfaces* and §5.2 *Common methods and
+properties* of the 2025 snapshot — one row per member, against the `WebApiFeatures` flag that provides it.
+**Every flag named is part of `WebApiFeatures.Default` unless the row says otherwise**, so a bare
+`UseWebApis()` gets you the whole list bar the rows that say it does not.
+
+Five entries need more than a flag name, stated here rather than left to be discovered:
+
+* **`WebAssembly.*`** — 16 of the members below, and a recorded decline rather than a to-do. Implementing it
+  means shipping a *second* virtual machine beside the first: a decoder, a validator and an execution engine
+  for a bytecode a tree-walking AST interpreter shares nothing with, since Jint deliberately has no bytecode
+  and no code generation of its own. It would be larger than the ECMAScript implementation it stood next to
+  and would reuse none of it, so it is absent and will stay absent.
+* **`Crypto`, `SubtleCrypto` and `Performance`** — the *interface objects*. `crypto`, `crypto.subtle` and
+  `performance` are all there and carry every member the standards give them, but as objects whose members
+  are their own rather than an interface prototype's, so there is no constructor to name and
+  `x instanceof Crypto` cannot be written. That is a documented simplification (the same one `console`
+  carries), and what a script can otherwise observe is unchanged — `Object.keys(crypto)` answers the empty
+  array in a browser too, because there the members live one level up.
+* **Eight of the Streams interfaces** — the two readers, the writer, the four controllers and
+  `ReadableStreamBYOBRequest`.
+  These are implemented and their interface objects are real: a reader's `constructor` is the genuine thing
+  and `new` on it behaves as the standard says. They are simply not installed on `globalThis`, which is the
+  deliberate reduction described under [Streams](#streams-including-byte-streams).
+* **`onerror`, `onunhandledrejection` and `onrejectionhandled`** — absent, and §6 *The global scope* is why:
+  a runtime whose global object is not an `EventTarget` "shall not support" those three properties, and must
+  instead fire the events through a suitable alternative mechanism. Jint's global is not an `EventTarget`
+  (`GlobalEvents` puts `addEventListener` on it as an ordinary function bound to a synthetic target), so
+  their absence is what conformance asks for rather than a gap. The same clause excuses a runtime from
+  implementing `ErrorEvent` and `PromiseRejectionEvent`; those are here anyway, and so are the `error`,
+  `unhandledrejection` and `rejectionhandled` events themselves.
+* **`Headers`, `Request`, `Response` and `fetch()`** — present, but behind flags `Default` does not include,
+  for the reason the whole section opens with: network egress is a grant a host makes rather than inherits.
+  The three interfaces come with `Fetch`, `CacheApi` or `FetchEvents`; the function comes with `Fetch` alone.
+
+§5.3 *Web workers* asks for `onerror`, `onunhandledrejection`, `onrejectionhandled` and `self` on any global
+that maps to a `WorkerGlobalScope`. Jint's does not map to one, so only `self` applies, and the three
+handlers are the §6 case above.
+
+**§5.1 Common interfaces**
+
+| Member | Defined by | Provided by |
+| --- | --- | --- |
+| `AbortController` | DOM | `Events` |
+| `AbortSignal` | DOM | `Events` |
+| `Event` | DOM | `Events` |
+| `EventTarget` | DOM | `Events` |
+| `CustomEvent` | DOM | `Events` |
+| `ErrorEvent` | HTML | `GlobalEvents` |
+| `MessageChannel` | HTML | `Messaging` |
+| `MessageEvent` | HTML | `Messaging` (also `EventSource`, `WebSocket`) |
+| `MessagePort` | HTML | `Messaging` |
+| `PromiseRejectionEvent` | HTML | `GlobalEvents` |
+| `DOMException` | WebIDL | *no flag — installed whenever any feature is* |
+| `Headers` | Fetch | `Fetch`, `CacheApi` or `FetchEvents` — **not in `Default`** |
+| `Request` | Fetch | `Fetch`, `CacheApi` or `FetchEvents` — **not in `Default`** |
+| `Response` | Fetch | `Fetch`, `CacheApi` or `FetchEvents` — **not in `Default`** |
+| `FormData` | XHR | `Files` |
+| `Blob` | File API | `Files` |
+| `File` | File API | `Files` |
+| `CompressionStream` | Compression | `Compression` **and** `Streams` |
+| `DecompressionStream` | Compression | `Compression` **and** `Streams` |
+| `ByteLengthQueuingStrategy` | Streams | `Streams` |
+| `CountQueuingStrategy` | Streams | `Streams` |
+| `ReadableStream` | Streams | `Streams` |
+| `TransformStream` | Streams | `Streams` |
+| `WritableStream` | Streams | `Streams` |
+| `ReadableByteStreamController` | Streams | `Streams` — implemented, **not a global** |
+| `ReadableStreamBYOBReader` | Streams | `Streams` — implemented, **not a global** |
+| `ReadableStreamBYOBRequest` | Streams | `Streams` — implemented, **not a global** |
+| `ReadableStreamDefaultController` | Streams | `Streams` — implemented, **not a global** |
+| `ReadableStreamDefaultReader` | Streams | `Streams` — implemented, **not a global** |
+| `TransformStreamDefaultController` | Streams | `Streams` — implemented, **not a global** |
+| `WritableStreamDefaultController` | Streams | `Streams` — implemented, **not a global** |
+| `WritableStreamDefaultWriter` | Streams | `Streams` — implemented, **not a global** |
+| `TextDecoder` | Encoding | `Encoding` |
+| `TextEncoder` | Encoding | `Encoding` |
+| `TextDecoderStream` | Encoding | `Encoding` **and** `Streams` |
+| `TextEncoderStream` | Encoding | `Encoding` **and** `Streams` |
+| `URL` | URL | `Url` |
+| `URLSearchParams` | URL | `Url` |
+| `URLPattern` | URL Pattern | `Url` |
+| `Crypto` | Web Crypto | **absent** — `crypto` has no interface object |
+| `CryptoKey` | Web Crypto | `Crypto` |
+| `SubtleCrypto` | Web Crypto | **absent** — `crypto.subtle` has no interface object |
+| `Performance` | HR-Time | **absent** — `performance` has no interface object |
+| `WebAssembly.Global` | Wasm JS API | **absent** — declined |
+| `WebAssembly.Instance` | Wasm JS API | **absent** — declined |
+| `WebAssembly.Memory` | Wasm JS API | **absent** — declined |
+| `WebAssembly.Module` | Wasm JS API | **absent** — declined |
+| `WebAssembly.Table` | Wasm JS API | **absent** — declined |
+| `WebAssembly.Tag` | Wasm JS API | **absent** — declined |
+| `WebAssembly.Exception` | Wasm JS API | **absent** — declined |
+| `WebAssembly.CompileError` | Wasm JS API | **absent** — declined |
+| `WebAssembly.LinkError` | Wasm JS API | **absent** — declined |
+| `WebAssembly.RuntimeError` | Wasm JS API | **absent** — declined |
+
+**§5.2 Common methods and properties**
+
+| Member | Defined by | Provided by |
+| --- | --- | --- |
+| `globalThis` | ECMAScript | the language — always there |
+| `atob()` | HTML | `Base64` |
+| `btoa()` | HTML | `Base64` |
+| `clearTimeout()` | HTML | `Timers` |
+| `clearInterval()` | HTML | `Timers` |
+| `navigator.userAgent` | HTML | `Navigator` |
+| `onerror` | HTML | **absent** — §6 asks for that; see above |
+| `onunhandledrejection` | HTML | **absent** — §6 asks for that; see above |
+| `onrejectionhandled` | HTML | **absent** — §6 asks for that; see above |
+| `queueMicrotask()` | HTML | `Timers` |
+| `reportError()` | HTML | `Reporting` |
+| `self` | HTML | `GlobalEvents` |
+| `setTimeout()` | HTML | `Timers` |
+| `setInterval()` | HTML | `Timers` |
+| `structuredClone()` | HTML | `StructuredClone` |
+| `fetch()` | Fetch | `Fetch` — **not in `Default`** |
+| `console` | Console | `Console` |
+| `crypto` | Web Crypto | `Crypto` |
+| `performance` | HR-Time | `Performance` |
+| `WebAssembly.compile()` | Wasm JS API | **absent** — declined |
+| `WebAssembly.compileStreaming()` | Wasm Web API | **absent** — declined |
+| `WebAssembly.instantiate()` | Wasm JS API | **absent** — declined |
+| `WebAssembly.instantiateStreaming()` | Wasm Web API | **absent** — declined |
+| `WebAssembly.JSTag` | Wasm JS API | **absent** — declined |
+| `WebAssembly.validate()` | Wasm JS API | **absent** — declined |
+
+§7 asks that `navigator.userAgent` be a single opaque RFC 7231 product token identifying the runtime; Jint
+answers `Jint/<version>`, which `Options.WebApi` does not let you change — a script that branches on the
+runtime should get the truth.
+
 ### Enabling web APIs on an engine that already exists
 
 `options.WebApi.Features` is read once, when the engine is built, so a pooled engine's feature set is fixed at


### PR DESCRIPTION
Two visibility items, and an honest correction to the claim that motivated the second.

Closes #3203.

**The REPL catches up with what shipped**: `UseWebApis(WebApiFeatures.Default)` instead of `Timers` alone, so every campaign feature is demoable from `dotnet run --project Jint.Repl` - plus a `--fetch` switch for outbound network, because a grant stays a grant even in a demo tool, and the help text says exactly that. Smoke-tested across the surface (crypto, URL, encoder, structuredClone, performance, self, URLPattern; fetch family absent without the switch, present with it; timeouts intact).

**A WinterTC Minimum Common API table in the README** - the TC55 standard's own §5.1/§5.2 index, 78 rows, one per member, each mapped to the `WebApiFeatures` flag that provides it, sourced from the live draft rather than memory. The honest part: the issue claimed "conformant minus `WebAssembly.*`", and **the member-by-member check disproved it** - 34 of 78 are absent from a bare `Default` engine. The five divergence families are stated above the tables rather than left to be discovered: the `WebAssembly.*` block (now a formally recorded decline with the second-VM argument), the `Crypto`/`SubtleCrypto`/`Performance` *interface objects* (the values exist and carry every member; the constructors don't - the documented `console`-style simplification), the eight non-global stream interfaces (the reduction #3195 is deciding), the `on*` handlers (whose absence §6 makes *conformant* for a non-EventTarget global - and Jint ships the events and both event interfaces anyway), and the fetch family behind its named grants.

The table is pinned by a new 12-case test that resolves all 78 members against a real `Default` engine and requires the absence list to match exactly - so a wrong row fails the build, in either direction (mutation-verified both ways: installing a listed-absent global and deleting a listed-present one each break it). One honest surviving-mutant note: nothing in the suite references `Jint.Repl`, so the REPL half is verified by the smoke matrix in the review notes, not by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014n5uCpi2vvHWBSiewUwBiY
