### PR TITLE
Wpt: give the driver the fetch object model, so the urlencoded formData() rows run

### DIFF
--- a/Jint.Tests/Runtime/WebApi/MultipartTests.cs
+++ b/Jint.Tests/Runtime/WebApi/MultipartTests.cs
@@ -17,6 +17,10 @@ namespace Jint.Tests.Runtime.WebApi;
 /// The serialization is asserted <b>byte for byte</b> against a hand-written expectation rather than only
 /// through a round trip: a writer and a reader that agree with each other and with nothing else would pass
 /// every round-trip test and still produce a body no server can read.
+/// <para>
+/// The sibling arm of the same algorithm, <c>application/x-www-form-urlencoded</c>, is in
+/// <see cref="UrlEncodedBodyTests"/>.
+/// </para>
 /// </remarks>
 public class MultipartTests
 {
@@ -267,21 +271,6 @@ public class MultipartTests
         engine.Evaluate("r.bodyUsed").AsBoolean().Should().BeTrue();
         engine.Evaluate("r.formData().then(() => 'resolved', e => e.constructor.name)")
             .UnwrapIfPromise().AsString().Should().Be("TypeError");
-    }
-
-    [Fact]
-    public void ParsesAnUrlEncodedBody()
-    {
-        var engine = WebEngine();
-        engine.Execute(@"var r = new Response('a=1&b=hello+world&a=%C3%A9', {
-                headers: { 'content-type': 'application/x-www-form-urlencoded;charset=UTF-8' } });");
-
-        engine.Evaluate("r.formData().then(fd => fd.getAll('a').join(',') + '|' + fd.get('b'))")
-            .UnwrapIfPromise().AsString().Should().Be("1,é|hello world");
-
-        // A URLSearchParams body implies that Content-Type, so it round-trips without one being set by hand.
-        engine.Evaluate("new Response(new URLSearchParams({ q: 'a b' })).formData().then(fd => fd.get('q'))")
-            .UnwrapIfPromise().AsString().Should().Be("a b");
     }
 
     [Fact]

