### PR TITLE
Fix/nested entry callstack trim

### DIFF
--- a/Jint.Tests.PublicInterface/CallStackTests.cs
+++ b/Jint.Tests.PublicInterface/CallStackTests.cs
@@ -107,4 +107,45 @@ b(7);
     at custom.ts:11:1".Replace("\r\n", "\n"));
     }
 
+    [Fact]
+    public void NestedEvaluationUnhandledThrowShouldNotClearOuterRunCallStack()
+    {
+        // A host callback invoked from a running script re-enters the engine with
+        // Engine.Execute (the browser-host "dynamically inserted <script>" shape) and
+        // contains that nested script's unhandled throw. The outer run is still live:
+        // its call-stack frames must survive, so stack traces captured by the outer
+        // script afterwards are complete and the outer run's pops stay balanced.
+        var engine = new Engine();
+
+        string nestedThrowMessageObservedByHost = null;
+        engine.SetValue("runNestedScriptContained", () =>
+        {
+            try
+            {
+                engine.Execute("throw new Error('nested failure');");
+            }
+            catch (JavaScriptException nestedScriptException)
+            {
+                nestedThrowMessageObservedByHost = nestedScriptException.Message;
+            }
+        });
+
+        engine.Execute("""
+            function makeProbeError() {
+                // 'new' exercises Construct's call-stack push/pop after the nested throw
+                return new Error('outer probe');
+            }
+            function outerFunction() {
+                runNestedScriptContained();
+                return makeProbeError().stack;
+            }
+            globalThis.outerStackAfterNestedFailure = outerFunction();
+            """);
+
+        nestedThrowMessageObservedByHost.Should().Be("nested failure");
+
+        var outerStack = engine.Evaluate("outerStackAfterNestedFailure").AsString();
+        outerStack.Should().Contain("at makeProbeError");
+        outerStack.Should().Contain("at outerFunction");
+    }
 }

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1416,6 +1416,13 @@ public sealed partial class Engine : IDisposable
             strict: _isStrict || scriptRecord.EcmaScriptCode.Strict);
 
         EnterExecutionContext(in scriptContext);
+
+        // Depth of the call stack when THIS evaluation began. A nested evaluation (a host callback
+        // inside a running script calling Execute/Evaluate) sits above live frames belonging to the
+        // outer run; an unhandled throw here must unwind only the frames this evaluation pushed,
+        // not clear the whole stack (which desynced the outer run's balanced pops and truncated its
+        // subsequently captured stack traces).
+        var callStackDepthOnEntry = CallStack.Count;
         try
         {
             var script = scriptRecord.EcmaScriptCode;
@@ -1436,14 +1443,14 @@ public sealed partial class Engine : IDisposable
             catch
             {
                 // unhandled exception
-                ResetCallStack();
+                CallStack.TrimTo(callStackDepthOnEntry);
                 throw;
             }
 
             if (result.Type == CompletionType.Throw)
             {
                 var ex = new JavaScriptException(result.GetValueOrDefault()).SetJavaScriptCallstack(this, result.Location);
-                ResetCallStack();
+                CallStack.TrimTo(callStackDepthOnEntry);
                 throw ex;
             }
 

--- a/Jint/Runtime/CallStack/JintCallStack.cs
+++ b/Jint/Runtime/CallStack/JintCallStack.cs
@@ -238,6 +238,22 @@ internal sealed class JintCallStack
         _profiler?.RecordAbandon();
     }
 
+    /// <summary>
+    /// Pops frames until only <paramref name="targetDepth"/> remain. Used when an unhandled throw
+    /// unwinds a nested script evaluation (a host callback re-entering the engine mid-run): only the
+    /// frames that evaluation pushed are discarded, so an OUTER still-live run keeps its frames \u2014
+    /// its stack traces stay intact and its balanced pops stay balanced. Popping (rather than
+    /// clearing) also keeps the recursion-depth statistics and the profiler's enter/exit stream
+    /// consistent. A no-op when the stack is already at or below <paramref name="targetDepth"/>.
+    /// </summary>
+    internal void TrimTo(int targetDepth)
+    {
+        while (_stack._size > targetDepth)
+        {
+            Pop();
+        }
+    }
+
     public override string ToString()
     {
         return string.Join("->", _stack.Select(static cse => cse.ToString()).Reverse());


### PR DESCRIPTION
## Summary

Prevent a nested Engine.Execute() that throws an exception from destroying (clearing) the parent-call stack, by trimming only back to the evaluation entry depth on unhandled throw.

## Details

When a host callback re-enters the engine mid-run (e.g. `Engine.Execute` for a dynamically-inserted script) and that nested evaluation ends in an unhandled throw, `ScriptEvaluation` called `ResetCallStack()` — clearing ALL frames, including those of the still-live outer run. Consequences:

- The outer run's balanced pops desync (formerly a `"stack is empty"` crash in `Construct`; now silently tolerated by the `TryPop` guards — the existing `// if call stack was reset due to recursive call to engine or similar` comments acknowledge this).
- `Error`s constructed by the outer script afterwards capture truncated/empty `stack` traces.

Fix: capture `CallStack.Count` at `ScriptEvaluation` entry and, on the unhandled-throw paths, pop down to that depth via a new `JintCallStack.TrimTo(int)`. Popping (vs. clearing) keeps the recursion-depth statistics and the profiler's enter/exit stream balanced. `Advanced.ResetCallStack()` is unchanged.

Reviewers: the two `ResetCallStack()` → `TrimTo(...)` replacements in `ScriptEvaluation` are the behavioral change; at a top-level entry the entry depth is 0, so `TrimTo` is equivalent to the old `Clear()`.

## Linked issue

(issue not opened)

## Test plan

- Unit test added (failed on old code, passes on new)
- Validated downstream in a browser-style host: nested inserted-script failures during real-page loads (e.g. google.com) no longer corrupt the outer run, and a 314-test visual regression suite shows 0 changes.

## Breaking change?

No. Internal-only; public API unchanged. Observable effect: outer-run `error.stack` is no longer truncated after a nested evaluation's unhandled throw.