### PR TITLE
Web streams: transfer a ReadableStream, a WritableStream or a TransformStream

### DIFF
--- a/Jint.Tests.PublicInterface/WebApiTransferableStreamTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiTransferableStreamTests.cs
@@ -1,0 +1,517 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.Threading;
+using Jint;
+using Jint.WebApi;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// A <c>ReadableStream</c>, a <c>WritableStream</c> or a <c>TransformStream</c> handed from one
+/// <see cref="Engine"/> to another over a <c>MessagePort</c> —
+/// https://streams.spec.whatwg.org/#transferrable-streams, seen from outside the assembly.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This project has no <c>InternalsVisibleTo</c>, so everything here is reachable by a third party: two
+/// engines connected with <c>Engine.Advanced.CreateMessagePortPair</c>, a stream named in a
+/// <c>postMessage</c> transfer list, and <c>Advanced.ProcessTasks()</c> on each in turn.
+/// </para>
+/// <para>
+/// <b>Both engines have to be pumped, and neither ever runs on the other's thread.</b> A transferred stream
+/// is a pipe on the sender feeding a channel, so a chunk costs a round trip: the receiver's read posts a
+/// <c>pull</c>, the sender's next pump answers it with a <c>chunk</c>, and the receiver's pump after that
+/// delivers it. Pumping alternately is what a host with its own loop does, and it is what makes the ordering
+/// assertions here mean something — two threads would test the operating system's scheduler instead.
+/// </para>
+/// </remarks>
+public class WebApiTransferableStreamTests
+{
+    private static Engine TransferEngine() => new(options => options.UseWebApis(
+        WebApiFeatures.Streams | WebApiFeatures.Messaging | WebApiFeatures.StructuredClone));
+
+    /// <summary>Two engines with an entangled port each, and a <c>log</c> array on both.</summary>
+    private static (Engine Host, Engine Worker) ConnectedPair()
+    {
+        var host = TransferEngine();
+        var worker = TransferEngine();
+
+        var pair = host.Advanced.CreateMessagePortPair(worker);
+        host.SetValue("port", pair.Local);
+        worker.SetValue("port", pair.Remote);
+
+        foreach (var engine in new[] { host, worker })
+        {
+            engine.Execute("var log = [];");
+            engine.Execute("""
+                function drain(stream, tag) {
+                  return (async function () {
+                    var reader = stream.getReader();
+                    try {
+                      for (;;) {
+                        var r = await reader.read();
+                        if (r.done) { log.push(tag + ':done'); return; }
+                        log.push(tag + ':' + r.value);
+                      }
+                    } catch (e) {
+                      log.push(tag + '!' + (e && e.name));
+                    }
+                  })();
+                }
+                """);
+        }
+
+        return (host, worker);
+    }
+
+    private static string Log(Engine engine) => engine.Evaluate("log.join(',')").AsString();
+
+    /// <summary>
+    /// Reads the log without running any script, which is the only honest way to ask an engine whether it has
+    /// received something: <c>Evaluate</c> drains the event loop once the script it ran has finished, so
+    /// asking in script is itself enough to make the answer yes.
+    /// </summary>
+    private static int LogLength(Engine engine) => (int) engine.GetValue("log").Get("length").AsNumber();
+
+    /// <summary>Pumps each engine <paramref name="rounds"/> times in turn, without running any script.</summary>
+    private static void PumpBoth(Engine host, Engine worker, int rounds)
+    {
+        for (var i = 0; i < rounds; i++)
+        {
+            host.Advanced.ProcessTasks();
+            worker.Advanced.ProcessTasks();
+        }
+    }
+
+    // ---------------------------------------------------------------- a ReadableStream across engines
+
+    [Fact]
+    public void AReadableStreamTransferredToAnotherEngineDeliversItsChunksThere()
+    {
+        var (host, worker) = ConnectedPair();
+
+        worker.Execute("port.onmessage = function (e) { drain(e.data, 'got'); };");
+
+        host.Execute("""
+            var rs = new ReadableStream({ start(c) { c.enqueue('a'); c.enqueue('b'); c.close(); } });
+            port.postMessage(rs, [rs]);
+            """);
+
+        // The transfer happened on the sender the moment postMessage returned; nothing has been delivered.
+        host.Evaluate("rs.locked").AsBoolean().Should().BeTrue();
+        Log(worker).Should().Be("");
+
+        PumpBoth(host, worker, 8);
+
+        worker.Evaluate("log.join(',')").AsString().Should().Be("got:a,got:b,got:done");
+    }
+
+    [Fact]
+    public void TheStreamArrivesAsAReadableStreamOfTheReceivingRealm()
+    {
+        var (host, worker) = ConnectedPair();
+
+        worker.Execute("var arrived = null; var portCount = -1; port.onmessage = function (e) { arrived = e.data; portCount = e.ports.length; };");
+        host.Execute("var rs = new ReadableStream(); port.postMessage(rs, [rs]);");
+
+        worker.Advanced.ProcessTasks();
+
+        worker.Evaluate("arrived instanceof ReadableStream").AsBoolean().Should().BeTrue();
+        worker.Evaluate("Object.getPrototypeOf(arrived) === ReadableStream.prototype").AsBoolean().Should().BeTrue();
+        worker.Evaluate("arrived.locked").AsBoolean().Should().BeFalse();
+
+        // event.ports carries the caller's ports and not the channel the stream created for itself, which no
+        // script on either engine can ever name.
+        worker.Evaluate("portCount").AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void NothingCrossesToAnEngineThatIsNeverPumped()
+    {
+        var (host, worker) = ConnectedPair();
+
+        worker.Execute("port.onmessage = function (e) { drain(e.data, 'got'); };");
+        host.Execute("""
+            var rs = new ReadableStream({ start(c) { c.enqueue('a'); c.close(); } });
+            port.postMessage(rs, [rs]);
+            """);
+
+        // Jint starts no threads, so the same contract a MessagePort carries applies to what rides one. The
+        // observation has to be a non-pumping one, which is what LogLength is for.
+        for (var i = 0; i < 5; i++)
+        {
+            host.Advanced.ProcessTasks();
+        }
+
+        LogLength(worker).Should().Be(0);
+        Thread.Sleep(50);
+        LogLength(worker).Should().Be(0);
+
+        PumpBoth(host, worker, 8);
+        Log(worker).Should().Be("got:a,got:done");
+    }
+
+    [Fact]
+    public void ChunksAreClonesOfTheReceivingRealmRatherThanSharedObjects()
+    {
+        var (host, worker) = ConnectedPair();
+
+        worker.Execute("var seen = []; port.onmessage = function (e) { drainInto(e.data); };");
+        worker.Execute("""
+            function drainInto(stream) {
+              (async function () {
+                var reader = stream.getReader();
+                for (;;) {
+                  var r = await reader.read();
+                  if (r.done) { return; }
+                  seen.push(r.value);
+                }
+              })();
+            }
+            """);
+
+        host.Execute("""
+            var rs = new ReadableStream({ start(c) { c.enqueue(new Map([['k', { n: 1 }]])); c.close(); } });
+            port.postMessage(rs, [rs]);
+            """);
+
+        PumpBoth(host, worker, 8);
+
+        worker.Evaluate("seen.length").AsNumber().Should().Be(1);
+        worker.Evaluate("seen[0] instanceof Map").AsBoolean().Should().BeTrue();
+        worker.Evaluate("seen[0].get('k').n").AsNumber().Should().Be(1);
+        worker.Evaluate("Object.getPrototypeOf(seen[0]) === Map.prototype").AsBoolean().Should().BeTrue();
+    }
+
+    // ---------------------------------------------------------------- backpressure across the boundary
+
+    [Fact]
+    public void TheSendingEngineDoesNotRunAheadOfTheReceivingOne()
+    {
+        var (host, worker) = ConnectedPair();
+
+        // A source with a large supply. Without backpressure it would be drained into the channel as fast as
+        // the sender is pumped, whatever the receiver did. Capped rather than endless so that a loss of
+        // backpressure fails an assertion instead of hanging the suite.
+        host.Execute("""
+            var produced = 0;
+            var rs = new ReadableStream({
+              pull(c) { if (produced >= 200) { c.close(); return; } c.enqueue('c' + produced++); }
+            });
+            port.postMessage(rs, [rs]);
+            """);
+
+        worker.Execute("var arrived = null; port.onmessage = function (e) { arrived = e.data; };");
+        worker.Advanced.ProcessTasks();
+
+        // Nobody has read yet, so the receiving side's high water mark of 0 has never asked for anything: the
+        // sender is parked with at most a couple of chunks in hand.
+        for (var i = 0; i < 20; i++)
+        {
+            host.Advanced.ProcessTasks();
+        }
+
+        var parked = host.Evaluate("produced").AsNumber();
+        parked.Should().BeLessThanOrEqualTo(3);
+
+        // One read releases a bounded amount of further production rather than the whole source.
+        worker.Execute("var reader = arrived.getReader(); reader.read().then(function (r) { log.push(r.value); });");
+        PumpBoth(host, worker, 6);
+
+        Log(worker).Should().Be("c0");
+        host.Evaluate("produced").AsNumber().Should().BeLessThanOrEqualTo(parked + 2);
+
+        worker.Execute("reader.read().then(function (r) { log.push(r.value); });");
+        PumpBoth(host, worker, 6);
+
+        Log(worker).Should().Be("c0,c1");
+    }
+
+    // ---------------------------------------------------------------- errors and closing, both directions
+
+    [Fact]
+    public void AnErrorOnTheSendingSideReachesTheReceivingStream()
+    {
+        var (host, worker) = ConnectedPair();
+
+        worker.Execute("""
+            port.onmessage = function (e) {
+              e.data.getReader().read().then(
+                function () { log.push('resolved'); },
+                function (err) { log.push('rejected:' + err.name + ':' + err.message); });
+            };
+            """);
+
+        host.Execute("""
+            var controller;
+            var rs = new ReadableStream({ start(c) { controller = c; } });
+            port.postMessage(rs, [rs]);
+            """);
+
+        PumpBoth(host, worker, 4);
+        Log(worker).Should().Be("");
+
+        host.Execute("controller.error(new RangeError('the source failed'));");
+        PumpBoth(host, worker, 4);
+
+        // The reason is structured-cloned, so the receiver gets an error of its own realm carrying the same
+        // name and message.
+        Log(worker).Should().Be("rejected:RangeError:the source failed");
+    }
+
+    [Fact]
+    public void CancellingOnTheReceivingSideCancelsTheSourceOnTheSendingSide()
+    {
+        var (host, worker) = ConnectedPair();
+
+        worker.Execute("var arrived = null; port.onmessage = function (e) { arrived = e.data; };");
+
+        host.Execute("""
+            var rs = new ReadableStream({
+              start(c) { c.enqueue('a'); },
+              cancel(reason) { log.push('source cancelled: ' + reason.message); }
+            });
+            port.postMessage(rs, [rs]);
+            """);
+
+        PumpBoth(host, worker, 4);
+        Log(host).Should().Be("");
+
+        worker.Execute("arrived.cancel(new Error('not interested'));");
+        PumpBoth(host, worker, 4);
+
+        Log(host).Should().Be("source cancelled: not interested");
+    }
+
+    [Fact]
+    public void ClosingTheSourcePropagatesForwardAcrossEngines()
+    {
+        var (host, worker) = ConnectedPair();
+
+        worker.Execute("port.onmessage = function (e) { drain(e.data, 'got'); };");
+
+        host.Execute("""
+            var controller;
+            var rs = new ReadableStream({ start(c) { controller = c; } });
+            port.postMessage(rs, [rs]);
+            """);
+
+        PumpBoth(host, worker, 4);
+        Log(worker).Should().Be("");
+
+        host.Execute("controller.enqueue('only');");
+        PumpBoth(host, worker, 4);
+        Log(worker).Should().Be("got:only");
+
+        host.Execute("controller.close();");
+        PumpBoth(host, worker, 4);
+        Log(worker).Should().Be("got:only,got:done");
+    }
+
+    [Fact]
+    public void ACloseAlreadyQueuedIsNotMistakenForALostChannel()
+    {
+        var (host, worker) = ConnectedPair();
+
+        worker.Execute("var arrived = null; port.onmessage = function (e) { arrived = e.data; };");
+
+        host.Execute("""
+            var rs = new ReadableStream({ start(c) { c.enqueue('only'); c.close(); } });
+            port.postMessage(rs, [rs]);
+            """);
+
+        worker.Advanced.ProcessTasks();
+
+        // Two reads outstanding at once, so that the *chunk*'s own dispatch leaves a read request waiting and
+        // ReadableStreamDefaultControllerEnqueue therefore pulls again on that very stack.
+        worker.Execute("""
+            var reader = arrived.getReader();
+            reader.read().then(function (r) { log.push('1:' + r.value); }, function (e) { log.push('1!' + e.name); });
+            reader.read().then(function (r) { log.push('2:' + r.value + ':' + r.done); }, function (e) { log.push('2!' + e.name); });
+            """);
+
+        // The host answers the pull, finishes the pipe and closes its end — all in one pump — so `chunk` and
+        // `close` are both on the worker's queue *and* the far side reads as gone before the worker runs
+        // again. That is the interleaving a cross-engine transfer makes reachable and a same-engine one does
+        // not, and it is what JsMessagePort.IsChannelExhausted's queue test exists for: asking only "has the
+        // far side gone" here would throw the `close` away and error a stream that is about to finish.
+        host.Advanced.ProcessTasks();
+        worker.Advanced.ProcessTasks();
+
+        Log(worker).Should().Be("1:only,2:undefined:true");
+    }
+
+    // ---------------------------------------------------------------- a WritableStream across engines
+
+    [Fact]
+    public void AWritableStreamTransferredToAnotherEngineDeliversWritesBackToItsSink()
+    {
+        var (host, worker) = ConnectedPair();
+
+        worker.Execute("""
+            var writer = null;
+            port.onmessage = function (e) { writer = e.data.getWriter(); writer.write('one'); writer.write('two'); };
+            """);
+
+        host.Execute("""
+            var ws = new WritableStream({
+              write(chunk) { log.push('wrote:' + chunk); },
+              close() { log.push('closed'); }
+            });
+            port.postMessage(ws, [ws]);
+            """);
+
+        host.Evaluate("ws.locked").AsBoolean().Should().BeTrue();
+
+        PumpBoth(host, worker, 8);
+        Log(host).Should().Be("wrote:one,wrote:two");
+
+        worker.Execute("writer.close();");
+        PumpBoth(host, worker, 8);
+        Log(host).Should().Be("wrote:one,wrote:two,closed");
+    }
+
+    // ---------------------------------------------------------------- a TransformStream across engines
+
+    [Fact]
+    public void ATransformStreamRoundTripsAcrossEngines()
+    {
+        var (host, worker) = ConnectedPair();
+
+        // The transformer stays on the host: what crosses is a writable that feeds it and a readable that
+        // drains it, each with a channel of its own.
+        worker.Execute("""
+            var writer = null;
+            port.onmessage = function (e) {
+              drain(e.data.readable, 'got');
+              writer = e.data.writable.getWriter();
+              writer.write('a');
+              writer.write('b');
+            };
+            """);
+
+        host.Execute("""
+            var ts = new TransformStream({ transform(chunk, c) { c.enqueue(chunk.toUpperCase()); } });
+            port.postMessage(ts, [ts]);
+            """);
+
+        host.Evaluate("ts.readable.locked").AsBoolean().Should().BeTrue();
+        host.Evaluate("ts.writable.locked").AsBoolean().Should().BeTrue();
+
+        PumpBoth(host, worker, 12);
+        Log(worker).Should().Be("got:A,got:B");
+
+        worker.Execute("writer.close();");
+        PumpBoth(host, worker, 12);
+        Log(worker).Should().Be("got:A,got:B,got:done");
+    }
+
+    // ---------------------------------------------------------------- what a restore does to the pipe
+
+    [Fact]
+    public void ARestoreOnTheSendingEngineEndsTheReceivingStream()
+    {
+        var (host, worker) = ConnectedPair();
+        var snapshot = host.Advanced.CaptureGlobalSnapshot();
+
+        worker.Execute("var arrived = null; port.onmessage = function (e) { arrived = e.data; };");
+
+        host.Execute("""
+            var controller;
+            var rs = new ReadableStream({ start(c) { controller = c; } });
+            port.postMessage(rs, [rs]);
+            """);
+
+        PumpBoth(host, worker, 4);
+        worker.Evaluate("arrived instanceof ReadableStream").AsBoolean().Should().BeTrue();
+
+        // The restore closes every port the host had, which is the cascade that ends the stream's channel too.
+        host.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        worker.Execute("""
+            arrived.getReader().read().then(
+              function () { log.push('resolved'); },
+              function (e) { log.push('rejected:' + e.name); });
+            """);
+
+        PumpBoth(host, worker, 4);
+
+        // Errored rather than left readable forever: the channel can never carry another chunk.
+        Log(worker).Should().Be("rejected:TypeError");
+    }
+
+    [Fact]
+    public void ARestoreOnTheReceivingEngineEndsTheSendersPipe()
+    {
+        var (host, worker) = ConnectedPair();
+        var snapshot = worker.Advanced.CaptureGlobalSnapshot();
+
+        worker.Execute("var arrived = null; port.onmessage = function (e) { arrived = e.data; arrived.getReader(); };");
+
+        host.Execute("""
+            var pulls = 0;
+            var controller;
+            var rs = new ReadableStream({
+              start(c) { controller = c; },
+              pull() { pulls++; },
+              cancel(reason) { log.push('source cancelled: ' + reason.name); }
+            });
+            port.postMessage(rs, [rs]);
+            """);
+
+        PumpBoth(host, worker, 4);
+
+        // The receiving engine's cycle ends, which closes its ports — including the one the stream travels on.
+        worker.Advanced.RestoreGlobalSnapshot(snapshot);
+
+        // The sender notices at its next write, which is the first moment it has anything to say. Until then
+        // it is parked on a read, costing nothing.
+        Log(host).Should().Be("");
+        host.Execute("controller.enqueue('too late');");
+
+        Log(host).Should().Be("source cancelled: TypeError");
+
+        // And nothing is left running against the side that has gone: the source is not pulled again however
+        // long the host is pumped.
+        var pullsAtTheEnd = host.Evaluate("pulls").AsNumber();
+        for (var i = 0; i < 5; i++)
+        {
+            host.Advanced.ProcessTasks();
+        }
+
+        host.Evaluate("pulls").AsNumber().Should().Be(pullsAtTheEnd);
+    }
+
+    [Fact]
+    public void DisposingTheReceivingEngineEndsTheSendersPipeTheSameWay()
+    {
+        var host = TransferEngine();
+        var worker = TransferEngine();
+        var pair = host.Advanced.CreateMessagePortPair(worker);
+        host.SetValue("port", pair.Local);
+        worker.SetValue("port", pair.Remote);
+
+        host.Execute("var log = [];");
+        worker.Execute("var arrived = null; port.onmessage = function (e) { arrived = e.data; arrived.getReader(); };");
+
+        host.Execute("""
+            var controller;
+            var rs = new ReadableStream({
+              start(c) { controller = c; },
+              cancel(reason) { log.push('source cancelled: ' + reason.name); }
+            });
+            port.postMessage(rs, [rs]);
+            """);
+
+        host.Advanced.ProcessTasks();
+        worker.Advanced.ProcessTasks();
+        host.Advanced.ProcessTasks();
+
+        worker.Dispose();
+
+        host.Execute("controller.enqueue('nobody there');");
+        host.Evaluate("log.join(',')").AsString().Should().Be("source cancelled: TypeError");
+    }
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/SerializationRecordTests.cs
+++ b/Jint.Tests/Runtime/WebApi/SerializationRecordTests.cs
@@ -165,6 +165,44 @@ public class SerializationRecordTests
         engine.Evaluate("moved.postMessage('inert') === undefined").AsBoolean().Should().BeTrue();
     }
 
+    [Fact]
+    public void CarriesExactlyOneChannelSideForATransferredReadableStream()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Streams));
+
+        var stream = engine.Evaluate("new ReadableStream({ start(c) { c.enqueue('a'); c.close(); } })");
+
+        var record = new StructuredSerializer(engine, engine.Realm).Serialize(stream, [stream]);
+
+        // A transferred stream is a pipe plus a channel, and only the channel travels: the record must reach
+        // exactly the one side the transfer detached and nothing else engine-affine — no ReadableStream, no
+        // controller, no promise, none of the closures the pipe on the sending side is made of.
+        var sides = new List<object>();
+        var visited = new HashSet<object>(ReferenceEqualityComparer.Instance);
+        var reached = 0;
+        Walk(record, visited, ref reached, sides);
+
+        sides.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void CarriesTwoChannelSidesForATransferredTransformStream()
+    {
+        var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Streams));
+
+        var stream = engine.Evaluate("new TransformStream()");
+
+        var record = new StructuredSerializer(engine, engine.Realm).Serialize(stream, [stream]);
+
+        // One per side, which is what makes a transform stream cost two channels — see TransferableStreams.
+        var sides = new List<object>();
+        var visited = new HashSet<object>(ReferenceEqualityComparer.Instance);
+        var reached = 0;
+        Walk(record, visited, ref reached, sides);
+
+        sides.Should().HaveCount(2);
+    }
+
     // ---------------------------------------------------------------- helpers
 
     private static bool Forbidden(Type type) => Array.Exists(_forbidden, forbidden => forbidden.IsAssignableFrom(type));