--- a/Jint.Tests/Runtime/WebApi/UrlEncodedBodyTests.cs
+++ b/Jint.Tests/Runtime/WebApi/UrlEncodedBodyTests.cs
@@ -1,0 +1,196 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Native;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// The <c>application/x-www-form-urlencoded</c> arm of <c>formData()</c>:
+/// https://fetch.spec.whatwg.org/#concept-body-package-data runs
+/// https://url.spec.whatwg.org/#concept-urlencoded-parser over the body's bytes and returns a
+/// <c>FormData</c> whose entry list is what came back.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The parser is <c>URLSearchParams</c>'s own, which is the point: a browser answers
+/// <c>new URLSearchParams(s)</c>, <c>new Request(url, { body: s }).formData()</c> and
+/// <c>new Response(s).formData()</c> with the same tuples, and
+/// <c>url/urlencoded-parser.any.js</c> asserts exactly that by feeding one corpus of 35 inputs through all
+/// three. What is pinned here is the part of that agreement the vendored corpus does not reach — the
+/// <c>Content-Type</c> that selects the arm, an empty and a null body, and the bytes a browser is never
+/// asked to parse.
+/// </para>
+/// <para>
+/// The sibling arm, <c>multipart/form-data</c>, is in <see cref="MultipartTests"/>.
+/// </para>
+/// </remarks>
+public class UrlEncodedBodyTests
+{
+    private static Engine WebEngine() => new(options => options.UseFetch());
+
+    /// <summary>The entry list of <paramref name="expression"/>'s <c>formData()</c>, as JSON.</summary>
+    private static string Entries(Engine engine, string expression)
+        => engine.Evaluate($"({expression}).formData().then(fd => JSON.stringify([...fd]))")
+            .UnwrapIfPromise()
+            .AsString();
+
+    /// <summary>
+    /// A response carrying <paramref name="body"/> under an <c>application/x-www-form-urlencoded</c> type,
+    /// with whatever <paramref name="parameters"/> the header should also carry.
+    /// </summary>
+    private static string Response(string body, string parameters = "")
+        => $"new Response('{body}', {{ headers: {{ 'content-type': 'application/x-www-form-urlencoded{parameters}' }} }})";
+
+    [Fact]
+    public void PlusIsASpaceAndPercentEscapesAreDecoded()
+    {
+        var engine = WebEngine();
+
+        // Both halves of a tuple are decoded, and a repeated name keeps both entries in order.
+        Entries(engine, Response("a=1&b=hello+world&a=%C3%A9"))
+            .Should().Be("""[["a","1"],["b","hello world"],["a","é"]]""");
+
+        // 0x2B (+) becomes 0x20 (SP) in the name as well as in the value, and the replacement happens
+        // *before* the percent-decoding — so "%2B" is a plus and "+" is a space, never the other way round.
+        Entries(engine, Response("d+e=f&%2B=%2B"))
+            .Should().Be("""[["d e","f"],["+","+"]]""");
+    }
+
+    [Fact]
+    public void TheEssenceAloneSelectsTheParserAndEveryParameterIsIgnored()
+    {
+        var engine = WebEngine();
+
+        // The two legacy charsets url/urlencoded-parser.any.js sends. The parser is UTF-8 only — the only
+        // conforming encoding — so "%C3%A9" is U+00E9 whatever the header claims.
+        Entries(engine, Response("a=%C3%A9", ";charset=windows-1252")).Should().Be("""[["a","é"]]""");
+        Entries(engine, Response("a=%C3%A9", ";charset=shift_jis")).Should().Be("""[["a","é"]]""");
+
+        // A MIME type's essence is ASCII-lowercased, and a parameter that means something to the *other*
+        // arm means nothing to this one.
+        Entries(engine, "new Response('a=1', { headers: { 'content-type': 'APPLICATION/X-WWW-FORM-URLENCODED' } })")
+            .Should().Be("""[["a","1"]]""");
+        Entries(engine, Response("a=1", ";boundary=\"nonsense\"; q=3")).Should().Be("""[["a","1"]]""");
+
+        // Leading and trailing HTTP whitespace is removed before the type is parsed.
+        Entries(engine, "new Response('a=1', { headers: { 'content-type': '  application/x-www-form-urlencoded  ' } })")
+            .Should().Be("""[["a","1"]]""");
+    }
+
+    [Fact]
+    public void AnEmptyBodyIsAnEmptyFormDataRatherThanAFailure()
+    {
+        var engine = WebEngine();
+
+        Entries(engine, Response("")).Should().Be("[]");
+
+        // A null body is not the same as an empty one — consume-body runs the success steps over an empty
+        // byte sequence without disturbing anything — but it packages to the same empty entry list.
+        Entries(engine, "new Response(null, { headers: { 'content-type': 'application/x-www-form-urlencoded' } })")
+            .Should().Be("[]");
+    }
+
+    [Fact]
+    public void ATupleWithNoEqualsHasAnEmptyValueAndAnEmptySequenceIsSkipped()
+    {
+        var engine = WebEngine();
+
+        // "Otherwise, let name have the value of bytes and let value be the empty byte sequence" — and step
+        // 5.1 drops an empty sequence, so neither the trailing nor the doubled "&" produces an entry.
+        Entries(engine, Response("a&b=1&")).Should().Be("""[["a",""],["b","1"]]""");
+        Entries(engine, Response("&&a=1&&")).Should().Be("""[["a","1"]]""");
+
+        // "If 0x3D (=) is the first byte, then name will be the empty byte sequence."
+        Entries(engine, Response("=v&k=")).Should().Be("""[["","v"],["k",""]]""");
+    }
+
+    [Fact]
+    public void ArbitraryBytesParseRatherThanFail()
+    {
+        var engine = WebEngine();
+
+        // The rows url/urlencoded-parser.any.js uses for this: a percent that begins no escape is kept
+        // verbatim, and one that begins a partial escape consumes only what it can.
+        Entries(engine, Response("id=0&value=%")).Should().Be("""[["id","0"],["value","%"]]""");
+        Entries(engine, Response("b=%2sf%2a")).Should().Be("""[["b","%2sf*"]]""");
+        Entries(engine, Response("b=%%2a")).Should().Be("""[["b","%*"]]""");
+
+        // An ill-formed UTF-8 run decodes to U+FFFD. There is no failure step in the parser at all, so
+        // formData()'s "if entries is failure, then throw a TypeError" has nothing to fire on.
+        engine.Evaluate("""
+            new Response(new Uint8Array([0x61, 0x3D, 0xFF, 0xFE]),
+                { headers: { 'content-type': 'application/x-www-form-urlencoded' } })
+                .formData().then(fd => Array.from(fd.get('a'), c => c.charCodeAt(0).toString(16)).join(','))
+            """).UnwrapIfPromise().AsString().Should().Be("fffd,fffd");
+
+        // "UTF-8 decode without BOM", so a leading BOM is part of the name rather than stripped from it.
+        engine.Evaluate("""
+            new Response(new Uint8Array([0xEF, 0xBB, 0xBF, 0x61, 0x3D, 0x31]),
+                { headers: { 'content-type': 'application/x-www-form-urlencoded' } })
+                .formData().then(fd => (fd.get('a') === null) + '|' + [...fd.keys()][0].charCodeAt(0))
+            """).UnwrapIfPromise().AsString().Should().Be("true|65279");
+    }
+
+    [Fact]
+    public void EveryEntryIsAString()
+    {
+        // "Return a new FormData object whose entry list is entries" — the format cannot carry a file, so
+        // no entry is ever a File however the value reads.
+        var engine = WebEngine();
+        engine.Execute("var parsed = " + Response("a=1&doc=hello") + ".formData();");
+
+        engine.Evaluate("parsed.then(fd => typeof fd.get('a') + ',' + typeof fd.get('doc'))")
+            .UnwrapIfPromise().AsString().Should().Be("string,string");
+        engine.Evaluate("parsed.then(fd => fd.get('doc') instanceof File)")
+            .UnwrapIfPromise().AsBoolean().Should().BeFalse();
+
+        // And it is a FormData of this realm.
+        engine.Evaluate("parsed.then(fd => fd instanceof FormData)")
+            .UnwrapIfPromise().AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void AnyOtherMimeTypeIsATypeError()
+    {
+        var engine = WebEngine();
+
+        // "Otherwise: throw a TypeError" — including for a body carrying no Content-Type at all, where the
+        // bytes would parse perfectly well.
+        engine.Evaluate("new Response('a=1').formData().then(() => 'resolved', e => e.constructor.name)")
+            .UnwrapIfPromise().AsString().Should().Be("TypeError");
+        engine.Evaluate("new Response('a=1', { headers: { 'content-type': 'text/plain' } }).formData().then(() => 'resolved', e => e.constructor.name)")
+            .UnwrapIfPromise().AsString().Should().Be("TypeError");
+
+        // A near miss is a miss: the essence is compared whole, never by prefix.
+        engine.Evaluate("new Response('a=1', { headers: { 'content-type': 'application/x-www-form-urlencoded-v2' } }).formData().then(() => 'resolved', e => e.constructor.name)")
+            .UnwrapIfPromise().AsString().Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void ARequestParsesItsOwnBodyTheSameWay()
+    {
+        var engine = WebEngine();
+
+        // The shape url/urlencoded-parser.any.js builds for its request half, custom method and all.
+        engine.Evaluate("""
+            new Request('about:blank', {
+                body: 'a=1&b=hello+world',
+                method: 'LADIDA',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded;charset=windows-1252' },
+            }).formData().then(fd => JSON.stringify([...fd]))
+            """).UnwrapIfPromise().AsString().Should().Be("""[["a","1"],["b","hello world"]]""");
+
+        // A URLSearchParams body implies the Content-Type, so it round-trips without one being set by hand.
+        engine.Evaluate("new Response(new URLSearchParams({ q: 'a b' })).formData().then(fd => fd.get('q'))")
+            .UnwrapIfPromise().AsString().Should().Be("a b");
+
+        // And a body that only ever existed as a stream reaches the same parser through the fully-read path.
+        engine.Evaluate("""
+            new Response(new Blob(['a=1&b=2']).stream(),
+                { headers: { 'content-type': 'application/x-www-form-urlencoded' } })
+                .formData().then(fd => JSON.stringify([...fd]))
+            """).UnwrapIfPromise().AsString().Should().Be("""[["a","1"],["b","2"]]""");
+    }
+}
+#endif

--- a/Jint.Tests/Wpt/Vendor/README.md
+++ b/Jint.Tests/Wpt/Vendor/README.md
@@ -13,12 +13,15 @@ keeps them intact through embedding.
 ## What runs this
 
 `Jint.Tests/Wpt/WptTestRunner.cs`, one xUnit theory case per `.any.js` file, on a fresh engine built with
-`UseWebApis(WebApiFeatures.Default)`. `Jint.Tests/Wpt/Prelude/testharness-shim.js` — *not* vendored — stands
-in for upstream's `testharness.js`; its header says what it implements and where it deliberately differs.
-`WptHarness.cs` documents the two decisions a reader is most likely to want: the engine supplies its own
-`setTimeout` — the shim's `step_timeout` is a forwarder onto it, so the streams suites' 45 timer sites are
-decided by the shipped `TimerQueue` — and `// META: variant=` sharding is ignored because one unsharded run
-is the union of every variant.
+`UseWebApis(WebApiFeatures.Default)` plus the fetch object model — `Headers`, `Request` and `Response`, and
+pointedly not `fetch`, so no suite gets outbound network access. `Jint.Tests/Wpt/Prelude/testharness-shim.js`
+— *not* vendored — stands in for upstream's `testharness.js`; its header says what it implements and where it
+deliberately differs. `WptHarness.cs` documents the three decisions a reader is most likely to want: the
+engine supplies its own `setTimeout` — the shim's `step_timeout` is a forwarder onto it, so the streams
+suites' 45 timer sites are decided by the shipped `TimerQueue` — `// META: variant=` sharding is ignored
+because one unsharded run is the union of every variant, and why the object model is there at all
+(`url/urlencoded-parser.any.js` runs each of its 35 inputs through `URLSearchParams`, `Request.formData()`
+and `Response.formData()`, one algorithm reached three ways).
 
 Four standards are vendored: `url/` and `encoding/` as one suite each, `WebCryptoAPI/` as **eight** and
 `streams/` as **six** — their root files plus one suite per sub-directory, because `WptCorpus.TestFiles`

--- a/Jint.Tests/Wpt/WptExclusions.cs
+++ b/Jint.Tests/Wpt/WptExclusions.cs
@@ -40,14 +40,6 @@ internal enum WptDivergence
     NeedsWebAssembly,
 
     /// <summary>
-    /// The test reaches for <c>Request</c> or <c>Response</c>. Those are the fetch object model, which lands
-    /// with the fetch feature; <c>WebApiFeatures.Default</c> deliberately never includes it, and this driver
-    /// enables nothing else. The suites keep these cases beside the <c>URLSearchParams</c> ones because a
-    /// browser parses <c>application/x-www-form-urlencoded</c> in both places with the same algorithm.
-    /// </summary>
-    NeedsFetchObjectModel,
-
-    /// <summary>
     /// The test detaches a buffer by posting it through a <c>MessageChannel</c>. Message ports are a worker
     /// primitive and Jint has no worker story, so this is the corpus meeting an environment it was not
     /// written for rather than a gap to close.

--- a/Jint.Tests/Wpt/WptHarness.cs
+++ b/Jint.Tests/Wpt/WptHarness.cs
@@ -6,6 +6,7 @@ using Jint.Native;
 using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Interop;
+using Jint.WebApi;
 
 namespace Jint.Tests.Wpt;
 
@@ -43,6 +44,22 @@ internal sealed record WptRunOutcome(IReadOnlyList<WptTestResult> Results, strin
 /// its assertions are decided by the queue's own ordering. The clock is <see cref="TimeProvider.System"/> and
 /// the drive loop below is what pumps it: a timer fires on a <c>ProcessTasks</c> at or after its due time,
 /// exactly as it does for an embedder.
+/// </para>
+/// <para>
+/// <b>The engine also carries the fetch object model, and pointedly not <c>fetch</c>.</b>
+/// <c>Headers</c>, <c>Request</c> and <c>Response</c> are not in <see cref="WebApiFeatures.Default"/> —
+/// they ship with <see cref="WebApiFeatures.Fetch"/> — but a corpus reaches an algorithm through every
+/// entry point the platform gives it, and for one file here that means the object model:
+/// <c>url/urlencoded-parser.any.js</c> runs each of its 35 inputs through <c>URLSearchParams</c>,
+/// <c>Request.formData()</c> <i>and</i> <c>Response.formData()</c>, because a browser parses
+/// <c>application/x-www-form-urlencoded</c> with one algorithm in all three places. Withholding the three
+/// interfaces would not test less of Jint, it would only turn a third of that file into an exclusion.
+/// <c>WebApiRegistration.InstallFetchModel</c> is the same door <c>Engine.Advanced.SetFetchHandler</c>
+/// opens for a host that must build a <c>Response</c> without being granted the network, and no shipped
+/// feature flag names the model on its own — <see cref="WebApiFeatures.Fetch"/>,
+/// <see cref="WebApiFeatures.CacheApi"/> and <see cref="WebApiFeatures.FetchEvents"/> each bring it with
+/// something else. <b>Outbound network access is still what no suite gets</b>: the three interfaces
+/// construct, parse and serialize, and nothing here can open a socket.
 /// </para>
 /// <para>
 /// <b>Variants are not sharded.</b> A <c>// META: variant=?1-1000</c> line splits a suite across browser
@@ -166,6 +183,9 @@ internal static class WptHarness
             // A guard on a hung script rather than a budget anything is measured against; see the field.
             options.TimeoutInterval(_harnessDeadline);
         });
+
+        // Headers, Request and Response, which no feature flag names on their own — see the class remarks.
+        WebApiRegistration.InstallFetchModel(engine);
 
         // The shim's `fetch` is this and nothing else: a reader over the vendored tree, so that a suite's
         // `fetch("resources/urltestdata.json")` finds its corpus. A path the corpus does not hold is a

--- a/Jint.Tests/Wpt/WptTestRunner.cs
+++ b/Jint.Tests/Wpt/WptTestRunner.cs
@@ -394,11 +394,6 @@ public class WptTestRunner
         new("encoding/textencoder-constructor-non-utf.any.js", "Encoding argument supported for decode: ISO-2022-JP", WptDivergence.NeedsLegacyMultiByteEncodings),
         new("encoding/textencoder-constructor-non-utf.any.js", "Encoding argument supported for decode: Shift_JIS", WptDivergence.NeedsLegacyMultiByteEncodings),
         new("encoding/textencoder-constructor-non-utf.any.js", "Encoding argument supported for decode: gb18030", WptDivergence.NeedsLegacyMultiByteEncodings),
-        // ---------------------------------------------------------------- url
-        // The second half of the urlencoded parser suite feeds the same corpus through Request.formData()
-        // and Response.formData(); the URLSearchParams half of every row passes.
-        new("url/urlencoded-parser.any.js", "request.formData() with input: *", WptDivergence.NeedsFetchObjectModel),
-        new("url/urlencoded-parser.any.js", "response.formData() with input: *", WptDivergence.NeedsFetchObjectModel),
 
         // ---------------------------------------------------------------- encoding
         // common/sab.js takes its SharedArrayBuffer constructor from WebAssembly.Memory. Note that

--- a/Jint/WebApi/Fetch/FetchBodyObject.cs
+++ b/Jint/WebApi/Fetch/FetchBodyObject.cs
@@ -616,6 +616,15 @@ internal static class FetchBody
 
         if (mimeType is not null && string.Equals(mimeType.Essence, FormUrlEncodedEssence, StringComparison.Ordinal))
         {
+            // The essence alone decides, so every parameter is ignored — including the `charset` the two
+            // legacy forms carry (`charset=windows-1252`, `charset=shift_jis`). The parser is UTF-8 only,
+            // which is the only conforming encoding; see FormUrlEncoded's own remarks.
+            //
+            // "If entries is failure, then throw a TypeError" has no reachable arm here:
+            // https://url.spec.whatwg.org/#concept-urlencoded-parser has no failure step at all — it splits
+            // on 0x26 (&), then on the first 0x3D (=), and percent-decodes what is left, so every byte
+            // sequence is a parse. An ill-formed UTF-8 run becomes U+FFFD rather than a failure, and a
+            // stray 0x25 (%) that begins no escape is kept verbatim.
             return BuildFormData(engine, realm, FormUrlEncoded.Parse(bytes.ToArray()));
         }
 

--- a/Jint/WebApi/Url/Parsing/FormUrlEncoded.cs
+++ b/Jint/WebApi/Url/Parsing/FormUrlEncoded.cs
@@ -35,6 +35,13 @@ internal static class FormUrlEncoded
     /// https://url.spec.whatwg.org/#concept-urlencoded-parser — the byte-sequence parser the string parser
     /// above is defined in terms of, and what a request body reaches directly.
     /// </summary>
+    /// <remarks>
+    /// <b>It cannot fail</b>, which is why it returns a list rather than a list-or-failure. The algorithm
+    /// splits on 0x26 (&amp;), then on the first 0x3D (=), and percent-decodes what is left; none of those
+    /// steps has a failure arm, an ill-formed UTF-8 run decodes to U+FFFD and a stray 0x25 (%) that begins
+    /// no escape is kept verbatim. Callers written against a specification that says "if entries is failure,
+    /// then throw a TypeError" — <c>formData()</c> is the one — therefore have nothing to test.
+    /// </remarks>
     internal static List<FormUrlEncodedEntry> Parse(byte[] bytes)
     {
         var output = new List<FormUrlEncodedEntry>();


### PR DESCRIPTION
Turns the 70 `formData()` rows of `url/urlencoded-parser.any.js` green and deletes the WPT table's two oldest non-crypto exclusions - by correcting the record rather than writing a parser.

Closes #3200.

**The issue's premise was wrong, and the proof came first**: `request.formData()`/`response.formData()` have parsed urlencoded bodies since the multipart work - `FetchBody.ParseFormData` matches the MIME essence and hands the bytes to `URLSearchParams`' own parser, pinned since #3145. What the two exclusions actually recorded is that the WPT *driver's* engine - `WebApiFeatures.Default` - carries no fetch object model, so the rows died on `ReferenceError: Request`. All 70 pass unmodified the moment the engine has one, measured before a line of production code was written.

The change is therefore the driver: `WptHarness.BuildEngine` installs the fetch object model through the same internal door `Engine.Advanced.SetFetchHandler` opens publicly (`Headers`/`Request`/`Response`, pointedly not `fetch`), documented in the class remarks. The alternatives were weighed and declined in the review notes: `Default | CacheApi` drags three unrelated globals in, and a new `FetchObjectModel` flag mid-campaign invites a silent bit collision - if a public door is wanted later, the flag is the right shape and the driver line becomes one word. Both exclusions and the now-empty `NeedsFetchObjectModel` category are deleted; removing the install turns the file red with 70 failures, so the deletion is driver-enforced, not decorative.

Seven new facts pin the parser's edges from the fetch side (plus-as-space, percent-decode order, essence-only matching with parameters ignored, no-equals tuples, empty-sequence skipping, arbitrary-bytes-never-fail with the BOM kept per the parser's "decode without BOM" step - the corpus row and the new pin are two witnesses to the same reading), and the existing urlencoded fact moved beside them so each file is one arm. 8/8 mutants killed, several by corpus and pins independently. Engine diff is comments only - every probed edge was already spec-correct.

Full matrix green on both TFMs including host-contract-verification legs; the whole Wpt filter holds at ~49 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014n5uCpi2vvHWBSiewUwBiY
