### PR TITLE
Tests: take the wall clock out of the concurrency-admission hand-offs

### DIFF
--- a/Jint.Tests.PublicInterface/HostEngineConcurrencyTests.cs
+++ b/Jint.Tests.PublicInterface/HostEngineConcurrencyTests.cs
@@ -1,17 +1,69 @@
 #nullable enable
 
+using System.Diagnostics;
 using Jint.Native;
 using Jint.Runtime;
 using Jint.Runtime.Debugger;
 using Jint.Runtime.Modules;
+using Xunit.Sdk;
 
 using Module = Jint.Runtime.Modules.Module;
 
 namespace Jint.Tests.PublicInterface;
 
+/// <summary>
+/// The engine's one-operation-at-a-time contract, from the outside: which public entries a second thread
+/// is refused, which authorized hand-offs it is granted, and that a refusal leaves the engine usable.
+/// </summary>
+/// <remarks>
+/// Every test here needs one thread parked inside the engine while another tries to enter, and none of
+/// them measures how long that takes. So the thread doing the parking is one the test starts itself, and
+/// the wait for it is released by a signal rather than by a clock — see <see cref="StartOwningThread"/>
+/// and <see cref="WaitUntilOwned"/>, and <see cref="HandoffCeiling"/> for the one clock left.
+/// </remarks>
 public class HostEngineConcurrencyTests
 {
     private const string ConcurrentUseMessage = "*already in use by another thread or has an asynchronous operation in progress*";
+
+    /// <summary>
+    /// Reached only by a genuine wedge. Every wait in this class is released by a thread the test owns, so
+    /// no amount of runner load can lose the race and only a hang can spend two minutes here.
+    /// </summary>
+    private static readonly TimeSpan HandoffCeiling = TimeSpan.FromMinutes(2);
+
+    /// <summary>
+    /// Runs the call that takes the engine and parks inside <c>block()</c> on a thread of the test's own.
+    /// Deliberately not <c>Task.Run</c>: this body occupies its thread for as long as the test keeps it
+    /// blocked, and a saturated thread pool injects a worker at roughly one per 500 ms — which is what
+    /// turned "has the other thread entered the engine yet" into a wall-clock race the ten-second budget
+    /// could lose on a loaded runner (sebastienros/jint#3201).
+    /// </summary>
+    private static Task StartOwningThread(Action body) => DedicatedThread.RunAsync(body);
+
+    /// <summary>
+    /// Waits until <paramref name="running"/> is provably parked inside <c>block()</c>, which is when the
+    /// engine is genuinely owned by that thread and the assertions below mean what they say. It ends on
+    /// the signal, on that thread finishing without ever reaching <c>block()</c> — reporting whatever
+    /// stopped it rather than a timeout — or on <see cref="HandoffCeiling"/>.
+    /// </summary>
+    private static async Task WaitUntilOwned(ManualResetEventSlim entered, Task running)
+    {
+        var elapsed = Stopwatch.StartNew();
+        while (!entered.Wait(TimeSpan.FromMilliseconds(20)))
+        {
+            if (running.IsCompleted)
+            {
+                // Rethrows the owning thread's own exception, with its stack, when it had one.
+                await running;
+                throw new XunitException("the owning call returned without ever entering block()");
+            }
+
+            if (elapsed.Elapsed > HandoffCeiling)
+            {
+                throw new XunitException($"the owning thread did not enter block() within {HandoffCeiling}");
+            }
+        }
+    }
 
     [Fact]
     public async Task ConcurrentExecuteIsRejectedAndTheEngineRecovers()
@@ -19,9 +71,9 @@ public class HostEngineConcurrencyTests
         using var entered = new ManualResetEventSlim();
         using var release = new ManualResetEventSlim();
         var engine = CreateBlockingEngine(entered, release);
-        var running = Task.Run(() => engine.Execute("block()"));
+        var running = StartOwningThread(() => engine.Execute("block()"));
 
-        entered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+        await WaitUntilOwned(entered, running);
         try
         {
             Invoking(() => engine.Execute("globalThis.concurrent = true"))
@@ -44,9 +96,9 @@ public class HostEngineConcurrencyTests
         using var entered = new ManualResetEventSlim();
         using var release = new ManualResetEventSlim();
         var engine = CreateBlockingEngine(entered, release);
-        var running = Task.Run(() => engine.Evaluate("block()"));
+        var running = StartOwningThread(() => engine.Evaluate("block()"));
 
-        entered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+        await WaitUntilOwned(entered, running);
         try
         {
             Invoking(() => engine.Evaluate("40 + 2"))
@@ -68,9 +120,9 @@ public class HostEngineConcurrencyTests
         using var release = new ManualResetEventSlim();
         var engine = CreateBlockingEngine(entered, release);
         engine.Execute("function waitForHost() { return block(); }");
-        var running = Task.Run(() => engine.Invoke("waitForHost"));
+        var running = StartOwningThread(() => engine.Invoke("waitForHost"));
 
-        entered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+        await WaitUntilOwned(entered, running);
         try
         {
             Invoking(() => engine.Invoke("waitForHost"))
@@ -91,9 +143,9 @@ public class HostEngineConcurrencyTests
         using var entered = new ManualResetEventSlim();
         using var release = new ManualResetEventSlim();
         var engine = CreateBlockingEngine(entered, release);
-        var running = Task.Run(() => engine.Execute("block()"));
+        var running = StartOwningThread(() => engine.Execute("block()"));
 
-        entered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+        await WaitUntilOwned(entered, running);
         try
         {
             Invoking(() => engine.SetValue("leaked", 42))
@@ -118,9 +170,9 @@ public class HostEngineConcurrencyTests
         using var entered = new ManualResetEventSlim();
         using var release = new ManualResetEventSlim();
         var engine = CreateBlockingEngine(entered, release);
-        var running = Task.Run(() => engine.Execute("block(); globalThis.finished = true"));
+        var running = StartOwningThread(() => engine.Execute("block(); globalThis.finished = true"));
 
-        entered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+        await WaitUntilOwned(entered, running);
         try
         {
             Action concurrent = () => _ = engine.EvaluateAsync("1");
@@ -390,9 +442,9 @@ public class HostEngineConcurrencyTests
         var engine = CreateBlockingEngine(entered, release);
         engine.SetValue("capture", new Action<Func<JsValue, JsValue[], JsValue>>(value => callback = value));
         engine.Execute("capture(() => 42)");
-        var running = Task.Run(() => engine.Execute("block()"));
+        var running = StartOwningThread(() => engine.Execute("block()"));
 
-        entered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+        await WaitUntilOwned(entered, running);
         try
         {
             Invoking(() => callback!(JsValue.Undefined, []))
@@ -421,9 +473,9 @@ public class HostEngineConcurrencyTests
         engineB.SetValue("capture", new Action<Func<int>>(value => callbackB = value));
         engineA.Execute(prepared);
         engineB.Execute(prepared);
-        var running = Task.Run(() => engineA.Execute("block()"));
+        var running = StartOwningThread(() => engineA.Execute("block()"));
 
-        entered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+        await WaitUntilOwned(entered, running);
         try
         {
             callbackB!().Should().Be(42);
@@ -448,11 +500,11 @@ public class HostEngineConcurrencyTests
         engine.SetValue("block", new Action(() =>
         {
             entered.Set();
-            release.Wait();
+            release.Wait(HandoffCeiling);
         }));
-        var running = Task.Run(() => engine.Execute("block()"));
+        var running = StartOwningThread(() => engine.Execute("block()"));
 
-        entered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+        await WaitUntilOwned(entered, running);
         try
         {
             Invoking(() => engine.Debugger.Evaluate("1"))
@@ -476,11 +528,11 @@ public class HostEngineConcurrencyTests
         engine.SetValue("block", new Action(() =>
         {
             entered.Set();
-            release.Wait();
+            release.Wait(HandoffCeiling);
         }));
-        var running = Task.Run(() => engine.Execute("block()"));
+        var running = StartOwningThread(() => engine.Execute("block()"));
 
-        entered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+        await WaitUntilOwned(entered, running);
         try
         {
             engine.Debugger.BreakPoints.Set(new BreakPoint(1, 0));
@@ -521,13 +573,13 @@ public class HostEngineConcurrencyTests
         engine.SetValue("block", new Action(() =>
         {
             entered.Set();
-            release.Wait();
+            release.Wait(HandoffCeiling);
         }));
         var operation = engine.Modules.StartImport("module");
         loader.Completion!.SetSource("block(); export const value = 42;");
-        var running = Task.Run(engine.Advanced.ProcessTasks);
+        var running = StartOwningThread(engine.Advanced.ProcessTasks);
 
-        entered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+        await WaitUntilOwned(entered, running);
         try
         {
             Invoking(() => _ = operation.IsCompleted)
@@ -549,7 +601,7 @@ public class HostEngineConcurrencyTests
         engine.SetValue("block", new Action(() =>
         {
             entered.Set();
-            release.Wait();
+            release.Wait(HandoffCeiling);
         }));
         return engine;
     }

--- a/Jint.Tests/Runtime/AsyncTests.cs
+++ b/Jint.Tests/Runtime/AsyncTests.cs
@@ -984,6 +984,27 @@ public class AsyncTests
         asyncTestClass.StringToAppend.Should().Be("123");
     });
 
+    // The four "an async host method invokes a JavaScript callback" tests — these two, and the ValueTask
+    // pair under the !NETFRAMEWORK guard below — are what sebastienros/jint#3201 saw fail on net472 with
+    // "This Engine is already in use by another thread". Nothing here is racing the engine, and nothing
+    // here can fix it: the mechanism is in the engine's callback admission and is recorded as such.
+    //
+    // DelegateWrapper.Invoke reserves the engine (Engine.SuspendHostCallForCallbacks) around a host call
+    // that was handed a JavaScript callback, precisely so the host may dispatch that callback to another
+    // thread. An `async` host method returns at its first await, which disposes that reservation, so by
+    // the time the continuation calls the callback Engine._asyncOwner is null again. The authorized
+    // callback then takes EnterTransferredHostCallback's `owner is null` branch, which falls through to
+    // EnterHostCall() — fail-fast for any thread that is not the owner. Whether the owner thread has yet
+    // reached the drain's own reservation (the WaitForWork inside DrainEventLoopUntil, the only other
+    // place it is held) is a scheduling coin flip. README.md's Thread-safety section and THREAT_MODEL.md
+    // TM-13 both promise the opposite for an authorized callback — "such an authorized transfer may wait
+    // for the current callback turn" — and the waiting primitive (AcquireHostCall) already exists, on the
+    // branch this one never reaches.
+    //
+    // Measured at 18 failures in 3000 serial runs (0.6%) of the shape below on an idle 16-core machine,
+    // every one of them an authorized callback. Left alone deliberately: lengthening the delay before the
+    // callback would only move the race, and asserting less would stop these tests pinning the
+    // task-callback path at all.
     [Fact]
     public Task ShouldCompleteWithAsyncTaskCallbacks() => DedicatedThread.RunAsync(() =>
     {

--- a/Jint.Tests/Runtime/EngineConcurrencyTests.cs
+++ b/Jint.Tests/Runtime/EngineConcurrencyTests.cs
@@ -1,7 +1,35 @@
+using System.Diagnostics;
+using Xunit.Sdk;
+
 namespace Jint.Tests.Runtime;
 
+/// <summary>
+/// What an engine does with a manual-promise completion that arrives from a thread other than the one
+/// using it: it enqueues, and it drains inline only when the settling thread can claim the engine.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Nothing here measures latency, so nothing here may be written as a wall-clock window. Every wait
+/// below ends on a signal raised by a thread the test started itself, and the only clock left is
+/// <see cref="HandoffCeiling"/> — a ceiling a wedge reports at instead of hanging CI, never a budget
+/// the hand-off has to beat.
+/// </para>
+/// <para>
+/// The blocked side runs on <see cref="DedicatedThread"/> rather than <c>Task.Run</c> for the same
+/// reason: its body occupies its thread until the test releases it, and a thread-pool worker that a
+/// saturated pool injects at roughly one per 500 ms turned "has the other thread entered the engine
+/// yet" into a race a fixed budget could lose. That is the flake this class was reported for
+/// (sebastienros/jint#3201, seen on net472 as "Expected boolean to be True").
+/// </para>
+/// </remarks>
 public class EngineConcurrencyTests
 {
+    /// <summary>
+    /// Reached only by a genuine wedge: every wait here is released by a thread the test owns, so a
+    /// second is already absurd and two minutes cannot be lost to load.
+    /// </summary>
+    private static readonly TimeSpan HandoffCeiling = TimeSpan.FromMinutes(2);
+
     [Fact]
     public async Task ConcurrentManualPromiseCompletionOnlyEnqueuesWork()
     {
@@ -15,18 +43,37 @@ public class EngineConcurrencyTests
         engine.SetValue("block", new Action(() =>
         {
             entered.Set();
-            release.Wait();
+            release.Wait(HandoffCeiling);
         }));
         engine.Execute("hostPromise.then(markContinued);");
 
-        var running = Task.Run(() => engine.Execute("block()"));
-        entered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
-        promise.Resolve(42);
-        Volatile.Read(ref continued).Should().BeFalse();
+        var running = DedicatedThread.RunAsync(() => engine.Execute("block()"));
 
-        release.Set();
+        try
+        {
+            await WaitUntilBlockedInsideTheEngine(entered, running);
+
+            // The engine belongs to the other thread, which is parked inside block(). A completion
+            // arriving here may only enqueue: draining it would run markContinued on THIS thread,
+            // concurrently with the script the other thread is in the middle of.
+            promise.Resolve(42);
+            Volatile.Read(ref continued).Should().BeFalse(
+                "a completion arriving from another thread may only enqueue while the engine is in use");
+        }
+        finally
+        {
+            // Unblock the engine thread whatever happened above, so a failure reports instead of
+            // leaving a thread parked on an event this method is about to dispose.
+            release.Set();
+        }
+
         await running;
-        Volatile.Read(ref continued).Should().BeTrue();
+
+        // Execute drains the loop on its way out, so the enqueued reaction has run by the time the
+        // owning thread's Execute has returned. No polling and no window: this is the same thread
+        // that was refused the inline drain above, now doing it at its own turn.
+        Volatile.Read(ref continued).Should().BeTrue(
+            "the enqueued reaction runs when the thread that owns the engine next drains");
     }
 
     [Fact]
@@ -37,9 +84,12 @@ public class EngineConcurrencyTests
         engine.SetValue("hostPromise", promise.Promise);
         engine.Execute("globalThis.result = 0; hostPromise.then(value => { result = value; });");
 
+        // The mirror image of the test above: Execute has returned, so no thread owns the engine and the
+        // settling thread claims it and drains inline. A thread of the test's own with a Join, never a
+        // pool hop — the Join is what puts the drain before the assertion with no window in between.
         var thread = new Thread(() => promise.Resolve(42));
         thread.Start();
-        thread.Join();
+        thread.Join(HandoffCeiling).Should().BeTrue("the settling thread must not still be running");
 
         engine.GetValue("result").AsNumber().Should().Be(42);
     }
@@ -55,5 +105,30 @@ public class EngineConcurrencyTests
         promise.Resolve(42);
 
         engine.GetValue("result").AsNumber().Should().Be(42);
+    }
+
+    /// <summary>
+    /// Waits until the engine thread is provably parked inside <c>block()</c>. It ends on one of three
+    /// things, and only the last of them is a clock: the signal, the engine thread finishing without
+    /// ever reaching <c>block()</c> — which surfaces whatever stopped it rather than reporting a
+    /// timeout — or <see cref="HandoffCeiling"/>.
+    /// </summary>
+    private static async Task WaitUntilBlockedInsideTheEngine(ManualResetEventSlim entered, Task running)
+    {
+        var elapsed = Stopwatch.StartNew();
+        while (!entered.Wait(TimeSpan.FromMilliseconds(20)))
+        {
+            if (running.IsCompleted)
+            {
+                // Rethrows the engine thread's own exception with its stack when it had one.
+                await running;
+                throw new XunitException("""engine.Execute("block()") returned without ever entering block()""");
+            }
+
+            if (elapsed.Elapsed > HandoffCeiling)
+            {
+                throw new XunitException($"the engine thread did not enter block() within {HandoffCeiling}");
+            }
+        }
     }
 }

--- a/Jint.Tests/Runtime/WebApi/EventSourceTests.cs
+++ b/Jint.Tests/Runtime/WebApi/EventSourceTests.cs
@@ -32,6 +32,17 @@ public class EventSourceTests
     private const string StreamUrl = "https://example.org/stream";
 
     /// <summary>
+    /// How long a test will wait for a signal raised by a thread-pool continuation — a cancelled read
+    /// resuming, a handler seeing its token fire. The claim being made is that the signal happens at all,
+    /// never how quickly, so this is a ceiling only a genuine failure to propagate can reach. It is
+    /// deliberately far past any plausible scheduling delay: a loaded runner injects pool workers at
+    /// roughly one per 500 ms once saturated, which is what made a five-second window a flake
+    /// (sebastienros/jint#3201) rather than a check. The test that waits on one also hands its body to
+    /// <see cref="DedicatedThread.RunAsync"/>, so it is not itself holding a worker the continuation needs.
+    /// </summary>
+    private static readonly TimeSpan TransportSignalCeiling = TimeSpan.FromMinutes(2);
+
+    /// <summary>
     /// A clock that only moves when a test moves it, so the reconnect delay is exact and instant.
     /// </summary>
     private sealed class ManualClock : TimeProvider
@@ -438,7 +449,7 @@ public class EventSourceTests
     }
 
     [Fact]
-    public void CloseStopsEverythingAndDispatchesNothingFurther()
+    public Task CloseStopsEverythingAndDispatchesNothingFurther() => DedicatedThread.RunAsync(() =>
     {
         var stream = new PushStream();
         var handler = new StubHandler { Responder = _ => Answer(stream) };
@@ -462,10 +473,11 @@ public class EventSourceTests
         engine.Evaluate("es.readyState").AsNumber().Should().Be(2);
 
         // The transport was told, not just the object: the read in flight was cancelled.
-        stream.ReadCancelled.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+        stream.ReadCancelled.Wait(TransportSignalCeiling).Should().BeTrue(
+            "closing an EventSource must cancel the read in flight, not merely mark the object CLOSED");
 
         stream.Complete();
-    }
+    });
 
     [Fact]
     public void CloseFromInsideAListenerStopsTheRestOfTheSameChunk()


### PR DESCRIPTION
Stabilizes the concurrency-admission flake cluster by removing the wall clock from every hand-off, and reports the engine finding the diagnosis surfaced — filed as #3206, deliberately not fixed here, exactly as the issue's boundary requires.

Closes #3201.

**The test-side mechanism.** The shape `Task.Run(() => engine.Execute("block()"))` + `entered.Wait(10s)` hands a saturated thread pool a worker it will not get back, and a loaded runner injects replacements at roughly one per 500 ms — so "has the other thread entered the engine yet" was a wall-clock race, which is precisely the `Expected boolean to be True` in the CI sightings. Twelve tests across `EngineConcurrencyTests` and its PublicInterface twin `HostEngineConcurrencyTests` now run the owning side on `DedicatedThread` and wait on a signal with three exits — the signal itself, the owning call completing without ever reaching `block()` (its own exception is rethrown rather than reported as a timeout), or a two-minute wedge ceiling only a genuine hang can reach. `release.Set()` moved into `finally` so a failed assertion cannot leave a thread parked on an event about to be disposed. No assertion changed in substance. `EventSourceTests`' close test gets the same treatment: it was blocking a pool worker while waiting on a pool continuation (`ReadCancelled` resumes via a channel that forbids synchronous continuations), the resource inversion `DedicatedThread` exists for.

**The engine finding (#3206).** `AsyncTests.ShouldCompleteWithAsyncTaskCallbacks`/`ShouldFromAsyncTaskCallbacks` are not racing the engine: an authorized callback arriving between an `async` host method's first `await` and the drain's own reservation is fail-fasted through `EnterTransferredHostCallback`'s fall-throughs, where README's Thread-safety section and TM-13 both say an authorized transfer may wait. Measured at 0.6% per run of the shape on an idle machine, ~1 full net472 suite run in 9 under load, with a deterministic repro; every probed rejection was of an *authorized* callback. Those two tests are left untouched apart from a comment recording the mechanism, the citations and the rate — lengthening the delay would only move the race, and asserting less would stop them pinning the task-callback path. They remain the known residual flake until #3206 is fixed.

**Mutation evidence.** Enqueue-only assertion: killed by a pre-#3035-shaped mutant (settle seizes ownership and drains inline) and by dropping the cross-thread completion. Ownership gate: un-gating `EnterHostCall`'s CAS kills 8 of the 10 hardened PublicInterface tests; the two survivors are correct and named (one pins the *allowed* breakpoint-administration path, one rejects via `ReserveAsyncHostOperation`, which the mutant does not touch). EventSource: removing `Abandon()`'s transport cancel kills the close test. One honest survivor: replacing the new wait helper with an immediate return still passes 26/26 even under 32 burner threads — the wait guards a race only a starved runner can produce, and its justification is the mechanism, not a red run.

Verification: solution build clean; `Jint.Tests` 9,768/7,049 and `Jint.Tests.PublicInterface` 2,052/1,582 green on net10.0/net472 including HCV legs; 8 consecutive full net472 runs clean; changed classes 10 rounds under CPU burners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014n5uCpi2vvHWBSiewUwBiY