--- a/Jint.Tests/Runtime/WebApi/TransferableStreamTests.cs
+++ b/Jint.Tests/Runtime/WebApi/TransferableStreamTests.cs
@@ -1,0 +1,642 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using Jint.Runtime;
+using Jint.WebApi.Streams;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// Transferring a <c>ReadableStream</c>, a <c>WritableStream</c> or a <c>TransformStream</c>, against
+/// https://streams.spec.whatwg.org/#transferrable-streams and the three interfaces' transfer steps.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Everything here is one engine transferring to itself through <c>structuredClone</c>, which is what the
+/// composition of the two phases gives — the transfer steps need a target <i>realm</i>, not a target agent.
+/// The cross-<i>engine</i> form is the same machinery with two pumps and lives in
+/// <c>Jint.Tests.PublicInterface.WebApiTransferableStreamTests</c>.
+/// </para>
+/// <para>
+/// <c>Engine.Execute</c> drains the event loop once the script has finished, so a test writes the whole
+/// asynchronous story into a <c>log</c> array and then reads it. A chunk crossing a transferred stream is
+/// several event-loop tasks — a <c>pull</c> one way, a <c>chunk</c> the other, each delivered as a port
+/// message — and the drain runs all of them.
+/// </para>
+/// </remarks>
+public class TransferableStreamTests
+{
+    private const WebApiFeatures TransferableStreamFeatures = WebApiFeatures.Streams | WebApiFeatures.StructuredClone;
+
+    private static Engine StreamEngine(WebApiFeatures features = TransferableStreamFeatures)
+    {
+        var engine = new Engine(options => options.UseWebApis(features));
+        engine.Execute("var log = [];");
+        engine.Execute("function err(f) { try { f(); return 'no error'; } catch (e) { return e.name; } }");
+        return engine;
+    }
+
+    private static string Log(Engine engine) => engine.Evaluate("log.join(',')").AsString();
+
+    private static string Err(Engine engine, string body) => engine.Evaluate("err(function() { " + body + " })").AsString();
+
+    /// <summary>Reads everything a readable stream will ever produce into <c>log</c>.</summary>
+    private const string DrainHelper = """
+        function drain(stream, tag) {
+          return (async function () {
+            var reader = stream.getReader();
+            try {
+              for (;;) {
+                var r = await reader.read();
+                if (r.done) { log.push(tag + ':done'); return; }
+                log.push(tag + ':' + r.value);
+              }
+            } catch (e) {
+              log.push(tag + '!' + (e && e.name));
+            }
+          })();
+        }
+        """;
+
+    // ---------------------------------------------------------------- a ReadableStream
+
+    [Fact]
+    public void ATransferredReadableStreamDeliversItsChunksToTheClone()
+    {
+        var engine = StreamEngine();
+        engine.Execute(DrainHelper);
+
+        engine.Execute("""
+            var rs = new ReadableStream({ start(c) { c.enqueue('a'); c.enqueue('b'); c.close(); } });
+            var moved = structuredClone(rs, { transfer: [rs] });
+            drain(moved, 'got');
+            """);
+
+        Log(engine).Should().Be("got:a,got:b,got:done");
+    }
+
+    [Fact]
+    public void TheCloneIsARealReadableStreamOfThisRealm()
+    {
+        var engine = StreamEngine();
+
+        engine.Execute("""
+            var rs = new ReadableStream();
+            var moved = structuredClone(rs, { transfer: [rs] });
+            """);
+
+        engine.Evaluate("moved instanceof ReadableStream").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.getPrototypeOf(moved) === ReadableStream.prototype").AsBoolean().Should().BeTrue();
+        engine.Evaluate("moved === rs").AsBoolean().Should().BeFalse();
+        engine.Evaluate("moved.locked").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void TheOriginalIsLockedAndDisturbedAfterwards()
+    {
+        var engine = StreamEngine();
+
+        engine.Execute("""
+            var rs = new ReadableStream({ start(c) { c.enqueue('a'); } });
+            var moved = structuredClone(rs, { transfer: [rs] });
+            """);
+
+        // "The original will become locked and no longer directly usable" — the pipe the transfer steps
+        // started holds a reader on it.
+        engine.Evaluate("rs.locked").AsBoolean().Should().BeTrue();
+        Err(engine, "rs.getReader();").Should().Be("TypeError");
+        Err(engine, "rs.tee();").Should().Be("TypeError");
+
+        // And disturbed, because ReadableStreamPipeTo reads from it. Nothing script-facing exposes the slot;
+        // it exists for the specifications built on top of this one, so it is asserted from the inside.
+        ((JsReadableStream) engine.Evaluate("rs").AsObject()).Disturbed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ALockedReadableStreamIsADataCloneError()
+    {
+        var engine = StreamEngine();
+        engine.Execute("var rs = new ReadableStream(); var reader = rs.getReader();");
+
+        Err(engine, "structuredClone(rs, { transfer: [rs] });").Should().Be("DataCloneError");
+
+        // The refusal happens before anything is moved: the stream is still exactly what it was.
+        engine.Evaluate("rs.locked").AsBoolean().Should().BeTrue();
+        ((JsReadableStream) engine.Evaluate("rs").AsObject()).Detached.Should().BeFalse();
+    }
+
+    [Fact]
+    public void TransferringTheSameStreamTwiceIsADataCloneError()
+    {
+        var engine = StreamEngine();
+        engine.Execute("""
+            var rs = new ReadableStream({ start(c) { c.close(); } });
+            var moved = structuredClone(rs, { transfer: [rs] });
+            """);
+
+        // The pipe has finished and released its reader by now, so the lock no longer refuses this — which is
+        // exactly what [[Detached]] is for.
+        engine.Evaluate("rs.locked").AsBoolean().Should().BeFalse();
+        Err(engine, "structuredClone(rs, { transfer: [rs] });").Should().Be("DataCloneError");
+    }
+
+    [Fact]
+    public void AStreamInTheMessageButNotInTheTransferListIsADataCloneError()
+    {
+        var engine = StreamEngine();
+
+        // Transferable and not serializable, exactly as a MessagePort is.
+        Err(engine, "structuredClone(new ReadableStream());").Should().Be("DataCloneError");
+        Err(engine, "structuredClone(new WritableStream());").Should().Be("DataCloneError");
+        Err(engine, "structuredClone(new TransformStream());").Should().Be("DataCloneError");
+        Err(engine, "structuredClone({ inner: new ReadableStream() });").Should().Be("DataCloneError");
+    }
+
+    [Fact]
+    public void ADuplicateInTheTransferListIsADataCloneError()
+    {
+        var engine = StreamEngine();
+        engine.Execute("var rs = new ReadableStream();");
+
+        Err(engine, "structuredClone(rs, { transfer: [rs, rs] });").Should().Be("DataCloneError");
+    }
+
+    [Fact]
+    public void AStreamReachedFromTheMessageResolvesToTheTransferredOne()
+    {
+        var engine = StreamEngine();
+        engine.Execute(DrainHelper);
+
+        engine.Execute("""
+            var rs = new ReadableStream({ start(c) { c.enqueue('x'); c.close(); } });
+            var out = structuredClone({ first: rs, second: rs }, { transfer: [rs] });
+            log.push('same=' + (out.first === out.second));
+            log.push('isRS=' + (out.first instanceof ReadableStream));
+            drain(out.first, 'got');
+            """);
+
+        Log(engine).Should().Be("same=true,isRS=true,got:x,got:done");
+    }
+
+    // ---------------------------------------------------------------- close and error propagation
+
+    [Fact]
+    public void ClosingTheSourceClosesTheTransferredStream()
+    {
+        var engine = StreamEngine();
+        engine.Execute(DrainHelper);
+
+        engine.Execute("""
+            var controller;
+            var rs = new ReadableStream({ start(c) { controller = c; } });
+            var moved = structuredClone(rs, { transfer: [rs] });
+            drain(moved, 'got');
+            """);
+
+        Log(engine).Should().Be("");
+
+        engine.Execute("controller.enqueue('one');");
+        Log(engine).Should().Be("got:one");
+
+        engine.Execute("controller.close();");
+        Log(engine).Should().Be("got:one,got:done");
+    }
+
+    [Fact]
+    public void ACloseStillOnTheQueueIsNotMistakenForALostChannel()
+    {
+        var engine = StreamEngine();
+
+        // Two reads outstanding at once is what puts the receiving side's `pull` on the very stack that
+        // dispatches a chunk: ReadableStreamDefaultControllerEnqueue fulfils the first read request and then
+        // calls CallPullIfNeeded, which sees the second one still waiting. At that instant the sender has
+        // already posted `close` AND disentangled — the close algorithm does both, in that order — so the
+        // channel's far side reads as closed while the message that closes this stream cleanly is still
+        // sitting on its queue. Asking only "has the far side gone" would throw that message away and error a
+        // stream that is about to finish; JsMessagePort.IsChannelExhausted asks about the queue too.
+        engine.Execute("""
+            var rs = new ReadableStream({ start(c) { c.enqueue('only'); c.close(); } });
+            var moved = structuredClone(rs, { transfer: [rs] });
+            var reader = moved.getReader();
+            reader.read().then(function (r) { log.push('1:' + r.value); }, function (e) { log.push('1!' + e.name); });
+            reader.read().then(function (r) { log.push('2:' + r.value + ':' + r.done); }, function (e) { log.push('2!' + e.name); });
+            """);
+
+        Log(engine).Should().Be("1:only,2:undefined:true");
+    }
+
+    [Fact]
+    public void ErroringTheSourceErrorsTheTransferredStreamWithTheSameReason()
+    {
+        var engine = StreamEngine();
+        engine.Execute(DrainHelper);
+
+        engine.Execute("""
+            var controller;
+            var rs = new ReadableStream({ start(c) { controller = c; } });
+            var moved = structuredClone(rs, { transfer: [rs] });
+            moved.getReader().read().then(
+              function () { log.push('resolved'); },
+              function (e) { log.push('rejected:' + e.name + ':' + e.message); });
+            """);
+
+        engine.Execute("controller.error(new RangeError('from the source'));");
+
+        // The reason is structured-cloned across, so it is an error of the receiving realm carrying the same
+        // name and message rather than the very object the source errored with.
+        Log(engine).Should().Be("rejected:RangeError:from the source");
+    }
+
+    [Fact]
+    public void CancellingTheTransferredStreamCancelsTheOriginalSource()
+    {
+        var engine = StreamEngine();
+
+        engine.Execute("""
+            var rs = new ReadableStream({
+              start(c) { c.enqueue('a'); },
+              cancel(reason) { log.push('source cancelled: ' + reason.message); }
+            });
+            var moved = structuredClone(rs, { transfer: [rs] });
+            """);
+
+        engine.Execute("moved.cancel(new Error('no longer wanted'));");
+
+        // Backward through the channel as an `error` message, then backward through the pipe as a cancel.
+        Log(engine).Should().Be("source cancelled: no longer wanted");
+    }
+
+    [Fact]
+    public void AChunkThatCannotBeClonedFailsTheTransferredStream()
+    {
+        var engine = StreamEngine();
+        engine.Execute(DrainHelper);
+
+        engine.Execute("""
+            var controller;
+            var rs = new ReadableStream({ start(c) { controller = c; } });
+            var moved = structuredClone(rs, { transfer: [rs] });
+            drain(moved, 'got');
+            """);
+
+        engine.Execute("controller.enqueue(function () {});");
+
+        // PackAndPostMessageHandlingError sends the DataCloneError to the readable side and rejects the write,
+        // which errors the writable and — through the pipe — cancels the source.
+        Log(engine).Should().Be("got!DataCloneError");
+    }
+
+    // ---------------------------------------------------------------- backpressure
+
+    [Fact]
+    public void TheSenderDoesNotRunAheadOfTheReceiver()
+    {
+        var engine = StreamEngine();
+
+        // The source records every pull it is asked for. The cross-realm writable's high water mark is 1 and
+        // the readable side's is 0, so nothing crosses until the receiving side actually reads. The supply is
+        // capped rather than unbounded so that a loss of backpressure is a failed assertion here and not a
+        // test that never returns.
+        engine.Execute("""
+            var pulls = 0;
+            var next = 0;
+            var rs = new ReadableStream({
+              pull(c) { pulls++; if (next >= 200) { c.close(); return; } c.enqueue('c' + (next++)); }
+            });
+            var moved = structuredClone(rs, { transfer: [rs] });
+            var reader = moved.getReader();
+            """);
+
+        // The pipe primed itself with one chunk in flight and one in the writable's queue, and then stopped.
+        var afterTransfer = engine.Evaluate("pulls").AsNumber();
+        afterTransfer.Should().BeLessThanOrEqualTo(3);
+
+        engine.Execute("reader.read().then(function (r) { log.push(r.value); });");
+        Log(engine).Should().Be("c0");
+
+        // One read releases a bounded amount of further work rather than draining the source.
+        engine.Evaluate("pulls").AsNumber().Should().BeLessThanOrEqualTo(afterTransfer + 2);
+
+        engine.Execute("reader.read().then(function (r) { log.push(r.value); });");
+        Log(engine).Should().Be("c0,c1");
+    }
+
+    // ---------------------------------------------------------------- a WritableStream
+
+    [Fact]
+    public void ATransferredWritableStreamDeliversWritesToTheOriginalSink()
+    {
+        var engine = StreamEngine();
+
+        engine.Execute("""
+            var ws = new WritableStream({
+              write(chunk) { log.push('wrote:' + chunk); },
+              close() { log.push('closed'); },
+              abort(reason) { log.push('aborted:' + reason.message); }
+            });
+            var moved = structuredClone(ws, { transfer: [ws] });
+            var writer = moved.getWriter();
+            writer.write('a');
+            writer.write('b');
+            """);
+
+        Log(engine).Should().Be("wrote:a,wrote:b");
+
+        engine.Execute("writer.close();");
+        Log(engine).Should().Be("wrote:a,wrote:b,closed");
+    }
+
+    [Fact]
+    public void TheOriginalWritableStreamIsLockedAfterwards()
+    {
+        var engine = StreamEngine();
+        engine.Execute("var ws = new WritableStream(); var moved = structuredClone(ws, { transfer: [ws] });");
+
+        engine.Evaluate("ws.locked").AsBoolean().Should().BeTrue();
+        engine.Evaluate("moved.locked").AsBoolean().Should().BeFalse();
+        Err(engine, "ws.getWriter();").Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void ALockedWritableStreamIsADataCloneError()
+    {
+        var engine = StreamEngine();
+        engine.Execute("var ws = new WritableStream(); var writer = ws.getWriter();");
+
+        Err(engine, "structuredClone(ws, { transfer: [ws] });").Should().Be("DataCloneError");
+    }
+
+    [Fact]
+    public void AbortingTheTransferredWritableStreamAbortsTheOriginalSink()
+    {
+        var engine = StreamEngine();
+
+        engine.Execute("""
+            var ws = new WritableStream({ abort(reason) { log.push('aborted:' + reason.message); } });
+            var moved = structuredClone(ws, { transfer: [ws] });
+            """);
+
+        engine.Execute("moved.abort(new Error('give up'));");
+
+        Log(engine).Should().Be("aborted:give up");
+    }
+
+    [Fact]
+    public void ErroringTheOriginalSinkErrorsTheTransferredWritableStream()
+    {
+        var engine = StreamEngine();
+
+        engine.Execute("""
+            var sinkController;
+            var ws = new WritableStream({ start(c) { sinkController = c; } });
+            var moved = structuredClone(ws, { transfer: [ws] });
+            var writer = moved.getWriter();
+            writer.closed.then(
+              function () { log.push('closed'); },
+              function (e) { log.push('rejected:' + e.name + ':' + e.message); });
+            """);
+
+        engine.Execute("sinkController.error(new TypeError('sink is gone'));");
+
+        Log(engine).Should().Be("rejected:TypeError:sink is gone");
+    }
+
+    // ---------------------------------------------------------------- a TransformStream
+
+    [Fact]
+    public void ATransferredTransformStreamStillTransforms()
+    {
+        var engine = StreamEngine();
+        engine.Execute(DrainHelper);
+
+        engine.Execute("""
+            var ts = new TransformStream({ transform(chunk, c) { c.enqueue(chunk.toUpperCase()); } });
+            var moved = structuredClone(ts, { transfer: [ts] });
+            drain(moved.readable, 'got');
+            var writer = moved.writable.getWriter();
+            writer.write('a');
+            writer.write('b');
+            """);
+
+        Log(engine).Should().Be("got:A,got:B");
+
+        engine.Execute("writer.close();");
+        Log(engine).Should().Be("got:A,got:B,got:done");
+    }
+
+    [Fact]
+    public void ATransferredTransformStreamLeavesBothOriginalSidesLocked()
+    {
+        var engine = StreamEngine();
+        engine.Execute("var ts = new TransformStream(); var moved = structuredClone(ts, { transfer: [ts] });");
+
+        engine.Evaluate("ts.readable.locked").AsBoolean().Should().BeTrue();
+        engine.Evaluate("ts.writable.locked").AsBoolean().Should().BeTrue();
+        engine.Evaluate("moved.readable.locked").AsBoolean().Should().BeFalse();
+        engine.Evaluate("moved.writable.locked").AsBoolean().Should().BeFalse();
+        engine.Evaluate("moved.readable instanceof ReadableStream").AsBoolean().Should().BeTrue();
+        engine.Evaluate("moved.writable instanceof WritableStream").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ATransformStreamWithALockedSideIsADataCloneError()
+    {
+        var readableLocked = StreamEngine();
+        readableLocked.Execute("var ts = new TransformStream(); var reader = ts.readable.getReader();");
+        Err(readableLocked, "structuredClone(ts, { transfer: [ts] });").Should().Be("DataCloneError");
+
+        // Neither side moved: the check for both comes before either transfer.
+        readableLocked.Evaluate("ts.writable.locked").AsBoolean().Should().BeFalse();
+
+        var writableLocked = StreamEngine();
+        writableLocked.Execute("var ts = new TransformStream(); var writer = ts.writable.getWriter();");
+        Err(writableLocked, "structuredClone(ts, { transfer: [ts] });").Should().Be("DataCloneError");
+        writableLocked.Evaluate("ts.readable.locked").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void ATransformStreamAndOneOfItsSidesInOneTransferListIsADataCloneError()
+    {
+        // The four combinations of streams/transferable/transform-stream-members.any.js, which the corpus
+        // runs too: transferring the transform stream locks and detaches both its sides, so naming one of
+        // them alongside it can only fail — whichever order they are named in.
+        var engine = StreamEngine();
+
+        Err(engine, "var t = new TransformStream(); structuredClone([t, t.readable], { transfer: [t, t.readable] });")
+            .Should().Be("DataCloneError");
+        Err(engine, "var t = new TransformStream(); structuredClone([t.readable, t], { transfer: [t.readable, t] });")
+            .Should().Be("DataCloneError");
+        Err(engine, "var t = new TransformStream(); structuredClone([t, t.writable], { transfer: [t, t.writable] });")
+            .Should().Be("DataCloneError");
+        Err(engine, "var t = new TransformStream(); structuredClone([t.writable, t], { transfer: [t.writable, t] });")
+            .Should().Be("DataCloneError");
+    }
+
+    [Fact]
+    public void OneSideOfATransformStreamCanBeTransferredOnItsOwn()
+    {
+        var engine = StreamEngine();
+        engine.Execute(DrainHelper);
+
+        engine.Execute("""
+            var ts = new TransformStream({ transform(chunk, c) { c.enqueue(chunk + '!'); } });
+            var movedReadable = structuredClone(ts.readable, { transfer: [ts.readable] });
+            drain(movedReadable, 'got');
+            var writer = ts.writable.getWriter();
+            writer.write('hi');
+            """);
+
+        Log(engine).Should().Be("got:hi!");
+    }
+
+    // ---------------------------------------------------------------- the port underneath
+
+    [Fact]
+    public void TheChannelAStreamTransferCreatesIsNotExposedAsAPort()
+    {
+        var engine = StreamEngine(WebApiFeatures.Default);
+
+        engine.Execute("""
+            var channel = new MessageChannel();
+            var seen = null;
+            channel.port2.onmessage = function (e) { seen = e; };
+            var rs = new ReadableStream({ start(c) { c.enqueue('a'); c.close(); } });
+            channel.port1.postMessage({ stream: rs }, [rs]);
+            """);
+
+        // event.ports is the caller's transfer list narrowed to ports, and a transferred stream contributes
+        // none of its own even though it created a whole channel.
+        engine.Evaluate("seen.ports.length").AsNumber().Should().Be(0);
+        engine.Evaluate("seen.data.stream instanceof ReadableStream").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void AStreamAndAPortInOneTransferListEachArriveWhereTheyBelong()
+    {
+        var engine = StreamEngine(WebApiFeatures.Default);
+        engine.Execute(DrainHelper);
+
+        engine.Execute("""
+            var main = new MessageChannel();
+            var side = new MessageChannel();
+            main.port2.onmessage = function (e) {
+              log.push('ports=' + e.ports.length);
+              e.ports[0].onmessage = function (m) { log.push('side:' + m.data); };
+              drain(e.data.stream, 'got');
+            };
+            var rs = new ReadableStream({ start(c) { c.enqueue('a'); c.close(); } });
+            main.port1.postMessage({ stream: rs }, [rs, side.port2]);
+            side.port1.postMessage('through the side channel');
+            """);
+
+        // The side channel's own message beats the stream's first chunk, and that is the protocol showing
+        // through rather than an accident: a transferred stream's first chunk costs a `pull` one way and a
+        // `chunk` the other, so it cannot arrive until the second round trip.
+        Log(engine).Should().Be("ports=1,side:through the side channel,got:a,got:done");
+    }
+
+    [Fact]
+    public void TransferringAStreamNeedsNoMessagingGlobals()
+    {
+        // The channel a transfer creates is engine-internal: it never reaches script, so it needs the
+        // MessagePort *intrinsics* and not the Messaging feature's globals.
+        var engine = StreamEngine();
+        engine.Execute(DrainHelper);
+
+        engine.Evaluate("typeof MessageChannel").AsString().Should().Be("undefined");
+
+        engine.Execute("""
+            var rs = new ReadableStream({ start(c) { c.enqueue('a'); c.close(); } });
+            drain(structuredClone(rs, { transfer: [rs] }), 'got');
+            """);
+
+        Log(engine).Should().Be("got:a,got:done");
+    }
+
+    // ---------------------------------------------------------------- stranding
+
+    [Fact]
+    public void AStreamTransferredIntoAClosedPortStrandsAndTheSourceIsCancelled()
+    {
+        var engine = StreamEngine(WebApiFeatures.Default);
+
+        engine.Execute("""
+            var pulls = 0;
+            var rs = new ReadableStream({
+              pull(c) { pulls++; c.enqueue('c' + pulls); },
+              cancel(reason) { log.push('source cancelled: ' + reason.name); }
+            });
+
+            var channel = new MessageChannel();
+            channel.port2.close();
+            channel.port1.postMessage({ stream: rs }, [rs]);
+            """);
+
+        // The message was serialized — the transfer happened, and the stream is gone from this realm — but
+        // step 6 had nowhere to deliver it, so the channel the transfer created was ended by
+        // StrandTransferredPorts. The pipe therefore stops rather than draining the source into nothing.
+        Log(engine).Should().Be("source cancelled: TypeError");
+
+        var pullsAfterStranding = engine.Evaluate("pulls").AsNumber();
+        engine.Advanced.ProcessTasks();
+        engine.Advanced.ProcessTasks();
+        engine.Evaluate("pulls").AsNumber().Should().Be(pullsAfterStranding, "no pipe may be left running against a stranded side");
+    }
+
+    [Fact]
+    public void AStreamStrandedByAThrowLaterInTheTransferListIsEndedToo()
+    {
+        var engine = StreamEngine(WebApiFeatures.Default);
+
+        engine.Execute("""
+            var pulls = 0;
+            var rs = new ReadableStream({
+              pull(c) { pulls++; c.enqueue('c' + pulls); },
+              cancel(reason) { log.push('source cancelled: ' + reason.name); }
+            });
+
+            var detached = new MessageChannel().port1;
+            detached.close();
+            """);
+
+        // The stream is transferred first and the already-detached port then refuses, so the whole
+        // serialization is discarded with a channel already created for the stream.
+        Err(engine, "structuredClone([rs, detached], { transfer: [rs, detached] });").Should().Be("DataCloneError");
+
+        engine.Execute("void 0;");
+        Log(engine).Should().Be("source cancelled: TypeError");
+
+        var pullsAfterStranding = engine.Evaluate("pulls").AsNumber();
+        engine.Advanced.ProcessTasks();
+        engine.Advanced.ProcessTasks();
+        engine.Evaluate("pulls").AsNumber().Should().Be(pullsAfterStranding);
+    }
+
+    [Fact]
+    public void AStreamWhoseUndeliveredMessageIsDiscardedIsEndedToo()
+    {
+        var engine = StreamEngine(WebApiFeatures.Default);
+
+        engine.Execute("""
+            var pulls = 0;
+            var rs = new ReadableStream({
+              pull(c) { pulls++; c.enqueue('c' + pulls); },
+              cancel(reason) { log.push('source cancelled: ' + reason.name); }
+            });
+
+            var channel = new MessageChannel();
+            channel.port1.postMessage({ stream: rs }, [rs]);
+
+            // Never started, so the message is still sitting on port2's queue when it is closed.
+            channel.port2.close();
+            """);
+
+        Log(engine).Should().Be("source cancelled: TypeError");
+
+        var pullsAfterStranding = engine.Evaluate("pulls").AsNumber();
+        engine.Advanced.ProcessTasks();
+        engine.Advanced.ProcessTasks();
+        engine.Evaluate("pulls").AsNumber().Should().Be(pullsAfterStranding);
+    }
+}
+#endif

--- a/Jint.Tests/Wpt/Vendor/README.md
+++ b/Jint.Tests/Wpt/Vendor/README.md
@@ -31,9 +31,9 @@ and `Response.formData()`, one algorithm reached three ways).
 
 Seven standards are vendored: `url/`, `encoding/`, `compression/` and `urlpattern/` as one suite each,
 `FileAPI/` as **three** (its root, `blob/` and `file/`), `WebCryptoAPI/` as **eight** and `streams/` as
-**six** — their root files plus one suite per sub-directory, because `WptCorpus.TestFiles` lists a
-directory's own files and never descends. That is 183 theory cases: 48 of them the WebCryptoAPI corpus's
-24,136 assertions, 64 the streams corpus's 1,150, 15 the compression corpus's 297, 3 the URL Pattern
+**seven** — their root files plus one suite per sub-directory, because `WptCorpus.TestFiles` lists a
+directory's own files and never descends. That is 184 theory cases: 48 of them the WebCryptoAPI corpus's
+24,136 assertions, 65 the streams corpus's 1,154, 15 the compression corpus's 297, 3 the URL Pattern
 corpus's 373 and 14 the File API's 342; the whole driver runs in about a minute.
 
 Tests that do not pass are named in the driver's exclusion table with the category they belong to. An entry
@@ -58,7 +58,7 @@ without revisiting the reason fails rather than quietly adding a red suite.
 | `WebCryptoAPI/secure_context/*` | A `.sub.html` test for a browsing context. |
 | `WebCryptoAPI/import_export/crashtests/*` | A crashtest — a regression reproduction rather than an assertion. |
 | `WebCryptoAPI/tools/*` | The corpus's own Python generator. |
-| `streams/transferable/*` | Transferring a stream through `postMessage()` is the one part of the Streams Standard Jint does not implement, there being nothing to transfer it to; the directory is worker, iframe and service-worker plumbing on top of that. [Issue #3186](https://github.com/sebastienros/jint/issues/3186). |
+| `streams/transferable/*.window.js`, `streams/transferable/resources/*` | The directory itself **is** vendored now that transferring a stream works ([issue #3199](https://github.com/sebastienros/jint/issues/3199)) — but it holds exactly one `.any.js` file. The two `.window.js` tests drive an iframe and a `MessagePort` helper page, and `resources/` is the iframe, worker, shared-worker and service-worker plumbing those and the directory's `.html` files load. The blanket "`.any.js` only" rule below already excludes all of it; these rows say so by name, because a half-vendored directory should not look like an oversight. |
 | `streams/readable-streams/owning-type*.tentative.any.js` | Upstream's `.tentative` marker again: owning-type readable streams are a proposal the Streams Standard has not adopted. |
 | `streams/*/crashtests/*` | A crashtest — a regression reproduction rather than an assertion. |
 | `streams/readable-byte-streams/construct-byob-request.any.js` | Reads `ReadableByteStreamController.prototype` and calls `new ReadableStreamBYOBRequest(…)` at *file scope*. Neither is a global here — see "Streams, including byte streams" in the repository README for the reduction — so the file throws before registering a test, and a harness error is for the whole file rather than something a per-test exclusion can name. The seven rows of `default-reader.any.js` that fail for the same reason fail *inside* test bodies, so those are in the exclusion table under `NeedsStreamInterfaceGlobals`. |
@@ -72,10 +72,11 @@ without revisiting the reason fails rather than quietly adding a red suite.
 Nothing was left out for being slow. Every vendored file was timed at the pin; the slowest is
 `derive_bits_keys/pbkdf2.https.any.js` at ~20 s for 8,632 cases (it is `// META: timeout=long` and sharded
 nine ways upstream), then `generateKey/successes_RSA-OAEP.https.any.js` at ~7 s, which really does generate
-156 RSA key pairs. Everything else is under 3 s. The whole streams corpus is 6.4 s for its 64 files, the
+156 RSA key pairs. Everything else is under 3 s. The whole streams corpus is 6.4 s for its 65 files, the
 slowest being `readable-byte-streams/templated.any.js` at ~2.1 s and `readable-streams/templated.any.js` at
 ~1.0 s — both are `rs-test-templates.js` run over every stream shape — so nothing there is near the bar
-either.
+either. `transferable/transform-stream-members.any.js`, the file this pin's newest change added, is four
+assertions and does not register.
 
 The three corpora added last measure 2.6 s (compression, 15 files), 3.1 s (urlpattern, 3 files) and 0.2 s
 (FileAPI, 14 files), run one after another on one thread. Two files carry almost all of that: `urlpattern.any.js`
@@ -127,9 +128,23 @@ prose where a browser answers `InvalidAccessError`.
 
 ## What the streams corpus says about this engine
 
+<<<<<<< HEAD
 1,150 assertions across 64 files, of which **16 do not pass** — 98.6%, which is what one expects of an
 implementation written operation by operation against the standard, and also why the sixteen are worth naming
 individually. (Only the URL Pattern corpus below beats it, at 100%.)
+=======
+1,154 assertions across 65 files, of which **16 do not pass** — the highest-passing corpus vendored so far,
+which is what one expects of an implementation written operation by operation against the standard, and also
+why the sixteen are worth naming individually.
+>>>>>>> 2bcb07e4f (Web streams: transfer a ReadableStream, a WritableStream or a TransformStream)
+
+`transferable/transform-stream-members.any.js` is the newest of the 65 and all four of its assertions pass.
+It is the whole `.any.js` surface of transferable streams, and it asks one thing four ways: naming a
+`TransformStream` *and* one of its two sides in a single transfer list must be a `DataCloneError`, in either
+order. It passes because the transform stream's own transfer steps transfer each side in turn, so by the time
+the list's other entry is reached that side is both locked and `[[Detached]]` — which is what makes the
+refusal fall out of the steps rather than needing a rule of its own. The file took 0.4 s at the pin,
+including the runner's start-up.
 
 Eleven are a decision already taken. Seven rows of `readable-streams/default-reader.any.js` reach for the
 `ReadableStreamDefaultReader` **global** (`NeedsStreamInterfaceGlobals`): only the five interfaces a script

--- a/Jint.Tests/Wpt/Vendor/streams/transferable/transform-stream-members.any.js
+++ b/Jint.Tests/Wpt/Vendor/streams/transferable/transform-stream-members.any.js
@@ -1,0 +1,18 @@
+// META: global=window,dedicatedworker
+
+const combinations = [
+  (t => [t, t.readable])(new TransformStream()),
+  (t => [t.readable, t])(new TransformStream()),
+  (t => [t, t.writable])(new TransformStream()),
+  (t => [t.writable, t])(new TransformStream()),
+];
+
+for (const combination of combinations) {
+  test(() => {
+    assert_throws_dom(
+      "DataCloneError",
+      () => structuredClone(combination, { transfer: combination }),
+      "structuredClone should throw"
+    );
+  }, `Transferring ${combination} should fail`);
+}

--- a/Jint.Tests/Wpt/WptTestRunner.cs
+++ b/Jint.Tests/Wpt/WptTestRunner.cs
@@ -101,10 +101,14 @@ public class WptTestRunner
         ("WebCryptoAPI/tools/*", "the corpus's own generator, not a test"),
 
         // ---------------------------------------------------------------- streams
-        // Transferring a stream through postMessage() is the one part of the Streams Standard Jint does not
-        // implement, there being nothing to transfer it to; the directory is worker, iframe and service-worker
-        // plumbing on top of that. https://github.com/sebastienros/jint/issues/3186 is where it lives.
-        ("streams/transferable/*", "transfers a stream through a MessagePort, issue #3186"),
+        // The transferable-streams directory is vendored now that transferring a stream works
+        // (https://github.com/sebastienros/jint/issues/3199), but only the one .any.js file it has. The two
+        // .window.js tests drive an iframe and a MessagePort helper page, and resources/ is the iframe,
+        // worker, shared-worker and service-worker plumbing they and the directory's .html files load — all
+        // of it a browsing context, which is what the blanket ".any.js only" rule already excludes; these two
+        // rows say so by name because the directory would otherwise look half-vendored by accident.
+        ("streams/transferable/*.window.js", "drives an iframe and a worker; there is no browsing context here"),
+        ("streams/transferable/resources/*", "the iframe, worker and service-worker pages those tests load"),
 
         // Upstream's ".tentative" marker again, this time without the ".https." the WebCryptoAPI files carry:
         // the owning-type readable streams, a proposal the Streams Standard has not adopted.
@@ -337,6 +341,8 @@ public class WptTestRunner
         ["streams/piping/then-interception.any.js"] = 2,
         ["streams/piping/throwing-options.any.js"] = 8,
         ["streams/piping/transform-streams.any.js"] = 1,
+
+        ["streams/transferable/transform-stream-members.any.js"] = 4,
 
         ["compression/compression-bad-chunks.any.js"] = 28,
         ["compression/compression-constructor-error.any.js"] = 3,
@@ -794,7 +800,8 @@ public class WptTestRunner
     /// <summary>
     /// The Streams Standard's corpus, split the same way the WebCryptoAPI one is: the root files are a suite
     /// and each sub-directory is another, because <see cref="WptCorpus.TestFiles"/> lists a directory's own
-    /// files and never descends. <c>transferable/</c> is not among them — see <see cref="_notVendored"/>.
+    /// files and never descends. <c>transferable/</c> contributes exactly one file — the rest of that
+    /// directory is a browsing context, see <see cref="_notVendored"/>.
     /// </summary>
     private static readonly string[] _streamsSuites =
     [
@@ -804,6 +811,7 @@ public class WptTestRunner
         "streams/writable-streams",
         "streams/transform-streams",
         "streams/piping",
+        "streams/transferable",
     ];
 
     public static IEnumerable<object[]> StreamsSuiteFiles() => Cases("streams");
@@ -817,6 +825,8 @@ public class WptTestRunner
     public static IEnumerable<object[]> TransformStreamsSuiteFiles() => Cases("streams/transform-streams");
 
     public static IEnumerable<object[]> StreamsPipingSuiteFiles() => Cases("streams/piping");
+
+    public static IEnumerable<object[]> TransferableStreamsSuiteFiles() => Cases("streams/transferable");
 
     /// <summary>
     /// The Compression Standard's corpus and the URL Pattern one, a single directory each.
@@ -906,6 +916,10 @@ public class WptTestRunner
     [Theory]
     [MemberData(nameof(StreamsPipingSuiteFiles))]
     public void RunsTheStreamsPipingSuite(string file) => RunSuiteFile(file);
+
+    [Theory]
+    [MemberData(nameof(TransferableStreamsSuiteFiles))]
+    public void RunsTheTransferableStreamsSuite(string file) => RunSuiteFile(file);
 
     [Theory]
     [MemberData(nameof(CompressionSuiteFiles))]

--- a/Jint/WebApi/Messaging/JsMessagePort.cs
+++ b/Jint/WebApi/Messaging/JsMessagePort.cs
@@ -102,6 +102,23 @@ internal sealed class JsMessagePort : JsEventTarget
 
     private readonly Action _drainJob;
 
+    /// <summary>
+    /// Where a message goes when the <i>engine</i> owns this port rather than a script — which today means the
+    /// cross-realm transform behind a transferred stream. Set, the deserialized message is handed straight to
+    /// it and no <c>message</c> event is created or dispatched at all.
+    /// </summary>
+    /// <remarks>
+    /// The Streams Standard writes its half as "add a handler for port's <c>message</c> event"
+    /// (https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformreadable), and this is that
+    /// handler. It is a delegate rather than an <see cref="EventListenerRegistration"/> for two reasons that
+    /// both come from the port never being reachable by script: no listener can compete with it, so the
+    /// dispatch algorithm has nothing to decide, and a listener would have to be a JavaScript function object
+    /// — one per transferred stream, plus a <c>MessageEvent</c> per chunk — to say exactly what one delegate
+    /// says. Everything else about the port is unchanged: the queue still starts disabled, <see cref="Start"/>
+    /// is still what enables it, and delivery is still one event-loop task per message.
+    /// </remarks>
+    internal Action<JsValue>? InternalMessageHandler { get; set; }
+
     internal JsMessagePort(Engine engine, Realm realm) : this(engine, realm, endpoint: null)
     {
     }
@@ -147,6 +164,41 @@ internal sealed class JsMessagePort : JsEventTarget
     /// prunes on.
     /// </summary>
     internal bool IsInert => _endpoint is not { Closed: false };
+
+    /// <summary>
+    /// Whether this port can never carry anything again: it has been detached or closed, or the side at the
+    /// other end has been closed and nothing it posted is still waiting on this one's queue.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Nothing in the specifications asks this question, and only the cross-realm transform does.</b> HTML
+    /// disentangles a port silently — <c>postMessage</c> to a port whose peer has gone is a no-op, and the
+    /// Streams Standard's <c>PackAndPostMessage</c> inherits that — so a stream piping into a channel whose
+    /// far end was ended would go on reading its source forever and writing into nothing. That is the one
+    /// thing Jint's transferred streams add: the write and pull algorithms consult this and end the stream
+    /// instead. See <c>CrossRealmTransform</c>.
+    /// </para>
+    /// <para>
+    /// The queue test is what makes it safe rather than merely conservative, and it is not an optimization: a
+    /// sender's last act is to post <c>close</c> and <i>then</i> disentangle, so a receiver that asked only
+    /// "is the far side closed" would discard the very message that closes it cleanly. Both halves are read on
+    /// this port's own engine's thread, and the peer's <see cref="MessagePortEndpoint.Closed"/> is written
+    /// after its <see cref="MessagePortEndpoint.Post"/> released this side's lock, so a <see langword="true"/>
+    /// here means every message that will ever arrive has already arrived.
+    /// </para>
+    /// </remarks>
+    internal bool IsChannelExhausted
+    {
+        get
+        {
+            if (_endpoint is not { Closed: false } endpoint)
+            {
+                return true;
+            }
+
+            return endpoint.Peer is not { Closed: false } && !endpoint.HasQueuedMessages;
+        }
+    }
 
     /// <summary>
     /// https://html.spec.whatwg.org/multipage/web-messaging.html#message-port-post-message-steps
@@ -331,6 +383,14 @@ internal sealed class JsMessagePort : JsEventTarget
     private void Dispatch(SerializationRecord record)
     {
         var message = new StructuredDeserializer(_engine, _realm).DeserializeWithTransfer(in record);
+
+        // An engine-owned port has no listener list to dispatch to, and nothing that could have added one.
+        if (InternalMessageHandler is { } handler)
+        {
+            handler(message.Value);
+            return;
+        }
+
         var messageEvent = _realm.Intrinsics.MessageEvent.CreateTrustedMessageEvent(_messageEventName, message.Value, message.Ports);
         DispatchEvent(messageEvent);
     }

--- a/Jint/WebApi/Streams/CrossRealmTransform.cs
+++ b/Jint/WebApi/Streams/CrossRealmTransform.cs
@@ -1,0 +1,369 @@
+#if NET8_0_OR_GREATER
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Native.Promise;
+using Jint.Runtime;
+using Jint.WebApi.Messaging;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// The "cross-realm transform" abstract operations — the identity transform whose writable side is in one
+/// realm and whose readable side is in another, which is the whole mechanism behind a transferred stream.
+/// <para>
+/// https://streams.spec.whatwg.org/#transferrable-streams
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Everything crosses as a <c>MessagePort</c> message, and deliberately so.</b> The standard's
+/// <c>PackAndPostMessage</c> builds an ordinary object <c>{ type, value }</c> and runs the <i>message port
+/// post message steps</i> on it, "to avoid having to duplicate" them — so a chunk is structured-serialized on
+/// the sending engine, travels as an engine-neutral
+/// <see cref="StructuredClone.SerializationRecord"/>, and is deserialized into the receiving realm, exactly as
+/// any other message. A chunk that cannot be cloned therefore fails the way the standard says it does, at the
+/// write, with the <c>DataCloneError</c> reported to the other side as well.
+/// </para>
+/// <para>
+/// The protocol is four message types on one channel. Sender to receiver: <c>chunk</c> carrying the value,
+/// <c>close</c>, and <c>error</c> carrying the reason. Receiver to sender: <c>pull</c>, which is the only
+/// backpressure signal there is — the writable side starts with an unresolved backpressure promise and the
+/// readable side's high water mark is 0, so the first chunk is not posted until the receiving script actually
+/// reads, and one <c>pull</c> releases exactly one chunk.
+/// </para>
+/// <para>
+/// <b>Both ends run on their own engine's own pump, and neither runs on the other's.</b> A cross-engine
+/// transferred stream is two engines that have to be pumped: a chunk written on the sender is a task on the
+/// receiver, so an engine nobody pumps receives nothing — the same contract a <c>MessagePort</c> carries, and
+/// for the same reason, since a port is exactly what this is.
+/// </para>
+/// <para>
+/// <b>One thing here is Jint's and not the standard's</b>, and it is the reason a transferred stream cannot
+/// leave a pipe running against nothing. HTML's post message steps drop a message posted into a disentangled
+/// channel without telling anybody, so <c>PackAndPostMessage</c> cannot fail that way and the standard's
+/// writable side would go on draining its source into a channel whose far end has been ended — by a message
+/// that was serialized and never delivered, by a <c>close()</c>, or by a <c>RestoreGlobalSnapshot</c> on the
+/// receiving engine. The write and pull algorithms therefore consult
+/// <see cref="JsMessagePort.IsChannelExhausted"/> first and end their stream when it answers yes. It can only
+/// answer yes where the standard leaves the outcome undefined: every orderly shutdown sends <c>close</c> or
+/// <c>error</c> <i>before</i> disentangling, and that message is still on the queue the predicate consults.
+/// </para>
+/// </remarks>
+internal static class CrossRealmTransform
+{
+    /// <summary>The message's <c>type</c> key, https://streams.spec.whatwg.org/#abstract-opdef-packandpostmessage.</summary>
+    private static readonly JsString _typeKey = new("type");
+
+    /// <summary>The message's <c>value</c> key.</summary>
+    private static readonly JsString _valueKey = new("value");
+
+    private static readonly JsString _chunkType = new("chunk");
+
+    private static readonly JsString _closeType = new("close");
+
+    private static readonly JsString _errorType = new("error");
+
+    private static readonly JsString _pullType = new("pull");
+
+    /// <summary>The size algorithm both sides get: "an algorithm that returns 1".</summary>
+    private static readonly Func<JsValue, double> _sizeOfOne = static _ => 1;
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformreadable — the receiving half:
+    /// a readable stream whose chunks arrive over <paramref name="port"/>.
+    /// </summary>
+    internal static void SetUpReadable(JsReadableStream stream, JsMessagePort port)
+    {
+        var engine = stream.Engine;
+        var realm = stream.Realm;
+
+        var controller = new JsReadableStreamDefaultController(engine, realm)
+        {
+            _prototype = realm.Intrinsics.ReadableStreamDefaultController.PrototypeObject,
+        };
+
+        // "Add a handler for port's message event." See JsMessagePort.InternalMessageHandler for why this is a
+        // delegate rather than a listener; there is no messageerror handler because Jint never fires one — a
+        // record built by this engine's own serializer always deserializes, which JsMessagePort documents.
+        port.InternalMessageHandler = data =>
+        {
+            if (!TryReadMessage(data, out var type, out var value))
+            {
+                // The standard asserts here and notes that "the input might come from an untrusted context".
+                // In Jint it cannot: neither port of the pair a transfer creates is ever handed to script, so
+                // the only writer of these messages is the sending half below. Refusing the message rather
+                // than trusting it costs one test and keeps that reasoning from having to hold forever.
+                return;
+            }
+
+            if (type.Equals(_chunkType))
+            {
+                ReadableStreamDefaultControllerOperations.Enqueue(controller, value);
+                return;
+            }
+
+            if (type.Equals(_closeType))
+            {
+                ReadableStreamDefaultControllerOperations.Close(controller);
+                Disentangle(port);
+                return;
+            }
+
+            if (type.Equals(_errorType))
+            {
+                ReadableStreamDefaultControllerOperations.Error(controller, value);
+                Disentangle(port);
+            }
+        };
+
+        // "Enable port's port message queue" — which is what makes whatever the transfer brought with it, and
+        // whatever the sender has posted since, reach the handler above.
+        port.Start();
+
+        ReadableStreamOperations.SetUpDefaultController(
+            stream,
+            controller,
+            startAlgorithm: static () => JsValue.Undefined,
+            pullAlgorithm: () =>
+            {
+                // Jint's addition; see the class remarks. A source that can never send again is a stream that
+                // will never produce another chunk, so it is errored rather than left readable forever.
+                if (port.IsChannelExhausted)
+                {
+                    Disentangle(port);
+                    ReadableStreamDefaultControllerOperations.Error(controller, ChannelGoneError(realm));
+                    return StreamPromises.ResolvedWithUndefined(engine, realm);
+                }
+
+                // "Perform ! PackAndPostMessage(port, "pull", undefined)": undefined always serializes, so the
+                // standard's `!` holds and there is nothing to handle.
+                PackAndPostMessage(port, _pullType, JsValue.Undefined);
+                return StreamPromises.ResolvedWithUndefined(engine, realm);
+            },
+            cancelAlgorithm: reason =>
+            {
+                var failure = PackAndPostMessageHandlingError(port, _errorType, reason);
+                Disentangle(port);
+
+                return failure is null
+                    ? StreamPromises.ResolvedWithUndefined(engine, realm)
+                    : StreamPromises.RejectedWith(engine, realm, failure);
+            },
+            highWaterMark: 0,
+            sizeAlgorithm: _sizeOfOne);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformwritable — the sending half: a
+    /// writable stream that posts everything written to it over <paramref name="port"/>.
+    /// </summary>
+    internal static void SetUpWritable(JsWritableStream stream, JsMessagePort port)
+    {
+        var engine = stream.Engine;
+        var realm = stream.Realm;
+
+        var controller = new JsWritableStreamDefaultController(engine, realm)
+        {
+            _prototype = realm.Intrinsics.WritableStreamDefaultController.PrototypeObject,
+        };
+
+        // "Let backpressurePromise be a new promise" — pending, so the very first chunk waits for the
+        // receiver's first read. Null stands for the standard's "undefined", i.e. nothing to wait on.
+        PromiseCapability? backpressure = StreamPromises.NewPromise(engine, realm);
+
+        void ReleaseBackpressure()
+        {
+            if (backpressure is not { } pending)
+            {
+                return;
+            }
+
+            backpressure = null;
+            pending.Resolve(JsValue.Undefined);
+        }
+
+        port.InternalMessageHandler = data =>
+        {
+            if (!TryReadMessage(data, out var type, out var value))
+            {
+                return;
+            }
+
+            if (type.Equals(_pullType))
+            {
+                ReleaseBackpressure();
+                return;
+            }
+
+            if (type.Equals(_errorType))
+            {
+                WritableStreamDefaultControllerOperations.ErrorIfNeeded(controller, value);
+
+                // Released after the error too: a write already waiting must not stay parked on a channel
+                // that has just reported failure.
+                ReleaseBackpressure();
+            }
+        };
+
+        port.Start();
+
+        WritableStreamDefaultControllerOperations.SetUp(
+            stream,
+            controller,
+            startAlgorithm: static () => JsValue.Undefined,
+            writeAlgorithm: chunk =>
+            {
+                // Jint's addition; see the class remarks. Checked before the backpressure wait rather than
+                // after it, because the pull that would end that wait is exactly what a channel with no far
+                // end can no longer send.
+                if (port.IsChannelExhausted)
+                {
+                    Disentangle(port);
+                    WritableStreamDefaultControllerOperations.ErrorIfNeeded(controller, ChannelGoneError(realm));
+
+                    // Resolved rather than rejected: the stream is erroring already, and the in-flight write
+                    // request has to finish before WritableStreamFinishErroring may run.
+                    return StreamPromises.ResolvedWithUndefined(engine, realm);
+                }
+
+                // Step 1, "if backpressurePromise is undefined, set it to a promise resolved with undefined",
+                // as a local rather than as an assignment: the reaction below replaces it unconditionally, and
+                // the only reader in between — ReleaseBackpressure — treats null and an already-resolved
+                // promise identically.
+                var waitOn = backpressure is { } pending
+                    ? StreamPromises.PromiseOf(pending)
+                    : StreamPromises.ResolvedWithUndefined(engine, realm);
+
+                return StreamPromises.TransformPromiseWith(
+                    engine,
+                    realm,
+                    waitOn,
+                    _ =>
+                    {
+                        // A fresh one before the post, so the next chunk waits for the next pull.
+                        backpressure = StreamPromises.NewPromise(engine, realm);
+
+                        var failure = PackAndPostMessageHandlingError(port, _chunkType, chunk);
+                        if (failure is null)
+                        {
+                            return JsValue.Undefined;
+                        }
+
+                        Disentangle(port);
+
+                        // The reaction's abrupt completion is what rejects the derived promise, which is the
+                        // write's own promise: an uncloneable chunk fails that write and errors the stream.
+                        throw new JavaScriptException(failure);
+                    },
+                    onRejected: null);
+            },
+            closeAlgorithm: () =>
+            {
+                PackAndPostMessage(port, _closeType, JsValue.Undefined);
+                Disentangle(port);
+                return StreamPromises.ResolvedWithUndefined(engine, realm);
+            },
+            abortAlgorithm: reason =>
+            {
+                var failure = PackAndPostMessageHandlingError(port, _errorType, reason);
+                Disentangle(port);
+
+                return failure is null
+                    ? StreamPromises.ResolvedWithUndefined(engine, realm)
+                    : StreamPromises.RejectedWith(engine, realm, failure);
+            },
+            highWaterMark: 1,
+            sizeAlgorithm: _sizeOfOne);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#abstract-opdef-packandpostmessage — build <c>{ type, value }</c> and
+    /// run the message port post message steps on it.
+    /// </summary>
+    /// <remarks>
+    /// The object's prototype is null, which the standard asks for so that <c>%Object.prototype%</c> cannot
+    /// interfere. It survives only as far as the serializer: structured cloning never carries a prototype, so
+    /// what the far side reads is an ordinary object of its own realm — whose own <c>type</c> and
+    /// <c>value</c> properties still outrank anything a script put on <c>Object.prototype</c> there.
+    /// </remarks>
+    private static void PackAndPostMessage(JsMessagePort port, JsString type, JsValue value)
+    {
+        var message = ObjectInstance.OrdinaryObjectCreate(port.Engine, proto: null);
+        message.CreateDataProperty(_typeKey, type);
+        message.CreateDataProperty(_valueKey, value);
+
+        port.PostMessage(message, transferList: null);
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#abstract-opdef-packandpostmessagehandlingerror — the same, reporting a
+    /// failure to the other side before handing it back.
+    /// </summary>
+    /// <returns>
+    /// The value the post threw, or <see langword="null"/> when it did not — the completion record the
+    /// standard returns, in the one shape a caller here ever inspects.
+    /// </returns>
+    private static JsValue? PackAndPostMessageHandlingError(JsMessagePort port, JsString type, JsValue value)
+    {
+        try
+        {
+            PackAndPostMessage(port, type, value);
+            return null;
+        }
+        catch (JavaScriptException e)
+        {
+            CrossRealmTransformSendError(port, e.Error);
+            return e.Error;
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#abstract-opdef-crossrealmtransformsenderror — "As we are already in an
+    /// errored state when this abstract operation is performed, we cannot handle further errors, so we just
+    /// discard them."
+    /// </summary>
+    private static void CrossRealmTransformSendError(JsMessagePort port, JsValue error)
+    {
+        try
+        {
+            PackAndPostMessage(port, _errorType, error);
+        }
+        catch (JavaScriptException)
+        {
+            // Discarded, as the note says. An error value that cannot itself be cloned — a DOMException can
+            // always be — leaves the far side to notice through the channel going quiet.
+        }
+    }
+
+    /// <summary>
+    /// "Disentangle port". HTML's disentangle is two-sided, and so is closing a side here: the peer's
+    /// <c>postMessage</c> consults it and finds it has no target — see <c>MessagePortEndpoint</c>.
+    /// </summary>
+    private static void Disentangle(JsMessagePort port) => port.Close();
+
+    /// <summary>
+    /// Reads the two properties the message carries. The standard asserts their shape; this returns
+    /// <see langword="false"/> instead, for the reason the readable side's handler gives.
+    /// </summary>
+    private static bool TryReadMessage(JsValue data, out JsString type, out JsValue value)
+    {
+        if (data is ObjectInstance envelope && envelope.Get(_typeKey) is JsString messageType)
+        {
+            type = messageType;
+            value = envelope.Get(_valueKey);
+            return true;
+        }
+
+        type = JsString.Empty;
+        value = JsValue.Undefined;
+        return false;
+    }
+
+    /// <summary>
+    /// The reason a stream is given when its channel has been ended without a <c>close</c> or an <c>error</c>
+    /// ever arriving. Jint's, not the standard's; see the class remarks.
+    /// </summary>
+    private static ObjectInstance ChannelGoneError(Realm realm) => realm.Intrinsics.TypeError.Construct(
+        "The transferred stream's channel was closed before the stream finished");
+}
+#endif

--- a/Jint/WebApi/Streams/JsReadableStream.cs
+++ b/Jint/WebApi/Streams/JsReadableStream.cs
@@ -33,9 +33,7 @@ internal enum ReadableStreamState
 /// </para>
 /// <para>
 /// The <c>[[controller]]</c> slot is a <see cref="JsReadableStreamDefaultController"/> or, for a stream
-/// constructed with <c>type: "bytes"</c>, a <see cref="JsReadableByteStreamController"/>. <c>[[Detached]]</c>
-/// has no counterpart, because a stream can only become detached by being transferred through
-/// <c>postMessage()</c>, and there is nothing to transfer it to.
+/// constructed with <c>type: "bytes"</c>, a <see cref="JsReadableByteStreamController"/>.
 /// </para>
 /// </remarks>
 internal sealed class JsReadableStream : ObjectInstance
@@ -66,6 +64,18 @@ internal sealed class JsReadableStream : ObjectInstance
     /// top, and is maintained so that they can be.
     /// </summary>
     internal bool Disturbed { get; set; }
+
+    /// <summary>
+    /// <c>[[Detached]]</c>, the slot every transferable object carries —
+    /// https://html.spec.whatwg.org/multipage/structured-data.html#transferable-objects. Set once the stream
+    /// has been transferred, which is what makes a second transfer a <c>DataCloneError</c>.
+    /// </summary>
+    /// <remarks>
+    /// Nothing else consults it, and it is deliberately not what makes a transferred stream unusable: the pipe
+    /// the transfer started holds a reader, so the original is <i>locked</i> for as long as it has anything
+    /// left to give. The slot is what still refuses the transfer once that pipe has finished and released it.
+    /// </remarks>
+    internal bool Detached { get; set; }
 
     /// <summary>
     /// https://streams.spec.whatwg.org/#readablestream-reader — the reader the stream is locked to, or

--- a/Jint/WebApi/Streams/JsTransformStream.cs
+++ b/Jint/WebApi/Streams/JsTransformStream.cs
@@ -50,5 +50,14 @@ internal sealed class JsTransformStream : ObjectInstance
     /// arrives while there is backpressure waits on it.
     /// </summary>
     internal PromiseCapability? BackpressureChangeCapability { get; set; }
+
+    /// <inheritdoc cref="JsReadableStream.Detached" />
+    /// <remarks>
+    /// A transform stream that arrived through a transfer has neither <see cref="Controller"/> nor
+    /// <see cref="Backpressure"/> — its transfer-receiving steps leave all three slots undefined, because a
+    /// transferred transform stream is a readable and a writable that were transferred separately and have no
+    /// transformer between them any more.
+    /// </remarks>
+    internal bool Detached { get; set; }
 }
 #endif

--- a/Jint/WebApi/Streams/JsWritableStream.cs
+++ b/Jint/WebApi/Streams/JsWritableStream.cs
@@ -109,5 +109,8 @@ internal sealed class JsWritableStream : ObjectInstance
 
     /// <summary>https://streams.spec.whatwg.org/#writablestream-backpressure</summary>
     internal bool Backpressure { get; set; }
+
+    /// <inheritdoc cref="JsReadableStream.Detached" />
+    internal bool Detached { get; set; }
 }
 #endif

--- a/Jint/WebApi/Streams/TransferableStreams.cs
+++ b/Jint/WebApi/Streams/TransferableStreams.cs
@@ -1,0 +1,184 @@
+#if NET8_0_OR_GREATER
+using Jint.Runtime;
+using Jint.WebApi.Messaging;
+using Jint.WebApi.StructuredClone;
+
+namespace Jint.WebApi.Streams;
+
+/// <summary>
+/// The <i>transfer steps</i> and <i>transfer-receiving steps</i> of the three transferable stream interfaces.
+/// <para>
+/// https://streams.spec.whatwg.org/#rs-transfer, https://streams.spec.whatwg.org/#ws-transfer and
+/// https://streams.spec.whatwg.org/#ts-transfer
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>A transferred stream is a pipe plus a channel.</b> Transferring a <c>ReadableStream</c> creates an
+/// entangled <c>MessagePort</c> pair in the sending realm, sets a cross-realm transform <i>writable</i> up on
+/// one port, pipes the original stream into it, and puts the other port in the data holder. The
+/// transfer-receiving steps build a cross-realm transform <i>readable</i> over the port that arrived. A
+/// <c>WritableStream</c> is the mirror image, and a <c>TransformStream</c> is both: its readable and its
+/// writable side are each transferred, so it costs two channels.
+/// </para>
+/// <para>
+/// <b>The port rides the transport that already exists.</b> The standard's data holder holds
+/// <c>StructuredSerializeWithTransfer(port2, « port2 »)</c> — a whole nested serialization whose result is one
+/// port data holder and nothing else. Jint's <see cref="SerializedMessagePort"/> <i>is</i> that data holder,
+/// so the stream's record carries one directly and the nesting collapses to a field. Nothing else changes:
+/// the side travels exactly as a script-transferred port's does, the receiving engine binds it to a
+/// <c>MessagePort</c> of its own realm, and a side that is never delivered is ended by the same stranding.
+/// </para>
+/// <para>
+/// <b>What the original stream is afterwards</b> is what the standard says: <c>[[Detached]]</c>, and locked,
+/// because the pipe holds a reader (or a writer) on it. A transferred <c>TransformStream</c> leaves both its
+/// sides detached and locked. The pipe runs entirely on the sending engine's own event loop; the receiving
+/// engine only ever sees messages.
+/// </para>
+/// </remarks>
+internal static class TransferableStreams
+{
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rs-transfer — the <c>ReadableStream</c> transfer steps, returning the
+    /// channel side the data holder carries.
+    /// </summary>
+    internal static MessagePortEndpoint TransferReadable(JsReadableStream value)
+    {
+        var engine = value.Engine;
+        var realm = value.Realm;
+
+        // StructuredSerializeWithTransfer step 5.2, which for a nested serialization is asked here rather than
+        // by the outer CompleteTransfers: transferring a TransformStream twice must be refused on the second
+        // attempt even though the TransformStream object itself is a different one each time.
+        if (value.Detached)
+        {
+            StructuredSerializer.ThrowDataCloneError(realm, "A ReadableStream that has already been transferred could not be cloned");
+        }
+
+        // Step 1.
+        if (ReadableStreamOperations.IsLocked(value))
+        {
+            StructuredSerializer.ThrowDataCloneError(realm, "A locked ReadableStream could not be cloned");
+        }
+
+        // Steps 2-4.
+        var (port1, port2) = MessagePortBridge.CreatePair(engine, realm, engine, realm);
+
+        // Steps 5-6: a WritableStream in the current realm, which is what the original is piped into.
+        var writable = new JsWritableStream(engine, realm)
+        {
+            _prototype = realm.Intrinsics.WritableStream.PrototypeObject,
+        };
+
+        CrossRealmTransform.SetUpWritable(writable, port1);
+
+        // Steps 7-8. Nothing observes the pipe's promise — the stream is gone from this realm's point of view
+        // — so it is marked handled rather than left to the rejection tracker.
+        var promise = ReadableStreamPipe.PipeTo(
+            value, writable, preventClose: false, preventAbort: false, preventCancel: false, signal: null);
+        StreamPromises.MarkHandled(promise);
+
+        // StructuredSerializeWithTransfer step 5's last act, done here so it covers the nested case too.
+        value.Detached = true;
+
+        // Step 9, reduced to the side the port data holder would have held; see the class remarks.
+        return port2.DetachForTransfer();
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#ws-transfer — the <c>WritableStream</c> transfer steps, the mirror
+    /// image of <see cref="TransferReadable"/>: a readable is created here and piped into the original.
+    /// </summary>
+    internal static MessagePortEndpoint TransferWritable(JsWritableStream value)
+    {
+        var engine = value.Engine;
+        var realm = value.Realm;
+
+        if (value.Detached)
+        {
+            StructuredSerializer.ThrowDataCloneError(realm, "A WritableStream that has already been transferred could not be cloned");
+        }
+
+        // Step 1.
+        if (WritableStreamOperations.IsLocked(value))
+        {
+            StructuredSerializer.ThrowDataCloneError(realm, "A locked WritableStream could not be cloned");
+        }
+
+        var (port1, port2) = MessagePortBridge.CreatePair(engine, realm, engine, realm);
+
+        var readable = new JsReadableStream(engine, realm)
+        {
+            _prototype = realm.Intrinsics.ReadableStream.PrototypeObject,
+        };
+
+        CrossRealmTransform.SetUpReadable(readable, port1);
+
+        var promise = ReadableStreamPipe.PipeTo(
+            readable, value, preventClose: false, preventAbort: false, preventCancel: false, signal: null);
+        StreamPromises.MarkHandled(promise);
+
+        value.Detached = true;
+
+        return port2.DetachForTransfer();
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#ts-transfer, steps 3 and 4: both sides have to be unlocked before
+    /// either is transferred, so a transform stream whose readable is locked leaves its writable alone.
+    /// </summary>
+    internal static void CheckTransformTransferable(JsTransformStream value)
+    {
+        var realm = value.Realm;
+
+        if (value.Detached)
+        {
+            StructuredSerializer.ThrowDataCloneError(realm, "A TransformStream that has already been transferred could not be cloned");
+        }
+
+        if (ReadableStreamOperations.IsLocked(value.Readable))
+        {
+            StructuredSerializer.ThrowDataCloneError(realm, "A TransformStream whose readable side is locked could not be cloned");
+        }
+
+        if (WritableStreamOperations.IsLocked(value.Writable))
+        {
+            StructuredSerializer.ThrowDataCloneError(realm, "A TransformStream whose writable side is locked could not be cloned");
+        }
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#rs-transfer — the <c>ReadableStream</c> transfer-receiving steps.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="endpoint"/> is the channel side the data holder carried, or <see langword="null"/> for
+    /// a record read a second time — which <see cref="SerializationRecord"/> forbids. Such a stream gets a
+    /// port entangled with nothing, which is inert, exactly as a twice-read <c>MessagePort</c> holder does.
+    /// </remarks>
+    internal static JsReadableStream ReceiveReadable(Engine engine, Realm realm, MessagePortEndpoint? endpoint)
+    {
+        var stream = new JsReadableStream(engine, realm)
+        {
+            _prototype = realm.Intrinsics.ReadableStream.PrototypeObject,
+        };
+
+        CrossRealmTransform.SetUpReadable(stream, new JsMessagePort(engine, realm, endpoint));
+        return stream;
+    }
+
+    /// <summary>
+    /// https://streams.spec.whatwg.org/#ws-transfer — the <c>WritableStream</c> transfer-receiving steps.
+    /// </summary>
+    /// <inheritdoc cref="ReceiveReadable" path="/remarks"/>
+    internal static JsWritableStream ReceiveWritable(Engine engine, Realm realm, MessagePortEndpoint? endpoint)
+    {
+        var stream = new JsWritableStream(engine, realm)
+        {
+            _prototype = realm.Intrinsics.WritableStream.PrototypeObject,
+        };
+
+        CrossRealmTransform.SetUpWritable(stream, new JsMessagePort(engine, realm, endpoint));
+        return stream;
+    }
+}
+#endif

--- a/Jint/WebApi/StructuredClone/SerializationRecord.cs
+++ b/Jint/WebApi/StructuredClone/SerializationRecord.cs
@@ -65,6 +65,13 @@ namespace Jint.WebApi.StructuredClone;
 /// is walked — a port referenced from the message must be the very object <c>ports</c> hands over — and
 /// because the event exposes them in order.
 /// </para>
+/// <para>
+/// It also carries the channels a <i>transferred stream</i> created for itself, which are the results of the
+/// nested serializations the stream transfer steps perform. Those are marked
+/// <see cref="SerializedMessagePort.Nested"/> and never reach <c>event.ports</c>; they are here because
+/// ending a side nobody will ever bind is exactly as necessary for them, and rather more so — a script can
+/// close a port it was given, and can do nothing at all about a stream's private one.
+/// </para>
 /// </param>
 [StructLayout(LayoutKind.Auto)]
 internal readonly record struct SerializationRecord(SerializedValue Root, List<SerializedMessagePort>? TransferredPorts = null);
@@ -272,6 +279,67 @@ internal sealed class SerializedArrayBufferView : SerializedObject
 internal sealed class SerializedMessagePort : SerializedObject
 {
     internal Messaging.MessagePortEndpoint? Endpoint { get; set; }
+
+    /// <summary>
+    /// Whether this holder belongs to a <i>nested</i> StructuredSerializeWithTransfer that a transferable's
+    /// own transfer steps performed — which today means the channel a transferred stream travels over — rather
+    /// than to the transfer list the caller wrote.
+    /// </summary>
+    /// <remarks>
+    /// It decides one thing: <c>event.ports</c> exposes the caller's ports and not a stream's private one. The
+    /// two kinds share <see cref="SerializationRecord.TransferredPorts"/> anyway, because the other thing that
+    /// list is for — ending a side nobody can ever bind — has to reach both, and a stream's channel is
+    /// precisely the side no script could ever end by hand.
+    /// </remarks>
+    internal bool Nested { get; init; }
+}
+
+/// <summary>
+/// A transferred <c>ReadableStream</c>: the standard's data holder, whose <c>[[port]]</c> is the receiving end
+/// of the channel the sender is piping the original stream into.
+/// <para>
+/// https://streams.spec.whatwg.org/#rs-transfer
+/// </para>
+/// </summary>
+/// <remarks>
+/// The standard's <c>[[port]]</c> is the <i>result of a nested StructuredSerializeWithTransfer</i> of one
+/// port; <see cref="SerializedMessagePort"/> is what that result amounts to here, so the field holds one
+/// directly — see <c>TransferableStreams</c>. Settable for the reason every transfer data holder's payload is:
+/// the holder is created before the graph is walked and filled in by step 5.
+/// </remarks>
+internal sealed class SerializedReadableStream : SerializedObject
+{
+    internal SerializedMessagePort Port { get; set; } = null!;
+}
+
+/// <summary>
+/// A transferred <c>WritableStream</c>, the mirror image of <see cref="SerializedReadableStream"/>: the sender
+/// is piping a readable of its own <i>into</i> the original stream, and the port is how chunks reach it.
+/// <para>
+/// https://streams.spec.whatwg.org/#ws-transfer
+/// </para>
+/// </summary>
+internal sealed class SerializedWritableStream : SerializedObject
+{
+    internal SerializedMessagePort Port { get; set; } = null!;
+}
+
+/// <summary>
+/// A transferred <c>TransformStream</c>: its two sides, each transferred in its own right.
+/// <para>
+/// https://streams.spec.whatwg.org/#ts-transfer
+/// </para>
+/// </summary>
+/// <remarks>
+/// <c>[[backpressure]]</c>, <c>[[backpressureChangePromise]]</c> and <c>[[controller]]</c> are deliberately
+/// absent: the standard's transfer-receiving steps set all three to undefined, because what arrives is a
+/// readable and a writable with two channels between them and no transformer of its own.
+/// </remarks>
+internal sealed class SerializedTransformStream : SerializedObject
+{
+    internal SerializedReadableStream Readable { get; set; } = null!;
+
+    internal SerializedWritableStream Writable { get; set; } = null!;
 }
 
 /// <summary>

--- a/Jint/WebApi/StructuredClone/StructuredDeserializer.cs
+++ b/Jint/WebApi/StructuredClone/StructuredDeserializer.cs
@@ -8,6 +8,7 @@ using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 using Jint.WebApi.DomException;
 using Jint.WebApi.Messaging;
+using Jint.WebApi.Streams;
 
 namespace Jint.WebApi.StructuredClone;
 
@@ -139,18 +140,37 @@ internal sealed class StructuredDeserializer
             return null;
         }
 
-        var ports = new List<JsMessagePort>(holders.Count);
+        List<JsMessagePort>? ports = null;
         foreach (var holder in holders)
         {
+            // A stream's own channel is not one of this serialization's transfer data holders — it belongs to
+            // the nested one its transfer steps performed — so it is neither created here nor exposed. Its
+            // stream's transfer-receiving steps take it, at the point the walk reaches the stream.
+            if (holder.Nested)
+            {
+                continue;
+            }
+
             var endpoint = holder.Endpoint;
             holder.Endpoint = null;
 
             var port = new JsMessagePort(_engine, _realm, endpoint);
             _memory[holder] = port;
-            ports.Add(port);
+            (ports ??= new List<JsMessagePort>(holders.Count)).Add(port);
         }
 
         return ports;
+    }
+
+    /// <summary>
+    /// Takes the channel side out of a data holder, so a record read twice cannot bind one side to two
+    /// engines — the same rule <see cref="DeserializeTransferredPorts"/> follows, for the same reason.
+    /// </summary>
+    private static Messaging.MessagePortEndpoint? TakeEndpoint(SerializedMessagePort holder)
+    {
+        var endpoint = holder.Endpoint;
+        holder.Endpoint = null;
+        return endpoint;
     }
 
     private void Drain()
@@ -233,6 +253,33 @@ internal sealed class StructuredDeserializer
             case SerializedDomException domException:
                 result = DeserializeDomException(domException);
                 break;
+
+            // The three streams' transfer-receiving steps. Each builds its half of a cross-realm transform
+            // over the channel side the sender detached, in this realm.
+            case SerializedReadableStream readableStream:
+                result = TransferableStreams.ReceiveReadable(_engine, _realm, TakeEndpoint(readableStream.Port));
+                break;
+
+            case SerializedWritableStream writableStream:
+                result = TransferableStreams.ReceiveWritable(_engine, _realm, TakeEndpoint(writableStream.Port));
+                break;
+
+            case SerializedTransformStream transformStream:
+                {
+                    // Registered before its two sides are built, exactly as the containers below are: the
+                    // sides are separate records, so a graph that names the transform stream twice must come
+                    // out as one object either way.
+                    var target = new JsTransformStream(_engine, _realm)
+                    {
+                        _prototype = _realm.Intrinsics.TransformStream.PrototypeObject,
+                    };
+
+                    _memory[record] = target;
+
+                    target.Readable = (JsReadableStream) DeserializeObject(transformStream.Readable);
+                    target.Writable = (JsWritableStream) DeserializeObject(transformStream.Writable);
+                    return target;
+                }
 
             // The four containers are registered before their contents are filled in, which is what lets a
             // cycle terminate.

--- a/Jint/WebApi/StructuredClone/StructuredSerializer.cs
+++ b/Jint/WebApi/StructuredClone/StructuredSerializer.cs
@@ -9,6 +9,7 @@ using Jint.Native.TypedArray;
 using Jint.Runtime;
 using Jint.WebApi.DomException;
 using Jint.WebApi.Messaging;
+using Jint.WebApi.Streams;
 
 namespace Jint.WebApi.StructuredClone;
 
@@ -535,11 +536,39 @@ internal sealed class StructuredSerializer
                 continue;
             }
 
-            // Step 2.1 / 2.2: an ArrayBuffer and a MessagePort are the transferables Jint has. A
-            // SharedArrayBuffer is explicitly not one.
+            // Step 2.4 for the three transferable stream interfaces, whose data holders are filled in by
+            // their own transfer steps in CompleteTransfers for exactly the same reason a port's is: the
+            // transfer has side effects — it locks the stream and starts a pipe — and the walk has to be able
+            // to throw first.
+            if (entry is JsReadableStream readable)
+            {
+                var holder = new SerializedReadableStream();
+                _memory[readable] = holder;
+                records.Add(new TransferRecord(readable, holder));
+                continue;
+            }
+
+            if (entry is JsWritableStream writable)
+            {
+                var holder = new SerializedWritableStream();
+                _memory[writable] = holder;
+                records.Add(new TransferRecord(writable, holder));
+                continue;
+            }
+
+            if (entry is JsTransformStream transform)
+            {
+                var holder = new SerializedTransformStream();
+                _memory[transform] = holder;
+                records.Add(new TransferRecord(transform, holder));
+                continue;
+            }
+
+            // Step 2.1 / 2.2: an ArrayBuffer, a MessagePort and the three streams above are the transferables
+            // Jint has. A SharedArrayBuffer is explicitly not one.
             if (entry is not JsArrayBuffer buffer || buffer.IsSharedArrayBuffer)
             {
-                ThrowDataCloneError("Only ArrayBuffer and MessagePort objects can be transferred");
+                ThrowDataCloneError("Only ArrayBuffer, MessagePort, ReadableStream, WritableStream and TransformStream objects can be transferred");
                 return null;
             }
 
@@ -599,6 +628,44 @@ internal sealed class StructuredSerializer
                 continue;
             }
 
+            // Step 5.5.4 for the streams, whose transfer steps live in TransferableStreams. Each of them
+            // performs a nested StructuredSerializeWithTransfer of a port, whose data holder is registered
+            // here so that a record which is never delivered ends that channel too — see
+            // SerializedMessagePort.Nested.
+            if (record.Source is JsReadableStream readable)
+            {
+                ((SerializedReadableStream) record.Target).Port = TransferStreamPort(TransferableStreams.TransferReadable(readable));
+                continue;
+            }
+
+            if (record.Source is JsWritableStream writable)
+            {
+                ((SerializedWritableStream) record.Target).Port = TransferStreamPort(TransferableStreams.TransferWritable(writable));
+                continue;
+            }
+
+            if (record.Source is JsTransformStream transform)
+            {
+                var holder = (SerializedTransformStream) record.Target;
+
+                // Steps 3 and 4 before either side moves: a transform stream with one side locked transfers
+                // neither, so its writable is not left piping into a channel nothing will ever read.
+                TransferableStreams.CheckTransformTransferable(transform);
+
+                holder.Readable = new SerializedReadableStream
+                {
+                    Port = TransferStreamPort(TransferableStreams.TransferReadable(transform.Readable)),
+                };
+
+                holder.Writable = new SerializedWritableStream
+                {
+                    Port = TransferStreamPort(TransferableStreams.TransferWritable(transform.Writable)),
+                };
+
+                transform.Detached = true;
+                continue;
+            }
+
             var buffer = (JsArrayBuffer) record.Source;
 
             // Step 5.1: a buffer detached during the walk cannot be transferred any more.
@@ -612,6 +679,19 @@ internal sealed class StructuredSerializer
             ((SerializedArrayBuffer) record.Target).Bytes = buffer.ArrayBufferData ?? [];
             buffer.DetachArrayBuffer();
         }
+    }
+
+    /// <summary>
+    /// Wraps the channel side a stream's transfer steps produced in the data holder the nested
+    /// StructuredSerializeWithTransfer would have returned, and registers it so that
+    /// <see cref="StrandTransferredPorts(in SerializationRecord)"/> and a discarded port message queue both
+    /// reach it.
+    /// </summary>
+    private SerializedMessagePort TransferStreamPort(Messaging.MessagePortEndpoint endpoint)
+    {
+        var holder = new SerializedMessagePort { Nested = true, Endpoint = endpoint };
+        (_transferredPorts ??= new List<SerializedMessagePort>()).Add(holder);
+        return holder;
     }
 
     [DoesNotReturn]
@@ -638,8 +718,12 @@ internal sealed class StructuredSerializer
 
             // A MessagePort is transferable but not serializable, so reaching one during the walk means it
             // was in the message and not in the transfer list — which the specification refuses at its
-            // "platform object that is not serializable" arm rather than at the transfer steps.
+            // "platform object that is not serializable" arm rather than at the transfer steps. The three
+            // stream interfaces are transferable and not serializable in exactly the same way.
             JsMessagePort => "A MessagePort that was not in the transfer list",
+            JsReadableStream => "A ReadableStream that was not in the transfer list",
+            JsWritableStream => "A WritableStream that was not in the transfer list",
+            JsTransformStream => "A TransformStream that was not in the transfer list",
             _ => "An object",
         };
 

--- a/README.md
+++ b/README.md
@@ -219,14 +219,14 @@ its own `console` (or any other name in the table below), enabling the feature l
 | `setTimeout` / `setInterval` / `clearTimeout` / `clearInterval` / `queueMicrotask` | `WebApiFeatures.Timers` | ✔ shipped |
 | `TextEncoder` (UTF-8) / `TextDecoder` (UTF-8, UTF-16LE/BE, every legacy single-byte encoding, `x-user-defined`; `fatal`, `ignoreBOM`, streaming) | `Encoding` | ✔ shipped |
 | `atob` / `btoa` | `Base64` | ✔ shipped |
-| `structuredClone` (incl. `{ transfer }` of `ArrayBuffer`s and `MessagePort`s) | `StructuredClone` | ✔ shipped |
+| `structuredClone` (incl. `{ transfer }` of `ArrayBuffer`s, `MessagePort`s and streams) | `StructuredClone` | ✔ shipped |
 | `crypto.getRandomValues` / `crypto.randomUUID` / `crypto.subtle` (SHA digests, HMAC, AES-GCM, RSA, ECDSA/ECDH, HKDF, PBKDF2, `CryptoKey`) | `WebApiFeatures.Crypto` | ✔ shipped |
 | `performance.now` / `timeOrigin` / `mark` / `measure` / `getEntries*` / `clearMarks` / `clearMeasures` | `WebApiFeatures.Performance` | ✔ shipped |
 | `Event` / `EventTarget` / `CustomEvent` / `AbortController` / `AbortSignal` | `Events` | ✔ shipped |
 | `URL` / `URLSearchParams` / `URLPattern` | `Url` | ✔ shipped |
 | `Blob` (incl. `stream()`) / `File` / `FormData` | `Files` | ✔ shipped |
 | `navigator.userAgent` | `Navigator` | ✔ shipped |
-| `ReadableStream` / `WritableStream` / `TransformStream` / `ByteLengthQueuingStrategy` / `CountQueuingStrategy` | `Streams` | ✔ shipped |
+| `ReadableStream` / `WritableStream` / `TransformStream` (all three transferable) / `ByteLengthQueuingStrategy` / `CountQueuingStrategy` | `Streams` | ✔ shipped |
 | `TextEncoderStream` / `TextDecoderStream` | `Encoding` **and** `Streams` | ✔ shipped |
 | `CompressionStream` / `DecompressionStream` (`gzip`, `deflate`, `deflate-raw`) | `Compression` **and** `Streams` | ✔ shipped |
 | `scheduler.postTask` / `scheduler.yield` / `TaskController` / `TaskSignal` | `Scheduler` | ✔ shipped |
@@ -1066,8 +1066,64 @@ One deliberate reduction: **only the five interfaces a script constructs by name
 `ReadableStreamDefaultReader`, `ReadableStreamBYOBReader`, `WritableStreamDefaultWriter`, the four
 controllers and `ReadableStreamBYOBRequest` exist as ordinary interface objects — a reader's `constructor` is
 the real thing, and `new` on it behaves as the standard says — but they are not installed on `globalThis`,
-where a browser would expose them. Transferring a stream through `postMessage()` is the one part of the
-standard that is absent, there being nothing to transfer it to.
+where a browser would expose them.
+
+#### All three streams are transferable
+
+`ReadableStream`, `WritableStream` and `TransformStream` are transferable objects, so a stream can be handed
+to another engine and read there — which is what makes a worker-style split able to pass a *pipeline* and not
+only a value:
+
+```csharp
+var host = new Engine(o => o.UseWebApis());
+var worker = new Engine(o => o.UseWebApis());
+var pair = host.Advanced.CreateMessagePortPair(worker);
+host.SetValue("port", pair.Local);
+worker.SetValue("port", pair.Remote);
+
+worker.Execute("""
+    port.onmessage = async e => {
+      for (const reader = e.data.getReader(); ; ) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        log(value);
+      }
+    };
+    """);
+
+host.Execute("""
+    const rs = new ReadableStream({ start(c) { c.enqueue('a'); c.enqueue('b'); c.close(); } });
+    port.postMessage(rs, [rs]);   // rs is now locked and no longer directly usable
+    """);
+```
+
+The mechanism is the standard's "cross-realm transform", and it is a `MessagePort` underneath: transferring a
+readable stream creates an entangled pair, wires a writable side onto one port, pipes the original stream into
+it and sends the other port along with the message. The receiving engine builds a readable stream over the
+port that arrived. A `WritableStream` is the mirror image, and a `TransformStream` is both — its two sides are
+transferred separately, so it costs two channels. `structuredClone(stream, { transfer: [stream] })` does the
+same thing into the current realm, which is what the two phases composed give you.
+
+**Both engines have to be pumped**, exactly as for a `MessagePort` and for timers: a chunk written on the
+sender is an event-loop task on the receiver, so an engine nobody pumps receives nothing. Backpressure crosses
+too — the receiving side's high water mark is 0 and each read sends one `pull` back — so the sender does not
+drain its source into the channel ahead of whoever is reading. Everything runs on each engine's own thread;
+nothing here starts one.
+
+The standard's refusals are implemented as written: transferring a **locked** stream is a `DataCloneError`,
+transferring the same stream twice is a `DataCloneError`, and a stream that is in the message but *not* in the
+transfer list is a `DataCloneError` — a stream is transferable and not serializable. After a transfer the
+original is **locked and disturbed**, because the pipe holds a reader (or a writer) on it, and a transferred
+`TransformStream` leaves both of its sides that way. Closing, erroring and cancelling all propagate across the
+boundary in both directions, and a chunk that cannot be structured-cloned fails that write and errors both
+ends.
+
+One thing goes beyond the standard, deliberately. HTML drops a message posted into a channel whose far end has
+gone, silently, so a transferred stream whose message is never delivered — or whose receiving engine calls
+`RestoreGlobalSnapshot`, or is disposed — would leave the sender's pipe reading its source forever and writing
+into nothing. Jint ends the stream instead: the next write (or the next read on the receiving side) finds the
+channel gone and errors, which cancels the source. A pipe is never left running against a side nobody can
+reach.
 
 ### Storage is opt-in on its own, and you decide where the data lives
 

--- a/docs/design/web-workers.md
+++ b/docs/design/web-workers.md
@@ -605,6 +605,14 @@ proposed.
   otherwise leave its peer posting into a queue nothing can ever drain. §8's "close both ports rather than
   merely forgetting the local one" is therefore already the shipped rule for ports, not only the proposed one
   for workers.
+- **Transferring a stream works too**, and it needed no new transport either: `ReadableStream`,
+  `WritableStream` and `TransformStream` are transferable, and the Streams Standard's transfer steps are a
+  `MessagePort` pair plus a pipe, so they ride the port transfer above. For the worker design that means
+  `worker.postMessage(rs, [rs])` hands a worker a *pipeline* rather than a value — with the same rule as
+  everything else here: both engines have to be pumped, because a chunk is a task on the receiver. The one
+  addition beyond the standard is that a channel whose far end has been ended errors the stream instead of
+  being written into forever, which is what makes §8's "restore or dispose on either side" also end a pipe
+  that was crossing the pair.
 - `Error` objects clone as data (name flattened to the seven standard names, plus message and stack); functions
   and symbols do not.
 


### PR DESCRIPTION
Implements transferable streams: `ReadableStream`, `WritableStream` and `TransformStream` can now ride a `postMessage` transfer list — or `structuredClone(stream, {transfer: [stream]})` — landing as live streams on the receiving side, per the Streams Standard's cross-realm transform.

Closes #3199.

**The design is the standard's own, on transport that already existed.** A transferred stream is a `MessagePort` pair plus a pipe: transferring a readable sets a cross-realm-transform *writable* over one port and pipes the original into it; a writable is the mirror image; a transform is both sides, two channels. Every chunk crosses as an ordinary port message (`{type, value}` structured-serialized on the sender, deserialized on the receiver), which is what makes an uncloneable chunk fail at the write with the `DataCloneError` reported to the far side, exactly as the spec writes it. Backpressure is the spec's too: the receiving side's HWM is 0 and one `pull` message releases one chunk, so nothing is posted until the receiving script actually reads. The standard's nested `StructuredSerializeWithTransfer` of the port collapses to a field: `SerializedMessagePort` *is* that result, marked `Nested` so it shares the record's port list — stranding and the discard cascade reach it — while `event.ports` skips it.

**One deliberate divergence, documented on `JsMessagePort.IsChannelExhausted`**: HTML drops a message posted into a disentangled channel silently, so the standard's sender would drain its source into nothing forever once the far end died (a receiver-side `RestoreGlobalSnapshot`, a stranded record). The write and pull algorithms consult the predicate and end their stream with a `TypeError` instead. It can only fire where the standard leaves the outcome undefined — every orderly shutdown posts `close`/`error` *before* disentangling, and the queue half of the predicate is what stops that final message being thrown away. Known limit, also documented: it fires at the sender's next write, so a pipe already parked on a backpressure promise whose resolver died stays idly parked; closing that would need the `MessagePort` `close` event Jint deliberately does not have.

**WPT**: `streams/transferable/transform-stream-members.any.js` vendored at the standing pin (byte-verified), a seventh streams suite — **4/4, no exclusion entry of any kind**; the `.window.js`/`resources/` browsing-context files stay out by name. 46 new tests in-repo (30 same-engine, 14 cross-engine over the public surface, 2 record-shape). Mutation: 16 mutants, 14 killed; the two survivors are the standard's own "Disentangle port" on shutdown paths whose stream the immediately-preceding message already finished — nothing script-visible changes, and observing the channel-object release would need a live-port diagnostic the change has no other reason to add.

Full matrix green both TFMs including HCV legs; whole Wpt filter 346/346 post-rebase on #3208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014n5uCpi2vvHWBSiewUwBiY
