### PR TITLE
Engine: park a host thread on the pump with Advanced.WaitForScheduledWork

### DIFF
--- a/Jint.Tests.PublicInterface/HostPumpWaitTests.cs
+++ b/Jint.Tests.PublicInterface/HostPumpWaitTests.cs
@@ -1,0 +1,102 @@
+#nullable enable
+
+using System.Diagnostics;
+using Jint.Native;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// <see cref="Engine.AdvancedOperations.WaitForScheduledWork"/> and
+/// <see cref="Engine.AdvancedOperations.WaitForScheduledWorkAsync"/> from the outside — the other half of
+/// <see cref="HostScheduledWorkTests"/>, which covers the <em>when to pump</em> question this one parks on.
+/// </summary>
+/// <remarks>
+/// Deliberately <b>not</b> gated on <c>NET8_0_OR_GREATER</c>: the wait is all-target-framework
+/// <c>Advanced</c> surface, and everything it is pointed at here — an event-loop job produced by settling a
+/// host-registered promise from another thread — is core engine machinery. The .NET 8 sources it also serves
+/// (a due timer) are covered in <c>Jint.Tests</c>.
+/// </remarks>
+public class HostPumpWaitTests
+{
+    private static readonly TimeSpan Ceiling = TimeSpan.FromSeconds(10);
+
+    private static readonly TimeSpan EarlyReturnMargin = TimeSpan.FromSeconds(5);
+
+    private static readonly TimeSpan WedgeCeiling = TimeSpan.FromMinutes(2);
+
+    /// <summary>
+    /// The shape the wait exists for: one thread parked on this engine, another handing it work. A settled
+    /// promise is the public core-engine way to do that — <c>Resolve</c> may be called from any thread and
+    /// enqueues onto the engine's own loop — and it stands in for every other cross-thread arrival a host sees
+    /// (a message posted from a second engine's thread, an asynchronous module load completing, an interop
+    /// <see cref="Task"/> settling). None of them has a due time, so nothing but the wake can report them, and
+    /// a host that slept on a ceiling instead paid that ceiling in latency on every one.
+    /// </summary>
+    /// <remarks>
+    /// The wait runs inside a host callback the script itself invokes, which is what makes the handshake
+    /// deterministic rather than timed: the engine is owned by this thread from the moment
+    /// <see cref="Engine.Execute(string, string?)"/> is entered, so the producer's settle can only ever be
+    /// enqueued — never drained on the producer's own thread — whichever side of the park it lands on. The
+    /// settle interval below therefore decides only <em>which</em> mechanism the run measures (the pre-check or
+    /// the wake), and never whether it passes.
+    /// </remarks>
+    [Fact]
+    public async Task WaitForScheduledWorkWakesOnACrossThreadPost()
+    {
+        using var engine = new Engine();
+        using var producerArmed = new ManualResetEventSlim();
+
+        var manual = engine.Advanced.RegisterPromise();
+        var elapsed = new Stopwatch();
+
+        engine.SetValue("hostWork", manual.Promise);
+        engine.SetValue("armProducer", new Action(() =>
+        {
+            elapsed.Start();
+            producerArmed.Set();
+        }));
+        engine.SetValue("park", new Func<bool>(() => engine.Advanced.WaitForScheduledWork(Ceiling)));
+
+        var producer = DedicatedThread.RunAsync(() =>
+        {
+            producerArmed.Wait(WedgeCeiling);
+
+            // Lets the wait be reached before the settle lands, so the wake rather than the pre-check is what
+            // ends it. Both are correct and both pass — see the remarks above.
+            Thread.Sleep(TimeSpan.FromMilliseconds(250));
+            manual.Resolve(JsValue.Undefined);
+        });
+
+        engine.Execute("""
+            globalThis.delivered = false;
+            hostWork.then(function () { globalThis.delivered = true; });
+            armProducer();
+            globalThis.reported = park();
+            """);
+
+        await producer;
+
+        engine.Evaluate("reported").AsBoolean().Should().BeTrue();
+        elapsed.Elapsed.Should().BeLessThan(EarlyReturnMargin);
+
+        // The wait reports work; the pump runs it. Execute's own trailing drain is that pump here.
+        engine.Evaluate("delivered").AsBoolean().Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The asynchronous form is reachable from outside the assembly, keeps the same contract, and hands the
+    /// engine back afterwards — the reservation it holds across the await must not outlive the returned task,
+    /// or a host's very next call would be refused as concurrent use. What it wakes on is the same set as the
+    /// synchronous form's, exercised by <c>Jint.Tests</c>'s <c>WakesOnACrossThreadEnqueueAsync</c>.
+    /// </summary>
+    [Fact]
+    public async Task WaitForScheduledWorkAsyncIsReachable()
+    {
+        using var engine = new Engine();
+
+        (await engine.Advanced.WaitForScheduledWorkAsync(TimeSpan.FromMilliseconds(50))).Should().BeFalse();
+
+        engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
+        (await engine.Advanced.WaitForScheduledWorkAsync(TimeSpan.Zero)).Should().BeFalse();
+    }
+}

--- a/Jint.Tests/Runtime/WaitForScheduledWorkTests.cs
+++ b/Jint.Tests/Runtime/WaitForScheduledWorkTests.cs
@@ -1,0 +1,353 @@
+#nullable enable
+
+using System.Diagnostics;
+using Xunit.Sdk;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// <see cref="Engine.AdvancedOperations.WaitForScheduledWork"/> and its asynchronous sibling — the pump wait,
+/// which parks a host thread until there is something for <see cref="Engine.AdvancedOperations.ProcessTasks"/>
+/// to run.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Nothing here is gated on <c>NET8_0_OR_GREATER</c>: the wait is core-engine surface on every target
+/// framework and knows nothing about which web APIs are enabled. The one source of scheduled work that only
+/// exists on .NET 8 and later — a due timer — has its own file, <c>WebApi.PumpWaitTests</c>.
+/// </para>
+/// <para>
+/// Every wait here is released by a thread the test owns, so the wall-clock numbers are ceilings and margins
+/// rather than expectations: <see cref="Ceiling"/> is what a wait is given, <see cref="EarlyReturnMargin"/> is
+/// the far smaller bound an early return has to beat, and a failure means the wake did not happen at all
+/// rather than that it happened slowly.
+/// </para>
+/// </remarks>
+public class WaitForScheduledWorkTests
+{
+    private const string ConcurrentUseMessage =
+        "*already in use by another thread or has an asynchronous operation in progress*";
+
+    /// <summary>
+    /// What a wait under test is given. Nothing should ever spend it: it is the bound a broken wake runs into.
+    /// </summary>
+    private static readonly TimeSpan Ceiling = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// The margin an early return has to beat. Half the ceiling, so the assertion separates "woke" from "ran
+    /// out the ceiling" and says nothing at all about latency.
+    /// </summary>
+    private static readonly TimeSpan EarlyReturnMargin = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Reached only by a genuine wedge — every handshake below is released by a thread the test owns.
+    /// </summary>
+    private static readonly TimeSpan WedgeCeiling = TimeSpan.FromMinutes(2);
+
+    /// <summary>
+    /// An engine with nothing queued and nothing scheduled has nothing to report, so the wait spends its whole
+    /// ceiling and answers <see langword="false"/> — and a zero ceiling answers it without waiting at all.
+    /// </summary>
+    [Fact]
+    public void ReturnsFalseOnTimeoutWhenNothingIsPending()
+    {
+        using var engine = new Engine();
+
+        engine.Advanced.WaitForScheduledWork(TimeSpan.Zero).Should().BeFalse();
+        engine.Advanced.WaitForScheduledWork(TimeSpan.FromMilliseconds(50)).Should().BeFalse();
+
+        // The wait owned the engine and gave it back, both times.
+        engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
+    }
+
+    /// <summary>
+    /// Work that is already queued is reported without any waiting — the check runs before the ceiling is even
+    /// consulted, which a zero ceiling is what proves: it cannot block, so a <see langword="true"/> can only
+    /// have come from there.
+    /// </summary>
+    [Fact]
+    public void ReturnsTrueImmediatelyWhenWorkIsAlreadyQueued()
+    {
+        using var engine = new Engine();
+        engine.AddToEventLoop(static () => { });
+
+        engine.Advanced.WaitForScheduledWork(TimeSpan.Zero).Should().BeTrue();
+
+        var elapsed = Stopwatch.StartNew();
+        engine.Advanced.WaitForScheduledWork(Ceiling).Should().BeTrue();
+        elapsed.Elapsed.Should().BeLessThan(EarlyReturnMargin);
+    }
+
+    /// <summary>
+    /// The reason this API exists: a job enqueued from another thread has no due time, so nothing but a wake
+    /// can tell a parked host about it.
+    /// </summary>
+    [Fact]
+    public async Task WakesOnACrossThreadEnqueue()
+    {
+        using var engine = new Engine();
+        using var waiterAboutToPark = new ManualResetEventSlim();
+
+        var producer = DedicatedThread.RunAsync(() =>
+        {
+            waiterAboutToPark.Wait(WedgeCeiling);
+            SettleBeforeEnqueueing();
+            engine.AddToEventLoop(static () => { });
+        });
+
+        var elapsed = Stopwatch.StartNew();
+        waiterAboutToPark.Set();
+        engine.Advanced.WaitForScheduledWork(Ceiling).Should().BeTrue();
+        elapsed.Elapsed.Should().BeLessThan(EarlyReturnMargin);
+
+        await producer;
+    }
+
+    /// <summary>
+    /// The token ends the wait, whether it was already cancelled when the wait started or fired while it was
+    /// parked, and either way the engine is handed back usable.
+    /// </summary>
+    [Fact]
+    public void ThrowsOperationCanceledOnTheToken()
+    {
+        using var engine = new Engine();
+
+        using var alreadyCancelled = new CancellationTokenSource();
+        alreadyCancelled.Cancel();
+        Invoking(() => engine.Advanced.WaitForScheduledWork(Ceiling, alreadyCancelled.Token))
+            .Should().Throw<OperationCanceledException>();
+
+        using var cancelledWhileParked = new CancellationTokenSource();
+        cancelledWhileParked.CancelAfter(SettleInterval);
+
+        var elapsed = Stopwatch.StartNew();
+        Invoking(() => engine.Advanced.WaitForScheduledWork(Ceiling, cancelledWhileParked.Token))
+            .Should().Throw<OperationCanceledException>();
+        elapsed.Elapsed.Should().BeLessThan(EarlyReturnMargin);
+
+        engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
+    }
+
+    /// <summary>
+    /// The other direction of the same claim, and the one that pins the wait's <em>own</em> ownership: a thread
+    /// parked in the wait holds the engine for the whole of it, so every guarded entry from every other thread
+    /// is refused until it returns. That is what makes one-drainer-per-engine self-enforcing rather than
+    /// merely advisory — a second host loop cannot quietly become a second drainer.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately separate from <see cref="ASecondThreadWaitingIsRefused"/>, which asks the reverse question
+    /// and would pass even with the wait's claim removed: the token linkage inside reads
+    /// <c>Constraints.Find&lt;CancellationConstraint&gt;()</c>, which takes an admission of its own and would
+    /// report the refusal from there. Only entering <em>while</em> a wait is parked distinguishes the two.
+    /// </remarks>
+    [Fact]
+    public async Task AParkedWaitOwnsTheEngineForItsWholeDuration()
+    {
+        using var engine = new Engine();
+        using var releaseWait = new CancellationTokenSource();
+
+        var parked = DedicatedThread.RunAsync(() =>
+        {
+            try
+            {
+                engine.Advanced.WaitForScheduledWork(WedgeCeiling, releaseWait.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                // How the test ends the park; the assertion is what happened while it was parked.
+            }
+        });
+
+        try
+        {
+            await WaitUntilRefused(engine, parked);
+        }
+        finally
+        {
+            releaseWait.Cancel();
+        }
+
+        await parked;
+
+        // The claim goes back with the wait rather than outliving it.
+        engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
+    }
+
+    /// <summary>
+    /// The wait is a guarded entry like any other, so an engine another thread is already using refuses it —
+    /// both forms, and the asynchronous one before a <see cref="Task"/> exists at all.
+    /// </summary>
+    [Fact]
+    public async Task ASecondThreadWaitingIsRefused()
+    {
+        using var entered = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        using var engine = new Engine();
+        engine.SetValue("block", new Action(() =>
+        {
+            entered.Set();
+            release.Wait(WedgeCeiling);
+        }));
+
+        var running = DedicatedThread.RunAsync(() => engine.Execute("block()"));
+        await WaitUntilOwned(entered, running);
+        try
+        {
+            Invoking(() => engine.Advanced.WaitForScheduledWork(TimeSpan.FromMilliseconds(50)))
+                .Should().Throw<InvalidOperationException>()
+                .WithMessage(ConcurrentUseMessage);
+
+            // Not awaited: the reservation the asynchronous form takes is claimed synchronously, precisely so
+            // that an engine already in use is refused before a Task exists.
+            Action concurrentAsync = () => _ = engine.Advanced.WaitForScheduledWorkAsync(TimeSpan.FromMilliseconds(50));
+            concurrentAsync.Should().Throw<InvalidOperationException>().WithMessage(ConcurrentUseMessage);
+        }
+        finally
+        {
+            release.Set();
+        }
+
+        await running;
+    }
+
+    /// <summary>
+    /// The asynchronous form times out the same way, and gives the engine back — the reservation it holds
+    /// across the await is released when the task completes, not left behind to refuse the host's next call.
+    /// </summary>
+    [Fact]
+    public async Task ReturnsFalseOnTimeoutWhenNothingIsPendingAsync()
+    {
+        using var engine = new Engine();
+
+        (await engine.Advanced.WaitForScheduledWorkAsync(TimeSpan.Zero)).Should().BeFalse();
+        (await engine.Advanced.WaitForScheduledWorkAsync(TimeSpan.FromMilliseconds(50))).Should().BeFalse();
+
+        engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
+    }
+
+    /// <summary>
+    /// The asynchronous form's pre-check, proved the same way: a zero ceiling cannot wait.
+    /// </summary>
+    [Fact]
+    public async Task ReturnsTrueImmediatelyWhenWorkIsAlreadyQueuedAsync()
+    {
+        using var engine = new Engine();
+        engine.AddToEventLoop(static () => { });
+
+        (await engine.Advanced.WaitForScheduledWorkAsync(TimeSpan.Zero)).Should().BeTrue();
+
+        var elapsed = Stopwatch.StartNew();
+        (await engine.Advanced.WaitForScheduledWorkAsync(Ceiling)).Should().BeTrue();
+        elapsed.Elapsed.Should().BeLessThan(EarlyReturnMargin);
+    }
+
+    /// <summary>
+    /// The asynchronous form wakes on the same cross-thread enqueue. Its reservation refuses every guarded
+    /// entry while it is outstanding, so the producer's handshake below is what an owned engine looks like from
+    /// the other side.
+    /// </summary>
+    [Fact]
+    public async Task WakesOnACrossThreadEnqueueAsync()
+    {
+        using var engine = new Engine();
+
+        using var waiterAboutToPark = new ManualResetEventSlim();
+        var producer = DedicatedThread.RunAsync(() =>
+        {
+            waiterAboutToPark.Wait(WedgeCeiling);
+            SettleBeforeEnqueueing();
+            engine.AddToEventLoop(static () => { });
+        });
+
+        var elapsed = Stopwatch.StartNew();
+        waiterAboutToPark.Set();
+        (await engine.Advanced.WaitForScheduledWorkAsync(Ceiling)).Should().BeTrue();
+        elapsed.Elapsed.Should().BeLessThan(EarlyReturnMargin);
+
+        await producer;
+    }
+
+    /// <summary>
+    /// How long a producer lets the waiter settle after being told it is about to park.
+    /// </summary>
+    private static readonly TimeSpan SettleInterval = TimeSpan.FromMilliseconds(250);
+
+    /// <summary>
+    /// Lets the waiter reach its park before the enqueue lands.
+    /// </summary>
+    /// <remarks>
+    /// Not a poll, and not something an assertion rides on: <b>both</b> interleavings pass — an enqueue that
+    /// beats the wait is seen by the pre-check, and one that does not exercises the wake — so this only decides
+    /// which of the two mechanisms the run measures. The waiter's next instruction after the signal is the
+    /// interlocked claim inside the wait, so a quarter of a second is not a race anything can realistically
+    /// lose; and if it did, the run would still be green, merely testing the weaker of the two paths. The
+    /// engine cannot offer a signal here — it does not run script while it waits — and probing its ownership
+    /// from this thread would have to <em>take</em> ownership, which is the one thing that could make the
+    /// waiter fail.
+    /// </remarks>
+    private static void SettleBeforeEnqueueing() => Thread.Sleep(SettleInterval);
+
+    /// <summary>
+    /// Polls a guarded entry until the engine refuses it, which is the only signal a parked wait can give:
+    /// it runs no script, so there is nothing for it to announce itself with. Ends on the refusal, on
+    /// <paramref name="parked"/> finishing without ever taking the engine — reporting whatever stopped it —
+    /// or on <see cref="WedgeCeiling"/>.
+    /// </summary>
+    /// <remarks>
+    /// A poll rather than a handshake, and deliberately not one an assertion times: the loop only decides
+    /// <em>when</em> the observation is made, never what it has to be. Each probe is a
+    /// <see cref="Engine.AdvancedOperations.ProcessTasks"/> on an engine with nothing queued, so a probe that
+    /// lands before the park runs the empty loop and costs nothing.
+    /// </remarks>
+    private static async Task WaitUntilRefused(Engine engine, Task parked)
+    {
+        var elapsed = Stopwatch.StartNew();
+        while (true)
+        {
+            try
+            {
+                engine.Advanced.ProcessTasks();
+            }
+            catch (InvalidOperationException e) when (e.Message.Contains("already in use", StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            if (parked.IsCompleted)
+            {
+                await parked;
+                throw new XunitException("the parked wait returned without ever owning the engine");
+            }
+
+            if (elapsed.Elapsed > WedgeCeiling)
+            {
+                throw new XunitException($"the wait did not claim the engine within {WedgeCeiling}");
+            }
+
+            Thread.Sleep(TimeSpan.FromMilliseconds(20));
+        }
+    }
+
+    /// <summary>
+    /// Waits until <paramref name="running"/> is provably parked inside <c>block()</c>. Ends on the signal, on
+    /// that thread finishing without ever reaching <c>block()</c> — reporting whatever stopped it rather than a
+    /// timeout — or on <see cref="WedgeCeiling"/>.
+    /// </summary>
+    private static async Task WaitUntilOwned(ManualResetEventSlim entered, Task running)
+    {
+        var elapsed = Stopwatch.StartNew();
+        while (!entered.Wait(TimeSpan.FromMilliseconds(20)))
+        {
+            if (running.IsCompleted)
+            {
+                await running;
+                throw new XunitException("the owning call returned without ever entering block()");
+            }
+
+            if (elapsed.Elapsed > WedgeCeiling)
+            {
+                throw new XunitException($"the owning thread did not enter block() within {WedgeCeiling}");
+            }
+        }
+    }
+}

--- a/Jint.Tests/Runtime/WebApi/PumpWaitTests.cs
+++ b/Jint.Tests/Runtime/WebApi/PumpWaitTests.cs
@@ -1,0 +1,44 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.Diagnostics;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// <see cref="Engine.AdvancedOperations.WaitForScheduledWork"/> against the one source of scheduled work that
+/// only exists on .NET 8 and later: a due web-API timer.
+/// </summary>
+/// <remarks>
+/// A file of its own rather than a gated region inside <c>Runtime.WaitForScheduledWorkTests</c>, because the
+/// wait itself is core surface on every target framework and only what it is being pointed at here is not —
+/// the same split <c>HostScheduledWorkTests</c> and <c>WebApiSchedulingSurfaceTests</c> already make for
+/// <see cref="Engine.AdvancedOperations.TimeUntilNextScheduledWork"/>.
+/// </remarks>
+public class PumpWaitTests
+{
+    /// <summary>
+    /// The wait is bounded internally by the engine's own next due time, not only by the ceiling the caller
+    /// passed: a <c>setTimeout</c> due in 50 ms wakes a wait that was given ten seconds. Without that clamp
+    /// nothing would end the wait — a timer coming due enqueues nothing, and so wakes nobody — and a host
+    /// pumping on a ceiling would run every timer at its own cadence instead of at the script's.
+    /// </summary>
+    [Fact]
+    public void ClampsToTheEnginesOwnSchedule()
+    {
+        using var engine = new Engine(options => options.UseWebApis(WebApiFeatures.Timers));
+        engine.Execute("globalThis.fired = false; setTimeout(function () { globalThis.fired = true; }, 50);");
+
+        // Nothing has run it yet: Execute drains the loop, but a timer 50 ms out is not due.
+        engine.Evaluate("fired").AsBoolean().Should().BeFalse();
+
+        var elapsed = Stopwatch.StartNew();
+        engine.Advanced.WaitForScheduledWork(TimeSpan.FromSeconds(10)).Should().BeTrue();
+        elapsed.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(5));
+
+        // The wait reports work; the pump is what runs it. That division is the whole contract.
+        engine.Advanced.ProcessTasks();
+        engine.Evaluate("fired").AsBoolean().Should().BeTrue();
+    }
+}
+#endif

--- a/Jint/Engine.Pump.cs
+++ b/Jint/Engine.Pump.cs
@@ -3,8 +3,15 @@
 // and keep conditional compilation out of the pump.
 #pragma warning disable CA1822
 
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Jint.Constraints;
 using Jint.Native.Atomics;
+using Jint.Runtime;
 
 namespace Jint;
 
@@ -15,6 +22,11 @@ namespace Jint;
 // TimeUntilNextPumpScheduledWork. Declaring every hook here on every target framework, with the conditional
 // compilation inside the bodies, is what keeps #if out of EventLoop.RunAvailableContinuations,
 // Engine.DrainEventLoopUntil and Engine.AwaitPromiseSettlementAsync entirely.
+//
+// The host-facing half of the same subject lives here too: TimeUntilNextScheduledWork answers *when* to pump,
+// and WaitForScheduledWork parks the calling thread until that answer is "now" — the piece a host driving one
+// engine per thread was missing, because a job arriving from another thread has no due time to report and so
+// could only be found by polling.
 public partial class Engine
 {
     /// <summary>
@@ -118,6 +130,31 @@ public partial class Engine
     }
 
     /// <summary>
+    /// Whether the pump has something to run the instant it is called, without consulting any clock: a job is
+    /// queued, or — on net8.0 and later — an idle callback is waiting for the queue to drain, which it does the
+    /// moment a pump starts.
+    /// </summary>
+    /// <remarks>
+    /// The one home for that composition, so that <see cref="AdvancedOperations.TimeUntilNextScheduledWork"/>
+    /// and <see cref="WaitForScheduledWork"/> can never disagree about what "work is available now" means. Like
+    /// every other hook in this file it is declared on every target framework with the conditional compilation
+    /// inside its body.
+    /// </remarks>
+    internal bool HasImmediatePumpWork()
+    {
+        if (_eventLoop.HasPendingJobs)
+        {
+            return true;
+        }
+
+#if NET8_0_OR_GREATER
+        return _webApi is { HasPendingIdleWork: true };
+#else
+        return false;
+#endif
+    }
+
+    /// <summary>
     /// How long the engine may idle before work it scheduled for itself needs the pump: the earlier of the
     /// next <c>Atomics.waitAsync</c> deadline and — on net8.0 and later — the next due web-API timer.
     /// <see langword="null"/> when neither pends; zero or negative means something is due right now.
@@ -135,6 +172,294 @@ public partial class Engine
 #endif
 
         return untilWaiter;
+    }
+
+    /// <summary>
+    /// What one pass of the pump wait needs to know: whether there is work the calling thread could run right
+    /// now, and otherwise how long the engine's own schedule allows it to idle before there will be.
+    /// </summary>
+    [StructLayout(LayoutKind.Auto)]
+    private readonly record struct ScheduledWorkState(bool IsAvailable, TimeSpan? UntilDue);
+
+    /// <summary>
+    /// Nothing to run and nothing scheduled: the answer for an engine that only another thread can wake.
+    /// </summary>
+    private static readonly ScheduledWorkState NoScheduledWork = new(IsAvailable: false, UntilDue: null);
+
+    /// <summary>
+    /// The pump wait's view of <see cref="AdvancedOperations.TimeUntilNextScheduledWork"/>, differing from it
+    /// in exactly one way: nested inside a running job nothing counts as available.
+    /// </summary>
+    /// <remarks>
+    /// That carve-out is the rule <see cref="Runtime.EventLoop.WaitForWork"/> and
+    /// <see cref="DrainEventLoopUntil"/> already apply, for the reason they document — the re-entrancy guard
+    /// makes the queue unrunnable from inside a job, so reporting it as available would hand the caller a
+    /// <see langword="true"/> whose <see cref="AdvancedOperations.ProcessTasks"/> does nothing, and its loop
+    /// would spin hot for the whole of its ceiling. Reporting nothing instead lets the wait run its course and
+    /// answer <see langword="false"/>, which costs one bounded idle and no CPU.
+    /// </remarks>
+    private ScheduledWorkState InspectScheduledWork()
+    {
+        if (_eventLoop.IsRunningJob)
+        {
+            return NoScheduledWork;
+        }
+
+        // Anything already queued is work the caller could run the moment this returns, and no clock can
+        // improve on that answer — the same first question TimeUntilNextScheduledWork asks, through the same
+        // helper, so the two can never disagree about what "now" means.
+        if (HasImmediatePumpWork())
+        {
+            return new ScheduledWorkState(IsAvailable: true, UntilDue: null);
+        }
+
+        if (TimeUntilNextPumpScheduledWork() is not { } untilDue)
+        {
+            return NoScheduledWork;
+        }
+
+        return untilDue <= TimeSpan.Zero
+            ? new ScheduledWorkState(IsAvailable: true, UntilDue: null)
+            : new ScheduledWorkState(IsAvailable: false, untilDue);
+    }
+
+    /// <summary>
+    /// The longest span a single blocking wait may ask for. <see cref="ManualResetEventSlim.Wait(TimeSpan)"/>
+    /// and <see cref="Task.Delay(TimeSpan)"/> both reject anything above <see cref="int.MaxValue"/>
+    /// milliseconds, and the wait loops around anyway, so a longer ceiling is served by several passes.
+    /// </summary>
+    private static readonly TimeSpan MaxSingleWaitInterval = TimeSpan.FromMilliseconds(int.MaxValue);
+
+    private static readonly double MillisecondsPerStopwatchTick = 1000.0 / Stopwatch.Frequency;
+
+    /// <summary>
+    /// How much of the caller's ceiling a wait has already spent, measured on the monotonic clock.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Stopwatch"/> rather than the wall clock, for the reason
+    /// <see cref="Native.Atomics.AtomicsWaiterDeadlines"/> beside it records: a ceiling a host passed must
+    /// not be cut short by an NTP step forwards or stretched by one backwards. Elapsed-since-start rather
+    /// than an absolute deadline, so that a ceiling as large as <see cref="TimeSpan.MaxValue"/> — which a
+    /// host spelling "effectively no bound" may well pass — cannot overflow the arithmetic.
+    /// </remarks>
+    private static TimeSpan ElapsedSince(long startTimestamp)
+        => TimeSpan.FromMilliseconds((Stopwatch.GetTimestamp() - startTimestamp) * MillisecondsPerStopwatchTick);
+
+    /// <summary>
+    /// Links the caller's token with a registered <see cref="CancellationConstraint"/>'s, exactly as
+    /// <see cref="DrainEventLoopUntil"/> does: an engine that has been cancelled has nothing worth waiting
+    /// for, and the two tokens keep different contracts on the way out.
+    /// </summary>
+    private CancellationToken BuildPumpWaitToken(
+        CancellationToken cancellationToken,
+        out CancellationTokenSource? linkedTokenSource)
+    {
+        linkedTokenSource = null;
+
+        var constraintToken = Constraints.Find<CancellationConstraint>()?.Token ?? default;
+        if (!cancellationToken.CanBeCanceled)
+        {
+            return constraintToken;
+        }
+
+        if (!constraintToken.CanBeCanceled)
+        {
+            return cancellationToken;
+        }
+
+        linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, constraintToken);
+        return linkedTokenSource.Token;
+    }
+
+    /// <summary>
+    /// Decides which contract a cancellation during an idle wait belongs to, mirroring
+    /// <see cref="DrainEventLoopUntil"/>: the caller's own token is reported back to the caller, while the
+    /// engine's <see cref="CancellationConstraint"/> surfaces the way per-statement execution reports it.
+    /// </summary>
+    [DoesNotReturn]
+    private static void RethrowPumpWaitCancellation(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Throw.ExecutionCanceledException();
+    }
+
+    /// <summary>
+    /// How long this pass may block: the smaller of what is left of the caller's ceiling and the engine's own
+    /// next due time, clamped to <see cref="MaxSingleWaitInterval"/>. <see langword="null"/> means the ceiling
+    /// has run out.
+    /// </summary>
+    private static TimeSpan? NextPumpWaitInterval(TimeSpan? remaining, TimeSpan? untilDue)
+    {
+        var interval = Timeout.InfiniteTimeSpan;
+        if (remaining is { } left)
+        {
+            if (left <= TimeSpan.Zero)
+            {
+                return null;
+            }
+
+            interval = left;
+        }
+
+        if (untilDue is { } due && (interval == Timeout.InfiniteTimeSpan || due < interval))
+        {
+            interval = due;
+        }
+
+        // Timeout.InfiniteTimeSpan is negative, so it can never trip this — a wait with no bound at all keeps
+        // asking for none, and only a genuinely huge ceiling is served in several passes.
+        return interval > MaxSingleWaitInterval ? MaxSingleWaitInterval : interval;
+    }
+
+    /// <summary>
+    /// The body of <see cref="AdvancedOperations.WaitForScheduledWork"/>, which owns the engine for the whole
+    /// of it — see that method's remarks for why.
+    /// </summary>
+    internal bool WaitForScheduledWork(TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        using var ownership = EnterHostCall();
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var state = InspectScheduledWork();
+        if (state.IsAvailable)
+        {
+            return true;
+        }
+
+        var infinite = timeout == Timeout.InfiniteTimeSpan;
+        if (!infinite && timeout <= TimeSpan.Zero)
+        {
+            return false;
+        }
+
+        var waitToken = BuildPumpWaitToken(cancellationToken, out var linkedTokenSource);
+        try
+        {
+            var start = Stopwatch.GetTimestamp();
+            while (true)
+            {
+                var remaining = infinite ? (TimeSpan?) null : timeout - ElapsedSince(start);
+                if (NextPumpWaitInterval(remaining, state.UntilDue) is not { } interval)
+                {
+                    return false;
+                }
+
+                try
+                {
+                    _eventLoop.WaitForWork(completedEvent: null, interval, waitToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    RethrowPumpWaitCancellation(cancellationToken);
+                }
+
+                state = InspectScheduledWork();
+                if (state.IsAvailable)
+                {
+                    return true;
+                }
+            }
+        }
+        finally
+        {
+            linkedTokenSource?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// The body of <see cref="AdvancedOperations.WaitForScheduledWorkAsync"/>. The reservation is taken by the
+    /// caller — synchronously, so an engine already in use refuses before a <see cref="Task"/> exists — and
+    /// released here, because everything after the first <c>await</c> belongs to this method.
+    /// </summary>
+    /// <remarks>
+    /// The discipline is the one every async host entry uses: <see cref="ReserveAsyncHostOperation"/> holds the
+    /// engine across every await, since no thread stays claimed over one, and each moment that actually reads
+    /// engine state re-claims the resuming thread with <see cref="EnterTransferredHostCall"/> — which is what
+    /// makes the timer and atomics heaps <see cref="TimeUntilNextPumpScheduledWork"/> walks safe to read from
+    /// whichever thread the continuation lands on. Deliberately <em>not</em> mirrored from
+    /// <see cref="AwaitPromiseSettlementAsync"/>: its <c>_hostCallbackAdmission</c> bracket around the await
+    /// exists to keep a converted host callback admissible while script is suspended, and this wait runs no
+    /// script at all. It also leaves <c>_pendingAsyncOperations</c> alone for the same reason — that counter
+    /// answers "is an evaluation suspended", and the reservation alone is what a restore has to refuse.
+    /// </remarks>
+    private async Task<bool> WaitForScheduledWorkCoreAsync(object owner, TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        CancellationTokenSource? linkedTokenSource = null;
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            ScheduledWorkState state;
+            CancellationToken waitToken;
+            using (EnterTransferredHostCall(owner))
+            {
+                state = InspectScheduledWork();
+                waitToken = BuildPumpWaitToken(cancellationToken, out linkedTokenSource);
+            }
+
+            if (state.IsAvailable)
+            {
+                return true;
+            }
+
+            var infinite = timeout == Timeout.InfiniteTimeSpan;
+            if (!infinite && timeout <= TimeSpan.Zero)
+            {
+                return false;
+            }
+
+            var start = Stopwatch.GetTimestamp();
+            while (true)
+            {
+                var remaining = infinite ? (TimeSpan?) null : timeout - ElapsedSince(start);
+                if (NextPumpWaitInterval(remaining, state.UntilDue) is not { } interval)
+                {
+                    return false;
+                }
+
+                try
+                {
+                    if (interval == Timeout.InfiniteTimeSpan)
+                    {
+                        // Nothing is scheduled and the caller asked for no ceiling, so only an Enqueue can
+                        // change the answer — and that is exactly what the unbounded overload waits for.
+                        await _eventLoop.WaitForEventAsync(waitToken).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        await _eventLoop.WaitForEventAsync(interval, waitToken).ConfigureAwait(false);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    RethrowPumpWaitCancellation(cancellationToken);
+                }
+
+                // The bounded overload reports a cancelled wait by returning rather than by throwing — it
+                // races the registration against a Task.Delay through WhenAny, which never throws — so the
+                // token has to be re-read here as well as caught above.
+                if (waitToken.IsCancellationRequested)
+                {
+                    RethrowPumpWaitCancellation(cancellationToken);
+                }
+
+                using (EnterTransferredHostCall(owner))
+                {
+                    state = InspectScheduledWork();
+                }
+
+                if (state.IsAvailable)
+                {
+                    return true;
+                }
+            }
+        }
+        finally
+        {
+            linkedTokenSource?.Dispose();
+            ReleaseAsyncHostOperation(owner);
+        }
     }
 
     public partial class AdvancedOperations
@@ -211,39 +536,30 @@ public partial class Engine
         ///     SleepUntilNextFrame();
         /// }
         /// </code>
-        /// A message pump with no frame of its own can sleep on the value instead, keeping a ceiling so that
-        /// work arriving from a background thread is still picked up:
+        /// A message pump with no frame of its own does not need to read the value at all:
+        /// <see cref="WaitForScheduledWork"/> already parks on it, and — unlike a sleep — also wakes on a job
+        /// that arrives from another thread, which has no due time for this property to report.
         /// <code>
-        /// var until = engine.Advanced.TimeUntilNextScheduledWork ?? TimeSpan.FromMilliseconds(50);
-        /// if (until > TimeSpan.Zero)
+        /// while (running)
         /// {
-        ///     Thread.Sleep(until &lt; TimeSpan.FromMilliseconds(50) ? until : TimeSpan.FromMilliseconds(50));
+        ///     engine.Advanced.ProcessTasks();
+        ///     engine.Advanced.WaitForScheduledWork(TimeSpan.FromMilliseconds(50), token);
         /// }
-        ///
-        /// engine.Advanced.ProcessTasks();
         /// </code>
         /// </example>
         public TimeSpan? TimeUntilNextScheduledWork
         {
             get
             {
-                // Anything already queued is work the pump can run now, so no clock can improve on the
-                // answer. This check lives here rather than in the internal aggregate below, because the
-                // engine's own wait loops clamp on that aggregate while the queue may be unrunnable from
-                // where they stand — a zero there would spin them hot for their caller's whole timeout.
-                if (_engine._eventLoop.HasPendingJobs)
+                // Anything already queued — and an idle callback, which becomes runnable the moment the queue
+                // drains — is work the pump can run now, so no clock can improve on the answer. This check
+                // lives here rather than in TimeUntilNextPumpScheduledWork, because the engine's own wait
+                // loops clamp on that aggregate while the queue may be unrunnable from where they stand — a
+                // zero there would spin them hot for their caller's whole timeout.
+                if (_engine.HasImmediatePumpWork())
                 {
                     return TimeSpan.Zero;
                 }
-
-#if NET8_0_OR_GREATER
-                // An idle callback becomes runnable the moment the job queue drains, so it is work for now
-                // rather than work for later.
-                if (_engine._webApi is { } webApi && webApi.HasPendingIdleWork)
-                {
-                    return TimeSpan.Zero;
-                }
-#endif
 
                 var next = _engine.TimeUntilNextPumpScheduledWork();
 
@@ -252,6 +568,149 @@ public partial class Engine
                 // I".
                 return next is { } value && value < TimeSpan.Zero ? TimeSpan.Zero : next;
             }
+        }
+
+        /// <summary>
+        /// Blocks the calling thread until this engine has work worth pumping, or <paramref name="timeout"/>
+        /// elapses. Returns <see langword="true"/> when there is (probably) work — call
+        /// <see cref="ProcessTasks"/> next — and <see langword="false"/> on timeout.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>It does not pump.</b> The canonical loop is still
+        /// <see cref="TimeUntilNextScheduledWork"/>/<see cref="ProcessTasks"/> and there is deliberately no
+        /// third method that drains for a budget; this answers only the question a sleep answered badly, which
+        /// is <i>how long may this thread idle</i>. What a sleep cannot do is notice a job that arrived from
+        /// <em>another</em> thread — a settled interop <see cref="Task"/>, a message posted into this engine,
+        /// a module load completing — because such a job has no due time for
+        /// <see cref="TimeUntilNextScheduledWork"/> to report and so could only be found by polling. That is
+        /// the whole of what this adds: a host that slept on a 20 ms ceiling paid up to 20 ms of latency on
+        /// every one of those arrivals.
+        /// </para>
+        /// <para>
+        /// The wait ends as soon as any of these is true, whichever comes first:
+        /// <list type="bullet">
+        /// <item><description>a job is enqueued, from this thread or any other;</description></item>
+        /// <item><description>
+        /// work the engine scheduled for <em>itself</em> comes due — a <c>setTimeout</c> or
+        /// <c>setInterval</c> callback, an <c>AbortSignal.timeout()</c>, a delayed <c>scheduler.postTask</c>,
+        /// an <c>Atomics.waitAsync</c> deadline. The wait is bounded internally by that due time, so a
+        /// <c>setTimeout(f, 1)</c> wakes it in about a millisecond rather than at
+        /// <paramref name="timeout"/>;
+        /// </description></item>
+        /// <item><description><paramref name="timeout"/> elapses, which is the <see langword="false"/>;</description></item>
+        /// <item><description>
+        /// <paramref name="cancellationToken"/> is cancelled, which throws
+        /// <see cref="OperationCanceledException"/>.
+        /// </description></item>
+        /// </list>
+        /// A registered <see cref="Constraints.CancellationConstraint"/> ends the wait too, and reports itself
+        /// as <see cref="ExecutionCanceledException"/> exactly as per-statement execution does — an engine that
+        /// has been cancelled has nothing left worth waiting for. Both exceptions leave the engine usable.
+        /// </para>
+        /// <para>
+        /// <b>Treat <see langword="true"/> as a hint and re-check your own condition.</b> Spurious wakes are
+        /// expected: work can be dropped at dequeue because it belongs to an evaluation cycle
+        /// <see cref="RestoreGlobalSnapshot"/> has ended, and a wake races anything else the host does. A
+        /// <see langword="false"/> is equally not a promise that nothing arrived — it says only that nothing
+        /// had arrived when the ceiling ran out.
+        /// </para>
+        /// <para>
+        /// <b>Single drainer.</b> The wait claims the engine for its whole duration, so a second thread calling
+        /// it — or calling any other guarded entry — is refused with
+        /// <see cref="InvalidOperationException"/>: <i>"This Engine is already in use by another thread or has
+        /// an asynchronous operation in progress."</i> That is the engine's ordinary admission rule rather than
+        /// anything this method adds, and it is what makes one-thread-per-engine self-enforcing. Enqueueing
+        /// into a waiting engine from another thread is unaffected — that path is deliberately unguarded, and
+        /// is what wakes the wait. One consequence worth knowing: an authorized host callback arriving from
+        /// another thread while this wait is parked is refused for as long as it is parked, where a
+        /// <c>Thread.Sleep</c> would have admitted it. A host that needs such callbacks admitted while idle
+        /// should not park the engine's own thread here.
+        /// </para>
+        /// <para>
+        /// <b>Do not call it from inside a job</b> — from host code reached by a promise reaction, a timer
+        /// callback or an event listener. The re-entrancy guard makes the queue unrunnable from there, so
+        /// nothing counts as available and the call simply idles out its ceiling and answers
+        /// <see langword="false"/>. That is the same rule the engine's own wait loops apply, and it is chosen
+        /// over refusing outright because this wait — unlike a blocking module import — genuinely can end:
+        /// what it cannot do is make the pump you would call next do anything.
+        /// </para>
+        /// <para>
+        /// Available on <b>every</b> target framework and unaffected by which web APIs are enabled.
+        /// </para>
+        /// </remarks>
+        /// <param name="timeout">
+        /// The ceiling on how long to block. A non-positive value does not block at all and simply answers
+        /// with what is available right now; <see cref="Timeout.InfiniteTimeSpan"/> waits indefinitely, which
+        /// is only safe together with a <paramref name="cancellationToken"/>.
+        /// </param>
+        /// <param name="cancellationToken">Ends the wait with an <see cref="OperationCanceledException"/>.</param>
+        /// <returns>Whether there is (probably) work for <see cref="ProcessTasks"/> to run.</returns>
+        /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> was cancelled.</exception>
+        /// <exception cref="ExecutionCanceledException">A registered cancellation constraint fired.</exception>
+        /// <exception cref="InvalidOperationException">Another thread is using this engine.</exception>
+        /// <example>
+        /// One thread per engine — the shape this exists for:
+        /// <code>
+        /// while (!token.IsCancellationRequested)
+        /// {
+        ///     engine.Advanced.ProcessTasks();
+        ///
+        ///     try
+        ///     {
+        ///         engine.Advanced.WaitForScheduledWork(TimeSpan.FromMilliseconds(50), token);
+        ///     }
+        ///     catch (OperationCanceledException)
+        ///     {
+        ///         break;
+        ///     }
+        /// }
+        /// </code>
+        /// </example>
+        public bool WaitForScheduledWork(TimeSpan timeout, CancellationToken cancellationToken = default)
+            => _engine.WaitForScheduledWork(timeout, cancellationToken);
+
+        /// <summary>
+        /// The asynchronous form of <see cref="WaitForScheduledWork"/>: the same contract, without holding a
+        /// thread while it waits.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Everything <see cref="WaitForScheduledWork"/> documents applies — it does not pump, a
+        /// <see langword="true"/> is a hint, the wait is bounded by the engine's own next due time, and a
+        /// registered <see cref="Constraints.CancellationConstraint"/> ends it as
+        /// <see cref="ExecutionCanceledException"/>. Only the ownership differs.
+        /// </para>
+        /// <para>
+        /// <b>Ownership spans the whole await.</b> No thread stays claimed across an <c>await</c>, so this
+        /// reserves the engine the way every other asynchronous host entry does: the reservation is taken
+        /// <em>synchronously</em>, so an engine already in use is refused with the admission
+        /// <see cref="InvalidOperationException"/> before a <see cref="Task"/> exists, and it is held until the
+        /// returned task completes. While it is held the engine refuses every guarded entry from every thread,
+        /// this one included — so <see cref="ProcessTasks"/> belongs after the <c>await</c>, never beside it.
+        /// The continuation resumes on whichever thread the runtime hands it, which is why the engine is
+        /// re-claimed for each look at its schedule.
+        /// </para>
+        /// <para>
+        /// Because the reservation is taken synchronously, this can never be called from inside a job: a job
+        /// runs with the engine already claimed, so the call is refused rather than idling out its ceiling the
+        /// way the synchronous form does.
+        /// </para>
+        /// </remarks>
+        /// <param name="timeout">
+        /// The ceiling on how long to wait. A non-positive value does not wait at all;
+        /// <see cref="Timeout.InfiniteTimeSpan"/> waits indefinitely.
+        /// </param>
+        /// <param name="cancellationToken">Ends the wait with an <see cref="OperationCanceledException"/>.</param>
+        /// <returns>Whether there is (probably) work for <see cref="ProcessTasks"/> to run.</returns>
+        /// <exception cref="InvalidOperationException">This engine is already in use.</exception>
+        public Task<bool> WaitForScheduledWorkAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
+        {
+            // Taken here rather than inside the async body so that the admission failure is reported to the
+            // caller synchronously, exactly as EvaluateAsync and its siblings report it; the body owns the
+            // release, because everything after its first await belongs to it.
+            var owner = _engine.ReserveAsyncHostOperation();
+            return _engine.WaitForScheduledWorkCoreAsync(owner, timeout, cancellationToken);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -901,8 +901,40 @@ positive span is how long until the earliest *timed* work — a `setTimeout`, an
 delayed `postTask`, a `requestIdleCallback` timeout, an `Atomics.waitAsync` deadline — comes due; `null` means
 nothing is scheduled. It is available on **every** target framework, not just .NET 8: the atomics deadline it
 reports is a core-engine one. It describes the engine's own schedule and not the outside world, so a `null` is
-"nothing timed is pending" rather than "nothing will ever happen" — keep a cadence of your own for the work
-that arrives from a background thread.
+"nothing timed is pending" rather than "nothing will ever happen".
+
+**`engine.Advanced.WaitForScheduledWork(timeout, token)` is the answer to the work that arrives from a
+background thread.** A loop with no frame of its own would otherwise have to sleep on a ceiling of its own
+choosing, and then a job enqueued from *another* thread — an interop `Task` settling, an asynchronous module
+load completing, a message posted in from a second engine — waits out that ceiling before anything notices it:
+such a job has no due time for `TimeUntilNextScheduledWork` to report, so polling was the only way to find it.
+The wait blocks until there is something worth pumping and returns `true`, or returns `false` when the ceiling
+runs out; the token ends it with an `OperationCanceledException`.
+
+```csharp
+while (!token.IsCancellationRequested)
+{
+    engine.Advanced.ProcessTasks();
+
+    try
+    {
+        engine.Advanced.WaitForScheduledWork(TimeSpan.FromMilliseconds(50), token);
+    }
+    catch (OperationCanceledException)
+    {
+        break;
+    }
+}
+```
+
+**It does not pump** — `ProcessTasks()` is still the pump, and there is still no third method that drains for
+a budget. It is bounded internally by the engine's own next due time, so a `setTimeout(f, 1)` wakes it in about
+a millisecond rather than at the ceiling above, and the ceiling is only a backstop. Treat a `true` as a hint and
+re-check your own condition: spurious wakes are expected. The wait **claims the engine for its whole duration**,
+so a second thread asking for it — or for anything else guarded — gets the usual *"This Engine is already in use
+by another thread"*, which is what makes one drainer per engine self-enforcing. `WaitForScheduledWorkAsync` is
+the same contract without holding a thread. Both are available on **every** target framework and are unaffected
+by which web APIs are enabled.
 
 **`engine.Advanced.CreateAbortSignal(cancellationToken)`** bridges your cancellation into script: hand the
 returned `AbortSignal` to `fetch`, to `scheduler.postTask`, or to a listener the script adds itself. Requires


### PR DESCRIPTION
PR 0 of the Web Workers plan (#3167 §3 and §14), and useful entirely on its own: the piece a host driving
one engine per thread was missing.

`Engine.Advanced.TimeUntilNextScheduledWork` answers *when to pump*, but a job that arrives from another
thread — an interop `Task` settling, a message posted in from a second engine, an asynchronous module load
completing — has no due time for it to report, so a dedicated pump thread could only find such work by
polling, paying up to its poll ceiling in latency on every arrival. This adds the wait that parks on it:

```csharp
public bool WaitForScheduledWork(TimeSpan timeout, CancellationToken cancellationToken = default);
public Task<bool> WaitForScheduledWorkAsync(TimeSpan timeout, CancellationToken cancellationToken = default);
```

**Contract.** Returns `true` when there is (probably) work — call `ProcessTasks()` next — and `false` on
timeout. **It does not pump**: `ProcessTasks` stays the pump and there is still no third method that drains
for a budget. The wait is bounded internally by the engine's own next due time, so a `setTimeout(f, 1)`
wakes it in about a millisecond rather than at the caller's ceiling; a cross-thread `EventLoop.Enqueue`
wakes it immediately through the work-arrived event that already existed for the module-load drain. A
registered `CancellationConstraint` ends it as `ExecutionCanceledException`, the caller's token as
`OperationCanceledException`, and spurious wakes are expected and documented.

**Ownership is the interesting part, and both forms follow existing discipline rather than inventing any.**
The synchronous form holds `EnterHostCall()` for its whole duration, so one drainer per engine is
self-enforcing — a second thread gets the engine's ordinary "already in use by another thread" admission
error, and enqueueing (deliberately unguarded) still works and is what wakes it. The asynchronous form takes
the async host-operation reservation *synchronously* — an engine in use is refused before a `Task` exists,
exactly as `EvaluateAsync` reports it — and re-claims the resuming thread per look at the schedule, since
the timer and atomics heaps it consults are engine-thread state. Entered from inside a job, the sync form
idles out and answers `false` (the queue is unrunnable from there — the same rule the engine's internal
waits apply), and the async form is refused by its own reservation.

The implementation is a thin assembly over internals that all existed (`EventLoop.WaitForWork` /
`WaitForEventAsync` / `TimeUntilNextPumpScheduledWork`): no new `Engine` field, no new synchronization. All
target frameworks, no web-API flag, nothing under `Jint/WebApi/`. README's host-loop section now shows the
park-and-pump shape instead of telling hosts to keep a cadence of their own.

Tests: 12 across `Jint.Tests` (mechanism, including the ownership pin that parks a wait and proves a
guarded entry is refused for its whole duration) and `Jint.Tests.PublicInterface` (a cross-thread promise
settle waking a parked host, on both TFMs including net472). Every pin was verified to fail against the
mutation it names — the queue-check, the schedule clamp, the sync ownership, the async reservation and
release, the token mapping, and `EventLoop.Enqueue`'s wake signal.

Part of #3167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PnghUC3EKrYa12xQ2LaYyd
